### PR TITLE
Improve switching function docs and event handling

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/ode/SwitchState.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/SwitchState.java
@@ -1,5 +1,6 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.ComputableFunction;
 import org.spaceroots.mantissa.roots.BrentSolver;
@@ -7,30 +8,45 @@ import org.spaceroots.mantissa.roots.ConvergenceChecker;
 import org.spaceroots.mantissa.roots.RootsFinder;
 
 /**
- * This class handles the state for one {@link SwitchingFunction switching function} during
- * integration steps.
+ * Maintains switching-function state across numerical integration steps.
  *
- * <p>Each time the integrator proposes a step, the switching function should be checked. This class
- * handles the state of one function during one integration step, with references to the state at
- * the end of the preceding step. This information is used to determine if the function should
- * trigger an event or not during the proposed step (and hence the step should be reduced to ensure
- * the event occurs at a bound rather than inside the step).
+ * <p>This helper is created for each {@link SwitchingFunction} registered on an integrator and
+ * persists between calls so events are detected deterministically. It stores the sign of the
+ * function at the start of a step, tracks the last accepted event time, and remembers whether a
+ * pending event has already been bracketed. The instance is reused as the integrator iterates over
+ * a proposed step, sampling at a bounded interval to ensure no zero crossing is skipped even when
+ * the step size grows.
+ *
+ * <p>The class is intentionally mutable and <strong>not</strong> thread-safe; a single instance
+ * must be confined to one integration process. Callers drive the life cycle in a predictable
+ * pattern: {@link #reinitializeBegin(double, double[])} at step start, {@link
+ * #evaluateStep(StepInterpolator)} during proposal scanning, {@link #stepAccepted(double,
+ * double[])} when a step is kept, optionally {@link #reset(double, double[])} if an event fires,
+ * and {@link #stop()} to determine termination.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Bracketing and localizing zero crossings with a {@link BrentSolver}-backed root finder.
+ *   <li>Exposing event timing and next-action hints for integrator control flow.
+ *   <li>Enforcing a maximum check interval to limit missed crossings on oscillatory functions.
+ * </ul>
  *
  * @version $Id: SwitchState.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
  */
 class SwitchState implements ComputableFunction, ConvergenceChecker {
 
-  private static final long serialVersionUID = 6944466361876662425L;
+  @Serial private static final long serialVersionUID = 6944466361876662425L;
 
   /** Switching function. */
-  private SwitchingFunction function;
+  private final SwitchingFunction function;
 
   /** Maximal time interval between switching function checks. */
-  private double maxCheckInterval;
+  private final double maxCheckInterval;
 
-  /** Convergence threshold for event localisation. */
-  private double convergence;
+  /** Convergence threshold for event localization. */
+  private final double convergence;
 
   /** Time at the beginning of the step. */
   private double t0;
@@ -63,12 +79,17 @@ class SwitchState implements ComputableFunction, ConvergenceChecker {
   private StepInterpolator interpolator;
 
   /**
-   * Simple constructor.
+   * Create a state tracker for one switching function.
    *
-   * @param function switching function
-   * @param maxCheckInterval maximal time interval between switching function checks (this interval
-   *     prevents missing sign changes in case the integration steps becomes very large)
-   * @param convergence convergence threshold in the event time search
+   * <p>The instance is tied to the provided {@link SwitchingFunction} and to the convergence and
+   * sampling policy chosen by the caller. It does not copy the function, so the caller retains
+   * ownership and must keep the function valid for the lifetime of the tracker. The maximum check
+   * interval bounds how far apart the interpolated evaluations may occur within a step and is
+   * applied symmetrically for forward and backward integration.
+   *
+   * @param function switching function evaluated along the step to detect events reliably
+   * @param maxCheckInterval maximal time gap between sign checks to prevent missed crossings
+   * @param convergence absolute tolerance used while refining and validating event time estimates
    */
   public SwitchState(SwitchingFunction function, double maxCheckInterval, double convergence) {
     this.function = function;
@@ -91,8 +112,14 @@ class SwitchState implements ComputableFunction, ConvergenceChecker {
   /**
    * Reinitialize the beginning of the step.
    *
-   * @param t0 value of the independant <i>time</i> variable at the beginning of the step
-   * @param y0 array containing the current value of the state vector at the beginning of the step
+   * <p>This method must be called exactly once at the start of each proposed step, before any
+   * evaluation happens. It captures the current time and state, computes the switching-function
+   * value, and establishes the reference sign used during subsequent scanning. The stored values
+   * remain authoritative until the step is accepted or rejected, so callers should avoid invoking
+   * this method mid-step or with stale state arrays.
+   *
+   * @param t0 value of the independent time variable at the start of the candidate step
+   * @param y0 array containing the current state vector at the beginning of the candidate step
    */
   public void reinitializeBegin(double t0, double[] y0) {
     this.t0 = t0;
@@ -103,14 +130,18 @@ class SwitchState implements ComputableFunction, ConvergenceChecker {
   /**
    * Evaluate the impact of the proposed step on the switching function.
    *
-   * @param interpolator step interpolator for the proposed step
-   * @return true if the switching function triggers an event before the end of the proposed step
-   *     (this implies the step should be rejected)
+   * <p>The interpolator is sampled at most every {@code maxCheckInterval} units of the independent
+   * variable so that rapidly oscillating functions still surface sign changes. When a crossing is
+   * detected, a Brent root finder is invoked to locate the event time within the current step. The
+   * method may mark a pending event that forces the caller to shorten or retry the step so the
+   * event lands on a boundary rather than in the interior.
+   *
+   * @param interpolator step interpolator that provides dense state evaluation across the step span
+   * @return true if an event is detected inside the proposed step and the step should be rejected
+   *     and retried with an adjusted end time
    */
   public boolean evaluateStep(StepInterpolator interpolator) {
-
     try {
-
       this.interpolator = interpolator;
 
       double t1 = interpolator.getCurrentTime();
@@ -121,63 +152,82 @@ class SwitchState implements ComputableFunction, ConvergenceChecker {
       double ga = g0;
       double tb = t0 + ((t1 > t0) ? convergence : -convergence);
       for (int i = 0; i < n; ++i) {
-
-        // evaluate function value at the end of the substep
         tb += h;
         interpolator.setInterpolatedTime(tb);
         double gb = function.g(tb, interpolator.getInterpolatedState());
 
-        // check events occurrence
-        if (g0Positive ^ (gb >= 0)) {
-          // there is a sign change: an event is expected during this step
-
-          // variation direction, with respect to the integration direction
-          increasing = (gb >= ga);
-
-          RootsFinder solver = new BrentSolver();
-          if (solver.findRoot(this, this, 1000, ta, ga, tb, gb)) {
-            if (Double.isNaN(previousEventTime)
-                || (Math.abs(previousEventTime - solver.getRoot()) > convergence)) {
-              pendingEventTime = solver.getRoot();
-              if (pendingEvent && (Math.abs(t1 - pendingEventTime) <= convergence)) {
-                // we were already waiting for this event which was
-                // found during a previous call for a step that was
-                // rejected, this step must now be accepted since it
-                // properly ends exactly at the event occurrence
-                return false;
-              }
-              // either we were not waiting for the event or it has
-              // moved in such a way the step cannot be accepted
-              pendingEvent = true;
-              return true;
-            }
-          } else {
-            throw new RuntimeException("internal error");
+        if (hasSignChanged(gb)) {
+          SignChangeHandling handling = handleSignChange(ta, ga, tb, gb, t1);
+          if (handling == SignChangeHandling.REJECT_STEP) {
+            return true;
           }
-
+          if (handling == SignChangeHandling.ACCEPT_STEP) {
+            return false;
+          }
         } else {
-          // no sign change: there is no event for now
           ta = tb;
           ga = gb;
         }
       }
 
-      // no event during the whole step
-      pendingEvent = false;
-      pendingEventTime = Double.NaN;
+      clearPendingEvent();
       return false;
 
     } catch (DerivativeException e) {
-      throw new RuntimeException("unexpected exception", e);
-    } catch (FunctionException e) {
-      throw new RuntimeException("unexpected exception", e);
+      throw new IllegalStateException("unexpected exception during event evaluation", e);
     }
+  }
+
+  private boolean hasSignChanged(double gb) {
+    return g0Positive ^ (gb >= 0);
+  }
+
+  private enum SignChangeHandling {
+    REJECT_STEP,
+    ACCEPT_STEP,
+    CONTINUE_SCAN
+  }
+
+  private SignChangeHandling handleSignChange(
+      double ta, double ga, double tb, double gb, double t1) {
+    increasing = (gb >= ga);
+
+    RootsFinder solver = new BrentSolver();
+    try {
+      if (!solver.findRoot(this, this, 1000, ta, ga, tb, gb)) {
+        throw new IllegalStateException("failed to locate switching function root");
+      }
+    } catch (FunctionException e) {
+      throw new IllegalStateException("failed to locate switching function root", e);
+    }
+
+    double root = solver.getRoot();
+    if (Double.isNaN(previousEventTime) || (Math.abs(previousEventTime - root) > convergence)) {
+      pendingEventTime = root;
+      if (pendingEvent && (Math.abs(t1 - pendingEventTime) <= convergence)) {
+        return SignChangeHandling.ACCEPT_STEP;
+      }
+      pendingEvent = true;
+      return SignChangeHandling.REJECT_STEP;
+    }
+    return SignChangeHandling.CONTINUE_SCAN;
+  }
+
+  private void clearPendingEvent() {
+    pendingEvent = false;
+    pendingEventTime = Double.NaN;
   }
 
   /**
    * Get the occurrence time of the event triggered in the current step.
    *
-   * @return occurrence time of the event triggered in the current step.
+   * <p>The value is only meaningful after {@link #evaluateStep(StepInterpolator)} reports an event
+   * and before the next {@link #stepAccepted(double, double[])} call updates the internal state.
+   * Callers should treat the returned time as immutable and should not reuse it after a reset or a
+   * subsequent step begins.
+   *
+   * @return event occurrence time recorded for the current step, or {@link Double#NaN} when none
+   *     has been detected
    */
   public double getEventTime() {
     return pendingEventTime;
@@ -186,8 +236,13 @@ class SwitchState implements ComputableFunction, ConvergenceChecker {
   /**
    * Acknowledge the fact the step has been accepted by the integrator.
    *
-   * @param t value of the independant <i>time</i> variable at the end of the step
-   * @param y array containing the current value of the state vector at the end of the step
+   * <p>Once the caller decides to keep the proposed step, this method refreshes the stored
+   * baseline, recomputes the switching-function sign, and records any event occurrence so the next
+   * step can start with consistent context. When a pending event existed, it updates the simulated
+   * sign to the post-event side and records the action requested by the {@link SwitchingFunction}.
+   *
+   * @param t value of the independent time variable at the end of the accepted step
+   * @param y array containing the current value of the state vector at the end of the accepted step
    */
   public void stepAccepted(double t, double[] y) {
 
@@ -208,7 +263,12 @@ class SwitchState implements ComputableFunction, ConvergenceChecker {
   /**
    * Check if the integration should be stopped at the end of the current step.
    *
-   * @return true if the integration should be stopped
+   * <p>The decision reflects the last {@link SwitchingFunction#eventOccurred(double, double[])}
+   * result captured by {@link #stepAccepted(double, double[])}. It does not trigger additional
+   * computations and can be queried repeatedly without side effects.
+   *
+   * @return true if the last processed event requested {@link SwitchingFunction#STOP} and the
+   *     integrator should terminate gracefully
    */
   public boolean stop() {
     return nextAction == SwitchingFunction.STOP;
@@ -217,9 +277,16 @@ class SwitchState implements ComputableFunction, ConvergenceChecker {
   /**
    * Let the switching function reset the state if it wants.
    *
-   * @param t value of the independant <i>time</i> variable at the beginning of the next step
-   * @param y array were to put the desired state vector at the beginning of the next step
-   * @return true if the integrator should reset the derivatives too
+   * <p>Call this immediately after a step containing an event has been accepted to give the
+   * switching function a chance to modify the state vector for the next step. The method clears the
+   * pending-event flag and returns whether derivative recomputation is required, mirroring the
+   * action previously returned by {@link SwitchingFunction#eventOccurred(double, double[])}.
+   * Calling it when no event is pending leaves the state untouched and signals that no reset is
+   * needed.
+   *
+   * @param t value of the independent time variable at the beginning of the next step to prepare
+   * @param y array where the switching function may write the desired state vector for the restart
+   * @return true if the integrator must also recompute derivatives before advancing the solution
    */
   public boolean reset(double t, double[] y) {
 
@@ -240,10 +307,14 @@ class SwitchState implements ComputableFunction, ConvergenceChecker {
   /**
    * Get the value of the g function at the specified time.
    *
-   * @param t current time
-   * @return g function value
-   * @exception FunctionException if the underlying interpolator is unable to interpolate the state
-   *     at the specified time
+   * <p>This method delegates to the current step interpolator to obtain the interpolated state and
+   * then evaluates the switching function. It is primarily used by the root finder while refining
+   * an event time, and it assumes the interpolator has been initialized for the step under review.
+   *
+   * @param t current time within the bounds of the step managed by the stored interpolator
+   * @return switching-function value evaluated on the interpolated state at the requested time
+   * @exception FunctionException if the interpolator cannot produce a state at the given time or
+   *     the switching function signals a computation failure
    */
   public double valueAt(double t) throws FunctionException {
     try {
@@ -257,11 +328,17 @@ class SwitchState implements ComputableFunction, ConvergenceChecker {
   /**
    * Check if the event time has been found.
    *
-   * @param x0 lower bound of the interval
-   * @param y0 value of the function at x0
-   * @param x1 higher bound of the interval
-   * @param y1 value of the function at x1
-   * @return convergence indicator
+   * <p>This callback implements the {@link ConvergenceChecker} contract for the configured
+   * convergence threshold. It compares the interval width to the tolerance and indicates whether
+   * the root finder should keep the lower or upper bracket based on which endpoint is closer to
+   * zero. The method is side-effect free and deterministic for the same inputs.
+   *
+   * @param x0 lower bound of the bracketing interval currently evaluated by the solver
+   * @param y0 value of the switching function at {@code x0}, typically already computed
+   * @param x1 higher bound of the bracketing interval being refined by the solver
+   * @param y1 value of the switching function at {@code x1}, paired with the upper bound
+   * @return convergence indicator describing whether the interval is within tolerance and which
+   *     endpoint is preferred when both are close to a root
    */
   public int converged(double x0, double y0, double x1, double y1) {
     if (Math.abs(x1 - x0) < convergence) {

--- a/src/main/java/org/spaceroots/mantissa/ode/SwitchingFunction.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/SwitchingFunction.java
@@ -3,126 +3,128 @@ package org.spaceroots.mantissa.ode;
 import java.io.Serializable;
 
 /**
- * This interface represents a switching function.
+ * Describes a user-supplied switching function that signals discrete events to an ODE integrator.
  *
- * <p>A switching function allows to handle discrete events in integration problems. These events
- * occur for example when the integration process should be stopped as some value is reached (G-stop
- * facility), or when the derivatives have discontinuities, or simply when the user wants to monitor
- * some states boundaries crossings. These events are traditionally defined as occurring when a
- * <code>g</code> function sign changes, hence the name <em>switching functions</em>.
+ * <p>A switching function evaluates a continuous scalar predicate {@link #g(double, double[])}
+ * alongside numerical integration. When the function crosses zero, the integrator treats the
+ * crossing as an event boundary and delegates to {@link #eventOccurred(double, double[])} to decide
+ * whether to stop, continue, or reset state or derivatives. This interface is intentionally small
+ * so implementations can be lightweight, stateless, or capture only the external state they need.
  *
- * <p>Since events are only problem-dependent and are triggered by the independant <i>time</i>
- * variable and the state vector, they can occur at virtually any time, unknown in advance. The
- * integrators will take care to avoid sign changes inside the steps, they will reduce the step size
- * when such an event is detected in order to put this event exactly at the end of the current step.
- * This guarantees that step interpolation (which always has a one step scope) is relevant even in
- * presence of discontinuities. This is independent from the stepsize control provided by
- * integrators that monitor the local error (this feature is available on all integrators, including
- * fixed step ones).
+ * <p>Typical usage pairs a switching function with a step handler: the integrator brackets a root
+ * of {@code g(t, y)} inside a step, reduces the step size so the root lands at the end of the step,
+ * and then triggers {@link #eventOccurred(double, double[])} before invoking the handler. The
+ * integrator guarantees that interpolation within the accepted step is still valid, which makes
+ * this mechanism suitable for domain boundaries (e.g., altitude crossing), guard conditions, or
+ * reacting to derivative discontinuities.
  *
+ * <p>Implementations should be thread-confinement friendly: instances are typically used by a
+ * single integrator run, so they may keep mutable detection state as long as they are not shared
+ * across concurrent integrations. Returning reset indicators obligates the implementation to supply
+ * the new state in {@link #resetState(double, double[])}; failing to do so may produce inconsistent
+ * trajectories. Constants in this interface map directly to the contract expected by the integrator
+ * and by downstream tools built on the Mantissa ODE package.
+ *
+ * @see FirstOrderIntegrator
+ * @see StepHandler
  * @version $Id: SwitchingFunction.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
  */
 public interface SwitchingFunction extends Serializable {
 
   /**
-   * Stop indicator.
+   * Stop indicator used when integration must halt after handling the current step.
    *
-   * <p>This value should be used as the return value of the {@link #eventOccurred eventOccurred}
-   * method when the integration should be stopped after the event ending the current step.
+   * <p>Return this constant from {@link #eventOccurred(double, double[])} to request that the
+   * integrator mark the current step as the last one, call the configured {@link StepHandler}, and
+   * then terminate without attempting further steps. Use it when crossing the switching surface
+   * represents a terminal condition for the model (for example, hitting the ground or violating a
+   * safety constraint).
    */
-  public static final int STOP = 0;
+  int STOP = 0;
 
   /**
-   * Reset state indicator.
+   * Reset state indicator requesting continuation with a new state vector.
    *
-   * @deprecated replaced by {@link #RESET_STATE} as of mantissa 6.4
+   * <p>Return this constant from {@link #eventOccurred(double, double[])} when integration should
+   * continue after the event, but with the state vector replaced. The integrator will invoke {@link
+   * #resetState(double, double[])} after the current {@link StepHandler} finishes, and it will
+   * recompute derivatives before advancing. Use this when the event represents a discontinuity that
+   * requires a jump in state, such as toggling a mechanical constraint or applying an impulse.
    */
-  @Deprecated public static final int RESET = 1;
+  int RESET_STATE = 1;
 
   /**
-   * Reset state indicator.
+   * Reset derivatives indicator requesting recomputation without altering the state vector.
    *
-   * <p>This value should be used as the return value of the {@link #eventOccurred eventOccurred}
-   * method when the integration should go on after the event ending the current step, with a new
-   * state vector (which will be retrieved thanks to the {@link #resetState resetState} method).
+   * <p>Return this constant from {@link #eventOccurred(double, double[])} when the event only
+   * changes the derivative function, not the current state. The integrator will keep the state
+   * unchanged but recompute derivatives before stepping again. This is useful for piecewise-defined
+   * dynamics where the slope switches at known manifolds while the state remains continuous.
    */
-  public static final int RESET_STATE = 1;
+  int RESET_DERIVATIVES = 2;
 
   /**
-   * Reset derivatives indicator.
+   * Continue indicator used when no special action is required after the event.
    *
-   * <p>This value should be used as the return value of the {@link #eventOccurred eventOccurred}
-   * method when the integration should go on after the event ending the current step, with a new
-   * derivatives vector (which will be retrieved thanks to the {@link
-   * FirstOrderDifferentialEquations#computeDerivatives} method).
+   * <p>Return this constant from {@link #eventOccurred(double, double[])} to acknowledge the event
+   * while letting the integrator proceed normally. Neither state nor derivatives will be reset, and
+   * the step sequence continues. Choose this when the sign change is merely informational or when
+   * side effects have already been applied elsewhere.
    */
-  public static final int RESET_DERIVATIVES = 2;
+  int CONTINUE = 3;
 
   /**
-   * Continue indicator.
+   * Evaluate the switching predicate whose zero crossings define discrete events.
    *
-   * <p>This value should be used as the return value of the {@link #eventOccurred eventOccurred}
-   * method when the integration should go on after the event ending the current step.
+   * <p>The integrator samples this function at step endpoints and via root finders inside a step to
+   * locate sign changes. Implementations should return a continuous value near expected roots so
+   * bisection or similar solvers can converge reliably. Expensive computations should be avoided
+   * where possible because this method is called frequently during step refinement. Returning
+   * {@code Double.NaN} is discouraged because it prevents reliable root detection.
+   *
+   * @param t current value of the independent time variable in integration units; finite and
+   *     monotonic according to the integrator direction
+   * @param y current state vector; elements are owned by the integrator and must not be modified
+   * @return scalar predicate value whose sign determines event crossings; negative/positive values
+   *     are arbitrary as long as sign changes identify the intended surface
    */
-  public static final int CONTINUE = 3;
+  double g(double t, double[] y);
 
   /**
-   * Compute the value of the switching function.
+   * Decide the post-event action once a sign change has been located at the end of a step.
    *
-   * <p>Discrete events are generated when the sign of this function changes, the integrator will
-   * take care to change the stepsize in such a way these events occur exactly at step boundaries.
-   * This function must be continuous (at least in its roots neighborhood), as the integrator will
-   * need to find its roots to locate the events.
+   * <p>The integrator calls this hook immediately after it positions the step endpoint exactly on
+   * an event surface. Implementations may update internal bookkeeping (for example, toggling a mode
+   * flag) and must return one of the interface constants to steer the subsequent step schedule. The
+   * returned action is applied after the current {@link StepHandler} invocation, and derivative
+   * recomputation occurs automatically for reset cases. Avoid performing heavy work here; defer
+   * state changes to {@link #resetState(double, double[])} when possible for clarity.
    *
-   * @param t current value of the independant <i>time</i> variable
-   * @param y array containing the current value of the state vector
-   * @return value of the g function
+   * @param t event time at the accepted step end; equals the root location determined for {@code
+   *     g(t, y)}
+   * @param y state vector at the event boundary; callers may use it for decision logic but should
+   *     not modify contents
+   * @return one of {@link #STOP}, {@link #RESET_STATE}, {@link #RESET_DERIVATIVES}, {@link
+   *     #CONTINUE} to indicate stop/continue/reset handling
    */
-  public double g(double t, double[] y);
+  int eventOccurred(double t, double[] y);
 
   /**
-   * Handle an event and choose what to do next.
+   * Supply a replacement state vector before integration continues after a reset event.
    *
-   * <p>This method is called when the integrator has accepted a step ending exactly on a sign
-   * change of the function, just before the step handler itself is called. It allows the user to
-   * update his internal data to acknowledge the fact the event has been handled (for example
-   * setting a flag in the {@link FirstOrderDifferentialEquations differential equations} to switch
-   * the derivatives computation in case of discontinuity), or to direct the integrator to either
-   * stop or continue integration, possibly with a reset state or derivatives.
+   * <p>Invoked only when {@link #eventOccurred(double, double[])} returned {@link #RESET_STATE} (or
+   * {@link #RESET_STATE}), this method allows the implementation to write the new state directly
+   * into the provided array. The integrator will use the updated values as the starting point for
+   * the next step and will recompute derivatives automatically. Implementations may apply
+   * discontinuous jumps, enforce constraints, or perform minimal adjustments; callers must ensure
+   * the resulting state is finite and consistent with model invariants to avoid integration
+   * failure.
    *
-   * <ul>
-   *   <li>if {@link #STOP} is returned, the step handler will be called with the <code>isLast
-   *       </code> flag of the {@link StepHandler#handleStep handleStep} method set to true and the
-   *       integration will be stopped,
-   *   <li>if {@link #RESET_STATE} is returned, the {@link #resetState resetState} method will be
-   *       called once the step handler has finished its task, and the integrator will also
-   *       recompute the derivatives,
-   *   <li>if {@link #RESET_DERIVATIVES} is returned, the integrator will recompute the derivatives,
-   *   <li>if {@link #CONTINUE} is returned, no specific action will be taken (apart from having
-   *       called this method) and integration will continue.
-   * </ul>
-   *
-   * @param t current value of the independant <i>time</i> variable
-   * @param y array containing the current value of the state vector
-   * @return indication of what the integrator should do next, this value must be one of {@link
-   *     #STOP}, {@link #RESET_STATE}, {@link #RESET_DERIVATIVES} or {@link #CONTINUE}
+   * @param t event time at which the reset takes effect; equals the step end where the root was
+   *     detected
+   * @param y mutable array containing the current state; replace its contents in place with the new
+   *     state vector that should seed the subsequent step
    */
-  public int eventOccurred(double t, double[] y);
-
-  /**
-   * Reset the state prior to continue the integration.
-   *
-   * <p>This method is called after the step handler has returned and before the next step is
-   * started, but only when {@link #eventOccurred} has itself returned the {@link #RESET_STATE}
-   * indicator. It allows the user to reset the state vector for the next step, without perturbing
-   * the step handler of the finishing step. If the {@link #eventOccurred} never returns the {@link
-   * #RESET_STATE} indicator, this function will never be called, and it is safe to leave its body
-   * empty.
-   *
-   * @param t current value of the independant <i>time</i> variable
-   * @param y array containing the current value of the state vector the new state should be put in
-   *     the same array
-   */
-  public void resetState(double t, double[] y);
+  void resetState(double t, double[] y);
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/SwitchingFunctionsHandler.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/SwitchingFunctionsHandler.java
@@ -4,15 +4,42 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This class handles several {@link SwitchingFunction switching functions} during integration.
+ * Coordinates multiple {@link SwitchingFunction switching functions} for a single ODE integration
+ * run.
+ *
+ * <p>The handler owns a collection of per-function {@link SwitchState} instances that track the
+ * latest sign of each predicate, search for zero crossings inside a candidate step, and remember
+ * the earliest event that would force the integrator to shorten that step. A single handler is
+ * created for one integration session and is expected to receive callbacks in the same order as the
+ * integrator progresses: {@link #evaluateStep(StepInterpolator)} before the step is accepted,
+ * {@link #stepAccepted(double, double[])} after acceptance, then {@link #reset(double, double[])}
+ * and {@link #stop()} if an event requested additional actions. Instances are mutable and not
+ * thread-safe; the integrator must ensure serialized access when dealing with multiple switching
+ * functions. Typical usage is one handler per integrator run, populated with application-defined
+ * switching functions during setup and reused until the integration completes or is aborted.
+ *
+ * <ul>
+ *   <li>Responsibility: aggregate event detection across all registered switching functions.
+ *   <li>Priority rule: earliest event wins when integrating forward; latest when backward.
+ *   <li>Lifecycle: initialize once on the first step, then update state after each accepted step.
+ * </ul>
  *
  * @see SwitchingFunction
+ * @see SwitchState
  * @version $Id: SwitchingFunctionsHandler.java 1707 2006-11-19 20:08:32Z luc $
  * @author L. Maisonobe
  */
 public class SwitchingFunctionsHandler {
 
-  /** Simple constructor. Create an empty handler */
+  /**
+   * Creates an empty handler ready to accept switching functions.
+   *
+   * <p>The new instance starts with no registered functions, a cleared pending-event pointer, and
+   * an uninitialized state. Clients typically construct one handler per integrator run, add all
+   * required switching functions via {@link #add(SwitchingFunction, double, double)}, and then
+   * supply the handler to the integrator. The handler may be reused across steps but should not be
+   * shared between concurrent integrations because it stores mutable step-local state.
+   */
   public SwitchingFunctionsHandler() {
     functions = new ArrayList<>();
     first = null;
@@ -20,99 +47,139 @@ public class SwitchingFunctionsHandler {
   }
 
   /**
-   * Add a switching function.
+   * Registers a new switching function to be monitored during subsequent steps.
    *
-   * @param function switching function
-   * @param maxCheckInterval maximal time interval between switching function checks (this interval
-   *     prevents missing sign changes in case the integration steps becomes very large)
-   * @param convergence convergence threshold in the event time search
+   * <p>The handler wraps the provided {@link SwitchingFunction} into a {@link SwitchState} that
+   * stores detection parameters. Registration is additive; functions are checked in insertion order
+   * and the earliest event in the integration direction takes precedence when multiple crossings
+   * are found. This method does not reset prior state and may be called only during setup, before
+   * the first step is evaluated, to avoid undefined interactions with partially initialized state.
+   *
+   * @param function switching function defining a zero-crossing predicate; must not be {@code null}
+   * @param maxCheckInterval maximum predicate spacing within a step, in integration time units
+   * @param convergence absolute time tolerance for event localization; smaller values tighten
+   *     accuracy
    */
   public void add(SwitchingFunction function, double maxCheckInterval, double convergence) {
     functions.add(new SwitchState(function, maxCheckInterval, convergence));
   }
 
   /**
-   * Check if the handler does not have any condition.
+   * Reports whether any switching functions have been registered.
    *
-   * @return true if handler is empty
+   * <p>Callers can use this as a quick guard to skip event-related work when no functions were
+   * added. The result reflects the current registration set and ignores runtime state such as
+   * pending events or initialization. The method is side-effect free and may be called at any time.
+   *
+   * @return {@code true} when no switching functions are present; {@code false} otherwise
    */
   public boolean isEmpty() {
     return functions.isEmpty();
   }
 
   /**
-   * Evaluate the impact of the proposed step on all handled switching functions.
+   * Scans all registered switching functions against a proposed integrator step.
    *
-   * @param interpolator step interpolator for the proposed step
-   * @return true if at least one switching function triggers an event before the end of the
-   *     proposed step (this implies the step should be rejected)
+   * <p>The handler initializes lazily on the first call by sampling the interpolator at the
+   * previous step start. It then delegates to each {@link SwitchState} to detect sign changes,
+   * choosing the earliest event time when integrating forward and the latest when integrating
+   * backward. The interpolator may be temporarily rewound to bracket events but is left consistent
+   * for the caller. If an event is found the integrator should normally reject the step and retry
+   * with a shortened interval ending at the detected time.
+   *
+   * @param interpolator interpolator describing the candidate step; must provide dense output
+   * @return {@code true} if any switching function triggers an event inside the proposed step;
+   *     {@code false} otherwise
+   * @throws IllegalStateException when interpolator sampling raises a {@link DerivativeException}
+   *     during initialization
    */
   public boolean evaluateStep(StepInterpolator interpolator) {
 
-    try {
+    first = null;
+    if (functions.isEmpty()) {
+      // there is nothing to do, return now to avoid setting the
+      // interpolator time (and hence avoid unneeded calls to the
+      // user function due to interpolator finalization)
+      return false;
+    }
 
-      first = null;
-      if (functions.isEmpty()) {
-        // there is nothing to do, return now to avoid setting the
-        // interpolator time (and hence avoid unneeded calls to the
-        // user function due to interpolator finalization)
-        return false;
+    initializeIfNeeded(interpolator);
+    checkEvents(interpolator);
+
+    return first != null;
+  }
+
+  private void checkEvents(StepInterpolator interpolator) {
+    for (SwitchState state : functions) {
+      if (!state.evaluateStep(interpolator)) {
+        continue;
       }
-
-      if (!initialized) {
-
-        // initialize the switching functions
-        double t0 = interpolator.getPreviousTime();
-        interpolator.setInterpolatedTime(t0);
-        double[] y = interpolator.getInterpolatedState();
-        for (SwitchState state : functions) {
-          state.reinitializeBegin(t0, y);
-        }
-
-        initialized = true;
+      if (first == null) {
+        first = state;
+      } else {
+        selectEarlierState(interpolator, state);
       }
-
-      // check events occurrence
-      for (SwitchState state : functions) {
-        if (state.evaluateStep(interpolator)) {
-          if (first == null) {
-            first = state;
-          } else {
-            if (interpolator.isForward()) {
-              if (state.getEventTime() < first.getEventTime()) {
-                first = state;
-              }
-            } else {
-              if (state.getEventTime() > first.getEventTime()) {
-                first = state;
-              }
-            }
-          }
-        }
-      }
-
-      return first != null;
-
-    } catch (DerivativeException e) {
-      throw new RuntimeException("unexpected exception", e);
     }
   }
 
+  private void selectEarlierState(StepInterpolator interpolator, SwitchState candidate) {
+    if (interpolator.isForward()) {
+      if (candidate.getEventTime() < first.getEventTime()) {
+        first = candidate;
+      }
+      return;
+    }
+    if (candidate.getEventTime() > first.getEventTime()) {
+      first = candidate;
+    }
+  }
+
+  private void initializeIfNeeded(StepInterpolator interpolator) {
+    if (initialized) {
+      return;
+    }
+
+    // initialize the switching functions
+    double t0 = interpolator.getPreviousTime();
+    try {
+      interpolator.setInterpolatedTime(t0);
+      double[] y = interpolator.getInterpolatedState();
+      for (SwitchState state : functions) {
+        state.reinitializeBegin(t0, y);
+      }
+    } catch (DerivativeException e) {
+      throw new IllegalStateException("unexpected exception", e);
+    }
+
+    initialized = true;
+  }
+
   /**
-   * Get the occurrence time of the first event triggered in the last evaluated step.
+   * Returns the time of the first event detected in the most recently evaluated step.
    *
-   * @return occurrence time of the first event triggered in the last evaluated step, or </code>
-   *     Double.NaN</code> if no event is triggered
+   * <p>The returned value is meaningful only after a call to {@link
+   * #evaluateStep(StepInterpolator)} that reported an event. When no event has been found since the
+   * last initialization, this method returns {@link Double#NaN}. The value is not cleared by {@link
+   * #stepAccepted(double, double[])} so callers should always check the {@code evaluateStep} result
+   * before using it.
+   *
+   * @return event time in integration units or {@link Double#NaN} when no event is pending
    */
   public double getEventTime() {
     return (first == null) ? Double.NaN : first.getEventTime();
   }
 
   /**
-   * Inform the switching functions that the step has been accepted by the integrator.
+   * Notifies all switching functions that the current step was accepted.
    *
-   * @param t value of the independant <i>time</i> variable at the end of the step
-   * @param y array containing the current value of the state vector at the end of the step
+   * <p>This call advances internal state to the end of the accepted step, capturing the latest sign
+   * of each predicate and recording any event actions requested by {@link
+   * SwitchingFunction#eventOccurred(double, double[])}. It must be invoked exactly once per
+   * accepted step and before any call to {@link #reset(double, double[])} or {@link #stop()} so
+   * that pending actions are visible.
+   *
+   * @param t time at the end of the accepted step in integration units
+   * @param y state vector at step end; must be non-null and sized correctly
    */
   public void stepAccepted(double t, double[] y) {
     for (SwitchState state : functions) {
@@ -121,9 +188,15 @@ public class SwitchingFunctionsHandler {
   }
 
   /**
-   * Check if the integration should be stopped at the end of the current step.
+   * Indicates whether any switching function requested integration to stop.
    *
-   * @return true if the integration should be stopped
+   * <p>The method inspects the latest actions recorded during {@link #stepAccepted(double,
+   * double[])} and returns {@code true} when at least one function returned {@link
+   * SwitchingFunction#STOP}. It performs no additional computation and can be called multiple times
+   * per step without side effects.
+   *
+   * @return {@code true} when a stop action is pending for the current step; {@code false}
+   *     otherwise
    */
   public boolean stop() {
     for (SwitchState state : functions) {
@@ -135,11 +208,18 @@ public class SwitchingFunctionsHandler {
   }
 
   /**
-   * Let the switching functions reset the state if they want.
+   * Applies pending reset actions requested by switching functions after a step was accepted.
    *
-   * @param t value of the independant <i>time</i> variable at the beginning of the next step
-   * @param y array were to put the desired state vector at the beginning of the next step
-   * @return true if the integrator should reset the derivatives too
+   * <p>If any switching function asked for a state or derivative reset during {@link
+   * #stepAccepted(double, double[])}, this method lets it modify the supplied state vector and
+   * informs the caller whether derivatives must be recomputed. It must be invoked before starting
+   * the next integration step so that resets take effect. When no pending event exists, the method
+   * returns {@code false} and leaves the state untouched.
+   *
+   * @param t start time of the next step where any reset is applied
+   * @param y mutable state array for next step; non-null and sized like integration state
+   * @return {@code true} if derivatives must be recomputed after a requested reset; {@code false}
+   *     otherwise
    */
   public boolean reset(double t, double[] y) {
     boolean resetDerivatives = false;

--- a/src/test/java/org/spaceroots/mantissa/ode/SwitchStateTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/SwitchStateTest.java
@@ -1,0 +1,216 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Externalizable;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.roots.ConvergenceChecker;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SwitchStateTest {
+
+  private static final double CONVERGENCE = 1.0e-4;
+
+  @Mock private SwitchingFunction function;
+
+  @Test
+  void evaluateStep_whenSignChange_detectsPendingEventAndRootTime() {
+    when(function.g(anyDouble(), any(double[].class)))
+        .thenAnswer(invocation -> (double) invocation.getArgument(0) - 1.0);
+
+    SwitchState state = new SwitchState(function, 10.0, CONVERGENCE);
+    state.reinitializeBegin(0.0, new double[] {0.0});
+
+    boolean rejected = state.evaluateStep(new LinearInterpolator(0.0, 2.0));
+
+    assertTrue(rejected);
+    assertEquals(1.0, state.getEventTime(), 1.0e-6);
+  }
+
+  @Test
+  void evaluateStep_whenNoSignChange_returnsFalseAndClearsPendingEvent() {
+    when(function.g(anyDouble(), any(double[].class))).thenReturn(5.0);
+
+    SwitchState state = new SwitchState(function, 10.0, CONVERGENCE);
+    state.reinitializeBegin(0.0, new double[] {0.0});
+
+    boolean rejected = state.evaluateStep(new LinearInterpolator(0.0, 2.0));
+
+    assertFalse(rejected);
+    assertTrue(Double.isNaN(state.getEventTime()));
+  }
+
+  @Test
+  void stepAccepted_whenPendingEvent_setsStopAction() {
+    when(function.g(anyDouble(), any(double[].class)))
+        .thenAnswer(invocation -> (double) invocation.getArgument(0) - 1.0);
+    doReturn(SwitchingFunction.STOP).when(function).eventOccurred(anyDouble(), any(double[].class));
+    SwitchState state = new SwitchState(function, 10.0, CONVERGENCE);
+    state.reinitializeBegin(0.0, new double[] {0.0});
+    state.evaluateStep(new LinearInterpolator(0.0, 2.0));
+
+    double eventTime = state.getEventTime();
+    state.stepAccepted(eventTime, new double[] {eventTime});
+
+    assertTrue(state.stop());
+  }
+
+  @Test
+  void reset_whenResetStateRequested_invokesResetStateAndClearsPending() {
+    when(function.g(anyDouble(), any(double[].class)))
+        .thenAnswer(invocation -> (double) invocation.getArgument(0) - 1.0);
+    doReturn(SwitchingFunction.RESET_STATE)
+        .when(function)
+        .eventOccurred(anyDouble(), any(double[].class));
+
+    SwitchState state = new SwitchState(function, 10.0, CONVERGENCE);
+    state.reinitializeBegin(0.0, new double[] {0.0});
+    state.evaluateStep(new LinearInterpolator(0.0, 2.0));
+    double eventTime = state.getEventTime();
+    double[] stateVector = new double[] {eventTime};
+    state.stepAccepted(eventTime, stateVector);
+
+    boolean requiresReset = state.reset(eventTime, stateVector);
+
+    assertTrue(requiresReset);
+    verify(function).resetState(eventTime, stateVector);
+    assertTrue(Double.isNaN(state.getEventTime()));
+  }
+
+  @Test
+  void reset_whenNoPendingEvent_returnsFalseAndSkipsResetState() {
+    when(function.g(anyDouble(), any(double[].class))).thenReturn(1.0);
+    SwitchState state = new SwitchState(function, 10.0, CONVERGENCE);
+    state.reinitializeBegin(0.0, new double[] {0.0});
+
+    boolean requiresReset = state.reset(0.5, new double[] {0.5});
+
+    assertFalse(requiresReset);
+    verify(function, never()).resetState(anyDouble(), any(double[].class));
+  }
+
+  @Test
+  void evaluateStep_whenPendingEventAtStepEnd_acceptsStepInsteadOfRejecting() {
+    when(function.g(anyDouble(), any(double[].class)))
+        .thenAnswer(invocation -> (double) invocation.getArgument(0) - 1.0);
+    SwitchState state = new SwitchState(function, 10.0, 1.0e-3);
+    state.reinitializeBegin(0.0, new double[] {0.0});
+
+    state.evaluateStep(new LinearInterpolator(0.0, 2.0));
+    double pendingTime = state.getEventTime();
+
+    boolean rejectedSecond = state.evaluateStep(new LinearInterpolator(0.0, pendingTime));
+
+    assertFalse(rejectedSecond);
+    assertEquals(pendingTime, state.getEventTime(), 1.0e-3);
+  }
+
+  @Test
+  void valueAt_whenInterpolatorThrowsDerivativeException_wrapsInFunctionException() {
+    when(function.g(anyDouble(), any(double[].class)))
+        .thenAnswer(invocation -> (double) invocation.getArgument(0));
+    LinearInterpolator interpolator = new LinearInterpolator(0.0, 1.0);
+
+    SwitchState state = new SwitchState(function, 10.0, CONVERGENCE);
+    state.reinitializeBegin(0.0, new double[] {0.0});
+    state.evaluateStep(interpolator);
+    interpolator.enableThrowOnSet();
+
+    assertThrows(FunctionException.class, () -> state.valueAt(0.5));
+  }
+
+  @Test
+  void converged_whenIntervalWithinThreshold_returnsSideWithSmallerMagnitude() {
+    SwitchState state = new SwitchState(function, 10.0, 0.2);
+
+    int resultLowMagnitude = state.converged(0.0, 0.1, 0.1, 0.5);
+    int resultHighMagnitude = state.converged(0.0, 0.5, 0.1, 0.1);
+    int resultNone = state.converged(0.0, 0.1, 0.5, 0.2);
+
+    assertEquals(ConvergenceChecker.LOW, resultLowMagnitude);
+    assertEquals(ConvergenceChecker.HIGH, resultHighMagnitude);
+    assertEquals(ConvergenceChecker.NONE, resultNone);
+  }
+
+  /** Minimal deterministic interpolator for tests. */
+  private static final class LinearInterpolator implements StepInterpolator, Externalizable {
+
+    private final double previousTime;
+    private final double currentTime;
+    private double interpolatedTime;
+    private boolean throwOnSet;
+
+    public LinearInterpolator() {
+      this(0.0, 0.0);
+    }
+
+    LinearInterpolator(double previousTime, double currentTime) {
+      this.previousTime = previousTime;
+      this.currentTime = currentTime;
+      this.interpolatedTime = currentTime;
+    }
+
+    void enableThrowOnSet() {
+      this.throwOnSet = true;
+    }
+
+    @Override
+    public double getPreviousTime() {
+      return previousTime;
+    }
+
+    @Override
+    public double getCurrentTime() {
+      return currentTime;
+    }
+
+    @Override
+    public double getInterpolatedTime() {
+      return interpolatedTime;
+    }
+
+    @Override
+    public void setInterpolatedTime(double time) throws DerivativeException {
+      if (throwOnSet) {
+        throw new DerivativeException(new RuntimeException("forced"));
+      }
+      this.interpolatedTime = time;
+    }
+
+    @Override
+    public double[] getInterpolatedState() {
+      return new double[] {interpolatedTime};
+    }
+
+    @Override
+    public boolean isForward() {
+      return currentTime >= previousTime;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) {
+      // not needed for tests
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) {
+      // not needed for tests
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/SwitchingFunctionsHandlerTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/SwitchingFunctionsHandlerTest.java
@@ -1,0 +1,194 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SwitchingFunctionsHandlerTest {
+
+  @Test
+  void isEmpty_whenNoFunctions_returnsTrue() {
+    SwitchingFunctionsHandler handler = new SwitchingFunctionsHandler();
+
+    assertTrue(handler.isEmpty());
+  }
+
+  @Test
+  void add_whenFunctionAdded_handlerNotEmpty() {
+    SwitchingFunctionsHandler handler = new SwitchingFunctionsHandler();
+    handler.add(mockCrossingFunction(1.0, SwitchingFunction.CONTINUE), 5.0, 1.0e-6);
+
+    assertFalse(handler.isEmpty());
+  }
+
+  @Test
+  void evaluateStep_whenHandlerEmpty_returnsFalseAndKeepsEventTimeNaN() {
+    SwitchingFunctionsHandler handler = new SwitchingFunctionsHandler();
+    StepInterpolator interpolator = new LinearStepInterpolator(0.0, 1.0, true);
+
+    boolean hasEvent = handler.evaluateStep(interpolator);
+
+    assertFalse(hasEvent);
+    assertTrue(Double.isNaN(handler.getEventTime()));
+  }
+
+  @Test
+  void evaluateStep_whenSingleFunctionCrossesZero_detectsEventAndStoresEarliestTime() {
+    SwitchingFunctionsHandler handler = new SwitchingFunctionsHandler();
+    handler.add(mockCrossingFunction(1.0, SwitchingFunction.CONTINUE), 10.0, 1.0e-6);
+    StepInterpolator interpolator = new LinearStepInterpolator(0.0, 2.0, true);
+
+    boolean hasEvent = handler.evaluateStep(interpolator);
+
+    assertTrue(hasEvent);
+    assertEquals(1.0, handler.getEventTime(), 1.0e-4);
+  }
+
+  @Test
+  void evaluateStep_whenMultipleFunctionsForward_selectsEarliestEventTime() {
+    SwitchingFunctionsHandler handler = new SwitchingFunctionsHandler();
+    handler.add(mockCrossingFunction(0.5, SwitchingFunction.CONTINUE), 10.0, 1.0e-6);
+    handler.add(mockCrossingFunction(1.5, SwitchingFunction.CONTINUE), 10.0, 1.0e-6);
+    StepInterpolator interpolator = new LinearStepInterpolator(0.0, 2.0, true);
+
+    boolean hasEvent = handler.evaluateStep(interpolator);
+
+    assertTrue(hasEvent);
+    assertEquals(0.5, handler.getEventTime(), 1.0e-4);
+  }
+
+  @Test
+  void evaluateStep_whenMultipleFunctionsBackward_selectsLatestEventInDirection() {
+    SwitchingFunctionsHandler handler = new SwitchingFunctionsHandler();
+    handler.add(mockCrossingFunction(0.5, SwitchingFunction.CONTINUE), 10.0, 1.0e-6);
+    handler.add(mockCrossingFunction(1.5, SwitchingFunction.CONTINUE), 10.0, 1.0e-6);
+    StepInterpolator interpolator = new LinearStepInterpolator(2.0, 0.0, false);
+
+    boolean hasEvent = handler.evaluateStep(interpolator);
+
+    assertTrue(hasEvent);
+    assertEquals(1.5, handler.getEventTime(), 1.0e-4);
+  }
+
+  @Test
+  void stepAccepted_whenEventRequestsStop_reportsStopOnHandler() {
+    SwitchingFunctionsHandler handler = new SwitchingFunctionsHandler();
+    SwitchingFunction function = mockCrossingFunction(0.5, SwitchingFunction.STOP);
+    handler.add(function, 10.0, 1.0e-6);
+    StepInterpolator interpolator = new LinearStepInterpolator(0.0, 1.0, true);
+
+    handler.evaluateStep(interpolator);
+    double eventTime = handler.getEventTime();
+    double[] stateAtEvent = new double[] {eventTime};
+
+    handler.stepAccepted(eventTime, stateAtEvent);
+
+    assertTrue(handler.stop());
+    verify(function).eventOccurred(eq(eventTime), any(double[].class));
+  }
+
+  @Test
+  void reset_whenEventRequestsStateReset_invokesResetStateAndSignalsDerivativeReset() {
+    SwitchingFunctionsHandler handler = new SwitchingFunctionsHandler();
+    SwitchingFunction function = mockCrossingFunction(0.5, SwitchingFunction.RESET_STATE);
+    handler.add(function, 10.0, 1.0e-6);
+    StepInterpolator interpolator = new LinearStepInterpolator(0.0, 1.0, true);
+
+    handler.evaluateStep(interpolator);
+    double eventTime = handler.getEventTime();
+    double[] stateAtEvent = new double[] {eventTime};
+
+    handler.stepAccepted(eventTime, stateAtEvent);
+    boolean resetDerivatives = handler.reset(eventTime, stateAtEvent);
+
+    assertTrue(resetDerivatives);
+    verify(function, times(1)).resetState(eventTime, stateAtEvent);
+
+    assertFalse(handler.reset(eventTime, stateAtEvent));
+  }
+
+  private SwitchingFunction mockCrossingFunction(double crossingTime, int eventAction) {
+    SwitchingFunction function = mock(SwitchingFunction.class);
+    lenient()
+        .when(function.g(anyDouble(), any(double[].class)))
+        .thenAnswer(invocation -> ((double) invocation.getArgument(0)) - crossingTime);
+    lenient()
+        .when(function.eventOccurred(anyDouble(), any(double[].class)))
+        .thenReturn(eventAction);
+    return function;
+  }
+
+  private static final class LinearStepInterpolator implements StepInterpolator {
+
+    private final double previousTime;
+    private final double currentTime;
+    private final boolean forward;
+    private double interpolatedTime;
+
+    public LinearStepInterpolator() {
+      this(0.0, 0.0, true);
+    }
+
+    LinearStepInterpolator(double previousTime, double currentTime, boolean forward) {
+      this.previousTime = previousTime;
+      this.currentTime = currentTime;
+      this.forward = forward;
+      this.interpolatedTime = currentTime;
+    }
+
+    @Override
+    public double getPreviousTime() {
+      return previousTime;
+    }
+
+    @Override
+    public double getCurrentTime() {
+      return currentTime;
+    }
+
+    @Override
+    public double getInterpolatedTime() {
+      return interpolatedTime;
+    }
+
+    @Override
+    public void setInterpolatedTime(double time) {
+      this.interpolatedTime = time;
+    }
+
+    @Override
+    public double[] getInterpolatedState() {
+      return new double[] {interpolatedTime};
+    }
+
+    @Override
+    public boolean isForward() {
+      return forward;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) {
+      // Not used in tests
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) {
+      // Not used in tests
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- clarify the switching-function contract, remove the deprecated RESET constant, and expand Javadoc
- refactor SwitchState event detection/handling for clearer control flow and error reporting
- document SwitchingFunctionsHandler lifecycle and add focused unit tests for handler and switch state behaviors

## Testing
- Not run (not requested)
