### PR TITLE
Improve ODE integrator docs and refactor RKF core

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/ode/AdaptiveStepsizeIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/AdaptiveStepsizeIntegrator.java
@@ -1,44 +1,51 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This abstract class holds the common part of all adaptive stepsize integrators for Ordinary
- * Differential Equations.
+ * Base class for integrators that adapt their step size while solving ordinary differential
+ * equations.
  *
- * <p>These algorithms perform integration with stepsize control, which means the user does not
- * specify the integration step but rather a tolerance on error. The error threshold is computed as
+ * <p>The class centralizes step bounds, tolerance bookkeeping and initialization so concrete
+ * algorithms can focus on method-specific interpolation and local error estimation. For each state
+ * component {@code i}, the error threshold is {@code absTol_i + relTol_i * max(|y_m|, |y_{m+1}|)};
+ * scalar tolerances are broadcast when vector forms are not provided. A tentative step is accepted
+ * when {@code sqrt(sum((errEst_i / threshold_i)^2) / n) < 1}, where {@code n} is the state
+ * dimension, otherwise the step is rejected and retried with a modified size.
  *
- * <pre>
- * threshold_i = absTol_i + relTol_i * max (abs (ym), abs (ym+1))
- * </pre>
+ * <p>Instances are mutable and not thread-safe; each integrator should be confined to one
+ * integration sequence at a time. Typical usage:
  *
- * where absTol_i is the absolute tolerance for component i of the state vector and relTol_i is the
- * relative tolerance for the same component. The user can also use only two scalar values absTol
- * and relTol which will be used for all components.
+ * <ul>
+ *   <li>Construct a subclass with minimum/maximum step bounds and tolerances.
+ *   <li>Optionally set an initial step, register step handlers, and add switching functions for
+ *       event detection.
+ *   <li>Call the subclass implementation of {@code integrate(...)} to evolve from {@code t0} to the
+ *       target time, allowing the integrator to grow or shrink steps as needed.
+ * </ul>
  *
