### PR TITLE
random: improve docs, seeding, and add generator/statistics tests

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/random/CorrelatedRandomVectorGenerator.java
+++ b/src/main/java/org/spaceroots/mantissa/random/CorrelatedRandomVectorGenerator.java
@@ -1,5 +1,6 @@
 package org.spaceroots.mantissa.random;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.spaceroots.mantissa.MantissaException;
 import org.spaceroots.mantissa.linalg.GeneralMatrix;
@@ -7,41 +8,58 @@ import org.spaceroots.mantissa.linalg.Matrix;
 import org.spaceroots.mantissa.linalg.SymetricalMatrix;
 
 /**
- * This class allows to generate random vectors with correlated components.
+ * Generates multivariate random vectors whose components follow a prescribed covariance structure.
  *
- * <p>Random vectors with correlated components are built by combining the uncorrelated components
- * of another random vector in such a way the resulting correlations are the ones specified by a
- * positive definite covariance matrix.
+ * <p>The generator combines an underlying {@link NormalizedRandomGenerator} that emits independent,
+ * zero-mean, unit-variance samples with a Cholesky-like factorization of the supplied covariance
+ * matrix. Each call to {@link #nextVector()} transforms freshly drawn normalized components by the
+ * rectangular root matrix so the returned vector respects both the requested mean and the
+ * correlations encoded in the covariance input. The implementation supports strictly positive
+ * definite matrices and semi-definite cases by computing a rectangular factor when the matrix rank
+ * is lower than its dimension, avoiding failures when small eigenvalues are effectively zero.
  *
- * <p>Sometimes, the covariance matrix for a given simulation is not strictly positive definite.
- * This means that the correlations are not all independant from each other. In this case, however,
- * the non strictly positive elements found during the Cholesky decomposition of the covariance
- * matrix should not be negative either, they should be null. This implies that rather than
- * computing <code>C =
- * L.Lt</code> where <code>C</code> is the covariance matrix and <code>L</code> is a
- * lower-triangular matrix, we compute <code>C =
- * B.Bt</code> where <code>B</code> is a rectangular matrix having more rows than columns. The
- * number of columns of <code>B</code> is the rank of the covariance matrix, and it is the dimension
- * of the uncorrelated random vector that is needed to compute the component of the correlated
- * vector. This class does handle this situation automatically.
+ * <p>Instances are mutable and not thread-safe: they retain intermediate buffers and the working
+ * permutation from the factorization. Create separate instances per thread or guard access
+ * externally if concurrent sampling is required. Typical usage wires a deterministic normalized
+ * generator (for reproducibility) and reuses this adapter to produce many correlated samples:
+ *
+ * <pre>{@code
+ * SymetricalMatrix covariance = ...;
+ * NormalizedRandomGenerator base = ...; // Gaussian or custom
+ * CorrelatedRandomVectorGenerator generator =
+ *     new CorrelatedRandomVectorGenerator(covariance, base);
+ * double[] sample = generator.nextVector();
+ * }</pre>
+ *
+ * <ul>
+ *   <li>Performs rank-revealing factorization to tolerate semi-definite covariance inputs.
+ *   <li>Returns fresh arrays on each invocation; callers own and may mutate them.
+ *   <li>Exposes the computed root matrix and rank for diagnostic or reuse scenarios.
+ * </ul>
  *
  * @version $Id: CorrelatedRandomVectorGenerator.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
+ * @see NormalizedRandomGenerator
+ * @see NotPositiveDefiniteMatrixException
  */
 public class CorrelatedRandomVectorGenerator implements Serializable, RandomVectorGenerator {
 
   /**
-   * Simple constructor.
+   * Creates a generator using explicit mean values and a full covariance matrix.
    *
-   * <p>Build a correlated random vector generator from its mean vector and covariance matrix.
+   * <p>The constructor defensively copies the mean vector, factorizes the covariance matrix, and
+   * stores the resulting root for reuse across calls to {@link #nextVector()}. The covariance must
+   * be positive definite or positive semi-definite; otherwise a checked exception is raised during
+   * construction. The supplied {@code generator} should emit independent, normalized components;
+   * deterministic seeds can be provided in its implementation to make correlated outputs
+   * repeatable.
    *
-   * @param mean expected mean values for all components
-   * @param covariance covariance matrix
-   * @param generator underlying generator for uncorrelated normalized components
-   * @exception IllegalArgumentException if there is a dimension mismatch between the mean vector
-   *     and the covariance matrix
-   * @exception NotPositiveDefiniteMatrixException if the covariance matrix is not strictly positive
-   *     definite
+   * @param mean expected mean value for each component; length must equal covariance order
+   * @param covariance square covariance matrix describing target correlations; must not be null
+   * @param generator underlying normalized generator producing zero-mean, unit-variance samples
+   * @throws IllegalArgumentException if {@code mean.length} differs from covariance dimension
+   * @throws NotPositiveDefiniteMatrixException if covariance has a negative diagonal pivot during
+   *     factorization
    */
   public CorrelatedRandomVectorGenerator(
       double[] mean, SymetricalMatrix covariance, NormalizedRandomGenerator generator)
@@ -55,7 +73,7 @@ public class CorrelatedRandomVectorGenerator implements Serializable, RandomVect
               new String[] {Integer.toString(mean.length), Integer.toString(order)});
       throw new IllegalArgumentException(message);
     }
-    this.mean = (double[]) mean.clone();
+    this.mean = mean.clone();
 
     factorize(covariance);
 
@@ -64,14 +82,18 @@ public class CorrelatedRandomVectorGenerator implements Serializable, RandomVect
   }
 
   /**
-   * Simple constructor.
+   * Creates a generator that produces zero-mean correlated vectors from a covariance matrix.
    *
-   * <p>Build a null mean random correlated vector generator from its covariance matrix.
+   * <p>This overload initializes the mean vector to zeros, computes a rank-revealing factorization
+   * of the covariance, and allocates internal buffers sized to the detected rank. It is convenient
+   * when callers only need covariance structure and do not require a non-zero mean shift. The
+   * {@code generator} supplies normalized components that will be linearly combined by the computed
+   * root matrix on each sampling call.
    *
-   * @param covariance covariance matrix
-   * @param generator underlying generator for uncorrelated normalized components
-   * @exception NotPositiveDefiniteMatrixException if the covariance matrix is not strictly positive
-   *     definite
+   * @param covariance square covariance matrix defining the desired correlations; must be non-null
+   * @param generator normalized component source that outputs independent, unit-variance values
+   * @throws NotPositiveDefiniteMatrixException if the matrix contains a significantly negative
+   *     diagonal pivot during factorization
    */
   public CorrelatedRandomVectorGenerator(
       SymetricalMatrix covariance, NormalizedRandomGenerator generator)
@@ -90,41 +112,61 @@ public class CorrelatedRandomVectorGenerator implements Serializable, RandomVect
   }
 
   /**
-   * Get the root of the covariance matrix. The root is the matrix <code>B</code> such that <code>
-   * B.Bt</code> is equal to the covariance matrix
+   * Returns the computed root matrix used to correlate normalized samples.
    *
-   * @return root of the square matrix
+   * <p>The root matrix {@code B} satisfies {@code B.Bt = C} where {@code C} is the user-supplied
+   * covariance matrix, possibly after row/column permutation. When the covariance is semi-definite,
+   * {@code B} is rectangular with a column count equal to the detected rank. The returned instance
+   * is owned by this generator; callers should treat it as read-only to preserve subsequent sample
+   * correctness.
+   *
+   * @return internal root matrix with dimensions {@code order x rank}; not null but mutable
    */
   public Matrix getRootMatrix() {
     return root;
   }
 
   /**
-   * Get the underlying normalized components generator.
+   * Provides the underlying normalized generator that supplies uncorrelated components.
    *
-   * @return underlying uncorrelated components generator
+   * <p>The returned object is the same reference passed to the constructor. It is consulted on each
+   * call to {@link #nextVector()}, so replacing it externally will affect subsequent samples.
+   * Implementations may or may not be thread-safe; this class does not add synchronization.
+   *
+   * @return normalized generator reference used during sampling; may be reused by callers
    */
   public NormalizedRandomGenerator getGenerator() {
     return generator;
   }
 
   /**
-   * Get the rank of the covariance matrix. The rank is the number of independant rows in the
-   * covariance matrix, it is also the number of columns of the rectangular matrix of the
-   * factorization.
+   * Reports the detected rank of the covariance matrix after factorization.
    *
-   * @return rank of the square matrix.
+   * <p>The rank equals the number of independent rows/columns in the covariance input and matches
+   * the column count of the internally stored root matrix. For full-rank, strictly positive
+   * definite inputs, this value equals the covariance order; for semi-definite inputs it is lower.
+   * The rank determines how many normalized components are requested from the underlying generator
+   * during sampling.
+   *
+   * @return rank value between {@code 1} and the covariance dimension, inclusive
    */
   public int getRank() {
     return rank;
   }
 
   /**
-   * Factorize the original square matrix.
+   * Performs a rank-revealing factorization of the covariance matrix.
    *
-   * @param covariance covariance matrix
-   * @exception NotPositiveDefiniteMatrixException if the covariance matrix is not strictly positive
-   *     definite
+   * <p>The routine duplicates the covariance to avoid mutating caller state, selects pivot rows to
+   * maximize numerical stability, and builds a rectangular lower-factor such that {@code B.Bt}
+   * reproduces the covariance. A negative pivot beyond tolerance triggers {@link
+   * NotPositiveDefiniteMatrixException}. This method mutates internal fields ({@code rank}, {@code
+   * root}) and should only be invoked during construction.
+   *
+   * @param covariance symmetric covariance matrix to decompose; must match previously validated
+   *     dimensions
+   * @throws NotPositiveDefiniteMatrixException if a diagonal pivot is sufficiently negative to
+   *     violate positive semi-definiteness
    */
   private void factorize(SymetricalMatrix covariance) throws NotPositiveDefiniteMatrixException {
 
@@ -133,73 +175,85 @@ public class CorrelatedRandomVectorGenerator implements Serializable, RandomVect
     GeneralMatrix b = new GeneralMatrix(order, order);
 
     int[] swap = new int[order];
+    int[] index = initIndex(order);
+
+    rank = 0;
+    while (rank < order) {
+      swap[rank] = findPivot(c, index, rank, order);
+      applySwap(index, rank, swap[rank]);
+
+      double diagonalValue = c.getElement(index[rank], index[rank]);
+      if (diagonalValue < 1.0e-12) {
+        handleSmallDiagonal(diagonalValue);
+        break;
+      }
+
+      updateDecomposition(c, b, index, order, diagonalValue);
+      ++rank;
+    }
+
+    buildRootMatrix(order, b, swap);
+  }
+
+  private int[] initIndex(int order) {
     int[] index = new int[order];
     for (int i = 0; i < order; ++i) {
       index[i] = i;
     }
+    return index;
+  }
 
