### PR TITLE
chore: suppress sonar warning in interpolator

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaStepInterpolator.java
@@ -207,5 +207,6 @@ public abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolato
    * It is provided by {@link #reinitialize(FirstOrderDifferentialEquations, double[], double[][],
    * boolean)} and is not owned by the interpolator.
    */
+  @SuppressWarnings("java:S1948")
   protected FirstOrderDifferentialEquations equations;
 }


### PR DESCRIPTION
## Summary
- suppress Sonar warning S1948 on the interpolator field in RungeKuttaStepInterpolator
- no functional changes; formatting already applied via spotless

## Testing
- not run (annotation-only change)
