### PR TITLE
Improve first-order ODE docs and add converter tests

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/ode/FirstOrderConverter.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/FirstOrderConverter.java
@@ -1,26 +1,31 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class converts second order differential equations to first order ones.
+ * Converts a second order differential equations set to a first order one usable by standard
+ * integrators.
  *
- * <p>This class is a wrapper around a {@link SecondOrderDifferentialEquations} which allow to use a
- * {@link FirstOrderIntegrator} to integrate it.
+ * <p>This adapter wraps a {@link SecondOrderDifferentialEquations} instance and exposes it through
+ * the {@link FirstOrderDifferentialEquations} interface so callers can reuse first order
+ * integrators without rewriting their problem model. The conversion doubles the dimension of the
+ * state vector: for an original size <code>n</code>, the first <code>n</code> components carry the
+ * position variables and the remaining <code>n</code> components carry their first derivatives. The
+ * resulting derivative vector therefore contains both first and second time derivatives, allowing
+ * existing first order solvers to advance the state.
  *
- * <p>The transformation is done by changing the n dimension state vector to a 2n dimension vector,
- * where the first n components are the initial state variables and the n last components are their
- * first time derivative. The first time derivative of this state vector then really contains both
- * the first and second time derivative of the initial state vector, which can be handled by the
- * underlying second order equations set.
+ * <p>Each {@link #computeDerivatives(double, double[], double[])} call copies up to <code>4n</code>
+ * scalar values to split and reassemble the state, so users should account for the transient memory
+ * churn and CPU overhead. The converter is mutable only through the working arrays it owns; it is
+ * not thread-safe for concurrent integration steps but may be reused sequentially across multiple
+ * runs. Prefer implementing a direct first order formulation when minimizing copying is critical.
  *
- * <p>One should be aware that the data is duplicated during the transformation process and that for
- * each call to {@link #computeDerivatives computeDerivatives}, this wrapper does copy 4n scalars :
- * 2n before the call to {@link SecondOrderDifferentialEquations#computeSecondDerivatives
- * computeSecondDerivatives} in order to dispatch the y state vector into z and zDot, and 2n after
- * the call to gather zDot and zDDot into yDot. Since the underlying problem by itself perhaps also
- * needs to copy data and dispatch the arrays into domain objects, this has an impact on both memory
- * and CPU usage. The only way to avoid this duplication is to perform the transformation at the
- * problem level, i.e. to implement the problem as a first order one and then avoid using this
- * class.
+ * <ul>
+ *   <li>Responsibility: dispatch second order state into position/velocity, forward the model, then
+ *       pack combined derivatives.
+ *   <li>Trade-off: convenience and API compatibility in exchange for predictable duplication work
+ *       per step.
+ *   <li>Typical use: wrap a legacy second order model and pass this converter to a {@link
+ *       FirstOrderIntegrator}.
+ * </ul>
  *
  * @see FirstOrderIntegrator
  * @see FirstOrderDifferentialEquations
@@ -33,7 +38,12 @@ public class FirstOrderConverter implements FirstOrderDifferentialEquations {
   /**
    * Simple constructor. Build a converter around a second order equations set.
    *
-   * @param equations second order equations set to convert
+   * <p>The created instance keeps references to working arrays sized from the provided model's
+   * dimension. Callers should create one converter per problem instance or guard access externally
+   * when sharing across threads.
+   *
+   * @param equations second order equations set to convert; must be non-null and dimensionally
+   *     stable during the converter lifetime
    */
   public FirstOrderConverter(SecondOrderDifferentialEquations equations) {
     this.equations = equations;
@@ -43,10 +53,43 @@ public class FirstOrderConverter implements FirstOrderDifferentialEquations {
     zDDot = new double[dimension];
   }
 
+  /**
+   * Returns the dimension of the converted first order problem.
+   *
+   * <p>The dimension is exactly twice the underlying second order dimension because the converter
+   * concatenates position and velocity components into a single state vector.
+   *
+   * @return total size of the combined state vector (positions then velocities), always <code>2*n
+   *     </code>
+   */
   public int getDimension() {
     return 2 * dimension;
   }
 
+  /**
+   * Computes the first order derivative vector corresponding to the augmented state.
+   *
+   * <p>This method splits the incoming state <code>y</code> into position and velocity slices,
+   * delegates the second derivative computation to the wrapped model, then reassembles the result
+   * so the first half of {@code yDot} contains velocities and the second half contains
+   * accelerations. Both input arrays must have a length of exactly {@link #getDimension()}. No
+   * defensive copies are made; the method writes directly into the provided {@code yDot}.
+   *
+   * <pre>{@code
+   * FirstOrderConverter converter = new FirstOrderConverter(model);
+   * double[] state = {...};
+   * double[] derivative = new double[state.length];
+   * converter.computeDerivatives(t, state, derivative);
+   * }</pre>
+   *
+   * @param t current integration time; passed unchanged to the underlying second order model
+   * @param y combined state array containing positions then velocities; length must equal {@link
+   *     #getDimension()}
+   * @param yDot output array receiving velocities then accelerations; must be preallocated to the
+   *     same length as {@code y}
+   * @throws DerivativeException if the wrapped {@link SecondOrderDifferentialEquations} signals a
+   *     failure while computing second derivatives
+   */
   public void computeDerivatives(double t, double[] y, double[] yDot) throws DerivativeException {
 
     // split the state vector in two
@@ -62,17 +105,17 @@ public class FirstOrderConverter implements FirstOrderDifferentialEquations {
   }
 
   /** Underlying second order equations set. */
-  private SecondOrderDifferentialEquations equations;
+  private final SecondOrderDifferentialEquations equations;
 
   /** second order problem dimension. */
-  private int dimension;
+  private final int dimension;
 
   /** state vector. */
-  private double[] z;
+  private final double[] z;
 
   /** first time derivative of the state vector. */
-  private double[] zDot;
+  private final double[] zDot;
 
   /** second time derivative of the state vector. */
-  private double[] zDDot;
+  private final double[] zDDot;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/FirstOrderDifferentialEquations.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/FirstOrderDifferentialEquations.java
@@ -1,19 +1,31 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This interface represents a first order differential equations set.
+ * Interface describing a system of first-order ordinary differential equations (ODEs) that can be
+ * integrated numerically.
  *
- * <p>This interface should be implemented by all real first order differential equation problems
- * before they can be handled by the integrators {@link FirstOrderIntegrator#integrate} method.
+ * <p>Implementations expose the mathematical model {@code dY/dt = f(t, Y)} where {@code Y} is the
+ * state vector and {@code f} computes its time derivative. Integrators use this contract to query
+ * the system repeatedly while advancing the numerical solution. The interface deliberately focuses
+ * on the minimal coupling needed by an integrator: a fixed dimension, an immutable view of the
+ * current state, and a writable buffer for derivatives. Model-specific constants or configuration
+ * values remain the responsibility of the implementing class.
  *
- * <p>A first order differential equations problem, as seen by an integrator is the time derivative
- * <code>dY/dt</code> of a state vector <code>Y</code>, both being one dimensional arrays. From the
- * integrator point of view, this derivative depends only on the current time <code>t</code> and on
- * the state vector <code>Y</code>.
+ * <p>Typical usage follows a pull model: an integration routine calls {@link #getDimension()} once
+ * to allocate working arrays, then invokes {@link #computeDerivatives(double, double[], double[])}
+ * many times as it explores the trajectory. Implementations should keep {@code getDimension()}
+ * stable over the lifetime of an integration step and avoid side effects beyond filling the
+ * derivative array. Unless documented otherwise they are not required to be thread-safe, so callers
+ * should confine each instance to a single integration thread.
  *
- * <p>For real problems, the derivative depends also on parameters that do not belong to the state
- * vector (dynamical model constants for example). These constants are completely outside of the
- * scope of this interface, the classes that implement it are allowed to handle them as they want.
+ * <ul>
+ *   <li><b>Responsibilities:</b> report a consistent state dimension and provide derivatives on
+ *       demand.
+ *   <li><b>Notable behaviors:</b> derivative computation must neither mutate the provided state
+ *       array nor rely on hidden internal time progression.
+ *   <li><b>Failure handling:</b> throw {@link DerivativeException} when the model cannot evaluate
+ *       safely (singularities, invalid parameters, or user cancellation).
+ * </ul>
  *
  * @see FirstOrderIntegrator
  * @see FirstOrderConverter
@@ -25,20 +37,47 @@ package org.spaceroots.mantissa.ode;
 public interface FirstOrderDifferentialEquations {
 
   /**
-   * Get the dimension of the problem.
+   * Return the number of state variables that define this first-order system.
    *
-   * @return dimension of the problem
+   * <p>The dimension is typically the length of every state vector {@code Y} passed to or produced
+   * by the integrator. Implementations should return a strictly positive value and keep it
+   * constant; integrators rely on this to size their work arrays, validate inputs, and detect
+   * mismatched states early. While most models expose physical units through each component, this
+   * method only reports the aggregate size and leaves interpretation to the caller. Implementations
+   * are encouraged to document component ordering separately to aid client code.
+   *
+   * @return size of the state vector, strictly positive and stable during integrator calls
    */
-  public int getDimension();
+  int getDimension();
 
   /**
-   * Get the current time derivative of the state vector.
+   * Compute the instantaneous time derivative of the supplied state vector.
    *
-   * @param t current value of the independent <I>time</I> variable
-   * @param y array containing the current value of the state vector
-   * @param yDot placeholder array where to put the time derivative of the state vector
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The integrator provides the current time and state and expects this method to populate the
+   * {@code yDot} buffer with {@code dY/dt}. Implementations must not reallocate or resize the
+   * arrays; instead they should write results directly into {@code yDot} using the same ordering
+   * and length reported by {@link #getDimension()}. The input state {@code y} should be treated as
+   * read-only. Any persistent model parameters (e.g., masses, forces, or system matrices) should be
+   * stored in the instance and consulted here. This method may be called thousands of times per
+   * integration step, so it should avoid unnecessary object creation. When evaluation cannot
+   * proceed safely (singularity, invalid input range, or external stop request), it should raise a
+   * {@link DerivativeException}.
+   *
+   * <pre>{@code
+   * // Example: simple exponential decay dY/dt = -k * Y
+   * public void computeDerivatives(double t, double[] y, double[] yDot) {
+   *   yDot[0] = -decayConstant * y[0];
+   * }
+   * }</pre>
+   *
+   * @param t current integration time, in the units defined by the model; may be increasing or
+   *     decreasing depending on integrator direction
+   * @param y state vector at time {@code t}; length must equal {@link #getDimension()}; contents
+   *     must remain unmodified by the implementation
+   * @param yDot destination array for computed derivatives; caller preallocates; length matches
+   *     {@code y}; implementation writes each component without allocating new storage
+   * @throws DerivativeException if the derivative cannot be evaluated reliably for the supplied
+   *     state or if the model detects an unrecoverable condition
    */
-  public void computeDerivatives(double t, double[] y, double[] yDot) throws DerivativeException;
+  void computeDerivatives(double t, double[] y, double[] yDot) throws DerivativeException;
 }

--- a/src/test/java/org/spaceroots/mantissa/ode/FirstOrderConverterTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/FirstOrderConverterTest.java
@@ -1,0 +1,92 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class FirstOrderConverterTest {
+
+  @Mock private SecondOrderDifferentialEquations equations;
+
+  @Test
+  void getDimension_whenCalled_returnsDoubleOriginalDimension() {
+    // Arrange
+    when(equations.getDimension()).thenReturn(3);
+    FirstOrderConverter converter = new FirstOrderConverter(equations);
+
+    // Act
+    int actual = converter.getDimension();
+
+    // Assert
+    assertEquals(6, actual);
+    verify(equations).getDimension();
+  }
+
+  @Test
+  void computeDerivatives_whenValidState_mapsToFirstOrderForm() throws DerivativeException {
+    // Arrange
+    when(equations.getDimension()).thenReturn(2);
+    FirstOrderConverter converter = new FirstOrderConverter(equations);
+    double[] state = new double[] {1.0, -2.0, 0.5, 4.0};
+    double[] derivative = new double[4];
+    double time = 1.5;
+
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              double[] z = invocation.getArgument(1);
+              double[] zDot = invocation.getArgument(2);
+              double[] zDDot = invocation.getArgument(3);
+              assertArrayEquals(new double[] {1.0, -2.0}, z);
+              assertArrayEquals(new double[] {0.5, 4.0}, zDot);
+              zDDot[0] = z[0] + zDot[0];
+              zDDot[1] = z[1] + zDot[1];
+              return null;
+            })
+        .when(equations)
+        .computeSecondDerivatives(
+            eq(time), any(double[].class), any(double[].class), any(double[].class));
+
+    // Act
+    converter.computeDerivatives(time, state, derivative);
+
+    // Assert
+    assertArrayEquals(new double[] {0.5, 4.0, 1.5, 2.0}, derivative);
+    verify(equations)
+        .computeSecondDerivatives(
+            eq(time), any(double[].class), any(double[].class), any(double[].class));
+  }
+
+  @Test
+  void computeDerivatives_whenUnderlyingThrows_propagatesDerivativeException()
+      throws DerivativeException {
+    // Arrange
+    when(equations.getDimension()).thenReturn(1);
+    FirstOrderConverter converter = new FirstOrderConverter(equations);
+    DerivativeException failure = new DerivativeException(new IllegalStateException("boom"));
+    org.mockito.Mockito.doThrow(failure)
+        .when(equations)
+        .computeSecondDerivatives(
+            anyDouble(), any(double[].class), any(double[].class), any(double[].class));
+    double[] state = new double[] {1.0, 0.5};
+    double[] derivative = new double[2];
+
+    // Act + Assert
+    DerivativeException thrown =
+        assertThrows(
+            DerivativeException.class, () -> converter.computeDerivatives(0.0, state, derivative));
+    assertSame(failure, thrown);
+  }
+}


### PR DESCRIPTION
## Summary
- clarify the FirstOrderDifferentialEquations contract and usage guidance
- expand FirstOrderConverter Javadoc and make internal buffers/fields final
- add unit tests for FirstOrderConverter to cover dimension and derivative mapping

## Testing
- Not run (not requested)