### PR TITLE
Add coverage and doclint cleanups for Mantissa utilities

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/utilities/ArrayMapper.java
+++ b/src/main/java/org/spaceroots/mantissa/utilities/ArrayMapper.java
@@ -4,10 +4,32 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This class dispatch data between an array and several domain objects.
+ * Dispatches state data between a flat {@code double[]} and multiple domain objects.
  *
- * <p>This class handles all the burden of mapping each domain object it handles to a slice of a
- * single array.
+ * <p>An {@code ArrayMapper} maintains an ordered list of {@link ArraySliceMappable} instances. Each
+ * managed object owns a contiguous slice of a single logical state vector. The mapper remembers the
+ * slice offset for each object and can copy data in either direction:
+ *
+ * <ul>
+ *   <li>{@link #updateObjects(double[])} reads from a flat array and pushes each slice into its
+ *       object via {@link ArraySliceMappable#mapStateFromArray(int, double[])}.
+ *   <li>{@link #updateArray(double[])} pulls each object's state via {@link
+ *       ArraySliceMappable#mapStateToArray(int, double[])} and writes into a flat array.
+ * </ul>
+ *
+ * <p>The total dimension of the logical state vector is the sum of the dimensions reported by all
+ * managed objects at the time they are added. Offsets are fixed once an object is managed; the
+ * mapper does not re-query dimensions or recompute offsets later.
+ *
+ * <p>The internal backing array is created lazily. If you never call {@link #getDataArray()},
+ * {@link #updateArray()}, or {@link #updateObjects()}, the mapper holds no array storage. Adding a
+ * new object after the internal array has been initialized resets that array to a new zero-filled
+ * instance sized for the enlarged state vector. Callers that need to preserve state across such a
+ * change should store it externally and reapply it after adding objects.
+ *
+ * <p>This class is mutable and not thread-safe. Typical usage is to build a mapper once during
+ * model setup, add all objects, then repeatedly synchronize between objects and arrays within a
+ * single-threaded numerical algorithm loop.
  *
  * @see ArraySliceMappable
  * @version $Id: ArrayMapper.java 1709 2006-12-03 21:16:50Z luc $
@@ -15,7 +37,14 @@ import java.util.List;
  */
 public class ArrayMapper {
 
-  /** Simple constructor. Build an empty array mapper */
+  /**
+   * Builds an empty mapper with no managed objects.
+   *
+   * <p>The logical state dimension is initially zero. The internal data array is not allocated
+   * until required by {@link #getDataArray()}, {@link #updateArray()}, or {@link #updateObjects()}.
+   *
+   * <p>Objects may be added later using {@link #manageMappable(ArraySliceMappable)}.
+   */
   public ArrayMapper() {
     domainObjects = new ArrayList<>();
     size = 0;
@@ -23,11 +52,19 @@ public class ArrayMapper {
   }
 
   /**
-   * Simple constructor. Build an array mapper managing one object. Other objects can be added later
-   * using the {@link #manageMappable manageMappable} method. This call is equivalent to build the
-   * mapper with the default constructor and adding the object.
+   * Builds a mapper that initially manages a single object.
    *
-   * @param object domain object to handle
+   * <p>The provided object is assigned offset {@code 0} and contributes its full dimension to the
+   * logical state vector. An internal data array of the corresponding size is allocated
+   * immediately. Additional objects may be added later using {@link
+   * #manageMappable(ArraySliceMappable)}; if that happens, the internal data array is reset to a
+   * new zero-filled array sized for the enlarged vector.
+   *
+   * <p>This constructor is equivalent to using {@link #ArrayMapper()} and then calling {@link
+   * #manageMappable(ArraySliceMappable)} once with the same object.
+   *
+   * @param object domain object to handle, owning the first slice; must not be {@code null}
+   * @throws NullPointerException if {@code object} is {@code null}
    */
   public ArrayMapper(ArraySliceMappable object) {
 
@@ -40,10 +77,22 @@ public class ArrayMapper {
   }
 
   /**
-   * Take a new domain object into account.
+   * Adds a new domain object to the mapper.
    *
-   * @param object domain object to handle
+   * <p>The object is appended to the current management order. Its slice starts at the current end
+   * of the logical state vector, and its dimension is added to the total size. Offsets of
+   * previously managed objects are unchanged.
+   *
+   * <p>If the internal data array has already been allocated (because of a prior call to {@link
+   * #getDataArray()}, {@link #updateArray()}, or {@link #updateObjects()}), this method replaces
+   * that array with a new zero-filled array of the new total size. No attempt is made to preserve
+   * any previous internal data.
+   *
+   * @param object domain object to handle, providing its dimension and slice mappings; must not be
+   *     {@code null}
+   * @throws NullPointerException if {@code object} is {@code null}
    */
+  @SuppressWarnings("unused")
   public void manageMappable(ArraySliceMappable object) {
 
     domainObjects.add(new ArrayMapperEntry(object, size));
@@ -56,10 +105,17 @@ public class ArrayMapper {
   }
 
   /**
-   * Get the data array.
+   * Returns a copy of the internal flat data array.
    *
-   * @return copy of the data array
+   * <p>If the internal array has not been created yet, it is allocated with the current total size
+   * and filled with zeros. The returned array is a defensive copy; modifying it does not affect the
+   * mapper. To push data into objects, use {@link #updateObjects(double[])} with the caller-owned
+   * array. To pull object state into a caller-owned array, use {@link #updateArray(double[])}.
+   *
+   * @return a newly allocated array containing the mapper's current internal data, never {@code
+   *     null}
    */
+  @SuppressWarnings("unused")
   public double[] getDataArray() {
     if (internalData == null) {
       internalData = new double[size];
@@ -67,7 +123,17 @@ public class ArrayMapper {
     return internalData.clone();
   }
 
-  /** Map data from the internal array to the domain objects. */
+  /**
+   * Maps data from the internal array to all managed objects.
+   *
+   * <p>If the internal array is not yet allocated, it is created and filled with zeros before
+   * dispatch. Each managed object receives a view of its slice through a call to {@link
+   * ArraySliceMappable#mapStateFromArray(int, double[])} using its fixed offset.
+   *
+   * <p>This method is convenient when the internal array is used as the authoritative state and the
+   * caller wants to refresh object views of that state.
+   */
+  @SuppressWarnings("unused")
   public void updateObjects() {
     if (internalData == null) {
       internalData = new double[size];
@@ -78,7 +144,17 @@ public class ArrayMapper {
   /**
    * Map data from the specified array to the domain objects.
    *
-   * @param data flat array holding the data to dispatch
+   * <p>The array is treated as a concatenation of all slices in management order. Each object is
+   * asked to reinitialize itself by reading its slice starting at its fixed offset.
+   *
+   * <p>The mapper does not validate array bounds or nullability beyond passing the array to managed
+   * objects. If {@code data} is shorter than the total size, an {@link
+   * ArrayIndexOutOfBoundsException} may be thrown by slice copies. If {@code data} is longer,
+   * excess elements are ignored.
+   *
+   * @param data flat array holding the data to dispatch; must be at least as long as the total
+   *     mapped size
+   * @throws NullPointerException if {@code data} is {@code null}
    */
   public void updateObjects(double[] data) {
     for (ArrayMapperEntry entry : domainObjects) {
@@ -86,7 +162,17 @@ public class ArrayMapper {
     }
   }
 
-  /** Map data from the domain objects to the internal array. */
+  /**
+   * Maps data from all managed objects to the internal array.
+   *
+   * <p>If the internal array is not yet allocated, it is created with the current total size and
+   * filled with zeros before being populated. Each object writes its slice into the internal array
+   * via {@link ArraySliceMappable#mapStateToArray(int, double[])} using its fixed offset.
+   *
+   * <p>This method is convenient when objects are mutated by client code and the caller wants to
+   * rebuild a consistent flat state vector.
+   */
+  @SuppressWarnings("unused")
   public void updateArray() {
     if (internalData == null) {
       internalData = new double[size];
@@ -97,7 +183,15 @@ public class ArrayMapper {
   /**
    * Map data from the domain objects to the specified array.
    *
-   * @param data flat array where to put the data
+   * <p>The array is treated as a concatenation of all slices in management order. Each managed
+   * object is asked to store its current state into its slice starting at its fixed offset.
+   *
+   * <p>The mapper does not validate array bounds. If {@code data} is too short, an {@link
+   * ArrayIndexOutOfBoundsException} may be thrown by slice copies. If {@code data} is longer, only
+   * the first {@code size} elements are written.
+   *
+   * @param data flat array where to put the data; must be at least as long as the total mapped size
+   * @throws NullPointerException if {@code data} is {@code null}
    */
   public void updateArray(double[] data) {
     for (ArrayMapperEntry entry : domainObjects) {

--- a/src/main/java/org/spaceroots/mantissa/utilities/ArrayMapper.java
+++ b/src/main/java/org/spaceroots/mantissa/utilities/ArrayMapper.java
@@ -158,7 +158,7 @@ public class ArrayMapper {
    */
   public void updateObjects(double[] data) {
     for (ArrayMapperEntry entry : domainObjects) {
-      entry.object.mapStateFromArray(entry.offset, data);
+      entry.object().mapStateFromArray(entry.offset(), data);
     }
   }
 
@@ -195,7 +195,7 @@ public class ArrayMapper {
    */
   public void updateArray(double[] data) {
     for (ArrayMapperEntry entry : domainObjects) {
-      entry.object.mapStateToArray(entry.offset, data);
+      entry.object().mapStateToArray(entry.offset(), data);
     }
   }
 

--- a/src/main/java/org/spaceroots/mantissa/utilities/ArrayMapperEntry.java
+++ b/src/main/java/org/spaceroots/mantissa/utilities/ArrayMapperEntry.java
@@ -1,27 +1,28 @@
 package org.spaceroots.mantissa.utilities;
 
 /**
- * This class is a simple container for an offset and an {@link ArraySliceMappable} object.
+ * Simple container for an offset and an {@link ArraySliceMappable} object.
  *
+ * <p>{@code ArrayMapperEntry} represents one managed slice within an {@link ArrayMapper}. Each
+ * entry pairs a single domain object (the slice owner) with the zero-based offset at which that
+ * object's state begins in the mapper's logical flat {@code double[]} vector. Entries are created
+ * when objects are registered with a mapper and then treated as immutable bookkeeping: the
+ * reference to the domain object and its offset never change for the lifetime of the entry.
+ *
+ * <p>This type is package-private and intended only for internal coordination. It performs no
+ * validation; in particular, offsets are assumed to be consistent with the mapper's sizing logic,
+ * and the object reference may be {@code null} if a caller supplies one. The record itself is
+ * shallowly immutable and thread-safe, but any thread-safety guarantees for the stored object are
+ * inherited from that object's implementation.
+ *
+ * <ul>
+ *   <li>Stores a direct reference to the managed {@link ArraySliceMappable} instance.
+ *   <li>Stores a fixed offset into the mapper's flat state vector.
+ * </ul>
+ *
+ * @param object domain object owning a contiguous slice; may be {@code null} if supplied.
+ * @param offset zero-based start index for the object's slice within the flat vector.
  * @version $Id: ArrayMapperEntry.java 1257 2002-06-20 17:53:26Z luc $
  * @author L. Maisonobe
  */
-class ArrayMapperEntry {
-
-  /** Mappable object. */
-  public final ArraySliceMappable object;
-
-  /** Offset from start of array. */
-  public final int offset;
-
-  /**
-   * Simple constructor.
-   *
-   * @param object mappable object
-   * @param offset offset from start of array
-   */
-  public ArrayMapperEntry(ArraySliceMappable object, int offset) {
-    this.object = object;
-    this.offset = offset;
-  }
-}
+record ArrayMapperEntry(ArraySliceMappable object, int offset) {}

--- a/src/main/java/org/spaceroots/mantissa/utilities/ArraySliceMappable.java
+++ b/src/main/java/org/spaceroots/mantissa/utilities/ArraySliceMappable.java
@@ -1,58 +1,72 @@
 package org.spaceroots.mantissa.utilities;
 
 /**
- * This interface is used to map objects to and from simple arrays.
+ * Maps a portion of a {@code double[]} to and from an object's internal state.
  *
- * <p>Lots of mathematical algorithms are generic ones which can process the data from domain
- * objects despite they ignore what this data represent. As an example, the same algorithm can
- * integrate either the orbit evolution of a spacecraft under a specified force model or the
- * electrical characteristics of a circuit after a switch is opened.
+ * <p>Many numerical algorithms in Mantissa operate on a flat vector of primitive values rather than
+ * on domain-specific objects. Examples include ODE integrators (see {@link
+ * org.spaceroots.mantissa.ode.FirstOrderDifferentialEquations}) and estimation routines (see {@link
+ * org.spaceroots.mantissa.estimation.EstimationProblem}). In real applications the overall state
+ * vector is often composed of several cooperating objects: for instance a spacecraft orbit,
+ * aerodynamic coefficients, and thruster parameters may all contribute elements to the same array.
+ * This interface provides a minimal contract that lets those objects expose their state as a
+ * contiguous slice of a larger array and restore themselves from that slice later.
  *
- * <p>The approach of the Mantissa library is to define an interface for each such algorithm to
- * represent the type of problem they can handle ({@link
- * org.spaceroots.mantissa.ode.FirstOrderDifferentialEquations FirstOrderDifferentialEquations} for
- * an ODE integrators, {@link org.spaceroots.mantissa.estimation.EstimationProblem
- * EstimationProblem} for least squares estimators, ...). Furthermore, the state data that is
- * handled by these algorithms is often a mixture of data coming from several domain objects (the
- * orbit, plus the aerodynamical coefficients of the spacecraft, plus the characteristics of the
- * thrusters, plus ...). Therefore, the user needs to gather and dispatch data between different
- * objects representing different levels of abstraction.
+ * <p>The typical usage pattern is:
  *
- * <p>This interface is designed to copy data back and forth between existing objects during the
- * iterative processing of these algorithms and avoid the cost of recreating the objects.
+ * <ul>
+ *   <li>each domain object implements {@code ArraySliceMappable}, defining its own slice length,
+ *   <li>an algorithm-specific adapter (for example, a {@code FirstOrderDifferentialEquations}
+ *       implementation) uses an {@link ArrayMapper} to assign non-overlapping slices, and
+ *   <li>during iterative processing, {@code mapStateFromArray} / {@code mapStateToArray} shuttle
+ *       values without allocating new objects.
+ * </ul>
  *
- * <p>The nominal way to use this interface is to have the domain objects implement it (either
- * directly or using inheritance to add this feature to already existing objects) and to create one
- * class that implements the problem interface (for example {@link
- * org.spaceroots.mantissa.ode.FirstOrderDifferentialEquations}) and uses the {@link ArrayMapper}
- * class to dispatch the data to and from the domain objects.
+ * <p>Implementations are generally mutable because they update internal fields from array data.
+ * Thread-safety is not prescribed by this interface; callers should assume implementations are not
+ * safe for concurrent mutation unless documented otherwise.
  *
  * @see ArrayMapper
- * @version $Id: ArraySliceMappable.java 1454 2003-01-15 19:28:40Z luc $
  * @author L. Maisonobe
+ * @version $Id: ArraySliceMappable.java 1454 2003-01-15 19:28:40Z luc $
  */
 public interface ArraySliceMappable {
 
   /**
-   * Get the dimension of the object.
+   * Returns the number of consecutive array elements that represent this object's state.
    *
-   * @return dimension of the object
+   * <p>The returned value defines the width of the slice that {@link #mapStateFromArray(int,
+   * double[])} reads and that {@link #mapStateToArray(int, double[])} writes. Callers typically use
+   * this dimension when composing a larger state vector from multiple {@code ArraySliceMappable}
+   * instances, ensuring slices do not overlap and the backing array is large enough.
+   *
+   * @return the non-negative size of this object's state slice in array elements
    */
-  public int getStateDimension();
+  int getStateDimension();
 
   /**
-   * Reinitialize internal state from the specified array slice data.
+   * Reinitializes this object's internal state from a slice of the given array.
    *
-   * @param start start index in the array
-   * @param array array holding the data to extract
+   * <p>The slice starts at {@code start} and is {@link #getStateDimension() getStateDimension()}
+   * elements long. Implementations should read values in increasing index order and update their
+   * internal fields accordingly. This method is intended for use inside iterative algorithms, so it
+   * should avoid unnecessary allocations when possible.
+   *
+   * @param start zero-based index of the first element belonging to this object
+   * @param array backing array holding the state vector; must contain this slice
    */
-  public void mapStateFromArray(int start, double[] array);
+  void mapStateFromArray(int start, double[] array);
 
   /**
-   * Store internal state data into the specified array slice.
+   * Stores this object's current internal state into a slice of the given array.
    *
-   * @param start start index in the array
-   * @param array array where data should be stored
+   * <p>The slice starts at {@code start} and is {@link #getStateDimension() getStateDimension()}
+   * elements long. Implementations should write values in increasing index order, matching the
+   * layout expected by {@link #mapStateFromArray(int, double[])}. Callers commonly invoke this
+   * method before passing the array to a numerical algorithm or when exporting a composite state.
+   *
+   * @param start zero-based index of the first element to write for this object
+   * @param array backing array that receives the state slice; must contain this slice
    */
-  public void mapStateToArray(int start, double[] array);
+  void mapStateToArray(int start, double[] array);
 }

--- a/src/main/java/org/spaceroots/mantissa/utilities/Interval.java
+++ b/src/main/java/org/spaceroots/mantissa/utilities/Interval.java
@@ -1,33 +1,60 @@
 package org.spaceroots.mantissa.utilities;
 
 /**
- * This class represents an interval on the real line.
+ * Represents a numeric interval on the real line.
  *
- * <p>This class allows to perform simple interval operations like point inclusion tests and
- * intersection operations.
+ * <p>An {@code Interval} stores two bounds and provides a small set of operations that are useful
+ * when reasoning about ranges of real-valued quantities. Typical usage is to construct an interval
+ * from two endpoints, query its bounds or length, and test containment or overlap with points or
+ * other intervals. The class is deliberately lightweight and does not depend on any external
+ * infrastructure.
  *
- * <p>There is no distinction between open and closed intervals because real numbers cannot be
- * represented exactly.
+ * <p>The bounds are normalized at construction time so that {@code inf <= sup} holds as an
+ * invariant. Both endpoints are treated as inclusive; there is no explicit distinction between open
+ * and closed intervals, as real numbers are represented approximately in {@code double} form.
+ * Operations that combine intervals (addition and intersection) follow this inclusive model and
+ * preserve the ordering invariant.
  *
- * @see IntervalsList
+ * <p>This type is mutable: methods such as {@link #addToSelf(Interval)} and {@link
+ * #intersectSelf(Interval)} modify the receiver. Instances are not thread-safe; if shared between
+ * threads, callers should provide external synchronization or use separate instances.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> store bounds, normalize ordering, and provide basic
+ *       range operations.
+ *   <li><strong>Notable behavior:</strong> adding disjoint intervals fills the gap between them,
+ *       and intersecting disjoint intervals collapses the result to a point.
+ * </ul>
+ *
  * @author Luc Maisonobe
  * @version $Id: Interval.java 1539 2003-12-13 19:31:14Z luc $
  */
 public class Interval {
 
-  /** Build the [0, 0] interval. */
+  /**
+   * Creates the degenerate interval {@code [0, 0]}.
+   *
+   * <p>This no-argument constructor initializes both bounds to zero, yielding an interval of length
+   * {@code 0.0}. It is primarily useful as a neutral starting point when bounds are accumulated
+   * later via {@link #addToSelf(Interval)} or {@link #intersectSelf(Interval)}.
+   */
   public Interval() {
     inf = 0;
     sup = 0;
   }
 
   /**
-   * Build an interval with the given bounds.
+   * Creates an interval with the specified bounds.
    *
-   * <p>The given bounds do not need to be ordered, they will be reordered by the constructor.
+   * <p>The constructor accepts two endpoints which may be provided in either order. The bounds are
+   * normalized so that the internal lower bound {@code inf} is the smaller of {@code a} and {@code
+   * b}, and the upper bound {@code sup} is the larger. This normalization establishes the invariant
+   * {@code getInf() <= getSup()} for all instances created through this constructor.
    *
-   * @param a first bound
-   * @param b second bound
+   * <p>Both endpoints are treated as inclusive. If you need a "point interval", pass equal values.
+   *
+   * @param a first endpoint; may be less than, equal to, or greater than {@code b}
+   * @param b second endpoint; may be less than, equal to, or greater than {@code a}
    */
   public Interval(double a, double b) {
     if (a <= b) {
@@ -42,7 +69,10 @@ public class Interval {
   /**
    * Copy-constructor.
    *
-   * @param i interval to copy
+   * <p>Creates a new interval with the same bounds as the supplied interval. The new instance is
+   * independent of {@code i}; later mutations to either interval do not affect the other.
+   *
+   * @param i interval to copy; must be non-null and already normalized
    */
   public Interval(Interval i) {
     inf = i.inf;
@@ -50,72 +80,101 @@ public class Interval {
   }
 
   /**
-   * Get the lower bound of the interval.
+   * Returns the lower bound of the interval.
    *
-   * @return lower bound of the interval
+   * <p>The returned value is the smallest endpoint after normalization. It is inclusive for all
+   * containment and intersection tests. This value is stable unless the interval is mutated.
+   *
+   * @return inclusive lower endpoint of this interval
    */
   public double getInf() {
     return inf;
   }
 
   /**
-   * Get the upper bound of the interval.
+   * Returns the upper bound of the interval.
    *
-   * @return upper bound of the interval
+   * <p>The returned value is the largest endpoint after normalization. It is inclusive for all
+   * containment and intersection tests. This value is stable unless the interval is mutated.
+   *
+   * @return inclusive upper endpoint of this interval
    */
   public double getSup() {
     return sup;
   }
 
   /**
-   * Get the length of the interval.
+   * Returns the length of the interval.
    *
-   * @return length of the interval
+   * <p>The length is computed as {@code getSup() - getInf()}. For a degenerate interval, this
+   * method returns {@code 0.0}. The length can be infinite if either bound is infinite.
+   *
+   * @return non-negative interval length, possibly {@code +Infinity}
    */
   public double getLength() {
     return sup - inf;
   }
 
   /**
-   * Check if the interval contains a point.
+   * Tests whether this interval contains the given point.
    *
-   * @param x point to check
-   * @return true if the interval contains x
+   * <p>Containment is inclusive on both ends: a point equal to {@code getInf()} or {@code getSup()}
+   * is considered contained. If {@code x} is {@code NaN}, the comparison rules of {@code double}
+   * make this method return {@code false}.
+   *
+   * @param x point to test against the interval bounds, in the same numeric space
+   * @return {@code true} when {@code getInf() <= x <= getSup()}, otherwise {@code false}
    */
   public boolean contains(double x) {
     return (inf <= x) && (x <= sup);
   }
 
   /**
-   * Check if the interval contains another interval.
+   * Tests whether this interval fully contains another interval.
    *
-   * @param i interval to check
-   * @return true if i is completely included in the instance
+   * <p>The argument is considered contained when its lower bound is not below this interval's lower
+   * bound and its upper bound is not above this interval's upper bound. Endpoints that touch are
+   * treated as contained due to inclusive bounds.
+   *
+   * @param i interval to test for full inclusion; must be non-null and normalized
+   * @return {@code true} if {@code i} lies entirely within this interval, otherwise {@code false}
    */
   public boolean contains(Interval i) {
     return (inf <= i.inf) && (i.sup <= sup);
   }
 
   /**
-   * Check if an interval intersects the instance.
+   * Tests whether another interval intersects this interval.
    *
-   * @param i interval to check
-   * @return true if i intersects the instance
+   * <p>Two intervals are considered intersecting when they share at least one point under the
+   * inclusive endpoint model. In particular, intervals that touch at a single endpoint intersect.
+   * If either bound of {@code i} is {@code NaN}, the comparisons evaluate to {@code false}.
+   *
+   * @param i interval to test for overlap; must be non-null and normalized
+   * @return {@code true} if the intervals overlap or touch, otherwise {@code false}
    */
   public boolean intersects(Interval i) {
     return (inf <= i.sup) && (i.inf <= sup);
   }
 
   /**
-   * Add an interval to the instance.
+   * Expands this interval to include another interval.
    *
-   * <p>This method expands the instance.
+   * <p>This method mutates the receiver by replacing its bounds with the minimum lower bound and
+   * maximum upper bound across the two intervals. The resulting interval therefore contains both
+   * the original interval and {@code i}.
    *
-   * <p>This operation is <strong>not</strong> a union operation. If the instance and the interval
-   * are disjoints (i.e. if {@link #intersects intersects(i)} would return <code>false</code>), then
-   * the hole between the intervals is filled in.
+   * <p>This operation is <strong>not</strong> a set union on potentially disjoint intervals. If the
+   * intervals are disjoint (meaning {@link #intersects(Interval)} would return {@code false}), the
+   * gap between them is filled in and becomes part of the expanded interval.
    *
-   * @param i interval to add to the instance
+   * <pre>{@code
+   * Interval a = new Interval(0.0, 1.0);
+   * a.addToSelf(new Interval(3.0, 4.0));
+   * // a is now [0.0, 4.0]
+   * }</pre>
+   *
+   * @param i interval to include in this interval; must be non-null and normalized
    */
   public void addToSelf(Interval i) {
     inf = Math.min(inf, i.inf);
@@ -123,15 +182,16 @@ public class Interval {
   }
 
   /**
-   * Add two intervals.
+   * Returns a new interval that covers both input intervals.
    *
-   * <p>This operation is <strong>not</strong> a union operation. If the intervals are disjoints
-   * (i.e. if {@link #intersects i1.intersects(i2)} would return <code>false</code>), then the hole
-   * between the intervals is filled in.
+   * <p>This is a convenience method that does not mutate its arguments. It creates a copy of {@code
+   * i1} and expands it with {@code i2} using {@link #addToSelf(Interval)}. As with {@code
+   * addToSelf}, this operation is <strong>not</strong> a union: if {@code i1} and {@code i2} are
+   * disjoint, the returned interval fills the gap between them.
    *
-   * @param i1 first interval
-   * @param i2 second interval
-   * @return a new interval
+   * @param i1 first interval providing an initial set of bounds; must be non-null and normalized
+   * @param i2 second interval to be included in the result; must be non-null and normalized
+   * @return new interval spanning both inputs, independent of the arguments
    */
   public static Interval add(Interval i1, Interval i2) {
     Interval copy = new Interval(i1);
@@ -140,24 +200,33 @@ public class Interval {
   }
 
   /**
-   * Intersects the instance with an interval.
+   * Reduces this interval to its intersection with another interval.
    *
-   * <p>This method reduces the instance, it could even become empty if the interval does not
-   * intersects the instance.
+   * <p>This method mutates the receiver by clamping its bounds to the overlap with {@code i}. The
+   * new lower bound becomes {@code max(this.inf, i.inf)}. The new upper bound is the smaller of the
+   * two upper bounds, but never below the new lower bound.
    *
-   * @param i interval with which the instance should be intersected
+   * <p>If the intervals are disjoint, the intersection is treated as empty and represented as a
+   * degenerate interval where {@code getInf() == getSup()} at the nearest boundary. Under the
+   * inclusive model, intervals touching at a point intersect at that point.
+   *
+   * @param i interval to intersect with this instance; must be non-null and normalized
    */
   public void intersectSelf(Interval i) {
     inf = Math.max(inf, i.inf);
-    sup = Math.max(Math.min(sup, i.sup), inf);
+    sup = Math.clamp(Math.min(sup, i.sup), inf, Double.POSITIVE_INFINITY);
   }
 
   /**
-   * Intersect two intervals.
+   * Returns a new interval that is the intersection of two intervals.
    *
-   * @param i1 first interval
-   * @param i2 second interval
-   * @return a new interval which is the intersection of i1 with i2
+   * <p>This method does not mutate either argument. It copies {@code i1} and applies {@link
+   * #intersectSelf(Interval)} with {@code i2}. The result follows the same inclusive intersection
+   * rules as {@code intersectSelf}, including the degenerate representation for disjoint intervals.
+   *
+   * @param i1 first interval to intersect; must be non-null and normalized
+   * @param i2 second interval to intersect; must be non-null and normalized
+   * @return new interval representing the overlap of {@code i1} and {@code i2}
    */
   public static Interval intersection(Interval i1, Interval i2) {
     Interval copy = new Interval(i1);

--- a/src/main/java/org/spaceroots/mantissa/utilities/IntervalsList.java
+++ b/src/main/java/org/spaceroots/mantissa/utilities/IntervalsList.java
@@ -4,29 +4,68 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This class represents an intervals list.
+ * Represents a mutable set of real-valued intervals.
  *
- * <p>An interval list represent a list of contiguous regions on the real line. All intervals of the
- * list are disjoints to each other, they are stored in ascending order.
+ * <p>An {@code IntervalsList} stores a collection of {@link Interval} instances that together form
+ * a set of points on the real line. The intervals are maintained in ascending order and are
+ * intended to be pairwise disjoint; most mutating operations in this class (for example {@link
+ * #addToSelf(Interval)} and {@link #subtractFromSelf(Interval)}) preserve this normalized
+ * representation by merging or splitting intervals as required.
  *
- * <p>The class supports the main set operations like union and intersection.
+ * <p>This type is useful when you need a compact representation of a union of ranges, and you want
+ * to apply basic set operations (union, intersection, and subtraction) incrementally. Typical usage
+ * is to construct an instance, add and remove intervals as a computation progresses, and query
+ * membership with {@link #contains(double)} or bounds with {@link #getInf()} and {@link #getSup()}.
+ *
+ * <pre>{@code
+ * IntervalsList allowed = new IntervalsList();
+ * allowed.addToSelf(new Interval(0.0, 10.0));
+ * allowed.subtractFromSelf(new Interval(4.0, 6.0));
+ * boolean ok = allowed.contains(5.0); // false
+ * }</pre>
+ *
+ * <p>Instances are mutable and are not thread-safe. The {@link #getIntervals()} accessor returns
+ * the internal backing list directly; callers are expected to treat it as read-only to avoid
+ * violating ordering and disjointness invariants.
+ *
+ * <ul>
+ *   <li>Union operations: {@link #addToSelf(Interval)} and {@link #addToSelf(IntervalsList)}
+ *   <li>Intersection operations: {@link #intersectSelf(Interval)} and {@link
+ *       #intersectSelf(IntervalsList)}
+ *   <li>Subtraction operations: {@link #subtractFromSelf(Interval)} and {@link
+ *       #subtractFromSelf(IntervalsList)}
+ * </ul>
  *
  * @see Interval
  * @author Luc Maisonobe
  * @version $Id: IntervalsList.java 1694 2006-09-03 19:53:48Z luc $
  */
+@SuppressWarnings("unused")
 public class IntervalsList {
 
-  /** Build an empty intervals list. */
+  /**
+   * Build an empty intervals list.
+   *
+   * <p>The created instance contains no intervals and therefore represents the empty set of points.
+   * It can be incrementally built up with {@link #addToSelf(Interval)} or {@link
+   * #addToSelf(IntervalsList)}. In the empty state, {@link #isEmpty()} returns {@code true}, {@link
+   * #getSize()} returns {@code 0}, and {@link #getInf()} / {@link #getSup()} return {@link
+   * Double#NaN}.
+   */
   public IntervalsList() {
     intervals = new ArrayList<>();
   }
 
   /**
-   * Build an intervals list containing only one interval.
+   * Build an intervals list containing a single interval defined by two bounds.
    *
-   * @param a first bound of the interval
-   * @param b second bound of the interval
+   * <p>The created instance initially contains exactly one {@link Interval}. The interpretation of
+   * the bounds (ordering, inclusiveness, and degeneracy) is delegated to {@link Interval}; if the
+   * bounds are provided out of order, the behavior follows the {@code Interval} constructor. The
+   * resulting list is connected (see {@link #isConnex()}) until further updates are applied.
+   *
+   * @param a first bound of the interval, in the same units as all future operations
+   * @param b second bound of the interval, in the same units as {@code a}
    */
   public IntervalsList(double a, double b) {
     intervals = new ArrayList<>();
@@ -34,9 +73,14 @@ public class IntervalsList {
   }
 
   /**
-   * Build an intervals list containing only one interval.
+   * Build an intervals list containing a single existing interval.
    *
-   * @param i interval
+   * <p>The provided {@link Interval} instance is stored as-is; it is not copied. This constructor
+   * is therefore a convenience for adopting an interval object as the initial state of the list. If
+   * the caller subsequently mutates {@code i} (if it is mutable), the list will observe those
+   * changes as well.
+   *
+   * @param i interval to store as the sole element of this list
    */
   public IntervalsList(Interval i) {
     intervals = new ArrayList<>();
@@ -44,10 +88,14 @@ public class IntervalsList {
   }
 
   /**
-   * Build an intervals list containing two intervals.
+   * Build an intervals list from two intervals, normalizing order and overlap.
    *
-   * @param i1 first interval
-   * @param i2 second interval
+   * <p>If the provided intervals intersect, they are merged into a single interval that spans from
+   * the minimum lower bound to the maximum upper bound. If they do not intersect, they are stored
+   * in ascending order by lower bound.
+   *
+   * @param i1 first interval to include in the new list, possibly overlapping {@code i2}
+   * @param i2 second interval to include in the new list, possibly overlapping {@code i1}
    */
   public IntervalsList(Interval i1, Interval i2) {
     intervals = new ArrayList<>();
@@ -66,10 +114,11 @@ public class IntervalsList {
   /**
    * Copy constructor.
    *
-   * <p>The copy operation is a deep copy: the underlying intervals are independant of the instances
-   * of the copied list.
+   * <p>The copy operation is a deep copy: newly created {@link Interval} instances are stored in
+   * the new list, so subsequent modifications to the source list's intervals do not affect the
+   * copy.
    *
-   * @param list intervals list to copy
+   * @param list intervals list to copy; must not be {@code null}
    */
   public IntervalsList(IntervalsList list) {
     intervals = new ArrayList<>(list.intervals.size());
@@ -79,76 +128,110 @@ public class IntervalsList {
   }
 
   /**
-   * Check if the instance is empty.
+   * Check whether this list currently contains no intervals.
    *
-   * @return true if the instance is empty
+   * <p>This is a pure query and does not modify the instance. An empty list represents the empty
+   * set of points; in this state, {@link #getInf()} and {@link #getSup()} return {@link
+   * Double#NaN}.
+   *
+   * @return {@code true} if the instance contains zero intervals, {@code false} otherwise
    */
   public boolean isEmpty() {
     return intervals.isEmpty();
   }
 
   /**
-   * Check if the instance is connected.
+   * Check whether this list represents a connected set.
    *
-   * <p>An interval list is connected if it contains only one interval.
+   * <p>An {@code IntervalsList} is considered connected when it contains exactly one interval. In
+   * particular, an empty list is not connected. This method does not attempt to infer connectivity
+   * from adjacency; it relies solely on the current normalized representation.
    *
-   * @return true is the instance is connected
+   * @return {@code true} if the list contains exactly one interval, {@code false} otherwise
    */
   public boolean isConnex() {
     return intervals.size() == 1;
   }
 
   /**
-   * Get the lower bound of the list.
+   * Get the lower bound of the whole list.
    *
-   * @return lower bound of the list or Double.NaN if the list does not contain any interval
+   * <p>The value returned is the infimum of all points contained by this list, which corresponds to
+   * the lower bound of the first stored interval. For an empty list, the method returns {@link
+   * Double#NaN}.
+   *
+   * @return lower bound of the list, or {@link Double#NaN} when the list is empty
    */
   public double getInf() {
-    return intervals.isEmpty() ? Double.NaN : intervals.get(0).getInf();
+    return intervals.isEmpty() ? Double.NaN : intervals.getFirst().getInf();
   }
 
   /**
-   * Get the upper bound of the list.
+   * Get the upper bound of the whole list.
    *
-   * @return upper bound of the list or Double.NaN if the list does not contain any interval
+   * <p>The value returned is the supremum of all points contained by this list, which corresponds
+   * to the upper bound of the last stored interval. For an empty list, the method returns {@link
+   * Double#NaN}.
+   *
+   * @return upper bound of the list, or {@link Double#NaN} when the list is empty
    */
   public double getSup() {
-    return intervals.isEmpty() ? Double.NaN : intervals.get(intervals.size() - 1).getSup();
+    return intervals.isEmpty() ? Double.NaN : intervals.getLast().getSup();
   }
 
   /**
-   * Get the number of intervals of the list.
+   * Get the number of stored intervals.
    *
-   * @return number of intervals in the list
+   * <p>The returned value is the size of the internal normalized representation, not a measure of
+   * length or measure on the real line. Many operations (like union and subtraction) can increase
+   * or decrease this count by merging or splitting intervals.
+   *
+   * @return number of {@link Interval} instances currently stored in this list
    */
   public int getSize() {
     return intervals.size();
   }
 
   /**
-   * Get an interval from the list.
+   * Get an interval from the list by index.
    *
-   * @param i index of the interval
-   * @return interval at index i
+   * <p>The index is in ascending order (the same order as returned by {@link #getIntervals()}). The
+   * returned object is the stored {@link Interval} instance; it is not copied. If the underlying
+   * {@code Interval} objects are mutable, callers should avoid modifying them as doing so may break
+   * ordering and disjointness assumptions used by this class.
+   *
+   * @param i index of the interval to return, in the range {@code [0, getSize())}
+   * @return the interval stored at the specified index, in ascending order
+   * @throws IndexOutOfBoundsException if {@code i} is not a valid interval index
    */
   public Interval getInterval(int i) {
     return intervals.get(i);
   }
 
   /**
-   * Get the ordered list of disjoints intervals.
+   * Get the ordered list of disjoint intervals backing this instance.
    *
-   * @return list of disjoints intervals in ascending order
+   * <p>This method returns the internal list directly (no defensive copy is performed). The list is
+   * ordered in ascending order and is expected to contain disjoint intervals. For correctness, the
+   * returned list should be treated as read-only by callers; external modification may violate the
+   * invariants assumed by mutating operations.
+   *
+   * @return the internal list of disjoint intervals, ordered by increasing lower bound
    */
   public List<Interval> getIntervals() {
     return intervals;
   }
 
   /**
-   * Check if the list contains a point.
+   * Check whether this list contains a point.
    *
-   * @param x point to check
-   * @return true if the list contains x
+   * <p>The membership test is performed by scanning the stored intervals and delegating point
+   * containment to {@link Interval#contains(double)}. For a normalized list, this is an {@code
+   * O(n)} operation in the number of stored intervals.
+   *
+   * @param x point to test for membership in this interval set
+   * @return {@code true} if {@code x} belongs to at least one stored interval, {@code false}
+   *     otherwise
    */
   public boolean contains(double x) {
     for (Interval interval : intervals) {
@@ -160,10 +243,15 @@ public class IntervalsList {
   }
 
   /**
-   * Check if the list contains an interval.
+   * Check whether this list fully contains an interval.
    *
-   * @param i interval to check
-   * @return true if i is completely included in the instance
+   * <p>The interval is considered contained if there exists a stored {@link Interval} that
+   * completely contains {@code i} according to {@link Interval#contains(Interval)}. Because this
+   * list stores disjoint intervals, partial coverage across multiple intervals does not count as
+   * containment.
+   *
+   * @param i interval to test for full containment within this list
+   * @return {@code true} if any stored interval contains {@code i} in full, {@code false} otherwise
    */
   public boolean contains(Interval i) {
     for (Interval interval : intervals) {
@@ -175,10 +263,15 @@ public class IntervalsList {
   }
 
   /**
-   * Check if an interval intersects the instance.
+   * Check whether an interval intersects this list.
    *
-   * @param i interval to check
-   * @return true if i intersects the instance
+   * <p>The intersection test is performed by scanning stored intervals and delegating to {@link
+   * Interval#intersects(Interval)}. The method returns as soon as an intersecting interval is
+   * found, making the best-case runtime constant and the worst-case runtime linear in the number of
+   * stored intervals.
+   *
+   * @param i interval to test for intersection with this interval set
+   * @return {@code true} if {@code i} intersects any stored interval, {@code false} otherwise
    */
   public boolean intersects(Interval i) {
     for (Interval interval : intervals) {
@@ -190,14 +283,18 @@ public class IntervalsList {
   }
 
   /**
-   * Add an interval to the instance.
+   * Add an interval to this list (in-place union).
    *
-   * <p>This method expands the instance.
+   * <p>This method modifies the instance to represent the union of its current set and the points
+   * contained by {@code i}. If {@code i} overlaps existing intervals, they are merged so the result
+   * remains normalized (sorted and disjoint). If {@code i} lies entirely in a gap, it is inserted
+   * at the appropriate position.
    *
-   * <p>This operation is a union operation. The number of intervals in the list can decrease if the
-   * interval fills some holes between existing intervals in the list.
+   * <p>The number of stored intervals may decrease when {@code i} connects two previously disjoint
+   * intervals. The operation scans the current intervals once and therefore runs in {@code O(n)}
+   * time for {@code n = getSize()}.
    *
-   * @param i interval to add to the instance
+   * @param i interval to add to the instance; must use the same coordinate system as existing data
    */
   public void addToSelf(Interval i) {
 
@@ -239,11 +336,16 @@ public class IntervalsList {
   }
 
   /**
-   * Add an intervals list and an interval.
+   * Return the union of an intervals list and a single interval.
    *
-   * @param list intervals list
-   * @param i interval
-   * @return a new intervals list which is the union of list and i
+   * <p>This is a pure helper that leaves the input list unchanged by working on a deep copy (see
+   * {@link #IntervalsList(IntervalsList)}). The semantics match {@link #addToSelf(Interval)}
+   * applied to the copied list.
+   *
+   * @param list base intervals list to union with {@code i}; must not be {@code null}
+   * @param i interval to add to the returned list; must not be {@code null}
+   * @return a new intervals list representing {@code list ∪ i}, normalized and independent of
+   *     {@code list}
    */
   public static IntervalsList add(IntervalsList list, Interval i) {
     IntervalsList copy = new IntervalsList(list);
@@ -252,13 +354,20 @@ public class IntervalsList {
   }
 
   /**
-   * Remove an interval from the list.
+   * Remove an interval from this list (in-place subtraction).
    *
-   * <p>This method reduces the instance. This operation is defined in terms of points set
-   * operation. As an example, if the [2, 3] interval is subtracted from the list containing only
-   * the [0, 10] interval, the result will be the [0, 2] U [3, 10] intervals list.
+   * <p>This method modifies the instance to represent the set difference between its current set
+   * and the points contained by {@code i}. If {@code i} is disjoint from the list, the operation is
+   * effectively a no-op. If {@code i} overlaps stored intervals, it may shrink them or split one
+   * interval into two disjoint intervals.
    *
-   * @param i interval to remove
+   * <p>The implementation derives the result by intersecting the current list with a list
+   * representing the complement of {@code i} over a temporary finite outer range. That outer range
+   * is chosen as {@code [a - 1, b + 1]} where {@code a} and {@code b} are the minimum and maximum
+   * bounds of the current list and {@code i}. Extreme input values may cause the temporary bounds
+   * to overflow to infinities.
+   *
+   * @param i interval to remove from the instance; must not be {@code null}
    */
   public void subtractFromSelf(Interval i) {
     double a = Math.min(getInf(), i.getInf());
@@ -268,11 +377,16 @@ public class IntervalsList {
   }
 
   /**
-   * Remove an interval from a list.
+   * Return the difference of an intervals list and a single interval.
    *
-   * @param list intervals list
-   * @param i interval to remove
-   * @return a new intervals list
+   * <p>This is a pure helper that leaves the input list unchanged by working on a deep copy (see
+   * {@link #IntervalsList(IntervalsList)}). The semantics match {@link #subtractFromSelf(Interval)}
+   * applied to the copied list.
+   *
+   * @param list base intervals list from which {@code i} is removed; must not be {@code null}
+   * @param i interval to remove from the returned list; must not be {@code null}
+   * @return a new intervals list representing {@code list \\ i}, normalized and independent of
+   *     {@code list}
    */
   public static IntervalsList subtract(IntervalsList list, Interval i) {
     IntervalsList copy = new IntervalsList(list);
@@ -281,9 +395,17 @@ public class IntervalsList {
   }
 
   /**
-   * Intersects the instance and an interval.
+   * Intersect this list with a single interval (in-place intersection).
    *
-   * @param i interval
+   * <p>This method modifies the instance to contain only the points that are present both in the
+   * current list and in {@code i}. Any stored interval that does not intersect {@code i} is
+   * removed; intersecting intervals are replaced by their pairwise intersection computed via {@link
+   * Interval#intersection(Interval, Interval)}.
+   *
+   * <p>The operation scans the current intervals once and therefore runs in {@code O(n)} time for
+   * {@code n = getSize()}.
+   *
+   * @param i interval to intersect with the current instance; must not be {@code null}
    */
   public void intersectSelf(Interval i) {
     List<Interval> newIntervals = new ArrayList<>(intervals.size());
@@ -296,11 +418,16 @@ public class IntervalsList {
   }
 
   /**
-   * Intersect a list and an interval.
+   * Return the intersection of an intervals list and a single interval.
    *
-   * @param list intervals list
-   * @param i interval
-   * @return the intersection of list and i
+   * <p>This is a pure helper that leaves the input list unchanged by working on a deep copy (see
+   * {@link #IntervalsList(IntervalsList)}). The semantics match {@link #intersectSelf(Interval)}
+   * applied to the copied list.
+   *
+   * @param list base intervals list to intersect with {@code i}; must not be {@code null}
+   * @param i interval to intersect with {@code list}; must not be {@code null}
+   * @return a new intervals list representing {@code list ∩ i}, normalized and independent of
+   *     {@code list}
    */
   public static IntervalsList intersection(IntervalsList list, Interval i) {
     IntervalsList copy = new IntervalsList(list);
@@ -309,14 +436,17 @@ public class IntervalsList {
   }
 
   /**
-   * Add an intervals list to the instance.
+   * Add another intervals list to this instance (in-place union).
    *
-   * <p>This method expands the instance.
+   * <p>This method modifies this instance to represent the union of its current set and all
+   * intervals contained in {@code list}. The operation iterates over the other list's internal
+   * intervals and applies {@link #addToSelf(Interval)} for each.
    *
-   * <p>This operation is a union operation. The number of intervals in the list can decrease if the
-   * list fills some holes between existing intervals in the instance.
+   * <p>Because each individual addition may scan the current list, the overall runtime is roughly
+   * {@code O(n * m)} for {@code n = getSize()} and {@code m = list.getSize()} in the worst case.
+   * The result remains normalized (sorted and disjoint).
    *
-   * @param list intervals list to add to the instance
+   * @param list intervals list to union into this instance; must not be {@code null}
    */
   public void addToSelf(IntervalsList list) {
     for (Interval interval : list.intervals) {
@@ -325,11 +455,16 @@ public class IntervalsList {
   }
 
   /**
-   * Add two intervals lists.
+   * Return the union of two intervals lists.
    *
-   * @param list1 first intervals list
-   * @param list2 second intervals list
-   * @return a new intervals list which is the union of list1 and list2
+   * <p>This is a pure helper that leaves the input lists unchanged by working on a deep copy of
+   * {@code list1} (see {@link #IntervalsList(IntervalsList)}). The semantics match calling {@link
+   * #addToSelf(IntervalsList)} on the copied list.
+   *
+   * @param list1 first intervals list providing the base content; must not be {@code null}
+   * @param list2 second intervals list to union into the result; must not be {@code null}
+   * @return a new intervals list representing {@code list1 ∪ list2}, normalized and independent of
+   *     the inputs
    */
   public static IntervalsList add(IntervalsList list1, IntervalsList list2) {
     IntervalsList copy = new IntervalsList(list1);
@@ -338,9 +473,17 @@ public class IntervalsList {
   }
 
   /**
-   * Remove an intervals list from the instance.
+   * Remove all intervals from another list from this instance (in-place subtraction).
    *
-   * @param list intervals list to remove
+   * <p>This method iterates over the other list's internal intervals and applies {@link
+   * #subtractFromSelf(Interval)} for each. Each subtraction may split existing intervals, and the
+   * number of stored intervals can increase or decrease accordingly.
+   *
+   * <p>The operation is order-dependent only with respect to intermediate representations; the
+   * final result corresponds to subtracting the union of all intervals in {@code list}.
+   *
+   * @param list intervals list whose points are removed from this instance; must not be {@code
+   *     null}
    */
   public void subtractFromSelf(IntervalsList list) {
     for (Interval interval : list.intervals) {
@@ -349,11 +492,16 @@ public class IntervalsList {
   }
 
   /**
-   * Remove an intervals list from another one.
+   * Return the difference of two intervals lists.
    *
-   * @param list1 intervals list
-   * @param list2 intervals list to remove
-   * @return a new intervals list
+   * <p>This is a pure helper that leaves the input lists unchanged by working on a deep copy of
+   * {@code list1} (see {@link #IntervalsList(IntervalsList)}). The semantics match calling {@link
+   * #subtractFromSelf(IntervalsList)} on the copied list.
+   *
+   * @param list1 base intervals list from which {@code list2} is removed; must not be {@code null}
+   * @param list2 intervals list to remove from the result; must not be {@code null}
+   * @return a new intervals list representing {@code list1 \\ list2}, normalized and independent of
+   *     the inputs
    */
   public static IntervalsList subtract(IntervalsList list1, IntervalsList list2) {
     IntervalsList copy = new IntervalsList(list1);
@@ -362,20 +510,35 @@ public class IntervalsList {
   }
 
   /**
-   * Intersect the instance and another intervals list.
+   * Intersect this list with another intervals list (in-place intersection).
    *
-   * @param list list to intersect with the instance
+   * <p>This method modifies the instance to contain only points that belong to both lists. The
+   * computation is performed via {@link #intersection(IntervalsList, IntervalsList)}, and the
+   * internal interval list is replaced with the result's internal representation.
+   *
+   * <p>Because this method replaces the backing list, any external references obtained earlier via
+   * {@link #getIntervals()} will not observe the updated contents.
+   *
+   * @param list list to intersect with this instance; must not be {@code null}
    */
   public void intersectSelf(IntervalsList list) {
     intervals = intersection(this, list).intervals;
   }
 
   /**
-   * Intersect two intervals lists.
+   * Return the intersection of two intervals lists.
    *
-   * @param list1 first intervals list
-   * @param list2 second intervals list
-   * @return a new list which is the intersection of list1 and list2
+   * <p>This method builds a new list containing only the points present in both inputs. The
+   * computation iterates over the second list's intervals and unions their individual intersections
+   * with {@code list1}. This approach keeps the intermediate and final results normalized.
+   *
+   * <p>The runtime depends on the sizes and shapes of the input lists; in the worst case it may be
+   * quadratic in the number of stored intervals.
+   *
+   * @param list1 first intervals list participating in the intersection; must not be {@code null}
+   * @param list2 second intervals list participating in the intersection; must not be {@code null}
+   * @return a new intervals list representing {@code list1 ∩ list2}, normalized and independent of
+   *     the inputs
    */
   public static IntervalsList intersection(IntervalsList list1, IntervalsList list2) {
     IntervalsList list = new IntervalsList();

--- a/src/main/java/org/spaceroots/mantissa/utilities/MappableArray.java
+++ b/src/main/java/org/spaceroots/mantissa/utilities/MappableArray.java
@@ -1,8 +1,25 @@
 package org.spaceroots.mantissa.utilities;
 
 /**
- * Wrapper class around an array in order to have it implement the {@link ArraySliceMappable}
- * interface.
+ * Wraps a {@code double[]} and exposes it through the {@link ArraySliceMappable} contract.
+ *
+ * <p>This type is a small adapter used when an algorithm expects an {@link ArraySliceMappable}
+ * instance but the state is naturally represented as a plain Java array. The instance owns an
+ * internal array and provides copy-based accessors to read from or write to slices of a larger
+ * workspace array. This makes it convenient to pack multiple states into a single buffer (for
+ * example, in integrators or optimizers) while still manipulating each state as a dedicated object.
+ *
+ * <p>The internal array is mutable through {@link #mapStateFromArray(int, double[])}, but callers
+ * never receive a direct reference to it: both the array constructor and {@link #getArray()}
+ * perform defensive copies. Instances are not thread-safe; if the same instance is accessed from
+ * multiple threads, external synchronization is required.
+ *
+ * <ul>
+ *   <li><strong>Responsibility:</strong> bridge between array slices and an owned state array
+ *   <li><strong>Invariant:</strong> the state dimension equals the internal array length
+ *   <li><strong>Copying:</strong> mapping operations use {@link System#arraycopy(Object, int,
+ *       Object, int, int)}
+ * </ul>
  *
  * @version $Id: MappableArray.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
@@ -10,9 +27,18 @@ package org.spaceroots.mantissa.utilities;
 public class MappableArray implements ArraySliceMappable {
 
   /**
-   * Simple constructor. Build a mappable array from its dimension
+   * Creates a new instance with the specified state dimension.
    *
-   * @param dimension dimension of the array
+   * <p>This constructor allocates an internal {@code double[]} of length {@code dimension} and
+   * initializes all entries to {@code 0.0}. The resulting instance can then be used with mapping
+   * methods to copy values from a larger workspace array into the internal state, or to export the
+   * internal state back into a workspace array.
+   *
+   * <p>The internal array is owned by this instance and is never exposed directly. The dimension is
+   * fixed for the lifetime of the instance.
+   *
+   * @param dimension number of state elements to allocate; must be non-negative
+   * @throws NegativeArraySizeException if {@code dimension} is negative
    */
   public MappableArray(int dimension) {
     internalArray = new double[dimension];
@@ -22,52 +48,96 @@ public class MappableArray implements ArraySliceMappable {
   }
 
   /**
-   * Simple constructor. Build a mappable array from an existing array
+   * Creates a new instance by copying values from an existing array.
    *
-   * @param array array to use
+   * <p>The provided {@code array} defines both the initial contents and the fixed state dimension.
+   * This constructor performs a defensive copy; subsequent changes to the caller's array do not
+   * affect this instance, and later updates to this instance do not mutate the caller's array.
+   *
+   * <p>Use {@link #getArray()} to retrieve a snapshot of the current state, or use the mapping
+   * methods to read from and write to slices of external workspace arrays.
+   *
+   * @param array source values to copy; must be non-null and fully initialized
+   * @throws NullPointerException if {@code array} is {@code null}
    */
   public MappableArray(double[] array) {
-    internalArray = (double[]) array.clone();
+    internalArray = array.clone();
   }
 
   /**
-   * Get the array stored in the instance.
+   * Returns a snapshot of the current internal state.
    *
-   * @return array stored in the instance
+   * <p>This method returns a defensive copy of the internal array so callers cannot mutate the
+   * instance state by accident. The returned array is owned by the caller and can be modified
+   * freely. For bulk copying into an existing workspace buffer, prefer {@link #mapStateToArray(int,
+   * double[])} to avoid allocating a new array.
+   *
+   * @return a newly allocated array containing the current state values
    */
   public double[] getArray() {
-    return (double[]) internalArray.clone();
+    return internalArray.clone();
   }
 
   /**
-   * Get the dimension of the internal array.
+   * Returns the dimension of the state represented by this instance.
    *
-   * @return dimension of the array
+   * <p>The dimension is defined as the length of the internal array and is fixed at construction
+   * time. Mapping operations copy exactly this many elements between this instance and a backing
+   * workspace array. This value can be used to size workspace arrays and to validate offsets before
+   * invoking {@link #mapStateFromArray(int, double[])} or {@link #mapStateToArray(int, double[])}.
+   *
+   * @return the number of {@code double} values in the state vector
    */
   public int getStateDimension() {
     return internalArray.length;
   }
 
   /**
-   * Reinitialize internal state from the specified array slice data.
+   * Updates the internal state by copying a slice from the provided array.
    *
-   * @param start start index in the array
-   * @param array array holding the data to extract
+   * <p>This method copies {@link #getStateDimension()} consecutive elements starting at {@code
+   * start} from {@code array} into this instance's internal array. It does not retain a reference
+   * to the provided array and performs the copy using {@link System#arraycopy(Object, int, Object,
+   * int, int)}.
+   *
+   * <p>The copy is not bounds-checked beyond what {@code arraycopy} performs; invalid indices
+   * result in runtime exceptions.
+   *
+   * @param start start index in {@code array} where the state slice begins
+   * @param array source array holding at least {@code start + getStateDimension()} elements
+   * @throws NullPointerException if {@code array} is {@code null}
+   * @throws ArrayIndexOutOfBoundsException if the requested slice is outside {@code array}
    */
   public void mapStateFromArray(int start, double[] array) {
     System.arraycopy(array, start, internalArray, 0, internalArray.length);
   }
 
   /**
-   * Store internal state data into the specified array slice.
+   * Stores the current internal state into a slice of the provided array.
    *
-   * @param start start index in the array
-   * @param array array where data should be stored
+   * <p>This method copies {@link #getStateDimension()} consecutive elements from this instance's
+   * internal array into {@code array}, starting at index {@code start}. It is useful for packing
+   * the state into a shared workspace buffer without allocating new arrays.
+   *
+   * <p>The copy is performed using {@link System#arraycopy(Object, int, Object, int, int)} and will
+   * fail fast with runtime exceptions if {@code array} is {@code null} or too small for the
+   * requested slice.
+   *
+   * @param start start index in {@code array} where the state slice is stored
+   * @param array destination array large enough to receive {@code getStateDimension()} values
+   * @throws NullPointerException if {@code array} is {@code null}
+   * @throws ArrayIndexOutOfBoundsException if the requested slice is outside {@code array}
    */
   public void mapStateToArray(int start, double[] array) {
     System.arraycopy(internalArray, 0, array, start, internalArray.length);
   }
 
-  /** Internal array holding all data. */
+  /**
+   * Internal array holding the current state values.
+   *
+   * <p>This field is intentionally package-private for use within the Mantissa utilities package.
+   * External callers should treat the state as encapsulated and use {@link #getArray()} or the
+   * mapping methods to access it via defensive copies.
+   */
   double[] internalArray;
 }

--- a/src/main/java/org/spaceroots/mantissa/utilities/MappableScalar.java
+++ b/src/main/java/org/spaceroots/mantissa/utilities/MappableScalar.java
@@ -1,50 +1,101 @@
 package org.spaceroots.mantissa.utilities;
 
 /**
- * Wrapper class around a scalar in order to have it implement the {@link ArraySliceMappable}
- * interface.
+ * Adapts a single {@code double} value to the {@link ArraySliceMappable} interface.
  *
+ * <p>This class is a lightweight bridge for APIs that operate on state vectors represented as
+ * contiguous slices of primitive arrays. It stores one scalar value and exposes it as a
+ * one-dimensional state: {@link #getStateDimension()} always returns {@code 1}, and the mapping
+ * methods read from and write to {@code array[start]} without copying or additional allocation.
+ *
+ * <p>The instance is intentionally mutable: callers may update the value via {@link
+ * #setValue(double)} or by calling {@link #mapStateFromArray(int, double[])}. This makes it
+ * convenient as a reusable container in iterative algorithms, but it also means the class is not
+ * thread-safe; external synchronization is required if the same instance is shared across threads.
+ *
+ * <ul>
+ *   <li>Represents a scalar as a one-element array slice for mapping APIs.
+ *   <li>Provides simple getters and setters for direct scalar access.
+ *   <li>Performs no bounds checking beyond what the JVM enforces.
+ * </ul>
+ *
+ * @see ArraySliceMappable
+ * @see #mapStateFromArray(int, double[])
+ * @see #mapStateToArray(int, double[])
  * @version $Id: MappableScalar.java 1346 2002-09-05 19:03:58Z luc $
  * @author L. Maisonobe
  */
+@SuppressWarnings("unused")
 public class MappableScalar implements ArraySliceMappable {
 
-  /** Simple constructor. Build a mappable scalar */
+  /**
+   * Creates a new instance with an initial value of {@code 0.0}.
+   *
+   * <p>This constructor is useful when the initial value is not known yet and will be provided
+   * later, either through {@link #setValue(double)} or through {@link #mapStateFromArray(int,
+   * double[])}. The created instance always reports a state dimension of {@code 1}.
+   *
+   * <p>No external resources are acquired, and construction is constant-time. The instance starts
+   * in a valid state immediately after construction and can be reused across multiple mapping
+   * operations by updating its value between calls.
+   */
   public MappableScalar() {
     value = 0;
   }
 
   /**
-   * Simple constructor. Build a mappable scalar from its initial value
+   * Creates a new instance initialized to the provided scalar value.
    *
-   * @param value initial value of the scalar
+   * <p>The provided value is stored as-is, without validation or normalization. In particular,
+   * {@code NaN} and infinite values are permitted and will be preserved when mapping to and from
+   * arrays. The created instance always reports a state dimension of {@code 1}.
+   *
+   * <p>Construction performs a single field assignment and does not allocate additional objects.
+   *
+   * @param value initial scalar value to store; any {@code double} is accepted
    */
   public MappableScalar(double value) {
     this.value = value;
   }
 
   /**
-   * Get the value stored in the instance.
+   * Returns the current scalar value stored in this instance.
    *
-   * @return value stored in the instance
+   * <p>The returned value reflects the most recent call to {@link #setValue(double)} or {@link
+   * #mapStateFromArray(int, double[])}. No defensive copying is required since the value is a
+   * primitive {@code double}. This method does not perform synchronization; if another thread
+   * mutates the instance concurrently, the returned value is simply whichever value is observed at
+   * the time of the read.
+   *
+   * @return the current scalar value stored in this mutable container
    */
   public double getValue() {
     return value;
   }
 
   /**
-   * Set the value stored in the instance.
+   * Updates the scalar value stored in this instance.
    *
-   * @param value value to store in the instance
+   * <p>This is a simple mutator with no side effects beyond updating the stored value. The value is
+   * stored as provided, including {@code NaN} and infinities. Subsequent calls to {@link
+   * #mapStateToArray(int, double[])} will write this value into the target array. This method does
+   * not perform synchronization; if the instance is shared across threads, callers must provide
+   * external synchronization to define update ordering.
+   *
+   * @param value new scalar value to store; any {@code double} is accepted
    */
   public void setValue(double value) {
     this.value = value;
   }
 
   /**
-   * Get the dimension of the internal array.
+   * Returns the dimension of the mapped state vector.
    *
-   * @return dimension of the array (always 1 for this class)
+   * <p>This implementation always returns {@code 1} because a {@code MappableScalar} represents a
+   * single scalar value when adapted to array-slice based APIs. Callers can use this constant
+   * dimension to size arrays or validate that a mapping target is compatible.
+   *
+   * @return {@code 1}, indicating a one-element state representation
    */
   public int getStateDimension() {
     return 1;
@@ -53,8 +104,15 @@ public class MappableScalar implements ArraySliceMappable {
   /**
    * Reinitialize internal state from the specified array slice data.
    *
-   * @param start start index in the array
-   * @param array array holding the data to extract
+   * <p>This method reads exactly one element from {@code array} and stores it as the current value.
+   * The read location is {@code array[start]}. No explicit bounds checks are performed; if {@code
+   * array} is {@code null} or {@code start} is out of range, the JVM will throw the corresponding
+   * runtime exception.
+   *
+   * @param start index of the scalar within {@code array}; must be in range
+   * @param array array holding state values; must be non-null and long enough
+   * @throws NullPointerException if {@code array} is {@code null}
+   * @throws ArrayIndexOutOfBoundsException if {@code start} is outside array bounds
    */
   public void mapStateFromArray(int start, double[] array) {
     value = array[start];
@@ -63,13 +121,20 @@ public class MappableScalar implements ArraySliceMappable {
   /**
    * Store internal state data into the specified array slice.
    *
-   * @param start start index in the array
-   * @param array array where data should be stored
+   * <p>This method writes exactly one element to {@code array}. The write location is {@code
+   * array[start]}, and the stored value is the current scalar as returned by {@link #getValue()}.
+   * No explicit bounds checks are performed; if {@code array} is {@code null} or {@code start} is
+   * out of range, the JVM will throw the corresponding runtime exception.
+   *
+   * @param start index of the scalar within {@code array}; must be in range
+   * @param array array where the scalar should be stored; must be non-null and writable
+   * @throws NullPointerException if {@code array} is {@code null}
+   * @throws ArrayIndexOutOfBoundsException if {@code start} is outside array bounds
    */
   public void mapStateToArray(int start, double[] array) {
     array[start] = value;
   }
 
-  /** Internal scalar. */
+  /** Current scalar value, mutated by setters and mapping operations. */
   double value;
 }

--- a/src/test/java/org/spaceroots/mantissa/utilities/ArrayMapperEntryTest.java
+++ b/src/test/java/org/spaceroots/mantissa/utilities/ArrayMapperEntryTest.java
@@ -1,0 +1,47 @@
+package org.spaceroots.mantissa.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ArrayMapperEntryTest {
+
+  @Mock private ArraySliceMappable mappable;
+
+  @Test
+  void constructor_whenGivenObjectAndOffset_expectFieldsExposedUnmodified() {
+    int offset = 5;
+
+    ArrayMapperEntry entry = new ArrayMapperEntry(mappable, offset);
+
+    assertSame(mappable, entry.object());
+    assertEquals(offset, entry.offset());
+  }
+
+  @Test
+  void constructor_whenObjectNull_expectNullStoredAndOffsetPreserved() {
+    int offset = 0;
+
+    ArrayMapperEntry entry = new ArrayMapperEntry(null, offset);
+
+    assertNull(entry.object());
+    assertEquals(offset, entry.offset());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, -1, Integer.MAX_VALUE, Integer.MIN_VALUE})
+  void constructor_whenOffsetBoundaryValues_expectExactValueStored(int offset) {
+    ArrayMapperEntry entry = new ArrayMapperEntry(mappable, offset);
+
+    assertEquals(offset, entry.offset());
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/utilities/ArrayMapperTest.java
+++ b/src/test/java/org/spaceroots/mantissa/utilities/ArrayMapperTest.java
@@ -1,0 +1,215 @@
+package org.spaceroots.mantissa.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ArrayMapperTest {
+
+  @Mock private ArraySliceMappable mock1;
+  @Mock private ArraySliceMappable mock2;
+
+  @Test
+  void constructor_default_whenNoObjects_expectEmptyDataArrayAndNoOpUpdates() {
+    ArrayMapper mapper = new ArrayMapper();
+
+    assertArrayEquals(new double[0], mapper.getDataArray());
+
+    mapper.updateArray();
+    mapper.updateObjects();
+  }
+
+  @Test
+  void constructor_withObject_whenInitialized_expectSizeAndUpdateArrayRoundTrip() {
+    DummyMappable dummy = new DummyMappable(2);
+    dummy.setState(7.0, 8.0);
+
+    ArrayMapper mapper = new ArrayMapper(dummy);
+
+    assertEquals(2, mapper.getDataArray().length);
+
+    mapper.updateArray();
+    assertArrayEquals(new double[] {7.0, 8.0}, mapper.getDataArray());
+
+    mapper.updateObjects(new double[] {1.0, 2.0});
+    assertArrayEquals(new double[] {1.0, 2.0}, dummy.getState());
+  }
+
+  @Test
+  void manageMappable_whenAddedToEmptyMapper_expectOffsetsAndDispatching() {
+    DummyMappable first = new DummyMappable(2);
+    DummyMappable second = new DummyMappable(3);
+
+    ArrayMapper mapper = new ArrayMapper();
+    mapper.manageMappable(first);
+    mapper.manageMappable(second);
+
+    double[] flat = new double[] {10.0, 11.0, 12.0, 13.0, 14.0};
+    mapper.updateObjects(flat);
+
+    assertArrayEquals(new double[] {10.0, 11.0}, first.getState());
+    assertArrayEquals(new double[] {12.0, 13.0, 14.0}, second.getState());
+
+    first.setState(20.0, 21.0);
+    second.setState(22.0, 23.0, 24.0);
+
+    double[] out = new double[5];
+    mapper.updateArray(out);
+    assertArrayEquals(new double[] {20.0, 21.0, 22.0, 23.0, 24.0}, out);
+  }
+
+  @Test
+  void updateObjects_whenInternalDataNull_expectLazyInitAndCorrectOffsets() {
+    when(mock1.getStateDimension()).thenReturn(1);
+    when(mock2.getStateDimension()).thenReturn(2);
+
+    ArrayMapper mapper = new ArrayMapper();
+    mapper.manageMappable(mock1);
+    mapper.manageMappable(mock2);
+
+    mapper.updateObjects();
+
+    ArgumentCaptor<double[]> captor = ArgumentCaptor.forClass(double[].class);
+    verify(mock1).mapStateFromArray(eq(0), captor.capture());
+    double[] dataForFirst = captor.getValue();
+
+    ArgumentCaptor<double[]> captorSecond = ArgumentCaptor.forClass(double[].class);
+    verify(mock2).mapStateFromArray(eq(1), captorSecond.capture());
+    double[] dataForSecond = captorSecond.getValue();
+
+    assertNotSame(null, dataForFirst);
+    assertEquals(3, dataForFirst.length);
+    assertEquals(dataForFirst, dataForSecond);
+  }
+
+  @Test
+  void updateArray_whenInternalDataNull_expectLazyInitAndCorrectOffsets() {
+    when(mock1.getStateDimension()).thenReturn(2);
+    when(mock2.getStateDimension()).thenReturn(1);
+
+    ArrayMapper mapper = new ArrayMapper();
+    mapper.manageMappable(mock1);
+    mapper.manageMappable(mock2);
+
+    mapper.updateArray();
+
+    ArgumentCaptor<double[]> captor = ArgumentCaptor.forClass(double[].class);
+    verify(mock1).mapStateToArray(eq(0), captor.capture());
+    double[] dataForFirst = captor.getValue();
+
+    ArgumentCaptor<double[]> captorSecond = ArgumentCaptor.forClass(double[].class);
+    verify(mock2).mapStateToArray(eq(2), captorSecond.capture());
+    double[] dataForSecond = captorSecond.getValue();
+
+    assertEquals(3, dataForFirst.length);
+    assertEquals(dataForFirst, dataForSecond);
+  }
+
+  @Test
+  void getDataArray_whenMutatedByCaller_expectDefensiveCopy() {
+    DummyMappable dummy = new DummyMappable(2);
+    ArrayMapper mapper = new ArrayMapper(dummy);
+
+    double[] first = mapper.getDataArray();
+    first[0] = 123.0;
+
+    double[] second = mapper.getDataArray();
+
+    assertEquals(0.0, second[0]);
+  }
+
+  @Test
+  void manageMappable_whenInternalDataAlreadyInitialized_expectInternalDataReset() {
+    DummyMappable first = new DummyMappable(2);
+    first.setState(5.0, 6.0);
+    DummyMappable second = new DummyMappable(1);
+
+    ArrayMapper mapper = new ArrayMapper(first);
+    mapper.updateArray();
+    assertArrayEquals(new double[] {5.0, 6.0}, mapper.getDataArray());
+
+    mapper.manageMappable(second);
+    mapper.updateObjects();
+
+    assertArrayEquals(new double[] {0.0, 0.0}, first.getState());
+    assertArrayEquals(new double[] {0.0}, second.getState());
+  }
+
+  @Test
+  void updateObjects_whenDataTooShort_expectArrayIndexOutOfBoundsException() {
+    DummyMappable dummy = new DummyMappable(3);
+    ArrayMapper mapper = new ArrayMapper(dummy);
+
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class, () -> mapper.updateObjects(new double[] {1.0, 2.0}));
+  }
+
+  @Test
+  void manageMappable_whenNullObject_expectNullPointerException() {
+    ArrayMapper mapper = new ArrayMapper();
+
+    assertThrows(NullPointerException.class, () -> mapper.manageMappable(null));
+  }
+
+  @Test
+  void updateArray_whenProvidedArray_expectCallsForAllObjectsInOrder() {
+    when(mock1.getStateDimension()).thenReturn(1);
+    when(mock2.getStateDimension()).thenReturn(1);
+
+    ArrayMapper mapper = new ArrayMapper();
+    mapper.manageMappable(mock1);
+    mapper.manageMappable(mock2);
+
+    double[] target = new double[2];
+    mapper.updateArray(target);
+
+    verify(mock1, times(1)).mapStateToArray(0, target);
+    verify(mock2, times(1)).mapStateToArray(1, target);
+  }
+
+  private static final class DummyMappable implements ArraySliceMappable {
+    private final int dimension;
+    private final double[] state;
+
+    private DummyMappable(int dimension) {
+      this.dimension = dimension;
+      this.state = new double[dimension];
+    }
+
+    @Override
+    public int getStateDimension() {
+      return dimension;
+    }
+
+    @Override
+    public void mapStateFromArray(int start, double[] array) {
+      System.arraycopy(array, start, state, 0, dimension);
+    }
+
+    @Override
+    public void mapStateToArray(int start, double[] array) {
+      System.arraycopy(state, 0, array, start, dimension);
+    }
+
+    private void setState(double... values) {
+      System.arraycopy(values, 0, state, 0, dimension);
+    }
+
+    private double[] getState() {
+      return state.clone();
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/utilities/IntervalTest.java
+++ b/src/test/java/org/spaceroots/mantissa/utilities/IntervalTest.java
@@ -1,0 +1,265 @@
+package org.spaceroots.mantissa.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@SuppressWarnings("java:S100")
+class IntervalTest {
+
+  @Test
+  void constructor_default_expectZeroBoundsAndLength() {
+    Interval interval = new Interval();
+
+    assertAll(
+        () -> assertEquals(0.0, interval.getInf()),
+        () -> assertEquals(0.0, interval.getSup()),
+        () -> assertEquals(0.0, interval.getLength()));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1.0,2.0,1.0,2.0",
+    "2.0,1.0,1.0,2.0",
+    "-5.0,-2.0,-5.0,-2.0",
+    "-2.0,-5.0,-5.0,-2.0",
+    "-1.0,3.0,-1.0,3.0"
+  })
+  void constructor_whenBoundsUnordered_expectOrderedInterval(
+      double a, double b, double expectedInf, double expectedSup) {
+    Interval interval = new Interval(a, b);
+
+    assertAll(
+        () -> assertEquals(expectedInf, interval.getInf()),
+        () -> assertEquals(expectedSup, interval.getSup()),
+        () -> assertEquals(expectedSup - expectedInf, interval.getLength()));
+  }
+
+  @Test
+  void constructor_copy_expectIndependentCopyWithSameValues() {
+    Interval original = new Interval(-2.0, 5.0);
+    Interval copy = new Interval(original);
+
+    assertAll(
+        () -> assertEquals(original.getInf(), copy.getInf()),
+        () -> assertEquals(original.getSup(), copy.getSup()),
+        () -> assertEquals(original.getLength(), copy.getLength()));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "-1.0,1.0,-1.0,true",
+    "-1.0,1.0,1.0,true",
+    "-1.0,1.0,0.0,true",
+    "-1.0,1.0,-1.0001,false",
+    "-1.0,1.0,1.0001,false"
+  })
+  void contains_whenPointProvided_expectCorrectInclusion(
+      double inf, double sup, double x, boolean expected) {
+    Interval interval = new Interval(inf, sup);
+
+    boolean result = interval.contains(x);
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void contains_whenPointIsNaN_expectFalse() {
+    Interval interval = new Interval(-1.0, 1.0);
+
+    boolean result = interval.contains(Double.NaN);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void contains_whenIntervalFullyInside_expectTrue() {
+    Interval outer = new Interval(-10.0, 10.0);
+    Interval inner = new Interval(-2.0, 3.0);
+
+    boolean result = outer.contains(inner);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void contains_whenIntervalTouchesBounds_expectTrue() {
+    Interval outer = new Interval(0.0, 5.0);
+    Interval touching = new Interval(0.0, 5.0);
+
+    boolean result = outer.contains(touching);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void contains_whenIntervalPartiallyOutside_expectFalse() {
+    Interval outer = new Interval(0.0, 5.0);
+    Interval other = new Interval(-1.0, 3.0);
+
+    boolean result = outer.contains(other);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void intersects_whenOverlapping_expectTrue() {
+    Interval i1 = new Interval(0.0, 5.0);
+    Interval i2 = new Interval(3.0, 7.0);
+
+    boolean result = i1.intersects(i2);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void intersects_whenDisjoint_expectFalse() {
+    Interval i1 = new Interval(0.0, 2.0);
+    Interval i2 = new Interval(3.0, 4.0);
+
+    boolean result = i1.intersects(i2);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void intersects_whenTouchingAtSinglePoint_expectTrue() {
+    Interval i1 = new Interval(0.0, 2.0);
+    Interval i2 = new Interval(2.0, 3.0);
+
+    boolean result = i1.intersects(i2);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void intersects_whenOtherHasNaNBound_expectFalse() {
+    Interval i1 = new Interval(0.0, 2.0);
+    Interval i2 = new Interval(Double.NaN, 1.0);
+
+    boolean result = i1.intersects(i2);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void addToSelf_whenOverlapping_expectExpandedBounds() {
+    Interval interval = new Interval(0.0, 5.0);
+    Interval toAdd = new Interval(3.0, 7.0);
+
+    interval.addToSelf(toAdd);
+
+    assertAll(
+        () -> assertEquals(0.0, interval.getInf()),
+        () -> assertEquals(7.0, interval.getSup()),
+        () -> assertEquals(7.0, interval.getLength()));
+  }
+
+  @Test
+  void addToSelf_whenDisjoint_expectHoleFilled() {
+    Interval interval = new Interval(0.0, 1.0);
+    Interval toAdd = new Interval(3.0, 4.0);
+
+    interval.addToSelf(toAdd);
+
+    assertAll(
+        () -> assertEquals(0.0, interval.getInf()),
+        () -> assertEquals(4.0, interval.getSup()),
+        () -> assertEquals(4.0, interval.getLength()));
+  }
+
+  @Test
+  void add_whenCalled_expectNewIntervalAndInputsUnchanged() {
+    Interval i1 = new Interval(0.0, 1.0);
+    Interval i2 = new Interval(3.0, 4.0);
+
+    Interval result = Interval.add(i1, i2);
+
+    assertAll(
+        () -> assertEquals(0.0, result.getInf()),
+        () -> assertEquals(4.0, result.getSup()),
+        () -> assertEquals(0.0, i1.getInf()),
+        () -> assertEquals(1.0, i1.getSup()),
+        () -> assertEquals(3.0, i2.getInf()),
+        () -> assertEquals(4.0, i2.getSup()));
+  }
+
+  @Test
+  void intersection_whenOverlapping_expectCorrectIntersection() {
+    Interval i1 = new Interval(0.0, 5.0);
+    Interval i2 = new Interval(3.0, 7.0);
+
+    Interval result = Interval.intersection(i1, i2);
+
+    assertAll(
+        () -> assertEquals(3.0, result.getInf()),
+        () -> assertEquals(5.0, result.getSup()),
+        () -> assertEquals(2.0, result.getLength()));
+  }
+
+  @Test
+  void intersection_whenDisjoint_expectEmptyIntersectionAtNearestPoint() {
+    Interval i1 = new Interval(0.0, 1.0);
+    Interval i2 = new Interval(3.0, 4.0);
+
+    Interval result = Interval.intersection(i1, i2);
+
+    assertAll(
+        () -> assertEquals(3.0, result.getInf()),
+        () -> assertEquals(3.0, result.getSup()),
+        () -> assertEquals(0.0, result.getLength()));
+  }
+
+  @Test
+  void intersectSelf_whenOverlapping_expectReducedBounds() {
+    Interval interval = new Interval(0.0, 5.0);
+    Interval other = new Interval(3.0, 7.0);
+
+    interval.intersectSelf(other);
+
+    assertAll(
+        () -> assertEquals(3.0, interval.getInf()),
+        () -> assertEquals(5.0, interval.getSup()),
+        () -> assertEquals(2.0, interval.getLength()));
+  }
+
+  @Test
+  void intersectSelf_whenDisjoint_expectCollapsedToPoint() {
+    Interval interval = new Interval(0.0, 1.0);
+    Interval other = new Interval(3.0, 4.0);
+
+    interval.intersectSelf(other);
+
+    assertAll(
+        () -> assertEquals(3.0, interval.getInf()),
+        () -> assertEquals(3.0, interval.getSup()),
+        () -> assertEquals(0.0, interval.getLength()));
+  }
+
+  @Test
+  void getLength_whenBoundsIncludeInfinity_expectInfinityLength() {
+    Interval interval = new Interval(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+
+    double length = interval.getLength();
+
+    assertEquals(Double.POSITIVE_INFINITY, length);
+  }
+
+  @Test
+  void staticAdd_whenOneInputIsSameObject_expectResultNotAliased() {
+    Interval interval = new Interval(0.0, 1.0);
+
+    Interval result = Interval.add(interval, interval);
+
+    assertAll(
+        () -> assertEquals(0.0, result.getInf()),
+        () -> assertEquals(1.0, result.getSup()),
+        () -> assertNotSame(interval, result));
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/utilities/IntervalsListTest.java
+++ b/src/test/java/org/spaceroots/mantissa/utilities/IntervalsListTest.java
@@ -1,0 +1,447 @@
+package org.spaceroots.mantissa.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class IntervalsListTest {
+
+  @Test
+  void constructor_whenNoArgs_expectEmptyListWithNaNBounds() {
+    // Arrange
+    IntervalsList list = new IntervalsList();
+
+    // Act + Assert
+    assertTrue(list.isEmpty());
+    assertFalse(list.isConnex());
+    assertEquals(0, list.getSize());
+    assertTrue(Double.isNaN(list.getInf()));
+    assertTrue(Double.isNaN(list.getSup()));
+    assertFalse(list.contains(0.0));
+    assertFalse(list.contains(Double.NaN));
+    assertFalse(list.contains(new Interval(0.0, 1.0)));
+    assertFalse(list.intersects(new Interval(0.0, 1.0)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("singleIntervalConstructorCases")
+  void constructor_whenTwoDoubles_expectSingleNormalizedInterval(
+      double a, double b, double expectedInf, double expectedSup) {
+    // Arrange
+    IntervalsList list = new IntervalsList(a, b);
+
+    // Act + Assert
+    assertFalse(list.isEmpty());
+    assertTrue(list.isConnex());
+    assertEquals(1, list.getSize());
+    assertEquals(expectedInf, list.getInf(), 0.0);
+    assertEquals(expectedSup, list.getSup(), 0.0);
+    assertEquals(expectedInf, list.getInterval(0).getInf(), 0.0);
+    assertEquals(expectedSup, list.getInterval(0).getSup(), 0.0);
+  }
+
+  static Stream<Arguments> singleIntervalConstructorCases() {
+    return Stream.of(
+        Arguments.of(0.0, 1.0, 0.0, 1.0),
+        Arguments.of(1.0, 0.0, 0.0, 1.0),
+        Arguments.of(-2.0, -5.0, -5.0, -2.0),
+        Arguments.of(3.5, 3.5, 3.5, 3.5));
+  }
+
+  @Test
+  void constructor_whenIntervalProvided_expectSameInstanceStored() {
+    // Arrange
+    Interval interval = new Interval(2.0, 3.0);
+
+    // Act
+    IntervalsList list = new IntervalsList(interval);
+
+    // Assert
+    assertSame(interval, list.getInterval(0));
+    assertTrue(list.contains(new Interval(2.1, 2.9)));
+  }
+
+  @Test
+  void constructor_whenTwoIntervalsOverlap_expectMergedSingleInterval() {
+    // Arrange
+    Interval i1 = new Interval(0.0, 2.0);
+    Interval i2 = new Interval(1.0, 3.0);
+
+    // Act
+    IntervalsList list = new IntervalsList(i1, i2);
+
+    // Assert
+    assertIntervals(list, 0.0, 3.0);
+  }
+
+  @Test
+  void constructor_whenTwoIntervalsAreDisjoint_expectSortedOrder() {
+    // Arrange
+    Interval i1 = new Interval(10.0, 11.0);
+    Interval i2 = new Interval(0.0, 1.0);
+
+    // Act
+    IntervalsList list = new IntervalsList(i1, i2);
+
+    // Assert
+    assertIntervals(list, 0.0, 1.0, 10.0, 11.0);
+  }
+
+  @Test
+  void copyConstructor_whenCopied_expectDeepCopyOfIntervals() {
+    // Arrange
+    Interval originalInterval = new Interval(0.0, 1.0);
+    IntervalsList original = new IntervalsList(originalInterval);
+
+    // Act
+    IntervalsList copy = new IntervalsList(original);
+    originalInterval.addToSelf(new Interval(10.0, 11.0));
+
+    // Assert
+    assertIntervals(copy, 0.0, 1.0);
+    assertNotSame(original.getInterval(0), copy.getInterval(0));
+  }
+
+  @Test
+  void getInterval_whenIndexOutOfBounds_expectException() {
+    // Arrange
+    IntervalsList list = new IntervalsList(0.0, 1.0);
+
+    // Act + Assert
+    assertThrows(IndexOutOfBoundsException.class, () -> list.getInterval(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> list.getInterval(1));
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {0.0, 1.0, 3.0, 4.0})
+  void contains_whenPointWithinEndpoints_expectTrue(double x) {
+    // Arrange
+    IntervalsList list = new IntervalsList(new Interval(0.0, 1.0), new Interval(3.0, 4.0));
+
+    // Act + Assert
+    assertTrue(list.contains(x));
+  }
+
+  @Test
+  void contains_whenPointIsInHole_expectFalse() {
+    // Arrange
+    IntervalsList list = new IntervalsList(new Interval(0.0, 1.0), new Interval(3.0, 4.0));
+
+    // Act + Assert
+    assertFalse(list.contains(2.0));
+  }
+
+  @Test
+  void contains_whenPointIsNaN_expectFalse() {
+    // Arrange
+    IntervalsList list = new IntervalsList(0.0, 1.0);
+
+    // Act + Assert
+    assertFalse(list.contains(Double.NaN));
+  }
+
+  @Test
+  void contains_whenIntervalFullyContained_expectTrue() {
+    // Arrange
+    IntervalsList list = new IntervalsList(new Interval(0.0, 1.0), new Interval(3.0, 4.0));
+
+    // Act + Assert
+    assertTrue(list.contains(new Interval(3.1, 3.9)));
+  }
+
+  @Test
+  void contains_whenIntervalSpansHole_expectFalse() {
+    // Arrange
+    IntervalsList list = new IntervalsList(new Interval(0.0, 1.0), new Interval(3.0, 4.0));
+
+    // Act + Assert
+    assertFalse(list.contains(new Interval(0.5, 3.5)));
+  }
+
+  @Test
+  void intersects_whenIntervalTouchesOrOverlapsAnyLocalInterval_expectTrue() {
+    // Arrange
+    IntervalsList list = new IntervalsList(new Interval(0.0, 1.0), new Interval(3.0, 4.0));
+
+    // Act + Assert
+    assertTrue(list.intersects(new Interval(1.0, 2.0)));
+    assertTrue(list.intersects(new Interval(2.5, 3.0)));
+    assertTrue(list.intersects(new Interval(0.5, 0.6)));
+  }
+
+  @Test
+  void intersects_whenIntervalIsInHole_expectFalse() {
+    // Arrange
+    IntervalsList list = new IntervalsList(new Interval(0.0, 1.0), new Interval(3.0, 4.0));
+
+    // Act + Assert
+    assertFalse(list.intersects(new Interval(1.5, 2.5)));
+  }
+
+  @Test
+  void addToSelf_whenDisjointIntervals_expectInsertionInOrder() {
+    // Arrange
+    IntervalsList list = new IntervalsList(5.0, 6.0);
+
+    // Act
+    list.addToSelf(new Interval(0.0, 1.0));
+    list.addToSelf(new Interval(10.0, 11.0));
+
+    // Assert
+    assertIntervals(list, 0.0, 1.0, 5.0, 6.0, 10.0, 11.0);
+  }
+
+  @Test
+  void addToSelf_whenOverlappingExistingInterval_expectMerge() {
+    // Arrange
+    IntervalsList list = new IntervalsList(0.0, 2.0);
+
+    // Act
+    list.addToSelf(new Interval(1.0, 3.0));
+
+    // Assert
+    assertIntervals(list, 0.0, 3.0);
+  }
+
+  @Test
+  void addToSelf_whenAddedIntervalOverlapsTwoIntervals_expectMergeAndFillHole() {
+    // Arrange
+    IntervalsList list = new IntervalsList(new Interval(0.0, 1.0), new Interval(4.0, 5.0));
+
+    // Act
+    list.addToSelf(new Interval(0.5, 4.5));
+
+    // Assert
+    assertIntervals(list, 0.0, 5.0);
+  }
+
+  @Test
+  void addToSelf_whenAddedIntervalFitsBetweenTwoIntervals_expectThreeIntervals() {
+    // Arrange
+    IntervalsList list = new IntervalsList(new Interval(0.0, 1.0), new Interval(4.0, 5.0));
+
+    // Act
+    list.addToSelf(new Interval(2.0, 3.0));
+
+    // Assert
+    assertIntervals(list, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0);
+  }
+
+  @Test
+  void add_whenCalled_expectNewListAndOriginalUnchanged() {
+    // Arrange
+    IntervalsList original = new IntervalsList(0.0, 1.0);
+
+    // Act
+    IntervalsList merged = IntervalsList.add(original, new Interval(2.0, 3.0));
+
+    // Assert
+    assertIntervals(original, 0.0, 1.0);
+    assertIntervals(merged, 0.0, 1.0, 2.0, 3.0);
+  }
+
+  @Test
+  void add_whenListToSelf_expectUnionAcrossAllIntervals() {
+    // Arrange
+    IntervalsList list1 = new IntervalsList(new Interval(0.0, 1.0), new Interval(4.0, 5.0));
+    IntervalsList list2 = new IntervalsList(new Interval(-2.0, -1.0), new Interval(0.5, 4.5));
+
+    // Act
+    list1.addToSelf(list2);
+
+    // Assert
+    assertIntervals(list1, -2.0, -1.0, 0.0, 5.0);
+  }
+
+  @Test
+  void add_whenStaticUnion_expectNewListAndInputsUnchanged() {
+    // Arrange
+    IntervalsList list1 = new IntervalsList(0.0, 1.0);
+    IntervalsList list2 = new IntervalsList(3.0, 4.0);
+
+    // Act
+    IntervalsList union = IntervalsList.add(list1, list2);
+
+    // Assert
+    assertIntervals(list1, 0.0, 1.0);
+    assertIntervals(list2, 3.0, 4.0);
+    assertIntervals(union, 0.0, 1.0, 3.0, 4.0);
+  }
+
+  @Test
+  void subtractFromSelf_whenSubtractInsideSingleInterval_expectSplitAndKeepEndpoints() {
+    // Arrange
+    IntervalsList list = new IntervalsList(0.0, 10.0);
+
+    // Act
+    list.subtractFromSelf(new Interval(2.0, 3.0));
+
+    // Assert
+    assertIntervals(list, 0.0, 2.0, 3.0, 10.0);
+    assertTrue(list.contains(2.0));
+    assertTrue(list.contains(3.0));
+    assertFalse(list.contains(2.5));
+  }
+
+  @Test
+  void subtractFromSelf_whenSubtractDisjointInterval_expectUnchanged() {
+    // Arrange
+    IntervalsList list = new IntervalsList(0.0, 1.0);
+
+    // Act
+    list.subtractFromSelf(new Interval(2.0, 3.0));
+
+    // Assert
+    assertIntervals(list, 0.0, 1.0);
+  }
+
+  @Test
+  void subtractFromSelf_whenSubtractCoversAll_expectEmpty() {
+    // Arrange
+    IntervalsList list = new IntervalsList(0.0, 1.0);
+
+    // Act
+    list.subtractFromSelf(new Interval(-10.0, 10.0));
+
+    // Assert
+    assertTrue(list.isEmpty());
+  }
+
+  @Test
+  void subtractFromSelf_whenCalledOnEmptyList_expectStillEmpty() {
+    // Arrange
+    IntervalsList list = new IntervalsList();
+
+    // Act
+    list.subtractFromSelf(new Interval(-10.0, 10.0));
+
+    // Assert
+    assertTrue(list.isEmpty());
+    assertEquals(0, list.getSize());
+  }
+
+  @Test
+  void subtract_whenStaticSubtract_expectNewListAndOriginalUnchanged() {
+    // Arrange
+    IntervalsList original = new IntervalsList(0.0, 10.0);
+
+    // Act
+    IntervalsList result = IntervalsList.subtract(original, new Interval(2.0, 3.0));
+
+    // Assert
+    assertIntervals(original, 0.0, 10.0);
+    assertIntervals(result, 0.0, 2.0, 3.0, 10.0);
+  }
+
+  @Test
+  void subtractFromSelf_whenSubtractList_expectSequentialSubtractions() {
+    // Arrange
+    IntervalsList list = new IntervalsList(0.0, 10.0);
+    IntervalsList toRemove = new IntervalsList(new Interval(2.0, 3.0), new Interval(6.0, 7.0));
+
+    // Act
+    list.subtractFromSelf(toRemove);
+
+    // Assert
+    assertIntervals(list, 0.0, 2.0, 3.0, 6.0, 7.0, 10.0);
+  }
+
+  @Test
+  void intersection_whenIntersectWithInterval_expectOnlyOverlappingParts() {
+    // Arrange
+    IntervalsList list = new IntervalsList(new Interval(0.0, 1.0), new Interval(3.0, 4.0));
+
+    // Act
+    list.intersectSelf(new Interval(0.5, 3.5));
+
+    // Assert
+    assertIntervals(list, 0.5, 1.0, 3.0, 3.5);
+  }
+
+  @Test
+  void intersection_whenStaticIntersectionWithInterval_expectNewListAndOriginalUnchanged() {
+    // Arrange
+    IntervalsList original = new IntervalsList(new Interval(0.0, 1.0), new Interval(3.0, 4.0));
+
+    // Act
+    IntervalsList intersection = IntervalsList.intersection(original, new Interval(0.5, 3.5));
+
+    // Assert
+    assertIntervals(original, 0.0, 1.0, 3.0, 4.0);
+    assertIntervals(intersection, 0.5, 1.0, 3.0, 3.5);
+  }
+
+  @Test
+  void intersection_whenIntersectTwoLists_expectCorrectResult() {
+    // Arrange
+    IntervalsList list1 = new IntervalsList(new Interval(0.0, 2.0), new Interval(4.0, 6.0));
+    IntervalsList list2 = new IntervalsList(new Interval(1.0, 5.0), new Interval(7.0, 8.0));
+
+    // Act
+    IntervalsList intersection = IntervalsList.intersection(list1, list2);
+
+    // Assert
+    assertIntervals(intersection, 1.0, 2.0, 4.0, 5.0);
+  }
+
+  @Test
+  void intersectSelf_whenIntersectTwoLists_expectInPlaceIntersection() {
+    // Arrange
+    IntervalsList list1 = new IntervalsList(new Interval(0.0, 2.0), new Interval(4.0, 6.0));
+    IntervalsList list2 = new IntervalsList(new Interval(1.0, 5.0), new Interval(7.0, 8.0));
+
+    // Act
+    list1.intersectSelf(list2);
+
+    // Assert
+    assertIntervals(list1, 1.0, 2.0, 4.0, 5.0);
+  }
+
+  @Test
+  void contains_whenIntervalIsMocked_expectDelegatedResult() {
+    // Arrange
+    Interval interval = mock(Interval.class);
+    when(interval.contains(123.0)).thenReturn(true);
+    when(interval.contains(124.0)).thenReturn(false);
+    IntervalsList list = new IntervalsList(interval);
+
+    // Act + Assert
+    assertTrue(list.contains(123.0));
+    assertFalse(list.contains(124.0));
+  }
+
+  private static void assertIntervals(IntervalsList list, double... bounds) {
+    assertEquals(0, bounds.length % 2);
+    assertEquals(bounds.length / 2, list.getSize());
+
+    for (int i = 0; i < bounds.length; i += 2) {
+      Interval interval = list.getInterval(i / 2);
+      assertEquals(bounds[i], interval.getInf(), 0.0);
+      assertEquals(bounds[i + 1], interval.getSup(), 0.0);
+    }
+
+    if (bounds.length == 0) {
+      assertTrue(Double.isNaN(list.getInf()));
+      assertTrue(Double.isNaN(list.getSup()));
+    } else {
+      assertEquals(bounds[0], list.getInf(), 0.0);
+      assertEquals(bounds[bounds.length - 1], list.getSup(), 0.0);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/utilities/MappableArrayTest.java
+++ b/src/test/java/org/spaceroots/mantissa/utilities/MappableArrayTest.java
@@ -1,0 +1,149 @@
+package org.spaceroots.mantissa.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class MappableArrayTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 3})
+  void constructor_whenUsingDimension_initializesWithZerosAndCorrectDimension(int dimension) {
+    // Arrange
+    MappableArray mappable = new MappableArray(dimension);
+
+    // Act
+    int stateDimension = mappable.getStateDimension();
+    double[] snapshot = mappable.getArray();
+
+    // Assert
+    assertEquals(dimension, stateDimension);
+    assertArrayEquals(new double[dimension], snapshot);
+  }
+
+  @Test
+  void constructor_whenDimensionNegative_throwsNegativeArraySizeException() {
+    assertThrows(NegativeArraySizeException.class, () -> new MappableArray(-1));
+  }
+
+  @Test
+  void constructor_whenUsingArray_clonesInputArray() {
+    // Arrange
+    double[] input = new double[] {1.0, 2.0, 3.0};
+
+    // Act
+    MappableArray mappable = new MappableArray(input);
+    input[1] = 999.0;
+
+    // Assert
+    assertArrayEquals(new double[] {1.0, 2.0, 3.0}, mappable.getArray());
+  }
+
+  @Test
+  void getArray_whenCalled_returnsDefensiveCopy() {
+    // Arrange
+    MappableArray mappable = new MappableArray(new double[] {4.0, 5.0});
+
+    // Act
+    double[] first = mappable.getArray();
+    first[0] = -123.0;
+    double[] second = mappable.getArray();
+
+    // Assert
+    assertArrayEquals(new double[] {4.0, 5.0}, second);
+  }
+
+  @Test
+  void mapStateFromArray_whenStartOffsetProvided_copiesSliceIntoInternalState() {
+    // Arrange
+    MappableArray mappable = new MappableArray(3);
+    double[] source = new double[] {10.0, 20.0, 30.0, 40.0, 50.0};
+
+    // Act
+    mappable.mapStateFromArray(1, source);
+
+    // Assert
+    assertArrayEquals(new double[] {20.0, 30.0, 40.0}, mappable.getArray());
+  }
+
+  @Test
+  void mapStateFromArray_whenSourceArrayNull_throwsNullPointerException() {
+    // Arrange
+    MappableArray mappable = new MappableArray(1);
+
+    // Act / Assert
+    assertThrows(NullPointerException.class, () -> mappable.mapStateFromArray(0, null));
+  }
+
+  @Test
+  void mapStateFromArray_whenStartNegative_throwsArrayIndexOutOfBoundsException() {
+    // Arrange
+    MappableArray mappable = new MappableArray(1);
+
+    // Act / Assert
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class,
+        () -> mappable.mapStateFromArray(-1, new double[] {1.0}));
+  }
+
+  @Test
+  void mapStateFromArray_whenNotEnoughSourceData_throwsArrayIndexOutOfBoundsException() {
+    // Arrange
+    MappableArray mappable = new MappableArray(2);
+
+    // Act / Assert
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class,
+        () -> mappable.mapStateFromArray(1, new double[] {1.0, 2.0}));
+  }
+
+  @Test
+  void mapStateToArray_whenStartOffsetProvided_writesInternalSliceIntoDestinationArray() {
+    // Arrange
+    MappableArray mappable = new MappableArray(new double[] {7.0, 8.0, 9.0});
+    double[] destination = new double[] {-1.0, -1.0, -1.0, -1.0, -1.0};
+
+    // Act
+    mappable.mapStateToArray(2, destination);
+
+    // Assert
+    assertArrayEquals(new double[] {-1.0, -1.0, 7.0, 8.0, 9.0}, destination);
+  }
+
+  @Test
+  void mapStateToArray_whenDestinationArrayNull_throwsNullPointerException() {
+    // Arrange
+    MappableArray mappable = new MappableArray(1);
+
+    // Act / Assert
+    assertThrows(NullPointerException.class, () -> mappable.mapStateToArray(0, null));
+  }
+
+  @Test
+  void mapStateToArray_whenStartNegative_throwsArrayIndexOutOfBoundsException() {
+    // Arrange
+    MappableArray mappable = new MappableArray(1);
+
+    // Act / Assert
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class, () -> mappable.mapStateToArray(-1, new double[1]));
+  }
+
+  @Test
+  void mapStateToArray_whenNotEnoughDestinationSpace_throwsArrayIndexOutOfBoundsException() {
+    // Arrange
+    MappableArray mappable = new MappableArray(2);
+
+    // Act / Assert
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class, () -> mappable.mapStateToArray(1, new double[2]));
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/utilities/MappableScalarTest.java
+++ b/src/test/java/org/spaceroots/mantissa/utilities/MappableScalarTest.java
@@ -1,0 +1,167 @@
+package org.spaceroots.mantissa.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class MappableScalarTest {
+
+  static Stream<Double> scalarValues() {
+    return Stream.of(
+        0.0, -0.0, 1.25, -42.5, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN);
+  }
+
+  @Test
+  void constructor_whenDefault_constructsWithZeroValue() {
+    // Arrange / Act
+    MappableScalar scalar = new MappableScalar();
+
+    // Assert
+    assertEquals(0.0, scalar.getValue());
+  }
+
+  @ParameterizedTest
+  @MethodSource("scalarValues")
+  void constructor_whenInitialValueProvided_storesValue(double initialValue) {
+    // Arrange / Act
+    MappableScalar scalar = new MappableScalar(initialValue);
+
+    // Assert
+    assertSameDoubleValue(initialValue, scalar.getValue());
+  }
+
+  @ParameterizedTest
+  @MethodSource("scalarValues")
+  void setValue_whenCalled_updatesValue(double newValue) {
+    // Arrange
+    MappableScalar scalar = new MappableScalar(123.0);
+
+    // Act
+    scalar.setValue(newValue);
+
+    // Assert
+    assertSameDoubleValue(newValue, scalar.getValue());
+  }
+
+  @Test
+  void getStateDimension_whenCalled_returnsOne() {
+    // Arrange
+    MappableScalar scalar = new MappableScalar(5.0);
+
+    // Act
+    int dimension = scalar.getStateDimension();
+
+    // Assert
+    assertEquals(1, dimension);
+  }
+
+  @ParameterizedTest
+  @MethodSource("scalarValues")
+  void mapStateFromArray_whenStartOffsetProvided_readsValueFromArray(double expectedValue) {
+    // Arrange
+    MappableScalar scalar = new MappableScalar(999.0);
+    double[] source = new double[] {-123.0, expectedValue, 456.0};
+
+    // Act
+    scalar.mapStateFromArray(1, source);
+
+    // Assert
+    assertSameDoubleValue(expectedValue, scalar.getValue());
+  }
+
+  @Test
+  void mapStateFromArray_whenArrayNull_throwsNullPointerException() {
+    // Arrange
+    MappableScalar scalar = new MappableScalar();
+
+    // Act / Assert
+    //noinspection DataFlowIssue
+    assertThrows(NullPointerException.class, () -> scalar.mapStateFromArray(0, null));
+  }
+
+  @Test
+  void mapStateFromArray_whenStartNegative_throwsArrayIndexOutOfBoundsException() {
+    // Arrange
+    MappableScalar scalar = new MappableScalar();
+
+    // Act / Assert
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class,
+        () -> scalar.mapStateFromArray(-1, new double[] {1.0}));
+  }
+
+  @Test
+  void mapStateFromArray_whenStartPastEnd_throwsArrayIndexOutOfBoundsException() {
+    // Arrange
+    MappableScalar scalar = new MappableScalar();
+
+    // Act / Assert
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class,
+        () -> scalar.mapStateFromArray(1, new double[] {1.0}));
+  }
+
+  @ParameterizedTest
+  @MethodSource("scalarValues")
+  void mapStateToArray_whenStartOffsetProvided_writesValueIntoArray(double value) {
+    // Arrange
+    MappableScalar scalar = new MappableScalar(value);
+    double[] destination = new double[] {-1.0, -1.0, -1.0};
+
+    // Act
+    scalar.mapStateToArray(1, destination);
+
+    // Assert
+    assertSameDoubleValue(value, destination[1]);
+    assertEquals(-1.0, destination[0]);
+    assertEquals(-1.0, destination[2]);
+  }
+
+  @Test
+  void mapStateToArray_whenArrayNull_throwsNullPointerException() {
+    // Arrange
+    MappableScalar scalar = new MappableScalar(1.0);
+
+    // Act / Assert
+    //noinspection DataFlowIssue
+    assertThrows(NullPointerException.class, () -> scalar.mapStateToArray(0, null));
+  }
+
+  @Test
+  void mapStateToArray_whenStartNegative_throwsArrayIndexOutOfBoundsException() {
+    // Arrange
+    MappableScalar scalar = new MappableScalar(1.0);
+
+    // Act / Assert
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class, () -> scalar.mapStateToArray(-1, new double[1]));
+  }
+
+  @Test
+  void mapStateToArray_whenStartPastEnd_throwsArrayIndexOutOfBoundsException() {
+    // Arrange
+    MappableScalar scalar = new MappableScalar(1.0);
+
+    // Act / Assert
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class, () -> scalar.mapStateToArray(1, new double[] {0.0}));
+  }
+
+  private static void assertSameDoubleValue(double expected, double actual) {
+    if (Double.isNaN(expected)) {
+      assertTrue(Double.isNaN(actual));
+      return;
+    }
+
+    assertEquals(Double.doubleToRawLongBits(expected), Double.doubleToRawLongBits(actual));
+  }
+}


### PR DESCRIPTION
## Summary
- Adds focused JUnit tests for Mantissa utilities (`ArrayMapper`, `ArrayMapperEntry`, `Interval`, `IntervalsList`, `MappableArray`, `MappableScalar`).
- Improves/clarifies Javadoc across the same utilities and the `ArraySliceMappable` contract (doclint-friendly).
- Refactors `ArrayMapperEntry` to a Java `record` and updates call sites.

## Notes
- `Interval#intersectSelf(...)` now uses `Math.clamp(...)` to keep bounds ordered after intersection.
- No behavior change intended outside the documented normalization/ordering invariants; changes are primarily test coverage + documentation.

## Commits
- 21c1799fc7 test: cover ArrayMapper and clean Javadoc
- aa26a41d80 refactor: convert ArrayMapperEntry to record
- 10ff6adb1c docs(mantissa): doclint-clean ArraySliceMappable Javadoc
- 8d76324679 test(utilities): cover Interval behavior
- 9ab46bc08f test: add IntervalsList unit tests
- 37c1c4dc3d test: add MappableArray unit tests
- 732e3967a0 test: add MappableScalar unit tests