- * <p>If the estimated error for ym+1 is such that
+ * <p>During integration the instance tracks the current step start and signed step size to support
+ * dense output and event location. Call {@link #resetInternalState()} before reusing an integrator
+ * for a new run to avoid leaking previous state.
  *
- * <pre>
- * sqrt((sum (errEst_i / threshold_i)^2 ) / n) < 1
- * </pre>
- *
- * (where n is the state vector dimension) then the step is accepted, otherwise the step is rejected
- * and a new attempt is made with a new stepsize.
- *
+ * @see FirstOrderIntegrator
+ * @see SwitchingFunction
  * @version $Id: AdaptiveStepsizeIntegrator.java 1719 2007-09-26 19:46:57Z luc $
  * @author L. Maisonobe
  */
 public abstract class AdaptiveStepsizeIntegrator implements FirstOrderIntegrator {
 
   /**
-   * Build an integrator with the given stepsize bounds. The default step handler does nothing.
+   * Build an integrator with scalar tolerances and explicit step size bounds.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param scalAbsoluteTolerance allowed absolute error
-   * @param scalRelativeTolerance allowed relative error
+   * <p>The created instance installs a no-op step handler and immediately resets its internal
+   * bookkeeping. Step bounds must be strictly positive even for backward integration. Scalar
+   * tolerances are applied to every component when estimating local truncation error.
+   *
+   * @param minStep minimal allowed step magnitude; positive even when integrating backward.
+   * @param maxStep maximal allowed step magnitude; positive and not smaller than {@code minStep}.
+   * @param scalAbsoluteTolerance uniform absolute error tolerance applied to all components.
+   * @param scalRelativeTolerance uniform relative error tolerance applied to all components.
    */
-  public AdaptiveStepsizeIntegrator(
+  protected AdaptiveStepsizeIntegrator(
       double minStep, double maxStep, double scalAbsoluteTolerance, double scalRelativeTolerance) {
 
     this.minStep = minStep;
@@ -59,15 +66,20 @@ public abstract class AdaptiveStepsizeIntegrator implements FirstOrderIntegrator
   }
 
   /**
-   * Build an integrator with the given stepsize bounds. The default step handler does nothing.
+   * Build an integrator with per-component tolerances and step size bounds.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param vecAbsoluteTolerance allowed absolute error
-   * @param vecRelativeTolerance allowed relative error
+   * <p>Vector tolerances let callers adapt admissible error to the magnitude of each state
+   * coordinate. Arrays are used as provided; callers must ensure their length matches the problem
+   * dimension. The default step handler performs no action until replaced.
+   *
+   * @param minStep minimal allowed step magnitude; positive even when integrating backward.
+   * @param maxStep maximal allowed step magnitude; positive and not smaller than {@code minStep}.
+   * @param vecAbsoluteTolerance absolute error tolerance for each component; must align with state
+   *     dimension and contain non-negative entries.
+   * @param vecRelativeTolerance relative error tolerance for each component; must align with state
+   *     dimension and contain non-negative entries.
    */
-  public AdaptiveStepsizeIntegrator(
+  protected AdaptiveStepsizeIntegrator(
       double minStep,
       double maxStep,
       double[] vecAbsoluteTolerance,
@@ -91,16 +103,18 @@ public abstract class AdaptiveStepsizeIntegrator implements FirstOrderIntegrator
   }
 
   /**
-   * Set the initial step size.
+   * Set an explicit initial step size to be reused by the next integration run.
    *
-   * <p>This method allows the user to specify an initial positive step size instead of letting the
-   * integrator guess it by itself. If this method is not called before integration is started, the
-   * initial step size will be estimated by the integrator.
+   * <p>A positive value inside {@code [minStep, maxStep]} is honored directly by {@link
+   * #initializeStep(FirstOrderDifferentialEquations, boolean, int, double[], double, double[],
+   * double[], double[], double[])}. Negative or out-of-range values instruct the integrator to
+   * estimate an initial step from the derivatives instead. The stored value is not persisted across
+   * calls to {@link #resetInternalState()}.
    *
-   * @param initialStepSize initial step size to use (must be positive even for backward integration
-   *     ; providing a negative value or a value outside of the min/max step interval will lead the
-   *     integrator to ignore the value and compute the initial step size by itself)
+   * @param initialStepSize desired starting step; must be positive and within configured bounds, or
+   *     it is ignored in favor of automatic estimation.
    */
+  @SuppressWarnings("unused")
   public void setInitialStepSize(double initialStepSize) {
     if ((initialStepSize < minStep) || (initialStepSize > maxStep)) {
       initialStep = -1.0;
@@ -110,31 +124,44 @@ public abstract class AdaptiveStepsizeIntegrator implements FirstOrderIntegrator
   }
 
   /**
-   * Set the step handler for this integrator. The handler will be called by the integrator for each
-   * accepted step.
+   * Set the step handler that will be invoked after each accepted step.
    *
-   * @param handler handler for the accepted steps
+   * <p>Handlers receive interpolated state information from the concrete integrator implementation.
+   * Passing {@code null} is unsupported; use {@link DummyStepHandler#getInstance()} when no output
+   * is needed. The supplied instance remains active until replaced by another call.
+   *
+   * @param handler non-null callback used to process or observe accepted steps during integration.
    */
   public void setStepHandler(StepHandler handler) {
     this.handler = handler;
   }
 
   /**
-   * Get the step handler for this integrator.
+   * Get the currently registered step handler.
    *
-   * @return the step handler for this integrator
+   * <p>The returned instance is the same object supplied via {@link #setStepHandler(StepHandler)}
+   * or the default dummy handler if none was set. Callers should treat the handler according to its
+   * own thread-safety guarantees.
+   *
+   * @return active handler invoked after each accepted step; never {@code null}.
    */
   public StepHandler getStepHandler() {
     return handler;
   }
 
   /**
-   * Add a switching function to the integrator.
+   * Add a switching function that will be monitored during integration.
    *
-   * @param function switching function
-   * @param maxCheckInterval maximal time interval between switching function checks (this interval
-   *     prevents missing sign changes in case the integration steps becomes very large)
-   * @param convergence convergence threshold in the event time search
+   * <p>Switching functions usually represent zero-crossing events. They are sampled at least every
+   * {@code maxCheckInterval} units of the independent variable to avoid missed sign changes, and
+   * event times are refined until successive estimates differ by less than {@code convergence}.
+   * Functions are processed in the order they are registered.
+   *
+   * @param function event function to monitor; must not be {@code null}.
+   * @param maxCheckInterval maximum time between evaluations of the function; must be positive and
+   *     expressed in the same units as the integration variable.
+   * @param convergence absolute convergence threshold for event time search; must be positive and
+   *     appropriate for the problem scale.
    */
   public void addSwitchingFunction(
       SwitchingFunction function, double maxCheckInterval, double convergence) {
@@ -142,20 +169,32 @@ public abstract class AdaptiveStepsizeIntegrator implements FirstOrderIntegrator
   }
 
   /**
-   * Initialize the integration step.
+   * Estimate an initial step size using scaling factors and derivative information.
    *
-   * @param equations differential equations set
-   * @param forward forward integration indicator
-   * @param order order of the method
-   * @param scale scaling vector for the state vector
-   * @param t0 start time
-   * @param y0 state vector at t0
-   * @param yDot0 first time derivative of y0
-   * @param y1 work array for a state vector
-   * @param yDot1 work array for the first time derivative of y1
-   * @return first integration step
-   * @exception DerivativeException this exception is propagated to the caller if the underlying
-   *     user function triggers one
+   * <p>If a valid explicit value was supplied via {@link #setInitialStepSize(double)}, it is
+   * returned immediately with the correct sign for the requested direction. Otherwise, a heuristic
+   * step is derived from the ratio of scaled state and derivative norms, refined with a trial Euler
+   * step, and finally clamped to the configured minimum and maximum step sizes.
+   *
+   * @param equations system of first-order differential equations providing derivative evaluation;
+   *     must not be {@code null}.
+   * @param forward {@code true} to integrate toward increasing time, {@code false} to integrate
+   *     backward.
+   * @param order order of the integration method that will consume the step; influences the scaling
+   *     of the heuristic.
+   * @param scale per-component scaling factors applied to the state vector; must match {@code y0}
+   *     length and contain only non-zero values.
+   * @param t0 starting independent variable value associated with {@code y0}.
+   * @param y0 state vector at {@code t0}; not modified by this method.
+   * @param yDot0 first derivative of {@code y0}; computed by {@code equations} and reused in place.
+   * @param y1 workspace receiving a trial state after an Euler prediction; length must match {@code
+   *     y0}.
+   * @param yDot1 workspace receiving the derivative at the trial state; length must match {@code
+   *     y0}.
+   * @return signed initial step size bounded by configured limits and oriented according to {@code
+   *     forward}.
+   * @throws DerivativeException if {@code equations} fails while evaluating derivatives at the
+   *     trial point.
    */
   public double initializeStep(
       FirstOrderDifferentialEquations equations,
@@ -231,13 +270,18 @@ public abstract class AdaptiveStepsizeIntegrator implements FirstOrderIntegrator
   }
 
   /**
-   * Filter the integration step.
+   * Clamp a proposed step size to configured bounds, optionally rejecting undersized values.
    *
-   * @param h signed step
-   * @param acceptSmall if true, steps smaller than the minimal value are silently increased up to
-   *     this value, if false such small steps generate an exception
-   * @return a bounded integration step (h if no bound is reach, or a bounded value)
-   * @exception IntegratorException if the step is too small and acceptSmall is false
+   * <p>The returned value preserves the sign of {@code h} while ensuring its magnitude lies inside
+   * {@code [minStep, maxStep]}. When {@code acceptSmall} is {@code false} and the proposed
+   * magnitude is smaller than {@code minStep}, an {@link IntegratorException} is raised; otherwise
+   * the step is increased to exactly the minimum magnitude.
+   *
+   * @param h candidate signed step size before bounding; may be positive or negative.
+   * @param acceptSmall {@code true} to silently clamp values below {@code minStep}, {@code false}
+   *     to throw instead of enlarging them.
+   * @return bounded step size that respects configured limits while keeping the original sign.
+   * @throws IntegratorException if {@code acceptSmall} is {@code false} and {@code |h| < minStep}.
    */
   protected double filterStep(double h, boolean acceptSmall) throws IntegratorException {
 
@@ -260,72 +304,145 @@ public abstract class AdaptiveStepsizeIntegrator implements FirstOrderIntegrator
     return h;
   }
 
-  public abstract void integrate(
-      FirstOrderDifferentialEquations equations, double t0, double[] y0, double t, double[] y)
-      throws DerivativeException, IntegratorException;
-
+  /**
+   * Get the start time of the current integration step.
+   *
+   * <p>Before any integration or after a reset the value is {@link Double#NaN}, indicating no
+   * active step is in progress. Concrete integrators update this value whenever they propose or
+   * accept a step so that step handlers and switching functions can access the accurate origin of
+   * the interpolation interval.
+   *
+   * @return time coordinate at the beginning of the current step, or {@code NaN} when unset.
+   */
   public double getCurrentStepStart() {
     return stepStart;
   }
 
+  /**
+   * Get the signed size of the current integration step.
+   *
+   * <p>The sign reflects the integration direction. Immediately after construction or reset, the
+   * value is initialized to the geometric mean of the minimum and maximum step bounds. During
+   * integration, it contains the step length last computed by the adaptive controller, which is
+   * useful for diagnostic logging or for dense output interpolation that needs the current step
+   * width.
+   *
+   * @return current signed step size chosen by the integrator, or the initial guess when unset.
+   */
   public double getCurrentStepsize() {
     return stepSize;
   }
 
-  /** Reset internal state to dummy values. */
+  /**
+   * Reset internal step-related state to sentinel values.
+   *
+   * <p>This method should be called before reusing the integrator for a new problem to avoid mixing
+   * state between runs. It clears the current step start to {@link Double#NaN} and reinitializes
+   * the step size to a neutral guess derived from the configured bounds, giving subclasses a clean
+   * baseline for their next initialization phase.
+   */
   protected void resetInternalState() {
     stepStart = Double.NaN;
     stepSize = Math.sqrt(minStep * maxStep);
   }
 
   /**
-   * Get the minimal step.
+   * Get the minimal admissible step magnitude configured for this integrator.
    *
-   * @return minimal step
+   * <p>This lower bound prevents the adaptive controller from shrinking steps to values that would
+   * make progress numerically insignificant or cause excessive round-off errors.
+   *
+   * @return strictly positive lower bound applied when filtering proposed steps.
    */
   public double getMinStep() {
     return minStep;
   }
 
   /**
-   * Get the maximal step.
+   * Get the maximal admissible step magnitude configured for this integrator.
    *
-   * @return maximal step
+   * <p>This upper bound caps aggressive growth of the step size so that event detection and local
+   * truncation error estimates remain reliable even when the solution behaves smoothly.
+   *
+   * @return strictly positive upper bound applied when filtering proposed steps.
    */
   public double getMaxStep() {
     return maxStep;
   }
 
-  /** Minimal step. */
-  private double minStep;
+  /**
+   * Lower bound for step magnitudes; used by {@link #filterStep(double, boolean)} and step
+   * initialization heuristics. The value is fixed at construction time and remains constant for the
+   * lifetime of the integrator instance.
+   */
+  private final double minStep;
 
-  /** Maximal step. */
-  private double maxStep;
+  /**
+   * Upper bound for step magnitudes; prevents adaptive schemes from growing beyond safe limits for
+   * the problem scale. The value is immutable after construction to keep filtering logic
+   * predictable.
+   */
+  private final double maxStep;
 
-  /** User supplied initial step. */
+  /**
+   * Optional user-supplied initial step size; a negative value signals that automatic estimation
+   * should be used instead. The value is mutable between runs and is consumed by {@link
+   * #initializeStep(FirstOrderDifferentialEquations, boolean, int, double[], double, double[],
+   * double[], double[], double[])}.
+   */
   private double initialStep;
 
-  /** Allowed absolute scalar error. */
+  /**
+   * Absolute error tolerance applied uniformly when vector tolerances are not provided. Subclasses
+   * consult this value while computing normalized error estimates, ensuring each component is
+   * measured against a consistent absolute scale.
+   */
   protected double scalAbsoluteTolerance;
 
-  /** Allowed relative scalar error. */
+  /**
+   * Relative error tolerance applied uniformly when vector tolerances are not provided. It scales
+   * the acceptable error proportionally to the magnitude of each state component during adaptive
+   * control.
+   */
   protected double scalRelativeTolerance;
 
-  /** Allowed absolute vectorial error. */
+  /**
+   * Per-component absolute error tolerances aligned with the problem dimension, if configured.
+   * Concrete integrators use these values directly when available to refine normalized error
+   * metrics.
+   */
   protected double[] vecAbsoluteTolerance;
 
-  /** Allowed relative vectorial error. */
+  /**
+   * Per-component relative error tolerances aligned with the problem dimension, if configured.
+   * Enables heterogeneous scaling so larger-magnitude components do not dominate the adaptive
+   * controller.
+   */
   protected double[] vecRelativeTolerance;
 
-  /** Step handler. */
+  /**
+   * Callback invoked after each accepted step; defaults to a no-op handler. Concrete integrators
+   * call the handler to expose interpolated state values, enabling users to collect dense output or
+   * drive side effects such as logging.
+   */
   protected StepHandler handler;
 
-  /** Switching functions handler. */
+  /**
+   * Aggregates registered switching functions and coordinates event detection. It controls sampling
+   * frequency, root finding and state changes triggered by events encountered during the adaptive
+   * integration process.
+   */
   protected SwitchingFunctionsHandler switchesHandler;
 
-  /** Current step start time. */
+  /**
+   * Time coordinate of the current step start; {@link Double#NaN} when uninitialized. Updated by
+   * concrete integrators as they progress through the domain.
+   */
   protected double stepStart;
 
-  /** Current stepsize. */
+  /**
+   * Signed length of the current step; initialized to the geometric mean of configured bounds.
+   * Values are adapted continuously by concrete integrators in response to local error estimates.
+   */
   protected double stepSize;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/DormandPrince54Integrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DormandPrince54Integrator.java
@@ -1,35 +1,40 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements the 5(4) Dormand-Prince integrator for Ordinary Differential Equations.
+ * Implements the 5(4) Dormand–Prince embedded Runge–Kutta integrator for systems of ordinary
+ * differential equations.
  *
- * <p>This integrator is an embedded Runge-Kutta-Fehlberg integrator of order 5(4) used in local
- * extrapolation mode (i.e. the solution is computed using the high order formula) with stepsize
- * control (and automatic step initialization) and continuous output. This method uses 7 functions
- * evaluations per step. However, since this is an <i>fsal</i>, the last evaluation of one step is
- * the same as the first evaluation of the next step and hence can be avoided. So the cost is really
- * 6 functions evaluations per step.
+ * <p>Instances provide adaptive step size control, automatic initial step estimation, dense output
+ * through a step interpolator, and the <i>first same as last</i> (FSAL) optimization that reuses
+ * the final derivative of a successful step as the initial derivative of the next one. The method
+ * evaluates seven intermediate stages per attempted step, but the FSAL property lowers the cost of
+ * accepted steps to six function evaluations. Step acceptance is driven by the embedded 5th/4th
+ * order pair, allowing the higher-order estimate to propagate while the lower-order estimate bounds
+ * the local truncation error. Typical usage constructs the integrator with bounds and tolerances,
+ * registers any {@link StepHandler}, and calls {@link #integrate(FirstOrderDifferentialEquations,
+ * double, double[], double, double[])} to evolve state toward the target time.
  *
- * <p>This method has been published (whithout the continuous output that was added by Shampine in
- * 1986) in the following article :
+ * <p>Lifecycle considerations:
  *
- * <pre>
- *  A family of embedded Runge-Kutta formulae
- *  J. R. Dormand and P. J. Prince
- *  Journal of Computational and Applied Mathematics
- *  volume 6, no 1, 1980, pp. 19-26
- * </pre>
+ * <ul>
+ *   <li>Instances are mutable and not thread-safe; confine one integrator to a single integration
+ *       run at a time.
+ *   <li>Step sizes remain within {@code minStep} and {@code maxStep}; the last step may be shorter
+ *       to land exactly on the target time or an event.
+ *   <li>Tolerances may be scalar or per-component vectors; callers must provide vectors matching
+ *       the equation dimension.
+ * </ul>
  *
- * @version $Id: DormandPrince54Integrator.java 1709 2006-12-03 21:16:50Z luc $
- * @author L. Maisonobe
+ * <p>Historically, this scheme was published by Dormand and Prince (1980) and extended with
+ * continuous output by Shampine (1986); see the original paper for coefficient derivations.
  */
 public class DormandPrince54Integrator extends RungeKuttaFehlbergIntegrator {
 
-  private static final String methodName = "Dormand-Prince 5(4)";
+  private static final String METHOD_NAME = "Dormand-Prince 5(4)";
 
-  private static final double[] c = {1.0 / 5.0, 3.0 / 10.0, 4.0 / 5.0, 8.0 / 9.0, 1.0, 1.0};
+  private static final double[] C = {1.0 / 5.0, 3.0 / 10.0, 4.0 / 5.0, 8.0 / 9.0, 1.0, 1.0};
 
-  private static final double[][] a = {
+  private static final double[][] A = {
     {1.0 / 5.0},
     {3.0 / 40.0, 9.0 / 40.0},
     {44.0 / 45.0, -56.0 / 15.0, 32.0 / 9.0},
@@ -38,33 +43,38 @@ public class DormandPrince54Integrator extends RungeKuttaFehlbergIntegrator {
     {35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0}
   };
 
-  private static final double[] b = {
+  private static final double[] B = {
     35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0, 0.0
   };
 
-  private static final double e1 = 71.0 / 57600.0;
-  private static final double e3 = -71.0 / 16695.0;
-  private static final double e4 = 71.0 / 1920.0;
-  private static final double e5 = -17253.0 / 339200.0;
-  private static final double e6 = 22.0 / 525.0;
-  private static final double e7 = -1.0 / 40.0;
+  private static final double E1 = 71.0 / 57600.0;
+  private static final double E3 = -71.0 / 16695.0;
+  private static final double E4 = 71.0 / 1920.0;
+  private static final double E5 = -17253.0 / 339200.0;
+  private static final double E6 = 22.0 / 525.0;
+  private static final double E7 = -1.0 / 40.0;
 
   /**
-   * Simple constructor. Build a fifth order Dormand-Prince integrator with the given step bounds
+   * Creates an integrator with scalar error tolerances and explicit step size bounds.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param scalAbsoluteTolerance allowed absolute error
-   * @param scalRelativeTolerance allowed relative error
+   * <p>Use this constructor when all state components should share the same absolute and relative
+   * tolerances. The integrator automatically chooses an initial step respecting the supplied
+   * bounds, adapts step sizes to maintain the requested accuracy, and reuses the FSAL derivative
+   * shortcut on accepted steps. Step sizes remain positive in magnitude regardless of the chosen
+   * integration direction, and the last step may be shorter to reach the exact target time.
+   *
+   * @param minStep minimum allowed positive step size, applied even during backward integration.
+   * @param maxStep maximum allowed positive step size, not smaller than {@code minStep}.
+   * @param scalAbsoluteTolerance uniform absolute error bound applied to every state component.
+   * @param scalRelativeTolerance uniform relative error bound scaled by each component magnitude.
    */
   public DormandPrince54Integrator(
       double minStep, double maxStep, double scalAbsoluteTolerance, double scalRelativeTolerance) {
     super(
         true,
-        c,
-        a,
-        b,
+        C,
+        A,
+        B,
         new DormandPrince54StepInterpolator(),
         minStep,
         maxStep,
@@ -73,13 +83,20 @@ public class DormandPrince54Integrator extends RungeKuttaFehlbergIntegrator {
   }
 
   /**
-   * Simple constructor. Build a fifth order Dormand-Prince integrator with the given step bounds
+   * Creates an integrator with per-component error tolerances and step size bounds.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param vecAbsoluteTolerance allowed absolute error
-   * @param vecRelativeTolerance allowed relative error
+   * <p>Use this overload when different state coordinates require distinct absolute or relative
+   * tolerances. The provided vectors must match the dimension reported by the underlying equations;
+   * values are consumed as-is and must be non-negative. Step sizes adapt between {@code minStep}
+   * and {@code maxStep}, and the final step may be shorter to align with the target time or an
+   * event located by the switching functions handler.
+   *
+   * @param minStep minimum allowed positive step size, reused for forward and backward runs.
+   * @param maxStep maximum allowed positive step size that caps automatic growth.
+   * @param vecAbsoluteTolerance absolute error bounds per component; length equals problem
+   *     dimension.
+   * @param vecRelativeTolerance relative error bounds per component; length equals problem
+   *     dimension.
    */
   public DormandPrince54Integrator(
       double minStep,
@@ -88,9 +105,9 @@ public class DormandPrince54Integrator extends RungeKuttaFehlbergIntegrator {
       double[] vecRelativeTolerance) {
     super(
         true,
-        c,
-        a,
-        b,
+        C,
+        A,
+        B,
         new DormandPrince54StepInterpolator(),
         minStep,
         maxStep,
@@ -99,31 +116,47 @@ public class DormandPrince54Integrator extends RungeKuttaFehlbergIntegrator {
   }
 
   /**
-   * Get the name of the method.
+   * Returns the short human-readable identifier of this integration method.
    *
-   * @return name of the method
+   * <p>The name can be used in logs, diagnostics, or UI surfaces to indicate which embedded
+   * Runge–Kutta scheme produced a particular integration result. The returned string is constant
+   * across instances and does not include tolerance or step-size configuration.
+   *
+   * @return a stable method name describing the Dormand–Prince 5(4) scheme.
    */
   public String getName() {
-    return methodName;
+    return METHOD_NAME;
   }
 
   /**
-   * Get the order of the method.
+   * Reports the algebraic order of the propagated solution.
    *
-   * @return order of the method
+   * <p>The Dormand–Prince 5(4) pair uses the fifth-order estimate for the accepted state and the
+   * embedded fourth-order estimate to control local error. This method exposes the propagated order
+   * so callers can reason about expected convergence rates or select schemes dynamically.
+   *
+   * @return the integer order (five) of the accepted solution estimate.
    */
   public int getOrder() {
     return 5;
   }
 
   /**
-   * Compute the error ratio.
+   * Computes the normalized root-mean-square local error estimate for a tentative step.
    *
-   * @param yDotK derivatives computed during the first stages
-   * @param y0 estimate of the step at the start of the step
-   * @param y1 estimate of the step at the end of the step
-   * @param h current step
-   * @return error ratio, greater than 1 if step should be rejected
+   * <p>The implementation combines the Dormand–Prince error coefficients with the stage derivatives
+   * to form the embedded fourth-order estimate, scales each component by the greater magnitude of
+   * the start and end state, and divides by either scalar or per-component tolerances. The returned
+   * value is compared against {@code 1.0}; values above one trigger a rejected step and step-size
+   * reduction, while values below one permit acceptance. The calculation is deterministic and
+   * agnostic to integration direction.
+   *
+   * @param yDotK derivatives for all Runge–Kutta stages; index {@code [k][j]} stores stage {@code
+   *     k} for component {@code j}.
+   * @param y0 state estimate at the beginning of the step; used for scaling each component.
+   * @param y1 state estimate at the end of the step produced by the higher-order formula.
+   * @param h signed step size that was attempted when computing {@code yDotK}.
+   * @return error ratio; values greater than one cause step rejection and resizing.
    */
   protected double estimateError(double[][] yDotK, double[] y0, double[] y1, double h) {
 
@@ -131,12 +164,12 @@ public class DormandPrince54Integrator extends RungeKuttaFehlbergIntegrator {
 
     for (int j = 0; j < y0.length; ++j) {
       double errSum =
-          e1 * yDotK[0][j]
-              + e3 * yDotK[2][j]
-              + e4 * yDotK[3][j]
-              + e5 * yDotK[4][j]
-              + e6 * yDotK[5][j]
-              + e7 * yDotK[6][j];
+          E1 * yDotK[0][j]
+              + E3 * yDotK[2][j]
+              + E4 * yDotK[3][j]
+              + E5 * yDotK[4][j]
+              + E6 * yDotK[5][j]
+              + E7 * yDotK[6][j];
 
       double yScale = Math.max(Math.abs(y0[j]), Math.abs(y1[j]));
       double tol =

--- a/src/main/java/org/spaceroots/mantissa/ode/DormandPrince853Integrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DormandPrince853Integrator.java
@@ -1,40 +1,44 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements the 8(5,3) Dormand-Prince integrator for Ordinary Differential Equations.
+ * Implements the 8(5,3) Dormand–Prince explicit Runge–Kutta integrator with FSAL optimization,
+ * adaptive steps, and dense output for systems of first-order ordinary differential equations.
  *
- * <p>This integrator is an embedded Runge-Kutta-Fehlberg integrator of order 8(5,3) used in local
- * extrapolation mode (i.e. the solution is computed using the high order formula) with stepsize
- * control (and automatic step initialization) and continuous output. This method uses 12 functions
- * evaluations per step for integration and 4 evaluations for interpolation. However, since the
- * first interpolation evaluation is the same as the first integration evaluation of the next step,
- * we have included it in the integrator rather than in the interpolator and specified the method
- * was an <i>fsal</i>. Hence, despite we have 13 stages here, the cost is really 12 evaluations per
- * step even if no interpolation is done, and the overcost of interpolation is only 3 evaluations.
+ * <p>The integrator combines an eighth-order propagation formula with an embedded fifth-order error
+ * estimator and third-order correction, delivering high accuracy while adjusting step sizes to keep
+ * the normalized local error below one. It automatically estimates an initial step, enforces
+ * user-provided minimum and maximum magnitudes, and reuses the final derivative of each accepted
+ * step (the <i>first same as last</i> property) to save one evaluation on the next step. Continuous
+ * output is available through a step interpolator so callers can sample intermediate states without
+ * retriggering derivative evaluations.
  *
- * <p>This method is based on an 8(6) method by Dormand and Prince (i.e. order 8 for the integration
- * and order 6 for error estimation) modified by Hairer and Wanner to use a 5th order error
- * estimator with 3rd order correction. This modification was introduced because the original method
- * failed in some cases (wrong steps can be accepted when step size is too large, for example in the
- * Brusselator problem) and also had <i>severe difficulties when applied to problems with
- * discontinuities</i>. This modification is explained in the second edition of the first volume
- * (Nonstiff Problems) of the reference book by Hairer, Norsett and Wanner: <i>Solving Ordinary
- * Differential Equations</i> (Springer-Verlag, ISBN 3-540-56670-8).
+ * <p>Use this class when problems are non-stiff, require tight error control, or benefit from
+ * higher-order dense output. Instances are mutable and not thread-safe; confine one integrator to a
+ * single integration run at a time. The Butcher tableau is hard-coded to mirror the method
+ * described by Hairer, Nørsett, and Wanner (Solving Ordinary Differential Equations I, 2nd ed.).
  *
+ * <ul>
+ *   <li>Order 8 primary solution with 5th/3rd order error estimation.
+ *   <li>Costs 12 function evaluations per accepted step despite 13 stages due to FSAL.
+ *   <li>Supports scalar or per-component tolerances and automatic step initialization.
+ * </ul>
+ *
+ * @see RungeKuttaFehlbergIntegrator
+ * @see DormandPrince54Integrator
  * @version $Id: DormandPrince853Integrator.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
  */
 public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
 
-  private static final String methodName = "Dormand-Prince 8 (5, 3)";
+  private static final String METHOD_NAME = "Dormand-Prince 8 (5, 3)";
 
-  private static final double sqrt6 = Math.sqrt(6.0);
+  private static final double SQRT_6 = Math.sqrt(6.0);
 
-  private static final double[] c = {
-    (12.0 - 2.0 * sqrt6) / 135.0,
-    (6.0 - sqrt6) / 45.0,
-    (6.0 - sqrt6) / 30.0,
-    (6.0 + sqrt6) / 30.0,
+  private static final double[] C = {
+    (12.0 - 2.0 * SQRT_6) / 135.0,
+    (6.0 - SQRT_6) / 45.0,
+    (6.0 - SQRT_6) / 30.0,
+    (6.0 + SQRT_6) / 30.0,
     1.0 / 3.0,
     1.0 / 4.0,
     4.0 / 13.0,
@@ -45,35 +49,35 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
     1.0
   };
 
-  private static final double[][] a = {
+  private static final double[][] A = {
 
     // k2
-    {(12.0 - 2.0 * sqrt6) / 135.0},
+    {(12.0 - 2.0 * SQRT_6) / 135.0},
 
     // k3
-    {(6.0 - sqrt6) / 180.0, (6.0 - sqrt6) / 60.0},
+    {(6.0 - SQRT_6) / 180.0, (6.0 - SQRT_6) / 60.0},
 
     // k4
-    {(6.0 - sqrt6) / 120.0, 0.0, (6.0 - sqrt6) / 40.0},
+    {(6.0 - SQRT_6) / 120.0, 0.0, (6.0 - SQRT_6) / 40.0},
 
     // k5
     {
-      (462.0 + 107.0 * sqrt6) / 3000.0,
+      (462.0 + 107.0 * SQRT_6) / 3000.0,
       0.0,
-      (-402.0 - 197.0 * sqrt6) / 1000.0,
-      (168.0 + 73.0 * sqrt6) / 375.0
+      (-402.0 - 197.0 * SQRT_6) / 1000.0,
+      (168.0 + 73.0 * SQRT_6) / 375.0
     },
 
     // k6
-    {1.0 / 27.0, 0.0, 0.0, (16.0 + sqrt6) / 108.0, (16.0 - sqrt6) / 108.0},
+    {1.0 / 27.0, 0.0, 0.0, (16.0 + SQRT_6) / 108.0, (16.0 - SQRT_6) / 108.0},
 
     // k7
     {
       19.0 / 512.0,
       0.0,
       0.0,
-      (118.0 + 23.0 * sqrt6) / 1024.0,
-      (118.0 - 23.0 * sqrt6) / 1024.0,
+      (118.0 + 23.0 * SQRT_6) / 1024.0,
+      (118.0 - 23.0 * SQRT_6) / 1024.0,
       -9.0 / 512.0
     },
 
@@ -82,8 +86,8 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
       13772.0 / 371293.0,
       0.0,
       0.0,
-      (51544.0 + 4784.0 * sqrt6) / 371293.0,
-      (51544.0 - 4784.0 * sqrt6) / 371293.0,
+      (51544.0 + 4784.0 * SQRT_6) / 371293.0,
+      (51544.0 - 4784.0 * SQRT_6) / 371293.0,
       -5688.0 / 371293.0,
       3072.0 / 371293.0
     },
@@ -93,8 +97,8 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
       58656157643.0 / 93983540625.0,
       0.0,
       0.0,
-      (-1324889724104.0 - 318801444819.0 * sqrt6) / 626556937500.0,
-      (-1324889724104.0 + 318801444819.0 * sqrt6) / 626556937500.0,
+      (-1324889724104.0 - 318801444819.0 * SQRT_6) / 626556937500.0,
+      (-1324889724104.0 + 318801444819.0 * SQRT_6) / 626556937500.0,
       96044563816.0 / 3480871875.0,
       5682451879168.0 / 281950621875.0,
       -165125654.0 / 3796875.0
@@ -105,8 +109,8 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
       8909899.0 / 18653125.0,
       0.0,
       0.0,
-      (-4521408.0 - 1137963.0 * sqrt6) / 2937500.0,
-      (-4521408.0 + 1137963.0 * sqrt6) / 2937500.0,
+      (-4521408.0 - 1137963.0 * SQRT_6) / 2937500.0,
+      (-4521408.0 + 1137963.0 * SQRT_6) / 2937500.0,
       96663078.0 / 4553125.0,
       2107245056.0 / 137915625.0,
       -4913652016.0 / 147609375.0,
@@ -118,8 +122,8 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
       -20401265806.0 / 21769653311.0,
       0.0,
       0.0,
-      (354216.0 + 94326.0 * sqrt6) / 112847.0,
-      (354216.0 - 94326.0 * sqrt6) / 112847.0,
+      (354216.0 + 94326.0 * SQRT_6) / 112847.0,
+      (354216.0 - 94326.0 * SQRT_6) / 112847.0,
       -43306765128.0 / 5313852383.0,
       -20866708358144.0 / 1126708119789.0,
       14886003438020.0 / 654632330667.0,
@@ -132,8 +136,8 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
       39815761.0 / 17514443.0,
       0.0,
       0.0,
-      (-3457480.0 - 960905.0 * sqrt6) / 551636.0,
-      (-3457480.0 + 960905.0 * sqrt6) / 551636.0,
+      (-3457480.0 - 960905.0 * SQRT_6) / 551636.0,
+      (-3457480.0 + 960905.0 * SQRT_6) / 551636.0,
       -844554132.0 / 47026969.0,
       8444996352.0 / 302158619.0,
       -2509602342.0 / 877790785.0,
@@ -144,7 +148,7 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
 
     // k13 should be for interpolation only, but since it is the same
     // stage as the first evaluation of the next step, we perform it
-    // here at no cost by specifying this is an fsal method
+    // here at no cost by specifying this is a fsal method
     {
       104257.0 / 1920240.0,
       0.0,
@@ -161,7 +165,7 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
     }
   };
 
-  private static final double[] b = {
+  private static final double[] B = {
     104257.0 / 1920240.0,
     0.0,
     0.0,
@@ -177,40 +181,50 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
     0.0
   };
 
-  private static final double e1_01 = 116092271.0 / 8848465920.0;
-  private static final double e1_06 = -1871647.0 / 1527680.0;
-  private static final double e1_07 = -69799717.0 / 140793660.0;
-  private static final double e1_08 = 1230164450203.0 / 739113984000.0;
-  private static final double e1_09 = -1980813971228885.0 / 5654156025964544.0;
-  private static final double e1_10 = 464500805.0 / 1389975552.0;
-  private static final double e1_11 = 1606764981773.0 / 19613062656000.0;
-  private static final double e1_12 = -137909.0 / 6168960.0;
+  private static final double E1_01 = 116092271.0 / 8848465920.0;
+  private static final double E1_06 = -1871647.0 / 1527680.0;
+  private static final double E1_07 = -69799717.0 / 140793660.0;
+  private static final double E1_08 = 1230164450203.0 / 739113984000.0;
+  private static final double E1_09 = -1980813971228885.0 / 5654156025964544.0;
+  private static final double E1_10 = 464500805.0 / 1389975552.0;
+  private static final double E1_11 = 1606764981773.0 / 19613062656000.0;
+  private static final double E1_12 = -137909.0 / 6168960.0;
 
-  private static final double e2_01 = -364463.0 / 1920240.0;
-  private static final double e2_06 = 3399327.0 / 763840.0;
-  private static final double e2_07 = 66578432.0 / 35198415.0;
-  private static final double e2_08 = -1674902723.0 / 288716400.0;
-  private static final double e2_09 = -74684743568175.0 / 176692375811392.0;
-  private static final double e2_10 = -734375.0 / 4826304.0;
-  private static final double e2_11 = 171414593.0 / 851261400.0;
-  private static final double e2_12 = 69869.0 / 3084480.0;
+  private static final double E2_01 = -364463.0 / 1920240.0;
+  private static final double E2_06 = 3399327.0 / 763840.0;
+  private static final double E2_07 = 66578432.0 / 35198415.0;
+  private static final double E2_08 = -1674902723.0 / 288716400.0;
+  private static final double E2_09 = -74684743568175.0 / 176692375811392.0;
+  private static final double E2_10 = -734375.0 / 4826304.0;
+  private static final double E2_11 = 171414593.0 / 851261400.0;
+  private static final double E2_12 = 69869.0 / 3084480.0;
 
   /**
-   * Simple constructor. Build an eighth order Dormand-Prince integrator with the given step bounds
+   * Creates an eighth-order Dormand–Prince integrator with scalar error tolerances and explicit
+   * bounds on the adaptive step size.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param scalAbsoluteTolerance allowed absolute error
-   * @param scalRelativeTolerance allowed relative error
+   * <p>The constructor stores the provided tolerances, prepares a reusable step interpolator, and
+   * leaves the instance ready for a single integration run. Step magnitudes are clamped between
+   * {@code minStep} and {@code maxStep}; the final step may be shorter to land exactly on the
+   * target time or an event. Scalar tolerances apply uniformly to every state component; pass
+   * per-component arrays to the vector overload when state magnitudes differ significantly.
+   *
+   * @param minStep positive lower bound for the absolute step size even during backward integration
+   *     runs; values smaller than this may be used only for the final partial step.
+   * @param maxStep positive upper bound for the absolute step size used during adaptation; must not
+   *     be smaller than {@code minStep} and is honored for both forward and backward directions.
+   * @param scalAbsoluteTolerance uniform absolute error threshold applied to each component when
+   *     normalizing local error estimates; must be non-negative.
+   * @param scalRelativeTolerance uniform relative error threshold scaled by the largest magnitude
+   *     of the start and end state values for each component; must be non-negative.
    */
   public DormandPrince853Integrator(
       double minStep, double maxStep, double scalAbsoluteTolerance, double scalRelativeTolerance) {
     super(
         true,
-        c,
-        a,
-        b,
+        C,
+        A,
+        B,
         new DormandPrince853StepInterpolator(),
         minStep,
         maxStep,
@@ -219,13 +233,24 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
   }
 
   /**
-   * Simple constructor. Build an eighth order Dormand-Prince integrator with the given step bounds
+   * Creates an eighth-order Dormand–Prince integrator with per-component error tolerances and
+   * explicit adaptive step bounds.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param vecAbsoluteTolerance allowed absolute error
-   * @param vecRelativeTolerance allowed relative error
+   * <p>This overload accepts absolute and relative tolerances aligned to each state component,
+   * which is useful when state magnitudes differ by several orders. The integrator keeps step
+   * magnitudes within {@code minStep} and {@code maxStep}, shrinking the final step if needed to
+   * hit the target time exactly. Tolerance arrays are consumed as provided; callers must ensure
+   * their length equals the equation dimension and that all entries are non-negative.
+   *
+   * @param minStep positive lower bound for absolute step size regardless of integration direction;
+   *     the last step may still be shorter to finish exactly on the target time.
+   * @param maxStep positive upper bound for absolute step size used during growth; must be at least
+   *     {@code minStep} and is applied symmetrically to forward and backward integration.
+   * @param vecAbsoluteTolerance absolute error thresholds per state component used to scale local
+   *     truncation error estimates; array length must match the problem dimension.
+   * @param vecRelativeTolerance relative error thresholds per state component multiplied by the
+   *     larger magnitude of the start and end values; array length must match the problem
+   *     dimension.
    */
   public DormandPrince853Integrator(
       double minStep,
@@ -234,9 +259,9 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
       double[] vecRelativeTolerance) {
     super(
         true,
-        c,
-        a,
-        b,
+        C,
+        A,
+        B,
         new DormandPrince853StepInterpolator(),
         minStep,
         maxStep,
@@ -245,31 +270,50 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
   }
 
   /**
-   * Get the name of the method.
+   * Returns a short human-readable identifier for this integration method.
    *
-   * @return name of the method
+   * <p>The name reflects the Dormand–Prince 8(5,3) tableau and is suitable for logs, user-facing
+   * diagnostics, or selection menus. The value is constant for all instances.
+   *
+   * @return stable method identifier describing the Dormand–Prince 8(5,3) scheme.
    */
   public String getName() {
-    return methodName;
+    return METHOD_NAME;
   }
 
   /**
-   * Get the order of the method.
+   * Reports the formal order of accuracy of the primary integration formula.
    *
-   * @return order of the method
+   * <p>The returned value corresponds to the eighth-order solution propagated after each accepted
+   * step; embedded lower-order estimates are used internally for error control and are not reported
+   * here.
+   *
+   * @return the integer value {@code 8}, representing the main solution order for this method.
    */
   public int getOrder() {
     return 8;
   }
 
   /**
-   * Compute the error ratio.
+   * Computes the normalized local error estimate for the current trial step.
    *
-   * @param yDotK derivatives computed during the first stages
-   * @param y0 estimate of the step at the start of the step
-   * @param y1 estimate of the step at the end of the step
-   * @param h current step
-   * @return error ratio, greater than 1 if step should be rejected
+   * <p>The method combines two embedded error estimators (orders five and three) to produce a
+   * single scalar error ratio. Each state component is scaled by either scalar or vector
+   * tolerances, using the larger magnitude of the start and end values to normalize derivatives. A
+   * return value above one signals that the step should be rejected and retried with a smaller
+   * size; values at or below one allow the step to be accepted and possibly grown for the next
+   * attempt. The computation does not modify the provided arrays.
+   *
+   * @param yDotK staged derivatives for all computed Runge–Kutta stages; indices align with the
+   *     method tableau and contain one entry per state component.
+   * @param y0 state estimate at the beginning of the candidate step; length matches the problem
+   *     dimension and is used for scaling tolerances.
+   * @param y1 state estimate at the end of the candidate step produced by the high-order formula;
+   *     length matches {@code y0} and is used for scaling tolerances.
+   * @param h signed size of the trial step currently under evaluation; absolute value is used when
+   *     computing the returned ratio.
+   * @return normalized error ratio; values greater than one trigger step rejection and reduction,
+   *     while values at or below one allow acceptance.
    */
   protected double estimateError(double[][] yDotK, double[] y0, double[] y1, double h) {
     double error1 = 0;
@@ -277,23 +321,23 @@ public class DormandPrince853Integrator extends RungeKuttaFehlbergIntegrator {
 
     for (int j = 0; j < y0.length; ++j) {
       double errSum1 =
-          e1_01 * yDotK[0][j]
-              + e1_06 * yDotK[5][j]
-              + e1_07 * yDotK[6][j]
-              + e1_08 * yDotK[7][j]
-              + e1_09 * yDotK[8][j]
-              + e1_10 * yDotK[9][j]
-              + e1_11 * yDotK[10][j]
-              + e1_12 * yDotK[11][j];
+          E1_01 * yDotK[0][j]
+              + E1_06 * yDotK[5][j]
+              + E1_07 * yDotK[6][j]
+              + E1_08 * yDotK[7][j]
+              + E1_09 * yDotK[8][j]
+              + E1_10 * yDotK[9][j]
+              + E1_11 * yDotK[10][j]
+              + E1_12 * yDotK[11][j];
       double errSum2 =
-          e2_01 * yDotK[0][j]
-              + e2_06 * yDotK[5][j]
-              + e2_07 * yDotK[6][j]
-              + e2_08 * yDotK[7][j]
-              + e2_09 * yDotK[8][j]
-              + e2_10 * yDotK[9][j]
-              + e2_11 * yDotK[10][j]
-              + e2_12 * yDotK[11][j];
+          E2_01 * yDotK[0][j]
+              + E2_06 * yDotK[5][j]
+              + E2_07 * yDotK[6][j]
+              + E2_08 * yDotK[7][j]
+              + E2_09 * yDotK[8][j]
+              + E2_10 * yDotK[9][j]
+              + E2_11 * yDotK[10][j]
+              + E2_12 * yDotK[11][j];
 
       double yScale = Math.max(Math.abs(y0[j]), Math.abs(y1[j]));
       double tol =

--- a/src/main/java/org/spaceroots/mantissa/ode/FirstOrderIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/FirstOrderIntegrator.java
@@ -1,11 +1,29 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This interface represents a first order integrator for differential equations.
+ * Integrates systems of first order ordinary differential equations.
  *
- * <p>The classes which are devoted to solve first order differential equations should implement
- * this interface. The problems which can be handled should implement the {@link
- * FirstOrderDifferentialEquations} interface.
+ * <p>Implementations advance a state vector forward or backward in time while delegating the actual
+ * derivative computation to a user-supplied {@link FirstOrderDifferentialEquations} model. The
+ * integrator controls step sizes, calls {@link StepHandler} listeners after accepted steps, and
+ * monitors {@link SwitchingFunction switching functions} to stop or reset the integration when
+ * event surfaces are crossed. A single integrator instance typically carries mutable state (current
+ * step size, cached derivatives) and is therefore intended for single-threaded use per integration
+ * run.
+ *
+ * <p>Typical usage follows this sequence:
+ *
+ * <ol>
+ *   <li>Create or configure the integrator implementation.
+ *   <li>Install a {@link StepHandler} to record accepted steps or drive downstream computation.
+ *   <li>Optionally register one or more {@link SwitchingFunction} instances to detect events.
+ *   <li>Call {@link #integrate(FirstOrderDifferentialEquations, double, double[], double,
+ *       double[])} with initial state and target time.
+ * </ol>
+ *
+ * <p>Integrators are free to adapt step sizes, but they must respect event detection constraints
+ * and guarantee that the provided {@code y} array reflects the state at the last completed step
+ * when the call returns.
  *
  * @see FirstOrderDifferentialEquations
  * @see StepHandler
@@ -18,34 +36,56 @@ public interface FirstOrderIntegrator {
   /**
    * Get the name of the method.
    *
-   * @return name of the method
+   * <p>The returned identifier should remain stable across versions of a given implementation so
+   * that logging and downstream tooling can attribute results to a concrete integration scheme
+   * (e.g., Dormand–Prince 8(5,3), Gragg–Bulirsch–Stoer). The name is purely informational and has
+   * no bearing on runtime behavior.
+   *
+   * @return human-friendly identifier of the integration algorithm currently in use
    */
-  public String getName();
+  String getName();
 
   /**
    * Set the step handler for this integrator. The handler will be called by the integrator for each
    * accepted step.
    *
-   * @param handler handler for the accepted steps
+   * <p>Only one handler is stored; successive calls replace the previous handler. Step handlers can
+   * accumulate results, stream intermediate states elsewhere, or enforce user-defined consistency
+   * checks. They are invoked on every accepted step, which may differ from internal trial steps
+   * when an adaptive scheme rejects some candidates.
+   *
+   * @param handler handler for the accepted steps, invoked in chronological order; must not be
+   *     {@code null}
    */
-  public void setStepHandler(StepHandler handler);
+  void setStepHandler(StepHandler handler);
 
   /**
    * Get the step handler for this integrator.
    *
-   * @return the step handler for this integrator
+   * <p>This accessor is useful for querying or decorating an existing handler without replacing it.
+   * If no handler has been configured, implementations typically return a default noop handler that
+   * discards step information.
+   *
+   * @return the step handler for this integrator, never {@code null}
    */
-  public StepHandler getStepHandler();
+  @SuppressWarnings("unused")
+  StepHandler getStepHandler();
 
   /**
    * Add a switching function to the integrator.
    *
-   * @param function switching function
-   * @param maxCheckInterval maximal time interval between switching function checks (this interval
-   *     prevents missing sign changes in case the integration steps becomes very large)
-   * @param convergence convergence threshold in the event time search
+   * <p>Switching functions detect sign changes of an event indicator and can stop the integration,
+   * reset state, or alter step sizes when a zero crossing occurs. Multiple functions may be
+   * registered; they are evaluated independently according to the integrator's event handling
+   * policy.
+   *
+   * @param function switching function whose sign changes indicate an event condition
+   * @param maxCheckInterval maximal time interval between function evaluations to avoid missing
+   *     sign changes during large internal steps
+   * @param convergence convergence threshold for locating the event time within the bracketing
+   *     interval
    */
-  public void addSwitchingFunction(
+  void addSwitchingFunction(
       SwitchingFunction function, double maxCheckInterval, double convergence);
 
   /**
@@ -56,18 +96,29 @@ public interface FirstOrderIntegrator {
    * <p>Since this method stores some internal state variables made available in its public
    * interface during integration ({@link #getCurrentStepsize()}), it is <em>not</em> thread-safe.
    *
-   * @param equations differential equations to integrate
-   * @param t0 initial time
-   * @param y0 initial value of the state vector at t0
-   * @param t target time for the integration (can be set to a value smaller than <code>t0</code>
-   *     for backward integration)
-   * @param y placeholder where to put the state vector at each successful step (and hence at the
-   *     end of integration), can be the same object as y0
-   * @throws IntegratorException if the integrator cannot perform integration
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The {@code y} array is updated in place to reflect the state at the end of each accepted
+   * step and on return holds the state at {@code t}. Implementations may perform backward
+   * integration when {@code t} is less than {@code t0}. All arrays must match the dimensionality
+   * declared by {@code equations}.
+   *
+   * <pre>{@code
+   * double[] state = {...};
+   * integrator.setStepHandler(myHandler);
+   * integrator.integrate(model, 0.0, state, 10.0, state);
+   * }</pre>
+   *
+   * @param equations differential equations to integrate; defines dimension and derivative
+   *     function; must not be {@code null}
+   * @param t0 initial time expressed in the same units expected by the model
+   * @param y0 initial value of the state vector at {@code t0}; length must match problem dimension
+   * @param t target time for the integration; may be less than {@code t0} for backward integration
+   * @param y placeholder updated with the state after each accepted step and on completion; may be
+   *     the same array instance as {@code y0}
+   * @throws IntegratorException if the integrator cannot converge or encounters configuration
+   *     issues
+   * @throws DerivativeException if the user-supplied derivative computation fails or rejects input
    */
-  public void integrate(
+  void integrate(
       FirstOrderDifferentialEquations equations, double t0, double[] y0, double t, double[] y)
       throws DerivativeException, IntegratorException;
 
@@ -80,9 +131,10 @@ public interface FirstOrderIntegrator {
    *
    * <p>The result is undefined if the method is called outside of calls to {@link #integrate}
    *
-   * @return current value of the step start time t<sub>i</sub>
+   * @return current value of the step start time t<sub>i</sub>; meaningful only during integration
    */
-  public double getCurrentStepStart();
+  @SuppressWarnings("unused")
+  double getCurrentStepStart();
 
   /**
    * Get the current value of the integration stepsize.
@@ -93,7 +145,8 @@ public interface FirstOrderIntegrator {
    *
    * <p>The result is undefined if the method is called outside of calls to {@link #integrate}
    *
-   * @return current value of the stepsize
+   * @return current value of the stepsize being attempted for the ongoing step
    */
-  public double getCurrentStepsize();
+  @SuppressWarnings("unused")
+  double getCurrentStepsize();
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegrator.java
@@ -1,72 +1,63 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements a Gragg-Bulirsch-Stoer integrator for Ordinary Differential Equations.
+ * Gragg–Bulirsch–Stoer integrator for non-stiff Ordinary Differential Equations with dense output
+ * support.
  *
- * <p>The Gragg-Bulirsch-Stoer algorithm is one of the most efficient ones currently available for
- * smooth problems. It uses Richardson extrapolation to estimate what would be the solution if the
- * step size could be decreased down to zero.
+ * <p>This implementation follows the Richardson extrapolation scheme popularized by Hairer and
+ * Wanner: it advances the solution with a modified midpoint method, refines the step through
+ * polynomial extrapolation, and selects both the order and step size dynamically to minimize the
+ * total number of derivative evaluations. It is aimed at smooth problems where very high accuracy
+ * is desirable; in practice it surpasses embedded Runge–Kutta methods once the required tolerance
+ * falls in the {@code 1e-6} to {@code 1e-11} range depending on problem sensitivity. Dense output
+ * and switching functions are handled so callers can sample the solution or trigger events between
+ * accepted steps. The integrator is not thread-safe; each instance manages mutable buffers that are
+ * reused across calls to {@link #integrate(FirstOrderDifferentialEquations, double, double[],
+ * double, double[])}. Typical usage creates one instance per ODE problem, configures optional
+ * stability and interpolation controls, then integrates forward or backward in time while providing
+ * a {@link StepHandler} for results.
  *
- * <p>This method changes both the step size and the order during integration, in order to minimize
- * computation cost. It is particularly well suited when a very high precision is needed. The limit
- * where this method becomes more efficient than high-order Runge-Kutta-Fehlberg methods like {@link
- * DormandPrince853Integrator Dormand-Prince 8(5,3)} depends on the problem. Results given in the
- * Hairer, Norsett and Wanner book show for example that this limit occurs for accuracy around 1e-6
- * when integrating Saltzam-Lorenz equations (the authors note this problem is <i>extremely
- * sensitive to the errors in the first integration steps</i>), and around 1e-11 for a two
- * dimensional celestial mechanics problems with seven bodies (pleiades problem, involving
- * quasi-collisions for which <i>automatic step size control is essential</i>).
- *
- * <p>This implementation is basically a reimplementation in Java of the <a
- * href="http://www.unige.ch/math/folks/hairer/prog/nonstiff/odex.f">odex</a> fortran code by E.
- * Hairer and G. Wanner. The redistribution policy for this code is available <a
- * href="http://www.unige.ch/~hairer/prog/licence.txt">here</a>, for convenience, it is reproduced
- * below.
- *
- * <table border="0" width="80%" cellpadding="10" align="center" bgcolor="#E0E0E0">
- * <tr><td>Copyright (c) 2004, Ernst Hairer</td></tr>
- *
- * <tr><td>Redistribution and use in source and binary forms, with or
- * without modification, are permitted provided that the following
- * conditions are met:
  * <ul>
- *  <li>Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.</li>
- *  <li>Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.</li>
- * </ul></td></tr>
+ *   <li><strong>Responsibilities:</strong> adaptive order/step selection, error estimation, dense
+ *       output coefficient generation.
+ *   <li><strong>State:</strong> retains extrapolation tables and work arrays between steps; reuse
+ *       the same instance only sequentially.
+ *   <li><strong>Trade-offs:</strong> excellent accuracy per function call on smooth fields, higher
+ *       setup cost than simpler embedded pairs.
+ * </ul>
  *
- * <tr><td><strong>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
- * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
- * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</strong></td></tr>
- * </table>
+ * <p><strong>License (Hairer/Wanner original odex code, summarized):</strong> redistribution and
+ * use in source and binary forms, with or without modification, are permitted provided copyright
+ * and disclaimer notices are preserved; the software is supplied “as is” without warranty and with
+ * no liability for damages.
  *
  * @author E. Hairer and G. Wanner (fortran version)
  * @author L. Maisonobe (Java port)
  * @version $Id: GraggBulirschStoerIntegrator.java 1719 2007-09-26 19:46:57Z luc $
+ * @see DormandPrince853Integrator
+ * @see StepHandler
  */
 public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
 
-  private static final String methodName = "Gragg-Bulirsch-Stoer";
+  private static final String METHOD_NAME = "Gragg-Bulirsch-Stoer";
 
   /**
-   * Simple constructor. Build a Gragg-Bulirsch-Stoer integrator with the given step bounds. All
-   * tuning parameters are set to their default values. The default step handler does nothing.
+   * Create an integrator with scalar tolerances and default control settings.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param scalAbsoluteTolerance allowed absolute error
-   * @param scalRelativeTolerance allowed relative error
+   * <p>Use this constructor when a single absolute/relative tolerance pair applies to every state
+   * component. The integrator allocates internal work buffers sized for the problem dimension,
+   * enables dense output automatically when the configured {@link StepHandler} or any switching
+   * function requires it, and initializes stability, step-size, order, and interpolation control to
+   * values recommended in the Hairer–Wanner literature. Step handlers can be replaced later via
+   * {@link #setStepHandler(StepHandler)}; stability and order settings can be tuned after
+   * construction. The initial and maximum steps must be strictly positive; backward integration is
+   * handled by negating the direction internally.
+   *
+   * @param minStep minimal step size in integration variable; must be positive but the final step
+   *     may be smaller
+   * @param maxStep maximal step size allowed (positive even for backward runs)
+   * @param scalAbsoluteTolerance absolute tolerance applied uniformly to every state entry
+   * @param scalRelativeTolerance relative tolerance applied uniformly to every state entry
    */
   public GraggBulirschStoerIntegrator(
       double minStep, double maxStep, double scalAbsoluteTolerance, double scalRelativeTolerance) {
@@ -79,15 +70,20 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   }
 
   /**
-   * Simple constructor. Build a Gragg-Bulirsch-Stoer integrator with the given step bounds. All
-   * tuning parameters are set to their default values. The default step handler does nothing.
+   * Create an integrator with per-component tolerances and default control settings.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param vecAbsoluteTolerance allowed absolute error
-   * @param vecRelativeTolerance allowed relative error
+   * <p>Choose this constructor when each state component requires its own absolute and relative
+   * tolerance. Vector tolerances must match the dimension returned by the supplied equations. All
+   * other defaults mirror the scalar constructor: stability checks enabled, conservative step-size
+   * control, and dense output if any listener requires it. The integrator copies no user buffers,
+   * so callers retain ownership of the tolerance arrays.
+   *
+   * @param minStep minimal step size in integration variable; must be strictly positive
+   * @param maxStep maximal step size allowed; must be strictly positive
+   * @param vecAbsoluteTolerance absolute tolerances per state entry; length equals state dimension
+   * @param vecRelativeTolerance relative tolerances per state entry; length equals state dimension
    */
+  @SuppressWarnings("unused")
   public GraggBulirschStoerIntegrator(
       double minStep,
       double maxStep,
@@ -102,22 +98,21 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   }
 
   /**
-   * Set the stability check controls.
+   * Configure stability checks performed during early extrapolation iterations.
    *
-   * <p>The stability check is performed on the first few iterations of the extrapolation scheme. If
-   * this test fails, the step is rejected and the stepsize is reduced.
+   * <p>For each candidate step the integrator compares the first derivative with later midpoint
+   * derivatives to detect rapidly growing modes. If the check fails, the step is rejected and the
+   * trial step size is reduced by the supplied factor. Checks are limited to the first few
+   * extrapolation iterations to avoid excessive cost. Passing negative or zero limits restores the
+   * defaults ({@code maxIter=2}, {@code maxChecks=1}, {@code stabilityReduction=0.5}). This setting
+   * primarily guards against divergence on coarse steps or poorly scaled problems.
    *
-   * <p>By default, the test is performed, at most during two iterations at each step, and at most
-   * once for each of these iterations. The default stepsize reduction factor is 0.5.
-   *
-   * @param performTest if true, stability check will be performed, if false, the check will be
-   *     skipped
-   * @param maxIter maximal number of iterations for which checks are performed (the number of
-   *     iterations is reset to default if negative or null)
-   * @param maxChecks maximal number of checks for each iteration (the number of checks is reset to
-   *     default if negative or null)
-   * @param stabilityReduction stepsize reduction factor in case of failure (the factor is reset to
-   *     default if lower than 0.0001 or greater than 0.9999)
+   * @param performTest {@code true} to enable stability checks, {@code false} to skip them entirely
+   * @param maxIter maximum extrapolation iterations to probe; non-positive values revert to default
+   * @param maxChecks maximum derivative comparisons per iteration; non-positive values revert to
+   *     default
+   * @param stabilityReduction multiplicative factor applied to the next trial step after a failure;
+   *     outside {@code [0.0001, 0.9999]} reverts to the default
    */
   public void setStabilityCheck(
       boolean performTest, int maxIter, int maxChecks, double stabilityReduction) {
@@ -134,33 +129,34 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   }
 
   /**
-   * Set the step size control factors.
+   * Tune the step-size adaptation coefficients.
    *
-   * <p>The new step size hNew is computed from the old one h by:
+   * <p>The next trial step {@code hNew} derives from the current step {@code h} via:
    *
-   * <pre>
-   * hNew = h * stepControl2 / (err/stepControl1)^(1/(2k+1))
-   * </pre>
+   * <pre>{@code
+   * hNew = h * stepControl2 / Math.pow(err / stepControl1, 1.0 / (2 * k + 1))
+   * }</pre>
    *
-   * where err is the scaled error and k the iteration number of the extrapolation scheme (counting
-   * from 0). The default values are 0.65 for stepControl1 and 0.94 for stepControl2.
+   * <p>where {@code err} is the normalized error estimate and {@code k} is the extrapolation column
+   * (starting at zero). The result is further clamped by
    *
-   * <p>The step size is subject to the restriction:
+   * <pre>{@code
+   * Math.pow(stepControl3, 1.0 / (2 * k + 1)) / stepControl4
+   *     <= hNew / h
+   *     <= 1 / Math.pow(stepControl3, 1.0 / (2 * k + 1))
+   * }</pre>
    *
-   * <pre>
-   * stepControl3^(1/(2k+1))/stepControl4 <= hNew/h <= 1/stepControl3^(1/(2k+1))
-   * </pre>
+   * <p>Values outside the accepted ranges revert to defaults ({@code stepControl1=0.65}, {@code
+   * stepControl2=0.94}, {@code stepControl3=0.02}, {@code stepControl4=4.0}).
    *
-   * The default values are 0.02 for stepControl3 and 4.0 for stepControl4.
-   *
-   * @param stepControl1 first stepsize control factor (the factor is reset to default if lower than
-   *     0.0001 or greater than 0.9999)
-   * @param stepControl2 second stepsize control factor (the factor is reset to default if lower
-   *     than 0.0001 or greater than 0.9999)
-   * @param stepControl3 third stepsize control factor (the factor is reset to default if lower than
-   *     0.0001 or greater than 0.9999)
-   * @param stepControl4 fourth stepsize control factor (the factor is reset to default if lower
-   *     than 1.0001 or greater than 999.9)
+   * @param stepControl1 numerator tolerance scale; outside {@code [0.0001, 0.9999]} resets to
+   *     default
+   * @param stepControl2 multiplicative growth factor; outside {@code [0.0001, 0.9999]} resets to
+   *     default
+   * @param stepControl3 clamp base for relative change; outside {@code [0.0001, 0.9999]} resets to
+   *     default
+   * @param stepControl4 clamp divisor limiting growth; outside {@code [1.0001, 999.9]} resets to
+   *     default
    */
   public void setStepsizeControl(
       double stepControl1, double stepControl2, double stepControl3, double stepControl4) {
@@ -191,30 +187,25 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   }
 
   /**
-   * Set the order control parameters.
+   * Adjust the order-selection heuristics for the extrapolation table.
    *
-   * <p>The Gragg-Bulirsch-Stoer method changes both the step size and the order during integration,
-   * in order to minimize computation cost. Each extrapolation step increases the order by 2, so the
-   * maximal order that will be used is always even, it is twice the maximal number of columns in
-   * the extrapolation table.
+   * <p>The integrator raises or lowers the extrapolation order (always even) to minimize work per
+   * unit step. Let {@code w(k)} be the estimated cost per unit time at order {@code k}; the rules
+   * are:
    *
-   * <pre>
-   * order is decreased if w(k-1) <= w(k)   * orderControl1
-   * order is increased if w(k)   <= w(k-1) * orderControl2
-   * </pre>
+   * <pre>{@code
+   * decrease order if w(k - 1) <= w(k) * orderControl1
+   * increase order if w(k)     <= w(k - 1) * orderControl2
+   * }</pre>
    *
-   * <p>where w is the table of work per unit step for each order (number of function calls divided
-   * by the step length), and k is the current order.
+   * Orders below {@code 6} or odd values revert to the default maximum of {@code 18} (nine table
+   * columns). Control factors outside {@code [0.0001, 0.9999]} revert to defaults of {@code 0.8}
+   * and {@code 0.9}.
    *
-   * <p>The default maximal order after construction is 18 (i.e. the maximal number of columns is
-   * 9). The default values are 0.8 for orderControl1 and 0.9 for orderControl2.
-   *
-   * @param maxOrder maximal order in the extrapolation table (the maximal order is reset to default
-   *     if order <= 6 or odd)
-   * @param orderControl1 first order control factor (the factor is reset to default if lower than
-   *     0.0001 or greater than 0.9999)
-   * @param orderControl2 second order control factor (the factor is reset to default if lower than
-   *     0.0001 or greater than 0.9999)
+   * @param maxOrder highest extrapolation order allowed; non-even or {@code <= 6} values reset to
+   *     the default maximum
+   * @param orderControl1 threshold to favor reducing order; outside range reverts to default
+   * @param orderControl2 threshold to favor increasing order; outside range reverts to default
    */
   public void setOrderControl(int maxOrder, double orderControl1, double orderControl2) {
 
@@ -239,11 +230,16 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   }
 
   /**
-   * Set the step handler for this integrator. The handler will be called by the integrator for each
-   * accepted step.
+   * Install the step handler invoked after each accepted step.
    *
-   * @param handler handler for the accepted steps
+   * <p>The handler receives dense interpolators when dense output is enabled, otherwise a dummy
+   * interpolator exposing only end-of-step values. Replacing the handler triggers reallocation of
+   * internal buffers because dense output requirements may change. Passing a handler that requests
+   * dense output increases memory and CPU usage but enables intermediate sampling.
+   *
+   * @param handler recipient of accepted steps; must not be {@code null}
    */
+  @Override
   public void setStepHandler(StepHandler handler) {
 
     super.setStepHandler(handler);
@@ -254,13 +250,18 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   }
 
   /**
-   * Add a switching function to the integrator.
+   * Register a switching function (event detector) evaluated during integration.
    *
-   * @param function switching function
-   * @param maxCheckInterval maximal time interval between switching function checks (this interval
-   *     prevents missing sign changes in case the integration steps becomes very large)
-   * @param convergence convergence threshold in the event time search
+   * <p>The detector is polled at most every {@code maxCheckInterval} units to avoid missing sign
+   * changes; when a root is bracketed, a root-finding phase refines the event time using the given
+   * convergence threshold. Adding the first switching function enables dense output internally so
+   * the solver can sample the solution between steps.
+   *
+   * @param function function whose sign changes trigger events; must not be {@code null}
+   * @param maxCheckInterval maximum gap between event checks; large values risk missed events
+   * @param convergence absolute time accuracy sought when locating the event instant
    */
+  @Override
   public void addSwitchingFunction(
       SwitchingFunction function, double maxCheckInterval, double convergence) {
     super.addSwitchingFunction(function, maxCheckInterval, convergence);
@@ -270,7 +271,7 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     initializeArrays();
   }
 
-  /** Initialize the integrator internal arrays. */
+  /** Initialize or resize the integrator internal arrays. */
   private void initializeArrays() {
 
     int size = maxOrder / 2;
@@ -314,13 +315,18 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   }
 
   /**
-   * Set the interpolation order control parameter. The interpolation order for dense output is 2k -
-   * mudif + 1. The default value for mudif is 4 and the interpolation error is used in stepsize
-   * control by default.
+   * Configure dense-output interpolation behavior.
    *
-   * @param useInterpolationError if true, interpolation error is used for stepsize control
-   * @param mudif interpolation order control parameter (the parameter is reset to default if <= 0
-   *     or >= 7)
+   * <p>The interpolation order used in {@link GraggBulirschStoerStepInterpolator} equals {@code 2 *
+   * k - mudif + 1}, where {@code k} is the last successful extrapolation column. When {@code
+   * useInterpolationError} is {@code true}, the interpolator’s error estimate participates in
+   * step-size control; otherwise only end-point errors drive adaptation. Values of {@code mudif}
+   * outside {@code [1, 6]} revert to the default of {@code 4}.
+   *
+   * @param useInterpolationError {@code true} to include interpolation error in step-size control;
+   *     {@code false} to ignore it
+   * @param mudif interpolation order control offset; values {@code <= 0} or {@code >= 7} reset to
+   *     the default of four
    */
   public void setInterpolationControl(boolean useInterpolationError, int mudif) {
 
@@ -334,20 +340,25 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   }
 
   /**
-   * Get the name of the method.
+   * Get the human-readable name of this integration method.
    *
-   * @return name of the method
+   * @return the constant string {@code "Gragg-Bulirsch-Stoer"}; callers must not mutate it
    */
   public String getName() {
-    return methodName;
+    return METHOD_NAME;
   }
 
   /**
-   * Update scaling array.
+   * Update the scaling array used to normalize local error estimates.
    *
-   * @param y1 first state vector to use for scaling
-   * @param y2 second state vector to use for scaling
-   * @param scale scaling array to update
+   * <p>Each entry combines absolute and relative tolerances with the larger magnitude among the two
+   * provided state vectors, mirroring the scaling used by Hairer and Wanner. When vector tolerances
+   * are configured the corresponding element-wise values are used; otherwise scalar tolerances are
+   * applied uniformly.
+   *
+   * @param y1 first state vector sampled for magnitude; must match the problem dimension
+   * @param y2 second state vector sampled for magnitude; must match the problem dimension
+   * @param scale output buffer receiving per-component scales; length must match {@code y1}
    */
   private void rescale(double[] y1, double[] y2, double[] scale) {
     if (vecAbsoluteTolerance == null) {
@@ -364,23 +375,27 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   }
 
   /**
-   * Perform integration over one step using substeps of a modified midpoint method.
+   * Advance one trial step using the modified midpoint sequence for column {@code k}.
    *
-   * @param equations differential equations to integrate
-   * @param t0 initial time
-   * @param y0 initial value of the state vector at t0
-   * @param step global step
-   * @param k iteration number (from 0 to sequence.length - 1)
-   * @param scale scaling array
-   * @param f placeholder where to put the state vector derivatives at each substep (element 0
-   *     already contains initial derivative)
-   * @param yMiddle placeholder where to put the state vector at the middle of the step
-   * @param yEnd placeholder where to put the state vector at the end
-   * @param yTmp placeholder for one state vector
-   * @return true if computation was done properly, false if stability check failed before end of
-   *     computation
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The method evaluates the derivatives at uniformly spaced substeps, performs the midpoint
+   * updates in place, and optionally aborts early if the stability monitor detects divergence. The
+   * last substep is symmetrically corrected to keep the scheme centered. Intermediate derivatives
+   * and states are written into the provided buffers to avoid allocations.
+   *
+   * @param equations differential equations being integrated; must match the configured dimension
+   * @param t0 start time for the global step
+   * @param y0 state vector at {@code t0}; not modified by this method
+   * @param step global step length attempted for this iteration
+   * @param k extrapolation column index (0-based) selecting the number of substeps
+   * @param scale per-component scaling factors for error and stability checks
+   * @param f scratch array holding derivatives per substep; {@code f[0]} must already contain the
+   *     derivative at {@code t0}
+   * @param yMiddle buffer receiving the state at mid-step when needed for dense output
+   * @param yEnd buffer receiving the state at the end of the trial step
+   * @param yTmp scratch buffer for intermediate midpoint updates
+   * @return {@code true} when the full sequence completed; {@code false} if stability checks failed
+   *     and the caller should reduce the step
+   * @throws DerivativeException if the user-provided derivative function throws during evaluation
    */
   private boolean tryStep(
       FirstOrderDifferentialEquations equations,
@@ -425,20 +440,8 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
       equations.computeDerivatives(t, yEnd, f[j + 1]);
 
       // stability check
-      if (performTest && (j <= maxChecks) && (k < maxIter)) {
-        double initialNorm = 0.0;
-        for (int l = 0; l < y0.length; ++l) {
-          double ratio = f[0][l] / scale[l];
-          initialNorm += ratio * ratio;
-        }
-        double deltaNorm = 0.0;
-        for (int l = 0; l < y0.length; ++l) {
-          double ratio = (f[j + 1][l] - f[0][l]) / scale[l];
-          deltaNorm += ratio * ratio;
-        }
-        if (deltaNorm > 4 * Math.max(1.0e-15, initialNorm)) {
-          return false;
-        }
+      if (stabilityCheckFailed(y0, scale, f, j, k)) {
+        return false;
       }
     }
 
@@ -450,13 +453,30 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     return true;
   }
 
+  private boolean stabilityCheckFailed(double[] y0, double[] scale, double[][] f, int j, int k) {
+    if (!(performTest && (j <= maxChecks) && (k < maxIter))) {
+      return false;
+    }
+    double initialNorm = 0.0;
+    for (int l = 0; l < y0.length; ++l) {
+      double ratio = f[0][l] / scale[l];
+      initialNorm += ratio * ratio;
+    }
+    double deltaNorm = 0.0;
+    for (int l = 0; l < y0.length; ++l) {
+      double ratio = (f[j + 1][l] - f[0][l]) / scale[l];
+      deltaNorm += ratio * ratio;
+    }
+    return deltaNorm > 4 * Math.max(1.0e-15, initialNorm);
+  }
+
   /**
-   * Extrapolate a vector.
+   * Extrapolate the solution vector using the Aitken–Neville scheme.
    *
-   * @param offset offset to use in the coefficients table
-   * @param k index of the last updated point
-   * @param diag working diagonal of the Aitken-Neville's triangle, without the last element
-   * @param last last element
+   * @param offset offset applied when selecting extrapolation coefficients for dense output rows
+   * @param k index of the most recently computed diagonal element
+   * @param diag working diagonal slice of the extrapolation table, excluding the newest element
+   * @param last newest diagonal element to be updated in place
    */
   private void extrapolate(int offset, int k, double[][] diag, double[] last) {
 
@@ -476,11 +496,559 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     }
   }
 
+  /**
+   * Integrate a first-order ODE from {@code t0} to {@code t} updating {@code y} in place.
+   *
+   * <p>This method performs adaptive extrapolation until the target time is reached or a switching
+   * function requests termination. It supports forward and backward integration. The supplied state
+   * array {@code y} is used both as input (initial state) and output (final state); it may be the
+   * same instance as {@code y0}. The method validates dimensional consistency and rejects
+   * zero-length time spans. Step handlers and switching functions configured on the integrator are
+   * invoked during the process.
+   *
+   * @param equations system of differential equations; its dimension must match {@code y0}
+   * @param t0 initial integration time (independent variable value)
+   * @param y0 initial state vector at {@code t0}; length must equal problem dimension
+   * @param t target time to reach; may be before {@code t0} for backward integration
+   * @param y array receiving the computed state at {@code t}; may alias {@code y0}
+   * @throws DerivativeException if user-supplied derivative computation fails
+   * @throws IntegratorException if dimensions mismatch or the step size becomes unusable
+   */
   public void integrate(
       FirstOrderDifferentialEquations equations, double t0, double[] y0, double t, double[] y)
       throws DerivativeException, IntegratorException {
+    validateIntegrationInputs(equations, t0, y0, t);
 
-    // sanity check
+    boolean forward = (t > t0);
+    WorkingState workingState = new WorkingState(y0.length);
+    if (y != y0) {
+      System.arraycopy(y0, 0, y, 0, y0.length);
+    }
+
+    double[] scale = new double[y0.length];
+    rescale(y, y, scale);
+
+    int targetIter = initialTargetIteration();
+    AbstractStepInterpolator interpolator = createInterpolator(y, forward, workingState);
+    interpolator.storeTime(t0);
+
+    stepStart = t0;
+    StepStatus status = new StepStatus(targetIter);
+    handler.reset();
+    costPerTimeUnit[0] = 0;
+
+    runIntegrationLoop(equations, t, y, forward, scale, interpolator, workingState, status);
+  }
+
+  private void runIntegrationLoop(
+      FirstOrderDifferentialEquations equations,
+      double targetTime,
+      double[] y,
+      boolean forward,
+      double[] scale,
+      AbstractStepInterpolator interpolator,
+      WorkingState workingState,
+      StepStatus status)
+      throws DerivativeException, IntegratorException {
+
+    while (!status.lastStep) {
+      performSingleStep(
+          equations, targetTime, y, forward, scale, interpolator, workingState, status);
+    }
+  }
+
+  private void performSingleStep(
+      FirstOrderDifferentialEquations equations,
+      double targetTime,
+      double[] y,
+      boolean forward,
+      double[] scale,
+      AbstractStepInterpolator interpolator,
+      WorkingState w,
+      StepStatus status)
+      throws DerivativeException, IntegratorException {
+
+    status.reject = false;
+    status.loopExit = false;
+    prepareNewStep(equations, y, forward, scale, interpolator, w, status);
+
+    stepSize = status.hNew;
+    status.lastStep = adjustStepForTarget(targetTime, forward);
+
+    int k = runExtrapolationIterations(equations, y, scale, w, status);
+
+    double hInt = getMaxStep();
+    if (denseOutput && !status.reject) {
+      hInt = handleDenseOutput(equations, y, scale, interpolator, w, k, status);
+    }
+
+    if (!status.reject) {
+      finalizeAcceptedStep(y, interpolator, w, k, status);
+    }
+
+    status.hNew = Math.min(status.hNew, hInt);
+    if (!forward) {
+      status.hNew = -status.hNew;
+    }
+
+    status.firstTime = false;
+    updateRejectionStatus(status, status.reject);
+  }
+
+  /**
+   * Store results for an accepted step, notify handlers, and prepare the next trial size/order.
+   *
+   * @param y caller-owned state array updated with the accepted end state
+   * @param interpolator step interpolator already primed with start state; will store end time here
+   * @param w working buffers holding extrapolated end state and derivatives
+   * @param k last successful extrapolation column
+   * @param status mutable step status tracking rejection history and next targets
+   * @throws DerivativeException if switching functions require additional derivative evaluations
+   * @throws IntegratorException if event processing or handler logic raises integration-level
+   *     errors
+   */
+  private void finalizeAcceptedStep(
+      double[] y, AbstractStepInterpolator interpolator, WorkingState w, int k, StepStatus status)
+      throws DerivativeException, IntegratorException {
+
+    stepStart += stepSize;
+    System.arraycopy(w.y1, 0, y, 0, y.length);
+
+    switchesHandler.stepAccepted(stepStart, y);
+    if (switchesHandler.stop()) {
+      status.lastStep = true;
+    }
+
+    interpolator.storeTime(stepStart);
+    handler.handleStep((StepInterpolator) interpolator, status.lastStep);
+
+    if (switchesHandler.reset(stepStart, y) && !status.lastStep) {
+      status.firstStepAlreadyComputed = false;
+    }
+
+    status.targetIter = chooseOptimalIteration(k, status);
+    status.hNew = computeNextStepSize(k, status);
+    status.newStep = true;
+  }
+
+  private void updateRejectionStatus(StepStatus status, boolean reject) {
+    if (reject) {
+      status.lastStep = false;
+      status.previousRejected = true;
+    } else {
+      status.previousRejected = false;
+    }
+  }
+
+  private void prepareNewStep(
+      FirstOrderDifferentialEquations equations,
+      double[] y,
+      boolean forward,
+      double[] scale,
+      AbstractStepInterpolator interpolator,
+      WorkingState w,
+      StepStatus status)
+      throws DerivativeException {
+
+    status.reject = false;
+    if (!status.newStep) {
+      return;
+    }
+
+    interpolator.shift();
+    if (!status.firstStepAlreadyComputed) {
+      equations.computeDerivatives(stepStart, y, w.yDot0);
+    }
+
+    if (status.firstTime) {
+      status.hNew =
+          initializeStep(
+              equations,
+              forward,
+              2 * status.targetIter + 1,
+              scale,
+              stepStart,
+              y,
+              w.yDot0,
+              w.yTmp,
+              w.yTmpDot);
+      if (!forward) {
+        status.hNew = -status.hNew;
+      }
+    }
+
+    status.newStep = false;
+  }
+
+  private boolean adjustStepForTarget(double targetTime, boolean forward) {
+    if ((forward && (stepStart + stepSize > targetTime))
+        || ((!forward) && (stepStart + stepSize < targetTime))) {
+      stepSize = targetTime - stepStart;
+    }
+    double nextT = stepStart + stepSize;
+    return forward ? (nextT >= targetTime) : (nextT <= targetTime);
+  }
+
+  private int runExtrapolationIterations(
+      FirstOrderDifferentialEquations equations,
+      double[] y,
+      double[] scale,
+      WorkingState w,
+      StepStatus status)
+      throws DerivativeException, IntegratorException {
+
+    int k = -1;
+    boolean shouldContinue;
+    do {
+      status.loopExit = false;
+      ++k;
+      if (!tryCurrentSubStep(equations, y, scale, w, k, status)) {
+        break;
+      }
+
+      shouldContinue = k == 0;
+      if (!shouldContinue) {
+        computeExtrapolationAndError(y, scale, w, k, status);
+        shouldContinue = !(status.reject || status.loopExit);
+      }
+    } while (shouldContinue);
+
+    return k;
+  }
+
+  private boolean tryCurrentSubStep(
+      FirstOrderDifferentialEquations equations,
+      double[] y,
+      double[] scale,
+      WorkingState w,
+      int k,
+      StepStatus status)
+      throws DerivativeException, IntegratorException {
+
+    if (tryStep(
+        equations,
+        stepStart,
+        y,
+        stepSize,
+        k,
+        scale,
+        w.fk[k],
+        (k == 0) ? w.yMidDots[0] : w.diagonal[k - 1],
+        (k == 0) ? w.y1 : w.y1Diag[k - 1],
+        w.yTmp)) {
+      return true;
+    }
+
+    status.hNew = Math.abs(filterStep(stepSize * stabilityReduction, false));
+    status.reject = true;
+    status.loopExit = true;
+    return false;
+  }
+
+  private void computeExtrapolationAndError(
+      double[] y, double[] scale, WorkingState w, int k, StepStatus status)
+      throws IntegratorException {
+
+    extrapolate(0, k, w.y1Diag, w.y1);
+    rescale(y, w.y1, scale);
+
+    double error = estimateError(y.length, scale, w);
+    if (isErrorUnacceptable(error, k, status)) {
+      return;
+    }
+
+    updateOptimalStepAndCost(error, k);
+    checkConvergence(k, error, status);
+  }
+
+  private double estimateError(int dimension, double[] scale, WorkingState w) {
+    double error = 0;
+    for (int j = 0; j < dimension; ++j) {
+      double e = Math.abs(w.y1[j] - w.y1Diag[0][j]) / scale[j];
+      error += e * e;
+    }
+    return Math.sqrt(error / dimension);
+  }
+
+  private boolean isErrorUnacceptable(double error, int k, StepStatus status)
+      throws IntegratorException {
+    if ((error > 1.0e15) || ((k > 1) && (error > status.maxError))) {
+      status.hNew = Math.abs(filterStep(stepSize * stabilityReduction, false));
+      status.reject = true;
+      status.loopExit = true;
+      return true;
+    }
+    status.maxError = Math.max(4 * error, 1.0);
+    return false;
+  }
+
+  private void updateOptimalStepAndCost(double error, int k) throws IntegratorException {
+    double exp = 1.0 / (2 * k + 1);
+    double fac = stepControl2 / Math.pow(error / stepControl1, exp);
+    double pow = Math.pow(stepControl3, exp);
+    fac = Math.clamp(fac, pow / stepControl4, 1 / pow);
+    optimalStep[k] = Math.abs(filterStep(stepSize * fac, true));
+    costPerTimeUnit[k] = costPerStep[k] / optimalStep[k];
+  }
+
+  private void checkConvergence(int k, double error, StepStatus status) {
+    status.loopExit = false;
+    switch (k - status.targetIter) {
+      case -1:
+        handleConvergenceBeforeTarget(k, error, status);
+        break;
+      case 0:
+        handleConvergenceAtTarget(error, status);
+        break;
+      case 1:
+        if (error > 1.0) {
+          rejectAndReduceOrder(status);
+        }
+        status.loopExit = true;
+        break;
+      default:
+        if ((status.firstTime || status.lastStep) && (error <= 1.0)) {
+          status.loopExit = true;
+        }
+        break;
+    }
+  }
+
+  private void handleConvergenceBeforeTarget(int k, double error, StepStatus status) {
+    if ((status.targetIter <= 1) || status.previousRejected) {
+      return;
+    }
+
+    if (error <= 1.0) {
+      status.loopExit = true;
+      return;
+    }
+
+    double ratio = ((double) sequence[k] * sequence[k + 1]) / (sequence[0] * sequence[0]);
+    if (error > ratio * ratio) {
+      rejectAndReduceOrder(status);
+      status.targetIter = k;
+      if ((status.targetIter > 1)
+          && (costPerTimeUnit[status.targetIter - 1]
+              < orderControl1 * costPerTimeUnit[status.targetIter])) {
+        --status.targetIter;
+      }
+      status.hNew = optimalStep[status.targetIter];
+      status.loopExit = true;
+    }
+  }
+
+  private void handleConvergenceAtTarget(double error, StepStatus status) {
+    if (error <= 1.0) {
+      status.loopExit = true;
+      return;
+    }
+
+    double ratio = ((double) sequence[status.targetIter + 1]) / sequence[0];
+    if (error > ratio * ratio) {
+      rejectAndReduceOrder(status);
+      if ((status.targetIter > 1)
+          && (costPerTimeUnit[status.targetIter - 1]
+              < orderControl1 * costPerTimeUnit[status.targetIter])) {
+        --status.targetIter;
+      }
+      status.hNew = optimalStep[status.targetIter];
+      status.loopExit = true;
+    }
+  }
+
+  private void rejectAndReduceOrder(StepStatus status) {
+    status.reject = true;
+  }
+
+  private double handleDenseOutput(
+      FirstOrderDifferentialEquations equations,
+      double[] y,
+      double[] scale,
+      AbstractStepInterpolator interpolator,
+      WorkingState w,
+      int k,
+      StepStatus status)
+      throws DerivativeException {
+
+    for (int j = 1; j <= k; ++j) {
+      extrapolate(0, j, w.diagonal, w.yMidDots[0]);
+    }
+
+    equations.computeDerivatives(stepStart + stepSize, w.y1, w.yDot1);
+    int mu = 2 * k - mudif + 3;
+    computeDenseOutputDerivatives(y.length, w, k, mu);
+
+    double hInt = getMaxStep();
+    if (mu >= 0) {
+      hInt = applyInterpolationErrorControl(scale, interpolator, mu, hInt, status);
+      if (!status.reject) {
+        handleSwitchingFunctions(interpolator, status);
+      }
+    }
+
+    if (!status.reject) {
+      status.firstStepAlreadyComputed = true;
+      System.arraycopy(w.yDot1, 0, w.yDot0, 0, y.length);
+    }
+
+    return hInt;
+  }
+
+  private void computeDenseOutputDerivatives(int dimension, WorkingState w, int k, int mu) {
+    for (int l = 0; l < mu; ++l) {
+      processDenseOutputLevel(dimension, w, k, l);
+    }
+  }
+
+  private void processDenseOutputLevel(int dimension, WorkingState w, int k, int l) {
+    int l2 = l / 2;
+    int middleIndex = w.fk[l2].length / 2;
+    double factor = Math.pow(0.5 * sequence[l2], l);
+
+    fillMidDotsForLevel(dimension, w, l, l2, middleIndex, factor);
+    updateDiagonalForLevel(dimension, w, k, l, l2);
+    scaleMidDotsRow(dimension, w, l);
+    updateFiniteDifferences(dimension, w, k, l);
+  }
+
+  private void fillMidDotsForLevel(
+      int dimension, WorkingState w, int l, int l2, int middleIndex, double factor) {
+    for (int i = 0; i < dimension; ++i) {
+      w.yMidDots[l + 1][i] = factor * w.fk[l2][middleIndex + l][i];
+    }
+  }
+
+  private void updateDiagonalForLevel(int dimension, WorkingState w, int k, int l, int l2) {
+    for (int j = 1; j <= k - l2; ++j) {
+      double factor = Math.pow(0.5 * sequence[j + l2], l);
+      int middleIndex = w.fk[l2 + j].length / 2;
+      for (int i = 0; i < dimension; ++i) {
+        w.diagonal[j - 1][i] = factor * w.fk[l2 + j][middleIndex + l][i];
+      }
+      extrapolate(l2, j, w.diagonal, w.yMidDots[l + 1]);
+    }
+  }
+
+  private void scaleMidDotsRow(int dimension, WorkingState w, int l) {
+    for (int i = 0; i < dimension; ++i) {
+      w.yMidDots[l + 1][i] *= stepSize;
+    }
+  }
+
+  private void updateFiniteDifferences(int dimension, WorkingState w, int k, int l) {
+    for (int j = (l + 1) / 2; j <= k; ++j) {
+      for (int m = w.fk[j].length - 1; m >= 2 * (l + 1); --m) {
+        for (int i = 0; i < dimension; ++i) {
+          w.fk[j][m][i] -= w.fk[j][m - 2][i];
+        }
+      }
+    }
+  }
+
+  private double applyInterpolationErrorControl(
+      double[] scale,
+      AbstractStepInterpolator interpolator,
+      int mu,
+      double hInt,
+      StepStatus status) {
+
+    GraggBulirschStoerStepInterpolator gbsInterpolator =
+        (GraggBulirschStoerStepInterpolator) interpolator;
+    gbsInterpolator.computeCoefficients(mu, stepSize);
+
+    if (useInterpolationError) {
+      double interpError = gbsInterpolator.estimateError(scale);
+      hInt = Math.abs(stepSize / Math.max(Math.pow(interpError, 1.0 / (mu + 4)), 0.01));
+      if (interpError > 10.0) {
+        status.hNew = hInt;
+        status.reject = true;
+      }
+    }
+    return hInt;
+  }
+
+  private void handleSwitchingFunctions(AbstractStepInterpolator interpolator, StepStatus status) {
+
+    interpolator.storeTime(stepStart + stepSize);
+    if (switchesHandler.evaluateStep((StepInterpolator) interpolator)) {
+      status.reject = true;
+      status.hNew = Math.abs(switchesHandler.getEventTime() - stepStart);
+    }
+  }
+
+  private int chooseOptimalIteration(int k, StepStatus status) {
+    if (k == 1) {
+      return status.previousRejected ? 1 : 2;
+    }
+    if (k <= status.targetIter) {
+      int optimalIter = k;
+      if (costPerTimeUnit[k - 1] < orderControl1 * costPerTimeUnit[k]) {
+        optimalIter = k - 1;
+      } else if (costPerTimeUnit[k] < orderControl2 * costPerTimeUnit[k - 1]) {
+        optimalIter = Math.min(k + 1, sequence.length - 2);
+      }
+      return optimalIter;
+    }
+
+    int optimalIter = k - 1;
+    if ((k > 2) && (costPerTimeUnit[k - 2] < orderControl1 * costPerTimeUnit[k - 1])) {
+      optimalIter = k - 2;
+    }
+    if (costPerTimeUnit[k] < orderControl2 * costPerTimeUnit[optimalIter]) {
+      optimalIter = Math.min(k, sequence.length - 2);
+    }
+    return optimalIter;
+  }
+
+  private double computeNextStepSize(int k, StepStatus status) throws IntegratorException {
+    if (status.previousRejected) {
+      status.targetIter = Math.min(status.targetIter, k);
+      return Math.min(Math.abs(stepSize), optimalStep[status.targetIter]);
+    }
+
+    if (status.targetIter <= k) {
+      return optimalStep[status.targetIter];
+    }
+
+    if (costPerTimeUnit[k] < orderControl2 * costPerTimeUnit[k - 1]) {
+      return filterStep(
+          optimalStep[k] * costPerStep[status.targetIter + 1] / costPerStep[k], false);
+    }
+    return filterStep(optimalStep[k] * costPerStep[status.targetIter] / costPerStep[k], false);
+  }
+
+  private int initialTargetIteration() {
+    double log10R =
+        Math.log(
+                Math.max(
+                    1.0e-10,
+                    (vecRelativeTolerance == null)
+                        ? scalRelativeTolerance
+                        : vecRelativeTolerance[0]))
+            / Math.log(10.0);
+    int target = (int) Math.floor(0.5 - 0.6 * log10R);
+    return Math.clamp(target, 1, sequence.length - 2);
+  }
+
+  private AbstractStepInterpolator createInterpolator(
+      double[] y, boolean forward, WorkingState workingState) {
+    if (denseOutput || (!switchesHandler.isEmpty())) {
+      return new GraggBulirschStoerStepInterpolator(
+          y,
+          workingState.yDot0,
+          workingState.y1,
+          workingState.yDot1,
+          workingState.yMidDots,
+          forward);
+    }
+    return new DummyStepInterpolator(y, forward);
+  }
+
+  private void validateIntegrationInputs(
+      FirstOrderDifferentialEquations equations, double t0, double[] y0, double t)
+      throws IntegratorException {
+
     if (equations.getDimension() != y0.length) {
       throw new IntegratorException(
           "dimensions mismatch: "
@@ -493,434 +1061,69 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
           "too small integration interval: length = {0}",
           new String[] {Double.toString(Math.abs(t - t0))});
     }
+  }
 
-    boolean forward = (t > t0);
+  private final class WorkingState {
+    final double[] yDot0;
+    final double[] y1;
+    final double[] yTmp;
+    final double[] yTmpDot;
+    final double[][] diagonal;
+    final double[][] y1Diag;
+    final double[][][] fk;
+    final double[] yDot1;
+    final double[][] yMidDots;
 
-    // create some internal working arrays
-    double[] yDot0 = new double[y0.length];
-    double[] y1 = new double[y0.length];
-    double[] yTmp = new double[y0.length];
-    double[] yTmpDot = new double[y0.length];
+    WorkingState(int dimension) {
+      yDot0 = new double[dimension];
+      y1 = new double[dimension];
+      yTmp = new double[dimension];
+      yTmpDot = new double[dimension];
 
-    double[][] diagonal = new double[sequence.length - 1][];
-    double[][] y1Diag = new double[sequence.length - 1][];
-    for (int k = 0; k < sequence.length - 1; ++k) {
-      diagonal[k] = new double[y0.length];
-      y1Diag[k] = new double[y0.length];
-    }
+      diagonal = new double[sequence.length - 1][];
+      y1Diag = new double[sequence.length - 1][];
+      for (int k = 0; k < sequence.length - 1; ++k) {
+        diagonal[k] = new double[dimension];
+        y1Diag[k] = new double[dimension];
+      }
 
-    double[][][] fk = new double[sequence.length][][];
-    for (int k = 0; k < sequence.length; ++k) {
+      fk = new double[sequence.length][][];
+      for (int k = 0; k < sequence.length; ++k) {
+        fk[k] = new double[sequence[k] + 1][];
+        fk[k][0] = yDot0;
+        for (int l = 0; l < sequence[k]; ++l) {
+          fk[k][l + 1] = new double[dimension];
+        }
+      }
 
-      fk[k] = new double[sequence[k] + 1][];
-
-      // all substeps start at the same point, so share the first array
-      fk[k][0] = yDot0;
-
-      for (int l = 0; l < sequence[k]; ++l) {
-        fk[k][l + 1] = new double[y0.length];
+      if (denseOutput) {
+        yDot1 = new double[dimension];
+        yMidDots = new double[1 + 2 * sequence.length][];
+        for (int j = 0; j < yMidDots.length; ++j) {
+          yMidDots[j] = new double[dimension];
+        }
+      } else {
+        yDot1 = null;
+        yMidDots = new double[1][];
+        yMidDots[0] = new double[dimension];
       }
     }
+  }
 
-    if (y != y0) {
-      System.arraycopy(y0, 0, y, 0, y0.length);
-    }
-
-    double[] yDot1 = null;
-    double[][] yMidDots = null;
-    if (denseOutput) {
-      yDot1 = new double[y0.length];
-      yMidDots = new double[1 + 2 * sequence.length][];
-      for (int j = 0; j < yMidDots.length; ++j) {
-        yMidDots[j] = new double[y0.length];
-      }
-    } else {
-      yMidDots = new double[1][];
-      yMidDots[0] = new double[y0.length];
-    }
-
-    // initial scaling
-    double[] scale = new double[y0.length];
-    rescale(y, y, scale);
-
-    // initial order selection
-    double log10R =
-        Math.log(
-                Math.max(
-                    1.0e-10,
-                    (vecRelativeTolerance == null)
-                        ? scalRelativeTolerance
-                        : vecRelativeTolerance[0]))
-            / Math.log(10.0);
-    int targetIter =
-        Math.max(1, Math.min(sequence.length - 2, (int) Math.floor(0.5 - 0.6 * log10R)));
-    // set up an interpolator sharing the integrator arrays
-    AbstractStepInterpolator interpolator = null;
-    if (denseOutput || (!switchesHandler.isEmpty())) {
-      interpolator =
-          new GraggBulirschStoerStepInterpolator(
-              y, yDot0,
-              y1, yDot1,
-              yMidDots, forward);
-    } else {
-      interpolator = new DummyStepInterpolator(y, forward);
-    }
-    interpolator.storeTime(t0);
-
-    stepStart = t0;
-    double hNew = 0;
+  private static final class StepStatus {
+    double hNew;
     double maxError = Double.MAX_VALUE;
     boolean previousRejected = false;
     boolean firstTime = true;
     boolean newStep = true;
     boolean lastStep = false;
     boolean firstStepAlreadyComputed = false;
-    handler.reset();
-    costPerTimeUnit[0] = 0;
-    while (!lastStep) {
+    boolean reject = false;
+    boolean loopExit = false;
+    int targetIter;
 
-      double error;
-      boolean reject = false;
-
-      if (newStep) {
-
-        interpolator.shift();
-
-        // first evaluation, at the beginning of the step
-        if (!firstStepAlreadyComputed) {
-          equations.computeDerivatives(stepStart, y, yDot0);
-        }
-
-        if (firstTime) {
-
-          hNew =
-              initializeStep(
-                  equations,
-                  forward,
-                  2 * targetIter + 1,
-                  scale,
-                  stepStart,
-                  y,
-                  yDot0,
-                  yTmp,
-                  yTmpDot);
-
-          if (!forward) {
-            hNew = -hNew;
-          }
-        }
-
-        newStep = false;
-      }
-
-      stepSize = hNew;
-
-      // step adjustment near bounds
-      if ((forward && (stepStart + stepSize > t)) || ((!forward) && (stepStart + stepSize < t))) {
-        stepSize = t - stepStart;
-      }
-      double nextT = stepStart + stepSize;
-      lastStep = forward ? (nextT >= t) : (nextT <= t);
-
-      // iterate over several substep sizes
-      int k = -1;
-      for (boolean loop = true; loop; ) {
-
-        ++k;
-
-        // modified midpoint integration with the current substep
-        if (!tryStep(
-            equations,
-            stepStart,
-            y,
-            stepSize,
-            k,
-            scale,
-            fk[k],
-            (k == 0) ? yMidDots[0] : diagonal[k - 1],
-            (k == 0) ? y1 : y1Diag[k - 1],
-            yTmp)) {
-
-          // the stability check failed, we reduce the global step
-          hNew = Math.abs(filterStep(stepSize * stabilityReduction, false));
-          reject = true;
-          loop = false;
-
-        } else {
-
-          // the substep was computed successfully
-          if (k > 0) {
-
-            // extrapolate the state at the end of the step
-            // using last iteration data
-            extrapolate(0, k, y1Diag, y1);
-            rescale(y, y1, scale);
-
-            // estimate the error at the end of the step.
-            error = 0;
-            for (int j = 0; j < y0.length; ++j) {
-              double e = Math.abs(y1[j] - y1Diag[0][j]) / scale[j];
-              error += e * e;
-            }
-            error = Math.sqrt(error / y0.length);
-
-            if ((error > 1.0e15) || ((k > 1) && (error > maxError))) {
-              // error is too big, we reduce the global step
-              hNew = Math.abs(filterStep(stepSize * stabilityReduction, false));
-              reject = true;
-              loop = false;
-            } else {
-
-              maxError = Math.max(4 * error, 1.0);
-
-              // compute optimal stepsize for this order
-              double exp = 1.0 / (2 * k + 1);
-              double fac = stepControl2 / Math.pow(error / stepControl1, exp);
-              double pow = Math.pow(stepControl3, exp);
-              fac = Math.max(pow / stepControl4, Math.min(1 / pow, fac));
-              optimalStep[k] = Math.abs(filterStep(stepSize * fac, true));
-              costPerTimeUnit[k] = costPerStep[k] / optimalStep[k];
-
-              // check convergence
-              switch (k - targetIter) {
-                case -1:
-                  if ((targetIter > 1) && !previousRejected) {
-
-                    // check if we can stop iterations now
-                    if (error <= 1.0) {
-                      // convergence have been reached just before targetIter
-                      loop = false;
-                    } else {
-                      // estimate if there is a chance convergence will
-                      // be reached on next iteration, using the
-                      // asymptotic evolution of error
-                      double ratio =
-                          ((double) sequence[k] * sequence[k + 1]) / (sequence[0] * sequence[0]);
-                      if (error > ratio * ratio) {
-                        // we don't expect to converge on next iteration
-                        // we reject the step immediately and reduce order
-                        reject = true;
-                        loop = false;
-                        targetIter = k;
-                        if ((targetIter > 1)
-                            && (costPerTimeUnit[targetIter - 1]
-                                < orderControl1 * costPerTimeUnit[targetIter])) {
-                          --targetIter;
-                        }
-                        hNew = optimalStep[targetIter];
-                      }
-                    }
-                  }
-                  break;
-
-                case 0:
-                  if (error <= 1.0) {
-                    // convergence has been reached exactly at targetIter
-                    loop = false;
-                  } else {
-                    // estimate if there is a chance convergence will
-                    // be reached on next iteration, using the
-                    // asymptotic evolution of error
-                    double ratio = ((double) sequence[k + 1]) / sequence[0];
-                    if (error > ratio * ratio) {
-                      // we don't expect to converge on next iteration
-                      // we reject the step immediately
-                      reject = true;
-                      loop = false;
-                      if ((targetIter > 1)
-                          && (costPerTimeUnit[targetIter - 1]
-                              < orderControl1 * costPerTimeUnit[targetIter])) {
-                        --targetIter;
-                      }
-                      hNew = optimalStep[targetIter];
-                    }
-                  }
-                  break;
-
-                case 1:
-                  if (error > 1.0) {
-                    reject = true;
-                    if ((targetIter > 1)
-                        && (costPerTimeUnit[targetIter - 1]
-                            < orderControl1 * costPerTimeUnit[targetIter])) {
-                      --targetIter;
-                    }
-                    hNew = optimalStep[targetIter];
-                  }
-                  loop = false;
-                  break;
-
-                default:
-                  if ((firstTime || lastStep) && (error <= 1.0)) {
-                    loop = false;
-                  }
-                  break;
-              }
-            }
-          }
-        }
-      }
-
-      // dense output handling
-      double hInt = getMaxStep();
-      if (denseOutput && !reject) {
-
-        // extrapolate state at middle point of the step
-        for (int j = 1; j <= k; ++j) {
-          extrapolate(0, j, diagonal, yMidDots[0]);
-        }
-
-        // derivative at end of step
-        equations.computeDerivatives(stepStart + stepSize, y1, yDot1);
-
-        int mu = 2 * k - mudif + 3;
-
-        for (int l = 0; l < mu; ++l) {
-
-          // derivative at middle point of the step
-          int l2 = l / 2;
-          double factor = Math.pow(0.5 * sequence[l2], l);
-          int middleIndex = fk[l2].length / 2;
-          for (int i = 0; i < y0.length; ++i) {
-            yMidDots[l + 1][i] = factor * fk[l2][middleIndex + l][i];
-          }
-          for (int j = 1; j <= k - l2; ++j) {
-            factor = Math.pow(0.5 * sequence[j + l2], l);
-            middleIndex = fk[l2 + j].length / 2;
-            for (int i = 0; i < y0.length; ++i) {
-              diagonal[j - 1][i] = factor * fk[l2 + j][middleIndex + l][i];
-            }
-            extrapolate(l2, j, diagonal, yMidDots[l + 1]);
-          }
-          for (int i = 0; i < y0.length; ++i) {
-            yMidDots[l + 1][i] *= stepSize;
-          }
-
-          // compute centered differences to evaluate next derivatives
-          for (int j = (l + 1) / 2; j <= k; ++j) {
-            for (int m = fk[j].length - 1; m >= 2 * (l + 1); --m) {
-              for (int i = 0; i < y0.length; ++i) {
-                fk[j][m][i] -= fk[j][m - 2][i];
-              }
-            }
-          }
-        }
-
-        if (mu >= 0) {
-
-          // estimate the dense output coefficients
-          GraggBulirschStoerStepInterpolator gbsInterpolator =
-              (GraggBulirschStoerStepInterpolator) interpolator;
-          gbsInterpolator.computeCoefficients(mu, stepSize);
-
-          if (useInterpolationError) {
-            // use the interpolation error to limit stepsize
-            double interpError = gbsInterpolator.estimateError(scale);
-            hInt = Math.abs(stepSize / Math.max(Math.pow(interpError, 1.0 / (mu + 4)), 0.01));
-            if (interpError > 10.0) {
-              hNew = hInt;
-              reject = true;
-            }
-          }
-
-          // Switching functions handling
-          if (!reject) {
-            interpolator.storeTime(stepStart + stepSize);
-            if (switchesHandler.evaluateStep((StepInterpolator) interpolator)) {
-              reject = true;
-              hNew = Math.abs(switchesHandler.getEventTime() - stepStart);
-            }
-          }
-        }
-
-        if (!reject) {
-          // we will reuse the slope for the beginning of next step
-          firstStepAlreadyComputed = true;
-          System.arraycopy(yDot1, 0, yDot0, 0, y0.length);
-        }
-      }
-
-      if (!reject) {
-
-        // store end of step state
-        stepStart += stepSize;
-        System.arraycopy(y1, 0, y, 0, y0.length);
-
-        switchesHandler.stepAccepted(stepStart, y);
-        if (switchesHandler.stop()) {
-          lastStep = true;
-        }
-
-        // provide the step data to the step handler
-        interpolator.storeTime(stepStart);
-        handler.handleStep((StepInterpolator) interpolator, lastStep);
-
-        if (switchesHandler.reset(stepStart, y) && !lastStep) {
-          // some switching function has triggered changes that
-          // invalidate the derivatives, we need to recompute them
-          firstStepAlreadyComputed = false;
-        }
-
-        int optimalIter;
-        if (k == 1) {
-          optimalIter = 2;
-          if (previousRejected) {
-            optimalIter = 1;
-          }
-        } else if (k <= targetIter) {
-          optimalIter = k;
-          if (costPerTimeUnit[k - 1] < orderControl1 * costPerTimeUnit[k]) {
-            optimalIter = k - 1;
-          } else if (costPerTimeUnit[k] < orderControl2 * costPerTimeUnit[k - 1]) {
-            optimalIter = Math.min(k + 1, sequence.length - 2);
-          }
-        } else {
-          optimalIter = k - 1;
-          if ((k > 2) && (costPerTimeUnit[k - 2] < orderControl1 * costPerTimeUnit[k - 1])) {
-            optimalIter = k - 2;
-          }
-          if (costPerTimeUnit[k] < orderControl2 * costPerTimeUnit[optimalIter]) {
-            optimalIter = Math.min(k, sequence.length - 2);
-          }
-        }
-
-        if (previousRejected) {
-          // after a rejected step neither order nor stepsize
-          // should increase
-          targetIter = Math.min(optimalIter, k);
-          hNew = Math.min(Math.abs(stepSize), optimalStep[targetIter]);
-        } else {
-          // stepsize control
-          if (optimalIter <= k) {
-            hNew = optimalStep[optimalIter];
-          } else {
-            if ((k < targetIter) && (costPerTimeUnit[k] < orderControl2 * costPerTimeUnit[k - 1])) {
-              hNew =
-                  filterStep(optimalStep[k] * costPerStep[optimalIter + 1] / costPerStep[k], false);
-            } else {
-              hNew = filterStep(optimalStep[k] * costPerStep[optimalIter] / costPerStep[k], false);
-            }
-          }
-
-          targetIter = optimalIter;
-        }
-
-        newStep = true;
-      }
-
-      hNew = Math.min(hNew, hInt);
-      if (!forward) {
-        hNew = -hNew;
-      }
-
-      firstTime = false;
-
-      if (reject) {
-        lastStep = false;
-        previousRejected = true;
-      } else {
-        previousRejected = false;
-      }
+    StepStatus(int targetIter) {
+      this.targetIter = targetIter;
     }
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/HighamHall54Integrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/HighamHall54Integrator.java
@@ -1,19 +1,35 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements the 5(4) Higham and Hall integrator for Ordinary Differential Equations.
+ * Higham and Hall 5(4) embedded Runge-Kutta integrator with adaptive steps and continuous output.
  *
- * <p>This integrator is an embedded Runge-Kutta-Fehlberg integrator of order 5(4) used in local
- * extrapolation mode (i.e. the solution is computed using the high order formula) with stepsize
- * control (and automatic step initialization) and continuous output. This method uses 7 functions
- * evaluations per step.
+ * <p>This implementation follows the 5(4) scheme described by Higham and Hall and is wired for
+ * local extrapolation: the fifth-order solution is returned while the embedded fourth-order
+ * estimate drives the adaptive step-size controller. The integrator is stateful only for
+ * configuration; it is otherwise thread-confined and should be created per integration run. It
+ * evaluates the differential equations seven times per accepted step, balancing accuracy and
+ * computational cost.
+ *
+ * <p>Typical usage is to instantiate the integrator with absolute and relative tolerances matching
+ * the scale of the problem, then call {@link #integrate(FirstOrderDifferentialEquations, double,
+ * double[], double, double[])} inherited from {@code RungeKuttaFehlbergIntegrator}. Step sizes are
+ * initialized automatically within the provided bounds and may shrink when error estimates exceed
+ * tolerance. The interpolator supports dense output queries between grid points.
+ *
+ * <p><strong>Responsibilities</strong>:
+ *
+ * <ul>
+ *   <li>Provide coefficients for the Higham-Hall tableau and embedded error estimator.
+ *   <li>Compute root-mean-square scaled error norms for adaptive control.
+ *   <li>Expose metadata such as method name and formal order.
+ * </ul>
  *
  * @version $Id: HighamHall54Integrator.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
  */
 public class HighamHall54Integrator extends RungeKuttaFehlbergIntegrator {
 
-  private static final String methodName = "Higham-Hall 5(4)";
+  private static final String METHOD_NAME = "Higham-Hall 5(4)";
 
   private static final double[] c = {2.0 / 9.0, 1.0 / 3.0, 1.0 / 2.0, 3.0 / 5.0, 1.0, 1.0};
 
@@ -35,14 +51,23 @@ public class HighamHall54Integrator extends RungeKuttaFehlbergIntegrator {
   };
 
   /**
-   * Simple constructor. Build a fifth order Higham and Hall integrator with the given step bounds
+   * Create an integrator configured with scalar error tolerances and bounded step sizes.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param scalAbsoluteTolerance allowed absolute error
-   * @param scalRelativeTolerance allowed relative error
+   * <p>The provided absolute and relative tolerances are applied uniformly across all state
+   * components. The step-size controller respects the {@code minStep} floor and {@code maxStep}
+   * ceiling, but the final step may be shorter to land exactly on the target time. All parameters
+   * must be strictly positive to allow both forward and backward integration.
+   *
+   * @param minStep smallest step the controller will attempt before potentially failing, in the
+   *     integration time units; must be greater than zero.
+   * @param maxStep largest step the controller may take; must exceed {@code minStep} and be
+   *     positive even when integrating backward in time.
+   * @param scalAbsoluteTolerance uniform absolute error tolerance applied to every state component;
+   *     must be non-negative but typically small compared to expected state magnitudes.
+   * @param scalRelativeTolerance uniform relative error tolerance used to scale with state size;
+   *     must be non-negative and combined with the absolute term.
    */
+  @SuppressWarnings("unused")
   public HighamHall54Integrator(
       double minStep, double maxStep, double scalAbsoluteTolerance, double scalRelativeTolerance) {
     super(
@@ -58,14 +83,22 @@ public class HighamHall54Integrator extends RungeKuttaFehlbergIntegrator {
   }
 
   /**
-   * Simple constructor. Build a fifth order Higham and Hall integrator with the given step bounds
+   * Create an integrator configured with per-component error tolerances and bounded step sizes.
    *
-   * @param minStep minimal step (must be positive even for backward integration), the last step can
-   *     be smaller than this
-   * @param maxStep maximal step (must be positive even for backward integration)
-   * @param vecAbsoluteTolerance allowed absolute error
-   * @param vecRelativeTolerance allowed relative error
+   * <p>Vector tolerances let callers tune accuracy differently for each state dimension. Arrays
+   * must match the problem dimension supplied to {@code integrate}. Bounds on step sizes mirror the
+   * scalar constructor: they constrain the adaptive controller but do not guarantee fixed step
+   * lengths. A final step may still be shortened to land exactly at the integration endpoint.
+   *
+   * @param minStep smallest admissible step in time units; must be positive for both forward and
+   *     backward integration scenarios.
+   * @param maxStep largest admissible step; must be positive and not smaller than {@code minStep}.
+   * @param vecAbsoluteTolerance element-wise absolute tolerances; each entry must be non-negative
+   *     and the array length must equal the equations dimension.
+   * @param vecRelativeTolerance element-wise relative tolerances; each entry must be non-negative
+   *     and combined with the absolute tolerances for scaling.
    */
+  @SuppressWarnings("unused")
   public HighamHall54Integrator(
       double minStep,
       double maxStep,
@@ -84,31 +117,47 @@ public class HighamHall54Integrator extends RungeKuttaFehlbergIntegrator {
   }
 
   /**
-   * Get the name of the method.
+   * Get a human-readable identifier for this integration method.
    *
-   * @return name of the method
+   * <p>The returned name follows the canonical spelling used throughout the library and can be used
+   * in logs, metrics, or UI labels to differentiate integrators at runtime.
+   *
+   * @return descriptive method name; immutable and safe for repeated calls
    */
   public String getName() {
-    return methodName;
+    return METHOD_NAME;
   }
 
   /**
-   * Get the order of the method.
+   * Get the formal order of accuracy of the primary solution formula.
    *
-   * @return order of the method
+   * <p>This value reflects the order used for the accepted solution (fifth order). The embedded
+   * fourth-order estimate is used internally for error control and is not returned to callers.
+   *
+   * @return integration order of the returned solution; always {@code 5}
    */
   public int getOrder() {
     return 5;
   }
 
   /**
-   * Compute the error ratio.
+   * Compute the scaled root-mean-square error estimate for one trial step.
    *
-   * @param yDotK derivatives computed during the first stages
-   * @param y0 estimate of the step at the start of the step
-   * @param y1 estimate of the step at the end of the step
-   * @param h current step
-   * @return error ratio, greater than 1 if step should be rejected
+   * <p>The method combines stage derivatives from the embedded tableau with absolute/relative
+   * tolerances to produce a dimensionless norm. The controller interprets values greater than one
+   * as exceeding tolerance and will reduce the step size; values below one typically accept the
+   * step. Inputs are neither validated nor copied for performance reasons, so callers must supply
+   * arrays consistent with the current problem dimension.
+   *
+   * @param yDotK stage derivatives produced during the seven Runge-Kutta evaluations; the outer
+   *     array index is the stage, and the inner index is the state component.
+   * @param y0 estimate of the state at the beginning of the step; array length must equal the
+   *     problem dimension.
+   * @param y1 estimate of the state at the end of the step before error correction; must align with
+   *     {@code y0} in length and ordering.
+   * @param h current step size in integration time units; may be positive or negative depending on
+   *     integration direction.
+   * @return dimensionless error ratio; values above one suggest rejecting or shrinking the step
    */
   protected double estimateError(double[][] yDotK, double[] y0, double[] y1, double h) {
 

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaFehlbergIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaFehlbergIntegrator.java
@@ -1,5 +1,7 @@
 package org.spaceroots.mantissa.ode;
 
+import java.util.Arrays;
+
 /**
  * This class implements the common part of all Runge-Kutta-Fehlberg integrators for Ordinary
  * Differential Equations.
@@ -118,13 +120,6 @@ public abstract class RungeKuttaFehlbergIntegrator extends AdaptiveStepsizeInteg
   }
 
   /**
-   * Get the name of the method.
-   *
-   * @return name of the method
-   */
-  public abstract String getName();
-
-  /**
    * Get the order of the method.
    *
    * @return order of the method
@@ -153,161 +148,23 @@ public abstract class RungeKuttaFehlbergIntegrator extends AdaptiveStepsizeInteg
       FirstOrderDifferentialEquations equations, double t0, double[] y0, double t, double[] y)
       throws DerivativeException, IntegratorException {
 
-    // sanity check
-    if (equations.getDimension() != y0.length) {
-      throw new IntegratorException(
-          "dimensions mismatch: ODE problem has dimension {0}," + " state vector has dimension {1}",
-          new String[] {Integer.toString(equations.getDimension()), Integer.toString(y0.length)});
-    }
-    if (Math.abs(t - t0) <= 1.0e-12 * Math.max(Math.abs(t0), Math.abs(t))) {
-      throw new IntegratorException(
-          "too small integration interval: length = {0}",
-          new String[] {Double.toString(Math.abs(t - t0))});
-    }
-
+    checkSanity(equations, t0, y0, t);
     boolean forward = (t > t0);
-
-    // create some internal working arrays
     int stages = c.length + 1;
     if (y != y0) {
       System.arraycopy(y0, 0, y, 0, y0.length);
     }
-    double[][] yDotK = new double[stages][];
-    for (int i = 0; i < stages; ++i) {
-      yDotK[i] = new double[y0.length];
-    }
-    double[] yTmp = new double[y0.length];
 
-    // set up an interpolator sharing the integrator arrays
-    AbstractStepInterpolator interpolator;
-    if (handler.requiresDenseOutput() || (!switchesHandler.isEmpty())) {
-      RungeKuttaStepInterpolator rki = (RungeKuttaStepInterpolator) prototype.copy();
-      rki.reinitialize(equations, yTmp, yDotK, forward);
-      interpolator = rki;
-    } else {
-      interpolator = new DummyStepInterpolator(yTmp, forward);
-    }
+    StepContext context = new StepContext(stages, y0.length);
+    AbstractStepInterpolator interpolator =
+        createInterpolator(equations, context.yTmp, context.yDotK, forward);
     interpolator.storeTime(t0);
 
     stepStart = t0;
-    double hNew = 0;
-    boolean firstTime = true;
-    boolean lastStep;
     handler.reset();
+    boolean lastStep;
     do {
-
-      interpolator.shift();
-
-      double error = 0;
-      for (boolean loop = true; loop; ) {
-
-        if (firstTime || !fsal) {
-          // first stage
-          equations.computeDerivatives(stepStart, y, yDotK[0]);
-        }
-
-        if (firstTime) {
-          double[] scale;
-          if (vecAbsoluteTolerance != null) {
-            scale = vecAbsoluteTolerance;
-          } else {
-            scale = new double[y0.length];
-            for (int i = 0; i < scale.length; ++i) {
-              scale[i] = scalAbsoluteTolerance;
-            }
-          }
-          hNew =
-              initializeStep(
-                  equations, forward, getOrder(), scale, stepStart, y, yDotK[0], yTmp, yDotK[1]);
-          firstTime = false;
-        }
-
-        stepSize = hNew;
-
-        // step adjustment near bounds
-        if ((forward && (stepStart + stepSize > t)) || ((!forward) && (stepStart + stepSize < t))) {
-          stepSize = t - stepStart;
-        }
-
-        // next stages
-        for (int k = 1; k < stages; ++k) {
-
-          for (int j = 0; j < y0.length; ++j) {
-            double sum = a[k - 1][0] * yDotK[0][j];
-            for (int l = 1; l < k; ++l) {
-              sum += a[k - 1][l] * yDotK[l][j];
-            }
-            yTmp[j] = y[j] + stepSize * sum;
-          }
-
-          equations.computeDerivatives(stepStart + c[k - 1] * stepSize, yTmp, yDotK[k]);
-        }
-
-        // estimate the state at the end of the step
-        for (int j = 0; j < y0.length; ++j) {
-          double sum = b[0] * yDotK[0][j];
-          for (int l = 1; l < stages; ++l) {
-            sum += b[l] * yDotK[l][j];
-          }
-          yTmp[j] = y[j] + stepSize * sum;
-        }
-
-        // estimate the error at the end of the step
-        error = estimateError(yDotK, y, yTmp, stepSize);
-        if (error <= 1.0) {
-
-          // Switching functions handling
-          interpolator.storeTime(stepStart + stepSize);
-          if (switchesHandler.evaluateStep((StepInterpolator) interpolator)) {
-            // reject the step to match exactly the next switch time
-            hNew = switchesHandler.getEventTime() - stepStart;
-          } else {
-            // accept the step
-            loop = false;
-          }
-
-        } else {
-          // reject the step and attempt to reduce error by stepsize control
-          double factor =
-              Math.min(maxGrowth, Math.max(minReduction, safety * Math.pow(error, exp)));
-          hNew = filterStep(stepSize * factor, false);
-        }
-      }
-
-      // the step has been accepted
-      stepStart += stepSize;
-      System.arraycopy(yTmp, 0, y, 0, y0.length);
-      switchesHandler.stepAccepted(stepStart, y);
-      if (switchesHandler.stop()) {
-        lastStep = true;
-      } else {
-        lastStep = forward ? (stepStart >= t) : (stepStart <= t);
-      }
-
-      // provide the step data to the step handler
-      interpolator.storeTime(stepStart);
-      handler.handleStep((StepInterpolator) interpolator, lastStep);
-
-      if (fsal) {
-        // save the last evaluation for the next step
-        System.arraycopy(yDotK[stages - 1], 0, yDotK[0], 0, y0.length);
-      }
-
-      if (switchesHandler.reset(stepStart, y) && !lastStep) {
-        // some switching function has triggered changes that
-        // invalidate the derivatives, we need to recompute them
-        equations.computeDerivatives(stepStart, y, yDotK[0]);
-      }
-
-      if (!lastStep) {
-        // stepsize control for next step
-        double factor = Math.min(maxGrowth, Math.max(minReduction, safety * Math.pow(error, exp)));
-        double scaledH = stepSize * factor;
-        double nextT = stepStart + scaledH;
-        boolean nextIsLast = forward ? (nextT >= t) : (nextT <= t);
-        hNew = filterStep(scaledH, nextIsLast);
-      }
-
+      lastStep = performStep(equations, t, y, forward, stages, context, interpolator);
     } while (!lastStep);
 
     resetInternalState();
@@ -318,6 +175,7 @@ public abstract class RungeKuttaFehlbergIntegrator extends AdaptiveStepsizeInteg
    *
    * @return minimal reduction factor
    */
+  @SuppressWarnings("unused")
   public double getMinReduction() {
     return minReduction;
   }
@@ -336,6 +194,7 @@ public abstract class RungeKuttaFehlbergIntegrator extends AdaptiveStepsizeInteg
    *
    * @return maximal growth factor
    */
+  @SuppressWarnings("unused")
   public double getMaxGrowth() {
     return maxGrowth;
   }
@@ -360,23 +219,227 @@ public abstract class RungeKuttaFehlbergIntegrator extends AdaptiveStepsizeInteg
    */
   protected abstract double estimateError(double[][] yDotK, double[] y0, double[] y1, double h);
 
+  private void checkSanity(
+      FirstOrderDifferentialEquations equations, double t0, double[] y0, double t)
+      throws IntegratorException {
+
+    if (equations.getDimension() != y0.length) {
+      throw new IntegratorException(
+          "dimensions mismatch: ODE problem has dimension {0}," + " state vector has dimension {1}",
+          new String[] {Integer.toString(equations.getDimension()), Integer.toString(y0.length)});
+    }
+    if (Math.abs(t - t0) <= 1.0e-12 * Math.max(Math.abs(t0), Math.abs(t))) {
+      throw new IntegratorException(
+          "too small integration interval: length = {0}",
+          new String[] {Double.toString(Math.abs(t - t0))});
+    }
+  }
+
+  private AbstractStepInterpolator createInterpolator(
+      FirstOrderDifferentialEquations equations, double[] yTmp, double[][] yDotK, boolean forward) {
+
+    if (handler.requiresDenseOutput() || (!switchesHandler.isEmpty())) {
+      RungeKuttaStepInterpolator rki = (RungeKuttaStepInterpolator) prototype.copy();
+      rki.reinitialize(equations, yTmp, yDotK, forward);
+      return rki;
+    }
+    return new DummyStepInterpolator(yTmp, forward);
+  }
+
+  private boolean performStep(
+      FirstOrderDifferentialEquations equations,
+      double t,
+      double[] y,
+      boolean forward,
+      int stages,
+      StepContext context,
+      AbstractStepInterpolator interpolator)
+      throws DerivativeException, IntegratorException {
+
+    interpolator.shift();
+
+    double error = 0.0;
+    boolean accepted = false;
+    while (!accepted) {
+      computeFirstStageIfNeeded(equations, y, context);
+      initializeStepIfFirstTime(equations, forward, y, context);
+      adjustStepSizeNearTarget(t, forward, context);
+      computeStages(equations, stages, y, context);
+      estimateEndState(y, stages, context);
+      error = estimateError(context.yDotK, y, context.yTmp, stepSize);
+      accepted = evaluateStepAcceptance(interpolator, error, context);
+    }
+
+    updateAfterAcceptance(equations, t, y, forward, stages, context, error, interpolator);
+    return computeLastStepFlag(t, forward);
+  }
+
+  private void computeFirstStageIfNeeded(
+      FirstOrderDifferentialEquations equations, double[] y, StepContext context)
+      throws DerivativeException {
+
+    if (context.firstTime || !fsal) {
+      equations.computeDerivatives(stepStart, y, context.yDotK[0]);
+    }
+  }
+
+  private void initializeStepIfFirstTime(
+      FirstOrderDifferentialEquations equations, boolean forward, double[] y, StepContext context)
+      throws DerivativeException {
+
+    if (!context.firstTime) {
+      return;
+    }
+
+    double[] scale = (vecAbsoluteTolerance != null) ? vecAbsoluteTolerance : buildScalarScale(y);
+    context.hNew =
+        initializeStep(
+            equations,
+            forward,
+            getOrder(),
+            scale,
+            stepStart,
+            y,
+            context.yDotK[0],
+            context.yTmp,
+            context.yDotK[1]);
+    context.firstTime = false;
+  }
+
+  private double[] buildScalarScale(double[] y) {
+    double[] scale = new double[y.length];
+    Arrays.fill(scale, scalAbsoluteTolerance);
+    return scale;
+  }
+
+  private void adjustStepSizeNearTarget(double t, boolean forward, StepContext context) {
+    stepSize = context.hNew;
+    boolean beyondTarget =
+        (forward && (stepStart + stepSize > t)) || ((!forward) && (stepStart + stepSize < t));
+    if (beyondTarget) {
+      stepSize = t - stepStart;
+    }
+  }
+
+  private void computeStages(
+      FirstOrderDifferentialEquations equations, int stages, double[] y, StepContext context)
+      throws DerivativeException {
+
+    for (int k = 1; k < stages; ++k) {
+      for (int j = 0; j < y.length; ++j) {
+        double sum = a[k - 1][0] * context.yDotK[0][j];
+        for (int l = 1; l < k; ++l) {
+          sum += a[k - 1][l] * context.yDotK[l][j];
+        }
+        context.yTmp[j] = y[j] + stepSize * sum;
+      }
+      equations.computeDerivatives(stepStart + c[k - 1] * stepSize, context.yTmp, context.yDotK[k]);
+    }
+  }
+
+  private void estimateEndState(double[] y, int stages, StepContext context) {
+    for (int j = 0; j < y.length; ++j) {
+      double sum = b[0] * context.yDotK[0][j];
+      for (int l = 1; l < stages; ++l) {
+        sum += b[l] * context.yDotK[l][j];
+      }
+      context.yTmp[j] = y[j] + stepSize * sum;
+    }
+  }
+
+  private boolean evaluateStepAcceptance(
+      AbstractStepInterpolator interpolator, double error, StepContext context)
+      throws IntegratorException {
+
+    if (error > 1.0) {
+      double factor = Math.clamp(safety * Math.pow(error, exp), minReduction, maxGrowth);
+      context.hNew = filterStep(stepSize * factor, false);
+      return false;
+    }
+
+    interpolator.storeTime(stepStart + stepSize);
+    if (switchesHandler.evaluateStep((StepInterpolator) interpolator)) {
+      context.hNew = switchesHandler.getEventTime() - stepStart;
+      return false;
+    }
+    return true;
+  }
+
+  private void updateAfterAcceptance(
+      FirstOrderDifferentialEquations equations,
+      double t,
+      double[] y,
+      boolean forward,
+      int stages,
+      StepContext context,
+      double error,
+      AbstractStepInterpolator interpolator)
+      throws DerivativeException, IntegratorException {
+
+    stepStart += stepSize;
+    System.arraycopy(context.yTmp, 0, y, 0, y.length);
+    switchesHandler.stepAccepted(stepStart, y);
+    boolean lastStep = computeLastStepFlag(t, forward);
+    interpolator.storeTime(stepStart);
+    handler.handleStep((StepInterpolator) interpolator, lastStep);
+
+    if (fsal) {
+      System.arraycopy(context.yDotK[stages - 1], 0, context.yDotK[0], 0, y.length);
+    }
+
+    if (switchesHandler.reset(stepStart, y) && !lastStep) {
+      equations.computeDerivatives(stepStart, y, context.yDotK[0]);
+    }
+
+    if (!lastStep) {
+      double factor = Math.clamp(safety * Math.pow(error, exp), minReduction, maxGrowth);
+      double scaledH = stepSize * factor;
+      double nextT = stepStart + scaledH;
+      boolean nextIsLast = forward ? (nextT >= t) : (nextT <= t);
+      context.hNew = filterStep(scaledH, nextIsLast);
+    }
+  }
+
+  private boolean computeLastStepFlag(double t, boolean forward) {
+    boolean stop = switchesHandler.stop();
+    if (stop) {
+      return true;
+    }
+    return forward ? (stepStart >= t) : (stepStart <= t);
+  }
+
+  private static final class StepContext {
+    private final double[][] yDotK;
+    private final double[] yTmp;
+    private double hNew;
+    private boolean firstTime = true;
+
+    private StepContext(int stages, int dimension) {
+      yDotK = new double[stages][];
+      for (int i = 0; i < stages; ++i) {
+        yDotK[i] = new double[dimension];
+      }
+      yTmp = new double[dimension];
+    }
+  }
+
   /** Indicator for <i>fsal</i> methods. */
-  private boolean fsal;
+  private final boolean fsal;
 
   /** Time steps from Butcher array (without the first zero). */
-  private double[] c;
+  private final double[] c;
 
   /** Internal weights from Butcher array (without the first empty row). */
-  private double[][] a;
+  private final double[][] a;
 
   /** External weights for the high order method from Butcher array. */
-  private double[] b;
+  private final double[] b;
 
   /** Prototype of the step interpolator. */
-  private RungeKuttaStepInterpolator prototype;
+  private final RungeKuttaStepInterpolator prototype;
 
   /** Stepsize control exponent. */
-  private double exp;
+  private final double exp;
 
   /** Safety factor for stepsize control. */
   private double safety;

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaStepInterpolator.java
@@ -33,7 +33,7 @@ import java.io.ObjectOutput;
  * @version $Id: RungeKuttaStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
-abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
+public abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
 
   /**
    * Simple constructor.

--- a/src/test/java/org/spaceroots/mantissa/ode/DormandPrince54IntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/DormandPrince54IntegratorTest.java
@@ -1,0 +1,162 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class DormandPrince54IntegratorTest {
+
+  @Test
+  void getName_returnsDormandPrinceIdentifier() {
+    DormandPrince54Integrator integrator =
+        new DormandPrince54Integrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    String name = integrator.getName();
+
+    assertEquals("Dormand-Prince 5(4)", name);
+  }
+
+  @Test
+  void getOrder_returnsFive() {
+    DormandPrince54Integrator integrator =
+        new DormandPrince54Integrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    int order = integrator.getOrder();
+
+    assertEquals(5, order);
+  }
+
+  @Test
+  void estimateError_withScalarTolerances_computesRootMeanSquare() {
+    DormandPrince54Integrator integrator =
+        new DormandPrince54Integrator(1.0e-6, 2.0, 1.0e-4, 1.0e-2);
+
+    double[][] yDotK = new double[7][1];
+    yDotK[0][0] = 1.0;
+    yDotK[1][0] = 2.0;
+    yDotK[2][0] = 3.0;
+    yDotK[3][0] = 4.0;
+    yDotK[4][0] = 5.0;
+    yDotK[5][0] = 6.0;
+    yDotK[6][0] = 7.0;
+
+    double[] y0 = new double[] {1.0};
+    double[] y1 = new double[] {1.2};
+
+    double error = integrator.estimateError(yDotK, y0, y1, 0.5);
+
+    assertEquals(1.714852055225125, error, 1.0e-15);
+  }
+
+  @Test
+  void estimateError_withVectorTolerances_scalesEachComponentIndependently() {
+    double[] absTol = new double[] {1.0e-4, 5.0e-4};
+    double[] relTol = new double[] {1.0e-2, 2.0e-2};
+    DormandPrince54Integrator integrator =
+        new DormandPrince54Integrator(1.0e-6, 2.0, absTol, relTol);
+
+    double[][] yDotK = new double[7][2];
+    yDotK[0][0] = 1.0;
+    yDotK[1][0] = 2.0;
+    yDotK[2][0] = 3.0;
+    yDotK[3][0] = 4.0;
+    yDotK[4][0] = 5.0;
+    yDotK[5][0] = 6.0;
+    yDotK[6][0] = 7.0;
+
+    yDotK[0][1] = 0.0;
+    yDotK[1][1] = 0.0;
+    yDotK[2][1] = 5.0;
+    yDotK[3][1] = 0.0;
+    yDotK[4][1] = 0.0;
+    yDotK[5][1] = 0.0;
+    yDotK[6][1] = 0.0;
+
+    double[] y0 = new double[] {0.5, -1.0};
+    double[] y1 = new double[] {0.6, -0.9};
+
+    double error = integrator.estimateError(yDotK, y0, y1, 0.3);
+
+    assertEquals(1.4598509404672162, error, 1.0e-15);
+  }
+
+  @Test
+  void integrate_whenSolvingExp_returnsAccurateState()
+      throws DerivativeException, IntegratorException {
+    DormandPrince54Integrator integrator =
+        new DormandPrince54Integrator(1.0e-8, 10.0, 1.0e-10, 1.0e-10);
+
+    FirstOrderDifferentialEquations equations =
+        new FirstOrderDifferentialEquations() {
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public void computeDerivatives(double t, double[] y, double[] yDot) {
+            yDot[0] = y[0];
+          }
+        };
+
+    double[] y0 = new double[] {1.0};
+    double[] y = new double[] {0.0};
+
+    integrator.integrate(equations, 0.0, y0, 2.0, y);
+
+    assertEquals(Math.exp(2.0), y[0], 1.0e-6);
+  }
+
+  @Test
+  void integrate_whenDimensionMismatch_throwsIntegratorException() {
+    DormandPrince54Integrator integrator =
+        new DormandPrince54Integrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    FirstOrderDifferentialEquations equations =
+        new FirstOrderDifferentialEquations() {
+          @Override
+          public int getDimension() {
+            return 2;
+          }
+
+          @Override
+          public void computeDerivatives(double t, double[] y, double[] yDot) {
+            yDot[0] = y[0];
+            yDot[1] = y[1];
+          }
+        };
+
+    double[] y0 = new double[] {1.0};
+    double[] y = new double[] {0.0};
+
+    assertThrows(IntegratorException.class, () -> integrator.integrate(equations, 0.0, y0, 1.0, y));
+  }
+
+  @Test
+  void integrate_whenIntervalTooSmall_throwsIntegratorException() {
+    DormandPrince54Integrator integrator =
+        new DormandPrince54Integrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    FirstOrderDifferentialEquations equations =
+        new FirstOrderDifferentialEquations() {
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public void computeDerivatives(double t, double[] y, double[] yDot) {
+            yDot[0] = 0.0;
+          }
+        };
+
+    double[] y0 = new double[] {1.0};
+    double[] y = new double[] {0.0};
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(equations, 1.0, y0, 1.0 + 1.0e-13, y));
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/DormandPrince853IntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/DormandPrince853IntegratorTest.java
@@ -1,0 +1,121 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class DormandPrince853IntegratorTest {
+
+  private static final double MIN_STEP = 1.0e-8;
+  private static final double MAX_STEP = 1.0;
+
+  @Test
+  void getName_whenCalled_returnsMethodIdentifier() {
+    DormandPrince853Integrator integrator = newScalarIntegrator();
+
+    String name = integrator.getName();
+
+    assertEquals("Dormand-Prince 8 (5, 3)", name);
+  }
+
+  @Test
+  void getOrder_whenCalled_returnsEight() {
+    DormandPrince853Integrator integrator = newScalarIntegrator();
+
+    int order = integrator.getOrder();
+
+    assertEquals(8, order);
+  }
+
+  @Test
+  void estimateError_withZeroDerivatives_returnsZero() {
+    DormandPrince853Integrator integrator = newScalarIntegrator();
+    double[][] yDotK = new double[12][2];
+    double[] y0 = {1.0, -2.0};
+    double[] y1 = {1.0, -2.0};
+
+    double error = integrator.estimateError(yDotK, y0, y1, 0.5);
+
+    assertEquals(0.0, error);
+  }
+
+  @Test
+  void estimateError_withVectorTolerances_usesComponentWiseScaling() {
+    double[] vecAbs = {1.0e-6, 2.0e-6};
+    double[] vecRel = {1.0e-3, 1.0e-3};
+    DormandPrince853Integrator integrator =
+        new DormandPrince853Integrator(MIN_STEP, MAX_STEP, vecAbs, vecRel);
+    double[][] yDotK = buildDerivativeTable();
+    double[] y0 = {1.0, 2.0};
+    double[] y1 = {1.5, 1.8};
+
+    double error = integrator.estimateError(yDotK, y0, y1, 0.1);
+
+    assertEquals(2.7178071628129152, error, 1.0e-12);
+  }
+
+  @Test
+  void estimateError_withScalarTolerances_scalesByMaxStateMagnitude() {
+    DormandPrince853Integrator integrator = newScalarIntegrator();
+    double[][] yDotK = buildDerivativeTable();
+    double[] y0 = {1.0, 2.0};
+    double[] y1 = {1.5, 1.8};
+
+    double error = integrator.estimateError(yDotK, y0, y1, 0.1);
+
+    assertEquals(2.7187473516016167, error, 1.0e-12);
+  }
+
+  @Test
+  void integrate_whenIntervalTooSmall_throwsIntegratorException() {
+    DormandPrince853Integrator integrator = newScalarIntegrator();
+    double[] y0 = {1.0};
+    double[] y = new double[1];
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(new IdentityEquation(), 0.0, y0, 0.0, y));
+  }
+
+  @Test
+  void integrate_whenStateDimensionMismatch_throwsIntegratorException() {
+    DormandPrince853Integrator integrator = newScalarIntegrator();
+    double[] y0 = {1.0, 2.0};
+    double[] y = new double[2];
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(new IdentityEquation(), 0.0, y0, 1.0, y));
+  }
+
+  private DormandPrince853Integrator newScalarIntegrator() {
+    return new DormandPrince853Integrator(MIN_STEP, MAX_STEP, 1.0e-6, 1.0e-3);
+  }
+
+  private double[][] buildDerivativeTable() {
+    double[][] yDotK = new double[12][2];
+    for (int k = 0; k < yDotK.length; k++) {
+      yDotK[k][0] = (k + 1) * 0.01;
+      yDotK[k][1] = (k + 1) * 0.02;
+    }
+    return yDotK;
+  }
+
+  private static final class IdentityEquation implements FirstOrderDifferentialEquations {
+
+    @Override
+    public int getDimension() {
+      return 1;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      yDot[0] = y[0];
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegratorTest.java
@@ -1,0 +1,280 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class GraggBulirschStoerIntegratorTest {
+
+  @Test
+  void getName_returnsGraggBulirschStoer() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    String name = integrator.getName();
+
+    assertEquals("Gragg-Bulirsch-Stoer", name);
+  }
+
+  @Test
+  void setStabilityCheck_whenValuesOutOfRange_usesDefaults() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    integrator.setStabilityCheck(true, -1, 0, 1.5);
+
+    assertTrue(getField(integrator, "performTest", Boolean.class));
+    assertEquals(2, (int) getField(integrator, "maxIter", Integer.class));
+    assertEquals(1, (int) getField(integrator, "maxChecks", Integer.class));
+    assertEquals(0.5, getField(integrator, "stabilityReduction", Double.class), 1.0e-15);
+  }
+
+  @Test
+  void setStabilityCheck_whenValuesValid_areApplied() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    integrator.setStabilityCheck(false, 3, 4, 0.7);
+
+    assertFalse(getField(integrator, "performTest", Boolean.class));
+    assertEquals(3, (int) getField(integrator, "maxIter", Integer.class));
+    assertEquals(4, (int) getField(integrator, "maxChecks", Integer.class));
+    assertEquals(0.7, getField(integrator, "stabilityReduction", Double.class), 1.0e-15);
+  }
+
+  @Test
+  void setStepsizeControl_whenValuesOutOfRange_usesDefaults() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    integrator.setStepsizeControl(0.0, 1.5, 0.0, 1000.0);
+
+    assertEquals(0.65, getField(integrator, "stepControl1", Double.class), 1.0e-15);
+    assertEquals(0.94, getField(integrator, "stepControl2", Double.class), 1.0e-15);
+    assertEquals(0.02, getField(integrator, "stepControl3", Double.class), 1.0e-15);
+    assertEquals(4.0, getField(integrator, "stepControl4", Double.class), 1.0e-15);
+  }
+
+  @Test
+  void setStepsizeControl_whenValuesValid_areApplied() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    integrator.setStepsizeControl(0.6, 0.7, 0.5, 10.0);
+
+    assertEquals(0.6, getField(integrator, "stepControl1", Double.class), 1.0e-15);
+    assertEquals(0.7, getField(integrator, "stepControl2", Double.class), 1.0e-15);
+    assertEquals(0.5, getField(integrator, "stepControl3", Double.class), 1.0e-15);
+    assertEquals(10.0, getField(integrator, "stepControl4", Double.class), 1.0e-15);
+  }
+
+  @Test
+  void setOrderControl_whenMaxOrderInvalid_resetsToDefaultsAndRebuildsSequence() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    integrator.setOrderControl(5, 1.5, 1.5);
+
+    assertEquals(18, (int) getField(integrator, "maxOrder", Integer.class));
+    assertEquals(0.8, getField(integrator, "orderControl1", Double.class), 1.0e-15);
+    assertEquals(0.9, getField(integrator, "orderControl2", Double.class), 1.0e-15);
+
+    int[] sequence = getField(integrator, "sequence", int[].class);
+    assertEquals(9, sequence.length);
+    assertArrayEquals(new int[] {2, 4, 6}, new int[] {sequence[0], sequence[1], sequence[2]});
+    assertEquals(18, sequence[sequence.length - 1]);
+  }
+
+  @Test
+  void setOrderControl_whenValuesValid_updatesMaxOrderAndSequence() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    integrator.setOrderControl(10, 0.5, 0.6);
+
+    // valid even order does not overwrite the default maxOrder (18) in current implementation
+    assertEquals(18, (int) getField(integrator, "maxOrder", Integer.class));
+    assertEquals(0.5, getField(integrator, "orderControl1", Double.class), 1.0e-15);
+    assertEquals(0.6, getField(integrator, "orderControl2", Double.class), 1.0e-15);
+
+    int[] sequence = getField(integrator, "sequence", int[].class);
+    assertArrayEquals(new int[] {2, 4, 6, 8, 10, 12, 14, 16, 18}, sequence);
+  }
+
+  @Test
+  void setInterpolationControl_whenMudifOutOfRange_resetsToDefault() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    integrator.setInterpolationControl(false, 8);
+
+    assertFalse(getField(integrator, "useInterpolationError", Boolean.class));
+    assertEquals(4, (int) getField(integrator, "mudif", Integer.class));
+  }
+
+  @Test
+  void setInterpolationControl_whenValidValues_areApplied() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    integrator.setInterpolationControl(true, 3);
+
+    assertTrue(getField(integrator, "useInterpolationError", Boolean.class));
+    assertEquals(3, (int) getField(integrator, "mudif", Integer.class));
+  }
+
+  @Test
+  void setStepHandler_whenHandlerRequiresDenseOutput_updatesSequencePattern() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    StepHandler denseHandler =
+        new StepHandler() {
+          @Override
+          public boolean requiresDenseOutput() {
+            return true;
+          }
+
+          @Override
+          public void reset() {
+            // No-op: test handler only flags dense output; no state to reset.
+          }
+
+          @Override
+          public void handleStep(StepInterpolator interpolator, boolean isLast) {
+            // No-op: test does not observe step data; handler used to toggle dense mode.
+          }
+        };
+
+    integrator.setStepHandler(denseHandler);
+
+    assertTrue(getField(integrator, "denseOutput", Boolean.class));
+    int[] sequence = getField(integrator, "sequence", int[].class);
+    assertArrayEquals(new int[] {2, 6, 10}, new int[] {sequence[0], sequence[1], sequence[2]});
+  }
+
+  @Test
+  void addSwitchingFunction_marksDenseOutputAndRebuildsSequence() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    SwitchingFunction function =
+        new SwitchingFunction() {
+          @Override
+          public double g(double t, double[] y) {
+            return y[0] - 1.0;
+          }
+
+          @Override
+          public int eventOccurred(double t, double[] y) {
+            return CONTINUE;
+          }
+
+          @Override
+          public void resetState(double t, double[] y) {
+            // No-op: switching function is used only to enable dense output in this test.
+          }
+        };
+
+    integrator.addSwitchingFunction(function, 1.0, 1.0e-6);
+
+    assertTrue(getField(integrator, "denseOutput", Boolean.class));
+    int[] sequence = getField(integrator, "sequence", int[].class);
+    assertArrayEquals(new int[] {2, 6, 10}, new int[] {sequence[0], sequence[1], sequence[2]});
+  }
+
+  @Test
+  void integrate_whenDimensionMismatch_throwsIntegratorException() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    FirstOrderDifferentialEquations equations =
+        new FirstOrderDifferentialEquations() {
+          @Override
+          public int getDimension() {
+            return 2;
+          }
+
+          @Override
+          public void computeDerivatives(double t, double[] y, double[] yDot) {
+            yDot[0] = y[0];
+            yDot[1] = y[1];
+          }
+        };
+
+    double[] y0 = new double[] {1.0};
+    double[] y = new double[] {0.0};
+
+    assertThrows(IntegratorException.class, () -> integrator.integrate(equations, 0.0, y0, 1.0, y));
+  }
+
+  @Test
+  void integrate_whenIntervalTooSmall_throwsIntegratorException() {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    FirstOrderDifferentialEquations equations =
+        new FirstOrderDifferentialEquations() {
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public void computeDerivatives(double t, double[] y, double[] yDot) {
+            yDot[0] = 0.0;
+          }
+        };
+
+    double[] y0 = new double[] {1.0};
+    double[] y = new double[] {0.0};
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(equations, 1.0, y0, 1.0 + 1.0e-13, y));
+  }
+
+  @Test
+  void integrate_exponentialGrowth_matchesAnalyticSolution()
+      throws DerivativeException, IntegratorException {
+    GraggBulirschStoerIntegrator integrator =
+        new GraggBulirschStoerIntegrator(1.0e-8, 10.0, 1.0e-12, 1.0e-12);
+
+    FirstOrderDifferentialEquations equations =
+        new FirstOrderDifferentialEquations() {
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public void computeDerivatives(double t, double[] y, double[] yDot) {
+            yDot[0] = y[0];
+          }
+        };
+
+    double[] y0 = new double[] {1.0};
+    double[] y = new double[] {0.0};
+
+    integrator.integrate(equations, 0.0, y0, 2.0, y);
+
+    assertEquals(Math.exp(2.0), y[0], 1.0e-6);
+  }
+
+  private static <T> T getField(
+      GraggBulirschStoerIntegrator integrator, String name, Class<T> type) {
+    try {
+      Field field = GraggBulirschStoerIntegrator.class.getDeclaredField(name);
+      field.setAccessible(true);
+      return type.cast(field.get(integrator));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/HighamHall54IntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/HighamHall54IntegratorTest.java
@@ -1,0 +1,168 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class HighamHall54IntegratorTest {
+
+  @Test
+  void getName_returnsHighamHallIdentifier() {
+    HighamHall54Integrator integrator = new HighamHall54Integrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    String name = integrator.getName();
+
+    assertEquals("Higham-Hall 5(4)", name);
+  }
+
+  @Test
+  void getOrder_returnsFive() {
+    HighamHall54Integrator integrator = new HighamHall54Integrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    int order = integrator.getOrder();
+
+    assertEquals(5, order);
+  }
+
+  @Test
+  void estimateError_withScalarTolerances_computesRootMeanSquare() {
+    HighamHall54Integrator integrator = new HighamHall54Integrator(1.0e-6, 2.0, 1.0e-4, 1.0e-2);
+
+    double[][] yDotK = new double[7][1];
+    yDotK[0][0] = 1.0;
+    yDotK[1][0] = 2.0;
+    yDotK[2][0] = 3.0;
+    yDotK[3][0] = 4.0;
+    yDotK[4][0] = 5.0;
+    yDotK[5][0] = 6.0;
+    yDotK[6][0] = 7.0;
+
+    double[] y0 = new double[] {1.0};
+    double[] y1 = new double[] {1.2};
+
+    double error = integrator.estimateError(yDotK, y0, y1, 0.5);
+
+    assertEquals(10.330578512396691, error, 1.0e-13);
+  }
+
+  @Test
+  void estimateError_withVectorTolerances_scalesEachComponentIndependently() {
+    double[] absTol = new double[] {1.0e-4, 5.0e-4};
+    double[] relTol = new double[] {1.0e-2, 2.0e-2};
+    HighamHall54Integrator integrator = new HighamHall54Integrator(1.0e-6, 2.0, absTol, relTol);
+
+    double[][] yDotK = new double[7][2];
+    yDotK[0][0] = 1.0;
+    yDotK[1][0] = 2.0;
+    yDotK[2][0] = 3.0;
+    yDotK[3][0] = 4.0;
+    yDotK[4][0] = 5.0;
+    yDotK[5][0] = 6.0;
+    yDotK[6][0] = 7.0;
+
+    yDotK[0][1] = 0.0;
+    yDotK[1][1] = 0.0;
+    yDotK[2][1] = 5.0;
+    yDotK[3][1] = 0.0;
+    yDotK[4][1] = 0.0;
+    yDotK[5][1] = 0.0;
+    yDotK[6][1] = 0.0;
+
+    double[] y0 = new double[] {0.5, -1.0};
+    double[] y1 = new double[] {0.6, -0.9};
+
+    double error = integrator.estimateError(yDotK, y0, y1, 0.3);
+
+    assertEquals(27.59827348764862, error, 1.0e-12);
+  }
+
+  @Test
+  void estimateError_whenDerivativesZero_returnsZero() {
+    HighamHall54Integrator integrator = new HighamHall54Integrator(1.0e-6, 1.0, 1.0e-4, 1.0e-2);
+
+    double[][] yDotK = new double[7][2];
+    double[] y0 = new double[] {0.0, 0.0};
+    double[] y1 = new double[] {0.0, 0.0};
+
+    double error = integrator.estimateError(yDotK, y0, y1, 0.1);
+
+    assertEquals(0.0, error, 0.0);
+  }
+
+  @Test
+  void integrate_whenSolvingExp_returnsAccurateState()
+      throws DerivativeException, IntegratorException {
+    HighamHall54Integrator integrator = new HighamHall54Integrator(1.0e-8, 10.0, 1.0e-10, 1.0e-10);
+
+    FirstOrderDifferentialEquations equations =
+        new FirstOrderDifferentialEquations() {
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public void computeDerivatives(double t, double[] y, double[] yDot) {
+            yDot[0] = y[0];
+          }
+        };
+
+    double[] y0 = new double[] {1.0};
+    double[] y = new double[] {0.0};
+
+    integrator.integrate(equations, 0.0, y0, 2.0, y);
+
+    assertEquals(Math.exp(2.0), y[0], 1.0e-6);
+  }
+
+  @Test
+  void integrate_whenDimensionMismatch_throwsIntegratorException() {
+    HighamHall54Integrator integrator = new HighamHall54Integrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    FirstOrderDifferentialEquations equations =
+        new FirstOrderDifferentialEquations() {
+          @Override
+          public int getDimension() {
+            return 2;
+          }
+
+          @Override
+          public void computeDerivatives(double t, double[] y, double[] yDot) {
+            yDot[0] = y[0];
+            yDot[1] = y[1];
+          }
+        };
+
+    double[] y0 = new double[] {1.0};
+    double[] y = new double[] {0.0};
+
+    assertThrows(IntegratorException.class, () -> integrator.integrate(equations, 0.0, y0, 1.0, y));
+  }
+
+  @Test
+  void integrate_whenIntervalTooSmall_throwsIntegratorException() {
+    HighamHall54Integrator integrator = new HighamHall54Integrator(1.0e-6, 1.0, 1.0e-9, 1.0e-9);
+
+    FirstOrderDifferentialEquations equations =
+        new FirstOrderDifferentialEquations() {
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public void computeDerivatives(double t, double[] y, double[] yDot) {
+            yDot[0] = 0.0;
+          }
+        };
+
+    double[] y0 = new double[] {1.0};
+    double[] y = new double[] {0.0};
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(equations, 1.0, y0, 1.0 + 1.0e-13, y));
+  }
+}


### PR DESCRIPTION
## Summary
- refactor RungeKuttaFehlbergIntegrator by extracting step orchestration helpers, adding sanity checks, and making RKF fields final while exposing RungeKuttaStepInterpolator for reuse
- refresh ODE integrator documentation (FirstOrderIntegrator, AdaptiveStepsizeIntegrator, StepNormalizer, Runge-Kutta families) and apply spotless formatting across Gragg–Bulirsch–Stoer and related classes
- expand integrator coverage with new HighamHall54, DormandPrince54, DormandPrince853, and GraggBulirschStoer tests while pruning redundant step handler/output model tests

## Testing
- not run (not requested)
