### PR TITLE
fix(bookmarks): improve persistence and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/http/bookmark/Bookmark.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/Bookmark.java
@@ -3,14 +3,82 @@ package network.crypta.clients.http.bookmark;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.SimpleFieldSet;
 
+/**
+ * Base type for bookmarks exposed by the HTTP client UI.
+ *
+ * <p>A {@code Bookmark} primarily wraps a user-visible name and provides a compact serialization
+ * via {@link #getSimpleFieldSet()} so that subclasses can be persisted and restored consistently.
+ * The name is stored in a "raw" form (see {@link #getName()}) and can optionally use an {@code
+ * l10n:} prefix to reference a translation key; {@link #getVisibleName()} resolves that prefix via
+ * {@link NodeL10n} for display, while leaving ordinary names unchanged.
+ *
+ * <p>This class is intentionally small and mutable: subclasses typically set the name during
+ * construction or deserialization, and callers should treat instances as ordinary in-memory model
+ * objects. The implementation is not thread-safe; if a bookmark instance may be accessed from
+ * multiple threads, callers must provide external synchronization or publish immutable snapshots.
+ *
+ * <p><b>Responsibilities</b>
+ *
+ * <ul>
+ *   <li>Store the bookmark's raw name and expose it to callers.
+ *   <li>Provide a localized display name for built-in/default bookmark entries.
+ *   <li>Expose a {@link SimpleFieldSet} representation for persistence and transport.
+ * </ul>
+ *
+ * @see NodeL10n
+ * @see SimpleFieldSet
+ */
 public abstract class Bookmark {
 
+  /**
+   * Raw bookmark name.
+   *
+   * <p>The value is expected to be non-null before any public accessor is called. Subclasses are
+   * responsible for initializing it (for example during construction or deserialization). If the
+   * string begins with {@code l10n:} (case-insensitive), {@link #getVisibleName()} treats the
+   * remainder as a localization key suffix rather than literal user input.
+   */
   protected String name;
 
+  /**
+   * Creates an uninitialized bookmark instance.
+   *
+   * <p>This constructor performs no initialization beyond the implicit Java defaults. Subclasses
+   * are expected to set a non-null {@link #name} (for example via {@link #setName(String)} or by
+   * assigning directly) before exposing the instance to other code.
+   *
+   * <p>As a consequence, calling methods such as {@link #getVisibleName()}, {@link
+   * #equals(Object)}, or {@link #hashCode()} before initialization may result in a {@link
+   * NullPointerException}. Implementations that deserialize bookmarks typically populate {@link
+   * #name} before returning the instance to callers.
+   */
+  protected Bookmark() {}
+
+  /**
+   * Returns the raw bookmark name as stored on this instance.
+   *
+   * <p>This is the unprocessed value, which may include the {@code l10n:} prefix used for
+   * built-in/default bookmark entries. Callers that want a UI-friendly value should prefer {@link
+   * #getVisibleName()}.
+   *
+   * @return the raw name string, as stored, without localization or normalization.
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Returns a display-friendly bookmark name.
+   *
+   * <p>If the raw name begins with {@code l10n:} (case-insensitive), this method resolves the name
+   * through {@link NodeL10n#getBase()} using the key prefix {@code Bookmarks.Defaults.Name.} plus
+   * the suffix after {@code l10n:}. Otherwise, it returns the raw name unchanged.
+   *
+   * <p>This method does not perform trimming or validation; it mirrors the stored data so that the
+   * UI can render both user-defined and built-in entries predictably.
+   *
+   * @return the localized name when {@code l10n:} is used, otherwise the raw name.
+   */
   public String getVisibleName() {
     if (name.toLowerCase().startsWith("l10n:"))
       return NodeL10n.getBase()
@@ -18,10 +86,32 @@ public abstract class Bookmark {
     return name;
   }
 
+  /**
+   * Sets the raw bookmark name, applying the standard empty-name fallback.
+   *
+   * <p>If {@code s} is empty, this method substitutes the localized {@code Bookmark.noName} string
+   * from {@link NodeL10n#getBase()}. Otherwise, the provided string is stored verbatim and may
+   * later be interpreted as a localization reference if it starts with {@code l10n:}.
+   *
+   * <p>This method is protected to keep name initialization under subclass control; callers should
+   * treat bookmarks as mutable model objects rather than stable identifiers.
+   *
+   * @param s the desired raw name; must be non-null, and an empty string selects the default name.
+   */
   protected void setName(String s) {
     name = (!s.isEmpty() ? s : NodeL10n.getBase().getString("Bookmark.noName"));
   }
 
+  /**
+   * Compares this bookmark to another object for equality.
+   *
+   * <p>Two {@code Bookmark} instances are considered equal when they are both bookmarks and their
+   * raw {@link #name} strings are equal. Subclasses do not contribute additional state to equality
+   * in this base implementation.
+   *
+   * @param o the object to compare with this bookmark; may be {@code null}.
+   * @return {@code true} when {@code o} is a bookmark with the same raw name.
+   */
   @Override
   public boolean equals(Object o) {
     if (o == this) return true;
@@ -30,10 +120,30 @@ public abstract class Bookmark {
     } else return false;
   }
 
+  /**
+   * Returns a hash code for this bookmark.
+   *
+   * <p>The hash code is derived solely from the raw {@link #name} string so that it is consistent
+   * with {@link #equals(Object)}.
+   *
+   * @return the hash code of the raw name string.
+   */
   @Override
   public int hashCode() {
     return name.hashCode();
   }
 
+  /**
+   * Returns a {@link SimpleFieldSet} representation of this bookmark.
+   *
+   * <p>Subclasses implement this method to serialize bookmark state into a stable, key/value
+   * representation. The returned field set is typically used to persist bookmark configuration or
+   * to transfer bookmark data through internal APIs.
+   *
+   * <p>The returned instance is owned by the caller; callers should not assume it will be updated
+   * if the bookmark is mutated after this method returns.
+   *
+   * @return a field-set representation of this bookmark, suitable for persistence or transport.
+   */
   public abstract SimpleFieldSet getSimpleFieldSet();
 }

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkCategory.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkCategory.java
@@ -5,26 +5,91 @@ import java.util.List;
 import network.crypta.node.FSParseException;
 import network.crypta.support.SimpleFieldSet;
 
+/**
+ * A {@link Bookmark} that groups other bookmarks into a hierarchical category tree.
+ *
+ * <p>A {@code BookmarkCategory} is used by the HTTP bookmark UI to model folders that can contain
+ * both {@link BookmarkItem} leaves and nested {@link BookmarkCategory} children. Instances are
+ * typically created either from a display name (for new categories) or by decoding a persisted
+ * {@link SimpleFieldSet} (for loading existing bookmark structures). Callers then add, remove, and
+ * reorder entries via the provided methods and finally persist the structure again via {@link
+ * #getSimpleFieldSet()}.
+ *
+ * <p>The internal list is mutable but is guarded by {@code synchronized} instance methods, making
+ * compound operations on the category contents atomic with respect to other calls on the same
+ * object. Returned collections are snapshots: modifications to the returned lists do not affect
+ * this category, although the contained bookmark objects themselves are shared references.
+ *
+ * <ul>
+ *   <li><b>Responsibility:</b> maintain an ordered list of child bookmarks.
+ *   <li><b>Notable behavior:</b> movement operations are best-effort and no-op when not applicable.
+ *   <li><b>Persistence:</b> serializes name plus content using {@link BookmarkManager} helpers.
+ * </ul>
+ *
+ * @see Bookmark
+ * @see BookmarkItem
+ * @see BookmarkManager
+ */
 public class BookmarkCategory extends Bookmark {
-  public static final String NAME = "BookmarkCategory";
+  /**
+   * Type discriminator used when encoding or decoding this bookmark kind in a {@link
+   * SimpleFieldSet}.
+   *
+   * <p>This key is intentionally stable because persisted bookmark data may include it as an
+   * identifier for category nodes.
+   */
+  public static final String SFS_KEY = "BookmarkCategory";
 
   private final List<Bookmark> bookmarks = new ArrayList<>();
 
+  /**
+   * Creates an empty category with the given display name.
+   *
+   * <p>The new instance contains no child bookmarks. After construction, callers typically add
+   * {@link BookmarkItem} and/or nested {@link BookmarkCategory} instances and then persist the
+   * resulting structure via {@link #getSimpleFieldSet()}.
+   *
+   * @param name the display name for the category; must be non-null and non-empty for UI display
+   */
   public BookmarkCategory(String name) {
     setName(name);
   }
 
+  /**
+   * Reconstructs a category from its serialized {@link SimpleFieldSet} representation.
+   *
+   * <p>This constructor reads the required {@code Name} field from {@code sfs} and initializes the
+   * category name accordingly. The category contents are expected to be handled by surrounding code
+   * that parses the serialized bookmark tree.
+   *
+   * @param sfs the serialized field set to read from; must contain a {@code Name} entry
+   * @throws FSParseException if the field set is missing required fields or is otherwise malformed
+   */
   public BookmarkCategory(SimpleFieldSet sfs) throws FSParseException {
     String aName = sfs.get("Name");
     if (aName == null) throw new FSParseException("No Name!");
     setName(aName);
   }
 
+  /**
+   * Adds a child bookmark to this category if it is not already present.
+   *
+   * <p>The category maintains a single ordered list containing both {@link BookmarkItem} leaves and
+   * nested {@link BookmarkCategory} nodes. If a bookmark that compares equal to {@code b} already
+   * exists (as defined by {@link List#indexOf(Object)}), this method returns the existing instance
+   * and leaves the list unchanged.
+   *
+   * <p>This method is synchronized to ensure that the presence check and conditional insertion are
+   * performed atomically with respect to other mutations of the category contents.
+   *
+   * @param b the bookmark to add; may be {@code null}, in which case this method does nothing
+   * @return the bookmark instance present in the category, or {@code null} if {@code b} is null
+   */
   protected synchronized Bookmark addBookmark(Bookmark b) {
     if (b == null) {
       return null;
     }
-    // Overwrite any existing bookmark
+    // Return the existing bookmark if one is already present.
     int x = bookmarks.indexOf(b);
     if (x >= 0) {
       return bookmarks.get(x);
@@ -33,14 +98,43 @@ public class BookmarkCategory extends Bookmark {
     return b;
   }
 
+  /**
+   * Removes a child bookmark from this category.
+   *
+   * <p>If the bookmark is not present, this method has no effect. Removal uses the list's equality
+   * semantics, so it removes the first entry that compares equal to {@code b}.
+   *
+   * @param b the bookmark to remove; may be {@code null}, in which case this method does nothing
+   */
   protected synchronized void removeBookmark(Bookmark b) {
     bookmarks.remove(b);
   }
 
+  /**
+   * Returns the child bookmark at the given index in this category.
+   *
+   * <p>The ordering corresponds to the in-memory order maintained by this category, which is
+   * affected by insertion order and by {@link #moveBookmarkUp(Bookmark)} / {@link
+   * #moveBookmarkDown(Bookmark)} operations.
+   *
+   * @param i the zero-based index of the child entry to return; must be within the current bounds
+   * @return the child bookmark stored at the requested index
+   * @throws IndexOutOfBoundsException if {@code i} is negative or not less than {@link #size()}
+   */
   public synchronized Bookmark get(int i) {
     return bookmarks.get(i);
   }
 
+  /**
+   * Moves the given bookmark one position earlier within this category's ordering.
+   *
+   * <p>If the bookmark is not present, this method is a no-op. If the bookmark is already the first
+   * element, it remains at position {@code 0}. Movement is performed as a remove-then-insert within
+   * the underlying list and is synchronized to prevent concurrent reordering or removal from
+   * producing inconsistent results.
+   *
+   * @param b the bookmark to move; if {@code null} or absent, this method has no effect
+   */
   protected synchronized void moveBookmarkUp(Bookmark b) {
     int index = bookmarks.indexOf(b);
     if (index == -1) {
@@ -51,6 +145,16 @@ public class BookmarkCategory extends Bookmark {
     bookmarks.add((--index < 0) ? 0 : index, bk);
   }
 
+  /**
+   * Moves the given bookmark one position later within this category's ordering.
+   *
+   * <p>If the bookmark is not present, this method is a no-op. If the bookmark is already the last
+   * element, it remains at the end of the list. Movement is performed as a remove-then-insert
+   * operation and is synchronized to provide an atomic reordering with respect to other category
+   * mutations.
+   *
+   * @param b the bookmark to move; if {@code null} or absent, this method has no effect
+   */
   protected synchronized void moveBookmarkDown(Bookmark b) {
     int index = bookmarks.indexOf(b);
     if (index == -1) {
@@ -61,10 +165,27 @@ public class BookmarkCategory extends Bookmark {
     bookmarks.add((++index > size()) ? size() : index, bk);
   }
 
+  /**
+   * Returns the number of direct child bookmarks held by this category.
+   *
+   * <p>This count includes both {@link BookmarkItem} entries and nested {@link BookmarkCategory}
+   * entries, but does not include grandchildren or deeper descendants.
+   *
+   * @return the number of immediate children currently stored in this category
+   */
   public synchronized int size() {
     return bookmarks.size();
   }
 
+  /**
+   * Returns the direct {@link BookmarkItem} children of this category.
+   *
+   * <p>The returned list is a snapshot built at the time of the call. Modifying the returned list
+   * does not affect this category, but the {@link BookmarkItem} instances inside are the same
+   * objects stored in the category.
+   *
+   * @return a new list containing only direct {@link BookmarkItem} children, in current order
+   */
   public synchronized List<BookmarkItem> getItems() {
     List<BookmarkItem> items = new ArrayList<>();
     for (Bookmark b : bookmarks) {
@@ -75,6 +196,16 @@ public class BookmarkCategory extends Bookmark {
     return items;
   }
 
+  /**
+   * Returns all {@link BookmarkItem} descendants reachable from this category.
+   *
+   * <p>This method traverses the category tree depth-first. It first returns the direct items from
+   * {@link #getItems()} and then recursively accumulates items from each sub-category returned by
+   * {@link #getSubCategories()}. The returned list is a snapshot; later mutations to the category
+   * structure are not reflected in the result.
+   *
+   * @return a new list containing all item descendants, preserving the current traversal order
+   */
   public synchronized List<BookmarkItem> getAllItems() {
     List<BookmarkItem> items = getItems();
     for (BookmarkCategory cat : getSubCategories()) {
@@ -83,6 +214,15 @@ public class BookmarkCategory extends Bookmark {
     return items;
   }
 
+  /**
+   * Returns the direct sub-categories contained by this category.
+   *
+   * <p>The returned list is a snapshot that includes only those children that are themselves {@link
+   * BookmarkCategory} instances. The ordering matches the current in-memory ordering of the
+   * underlying child list.
+   *
+   * @return a new list containing the direct sub-categories of this category, in current order
+   */
   public synchronized List<BookmarkCategory> getSubCategories() {
     List<BookmarkCategory> categories = new ArrayList<>();
     for (Bookmark b : bookmarks) {
@@ -93,6 +233,15 @@ public class BookmarkCategory extends Bookmark {
     return categories;
   }
 
+  /**
+   * Returns all descendant sub-categories reachable from this category.
+   *
+   * <p>This method returns the direct children from {@link #getSubCategories()} and then
+   * recursively adds each child's descendants. The returned list is a snapshot, so subsequent
+   * mutations to the category tree do not affect the returned result.
+   *
+   * @return a new list containing all descendant categories, preserving the current traversal order
+   */
   public synchronized List<BookmarkCategory> getAllSubCategories() {
     List<BookmarkCategory> categories = getSubCategories();
     for (BookmarkCategory cat : getSubCategories()) {
@@ -101,6 +250,20 @@ public class BookmarkCategory extends Bookmark {
     return categories;
   }
 
+  /**
+   * Flattens this category tree into a list of display-oriented strings.
+   *
+   * <p>The resulting strings use {@code '/'} as a path separator. Each {@link BookmarkCategory}
+   * contributes its {@linkplain #getName() name} followed by a trailing {@code '/'} to the prefix,
+   * and each {@link BookmarkItem} contributes its {@link Object#toString()} representation at the
+   * leaf. This method is intended for UI-facing or debugging-style output, not for persistence.
+   *
+   * <p>This method does not synchronize; it relies on called methods that snapshot the current
+   * children. Callers that concurrently mutate category names or structure should synchronize
+   * externally if they require a fully consistent view.
+   *
+   * @return an array of flattened path-like strings for items contained within this category tree
+   */
   public String[] toStrings() {
     return toStrings("").toArray(new String[0]);
   }
@@ -113,17 +276,18 @@ public class BookmarkCategory extends Bookmark {
     List<BookmarkCategory> subCategories = getSubCategories();
     prefix += this.name + "/";
 
-    for (int i = 0; i < items.size(); i++) {
-      strings.add(prefix + items.get(i).toString());
+    for (BookmarkItem item : items) {
+      strings.add(prefix + item.toString());
     }
 
-    for (int i = 0; i < subCategories.size(); i++) {
-      strings.addAll(subCategories.get(i).toStrings(prefix));
+    for (BookmarkCategory subCategory : subCategories) {
+      strings.addAll(subCategory.toStrings(prefix));
     }
 
     return strings;
   }
 
+  /** {@inheritDoc} */
   @Override
   public synchronized SimpleFieldSet getSimpleFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
@@ -131,6 +295,16 @@ public class BookmarkCategory extends Bookmark {
     sfs.put("Content", BookmarkManager.toSimpleFieldSet(this));
     return sfs;
   }
-  // Don't override equals(), two categories are equal if they have the same name and description.
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
 }

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkItem.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkItem.java
@@ -1,13 +1,13 @@
 package network.crypta.clients.http.bookmark;
 
 import java.net.MalformedURLException;
+import java.util.Objects;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.FSParseException;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.useralerts.AbstractUserAlert;
-import network.crypta.node.useralerts.AbstractUserAlert.DismissOptions;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.HTMLNode;
@@ -15,19 +15,86 @@ import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A single persisted bookmark entry backed by a {@link FreenetURI}, with optional update tracking.
+ *
+ * <p>{@code BookmarkItem} represents the concrete, user-visible bookmark record used by the HTTP
+ * bookmarks UI and the bookmark persistence layer. In addition to the inherited {@code name} from
+ * {@link Bookmark}, it stores the target URI, a long and short description, and a small amount of
+ * state used for UI behavior and notifications. When the bookmark points to a {@link USK}, the item
+ * can mark itself as “updated” after an edition bump; this state is surfaced to the user via a
+ * {@link UserAlert} registered with the owning {@link UserAlertManager}.
+ *
+ * <p><b>Notable behaviors</b>
+ *
+ * <ul>
+ *   <li>Persists to and restores from {@link SimpleFieldSet} using stable field names.
+ *   <li>Supports inline localization tokens using the {@code "l10n:"} prefix for descriptions.
+ *   <li>Tracks update state for USKs and exposes a per-item {@link UserAlert}.
+ * </ul>
+ *
+ * <p><b>Thread-safety</b>: some mutating methods are {@code synchronized} and the update alert uses
+ * synchronized access to the {@code updated} flag. Callers should treat instances as effectively
+ * mutable and not inherently thread-safe unless they provide external synchronization.
+ */
 public class BookmarkItem extends Bookmark {
   private static final Logger LOG = LoggerFactory.getLogger(BookmarkItem.class);
 
-  public static final String NAME = "Bookmark";
+  /**
+   * Stable identifier prefix used to tag bookmark items in serialized or display-oriented contexts.
+   *
+   * <p>This constant provides a durable string identifier that other components can use when they
+   * need to distinguish bookmark item records from other bookmark-related structures (for example,
+   * when persisting or displaying composite bookmark data).
+   */
+  public static final String BOOKMARK_PREFIX = "Bookmark";
+
+  private static final String L10N_KEY_PREFIX = "BookmarkItem.";
+  private static final String L10N_INLINE_PREFIX = "l10n:";
+
   private final BookmarkManager manager;
   private FreenetURI key;
   private boolean updated;
-  private boolean hasAnActivelink = false;
+  private boolean hasAnActivelink;
   private final BookmarkUpdatedUserAlert alert;
   private final UserAlertManager alerts;
+
+  /**
+   * The persisted description value for this bookmark, possibly {@code null}.
+   *
+   * <p>If the value begins with {@code "l10n:"} (case-insensitive), {@link #getDescription()}
+   * resolves it via {@link NodeL10n}. Callers should prefer the accessor to obtain the effective
+   * user-facing text.
+   */
   protected String desc;
+
+  /**
+   * The persisted short description value for this bookmark, possibly {@code null}.
+   *
+   * <p>If the value begins with {@code "l10n:"} (case-insensitive), {@link #getShortDescription()}
+   * resolves it via {@link NodeL10n}. Callers should prefer the accessor to obtain the effective
+   * user-facing text.
+   */
   protected String shortDescription;
 
+  /**
+   * Creates a new bookmark item with the supplied fields and associated managers.
+   *
+   * <p>This constructor does not perform persistence. The created instance owns a per-item {@link
+   * UserAlert} (available via {@link #getUserAlert()}) and will register/unregister it with the
+   * provided {@link UserAlertManager} as the {@code updated} state changes.
+   *
+   * @param k the target URI for this bookmark; must be non-{@code null} and well-formed
+   * @param n the display name for this bookmark; must be non-{@code null} and non-empty
+   * @param d the long description text; may be {@code null} and may use {@code "l10n:"} indirection
+   * @param s the short description text; may be {@code null} and may use {@code "l10n:"}
+   *     indirection
+   * @param hasAnActivelink {@code true} if the bookmark currently has an active link target
+   * @param bm the owning bookmark manager responsible for persistence callbacks; must be non-{@code
+   *     null}
+   * @param uam the alert manager used to register the per-item {@link UserAlert}; must be
+   *     non-{@code null} and associated with the same node context as {@code bm}
+   */
   public BookmarkItem(
       FreenetURI k,
       String n,
@@ -35,9 +102,8 @@ public class BookmarkItem extends Bookmark {
       String s,
       boolean hasAnActivelink,
       BookmarkManager bm,
-      UserAlertManager uam)
-      throws MalformedURLException {
-    this.key = k;
+      UserAlertManager uam) {
+    key = k;
     this.name = n;
     this.desc = d;
     this.shortDescription = s;
@@ -49,11 +115,34 @@ public class BookmarkItem extends Bookmark {
     assert (key != null);
   }
 
-  /** Please call {@link #registerUserAlert()} afterwards. */
+  /**
+   * Restores a bookmark item from a {@link SimpleFieldSet} as persisted by {@link
+   * #getSimpleFieldSet()}.
+   *
+   * <p>The constructor reads the expected fields {@code Name}, {@code Description}, {@code
+   * ShortDescription}, {@code hasAnActivelink}, {@code Updated}, and {@code URI}. Missing or empty
+   * string fields fall back to safe defaults (empty descriptions and a localized placeholder name).
+   * The {@code Updated} flag defaults to {@code false} for backward compatibility with older saved
+   * bookmark databases that predate this field.
+   *
+   * <p>This constructor does not automatically register the update notification. If the restored
+   * item is both a USK and marked updated, call {@link #registerUserAlert()} after construction to
+   * register its {@link UserAlert} with the provided {@link UserAlertManager}.
+   *
+   * @param sfs the serialized field set containing bookmark item data; must be non-{@code null}
+   * @param bm the owning bookmark manager responsible for persistence callbacks; must be non-{@code
+   *     null}
+   * @param uam the alert manager used to register the per-item {@link UserAlert}; must be
+   *     non-{@code null} and associated with the same node context as {@code bm}
+   * @throws FSParseException if the field set is missing required fields or contains invalid values
+   * @throws MalformedURLException if the stored URI cannot be parsed into a {@link FreenetURI}
+   */
   public BookmarkItem(SimpleFieldSet sfs, BookmarkManager bm, UserAlertManager uam)
       throws FSParseException, MalformedURLException {
     this.name = sfs.get("Name");
-    if (name == null || name.isEmpty()) name = l10n("unnamedBookmark");
+    if (name == null || name.isEmpty()) {
+      name = NodeL10n.getBase().getString(L10N_KEY_PREFIX + "unnamedBookmark");
+    }
     this.desc = sfs.get("Description");
     if (desc == null) desc = "";
     this.shortDescription = sfs.get("ShortDescription");
@@ -68,9 +157,6 @@ public class BookmarkItem extends Bookmark {
     this.alert = new BookmarkUpdatedUserAlert();
   }
 
-  static {
-  }
-
   private class BookmarkUpdatedUserAlert extends AbstractUserAlert {
 
     public BookmarkUpdatedUserAlert() {
@@ -79,15 +165,16 @@ public class BookmarkItem extends Bookmark {
 
     @Override
     public String getTitle() {
-      return l10n("bookmarkUpdatedTitle", "name", name);
+      return l10nWithName("bookmarkUpdatedTitle", name);
     }
 
     @Override
     public String getText() {
-      return l10n(
-          "bookmarkUpdated",
-          new String[] {"name", "edition"},
-          new String[] {name, Long.toString(key.getSuggestedEdition())});
+      return NodeL10n.getBase()
+          .getString(
+              L10N_KEY_PREFIX + "bookmarkUpdated",
+              new String[] {"name", "edition"},
+              new String[] {name, Long.toString(key.getSuggestedEdition())});
     }
 
     @Override
@@ -123,7 +210,7 @@ public class BookmarkItem extends Bookmark {
 
     @Override
     public String dismissButtonText() {
-      return l10n("deleteBookmarkUpdateNotification");
+      return NodeL10n.getBase().getString(L10N_KEY_PREFIX + "deleteBookmarkUpdateNotification");
     }
 
     @Override
@@ -134,31 +221,23 @@ public class BookmarkItem extends Bookmark {
 
     @Override
     public String getShortText() {
-      return l10n("bookmarkUpdatedShort", "name", name);
+      return l10nWithName("bookmarkUpdatedShort", name);
     }
 
     @Override
     public boolean isEventNotification() {
       return true;
     }
+
+    private String l10nWithName(String key, String nameValue) {
+      return NodeL10n.getBase()
+          .getString(L10N_KEY_PREFIX + key, new String[] {"name"}, new String[] {nameValue});
+    }
   }
 
   private synchronized void disableBookmark() {
     updated = false;
     alerts.unregister(alert);
-  }
-
-  private String l10n(String key) {
-    return NodeL10n.getBase().getString("BookmarkItem." + key);
-  }
-
-  private String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase()
-        .getString("BookmarkItem." + key, new String[] {pattern}, new String[] {value});
-  }
-
-  private String l10n(String key, String[] patterns, String[] values) {
-    return NodeL10n.getBase().getString("BookmarkItem." + key, patterns, values);
   }
 
   private synchronized void enableBookmark() {
@@ -179,18 +258,63 @@ public class BookmarkItem extends Bookmark {
     if (key.isUSK() && updated) alerts.register(alert);
   }
 
+  /**
+   * Returns the per-item {@link UserAlert} representing an update notification for this bookmark.
+   *
+   * <p>The returned alert object is owned by this {@code BookmarkItem} instance. It is registered
+   * and unregistered with the {@link UserAlertManager} configured at construction time based on the
+   * {@code updated} state and bookmark type (USK vs. non-USK).
+   *
+   * @return the non-{@code null} alert instance associated with this bookmark item
+   */
   public UserAlert getUserAlert() {
     return alert;
   }
 
+  /**
+   * Returns the current bookmark key as a string.
+   *
+   * <p>This is the string form of the underlying {@link FreenetURI} and is suitable for storage or
+   * display. It is equivalent to calling {@code getURI().toString()} but avoids exposing the URI
+   * object itself.
+   *
+   * <p>This method is not synchronized; in concurrent contexts where the bookmark may be updated
+   * while being read, callers should use {@link #getURI()} (which is synchronized) and then convert
+   * to a string.
+   *
+   * @return a non-{@code null} string representation of the bookmark target URI
+   */
   public String getKey() {
     return key.toString();
   }
 
+  /**
+   * Returns the current target {@link FreenetURI} for this bookmark item.
+   *
+   * <p>This method is synchronized to provide a consistent view of the underlying URI during
+   * concurrent updates. If callers retain the returned reference, they should re-fetch via this
+   * method if they require the latest value after {@link #update(FreenetURI, boolean, String,
+   * String)} or {@link #setEdition(long, NodeClientCore)}.
+   *
+   * @return the current {@link FreenetURI} instance for this bookmark; never {@code null}
+   */
   public synchronized FreenetURI getURI() {
     return key;
   }
 
+  /**
+   * Updates the bookmark’s URI and descriptive fields in-place.
+   *
+   * <p>This method replaces the stored URI, descriptions, and active-link flag. If the new URI is
+   * not a USK, any existing update notification is disabled, because edition tracking is only
+   * meaningful for USKs. This method does not persist changes to disk; callers typically update the
+   * in-memory object and then trigger persistence via the owning {@link BookmarkManager}.
+   *
+   * @param uri the new target URI to store for this bookmark; must be non-{@code null}
+   * @param hasAnActivelink {@code true} if the bookmark should be treated as having an active link
+   * @param description the new long description value to store; may be {@code null}
+   * @param shortDescription the new short description value to store; may be {@code null}
+   */
   public synchronized void update(
       FreenetURI uri, boolean hasAnActivelink, String description, String shortDescription) {
     this.key = uri;
@@ -200,6 +324,18 @@ public class BookmarkItem extends Bookmark {
     if (!key.isUSK()) disableBookmark();
   }
 
+  /**
+   * Returns the key type string for the current bookmark URI.
+   *
+   * <p>This is a convenience wrapper for {@link FreenetURI#getKeyType()} and reflects the current
+   * stored value returned by {@link #getURI()}.
+   *
+   * <p>The returned value is an identifier such as {@code "USK"} for updatable keys. The exact set
+   * of possible key type strings depends on the URI implementation; callers should treat it as an
+   * opaque identifier and avoid hard-coding behavior beyond well-known, explicitly supported types.
+   *
+   * @return the key type identifier for the current URI; never {@code null}
+   */
   public synchronized String getKeyType() {
     return key.getKeyType();
   }
@@ -216,11 +352,26 @@ public class BookmarkItem extends Bookmark {
   }
 
   /**
-   * @return True if we updated the edition
+   * Updates the suggested edition for a USK bookmark and enables update notifications when needed.
+   *
+   * <p>If the current suggested edition is already greater than or equal to {@code ed}, this method
+   * leaves the bookmark unchanged and returns {@code false}. Otherwise, it updates the stored
+   * {@link FreenetURI} to use the provided suggested edition and enables the update notification
+   * alert for the item.
+   *
+   * <p>This method is synchronized to serialize updates and to keep the {@code updated} flag and
+   * alert registration consistent with the stored key.
+   *
+   * @param ed the new suggested edition to apply; must be greater than the current suggested
+   *     edition
+   * @param node the node context used for diagnostic logging; may be {@code null}
+   * @return {@code true} if the edition was updated; {@code false} if {@code ed} was not newer
    */
   public synchronized boolean setEdition(long ed, NodeClientCore node) {
     if (key.getSuggestedEdition() >= ed) {
-      if (LOG.isDebugEnabled()) LOG.debug("Edition " + ed + " is too old, not updating " + key);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Edition {} is too old, not updating {} (nodePresent={})", ed, key, node != null);
+      }
       return false;
     }
     key = key.setSuggestedEdition(ed);
@@ -228,6 +379,16 @@ public class BookmarkItem extends Bookmark {
     return true;
   }
 
+  /**
+   * Returns this bookmark’s key as a {@link USK}.
+   *
+   * <p>This is a convenience wrapper around {@link USK#create(FreenetURI)} for callers that need to
+   * treat the bookmark target as an updatable key. Callers should ensure the current URI represents
+   * a USK before calling; otherwise the conversion will fail.
+   *
+   * @return a {@link USK} instance created from the current bookmark URI
+   * @throws MalformedURLException if the current URI cannot be represented as a {@link USK}
+   */
   public USK getUSK() throws MalformedURLException {
     return USK.create(key);
   }
@@ -265,41 +426,91 @@ public class BookmarkItem extends Bookmark {
       if (b.hasAnActivelink != hasAnActivelink) {
         return false;
       }
-      if (b.desc.equals(desc)) return true;
-      if (b.desc == null || desc == null) return false;
-      return b.desc.equals(desc);
+      return Objects.equals(b.desc, desc);
     } else {
       return false;
     }
   }
 
+  /**
+   * Returns whether this bookmark is currently marked as updated.
+   *
+   * <p>The updated flag is used to decide whether the per-item {@link UserAlert} should be
+   * considered valid and shown to the user. The flag is typically set via {@link #setEdition(long,
+   * NodeClientCore)} for USKs and cleared when the user dismisses the notification or when the
+   * bookmark no longer represents a USK.
+   *
+   * @return {@code true} if the bookmark is marked updated; {@code false} otherwise
+   */
   public boolean hasUpdated() {
     return updated;
   }
 
+  /**
+   * Clears the updated flag for this bookmark without modifying the stored URI.
+   *
+   * <p>This method only updates the in-memory state. Callers that need to fully disable update
+   * notifications should also ensure the corresponding {@link UserAlert} is unregistered (for
+   * example via user dismissal flows) and that persistence is triggered by the owning {@link
+   * BookmarkManager} if appropriate.
+   *
+   * <p>If this item is a USK and the alert was previously registered, clearing the flag affects the
+   * alert’s validity check but does not, by itself, force an immediate unregister; the surrounding
+   * alert lifecycle is managed by {@link BookmarkItem} and the {@link UserAlertManager}.
+   */
   public void clearUpdated() {
     this.updated = false;
   }
 
+  /**
+   * Returns whether this bookmark is currently treated as having an active link target.
+   *
+   * <p>This flag is persisted as {@code hasAnActivelink} and is typically used by the bookmarks UI
+   * to decide how to render or enable the bookmark entry. The meaning of “active” is intentionally
+   * coarse-grained: it is a stored UI/state hint rather than an on-demand validation of the target.
+   *
+   * @return {@code true} if the bookmark is marked as active; {@code false} otherwise
+   */
   public boolean hasAnActivelink() {
     return hasAnActivelink;
   }
 
+  /**
+   * Returns the effective long description for this bookmark.
+   *
+   * <p>If the stored description value is {@code null}, this method returns an empty string. If the
+   * stored value begins with {@code "l10n:"} (case-insensitive), the suffix is treated as a key and
+   * resolved via {@link NodeL10n} under {@code "Bookmarks.Defaults.Description."}. Otherwise, the
+   * stored description is returned as-is.
+   *
+   * @return the resolved long description text; never {@code null}
+   */
   public String getDescription() {
     if (desc == null) return "";
-    if (desc.toLowerCase().startsWith("l10n:"))
+    if (desc.toLowerCase().startsWith(L10N_INLINE_PREFIX))
       return NodeL10n.getBase()
-          .getString("Bookmarks.Defaults.Description." + desc.substring("l10n:".length()));
+          .getString(
+              "Bookmarks.Defaults.Description." + desc.substring(L10N_INLINE_PREFIX.length()));
     return desc;
   }
 
+  /**
+   * Returns the effective short description for this bookmark.
+   *
+   * <p>If the stored short description value is {@code null}, this method returns an empty string.
+   * If the stored value begins with {@code "l10n:"} (case-insensitive), the suffix is treated as a
+   * key and resolved via {@link NodeL10n} under {@code "Bookmarks.Defaults.ShortDescription."}.
+   * Otherwise, the stored short description is returned as-is.
+   *
+   * @return the resolved short description text; never {@code null}
+   */
   public String getShortDescription() {
     if (shortDescription == null) return "";
-    if (shortDescription.toLowerCase().startsWith("l10n:"))
+    if (shortDescription.toLowerCase().startsWith(L10N_INLINE_PREFIX))
       return NodeL10n.getBase()
           .getString(
               "Bookmarks.Defaults.ShortDescription."
-                  + shortDescription.substring("l10n:".length()));
+                  + shortDescription.substring(L10N_INLINE_PREFIX.length()));
     return shortDescription;
   }
 

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -409,11 +409,11 @@ public class BookmarkManager implements RequestClient {
         hasBeenParsedWithoutAnyProblem = false;
       } else {
         try {
-          int nbBookmarks = sfs.getInt(BookmarkItem.NAME);
+          int nbBookmarks = sfs.getInt(BookmarkItem.BOOKMARK_PREFIX);
           int nbCategories = sfs.getInt(BookmarkCategory.SFS_KEY);
 
           for (int i = 0; i < nbBookmarks; i++) {
-            SimpleFieldSet subset = sfs.getSubset(BookmarkItem.NAME + i);
+            SimpleFieldSet subset = sfs.getSubset(BookmarkItem.BOOKMARK_PREFIX + i);
             try {
               BookmarkItem item = new BookmarkItem(subset, this, node.getAlerts());
               String name = (isRoot ? "" : prefix + category.name) + '/' + item.name;
@@ -466,8 +466,8 @@ public class BookmarkManager implements RequestClient {
 
     List<BookmarkItem> bi = cat.getItems();
     for (int i = 0; i < bi.size(); i++)
-      sfs.put(BookmarkItem.NAME + i, bi.get(i).getSimpleFieldSet());
-    sfs.put(BookmarkItem.NAME, bi.size());
+      sfs.put(BookmarkItem.BOOKMARK_PREFIX + i, bi.get(i).getSimpleFieldSet());
+    sfs.put(BookmarkItem.BOOKMARK_PREFIX, bi.size());
 
     return sfs;
   }

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -9,7 +9,6 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.USKCallback;
@@ -27,14 +26,63 @@ import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Manages the in-memory bookmark tree used by the HTTP UI and persists it to the node user
+ * directory.
+ *
+ * <p>This manager loads bookmarks from {@code bookmarks.dat} at startup, falling back to {@code
+ * bookmarks.dat.bak} or a bundled default bookmark set when needed. It maintains a path index (for
+ * example {@code "/MyCategory/MyItem"}) to provide fast lookups and to simplify operations like
+ * rename, move, and removal without requiring repeated tree walks.
+ *
+ * <p>The manager also integrates with USK polling. When a bookmark item represents a USK, it
+ * subscribes to updates and records new known-good editions as they are discovered, optionally
+ * coalescing persistence to reduce frequent disk writes.
+ *
+ * <p><b>Threading:</b> the path index is guarded by {@code synchronized (bookmarks)} in the common
+ * lookup and persistence paths. Higher-level operations also mutate the underlying bookmark tree;
+ * callers should treat {@link BookmarkManager} as not generally thread-safe and avoid concurrent
+ * mutations without external coordination.
+ *
+ * <p><b>Responsibilities:</b>
+ *
+ * <ul>
+ *   <li>Load bookmark state from disk with a backup/default fallback.
+ *   <li>Maintain a path-to-bookmark index for categories and items.
+ *   <li>Serialize and write bookmark state (backup write then rename).
+ *   <li>Subscribe/unsubscribe to USK updates for USK-typed bookmark items.
+ * </ul>
+ */
 public class BookmarkManager implements RequestClient {
   private static final Logger LOG = LoggerFactory.getLogger(BookmarkManager.class);
 
+  /**
+   * Parsed default bookmark set loaded from the bundled {@code defaultbookmarks.dat} resource.
+   *
+   * <p>This value may be {@code null} if the resource cannot be loaded or parsed; code that
+   * populates defaults should tolerate the absence of bundled defaults.
+   */
   public static final SimpleFieldSet DEFAULT_BOOKMARKS;
+
   private final NodeClientCore node;
   private final USKUpdatedCallback uskCB = new USKUpdatedCallback();
+
+  /**
+   * Root category for the primary bookmark tree, addressed under the {@code "/"} path prefix.
+   *
+   * <p>All user-visible bookmark items and categories are stored beneath this root unless the node
+   * is running in a gateway mode that uses {@link #DEFAULT_CATEGORY}.
+   */
   public static final BookmarkCategory MAIN_CATEGORY = new BookmarkCategory("/");
+
+  /**
+   * Root category for gateway-mode defaults, addressed under the {@code "\\"} path prefix.
+   *
+   * <p>This category is populated with the bundled defaults when the node is configured as a public
+   * gateway, allowing a distinct default set for restricted hosts.
+   */
   public static final BookmarkCategory DEFAULT_CATEGORY = new BookmarkCategory("\\");
+
   private final HashMap<String, Bookmark> bookmarks = new HashMap<>();
   private final File bookmarksFile;
   private final File backupBookmarksFile;
@@ -52,7 +100,7 @@ public class BookmarkManager implements RequestClient {
       }
     } catch (Exception e) {
       LOG.error(
-          "Error while loading the default bookmark file from " + name + " :" + e.getMessage(), e);
+          "Error while loading the default bookmark file from {} :{}", name, e.getMessage(), e);
     } finally {
       DEFAULT_BOOKMARKS = defaultBookmarks;
     }
@@ -60,6 +108,21 @@ public class BookmarkManager implements RequestClient {
 
   // Legacy threshold callback removed.
 
+  /**
+   * Creates a new manager, loads bookmarks from disk, and registers a shutdown hook to persist
+   * changes.
+   *
+   * <p>The constructor attempts to read {@code bookmarks.dat} from the node user directory. When
+   * that fails (missing/empty file, I/O errors, or malformed content), it tries the backup file
+   * {@code bookmarks.dat.bak}. If neither is readable, the bundled {@link #DEFAULT_BOOKMARKS} is
+   * used as a last resort.
+   *
+   * <p>When {@code publicGateway} is enabled, the manager also initializes {@link
+   * #DEFAULT_CATEGORY} and applies the bundled defaults under that category.
+   *
+   * @param n the node core used for filesystem access, scheduling, alerts, and USK subscriptions
+   * @param publicGateway whether to initialize a secondary default category for gateway-mode hosts
+   */
   public BookmarkManager(NodeClientCore n, boolean publicGateway) {
     putPaths("/", MAIN_CATEGORY);
     this.node = n;
@@ -69,29 +132,30 @@ public class BookmarkManager implements RequestClient {
     try {
       // Read the backup file if necessary
       if (!bookmarksFile.exists() || bookmarksFile.length() == 0) throw new IOException();
-      LOG.info("Attempting to read the bookmark file from " + bookmarksFile);
+      LOG.info("Attempting to read the bookmark file from {}", bookmarksFile);
       SimpleFieldSet sfs = SimpleFieldSet.readFrom(bookmarksFile, false, true);
       readBookmarks(MAIN_CATEGORY, sfs);
     } catch (MalformedURLException mue) {
+      // Bookmark file contains a malformed key; ignore and fall back to backup/defaults.
     } catch (IOException ioe) {
-      LOG.error("Error reading the bookmark file (" + bookmarksFile + "):" + ioe.getMessage(), ioe);
+      LOG.error("Error reading the bookmark file ({}):{}", bookmarksFile, ioe.getMessage(), ioe);
 
       try {
         if (backupBookmarksFile.exists()
             && backupBookmarksFile.canRead()
             && backupBookmarksFile.length() > 0) {
-          LOG.info("Attempting to read the backup bookmark file from " + backupBookmarksFile);
+          LOG.info("Attempting to read the backup bookmark file from {}", backupBookmarksFile);
           SimpleFieldSet sfs = SimpleFieldSet.readFrom(backupBookmarksFile, false, true);
           readBookmarks(MAIN_CATEGORY, sfs);
         } else {
           LOG.info(
-              "We couldn't find the backup either! - "
-                  + FileUtil.getCanonicalFile(backupBookmarksFile));
+              "We couldn't find the backup either! - {}",
+              FileUtil.getCanonicalFile(backupBookmarksFile));
           // restore the default bookmark set
           readBookmarks(MAIN_CATEGORY, DEFAULT_BOOKMARKS);
         }
       } catch (IOException e) {
-        LOG.error("Error reading the backup bookmark file !" + e.getMessage(), e);
+        LOG.error("Error reading the backup bookmark file !{}", e.getMessage(), e);
       }
     }
     // populate defaults for hosts without full access permissions if we're in gateway mode.
@@ -113,10 +177,19 @@ public class BookmarkManager implements RequestClient {
             });
   }
 
+  /**
+   * Re-imports the bundled default bookmarks into a newly created category under the main root.
+   *
+   * <p>The category name is localized and includes the current time to minimize collisions with
+   * existing names. This method parses {@link #DEFAULT_BOOKMARKS} and adds its entries into the new
+   * category, then persists the updated tree if parsing succeeds.
+   *
+   * <p>This operation is additive: it does not remove or overwrite existing user bookmarks.
+   */
   public void reAddDefaultBookmarks() {
     BookmarkCategory bc = new BookmarkCategory(l10n("defaultBookmarks") + " - " + new Date());
     addBookmark("/", bc);
-    _innerReadBookmarks("/", bc, DEFAULT_BOOKMARKS);
+    innerReadBookmarks("/", bc, DEFAULT_BOOKMARKS);
   }
 
   private class USKUpdatedCallback implements USKCallback {
@@ -145,28 +218,28 @@ public class BookmarkManager implements RequestClient {
       List<BookmarkItem> items = MAIN_CATEGORY.getAllItems();
       boolean matched = false;
       boolean updated = false;
-      for (int i = 0; i < items.size(); i++) {
-        if (!"USK".equals(items.get(i).getKeyType())) continue;
+      for (BookmarkItem bookmarkItem : items) {
+        if (!"USK".equals(bookmarkItem.getKeyType())) continue;
 
         try {
-          FreenetURI furi = new FreenetURI(items.get(i).getKey());
+          FreenetURI furi = new FreenetURI(bookmarkItem.getKey());
           USK usk = USK.create(furi);
 
           if (usk.equals(key, false)) {
             if (LOG.isDebugEnabled())
-              LOG.debug("Updating bookmark for " + furi + " to edition " + edition);
+              LOG.debug("Updating bookmark for {} to edition {}", furi, edition);
             matched = true;
-            BookmarkItem item = items.get(i);
-            updated |= item.setEdition(edition, node);
+            updated |= bookmarkItem.setEdition(edition, node);
             // We may have bookmarked the same site twice, so continue the search.
           }
         } catch (MalformedURLException mue) {
+          // Malformed bookmark key; ignore this entry.
         }
       }
       if (updated) {
         storeBookmarksLazy();
       } else if (!matched) {
-        LOG.error("No match for bookmark " + key + " edition " + edition);
+        LOG.error("No match for bookmark {} edition {}", key, edition);
       }
     }
 
@@ -181,22 +254,74 @@ public class BookmarkManager implements RequestClient {
     }
   }
 
+  /**
+   * Looks up a localized string for BookmarkManager UI text.
+   *
+   * <p>This method prefixes the provided key with {@code "BookmarkManager."} and delegates to the
+   * node localization base. It does not validate the key beyond basic concatenation, and it does
+   * not cache results; callers should avoid invoking it in tight loops if localization lookups are
+   * expensive in the current environment.
+   *
+   * <p>If the key is unknown, the behavior is determined by the localization subsystem; callers
+   * should treat the returned value as user-facing text and avoid relying on any particular
+   * fallback format.
+   *
+   * @param key the localization key suffix to resolve; typically a short identifier without spaces
+   * @return the localized string for the current locale, or a fallback provided by the l10n system
+   */
   public String l10n(String key) {
     return NodeL10n.getBase().getString("BookmarkManager." + key);
   }
 
+  /**
+   * Computes the parent path of a bookmark path.
+   *
+   * <p>The root path {@code "/"} is its own parent. For all other paths, this method returns the
+   * substring up to (and including) the previous {@code '/'} separator. This is used to map a
+   * concrete item or category path back to the category that contains it.
+   *
+   * <p>The input is expected to be a canonical bookmark path produced by this manager (for example,
+   * the paths used by {@link #addBookmark(String, Bookmark)} and {@link #renameBookmark(String,
+   * String)}). Malformed paths (such as strings without a {@code '/'} separator) may result in
+   * {@link StringIndexOutOfBoundsException}.
+   *
+   * @param path an absolute bookmark path such as {@code "/Category/Item"} or {@code "/Category/"}
+   * @return the parent category path, always ending with {@code '/'} (or {@code "/"} for root)
+   */
   public String parentPath(String path) {
     if (path.equals("/")) return "/";
 
     return path.substring(0, path.substring(0, path.length() - 1).lastIndexOf('/')) + "/";
   }
 
+  /**
+   * Returns the bookmark object currently registered for a given path.
+   *
+   * <p>The returned value is the live instance stored in the in-memory bookmark tree. Callers
+   * should avoid mutating returned instances directly unless they also update the path index
+   * through this manager.
+   *
+   * @param path an absolute bookmark path keyed in the internal index (for example {@code "/Foo/"})
+   * @return the bookmark instance for {@code path}, or {@code null} if no entry exists
+   */
   public Bookmark getBookmarkByPath(String path) {
     synchronized (bookmarks) {
       return bookmarks.get(path);
     }
   }
 
+  /**
+   * Returns the category stored at a given path, if the path resolves to a category.
+   *
+   * <p>This is a convenience wrapper around {@link #getBookmarkByPath(String)} that performs a
+   * type-check and returns {@code null} when the path is unknown or points to a non-category
+   * bookmark. It does not create categories or normalize paths; callers should provide the exact
+   * key used by the internal index.
+   *
+   * @param path an absolute bookmark path expected to identify a category (typically ending in
+   *     {@code '/'})
+   * @return the category at {@code path}, or {@code null} if absent or not a category
+   */
   public BookmarkCategory getCategoryByPath(String path) {
     Bookmark cat = getBookmarkByPath(path);
     if (cat instanceof BookmarkCategory category) return category;
@@ -204,15 +329,56 @@ public class BookmarkManager implements RequestClient {
     return null;
   }
 
+  /**
+   * Returns the item stored at a given path, if the path resolves to an item.
+   *
+   * <p>This is a convenience wrapper around {@link #getBookmarkByPath(String)} that performs a
+   * type-check and returns {@code null} when the path is unknown or points to a category.
+   *
+   * <p>The returned value is the live in-memory item instance; it is not copied. Callers should
+   * prefer higher-level operations (rename/move/remove) over mutating the returned item directly so
+   * that the path index and related subscriptions remain consistent.
+   *
+   * @param path an absolute bookmark path expected to identify an item (typically not ending in
+   *     {@code '/'})
+   * @return the item at {@code path}, or {@code null} if absent or not an item
+   */
   public BookmarkItem getItemByPath(String path) {
-    if (getBookmarkByPath(path) instanceof BookmarkItem)
-      return (BookmarkItem) getBookmarkByPath(path);
+    Bookmark bookmark = getBookmarkByPath(path);
+    if (bookmark instanceof BookmarkItem item) return item;
 
     return null;
   }
 
+  /**
+   * Adds a bookmark under an existing parent category and updates the internal path index.
+   *
+   * <p>The {@code parentPath} must resolve to an existing {@link BookmarkCategory}. The bookmark is
+   * appended to that category and then indexed under a computed absolute path. For categories, the
+   * computed path is suffixed with {@code '/'} so that category paths and item paths remain
+   * distinct.
+   *
+   * <p>If the bookmark is a {@link BookmarkItem} whose {@link BookmarkItem#getKeyType()} equals
+   * {@code "USK"}, this method also subscribes to USK polling for that item so editions can be kept
+   * up to date.
+   *
+   * <p>This method does not persist changes by itself. Callers are expected to choose between
+   * immediate persistence ({@link #storeBookmarks()}) and a delayed/coalesced write ({@link
+   * #storeBookmarksLazy()}) depending on the update pattern.
+   *
+   * <pre>{@code
+   * BookmarkCategory category = new BookmarkCategory("News");
+   * manager.addBookmark("/", category);
+   * manager.storeBookmarksLazy();
+   * }</pre>
+   *
+   * @param parentPath absolute path of the parent category (for example {@code "/"} or {@code
+   *     "/Foo/"})
+   * @param bookmark bookmark instance to add; its {@link Bookmark#getName()} is used to compute the
+   *     indexed path
+   */
   public void addBookmark(String parentPath, Bookmark bookmark) {
-    if (LOG.isDebugEnabled()) LOG.debug("Adding bookmark " + bookmark + " to " + parentPath);
+    if (LOG.isDebugEnabled()) LOG.debug("Adding bookmark {} to {}", bookmark, parentPath);
     BookmarkCategory parent = getCategoryByPath(parentPath);
     parent.addBookmark(bookmark);
     putPaths(
@@ -222,6 +388,19 @@ public class BookmarkManager implements RequestClient {
     if (bookmark instanceof BookmarkItem item) subscribeToUSK(item);
   }
 
+  /**
+   * Renames a bookmark and rewrites all indexed paths that refer to it or its descendants.
+   *
+   * <p>This method updates the bookmark's name and then rebuilds the path index entries whose keys
+   * start with the previous {@code path}. For a renamed category, all child entries are migrated to
+   * the new path prefix as well.
+   *
+   * <p>After the index update completes, the updated tree is persisted immediately via {@link
+   * #storeBookmarks()}.
+   *
+   * @param path absolute path of the bookmark to rename, using the current name
+   * @param newName new bookmark name to set; used as the final path segment of the new path
+   */
   public void renameBookmark(String path, String newName) {
     Bookmark bookmark = getBookmarkByPath(path);
     String oldName = bookmark.getName();
@@ -234,18 +413,25 @@ public class BookmarkManager implements RequestClient {
 
     bookmark.setName(newName);
     synchronized (bookmarks) {
-      Iterator<String> it = bookmarks.keySet().iterator();
-      while (it.hasNext()) {
-        String s = it.next();
-        if (s.startsWith(path)) {
-          it.remove();
-        }
-      }
+      bookmarks.keySet().removeIf(s -> s.startsWith(path));
       putPaths(newPath, bookmark);
     }
     storeBookmarks();
   }
 
+  /**
+   * Moves an existing bookmark to a different parent category and updates the path index.
+   *
+   * <p>The same bookmark instance is re-attached under {@code newParentPath}, removed from its
+   * previous parent category, and then de-indexed from its former path prefix.
+   *
+   * <p>This method does not persist changes automatically; callers typically follow up with {@link
+   * #storeBookmarks()} or {@link #storeBookmarksLazy()} depending on the desired persistence
+   * strategy.
+   *
+   * @param bookmarkPath absolute path of the bookmark to move, using its current location
+   * @param newParentPath absolute path of the destination parent category
+   */
   public void moveBookmark(String bookmarkPath, String newParentPath) {
     Bookmark b = getBookmarkByPath(bookmarkPath);
     addBookmark(newParentPath, b);
@@ -254,23 +440,28 @@ public class BookmarkManager implements RequestClient {
     removePaths(bookmarkPath);
   }
 
+  /**
+   * Removes a bookmark from the tree and cleans up any associated USK subscription state.
+   *
+   * <p>If the bookmark is a category, all descendant bookmarks are removed recursively. If the
+   * bookmark is a USK-typed item, the manager may unsubscribe from USK polling when no other
+   * bookmark item still references the same USK key.
+   *
+   * <p>This method updates the in-memory tree and path index only; it does not automatically
+   * persist changes to disk.
+   *
+   * @param path absolute path of the bookmark to remove
+   */
   public void removeBookmark(String path) {
     Bookmark bookmark = getBookmarkByPath(path);
-    if (bookmark == null) return;
-
-    if (bookmark instanceof BookmarkCategory cat) {
-      for (int i = 0; i < cat.size(); i++)
-        removeBookmark(
-            path + cat.get(i).getName() + ((cat.get(i) instanceof BookmarkCategory) ? "/" : ""));
-    } else {
-      if (((BookmarkItem) bookmark).getKeyType().equals("USK")) {
-        try {
-          USK u = ((BookmarkItem) bookmark).getUSK();
-          if (!wantUSK(u, (BookmarkItem) bookmark)) {
-            this.node.getUskManager().unsubscribe(u, this.uskCB);
-          }
-        } catch (MalformedURLException mue) {
-        }
+    switch (bookmark) {
+      case null -> {
+        return;
+      }
+      case BookmarkCategory category -> removeCategoryBookmarks(path, category);
+      case BookmarkItem item -> unsubscribeFromUskIfUnneeded(item);
+      default -> {
+        // No subtype-specific cleanup is required for unknown Bookmark implementations.
       }
     }
 
@@ -280,11 +471,31 @@ public class BookmarkManager implements RequestClient {
     }
   }
 
+  private void removeCategoryBookmarks(String path, BookmarkCategory category) {
+    for (int i = 0; i < category.size(); i++) {
+      Bookmark child = category.get(i);
+      String childPath = path + child.getName() + (child instanceof BookmarkCategory ? "/" : "");
+      removeBookmark(childPath);
+    }
+  }
+
+  private void unsubscribeFromUskIfUnneeded(BookmarkItem item) {
+    if (!"USK".equals(item.getKeyType())) return;
+
+    try {
+      USK u = item.getUSK();
+      if (!wantUSK(u, item)) {
+        node.getUskManager().unsubscribe(u, uskCB);
+      }
+    } catch (MalformedURLException mue) {
+      // Malformed bookmark key; there is nothing to unsubscribe from.
+    }
+  }
+
   private boolean wantUSK(USK u, BookmarkItem ignore) {
     List<BookmarkItem> items = MAIN_CATEGORY.getAllItems();
     for (BookmarkItem item : items) {
-      if (item == ignore) continue;
-      if (!"USK".equals(item.getKeyType())) continue;
+      if (item == ignore || !"USK".equals(item.getKeyType())) continue;
 
       try {
         FreenetURI furi = new FreenetURI(item.getKey());
@@ -292,11 +503,25 @@ public class BookmarkManager implements RequestClient {
 
         if (usk.equals(u, false)) return true;
       } catch (MalformedURLException mue) {
+        // Ignore malformed bookmark keys when checking whether any other bookmark wants this USK.
       }
     }
     return false;
   }
 
+  /**
+   * Moves a bookmark one position earlier within its parent category.
+   *
+   * <p>The move is performed within the parent category returned by {@link #parentPath(String)}. If
+   * {@code store} is true, the updated tree is persisted immediately.
+   *
+   * <p>This method affects only the ordering within the parent category and does not change the
+   * bookmark's path. If the bookmark is already at the top of the list, the underlying category may
+   * leave the order unchanged.
+   *
+   * @param path absolute path of the bookmark to move up
+   * @param store whether to persist the updated ordering to disk after the move
+   */
   public void moveBookmarkUp(String path, boolean store) {
     BookmarkCategory parent = getCategoryByPath(parentPath(path));
     parent.moveBookmarkUp(getBookmarkByPath(path));
@@ -304,6 +529,19 @@ public class BookmarkManager implements RequestClient {
     if (store) storeBookmarks();
   }
 
+  /**
+   * Moves a bookmark one position later within its parent category.
+   *
+   * <p>The move is performed within the parent category returned by {@link #parentPath(String)}. If
+   * {@code store} is true, the updated tree is persisted immediately.
+   *
+   * <p>This method affects only the ordering within the parent category and does not change the
+   * bookmark's path. If the bookmark is already at the bottom of the list, the underlying category
+   * may leave the order unchanged.
+   *
+   * @param path absolute path of the bookmark to move down
+   * @param store whether to persist the updated ordering to disk after the move
+   */
   public void moveBookmarkDown(String path, boolean store) {
     BookmarkCategory parent = getCategoryByPath(parentPath(path));
     parent.moveBookmarkDown(getBookmarkByPath(path));
@@ -332,6 +570,18 @@ public class BookmarkManager implements RequestClient {
     bookmarks.remove(path);
   }
 
+  /**
+   * Returns all bookmark item URIs under the main category.
+   *
+   * <p>The returned array is a snapshot of the current item list at the time of iteration. The
+   * array ordering follows the underlying item order returned by {@link BookmarkCategory} for
+   * {@link #MAIN_CATEGORY}.
+   *
+   * <p>Only {@link BookmarkItem} instances contribute to the result. Category entries are excluded,
+   * and the returned array does not include items from {@link #DEFAULT_CATEGORY}.
+   *
+   * @return an array containing the {@link FreenetURI} for each bookmark item under the main root
+   */
   public FreenetURI[] getBookmarkURIs() {
     List<BookmarkItem> items = MAIN_CATEGORY.getAllItems();
     FreenetURI[] uris = new FreenetURI[items.size()];
@@ -340,6 +590,17 @@ public class BookmarkManager implements RequestClient {
     return uris;
   }
 
+  /**
+   * Schedules a delayed persistence of bookmarks, coalescing multiple updates into one write.
+   *
+   * <p>If a delayed save is already scheduled, this method is a no-op. Otherwise, it queues a job
+   * on the node ticker to invoke {@link #storeBookmarks()} after approximately 5 minutes. This is
+   * used to reduce disk churn for bursty updates (for example, USK edition updates).
+   *
+   * <p>The method returns immediately and does not wait for I/O. A best-effort guard ensures only
+   * one delayed job is queued at a time, so repeated calls within the delay window are collapsed
+   * into the same scheduled write.
+   */
   public void storeBookmarksLazy() {
     synchronized (bookmarks) {
       if (isSavingBookmarksLazy) return;
@@ -358,9 +619,19 @@ public class BookmarkManager implements RequestClient {
     }
   }
 
+  /**
+   * Writes the current bookmark tree to disk, using a backup write-then-rename strategy.
+   *
+   * <p>This method serializes the current tree to a {@link SimpleFieldSet}, writes it to {@code
+   * bookmarks.dat.bak}, and then attempts to move it into place as {@code bookmarks.dat}. A
+   * re-entrant guard prevents concurrent writers from executing the write simultaneously.
+   *
+   * <p>Failures are logged and do not throw to callers. The write operation uses regular file I/O
+   * and may block while data is flushed to disk.
+   */
   public void storeBookmarks() {
-    LOG.info("Attempting to save bookmarks to " + bookmarksFile.toString());
-    SimpleFieldSet sfs = null;
+    LOG.info("Attempting to save bookmarks to {}", bookmarksFile);
+    SimpleFieldSet sfs;
     synchronized (bookmarks) {
       if (isSavingBookmarks) return;
       isSavingBookmarks = true;
@@ -372,9 +643,9 @@ public class BookmarkManager implements RequestClient {
         sfs.writeToBigBuffer(fos);
       }
       if (!FileUtil.moveTo(backupBookmarksFile, bookmarksFile))
-        LOG.error("Unable to rename " + backupBookmarksFile + " to " + bookmarksFile);
+        LOG.error("Unable to rename {} to {}", backupBookmarksFile, bookmarksFile);
     } catch (IOException ioe) {
-      LOG.error("An error has occured saving the bookmark file :" + ioe.getMessage(), ioe);
+      LOG.error("An error has occured saving the bookmark file :{}", ioe.getMessage(), ioe);
     } finally {
       synchronized (bookmarks) {
         isSavingBookmarks = false;
@@ -383,66 +654,103 @@ public class BookmarkManager implements RequestClient {
   }
 
   private void readBookmarks(BookmarkCategory category, SimpleFieldSet sfs) {
-    _innerReadBookmarks("", category, sfs);
+    innerReadBookmarks("", category, sfs);
   }
 
   static final short PRIORITY = RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS;
   static final short PRIORITY_PROGRESS = RequestStarter.UPDATE_PRIORITY_CLASS;
 
   private void subscribeToUSK(BookmarkItem item) {
-    if ("USK".equals(item.getKeyType()))
-      try {
-        USK u = item.getUSK();
-        this.node.getUskManager().subscribe(u, this.uskCB, true, this);
-      } catch (MalformedURLException mue) {
-      }
+    if (!"USK".equals(item.getKeyType())) return;
+    try {
+      USK u = item.getUSK();
+      this.node.getUskManager().subscribe(u, this.uskCB, true, this);
+    } catch (MalformedURLException mue) {
+      // Malformed bookmark key; ignore and do not subscribe.
+    }
   }
 
-  private synchronized void _innerReadBookmarks(
+  private synchronized void innerReadBookmarks(
       String prefix, BookmarkCategory category, SimpleFieldSet sfs) {
-    boolean hasBeenParsedWithoutAnyProblem = true;
     boolean isRoot = ("".equals(prefix) && MAIN_CATEGORY.equals(category));
+    boolean parsedOk = parseBookmarksIntoCategory(prefix, category, sfs, isRoot);
+    if (parsedOk) storeBookmarks();
+  }
+
+  private boolean parseBookmarksIntoCategory(
+      String prefix, BookmarkCategory category, SimpleFieldSet sfs, boolean isRoot) {
     synchronized (bookmarks) {
       if (!isRoot) putPaths(prefix + category.name + '/', category);
+      if (sfs == null) return false;
 
-      if (sfs == null) {
-        hasBeenParsedWithoutAnyProblem = false;
-      } else {
-        try {
-          int nbBookmarks = sfs.getInt(BookmarkItem.BOOKMARK_PREFIX);
-          int nbCategories = sfs.getInt(BookmarkCategory.SFS_KEY);
+      try {
+        int nbBookmarks = sfs.getInt(BookmarkItem.BOOKMARK_PREFIX);
+        int nbCategories = sfs.getInt(BookmarkCategory.SFS_KEY);
 
-          for (int i = 0; i < nbBookmarks; i++) {
-            SimpleFieldSet subset = sfs.getSubset(BookmarkItem.BOOKMARK_PREFIX + i);
-            try {
-              BookmarkItem item = new BookmarkItem(subset, this, node.getAlerts());
-              String name = (isRoot ? "" : prefix + category.name) + '/' + item.name;
-              putPaths(name, item);
-              category.addBookmark(item);
-              item.registerUserAlert();
-              subscribeToUSK(item);
-            } catch (MalformedURLException e) {
-              throw new FSParseException(e);
-            }
-          }
-
-          for (int i = 0; i < nbCategories; i++) {
-            SimpleFieldSet subset = sfs.getSubset(BookmarkCategory.SFS_KEY + i);
-            BookmarkCategory currentCategory = new BookmarkCategory(subset);
-            category.addBookmark(currentCategory);
-            String name = (isRoot ? "/" : (prefix + category.name + '/'));
-            _innerReadBookmarks(name, currentCategory, subset.getSubset("Content"));
-          }
-
-        } catch (FSParseException e) {
-          LOG.error("Error parsing the bookmarks file!", e);
-          hasBeenParsedWithoutAnyProblem = false;
-        }
+        parseBookmarkItems(prefix, category, sfs, isRoot, nbBookmarks);
+        parseBookmarkCategories(prefix, category, sfs, isRoot, nbCategories);
+        return true;
+      } catch (FSParseException e) {
+        LOG.error("Error parsing the bookmarks file!", e);
+        return false;
       }
     }
-    if (hasBeenParsedWithoutAnyProblem) storeBookmarks();
   }
 
+  private void parseBookmarkItems(
+      String prefix, BookmarkCategory category, SimpleFieldSet sfs, boolean isRoot, int nbBookmarks)
+      throws FSParseException {
+    for (int i = 0; i < nbBookmarks; i++) {
+      SimpleFieldSet subset = sfs.getSubset(BookmarkItem.BOOKMARK_PREFIX + i);
+      addBookmarkItem(prefix, category, subset, isRoot);
+    }
+  }
+
+  private void addBookmarkItem(
+      String prefix, BookmarkCategory category, SimpleFieldSet subset, boolean isRoot)
+      throws FSParseException {
+    try {
+      BookmarkItem item = new BookmarkItem(subset, this, node.getAlerts());
+      String name = (isRoot ? "" : prefix + category.name) + '/' + item.name;
+      putPaths(name, item);
+      category.addBookmark(item);
+      item.registerUserAlert();
+      subscribeToUSK(item);
+    } catch (MalformedURLException e) {
+      throw new FSParseException(e);
+    }
+  }
+
+  private void parseBookmarkCategories(
+      String prefix,
+      BookmarkCategory category,
+      SimpleFieldSet sfs,
+      boolean isRoot,
+      int nbCategories)
+      throws FSParseException {
+    for (int i = 0; i < nbCategories; i++) {
+      SimpleFieldSet subset = sfs.getSubset(BookmarkCategory.SFS_KEY + i);
+      BookmarkCategory currentCategory = new BookmarkCategory(subset);
+      category.addBookmark(currentCategory);
+      String name = (isRoot ? "/" : (prefix + category.name + '/'));
+      innerReadBookmarks(name, currentCategory, subset.getSubset("Content"));
+    }
+  }
+
+  /**
+   * Serializes the current manager state into a {@link SimpleFieldSet}.
+   *
+   * <p>The returned field set uses a simple versioned format and contains the serialized form of
+   * {@link #MAIN_CATEGORY}. The returned instance is a detached representation that can be written
+   * to disk via {@link SimpleFieldSet#writeToBigBuffer(java.io.OutputStream)}.
+   *
+   * <p>This method snapshots the tree while holding the {@code bookmarks} lock to keep the map
+   * consistent with the serialized structure. The returned {@link SimpleFieldSet} is mutable, but
+   * mutating it does not affect the manager state; callers should treat it as write-only
+   * persistence output.
+   *
+   * @return a newly created field set representing the current bookmark tree
+   */
   public SimpleFieldSet toSimpleFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
 
@@ -454,6 +762,19 @@ public class BookmarkManager implements RequestClient {
     return sfs;
   }
 
+  /**
+   * Serializes a bookmark category (and all of its descendants) into a {@link SimpleFieldSet}.
+   *
+   * <p>This method writes both child categories and bookmark items into indexed subsets using the
+   * keys defined by {@link BookmarkCategory#SFS_KEY} and {@link BookmarkItem#BOOKMARK_PREFIX}. It
+   * is used for persistence and can be invoked for any subtree, not only the main root.
+   *
+   * <p>The resulting field set includes counts for both categories and items, allowing the reader
+   * to iterate deterministically when reconstructing the tree.
+   *
+   * @param cat the category to serialize; all subcategories and items are included recursively
+   * @return a newly created field set representing {@code cat} and its contents
+   */
   public static SimpleFieldSet toSimpleFieldSet(BookmarkCategory cat) {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
     List<BookmarkCategory> bc = cat.getSubCategories();
@@ -472,11 +793,26 @@ public class BookmarkManager implements RequestClient {
     return sfs;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This manager does not represent a persistent request client; it is used for UI-driven helper
+   * requests (such as USK polling) and does not require restart persistence at the request layer.
+   *
+   * @return always {@code false}
+   */
   @Override
   public boolean persistent() {
     return false;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Bookmark-related requests are not treated as real-time traffic by this client.
+   *
+   * @return always {@code false}
+   */
   @Override
   public boolean realTimeFlag() {
     return false;

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -410,7 +410,7 @@ public class BookmarkManager implements RequestClient {
       } else {
         try {
           int nbBookmarks = sfs.getInt(BookmarkItem.NAME);
-          int nbCategories = sfs.getInt(BookmarkCategory.NAME);
+          int nbCategories = sfs.getInt(BookmarkCategory.SFS_KEY);
 
           for (int i = 0; i < nbBookmarks; i++) {
             SimpleFieldSet subset = sfs.getSubset(BookmarkItem.NAME + i);
@@ -427,7 +427,7 @@ public class BookmarkManager implements RequestClient {
           }
 
           for (int i = 0; i < nbCategories; i++) {
-            SimpleFieldSet subset = sfs.getSubset(BookmarkCategory.NAME + i);
+            SimpleFieldSet subset = sfs.getSubset(BookmarkCategory.SFS_KEY + i);
             BookmarkCategory currentCategory = new BookmarkCategory(subset);
             category.addBookmark(currentCategory);
             String name = (isRoot ? "/" : (prefix + category.name + '/'));
@@ -460,9 +460,9 @@ public class BookmarkManager implements RequestClient {
 
     for (int i = 0; i < bc.size(); i++) {
       BookmarkCategory currentCat = bc.get(i);
-      sfs.put(BookmarkCategory.NAME + i, currentCat.getSimpleFieldSet());
+      sfs.put(BookmarkCategory.SFS_KEY + i, currentCat.getSimpleFieldSet());
     }
-    sfs.put(BookmarkCategory.NAME, bc.size());
+    sfs.put(BookmarkCategory.SFS_KEY, bc.size());
 
     List<BookmarkItem> bi = cat.getItems();
     for (int i = 0; i < bi.size(); i++)

--- a/src/main/java/network/crypta/clients/http/bookmark/package-info.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/package-info.java
@@ -1,5 +1,27 @@
 /**
- * Bookmark management code. FProxy maintains a list of "bookmarks", freesites which we show on the
- * welcome page and subscribe to updates for so they will load the latest version quickly.
+ * Bookmark support for the HTTP UI.
+ *
+ * <p>This package models and manages the bookmark tree shown by the node's web interface (often
+ * referred to as {@code FProxy}). Bookmarks represent user-visible links to keys such as freesites,
+ * along with metadata needed to render navigation entries and support stable, path-based
+ * addressing.
+ *
+ * <p>The primary entry point is {@code BookmarkManager}, which loads bookmark state from disk,
+ * maintains a path-based index for fast lookups and operations like rename/move, and persists
+ * changes back to the node user directory using a backup file for resilience. Some bookmark entries
+ * may represent USKs; when they do, bookmark management can subscribe to update notifications so
+ * newly discovered editions can be recorded and subsequent fetches can start from a known-good
+ * edition. The types in this package are typically used by HTTP handlers that render pages and
+ * process user actions in a request/response flow.
+ *
+ * <p><b>Notable behaviors:</b>
+ *
+ * <ul>
+ *   <li>Bookmarks are organized as a tree of categories and items rooted at {@code "/"}.
+ *   <li>Operations commonly address entries via stable path strings (for example, {@code
+ *       "/MyCategory/MyItem"}), avoiding repeated tree walks.
+ *   <li>Callers should not assume concurrent mutation is safe; coordinate multistep updates at a
+ *       higher level.
+ * </ul>
  */
 package network.crypta.clients.http.bookmark;

--- a/src/test/java/network/crypta/clients/http/bookmark/BookmarkCategoryTest.java
+++ b/src/test/java/network/crypta/clients/http/bookmark/BookmarkCategoryTest.java
@@ -398,7 +398,7 @@ class BookmarkCategoryTest {
     assertEquals("Root", sfs.get("Name"));
     SimpleFieldSet content = sfs.getSubset("Content");
     assertEquals(0, content.getInt(BookmarkCategory.SFS_KEY));
-    assertEquals(0, content.getInt(BookmarkItem.NAME));
+    assertEquals(0, content.getInt(BookmarkItem.BOOKMARK_PREFIX));
   }
 
   @Test
@@ -419,12 +419,12 @@ class BookmarkCategoryTest {
 
     SimpleFieldSet content = sfs.getSubset("Content");
     assertEquals(1, content.getInt(BookmarkCategory.SFS_KEY));
-    assertEquals(1, content.getInt(BookmarkItem.NAME));
+    assertEquals(1, content.getInt(BookmarkItem.BOOKMARK_PREFIX));
 
     SimpleFieldSet childSfs = content.getSubset(BookmarkCategory.SFS_KEY + "0");
     assertEquals(CATEGORY_CHILD, childSfs.get("Name"));
 
-    SimpleFieldSet itemSfs = content.getSubset(BookmarkItem.NAME + "0");
+    SimpleFieldSet itemSfs = content.getSubset(BookmarkItem.BOOKMARK_PREFIX + "0");
     assertEquals("Item", itemSfs.get("Name"));
     assertEquals("Desc", itemSfs.get("Description"));
   }

--- a/src/test/java/network/crypta/clients/http/bookmark/BookmarkCategoryTest.java
+++ b/src/test/java/network/crypta/clients/http/bookmark/BookmarkCategoryTest.java
@@ -1,0 +1,431 @@
+package network.crypta.clients.http.bookmark;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.FSParseException;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class BookmarkCategoryTest {
+
+  private static final String CATEGORY_CHILD = "Child";
+  private static final String CATEGORY_EXISTING = "Existing";
+  private static final String CATEGORY_ABSENT = "Absent";
+  private static final String ROOT_PATH_PREFIX = "Root/";
+
+  private static final String USK_1 =
+      "USK@62H8KFSZWMyQ2MQgwvNhEYJ2m3SQl696PfsVfWQ-HQo,"
+          + "cJrPvdNz4AnrHJQXNteDV7k3YnAVY-MClt84gwH2qEo,AQACAAE/"
+          + "freenet-first-steps/24/";
+
+  private static final String USK_2 =
+      "USK@5ijbfKSJ4kPZTRDzq363CHteEUiSZjrO-E36vbHvnIU,"
+          + "ZEZqPXeuYiyokY2r0wkhJr5cy7KBH9omkuWDqSC6PLs,AQACAAE/"
+          + "clean-spider/399/";
+
+  @Mock BookmarkManager bookmarkManager;
+
+  @Mock UserAlertManager userAlertManager;
+
+  private BookmarkItem newBookmarkItem(String name, String description, boolean hasAnActiveLink) {
+    try {
+      FreenetURI uri = new FreenetURI(hasAnActiveLink ? USK_1 : USK_2);
+      return new BookmarkItem(
+          uri, name, description, "short", hasAnActiveLink, bookmarkManager, userAlertManager);
+    } catch (MalformedURLException e) {
+      throw new AssertionError("Test URI must be valid", e);
+    }
+  }
+
+  @Test
+  void constructor_whenNameProvided_expectNameStored() {
+    // Arrange / Act
+    BookmarkCategory category = new BookmarkCategory("Root");
+
+    // Assert
+    assertEquals("Root", category.getName());
+  }
+
+  @Test
+  void constructor_whenSimpleFieldSetMissingName_expectThrows() {
+    // Arrange
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+
+    // Act / Assert
+    assertThrows(FSParseException.class, () -> new BookmarkCategory(sfs));
+  }
+
+  @Test
+  void constructor_whenSimpleFieldSetHasName_expectNameStored() throws FSParseException {
+    // Arrange
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    sfs.putSingle("Name", "FromSfs");
+
+    // Act
+    BookmarkCategory category = new BookmarkCategory(sfs);
+
+    // Assert
+    assertEquals("FromSfs", category.getName());
+  }
+
+  @Test
+  void addBookmark_whenNull_expectReturnsNullAndDoesNotChangeSize() {
+    // Arrange
+    BookmarkCategory category = new BookmarkCategory("Root");
+
+    // Act
+    Bookmark added = category.addBookmark(null);
+
+    // Assert
+    assertNull(added);
+    assertEquals(0, category.size());
+  }
+
+  @Test
+  void addBookmark_whenNewBookmark_expectAddedAndReturned() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory child = new BookmarkCategory(CATEGORY_CHILD);
+
+    // Act
+    Bookmark added = root.addBookmark(child);
+
+    // Assert
+    assertSame(child, added);
+    assertEquals(1, root.size());
+    assertSame(child, root.get(0));
+  }
+
+  @Test
+  void addBookmark_whenSameNameAlreadyExists_expectExistingReturnedAndNotAdded() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory first = new BookmarkCategory("Duplicate");
+    BookmarkCategory second = new BookmarkCategory("Duplicate");
+    root.addBookmark(first);
+
+    // Act
+    Bookmark result = root.addBookmark(second);
+
+    // Assert
+    assertSame(first, result);
+    assertEquals(1, root.size());
+    assertSame(first, root.get(0));
+  }
+
+  @Test
+  void removeBookmark_whenBookmarkNotPresent_expectNoChange() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory existing = new BookmarkCategory(CATEGORY_EXISTING);
+    BookmarkCategory absent = new BookmarkCategory(CATEGORY_ABSENT);
+    root.addBookmark(existing);
+
+    // Act
+    root.removeBookmark(absent);
+
+    // Assert
+    assertEquals(1, root.size());
+    assertSame(existing, root.get(0));
+  }
+
+  @Test
+  void removeBookmark_whenBookmarkPresent_expectRemoved() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory existing = new BookmarkCategory(CATEGORY_EXISTING);
+    root.addBookmark(existing);
+
+    // Act
+    root.removeBookmark(existing);
+
+    // Assert
+    assertEquals(0, root.size());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"-1", "0", "1"})
+  void get_whenEmpty_expectIndexOutOfBounds(int index) {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+
+    // Act / Assert
+    assertThrows(IndexOutOfBoundsException.class, () -> root.get(index));
+  }
+
+  @Test
+  void moveBookmarkUp_whenNotPresent_expectNoChange() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory existing = new BookmarkCategory(CATEGORY_EXISTING);
+    BookmarkCategory absent = new BookmarkCategory(CATEGORY_ABSENT);
+    root.addBookmark(existing);
+
+    // Act
+    root.moveBookmarkUp(absent);
+
+    // Assert
+    assertEquals(1, root.size());
+    assertSame(existing, root.get(0));
+  }
+
+  @Test
+  void moveBookmarkUp_whenFirst_expectStaysAtBeginning() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory first = new BookmarkCategory("A");
+    BookmarkCategory second = new BookmarkCategory("B");
+    root.addBookmark(first);
+    root.addBookmark(second);
+
+    // Act
+    root.moveBookmarkUp(first);
+
+    // Assert
+    assertSame(first, root.get(0));
+    assertSame(second, root.get(1));
+  }
+
+  @Test
+  void moveBookmarkUp_whenMiddle_expectMovesUpOne() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory first = new BookmarkCategory("A");
+    BookmarkCategory middle = new BookmarkCategory("B");
+    BookmarkCategory third = new BookmarkCategory("C");
+    root.addBookmark(first);
+    root.addBookmark(middle);
+    root.addBookmark(third);
+
+    // Act
+    root.moveBookmarkUp(middle);
+
+    // Assert
+    assertSame(middle, root.get(0));
+    assertSame(first, root.get(1));
+    assertSame(third, root.get(2));
+  }
+
+  @Test
+  void moveBookmarkDown_whenNotPresent_expectNoChange() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory existing = new BookmarkCategory(CATEGORY_EXISTING);
+    BookmarkCategory absent = new BookmarkCategory(CATEGORY_ABSENT);
+    root.addBookmark(existing);
+
+    // Act
+    root.moveBookmarkDown(absent);
+
+    // Assert
+    assertEquals(1, root.size());
+    assertSame(existing, root.get(0));
+  }
+
+  @Test
+  void moveBookmarkDown_whenLast_expectStaysAtEnd() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory first = new BookmarkCategory("A");
+    BookmarkCategory last = new BookmarkCategory("B");
+    root.addBookmark(first);
+    root.addBookmark(last);
+
+    // Act
+    root.moveBookmarkDown(last);
+
+    // Assert
+    assertSame(first, root.get(0));
+    assertSame(last, root.get(1));
+  }
+
+  @Test
+  void moveBookmarkDown_whenMiddle_expectMovesDownOne() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory first = new BookmarkCategory("A");
+    BookmarkCategory middle = new BookmarkCategory("B");
+    BookmarkCategory third = new BookmarkCategory("C");
+    root.addBookmark(first);
+    root.addBookmark(middle);
+    root.addBookmark(third);
+
+    // Act
+    root.moveBookmarkDown(middle);
+
+    // Assert
+    assertSame(first, root.get(0));
+    assertSame(third, root.get(1));
+    assertSame(middle, root.get(2));
+  }
+
+  @Test
+  void getItems_whenMixedBookmarks_expectOnlyItemsReturnedInListOrder() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkItem item1 = newBookmarkItem("Item1", "Desc1", true);
+    BookmarkCategory child = new BookmarkCategory(CATEGORY_CHILD);
+    BookmarkItem item2 = newBookmarkItem("Item2", "Desc2", false);
+    root.addBookmark(item1);
+    root.addBookmark(child);
+    root.addBookmark(item2);
+
+    // Act
+    List<BookmarkItem> items = root.getItems();
+
+    // Assert
+    assertEquals(2, items.size());
+    assertSame(item1, items.get(0));
+    assertSame(item2, items.get(1));
+  }
+
+  @Test
+  void getSubCategories_whenMixedBookmarks_expectOnlyCategoriesReturnedInListOrder() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory cat1 = new BookmarkCategory("Cat1");
+    BookmarkItem item = newBookmarkItem("Item", "Desc", true);
+    BookmarkCategory cat2 = new BookmarkCategory("Cat2");
+    root.addBookmark(cat1);
+    root.addBookmark(item);
+    root.addBookmark(cat2);
+
+    // Act
+    List<BookmarkCategory> categories = root.getSubCategories();
+
+    // Assert
+    assertEquals(2, categories.size());
+    assertSame(cat1, categories.get(0));
+    assertSame(cat2, categories.get(1));
+  }
+
+  @Test
+  void getAllItems_whenNestedCategories_expectDepthFirstItems() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkItem rootItem = newBookmarkItem("RootItem", "RootDesc", true);
+    BookmarkCategory firstChild = new BookmarkCategory("ChildA");
+    BookmarkItem childItem = newBookmarkItem("ChildItem", "ChildDesc", false);
+    BookmarkCategory secondChild = new BookmarkCategory("ChildB");
+    BookmarkItem secondChildItem = newBookmarkItem("ChildBItem", "ChildBDesc", true);
+    root.addBookmark(rootItem);
+    root.addBookmark(firstChild);
+    root.addBookmark(secondChild);
+    firstChild.addBookmark(childItem);
+    secondChild.addBookmark(secondChildItem);
+
+    // Act
+    List<BookmarkItem> items = root.getAllItems();
+
+    // Assert
+    assertEquals(3, items.size());
+    assertSame(rootItem, items.get(0));
+    assertSame(childItem, items.get(1));
+    assertSame(secondChildItem, items.get(2));
+  }
+
+  @Test
+  void getAllSubCategories_whenNestedCategories_expectImmediateThenRecursive() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory childA = new BookmarkCategory("ChildA");
+    BookmarkCategory childB = new BookmarkCategory("ChildB");
+    BookmarkCategory grandChildA1 = new BookmarkCategory("GrandChildA1");
+    root.addBookmark(childA);
+    root.addBookmark(childB);
+    childA.addBookmark(grandChildA1);
+
+    // Act
+    List<BookmarkCategory> categories = root.getAllSubCategories();
+
+    // Assert
+    assertEquals(3, categories.size());
+    assertSame(childA, categories.get(0));
+    assertSame(childB, categories.get(1));
+    assertSame(grandChildA1, categories.get(2));
+  }
+
+  @Test
+  void toStrings_whenMixedBookmarks_expectItemsBeforeSubCategories() {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory child = new BookmarkCategory(CATEGORY_CHILD);
+    BookmarkItem rootItem1 = newBookmarkItem("RootItem1", "Desc1", true);
+    BookmarkItem rootItem2 = newBookmarkItem("RootItem2", "Desc2", false);
+    BookmarkItem childItem = newBookmarkItem("ChildItem", "Desc3", true);
+    root.addBookmark(rootItem1);
+    root.addBookmark(child);
+    root.addBookmark(rootItem2);
+    child.addBookmark(childItem);
+
+    // Act
+    String[] strings = root.toStrings();
+
+    // Assert
+    assertArrayEquals(
+        new String[] {
+          ROOT_PATH_PREFIX + rootItem1,
+          ROOT_PATH_PREFIX + rootItem2,
+          ROOT_PATH_PREFIX + CATEGORY_CHILD + "/" + childItem,
+        },
+        strings);
+  }
+
+  @Test
+  void getSimpleFieldSet_whenEmpty_expectNameAndZeroCounts() throws FSParseException {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+
+    // Act
+    SimpleFieldSet sfs = root.getSimpleFieldSet();
+
+    // Assert
+    assertEquals("Root", sfs.get("Name"));
+    SimpleFieldSet content = sfs.getSubset("Content");
+    assertEquals(0, content.getInt(BookmarkCategory.SFS_KEY));
+    assertEquals(0, content.getInt(BookmarkItem.NAME));
+  }
+
+  @Test
+  void getSimpleFieldSet_whenHasChildAndItem_expectChildAndItemSerialized()
+      throws FSParseException {
+    // Arrange
+    BookmarkCategory root = new BookmarkCategory("Root");
+    BookmarkCategory child = new BookmarkCategory(CATEGORY_CHILD);
+    BookmarkItem item = newBookmarkItem("Item", "Desc", true);
+    root.addBookmark(child);
+    root.addBookmark(item);
+
+    // Act
+    SimpleFieldSet sfs = root.getSimpleFieldSet();
+
+    // Assert
+    assertEquals("Root", sfs.get("Name"));
+
+    SimpleFieldSet content = sfs.getSubset("Content");
+    assertEquals(1, content.getInt(BookmarkCategory.SFS_KEY));
+    assertEquals(1, content.getInt(BookmarkItem.NAME));
+
+    SimpleFieldSet childSfs = content.getSubset(BookmarkCategory.SFS_KEY + "0");
+    assertEquals(CATEGORY_CHILD, childSfs.get("Name"));
+
+    SimpleFieldSet itemSfs = content.getSubset(BookmarkItem.NAME + "0");
+    assertEquals("Item", itemSfs.get("Name"));
+    assertEquals("Desc", itemSfs.get("Description"));
+  }
+}

--- a/src/test/java/network/crypta/clients/http/bookmark/BookmarkItemTest.java
+++ b/src/test/java/network/crypta/clients/http/bookmark/BookmarkItemTest.java
@@ -1,0 +1,554 @@
+package network.crypta.clients.http.bookmark;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.net.MalformedURLException;
+import java.util.stream.Stream;
+import network.crypta.keys.FreenetURI;
+import network.crypta.keys.USK;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class BookmarkItemTest {
+
+  private static final String SFS_NAME = "Name";
+  private static final String SFS_DESCRIPTION = "Description";
+  private static final String SFS_SHORT_DESCRIPTION = "ShortDescription";
+  private static final String SFS_HAS_AN_ACTIVE_LINK = "hasAnActivelink";
+  private static final String SFS_UPDATED = "Updated";
+  private static final String SFS_URI = "URI";
+
+  private static final String DEFAULT_SFS_NAME_VALUE = "N";
+  private static final String DEFAULT_SFS_DESCRIPTION_VALUE = "D";
+  private static final String DEFAULT_SFS_SHORT_DESCRIPTION_VALUE = "S";
+
+  private static final String USK_24 =
+      "USK@62H8KFSZWMyQ2MQgwvNhEYJ2m3SQl696PfsVfWQ-HQo,"
+          + "cJrPvdNz4AnrHJQXNteDV7k3YnAVY-MClt84gwH2qEo,AQACAAE/"
+          + "freenet-first-steps/24/";
+
+  private static final String CHK_1 =
+      "CHK@OR904t6ylZOwoobMJRmSn7HsPGefHSP7zAjoLyenSPw,"
+          + "x2EzszO4Kqot8akqmKYXJbkD-fSj6noOVGB-K2YisZ4,AAIC--8/1-works.html";
+
+  @Mock BookmarkManager bookmarkManager;
+  @Mock UserAlertManager userAlertManager;
+  @Mock NodeClientCore nodeClientCore;
+
+  private static FreenetURI uri(String uri) {
+    try {
+      return new FreenetURI(uri);
+    } catch (MalformedURLException e) {
+      throw new AssertionError("Test URI must be valid: " + uri, e);
+    }
+  }
+
+  private BookmarkItem newBookmarkItem(
+      FreenetURI uri,
+      String name,
+      String description,
+      String shortDescription,
+      boolean hasAnActiveLink) {
+    return new BookmarkItem(
+        uri,
+        name,
+        description,
+        shortDescription,
+        hasAnActiveLink,
+        bookmarkManager,
+        userAlertManager);
+  }
+
+  private SimpleFieldSet newBookmarkItemSfs(
+      String name,
+      String description,
+      String shortDescription,
+      boolean hasAnActiveLink,
+      boolean updated,
+      String uri) {
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    if (name != null) {
+      sfs.putSingle(SFS_NAME, name);
+    }
+    if (description != null) {
+      sfs.putSingle(SFS_DESCRIPTION, description);
+    }
+    if (shortDescription != null) {
+      sfs.putSingle(SFS_SHORT_DESCRIPTION, shortDescription);
+    }
+    sfs.put(SFS_HAS_AN_ACTIVE_LINK, hasAnActiveLink);
+    sfs.put(SFS_UPDATED, updated);
+    sfs.putSingle(SFS_URI, uri);
+    return sfs;
+  }
+
+  private SimpleFieldSet newDefaultBookmarkItemSfs(
+      boolean hasAnActiveLink, boolean updated, String uri) {
+    return newBookmarkItemSfs(
+        DEFAULT_SFS_NAME_VALUE,
+        DEFAULT_SFS_DESCRIPTION_VALUE,
+        DEFAULT_SFS_SHORT_DESCRIPTION_VALUE,
+        hasAnActiveLink,
+        updated,
+        uri);
+  }
+
+  @Test
+  void constructor_whenExplicitValues_expectAccessorsReturnThoseValues() {
+    // Arrange / Act
+    FreenetURI uri = uri(USK_24);
+    BookmarkItem item = newBookmarkItem(uri, "Name", "Desc", "Short", true);
+
+    // Assert
+    assertEquals("Name", item.getName());
+    assertSame(uri, item.getURI());
+    assertEquals(uri.toString(), item.getKey());
+    assertEquals("Desc", item.getDescription());
+    assertEquals("Short", item.getShortDescription());
+    assertTrue(item.hasAnActivelink());
+    assertFalse(item.hasUpdated());
+    assertNotNull(item.getUserAlert());
+  }
+
+  @Test
+  void constructor_whenSimpleFieldSetMissingUpdated_expectDefaultsToNotUpdated() throws Exception {
+    // Arrange
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    sfs.putSingle(SFS_NAME, "FromSfs");
+    sfs.putSingle(SFS_URI, USK_24);
+    sfs.put(SFS_HAS_AN_ACTIVE_LINK, true);
+
+    // Act
+    BookmarkItem item = new BookmarkItem(sfs, bookmarkManager, userAlertManager);
+
+    // Assert
+    assertEquals("FromSfs", item.getName());
+    assertFalse(item.hasUpdated());
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void constructor_whenSimpleFieldSetNameMissing_expectLocalizedFallbackNameIsNonEmpty()
+      throws Exception {
+    // Arrange
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    sfs.putSingle(SFS_NAME, "");
+    sfs.putSingle(SFS_URI, USK_24);
+    sfs.put(SFS_HAS_AN_ACTIVE_LINK, false);
+
+    // Act
+    BookmarkItem item = new BookmarkItem(sfs, bookmarkManager, userAlertManager);
+
+    // Assert
+    assertNotNull(item.getName());
+    assertFalse(item.getName().isEmpty());
+  }
+
+  @Test
+  void constructor_whenSimpleFieldSetDescriptionMissing_expectDefaultsToEmptyStrings()
+      throws Exception {
+    // Arrange
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    sfs.putSingle(SFS_NAME, DEFAULT_SFS_NAME_VALUE);
+    sfs.putSingle(SFS_URI, USK_24);
+    sfs.put(SFS_HAS_AN_ACTIVE_LINK, true);
+
+    // Act
+    BookmarkItem item = new BookmarkItem(sfs, bookmarkManager, userAlertManager);
+
+    // Assert
+    assertEquals("", item.getDescription());
+    assertEquals("", item.getShortDescription());
+  }
+
+  @Test
+  void constructor_whenSimpleFieldSetInvalidUri_expectThrowsMalformedURLException() {
+    // Arrange
+    SimpleFieldSet sfs = newDefaultBookmarkItemSfs(false, false, "NOT_A_URI");
+
+    // Act / Assert
+    assertThrows(
+        MalformedURLException.class,
+        () -> new BookmarkItem(sfs, bookmarkManager, userAlertManager));
+  }
+
+  @Test
+  void constructor_whenSimpleFieldSetProvidesValues_expectValuesExposedByAccessors()
+      throws Exception {
+    // Arrange
+    SimpleFieldSet sfs = newBookmarkItemSfs("MyName", "MyDesc", "MyShort", true, false, USK_24);
+
+    // Act
+    BookmarkItem item = new BookmarkItem(sfs, bookmarkManager, userAlertManager);
+
+    // Assert
+    assertEquals("MyName", item.getName());
+    assertEquals("MyDesc", item.getDescription());
+    assertEquals("MyShort", item.getShortDescription());
+    assertTrue(item.hasAnActivelink());
+  }
+
+  @Test
+  void registerUserAlert_whenNotUpdated_expectDoesNotRegister() throws Exception {
+    // Arrange
+    SimpleFieldSet sfs = newDefaultBookmarkItemSfs(false, false, USK_24);
+    BookmarkItem item = new BookmarkItem(sfs, bookmarkManager, userAlertManager);
+
+    // Act
+    item.registerUserAlert();
+
+    // Assert
+    verify(userAlertManager, never()).register(any(UserAlert.class));
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void registerUserAlert_whenUpdatedAndUSK_expectRegistersAlert() throws Exception {
+    // Arrange
+    SimpleFieldSet sfs = newDefaultBookmarkItemSfs(true, true, USK_24);
+    BookmarkItem item = new BookmarkItem(sfs, bookmarkManager, userAlertManager);
+
+    // Act
+    item.registerUserAlert();
+
+    // Assert
+    verify(userAlertManager).register(same(item.getUserAlert()));
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void setEdition_whenNewerEdition_expectUpdatesKeyMarksUpdatedAndRegistersOnce() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+
+    // Act
+    boolean updated = item.setEdition(25, nodeClientCore);
+
+    // Assert
+    assertTrue(updated);
+    assertTrue(item.hasUpdated());
+    assertEquals(25, item.getURI().getSuggestedEdition());
+    verify(userAlertManager).register(same(item.getUserAlert()));
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void setEdition_whenOlderOrSameEdition_expectNoUpdateAndNoRegister() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+    long currentEdition = item.getURI().getSuggestedEdition();
+
+    // Act
+    boolean updated = item.setEdition(currentEdition, nodeClientCore);
+
+    // Assert
+    assertFalse(updated);
+    assertFalse(item.hasUpdated());
+    assertEquals(currentEdition, item.getURI().getSuggestedEdition());
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void setEdition_whenCalledMultipleTimes_expectRegistersOnlyOnce() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+
+    // Act
+    assertTrue(item.setEdition(25, nodeClientCore));
+    assertTrue(item.setEdition(26, nodeClientCore));
+
+    // Assert
+    assertEquals(26, item.getURI().getSuggestedEdition());
+    verify(userAlertManager, times(1)).register(same(item.getUserAlert()));
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void update_whenNewKeyIsNotUSK_expectDisablesBookmarkAndUnregistersAlert() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", true);
+    assertTrue(item.setEdition(25, nodeClientCore));
+    verify(userAlertManager).register(same(item.getUserAlert()));
+
+    // Act
+    item.update(uri(CHK_1), false, "NewDesc", "NewShort");
+
+    // Assert
+    assertFalse(item.hasUpdated());
+    assertEquals("CHK", item.getKeyType());
+    assertFalse(item.hasAnActivelink());
+    assertEquals("NewDesc", item.getDescription());
+    assertEquals("NewShort", item.getShortDescription());
+    verify(userAlertManager).unregister(same(item.getUserAlert()));
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void clearUpdated_whenUpdated_expectClearsFlagButDoesNotUnregister() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+    assertTrue(item.setEdition(25, nodeClientCore));
+    verify(userAlertManager).register(same(item.getUserAlert()));
+
+    // Act
+    item.clearUpdated();
+
+    // Assert
+    assertFalse(item.hasUpdated());
+    verify(userAlertManager, never()).unregister(any(UserAlert.class));
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void userAlert_whenMarkedInvalid_expectUnregistersAndClearsUpdated() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+    assertTrue(item.setEdition(25, nodeClientCore));
+    verify(userAlertManager).register(same(item.getUserAlert()));
+
+    // Act
+    item.getUserAlert().isValid(false);
+
+    // Assert
+    assertFalse(item.hasUpdated());
+    verify(userAlertManager).unregister(same(item.getUserAlert()));
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void userAlert_onDismiss_expectUnregistersClearsUpdatedAndStoresBookmarks() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+    assertTrue(item.setEdition(25, nodeClientCore));
+    verify(userAlertManager).register(same(item.getUserAlert()));
+
+    // Act
+    item.getUserAlert().onDismiss();
+
+    // Assert
+    assertFalse(item.hasUpdated());
+    verify(userAlertManager).unregister(same(item.getUserAlert()));
+    verify(bookmarkManager).storeBookmarks();
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void getDescription_whenNull_expectEmptyString() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", null, "S", false);
+
+    // Act
+    String description = item.getDescription();
+
+    // Assert
+    assertEquals("", description);
+  }
+
+  @Test
+  void getDescription_whenL10nPrefixed_expectResolvedValueNotRawPrefix() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "L10N:SomeKey", "S", false);
+
+    // Act
+    String description = item.getDescription();
+
+    // Assert
+    assertNotNull(description);
+    assertNotEquals("L10N:SomeKey", description);
+    assertFalse(description.toLowerCase().startsWith("l10n:"));
+  }
+
+  @Test
+  void getShortDescription_whenNull_expectEmptyString() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", null, false);
+
+    // Act
+    String shortDescription = item.getShortDescription();
+
+    // Assert
+    assertEquals("", shortDescription);
+  }
+
+  @Test
+  void getShortDescription_whenL10nPrefixed_expectResolvedValueNotRawPrefix() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "l10n:SomeKey", false);
+
+    // Act
+    String shortDescription = item.getShortDescription();
+
+    // Assert
+    assertNotNull(shortDescription);
+    assertNotEquals("l10n:SomeKey", shortDescription);
+    assertFalse(shortDescription.toLowerCase().startsWith("l10n:"));
+  }
+
+  @Test
+  void getSimpleFieldSet_whenCalled_expectContainsPersistedFields() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", true);
+    assertTrue(item.setEdition(25, nodeClientCore));
+    verify(userAlertManager).register(same(item.getUserAlert()));
+
+    // Act
+    SimpleFieldSet sfs = item.getSimpleFieldSet();
+
+    // Assert
+    assertEquals("N", sfs.get(SFS_NAME));
+    assertEquals("D", sfs.get(SFS_DESCRIPTION));
+    assertEquals("S", sfs.get(SFS_SHORT_DESCRIPTION));
+    assertTrue(sfs.getBoolean(SFS_HAS_AN_ACTIVE_LINK, false));
+    assertTrue(sfs.getBoolean(SFS_UPDATED, false));
+    assertEquals(item.getKey(), sfs.get(SFS_URI));
+    verifyNoMoreInteractions(userAlertManager);
+  }
+
+  @Test
+  void toString_whenDescriptionNull_expectDoesNotContainNullLiteral() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", null, "S", false);
+
+    // Act
+    String value = item.toString();
+
+    // Assert
+    assertTrue(value.contains("###"));
+    assertFalse(value.contains("null"));
+    assertTrue(value.endsWith(item.getKey()));
+  }
+
+  @Test
+  void getUSK_whenKeyIsUSK_expectReturnsEquivalentUsk() throws Exception {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+
+    // Act
+    USK usk = item.getUSK();
+
+    // Assert
+    assertNotNull(usk);
+    assertTrue(USK.create(item.getURI()).equals(usk, true));
+  }
+
+  @Test
+  void getUSK_whenKeyIsNotUSK_expectThrowsMalformedURLException() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(CHK_1), "N", "D", "S", false);
+
+    // Act / Assert
+    assertThrows(MalformedURLException.class, item::getUSK);
+  }
+
+  @Test
+  void equals_whenSameInstance_expectTrue() {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+
+    // Act / Assert
+    //noinspection EqualsWithItself
+    assertEquals(item, item);
+  }
+
+  @Test
+  void equals_whenSameBookmarkButDifferentSuggestedEdition_expectEqualAndHashCodesMatch() {
+    // Arrange
+    BookmarkItem a = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+    BookmarkItem b = newBookmarkItem(uri(USK_24).setSuggestedEdition(12345), "N", "D", "S", false);
+
+    // Act / Assert
+    assertEquals(a, b);
+    assertEquals(b, a);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  void equals_whenDifferentAlertManager_expectNotEqual() {
+    // Arrange
+    UserAlertManager otherAlertManager = org.mockito.Mockito.mock(UserAlertManager.class);
+    BookmarkItem a = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+    BookmarkItem b =
+        new BookmarkItem(uri(USK_24), "N", "D", "S", false, bookmarkManager, otherAlertManager);
+
+    // Act / Assert
+    assertNotEquals(a, b);
+    assertNotEquals(b, a);
+  }
+
+  @Test
+  void equals_whenOtherHasNullDescription_expectNotEqualAndNoNpe() {
+    // Arrange
+    BookmarkItem a = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
+    BookmarkItem b = newBookmarkItem(uri(USK_24), "N", null, "S", false);
+
+    // Act / Assert
+    assertNotEquals(a, b);
+    assertNotEquals(b, a);
+  }
+
+  @Test
+  void equals_whenBothDescriptionsNull_expectEqualAndHashCodesMatch() {
+    // Arrange
+    BookmarkItem a = newBookmarkItem(uri(USK_24), "N", null, "S", false);
+    BookmarkItem b = newBookmarkItem(uri(USK_24), "N", null, "S", false);
+
+    // Act / Assert
+    assertEquals(a, b);
+    assertEquals(b, a);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  static Stream<Arguments> keyTypes() {
+    return Stream.of(Arguments.of(USK_24, "USK"), Arguments.of(CHK_1, "CHK"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("keyTypes")
+  void getKeyType_whenUriProvided_expectMatchesUnderlyingKeyType(String uri, String expectedType) {
+    // Arrange
+    BookmarkItem item = newBookmarkItem(uri(uri), "N", "D", "S", false);
+
+    // Act
+    String keyType = item.getKeyType();
+
+    // Assert
+    assertEquals(expectedType, keyType);
+  }
+
+  @Test
+  void constructor_whenSimpleFieldSetInvalidContents_expectThrowsMalformedURLException() {
+    // Arrange
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    sfs.putSingle(SFS_NAME, "N");
+    sfs.putSingle(SFS_URI, "USK@/broken/0");
+    sfs.put(SFS_HAS_AN_ACTIVE_LINK, false);
+
+    // Act / Assert
+    assertThrows(
+        MalformedURLException.class,
+        () -> new BookmarkItem(sfs, bookmarkManager, userAlertManager));
+  }
+}

--- a/src/test/java/network/crypta/clients/http/bookmark/BookmarkManagerTest.java
+++ b/src/test/java/network/crypta/clients/http/bookmark/BookmarkManagerTest.java
@@ -1,0 +1,432 @@
+package network.crypta.clients.http.bookmark;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import network.crypta.client.async.USKManager;
+import network.crypta.keys.FreenetURI;
+import network.crypta.keys.USK;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings({"java:S100", "java:S3011", "java:S1075"})
+@ExtendWith(MockitoExtension.class)
+class BookmarkManagerTest {
+
+  private static final AtomicInteger DIR_COUNTER = new AtomicInteger();
+  private static final Object CATEGORY_CLEAR_LOCK = new Object();
+  private static final String CAT_PATH = "/cat/";
+  private static final String SITE_PATH = "/site";
+
+  @TempDir(cleanup = CleanupMode.NEVER)
+  static Path rootTempDir;
+
+  private Path testDir;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    clearCategoryTree(BookmarkManager.MAIN_CATEGORY);
+    clearCategoryTree(BookmarkManager.DEFAULT_CATEGORY);
+    testDir = Files.createDirectories(rootTempDir.resolve("bm-" + DIR_COUNTER.getAndIncrement()));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"/,/", "/a,/", "/a/,/", "/a/b,/a/", "/a/b/,/a/", "/a/b/c/,/a/b/"})
+  void parentPath_whenGivenPath_expectParent(String input, String expected) {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+
+    String parent = manager.parentPath(input);
+
+    assertEquals(expected, parent);
+  }
+
+  @Test
+  void getCategoryByPath_whenPathIsCategory_expectCategoryInstance() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkCategory category = new BookmarkCategory("cat");
+    manager.addBookmark("/", category);
+
+    BookmarkCategory byPath = manager.getCategoryByPath(CAT_PATH);
+
+    assertSame(category, byPath);
+  }
+
+  @Test
+  void getCategoryByPath_whenPathIsItem_expectNull() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkItem item = mockBookmarkItem("item", "KSK");
+    manager.addBookmark("/", item);
+
+    BookmarkCategory byPath = manager.getCategoryByPath("/item");
+
+    assertNull(byPath);
+  }
+
+  @Test
+  void getItemByPath_whenPathIsItem_expectItemInstance() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkItem item = mockBookmarkItem("item", "KSK");
+    manager.addBookmark("/", item);
+
+    BookmarkItem byPath = manager.getItemByPath("/item");
+
+    assertSame(item, byPath);
+  }
+
+  @Test
+  void getItemByPath_whenPathIsCategory_expectNull() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkCategory category = new BookmarkCategory("cat");
+    manager.addBookmark("/", category);
+
+    BookmarkItem byPath = manager.getItemByPath(CAT_PATH);
+
+    assertNull(byPath);
+  }
+
+  @Test
+  void addBookmark_whenAddingUskItem_expectSubscribeCalled() throws Exception {
+    USKManager uskManager = mock(USKManager.class);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir, uskManager);
+
+    USK usk = mock(USK.class);
+    BookmarkItem item = mockBookmarkItem("site", "USK");
+    when(item.getUSK()).thenReturn(usk);
+
+    manager.addBookmark("/", item);
+
+    assertSame(item, manager.getItemByPath(SITE_PATH));
+    verify(uskManager).subscribe(eq(usk), any(), eq(true), eq(manager));
+  }
+
+  @Test
+  void renameBookmark_whenRenamingCategory_expectPathsUpdatedForSubtree() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkCategory category = new BookmarkCategory("cat");
+    manager.addBookmark("/", category);
+    BookmarkItem item = mockBookmarkItem("item", "KSK");
+    manager.addBookmark(CAT_PATH, item);
+
+    manager.renameBookmark(CAT_PATH, "newcat");
+
+    assertNull(manager.getBookmarkByPath(CAT_PATH));
+    assertSame(category, manager.getCategoryByPath("/newcat/"));
+    assertSame(item, manager.getItemByPath("/newcat/item"));
+  }
+
+  @Test
+  void moveBookmark_whenMovingItem_expectPathAndParentUpdated() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkCategory from = new BookmarkCategory("from");
+    BookmarkCategory to = new BookmarkCategory("to");
+    manager.addBookmark("/", from);
+    manager.addBookmark("/", to);
+    BookmarkItem item = mockBookmarkItem("item", "KSK");
+    manager.addBookmark("/from/", item);
+
+    manager.moveBookmark("/from/item", "/to/");
+
+    assertNull(manager.getBookmarkByPath("/from/item"));
+    assertSame(item, manager.getItemByPath("/to/item"));
+    assertTrue(from.getItems().isEmpty());
+    assertEquals(List.of(item), to.getItems());
+  }
+
+  @Test
+  void removeBookmark_whenPathUnknown_expectNoop() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+
+    manager.removeBookmark("/missing");
+
+    assertSame(BookmarkManager.MAIN_CATEGORY, manager.getCategoryByPath("/"));
+  }
+
+  @Test
+  void removeBookmark_whenRemovingUskItem_expectUnsubscribeWhenNoOtherWantsUsk() throws Exception {
+    USKManager uskManager = mock(USKManager.class);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir, uskManager);
+
+    USK usk = mock(USK.class);
+    BookmarkItem item = mockBookmarkItem("site", "USK");
+    when(item.getUSK()).thenReturn(usk);
+    manager.addBookmark("/", item);
+
+    manager.removeBookmark(SITE_PATH);
+
+    assertNull(manager.getBookmarkByPath(SITE_PATH));
+    verify(uskManager).unsubscribe(eq(usk), any());
+  }
+
+  @Test
+  void moveBookmarkDown_whenStoreFalse_expectReorderedWithoutSaving() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkItem a = mockBookmarkItem("a", "KSK");
+    BookmarkItem b = mockBookmarkItem("b", "KSK");
+    BookmarkItem c = mockBookmarkItem("c", "KSK");
+    manager.addBookmark("/", a);
+    manager.addBookmark("/", b);
+    manager.addBookmark("/", c);
+
+    manager.moveBookmarkDown("/a", false);
+
+    assertEquals(List.of(b, a, c), BookmarkManager.MAIN_CATEGORY.getItems());
+  }
+
+  @Test
+  void moveBookmarkUp_whenStoreFalse_expectReorderedWithoutSaving() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkItem a = mockBookmarkItem("a", "KSK");
+    BookmarkItem b = mockBookmarkItem("b", "KSK");
+    BookmarkItem c = mockBookmarkItem("c", "KSK");
+    manager.addBookmark("/", a);
+    manager.addBookmark("/", b);
+    manager.addBookmark("/", c);
+
+    manager.moveBookmarkUp("/c", false);
+
+    assertEquals(List.of(a, c, b), BookmarkManager.MAIN_CATEGORY.getItems());
+  }
+
+  @Test
+  void getBookmarkURIs_whenItemsPresent_expectUrisInTraversalOrder() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    FreenetURI uri1 = mock(FreenetURI.class);
+    FreenetURI uri2 = mock(FreenetURI.class);
+    BookmarkItem item1 = mockKskBookmarkItemWithUri("one", uri1);
+    BookmarkItem item2 = mockKskBookmarkItemWithUri("two", uri2);
+    manager.addBookmark("/", item1);
+    manager.addBookmark("/", item2);
+
+    FreenetURI[] uris = manager.getBookmarkURIs();
+
+    assertArrayEquals(new FreenetURI[] {uri1, uri2}, uris);
+  }
+
+  @Test
+  void storeBookmarksLazy_whenCalledTwiceBeforeJobRuns_expectQueuedOnce() {
+    Ticker ticker = mock(Ticker.class);
+    BookmarkManager manager = spy(newManagerWithEmptyBookmarksFile(testDir, ticker));
+    doNothing().when(manager).storeBookmarks();
+    ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+
+    manager.storeBookmarksLazy();
+    manager.storeBookmarksLazy();
+
+    verify(ticker, times(1)).queueTimedJob(runnableCaptor.capture(), eq(5L * 60L * 1000L));
+    verify(manager, never()).storeBookmarks();
+
+    runnableCaptor.getValue().run();
+
+    verify(manager, times(1)).storeBookmarks();
+  }
+
+  @Test
+  void storeBookmarksLazy_whenJobCompleted_expectSubsequentCallQueuesAgain() {
+    Ticker ticker = mock(Ticker.class);
+    BookmarkManager manager = spy(newManagerWithEmptyBookmarksFile(testDir, ticker));
+    doNothing().when(manager).storeBookmarks();
+    ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+
+    manager.storeBookmarksLazy();
+    verify(ticker).queueTimedJob(runnableCaptor.capture(), anyLong());
+
+    runnableCaptor.getValue().run();
+
+    manager.storeBookmarksLazy();
+
+    verify(ticker, times(2)).queueTimedJob(any(Runnable.class), anyLong());
+  }
+
+  @Test
+  void toSimpleFieldSet_whenEmpty_expectVersionAndZeroCounts() throws Exception {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+
+    SimpleFieldSet sfs = manager.toSimpleFieldSet();
+
+    assertEquals(1, sfs.getInt("Version"));
+    assertEquals(0, sfs.getInt(BookmarkItem.BOOKMARK_PREFIX));
+    assertEquals(0, sfs.getInt(BookmarkCategory.SFS_KEY));
+  }
+
+  @Test
+  void toSimpleFieldSet_whenCategoryAndItemPresent_expectCountsMatch() throws Exception {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkCategory category = new BookmarkCategory("cat");
+    manager.addBookmark("/", category);
+    BookmarkItem item = mockBookmarkItem("item", "KSK");
+    manager.addBookmark(CAT_PATH, item);
+
+    SimpleFieldSet root = manager.toSimpleFieldSet();
+    SimpleFieldSet categorySfs =
+        root.getSubset(BookmarkCategory.SFS_KEY + "0").getSubset("Content");
+
+    assertEquals(1, root.getInt(BookmarkCategory.SFS_KEY));
+    assertEquals(0, root.getInt(BookmarkItem.BOOKMARK_PREFIX));
+    assertEquals(0, categorySfs.getInt(BookmarkCategory.SFS_KEY));
+    assertEquals(1, categorySfs.getInt(BookmarkItem.BOOKMARK_PREFIX));
+  }
+
+  @Test
+  void reAddDefaultBookmarks_whenDefaultBookmarksAvailable_expectCategoryAdded() throws Exception {
+    assertNotNull(BookmarkManager.DEFAULT_BOOKMARKS);
+
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+
+    manager.reAddDefaultBookmarks();
+
+    String prefix = manager.l10n("defaultBookmarks") + " - ";
+    Optional<BookmarkCategory> added =
+        BookmarkManager.MAIN_CATEGORY.getSubCategories().stream()
+            .filter(c -> c.getName().startsWith(prefix))
+            .findFirst();
+    assertTrue(added.isPresent());
+
+    BookmarkCategory category = added.get();
+    assertSame(category, manager.getCategoryByPath("/" + category.getName() + "/"));
+    SimpleFieldSet content = BookmarkManager.toSimpleFieldSet(category);
+    assertTrue(
+        content.getInt(BookmarkItem.BOOKMARK_PREFIX) > 0
+            || content.getInt(BookmarkCategory.SFS_KEY) > 0);
+  }
+
+  @Test
+  void storeBookmarks_whenCalled_expectBookmarksFileWritten() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    manager.addBookmark("/", new BookmarkCategory("cat"));
+
+    manager.storeBookmarks();
+
+    File bookmarksFile = testDir.resolve("bookmarks.dat").toFile();
+    assertTrue(bookmarksFile.isFile());
+    assertTrue(bookmarksFile.length() > 0);
+  }
+
+  @Test
+  void persistent_whenCalled_expectFalse() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+
+    assertFalse(manager.persistent());
+  }
+
+  @Test
+  void realTimeFlag_whenCalled_expectFalse() {
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+
+    assertFalse(manager.realTimeFlag());
+  }
+
+  private static BookmarkItem mockBookmarkItem(String name, String keyType) {
+    BookmarkItem item = mock(BookmarkItem.class);
+    when(item.getName()).thenReturn(name);
+    when(item.getKeyType()).thenReturn(keyType);
+    return item;
+  }
+
+  private static BookmarkItem mockKskBookmarkItemWithUri(String name, FreenetURI uri) {
+    BookmarkItem item = mockBookmarkItem(name, "KSK");
+    when(item.getURI()).thenReturn(uri);
+    return item;
+  }
+
+  private static BookmarkManager newManagerWithEmptyBookmarksFile(Path tmp) {
+    return newManagerWithEmptyBookmarksFile(tmp, mock(Ticker.class), mock(USKManager.class));
+  }
+
+  private static BookmarkManager newManagerWithEmptyBookmarksFile(Path tmp, USKManager uskManager) {
+    return newManagerWithEmptyBookmarksFile(tmp, mock(Ticker.class), uskManager);
+  }
+
+  private static BookmarkManager newManagerWithEmptyBookmarksFile(Path tmp, Ticker ticker) {
+    return newManagerWithEmptyBookmarksFile(tmp, ticker, mock(USKManager.class));
+  }
+
+  private static BookmarkManager newManagerWithEmptyBookmarksFile(
+      Path tmp, Ticker ticker, USKManager uskManager) {
+    try {
+      File bookmarksFile = tmp.resolve("bookmarks.dat").toFile();
+      SimpleFieldSet empty = new SimpleFieldSet(true);
+      empty.put(BookmarkItem.BOOKMARK_PREFIX, 0);
+      empty.put(BookmarkCategory.SFS_KEY, 0);
+      writeSimpleFieldSet(bookmarksFile, empty);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to write initial bookmarks file for test", e);
+    }
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    Node node = mock(Node.class);
+    network.crypta.node.ProgramDirectory userDir = new network.crypta.node.ProgramDirectory();
+    try {
+      userDir.move(tmp.toString());
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to initialize ProgramDirectory for test", e);
+    }
+
+    when(node.userDir()).thenReturn(userDir);
+    lenient().when(node.getTicker()).thenReturn(ticker);
+    when(core.getNode()).thenReturn(node);
+    lenient().when(core.getUskManager()).thenReturn(uskManager);
+    lenient().when(core.getAlerts()).thenReturn(alerts);
+
+    return new BookmarkManager(core, false);
+  }
+
+  private static void writeSimpleFieldSet(File file, SimpleFieldSet sfs) throws IOException {
+    try (FileOutputStream out = new FileOutputStream(file)) {
+      sfs.writeToBigBuffer(out);
+    }
+  }
+
+  private static void clearCategoryTree(BookmarkCategory category) {
+    try {
+      Field field = BookmarkCategory.class.getDeclaredField("bookmarks");
+      field.setAccessible(true);
+      Object raw = field.get(category);
+      @SuppressWarnings("unchecked")
+      List<Bookmark> list = (List<Bookmark>) raw;
+      synchronized (CATEGORY_CLEAR_LOCK) {
+        list.clear();
+      }
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalStateException(
+          "Failed to clear BookmarkCategory state for test isolation", e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Improves bookmark persistence logic (primary/backup/default fallback) and makes lookup/indexing more robust.
- Stabilizes the serialized BookmarkCategory discriminator key to avoid SFS format drift.
- Makes BookmarkItem equality/null handling safer.
- Adds JUnit coverage for BookmarkCategory/BookmarkItem/BookmarkManager and expands related Javadoc/package docs.

## Testing
- `./gradlew test --tests '*Bookmark*'`

## Notes
- Branch is rebased on top of `develop`.