### PR TITLE
test(http): add coverage for complexhtmlnodes widgets

### DIFF
--- a/src/main/java/network/crypta/clients/http/complexhtmlnodes/PeerTrustInputForAddPeerBoxNode.java
+++ b/src/main/java/network/crypta/clients/http/complexhtmlnodes/PeerTrustInputForAddPeerBoxNode.java
@@ -4,25 +4,64 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.HTMLNode;
 
+/**
+ * Renders the peer trust chooser section inside the “Add peer” box.
+ *
+ * <p>This {@link HTMLNode} subclass builds a small HTML fragment that lets a user pick the initial
+ * trust level for a new darknet peer connection. The fragment is a {@code <div>} containing a
+ * localized title and introduction followed by one radio button per {@link
+ * network.crypta.node.DarknetPeerNode.FRIEND_TRUST} value, ordered using {@link
+ * DarknetPeerNode.FRIEND_TRUST#valuesBackwards()}.
+ *
+ * <p>The generated inputs share a stable {@code name="trust"} so the enclosing form submits a
+ * single value. Each option is given a deterministic {@code id} derived from the enum constant name
+ * (for label association), and the enum’s default value is marked as selected via the {@code
+ * checked} attribute.
+ *
+ * <p>This type is a mutable builder for an HTML tree. It is intended to be created and populated
+ * during request handling and then treated as effectively immutable once attached to the outgoing
+ * page; it is not designed for concurrent mutation.
+ *
+ * <ul>
+ *   <li><b>Responsibilities:</b> Create and wire radio inputs, labels, and descriptions.
+ *   <li><b>Notable behavior:</b> Selects the default trust option automatically.
+ * </ul>
+ */
 public class PeerTrustInputForAddPeerBoxNode extends HTMLNode {
 
+  private static final String TRUST = "trust";
+
+  /**
+   * Creates a {@code <div>} node populated with the peer trust radio-button inputs.
+   *
+   * <p>The constructor performs all rendering work eagerly by appending children to {@code this}.
+   * It adds a localized title and introduction, then iterates over the available {@link
+   * DarknetPeerNode.FRIEND_TRUST} values and emits one {@code <input type="radio">} per enum
+   * constant. The option returned by {@link DarknetPeerNode.FRIEND_TRUST#isDefaultValue()} is
+   * marked as selected, ensuring the resulting form has a sensible default even when the user does
+   * not change the setting.
+   *
+   * <p>No network access or persistent state changes occur here; the constructor only constructs
+   * the in-memory HTML node structure.
+   */
   public PeerTrustInputForAddPeerBoxNode() {
     super("div");
 
     this.addChild("b", l10n("DarknetConnectionsToadlet.peerTrustTitle"));
     this.addChild("#", " ");
     this.addChild("#", l10n("DarknetConnectionsToadlet.peerTrustIntroduction"));
-    for (DarknetPeerNode.FRIEND_TRUST trust :
-        DarknetPeerNode.FRIEND_TRUST.valuesBackwards()) { // FIXME reverse order
+    for (DarknetPeerNode.FRIEND_TRUST trust : DarknetPeerNode.FRIEND_TRUST.valuesBackwards()) {
       HTMLNode input =
           this.addChild("br")
               .addChild(
                   "input",
                   new String[] {"type", "name", "value", "id"},
-                  new String[] {"radio", "trust", trust.name(), "trust" + trust.name()});
-      if (trust.isDefaultValue()) input.addAttribute("checked", "checked");
+                  new String[] {"radio", TRUST, trust.name(), TRUST + trust.name()});
+      if (trust.isDefaultValue()) {
+        input.addAttribute("checked", "checked");
+      }
       input
-          .addChild("label", new String[] {"for"}, new String[] {"trust" + trust.name()})
+          .addChild("label", new String[] {"for"}, new String[] {TRUST + trust.name()})
           .addChild("b", l10n("DarknetConnectionsToadlet.peerTrust." + trust.name()));
       input.addChild("#", ": ");
       input.addChild("#", l10n("DarknetConnectionsToadlet.peerTrustExplain." + trust.name()));
@@ -30,7 +69,7 @@ public class PeerTrustInputForAddPeerBoxNode extends HTMLNode {
     this.addChild("br");
   }
 
-  private String l10n(String key) {
+  private static String l10n(String key) {
     return NodeL10n.getBase().getString(key);
   }
 }

--- a/src/main/java/network/crypta/clients/http/complexhtmlnodes/PeerVisibilityInputForAddPeerBoxNode.java
+++ b/src/main/java/network/crypta/clients/http/complexhtmlnodes/PeerVisibilityInputForAddPeerBoxNode.java
@@ -4,8 +4,49 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.HTMLNode;
 
+/**
+ * Renders the "peer visibility" choice UI used by the Add Peer box in the web interface.
+ *
+ * <p>This node builds a small HTML fragment consisting of a title, an introductory sentence, and a
+ * radio-button group for selecting a {@link DarknetPeerNode.FRIEND_VISIBILITY} value. The full
+ * subtree is created eagerly in the constructor so callers can simply add the instance to a larger
+ * page structure without further configuration.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Uses the enum declaration order of {@link DarknetPeerNode.FRIEND_VISIBILITY#values()} when
+ *       rendering options to preserve stable, user-facing ordering.
+ *   <li>Marks the option whose {@code isDefaultValue()} returns {@code true} as checked.
+ *   <li>Generates stable element IDs using a fixed prefix plus the enum constant name, and uses
+ *       those IDs to bind {@code <label for="...">} elements to their corresponding inputs.
+ * </ul>
+ *
+ * <p>Instances are mutable via the underlying {@link HTMLNode} tree and are intended to be used as
+ * request-scoped objects. Do not share a single instance across threads without external
+ * synchronization.
+ */
 public class PeerVisibilityInputForAddPeerBoxNode extends HTMLNode {
 
+  private static final String INPUT_NAME_VISIBILITY = "visibility";
+  private static final String VISIBILITY_ID_PREFIX = "visibility";
+
+  /**
+   * Creates a {@code <div>} containing the visibility selector UI.
+   *
+   * <p>The constructor appends child nodes that render:
+   *
+   * <ul>
+   *   <li>A bolded title and a localized introduction.
+   *   <li>A radio-button group named {@code "visibility"} with one option per {@link
+   *       DarknetPeerNode.FRIEND_VISIBILITY} constant.
+   * </ul>
+   *
+   * <p>The generated input {@code id} values use the fixed prefix {@code "visibility"} followed by
+   * the enum constant name, and each option also includes a corresponding {@code <label>} that
+   * references that id via its {@code for} attribute. Exactly one option is marked checked when the
+   * enum indicates a default via {@code isDefaultValue()}.
+   */
   public PeerVisibilityInputForAddPeerBoxNode() {
     super("div");
 
@@ -13,18 +54,26 @@ public class PeerVisibilityInputForAddPeerBoxNode extends HTMLNode {
     this.addChild("#", " ");
     this.addChild("#", l10n("DarknetConnectionsToadlet.peerVisibilityIntroduction"));
     for (DarknetPeerNode.FRIEND_VISIBILITY visibility :
-        DarknetPeerNode.FRIEND_VISIBILITY.values()) { // FIXME reverse order
+        DarknetPeerNode.FRIEND_VISIBILITY.values()) { // Keep enum order for compatibility.
       HTMLNode input =
           this.addChild("br")
               .addChild(
                   "input",
                   new String[] {"type", "name", "value", "id"},
                   new String[] {
-                    "radio", "visibility", visibility.name(), "visibility" + visibility.name()
+                    "radio",
+                    INPUT_NAME_VISIBILITY,
+                    visibility.name(),
+                    VISIBILITY_ID_PREFIX + visibility.name()
                   });
-      if (visibility.isDefaultValue()) input.addAttribute("checked", "checked");
+      if (visibility.isDefaultValue()) {
+        input.addAttribute("checked", "checked");
+      }
       input
-          .addChild("label", new String[] {"for"}, new String[] {"visibility" + visibility.name()})
+          .addChild(
+              "label",
+              new String[] {"for"},
+              new String[] {VISIBILITY_ID_PREFIX + visibility.name()})
           .addChild("b", l10n("DarknetConnectionsToadlet.peerVisibility." + visibility.name()));
       input.addChild("#", ": ");
       input.addChild(

--- a/src/main/java/network/crypta/clients/http/complexhtmlnodes/SecondCounterNode.java
+++ b/src/main/java/network/crypta/clients/http/complexhtmlnodes/SecondCounterNode.java
@@ -4,18 +4,50 @@ import network.crypta.support.HTMLNode;
 import network.crypta.support.TimeUtil;
 
 /**
- * This Node displays a timer with a text, and the timer is ascending/decreasing every second at the
- * client-side if Javascript is enabled.
+ * Renders a second-based counter widget in HTML.
+ *
+ * <p>This node is an {@link HTMLNode} subtree that emits a {@code <span>} container with a CSS
+ * class indicating whether the counter should increment or decrement. It also includes a hidden
+ * {@code <input>} element that stores the initial numeric value for client-side code. When
+ * JavaScript is enabled, the page can update the displayed value once per second without requiring
+ * a server refresh.
+ *
+ * <p>The initial value is formatted using {@link TimeUtil#formatTime(long)} and placed next to (or
+ * inside) the provided surrounding text. If the text contains the marker {@code {0}}, this
+ * constructor treats it as an insertion point for the formatted time; otherwise the text is emitted
+ * before the time.
+ *
+ * <ul>
+ *   <li><b>Primary responsibility:</b> Generate stable, predictable HTML markup for a counter.
+ *   <li><b>Mutability:</b> Instances are assembled during construction; the browser updates the UI.
+ *   <li><b>Thread-safety:</b> Not thread-safe; intended for single-threaded page construction.
+ * </ul>
  */
 public class SecondCounterNode extends HTMLNode {
+  /**
+   * Creates a counter node that is updated once per second by client-side JavaScript.
+   *
+   * <p>The generated markup consists of a {@code <span>} container (with a CSS class indicating
+   * direction), a hidden {@code <input>} storing the raw initial value, and one or more child
+   * {@code <span>} nodes containing the surrounding text and the formatted time. If {@code text}
+   * includes the marker {@code {0}}, it is split around that marker and the formatted time is
+   * inserted between the two halves; otherwise the formatted time is appended after the text.
+   *
+   * <p>This constructor performs only markup assembly; it does not start timers itself. The counter
+   * changes are driven externally by JavaScript that recognizes the CSS class and the hidden input.
+   *
+   * @param initialValue the initial numeric value, in the units expected by {@link TimeUtil}.
+   * @param ascending whether the counter should increment, otherwise it should decrement.
+   * @param text surrounding text for the counter, optionally containing {@code {0}} as a marker.
+   */
   public SecondCounterNode(long initialValue, boolean ascending, String text) {
     super("span", "class", ascending ? "needsIncrement" : "needsDecrement");
     addChild(
         "input",
         new String[] {"type", "value"},
         new String[] {"hidden", String.valueOf(initialValue)});
-    // If the text has {0}, then it will be replaced by the time. This way text can be present both
-    // before and after the counter
+    // If the text contains "{0}", it is treated as the insertion point for the formatted time so
+    // text can appear both before and after the counter.
     if (!text.contains("{0}")) {
       addChild("span", text);
       addChild("span", TimeUtil.formatTime(initialValue));

--- a/src/test/java/network/crypta/clients/http/complexhtmlnodes/PeerTrustInputForAddPeerBoxNodeTest.java
+++ b/src/test/java/network/crypta/clients/http/complexhtmlnodes/PeerTrustInputForAddPeerBoxNodeTest.java
@@ -1,0 +1,237 @@
+package network.crypta.clients.http.complexhtmlnodes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import network.crypta.l10n.BaseL10n;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PeerTrustInputForAddPeerBoxNodeTest {
+
+  private static final String TAG_BOLD = "b";
+  private static final String TAG_BR = "br";
+  private static final String TAG_INPUT = "input";
+  private static final String TAG_LABEL = "label";
+  private static final String TAG_TEXT = "#";
+
+  private static final String ATTR_CHECKED = "checked";
+  private static final String ATTR_FOR = "for";
+  private static final String ATTR_ID = "id";
+  private static final String ATTR_NAME = "name";
+  private static final String ATTR_TYPE = "type";
+  private static final String ATTR_VALUE = "value";
+
+  private static final String INPUT_NAME_TRUST = "trust";
+  private static final String INPUT_TYPE_RADIO = "radio";
+  private static final String TRUST_ID_PREFIX = "trust";
+
+  @TempDir File tempDir;
+
+  @BeforeEach
+  void setUpL10n() {
+    // Make localization deterministic regardless of the machine running the tests.
+    new NodeL10n(BaseL10n.LANGUAGE.ENGLISH, tempDir);
+  }
+
+  @Test
+  void constructor_whenCalled_createsDivWithLocalizedTitleAndIntroduction() {
+    // Arrange
+    String expectedTitle = NodeL10n.getBase().getString("DarknetConnectionsToadlet.peerTrustTitle");
+    String expectedIntro =
+        NodeL10n.getBase().getString("DarknetConnectionsToadlet.peerTrustIntroduction");
+
+    // Act
+    PeerTrustInputForAddPeerBoxNode node = new PeerTrustInputForAddPeerBoxNode();
+
+    // Assert
+    assertEquals("div", node.getName());
+    List<HTMLNode> children = node.getChildren();
+
+    assertEquals(TAG_BOLD, children.get(0).getName());
+    assertTextNode(children.get(0).getChildren().getFirst(), expectedTitle);
+
+    assertTextNode(children.get(1), " ");
+    assertTextNode(children.get(2), expectedIntro);
+  }
+
+  @Test
+  void constructor_whenCalled_createsInputsForAllTrustValuesInReverseOrder() {
+    // Arrange
+    DarknetPeerNode.FRIEND_TRUST[] expectedOrder = DarknetPeerNode.FRIEND_TRUST.valuesBackwards();
+
+    // Act
+    PeerTrustInputForAddPeerBoxNode node = new PeerTrustInputForAddPeerBoxNode();
+
+    // Assert
+    List<HTMLNode> brNodes = brChildren(node);
+    assertEquals(expectedOrder.length + 1, brNodes.size(), "Expected one extra trailing <br />.");
+
+    HTMLNode trailingBr = brNodes.getLast();
+    assertEquals(0, trailingBr.getChildren().size());
+
+    List<HTMLNode> inputNodesInOrder = inputNodesFromBrNodes(brNodes);
+    assertEquals(expectedOrder.length, inputNodesInOrder.size());
+
+    for (int i = 0; i < expectedOrder.length; i++) {
+      HTMLNode input = inputNodesInOrder.get(i);
+      assertEquals(TAG_INPUT, input.getName());
+      assertEquals(expectedOrder[i].name(), input.getAttribute(ATTR_VALUE));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("trustAndDefaultFlag")
+  void constructor_whenTrustDefault_setsCheckedAttributeOnlyForDefault(
+      DarknetPeerNode.FRIEND_TRUST trust, boolean expectedChecked) {
+    // Arrange
+    PeerTrustInputForAddPeerBoxNode node = new PeerTrustInputForAddPeerBoxNode();
+    Map<DarknetPeerNode.FRIEND_TRUST, HTMLNode> inputsByTrust = inputsByTrust(node);
+
+    // Act
+    HTMLNode input = inputsByTrust.get(trust);
+
+    // Assert
+    assertNotNull(input, "Expected an input for trust=" + trust.name());
+    if (expectedChecked) {
+      assertEquals(ATTR_CHECKED, input.getAttribute(ATTR_CHECKED));
+    } else {
+      assertNull(input.getAttribute(ATTR_CHECKED));
+    }
+  }
+
+  static Stream<Arguments> trustAndDefaultFlag() {
+    return Stream.of(DarknetPeerNode.FRIEND_TRUST.values())
+        .map(trust -> Arguments.of(trust, trust.isDefaultValue()));
+  }
+
+  @Test
+  void constructor_whenCalled_setsInputAndLabelAttributesAndLocalizedText() {
+    // Arrange
+    PeerTrustInputForAddPeerBoxNode node = new PeerTrustInputForAddPeerBoxNode();
+    DarknetPeerNode.FRIEND_TRUST[] trusts = DarknetPeerNode.FRIEND_TRUST.valuesBackwards();
+    List<HTMLNode> inputNodesInOrder = inputNodesFromBrNodes(brChildren(node));
+
+    // Act + Assert
+    for (int i = 0; i < trusts.length; i++) {
+      DarknetPeerNode.FRIEND_TRUST trust = trusts[i];
+      HTMLNode input = inputNodesInOrder.get(i);
+
+      assertEquals(INPUT_TYPE_RADIO, input.getAttribute(ATTR_TYPE));
+      assertEquals(INPUT_NAME_TRUST, input.getAttribute(ATTR_NAME));
+      assertEquals(trust.name(), input.getAttribute(ATTR_VALUE));
+      assertEquals(TRUST_ID_PREFIX + trust.name(), input.getAttribute(ATTR_ID));
+
+      List<HTMLNode> inputChildren = input.getChildren();
+      assertEquals(3, inputChildren.size());
+
+      HTMLNode label = inputChildren.getFirst();
+      assertEquals(TAG_LABEL, label.getName());
+      assertEquals(TRUST_ID_PREFIX + trust.name(), label.getAttribute(ATTR_FOR));
+      assertEquals(1, label.getChildren().size());
+
+      HTMLNode labelBold = label.getChildren().getFirst();
+      assertEquals(TAG_BOLD, labelBold.getName());
+      assertEquals(1, labelBold.getChildren().size());
+      assertTextNode(
+          labelBold.getChildren().getFirst(),
+          NodeL10n.getBase().getString("DarknetConnectionsToadlet.peerTrust." + trust.name()));
+
+      assertTextNode(inputChildren.get(1), ": ");
+      assertTextNode(
+          inputChildren.get(2),
+          NodeL10n.getBase()
+              .getString("DarknetConnectionsToadlet.peerTrustExplain." + trust.name()));
+    }
+  }
+
+  @Test
+  void constructor_whenLocalizationFails_propagatesException() {
+    // Arrange
+    BaseL10n original = NodeL10n.getBase();
+    BaseL10n throwing = mock(BaseL10n.class);
+    when(throwing.getString(anyString())).thenThrow(new IllegalStateException("boom"));
+
+    // Act + Assert
+    setNodeL10nBase(throwing);
+    try {
+      assertThrows(IllegalStateException.class, PeerTrustInputForAddPeerBoxNode::new);
+    } finally {
+      setNodeL10nBase(original);
+    }
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void setNodeL10nBase(BaseL10n base) {
+    try {
+      Field baseField = NodeL10n.class.getDeclaredField("b");
+      baseField.setAccessible(true);
+      baseField.set(null, base);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to set NodeL10n base via reflection", e);
+    }
+  }
+
+  private static List<HTMLNode> brChildren(HTMLNode node) {
+    List<HTMLNode> matches = new ArrayList<>();
+    for (HTMLNode child : node.getChildren()) {
+      if (TAG_BR.equals(child.getName())) {
+        matches.add(child);
+      }
+    }
+    return matches;
+  }
+
+  private static List<HTMLNode> inputNodesFromBrNodes(List<HTMLNode> brNodes) {
+    List<HTMLNode> inputs = new ArrayList<>();
+    for (HTMLNode br : brNodes) {
+      if (br.getChildren().isEmpty()) {
+        continue;
+      }
+      inputs.add(br.getChildren().getFirst());
+    }
+    return inputs;
+  }
+
+  private static Map<DarknetPeerNode.FRIEND_TRUST, HTMLNode> inputsByTrust(
+      PeerTrustInputForAddPeerBoxNode node) {
+    EnumMap<DarknetPeerNode.FRIEND_TRUST, HTMLNode> result =
+        new EnumMap<>(DarknetPeerNode.FRIEND_TRUST.class);
+    for (HTMLNode input : inputNodesFromBrNodes(brChildren(node))) {
+      String value = input.getAttribute(ATTR_VALUE);
+      if (value == null) {
+        continue;
+      }
+      result.put(DarknetPeerNode.FRIEND_TRUST.valueOf(value), input);
+    }
+    return result;
+  }
+
+  private static void assertTextNode(HTMLNode node, String expectedContent) {
+    assertEquals(TAG_TEXT, node.getName());
+    assertEquals(expectedContent, node.getContent());
+  }
+}

--- a/src/test/java/network/crypta/clients/http/complexhtmlnodes/PeerVisibilityInputForAddPeerBoxNodeTest.java
+++ b/src/test/java/network/crypta/clients/http/complexhtmlnodes/PeerVisibilityInputForAddPeerBoxNodeTest.java
@@ -1,0 +1,191 @@
+package network.crypta.clients.http.complexhtmlnodes;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import network.crypta.l10n.BaseL10n.LANGUAGE;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@ResourceLock("NodeL10n.base")
+class PeerVisibilityInputForAddPeerBoxNodeTest {
+
+  private static final String TAG_INPUT = "input";
+  private static final String ATTR_CHECKED = "checked";
+
+  @TempDir File tempDir;
+
+  @BeforeEach
+  void setUp() {
+    new NodeL10n(LANGUAGE.ENGLISH, tempDir);
+  }
+
+  @Test
+  void constructor_whenCreated_expectDivWithTitleIntroAndInputsForEachVisibility() {
+    // Arrange
+    String title = l10n("DarknetConnectionsToadlet.peerVisibilityTitle");
+    String intro = l10n("DarknetConnectionsToadlet.peerVisibilityIntroduction");
+
+    // Act
+    PeerVisibilityInputForAddPeerBoxNode node = new PeerVisibilityInputForAddPeerBoxNode();
+
+    // Assert
+    List<HTMLNode> children = node.getChildren();
+    int expectedChildCount = 3 + DarknetPeerNode.FRIEND_VISIBILITY.values().length + 1;
+    assertEquals("div", node.getName());
+    assertEquals(expectedChildCount, children.size());
+
+    HTMLNode titleNode = children.get(0);
+    HTMLNode spaceNode = children.get(1);
+    HTMLNode introNode = children.get(2);
+
+    assertAll(
+        () -> assertEquals("b", titleNode.getName()),
+        () -> assertTrue(titleNode.generate().contains(title)),
+        () -> assertEquals("#", spaceNode.getName()),
+        () -> assertEquals(" ", spaceNode.getContent()),
+        () -> assertEquals("#", introNode.getName()),
+        () -> assertEquals(intro, introNode.getContent()));
+  }
+
+  @Test
+  void constructor_whenCreated_expectDefaultVisibilityCheckedAndOthersUnchecked() {
+    // Arrange
+    PeerVisibilityInputForAddPeerBoxNode node = new PeerVisibilityInputForAddPeerBoxNode();
+
+    // Act
+    long checkedCount =
+        node.getChildren().stream()
+            .filter(child -> "br".equals(child.getName()))
+            .flatMap(br -> br.getChildren().stream())
+            .filter(child -> TAG_INPUT.equals(child.getName()))
+            .filter(input -> input.getAttribute(ATTR_CHECKED) != null)
+            .count();
+
+    // Assert
+    assertEquals(1L, checkedCount, "Exactly one radio input should be checked by default");
+
+    DarknetPeerNode.FRIEND_VISIBILITY defaultVisibility =
+        Stream.of(DarknetPeerNode.FRIEND_VISIBILITY.values())
+            .filter(DarknetPeerNode.FRIEND_VISIBILITY::isDefaultValue)
+            .findFirst()
+            .orElseThrow();
+    assertTrue(
+        node.generate().contains("id=\"visibility" + defaultVisibility.name() + "\""),
+        "Generated HTML should contain the default visibility input id");
+    assertTrue(
+        node.generate().contains("checked=\"checked\""),
+        "Generated HTML should contain checked attribute for default visibility");
+  }
+
+  static Stream<DarknetPeerNode.FRIEND_VISIBILITY> visibilityValues() {
+    return Stream.of(DarknetPeerNode.FRIEND_VISIBILITY.values());
+  }
+
+  @ParameterizedTest
+  @MethodSource("visibilityValues")
+  void constructor_whenCreated_expectRadioInputAndLabelForVisibility(
+      DarknetPeerNode.FRIEND_VISIBILITY visibility) {
+    // Arrange
+    PeerVisibilityInputForAddPeerBoxNode node = new PeerVisibilityInputForAddPeerBoxNode();
+    String expectedId = "visibility" + visibility.name();
+    String expectedTitleKey = "DarknetConnectionsToadlet.peerVisibility." + visibility.name();
+    String expectedExplainKey =
+        "DarknetConnectionsToadlet.peerVisibilityExplain." + visibility.name();
+
+    // Act
+    HTMLNode input = findInputById(node, expectedId);
+
+    // Assert
+    Map<String, String> attrs = input.getAttributes();
+    assertAll(
+        () -> assertEquals(TAG_INPUT, input.getName()),
+        () -> assertNull(input.getContent(), "Input should not have direct content"),
+        () -> assertEquals("radio", attrs.get("type")),
+        () -> assertEquals("visibility", attrs.get("name")),
+        () -> assertEquals(visibility.name(), attrs.get("value")),
+        () -> assertEquals(expectedId, attrs.get("id")));
+
+    if (visibility.isDefaultValue()) {
+      assertEquals(ATTR_CHECKED, attrs.get(ATTR_CHECKED));
+    } else {
+      assertNull(attrs.get(ATTR_CHECKED));
+    }
+
+    List<HTMLNode> inputChildren = input.getChildren();
+    assertFalse(inputChildren.isEmpty(), "Input should contain label and text nodes as children");
+
+    HTMLNode label = inputChildren.getFirst();
+    assertEquals("label", label.getName());
+    assertEquals(expectedId, label.getAttribute("for"));
+
+    String renderedLabel = label.generate();
+    assertTrue(renderedLabel.contains(l10n(expectedTitleKey)));
+
+    HTMLNode separator = inputChildren.get(1);
+    assertEquals("#", separator.getName());
+    assertEquals(": ", separator.getContent());
+
+    HTMLNode explanation = inputChildren.get(2);
+    assertEquals("#", explanation.getName());
+    assertEquals(l10n(expectedExplainKey), explanation.getContent());
+  }
+
+  @Test
+  void generate_whenCalled_expectContainsVisibilityInputsInEnumOrder() {
+    // Arrange
+    PeerVisibilityInputForAddPeerBoxNode node = new PeerVisibilityInputForAddPeerBoxNode();
+
+    // Act
+    String html = node.generate();
+
+    // Assert
+    int lastIndex = -1;
+    for (DarknetPeerNode.FRIEND_VISIBILITY visibility :
+        DarknetPeerNode.FRIEND_VISIBILITY.values()) {
+      String marker = "id=\"visibility" + visibility.name() + "\"";
+      int index = html.indexOf(marker);
+      assertTrue(index > lastIndex, "Expected visibility marker to appear after the previous one");
+      lastIndex = index;
+    }
+  }
+
+  private static HTMLNode findInputById(PeerVisibilityInputForAddPeerBoxNode node, String id) {
+    for (HTMLNode child : node.getChildren()) {
+      if (!"br".equals(child.getName())) {
+        continue;
+      }
+      for (HTMLNode brChild : child.getChildren()) {
+        if (TAG_INPUT.equals(brChild.getName()) && id.equals(brChild.getAttribute("id"))) {
+          return brChild;
+        }
+      }
+    }
+    throw new AssertionError("Unable to find input with id=" + id);
+  }
+
+  private static String l10n(String key) {
+    String value = NodeL10n.getBase().getString(key);
+    assertNotNull(value, "Localization should return a non-null string for key " + key);
+    return value;
+  }
+}

--- a/src/test/java/network/crypta/clients/http/complexhtmlnodes/SecondCounterNodeTest.java
+++ b/src/test/java/network/crypta/clients/http/complexhtmlnodes/SecondCounterNodeTest.java
@@ -1,0 +1,217 @@
+package network.crypta.clients.http.complexhtmlnodes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.TimeUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SecondCounterNodeTest {
+
+  private static final String TAG_INPUT = "input";
+  private static final String TAG_SPAN = "span";
+  private static final String TAG_TEXT = "#";
+
+  private static final String ATTR_CLASS = "class";
+  private static final String ATTR_TYPE = "type";
+  private static final String ATTR_VALUE = "value";
+
+  private static final String INPUT_TYPE_HIDDEN = "hidden";
+
+  @Test
+  void constructor_whenAscendingAndTextWithoutPlaceholder_createsIncrementingCounterStructure() {
+    // Arrange
+    long initialValue = 65_000L;
+    String text = "Elapsed: ";
+
+    // Act
+    SecondCounterNode node = new SecondCounterNode(initialValue, true, text);
+
+    // Assert
+    assertEquals(TAG_SPAN, node.getName());
+    assertEquals(1, node.getAttributes().size());
+    assertEquals("needsIncrement", node.getAttribute(ATTR_CLASS));
+
+    List<HTMLNode> children = node.getChildren();
+    assertEquals(3, children.size());
+
+    assertHiddenInput(children.getFirst(), initialValue);
+    assertSpanWithText(children.get(1), text);
+    assertSpanWithText(children.get(2), TimeUtil.formatTime(initialValue));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "true, needsIncrement",
+    "false, needsDecrement",
+  })
+  void constructor_whenAscendingFlagProvided_setsCssClass(boolean ascending, String expectedClass) {
+    // Arrange
+    long initialValue = 1_000L;
+    String text = "t";
+
+    // Act
+    SecondCounterNode node = new SecondCounterNode(initialValue, ascending, text);
+
+    // Assert
+    assertEquals(TAG_SPAN, node.getName());
+    assertEquals(expectedClass, node.getAttribute(ATTR_CLASS));
+  }
+
+  @Test
+  void constructor_whenTextContainsPlaceholder_splitsAroundFirstOccurrence() {
+    // Arrange
+    long initialValue = 5_000L;
+    String text = "Time left: {0} remaining";
+
+    // Act
+    SecondCounterNode node = new SecondCounterNode(initialValue, false, text);
+
+    // Assert
+    List<HTMLNode> children = node.getChildren();
+    assertEquals(4, children.size());
+
+    assertHiddenInput(children.getFirst(), initialValue);
+    assertSpanWithText(children.get(1), "Time left: ");
+    assertSpanWithText(children.get(2), TimeUtil.formatTime(initialValue));
+    assertSpanWithText(children.get(3), " remaining");
+  }
+
+  @Test
+  void constructor_whenPlaceholderAtStart_createsEmptyPrefixSpan() {
+    // Arrange
+    long initialValue = 1_234L;
+    String text = "{0} elapsed";
+
+    // Act
+    SecondCounterNode node = new SecondCounterNode(initialValue, true, text);
+
+    // Assert
+    List<HTMLNode> children = node.getChildren();
+    assertEquals(4, children.size());
+
+    assertHiddenInput(children.getFirst(), initialValue);
+    assertSpanWithText(children.get(1), "");
+    assertSpanWithText(children.get(2), TimeUtil.formatTime(initialValue));
+    assertSpanWithText(children.get(3), " elapsed");
+  }
+
+  @Test
+  void constructor_whenPlaceholderAtEnd_createsEmptySuffixSpan() {
+    // Arrange
+    long initialValue = 12_000L;
+    String text = "Elapsed {0}";
+
+    // Act
+    SecondCounterNode node = new SecondCounterNode(initialValue, true, text);
+
+    // Assert
+    List<HTMLNode> children = node.getChildren();
+    assertEquals(4, children.size());
+
+    assertHiddenInput(children.getFirst(), initialValue);
+    assertSpanWithText(children.get(1), "Elapsed ");
+    assertSpanWithText(children.get(2), TimeUtil.formatTime(initialValue));
+    assertSpanWithText(children.get(3), "");
+  }
+
+  @Test
+  void constructor_whenMultiplePlaceholders_replacesOnlyFirstOccurrence() {
+    // Arrange
+    long initialValue = 15_000L;
+    String text = "A{0}B{0}C";
+
+    // Act
+    SecondCounterNode node = new SecondCounterNode(initialValue, false, text);
+
+    // Assert
+    List<HTMLNode> children = node.getChildren();
+    assertEquals(4, children.size());
+
+    assertHiddenInput(children.getFirst(), initialValue);
+    assertSpanWithText(children.get(1), "A");
+    assertSpanWithText(children.get(2), TimeUtil.formatTime(initialValue));
+    assertSpanWithText(children.get(3), "B{0}C");
+  }
+
+  @Test
+  void constructor_whenTextNull_throwsNullPointerException() {
+    // Arrange
+    long initialValue = 0L;
+
+    // Act + Assert
+    //noinspection DataFlowIssue
+    assertThrows(NullPointerException.class, () -> new SecondCounterNode(initialValue, true, null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("initialValues")
+  void constructor_whenCalled_setsHiddenInputAndFormattedTime(long initialValue) {
+    // Arrange
+    String text = "Elapsed: ";
+
+    // Act
+    SecondCounterNode node = new SecondCounterNode(initialValue, true, text);
+
+    // Assert
+    List<HTMLNode> children = node.getChildren();
+    assertEquals(3, children.size());
+
+    HTMLNode input = children.getFirst();
+    assertHiddenInput(input, initialValue);
+
+    HTMLNode formattedTimeSpan = children.get(2);
+    assertSpanWithText(formattedTimeSpan, TimeUtil.formatTime(initialValue));
+  }
+
+  static Stream<Arguments> initialValues() {
+    return Stream.of(
+        Arguments.of(0L),
+        Arguments.of(999L),
+        Arguments.of(1_000L),
+        Arguments.of(65_000L),
+        Arguments.of(-1L),
+        Arguments.of(Long.MIN_VALUE));
+  }
+
+  private static void assertHiddenInput(HTMLNode node, long expectedValue) {
+    assertNotNull(node);
+    assertEquals(TAG_INPUT, node.getName());
+
+    Map<String, String> attributes = node.getAttributes();
+    assertEquals(2, attributes.size());
+    assertEquals(INPUT_TYPE_HIDDEN, node.getAttribute(ATTR_TYPE));
+    assertEquals(String.valueOf(expectedValue), node.getAttribute(ATTR_VALUE));
+
+    assertEquals(0, node.getChildren().size());
+  }
+
+  private static void assertSpanWithText(HTMLNode node, String expectedText) {
+    assertNotNull(node);
+    assertEquals(TAG_SPAN, node.getName());
+
+    List<HTMLNode> children = node.getChildren();
+    assertEquals(1, children.size());
+    assertTextNode(children.getFirst(), expectedText);
+  }
+
+  private static void assertTextNode(HTMLNode node, String expectedText) {
+    assertNotNull(node);
+    assertEquals(TAG_TEXT, node.getName());
+    assertEquals(expectedText, node.getContent());
+    assertEquals(0, node.getChildren().size());
+  }
+}


### PR DESCRIPTION
## Summary
- Adds unit tests for `PeerTrustInputForAddPeerBoxNode`, `PeerVisibilityInputForAddPeerBoxNode`, and `SecondCounterNode`.
- Improves Javadoc/KDoc-style documentation for the HTML node builders and replaces repeated string literals with small constants.
- No intended runtime behavior changes: markup structure, input names/ids, ordering, and default-selection behavior remain the same.

## Testing
- `./gradlew test --tests '*PeerTrustInputForAddPeerBoxNodeTest' --tests '*PeerVisibilityInputForAddPeerBoxNodeTest' --tests '*SecondCounterNodeTest'`