### PR TITLE
Fix Gauss-Legendre orientation; improve scalar integrators docs/tests

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/ComputableFunctionIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/ComputableFunctionIntegrator.java
@@ -4,11 +4,34 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.ComputableFunction;
 
 /**
- * This interface represents an integrator for scalar functions.
+ * Contract for numerical integration of single-variable scalar functions.
  *
- * <p>The classes which are devoted to integrate scalar functions should implement this interface.
- * The functions which can be handled should implement the {@link ComputableFunction
- * ComputableFunction} interface.
+ * <p>This interface defines the minimal operations required by quadrature engines that evaluate
+ * {@link ComputableFunction} instances over finite intervals. Implementations encapsulate the
+ * algorithmic details (adaptive refinement, fixed-rule quadrature, error estimation, or sampling
+ * reuse) while exposing a stable entry point for callers that only need the integral value. Typical
+ * usage is to select an integrator suited to the expected smoothness of the function, create or
+ * supply a {@code ComputableFunction} that returns deterministic values for any <em>x</em>, and
+ * invoke {@link #integrate(ComputableFunction, double, double)} with the desired bounds. Intervals
+ * may be provided in either order; the mathematical orientation of the integral is preserved, so
+ * swapped bounds generally produce a sign change rather than an exception.
+ *
+ * <p>Implementations may be stateful (for example, caching samples or adapting tolerance), so
+ * thread-safety is determined by the specific class. Callers should either confine each integrator
+ * instance to a single thread or consult the concrete implementation before concurrent use.
+ * Numerical stability depends on the chosen algorithm and the function's smoothness; functions with
+ * discontinuities or singularities may require specialized integrators or preprocessing. Returned
+ * results are usually approximations within an algorithm-defined tolerance rather than exact
+ * analytic values.
+ *
+ * <ul>
+ *   <li>Usual responsibilities: set integration bounds, evaluate the supplied function, accumulate
+ *       the oriented area.
+ *   <li>Expected behavior: reject or propagate evaluation failures from the wrapped function
+ *       unchanged.
+ *   <li>Common pattern: create integrator → call {@code integrate(f, a, b)} → inspect scalar
+ *       result.
+ * </ul>
  *
  * @see ComputableFunction
  * @version $Id: ComputableFunctionIntegrator.java 1231 2002-03-12 20:07:04Z luc $
@@ -16,13 +39,23 @@ import org.spaceroots.mantissa.functions.scalar.ComputableFunction;
  */
 public interface ComputableFunctionIntegrator {
   /**
-   * Integrate a function over a defined range.
+   * Integrate the supplied function over the oriented interval {@code [a, b]}.
    *
-   * @param f function to integrate
-   * @param a first bound of the range (can be lesser or greater than b)
-   * @param b second bound of the range (can be lesser or greater than a)
-   * @return value of the integral over the range
-   * @exception FunctionException if the underlying function throws one
+   * <p>The integrator samples the provided {@link ComputableFunction} across the closed interval,
+   * applying whatever quadrature rule the concrete implementation supports. The bounds are allowed
+   * in either order; when {@code a > b} the returned value reflects the mathematically negative
+   * orientation rather than raising an error. Implementations are expected to honor any internal
+   * tolerance or evaluation limits they expose elsewhere, and they may perform adaptive refinement
+   * to achieve a stable result. Callers should ensure the function is well-behaved on the interval;
+   * steep gradients or discontinuities can degrade accuracy or increase the number of evaluations
+   * required. The method is not guaranteed to be idempotent if the function has side effects or
+   * depends on external mutable state.
+   *
+   * @param f computable scalar function supplying deterministic values for quadrature evaluation
+   * @param a lower or upper bound; values greater than {@code b} reverse interval orientation
+   * @param b upper or lower bound; values less than {@code a} preserve signed integral semantics
+   * @return definite integral estimate over {@code [a, b]} with orientation preserved
+   * @exception FunctionException if the underlying function throws one during evaluation steps
    */
-  public double integrate(ComputableFunction f, double a, double b) throws FunctionException;
+  double integrate(ComputableFunction f, double a, double b) throws FunctionException;
 }

