### PR TITLE
fix(roots): refactor BrentSolver and add tests

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/roots/BrentSolver.java
+++ b/src/main/java/org/spaceroots/mantissa/roots/BrentSolver.java
@@ -4,38 +4,100 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.ComputableFunction;
 
 /**
- * This class implements the Brent algorithm to compute the roots of a function in an interval.
+ * Root finder based on Brent’s method for one-dimensional scalar functions.
  *
- * <p>This class is basically a translation in Java of a fortran implementation found at netlib (<a
- * href="http://www.netlib.org/fmm/zeroin.f">zeroin.f</a>).
+ * <p>{@code BrentSolver} locates a zero of a {@link ComputableFunction} within a user-provided
+ * interval that is known (or assumed) to bracket a root. The implementation follows the classic
+ * Brent algorithm: each iteration chooses between bisection and interpolation (secant or inverse
+ * quadratic) to guarantee convergence while retaining fast superlinear behavior on smooth
+ * functions. Callers typically evaluate the function at both ends of an interval, then invoke
+ * {@link #findRoot(ComputableFunction, ConvergenceChecker, int, double, double, double, double)} to
+ * advance the search until a {@link ConvergenceChecker} reports convergence or a maximum iteration
+ * count is exceeded.
  *
+ * <p>The solver is stateful: a successful call to {@code findRoot} stores the last computed root,
+ * which can later be retrieved through {@link #getRoot()}. Instances are not thread-safe; if you
+ * need to solve multiple problems concurrently, use a separate solver per thread. Apart from the
+ * stored root value, the class has no external side effects.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> perform robust bracketing root searches using Brent’s
+ *       decision logic and a pluggable convergence policy.
+ *   <li><strong>Notable behavior:</strong> falls back to bisection when interpolation steps are
+ *       unsafe or stagnating, preserving convergence guarantees.
+ * </ul>
+ *
+ * @see RootsFinder
+ * @see ConvergenceChecker
  * @version $Id: BrentSolver.java 1499 2003-03-29 12:50:08Z luc $
  * @author L. Maisonobe
  */
 public class BrentSolver implements RootsFinder {
 
-  /** IEEE 754 epsilon . */
-  private static final double epsilon = Math.pow(2.0, -52);
+  /** IEEE 754 epsilon. */
+  private static final double EPSILON = Math.pow(2.0, -52);
 
   /** Root found. */
   private double root;
 
-  /** Simple constructor. Build a Brent solver */
+  /**
+   * Creates a new solver instance with no previously computed root.
+   *
+   * <p>The solver starts in an uninitialized state; {@link #getRoot()} will return {@link
+   * Double#NaN} until a call to {@link #findRoot(ComputableFunction, ConvergenceChecker, int,
+   * double, double, double, double)} succeeds. A single instance may be reused across multiple root
+   * searches, but it should not be shared across threads without external synchronization.
+   */
   public BrentSolver() {
     root = Double.NaN;
   }
 
+  private static final class State {
+    double a;
+    double fa;
+    double b;
+    double fb;
+    double c;
+    double fc;
+    double d;
+    double e;
+
+    State(double x0, double f0, double x1, double f1) {
+      a = x0;
+      fa = f0;
+      b = x1;
+      fb = f1;
+      c = a;
+      fc = fa;
+      d = b - a;
+      e = d;
+    }
+  }
+
   /**
-   * Solve a function in a given interval known to contain a root.
+   * Searches for a root inside a bracketing interval using Brent’s algorithm.
    *
-   * @param function function for which a root should be found
-   * @param checker checker for the convergence of the function
-   * @param maxIter maximal number of iteration allowed
-   * @param x0 abscissa of the lower bound of the interval
-   * @param f0 value of the function the lower bound of the interval
-   * @param x1 abscissa of the higher bound of the interval
-   * @param f1 value of the function the higher bound of the interval
-   * @return true if a root has been found in the given interval
+   * <p>This method assumes that {@code x0} and {@code x1} bound an interval that contains at least
+   * one root, i.e. the function values are of opposite signs or another bracketing condition is
+   * satisfied by the caller. The algorithm iteratively refines the bracket, selecting interpolation
+   * steps when they appear safe and sufficiently progress-making, and otherwise falling back to
+   * bisection. On success, the best root estimate is stored in this instance and may be read via
+   * {@link #getRoot()}.
+   *
+   * <p>The convergence policy is delegated to {@code checker}. The solver also treats tiny function
+   * values or a bracket width below a machine-scaled tolerance as converged. If the maximum
+   * iteration count is reached without convergence, the root value is left at the last iterate and
+   * the method returns {@code false}.
+   *
+   * @param function function to evaluate; should be continuous on the interval for guarantees.
+   * @param checker convergence checker that decides when the bracket is acceptable.
+   * @param maxIter maximum number of iterations to perform before giving up.
+   * @param x0 lower bound of the initial bracketing interval, in x-units.
+   * @param f0 precomputed {@code function.valueAt(x0)} for efficiency and consistency.
+   * @param x1 upper bound of the initial bracketing interval, in x-units.
+   * @param f1 precomputed {@code function.valueAt(x1)} for efficiency and consistency.
+   * @return {@code true} when a root satisfying {@code checker} is found; {@code false} otherwise.
+   * @throws FunctionException if {@code function.valueAt(...)} fails during evaluation.
    */
   public boolean findRoot(
       ComputableFunction function,
@@ -47,121 +109,154 @@ public class BrentSolver implements RootsFinder {
       double f1)
       throws FunctionException {
 
-    double a = x0;
-    double fa = f0;
-    double b = x1;
-    double fb = f1;
-
-    double c = a;
-    double fc = fa;
-
-    double d = b - a;
-    double e = d;
-
-    double tolS;
+    State state = new State(x0, f0, x1, f1);
     for (int iter = 0; iter < maxIter; ++iter) {
 
-      if (Math.abs(fc) < Math.abs(fb)) {
-        // invert points
-        a = b;
-        b = c;
-        c = a;
-        fa = fb;
-        fb = fc;
-        fc = fa;
+      invertPointsIfNeeded(state);
+
+      double tolS = 2 * EPSILON * Math.abs(state.b);
+      double xm = 0.5 * (state.c - state.b);
+
+      if (tryConverge(state, checker, tolS, xm)) {
+        return true;
       }
 
-      tolS = 2 * epsilon * Math.abs(b);
-      double xm = 0.5 * (c - b);
-
-      // convergence test
-      double xLow, fLow, xHigh, fHigh;
-      if (b < c) {
-        xLow = b;
-        fLow = fb;
-        xHigh = c;
-        fHigh = fc;
-      } else {
-        xLow = c;
-        fLow = fc;
-        xHigh = b;
-        fHigh = fb;
-      }
-
-      switch (checker.converged(xLow, fLow, xHigh, fHigh)) {
-        case ConvergenceChecker.LOW:
-          root = xLow;
-          return true;
-        case ConvergenceChecker.HIGH:
-          root = xHigh;
-          return true;
-        default:
-          if ((Math.abs(xm) < tolS) || (Math.abs(fb) < Double.MIN_VALUE)) {
-            root = b;
-            return true;
-          }
-      }
-
-      if ((Math.abs(e) < tolS) || (Math.abs(fa) <= Math.abs(fb))) {
-        // use bisection method
-        d = xm;
-        e = d;
-      } else {
-        // use secant method
-        double p, q, r, s;
-        s = fb / fa;
-        if (Math.abs(a - c) < epsilon * Math.max(Math.abs(a), Math.abs(c))) {
-          // linear interpolation using only b and c points
-          p = 2.0 * xm * s;
-          q = 1.0 - s;
-        } else {
-          // inverse quadratic interpolation using a, b and c points
-          q = fa / fc;
-          r = fb / fc;
-          p = s * (2.0 * xm * q * (q - r) - (b - a) * (r - 1.0));
-          q = (q - 1.0) * (r - 1.0) * (s - 1.0);
-        }
-
-        // signs adjustment
-        if (p > 0.0) {
-          q = -q;
-        } else {
-          p = -p;
-        }
-
-        // is interpolation acceptable ?
-        if (((2.0 * p) < (3.0 * xm * q - Math.abs(tolS * q))) && (p < Math.abs(0.5 * e * q))) {
-          e = d;
-          d = p / q;
-        } else {
-          // no, we need to fall back to bisection
-          d = xm;
-          e = d;
-        }
-      }
-
-      // complete step
-      a = b;
-      fa = fb;
-      b += ((Math.abs(d) > tolS) ? d : (xm > 0.0 ? tolS : -tolS));
-      fb = function.valueAt(b);
-
-      if (fb * fc > 0) {
-        c = a;
-        fc = fa;
-        d = b - a;
-        e = d;
-      }
+      updateStep(state, tolS, xm);
+      completeStep(state, function, tolS, xm);
     }
 
     // we have exceeded the maximal number of iterations
     return false;
   }
 
+  @SuppressWarnings("UnnecessaryLocalVariable")
+  private static void invertPointsIfNeeded(State state) {
+    if (Math.abs(state.fc) < Math.abs(state.fb)) {
+      double aNew = state.b;
+      double bNew = state.c;
+      double cNew = aNew;
+      double faNew = state.fb;
+      double fbNew = state.fc;
+      double fcNew = faNew;
+
+      state.a = aNew;
+      state.b = bNew;
+      state.c = cNew;
+      state.fa = faNew;
+      state.fb = fbNew;
+      state.fc = fcNew;
+    }
+  }
+
+  private boolean tryConverge(State state, ConvergenceChecker checker, double tolS, double xm) {
+    // convergence test
+    double xLow;
+    double fLow;
+    double xHigh;
+    double fHigh;
+    if (state.b < state.c) {
+      xLow = state.b;
+      fLow = state.fb;
+      xHigh = state.c;
+      fHigh = state.fc;
+    } else {
+      xLow = state.c;
+      fLow = state.fc;
+      xHigh = state.b;
+      fHigh = state.fb;
+    }
+
+    int status = checker.converged(xLow, fLow, xHigh, fHigh);
+    if (status == ConvergenceChecker.LOW) {
+      root = xLow;
+      return true;
+    }
+    if (status == ConvergenceChecker.HIGH) {
+      root = xHigh;
+      return true;
+    }
+
+    if ((Math.abs(xm) < tolS) || (Math.abs(state.fb) < Double.MIN_VALUE)) {
+      root = state.b;
+      return true;
+    }
+
+    return false;
+  }
+
+  private static void updateStep(State state, double tolS, double xm) {
+    if ((Math.abs(state.e) < tolS) || (Math.abs(state.fa) <= Math.abs(state.fb))) {
+      // use bisection method
+      state.d = xm;
+      state.e = state.d;
+      return;
+    }
+
+    // use secant method
+    double p;
+    double q;
+    double r;
+    double s = state.fb / state.fa;
+    if (Math.abs(state.a - state.c) < EPSILON * Math.max(Math.abs(state.a), Math.abs(state.c))) {
+      // linear interpolation using only b and c points
+      p = 2.0 * xm * s;
+      q = 1.0 - s;
+    } else {
+      // inverse quadratic interpolation using a, b and c points
+      q = state.fa / state.fc;
+      r = state.fb / state.fc;
+      p = s * (2.0 * xm * q * (q - r) - (state.b - state.a) * (r - 1.0));
+      q = (q - 1.0) * (r - 1.0) * (s - 1.0);
+    }
+
+    // signs adjustment
+    if (p > 0.0) {
+      q = -q;
+    } else {
+      p = -p;
+    }
+
+    // is interpolation acceptable ?
+    if (((2.0 * p) < (3.0 * xm * q - Math.abs(tolS * q))) && (p < Math.abs(0.5 * state.e * q))) {
+      state.e = state.d;
+      state.d = p / q;
+    } else {
+      // no, we need to fall back to bisection
+      state.d = xm;
+      state.e = state.d;
+    }
+  }
+
+  private static void completeStep(State state, ComputableFunction function, double tolS, double xm)
+      throws FunctionException {
+    // complete step
+    state.a = state.b;
+    state.fa = state.fb;
+    double step = state.d;
+    if (Math.abs(step) <= tolS) {
+      step = xm > 0.0 ? tolS : -tolS;
+    }
+    state.b += step;
+    state.fb = function.valueAt(state.b);
+
+    if (state.fb * state.fc > 0) {
+      state.c = state.a;
+      state.fc = state.fa;
+      state.d = state.b - state.a;
+      state.e = state.d;
+    }
+  }
+
   /**
-   * Get the abscissa of the root.
+   * Returns the abscissa of the most recently computed root.
    *
-   * @return abscissa of the root
+   * <p>After a successful call to {@link #findRoot(ComputableFunction, ConvergenceChecker, int,
+   * double, double, double, double)}, this value is the solver’s best estimate of a root within the
+   * last bracketing interval. If no successful solve has been performed yet, the method returns
+   * {@link Double#NaN}. The returned value is a snapshot of internal state and does not update
+   * unless {@code findRoot} is invoked again.
+   *
+   * @return last computed root abscissa, or {@link Double#NaN} if none is available.
    */
   public double getRoot() {
     return root;

--- a/src/main/java/org/spaceroots/mantissa/roots/ConvergenceChecker.java
+++ b/src/main/java/org/spaceroots/mantissa/roots/ConvergenceChecker.java
@@ -1,36 +1,72 @@
 package org.spaceroots.mantissa.roots;
 
 /**
- * This interface specifies methods to check if a root-finding algorithm has converged.
+ * Strategy interface used by root-finding algorithms to decide when an iteration has converged.
  *
- * <p>Deciding if convergence has been reached is a problem-dependent issue. The user should provide
- * a class implementing this interface to allow the root-finding algorithm to stop its search
- * according to the problem at hand.
+ * <p>Implementations evaluate the current bracketing interval and return a small integer flag
+ * indicating whether the algorithm should continue or stop. The interval is described by the
+ * abscissae of its lower and upper bounds and by the corresponding function values. A typical call
+ * pattern is that a solver invokes {@link #converged(double, double, double, double)} at the end of
+ * each iteration once it has ensured the interval still brackets a root, and terminates when the
+ * returned indicator is not {@link #NONE}.
+ *
+ * <p>The convergence criteria are inherently problem-dependent. Some implementations may rely on
+ * interval width, on the magnitude of the function values at the bounds, or on a mix of absolute
+ * and relative tolerances. Implementations are expected to be side-effect free and inexpensive
+ * because they can be called frequently. Unless stated otherwise by a particular implementation,
+ * instances are immutable and therefore safe to share between solvers and threads.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> interpret solver state and report convergence.
+ *   <li><strong>Notable behavior:</strong> distinguishes convergence at lower vs upper bounds.
+ * </ul>
  *
  * @version $Id: ConvergenceChecker.java 1499 2003-03-29 12:50:08Z luc $
  * @author L. Maisonobe
  */
 public interface ConvergenceChecker {
 
-  /** Indicator for no convergence. */
-  public static final int NONE = 0;
-
-  /** Indicator for convergence on the lower bound of the interval. */
-  public static final int LOW = 1;
-
-  /** Indicator for convergence on the higher bound of the interval. */
-  public static final int HIGH = 2;
+  /**
+   * Indicator meaning the solver has not yet converged.
+   *
+   * <p>Returned from {@link #converged(double, double, double, double)} when the provided interval
+   * does not satisfy the implementation's stopping criteria. Solvers should treat this value as a
+   * request to continue iterating.
+   */
+  int NONE = 0;
 
   /**
-   * Check if the root-finding algorithm has converged on the interval. The interval defined by the
-   * arguments contains one root (if there was at least one in the initial interval given by the
-   * user to the root-finding algorithm, of course)
+   * Indicator meaning convergence is achieved at the lower bound of the interval.
    *
-   * @param xLow abscissa of the lower bound of the interval
-   * @param fLow value of the function the lower bound of the interval
-   * @param xHigh abscissa of the higher bound of the interval
-   * @param fHigh value of the function the higher bound of the interval
-   * @return convergence indicator, must be one of {@link #NONE}, {@link #LOW} or {@link #HIGH}
+   * <p>Returned when the implementation considers the lower endpoint {@code xLow} to be an
+   * acceptable approximation of the root. The distinction from {@link #HIGH} allows solvers to
+   * preserve information about which endpoint met the criteria.
    */
-  public int converged(double xLow, double fLow, double xHigh, double fHigh);
+  int LOW = 1;
+
+  /**
+   * Indicator meaning convergence is achieved at the upper bound of the interval.
+   *
+   * <p>Returned when the implementation considers the upper endpoint {@code xHigh} to be an
+   * acceptable approximation of the root. This value mirrors {@link #LOW} for the opposite
+   * endpoint.
+   */
+  int HIGH = 2;
+
+  /**
+   * Checks whether the solver should stop based on the current bracketing interval.
+   *
+   * <p>The interval defined by the arguments is assumed to bracket a root. Implementations examine
+   * the interval endpoints and their function values to decide if convergence has been reached. If
+   * convergence is detected, the returned indicator identifies which endpoint should be taken as
+   * the root approximation. If convergence is not detected, {@link #NONE} is returned. This method
+   * must not modify solver state and should be deterministic for a given set of arguments.
+   *
+   * @param xLow abscissa of the lower bound of the interval, in solver units
+   * @param fLow function value at the lower bound, typically matching {@code f(xLow)}
+   * @param xHigh abscissa of the upper bound of the interval, in solver units
+   * @param fHigh function value at the upper bound, typically matching {@code f(xHigh)}
+   * @return convergence indicator: {@link #NONE} to continue, or {@link #LOW}/{@link #HIGH} to stop
+   */
+  int converged(double xLow, double fLow, double xHigh, double fHigh);
 }

--- a/src/main/java/org/spaceroots/mantissa/roots/RootsFinder.java
+++ b/src/main/java/org/spaceroots/mantissa/roots/RootsFinder.java
@@ -4,26 +4,55 @@ import org.spaceroots.mantissa.functions.FunctionException;
 import org.spaceroots.mantissa.functions.scalar.ComputableFunction;
 
 /**
- * This interface specifies root-finding methods for scalar functions.
+ * Contract for algorithms that locate a real root of a scalar function.
+ *
+ * <p>This interface defines a small, implementation-agnostic API for solving {@link
+ * ComputableFunction} instances on a bounded interval. Callers supply the interval endpoints and
+ * their already-evaluated function values, along with a {@link ConvergenceChecker} that encodes the
+ * stopping criteria (for example, tolerance on the abscissa, on the function value, or on both).
+ * Implementations are expected to iterate up to a caller-provided maximum and to record the most
+ * recently accepted root estimate for later retrieval.
+ *
+ * <p>The typical usage pattern is: (1) bracket a root in {@code [x0, x1]}, (2) evaluate the
+ * function at the endpoints to obtain {@code f0} and {@code f1}, (3) invoke {@link
+ * #findRoot(ComputableFunction, ConvergenceChecker, int, double, double, double, double)}, and (4)
+ * if it returns {@code true}, read the solution with {@link #getRoot()}.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> run a deterministic root search within the provided
+ *       bounds and expose the accepted root estimate.
+ *   <li><strong>Statefulness:</strong> implementations typically store the last root estimate;
+ *       callers should not assume thread-safety unless documented by the concrete class.
+ * </ul>
  *
  * @version $Id: RootsFinder.java 1499 2003-03-29 12:50:08Z luc $
  * @author L. Maisonobe
+ * @see ConvergenceChecker
+ * @see ComputableFunction
  */
 public interface RootsFinder {
 
   /**
-   * Solve a function in a given interval known to contain a root.
+   * Searches for a root of the supplied function inside the given interval.
    *
-   * @param function function for which a root should be found
-   * @param checker checker for the convergence of the function
-   * @param maxIter maximal number of iteration allowed
-   * @param x0 abscissa of the lower bound of the interval
-   * @param f0 value of the function the lower bound of the interval
-   * @param x1 abscissa of the higher bound of the interval
-   * @param f1 value of the function the higher bound of the interval
-   * @return true if a root has been found in the given interval
+   * <p>The caller provides an interval {@code [x0, x1]} that is known (by external reasoning) to
+   * contain at least one root, together with the corresponding function values {@code f0} and
+   * {@code f1}. Supplying endpoint values allows implementations to avoid redundant evaluations and
+   * to validate assumptions about the interval. The algorithm iterates until the {@code checker}
+   * reports convergence or {@code maxIter} iterations have been performed. When this method returns
+   * {@code true}, {@link #getRoot()} returns the accepted root estimate.
+   *
+   * @param function function to solve; evaluated repeatedly during the search
+   * @param checker convergence policy that decides when the estimate is acceptable
+   * @param maxIter maximum number of iterations before giving up
+   * @param x0 lower bound abscissa of the search interval
+   * @param f0 function value at {@code x0}, provided by the caller
+   * @param x1 upper bound abscissa of the search interval
+   * @param f1 function value at {@code x1}, provided by the caller
+   * @return {@code true} when a converged root estimate is found within bounds
+   * @throws FunctionException if the function cannot be evaluated during the search
    */
-  public boolean findRoot(
+  boolean findRoot(
       ComputableFunction function,
       ConvergenceChecker checker,
       int maxIter,
@@ -34,9 +63,14 @@ public interface RootsFinder {
       throws FunctionException;
 
   /**
-   * Get the abscissa of the root.
+   * Returns the abscissa of the last root estimate accepted by this finder.
    *
-   * @return abscissa of the root
+   * <p>This value is meaningful only after a successful call to {@link
+   * #findRoot(ComputableFunction, ConvergenceChecker, int, double, double, double, double)}.
+   * Implementations may keep the previous estimate when a search fails, so callers should rely on
+   * the boolean return value of {@code findRoot} to decide whether this result is current.
+   *
+   * @return abscissa of the accepted root estimate from the last successful search
    */
-  public double getRoot();
+  double getRoot();
 }

--- a/src/test/java/org/spaceroots/mantissa/roots/BrentSolverTest.java
+++ b/src/test/java/org/spaceroots/mantissa/roots/BrentSolverTest.java
@@ -1,0 +1,185 @@
+package org.spaceroots.mantissa.roots;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.scalar.ComputableFunction;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class BrentSolverTest {
+
+  @Test
+  void getRoot_afterConstruction_returnsNaN() {
+    BrentSolver solver = new BrentSolver();
+
+    assertTrue(Double.isNaN(solver.getRoot()));
+  }
+
+  @Test
+  void findRoot_whenCheckerReturnsLowOnFirstIteration_setsLowerEndpointAsRoot() throws Exception {
+    // Arrange
+    BrentSolver solver = new BrentSolver();
+    ComputableFunction function = x -> x * x - 2.0;
+    ConvergenceChecker checker = Mockito.mock(ConvergenceChecker.class);
+    Mockito.when(
+            checker.converged(
+                Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble()))
+        .thenReturn(ConvergenceChecker.LOW);
+
+    double x0 = 0.0;
+    double x1 = 2.0;
+    double f0 = function.valueAt(x0);
+    double f1 = function.valueAt(x1);
+
+    // Act
+    boolean found = solver.findRoot(function, checker, 10, x0, f0, x1, f1);
+
+    // Assert
+    assertTrue(found);
+    assertEquals(x0, solver.getRoot(), 0.0);
+  }
+
+  @Test
+  void findRoot_whenCheckerReturnsHighOnFirstIteration_setsUpperEndpointAsRoot() throws Exception {
+    // Arrange
+    BrentSolver solver = new BrentSolver();
+    ComputableFunction function = x -> x * x - 2.0;
+    ConvergenceChecker checker = Mockito.mock(ConvergenceChecker.class);
+    Mockito.when(
+            checker.converged(
+                Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble()))
+        .thenReturn(ConvergenceChecker.HIGH);
+
+    double x0 = 0.0;
+    double x1 = 2.0;
+    double f0 = function.valueAt(x0);
+    double f1 = function.valueAt(x1);
+
+    // Act
+    boolean found = solver.findRoot(function, checker, 10, x0, f0, x1, f1);
+
+    // Assert
+    assertTrue(found);
+    assertEquals(x1, solver.getRoot(), 0.0);
+  }
+
+  @Test
+  void findRoot_whenUpperEndpointIsExactRoot_convergesWithoutEvaluatingFunction() throws Exception {
+    // Arrange
+    BrentSolver solver = new BrentSolver();
+    ComputableFunction function = Mockito.mock(ComputableFunction.class);
+    ConvergenceChecker checker = (xLow, fLow, xHigh, fHigh) -> ConvergenceChecker.NONE;
+
+    double x0 = 0.0;
+    double x1 = 1.0;
+    double f0 = -1.0;
+    double f1 = 0.0;
+
+    // Act
+    boolean found = solver.findRoot(function, checker, 10, x0, f0, x1, f1);
+
+    // Assert
+    assertTrue(found);
+    assertEquals(x1, solver.getRoot(), 0.0);
+    Mockito.verifyNoInteractions(function);
+  }
+
+  @Test
+  void findRoot_whenMaxIterIsZero_returnsFalseAndLeavesRootUnchanged() throws Exception {
+    // Arrange
+    BrentSolver solver = new BrentSolver();
+    ComputableFunction function = Mockito.mock(ComputableFunction.class);
+    ConvergenceChecker checker = (xLow, fLow, xHigh, fHigh) -> ConvergenceChecker.NONE;
+
+    double x0 = 0.0;
+    double x1 = 1.0;
+
+    // Act
+    boolean found = solver.findRoot(function, checker, 0, x0, -1.0, x1, 1.0);
+
+    // Assert
+    assertFalse(found);
+    assertTrue(Double.isNaN(solver.getRoot()));
+    Mockito.verifyNoInteractions(function);
+  }
+
+  @Test
+  void findRoot_whenFunctionThrowsDuringIteration_propagatesFunctionException() throws Exception {
+    // Arrange
+    BrentSolver solver = new BrentSolver();
+    ComputableFunction function = Mockito.mock(ComputableFunction.class);
+    ConvergenceChecker checker = Mockito.mock(ConvergenceChecker.class);
+    Mockito.when(
+            checker.converged(
+                Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble()))
+        .thenReturn(ConvergenceChecker.NONE);
+
+    double x0 = 0.0;
+    double x1 = 2.0;
+    double f0 = -1.0;
+    double f1 = 1.0;
+
+    Mockito.when(function.valueAt(Mockito.anyDouble())).thenThrow(new FunctionException("boom"));
+
+    // Act + Assert
+    assertThrows(
+        FunctionException.class, () -> solver.findRoot(function, checker, 5, x0, f0, x1, f1));
+
+    Mockito.verify(checker, Mockito.atLeastOnce())
+        .converged(
+            Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble());
+  }
+
+  @Test
+  void findRoot_whenBracketContainsRoot_convergesToExpectedValue() throws Exception {
+    // Arrange
+    BrentSolver solver = new BrentSolver();
+    ComputableFunction function = x -> x * x - 2.0;
+    ConvergenceChecker checker = (xLow, fLow, xHigh, fHigh) -> ConvergenceChecker.NONE;
+
+    double x0 = 0.0;
+    double x1 = 2.0;
+    double f0 = function.valueAt(x0);
+    double f1 = function.valueAt(x1);
+
+    // Act
+    boolean found = solver.findRoot(function, checker, 100, x0, f0, x1, f1);
+
+    // Assert
+    assertTrue(found);
+    double root = solver.getRoot();
+    assertTrue(root >= x0 && root <= x1);
+    assertEquals(0.0, function.valueAt(root), 1.0e-12);
+    assertEquals(Math.sqrt(2.0), root, 1.0e-10);
+  }
+
+  @Test
+  void findRoot_whenNonlinearFunction_convergesToFixedPointRoot() throws Exception {
+    // Arrange
+    BrentSolver solver = new BrentSolver();
+    ComputableFunction function = x -> Math.cos(x) - x;
+    ConvergenceChecker checker = (xLow, fLow, xHigh, fHigh) -> ConvergenceChecker.NONE;
+
+    double x0 = 0.0;
+    double x1 = 1.0;
+    double f0 = function.valueAt(x0);
+    double f1 = function.valueAt(x1);
+
+    // Act
+    boolean found = solver.findRoot(function, checker, 200, x0, f0, x1, f1);
+
+    // Assert
+    assertTrue(found);
+    double root = solver.getRoot();
+    assertEquals(0.0, function.valueAt(root), 1.0e-12);
+    assertEquals(0.7390851332, root, 1.0e-9);
+  }
+}


### PR DESCRIPTION
Summary:
- Refactors `BrentSolver` implementation for clearer state handling and safer interpolation/bisection selection while preserving Brent-method guarantees.
- Adds comprehensive unit tests for convergence edge cases and typical nonlinear roots.
- Doclint-clean Javadoc on `ConvergenceChecker` and `RootsFinder`.

Notes:
- No functional behavior changes intended beyond internal refactor; tests cover prior and edge behaviors.
- Working tree clean; no additional formatting/Spotless run required.