### PR TITLE
Fix serialization warning in ContinuousOutputModel

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/ode/ContinuousOutputModel.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/ContinuousOutputModel.java
@@ -299,6 +299,7 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
   private int index;
 
   /** Steps table. */
+  @SuppressWarnings("java:S1948")
   private final List<AbstractStepInterpolator> steps;
 
   private int findIndex(double time, int iMin, int iMax, double tMin, double tMax) {


### PR DESCRIPTION
## Summary
- keep `ContinuousOutputModel` on default Java serialization format to preserve compatibility
- add `@SuppressWarnings("java:S1948")` on the `steps` list to silence false-positive non-serializable field warning

## Testing
- `./gradlew spotlessApply`