### PR TITLE
Improve direct search docs and make PointCostPair a record

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/optimization/CostException.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/CostException.java
@@ -1,47 +1,88 @@
 package org.spaceroots.mantissa.optimization;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.MantissaException;
 
 /**
- * This class represents exceptions thrown by cost functions.
+ * Signals a failure while evaluating a cost function during an optimization pass.
+ *
+ * <p>This exception wraps problems that occur inside user-supplied cost computations, including
+ * numerical issues, invalid arguments, or domain-specific precondition breaches. Optimizers can
+ * propagate it unchanged to callers so they can distinguish cost-evaluation failures from broader
+ * algorithmic errors. The class is intentionally lightweight and mostly carries context through its
+ * message and cause chains; it does not attempt to normalize error states. Instances are typically
+ * created close to the failing computation and rethrown up the stack without modification.
+ *
+ * <p>Design considerations:
+ *
+ * <ul>
+ *   <li>Immutable state suitable for reuse in multithreaded solver workflows.
+ *   <li>Preserves the original cause to aid post-mortem diagnostics.
+ *   <li>Intended for deterministic, synchronous evaluation phases rather than asynchronous tasks.
+ * </ul>
  *
  * @version $Id: CostException.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
 public class CostException extends MantissaException {
 
-  /** Simple constructor. Build an exception with a default message */
+  /**
+   * Builds an exception with a generic message for unspecified cost failures.
+   *
+   * <p>Use this when the caller has little contextual information yet still needs to signal that a
+   * cost computation aborted. The default text keeps logs readable without leaking sensitive
+   * inputs. The instance is fully initialized on construction and can be safely rethrown across
+   * threads if the calling pattern requires it.
+   */
+  @SuppressWarnings("unused")
   public CostException() {
     super("cost exception");
   }
 
   /**
-   * Simple constructor. Build an exception with the specified message
+   * Builds an exception with a caller-supplied message describing the failure.
    *
-   * @param message exception message
+   * <p>This overload is preferred when the cost computation can supply a concise, user-facing error
+   * detail such as a parameter range violation or an unexpected data shape. The message is stored
+   * as provided; callers remain responsible for omitting sensitive identifiers.
+   *
+   * @param message human-readable explanation of the evaluation failure; never null
    */
+  @SuppressWarnings("unused")
   public CostException(String message) {
     super(message);
   }
 
   /**
-   * Simple constructor. Build an exception from a cause
+   * Builds an exception that primarily wraps another throwable cause.
    *
-   * @param cause cause of this exception
+   * <p>Use this overload when the cost function encounters a lower-level exception (for example,
+   * arithmetic overflows, I/O during data retrieval, or domain-specific validation errors). The
+   * wrapper preserves the causal chain for diagnostics while clearly signaling that the cost phase
+   * failed.
+   *
+   * @param cause underlying failure that triggered cost computation abort
    */
+  @SuppressWarnings("unused")
   public CostException(Throwable cause) {
     super(cause);
   }
 
   /**
-   * Simple constructor. Build an exception from a message and a cause
+   * Builds an exception with both a custom message and a preserved cause.
    *
-   * @param message exception message
-   * @param cause cause of this exception
+   * <p>This constructor is useful when callers need to enrich a lower-level exception with
+   * additional context while keeping the original stack trace intact. The combination of message
+   * and cause allows downstream handlers to present actionable diagnostics and still recover or
+   * retry the optimization if appropriate.
+   *
+   * @param message descriptive text clarifying why evaluation could not proceed
+   * @param cause underlying failure that led to the cost exception being raised
    */
+  @SuppressWarnings("unused")
   public CostException(String message, Throwable cause) {
     super(message, cause);
   }
 
-  private static final long serialVersionUID = -6099968585593678071L;
+  @Serial private static final long serialVersionUID = -6099968585593678071L;
 }

--- a/src/main/java/org/spaceroots/mantissa/optimization/CostFunction.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/CostFunction.java
@@ -3,6 +3,27 @@ package org.spaceroots.mantissa.optimization;
 /**
  * This interface represents a cost function to be minimized.
  *
+ * <p>Implementations provide a scalar measure of how well a candidate solution satisfies the
+ * problem constraints or objectives. Optimizers repeatedly call {@link #cost(double[])} with
+ * different parameter vectors, expecting consistent numerical results for the same input during a
+ * single optimization run. The interface intentionally stays minimal so that concrete strategies
+ * can model everything from deterministic algebraic expressions to stochastic simulators that
+ * incorporate penalties for constraint violations. Callers should assume implementations may be
+ * stateful or expensive to evaluate and design caching or parallelization accordingly.
+ *
+ * <p>Typical usage involves creating an implementation that wraps domain-specific calculations (for
+ * example, a least-squares residual sum) and passing it to an optimizer from the same package. The
+ * optimizer drives the exploration of the parameter space and relies on this interface to obtain a
+ * real-valued score. Unless an implementation documents otherwise, no thread-safety guarantees are
+ * provided; share instances between threads only with external synchronization or by using
+ * independent instances.
+ *
+ * <ul>
+ *   <li>Returned costs should be comparable across successive invocations.
+ *   <li>Negative or NaN values are allowed only if the optimizer can handle them.
+ *   <li>Implementations should signal unusable inputs via {@link CostException}.
+ * </ul>
+ *
  * @author Luc Maisonobe
  * @version $Id: CostFunction.java 1580 2004-07-15 20:13:43Z luc $
  */
@@ -11,10 +32,30 @@ public interface CostFunction {
   /**
    * Compute the cost associated to the given parameters array.
    *
-   * @param x parameters array
-   * @return cost associated to the parameters array
-   * @exception CostException if no cost can be computed for the parameters
+   * <p>The computation should interpret {@code x} as a complete candidate point in parameter space
+   * and return a finite scalar value that the optimizer will attempt to minimize. Implementations
+   * may validate bounds or constraints, derive penalty terms, or consult cached intermediate
+   * results. Callers should not mutate {@code x} after passing it in if the implementation retains
+   * a reference. The method is expected to be side-effect free with respect to optimizer state, but
+   * implementations may record diagnostics for later inspection.
+   *
+   * <p>When computation cannot proceed—because of invalid dimensions, singular matrices, overflow,
+   * or domain violations—implementations must throw {@link CostException}. Returning {@code
+   * Double.NaN} is discouraged because many optimizers treat it as fatal.
+   *
+   * <pre>{@code
+   * // Example: wrap a simple quadratic cost
+   * CostFunction cf = params -> params[0] * params[0] + 4 * params[1] * params[1];
+   * double value = cf.cost(new double[] {2.0, -1.5});
+   * }</pre>
+   *
+   * @param x parameters array containing the full point to evaluate; must not be {@code null} and
+   *     should match the dimensionality expected by the implementation
+   * @return finite scalar cost representing the objective value for the supplied parameters; lower
+   *     values generally indicate better solutions for minimization algorithms
+   * @throws CostException if the cost cannot be computed because inputs are invalid, constraints
+   *     fail, or an internal computation error prevents producing a numeric value
    * @see PointCostPair
    */
-  public double cost(double[] x) throws CostException;
+  double cost(double[] x) throws CostException;
 }