--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/EnhancedSimpsonIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/EnhancedSimpsonIntegrator.java
@@ -5,28 +5,84 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
 
 /**
- * This class implements an enhanced Simpson-like integrator.
+ * Adaptive Simpson-style accumulator for streamed samples of a scalar function.
  *
- * <p>A traditional Simpson integrator is based on a quadratic approximation of the function on
- * three equally spaced points. This integrator does the same thing but can handle non-equally
- * spaced points. If it is used on a regular sample, it behaves exactly as a traditional Simpson
- * integrator.
+ * <p>The integrator consumes a {@link SampledFunctionIterator} that yields abscissa/value pairs in
+ * order and converts them into a running definite integral. It delegates per-step math to {@link
+ * EnhancedSimpsonIntegratorSampler}, which applies a Simpson-like rule when three consecutive
+ * points are available and falls back to a trapezoidal rule for any trailing pair. Unlike composite
+ * Simpson integrators that require uniform spacing, this implementation tolerates varying step
+ * widths while still delivering third-order accuracy on well-behaved curves. Typical usage pulls
+ * samples from a lazily evaluated function and streams the output integral into higher level
+ * routines without holding the entire series in memory.
+ *
+ * <p>The class is stateful and not thread-safe: each call to {@link
+ * #integrate(SampledFunctionIterator)} consumes the supplied iterator exactly once. Callers should
+ * provide monotonically increasing abscissae to preserve numerical stability and avoid reusing
+ * iterators that are shared across threads. Error conditions propagate directly from the underlying
+ * iterator or sampler so callers can react to depleted samples or function-evaluation failures.
+ *
+ * <ul>
+ *   <li>Responsibilities: drive sampling, accumulate area, and return the final integral.
+ *   <li>Notable behavior: mixes Simpson and trapezoid rules to handle uneven sample spacing.
+ *   <li>Mutability: a new instance carries no state beyond the active integration loop.
+ * </ul>
  *
  * @version $Id: EnhancedSimpsonIntegrator.java 1237 2002-03-20 21:01:57Z luc $
  * @author L. Maisonobe
  */
 public class EnhancedSimpsonIntegrator implements SampledFunctionIntegrator {
+
+  /**
+   * Builds a stateless integrator instance ready for single-threaded use.
+   *
+   * <p>No initialization is required because per-run state is allocated inside {@link
+   * #integrate(SampledFunctionIterator)}. Clients may reuse the same instance across multiple
+   * integrations as long as invocations are not concurrent.
+   */
+  public EnhancedSimpsonIntegrator() {
+    // no internal state to initialize
+  }
+
+  /**
+   * Integrates all samples provided by the iterator into a single accumulated value.
+   *
+   * <p>The method repeatedly requests successive samples from {@link
+   * EnhancedSimpsonIntegratorSampler} until the sampler reports exhaustion. Each step contributes
+   * either a Simpson-style area when three consecutive samples are available or a trapezoidal area
+   * for the final, possibly incomplete, segment. The iterator is consumed fully; subsequent calls
+   * on the same iterator instance are not supported. Callers should ensure the iterator begins with
+   * at least one sample and that abscissae progress forward to avoid negative widths and unstable
+   * weights. Any function-evaluation failures surface immediately as {@link FunctionException}
+   * without altering partial results.
+   *
+   * <pre>{@code
+   * SampledFunctionIterator it = buildIterator();
+   * double area = new EnhancedSimpsonIntegrator().integrate(it);
+   * }</pre>
+   *
+   * @param iter iterator delivering ordered scalar samples; must not be {@code null} and must
+   *     supply at least one point before exhaustion
+   * @return accumulated integral value corresponding to the last sample position; intermediate
+   *     results are not exposed or cached
+   * @throws ExhaustedSampleException if the iterator is empty at start or ends unexpectedly while
+   *     building the initial window of points
+   * @throws FunctionException if evaluating the underlying function to obtain a sample fails at any
+   *     point in the traversal
+   */
   public double integrate(SampledFunctionIterator iter)
       throws ExhaustedSampleException, FunctionException {
 
     EnhancedSimpsonIntegratorSampler sampler = new EnhancedSimpsonIntegratorSampler(iter);
     double sum = 0.0;
 
-    try {
-      while (true) {
+    boolean finished = false;
+    while (!finished) {
+      try {
         sum = sampler.nextSamplePoint().getY();
+      } catch (ExhaustedSampleException e) {
+        finished = true;
       }
-    } catch (ExhaustedSampleException e) {
     }
 
     return sum;

--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/EnhancedSimpsonIntegratorSampler.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/EnhancedSimpsonIntegratorSampler.java
@@ -5,21 +5,37 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.*;
 
 /**
- * This class implements an enhanced Simpson integrator as a sample.
+ * Sample iterator that integrates a scalar function on the fly using an enhanced Simpson rule.
  *
- * <p>A traditional Simpson integrator is based on a quadratic approximation of the function on
- * three equally spaced points. This integrator does the same thing but can handle non-equally
- * spaced points. If it is used on a regular sample, it behaves exactly as a traditional Simpson
- * integrator.
+ * <p>The sampler wraps another {@link SampledFunctionIterator} and transforms each triple of
+ * successive sample points into an incremental area estimate. Compared to the classical Simpson
+ * formula, this variant accepts uneven spacing between abscissae and automatically falls back to a
+ * trapezoidal step when the final chunk has only two points available. Clients consume it exactly
+ * like the underlying iterator: call {@link #hasNext()} and {@link #nextSamplePoint()} to stream
+ * accumulated integrals without first materializing the input data set.
+ *
+ * <p>Typical usage is in post-processing of numerically sampled or measured data where the grid is
+ * not perfectly uniform. The class is stateful: each call advances the wrapped iterator and updates
+ * an internal running sum stored as a primitive double. Instances are not thread-safe and should be
+ * confined to a single traversal. Because the sampler never rewinds, it is best suited to one-pass
+ * analyses such as plotting cumulative area or feeding downstream integrators.
+ *
+ * <ul>
+ *   <li>Accepts irregular spacing while preserving Simpson-like accuracy.
+ *   <li>Emits {@link ScalarValuedPair} whose abscissa is the last consumed point and ordinate is
+ *       the cumulative integral up to that abscissa.
+ *   <li>Falls back to trapezoidal integration for the final incomplete segment.
+ * </ul>
  *
  * @see EnhancedSimpsonIntegrator
+ * @see SampledFunctionIterator
  * @version $Id: EnhancedSimpsonIntegratorSampler.java 1237 2002-03-20 21:01:57Z luc $
  * @author L. Maisonobe
  */
 public class EnhancedSimpsonIntegratorSampler implements SampledFunctionIterator {
 
   /** Underlying sampled function iterator. */
-  private SampledFunctionIterator iter;
+  private final SampledFunctionIterator iter;
 
   /** Next point. */
   private ScalarValuedPair next;
@@ -28,9 +44,19 @@ public class EnhancedSimpsonIntegratorSampler implements SampledFunctionIterator
   private double sum;
 
   /**
-   * Constructor. Build an integrator from an underlying sample iterator.
+   * Builds an integrating iterator that wraps the provided sampled function stream.
    *
-   * @param iter iterator over the base function
+   * <p>The constructor eagerly consumes the first sample point so subsequent calls to {@link
+   * #nextSamplePoint()} can operate on complete segments. Callers must supply an iterator that
+   * yields at least one point; otherwise an {@link ExhaustedSampleException} is propagated. The
+   * running integral starts at zero and accumulates with every call to {@code nextSamplePoint()}.
+   * No copies of the underlying samples are retained beyond what is needed for the current step.
+   *
+   * @param iter iterator over the base function; must be non-null and able to provide at least one
+   *     sample without side effects between calls.
+   * @throws ExhaustedSampleException if the underlying iterator has no sample available during
+   *     construction.
+   * @throws FunctionException if the underlying iterator fails while producing the first sample.
    */
   public EnhancedSimpsonIntegratorSampler(SampledFunctionIterator iter)
       throws ExhaustedSampleException, FunctionException {
@@ -44,10 +70,37 @@ public class EnhancedSimpsonIntegratorSampler implements SampledFunctionIterator
     sum = 0.0;
   }
 
+  /**
+   * Reports whether another integrated sample can be produced without advancing state.
+   *
+   * <p>This method delegates to the wrapped iterator and does not alter the internal running sum.
+   * Repeated calls are inexpensive and safe; however, once {@code false} is returned any further
+   * call to {@link #nextSamplePoint()} will raise {@link ExhaustedSampleException}.
+   *
+   * @return {@code true} when at least one more integrated point can be obtained from the
+   *     underlying sampler.
+   */
   public boolean hasNext() {
     return iter.hasNext();
   }
 
+  /**
+   * Advances the iterator one step and returns the cumulative integral at the new abscissa.
+   *
+   * <p>The method consumes one or two points from the wrapped iterator depending on whether a full
+   * three-point Simpson window is available. When three consecutive points are present, it applies
+   * the enhanced Simpson weights that tolerate non-uniform spacing. If only two points remain at
+   * the end of the stream, it uses a trapezoidal approximation for the last segment. The returned
+   * pair owns primitive copies of the abscissa and integral; modifying it does not affect internal
+   * state. Successive calls accumulate into the same running sum.
+   *
+   * @return new pair whose abscissa equals the most recently consumed point and whose ordinate is
+   *     the total integrated value up to that abscissa.
+   * @throws ExhaustedSampleException if called after the underlying iterator is depleted or if the
+   *     initial construction exhausted the stream.
+   * @throws FunctionException if the wrapped iterator fails while producing any required sample
+   *     point.
+   */
   public ScalarValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException {
     // performs one step of an enhanced Simpson scheme
     ScalarValuedPair previous = next;

--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/GaussLegendreIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/GaussLegendreIntegrator.java
@@ -111,9 +111,10 @@ public class GaussLegendreIntegrator implements ComputableFunctionIntegrator {
    * <p>The method partitions {@code [a, b]} into equal-width segments whose size is derived from
    * the configured raw step. For each segment it evaluates the function at precomputed interior
    * points, scales the results by the Gauss-Legendre weights, and accumulates a running sum. When
-   * the bounds are provided in descending order, the algorithm swaps them to preserve mathematical
-   * sign consistency. No adaptive refinement or error estimation is performed; accuracy depends on
-   * function smoothness, the chosen rule order, and the resulting step width.
+   * the bounds are provided in descending order, the algorithm integrates over the magnitude of the
+   * interval and reapplies a negative sign so that orientation is preserved. No adaptive refinement
+   * or error estimation is performed; accuracy depends on function smoothness, the chosen rule
+   * order, and the resulting step width.
    *
    * <pre>{@code
    * ComputableFunction f = x -> Math.sin(x);
@@ -136,11 +137,13 @@ public class GaussLegendreIntegrator implements ComputableFunctionIntegrator {
   @Override
   public double integrate(ComputableFunction f, double a, double b) throws FunctionException {
 
-    // swap the bounds if they are not in ascending order
+    double orientation = 1.0;
+    // use ascending bounds for quadrature while keeping the caller's requested sign
     if (b < a) {
       double tmp = b;
       b = a;
       a = tmp;
+      orientation = -1.0;
     }
 
     // adjust the step according to the bounds
@@ -158,7 +161,7 @@ public class GaussLegendreIntegrator implements ComputableFunctionIntegrator {
       midPoint += step;
     }
 
-    return halfStep * sum;
+    return orientation * halfStep * sum;
   }
 
   private final double[][] weightedRoots;

--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/GaussLegendreIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/GaussLegendreIntegrator.java
@@ -4,43 +4,51 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.ComputableFunction;
 
 /**
- * This class implements a Gauss-Legendre integrator.
+ * Fixed-step Gauss-Legendre quadrature for scalar, single-variable functions.
  *
- * <p>Gauss-Legendre integrators are efficient integrators that can accurately integrate functions
- * with few functions evaluations. A Gauss-Legendre integrator using an n-points quadrature formula
- * can integrate exactly 2n-1 degree polynoms.
+ * <p>This integrator evaluates {@link ComputableFunction} instances using precomputed
+ * Gauss-Legendre abscissas and weights. It is suited to smooth functions over finite intervals when
+ * the caller prefers predictable work per step instead of adaptive refinement. Each step samples
+ * the function at {@code n} non-uniform interior points and combines the results with matching
+ * weights to reach exactness for polynomials up to degree {@code 2n-1}. Boundary values are never
+ * probed, allowing integrands that are undefined or poorly behaved at the interval ends.
  *
- * <p>These integrators evaluate the function on n carefully chosen points in each step interval.
- * These points are not evenly spaced. The function is <emph>never</emph> evaluated at the boundary
- * points, which means it can be undefined at these points.
+ * <p>Usage pattern: construct with a minimal point count and a nominal step size, then invoke
+ * {@link #integrate(ComputableFunction, double, double)} for each definite integral needed. The
+ * integrator adjusts the raw step to divide the interval evenly while preserving orientation when
+ * bounds are reversed. Instances are stateless after construction; reuse across calls is safe from
+ * a mutability perspective, but thread confinement is recommended unless the wrapped function is
+ * itself thread-safe.
+ *
+ * <ul>
+ *   <li>Quadrature rule: Gauss-Legendre of order 2–5 (inclusive) selected from the provided minimum
+ *       point count.
+ *   <li>Step model: fixed width derived from the requested raw step to tile the interval exactly.
+ *   <li>Error behavior: no adaptive control; accuracy depends on function smoothness and point
+ *       count.
+ * </ul>
  *
  * @version $Id: GaussLegendreIntegrator.java 1231 2002-03-12 20:07:04Z luc $
  * @author L. Maisonobe
+ * @see ComputableFunctionIntegrator
+ * @see ComputableFunction
  */
 public class GaussLegendreIntegrator implements ComputableFunctionIntegrator {
   /**
-   * Build a Gauss-Legendre integrator.
+   * Create an integrator configured with a minimum number of quadrature points and a nominal step.
    *
-   * <p>A Gauss-Legendre integrator is a formula like:
+   * <p>The constructor selects a built-in Gauss-Legendre rule between two and five points, using
+   * the smallest available rule whose order is at least {@code minPoints}. The provided {@code
+   * rawStep} is treated as a target width; the integrator will later adjust it slightly so that the
+   * requested interval can be tiled with an integer number of equal segments. Coefficients and
+   * abscissas are precomputed at construction time and reused for all subsequent evaluations,
+   * keeping runtime overhead low and deterministic.
    *
-   * <pre>
-   *    int (f) from -1 to +1 = Sum (ai * f(xi))
-   * </pre>
-   *
-   * <p>The coefficients of the formula are computed as follow:
-   *
-   * <pre>
-   *   let n be the desired number of points
-   *   the xi are the roots of the degree n Legendre polynomial
-   *   the ai are the integrals int (Li^2) from -1 to +1
-   *   where Li (x) = Prod (x-xk)/(xi-xk) for k != i
-   * </pre>
-   *
-   * <p>A formula in n points can integrate exactly polynoms of degree up to 2n-1.
-   *
-   * @param minPoints minimal number of points desired
-   * @param rawStep raw integration step (the precise step will be adjusted in order to have an
-   *     integer number of steps in the integration range).
+   * @param minPoints minimal acceptable number of Gauss-Legendre abscissas; values below two clamp
+   *     to the two-point rule, values above five select the five-point rule.
+   * @param rawStep preferred absolute step size in integration variable units; will be scaled to an
+   *     exact divisor of the requested integration interval during {@link
+   *     #integrate(ComputableFunction, double, double)}.
    */
   public GaussLegendreIntegrator(int minPoints, double rawStep) {
     if (minPoints <= 2) {
@@ -49,53 +57,35 @@ public class GaussLegendreIntegrator implements ComputableFunctionIntegrator {
             {1.0, -1.0 / Math.sqrt(3.0)},
             {1.0, 1.0 / Math.sqrt(3.0)}
           };
-    } else if (minPoints <= 3) {
+    } else if (minPoints == 3) {
       weightedRoots =
           new double[][] {
             {5.0 / 9.0, -Math.sqrt(0.6)},
             {8.0 / 9.0, 0.0},
             {5.0 / 9.0, Math.sqrt(0.6)}
           };
-    } else if (minPoints <= 4) {
+    } else if (minPoints == 4) {
+      double sqrt30 = Math.sqrt(30.0);
+      double positiveTerm = Math.sqrt((15.0 + 2.0 * sqrt30) / 35.0);
+      double negativeTerm = Math.sqrt((15.0 - 2.0 * sqrt30) / 35.0);
       weightedRoots =
           new double[][] {
-            {
-              (90.0 - 5.0 * Math.sqrt(30.0)) / 180.0,
-              -Math.sqrt((15.0 + 2.0 * Math.sqrt(30.0)) / 35.0)
-            },
-            {
-              (90.0 + 5.0 * Math.sqrt(30.0)) / 180.0,
-              -Math.sqrt((15.0 - 2.0 * Math.sqrt(30.0)) / 35.0)
-            },
-            {
-              (90.0 + 5.0 * Math.sqrt(30.0)) / 180.0,
-              Math.sqrt((15.0 - 2.0 * Math.sqrt(30.0)) / 35.0)
-            },
-            {
-              (90.0 - 5.0 * Math.sqrt(30.0)) / 180.0,
-              Math.sqrt((15.0 + 2.0 * Math.sqrt(30.0)) / 35.0)
-            }
+            {(90.0 - 5.0 * Math.sqrt(30.0)) / 180.0, -positiveTerm},
+            {(90.0 + 5.0 * Math.sqrt(30.0)) / 180.0, -negativeTerm},
+            {(90.0 + 5.0 * Math.sqrt(30.0)) / 180.0, negativeTerm},
+            {(90.0 - 5.0 * Math.sqrt(30.0)) / 180.0, positiveTerm}
           };
     } else {
+      double sqrt70 = Math.sqrt(70.0);
+      double positiveTerm = Math.sqrt((35.0 + 2.0 * sqrt70) / 63.0);
+      double negativeTerm = Math.sqrt((35.0 - 2.0 * sqrt70) / 63.0);
       weightedRoots =
           new double[][] {
-            {
-              (322.0 - 13.0 * Math.sqrt(70.0)) / 900.0,
-              -Math.sqrt((35.0 + 2.0 * Math.sqrt(70.0)) / 63.0)
-            },
-            {
-              (322.0 + 13.0 * Math.sqrt(70.0)) / 900.0,
-              -Math.sqrt((35.0 - 2.0 * Math.sqrt(70.0)) / 63.0)
-            },
+            {(322.0 - 13.0 * Math.sqrt(70.0)) / 900.0, -positiveTerm},
+            {(322.0 + 13.0 * Math.sqrt(70.0)) / 900.0, -negativeTerm},
             {128.0 / 225.0, 0.0},
-            {
-              (322.0 + 13.0 * Math.sqrt(70.0)) / 900.0,
-              Math.sqrt((35.0 - 2.0 * Math.sqrt(70.0)) / 63.0)
-            },
-            {
-              (322.0 - 13.0 * Math.sqrt(70.0)) / 900.0,
-              Math.sqrt((35.0 + 2.0 * Math.sqrt(70.0)) / 63.0)
-            }
+            {(322.0 + 13.0 * Math.sqrt(70.0)) / 900.0, negativeTerm},
+            {(322.0 - 13.0 * Math.sqrt(70.0)) / 900.0, positiveTerm}
           };
     }
 
@@ -103,14 +93,47 @@ public class GaussLegendreIntegrator implements ComputableFunctionIntegrator {
   }
 
   /**
-   * Get the number of functions evaluation per step.
+   * Number of function evaluations performed on each fixed step.
    *
-   * @return number of function evaluation per step
+   * <p>This value equals the selected Gauss-Legendre order and remains constant for the lifetime of
+   * the integrator. Callers can use it to estimate total work or to pre-size caches used by the
+   * supplied {@link ComputableFunction} implementation.
+   *
+   * @return count of {@link ComputableFunction#valueAt(double)} invocations per step of integration
    */
   public int getEvaluationsPerStep() {
     return weightedRoots.length;
   }
 
+  /**
+   * Compute the oriented definite integral of the supplied function over the closed interval.
+   *
+   * <p>The method partitions {@code [a, b]} into equal-width segments whose size is derived from
+   * the configured raw step. For each segment it evaluates the function at precomputed interior
+   * points, scales the results by the Gauss-Legendre weights, and accumulates a running sum. When
+   * the bounds are provided in descending order, the algorithm swaps them to preserve mathematical
+   * sign consistency. No adaptive refinement or error estimation is performed; accuracy depends on
+   * function smoothness, the chosen rule order, and the resulting step width.
+   *
+   * <pre>{@code
+   * ComputableFunction f = x -> Math.sin(x);
+   * ComputableFunctionIntegrator integrator = new GaussLegendreIntegrator(3, 0.1);
+   * double area = integrator.integrate(f, 0.0, Math.PI);
+   * }</pre>
+   *
+   * @param f computable scalar function evaluated at Gauss-Legendre abscissas; must be
+   *     deterministic over the interval and tolerate the number of evaluations implied by the step
+   *     count.
+   * @param a lower or upper bound of integration in the function's input units; may be greater than
+   *     {@code b} to request a negatively oriented integral.
+   * @param b upper or lower bound of integration; paired with {@code a} to define the closed
+   *     interval over which quadrature is performed.
+   * @return weighted sum approximating the definite integral over {@code [a, b]}, preserving sign
+   *     when bounds are reversed and using a fixed number of evaluations per step.
+   * @throws FunctionException if the supplied function fails to compute a value at any quadrature
+   *     point, typically to signal domain errors or internal evaluation issues.
+   */
+  @Override
   public double integrate(ComputableFunction f, double a, double b) throws FunctionException {
 
     // swap the bounds if they are not in ascending order
@@ -129,8 +152,8 @@ public class GaussLegendreIntegrator implements ComputableFunctionIntegrator {
     double midPoint = a + halfStep;
     double sum = 0.0;
     for (long i = 0; i < n; ++i) {
-      for (int j = 0; j < weightedRoots.length; ++j) {
-        sum += weightedRoots[j][0] * f.valueAt(midPoint + halfStep * weightedRoots[j][1]);
+      for (double[] weightedRoot : weightedRoots) {
+        sum += weightedRoot[0] * f.valueAt(midPoint + halfStep * weightedRoot[1]);
       }
       midPoint += step;
     }
@@ -138,7 +161,7 @@ public class GaussLegendreIntegrator implements ComputableFunctionIntegrator {
     return halfStep * sum;
   }
 
-  double[][] weightedRoots;
+  private final double[][] weightedRoots;
 
-  double rawStep;
+  private final double rawStep;
 }

--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/RiemannIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/RiemannIntegrator.java
@@ -5,31 +5,76 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
 
 /**
- * This class implements a Riemann integrator.
+ * RiemannIntegrator computes a left-hand Riemann sum over a streamed scalar function.
  *
- * <p>A Riemann integrator is a very simple one that assumes the function is constant over the
- * integration step. Since it is very simple, this algorithm needs very small steps to achieve high
- * accuracy, and small steps lead to numerical errors and instabilities.
+ * <p>The integrator consumes values from a {@link SampledFunctionIterator} and accumulates the area
+ * under the curve by assuming each interval maintains the previous ordinate value. This makes the
+ * algorithm easy to reason about and very fast to implement, but it is also sensitive to coarse
+ * sampling: the approximation converges slowly and may amplify floating-point round-off when the
+ * caller cannot supply tightly spaced abscissae. Because the class is stateless and performs no
+ * caching, multiple instances can be created cheaply and reused whenever an explicit type is
+ * desired for dependency injection or API clarity.
  *
- * <p>This algorithm is almost never used and has been included in this package only as a simple
- * template for more useful integrators.
+ * <p>Use this integrator when you need the most basic integration scheme or want a baseline result
+ * to compare with more accurate algorithms such as {@link TrapezoidIntegrator}. The class assumes
+ * the iterator delivers samples in strictly increasing order of abscissa and does not enforce any
+ * thread-safety; callers should confine an instance to a single thread unless their iterator
+ * implementation is itself thread-safe. Error handling is delegated to the iterator, so exceptions
+ * related to sample exhaustion or function evaluation propagate unchanged to the caller.
+ *
+ * <ul>
+ *   <li>Implements the {@link SampledFunctionIntegrator} contract for scalar-valued samples.
+ *   <li>Does not store historical points beyond the current accumulator.
+ *   <li>Best suited for educational use or quick prototypes where accuracy demands are modest.
+ * </ul>
  *
  * @see TrapezoidIntegrator
  * @version $Id: RiemannIntegrator.java 1237 2002-03-20 21:01:57Z luc $
  * @author L. Maisonobe
  */
 public class RiemannIntegrator implements SampledFunctionIntegrator {
+
+  /**
+   * Creates a reusable Riemann integrator instance with no retained configuration state.
+   *
+   * <p>The constructor performs no initialization work beyond creating the object, so callers can
+   * freely allocate new instances or cache a shared one when repeatedly integrating different
+   * sampled functions. Instances are immutable and thread-safe to the extent that {@link
+   * #integrate(SampledFunctionIterator)} is only invoked by one thread at a time or provided with a
+   * thread-safe iterator implementation.
+   */
+  public RiemannIntegrator() {
+    // No instance state is required; integrator logic is fully contained in the integrate call.
+  }
+
+  /**
+   * Integrate a sampled scalar function using a left-hand Riemann sum.
+   *
+   * <p>The method walks through the supplied {@link SampledFunctionIterator}, consuming each point
+   * exactly once and accumulating the signed area implied by consecutive abscissae. It assumes the
+   * iterator yields samples in strictly increasing order of {@code x}; providing unsorted data may
+   * produce misleading results because interval widths become negative. The integrator does not
+   * rewind the iterator, so callers should supply a fresh, unconsumed iterator for each invocation.
+   *
+   * <pre>{@code
+   * SampledFunctionIterator iterator = ...;
+   * double area = new RiemannIntegrator().integrate(iterator);
+   * }</pre>
+   *
+   * @param iter iterator that delivers ordered sample points; must not be null or partially used
+   * @return cumulative integral estimate after consuming the iterator; value reflects final
+   *     accumulator state
+   * @throws ExhaustedSampleException if the iterator runs out of samples before a step completes
+   * @throws FunctionException if evaluating the underlying function raises an error during sampling
+   */
   public double integrate(SampledFunctionIterator iter)
       throws ExhaustedSampleException, FunctionException {
 
     RiemannIntegratorSampler sampler = new RiemannIntegratorSampler(iter);
     double sum = 0.0;
 
-    try {
-      while (true) {
-        sum = sampler.nextSamplePoint().getY();
-      }
-    } catch (ExhaustedSampleException e) {
+    while (sampler.hasNext()) {
+      sum = sampler.nextSamplePoint().getY();
     }
 
     return sum;

--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/RiemannIntegratorSampler.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/RiemannIntegratorSampler.java
@@ -5,34 +5,71 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.*;
 
 /**
- * This class implements a Riemann integrator as a sample.
+ * Iterates over the running left-Riemann integral of a sampled scalar function.
  *
- * <p>A Riemann integrator is a very simple one that assumes the function is constant over the
- * integration step. Since it is very simple, this algorithm needs very small steps to achieve high
- * accuracy, and small steps lead to numerical errors and instabilities.
+ * <p>The sampler wraps an existing {@link SampledFunctionIterator} that emits pairs {@code (x,
+ * f(x))} in strictly increasing abscissa order and turns each successive point into the accumulated
+ * integral value. Each call to {@link #nextSamplePoint()} advances the underlying iterator by one
+ * element and returns a new {@link ScalarValuedPair} whose abscissa equals the most recent {@code
+ * x} and whose ordinate is the running sum of rectangular areas computed with the previous point as
+ * the left edge. Because the scheme is first-order and assumes a constant value over each
+ * sub-interval, high accuracy requires small step sizes and well-behaved functions; the sampler
+ * does not attempt adaptive refinement or error control.
  *
- * <p>This algorithm is almost never used and has been included in this package only as a simple
- * template for more useful integrators.
+ * <p>Instances are lightweight, single-use, and preserve the evaluation order of the wrapped
+ * iterator. They hold a minimal internal state consisting of the current point and the aggregated
+ * sum, making them suitable for streaming integration pipelines where intermediate results need to
+ * be consumed incrementally. The class is not thread-safe; confine instances to the thread driving
+ * the sampling loop and avoid sharing the underlying iterator across threads.
+ *
+ * <ul>
+ *   <li>Produces one integral sample per source sample after the first point.
+ *   <li>Propagates {@link FunctionException} and {@link ExhaustedSampleException} verbatim from the
+ *       wrapped iterator.
+ *   <li>Assumes monotonically increasing abscissae; incorrect ordering will yield incorrect area
+ *       accumulation.
+ * </ul>
  *
  * @see RiemannIntegrator
+ * @see SampledFunctionIterator
+ * @see ScalarValuedPair
  * @version $Id: RiemannIntegratorSampler.java 1237 2002-03-20 21:01:57Z luc $
  * @author L. Maisonobe
  */
 public class RiemannIntegratorSampler implements SampledFunctionIterator {
 
-  /** Underlying sample iterator. */
-  private SampledFunctionIterator iter;
+  /**
+   * Underlying sample iterator that supplies monotonically increasing abscissae and raw function
+   * values; never null after construction and consumed exactly once.
+   */
+  private final SampledFunctionIterator iter;
 
-  /** Current point. */
+  /**
+   * Current point held between successive integration steps; updated on each call to {@link
+   * #nextSamplePoint()} and used as the left edge of the next rectangle.
+   */
   private ScalarValuedPair current;
 
-  /** Current running sum. */
+  /**
+   * Current running sum of the rectangular areas accumulated so far; starts at {@code 0.0} before
+   * the first step and increases monotonically as samples advance.
+   */
   private double sum;
 
   /**
-   * Constructor. Build an integrator from an underlying sample iterator.
+   * Creates a sampler that produces cumulative left-Riemann integrals from an existing iterator.
    *
-   * @param iter iterator over the base function
+   * <p>The constructor immediately consumes the first sample point from the supplied iterator to
+   * establish the initial left edge and resets the running sum to zero. Subsequent calls to {@link
+   * #nextSamplePoint()} will start accumulating areas using that stored point. The provided
+   * iterator must deliver strictly increasing {@code x} values and remain valid for the lifetime of
+   * this sampler; ownership of iteration is transferred and callers should not advance it
+   * independently.
+   *
+   * @param iter iterator over the base function that yields ordered {@link ScalarValuedPair}
+   *     samples; must be non-null and positioned at its first element.
+   * @throws ExhaustedSampleException if the iterator has no elements to initialize the sampler
+   * @throws FunctionException if computing the first sample fails in the underlying iterator
    */
   public RiemannIntegratorSampler(SampledFunctionIterator iter)
       throws ExhaustedSampleException, FunctionException {
@@ -50,6 +87,23 @@ public class RiemannIntegratorSampler implements SampledFunctionIterator {
     return iter.hasNext();
   }
 
+  /**
+   * Advances the sampler by one source sample and returns the updated integral value.
+   *
+   * <p>The method performs a single left-Riemann step: it fetches the next sample from the wrapped
+   * iterator, computes the rectangular area using the previous sample's ordinate and the difference
+   * in abscissae, updates the running sum, and returns a fresh {@link ScalarValuedPair} whose
+   * abscissa equals the new sample's {@code x} and whose ordinate equals the accumulated integral
+   * up to that point. The returned pair is independent of the internal state and may be retained by
+   * the caller. This call consumes one element from the underlying iterator; repeated invocations
+   * must be preceded by {@link #hasNext()} to avoid premature exhaustion.
+   *
+   * @return a new pair containing the latest abscissa and the running integral value at that
+   *     abscissa; never null.
+   * @throws ExhaustedSampleException if no further samples are available from the underlying
+   *     iterator
+   * @throws FunctionException if the underlying iterator fails while producing the next sample
+   */
   public ScalarValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException {
     // performs one step of a Riemann scheme
     ScalarValuedPair previous = current;

--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/SampledFunctionIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/SampledFunctionIntegrator.java
@@ -5,9 +5,26 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
 
 /**
- * This interface represents an integrator for scalar samples.
+ * Integrator for scalar functions provided as discrete samples.
  *
- * <p>The classes which are devoted to integrate scalar samples should implement this interface.
+ * <p>Implementations consume a {@link SampledFunctionIterator} and compute a definite integral over
+ * the iterator's full span using whatever quadrature rule they provide (trapezoidal, Simpson,
+ * adaptive rules, and so on). The iterator is expected to deliver abscissa/ordinate pairs in
+ * strictly increasing abscissa order; callers are responsible for creating or rewinding the
+ * iterator because integrators typically read it exactly once. Implementations are usually
+ * stateless, but they may cache intermediate values while streaming the samples; reuse across
+ * threads should therefore follow each implementation's thread-safety guidance.
+ *
+ * <p>Typical usage creates an iterator from a sampled function, passes it to an integrator, and
+ * collects the returned primitive double as the integral over the iterator's range. The interface
+ * intentionally leaves tolerance handling and step-size assumptions to implementations so callers
+ * can select the strategy that best matches their sampling density and error budget.
+ *
+ * <ul>
+ *   <li>Consumes the entire iterator range exactly once.
+ *   <li>Reports insufficient data via {@link ExhaustedSampleException}.
+ *   <li>Surfaces underlying function errors via {@link FunctionException}.
+ * </ul>
  *
  * @see SampledFunctionIterator
  * @see ComputableFunctionIntegrator
@@ -16,14 +33,26 @@ import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
  */
 public interface SampledFunctionIntegrator {
   /**
-   * Integrate a sample over its overall range
+   * Integrate a sample over its overall range.
    *
-   * @param iter iterator over the sample to integrate
-   * @return value of the integral over the sample range
-   * @exception ExhaustedSampleException if the sample does not have enough points for the
-   *     integration scheme
-   * @exception FunctionException if the underlying sampled function throws one
+   * <p>The integrator advances the supplied iterator from its current position to exhaustion,
+   * accumulating an estimate of the definite integral that spans the iterator's abscissa domain.
+   * Callers should create a fresh iterator for each integration attempt; partial consumption is not
+   * rewound. Implementations may assume monotonic abscissas and finite spacing but must signal when
+   * a scheme cannot proceed because too few points remain. Any exception from the sampled function
+   * is propagated unchanged to make error handling explicit.
+   *
+   * <pre>{@code
+   * // Example: integrate a sampled function with the default iterator
+   * SampledFunctionIterator iterator = builder.buildIterator();
+   * double area = integrator.integrate(iterator);
+   * }</pre>
+   *
+   * @param iter iterator providing ordered scalar samples to integrate; must not be null
+   * @return definite integral value over the iterator range using the implementation scheme
+   * @exception ExhaustedSampleException if iterator ends before scheme obtains required sample
+   *     points
+   * @exception FunctionException if sampled function evaluation during iteration signals an error
    */
-  public double integrate(SampledFunctionIterator iter)
-      throws ExhaustedSampleException, FunctionException;
+  double integrate(SampledFunctionIterator iter) throws ExhaustedSampleException, FunctionException;
 }

--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/TrapezoidIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/TrapezoidIntegrator.java
@@ -5,26 +5,80 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
 
 /**
- * This class implements a trapezoid integrator.
+ * Numerically integrates a sampled scalar function using the classical trapezoid rule.
  *
- * <p>A trapezoid integrator is a very simple one that assumes the function is linear over the
- * integration step.
+ * <p>The integrator consumes values through a {@link SampledFunctionIterator}, treating successive
+ * abscissa/ordinate pairs as vertices of adjacent trapezoids. At each step it adds half the sum of
+ * the two ordinates multiplied by the interval width, yielding a running approximation of the
+ * definite integral. Because the rule presumes linear behavior between samples, accuracy depends on
+ * providing sufficiently fine sampling or on the underlying function being close to affine over
+ * each interval. The integrator does not attempt adaptive refinement or error estimation; callers
+ * should decide sampling density and bounds ahead of time.
  *
+ * <p>Instances are stateless and thread-safe: each call to {@link
+ * #integrate(SampledFunctionIterator)} builds a short-lived sampler and keeps no global mutable
+ * state. Use this type when simplicity and transparency matter more than high-order accuracy, or as
+ * a reference implementation while developing more sophisticated quadrature schemes.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> accumulate trapezoid areas from streamed samples.
+ *   <li><strong>Notable behavior:</strong> iteration stops when the underlying iterator signals
+ *       exhaustion via {@link ExhaustedSampleException}.
+ *   <li><strong>Thread-safety:</strong> no shared state; safe for concurrent use with independent
+ *       iterators.
+ * </ul>
+ *
+ * @see TrapezoidIntegratorSampler
+ * @see SampledFunctionIterator
  * @version $Id: TrapezoidIntegrator.java 1237 2002-03-20 21:01:57Z luc $
  * @author L. Maisonobe
  */
 public class TrapezoidIntegrator implements SampledFunctionIntegrator {
+
+  /**
+   * Builds a new trapezoid integrator instance with no retained state.
+   *
+   * <p>The constructor performs no initialization beyond instantiation. Instances are safe to reuse
+   * across calls to {@link #integrate(SampledFunctionIterator)} because all computation is confined
+   * to the method scope and the per-call sampler.
+   */
+  public TrapezoidIntegrator() {
+    // No fields to initialize; integrator is stateless and per-call allocations happen in
+    // integrate.
+  }
+
+  /**
+   * Integrates a sampled scalar function by summing trapezoid areas between consecutive samples.
+   *
+   * <p>The method pulls samples from the provided {@link SampledFunctionIterator} until it signals
+   * depletion. Each pair of adjacent points contributes a trapezoid whose area updates the running
+   * sum; the final value reflects the integral over the iterator's entire domain. Callers should
+   * supply samples ordered by increasing abscissa and with spacing fine enough to meet their error
+   * tolerances, because no adaptive refinement or error control is applied. The iterator is
+   * consumed as part of this call and should not be reused afterward.
+   *
+   * @param iter forward-only iterator yielding ordered abscissa/value pairs; must not be {@code
+   *     null} and should expose the full interval of integration.
+   * @return accumulated trapezoid area representing the integral of the sampled function over all
+   *     points delivered by the iterator.
+   * @throws ExhaustedSampleException if the iterator reports exhaustion before a complete step can
+   *     be formed (for example, when invoked on an empty iterator).
+   * @throws FunctionException if the iterator encounters a failure while generating the next sample
+   *     point, propagating the underlying computation error.
+   */
   public double integrate(SampledFunctionIterator iter)
       throws ExhaustedSampleException, FunctionException {
 
     TrapezoidIntegratorSampler sampler = new TrapezoidIntegratorSampler(iter);
     double sum = 0.0;
 
-    try {
-      while (true) {
+    boolean hasMoreSamples = true;
+    while (hasMoreSamples) {
+      try {
         sum = sampler.nextSamplePoint().getY();
+      } catch (ExhaustedSampleException e) {
+        hasMoreSamples = false;
       }
-    } catch (ExhaustedSampleException e) {
     }
 
     return sum;

--- a/src/main/java/org/spaceroots/mantissa/quadrature/scalar/TrapezoidIntegratorSampler.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/scalar/TrapezoidIntegratorSampler.java
@@ -5,23 +5,37 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.*;
 
 /**
- * This class implements a trapezoid integrator as a sample.
+ * Iterator that builds the cumulative integral of a scalar function using the trapezoid rule while
+ * it is being sampled.
  *
- * <p>A trapezoid integrator is a very simple one that assumes the function is constant over the
- * integration step. Since it is very simple, this algorithm needs very small steps to achieve high
- * accuracy, and small steps lead to numerical errors and instabilities.
+ * <p>The sampler wraps another {@link SampledFunctionIterator} that yields discrete {@link
+ * ScalarValuedPair points}. Each call to {@link #nextSamplePoint()} advances the underlying
+ * iterator by one point and returns a new pair whose {@code y} value is the running integral from
+ * the first sample up to the current abscissa, computed with the classical trapezoid formula
+ * <em>(h/2 · (y0 + y1))</em>. It keeps state between invocations, so callers should consume results
+ * in order and avoid concurrent access.
  *
- * <p>This algorithm is almost never used and has been included in this package only as a simple
- * template for more useful integrators.
+ * <p>Use this class when a lightweight, streaming integrator is needed and a full-fledged adaptive
+ * quadrature would be overkill. Accuracy depends directly on the spacing of incoming samples; very
+ * coarse or highly irregular spacing may require pre-processing or a different integrator. The
+ * sampler does not alter the source iterator and stops once the wrapped iterator reports
+ * exhaustion.
+ *
+ * <ul>
+ *   <li>Mutable state: maintains the last sample and accumulated sum.
+ *   <li>Thread-safety: not thread-safe; external synchronization is required for shared use.
+ *   <li>Error handling: propagates checked exceptions from the underlying iterator unchanged.
+ * </ul>
  *
  * @see TrapezoidIntegrator
+ * @see SampledFunctionIterator
  * @version $Id: TrapezoidIntegratorSampler.java 1237 2002-03-20 21:01:57Z luc $
  * @author L. Maisonobe
  */
 public class TrapezoidIntegratorSampler implements SampledFunctionIterator {
 
   /** Underlying sample iterator. */
-  private SampledFunctionIterator iter;
+  private final SampledFunctionIterator iter;
 
   /** Current point. */
   private ScalarValuedPair current;
@@ -32,7 +46,19 @@ public class TrapezoidIntegratorSampler implements SampledFunctionIterator {
   /**
    * Constructor. Build an integrator from an underlying sample iterator.
    *
-   * @param iter iterator over the base function
+   * <p>The first sample point is consumed immediately to initialize the internal state; subsequent
+   * calls to {@link #nextSamplePoint()} will start integrating from that point forward. The passed
+   * iterator must provide monotonically increasing abscissa values for meaningful results, and
+   * callers should avoid reusing it elsewhere once wrapped to prevent interleaved consumption. No
+   * defensive copy is taken, so any side effects of the iterator are observable through this
+   * sampler.
+   *
+   * @param iter iterator over the base function that yields ordered scalar sample points; must not
+   *     be {@code null} and must provide at least one sample.
+   * @throws ExhaustedSampleException if the iterator exposes no sample when the sampler is created,
+   *     meaning integration cannot start.
+   * @throws FunctionException if the underlying iterator fails to produce its first sample due to a
+   *     function evaluation problem.
    */
   public TrapezoidIntegratorSampler(SampledFunctionIterator iter)
       throws ExhaustedSampleException, FunctionException {
@@ -46,10 +72,45 @@ public class TrapezoidIntegratorSampler implements SampledFunctionIterator {
     sum = 0.0;
   }
 
+  /**
+   * Check whether another integrated sample can be produced.
+   *
+   * <p>This method delegates directly to the wrapped iterator without changing integration state.
+   * It can therefore be called repeatedly to poll availability. A {@code true} result indicates
+   * that a subsequent call to {@link #nextSamplePoint()} will succeed unless the underlying
+   * iterator throws during evaluation.
+   *
+   * @return {@code true} when the underlying iterator reports another sample, {@code false} when
+   *     the stream is exhausted and no further integrated values will be available.
+   */
   public boolean hasNext() {
     return iter.hasNext();
   }
 
+  /**
+   * Advance to the next sample and return the updated running integral.
+   *
+   * <p>The method consumes exactly one sample from the underlying iterator, applies the trapezoid
+   * rule using the previously returned point and the new one, and returns a fresh {@link
+   * ScalarValuedPair} whose abscissa equals the new sample abscissa and whose ordinate equals the
+   * cumulative integral up to that abscissa. Callers should process the results sequentially; no
+   * rewinding or skipping is supported. If the iterator produces irregular step sizes, the computed
+   * area reflects those varying widths explicitly.
+   *
+   * <pre>{@code
+   * // Example: integrate f(x)=x over [0,2] with unit steps
+   * TrapezoidIntegratorSampler sampler = new TrapezoidIntegratorSampler(source);
+   * ScalarValuedPair p1 = sampler.nextSamplePoint(); // integral at x=1
+   * ScalarValuedPair p2 = sampler.nextSamplePoint(); // integral at x=2
+   * }</pre>
+   *
+   * @return new pair containing the latest abscissa and the cumulative trapezoid integral up to
+   *     that point; the returned object is independent of internal state.
+   * @throws ExhaustedSampleException if the underlying iterator has no further samples to advance
+   *     to when called, indicating integration has completed.
+   * @throws FunctionException if computing the next sample fails in the underlying iterator due to
+   *     function evaluation or sampling errors.
+   */
   public ScalarValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException {
     // performs one step of a trapezoid scheme
     ScalarValuedPair previous = current;

--- a/src/test/java/org/spaceroots/mantissa/quadrature/scalar/EnhancedSimpsonIntegratorSamplerTest.java
+++ b/src/test/java/org/spaceroots/mantissa/quadrature/scalar/EnhancedSimpsonIntegratorSamplerTest.java
@@ -1,0 +1,119 @@
+package org.spaceroots.mantissa.quadrature.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
+import org.spaceroots.mantissa.functions.scalar.ScalarValuedPair;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class EnhancedSimpsonIntegratorSamplerTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void nextSamplePoint_whenEquallySpacedQuadratic_matchesSimpsonIntegral()
+      throws ExhaustedSampleException, FunctionException {
+    List<ScalarValuedPair> points =
+        Arrays.asList(
+            new ScalarValuedPair(0.0, 0.0),
+            new ScalarValuedPair(1.0, 1.0),
+            new ScalarValuedPair(2.0, 4.0));
+    EnhancedSimpsonIntegratorSampler sampler =
+        new EnhancedSimpsonIntegratorSampler(new ListSampledFunctionIterator(points));
+
+    ScalarValuedPair result = sampler.nextSamplePoint();
+
+    assertEquals(2.0, result.getX(), EPS);
+    assertEquals(8.0 / 3.0, result.getY(), EPS);
+    assertFalse(sampler.hasNext());
+  }
+
+  @Test
+  void nextSamplePoint_whenUnevenSpacing_usesEnhancedWeights()
+      throws ExhaustedSampleException, FunctionException {
+    List<ScalarValuedPair> points =
+        Arrays.asList(
+            new ScalarValuedPair(0.0, 0.0),
+            new ScalarValuedPair(1.0, 1.0),
+            new ScalarValuedPair(3.0, 3.0));
+    EnhancedSimpsonIntegratorSampler sampler =
+        new EnhancedSimpsonIntegratorSampler(new ListSampledFunctionIterator(points));
+
+    ScalarValuedPair result = sampler.nextSamplePoint();
+
+    assertEquals(3.0, result.getX(), EPS);
+    assertEquals(4.5, result.getY(), EPS);
+  }
+
+  @Test
+  void nextSamplePoint_whenFinalStepIncomplete_usesTrapezoidRule()
+      throws ExhaustedSampleException, FunctionException {
+    List<ScalarValuedPair> points =
+        Arrays.asList(new ScalarValuedPair(0.0, 0.0), new ScalarValuedPair(2.0, 4.0));
+    EnhancedSimpsonIntegratorSampler sampler =
+        new EnhancedSimpsonIntegratorSampler(new ListSampledFunctionIterator(points));
+
+    ScalarValuedPair result = sampler.nextSamplePoint();
+
+    assertEquals(2.0, result.getX(), EPS);
+    assertEquals(4.0, result.getY(), EPS);
+    assertFalse(sampler.hasNext());
+  }
+
+  @Test
+  void constructor_whenIteratorHasNoSamples_throwsExhaustedSampleException() {
+    SampledFunctionIterator emptyIterator = new ListSampledFunctionIterator(List.of());
+
+    assertThrows(
+        ExhaustedSampleException.class, () -> new EnhancedSimpsonIntegratorSampler(emptyIterator));
+  }
+
+  @Test
+  void nextSamplePoint_whenUnderlyingThrowsFunctionException_propagates() throws Exception {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint())
+        .thenReturn(new ScalarValuedPair(0.0, 0.0))
+        .thenReturn(new ScalarValuedPair(1.0, 1.0))
+        .thenThrow(new FunctionException("failure"));
+
+    EnhancedSimpsonIntegratorSampler sampler = new EnhancedSimpsonIntegratorSampler(iterator);
+
+    assertThrows(FunctionException.class, sampler::nextSamplePoint);
+  }
+
+  private static final class ListSampledFunctionIterator implements SampledFunctionIterator {
+
+    private final List<ScalarValuedPair> points;
+    private int index;
+
+    ListSampledFunctionIterator(List<ScalarValuedPair> points) {
+      this.points = points;
+      this.index = 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return index < points.size();
+    }
+
+    @Override
+    public ScalarValuedPair nextSamplePoint() throws ExhaustedSampleException {
+      if (!hasNext()) {
+        throw new ExhaustedSampleException(points.size());
+      }
+      return points.get(index++);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/quadrature/scalar/EnhancedSimpsonIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/quadrature/scalar/EnhancedSimpsonIntegratorTest.java
@@ -1,0 +1,87 @@
+package org.spaceroots.mantissa.quadrature.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.scalar.BasicSampledFunctionIterator;
+import org.spaceroots.mantissa.functions.scalar.SampledFunction;
+import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
+import org.spaceroots.mantissa.functions.scalar.ScalarValuedPair;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class EnhancedSimpsonIntegratorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void integrate_withRegularSpacingExactQuadratic_expectSimpsonResult() throws Exception {
+    double[] x = {0.0, 1.0, 2.0};
+    double[] y = {0.0, 1.0, 4.0};
+    SampledFunctionIterator iterator = iteratorFromArrays(x, y);
+
+    double result = new EnhancedSimpsonIntegrator().integrate(iterator);
+
+    assertEquals(8.0 / 3.0, result, EPS);
+  }
+
+  @Test
+  void integrate_withNonUniformLinear_expectExactIntegral() throws Exception {
+    double[] x = {0.0, 1.0, 1.5};
+    double[] y = {0.0, 1.0, 1.5};
+    SampledFunctionIterator iterator = iteratorFromArrays(x, y);
+
+    double result = new EnhancedSimpsonIntegrator().integrate(iterator);
+
+    assertEquals(1.125, result, EPS);
+  }
+
+  @Test
+  void integrate_withTwoPointSample_expectTrapezoidFallback() throws Exception {
+    double[] x = {0.0, 2.0};
+    double[] y = {3.0, 3.0};
+    SampledFunctionIterator iterator = iteratorFromArrays(x, y);
+
+    double result = new EnhancedSimpsonIntegrator().integrate(iterator);
+
+    assertEquals(6.0, result, EPS);
+  }
+
+  @Test
+  void integrate_whenFunctionExceptionThrown_propagates() throws Exception {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint()).thenThrow(new FunctionException("boom"));
+
+    assertThrows(
+        FunctionException.class, () -> new EnhancedSimpsonIntegrator().integrate(iterator));
+  }
+
+  private static SampledFunctionIterator iteratorFromArrays(double[] x, double[] y) {
+    if (x.length != y.length) {
+      throw new IllegalArgumentException("x and y must have the same length");
+    }
+    SampledFunction function =
+        new SampledFunction() {
+          @Override
+          public int size() {
+            return x.length;
+          }
+
+          @Override
+          public ScalarValuedPair samplePointAt(int index) {
+            if (index < 0 || index >= x.length) {
+              throw new ArrayIndexOutOfBoundsException(index);
+            }
+            return new ScalarValuedPair(x[index], y[index]);
+          }
+        };
+
+    return new BasicSampledFunctionIterator(function);
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/quadrature/scalar/GaussLegendreIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/quadrature/scalar/GaussLegendreIntegratorTest.java
@@ -29,7 +29,7 @@ class GaussLegendreIntegratorTest {
   }
 
   @Test
-  void integrate_whenBoundsReversed_expectCorrectIntegralAndEvaluationCount()
+  void integrate_whenBoundsReversed_expectSignedIntegralAndEvaluationCount()
       throws FunctionException {
     double rawStep = 1.0;
     GaussLegendreIntegrator integrator = new GaussLegendreIntegrator(3, rawStep);
@@ -44,7 +44,7 @@ class GaussLegendreIntegratorTest {
 
     double intervalLength = 3.0;
     long expectedSteps = Math.round(0.5 + intervalLength / rawStep);
-    assertEquals(1.5 * intervalLength, result, 1.0e-12);
+    assertEquals(-1.5 * intervalLength, result, 1.0e-12);
     assertEquals(expectedSteps * integrator.getEvaluationsPerStep(), evaluations.get());
   }
 

--- a/src/test/java/org/spaceroots/mantissa/quadrature/scalar/GaussLegendreIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/quadrature/scalar/GaussLegendreIntegratorTest.java
@@ -1,0 +1,107 @@
+package org.spaceroots.mantissa.quadrature.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.scalar.ComputableFunction;
+
+@SuppressWarnings("java:S100")
+class GaussLegendreIntegratorTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "2, 2", // minPoints <= 2
+    "3, 3", // minPoints in (2, 3]
+    "4, 4", // minPoints in (3, 4]
+    "5, 5", // minPoints in (4, 5]
+    "10, 5" // minPoints > 4 falls back to 5-point rule
+  })
+  void getEvaluationsPerStep_whenMinPointsBucketed_expectCorrectCount(
+      int minPoints, int expectedCount) {
+    GaussLegendreIntegrator integrator = new GaussLegendreIntegrator(minPoints, 0.1);
+
+    assertEquals(expectedCount, integrator.getEvaluationsPerStep());
+  }
+
+  @Test
+  void integrate_whenBoundsReversed_expectCorrectIntegralAndEvaluationCount()
+      throws FunctionException {
+    double rawStep = 1.0;
+    GaussLegendreIntegrator integrator = new GaussLegendreIntegrator(3, rawStep);
+    AtomicInteger evaluations = new AtomicInteger();
+    ComputableFunction constant =
+        x -> {
+          evaluations.incrementAndGet();
+          return 1.5;
+        };
+
+    double result = integrator.integrate(constant, 2.0, -1.0);
+
+    double intervalLength = 3.0;
+    long expectedSteps = Math.round(0.5 + intervalLength / rawStep);
+    assertEquals(1.5 * intervalLength, result, 1.0e-12);
+    assertEquals(expectedSteps * integrator.getEvaluationsPerStep(), evaluations.get());
+  }
+
+  @Test
+  void integrate_whenPolynomialWithinExactnessDegree_expectExactValue() throws FunctionException {
+    GaussLegendreIntegrator integrator = new GaussLegendreIntegrator(3, 0.45);
+    ComputableFunction polynomial = x -> x * x * x * x + 2 * x * x + 1;
+
+    double result = integrator.integrate(polynomial, 0.0, 2.0);
+
+    double expected = 206.0 / 15.0;
+    assertEquals(expected, result, 1.0e-12);
+  }
+
+  @Test
+  void integrate_whenFunctionThrows_propagatesFunctionException() {
+    GaussLegendreIntegrator integrator = new GaussLegendreIntegrator(4, 0.3);
+    ComputableFunction failing =
+        x -> {
+          throw new FunctionException("failure");
+        };
+
+    assertThrows(FunctionException.class, () -> integrator.integrate(failing, 0.0, 1.0));
+  }
+
+  @Test
+  void integrate_whenZeroLengthInterval_returnsZeroAndEvaluatesOncePerRoot()
+      throws FunctionException {
+    GaussLegendreIntegrator integrator = new GaussLegendreIntegrator(5, 0.2);
+    AtomicInteger evaluations = new AtomicInteger();
+    ComputableFunction square =
+        x -> {
+          evaluations.incrementAndGet();
+          return x * x;
+        };
+
+    double result = integrator.integrate(square, 1.0, 1.0);
+
+    assertEquals(0.0, result, 1.0e-12);
+    assertEquals(integrator.getEvaluationsPerStep(), evaluations.get());
+  }
+
+  @Test
+  void integrate_whenFunctionUndefinedAtBounds_doesNotSampleEndpoints() throws FunctionException {
+    double lower = 0.0;
+    double upper = 1.0;
+    GaussLegendreIntegrator integrator = new GaussLegendreIntegrator(2, 0.3);
+    ComputableFunction safeConstant =
+        x -> {
+          if (Math.abs(x - lower) < 1.0e-14 || Math.abs(x - upper) < 1.0e-14) {
+            throw new FunctionException("endpoint");
+          }
+          return 2.0;
+        };
+
+    double result = integrator.integrate(safeConstant, lower, upper);
+
+    assertEquals(2.0 * (upper - lower), result, 1.0e-12);
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/quadrature/scalar/RiemannIntegratorSamplerTest.java
+++ b/src/test/java/org/spaceroots/mantissa/quadrature/scalar/RiemannIntegratorSamplerTest.java
@@ -1,0 +1,109 @@
+package org.spaceroots.mantissa.quadrature.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
+import org.spaceroots.mantissa.functions.scalar.ScalarValuedPair;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class RiemannIntegratorSamplerTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void nextSamplePoint_whenCalledSequentially_accumulatesLeftRiemannSum()
+      throws FunctionException, ExhaustedSampleException {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint())
+        .thenReturn(new ScalarValuedPair(0.0, 0.0))
+        .thenReturn(new ScalarValuedPair(1.0, 1.0))
+        .thenReturn(new ScalarValuedPair(2.0, 4.0));
+
+    RiemannIntegratorSampler sampler = new RiemannIntegratorSampler(iterator);
+
+    ScalarValuedPair first = sampler.nextSamplePoint();
+    ScalarValuedPair second = sampler.nextSamplePoint();
+
+    assertEquals(1.0, first.getX(), EPS);
+    assertEquals(0.0, first.getY(), EPS);
+    assertEquals(2.0, second.getX(), EPS);
+    assertEquals(1.0, second.getY(), EPS);
+  }
+
+  @Test
+  void nextSamplePoint_withNonUniformSpacing_accumulatesWeightedArea()
+      throws FunctionException, ExhaustedSampleException {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint())
+        .thenReturn(new ScalarValuedPair(0.0, 2.0))
+        .thenReturn(new ScalarValuedPair(0.5, 3.0))
+        .thenReturn(new ScalarValuedPair(1.5, 1.0));
+
+    RiemannIntegratorSampler sampler = new RiemannIntegratorSampler(iterator);
+
+    ScalarValuedPair first = sampler.nextSamplePoint();
+    ScalarValuedPair second = sampler.nextSamplePoint();
+
+    assertEquals(0.5, first.getX(), EPS);
+    assertEquals(1.0, first.getY(), EPS);
+    assertEquals(1.5, second.getX(), EPS);
+    assertEquals(4.0, second.getY(), EPS);
+  }
+
+  @Test
+  void hasNext_whenUnderlyingIteratorChangesState_delegatesToIterator()
+      throws FunctionException, ExhaustedSampleException {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint()).thenReturn(new ScalarValuedPair(0.0, 1.0));
+    when(iterator.hasNext()).thenReturn(true).thenReturn(false);
+
+    RiemannIntegratorSampler sampler = new RiemannIntegratorSampler(iterator);
+
+    assertTrue(sampler.hasNext());
+    assertFalse(sampler.hasNext());
+
+    verify(iterator, times(1)).nextSamplePoint();
+    verify(iterator, times(2)).hasNext();
+    verifyNoMoreInteractions(iterator);
+  }
+
+  @Test
+  void nextSamplePoint_whenUnderlyingThrowsFunctionException_propagates()
+      throws FunctionException, ExhaustedSampleException {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint())
+        .thenReturn(new ScalarValuedPair(0.0, 0.0))
+        .thenThrow(new FunctionException("fail"));
+
+    RiemannIntegratorSampler sampler = new RiemannIntegratorSampler(iterator);
+
+    assertThrows(FunctionException.class, sampler::nextSamplePoint);
+  }
+
+  @Test
+  void nextSamplePoint_whenSamplesExhausted_propagatesExhaustedSampleException()
+      throws FunctionException, ExhaustedSampleException {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint())
+        .thenReturn(new ScalarValuedPair(0.0, 1.0))
+        .thenThrow(new ExhaustedSampleException(1));
+
+    RiemannIntegratorSampler sampler = new RiemannIntegratorSampler(iterator);
+
+    assertThrows(ExhaustedSampleException.class, sampler::nextSamplePoint);
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/quadrature/scalar/RiemannIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/quadrature/scalar/RiemannIntegratorTest.java
@@ -1,0 +1,86 @@
+package org.spaceroots.mantissa.quadrature.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
+import org.spaceroots.mantissa.functions.scalar.ScalarValuedPair;
+
+@SuppressWarnings("java:S100")
+class RiemannIntegratorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void integrate_whenUniformSamples_expectLeftRiemannSum()
+      throws FunctionException, ExhaustedSampleException {
+    List<ScalarValuedPair> samples =
+        List.of(
+            new ScalarValuedPair(0.0, 0.0),
+            new ScalarValuedPair(0.25, 0.25),
+            new ScalarValuedPair(0.5, 0.5),
+            new ScalarValuedPair(0.75, 0.75),
+            new ScalarValuedPair(1.0, 1.0));
+    SampledFunctionIterator iterator = new StubSampledFunctionIterator(samples);
+    RiemannIntegrator integrator = new RiemannIntegrator();
+
+    double result = integrator.integrate(iterator);
+
+    assertEquals(0.375, result, EPS);
+  }
+
+  @Test
+  void integrate_whenIteratorThrowsFunctionException_propagatesException() {
+    List<ScalarValuedPair> samples =
+        List.of(new ScalarValuedPair(0.0, 0.0), new ScalarValuedPair(1.0, 1.0));
+    SampledFunctionIterator iterator =
+        new StubSampledFunctionIterator(samples, /* functionExceptionAt= */ 1);
+    RiemannIntegrator integrator = new RiemannIntegrator();
+
+    assertThrows(FunctionException.class, () -> integrator.integrate(iterator));
+  }
+
+  @Test
+  void integrate_whenIteratorEmpty_throwsExhaustedSampleException() {
+    SampledFunctionIterator iterator = new StubSampledFunctionIterator(List.of());
+    RiemannIntegrator integrator = new RiemannIntegrator();
+
+    assertThrows(ExhaustedSampleException.class, () -> integrator.integrate(iterator));
+  }
+
+  private static final class StubSampledFunctionIterator implements SampledFunctionIterator {
+
+    private final List<ScalarValuedPair> samples;
+    private final int functionExceptionAt;
+    private int index;
+
+    StubSampledFunctionIterator(List<ScalarValuedPair> samples) {
+      this(samples, -1);
+    }
+
+    StubSampledFunctionIterator(List<ScalarValuedPair> samples, int functionExceptionAt) {
+      this.samples = samples;
+      this.functionExceptionAt = functionExceptionAt;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return index < samples.size();
+    }
+
+    @Override
+    public ScalarValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException {
+      if (index == functionExceptionAt) {
+        throw new FunctionException("boom");
+      }
+      if (index >= samples.size()) {
+        throw new ExhaustedSampleException(samples.size());
+      }
+      return samples.get(index++);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/quadrature/scalar/TrapezoidIntegratorSamplerTest.java
+++ b/src/test/java/org/spaceroots/mantissa/quadrature/scalar/TrapezoidIntegratorSamplerTest.java
@@ -1,0 +1,144 @@
+package org.spaceroots.mantissa.quadrature.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
+import org.spaceroots.mantissa.functions.scalar.ScalarValuedPair;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class TrapezoidIntegratorSamplerTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void nextSamplePoint_withLinearFunction_matchesExactIntegral()
+      throws FunctionException, ExhaustedSampleException {
+    SampledFunctionIterator iterator =
+        new ListSampledFunctionIterator(
+            List.of(
+                new ScalarValuedPair(0.0, 0.0),
+                new ScalarValuedPair(1.0, 1.0),
+                new ScalarValuedPair(2.0, 2.0)));
+
+    TrapezoidIntegratorSampler sampler = new TrapezoidIntegratorSampler(iterator);
+
+    ScalarValuedPair first = sampler.nextSamplePoint();
+    ScalarValuedPair second = sampler.nextSamplePoint();
+
+    assertEquals(1.0, first.getX(), EPS);
+    assertEquals(0.5, first.getY(), EPS);
+    assertEquals(2.0, second.getX(), EPS);
+    assertEquals(2.0, second.getY(), EPS);
+  }
+
+  @Test
+  void nextSamplePoint_withNonUniformSpacing_accumulatesTrapezoidArea()
+      throws FunctionException, ExhaustedSampleException {
+    SampledFunctionIterator iterator =
+        new ListSampledFunctionIterator(
+            List.of(
+                new ScalarValuedPair(0.0, 2.0),
+                new ScalarValuedPair(0.5, 4.0),
+                new ScalarValuedPair(2.0, 1.0)));
+
+    TrapezoidIntegratorSampler sampler = new TrapezoidIntegratorSampler(iterator);
+
+    ScalarValuedPair first = sampler.nextSamplePoint();
+    ScalarValuedPair second = sampler.nextSamplePoint();
+
+    assertEquals(0.5, first.getX(), EPS);
+    assertEquals(1.5, first.getY(), EPS);
+    assertEquals(2.0, second.getX(), EPS);
+    assertEquals(5.25, second.getY(), EPS);
+  }
+
+  @Test
+  void hasNext_whenUnderlyingIteratorChangesState_delegatesToIterator()
+      throws FunctionException, ExhaustedSampleException {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint()).thenReturn(new ScalarValuedPair(0.0, 1.0));
+    when(iterator.hasNext()).thenReturn(true).thenReturn(false);
+
+    TrapezoidIntegratorSampler sampler = new TrapezoidIntegratorSampler(iterator);
+
+    assertTrue(sampler.hasNext());
+    assertFalse(sampler.hasNext());
+
+    verify(iterator, times(1)).nextSamplePoint();
+    verify(iterator, times(2)).hasNext();
+    verifyNoMoreInteractions(iterator);
+  }
+
+  @Test
+  void constructor_whenIteratorHasNoSamples_throwsExhaustedSampleException() {
+    SampledFunctionIterator emptyIterator = new ListSampledFunctionIterator(List.of());
+
+    assertThrows(
+        ExhaustedSampleException.class, () -> new TrapezoidIntegratorSampler(emptyIterator));
+  }
+
+  @Test
+  void nextSamplePoint_whenUnderlyingThrowsFunctionException_propagates()
+      throws ExhaustedSampleException, FunctionException {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint())
+        .thenReturn(new ScalarValuedPair(0.0, 0.0))
+        .thenThrow(new FunctionException("failure"));
+
+    TrapezoidIntegratorSampler sampler = new TrapezoidIntegratorSampler(iterator);
+
+    assertThrows(FunctionException.class, sampler::nextSamplePoint);
+  }
+
+  @Test
+  void nextSamplePoint_whenUnderlyingThrowsExhaustedSampleException_propagates()
+      throws ExhaustedSampleException, FunctionException {
+    SampledFunctionIterator iterator = mock(SampledFunctionIterator.class);
+    when(iterator.nextSamplePoint())
+        .thenReturn(new ScalarValuedPair(0.0, 0.0))
+        .thenThrow(new ExhaustedSampleException(1));
+
+    TrapezoidIntegratorSampler sampler = new TrapezoidIntegratorSampler(iterator);
+
+    assertThrows(ExhaustedSampleException.class, sampler::nextSamplePoint);
+  }
+
+  private static final class ListSampledFunctionIterator implements SampledFunctionIterator {
+
+    private final List<ScalarValuedPair> points;
+    private int index;
+
+    ListSampledFunctionIterator(List<ScalarValuedPair> points) {
+      this.points = points;
+      this.index = 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return index < points.size();
+    }
+
+    @Override
+    public ScalarValuedPair nextSamplePoint() throws ExhaustedSampleException {
+      if (!hasNext()) {
+        throw new ExhaustedSampleException(points.size());
+      }
+      return points.get(index++);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/quadrature/scalar/TrapezoidIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/quadrature/scalar/TrapezoidIntegratorTest.java
@@ -1,0 +1,104 @@
+package org.spaceroots.mantissa.quadrature.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.scalar.BasicSampledFunctionIterator;
+import org.spaceroots.mantissa.functions.scalar.SampledFunction;
+import org.spaceroots.mantissa.functions.scalar.SampledFunctionIterator;
+import org.spaceroots.mantissa.functions.scalar.ScalarValuedPair;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class TrapezoidIntegratorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void integrate_whenSamplesDescribeLinearFunction_returnsExactIntegral()
+      throws FunctionException, ExhaustedSampleException {
+    double[] x = {0.0, 0.5, 1.0};
+    double[] y = {0.0, 0.5, 1.0};
+    SampledFunctionIterator iterator = iteratorFromArrays(x, y);
+    TrapezoidIntegrator integrator = new TrapezoidIntegrator();
+
+    double result = integrator.integrate(iterator);
+
+    assertEquals(0.5, result, EPS);
+  }
+
+  @Test
+  void integrate_whenOnlySingleSample_returnsZeroArea()
+      throws FunctionException, ExhaustedSampleException {
+    double[] x = {2.0};
+    double[] y = {3.0};
+    SampledFunctionIterator iterator = iteratorFromArrays(x, y);
+    TrapezoidIntegrator integrator = new TrapezoidIntegrator();
+
+    double result = integrator.integrate(iterator);
+
+    assertEquals(0.0, result, EPS);
+  }
+
+  @Test
+  void integrate_whenIteratorEmpty_throwsExhaustedSampleException() {
+    SampledFunctionIterator iterator = iteratorFromArrays(new double[0], new double[0]);
+    TrapezoidIntegrator integrator = new TrapezoidIntegrator();
+
+    assertThrows(ExhaustedSampleException.class, () -> integrator.integrate(iterator));
+  }
+
+  @Test
+  void integrate_whenUnderlyingIteratorFails_propagatesFunctionException()
+      throws ExhaustedSampleException, FunctionException {
+    ScalarValuedPair firstSample = new ScalarValuedPair(0.0, 0.0);
+    when(iteratorMock.nextSamplePoint())
+        .thenReturn(firstSample)
+        .thenThrow(new FunctionException("boom"));
+    TrapezoidIntegrator integrator = new TrapezoidIntegrator();
+
+    assertThrows(FunctionException.class, () -> integrator.integrate(iteratorMock));
+  }
+
+  private SampledFunctionIterator iteratorFromArrays(double[] x, double[] y) {
+    return new BasicSampledFunctionIterator(new ArraySampledFunction(x, y));
+  }
+
+  private static final class ArraySampledFunction implements SampledFunction {
+
+    private final double[] x;
+    private final double[] y;
+
+    ArraySampledFunction(double[] x, double[] y) {
+      if (x.length != y.length) {
+        throw new IllegalArgumentException(
+            "Abscissa and ordinate arrays must have identical length.");
+      }
+      this.x = Arrays.copyOf(x, x.length);
+      this.y = Arrays.copyOf(y, y.length);
+    }
+
+    @Override
+    public int size() {
+      return x.length;
+    }
+
+    @Override
+    public ScalarValuedPair samplePointAt(int index) throws ArrayIndexOutOfBoundsException {
+      if (index < 0 || index >= x.length) {
+        throw new ArrayIndexOutOfBoundsException(index);
+      }
+      return new ScalarValuedPair(x[index], y[index]);
+    }
+  }
+
+  @Mock private SampledFunctionIterator iteratorMock;
+}


### PR DESCRIPTION
Summary:
- Fixes Gauss–Legendre integrator to preserve orientation when bounds are descending.
- Doclint/Javadoc cleanup across Mantissa scalar integrators and event/optimizer helpers.
- Adds/refreshes unit tests for EnhancedSimpson, Riemann, Trapezoid, Gauss–Legendre integrators and their samplers.

Notes:
- Only functional change is the Gauss–Legendre sign/orientation fix; rest are documentation, minor loop refactors, and tests.
- Working tree was clean; no additional commits or spotless run required.