-    rank = 0;
-    for (boolean loop = true; loop; ) {
-
-      // find maximal diagonal element
-      swap[rank] = rank;
-      for (int i = rank + 1; i < order; ++i) {
-        if (c.getElement(index[i], index[i]) > c.getElement(index[swap[i]], index[swap[i]])) {
-          swap[rank] = i;
-        }
-      }
-
-      // swap elements
-      if (swap[rank] != rank) {
-        int tmp = index[rank];
-        index[rank] = index[swap[rank]];
-        index[swap[rank]] = tmp;
-      }
-
-      // check diagonal element
-      if (c.getElement(index[rank], index[rank]) < 1.0e-12) {
-
-        if (rank == 0) {
-          throw new NotPositiveDefiniteMatrixException();
-        }
-
-        // check remaining diagonal elements
-        for (int i = rank; i < order; ++i) {
-          if (c.getElement(index[rank], index[rank]) < -1.0e-12) {
-            // there is at least one sufficiently negative diagonal element,
-            // the covariance matrix is wrong
-            throw new NotPositiveDefiniteMatrixException();
-          }
-        }
-
-        // all remaining diagonal elements are close to zero,
-        // we consider we have found the rank of the covariance matrix
-        ++rank;
-        loop = false;
-
-      } else {
-
-        // transform the matrix
-        double sqrt = Math.sqrt(c.getElement(index[rank], index[rank]));
-        b.setElement(rank, rank, sqrt);
-        double inverse = 1 / sqrt;
-        for (int i = rank + 1; i < order; ++i) {
-          double e = inverse * c.getElement(index[i], index[rank]);
-          b.setElement(i, rank, e);
-          c.setElement(index[i], index[i], c.getElement(index[i], index[i]) - e * e);
-          for (int j = rank + 1; j < i; ++j) {
-            double f = b.getElement(j, rank);
-            c.setElementAndSymetricalElement(
-                index[i], index[j], c.getElement(index[i], index[j]) - e * f);
-          }
-        }
-
-        // prepare next iteration
-        loop = ++rank < order;
+  private int findPivot(SymetricalMatrix c, int[] index, int currentRank, int order) {
+    int pivot = currentRank;
+    double pivotValue = c.getElement(index[currentRank], index[currentRank]);
+    for (int i = currentRank + 1; i < order; ++i) {
+      double candidate = c.getElement(index[i], index[i]);
+      if (candidate > pivotValue) {
+        pivot = i;
+        pivotValue = candidate;
       }
     }
+    return pivot;
+  }
 
-    // build the root matrix
+  private void applySwap(int[] index, int currentRank, int pivot) {
+    if (pivot != currentRank) {
+      int tmp = index[currentRank];
+      index[currentRank] = index[pivot];
+      index[pivot] = tmp;
+    }
+  }
+
+  private void handleSmallDiagonal(double diagonalValue) throws NotPositiveDefiniteMatrixException {
+
+    if (rank == 0 || diagonalValue < -1.0e-12) {
+      throw new NotPositiveDefiniteMatrixException();
+    }
+
+    // all remaining diagonal elements are close to zero,
+    // we consider we have found the rank of the covariance matrix
+    ++rank;
+  }
+
+  private void updateDecomposition(
+      SymetricalMatrix c, GeneralMatrix b, int[] index, int order, double diagonalValue) {
+
+    double sqrt = Math.sqrt(diagonalValue);
+    b.setElement(rank, rank, sqrt);
+    double inverse = 1 / sqrt;
+    for (int i = rank + 1; i < order; ++i) {
+      double e = inverse * c.getElement(index[i], index[rank]);
+      b.setElement(i, rank, e);
+      c.setElement(index[i], index[i], c.getElement(index[i], index[i]) - e * e);
+      for (int j = rank + 1; j < i; ++j) {
+        double f = b.getElement(j, rank);
+        c.setElementAndSymetricalElement(
+            index[i], index[j], c.getElement(index[i], index[j]) - e * f);
+      }
+    }
+  }
+
+  private void buildRootMatrix(int order, GeneralMatrix b, int[] swap) {
     root = new GeneralMatrix(order, rank);
     for (int i = 0; i < order; ++i) {
       for (int j = 0; j < rank; ++j) {
@@ -209,10 +263,16 @@ public class CorrelatedRandomVectorGenerator implements Serializable, RandomVect
   }
 
   /**
-   * Generate a correlated random vector.
+   * Generates a single correlated random vector using the precomputed factorization.
    *
-   * @return a random vector as an array of double. The returned array is created at each call, the
-   *     caller can do what it wants with it.
+   * <p>Each invocation pulls {@link #getRank()} normalized scalars from the underlying generator,
+   * multiplies them by the root matrix, and adds the stored mean component-wise. A fresh array is
+   * allocated on every call; callers own the returned buffer and may modify it without affecting
+   * subsequent samples. The method performs no synchronization and is not thread-safe when sharing
+   * an instance across threads.
+   *
+   * @return newly allocated vector whose length equals the covariance order; values honor mean and
+   *     covariance shape
    */
   public double[] nextVector() {
 
@@ -234,7 +294,7 @@ public class CorrelatedRandomVectorGenerator implements Serializable, RandomVect
   }
 
   /** Mean vector. */
-  private double[] mean;
+  private final double[] mean;
 
   /** Permutated Cholesky root of the covariance matrix. */
   private Matrix root;
@@ -246,7 +306,7 @@ public class CorrelatedRandomVectorGenerator implements Serializable, RandomVect
   NormalizedRandomGenerator generator;
 
   /** Storage for the normalized vector. */
-  private double[] normalized;
+  private final double[] normalized;
 
-  private static final long serialVersionUID = -88563624902398453L;
+  @Serial private static final long serialVersionUID = -88563624902398453L;
 }

--- a/src/main/java/org/spaceroots/mantissa/random/FourTapRandom.java
+++ b/src/main/java/org/spaceroots/mantissa/random/FourTapRandom.java
@@ -1,54 +1,88 @@
 package org.spaceroots.mantissa.random;
 
+import java.io.Serial;
 import java.util.Random;
 
 /**
- * This class implements a powerful pseudo-random number generator studied by Robert M Ziff.
+ * Pseudo-random number generator using the four-tap GFSR scheme defined by Robert M. Ziff.
  *
- * <p>This generator belongs to the family of Generalized Feedback Shift-Register (GFSR) generators,
- * but uses four feedback taps instead of two, thus greatly improving their quality for Monte-Carlo
- * simulations.
+ * <p>The generator keeps a circular buffer of 16,384 32-bit values and combines four widely spaced
+ * taps with XOR to produce the next state. The configuration corresponds to generator {@code R(471,
+ * 1586, 6988, 9689)} in Ziff's 1997 paper <a href="http://arxiv.org/abs/cond-mat/9710104">Four-tap
+ * shift-register-sequence random-number generators</a>. Extending {@link Random} makes it a drop-in
+ * replacement for code that already expects the JDK API while providing higher-quality sequences
+ * for Monte-Carlo style workloads.
  *
- * <p>This generator is described in a paper by Robert M. Ziff in 1997: <a
- * href="http://arxiv.org/abs/cond-mat/9710104">Four-tap shift-register-sequence random-number
- * generators</a>, it is generator 9f (defined as <code>R(471, 1586, 6988, 9689)</code>) of the
- * paper. It has been kindly contributed to mantissa by Bill Maier.
+ * <p>Typical usage mirrors {@link Random}: build an instance, optionally provide a fixed seed for
+ * reproducibility, then call generation methods such as {@link #nextInt()}, {@link #nextDouble()}
+ * or {@link #nextLong()}. The buffer is repopulated during construction or {@link #setSeed(long)}
+ * and advances on every call to {@link #next(int)}, which all public generation methods delegate
+ * to.
  *
- * <p>The class is implemented as a specialization of the standard <code>java.util.Random</code>
- * class. This allows to use it in algorithms expecting a standard random generator, and hence
- * benefit from a better generator without code change.
+ * <p>The class is mutable and not inherently thread-safe, matching {@link Random}. External
+ * synchronization is required when sharing an instance across threads; {@link #setSeed(long)} is
+ * synchronized to mirror {@link Random#setSeed(long)} and avoid races during reinitialization.
+ *
+ * <ul>
+ *   <li>State size: 16,384 integers forming a ring buffer of previous outputs.
+ *   <li>Determinism: identical seeds yield identical sequences across JVMs that preserve {@link
+ *       Random} bit semantics.
+ *   <li>Compatibility: fully honors the {@link Random} contract for all public generation methods.
+ * </ul>
  *
  * @author Bill Maier (java.util.Random specialization by Luc Maisonobe)
  * @version $Id: FourTapRandom.java 1666 2005-12-15 16:37:55Z luc $
+ * @see Random
  */
 public class FourTapRandom extends Random {
 
   /**
-   * Creates a new random number generator.
+   * Builds a generator seeded from the current system clock to provide a fresh, unpredictable
+   * sequence.
    *
-   * <p>The instance is initialized using the current time as the seed.
+   * <p>The constructor allocates the internal ring buffer immediately and forwards to {@link
+   * #setSeed(long)} to populate it with 32-bit values derived from the seed. Because the seed comes
+   * from {@link System#currentTimeMillis()}, two instances created in rapid succession may still
+   * diverge if the clock ticks; use {@link #FourTapRandom(long)} for reproducible runs. The
+   * resulting instance follows all {@link Random} semantics and can be used with any API that
+   * expects a standard random generator.
    */
   public FourTapRandom() {
     setSeed(System.currentTimeMillis());
   }
 
   /**
-   * Creates a new random number generator using a single long seed.
+   * Builds a generator with a user-supplied seed for reproducible sequences.
    *
-   * @param seed the initial seed
+   * <p>Supplying the seed allows callers to generate deterministic series across JVM executions,
+   * which is often desirable in simulations and tests. Construction eagerly fills the internal
+   * buffer so the instance is ready for immediate use. The seed value is passed verbatim to {@link
+   * #setSeed(long)}, which mirrors {@link Random#setSeed(long)} semantics and resets any prior
+   * state. As with {@link Random}, callers should externally synchronize when sharing the same
+   * generator instance between threads.
+   *
+   * @param seed initial 64-bit value used to derive the internal 32-bit buffer contents; identical
+   *     seeds always reproduce identical sequences.
    */
   public FourTapRandom(long seed) {
     setSeed(seed);
   }
 
   /**
-   * Reinitialize the generator as if just built with the given seed.
+   * Reinitializes the generator as if newly constructed with the specified seed.
    *
-   * <p>The state of the generator is exactly the same as a new generator built with the same seed.
+   * <p>This synchronized method matches the thread-safety contract of {@link Random#setSeed(long)}
+   * and completely resets the internal ring buffer and index. It first seeds the superclass, then
+   * fills all 16,384 buffer slots by delegating to {@link Random#next(int)} to preserve consistency
+   * with {@link Random} bit production. After completion, the next generated value will be
+   * identical to that of a freshly created {@link FourTapRandom} with the same seed, ensuring
+   * reproducible replay of sequences even after previous usage.
    *
-   * @param seed the initial seed
+   * @param seed 64-bit value used to regenerate the buffer; any {@code long} is accepted and equal
+   *     seeds guarantee identical subsequent outputs.
    */
-  public void setSeed(long seed) {
+  @Override
+  public synchronized void setSeed(long seed) {
     super.setSeed(seed);
     fourTapBuffer = new int[TAP4M + 1];
     for (int j = 0; j <= TAP4M; j++) {
@@ -58,16 +92,22 @@ public class FourTapRandom extends Random {
   }
 
   /**
-   * Generate next pseudorandom number.
+   * Produces the requested number of pseudo-random high-order bits from the current generator
+   * state.
    *
-   * <p>This method is the core generation algorithm. As per {@link Random Random} contract, it is
-   * used by all the public generation methods for the various primitive types {@link
-   * Random#nextBoolean nextBoolean}, {@link Random#nextBytes nextBytes}, {@link Random#nextDouble
-   * nextDouble}, {@link Random#nextFloat nextFloat}, {@link Random#nextGaussian nextGaussian},
-   * {@link Random#nextInt() nextInt} and {@link Random#nextLong nextLong}.
+   * <p>This is the core algorithm used by all {@link Random} convenience methods. Each call
+   * advances the circular buffer index, computes a new 32-bit value by XOR-ing four distant taps,
+   * stores it back into the buffer, and returns the upper {@code bits} of that value. Calling this
+   * method with the same prior state and bit count always yields identical results, making it
+   * suitable as a deterministic foundation for higher-level generators. The expected {@code bits}
+   * range is between 1 and 32 inclusive; larger values would shift the value into zero.
    *
-   * @param bits number of random bits to produce
+   * @param bits number of leading bits to return; typically 1–32, where larger values provide more
+   *     entropy but still derive from the same 32-bit buffer entry.
+   * @return non-negative integer containing exactly the requested number of high-order bits of the
+   *     freshly generated 32-bit word; lower bits are zeroed by the unsigned shift.
    */
+  @Override
   protected int next(int bits) {
     ++n4TapJ;
     fourTapBuffer[n4TapJ & TAP4M] =
@@ -84,8 +124,14 @@ public class FourTapRandom extends Random {
   private static final int TAP4D = 9689;
   private static final int TAP4M = 16383;
 
+  /** Ring buffer that stores the last 16,384 generated 32-bit values for tap-based recurrence. */
   private int[] fourTapBuffer;
+
+  /** Current write index into {@link #fourTapBuffer}, incremented once per {@link #next(int)}. */
   private int n4TapJ;
 
-  private static final long serialVersionUID = -4095251494398895580L;
+  /**
+   * Serialization identifier to preserve compatibility with previously persisted generator states.
+   */
+  @Serial private static final long serialVersionUID = -4095251494398895580L;
 }

--- a/src/main/java/org/spaceroots/mantissa/random/GaussianRandomGenerator.java
+++ b/src/main/java/org/spaceroots/mantissa/random/GaussianRandomGenerator.java
@@ -1,10 +1,36 @@
 package org.spaceroots.mantissa.random;
 
+import java.io.Serial;
+
 /**
- * This class is a gaussian normalized random generator for scalars.
+ * Generates scalar values distributed as a standard (mean&nbsp;0, variance&nbsp;1) Gaussian.
  *
- * <p>This class is a simple interface adaptor around the {@link MersenneTwister MersenneTwister}
- * generator, which calls its {@link java.util.Random#nextGaussian nextGaussian} method.
+ * <p>This class is a lightweight adapter that exposes the {@link NormalizedRandomGenerator}
+ * interface on top of a {@link MersenneTwister} pseudo‑random number generator. Each call to {@link
+ * #nextDouble()} returns the next value from {@link java.util.Random#nextGaussian()}, computed by
+ * the underlying Mersenne Twister instance. The resulting sequence is fully deterministic for a
+ * given seed, and two instances created with the same seed will produce identical sequences.
+ *
+ * <p>The generator is stateful and advances its internal state on every call. It is not designed
+ * for concurrent use without external synchronization; sharing a single instance across threads may
+ * lead to interleaved sequences. If you need independent streams, create separate instances with
+ * distinct seeds.
+ *
+ * <p>Typical usage is to construct a seeded generator during test setup or simulation
+ * initialization and then call {@link #nextDouble()} whenever a standard normal deviate is
+ * required.
+ *
+ * <ul>
+ *   <li><strong>Distribution:</strong> Standard normal, as defined by {@code
+ *       Random.nextGaussian()}.
+ *   <li><strong>Determinism:</strong> Fully determined by the supplied seed.
+ *   <li><strong>State:</strong> Advances on each generated value.
+ * </ul>
+ *
+ * <pre>{@code
+ * GaussianRandomGenerator gen = new GaussianRandomGenerator(1234);
+ * double noise = gen.nextDouble();
+ * }</pre>
  *
  * @see MersenneTwister
  * @version $Id: GaussianRandomGenerator.java 1709 2006-12-03 21:16:50Z luc $
@@ -12,7 +38,16 @@ package org.spaceroots.mantissa.random;
  */
 public class GaussianRandomGenerator implements NormalizedRandomGenerator {
 
-  /** Create a new generator. The seed of the generator is related to the current time. */
+  /**
+   * Create a new generator seeded from the current time.
+   *
+   * <p>This constructor creates a fresh {@link MersenneTwister} instance using its default seeding
+   * strategy, which is typically based on the system clock. The produced sequence is therefore
+   * different across JVM runs unless the environment or underlying implementation fixes the seed.
+   *
+   * <p>Use one of the explicit seed constructors when reproducibility is required (for example, in
+   * unit tests or deterministic simulations).
+   */
   public GaussianRandomGenerator() {
     generator = new MersenneTwister();
   }
@@ -20,7 +55,10 @@ public class GaussianRandomGenerator implements NormalizedRandomGenerator {
   /**
    * Creates a new random number generator using a single int seed.
    *
-   * @param seed the initial seed (32 bits integer)
+   * <p>The generated Gaussian sequence is completely determined by {@code seed}. Two generators
+   * created with the same integer seed will produce identical values in the same order.
+   *
+   * @param seed initial 32‑bit seed value controlling the deterministic output sequence
    */
   public GaussianRandomGenerator(int seed) {
     generator = new MersenneTwister(seed);
@@ -29,8 +67,11 @@ public class GaussianRandomGenerator implements NormalizedRandomGenerator {
   /**
    * Creates a new random number generator using an int array seed.
    *
-   * @param seed the initial seed (32 bits integers array), if null the seed of the generator will
-   *     be related to the current time
+   * <p>The seed array allows finer control over the initial state than a single integer. Providing
+   * equal arrays (element‑wise) results in identical output sequences. If {@code seed} is {@code
+   * null}, the underlying generator falls back to time‑based seeding.
+   *
+   * @param seed initial 32‑bit integer array seed; {@code null} uses a time‑derived seed instead
    */
   public GaussianRandomGenerator(int[] seed) {
     generator = new MersenneTwister(seed);
@@ -39,7 +80,11 @@ public class GaussianRandomGenerator implements NormalizedRandomGenerator {
   /**
    * Create a new generator initialized with a single long seed.
    *
-   * @param seed seed for the generator (64 bits integer)
+   * <p>Long seeds provide a larger initialization space than integer seeds while keeping
+   * determinism. Two instances created with the same long seed will return the same sequence of
+   * Gaussian values.
+   *
+   * @param seed initial 64‑bit seed value controlling the deterministic output sequence
    */
   public GaussianRandomGenerator(long seed) {
     generator = new MersenneTwister(seed);
@@ -48,14 +93,27 @@ public class GaussianRandomGenerator implements NormalizedRandomGenerator {
   /**
    * Generate a random scalar with null mean and unit standard deviation.
    *
-   * @return a random scalar with null mean and unit standard deviation
+   * <p>This method delegates directly to the underlying {@link MersenneTwister}'s {@link
+   * java.util.Random#nextGaussian()} implementation. Each invocation advances the internal state
+   * and returns the next value in the standard normal sequence.
+   *
+   * <p>The return value is typically unbounded in range (as with any Gaussian distribution). The
+   * sequence is deterministic with respect to the constructor seed and the number of prior calls.
+   *
+   * @return next pseudo‑random value from a standard normal distribution (mean&nbsp;0, standard
+   *     deviation&nbsp;1)
    */
   public double nextDouble() {
     return generator.nextGaussian();
   }
 
-  /** Underlying generator. */
+  /**
+   * Underlying pseudo‑random generator used to produce Gaussian deviates.
+   *
+   * <p>This field is package‑private to allow collaboration with other Mantissa random utilities.
+   * It is stateful and mutated on each call to {@link #nextDouble()}.
+   */
   MersenneTwister generator;
 
-  private static final long serialVersionUID = 5504568059866195697L;
+  @Serial private static final long serialVersionUID = 5504568059866195697L;
 }

--- a/src/main/java/org/spaceroots/mantissa/random/MersenneTwister.java
+++ b/src/main/java/org/spaceroots/mantissa/random/MersenneTwister.java
@@ -1,10 +1,24 @@
 package org.spaceroots.mantissa.random;
 
+import java.io.Serial;
 import java.util.Random;
 
 /**
  * This class implements a powerful pseudo-random number generator developed by Makoto Matsumoto and
  * Takuji Nishimura during 1996-1997.
+ *
+ * <p>This implementation behaves like a drop‑in replacement for {@link java.util.Random} with
+ * significantly better statistical properties for simulation, sampling, and randomized algorithms
+ * that are sensitive to correlation artifacts. The generator maintains an internal 624‑element
+ * state vector and produces 32‑bit values in batches; the public {@code nextInt()}, {@code
+ * nextLong()}, and other {@code Random} methods all delegate to {@link #next(int)} to obtain the
+ * requested number of bits. Calling any {@code setSeed} method fully resets that internal state so
+ * that two instances seeded identically will produce the same sequence of values.
+ *
+ * <p>Instances are mutable and not intended to be shared across threads without external
+ * synchronization. The core generation path in {@link #next(int)} does not synchronize, so callers
+ * that access a single instance concurrently must provide their own locking to preserve sequence
+ * determinism and avoid races during state refresh.
  *
  * <p>This generator features an extremely long period (2<sup>19937</sup>-1) and 623-dimensional
  * equidistribution up to 32 bits accuracy. The home page for this generator is located at <a
@@ -21,40 +35,36 @@ import java.util.Random;
  * benefit from a better generator without code change.
  *
  * <p>This class is mainly a Java port of the 2002-01-26 version of the generator written in C by
- * Makoto Matsumoto and Takuji Nishimura. Here is their original copyright:
+ * Makoto Matsumoto and Takuji Nishimura. The following license text is reproduced from the original
+ * C implementation:
  *
- * <table border="0" width="80%" cellpadding="10" align="center" bgcolor="#E0E0E0">
- * <tr><td>Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
- *     All rights reserved.</td></tr>
+ * <pre>{@code
+ * Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+ * All rights reserved.
+ * }</pre>
  *
- * <tr><td>Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * <p>Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
  * <ol>
- *   <li>Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.</li>
- *   <li>Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.</li>
- *   <li>The names of its contributors may not be used to endorse or promote
- *       products derived from this software without specific prior written
- *       permission.</li>
- * </ol></td></tr>
+ *   <li>Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *   <li>Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *   <li>The names of its contributors may not be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * </ol>
  *
- * <tr><td><strong>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
- * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
- * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
- * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
- * DAMAGE.</strong></td></tr>
- * </table>
+ * <p><strong>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.</strong>
  *
  * @author Makoto Matsumoto and Takuji Nishimura (C version), Luc Maisonobe (Java port)
  * @version $Id: MersenneTwister.java 1666 2005-12-15 16:37:55Z luc $
@@ -64,7 +74,14 @@ public class MersenneTwister extends Random {
   /**
    * Creates a new random number generator.
    *
-   * <p>The instance is initialized using the current time as the seed.
+   * <p>The instance is initialized using the current time as the seed. This constructor is a
+   * convenience for typical use when a non‑deterministic seed is acceptable, such as in interactive
+   * applications or ad‑hoc sampling. The generated sequence is otherwise identical to an instance
+   * created with {@link #MersenneTwister(long)} using the same millisecond timestamp value.
+   *
+   * <p>Because the seed is derived from wall‑clock time, two instances created in rapid succession
+   * may share the same starting state and thus produce identical outputs. If you require distinct
+   * streams, prefer explicit seeding or incorporate additional entropy externally.
    */
   public MersenneTwister() {
     mt = new int[N];
@@ -74,7 +91,12 @@ public class MersenneTwister extends Random {
   /**
    * Creates a new random number generator using a single int seed.
    *
-   * @param seed the initial seed (32 bits integer)
+   * <p>This constructor produces a deterministic generator state from a 32‑bit seed value. The
+   * resulting sequence is fully repeatable and can be used for tests or simulations where
+   * reproducibility matters. The seed is expanded into the full internal state using the standard
+   * Mersenne Twister initialization routine.
+   *
+   * @param seed initial 32‑bit seed value that deterministically defines the output sequence
    */
   public MersenneTwister(int seed) {
     mt = new int[N];
@@ -84,8 +106,14 @@ public class MersenneTwister extends Random {
   /**
    * Creates a new random number generator using an int array seed.
    *
-   * @param seed the initial seed (32 bits integers array), if null the seed of the generator will
-   *     be related to the current time
+   * <p>This constructor allows seeding from multiple 32‑bit values, matching the reference C
+   * implementation’s array initialization algorithm. Providing a longer or more variable seed array
+   * can help separate streams that might otherwise collide when using single‑word seeds.
+   *
+   * <p>If {@code seed} is {@code null}, the generator falls back to seeding from the current time,
+   * equivalent to {@link #MersenneTwister()}.
+   *
+   * @param seed array of 32‑bit seed values used to initialize the full state; may be {@code null}
    */
   public MersenneTwister(int[] seed) {
     mt = new int[N];
@@ -95,7 +123,11 @@ public class MersenneTwister extends Random {
   /**
    * Creates a new random number generator using a single long seed.
    *
-   * @param seed the initial seed (64 bits integer)
+   * <p>This constructor seeds the generator with a 64‑bit value. The seed is split into two 32‑bit
+   * words and then expanded into the internal state vector. Two instances constructed with the same
+   * {@code seed} will generate identical sequences of values across all {@code Random} methods.
+   *
+   * @param seed initial 64‑bit seed value that deterministically defines the output sequence
    */
   public MersenneTwister(long seed) {
     mt = new int[N];
@@ -106,8 +138,12 @@ public class MersenneTwister extends Random {
    * Reinitialize the generator as if just built with the given int seed.
    *
    * <p>The state of the generator is exactly the same as a new generator built with the same seed.
+   * This method resets all internal counters and rewrites the state vector using the standard
+   * initialization recurrence from the reference implementation. After calling this method, the
+   * next value returned by any {@code Random} method corresponds to the first value in the sequence
+   * for that seed.
    *
-   * @param seed the initial seed (32 bits integer)
+   * @param seed initial 32‑bit seed value used to rebuild the internal state vector
    */
   public void setSeed(int seed) {
     // we use a long masked by 0xffffffffL as a poor man unsigned int
@@ -116,7 +152,7 @@ public class MersenneTwister extends Random {
     for (mti = 1; mti < N; ++mti) {
       // See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier.
       // initializer from the 2002-01-09 C version by Makoto Matsumoto
-      longMT = (1812433253l * (longMT ^ (longMT >> 30)) + mti) & 0xffffffffL;
+      longMT = (1812433253L * (longMT ^ (longMT >> 30)) + mti) & 0xffffffffL;
       mt[mti] = (int) longMT;
     }
   }
@@ -124,10 +160,14 @@ public class MersenneTwister extends Random {
   /**
    * Reinitialize the generator as if just built with the given int array seed.
    *
-   * <p>The state of the generator is exactly the same as a new generator built with the same seed.
+   * <p>The state of the generator is exactly the same as a new generator built with the same seed
+   * array. The method first performs the single‑word initialization, then mixes each seed element
+   * into the state using the same two‑phase non‑linear recurrence as the original C code.
    *
-   * @param seed the initial seed (32 bits integers array), if null the seed of the generator will
-   *     be related to the current time
+   * <p>If {@code seed} is {@code null}, the generator is reseeded from the current time, which
+   * makes the resulting sequence non‑deterministic.
+   *
+   * @param seed array of 32‑bit seed values used to rebuild internal state; may be {@code null}
    */
   public void setSeed(int[] seed) {
 
@@ -136,56 +176,29 @@ public class MersenneTwister extends Random {
       return;
     }
 
-    setSeed(19650218);
-    int i = 1;
-    int j = 0;
-
-    for (int k = Math.max(N, seed.length); k != 0; k--) {
-      long l0 = (mt[i] & 0x7fffffffl) | ((mt[i] < 0) ? 0x80000000l : 0x0l);
-      long l1 = (mt[i - 1] & 0x7fffffffl) | ((mt[i - 1] < 0) ? 0x80000000l : 0x0l);
-      long l = (l0 ^ ((l1 ^ (l1 >> 30)) * 1664525l)) + seed[j] + j; // non linear
-      mt[i] = (int) (l & 0xffffffffl);
-      i++;
-      j++;
-      if (i >= N) {
-        mt[0] = mt[N - 1];
-        i = 1;
-      }
-      if (j >= seed.length) {
-        j = 0;
-      }
-    }
-
-    for (int k = N - 1; k != 0; k--) {
-      long l0 = (mt[i] & 0x7fffffffl) | ((mt[i] < 0) ? 0x80000000l : 0x0l);
-      long l1 = (mt[i - 1] & 0x7fffffffl) | ((mt[i - 1] < 0) ? 0x80000000l : 0x0l);
-      long l = (l0 ^ ((l1 ^ (l1 >> 30)) * 1566083941l)) - i; // non linear
-      mt[i] = (int) (l & 0xffffffffL);
-      i++;
-      if (i >= N) {
-        mt[0] = mt[N - 1];
-        i = 1;
-      }
-    }
-
-    mt[0] = 0x80000000; // MSB is 1; assuring non-zero initial array
+    initializeWithSeedArray(seed);
   }
 
   /**
    * Reinitialize the generator as if just built with the given long seed.
    *
    * <p>The state of the generator is exactly the same as a new generator built with the same seed.
+   * The 64‑bit input is split into two 32‑bit values, which are then used to perform array seeding.
+   * This override is synchronized to preserve the {@link Random} contract during construction and
+   * seeding, but generation itself is not synchronized.
    *
-   * @param seed the initial seed (64 bits integer)
+   * @param seed initial 64‑bit seed value used to rebuild internal state; higher bits contribute
+   *     independently of lower bits
    */
-  public void setSeed(long seed) {
+  @Override
+  public synchronized void setSeed(long seed) {
     if (mt == null) {
       // this is probably a spurious call from base class constructor,
       // we do nothing and wait for the setSeed in our own
       // constructors after array allocation
       return;
     }
-    setSeed(new int[] {(int) (seed >>> 32), (int) (seed & 0xffffffffl)});
+    setSeed(new int[] {(int) (seed >>> 32), (int) (seed & 0xffffffffL)});
   }
 
   /**
@@ -197,8 +210,16 @@ public class MersenneTwister extends Random {
    * nextDouble}, {@link Random#nextFloat nextFloat}, {@link Random#nextGaussian nextGaussian},
    * {@link Random#nextInt() nextInt} and {@link Random#nextLong nextLong}.
    *
-   * @param bits number of random bits to produce
+   * <p>The implementation refreshes the internal state vector in blocks of {@link #N} words. When
+   * the current block is exhausted, a new block is generated using the standard twist transform,
+   * then tempered to improve equidistribution. The returned value contains the requested number of
+   * high‑order bits from the next 32‑bit output word.
+   *
+   * @param bits number of high‑order random bits to produce, between 1 and 32 as required by {@link
+   *     Random}'s contract
+   * @return next pseudorandom value containing {@code bits} high‑order bits from the generator
    */
+  @Override
   protected int next(int bits) {
 
     int y;
@@ -238,8 +259,57 @@ public class MersenneTwister extends Random {
   private static final int M = 397;
   private static final int[] MAG01 = {0x0, 0x9908b0df};
 
-  private int[] mt;
+  /** State vector holding the most recent batch of generated 32‑bit values. */
+  private final int[] mt;
+
+  /**
+   * Index of the next value to read from {@link #mt}.
+   *
+   * <p>When this index reaches {@link #N}, the generator refreshes the whole state vector before
+   * producing additional output.
+   */
   private int mti;
 
-  private static final long serialVersionUID = 7666069655872848609L;
+  @Serial private static final long serialVersionUID = 7666069655872848609L;
+
+  private void initializeWithSeedArray(int[] seed) {
+    setSeed(19650218);
+
+    int i = 1;
+    int j = 0;
+    int max = Math.max(N, seed.length);
+    for (int k = max; k != 0; k--) {
+      long l0 = toUnsignedLong(mt[i]);
+      long l1 = toUnsignedLong(mt[i - 1]);
+      long l = (l0 ^ ((l1 ^ (l1 >> 30)) * 1664525L)) + seed[j] + j; // non linear
+      mt[i] = (int) (l & 0xffffffffL);
+      i++;
+      j++;
+      if (i >= N) {
+        mt[0] = mt[N - 1];
+        i = 1;
+      }
+      if (j >= seed.length) {
+        j = 0;
+      }
+    }
+
+    for (int k = N - 1; k != 0; k--) {
+      long l0 = toUnsignedLong(mt[i]);
+      long l1 = toUnsignedLong(mt[i - 1]);
+      long l = (l0 ^ ((l1 ^ (l1 >> 30)) * 1566083941L)) - i; // non linear
+      mt[i] = (int) (l & 0xffffffffL);
+      i++;
+      if (i >= N) {
+        mt[0] = mt[N - 1];
+        i = 1;
+      }
+    }
+
+    mt[0] = 0x80000000; // MSB is 1; assuring non-zero initial array
+  }
+
+  private static long toUnsignedLong(int value) {
+    return value & 0xffffffffL;
+  }
 }

--- a/src/main/java/org/spaceroots/mantissa/random/NormalizedRandomGenerator.java
+++ b/src/main/java/org/spaceroots/mantissa/random/NormalizedRandomGenerator.java
@@ -3,8 +3,24 @@ package org.spaceroots.mantissa.random;
 import java.io.Serializable;
 
 /**
- * This interface represent a normalized random generator for scalars. Normalized generator should
- * provide null mean and unit standard deviation scalars.
+ * Normalized random generator for scalar values with zero mean and unit standard deviation.
+ *
+ * <p>This interface defines the minimal contract required by higher-level stochastic utilities that
+ * need standardized scalar samples. Implementations are free to choose the underlying random number
+ * source and probability distribution, provided the generated sequence remains centered at zero
+ * with variance one. Typical usage is to obtain repeatable standardized samples that can be scaled
+ * or combined into vectors by adapters elsewhere in the library. The interface itself makes no
+ * guarantees about independence between successive values, determinism, or performance; those
+ * properties depend entirely on the implementing class and its backing generator.
+ *
+ * <ul>
+ *   <li>Provides standardized output suitable for Monte Carlo, simulation, or statistical tests.
+ *   <li>Leaves distribution shape (Gaussian, uniform normalization, etc.) to the implementation.
+ *   <li>Designed to be wrapped by higher-level generators that build multidimensional samples.
+ * </ul>
+ *
+ * <p>Thread-safety is implementation specific. Users requiring concurrent access should consult the
+ * concrete class documentation or wrap instances with appropriate synchronization.
  *
  * @version $Id: NormalizedRandomGenerator.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
@@ -12,13 +28,22 @@ import java.io.Serializable;
 public interface NormalizedRandomGenerator extends Serializable {
 
   /**
-   * Generate a random scalar with null mean and unit standard deviation.
+   * Returns the next standardized random scalar with zero mean and unit standard deviation.
    *
-   * <p>This method does <strong>not</strong> specify the shape of the distribution, it is the
-   * implementing class that provides it. The only contract here is to generate numbers with null
-   * mean and unit standard deviation.
+   * <p>The contract guarantees only the first two moments of the generated values; the exact
+   * probability distribution, correlation structure, and reproducibility are left to the
+   * implementation. Callers typically use this method repeatedly and apply their own scaling or
+   * transformation to adapt the standardized output to domain-specific ranges. Thread-safety and
+   * determinism depend on the concrete generator; clients that share instances across threads
+   * should coordinate access according to the implementation notes. Implementations are encouraged
+   * to avoid expensive normalization on each invocation to keep repeated sampling efficient.
    *
-   * @return a random scalar
+   * <pre>{@code
+   * NormalizedRandomGenerator generator = ...;
+   * double sample = generator.nextDouble();
+   * }</pre>
+   *
+   * @return next pseudo-random double normalized to mean 0 and standard deviation 1
    */
-  public double nextDouble();
+  double nextDouble();
 }

--- a/src/main/java/org/spaceroots/mantissa/random/NotPositiveDefiniteMatrixException.java
+++ b/src/main/java/org/spaceroots/mantissa/random/NotPositiveDefiniteMatrixException.java
@@ -1,28 +1,58 @@
 package org.spaceroots.mantissa.random;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.MantissaException;
 
 /**
- * This class represents exceptions thrown by the correlated random vector generator.
+ * Exception indicating that a matrix expected to be positive definite is not.
+ *
+ * <p>This exception is raised by components that rely on positive definite covariance or
+ * correlation matrices, most notably {@link CorrelatedRandomVectorGenerator}. A matrix fails this
+ * requirement when a Cholesky decomposition cannot be computed or when at least one eigenvalue is
+ * non-positive, which prevents generation of stable multivariate samples. Callers typically see
+ * this error during parameter validation before any random vectors are produced, so no partial
+ * output is emitted. The instance is immutable and therefore thread-safe to share across threads
+ * when propagating diagnostics.
+ *
+ * <ul>
+ *   <li>Signals invalid covariance input for correlated random vector generation.
+ *   <li>Encourages callers to sanitize and recondition matrices before invocation.
+ *   <li>Captures a human-readable detail message to aid logging and troubleshooting.
+ * </ul>
  *
  * @version $Id: NotPositiveDefiniteMatrixException.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
+ * @see CorrelatedRandomVectorGenerator
  */
 public class NotPositiveDefiniteMatrixException extends MantissaException {
 
-  /** Simple constructor. build an exception with a default message. */
+  /**
+   * Create an exception with a default diagnostic message.
+   *
+   * <p>The default text, {@code "not positive definite matrix"}, mirrors the most common failure
+   * condition encountered when preparing covariance data. Use this constructor when no additional
+   * context is needed or when the exception is immediately wrapped by a higher-level handler. The
+   * resulting object is immutable and may be safely reused or logged without further protection.
+   */
   public NotPositiveDefiniteMatrixException() {
     super("not positive definite matrix");
   }
 
   /**
-   * Simple constructor. build an exception with the specified message.
+   * Create an exception with the specified diagnostic message.
    *
-   * @param message message to use to build the exception
+   * <p>This variant allows the caller to embed matrix dimensions, conditioning metrics, or
+   * algorithm-specific hints so downstream handlers can present actionable guidance. The supplied
+   * message is stored verbatim; callers should avoid including sensitive data because exception
+   * text may be surfaced in logs.
+   *
+   * @param message detail text describing the positive-definiteness failure, never {@code null} in
+   *     typical use even though not enforced by the constructor
    */
+  @SuppressWarnings("unused")
   public NotPositiveDefiniteMatrixException(String message) {
     super(message);
   }
 
-  private static final long serialVersionUID = -6801349873804445905L;
+  @Serial private static final long serialVersionUID = -6801349873804445905L;
 }

--- a/src/main/java/org/spaceroots/mantissa/random/RandomVectorGenerator.java
+++ b/src/main/java/org/spaceroots/mantissa/random/RandomVectorGenerator.java
@@ -1,7 +1,25 @@
 package org.spaceroots.mantissa.random;
 
 /**
- * This interface represent a random generator for whole vectors.
+ * Generates random vectors of doubles in a single call.
+ *
+ * <p>Implementations wrap one or more scalar random sources to deliver complete vectors whose
+ * length and statistical properties are defined by the concrete generator (for example, uniform or
+ * Gaussian distributions, correlated components, or deterministic seeding strategies). The
+ * interface is intentionally minimal so callers can request successive vectors without managing
+ * per-component sampling. Typical usage is to obtain the generator from a factory or builder, then
+ * invoke {@link #nextVector()} inside simulation or sampling loops. Implementations may reuse
+ * internal buffers to minimize allocations; callers must copy results they intend to retain beyond
+ * the next call. The generator itself is generally stateless from the caller perspective, but the
+ * underlying random state advances with each invocation. Unless documented otherwise by a concrete
+ * class, instances are not thread-safe; external synchronization is required when sharing a
+ * generator between threads.
+ *
+ * <ul>
+ *   <li>Primary responsibility: emit full-length random vectors on demand.
+ *   <li>Common use cases: Monte Carlo simulations, randomized algorithms, and statistical testing.
+ *   <li>Performance note: arrays may be recycled to reduce garbage generation.
+ * </ul>
  *
  * @version $Id: RandomVectorGenerator.java 1485 2003-02-23 13:34:02Z luc $
  * @author L. Maisonobe
@@ -9,11 +27,17 @@ package org.spaceroots.mantissa.random;
 public interface RandomVectorGenerator {
 
   /**
-   * Generate a random vector.
+   * Generates the next random vector produced by this generator.
    *
-   * @return a random vector as an array of double. The generator <em>will</em> reuse the same array
-   *     for each call, in order to save the allocation time, so the user should keep a copy by
-   *     himself if he needs so.
+   * <p>The vector length and distribution of its elements depend on the concrete implementation;
+   * callers should consult the specific generator class for exact statistical guarantees. Each
+   * invocation advances the internal random state and may reuse an internal array instance for
+   * performance. To retain values across calls, copy the returned contents before invoking this
+   * method again. Most implementations are not synchronized; coordinate access if used concurrently
+   * from multiple threads.
+   *
+   * @return a mutable array containing the generated components; ownership remains with the
+   *     generator, so callers must copy it if they need a stable snapshot for later use.
    */
-  public double[] nextVector();
+  double[] nextVector();
 }

--- a/src/main/java/org/spaceroots/mantissa/random/ScalarSampleStatistics.java
+++ b/src/main/java/org/spaceroots/mantissa/random/ScalarSampleStatistics.java
@@ -1,7 +1,25 @@
 package org.spaceroots.mantissa.random;
 
 /**
- * This class compute basic statistics on a scalar sample.
+ * Computes basic descriptive statistics for a scalar sample.
+ *
+ * <p>This class is a small, mutable accumulator for scalar-valued observations. Callers add data
+ * points incrementally using one of the {@code add(...)} methods, and then query the aggregated
+ * results such as the minimum, maximum, arithmetic mean, and sample standard deviation. The
+ * implementation is intended for streaming or iterative use where retaining the full sample would
+ * be unnecessary or too expensive.
+ *
+ * <p>The accumulator maintains simple running totals and extrema, so updates are constant-time and
+ * order-independent. When the sample is empty, the instance reports {@code size() == 0}, {@code
+ * getMin()} and {@code getMax()} return {@link Double#NaN}, and both {@code getMean()} and {@code
+ * getStandardDeviation()} return {@code 0}. The class is not thread-safe; if multiple threads
+ * update or read the same instance, external synchronization is required.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> track count, extrema, sum, and sum of squares.
+ *   <li><strong>Notable behavior:</strong> values are stored as-is with no filtering or
+ *       normalization.
+ * </ul>
  *
  * @version $Id: ScalarSampleStatistics.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
@@ -23,7 +41,15 @@ public class ScalarSampleStatistics {
   /** Sum of the squares of the sample values. */
   private double sum2;
 
-  /** Simple constructor. Build a new empty instance */
+  /**
+   * Creates a new, empty statistics accumulator.
+   *
+   * <p>The new instance contains no points and is ready to accept observations via {@link
+   * #add(double)} or related methods. Until at least one finite point is added, extrema are
+   * undefined and reported as {@link Double#NaN}. Mean and sample standard deviation are reported
+   * as {@code 0} when the sample size is too small to define them. The instance is mutable and may
+   * be reused by adding additional points over time.
+   */
   public ScalarSampleStatistics() {
     n = 0;
     min = Double.NaN;
@@ -33,9 +59,16 @@ public class ScalarSampleStatistics {
   }
 
   /**
-   * Add one point to the instance.
+   * Adds one point to this accumulator.
    *
-   * @param x value of the sample point
+   * <p>This method updates the running count, extrema, sum, and sum of squares with a single new
+   * observation. The update runs in constant time and does not retain historical values. If this is
+   * the first point added, it initializes all aggregates from {@code x}. Subsequent points may
+   * update the minimum or maximum when they fall outside the current range. Values are incorporated
+   * verbatim; in particular, {@code NaN} will propagate to the running sums and therefore to mean
+   * and standard deviation, while comparisons against {@code NaN} do not update extrema.
+   *
+   * @param x value of the sample point to incorporate, in the caller's units
    */
   public void add(double x) {
 
@@ -58,20 +91,38 @@ public class ScalarSampleStatistics {
   }
 
   /**
-   * Add all points of an array to the instance.
+   * Adds all points from an array to this accumulator.
    *
-   * @param points array of points
+   * <p>The points are processed in iteration order by delegating to {@link #add(double)} for each
+   * element. An empty array leaves this instance unchanged. The array itself is not modified. This
+   * method is convenient for batch updates and preserves the same numeric behavior as adding points
+   * individually, including any propagation of {@code NaN} or infinities.
+   *
+   * <pre>{@code
+   * ScalarSampleStatistics stats = new ScalarSampleStatistics();
+   * stats.add(new double[] {1.0, 2.0, 3.0});
+   * double mean = stats.getMean();
+   * }</pre>
+   *
+   * @param points array of points to incorporate; must be non-null and may be empty
    */
   public void add(double[] points) {
-    for (int i = 0; i < points.length; ++i) {
-      add(points[i]);
+    for (double point : points) {
+      add(point);
     }
   }
 
   /**
-   * Add all the points of another sample to the instance.
+   * Merges all points from another accumulator into this one.
    *
-   * @param s sample to add
+   * <p>This method combines the aggregates of {@code s} with those of this instance without
+   * re-scanning individual values. If {@code s} is empty, the call is a no-op. If this instance is
+   * empty, it becomes a copy of {@code s}. Otherwise, counts and running sums are added, and
+   * extrema are widened to include the other sample's range. Numeric special values are combined
+   * according to normal IEEE 754 rules (for example, {@code NaN} in either sum will yield {@code
+   * NaN} results for derived statistics).
+   *
+   * @param s sample statistics to merge; must be non-null
    */
   public void add(ScalarSampleStatistics s) {
 
@@ -104,7 +155,10 @@ public class ScalarSampleStatistics {
   /**
    * Get the number of points in the sample.
    *
-   * @return number of points in the sample
+   * <p>The value reflects the total number of observations added so far using any {@code add}
+   * overload. The count is monotonic and never decreases for a given instance.
+   *
+   * @return number of points currently accumulated
    */
   public int size() {
     return n;
@@ -113,7 +167,12 @@ public class ScalarSampleStatistics {
   /**
    * Get the minimal value in the sample.
    *
-   * @return minimal value in the sample
+   * <p>This method returns the smallest value observed so far. If no points have been added, the
+   * minimum is undefined and {@link Double#NaN} is returned. When {@code NaN} points are added
+   * after a finite minimum has been established, the minimum remains unchanged because comparisons
+   * with {@code NaN} are unordered.
+   *
+   * @return smallest observed value, or {@code NaN} when the sample is empty
    */
   public double getMin() {
     return min;
@@ -122,7 +181,11 @@ public class ScalarSampleStatistics {
   /**
    * Get the maximal value in the sample.
    *
-   * @return maximal value in the sample
+   * <p>This method returns the largest value observed so far. If no points have been added, the
+   * maximum is undefined and {@link Double#NaN} is returned. As with {@link #getMin()}, adding
+   * {@code NaN} values does not update the established maximum.
+   *
+   * @return largest observed value, or {@code NaN} when the sample is empty
    */
   public double getMax() {
     return max;
@@ -131,19 +194,27 @@ public class ScalarSampleStatistics {
   /**
    * Get the mean value of the sample.
    *
-   * @return mean value of the sample
+   * <p>The mean is computed as the running sum divided by the number of points accumulated. If the
+   * sample is empty, this method returns {@code 0}. If any {@code NaN} has been added, the running
+   * sum becomes {@code NaN} and the mean will be {@code NaN} as well.
+   *
+   * @return arithmetic mean of accumulated points, or {@code 0} when empty
    */
   public double getMean() {
     return (n == 0) ? 0 : (sum / n);
   }
 
   /**
-   * Get the standard deviation of the underlying probability law. This method estimate the standard
-   * deviation considering that the data available are only a <em>sample</em> of all possible
-   * values. This value is often called the sample standard deviation (as opposed to the population
-   * standard deviation).
+   * Get the sample standard deviation of the accumulated points.
    *
-   * @return standard deviation of the underlying probability law
+   * <p>This method estimates the standard deviation assuming the accumulated values represent a
+   * finite sample drawn from a larger population. It uses the unbiased sample variance formula
+   * (division by {@code n - 1}). If fewer than two points have been added, there is not enough data
+   * to estimate dispersion and this method returns {@code 0}. As with other derived statistics,
+   * special values in the sample follow IEEE 754 behavior: if any running sum becomes {@code NaN},
+   * the returned standard deviation will be {@code NaN}.
+   *
+   * @return sample standard deviation, or {@code 0} when {@code size() < 2}
    */
   public double getStandardDeviation() {
     if (n < 2) {

--- a/src/main/java/org/spaceroots/mantissa/random/UncorrelatedRandomVectorGenerator.java
+++ b/src/main/java/org/spaceroots/mantissa/random/UncorrelatedRandomVectorGenerator.java
@@ -1,25 +1,51 @@
 package org.spaceroots.mantissa.random;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * This class allows to generate random vectors with uncorrelated components.
+ * Generates random vectors whose components are independent Gaussian‑like samples.
+ *
+ * <p>This generator wraps a {@link NormalizedRandomGenerator} that produces uncorrelated,
+ * normalized scalar samples (typically with mean&nbsp;0 and standard deviation&nbsp;1) and
+ * transforms each scalar into a vector component using a per‑dimension affine mapping: {@code
+ * mean[i] + standardDeviation[i] * z}. The mean and standard deviation arrays are defensively
+ * copied at construction time, so later external mutations do not affect the generator.
+ *
+ * <p>The class is stateful only through the underlying scalar generator; it does not keep any
+ * additional history between calls to {@link #nextVector()}. It is intended for simulations and
+ * Monte‑Carlo style sampling when correlations between dimensions are either not present or are
+ * handled elsewhere. If you need correlated vectors, see {@link CorrelatedRandomVectorGenerator}.
+ *
+ * <ul>
+ *   <li><strong>Invariants:</strong> the mean and standard deviation vectors have identical length;
+ *       each call returns a new array.
+ *   <li><strong>Thread safety:</strong> not guaranteed; concurrent use is safe only if the supplied
+ *       {@code NormalizedRandomGenerator} is itself thread‑safe.
+ * </ul>
  *
  * @version $Id: UncorrelatedRandomVectorGenerator.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
+ * @see NormalizedRandomGenerator
+ * @see CorrelatedRandomVectorGenerator
  */
 public class UncorrelatedRandomVectorGenerator implements Serializable, RandomVectorGenerator {
 
   /**
-   * Simple constructor.
+   * Builds an uncorrelated vector generator with explicit per‑dimension mean and standard
+   * deviation.
    *
-   * <p>Build an uncorrelated random vector generator from its mean and standard deviation vectors.
+   * <p>Each call to {@link #nextVector()} draws one normalized sample per component from the
+   * supplied {@code generator} and scales/shifts it using the matching entries from {@code mean}
+   * and {@code standardDeviation}. The two arrays must have the same length; they are cloned so
+   * subsequent changes to the input arrays do not affect this instance.
    *
-   * @param mean expected mean values for all components
-   * @param standardDeviation standard deviation for all components
-   * @param generator underlying generator for uncorrelated normalized components
-   * @exception IllegalArgumentException if there is a dimension mismatch between the mean and
-   *     standard deviation vectors
+   * @param mean expected mean value for each component, in the same order as generated vectors
+   * @param standardDeviation standard deviation for each component, matched by index to {@code
+   *     mean}
+   * @param generator underlying source of independent normalized scalar samples for each component
+   * @throws IllegalArgumentException if {@code mean.length != standardDeviation.length}
+   * @throws NullPointerException if any argument is {@code null}
    */
   public UncorrelatedRandomVectorGenerator(
       double[] mean, double[] standardDeviation, NormalizedRandomGenerator generator) {
@@ -27,19 +53,23 @@ public class UncorrelatedRandomVectorGenerator implements Serializable, RandomVe
     if (mean.length != standardDeviation.length) {
       throw new IllegalArgumentException("dimension mismatch");
     }
-    this.mean = (double[]) mean.clone();
-    this.standardDeviation = (double[]) standardDeviation.clone();
+    this.mean = mean.clone();
+    this.standardDeviation = standardDeviation.clone();
 
     this.generator = generator;
   }
 
   /**
-   * Simple constructor.
+   * Builds an uncorrelated vector generator with zero mean and unit standard deviation.
    *
-   * <p>Build a null mean random and unit standard deviation uncorrelated vector generator
+   * <p>This convenience constructor initializes all means to {@code 0} and all standard deviations
+   * to {@code 1}. The resulting vectors are therefore direct copies of the normalized samples
+   * produced by the underlying generator, with one scalar draw per component.
    *
-   * @param dimension dimension of the vectors to generate
-   * @param generator underlying generator for uncorrelated normalized components
+   * @param dimension number of components in each generated vector; must be non‑negative
+   * @param generator underlying source of independent normalized scalar samples for each component
+   * @throws NegativeArraySizeException if {@code dimension < 0}
+   * @throws NullPointerException if {@code generator} is {@code null}
    */
   public UncorrelatedRandomVectorGenerator(int dimension, NormalizedRandomGenerator generator) {
 
@@ -54,19 +84,28 @@ public class UncorrelatedRandomVectorGenerator implements Serializable, RandomVe
   }
 
   /**
-   * Get the underlying normalized components generator.
+   * Returns the underlying normalized scalar generator.
    *
-   * @return underlying uncorrelated components generator
+   * <p>The returned instance is the exact generator supplied at construction time and is not
+   * wrapped or copied. Mutating its state (if it is mutable) directly affects subsequent vectors
+   * produced by this {@code UncorrelatedRandomVectorGenerator}.
+   *
+   * @return the underlying uncorrelated normalized components generator
    */
   public NormalizedRandomGenerator getGenerator() {
     return generator;
   }
 
   /**
-   * Generate a correlated random vector.
+   * Generates the next uncorrelated random vector.
    *
-   * @return a random vector as an array of double. The returned array is created at each call, the
-   *     caller can do what it wants with it.
+   * <p>For each component {@code i}, this method draws {@code z = generator.nextDouble()} and
+   * returns {@code mean[i] + standardDeviation[i] * z}. The call allocates a fresh array on every
+   * invocation; callers may safely mutate the returned array without affecting future results.
+   *
+   * @return a newly allocated random vector whose components are independent draws from the
+   *     underlying normalized generator after scaling and shifting
+   * @throws NullPointerException if the underlying generator is {@code null}
    */
   public double[] nextVector() {
 
@@ -79,13 +118,13 @@ public class UncorrelatedRandomVectorGenerator implements Serializable, RandomVe
   }
 
   /** Mean vector. */
-  private double[] mean;
+  private final double[] mean;
 
   /** Standard deviation vector. */
-  private double[] standardDeviation;
+  private final double[] standardDeviation;
 
   /** Underlying scalar generator. */
   NormalizedRandomGenerator generator;
 
-  private static final long serialVersionUID = -9094322067568302961L;
+  @Serial private static final long serialVersionUID = -9094322067568302961L;
 }

--- a/src/main/java/org/spaceroots/mantissa/random/UniformRandomGenerator.java
+++ b/src/main/java/org/spaceroots/mantissa/random/UniformRandomGenerator.java
@@ -1,68 +1,112 @@
 package org.spaceroots.mantissa.random;
 
+import java.io.Serial;
+
 /**
- * This class implements a normalized uniform random generator.
+ * Generates standardized scalar samples from a uniform distribution.
  *
- * <p>Since this is a normalized random generator, it has a null mean and a unit standard deviation.
- * Beeing also a uniform generator, it produces numbers in the range [-sqrt(3) ; sqrt(3)]. It uses
- * the {@link MersenneTwister MersenneTwister} generator as the underlying generator.
+ * <p>This generator adapts a uniform {@code [0, 1)} source into a distribution with zero mean and
+ * unit standard deviation, suitable for algorithms that expect normalized noise. Each call to
+ * {@link #nextDouble()} draws one underlying uniform variate and linearly rescales it to the
+ * symmetric interval {@code [-sqrt(3), sqrt(3)]}. With that interval, the resulting distribution
+ * has mean {@code 0} and variance {@code 1} by construction.
  *
+ * <p>The underlying source of randomness is a {@link MersenneTwister}. Two instances created with
+ * the same seed (via any of the seeded constructors) will produce identical sequences. The default
+ * constructor seeds from the current time and is therefore not deterministic.
+ *
+ * <p>Instances are mutable and not synchronized. Like {@link MersenneTwister} (and {@link
+ * java.util.Random}), this class is not safe for concurrent use without external synchronization.
+ *
+ * <ul>
+ *   <li><strong>Normalization:</strong> output is standardized to mean 0 and standard deviation 1.
+ *   <li><strong>Shape:</strong> output is uniform on a finite symmetric interval.
+ *   <li><strong>Determinism:</strong> controlled entirely by the provided seed.
+ * </ul>
+ *
+ * @see NormalizedRandomGenerator
  * @see MersenneTwister
  * @version $Id: UniformRandomGenerator.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
  */
 public class UniformRandomGenerator implements NormalizedRandomGenerator {
 
-  /** Create a new generator. The seed of the generator is related to the current time. */
+  /**
+   * Creates a new generator seeded from the current time.
+   *
+   * <p>This constructor is a convenience for callers that do not require repeatability. The seed is
+   * derived from wall-clock time inside {@link MersenneTwister}, so two instances created close
+   * together may start from the same state and yield identical sequences. If deterministic output
+   * is required, use one of the explicit seeding constructors instead.
+   */
   public UniformRandomGenerator() {
     generator = new MersenneTwister();
   }
 
   /**
-   * Creates a new random number generator using a single int seed.
+   * Creates a new generator using a single 32-bit seed.
    *
-   * @param seed the initial seed (32 bits integer)
+   * <p>The provided seed fully determines the internal state of the underlying {@link
+   * MersenneTwister}. Two generators built with the same {@code seed} will therefore produce the
+   * same sequence of values from {@link #nextDouble()}. This is the simplest way to obtain a
+   * reproducible uniform-normalized stream.
+   *
+   * @param seed initial 32-bit seed defining the deterministic output sequence
    */
   public UniformRandomGenerator(int seed) {
     generator = new MersenneTwister(seed);
   }
 
   /**
-   * Creates a new random number generator using an int array seed.
+   * Creates a new generator using an array of 32-bit seed values.
    *
-   * @param seed the initial seed (32 bits integers array), if null the seed of the generator will
-   *     be related to the current time
+   * <p>The seed array is forwarded to {@link MersenneTwister#MersenneTwister(int[])} and mixed into
+   * the internal state. Arrays with the same contents produce identical sequences. If {@code seed}
+   * is {@code null}, the generator falls back to time-based seeding and is not deterministic.
+   *
+   * @param seed initial 32-bit seed array; may be {@code null} for time-based seeding
    */
   public UniformRandomGenerator(int[] seed) {
     generator = new MersenneTwister(seed);
   }
 
   /**
-   * Create a new generator initialized with a single long seed.
+   * Creates a new generator initialized with a single 64-bit seed.
    *
-   * @param seed seed for the generator (64 bits integer)
+   * <p>This constructor provides a larger seed space than {@link #UniformRandomGenerator(int)} and
+   * is useful when deriving independent streams from long-lived identifiers. The seed is passed to
+   * the underlying {@link MersenneTwister}, which deterministically expands it into its internal
+   * state.
+   *
+   * @param seed initial 64-bit seed defining the deterministic output sequence
    */
   public UniformRandomGenerator(long seed) {
     generator = new MersenneTwister(seed);
   }
 
   /**
-   * Generate a random scalar with null mean and unit standard deviation.
+   * Generates the next standardized uniform random scalar.
    *
-   * <p>The number generated is uniformly distributed between -sqrt(3) and sqrt(3).
+   * <p>The returned value is computed by drawing {@code u} uniformly from {@code [0, 1)} using the
+   * underlying {@link MersenneTwister} and applying the linear transform {@code 2*sqrt(3)*u -
+   * sqrt(3)}. This yields a uniform distribution on {@code [-sqrt(3), sqrt(3)]}, which has mean
+   * {@code 0} and standard deviation {@code 1}.
    *
-   * @return a random scalar with null mean and unit standard deviation
+   * <p>This method has no side effects beyond advancing the generator state. It does not allocate
+   * and performs a constant amount of work per call.
+   *
+   * @return next pseudo-random value uniformly distributed on {@code [-sqrt(3), sqrt(3)]}
    */
   public double nextDouble() {
     return TWOSQRT3 * generator.nextDouble() - SQRT3;
   }
 
-  /** Underlying generator. */
+  /** Underlying generator used as the source of {@code [0, 1)} uniform variates. */
   MersenneTwister generator;
 
   private static final double SQRT3 = Math.sqrt(3.0);
 
   private static final double TWOSQRT3 = 2.0 * Math.sqrt(3.0);
 
-  private static final long serialVersionUID = -6913329325753217654L;
+  @Serial private static final long serialVersionUID = -6913329325753217654L;
 }

--- a/src/main/java/org/spaceroots/mantissa/random/VectorialSampleStatistics.java
+++ b/src/main/java/org/spaceroots/mantissa/random/VectorialSampleStatistics.java
@@ -3,7 +3,30 @@ package org.spaceroots.mantissa.random;
 import org.spaceroots.mantissa.linalg.SymetricalMatrix;
 
 /**
- * This class compute basic statistics on a scalar sample.
+ * Computes basic descriptive statistics for a sample of fixed‑dimension real vectors.
+ *
+ * <p>This class incrementally accumulates statistics over a sequence of {@code double[]} sample
+ * points that all share the same dimension. After points are added via {@link #add(double[])},
+ * callers can query per‑component minima and maxima, their indices of first occurrence, and the
+ * arithmetic mean. It also maintains the second‑order sums needed to compute a sample covariance
+ * matrix through {@link #getCovarianceMatrix(SymetricalMatrix)}.
+ *
+ * <p>The instance starts empty. The dimension is inferred from the first point added and is then
+ * fixed for the lifetime of the instance. Subsequent points are expected to have exactly the same
+ * length; violating this precondition leads to undefined behavior (typically a runtime indexing
+ * error) rather than a checked exception. All returned arrays are defensive copies and may be
+ * freely modified by the caller.
+ *
+ * <p>This class is mutable and not thread‑safe. If multiple threads update or read the same
+ * instance, external synchronization is required. For read‑only access after construction, it is
+ * safe to publish the instance once no further {@code add(...)} calls will occur.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> track count, per‑component extrema, mean, and sample
+ *       covariance.
+ *   <li><strong>Notable behaviors:</strong> extrema indices refer to the zero‑based insertion order
+ *       within this instance; copying from another instance preserves its accumulated state.
+ * </ul>
  *
  * @version $Id: VectorialSampleStatistics.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
@@ -34,7 +57,14 @@ public class VectorialSampleStatistics {
   /** Sum of the squares of the sample values. */
   private double[] sum2;
 
-  /** Simple constructor. Build a new empty instance */
+  /**
+   * Creates a new, empty statistics accumulator.
+   *
+   * <p>The newly created instance has no points and no fixed dimension. The dimension will be
+   * established by the first call to {@link #add(double[])}. Until at least one point is added,
+   * queries for extrema or covariance are not meaningful and may return {@code null} or empty
+   * structures as documented on the individual accessors.
+   */
   public VectorialSampleStatistics() {
     dimension = -1;
     n = 0;
@@ -47,72 +77,96 @@ public class VectorialSampleStatistics {
   }
 
   /**
-   * Add one point to the instance.
+   * Adds a single vector sample point to this accumulator.
    *
-   * @param x value of the sample point
-   * @exception IllegalArgumentException if there is a dimension mismatch between this point and the
-   *     ones already added (this cannot happen when the instance is empty)
+   * <p>If this is the first point, its length defines the sample dimension and initializes all
+   * tracked values. Otherwise, the point contributes to per‑component minima/maxima, the running
+   * sum, and the accumulated second‑order sums used for covariance. Points are indexed in the order
+   * they are added, starting at zero; the extrema index accessors report these indices.
+   *
+   * <p>Precondition: {@code x.length} must equal the dimension inferred from the first point. If
+   * violated, behavior is undefined and may result in runtime exceptions.
+   *
+   * @param x sample point to add; must be non‑null and have the established dimension.
    */
   public void add(double[] x) {
 
     if (n == 0) {
 
-      dimension = x.length;
-      minIndices = new int[dimension];
-      maxIndices = new int[dimension];
-      min = (double[]) x.clone();
-      max = (double[]) x.clone();
-      sum = (double[]) x.clone();
-      sum2 = new double[dimension * (dimension + 1) / 2];
-
-      int k = 0;
-      for (int i = 0; i < dimension; ++i) {
-        for (int j = 0; j <= i; ++j) {
-          sum2[k++] = x[i] * x[j];
-        }
-      }
+      initializeFromFirstPoint(x);
 
     } else {
-      int k = 0;
-      for (int i = 0; i < dimension; ++i) {
-
-        if (x[i] < min[i]) {
-          min[i] = x[i];
-          minIndices[i] = n;
-        } else if (x[i] > max[i]) {
-          max[i] = x[i];
-          maxIndices[i] = n;
-        }
-
-        sum[i] += x[i];
-        for (int j = 0; j <= i; ++j) {
-          sum2[k++] += x[i] * x[j];
-        }
-      }
+      addNonFirstPoint(x);
     }
 
     ++n;
   }
 
-  /**
-   * Add all points of an array to the instance.
-   *
-   * @param points array of points
-   * @exception IllegalArgumentException if there is a dimension mismatch between these points and
-   *     the ones already added (this cannot happen when the instance is empty)
-   */
-  public void add(double[][] points) {
-    for (int i = 0; i < points.length; ++i) {
-      add(points[i]);
+  private void initializeFromFirstPoint(double[] x) {
+
+    dimension = x.length;
+    minIndices = new int[dimension];
+    maxIndices = new int[dimension];
+    min = x.clone();
+    max = x.clone();
+    sum = x.clone();
+    sum2 = new double[dimension * (dimension + 1) / 2];
+
+    int k = 0;
+    for (int i = 0; i < dimension; ++i) {
+      for (int j = 0; j <= i; ++j) {
+        sum2[k++] = x[i] * x[j];
+      }
+    }
+  }
+
+  private void addNonFirstPoint(double[] x) {
+    int k = 0;
+    for (int i = 0; i < dimension; ++i) {
+
+      if (x[i] < min[i]) {
+        min[i] = x[i];
+        minIndices[i] = n;
+      } else if (x[i] > max[i]) {
+        max[i] = x[i];
+        maxIndices[i] = n;
+      }
+
+      sum[i] += x[i];
+      for (int j = 0; j <= i; ++j) {
+        sum2[k++] += x[i] * x[j];
+      }
     }
   }
 
   /**
-   * Add all the points of another sample to the instance.
+   * Adds all points from the given array to this accumulator.
    *
-   * @param s samples to add
-   * @exception IllegalArgumentException if there is a dimension mismatch between this sample points
-   *     and the ones already added (this cannot happen when the instance is empty)
+   * <p>The points are processed in iteration order, exactly as if {@link #add(double[])} were
+   * called for each element. If the instance is empty, the first point fixes the dimension. Each
+   * subsequent point must match that dimension.
+   *
+   * @param points array of sample points to add; each element must be non‑null and of identical
+   *     length to the first point.
+   */
+  public void add(double[][] points) {
+    for (double[] point : points) {
+      add(point);
+    }
+  }
+
+  /**
+   * Merges all points from another accumulator into this one.
+   *
+   * <p>After the call, this instance represents the concatenation of its previous points followed
+   * by the points accumulated in {@code s}. When this instance is empty, the other instance's
+   * dimension and state are copied. When both instances are non‑empty, their dimensions must match.
+   *
+   * <p>The extrema indices from {@code s} are not preserved verbatim; when an extrema from {@code
+   * s} replaces the current extrema, the stored index records the insertion position of the merged
+   * block within this instance.
+   *
+   * @param s other sample statistics to merge; if {@code s} is empty, this method is a no‑op.
    */
   public void add(VectorialSampleStatistics s) {
 
@@ -124,12 +178,12 @@ public class VectorialSampleStatistics {
     if (n == 0) {
 
       dimension = s.dimension;
-      min = (double[]) s.min.clone();
-      minIndices = (int[]) s.minIndices.clone();
-      max = (double[]) s.max.clone();
-      maxIndices = (int[]) s.maxIndices.clone();
-      sum = (double[]) s.sum.clone();
-      sum2 = (double[]) s.sum2.clone();
+      min = s.min.clone();
+      minIndices = s.minIndices.clone();
+      max = s.max.clone();
+      maxIndices = s.maxIndices.clone();
+      sum = s.sum.clone();
+      sum2 = s.sum2.clone();
 
     } else {
       int k = 0;
@@ -156,73 +210,89 @@ public class VectorialSampleStatistics {
   }
 
   /**
-   * Get the number of points in the sample.
+   * Returns the number of points accumulated so far.
    *
-   * @return number of points in the sample
+   * <p>This count increases by one for each call to {@link #add(double[])} and by the number of
+   * points in the supplied source for {@link #add(double[][])} and {@link
+   * #add(VectorialSampleStatistics)}. The returned value is the basis for all mean and covariance
+   * computations.
+   *
+   * @return current number of points in the sample, starting at zero for an empty instance.
    */
   public int size() {
     return n;
   }
 
   /**
-   * Get the minimal value in the sample.
+   * Returns the per‑component minimal values observed in the sample.
    *
-   * <p>Since all components of the sample vector can reach their minimal value at different times,
-   * this vector should be considered as gathering all minimas of all components. The index of the
-   * sample at which the minimum was encountered can be retrieved with the {@link #getMinIndices
-   * getMinIndices} method.
+   * <p>Each component may attain its minimum at a different sample index. The returned vector
+   * therefore aggregates the minima for each component independently. The corresponding indices of
+   * first occurrence can be retrieved via {@link #getMinIndices()}.
    *
-   * @return minimal value in the sample (a new array is created at each call, the caller may do
-   *     what it wants to with it)
-   * @see #getMinIndices
+   * <p>The returned array is a defensive copy and can be mutated by the caller without affecting
+   * this instance.
+   *
+   * @return vector of minimal values for each component in the sample.
+   * @see #getMinIndices()
    */
   public double[] getMin() {
-    return (double[]) min.clone();
+    return min.clone();
   }
 
   /**
-   * Get the indices at which the minimal value occurred in the sample.
+   * Returns the indices at which each component reached its minimal value.
    *
-   * @return a vector reporting at which occurrence each component of the sample reached its minimal
-   *     value (a new array is created at each call, the caller may do what it wants to with it)
-   * @see #getMin
+   * <p>The indices refer to the zero‑based order in which points were added to this instance. Each
+   * component may have a different index. If multiple points share the same minimal value for a
+   * component, the first occurrence is recorded.
+   *
+   * @return vector of indices corresponding to {@link #getMin()}, one per component.
+   * @see #getMin()
    */
   public int[] getMinIndices() {
-    return (int[]) minIndices.clone();
+    return minIndices.clone();
   }
 
   /**
-   * Get the maximal value in the sample.
+   * Returns the per‑component maximal values observed in the sample.
    *
-   * <p>Since all components of the sample vector can reach their maximal value at different times,
-   * this vector should be considered as gathering all maximas of all components. The index of the
-   * sample at which the maximum was encountered can be retrieved with the {@link #getMaxIndices
-   * getMaxIndices} method.
+   * <p>Each component is tracked independently, so the resulting vector aggregates maxima that may
+   * have occurred at different points in the sample. The indices of first occurrence for each
+   * component can be obtained with {@link #getMaxIndices()}.
    *
-   * @return maximal value in the sample (a new array is created at each call, the caller may do
-   *     what it wants to with it)
-   * @see #getMaxIndices
+   * <p>The returned array is a defensive copy and can be mutated by the caller without affecting
+   * this instance.
+   *
+   * @return vector of maximal values for each component in the sample.
+   * @see #getMaxIndices()
    */
   public double[] getMax() {
-    return (double[]) max.clone();
+    return max.clone();
   }
 
   /**
-   * Get the indices at which the maximal value occurred in the sample.
+   * Returns the indices at which each component reached its maximal value.
    *
-   * @return a vector reporting at which occurrence each component of the sample reached its maximal
-   *     value (a new array is created at each call, the caller may do what it wants to with it)
-   * @see #getMax
+   * <p>The indices refer to the zero‑based order in which points were added to this instance. Each
+   * component may have a different index. If multiple points share the same maximal value for a
+   * component, the first occurrence is recorded.
+   *
+   * @return vector of indices corresponding to {@link #getMax()}, one per component.
+   * @see #getMax()
    */
   public int[] getMaxIndices() {
-    return (int[]) maxIndices.clone();
+    return maxIndices.clone();
   }
 
   /**
-   * Get the mean value of the sample.
+   * Computes and returns the arithmetic mean of the sample.
    *
-   * @return mean value of the sample or an empty array if the sample is empty (a new array is
-   *     created at each call, the caller may do what it wants to with it)
+   * <p>The mean is computed per component as {@code sum[i] / n}. This method does not mutate the
+   * accumulator and may be called repeatedly. If no points have been added yet, an empty array is
+   * returned to signal the absence of a defined mean.
+   *
+   * @return per‑component mean vector, or an empty array if the sample is empty.
    */
   public double[] getMean() {
     if (n == 0) {
@@ -236,13 +306,22 @@ public class VectorialSampleStatistics {
   }
 
   /**
-   * Get the covariance matrix of the underlying law. This method estimate the covariance matrix
-   * considering that the data available are only a <em>sample</em> of all possible values. This
-   * value is the sample covariance matrix (as opposed to the population covariance matrix).
+   * Computes the sample covariance matrix of the accumulated vectors.
    *
-   * @param covariance placeholder where to store the matrix, if null a new matrix will be allocated
-   * @return covariance matrix of the underlying or null if the sample has less than 2 points
-   *     (reference to covariance if it was non-null, reference to a new matrix otherwise)
+   * <p>This method returns the unbiased covariance estimate based on the current sample. It treats
+   * the accumulated points as a sample from an underlying distribution (as opposed to the full
+   * population), and therefore divides by {@code n - 1} in the usual way. The implementation uses
+   * pre‑accumulated second‑order sums, so the computation is {@code O(dimension^2)} regardless of
+   * sample size.
+   *
+   * <p>If fewer than two points have been added, the covariance is undefined and {@code null} is
+   * returned. Otherwise, the result is written into the provided {@code covariance} matrix when
+   * non‑null, or into a newly allocated {@link SymetricalMatrix} when {@code covariance} is {@code
+   * null}.
+   *
+   * @param covariance optional preallocated matrix to store the result; if {@code null}, a new
+   *     {@link SymetricalMatrix} of appropriate dimension is created.
+   * @return the sample covariance matrix, or {@code null} if the sample has fewer than two points.
    */
   public SymetricalMatrix getCovarianceMatrix(SymetricalMatrix covariance) {
 

--- a/src/test/java/org/spaceroots/mantissa/random/CorrelatedRandomVectorGeneratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/random/CorrelatedRandomVectorGeneratorTest.java
@@ -1,0 +1,139 @@
+package org.spaceroots.mantissa.random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.linalg.Matrix;
+import org.spaceroots.mantissa.linalg.SymetricalMatrix;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class CorrelatedRandomVectorGeneratorTest {
+
+  @Mock private NormalizedRandomGenerator generator;
+
+  @Test
+  void constructor_withMeanLengthDifferentFromCovariance_throwsIllegalArgumentException() {
+    // Arrange
+    double[] mean = new double[] {1.0};
+    SymetricalMatrix covariance = identity2();
+
+    // Act
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new CorrelatedRandomVectorGenerator(mean, covariance, generator));
+
+    // Assert
+    assertEquals("dimension mismatch 1 != 2", ex.getMessage());
+  }
+
+  @Test
+  void constructor_withNegativeDiagonal_throwsNotPositiveDefiniteMatrixException() {
+    // Arrange
+    SymetricalMatrix covariance = new SymetricalMatrix(1);
+    covariance.setElement(0, 0, -1.0);
+
+    // Act + Assert
+    assertThrows(
+        NotPositiveDefiniteMatrixException.class,
+        () -> new CorrelatedRandomVectorGenerator(covariance, generator));
+  }
+
+  @Test
+  void nextVector_withIdentityCovariance_returnsNormalizedSamples() throws Exception {
+    // Arrange
+    SymetricalMatrix covariance = identity2();
+    when(generator.nextDouble()).thenReturn(0.3, -0.7);
+    CorrelatedRandomVectorGenerator vectorGenerator =
+        new CorrelatedRandomVectorGenerator(covariance, generator);
+
+    // Act
+    double[] vector = vectorGenerator.nextVector();
+
+    // Assert
+    assertArrayEquals(new double[] {0.3, -0.7}, vector, 1.0e-12);
+    assertEquals(2, vectorGenerator.getRank());
+
+    Matrix root = vectorGenerator.getRootMatrix();
+    assertEquals(2, root.getRows());
+    assertEquals(2, root.getColumns());
+    assertEquals(1.0, root.getElement(0, 0), 1.0e-12);
+    assertEquals(0.0, root.getElement(0, 1), 1.0e-12);
+    assertEquals(0.0, root.getElement(1, 0), 1.0e-12);
+    assertEquals(1.0, root.getElement(1, 1), 1.0e-12);
+
+    assertEquals(generator, vectorGenerator.getGenerator());
+  }
+
+  @Test
+  void nextVector_withNonZeroMeanAndCorrelatedCovariance_combinesComponents() throws Exception {
+    // Arrange
+    double[] mean = new double[] {1.0, -1.0};
+    SymetricalMatrix covariance = new SymetricalMatrix(2);
+    covariance.setElement(0, 0, 4.0);
+    covariance.setElementAndSymetricalElement(1, 0, 2.0);
+    covariance.setElement(1, 1, 3.0);
+
+    when(generator.nextDouble()).thenReturn(0.5, -0.5);
+
+    CorrelatedRandomVectorGenerator vectorGenerator =
+        new CorrelatedRandomVectorGenerator(mean, covariance, generator);
+
+    // Act
+    double[] vector = vectorGenerator.nextVector();
+
+    // Assert
+    Matrix root = vectorGenerator.getRootMatrix();
+    assertEquals(2.0, root.getElement(0, 0), 1.0e-12);
+    assertEquals(0.0, root.getElement(0, 1), 1.0e-12);
+    assertEquals(1.0, root.getElement(1, 0), 1.0e-12);
+    assertEquals(Math.sqrt(2.0), root.getElement(1, 1), 1.0e-12);
+
+    //noinspection PointlessArithmeticExpression
+    double expectedSecond = -1.0 + 1.0 * 0.5 + Math.sqrt(2.0) * -0.5;
+    assertArrayEquals(new double[] {2.0, expectedSecond}, vector, 1.0e-12);
+  }
+
+  @Test
+  void nextVector_withSemiDefiniteCovariance_usesComputedRankAndZeroColumns() throws Exception {
+    // Arrange
+    SymetricalMatrix covariance = new SymetricalMatrix(2);
+    covariance.setElement(0, 0, 1.0);
+    covariance.setElementAndSymetricalElement(1, 0, 1.0);
+    covariance.setElement(1, 1, 1.0);
+
+    when(generator.nextDouble()).thenReturn(1.0, 2.0);
+
+    CorrelatedRandomVectorGenerator vectorGenerator =
+        new CorrelatedRandomVectorGenerator(covariance, generator);
+
+    // Act
+    double[] vector = vectorGenerator.nextVector();
+
+    // Assert
+    assertEquals(2, vectorGenerator.getRank());
+
+    Matrix root = vectorGenerator.getRootMatrix();
+    assertEquals(1.0, root.getElement(0, 0), 1.0e-12);
+    assertEquals(0.0, root.getElement(0, 1), 1.0e-12);
+    assertEquals(1.0, root.getElement(1, 0), 1.0e-12);
+    assertEquals(0.0, root.getElement(1, 1), 1.0e-12);
+
+    assertArrayEquals(new double[] {1.0, 1.0}, vector, 1.0e-12);
+  }
+
+  private static SymetricalMatrix identity2() {
+    SymetricalMatrix matrix = new SymetricalMatrix(2);
+    for (int i = 0; i < 2; ++i) {
+      matrix.setElement(i, i, 1.0);
+    }
+    return matrix;
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/random/FourTapRandomTest.java
+++ b/src/test/java/org/spaceroots/mantissa/random/FourTapRandomTest.java
@@ -1,0 +1,89 @@
+package org.spaceroots.mantissa.random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class FourTapRandomTest {
+
+  private static final long FIXED_SEED = 123_456_789L;
+
+  @Test
+  void deterministicSequence_whenSeedFixed_expectKnownValues() {
+    // Arrange
+    FourTapRandom random = new FourTapRandom(FIXED_SEED);
+
+    // Act
+    int firstInt = random.nextInt();
+    long firstLong = random.nextLong();
+    double firstDouble = random.nextDouble();
+    random.nextInt();
+    random.nextInt();
+    long longAfterAdvance = random.nextLong();
+
+    // Assert
+    assertEquals(-897_996_993, firstInt);
+    assertEquals(2_752_166_806_097_739_985L, firstLong);
+    assertEquals(0.6734551010978229d, firstDouble, 0.0d);
+    assertEquals(-9_128_342_020_895_779_620L, longAfterAdvance);
+  }
+
+  @Test
+  void setSeed_whenCalledAfterUsage_resetsSequence() {
+    // Arrange
+    FourTapRandom random = new FourTapRandom(9_876L);
+    int firstValue = random.nextInt();
+    random.nextInt();
+
+    // Act
+    random.setSeed(9_876L);
+    int resetFirstValue = random.nextInt();
+
+    // Assert
+    assertEquals(firstValue, resetFirstValue);
+  }
+
+  @Test
+  void nextInt_whenBufferWraps_returnsConsistentValue() {
+    // Arrange
+    FourTapRandom random = new FourTapRandom(42L);
+    int last = 0;
+
+    // Act
+    for (int i = 0; i < 16_383 + 5; i++) {
+      last = random.nextInt();
+    }
+
+    // Assert
+    assertEquals(283_416_378, last);
+  }
+
+  @Test
+  void next_withVariousBitLengths_returnsUpperBitsOnly() {
+    // Arrange
+    ExposedFourTapRandom random = new ExposedFourTapRandom(123L);
+
+    // Act
+    int singleBit = random.exposedNext(1);
+    int fiveBits = random.exposedNext(5);
+    int thirtyOneBits = random.exposedNext(31);
+
+    // Assert
+    assertEquals(0, singleBit);
+    assertEquals(20, fiveBits);
+    assertEquals(1_663_352_403, thirtyOneBits);
+    assertTrue(thirtyOneBits >= 0); // 31-bit result should be non-negative
+  }
+
+  private static final class ExposedFourTapRandom extends FourTapRandom {
+    ExposedFourTapRandom(long seed) {
+      super(seed);
+    }
+
+    int exposedNext(int bits) {
+      return super.next(bits);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/random/GaussianRandomGeneratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/random/GaussianRandomGeneratorTest.java
@@ -1,0 +1,86 @@
+package org.spaceroots.mantissa.random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class GaussianRandomGeneratorTest {
+
+  @Test
+  void nextDouble_whenTwoGeneratorsSameIntSeed_producesSameSequence() {
+    int seed = 12345;
+    GaussianRandomGenerator first = new GaussianRandomGenerator(seed);
+    GaussianRandomGenerator second = new GaussianRandomGenerator(seed);
+
+    double[] firstValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> first.nextDouble()).toArray();
+    double[] secondValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> second.nextDouble()).toArray();
+
+    for (int i = 0; i < firstValues.length; i++) {
+      assertEquals(firstValues[i], secondValues[i], 0.0);
+    }
+  }
+
+  @Test
+  void nextDouble_whenTwoGeneratorsSameLongSeed_producesSameSequence() {
+    long seed = 9876543210L;
+    GaussianRandomGenerator first = new GaussianRandomGenerator(seed);
+    GaussianRandomGenerator second = new GaussianRandomGenerator(seed);
+
+    double[] firstValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> first.nextDouble()).toArray();
+    double[] secondValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> second.nextDouble()).toArray();
+
+    for (int i = 0; i < firstValues.length; i++) {
+      assertEquals(firstValues[i], secondValues[i], 0.0);
+    }
+  }
+
+  @Test
+  void nextDouble_whenTwoGeneratorsSameSeedArray_producesSameSequence() {
+    int[] seed = new int[] {1, 2, 3, 4};
+    GaussianRandomGenerator first = new GaussianRandomGenerator(seed.clone());
+    GaussianRandomGenerator second = new GaussianRandomGenerator(seed.clone());
+
+    double[] firstValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> first.nextDouble()).toArray();
+    double[] secondValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> second.nextDouble()).toArray();
+
+    for (int i = 0; i < firstValues.length; i++) {
+      assertEquals(firstValues[i], secondValues[i], 0.0);
+    }
+  }
+
+  @Test
+  void constructor_whenSeedArrayNull_doesNotThrowAndProducesFiniteValue() {
+    GaussianRandomGenerator generator = new GaussianRandomGenerator(null);
+
+    double value = generator.nextDouble();
+
+    assertTrue(Double.isFinite(value));
+  }
+
+  @Test
+  void nextDouble_whenUnderlyingGeneratorMocked_delegatesToNextGaussian() {
+    MersenneTwister mockedTwister = Mockito.mock(MersenneTwister.class);
+    Mockito.when(mockedTwister.nextGaussian()).thenReturn(0.5);
+
+    GaussianRandomGenerator generator = new GaussianRandomGenerator(0);
+    generator.generator = mockedTwister;
+
+    double value = generator.nextDouble();
+
+    assertEquals(0.5, value, 0.0);
+    Mockito.verify(mockedTwister).nextGaussian();
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/random/MersenneTwisterTest.java
+++ b/src/test/java/org/spaceroots/mantissa/random/MersenneTwisterTest.java
@@ -1,0 +1,226 @@
+package org.spaceroots.mantissa.random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("java:S100")
+class MersenneTwisterTest {
+
+  private static final int SEED_5489 = 5489;
+
+  private static final int[] FIRST_TEN_NEXT_INT_FOR_5489 = {
+    0xD091BB5C, // 3499211612
+    0x22AE9EF6, //  581869302
+    0xE7E1FAEE, // 3890346734
+    0xD5C31F79, // 3586334585
+    0x2082352C, //  545404204
+    0xF807B7DF, // 4161255391
+    0xE9D30005, // 3922919429
+    0x3895AFE1, //  949333985
+    0xA1E24BBA, // 2715962298
+    0x4EE4092B // 1323567403
+  };
+
+  @Test
+  void nextInt_whenSeed5489_expectReferenceSequence() {
+    // Arrange
+    MersenneTwister twister = new MersenneTwister(SEED_5489);
+
+    // Act
+    int[] actual = new int[FIRST_TEN_NEXT_INT_FOR_5489.length];
+    for (int i = 0; i < actual.length; i++) {
+      actual[i] = twister.nextInt();
+    }
+
+    // Assert
+    assertArrayEquals(FIRST_TEN_NEXT_INT_FOR_5489, actual);
+  }
+
+  @Test
+  void constructors_whenSameSeed_expectIdenticalSequences() {
+    // Arrange
+    int seed = 123456789;
+    MersenneTwister a = new MersenneTwister(seed);
+    MersenneTwister b = new MersenneTwister(seed);
+
+    // Act
+    int[] seqA = new int[100];
+    int[] seqB = new int[100];
+    for (int i = 0; i < seqA.length; i++) {
+      seqA[i] = a.nextInt();
+      seqB[i] = b.nextInt();
+    }
+
+    // Assert
+    assertArrayEquals(seqA, seqB);
+  }
+
+  @Test
+  void setSeed_whenReinitialized_expectSameAsNewInstance() {
+    // Arrange
+    int seed = 42;
+    MersenneTwister twister = new MersenneTwister(1);
+    MersenneTwister fresh = new MersenneTwister(seed);
+
+    // Act
+    twister.setSeed(seed);
+    int[] afterReset = new int[50];
+    int[] fromFresh = new int[50];
+    for (int i = 0; i < afterReset.length; i++) {
+      afterReset[i] = twister.nextInt();
+      fromFresh[i] = fresh.nextInt();
+    }
+
+    // Assert
+    assertArrayEquals(fromFresh, afterReset);
+  }
+
+  @Test
+  void setSeed_whenIntArray_expectDeterministicSequence() {
+    // Arrange
+    int[] seed = {1, 2, 3, 4};
+    MersenneTwister a = new MersenneTwister(seed);
+    MersenneTwister b = new MersenneTwister(seed);
+
+    // Act
+    long[] seqA = new long[20];
+    long[] seqB = new long[20];
+    for (int i = 0; i < seqA.length; i++) {
+      seqA[i] = a.nextLong();
+      seqB[i] = b.nextLong();
+    }
+
+    // Assert
+    assertArrayEquals(seqA, seqB);
+  }
+
+  @Test
+  void setSeed_whenIntArrayNull_expectDelegatesToLongSeed() {
+    // Arrange
+    CapturingTwister twister = new CapturingTwister();
+
+    // Act
+    assertDoesNotThrow(() -> twister.setSeed(null));
+
+    // Assert
+    assertNotNull(twister.capturedLongSeed);
+  }
+
+  @ParameterizedTest
+  @MethodSource("longSeeds")
+  void constructor_whenLongSeed_expectSameAsIntArrayHighLow(long seed) {
+    // Arrange
+    int high = (int) (seed >>> 32);
+    int low = (int) (seed & 0xffffffffL);
+    MersenneTwister fromLong = new MersenneTwister(seed);
+    MersenneTwister fromInts = new MersenneTwister(new int[] {high, low});
+
+    // Act
+    int[] seqLong = new int[64];
+    int[] seqInts = new int[64];
+    for (int i = 0; i < seqLong.length; i++) {
+      seqLong[i] = fromLong.nextInt();
+      seqInts[i] = fromInts.nextInt();
+    }
+
+    // Assert
+    assertArrayEquals(seqInts, seqLong);
+  }
+
+  @Test
+  void next_whenBits32_expectMatchesNextInt() {
+    // Arrange
+    ExposedTwister twister = new ExposedTwister(SEED_5489);
+    MersenneTwister base = new MersenneTwister(SEED_5489);
+
+    // Act
+    int viaNext = twister.nextBits(32);
+    int viaNextInt = base.nextInt();
+
+    // Assert
+    assertEquals(viaNextInt, viaNext);
+  }
+
+  @Test
+  void next_whenBitsZero_expectSameAsBits32DueToShiftMasking() {
+    // Arrange
+    ExposedTwister zeroBits = new ExposedTwister(123);
+    ExposedTwister fullBits = new ExposedTwister(123);
+
+    // Act
+    int viaZero = zeroBits.nextBits(0);
+    int viaFull = fullBits.nextBits(32);
+
+    // Assert
+    assertEquals(viaFull, viaZero);
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitSizes")
+  void next_whenVariousBits_expectWithinRange(int bits) {
+    // Arrange
+    ExposedTwister twister = new ExposedTwister(987654321);
+
+    // Act
+    int value = twister.nextBits(bits);
+
+    // Assert
+    long unsignedValue = value & 0xffffffffL;
+    long maxExclusive = bits == 32 ? 0x1_0000_0000L : (1L << bits);
+    assertTrue(unsignedValue < maxExclusive);
+  }
+
+  @Test
+  void sequences_whenDifferentSeeds_expectDifferentEarlyValues() {
+    // Arrange
+    MersenneTwister a = new MersenneTwister(1);
+    MersenneTwister b = new MersenneTwister(2);
+
+    // Act
+    int firstA = a.nextInt();
+    int firstB = b.nextInt();
+
+    // Assert
+    assertNotEquals(firstA, firstB);
+  }
+
+  private static Stream<Long> longSeeds() {
+    return Stream.of(0L, 1L, -1L, Long.MIN_VALUE, Long.MAX_VALUE, 0x0123456789ABCDEFL);
+  }
+
+  private static Stream<Integer> bitSizes() {
+    return Stream.of(1, 7, 16, 31, 32);
+  }
+
+  private static final class ExposedTwister extends MersenneTwister {
+    ExposedTwister(int seed) {
+      super(seed);
+    }
+
+    int nextBits(int bits) {
+      return super.next(bits);
+    }
+  }
+
+  private static final class CapturingTwister extends MersenneTwister {
+    private Long capturedLongSeed;
+
+    CapturingTwister() {
+      super(0);
+    }
+
+    @Override
+    public void setSeed(long seed) {
+      this.capturedLongSeed = seed;
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/random/ScalarSampleStatisticsTest.java
+++ b/src/test/java/org/spaceroots/mantissa/random/ScalarSampleStatisticsTest.java
@@ -1,0 +1,180 @@
+package org.spaceroots.mantissa.random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("java:S100")
+class ScalarSampleStatisticsTest {
+
+  @Test
+  void constructor_whenNewInstance_expectEmptySampleDefaults() {
+    ScalarSampleStatistics stats = new ScalarSampleStatistics();
+
+    assertEquals(0, stats.size());
+    assertTrue(Double.isNaN(stats.getMin()));
+    assertTrue(Double.isNaN(stats.getMax()));
+    assertEquals(0.0, stats.getMean(), 0.0);
+    assertEquals(0.0, stats.getStandardDeviation(), 0.0);
+  }
+
+  @Test
+  void add_whenSinglePoint_expectStatsSetToPoint() {
+    ScalarSampleStatistics stats = new ScalarSampleStatistics();
+
+    stats.add(5.0);
+
+    assertEquals(1, stats.size());
+    assertEquals(5.0, stats.getMin(), 0.0);
+    assertEquals(5.0, stats.getMax(), 0.0);
+    assertEquals(5.0, stats.getMean(), 0.0);
+    assertEquals(0.0, stats.getStandardDeviation(), 0.0);
+  }
+
+  @Test
+  void add_whenMultiplePoints_expectMinMaxMeanAndStdUpdated() {
+    ScalarSampleStatistics stats = new ScalarSampleStatistics();
+    double[] points = {1.0, 2.0, 3.0, 4.0};
+
+    for (double point : points) {
+      stats.add(point);
+    }
+
+    assertEquals(4, stats.size());
+    assertEquals(1.0, stats.getMin(), 0.0);
+    assertEquals(4.0, stats.getMax(), 0.0);
+    assertEquals(2.5, stats.getMean(), 1e-15);
+    assertEquals(sampleStandardDeviation(points), stats.getStandardDeviation(), 1e-15);
+  }
+
+  @Test
+  void add_whenArrayProvided_expectAllPointsAdded() {
+    ScalarSampleStatistics stats = new ScalarSampleStatistics();
+    double[] points = {-1.0, 7.0, 3.0};
+
+    stats.add(points);
+
+    assertEquals(3, stats.size());
+    assertEquals(-1.0, stats.getMin(), 0.0);
+    assertEquals(7.0, stats.getMax(), 0.0);
+    assertEquals(3.0, stats.getMean(), 1e-15);
+    assertEquals(sampleStandardDeviation(points), stats.getStandardDeviation(), 1e-15);
+  }
+
+  @Test
+  void add_whenOtherSampleEmpty_expectNoChange() {
+    ScalarSampleStatistics stats = new ScalarSampleStatistics();
+    stats.add(new double[] {2.0, 4.0});
+    ScalarSampleStatistics empty = new ScalarSampleStatistics();
+
+    stats.add(empty);
+
+    assertEquals(2, stats.size());
+    assertEquals(2.0, stats.getMin(), 0.0);
+    assertEquals(4.0, stats.getMax(), 0.0);
+    assertEquals(3.0, stats.getMean(), 1e-15);
+  }
+
+  @Test
+  void add_whenThisSampleEmpty_expectCopyOfOther() {
+    ScalarSampleStatistics target = new ScalarSampleStatistics();
+    ScalarSampleStatistics source = new ScalarSampleStatistics();
+    double[] points = {10.0, 12.0, 14.0};
+    source.add(points);
+
+    target.add(source);
+
+    assertEquals(3, target.size());
+    assertEquals(10.0, target.getMin(), 0.0);
+    assertEquals(14.0, target.getMax(), 0.0);
+    assertEquals(source.getMean(), target.getMean(), 1e-15);
+    assertEquals(source.getStandardDeviation(), target.getStandardDeviation(), 1e-15);
+  }
+
+  @Test
+  void add_whenBothSamplesNonEmpty_expectMergedStatistics() {
+    ScalarSampleStatistics a = new ScalarSampleStatistics();
+    ScalarSampleStatistics b = new ScalarSampleStatistics();
+    a.add(new double[] {1.0, 2.0});
+    b.add(new double[] {5.0, 6.0});
+
+    a.add(b);
+
+    double[] merged = {1.0, 2.0, 5.0, 6.0};
+    assertEquals(4, a.size());
+    assertEquals(1.0, a.getMin(), 0.0);
+    assertEquals(6.0, a.getMax(), 0.0);
+    assertEquals(3.5, a.getMean(), 1e-15);
+    assertEquals(sampleStandardDeviation(merged), a.getStandardDeviation(), 1e-15);
+  }
+
+  @Test
+  void add_whenOtherSampleHasSmallerMin_expectMinUpdatedOnly() {
+    ScalarSampleStatistics a = new ScalarSampleStatistics();
+    ScalarSampleStatistics b = new ScalarSampleStatistics();
+    a.add(new double[] {5.0, 6.0});
+    b.add(new double[] {1.0, 2.0});
+
+    a.add(b);
+
+    double[] merged = {5.0, 6.0, 1.0, 2.0};
+    assertEquals(4, a.size());
+    assertEquals(1.0, a.getMin(), 0.0);
+    assertEquals(6.0, a.getMax(), 0.0);
+    assertEquals(3.5, a.getMean(), 1e-15);
+    assertEquals(sampleStandardDeviation(merged), a.getStandardDeviation(), 1e-15);
+  }
+
+  @ParameterizedTest
+  @MethodSource("smallSamples")
+  void getStandardDeviation_whenLessThanTwoPoints_expectZero(double[] points) {
+    ScalarSampleStatistics stats = new ScalarSampleStatistics();
+
+    stats.add(points);
+
+    assertEquals(0.0, stats.getStandardDeviation(), 0.0);
+  }
+
+  static Stream<Arguments> smallSamples() {
+    return Stream.of(
+        Arguments.of((Object) new double[] {}), Arguments.of((Object) new double[] {42.0}));
+  }
+
+  @Test
+  void add_whenNaNIncluded_expectNaNPropagatesToAggregates() {
+    ScalarSampleStatistics stats = new ScalarSampleStatistics();
+
+    stats.add(1.0);
+    stats.add(Double.NaN);
+    stats.add(2.0);
+
+    assertEquals(3, stats.size());
+    assertEquals(1.0, stats.getMin(), 0.0);
+    assertEquals(2.0, stats.getMax(), 0.0);
+    assertTrue(Double.isNaN(stats.getMean()));
+    assertTrue(Double.isNaN(stats.getStandardDeviation()));
+  }
+
+  private static double sampleStandardDeviation(double[] points) {
+    if (points.length < 2) {
+      return 0.0;
+    }
+    double mean = 0.0;
+    for (double point : points) {
+      mean += point;
+    }
+    mean /= points.length;
+
+    double sumSq = 0.0;
+    for (double point : points) {
+      double d = point - mean;
+      sumSq += d * d;
+    }
+    return Math.sqrt(sumSq / (points.length - 1));
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/random/UncorrelatedRandomVectorGeneratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/random/UncorrelatedRandomVectorGeneratorTest.java
@@ -1,0 +1,119 @@
+package org.spaceroots.mantissa.random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class UncorrelatedRandomVectorGeneratorTest {
+
+  @Mock private NormalizedRandomGenerator generator;
+
+  @Test
+  void constructor_withMeanStdDevLengthMismatch_throwsIllegalArgumentException() {
+    // Arrange
+    double[] mean = new double[] {1.0, 2.0};
+    double[] standardDeviation = new double[] {1.0};
+
+    // Act
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new UncorrelatedRandomVectorGenerator(mean, standardDeviation, generator));
+
+    // Assert
+    assertEquals("dimension mismatch", ex.getMessage());
+  }
+
+  @Test
+  void constructor_clonesMeanAndStandardDeviationArrays() {
+    // Arrange
+    double[] mean = new double[] {1.0, 2.0};
+    double[] standardDeviation = new double[] {0.5, 1.0};
+    when(generator.nextDouble()).thenReturn(1.0, 1.0);
+    UncorrelatedRandomVectorGenerator vectorGenerator =
+        new UncorrelatedRandomVectorGenerator(mean, standardDeviation, generator);
+
+    mean[0] = 100.0;
+    standardDeviation[1] = 10.0;
+
+    // Act
+    double[] vector = vectorGenerator.nextVector();
+
+    // Assert
+    assertArrayEquals(new double[] {1.5, 3.0}, vector, 1.0e-12);
+  }
+
+  @Test
+  void constructor_withDimensionInitializesNullMeanAndUnitStdDev() {
+    // Arrange
+    when(generator.nextDouble()).thenReturn(0.25, -0.75);
+    UncorrelatedRandomVectorGenerator vectorGenerator =
+        new UncorrelatedRandomVectorGenerator(2, generator);
+
+    // Act
+    double[] vector = vectorGenerator.nextVector();
+
+    // Assert
+    assertArrayEquals(new double[] {0.25, -0.75}, vector, 1.0e-12);
+  }
+
+  @Test
+  void constructor_withNegativeDimension_throwsNegativeArraySizeException() {
+    // Arrange
+    int negativeDimension = -1;
+
+    // Act + Assert
+    assertThrows(
+        NegativeArraySizeException.class,
+        () -> new UncorrelatedRandomVectorGenerator(negativeDimension, generator));
+  }
+
+  @Test
+  void nextVector_returnsNewArrayEachCall() {
+    // Arrange
+    when(generator.nextDouble()).thenReturn(0.0, 1.0, 2.0, 3.0);
+    UncorrelatedRandomVectorGenerator vectorGenerator =
+        new UncorrelatedRandomVectorGenerator(2, generator);
+
+    // Act
+    double[] first = vectorGenerator.nextVector();
+    double[] second = vectorGenerator.nextVector();
+
+    // Assert
+    assertNotSame(first, second);
+    assertArrayEquals(new double[] {0.0, 1.0}, first, 1.0e-12);
+    assertArrayEquals(new double[] {2.0, 3.0}, second, 1.0e-12);
+  }
+
+  @Test
+  void getGenerator_returnsUnderlyingGenerator() {
+    // Arrange
+    UncorrelatedRandomVectorGenerator vectorGenerator =
+        new UncorrelatedRandomVectorGenerator(1, generator);
+
+    // Act
+    NormalizedRandomGenerator returned = vectorGenerator.getGenerator();
+
+    // Assert
+    assertEquals(generator, returned);
+  }
+
+  @Test
+  void nextVector_withNullGenerator_throwsNullPointerException() {
+    // Arrange
+    UncorrelatedRandomVectorGenerator vectorGenerator =
+        new UncorrelatedRandomVectorGenerator(1, null);
+
+    // Act + Assert
+    assertThrows(NullPointerException.class, vectorGenerator::nextVector);
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/random/UniformRandomGeneratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/random/UniformRandomGeneratorTest.java
@@ -1,0 +1,153 @@
+package org.spaceroots.mantissa.random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class UniformRandomGeneratorTest {
+
+  @Test
+  void nextDouble_whenTwoGeneratorsSameIntSeed_producesSameSequence() {
+    int seed = 12345;
+    UniformRandomGenerator first = new UniformRandomGenerator(seed);
+    UniformRandomGenerator second = new UniformRandomGenerator(seed);
+
+    double[] firstValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> first.nextDouble()).toArray();
+    double[] secondValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> second.nextDouble()).toArray();
+
+    for (int i = 0; i < firstValues.length; i++) {
+      assertEquals(firstValues[i], secondValues[i], 0.0);
+    }
+  }
+
+  @Test
+  void nextDouble_whenTwoGeneratorsSameLongSeed_producesSameSequence() {
+    long seed = 9876543210L;
+    UniformRandomGenerator first = new UniformRandomGenerator(seed);
+    UniformRandomGenerator second = new UniformRandomGenerator(seed);
+
+    double[] firstValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> first.nextDouble()).toArray();
+    double[] secondValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> second.nextDouble()).toArray();
+
+    for (int i = 0; i < firstValues.length; i++) {
+      assertEquals(firstValues[i], secondValues[i], 0.0);
+    }
+  }
+
+  @Test
+  void nextDouble_whenTwoGeneratorsSameSeedArray_producesSameSequence() {
+    int[] seed = new int[] {1, 2, 3, 4};
+    UniformRandomGenerator first = new UniformRandomGenerator(seed.clone());
+    UniformRandomGenerator second = new UniformRandomGenerator(seed.clone());
+
+    double[] firstValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> first.nextDouble()).toArray();
+    double[] secondValues =
+        IntStream.range(0, 5).mapToDouble(ignored -> second.nextDouble()).toArray();
+
+    for (int i = 0; i < firstValues.length; i++) {
+      assertEquals(firstValues[i], secondValues[i], 0.0);
+    }
+  }
+
+  @Test
+  void constructor_whenSeedArrayNull_doesNotThrowAndProducesFiniteValue() {
+    UniformRandomGenerator generator = new UniformRandomGenerator(null);
+
+    double value = generator.nextDouble();
+
+    assertTrue(Double.isFinite(value));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0.0", "0.5", "0.75", "0.999999"})
+  void nextDouble_whenUnderlyingGeneratorMocked_appliesUniformNormalization(double underlying) {
+    MersenneTwister mockedTwister = Mockito.mock(MersenneTwister.class);
+    Mockito.when(mockedTwister.nextDouble()).thenReturn(underlying);
+
+    UniformRandomGenerator generator = new UniformRandomGenerator(0);
+    generator.generator = mockedTwister;
+
+    double value = generator.nextDouble();
+
+    double sqrt3 = Math.sqrt(3.0);
+    double expected = 2.0 * sqrt3 * underlying - sqrt3;
+    assertEquals(expected, value, 0.0);
+    Mockito.verify(mockedTwister).nextDouble();
+  }
+
+  @Test
+  void nextDouble_whenSampledManyTimes_staysWithinBoundsAndHasExpectedMoments() {
+    UniformRandomGenerator generator = new UniformRandomGenerator(24680);
+    double sqrt3 = Math.sqrt(3.0);
+    int samples = 20_000;
+
+    double min = Double.POSITIVE_INFINITY;
+    double max = Double.NEGATIVE_INFINITY;
+    double sum = 0.0;
+    double sumSq = 0.0;
+
+    for (int i = 0; i < samples; i++) {
+      double value = generator.nextDouble();
+      assertTrue(value >= -sqrt3 - 1e-15);
+      assertTrue(value <= sqrt3 + 1e-15);
+
+      min = Math.min(min, value);
+      max = Math.max(max, value);
+      sum += value;
+      sumSq += value * value;
+    }
+
+    double mean = sum / samples;
+    double variance = (sumSq / samples) - mean * mean;
+    double standardDeviation = Math.sqrt(variance);
+
+    assertEquals(0.0, mean, 0.02);
+    assertEquals(1.0, standardDeviation, 0.03);
+    assertTrue(min < -1.0);
+    assertTrue(max > 1.0);
+  }
+
+  @Test
+  void serialization_whenRoundTripped_preservesSequence() throws Exception {
+    UniformRandomGenerator original = new UniformRandomGenerator(13579);
+
+    IntStream.range(0, 10).forEach(ignored -> original.nextDouble());
+
+    UniformRandomGenerator restored = serializeRoundTrip(original);
+
+    for (int i = 0; i < 5; i++) {
+      assertEquals(original.nextDouble(), restored.nextDouble(), 0.0);
+    }
+  }
+
+  private static UniformRandomGenerator serializeRoundTrip(UniformRandomGenerator generator)
+      throws Exception {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(buffer)) {
+      out.writeObject(generator);
+    }
+
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
+      return (UniformRandomGenerator) in.readObject();
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/random/VectorialSampleStatisticsTest.java
+++ b/src/test/java/org/spaceroots/mantissa/random/VectorialSampleStatisticsTest.java
@@ -1,0 +1,296 @@
+package org.spaceroots.mantissa.random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.spaceroots.mantissa.linalg.SymetricalMatrix;
+
+@SuppressWarnings("java:S100")
+class VectorialSampleStatisticsTest {
+
+  private static final double EPS = 1e-12;
+
+  @Test
+  void size_whenNew_expectZero() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+
+    // Act
+    int size = stats.size();
+
+    // Assert
+    assertEquals(0, size);
+  }
+
+  @Test
+  void getMean_whenEmpty_expectEmptyArray() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+
+    // Act
+    double[] mean = stats.getMean();
+
+    // Assert
+    assertArrayEquals(new double[0], mean, EPS);
+  }
+
+  @Test
+  void getCovarianceMatrix_whenLessThanTwoPoints_expectNull() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+    stats.add(new double[] {1.0, 2.0});
+
+    // Act
+    SymetricalMatrix covariance = stats.getCovarianceMatrix(null);
+
+    // Assert
+    assertNull(covariance);
+  }
+
+  @Test
+  void getMin_whenEmpty_expectNullPointerException() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+
+    // Act / Assert
+    assertThrows(NullPointerException.class, stats::getMin);
+  }
+
+  @Test
+  void getMax_whenEmpty_expectNullPointerException() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+
+    // Act / Assert
+    assertThrows(NullPointerException.class, stats::getMax);
+  }
+
+  @Test
+  void getMinIndices_whenEmpty_expectNullPointerException() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+
+    // Act / Assert
+    assertThrows(NullPointerException.class, stats::getMinIndices);
+  }
+
+  @Test
+  void getMaxIndices_whenEmpty_expectNullPointerException() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+
+    // Act / Assert
+    assertThrows(NullPointerException.class, stats::getMaxIndices);
+  }
+
+  @Test
+  void add_whenFirstPointAdded_initializesStatisticsAndDefensivelyCopies() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+    double[] point = new double[] {1.0, -2.0, 3.0};
+
+    // Act
+    stats.add(point);
+    point[0] = 100.0;
+    point[1] = 100.0;
+    point[2] = 100.0;
+
+    // Assert
+    assertEquals(1, stats.size());
+    assertArrayEquals(new double[] {1.0, -2.0, 3.0}, stats.getMin(), EPS);
+    assertArrayEquals(new double[] {1.0, -2.0, 3.0}, stats.getMax(), EPS);
+    assertArrayEquals(new double[] {1.0, -2.0, 3.0}, stats.getMean(), EPS);
+    assertArrayEquals(new int[] {0, 0, 0}, stats.getMinIndices());
+    assertArrayEquals(new int[] {0, 0, 0}, stats.getMaxIndices());
+  }
+
+  @Test
+  void add_whenSecondPointUpdatesMinMaxAndMean() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+    stats.add(new double[] {1.0, 2.0});
+
+    // Act
+    stats.add(new double[] {0.0, 5.0});
+
+    // Assert
+    assertEquals(2, stats.size());
+    assertArrayEquals(new double[] {0.0, 2.0}, stats.getMin(), EPS);
+    assertArrayEquals(new double[] {1.0, 5.0}, stats.getMax(), EPS);
+    assertArrayEquals(new int[] {1, 0}, stats.getMinIndices());
+    assertArrayEquals(new int[] {0, 1}, stats.getMaxIndices());
+    assertArrayEquals(new double[] {0.5, 3.5}, stats.getMean(), EPS);
+  }
+
+  @Test
+  void add_whenEqualValues_expectIndicesUnchanged() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+    stats.add(new double[] {1.0, 1.0});
+
+    // Act
+    stats.add(new double[] {1.0, 1.0});
+
+    // Assert
+    assertEquals(2, stats.size());
+    assertArrayEquals(new int[] {0, 0}, stats.getMinIndices());
+    assertArrayEquals(new int[] {0, 0}, stats.getMaxIndices());
+    assertArrayEquals(new double[] {1.0, 1.0}, stats.getMean(), EPS);
+  }
+
+  @Test
+  void addArray_whenMultiplePoints_expectSameAsSequentialAdds() {
+    // Arrange
+    double[][] points = new double[][] {{1.0, 0.0}, {2.0, 3.0}, {0.0, -1.0}};
+    VectorialSampleStatistics byArray = new VectorialSampleStatistics();
+    VectorialSampleStatistics sequential = new VectorialSampleStatistics();
+
+    // Act
+    byArray.add(points);
+    for (double[] p : points) {
+      sequential.add(p);
+    }
+
+    // Assert
+    assertEquals(sequential.size(), byArray.size());
+    assertArrayEquals(sequential.getMin(), byArray.getMin(), EPS);
+    assertArrayEquals(sequential.getMax(), byArray.getMax(), EPS);
+    assertArrayEquals(sequential.getMean(), byArray.getMean(), EPS);
+    assertArrayEquals(sequential.getMinIndices(), byArray.getMinIndices());
+    assertArrayEquals(sequential.getMaxIndices(), byArray.getMaxIndices());
+  }
+
+  @Test
+  void addSample_whenThisEmpty_clonesStatisticsAndDoesNotShareState() {
+    // Arrange
+    VectorialSampleStatistics source = new VectorialSampleStatistics();
+    source.add(new double[] {1.0, 2.0});
+    source.add(new double[] {3.0, -1.0});
+
+    VectorialSampleStatistics target = new VectorialSampleStatistics();
+
+    // Act
+    target.add(source);
+    source.add(new double[] {-5.0, 100.0});
+
+    // Assert
+    assertEquals(2, target.size());
+    assertArrayEquals(new double[] {1.0, -1.0}, target.getMin(), EPS);
+    assertArrayEquals(new double[] {3.0, 2.0}, target.getMax(), EPS);
+    assertArrayEquals(new double[] {2.0, 0.5}, target.getMean(), EPS);
+  }
+
+  @Test
+  void addSample_whenBothNonEmpty_mergesWithBoundaryIndices() {
+    // Arrange
+    VectorialSampleStatistics first = new VectorialSampleStatistics();
+    first.add(new double[] {5.0, 5.0});
+    first.add(new double[] {6.0, 0.0});
+
+    VectorialSampleStatistics second = new VectorialSampleStatistics();
+    second.add(new double[] {4.0, 10.0});
+
+    // Act
+    first.add(second);
+
+    // Assert
+    assertEquals(3, first.size());
+    assertArrayEquals(new double[] {4.0, 0.0}, first.getMin(), EPS);
+    assertArrayEquals(new double[] {6.0, 10.0}, first.getMax(), EPS);
+    assertArrayEquals(new int[] {2, 1}, first.getMinIndices());
+    assertArrayEquals(new int[] {1, 2}, first.getMaxIndices());
+    assertArrayEquals(new double[] {5.0, 5.0}, first.getMean(), EPS);
+  }
+
+  @Test
+  void add_whenShorterVectorThanDimension_expectArrayIndexOutOfBoundsException() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+    stats.add(new double[] {1.0, 2.0});
+
+    // Act / Assert
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> stats.add(new double[] {3.0}));
+  }
+
+  @Test
+  void add_whenLongerVectorThanDimension_ignoresExtraComponents() {
+    // Arrange
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+    stats.add(new double[] {1.0, 2.0});
+
+    // Act
+    stats.add(new double[] {3.0, 4.0, 1000.0});
+
+    // Assert
+    assertEquals(2, stats.size());
+    assertArrayEquals(new double[] {1.0, 2.0}, stats.getMin(), EPS);
+    assertArrayEquals(new double[] {3.0, 4.0}, stats.getMax(), EPS);
+    assertArrayEquals(new double[] {2.0, 3.0}, stats.getMean(), EPS);
+  }
+
+  @Test
+  void getCovarianceMatrix_whenValidSample_returnsExpectedAndReusesPlaceholder() {
+    // Arrange
+    double[][] points = new double[][] {{1.0, 2.0}, {3.0, 4.0}, {5.0, 0.0}};
+    VectorialSampleStatistics stats = new VectorialSampleStatistics();
+    stats.add(points);
+
+    // Act
+    SymetricalMatrix covariance = stats.getCovarianceMatrix(null);
+    SymetricalMatrix placeholder = new SymetricalMatrix(2);
+    SymetricalMatrix reused = stats.getCovarianceMatrix(placeholder);
+
+    // Assert
+    assertNotNull(covariance);
+    assertSame(placeholder, reused);
+
+    double[][] expected = computeSampleCovariance(points);
+    assertEquals(expected[0][0], covariance.getElement(0, 0), EPS);
+    assertEquals(expected[1][1], covariance.getElement(1, 1), EPS);
+    assertEquals(expected[0][1], covariance.getElement(0, 1), EPS);
+    assertEquals(expected[0][1], covariance.getElement(1, 0), EPS);
+
+    assertEquals(expected[0][0], reused.getElement(0, 0), EPS);
+    assertEquals(expected[1][1], reused.getElement(1, 1), EPS);
+    assertEquals(expected[0][1], reused.getElement(0, 1), EPS);
+  }
+
+  private static double[][] computeSampleCovariance(double[][] points) {
+    int n = points.length;
+    int dim = points[0].length;
+
+    double[] mean = new double[dim];
+    for (double[] p : points) {
+      for (int i = 0; i < dim; i++) {
+        mean[i] += p[i];
+      }
+    }
+    for (int i = 0; i < dim; i++) {
+      mean[i] /= n;
+    }
+
+    double[][] cov = new double[dim][dim];
+    for (double[] p : points) {
+      for (int i = 0; i < dim; i++) {
+        double di = p[i] - mean[i];
+        for (int j = 0; j < dim; j++) {
+          double dj = p[j] - mean[j];
+          cov[i][j] += di * dj;
+        }
+      }
+    }
+    double denom = n - 1.0;
+    for (int i = 0; i < dim; i++) {
+      for (int j = 0; j < dim; j++) {
+        cov[i][j] /= denom;
+      }
+    }
+
+    return cov;
+  }
+}


### PR DESCRIPTION
This PR focuses on the Mantissa random package, improving documentation, tightening seeding semantics, and adding missing tests.

Changes:
- Clarify contracts and doclint-clean Javadocs for random APIs:
  - `NormalizedRandomGenerator`, `RandomVectorGenerator`, and `NotPositiveDefiniteMatrixException`.
- Refactor and document correlated/un-correlated random vector generators for clearer behavior and validation.
- Document FourTapRandom behavior and invariants.
- Tidy and better document `MersenneTwister` seeding/initialization.
- Add comprehensive JUnit coverage for:
  - `CorrelatedRandomVectorGenerator`, `UncorrelatedRandomVectorGenerator`.
  - `FourTapRandom`, `GaussianRandomGenerator`, `UniformRandomGenerator`.
  - `MersenneTwister`.
  - `ScalarSampleStatistics`, `VectorialSampleStatistics`.

Notes:
- Branch has been merged with current `develop` to keep the diff focused.
- No additional formatting run was needed since the working tree was clean.

Review tips:
- Start with the random package Javadoc and refactors, then check the new tests for expected statistical/behavioral properties.