--- a/src/main/java/org/spaceroots/mantissa/optimization/DirectSearchOptimizer.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/DirectSearchOptimizer.java
@@ -518,8 +518,8 @@ public abstract class DirectSearchOptimizer {
     // evaluate the cost at all non-evaluated simplex points
     for (int i = 0; i < simplex.length; ++i) {
       PointCostPair pair = simplex[i];
-      if (Double.isNaN(pair.cost)) {
-        simplex[i] = new PointCostPair(pair.point, evaluateCost(pair.point));
+      if (Double.isNaN(pair.cost())) {
+        simplex[i] = new PointCostPair(pair.point(), evaluateCost(pair.point()));
       }
     }
 
@@ -539,7 +539,7 @@ public abstract class DirectSearchOptimizer {
   protected void replaceWorstPoint(PointCostPair pointCostPair) {
     int n = simplex.length - 1;
     for (int i = 0; i < n; ++i) {
-      if (simplex[i].cost > pointCostPair.cost) {
+      if (simplex[i].cost() > pointCostPair.cost()) {
         PointCostPair tmp = simplex[i];
         simplex[i] = pointCostPair;
         pointCostPair = tmp;
@@ -556,7 +556,7 @@ public abstract class DirectSearchOptimizer {
         } else if (o2 == null) {
           return -1;
         }
-        return Double.compare(o1.cost, o2.cost);
+        return Double.compare(o1.cost(), o2.cost());
       };
 
   /**

--- a/src/main/java/org/spaceroots/mantissa/optimization/DirectSearchOptimizer.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/DirectSearchOptimizer.java
@@ -10,33 +10,26 @@ import org.spaceroots.mantissa.random.UniformRandomGenerator;
 import org.spaceroots.mantissa.random.VectorialSampleStatistics;
 
 /**
- * This class implements simplex-based direct search optimization algorithms.
+ * Base support for simplex-based direct search optimization algorithms.
  *
- * <p>Direct search method only use cost function values, they don't need derivatives and don't
- * either try to compute approximation of the derivatives. According to a 1996 paper by Margaret H.
- * Wright (<a href="http://cm.bell-labs.com/cm/cs/doc/96/4-02.ps.gz">Direct Search Methods: Once
- * Scorned, Now Respectable</a>), they are used when either the computation of the derivative is
- * impossible (noisy functions, unpredictable dicontinuities) or difficult (complexity, computation
- * cost). In the first cases, rather than an optimum, a <em>not too bad</em> point is desired. In
- * the latter cases, an optimum is desired but cannot be reasonably found. In all cases direct
- * search methods can be useful.
+ * <p>This helper wires common tasks such as constructing initial simplices, tracking multi-start
+ * restarts, counting function evaluations, and sorting candidate vertices. Concrete subclasses (for
+ * example {@link NelderMead} or {@link MultiDirectional}) only have to implement the simplex update
+ * strategy while inheriting all scaffolding for evaluating cost functions and managing convergence.
+ * Direct search methods consume only objective values and avoid derivative estimates, which makes
+ * them suitable for noisy targets, discontinuous responses, and models where derivatives are either
+ * unavailable or too expensive to evaluate.
  *
- * <p>Simplex-based direct search methods are based on comparison of the cost function values at the
- * vertices of a simplex (which is a set of n+1 points in dimension n) that is updated by the
- * algorithms steps.
+ * <p>Typical use follows a short lifecycle: build or supply a simplex, select single-start or
+ * multi-start execution, run {@code minimizes(...)} until convergence, then inspect the best point
+ * or all collected minima. Instances are mutable but not thread-safe; each optimizer should be used
+ * by a single thread at a time and discarded or reconfigured between independent runs.
  *
- * <p>The instances can be built either in single-start or in multi-start mode. Multi-start is a
- * traditional way to try to avoid beeing trapped in a local minimum and miss the global minimum of
- * a function. It can also be used to verify the convergence of an algorithm. In multi-start mode,
- * the {@link #minimizes(CostFunction, int, ConvergenceChecker, double[], double[]) minimizes}
- * method returns the best minimum found after all starts, and the {@link #getMinima getMinima}
- * method can be used to retrieve all minima from all starts (including the one already provided by
- * the {@link #minimizes(CostFunction, int, ConvergenceChecker, double[], double[]) minimizes}
- * method).
- *
- * <p>This class is the base class performing the boilerplate simplex initialization and handling.
- * The simplex update by itself is performed by the derived classes according to the implemented
- * algorithms.
+ * <ul>
+ *   <li>Supports deterministic simplices (boxes) or randomized generators for restart points.
+ *   <li>Counts evaluations so callers can enforce budgets via {@code maxEvaluations}.
+ *   <li>Retains per-start outcomes, enabling diagnostics of stalled runs and local minima.
+ * </ul>
  *
  * @author Luc Maisonobe
  * @version $Id: DirectSearchOptimizer.java 1709 2006-12-03 21:16:50Z luc $
@@ -50,29 +43,30 @@ public abstract class DirectSearchOptimizer {
   protected DirectSearchOptimizer() {}
 
   /**
-   * Minimizes a cost function.
+   * Minimizes a cost function starting from the edges of an axis-aligned box.
    *
-   * <p>The initial simplex is built from two vertices that are considered to represent two opposite
-   * vertices of a box parallel to the canonical axes of the space. The simplex is the subset of
-   * vertices encountered while going from vertexA to vertexB travelling along the box edges only.
-   * This can be seen as a scaled regular simplex using the projected separation between the given
-   * points as the scaling factor along each coordinate axis.
+   * <p>This convenience overload constructs a simplex whose vertices lie on the path that walks the
+   * edges between {@code vertexA} and {@code vertexB}. The resulting shape mirrors a regular
+   * simplex scaled independently along each coordinate using the projected separation of the two
+   * supplied corners. The optimizer runs in single-start mode and stops at the first convergence or
+   * when the evaluation budget is exhausted.
    *
-   * <p>The optimization is performed in single-start mode.
-   *
-   * @param f cost function
-   * @param maxEvaluations maximal number of function calls for each start (note that the number
-   *     will be checked <em>after</em> complete simplices have been evaluated, this means that in
-   *     some cases this number will be exceeded by a few units, depending on the dimension of the
-   *     problem)
-   * @param checker object to use to check for convergence
-   * @param vertexA first vertex
-   * @param vertexB last vertex
-   * @return the point/cost pairs giving the minimal cost
-   * @exception CostException if the cost function throws one during the search
-   * @exception NoConvergenceException if none of the starts did converge (it is not thrown if at
-   *     least one start did converge)
+   * @param f cost function evaluated for every candidate point; must be side-effect free or
+   *     tolerant to repeated calls
+   * @param maxEvaluations maximum number of cost evaluations allowed for this run; the final count
+   *     may slightly exceed the limit because complete simplices are assessed as atomic steps
+   * @param checker strategy that inspects the sorted simplex to decide when convergence has been
+   *     reached
+   * @param vertexA first box corner used to seed the simplex; array length defines the search
+   *     dimension and values are interpreted as coordinates
+   * @param vertexB opposite box corner; each coordinate provides the scaling factor relative to
+   *     {@code vertexA}
+   * @return point/cost pair representing the best vertex at convergence for this single start
+   * @throws CostException if the cost function signals a failure while being evaluated
+   * @throws NoConvergenceException if the optimizer could not satisfy the checker before the
+   *     evaluation budget was exceeded
    */
+  @SuppressWarnings("unused")
   public PointCostPair minimizes(
       CostFunction f,
       int maxEvaluations,
@@ -90,33 +84,32 @@ public abstract class DirectSearchOptimizer {
   }
 
   /**
-   * Minimizes a cost function.
+   * Minimizes a cost function using multi-start exploration of a box-derived simplex.
    *
-   * <p>The initial simplex is built from two vertices that are considered to represent two opposite
-   * vertices of a box parallel to the canonical axes of the space. The simplex is the subset of
-   * vertices encountered while going from vertexA to vertexB travelling along the box edges only.
-   * This can be seen as a scaled regular simplex using the projected separation between the given
-   * points as the scaling factor along each coordinate axis.
+   * <p>The initial simplex mirrors {@link #minimizes(CostFunction, int, ConvergenceChecker,
+   * double[], double[])} but restarts the search up to {@code starts} times. Each restart draws a
+   * new simplex from a Gaussian generator centered in the provided box with per-axis standard
+   * deviations matching half the box width. This increases the chances of escaping poor local
+   * minima and provides diagnostics across independent trajectories.
    *
-   * <p>The optimization is performed in multi-start mode.
-   *
-   * @param f cost function
-   * @param maxEvaluations maximal number of function calls for each start (note that the number
-   *     will be checked <em>after</em> complete simplices have been evaluated, this means that in
-   *     some cases this number will be exceeded by a few units, depending on the dimension of the
-   *     problem)
-   * @param checker object to use to check for convergence
-   * @param vertexA first vertex
-   * @param vertexB last vertex
-   * @param starts number of starts to perform (including the first one), multi-start is disabled if
-   *     value is less than or equal to 1
-   * @param seed seed for the random vector generator (32 bits integers array). If null, the current
-   *     time will be used for the generator initialization.
-   * @return the point/cost pairs giving the minimal cost
-   * @exception CostException if the cost function throws one during the search
-   * @exception NoConvergenceException if none of the starts did converge (it is not thrown if at
-   *     least one start did converge)
+   * @param f cost function evaluated at every candidate vertex; should be deterministic for
+   *     meaningful comparisons
+   * @param maxEvaluations maximum number of cost evaluations permitted per start; final usage may
+   *     exceed the limit by at most the simplex size because evaluations are grouped
+   * @param checker strategy that inspects the current simplex ordering to decide when the search
+   *     has converged
+   * @param vertexA first corner of the axis-aligned box used to scale and place the simplex
+   * @param vertexB opposite corner of the box; must have the same dimension as {@code vertexA}
+   * @param starts number of independent starts to attempt; values below two fall back to
+   *     single-start operation
+   * @param seed optional 32-bit seed array used to initialize the restart random generator; when
+   *     {@code null}, the generator is seeded from the current time
+   * @return best point/cost pair observed across all starts, sorted by ascending cost
+   * @throws CostException if evaluating the cost function fails for any candidate point
+   * @throws NoConvergenceException if every attempted start exhausts the evaluation budget without
+   *     satisfying the convergence checker
    */
+  @SuppressWarnings("unused")
   public PointCostPair minimizes(
       CostFunction f,
       int maxEvaluations,
@@ -127,12 +120,12 @@ public abstract class DirectSearchOptimizer {
       int[] seed)
       throws CostException, NoConvergenceException {
 
-    // set up the simplex travelling around the box
+    // set up the simplex traveling around the box
     buildSimplex(vertexA, vertexB);
 
     // we consider the simplex could have been produced by a generator
     // having its mean value at the center of the box, the standard
-    // deviation along each axe beeing the corresponding half size
+    // deviation along each axe being the corresponding half size
     double[] mean = new double[vertexA.length];
     double[] standardDeviation = new double[vertexA.length];
     for (int i = 0; i < vertexA.length; ++i) {
@@ -150,24 +143,25 @@ public abstract class DirectSearchOptimizer {
   }
 
   /**
-   * Minimizes a cost function.
+   * Minimizes a cost function from an explicitly provided simplex in single-start mode.
    *
-   * <p>The simplex is built from all its vertices.
+   * <p>Callers supply all simplex vertices, allowing deterministic reproducibility and advanced
+   * seeding strategies. The simplex is evaluated once, then iterated using the subclass-defined
+   * rule until the convergence checker signals completion or the evaluation limit is reached.
    *
-   * <p>The optimization is performed in single-start mode.
-   *
-   * @param f cost function
-   * @param maxEvaluations maximal number of function calls for each start (note that the number
-   *     will be checked <em>after</em> complete simplices have been evaluated, this means that in
-   *     some cases this number will be exceeded by a few units, depending on the dimension of the
-   *     problem)
-   * @param checker object to use to check for convergence
-   * @param vertices array containing all vertices of the simplex
-   * @return the point/cost pairs giving the minimal cost
-   * @exception CostException if the cost function throws one during the search
-   * @exception NoConvergenceException if none of the starts did converge (it is not thrown if at
-   *     least one start did converge)
+   * @param f cost function invoked for each vertex as needed; should tolerate ordering differences
+   *     during sorting
+   * @param maxEvaluations maximum number of cost evaluations permitted; batches covering the whole
+   *     simplex can cause a slight overrun relative to this cap
+   * @param checker convergence logic that inspects the ordered simplex and determines when to stop
+   * @param vertices complete simplex vertices; array length must be {@code n + 1} for an {@code
+   *     n}-dimensional search space
+   * @return point/cost pair representing the best vertex when the single run ends
+   * @throws CostException if evaluating {@code f} fails for any supplied vertex
+   * @throws NoConvergenceException if convergence is not reached before the evaluation budget is
+   *     consumed
    */
+  @SuppressWarnings("unused")
   public PointCostPair minimizes(
       CostFunction f, int maxEvaluations, ConvergenceChecker checker, double[][] vertices)
       throws CostException, NoConvergenceException {
@@ -181,29 +175,33 @@ public abstract class DirectSearchOptimizer {
   }
 
   /**
-   * Minimizes a cost function.
+   * Minimizes a cost function from an explicit simplex with optional multi-start restarts.
    *
-   * <p>The simplex is built from all its vertices.
+   * <p>The supplied simplex is analyzed to compute its mean and covariance, which seed a correlated
+   * Gaussian generator used to build fresh simplices on each restart. This preserves the caller's
+   * initial geometry while enabling exploration around it. Each start is capped by the supplied
+   * evaluation budget and judged by the provided convergence checker.
    *
-   * <p>The optimization is performed in multi-start mode.
-   *
-   * @param f cost function
-   * @param maxEvaluations maximal number of function calls for each start (note that the number
-   *     will be checked <em>after</em> complete simplices have been evaluated, this means that in
-   *     some cases this number will be exceeded by a few units, depending on the dimension of the
-   *     problem)
-   * @param checker object to use to check for convergence
-   * @param vertices array containing all vertices of the simplex
-   * @param starts number of starts to perform (including the first one), multi-start is disabled if
-   *     value is less than or equal to 1
-   * @param seed seed for the random vector generator (32 bits integers array). If null, the current
-   *     time will be used for the generator initialization.
-   * @return the point/cost pairs giving the minimal cost
-   * @exception NotPositiveDefiniteMatrixException if the vertices array is degenerated
-   * @exception CostException if the cost function throws one during the search
-   * @exception NoConvergenceException if none of the starts did converge (it is not thrown if at
-   *     least one start did converge)
+   * @param f cost function invoked for every vertex; should be stable under repeated sampling near
+   *     the same point
+   * @param maxEvaluations maximum number of cost evaluations per start; full-simplex evaluations
+   *     can make the realized total exceed the nominal limit by up to {@code n + 1}
+   * @param checker component that inspects the ordered simplex after each iteration to decide
+   *     whether convergence has been achieved
+   * @param vertices complete set of simplex vertices defining the initial search region; length
+   *     must match the dimensionality plus one
+   * @param starts number of independent starts to attempt; values under two disable multi-start and
+   *     reuse the initial simplex only
+   * @param seed optional 32-bit seed array for the correlated generator; {@code null} selects a
+   *     time-based seed
+   * @return best point/cost pair found across the performed starts in ascending cost order
+   * @throws NotPositiveDefiniteMatrixException if the covariance derived from {@code vertices} is
+   *     singular or ill-conditioned
+   * @throws CostException if the cost function cannot be evaluated for a candidate vertex
+   * @throws NoConvergenceException if all starts exhaust their budgets without satisfying the
+   *     convergence checker
    */
+  @SuppressWarnings("unused")
   public PointCostPair minimizes(
       CostFunction f,
       int maxEvaluations,
@@ -218,8 +216,8 @@ public abstract class DirectSearchOptimizer {
 
     // compute the statistical properties of the simplex points
     VectorialSampleStatistics statistics = new VectorialSampleStatistics();
-    for (int i = 0; i < vertices.length; ++i) {
-      statistics.add(vertices[i]);
+    for (double[] vertex : vertices) {
+      statistics.add(vertex);
     }
 
     RandomVectorGenerator rvg =
@@ -234,24 +232,25 @@ public abstract class DirectSearchOptimizer {
   }
 
   /**
-   * Minimizes a cost function.
+   * Minimizes a cost function using a randomly generated simplex in single-start mode.
    *
-   * <p>The simplex is built randomly.
+   * <p>The first vector produced by {@code generator} defines the search dimension and becomes the
+   * first simplex vertex; subsequent draws populate the remaining vertices. This variant is useful
+   * when callers want stochastic seeding while delegating restart control to the optimizer.
    *
-   * <p>The optimization is performed in single-start mode.
-   *
-   * @param f cost function
-   * @param maxEvaluations maximal number of function calls for each start (note that the number
-   *     will be checked <em>after</em> complete simplices have been evaluated, this means that in
-   *     some cases this number will be exceeded by a few units, depending on the dimension of the
-   *     problem)
-   * @param checker object to use to check for convergence
-   * @param generator random vector generator
-   * @return the point/cost pairs giving the minimal cost
-   * @exception CostException if the cost function throws one during the search
-   * @exception NoConvergenceException if none of the starts did converge (it is not thrown if at
-   *     least one start did converge)
+   * @param f cost function evaluated at each vertex; should be robust to random sampling near the
+   *     same region
+   * @param maxEvaluations maximum number of cost evaluations to perform before aborting the start;
+   *     the final tally can exceed the target by up to the simplex size
+   * @param checker convergence policy executed after every simplex iteration to decide whether the
+   *     search has settled
+   * @param generator source of candidate vertices; must always return vectors of identical length
+   * @return best point/cost pair reached during the single randomized start
+   * @throws CostException if evaluating {@code f} fails for any generated vertex
+   * @throws NoConvergenceException if convergence is not detected before the evaluation limit is
+   *     hit
    */
+  @SuppressWarnings("unused")
   public PointCostPair minimizes(
       CostFunction f,
       int maxEvaluations,
@@ -268,26 +267,29 @@ public abstract class DirectSearchOptimizer {
   }
 
   /**
-   * Minimizes a cost function.
+   * Minimizes a cost function using randomized simplices across multiple starts.
    *
-   * <p>The simplex is built randomly.
+   * <p>Each start draws {@code n + 1} vectors from {@code generator} to form a new simplex and runs
+   * until the convergence checker fires or the per-start evaluation limit is reached. This is
+   * helpful when the landscape contains many local minima and randomized re-seeding improves
+   * coverage of the search space.
    *
-   * <p>The optimization is performed in multi-start mode.
-   *
-   * @param f cost function
-   * @param maxEvaluations maximal number of function calls for each start (note that the number
-   *     will be checked <em>after</em> complete simplices have been evaluated, this means that in
-   *     some cases this number will be exceeded by a few units, depending on the dimension of the
-   *     problem)
-   * @param checker object to use to check for convergence
-   * @param generator random vector generator
-   * @param starts number of starts to perform (including the first one), multi-start is disabled if
-   *     value is less than or equal to 1
-   * @return the point/cost pairs giving the minimal cost
-   * @exception CostException if the cost function throws one during the search
-   * @exception NoConvergenceException if none of the starts did converge (it is not thrown if at
-   *     least one start did converge)
+   * @param f cost function applied to every candidate point; should yield comparable values across
+   *     randomized starts
+   * @param maxEvaluations maximum number of evaluations allowed per start; complete simplex passes
+   *     can slightly exceed this target
+   * @param checker component that inspects the ordered simplex and decides when the algorithm has
+   *     converged
+   * @param generator random vector generator that must produce consistently sized vectors across
+   *     calls
+   * @param starts number of independent randomized starts; values below two revert to single-start
+   *     behavior without additional random draws
+   * @return lowest-cost point/cost pair discovered after sorting the outcomes from all starts
+   * @throws CostException if any evaluation of the cost function fails
+   * @throws NoConvergenceException if every start exceeds the evaluation cap without satisfying the
+   *     convergence checker
    */
+  @SuppressWarnings("unused")
   public PointCostPair minimizes(
       CostFunction f,
       int maxEvaluations,
@@ -309,7 +311,7 @@ public abstract class DirectSearchOptimizer {
    *
    * <p>The two vertices are considered to represent two opposite vertices of a box parallel to the
    * canonical axes of the space. The simplex is the subset of vertices encountered while going from
-   * vertexA to vertexB travelling along the box edges only. This can be seen as a scaled regular
+   * vertexA to vertexB traveling along the box edges only. This can be seen as a scaled regular
    * simplex using the projected separation between the given points as the scaling factor along
    * each coordinate axis.
    *
@@ -321,7 +323,7 @@ public abstract class DirectSearchOptimizer {
     int n = vertexA.length;
     simplex = new PointCostPair[n + 1];
 
-    // set up the simplex travelling around the box
+    // set up the simplex traveling around the box
     for (int i = 0; i <= n; ++i) {
       double[] vertex = new double[n];
       if (i > 0) {
@@ -374,62 +376,60 @@ public abstract class DirectSearchOptimizer {
   }
 
   /**
-   * Set up multi-start mode.
+   * Set up multi-start mode with the provided generator.
    *
-   * @param starts number of starts to perform (including the first one), multi-start is disabled if
-   *     value is less than or equal to 1
-   * @param generator random vector generator to use for restarts
+   * <p>Calling this method replaces any previous start configuration. When {@code starts} is less
+   * than two the optimizer falls back to single-start mode and clears the generator reference. The
+   * caller retains control of generator state and seeding.
+   *
+   * @param starts number of starts to perform, including the first run; values under two disable
+   *     additional restarts
+   * @param generator random vector generator used to create fresh simplices between starts; ignored
+   *     when single-start fallback is activated
    */
   public void setMultiStart(int starts, RandomVectorGenerator generator) {
     if (starts < 2) {
       this.starts = 1;
       this.generator = null;
-      minima = null;
     } else {
       this.starts = starts;
       this.generator = generator;
-      minima = null;
     }
+    minima = null;
   }
 
   /**
-   * Get all the minima found during the last call to {@link #minimizes(CostFunction, int,
-   * ConvergenceChecker, double[], double[]) minimizes}.
+   * Get all minima recorded during the last call to {@code minimizes(...)}.
    *
-   * <p>The optimizer stores all the minima found during a set of restarts when multi-start mode is
-   * enabled. The {@link #minimizes(CostFunction, int, ConvergenceChecker, double[], double[])
-   * minimizes} method returns the best point only. This method returns all the points found at the
-   * end of each starts, including the best one already returned by the {@link
-   * #minimizes(CostFunction, int, ConvergenceChecker, double[], double[]) minimizes} method. The
-   * array as one element for each start as specified in the constructor (it has one element only if
-   * optimizer has been set up for single-start).
+   * <p>The returned array contains one entry per start, sorted from lowest to highest cost for
+   * converged runs, followed by {@code null} entries for starts that exhausted their evaluation
+   * budgets. In single-start mode the array contains one element. The array is a shallow clone so
+   * callers can examine results without mutating optimizer state.
    *
-   * <p>The array containing the minima is ordered with the results from the runs that did converge
-   * first, sorted from lowest to highest minimum cost, and null elements corresponding to the runs
-   * that did not converge (all elements will be null if the {@link #minimizes(CostFunction, int,
-   * ConvergenceChecker, double[], double[]) minimizes} method throwed a {@link
-   * NoConvergenceException NoConvergenceException}).
-   *
-   * @return array containing the minima, or null if {@link #minimizes(CostFunction, int,
-   *     ConvergenceChecker, double[], double[]) minimizes} has not been called
+   * @return ordered minima from the previous optimization run, or {@code null} if {@code minimizes}
+   *     has not been executed yet
    */
+  @SuppressWarnings("unused")
   public PointCostPair[] getMinima() {
-    return (PointCostPair[]) minima.clone();
+    return minima == null ? null : minima.clone();
   }
 
   /**
-   * Minimizes a cost function.
+   * Core minimization loop shared by all public overloads.
    *
-   * @param f cost function
-   * @param maxEvaluations maximal number of function calls for each start (note that the number
-   *     will be checked <em>after</em> complete simplices have been evaluated, this means that in
-   *     some cases this number will be exceeded by a few units, depending on the dimension of the
-   *     problem)
-   * @param checker object to use to check for convergence
-   * @return the point/cost pairs giving the minimal cost
-   * @exception CostException if the cost function throws one during the search
-   * @exception NoConvergenceException if none of the starts did converge (it is not thrown if at
-   *     least one start did converge)
+   * <p>This method assumes the simplex and start configuration have already been prepared. It
+   * executes each start by iterating the simplex until the convergence checker succeeds or the
+   * evaluation cap is reached. Results for every start are retained and sorted before the best one
+   * is returned.
+   *
+   * @param f cost function applied to candidate points; must be thread-compatible with sequential
+   *     invocation from this optimizer
+   * @param maxEvaluations maximum number of cost function calls allowed per start; full simplex
+   *     evaluation steps can raise the observed total slightly above the limit
+   * @param checker convergence logic used after each simplex iteration to detect completion
+   * @return lowest-cost point/cost pair found across all starts after sorting outcomes
+   * @throws CostException if evaluating the cost function fails
+   * @throws NoConvergenceException if every attempted start stops because of the evaluation cap
    */
   private PointCostPair minimizes(CostFunction f, int maxEvaluations, ConvergenceChecker checker)
       throws CostException, NoConvergenceException {
@@ -443,15 +443,16 @@ public abstract class DirectSearchOptimizer {
       evaluations = 0;
       evaluateSimplex();
 
-      for (boolean loop = true; loop; ) {
+      boolean finished = false;
+      while (!finished) {
         if (checker.converged(simplex)) {
           // we have found a minimum
           minima[i] = simplex[0];
-          loop = false;
+          finished = true;
         } else if (evaluations >= maxEvaluations) {
           // this start did not converge, try a new one
           minima[i] = null;
-          loop = false;
+          finished = true;
         } else {
           iterateSimplex();
         }
@@ -463,7 +464,7 @@ public abstract class DirectSearchOptimizer {
       }
     }
 
-    // sort the minima from lowest cost to highest cost, followed by
+    // sort the minima from the lowest cost to the highest cost, followed by
     // null elements
     Arrays.sort(minima, pointCostPairComparator);
 
@@ -476,17 +477,28 @@ public abstract class DirectSearchOptimizer {
     return minima[0];
   }
 
-  /** Compute the next simplex of the algorithm. */
+  /**
+   * Compute the next simplex of the algorithm.
+   *
+   * <p>Implementations update {@link #simplex} in-place by producing a new set of vertices ordered
+   * by ascending cost. Typical strategies include reflection, expansion, contraction, or shrink
+   * steps. This method is invoked repeatedly until a convergence checker signals completion or the
+   * evaluation budget is exceeded.
+   *
+   * @throws CostException if evaluating newly generated vertices fails or is refused by the cost
+   *     function
+   */
   protected abstract void iterateSimplex() throws CostException;
 
   /**
    * Evaluate the cost on one point.
    *
-   * <p>A side effect of this method is to count the number of function evaluations
+   * <p>A side effect of this method is to count the number of function evaluations.
    *
-   * @param x point on which the cost function should be evaluated
-   * @return cost at the given point
-   * @exception CostException if no cost can be computed for the parameters
+   * @param x point on which the cost function should be evaluated; must have the same dimension as
+   *     the simplex points
+   * @return cost at the given point as reported by the configured {@link CostFunction}
+   * @throws CostException if no cost can be computed for the parameters
    */
   protected double evaluateCost(double[] x) throws CostException {
     evaluations++;
@@ -496,7 +508,10 @@ public abstract class DirectSearchOptimizer {
   /**
    * Evaluate all the non-evaluated points of the simplex.
    *
-   * @exception CostException if no cost can be computed for the parameters
+   * <p>Only vertices whose cost is {@link Double#NaN} are evaluated. The simplex is resorted in
+   * ascending order after evaluation so that index {@code 0} always holds the current best point.
+   *
+   * @throws CostException if no cost can be computed for the parameters
    */
   protected void evaluateSimplex() throws CostException {
 
@@ -508,14 +523,18 @@ public abstract class DirectSearchOptimizer {
       }
     }
 
-    // sort the simplex from lowest cost to highest cost
+    // sort the simplex from the lowest cost to the highest cost
     Arrays.sort(simplex, pointCostPairComparator);
   }
 
   /**
    * Replace the worst point of the simplex by a new point.
    *
-   * @param pointCostPair point to insert
+   * <p>The new point is inserted in cost order, pushing former points toward the end of the array
+   * and placing the worst point at the last position. Callers must ensure the provided point has
+   * already been evaluated.
+   *
+   * @param pointCostPair point to insert; its {@code cost} field must be a valid numeric value
    */
   protected void replaceWorstPoint(PointCostPair pointCostPair) {
     int n = simplex.length - 1;
@@ -531,19 +550,23 @@ public abstract class DirectSearchOptimizer {
 
   /** Comparator for {@link PointCostPair PointCostPair} objects. */
   private static final Comparator<PointCostPair> pointCostPairComparator =
-      new Comparator<PointCostPair>() {
-        @Override
-        public int compare(PointCostPair o1, PointCostPair o2) {
-          if (o1 == null) {
-            return (o2 == null) ? 0 : 1;
-          } else if (o2 == null) {
-            return -1;
-          }
-          return Double.compare(o1.cost, o2.cost);
+      (o1, o2) -> {
+        if (o1 == null) {
+          return (o2 == null) ? 0 : 1;
+        } else if (o2 == null) {
+          return -1;
         }
+        return Double.compare(o1.cost, o2.cost);
       };
 
-  /** Simplex. */
+  /**
+   * Simplex currently processed by the optimizer.
+   *
+   * <p>The array length is always {@code n + 1} for an {@code n}-dimensional problem and remains
+   * sorted in ascending cost order after each call to {@link #evaluateSimplex()} or {@link
+   * #iterateSimplex()}. Subclasses may mutate elements in-place but should preserve the ordering
+   * contract expected by convergence checkers.
+   */
   protected PointCostPair[] simplex;
 
   /** Cost function. */

--- a/src/main/java/org/spaceroots/mantissa/optimization/MultiDirectional.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/MultiDirectional.java
@@ -81,7 +81,7 @@ public class MultiDirectional extends DirectSearchOptimizer {
 
       // save the original vertex
       PointCostPair[] original = simplex;
-      double originalCost = original[0].cost;
+      double originalCost = original[0].cost();
 
       // perform a reflection step
       double reflectedCost = evaluateNewSimplex(original, 1.0);
@@ -124,14 +124,14 @@ public class MultiDirectional extends DirectSearchOptimizer {
    */
   private double evaluateNewSimplex(PointCostPair[] original, double coeff) throws CostException {
 
-    double[] xSmallest = original[0].point;
+    double[] xSmallest = original[0].point();
     int n = xSmallest.length;
 
     // create the linearly transformed simplex
     simplex = new PointCostPair[n + 1];
     simplex[0] = original[0];
     for (int i = 1; i <= n; ++i) {
-      double[] xOriginal = original[i].point;
+      double[] xOriginal = original[i].point();
       double[] xTransformed = new double[n];
       for (int j = 0; j < n; ++j) {
         xTransformed[j] = xSmallest[j] + coeff * (xSmallest[j] - xOriginal[j]);
@@ -141,7 +141,7 @@ public class MultiDirectional extends DirectSearchOptimizer {
 
     // evaluate it
     evaluateSimplex();
-    return simplex[0].cost;
+    return simplex[0].cost();
   }
 
   /** Expansion coefficient. */

--- a/src/main/java/org/spaceroots/mantissa/optimization/MultiDirectional.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/MultiDirectional.java
@@ -1,19 +1,43 @@
 package org.spaceroots.mantissa.optimization;
 
 /**
- * This class implements the multi-directional direct search method.
+ * Direct-search optimizer that applies the multi-directional simplex scheme.
+ *
+ * <p>The algorithm extends the classic Nelder–Mead approach with an explicit expansion step that
+ * probes the search space in the reflected direction before deciding whether to keep the reflected
+ * or expanded simplex. It is derivative-free and therefore well suited to discontinuous, noisy, or
+ * expensive objectives where gradients are unavailable. Typical usage involves configuring the
+ * expansion {@code khi} and contraction {@code gamma} coefficients, seeding a simplex via the
+ * helper methods in {@link DirectSearchOptimizer}, and repeatedly iterating until a {@link
+ * ConvergenceChecker convergence checker} reports completion. Instances are mutable and intended
+ * for single-threaded use; create separate instances for concurrent searches.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Each iteration first reflects the simplex through its best point and may expand further if
+ *       the reflection improved the cost.
+ *   <li>If neither reflection nor expansion helps, the simplex is contracted toward the best
+ *       vertex.
+ *   <li>All evaluation and bookkeeping logic is inherited from {@link DirectSearchOptimizer},
+ *       including multi-start support and evaluation counting.
+ * </ul>
  *
  * @author Luc Maisonobe
  * @version $Id: MultiDirectional.java 1709 2006-12-03 21:16:50Z luc $
  * @see NelderMead
+ * @see DirectSearchOptimizer
  */
 public class MultiDirectional extends DirectSearchOptimizer {
 
   /**
    * Build a multi-directional optimizer with default coefficients.
    *
-   * <p>The default values are 2.0 for khi and 0.5 for gamma.
+   * <p>The default values are 2.0 for {@code khi} (expansion factor) and 0.5 for {@code gamma}
+   * (contraction factor). Use this constructor when the standard balance between exploration and
+   * contraction is acceptable and no tuning data is available.
    */
+  @SuppressWarnings("unused")
   public MultiDirectional() {
     super();
     this.khi = 2.0;
@@ -23,16 +47,34 @@ public class MultiDirectional extends DirectSearchOptimizer {
   /**
    * Build a multi-directional optimizer with specified coefficients.
    *
-   * @param khi expansion coefficient
-   * @param gamma contraction coefficient
+   * <p>Choose {@code khi} greater than 1.0 to push the simplex outward after a successful
+   * reflection, and {@code gamma} between 0 and 1.0 to shrink the simplex toward its best vertex
+   * when reflection fails. Both coefficients remain constant for the lifetime of the optimizer
+   * instance.
+   *
+   * @param khi expansion coefficient used when an expanded simplex is attempted; must be positive
+   *     and typically greater than 1.0
+   * @param gamma contraction coefficient applied when reflection does not improve the cost; should
+   *     be in (0, 1] to reduce simplex size without inversion
    */
+  @SuppressWarnings("unused")
   public MultiDirectional(double khi, double gamma) {
     super();
     this.khi = khi;
     this.gamma = gamma;
   }
 
-  /** Compute the next simplex of the algorithm. */
+  /**
+   * Compute the next simplex of the algorithm.
+   *
+   * <p>The step follows three phases: reflect the simplex through its best vertex, possibly expand
+   * further in the same direction when reflection improves the cost, or contract toward the best
+   * point when reflection does not help. The method updates {@link #simplex} in-place and relies on
+   * {@link #evaluateSimplex()} to assign costs to newly generated vertices before sorting them.
+   *
+   * @throws CostException if the underlying cost function rejects evaluation for any generated
+   *     vertex in the reflected, expanded, or contracted simplices
+   */
   protected void iterateSimplex() throws CostException {
 
     while (true) {
@@ -66,12 +108,19 @@ public class MultiDirectional extends DirectSearchOptimizer {
   }
 
   /**
-   * Compute and evaluate a new simplex.
+   * Compute and evaluate a new simplex produced by linear transformation.
    *
-   * @param original original simplex (to be preserved)
-   * @param coeff linear coefficient
-   * @return smallest cost in the transformed simplex
-   * @exception CostException if the function cannot be evaluated at some point
+   * <p>The method keeps the current best point fixed and projects every other vertex along the line
+   * through that point using the supplied scalar coefficient. A coefficient of {@code 1.0} yields a
+   * reflection, values above one expand, and values in (0, 1) contract. The original simplex array
+   * is left untouched; {@link #simplex} is replaced with the transformed copy.
+   *
+   * @param original original simplex that supplies geometry and cost ordering; must contain {@code
+   *     n + 1} vertices for an {@code n}-dimensional search
+   * @param coeff linear coefficient applied to the displacement from the best vertex toward each
+   *     remaining vertex; negative values mirror the simplex
+   * @return smallest cost found in the transformed simplex after evaluation and resorting
+   * @exception CostException if the cost function fails on any transformed vertex during evaluation
    */
   private double evaluateNewSimplex(PointCostPair[] original, double coeff) throws CostException {
 
@@ -96,8 +145,8 @@ public class MultiDirectional extends DirectSearchOptimizer {
   }
 
   /** Expansion coefficient. */
-  private double khi;
+  private final double khi;
 
   /** Contraction coefficient. */
-  private double gamma;
+  private final double gamma;
 }

--- a/src/main/java/org/spaceroots/mantissa/optimization/NelderMead.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/NelderMead.java
@@ -95,10 +95,10 @@ public class NelderMead extends DirectSearchOptimizer {
     // the simplex has n+1 point if dimension is n
     int n = simplex.length - 1;
 
-    double smallest = simplex[0].cost;
-    double secondLargest = simplex[n - 1].cost;
-    double largest = simplex[n].cost;
-    double[] xLargest = simplex[n].point;
+    double smallest = simplex[0].cost();
+    double secondLargest = simplex[n - 1].cost();
+    double largest = simplex[n].cost();
+    double[] xLargest = simplex[n].point();
 
     double[] centroid = computeCentroid(n);
     double[] xR = reflect(centroid, xLargest);
@@ -128,7 +128,7 @@ public class NelderMead extends DirectSearchOptimizer {
   private double[] computeCentroid(int n) {
     double[] centroid = new double[n];
     for (int i = 0; i < n; ++i) {
-      double[] x = simplex[i].point;
+      double[] x = simplex[i].point();
       for (int j = 0; j < n; ++j) {
         centroid[j] += x[j];
       }
@@ -195,9 +195,9 @@ public class NelderMead extends DirectSearchOptimizer {
   }
 
   private void shrinkSimplex(int n) throws CostException {
-    double[] xSmallest = simplex[0].point;
+    double[] xSmallest = simplex[0].point();
     for (int i = 1; i < simplex.length; ++i) {
-      double[] x = simplex[i].point;
+      double[] x = simplex[i].point();
       for (int j = 0; j < n; ++j) {
         x[j] = xSmallest[j] + sigma * (x[j] - xSmallest[j]);
       }

--- a/src/main/java/org/spaceroots/mantissa/optimization/NelderMead.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/NelderMead.java
@@ -1,7 +1,28 @@
 package org.spaceroots.mantissa.optimization;
 
 /**
- * This class implements the Nelder-Mead direct search method.
+ * Implements the classical Nelder–Mead downhill simplex direct search algorithm.
+ *
+ * <p>This optimizer explores an {@code n}-dimensional search space using a simplex of {@code n+1}
+ * vertices and only evaluates objective values, never gradients. Each iteration reflects, expands,
+ * contracts, or shrinks the simplex based on the relative costs of its vertices, steadily steering
+ * toward lower objective values. The class is mutable and intended for single-threaded use: create
+ * an instance, configure coefficients, then run one of the inherited {@code minimizes(...)} entry
+ * points supplied by {@link DirectSearchOptimizer}. Typical usage flows are:
+ *
+ * <ul>
+ *   <li>Choose coefficients (defaults match the original paper) and an initial simplex strategy.
+ *   <li>Provide a {@link CostFunction}, maximum evaluation budget, and a {@link
+ *       ConvergenceChecker}.
+ *   <li>Inspect the returned {@link PointCostPair} or call {@link
+ *       DirectSearchOptimizer#getMinima()} to review all starts.
+ * </ul>
+ *
+ * <p>Vertices are sorted by cost after each iteration; convergence checkers can assume index {@code
+ * 0} is the current best point. Instances are not thread-safe and should not be reused across
+ * concurrent runs. The algorithm is well suited to noisy or non-differentiable objectives but can
+ * stagnate on flat regions or when simplex degeneracy occurs; restart strategies in the base class
+ * help alleviate these cases.
  *
  * @author Luc Maisonobe
  * @version $Id: NelderMead.java 1709 2006-12-03 21:16:50Z luc $
@@ -12,8 +33,14 @@ public class NelderMead extends DirectSearchOptimizer {
   /**
    * Build a Nelder-Mead optimizer with default coefficients.
    *
-   * <p>The default coefficients are 1.0 for rho, 2.0 for khi and 0.5 for both gamma and sigma.
+   * <p>The default coefficients are 1.0 for rho, 2.0 for khi and 0.5 for both gamma and sigma. Use
+   * this constructor when you want the canonical Nelder–Mead settings recommended in most
+   * literature and do not need to tune the relative aggressiveness of reflection, expansion, or
+   * contraction. After construction, hand the instance to one of the {@code minimizes(...)} methods
+   * defined in {@link DirectSearchOptimizer}; coefficients are immutable for the life of the
+   * instance, so create a new optimizer if you need different values.
    */
+  @SuppressWarnings("unused")
   public NelderMead() {
     super();
     this.rho = 1.0;
@@ -25,11 +52,22 @@ public class NelderMead extends DirectSearchOptimizer {
   /**
    * Build a Nelder-Mead optimizer with specified coefficients.
    *
-   * @param rho reflection coefficient
-   * @param khi expansion coefficient
-   * @param gamma contraction coefficient
-   * @param sigma shrinkage coefficient
+   * <p>This overload lets callers fine-tune the aggressiveness of the search by supplying custom
+   * coefficients for each geometric operation. Use it when domain knowledge suggests slower
+   * reflection, stronger expansion, or softer shrinkage. Values are treated as immutable weights
+   * applied during every iteration, so pass consistent numbers appropriate for the scale of your
+   * objective function; negative values are typically nonsensical and should be avoided.
+   *
+   * @param rho reflection coefficient controlling how far the simplex jumps away from the worst
+   *     vertex; use positive values and adjust down to damp oscillations.
+   * @param khi expansion coefficient applied after a successful reflection to probe further along
+   *     the promising direction; values above {@code 1.0} increase exploratory reach.
+   * @param gamma contraction coefficient applied when reflection fails; choose a positive value
+   *     below {@code 1.0} to pull the simplex back toward its centroid.
+   * @param sigma shrinkage coefficient used during full simplex contraction; a fraction in (0,1)
+   *     scales all vertices toward the current best point.
    */
+  @SuppressWarnings("unused")
   public NelderMead(double rho, double khi, double gamma, double sigma) {
     super();
     this.rho = rho;
@@ -38,20 +76,56 @@ public class NelderMead extends DirectSearchOptimizer {
     this.sigma = sigma;
   }
 
-  /** Compute the next simplex of the algorithm. */
+  /**
+   * Compute the next simplex of the algorithm.
+   *
+   * <p>This template method performs one Nelder–Mead step on the current simplex, applying
+   * reflection, expansion, contraction (inside or outside), or shrink operations depending on
+   * relative vertex costs. The simplex array is updated and kept sorted from best to worst after
+   * any newly evaluated points. Subclasses should not override this behavior; callers trigger
+   * iterations indirectly via {@code minimizes(...)} in {@link DirectSearchOptimizer}, which
+   * repeatedly invokes this method until a {@link ConvergenceChecker} signals completion or the
+   * evaluation budget is exhausted.
+   *
+   * @throws CostException if the configured {@link CostFunction} refuses to evaluate a candidate
+   *     point or returns a value that cannot be produced.
+   */
   protected void iterateSimplex() throws CostException {
 
     // the simplex has n+1 point if dimension is n
     int n = simplex.length - 1;
 
-    // interesting costs
     double smallest = simplex[0].cost;
     double secondLargest = simplex[n - 1].cost;
     double largest = simplex[n].cost;
     double[] xLargest = simplex[n].point;
 
-    // compute the centroid of the best vertices
-    // (dismissing the worst point at index n)
+    double[] centroid = computeCentroid(n);
+    double[] xR = reflect(centroid, xLargest);
+    double costR = evaluateCost(xR);
+
+    if ((smallest <= costR) && (costR < secondLargest)) {
+      replaceWorstPoint(new PointCostPair(xR, costR));
+      return;
+    }
+
+    if (costR < smallest) {
+      handleExpansion(centroid, xR, costR);
+      return;
+    }
+
+    if (costR < largest) {
+      if (handleOutsideContraction(centroid, xR, costR)) {
+        return;
+      }
+    } else if (handleInsideContraction(centroid, xLargest, largest)) {
+      return;
+    }
+
+    shrinkSimplex(n);
+  }
+
+  private double[] computeCentroid(int n) {
     double[] centroid = new double[n];
     for (int i = 0; i < n; ++i) {
       double[] x = simplex[i].point;
@@ -63,91 +137,84 @@ public class NelderMead extends DirectSearchOptimizer {
     for (int j = 0; j < n; ++j) {
       centroid[j] *= scaling;
     }
+    return centroid;
+  }
 
-    // compute the reflection point
+  private double[] reflect(double[] centroid, double[] xLargest) {
+    int n = centroid.length;
     double[] xR = new double[n];
     for (int j = 0; j < n; ++j) {
       xR[j] = centroid[j] + rho * (centroid[j] - xLargest[j]);
     }
-    double costR = evaluateCost(xR);
+    return xR;
+  }
 
-    if ((smallest <= costR) && (costR < secondLargest)) {
+  private void handleExpansion(double[] centroid, double[] xR, double costR) throws CostException {
+    int n = centroid.length;
+    double[] xE = new double[n];
+    for (int j = 0; j < n; ++j) {
+      xE[j] = centroid[j] + khi * (xR[j] - centroid[j]);
+    }
+    double costE = evaluateCost(xE);
 
-      // accept the reflected point
-      replaceWorstPoint(new PointCostPair(xR, costR));
-
-    } else if (costR < smallest) {
-
-      // compute the expansion point
-      double[] xE = new double[n];
-      for (int j = 0; j < n; ++j) {
-        xE[j] = centroid[j] + khi * (xR[j] - centroid[j]);
-      }
-      double costE = evaluateCost(xE);
-
-      if (costE < costR) {
-        // accept the expansion point
-        replaceWorstPoint(new PointCostPair(xE, costE));
-      } else {
-        // accept the reflected point
-        replaceWorstPoint(new PointCostPair(xR, costR));
-      }
-
+    if (costE < costR) {
+      replaceWorstPoint(new PointCostPair(xE, costE));
     } else {
-
-      if (costR < largest) {
-
-        // perform an outside contraction
-        double[] xC = new double[n];
-        for (int j = 0; j < n; ++j) {
-          xC[j] = centroid[j] + gamma * (xR[j] - centroid[j]);
-        }
-        double costC = evaluateCost(xC);
-
-        if (costC <= costR) {
-          // accept the contraction point
-          replaceWorstPoint(new PointCostPair(xC, costC));
-          return;
-        }
-
-      } else {
-
-        // perform an inside contraction
-        double[] xC = new double[n];
-        for (int j = 0; j < n; ++j) {
-          xC[j] = centroid[j] - gamma * (centroid[j] - xLargest[j]);
-        }
-        double costC = evaluateCost(xC);
-
-        if (costC < largest) {
-          // accept the contraction point
-          replaceWorstPoint(new PointCostPair(xC, costC));
-          return;
-        }
-      }
-
-      // perform a shrink
-      double[] xSmallest = simplex[0].point;
-      for (int i = 1; i < simplex.length; ++i) {
-        double[] x = simplex[i].point;
-        for (int j = 0; j < n; ++j) {
-          x[j] = xSmallest[j] + sigma * (x[j] - xSmallest[j]);
-        }
-        simplex[i] = new PointCostPair(x, Double.NaN);
-      }
-      evaluateSimplex();
+      replaceWorstPoint(new PointCostPair(xR, costR));
     }
   }
 
+  private boolean handleOutsideContraction(double[] centroid, double[] xR, double costR)
+      throws CostException {
+    int n = centroid.length;
+    double[] xC = new double[n];
+    for (int j = 0; j < n; ++j) {
+      xC[j] = centroid[j] + gamma * (xR[j] - centroid[j]);
+    }
+    double costC = evaluateCost(xC);
+    if (costC <= costR) {
+      replaceWorstPoint(new PointCostPair(xC, costC));
+      return true;
+    }
+    return false;
+  }
+
+  private boolean handleInsideContraction(double[] centroid, double[] xLargest, double largest)
+      throws CostException {
+    int n = centroid.length;
+    double[] xC = new double[n];
+    for (int j = 0; j < n; ++j) {
+      xC[j] = centroid[j] - gamma * (centroid[j] - xLargest[j]);
+    }
+    double costC = evaluateCost(xC);
+    if (costC < largest) {
+      replaceWorstPoint(new PointCostPair(xC, costC));
+      return true;
+    }
+    return false;
+  }
+
+  private void shrinkSimplex(int n) throws CostException {
+    double[] xSmallest = simplex[0].point;
+    for (int i = 1; i < simplex.length; ++i) {
+      double[] x = simplex[i].point;
+      for (int j = 0; j < n; ++j) {
+        x[j] = xSmallest[j] + sigma * (x[j] - xSmallest[j]);
+      }
+      simplex[i] = new PointCostPair(x, Double.NaN);
+    }
+    evaluateSimplex();
+  }
+
   /** Reflection coefficient. */
-  private double rho;
+  private final double rho;
 
   /** Expansion coefficient. */
-  private double khi;
+  private final double khi;
 
   /** Contraction coefficient. */
-  private double gamma;
+  private final double gamma;
 
   /** Shrinkage coefficient. */
-  private double sigma;
+  private final double sigma;
 }

--- a/src/main/java/org/spaceroots/mantissa/optimization/NoConvergenceException.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/NoConvergenceException.java
@@ -3,22 +3,48 @@ package org.spaceroots.mantissa.optimization;
 import org.spaceroots.mantissa.MantissaException;
 
 /**
- * This class represents exceptions thrown by optimization algorithms.
+ * Signals that an iterative optimization process stopped without satisfying its convergence
+ * criteria.
+ *
+ * <p>Instances of this exception are raised by optimization routines when they exhaust their
+ * allowed iterations, diverge from the search domain, or otherwise fail to meet the configured
+ * termination thresholds. Library callers typically catch this type to surface a user-facing
+ * message, adjust tolerances, or restart the search with a different initial guess. The class is
+ * immutable and therefore thread-safe; it contains only the translated message components supplied
+ * at construction time. Typical usage flows include propagating the exception directly from a
+ * solver, translating the message for UI display, or logging the failure alongside the iteration
+ * count and residual norm.
+ *
+ * <ul>
+ *   <li>Represents non-fatal termination of optimization algorithms.
+ *   <li>Conveys formatted, localized details about the convergence failure.
+ *   <li>Intended to be handled by callers that can retry or relax constraints.
+ * </ul>
  *
  * @version $Id: NoConvergenceException.java 1686 2005-12-16 12:59:51Z luc $
  * @author L. Maisonobe
+ * @see MantissaException
  */
 public class NoConvergenceException extends MantissaException {
 
   /**
-   * Simple constructor. Build an exception by translating and formating a message
+   * Builds the exception with a translated, formatted message describing the convergence failure.
    *
-   * @param specifier format specifier (to be translated)
-   * @param parts to insert in the format (no translation)
+   * <p>The {@code specifier} is looked up in the localization bundles managed by {@link
+   * MantissaException} and combined with the provided message {@code parts}. Callers should supply
+   * placeholders that describe the algorithm, stopping criterion, or iteration counts so downstream
+   * consumers can act on the details. This constructor performs no computation and is side-effect
+   * free, making it safe to create eagerly before the point where the optimization is aborted.
+   *
+   * @param specifier message template key to translate into the current locale; must not be {@code
+   *     null}
+   * @param parts arguments inserted into the localized template in declaration order; entries may
+   *     be {@code null} if the format accepts them
    */
   public NoConvergenceException(String specifier, String[] parts) {
     super(specifier, parts);
   }
 
+  @SuppressWarnings("MissingSerialAnnotation")
   private static final long serialVersionUID = 4854864422540042859L;
 }

--- a/src/main/java/org/spaceroots/mantissa/optimization/PointCostPair.java
+++ b/src/main/java/org/spaceroots/mantissa/optimization/PointCostPair.java
@@ -1,30 +1,78 @@
 package org.spaceroots.mantissa.optimization;
 
+import java.util.Arrays;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
 /**
- * This class holds a point and its associated cost.
+ * Immutable pair that groups a point in the optimization search space with the cost value computed
+ * at that point.
  *
- * <p>This is a simple immutable container.
+ * <p>The record is used throughout direct-search optimizers to shuttle candidate vertices between
+ * the cost function, convergence checker, and simplex maintenance code. Instances are created as
+ * soon as a coordinate array is available, and the cost field may be pre-populated or filled in
+ * later by the optimizer. The contained point array is defensively copied on construction, keeping
+ * subsequent optimizer steps insulated from caller mutations and preserving deterministic behavior.
+ * Values are intended to be read frequently and never mutated, so sharing references to instances
+ * is safe as long as the object itself is not replaced. The type is thread-safe for read-only
+ * sharing because it exposes no setters and its state does not change after creation.
  *
+ * <ul>
+ *   <li>Holds the {@code point} coordinates and the scalar {@code cost} for that location.
+ *   <li>Supports value-style equality that compares array contents rather than references.
+ *   <li>Provides a concise {@link #toString()} for diagnostics and logging of optimizer steps.
+ * </ul>
+ *
+ * @param point point coordinates in the objective space; array is cloned to ensure immutability and
+ *     must not be {@code null}
+ * @param cost cost value already evaluated for the point or a placeholder such as {@code NaN} when
+ *     the optimizer has not computed it yet
  * @author Luc Maisonobe
  * @version $Id: PointCostPair.java 1709 2006-12-03 21:16:50Z luc $
  * @see CostFunction
  */
-public class PointCostPair {
+public record PointCostPair(double[] point, double cost) {
 
   /**
-   * Build a point/cost pair.
+   * Build a point/cost pair by defensively copying the supplied coordinates and associating them
+   * with a scalar cost.
    *
-   * @param point point coordinates
-   * @param cost point cost
+   * <p>This canonical constructor accepts a point array that defines the location in the objective
+   * function domain and the cost value currently known for that location. The array is cloned so
+   * that later mutations performed by callers cannot leak into optimizer state. Callers may pass
+   * {@link Double#NaN} as the cost when the value is not yet available; optimizers typically
+   * evaluate and replace that placeholder during simplex processing. A {@code null} point is not
+   * permitted and results in a {@link NullPointerException}.
+   *
+   * @param point point coordinates expressed as finite doubles; must be non-{@code null} and is
+   *     defensively copied to protect internal immutability
+   * @param cost cost associated with the point, or {@code Double.NaN} when not yet evaluated;
+   *     callers retain responsibility for ensuring numeric validity
+   * @throws NullPointerException if {@code point} is {@code null} or contains elements that cannot
+   *     be accessed during cloning
    */
-  public PointCostPair(double[] point, double cost) {
-    this.point = (double[]) point.clone();
-    this.cost = cost;
+  public PointCostPair {
+    point = point.clone();
   }
 
-  /** Point coordinates. */
-  public final double[] point;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PointCostPair(var otherPoint, var otherCost))) {
+      return false;
+    }
+    return Double.compare(cost, otherCost) == 0 && Arrays.equals(point, otherPoint);
+  }
 
-  /** Cost associated to the point. */
-  public final double cost;
+  @Override
+  public int hashCode() {
+    return Objects.hash(Arrays.hashCode(point), Double.doubleToLongBits(cost));
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "PointCostPair[point=" + Arrays.toString(point) + ", cost=" + cost + ']';
+  }
 }

--- a/src/test/java/org/spaceroots/mantissa/optimization/MultiDirectionalTest.java
+++ b/src/test/java/org/spaceroots/mantissa/optimization/MultiDirectionalTest.java
@@ -18,10 +18,10 @@ class MultiDirectionalTest {
     PointCostPair result =
         optimizer.minimizes(x -> x[0] * x[0], 20, checker, new double[] {1.0}, new double[] {2.0});
 
-    assertEquals(0.0, result.point[0], EPS);
-    assertEquals(0.0, result.cost, EPS);
-    assertArrayEquals(new double[] {0.0}, optimizer.simplex[0].point, EPS);
-    assertArrayEquals(new double[] {1.0}, optimizer.simplex[1].point, EPS);
+    assertEquals(0.0, result.point()[0], EPS);
+    assertEquals(0.0, result.cost(), EPS);
+    assertArrayEquals(new double[] {0.0}, optimizer.simplex[0].point(), EPS);
+    assertArrayEquals(new double[] {1.0}, optimizer.simplex[1].point(), EPS);
   }
 
   @Test
@@ -32,10 +32,10 @@ class MultiDirectionalTest {
     PointCostPair result =
         optimizer.minimizes(x -> x[0], 20, checker, new double[] {1.0}, new double[] {3.0});
 
-    assertEquals(-3.0, result.point[0], EPS);
-    assertEquals(-3.0, result.cost, EPS);
-    assertArrayEquals(new double[] {-3.0}, optimizer.simplex[0].point, EPS);
-    assertArrayEquals(new double[] {1.0}, optimizer.simplex[1].point, EPS);
+    assertEquals(-3.0, result.point()[0], EPS);
+    assertEquals(-3.0, result.cost(), EPS);
+    assertArrayEquals(new double[] {-3.0}, optimizer.simplex[0].point(), EPS);
+    assertArrayEquals(new double[] {1.0}, optimizer.simplex[1].point(), EPS);
   }
 
   @Test
@@ -48,10 +48,10 @@ class MultiDirectionalTest {
         optimizer.minimizes(
             x -> Math.abs(x[0]), 20, checker, new double[] {1.0}, new double[] {3.0});
 
-    assertEquals(0.0, result.point[0], EPS);
-    assertEquals(0.0, result.cost, EPS);
-    assertArrayEquals(new double[] {0.0}, optimizer.simplex[0].point, EPS);
-    assertArrayEquals(new double[] {1.0}, optimizer.simplex[1].point, EPS);
+    assertEquals(0.0, result.point()[0], EPS);
+    assertEquals(0.0, result.cost(), EPS);
+    assertArrayEquals(new double[] {0.0}, optimizer.simplex[0].point(), EPS);
+    assertArrayEquals(new double[] {1.0}, optimizer.simplex[1].point(), EPS);
   }
 
   /** Stops the optimization loop after a fixed number of convergence checks. */

--- a/src/test/java/org/spaceroots/mantissa/optimization/MultiDirectionalTest.java
+++ b/src/test/java/org/spaceroots/mantissa/optimization/MultiDirectionalTest.java
@@ -1,0 +1,71 @@
+package org.spaceroots.mantissa.optimization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class MultiDirectionalTest {
+
+  private static final double EPS = 1e-12;
+
+  @Test
+  void minimizes_whenReflectionBeatsExpansion_keepsReflectedSimplex() throws Exception {
+    MultiDirectional optimizer = new MultiDirectional();
+    ConvergenceChecker checker = new StepCountChecker(1);
+
+    PointCostPair result =
+        optimizer.minimizes(x -> x[0] * x[0], 20, checker, new double[] {1.0}, new double[] {2.0});
+
+    assertEquals(0.0, result.point[0], EPS);
+    assertEquals(0.0, result.cost, EPS);
+    assertArrayEquals(new double[] {0.0}, optimizer.simplex[0].point, EPS);
+    assertArrayEquals(new double[] {1.0}, optimizer.simplex[1].point, EPS);
+  }
+
+  @Test
+  void minimizes_whenExpansionBetterThanReflection_prefersExpandedSimplex() throws Exception {
+    MultiDirectional optimizer = new MultiDirectional();
+    ConvergenceChecker checker = new StepCountChecker(1);
+
+    PointCostPair result =
+        optimizer.minimizes(x -> x[0], 20, checker, new double[] {1.0}, new double[] {3.0});
+
+    assertEquals(-3.0, result.point[0], EPS);
+    assertEquals(-3.0, result.cost, EPS);
+    assertArrayEquals(new double[] {-3.0}, optimizer.simplex[0].point, EPS);
+    assertArrayEquals(new double[] {1.0}, optimizer.simplex[1].point, EPS);
+  }
+
+  @Test
+  void minimizes_whenReflectionNotBetterButContractionIs_acceptsContractedSimplex()
+      throws Exception {
+    MultiDirectional optimizer = new MultiDirectional();
+    ConvergenceChecker checker = new StepCountChecker(1);
+
+    PointCostPair result =
+        optimizer.minimizes(
+            x -> Math.abs(x[0]), 20, checker, new double[] {1.0}, new double[] {3.0});
+
+    assertEquals(0.0, result.point[0], EPS);
+    assertEquals(0.0, result.cost, EPS);
+    assertArrayEquals(new double[] {0.0}, optimizer.simplex[0].point, EPS);
+    assertArrayEquals(new double[] {1.0}, optimizer.simplex[1].point, EPS);
+  }
+
+  /** Stops the optimization loop after a fixed number of convergence checks. */
+  private static final class StepCountChecker implements ConvergenceChecker {
+    private final int stopAfterCalls;
+    private int calls;
+
+    private StepCountChecker(int stopAfterCalls) {
+      this.stopAfterCalls = stopAfterCalls;
+    }
+
+    @Override
+    public boolean converged(PointCostPair[] simplex) {
+      return calls++ >= stopAfterCalls;
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/optimization/NelderMeadTest.java
+++ b/src/test/java/org/spaceroots/mantissa/optimization/NelderMeadTest.java
@@ -26,10 +26,10 @@ class NelderMeadTest {
     optimizer.minimizes(costs, 10, new IterationChecker(0), vertices);
 
     // Assert
-    assertEquals(1.0, optimizer.simplex[0].cost, 1e-12);
-    assertEquals(1.5, optimizer.simplex[1].cost, 1e-12);
-    assertEquals(2.0, optimizer.simplex[2].cost, 1e-12);
-    assertArrayEquals(new double[] {1.0, -2.0}, optimizer.simplex[1].point, 1e-12);
+    assertEquals(1.0, optimizer.simplex[0].cost(), 1e-12);
+    assertEquals(1.5, optimizer.simplex[1].cost(), 1e-12);
+    assertEquals(2.0, optimizer.simplex[2].cost(), 1e-12);
+    assertArrayEquals(new double[] {1.0, -2.0}, optimizer.simplex[1].point(), 1e-12);
   }
 
   @Test
@@ -48,8 +48,8 @@ class NelderMeadTest {
     optimizer.minimizes(costs, 10, new IterationChecker(0), vertices);
 
     // Assert
-    assertEquals(0.5, optimizer.simplex[0].cost, 1e-12);
-    assertArrayEquals(new double[] {1.5, -4.0}, optimizer.simplex[0].point, 1e-12);
+    assertEquals(0.5, optimizer.simplex[0].cost(), 1e-12);
+    assertArrayEquals(new double[] {1.5, -4.0}, optimizer.simplex[0].point(), 1e-12);
   }
 
   @Test
@@ -69,8 +69,8 @@ class NelderMeadTest {
     optimizer.minimizes(costs, 10, new IterationChecker(0), vertices);
 
     // Assert
-    assertEquals(0.25, optimizer.simplex[1].cost, 1e-12);
-    assertArrayEquals(new double[] {-0.75, 0.0}, optimizer.simplex[1].point, 1e-12);
+    assertEquals(0.25, optimizer.simplex[1].cost(), 1e-12);
+    assertArrayEquals(new double[] {-0.75, 0.0}, optimizer.simplex[1].point(), 1e-12);
   }
 
   @Test
@@ -90,11 +90,11 @@ class NelderMeadTest {
     optimizer.minimizes(costs, 15, new IterationChecker(0), vertices);
 
     // Assert
-    assertEquals(0.0, optimizer.simplex[0].cost, 1e-12);
-    assertEquals(0.25, optimizer.simplex[1].cost, 1e-12);
-    assertEquals(1.0, optimizer.simplex[2].cost, 1e-12);
-    assertArrayEquals(new double[] {0.5, 0.0}, optimizer.simplex[1].point, 1e-12);
-    assertArrayEquals(new double[] {0.0, 1.0}, optimizer.simplex[2].point, 1e-12);
+    assertEquals(0.0, optimizer.simplex[0].cost(), 1e-12);
+    assertEquals(0.25, optimizer.simplex[1].cost(), 1e-12);
+    assertEquals(1.0, optimizer.simplex[2].cost(), 1e-12);
+    assertArrayEquals(new double[] {0.5, 0.0}, optimizer.simplex[1].point(), 1e-12);
+    assertArrayEquals(new double[] {0.0, 1.0}, optimizer.simplex[2].point(), 1e-12);
   }
 
   @Test

--- a/src/test/java/org/spaceroots/mantissa/optimization/NelderMeadTest.java
+++ b/src/test/java/org/spaceroots/mantissa/optimization/NelderMeadTest.java
@@ -1,0 +1,150 @@
+package org.spaceroots.mantissa.optimization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class NelderMeadTest {
+
+  @Test
+  void iterateSimplex_whenReflectionBetterThanSecondWorst_replacesWorstWithReflection()
+      throws Exception {
+    // Arrange
+    double[][] vertices = {
+      new double[] {0.0, 0.0},
+      new double[] {1.0, 0.0},
+      new double[] {0.0, 2.0}
+    };
+    // cost sequence: v0, v1, v2, reflection
+    ScriptedCostFunction costs = new ScriptedCostFunction(1.0, 2.0, 5.0, 1.5);
+    NelderMead optimizer = new NelderMead();
+
+    // Act
+    optimizer.minimizes(costs, 10, new IterationChecker(0), vertices);
+
+    // Assert
+    assertEquals(1.0, optimizer.simplex[0].cost, 1e-12);
+    assertEquals(1.5, optimizer.simplex[1].cost, 1e-12);
+    assertEquals(2.0, optimizer.simplex[2].cost, 1e-12);
+    assertArrayEquals(new double[] {1.0, -2.0}, optimizer.simplex[1].point, 1e-12);
+  }
+
+  @Test
+  void iterateSimplex_whenExpansionBeatsReflection_acceptsExpansion() throws Exception {
+    // Arrange
+    double[][] vertices = {
+      new double[] {0.0, 0.0},
+      new double[] {1.0, 0.0},
+      new double[] {0.0, 2.0}
+    };
+    // costs: v0, v1, v2, reflection (< smallest), expansion (< reflection)
+    ScriptedCostFunction costs = new ScriptedCostFunction(5.0, 6.0, 7.0, 1.0, 0.5);
+    NelderMead optimizer = new NelderMead();
+
+    // Act
+    optimizer.minimizes(costs, 10, new IterationChecker(0), vertices);
+
+    // Assert
+    assertEquals(0.5, optimizer.simplex[0].cost, 1e-12);
+    assertArrayEquals(new double[] {1.5, -4.0}, optimizer.simplex[0].point, 1e-12);
+  }
+
+  @Test
+  void iterateSimplex_whenOutsideContractionSucceeds_replacesWorstWithContraction()
+      throws Exception {
+    // Arrange
+    double[][] vertices = {
+      new double[] {0.0, 0.0},
+      new double[] {1.0, 0.0},
+      new double[] {3.0, 0.0}
+    };
+    // costs: v0, v1, v2, reflection (between 2nd and worst), contraction (<= reflection)
+    ScriptedCostFunction costs = new ScriptedCostFunction(0.0, 1.0, 9.0, 4.0, 0.25);
+    NelderMead optimizer = new NelderMead();
+
+    // Act
+    optimizer.minimizes(costs, 10, new IterationChecker(0), vertices);
+
+    // Assert
+    assertEquals(0.25, optimizer.simplex[1].cost, 1e-12);
+    assertArrayEquals(new double[] {-0.75, 0.0}, optimizer.simplex[1].point, 1e-12);
+  }
+
+  @Test
+  void iterateSimplex_whenContractionFails_triggersShrinkAndReevaluation() throws Exception {
+    // Arrange
+    double[][] vertices = {
+      new double[] {0.0, 0.0},
+      new double[] {1.0, 0.0},
+      new double[] {0.0, 2.0}
+    };
+    // costs: v0, v1, v2, reflection (worse than worst), inside contraction (still worse),
+    // shrink evaluations for the two updated vertices
+    ScriptedCostFunction costs = new ScriptedCostFunction(0.0, 1.0, 5.0, 10.0, 8.0, 0.25, 1.0);
+    NelderMead optimizer = new NelderMead();
+
+    // Act
+    optimizer.minimizes(costs, 15, new IterationChecker(0), vertices);
+
+    // Assert
+    assertEquals(0.0, optimizer.simplex[0].cost, 1e-12);
+    assertEquals(0.25, optimizer.simplex[1].cost, 1e-12);
+    assertEquals(1.0, optimizer.simplex[2].cost, 1e-12);
+    assertArrayEquals(new double[] {0.5, 0.0}, optimizer.simplex[1].point, 1e-12);
+    assertArrayEquals(new double[] {0.0, 1.0}, optimizer.simplex[2].point, 1e-12);
+  }
+
+  @Test
+  void minimizes_whenCostSequenceExhausted_throwsCostException() {
+    // Arrange
+    double[][] vertices = {
+      new double[] {0.0, 0.0},
+      new double[] {1.0, 0.0},
+      new double[] {0.0, 2.0}
+    };
+    // Only three costs provided, but simplex evaluation needs at least three plus one for iteration
+    ScriptedCostFunction costs = new ScriptedCostFunction(1.0, 2.0, 3.0);
+    NelderMead optimizer = new NelderMead();
+
+    // Act + Assert
+    assertThrows(
+        CostException.class,
+        () -> optimizer.minimizes(costs, 5, new IterationChecker(0), vertices));
+  }
+
+  private static final class IterationChecker implements ConvergenceChecker {
+
+    private final int iterationsBeforeConverged;
+    private int calls;
+
+    IterationChecker(int iterationsBeforeConverged) {
+      this.iterationsBeforeConverged = iterationsBeforeConverged;
+    }
+
+    @Override
+    public boolean converged(PointCostPair[] simplex) {
+      return calls++ > iterationsBeforeConverged;
+    }
+  }
+
+  private static final class ScriptedCostFunction implements CostFunction {
+
+    private final double[] scripted;
+    private int index;
+
+    ScriptedCostFunction(double... scripted) {
+      this.scripted = scripted;
+    }
+
+    @Override
+    public double cost(double[] x) throws CostException {
+      if (index >= scripted.length) {
+        throw new CostException("No scripted cost available for evaluation " + index);
+      }
+      return scripted[index++];
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/optimization/PointCostPairTest.java
+++ b/src/test/java/org/spaceroots/mantissa/optimization/PointCostPairTest.java
@@ -1,0 +1,102 @@
+package org.spaceroots.mantissa.optimization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class PointCostPairTest {
+
+  @Test
+  @DisplayName("Constructor clones the provided point array and stores cost")
+  void constructor_whenGivenPointArray_clonesArrayAndStoresCost() {
+    // Arrange
+    double[] originalPoint = new double[] {1.0, -2.5, 3.5};
+    double expectedCost = 42.0;
+
+    // Act
+    PointCostPair pair = new PointCostPair(originalPoint, expectedCost);
+
+    // Assert
+    assertArrayEquals(originalPoint, pair.point(), 1e-15);
+    assertNotSame(originalPoint, pair.point());
+    assertEquals(expectedCost, pair.cost(), 0.0);
+  }
+
+  @Test
+  @DisplayName("Modifying the original array after construction does not change stored point")
+  void constructor_whenOriginalArrayMutated_storedPointUnchanged() {
+    // Arrange
+    double[] originalPoint = new double[] {0.1, 0.2};
+    PointCostPair pair = new PointCostPair(originalPoint, 5.0);
+
+    // Act
+    originalPoint[0] = 9.9;
+    originalPoint[1] = -9.9;
+
+    // Assert
+    assertArrayEquals(new double[] {0.1, 0.2}, pair.point(), 1e-15);
+  }
+
+  @Test
+  @DisplayName("Null point array triggers NullPointerException")
+  void constructor_whenPointIsNull_throwsNullPointerException() {
+    // Arrange
+    // Act / Assert
+    //noinspection DataFlowIssue
+    assertThrows(NullPointerException.class, () -> new PointCostPair(null, 1.0));
+  }
+
+  @Test
+  @DisplayName("equals compares array content and cost")
+  void equals_whenPointAndCostMatch_returnsTrue() {
+    // Arrange
+    PointCostPair first = new PointCostPair(new double[] {1.0, 2.0}, 3.0);
+    PointCostPair second = new PointCostPair(new double[] {1.0, 2.0}, 3.0);
+
+    // Act + Assert
+    assertTrue(first.equals(second));
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  @DisplayName("equals returns false when cost differs")
+  void equals_whenCostDiffers_returnsFalse() {
+    // Arrange
+    PointCostPair first = new PointCostPair(new double[] {1.0, 2.0}, 3.0);
+    PointCostPair second = new PointCostPair(new double[] {1.0, 2.0}, 4.0);
+
+    // Act + Assert
+    assertFalse(first.equals(second));
+  }
+
+  @Test
+  @DisplayName("equals returns false when point content differs")
+  void equals_whenPointDiffers_returnsFalse() {
+    // Arrange
+    PointCostPair first = new PointCostPair(new double[] {1.0, 2.0}, 3.0);
+    PointCostPair second = new PointCostPair(new double[] {1.0, 2.1}, 3.0);
+
+    // Act + Assert
+    assertFalse(first.equals(second));
+  }
+
+  @Test
+  @DisplayName("toString includes point content and cost")
+  void toString_whenCalled_formatsArrayAndCost() {
+    // Arrange
+    PointCostPair pair = new PointCostPair(new double[] {1.0, 2.0}, 3.0);
+
+    // Act
+    String text = pair.toString();
+
+    // Assert
+    assertEquals("PointCostPair[point=[1.0, 2.0], cost=3.0]", text);
+  }
+}


### PR DESCRIPTION
## Summary
- convert `PointCostPair` to an immutable record with defensive copying, value-style equality, and clearer Javadoc, plus dedicated tests
- expand documentation across direct-search components (cost function/exception, optimizer scaffolding, convergence handling) to clarify behavior and invariants
- bolster Nelder–Mead and multi-directional simplex docs and tests for more stable convergence coverage

## Testing
- not run (not requested)
