### PR TITLE
test(ajaxpush): add coverage for Ajax push toadlets

### DIFF
--- a/.spotlessignore
+++ b/.spotlessignore
@@ -5,3 +5,4 @@ tools/flatpak/work/
 tools/flatpak/local/
 build/
 build-logic/build/
+.idea/

--- a/build-logic/src/main/kotlin/cryptad.spotless.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.spotless.gradle.kts
@@ -17,6 +17,11 @@ spotless {
   }
   kotlinGradle {
     target("**/*.gradle.kts")
+    // Avoid scanning generated build output (including Spotless' own working directories) and IDE
+    // metadata which may contain non-UTF8 content or filenames.
+    targetExclude("**/build/**")
+    targetExclude("**/.gradle/**")
+    targetExclude("**/.idea/**")
     ktfmt("0.58").googleStyle()
   }
 }

--- a/src/main/java/network/crypta/clients/http/ajaxpush/DismissAlertToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/DismissAlertToadlet.java
@@ -13,32 +13,88 @@ import network.crypta.support.api.HTTPRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** This toadlet is used to dismiss alerts from the client side */
+/**
+ * Toadlet endpoint that acknowledges a client-side request to dismiss a UI alert.
+ *
+ * <p>This handler is part of the AJAX push/update subsystem used by FProxy. Browsers call the
+ * endpoint with an {@code anchor} parameter that identifies a particular alert instance that the UI
+ * wants to hide. The request is lightweight and side-effect oriented: on success it returns a small
+ * HTML body containing a status token that client scripts interpret as either a success or failure
+ * signal.
+ *
+ * <p>At present, server-side dismissal is intentionally disabled in the reference daemon. The
+ * toadlet still accepts requests and always responds with {@link
+ * network.crypta.clients.http.updateableelements.UpdaterConstants#SUCCESS} so existing clients do
+ * not break, while keeping the wire contract stable for future re-enablement.
+ *
+ * <ul>
+ *   <li><strong>Input:</strong> a single query parameter {@code anchor}, decoded from HTML entity
+ *       form.
+ *   <li><strong>Output:</strong> HTTP 200 with a short HTML reply indicating success.
+ *   <li><strong>State:</strong> stateless per request; no persistent mutation currently occurs.
+ * </ul>
+ *
+ * <p>This toadlet is safe for concurrent use assuming its superclass contracts are respected; it
+ * performs no shared mutable writes and delegates response emission to the {@link ToadletContext}.
+ *
+ * <p>Registration is performed by the HTTP container setup for the node.
+ */
 public class DismissAlertToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(DismissAlertToadlet.class);
 
-  static {
-  }
-
+  /**
+   * Creates a new dismiss-alert toadlet bound to the node's high-level client helper.
+   *
+   * <p>The client is passed through to {@link Toadlet}'s constructor for consistency with other
+   * HTTP toadlets, even though this endpoint does not currently perform network operations itself.
+   * The instance is expected to be registered once with a {@link
+   * network.crypta.clients.http.ToadletContainer} and then reused for incoming requests.
+   *
+   * @param client High-level client associated with the node; must be non-null.
+   */
   public DismissAlertToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Handles a GET request that asks the node to dismiss an alert identified by its anchor.
+   *
+   * <p>The method reads {@code anchor} from the query string via {@link
+   * HTTPRequest#getParam(String)} and decodes HTML entities using {@link
+   * HTMLDecoder#decode(String)}. The decoded anchor is only used for logging today. The server-side
+   * dismissal path is disabled, so the handler always returns a success token and HTTP 200. Clients
+   * treat the returned body as a simple status value.
+   *
+   * <p>Preconditions: the {@code anchor} parameter should be present (possibly empty) and the
+   * {@code ctx} must be open for writing. If the parameter is missing, {@link HTMLDecoder#decode}
+   * will throw a {@link NullPointerException}.
+   *
+   * @param uri The requested URI, including any query parameters; not used beyond routing.
+   * @param req Parsed HTTP request providing access to query parameters and headers.
+   * @param ctx Active toadlet context used to write the HTTP response.
+   * @throws ToadletContextClosedException If the client disconnects before the reply is written.
+   * @throws IOException If writing the response fails due to I/O problems.
+   * @throws RedirectException Never thrown by this implementation, but declared by contract.
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     // The anchor is used to identify the alert
     String anchor = HTMLDecoder.decode(req.getParam("anchor"));
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Dismissing alert with anchor:" + anchor);
+      LOG.debug("Dismissing alert with anchor: {}", anchor);
     }
-    // Dismiss the alert
-    // boolean success = ((SimpleToadletServer)
-    // ctx.getContainer()).getCore().alerts.dismissByAnchor(anchor);
-    // TODO:it's disabled
-    boolean success = true;
-    writeHTMLReply(ctx, 200, "OK", success ? UpdaterConstants.SUCCESS : UpdaterConstants.FAILURE);
+    // Alert dismissal is currently disabled; always report success.
+    writeHTMLReply(ctx, 200, "OK", UpdaterConstants.SUCCESS);
   }
 
+  /**
+   * Returns the HTTP mount path for this toadlet.
+   *
+   * <p>The container registers this endpoint under {@link UpdaterConstants#dismissAlertPath}. The
+   * value is stable and is used by client-side scripts to issue dismissal requests.
+   *
+   * @return Absolute path fragment for the dismiss-alert endpoint.
+   */
   @Override
   public String path() {
     return UpdaterConstants.dismissAlertPath;

--- a/src/main/java/network/crypta/clients/http/ajaxpush/LogWritebackToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/LogWritebackToadlet.java
@@ -14,29 +14,94 @@ import network.crypta.support.api.HTTPRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** This toadlet is used to let the client write to the logs */
+/**
+ * Receives client-side log messages and forwards them to the node logger.
+ *
+ * <p>This toadlet exists primarily as a low-friction bridge for web UI components (for example,
+ * Ajax-driven pages) to report diagnostics back to the server-side log stream during development or
+ * troubleshooting. The endpoint accepts an HTTP GET request containing a single query parameter
+ * named {@code msg}. When server-side debug logging is enabled for this class, the handler decodes
+ * the parameter as a raw percent-encoded URI component via {@link URLDecoder} (not {@code
+ * application/x-www-form-urlencoded}) and emits the decoded content as a debug log line.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Logging is conditional: when debug logging is disabled, the message is ignored and only the
+ *       success reply is returned.
+ *   <li>Malformed percent-escapes are handled defensively: the undecoded {@code msg} value is
+ *       logged at error level, and the request still receives a successful response.
+ *   <li>The HTTP response body is always {@link UpdaterConstants#SUCCESS} with status {@code 200
+ *       OK}; this endpoint is intended for fire-and-forget client usage.
+ * </ul>
+ *
+ * <p>Thread-safety: instances are stateless and safe to reuse concurrently as long as the
+ * surrounding {@link Toadlet} infrastructure is used as intended.
+ */
 public class LogWritebackToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(LogWritebackToadlet.class);
 
-  static {
-  }
-
+  /**
+   * Creates a new instance bound to the provided high-level client helper.
+   *
+   * <p>The client is required by the {@link Toadlet} base type even though this particular endpoint
+   * does not perform network fetches or inserts. Callers typically construct this once and register
+   * it with the HTTP container that routes requests based on {@link #path()}.
+   *
+   * @param client non-null client helper retained by the base {@link Toadlet}; unused by this
+   *     implementation but required for consistent wiring and future compatibility
+   */
   public LogWritebackToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Handles a client log writeback request.
+   *
+   * <p>This handler reads {@code msg} from the supplied {@link HTTPRequest} and, when debug logging
+   * is enabled, attempts to decode it using {@link URLDecoder#decode(String, boolean)} with {@code
+   * tolerant=false}. If decoding succeeds, the decoded message is logged at debug level; if it
+   * fails with {@link URLEncodedFormatException}, the raw parameter value is logged as an error.
+   *
+   * <p>Regardless of logging outcome, the handler sends an HTML response with status {@code 200},
+   * reason phrase {@code "OK"}, and body {@link UpdaterConstants#SUCCESS}. The method is intended
+   * to be idempotent: repeated calls with the same input do not change server state beyond
+   * producing log output.
+   *
+   * @param uri request URI passed by the container; not used by this handler but provided for
+   *     consistency with other toadlets and potential future use
+   * @param req parsed HTTP request providing query parameters; {@code msg} is read via {@link
+   *     HTTPRequest#getParam(String)} and defaults to an empty string when missing
+   * @param ctx response context used to write the {@code 200 OK} success reply; must be open when
+   *     called or a close exception is thrown by the context implementation
+   * @throws ToadletContextClosedException if the client disconnects before the success reply can be
+   *     written to the {@link ToadletContext}
+   * @throws IOException if writing the response fails due to an underlying I/O error
+   * @throws RedirectException declared for the base dispatch contract; this implementation does not
+   *     initiate redirects
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     if (LOG.isDebugEnabled()) {
       try {
-        LOG.debug("GWT:" + URLDecoder.decode(req.getParam("msg"), false));
+        LOG.debug("GWT:{}", URLDecoder.decode(req.getParam("msg"), false));
       } catch (URLEncodedFormatException e) {
-        LOG.error("Invalid GWT:" + req.getParam("msg"));
+        LOG.error("Invalid GWT:{}", req.getParam("msg"));
       }
     }
     writeHTMLReply(ctx, 200, "OK", UpdaterConstants.SUCCESS);
   }
 
+  /**
+   * Returns the mount path for this toadlet.
+   *
+   * <p>The HTTP container uses this value to route incoming requests and to build links. The path
+   * is a stable constant defined in {@link UpdaterConstants} so both client-side scripts and
+   * server-side code refer to the same endpoint.
+   *
+   * @return the absolute path fragment under which this toadlet is served, typically {@code
+   *     "/logwriteback/"}
+   */
   @Override
   public String path() {
     return UpdaterConstants.logWritebackPath;

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushDataToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushDataToadlet.java
@@ -17,29 +17,93 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A toadlet that provides the current data of pushed elements. It requires the requestId and the
- * elementId parameters.
+ * Serves the current rendered state of a pushed, updateable element.
+ *
+ * <p>This toadlet is part of the browser-side “AJAX push” mechanism: client-side JavaScript polls
+ * {@link network.crypta.clients.http.updateableelements.UpdaterConstants#dataPath} and expects the
+ * server to return a compact payload describing how to update the DOM for a previously rendered
+ * element. The request identifies both the page/request session and the specific element via query
+ * parameters. The element identifier is expected to be Base64-like and therefore may contain {@code
+ * '+'}; some clients decode {@code '+'} as a space when placed in a query string, so this endpoint
+ * normalizes {@code ' '} back to {@code '+'} before looking up the element.
+ *
+ * <p>On success, the reply body is formatted as {@code SUCCESS:<type>:<children>} where {@code
+ * <type>} is the UTF-8 Base64 encoding of {@link
+ * network.crypta.clients.http.updateableelements.BaseUpdateableElement#getUpdaterType()} and {@code
+ * <children>} is the UTF-8 Base64 encoding of {@link
+ * network.crypta.clients.http.updateableelements.BaseUpdateableElement#generateChildren()}.
+ *
+ * <ul>
+ *   <li>Responsibilities: translate request parameters into a rendered-element lookup and return a
+ *       minimal update payload.
+ *   <li>Thread-safety: this type is stateless per request; concurrency guarantees depend on the
+ *       underlying {@link network.crypta.clients.http.updateableelements.PushDataManager}.
+ * </ul>
+ *
+ * @see network.crypta.clients.http.updateableelements.PushDataManager
+ * @see network.crypta.clients.http.updateableelements.BaseUpdateableElement
+ * @see network.crypta.clients.http.updateableelements.UpdaterConstants
  */
 public class PushDataToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushDataToadlet.class);
 
+  /**
+   * Creates a new toadlet instance bound to the supplied high-level client helper.
+   *
+   * <p>The client is stored by the {@link network.crypta.clients.http.Toadlet} base class and is
+   * available for toadlets that need to perform networked operations. This specific endpoint only
+   * reads request parameters and queries the {@link
+   * network.crypta.clients.http.updateableelements.PushDataManager}, but it follows the same
+   * construction pattern as other toadlets and is typically registered with the toadlet container
+   * during HTTP server initialization.
+   *
+   * @param client Non-null client helper provided by the node for toadlet operations.
+   */
   public PushDataToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Returns the current update payload for a previously rendered pushed element.
+   *
+   * <p>The handler expects two query parameters on {@code req}: {@code requestId} identifying the
+   * request/session that rendered the element and {@code elementId} identifying the element within
+   * that request. Because {@code elementId} may contain {@code '+'} characters (common in Base64),
+   * the value is normalized by replacing spaces with {@code '+'} before the lookup. The element is
+   * retrieved from the {@link network.crypta.clients.http.updateableelements.PushDataManager}
+   * attached to the current {@link network.crypta.clients.http.SimpleToadletServer}.
+   *
+   * <p>On success, the method responds with HTTP {@code 200 OK} and a {@code text/html} body in the
+   * format documented on the class. If the server cannot resolve the element, runtime failures may
+   * occur (for example, a {@link NullPointerException} when dereferencing a missing element), which
+   * is consistent with the historical behavior of this endpoint.
+   *
+   * <pre>{@code
+   * // Example request shape:
+   * // GET /pushdata/?requestId=<id>&elementId=<base64>
+   * }</pre>
+   *
+   * @param uri Parsed request URI, currently unused by this handler but provided by the container.
+   * @param req Parsed HTTP request providing query parameters for the lookup operation.
+   * @param ctx Request context used to resolve the server container and write the reply.
+   * @throws ToadletContextClosedException If the connection is closed while writing the response.
+   * @throws IOException If writing the response fails due to an I/O error.
+   * @throws RedirectException If the container requests a redirect while processing this request.
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");
     String elementId = req.getParam("elementId");
     elementId =
         elementId.replace(
-            " ", "+"); // This is needed, because BASE64 has '+', but it is a HTML escape for ' '
-    if (LOG.isDebugEnabled()) LOG.debug("Getting data for element:{}", elementId);
+            " ", "+"); // This is needed, because BASE64 has '+', but it is an HTML escape for ' '
+    if (LOG.isDebugEnabled()) LOG.debug("Fetching push data for elementId={}", elementId);
     BaseUpdateableElement node =
         ((SimpleToadletServer) ctx.getContainer())
             .getPushDataManager()
             .getRenderedElement(requestId, elementId);
-    if (LOG.isDebugEnabled()) LOG.debug("Data got element:{}", node.generateChildren());
+    if (LOG.isDebugEnabled())
+      LOG.debug("Fetched push data childrenHtml={}", node.generateChildren());
     writeHTMLReply(
         ctx,
         200,
@@ -51,6 +115,15 @@ public class PushDataToadlet extends Toadlet {
             + Base64.encodeStandard(node.generateChildren().getBytes(StandardCharsets.UTF_8)));
   }
 
+  /**
+   * Returns the canonical HTTP mount path for this toadlet.
+   *
+   * <p>The returned value is used by the toadlet container for routing and by clients to locate the
+   * endpoint that serves update payloads. The path is stable and defined by {@link
+   * network.crypta.clients.http.updateableelements.UpdaterConstants#dataPath}.
+   *
+   * @return The absolute path prefix under which this toadlet is reachable.
+   */
   @Override
   public String path() {
     return UpdaterConstants.dataPath;

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushFailoverToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushFailoverToadlet.java
@@ -14,19 +14,79 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A toadlet that the client can use for push failover. It requires the requestId and
- * originalRequestId parameter.
+ * Handles push-leader failover for the AJAX push subsystem.
+ *
+ * <p>This toadlet implements a small HTTP endpoint used by the browser-side “AJAX push” code when
+ * leadership for a page/session changes. In that situation, outstanding update notifications that
+ * were waiting on the previous leader request may need to be reassigned to the new leader request
+ * so polling continues without losing queued updates.
+ *
+ * <p>The handler reads two query parameters from the incoming request: {@code originalRequestId}
+ * (the request id that previously acted as leader) and {@code requestId} (the request id that is
+ * taking over). It then delegates to {@link
+ * network.crypta.clients.http.updateableelements.PushDataManager#failover(String, String)} via the
+ * {@link network.crypta.clients.http.SimpleToadletServer} container. The response body is a simple
+ * success/failure token defined by {@link
+ * network.crypta.clients.http.updateableelements.UpdaterConstants} and is suitable for use by
+ * lightweight client-side scripts.
+ *
+ * <ul>
+ *   <li>Responsibilities: translate request parameters into a {@code PushDataManager} failover call
+ *       and return a compact status response.
+ *   <li>Thread-safety: this type is stateless per request; concurrency guarantees depend on the
+ *       synchronized {@code PushDataManager} implementation.
+ * </ul>
+ *
+ * @see network.crypta.clients.http.updateableelements.PushDataManager#failover(String, String)
+ * @see network.crypta.clients.http.ajaxpush.PushDataToadlet
+ * @see network.crypta.clients.http.ajaxpush.PushNotificationToadlet
  */
 public class PushFailoverToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushFailoverToadlet.class);
 
-  static {
-  }
-
+  /**
+   * Creates a new toadlet instance bound to the supplied high-level client helper.
+   *
+   * <p>The {@link network.crypta.clients.http.Toadlet} base class stores the client reference for
+   * use by endpoints that need to perform node-backed operations. This specific toadlet delegates
+   * to the {@link network.crypta.clients.http.updateableelements.PushDataManager} attached to the
+   * active {@link network.crypta.clients.http.SimpleToadletServer}, but it follows the same
+   * construction pattern as the rest of the HTTP toadlets and is typically registered during HTTP
+   * server startup.
+   *
+   * @param client Non-null client helper provided by the node for toadlet operations.
+   */
   public PushFailoverToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Performs a push failover by moving queued notifications from one request id to another.
+   *
+   * <p>The request must provide the {@code originalRequestId} query parameter identifying the
+   * request/session that previously acted as the leader and the {@code requestId} query parameter
+   * identifying the new leader request. The method delegates to {@link
+   * network.crypta.clients.http.updateableelements.PushDataManager#failover(String, String)} and
+   * writes a {@code 200 OK} response whose body is either {@link
+   * network.crypta.clients.http.updateableelements.UpdaterConstants#SUCCESS} or {@link
+   * network.crypta.clients.http.updateableelements.UpdaterConstants#FAILURE}.
+   *
+   * <p>This endpoint does not perform additional validation of the supplied ids. If the underlying
+   * manager cannot perform the reassignment (for example, because the original id is unknown), the
+   * result is reported as {@code FAILURE} while still returning HTTP {@code 200 OK}.
+   *
+   * <pre>{@code
+   * // Example request shape:
+   * // GET /pushfailover/?originalRequestId=<old>&requestId=<new>
+   * }</pre>
+   *
+   * @param uri Parsed request URI, currently unused by this handler but provided by the container.
+   * @param req Parsed HTTP request providing the failover query parameters.
+   * @param ctx Request context used to resolve the server container and write the reply.
+   * @throws ToadletContextClosedException If the connection is closed while writing the response.
+   * @throws IOException If writing the response fails due to an I/O error.
+   * @throws RedirectException If the container requests a redirect while processing this request.
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");
@@ -36,12 +96,20 @@ public class PushFailoverToadlet extends Toadlet {
             .getPushDataManager()
             .failover(originalRequestId, requestId);
     if (LOG.isDebugEnabled()) {
-      LOG.debug(
-          "Failover from:" + originalRequestId + " to:" + requestId + " with result:" + result);
+      LOG.debug("Failover from:{} to:{} with result:{}", originalRequestId, requestId, result);
     }
     writeHTMLReply(ctx, 200, "OK", result ? UpdaterConstants.SUCCESS : UpdaterConstants.FAILURE);
   }
 
+  /**
+   * Returns the canonical HTTP mount path for this toadlet.
+   *
+   * <p>The returned value is used by the toadlet container for routing and by clients to locate the
+   * endpoint that triggers a {@code PushDataManager} failover. The path is stable and defined by
+   * {@link network.crypta.clients.http.updateableelements.UpdaterConstants#failoverPath}.
+   *
+   * @return The absolute path prefix under which this toadlet is reachable.
+   */
   @Override
   public String path() {
     return UpdaterConstants.failoverPath;

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushKeepaliveToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushKeepaliveToadlet.java
@@ -14,24 +14,73 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This toadlet receives keepalives. It requires the requestId parameter. If the keepalive is
- * failed, the request is already deleted.
+ * Receives AJAX-push keepalive requests for an existing push stream.
+ *
+ * <p>This toadlet implements a small HTTP endpoint used by the browser-side updater/long-poll
+ * plumbing to indicate that a previously established push request is still active. The client
+ * supplies a {@code requestId} parameter, which is forwarded to the owning {@link
+ * network.crypta.clients.http.updateableelements.PushDataManager} via {@link
+ * network.crypta.clients.http.SimpleToadletServer#getPushDataManager()}.
+ *
+ * <p>The endpoint deliberately responds with HTTP 200 in both the success and failure cases and
+ * communicates the outcome via the response body ({@link
+ * network.crypta.clients.http.updateableelements.UpdaterConstants#SUCCESS} or {@link
+ * network.crypta.clients.http.updateableelements.UpdaterConstants#FAILURE}). A failure typically
+ * means the {@code requestId} is no longer known (for example, it was already cleaned up).
+ *
+ * <ul>
+ *   <li><b>Primary responsibility:</b> translate a keepalive HTTP request into a push-manager
+ *       liveness signal.
+ *   <li><b>Thread safety:</b> instances are stateless; concurrency properties depend on the
+ *       container and push manager implementation.
+ * </ul>
+ *
+ * @see network.crypta.clients.http.updateableelements.PushDataManager#keepAliveReceived(String)
+ * @see network.crypta.clients.http.updateableelements.UpdaterConstants#keepalivePath
  */
 public class PushKeepaliveToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushKeepaliveToadlet.class);
 
-  static {
-  }
-
+  /**
+   * Creates a keepalive endpoint bound to the given client context.
+   *
+   * <p>The {@code HighLevelSimpleClient} is passed through to the {@link Toadlet} base class and is
+   * used by shared toadlet infrastructure (for example, reply helpers and common request wiring).
+   * This toadlet itself does not retain additional mutable state beyond what the superclass
+   * maintains.
+   *
+   * @param client client context used by the {@link Toadlet} superclass; must be non-null
+   */
   public PushKeepaliveToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Handles an HTTP {@code GET} keepalive request for an existing push request.
+   *
+   * <p>The request is expected to include a {@code requestId} parameter, which identifies the push
+   * request to keep alive. The identifier is forwarded to {@link
+   * network.crypta.clients.http.updateableelements.PushDataManager#keepAliveReceived(String)} via
+   * the {@link network.crypta.clients.http.SimpleToadletServer} container. The response is always
+   * HTTP 200 with a small HTML body indicating success or failure; callers should treat the body as
+   * the authoritative result rather than the status code.
+   *
+   * <p>This handler is typically safe to call repeatedly; it does not create new push requests, it
+   * only refreshes liveness for an existing {@code requestId}. If the identifier is missing or no
+   * longer recognized, the outcome depends on the push manager and is reported as a failure body.
+   *
+   * @param uri request URI for this toadlet invocation; supplied by the server and not modified
+   * @param req HTTP request wrapper providing parameters such as {@code requestId}
+   * @param ctx request context used to access the container and to write the HTTP response
+   * @throws ToadletContextClosedException if the context closes before the response is written
+   * @throws IOException if writing the response fails due to an underlying I/O problem
+   * @throws RedirectException if the request must be redirected by the surrounding toadlet logic
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Got keepalive:" + requestId);
+      LOG.debug("Received push keepalive for requestId={}", requestId);
     }
     boolean success =
         ((SimpleToadletServer) ctx.getContainer())
@@ -44,6 +93,14 @@ public class PushKeepaliveToadlet extends Toadlet {
     }
   }
 
+  /**
+   * Returns the HTTP path at which this toadlet is mounted.
+   *
+   * <p>The returned value is a stable constant used by the client-side updater to locate the
+   * keepalive endpoint. It is not derived from runtime configuration.
+   *
+   * @return the keepalive endpoint path for AJAX push, as defined in {@link UpdaterConstants}
+   */
   @Override
   public String path() {
     return UpdaterConstants.keepalivePath;

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushLeavingToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushLeavingToadlet.java
@@ -14,30 +14,84 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This toadlet allows the client to notify the server about page leaving. All of it's data is then
- * erased, it's elements disposed, and notifications removed. It needs the requestId parameter.
+ * Handles the Ajax/Push “page leaving” notification from the web UI.
+ *
+ * <p>This toadlet provides a small HTTP endpoint that a browser page calls just before navigating
+ * away or being unloaded. The handler extracts a {@code requestId} parameter from the request and
+ * forwards it to the push-data subsystem so that server-side state associated with that request can
+ * be released. This helps avoid retaining updateable element registrations, queued notifications,
+ * or other per-page resources after the client is no longer present.
+ *
+ * <p><strong>Thread-safety:</strong> Instances are used by the toadlet server and may be invoked
+ * concurrently for different connections. This class is effectively stateless; all mutable state is
+ * owned by the container and its push-data manager.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Accepting a GET request on {@link #path()}.
+ *   <li>Reading the request identifier from {@link HTTPRequest#getParam(String)}.
+ *   <li>Notifying the server that the client has left and returning a small success body.
+ * </ul>
+ *
+ * @see UpdaterConstants#leavingPath
  */
 public class PushLeavingToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushLeavingToadlet.class);
 
-  static {
-  }
-
+  /**
+   * Creates a toadlet instance that can be registered on a {@link SimpleToadletServer}.
+   *
+   * <p>The provided client is forwarded to the {@link Toadlet} base type and is used for common
+   * toadlet functionality. This implementation does not store additional mutable state; request
+   * handling delegates to the container's push-data manager obtained from the {@link
+   * ToadletContext} provided at request time.
+   *
+   * @param client the node client backing this toadlet, passed to the superclass for shared
+   *     services and request handling support
+   */
   public PushLeavingToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Handles the HTTP GET request that signals that a browser page is leaving.
+   *
+   * <p>This endpoint expects a {@code requestId} parameter identifying the page/session to clean
+   * up. The implementation forwards the identifier to the push-data manager so that associated
+   * server-side registrations and pending notifications can be discarded. On success, it responds
+   * with an {@code 200 OK} and the {@link UpdaterConstants#SUCCESS} body, regardless of whether any
+   * state existed for the provided identifier.
+   *
+   * @param uri the request URI for this toadlet invocation, used for routing and logging context
+   * @param req the HTTP request providing the {@code requestId} parameter and any other metadata
+   * @param ctx the per-request toadlet context used to access the container and write the response
+   * @throws ToadletContextClosedException if the connection closes while writing the response
+   * @throws IOException if generating or sending the response fails due to I/O problems
+   * @throws RedirectException if the framework requires redirecting this request to another
+   *     location
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");
     boolean deleted =
         ((SimpleToadletServer) ctx.getContainer()).getPushDataManager().leaving(requestId);
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Page leaving. requestid:" + requestId + " deleted:" + deleted);
+      LOG.debug("Client left page (requestId={}, deleted={})", requestId, deleted);
     }
     writeHTMLReply(ctx, 200, "OK", UpdaterConstants.SUCCESS);
   }
 
+  /**
+   * Returns the fixed server path for “page leaving” notifications.
+   *
+   * <p>The returned value is a constant route used by the web UI to notify the node that a page is
+   * no longer active. Callers should treat this value as an opaque, versioned endpoint identifier
+   * and avoid hard-coding a separate copy; using this method keeps routing consistent with the
+   * updater/push subsystem.
+   *
+   * @return the HTTP path that maps to this toadlet, typically {@link UpdaterConstants#leavingPath}
+   */
   @Override
   public String path() {
     return UpdaterConstants.leavingPath;

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushNotificationToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushNotificationToadlet.java
@@ -17,19 +17,70 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This toadlet provides notifications for clients. It will block until one is present. It requires
- * the requestId parameter.
+ * Long-poll endpoint that delivers the next pending AJAX push notification for a client.
+ *
+ * <p>This {@link Toadlet} is used by the browser-side update mechanism to wait for an event and
+ * then return a compact, machine-readable payload. Callers typically issue a GET request to {@link
+ * #path()} with a {@code requestId} parameter; the handler consults the {@link PushDataManager}
+ * from the current {@link SimpleToadletServer} and blocks until the next {@link
+ * PushDataManager.UpdateEvent} becomes available for that request.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Uses long-poll semantics: it may block until an event arrives or the request context
+ *       closes.
+ *   <li>Returns either a success payload containing identifiers, or a failure sentinel string.
+ *   <li>Performs no state mutation itself; it delegates event sequencing to {@link
+ *       PushDataManager}.
+ * </ul>
+ *
+ * <p>Thread-safety: instances are expected to be invoked concurrently by the HTTP server; this
+ * implementation performs only local computations and relies on {@link PushDataManager} for
+ * synchronization and ordering.
+ *
+ * @see PushDataManager#getNextNotification(String)
+ * @see UpdaterConstants#notificationPath
  */
 public class PushNotificationToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushNotificationToadlet.class);
 
-  static {
-  }
-
+  /**
+   * Create a toadlet bound to a client context.
+   *
+   * <p>The provided client is passed to the parent {@link Toadlet} and is used for shared
+   * HTTP/toadlet infrastructure. This class does not retain additional mutable state, so a single
+   * instance can serve multiple requests over its lifetime as managed by the server.
+   *
+   * @param client client context used by the toadlet framework; must be non-null for normal
+   *     operation
+   */
   public PushNotificationToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Wait for and return the next notification event for the given long-poll request.
+   *
+   * <p>This handler reads the {@code requestId} query parameter from {@code req} and forwards it to
+   * {@link PushDataManager#getNextNotification(String)}. When an event is available, it returns a
+   * success payload composed of the event's request identifier and element identifier; otherwise it
+   * returns a failure sentinel value. The response body is intended to be parsed by the
+   * browser-side updater logic and is not meant for direct human consumption.
+   *
+   * <p>The method may block while waiting for an event. If the request context closes while
+   * blocked, {@link ToadletContextClosedException} can be thrown by the underlying server
+   * infrastructure.
+   *
+   * @param uri request URI associated with this call; currently unused but provided by the
+   *     framework
+   * @param req HTTP request carrying query parameters such as {@code requestId}; must be non-null
+   * @param ctx request context used to write the reply; must be open for the duration of the call
+   * @throws ToadletContextClosedException if the client disconnects or the context closes during
+   *     handling
+   * @throws IOException if writing the HTTP response fails due to an underlying I/O error
+   * @throws RedirectException if the framework requires a redirect response for this request
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");
@@ -50,13 +101,21 @@ public class PushNotificationToadlet extends Toadlet {
               + UpdaterConstants.SEPARATOR
               + elementId);
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Notification got:" + event);
+        LOG.debug("Notification got: {}", event);
       }
     } else {
       writeHTMLReply(ctx, 200, "OK", UpdaterConstants.FAILURE);
     }
   }
 
+  /**
+   * Return the HTTP path that routes requests to this toadlet.
+   *
+   * <p>The returned value is a stable server-side constant used by the AJAX push client code to
+   * construct the notification polling URL.
+   *
+   * @return the configured notification endpoint path for this toadlet
+   */
   @Override
   public String path() {
     return UpdaterConstants.notificationPath;

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushTesterToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushTesterToadlet.java
@@ -13,14 +13,69 @@ import network.crypta.clients.http.updateableelements.TesterElement;
 import network.crypta.support.api.HTTPRequest;
 
 /**
- * This toadlet provides a simple page with pushed elements, making it suitable for automated tests.
+ * A small {@link Toadlet} that serves a deterministic page containing push-capable test elements.
+ *
+ * <p>This endpoint is intentionally minimal: it constructs a single HTML page and injects a fixed
+ * number of {@link TesterElement} instances into the page content. The primary use is automated or
+ * manual verification of the Ajax push/updateable-elements plumbing (rendering, incremental
+ * updates, and client-side consumption) without having to navigate through unrelated UI flows.
+ *
+ * <p>The implementation is deliberately deterministic: it always produces 600 elements with stable,
+ * numeric ids ("0" through "599") and a fixed per-element configuration value. The instance itself
+ * is effectively stateless; request-specific state is carried by the provided {@link
+ * ToadletContext} and the element implementations.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Disables navigation links in the rendered page template to reduce unrelated markup churn.
+ *   <li>Returns an {@code HTTP 200} response with a simple {@code OK} status message.
+ *   <li>Constructs elements eagerly during request handling; there is no caching across requests.
+ * </ul>
+ *
+ * @see TesterElement
  */
 public class PushTesterToadlet extends Toadlet {
 
+  /**
+   * Creates a new instance that serves the push-test page.
+   *
+   * <p>The provided {@link HighLevelSimpleClient} is forwarded to the {@link Toadlet} superclass.
+   * This class does not retain additional mutable state, so instances are safe to reuse across
+   * requests as long as the surrounding toadlet container provides the usual per-request {@link
+   * ToadletContext}.
+   *
+   * @param client client instance passed to the {@link Toadlet} superclass; must be non-null and
+   *     configured
+   */
   public PushTesterToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Handles {@code GET} requests by emitting a page populated with a fixed set of {@link
+   * TesterElement} instances.
+   *
+   * <p>This method creates a page titled {@code Push tester} with navigation links disabled, then
+   * adds 600 elements to the page content. Each element id is the decimal string of its index (from
+   * {@code "0"} through {@code "599"}), and each is constructed with a fixed configuration value of
+   * {@code 100} as required by the {@link TesterElement} constructor.
+   *
+   * <p>The response is written immediately via {@code writeHTMLReply(...)} using a {@code 200}
+   * status code and an {@code OK} message. The method does not mutate instance state; any request
+   * lifecycle, threading, or streaming concerns are handled by {@code ctx} and the underlying HTTP
+   * server.
+   *
+   * @param uri request URI, used for routing and diagnostics by the surrounding toadlet framework
+   * @param req parsed HTTP request wrapper, providing access to headers and request metadata as
+   *     needed
+   * @param ctx per-request context used to build the page and write the HTTP response to the client
+   * @throws ToadletContextClosedException if the HTTP context closes before or while the reply is
+   *     written
+   * @throws IOException if an I/O error occurs while generating or writing the HTML response body
+   * @throws RedirectException if the framework requests a redirect instead of sending a direct
+   *     reply
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     PageNode pageNode =
@@ -32,6 +87,14 @@ public class PushTesterToadlet extends Toadlet {
     writeHTMLReply(ctx, 200, "OK", pageNode.generate());
   }
 
+  /**
+   * Returns the HTTP path prefix that routes requests to this test endpoint.
+   *
+   * <p>The returned value is a fixed, absolute path and includes a trailing slash to match typical
+   * toadlet routing conventions.
+   *
+   * @return the path prefix for the push-tester toadlet, always {@code "/pushtester/"}
+   */
   @Override
   public String path() {
     return "/pushtester/";

--- a/src/test/java/network/crypta/clients/http/ajaxpush/DismissAlertToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ajaxpush/DismissAlertToadletTest.java
@@ -1,0 +1,98 @@
+package network.crypta.clients.http.ajaxpush;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ToadletContext;
+import network.crypta.clients.http.updateableelements.UpdaterConstants;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class DismissAlertToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private HTTPRequest request;
+  @Mock private ToadletContext context;
+
+  @Test
+  void handleMethodGET_whenAnchorContainsHtmlEntities_writesSuccessReplyAndStatus200()
+      throws Exception {
+    // Arrange
+    CapturingDismissAlertToadlet toadlet = new CapturingDismissAlertToadlet(client);
+    URI uri = URI.create("/dismissalert/?anchor=foo");
+    org.mockito.Mockito.when(request.getParam("anchor")).thenReturn("foo&amp;bar");
+
+    // Act
+    toadlet.handleMethodGET(uri, request, context);
+
+    // Assert
+    assertEquals(context, toadlet.capturedContext);
+    assertEquals(200, toadlet.capturedCode);
+    assertEquals("OK", toadlet.capturedDescription);
+    assertEquals(UpdaterConstants.SUCCESS, toadlet.capturedReply);
+  }
+
+  @Test
+  void handleMethodGET_whenAnchorEmpty_writesSuccessReply() throws Exception {
+    // Arrange
+    CapturingDismissAlertToadlet toadlet = new CapturingDismissAlertToadlet(client);
+    URI uri = URI.create("/dismissalert/?anchor=");
+    org.mockito.Mockito.when(request.getParam("anchor")).thenReturn("");
+
+    // Act
+    toadlet.handleMethodGET(uri, request, context);
+
+    // Assert
+    assertEquals(200, toadlet.capturedCode);
+    assertEquals(UpdaterConstants.SUCCESS, toadlet.capturedReply);
+  }
+
+  @Test
+  void handleMethodGET_whenAnchorParamNull_throwsNullPointerException() {
+    // Arrange
+    DismissAlertToadlet toadlet = new DismissAlertToadlet(client);
+    URI uri = URI.create("/dismissalert/");
+    org.mockito.Mockito.when(request.getParam("anchor")).thenReturn(null);
+
+    // Act / Assert
+    assertThrows(NullPointerException.class, () -> toadlet.handleMethodGET(uri, request, context));
+  }
+
+  @Test
+  void path_whenCalled_returnsDismissAlertPathConstant() {
+    // Arrange
+    DismissAlertToadlet toadlet = new DismissAlertToadlet(client);
+
+    // Act
+    String path = toadlet.path();
+
+    // Assert
+    assertEquals(UpdaterConstants.dismissAlertPath, path);
+  }
+
+  private static final class CapturingDismissAlertToadlet extends DismissAlertToadlet {
+    private ToadletContext capturedContext;
+    private int capturedCode;
+    private String capturedDescription;
+    private String capturedReply;
+
+    private CapturingDismissAlertToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      this.capturedContext = ctx;
+      this.capturedCode = code;
+      this.capturedDescription = desc;
+      this.capturedReply = reply;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/http/ajaxpush/LogWritebackToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ajaxpush/LogWritebackToadletTest.java
@@ -1,0 +1,206 @@
+package network.crypta.clients.http.ajaxpush;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import java.io.IOException;
+import java.net.URI;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ToadletContext;
+import network.crypta.clients.http.updateableelements.UpdaterConstants;
+import network.crypta.support.URLDecoder;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class LogWritebackToadletTest {
+
+  private static final String HELLO_ENCODED = "hello%20world";
+
+  @Mock private HighLevelSimpleClient client;
+
+  @Mock private HTTPRequest request;
+
+  @Mock private ToadletContext context;
+
+  @Test
+  void path_whenCalled_expectUpdaterConstant() {
+    // Arrange
+    LogWritebackToadlet toadlet = new LogWritebackToadlet(client);
+
+    // Act
+    String path = toadlet.path();
+
+    // Assert
+    assertEquals(UpdaterConstants.logWritebackPath, path);
+  }
+
+  @Test
+  void handleMethodGET_whenDebugDisabled_expectSuccessReplyAndNoDecode() throws Exception {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(LogWritebackToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    try (MockedStatic<URLDecoder> urlDecoder = Mockito.mockStatic(URLDecoder.class)) {
+      CapturingLogWritebackToadlet toadlet = new CapturingLogWritebackToadlet(client);
+
+      // Act
+      toadlet.handleMethodGET(
+          URI.create("http://localhost/logwriteback/?msg=" + HELLO_ENCODED), request, context);
+
+      // Assert
+      assertEquals(1, toadlet.writeHtmlReplyCalls);
+      assertSame(context, toadlet.capturedContext);
+      assertEquals(200, toadlet.capturedStatusCode);
+      assertEquals("OK", toadlet.capturedDescription);
+      assertEquals(UpdaterConstants.SUCCESS, toadlet.capturedReply);
+      urlDecoder.verifyNoInteractions();
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenDebugEnabledAndDecodeSucceeds_expectDecodeCalledAndSuccessReply()
+      throws Exception {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(LogWritebackToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
+    try (MockedStatic<URLDecoder> urlDecoder = Mockito.mockStatic(URLDecoder.class)) {
+      CapturingLogWritebackToadlet toadlet = new CapturingLogWritebackToadlet(client);
+      Mockito.when(request.getParam("msg")).thenReturn(HELLO_ENCODED);
+      urlDecoder.when(() -> URLDecoder.decode(HELLO_ENCODED, false)).thenReturn("hello world");
+
+      // Act
+      toadlet.handleMethodGET(
+          URI.create("http://localhost/logwriteback/?msg=" + HELLO_ENCODED), request, context);
+
+      // Assert
+      urlDecoder.verify(() -> URLDecoder.decode(HELLO_ENCODED, false));
+      assertEquals(1, toadlet.writeHtmlReplyCalls);
+      assertEquals(UpdaterConstants.SUCCESS, toadlet.capturedReply);
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenDebugEnabledAndDecodeThrows_expectSuccessReply() throws Exception {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(LogWritebackToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
+    try {
+      CapturingLogWritebackToadlet toadlet = new CapturingLogWritebackToadlet(client);
+      Mockito.when(request.getParam("msg")).thenReturn("%");
+
+      // Act
+      toadlet.handleMethodGET(
+          URI.create("http://localhost/logwriteback/?msg=%25"), request, context);
+
+      // Assert
+      assertEquals(1, toadlet.writeHtmlReplyCalls);
+      assertEquals(UpdaterConstants.SUCCESS, toadlet.capturedReply);
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "plain", "%E2%9C%93"})
+  void handleMethodGET_whenDebugEnabledAndMessageDecodes_expectSuccessReply(String msg)
+      throws Exception {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(LogWritebackToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
+    try {
+      CapturingLogWritebackToadlet toadlet = new CapturingLogWritebackToadlet(client);
+      Mockito.when(request.getParam("msg")).thenReturn(msg);
+
+      // Act
+      toadlet.handleMethodGET(URI.create("http://localhost/logwriteback/"), request, context);
+
+      // Assert
+      assertEquals(1, toadlet.writeHtmlReplyCalls);
+      assertEquals(UpdaterConstants.SUCCESS, toadlet.capturedReply);
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenWriteHtmlReplyThrowsIOException_expectExceptionPropagates() {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(LogWritebackToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    try {
+      IOException failingIoException = new IOException("fail");
+      LogWritebackToadlet toadlet = new ThrowingLogWritebackToadlet(client, failingIoException);
+
+      // Act
+      IOException thrown =
+          assertThrows(
+              IOException.class,
+              () ->
+                  toadlet.handleMethodGET(
+                      URI.create("http://localhost/logwriteback/?msg=plain"), request, context));
+
+      // Assert
+      assertSame(failingIoException, thrown);
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  private static final class CapturingLogWritebackToadlet extends LogWritebackToadlet {
+    private int writeHtmlReplyCalls;
+    private ToadletContext capturedContext;
+    private int capturedStatusCode;
+    private String capturedDescription;
+    private String capturedReply;
+
+    private CapturingLogWritebackToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      writeHtmlReplyCalls++;
+      capturedContext = ctx;
+      capturedStatusCode = code;
+      capturedDescription = desc;
+      capturedReply = reply;
+    }
+  }
+
+  private static final class ThrowingLogWritebackToadlet extends LogWritebackToadlet {
+    private final IOException exceptionToThrow;
+
+    private ThrowingLogWritebackToadlet(
+        HighLevelSimpleClient client, IOException exceptionToThrow) {
+      super(client);
+      this.exceptionToThrow = exceptionToThrow;
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply)
+        throws IOException {
+      throw exceptionToThrow;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/http/ajaxpush/PushDataToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ajaxpush/PushDataToadletTest.java
@@ -1,0 +1,281 @@
+package network.crypta.clients.http.ajaxpush;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.clients.http.ToadletContext;
+import network.crypta.clients.http.updateableelements.BaseUpdateableElement;
+import network.crypta.clients.http.updateableelements.PushDataManager;
+import network.crypta.clients.http.updateableelements.UpdaterConstants;
+import network.crypta.support.Base64;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PushDataToadletTest {
+
+  private static final String PARAM_REQUEST_ID = "requestId";
+  private static final String PARAM_ELEMENT_ID = "elementId";
+  private static final URI PUSH_DATA_URI = URI.create("http://localhost/pushdata/");
+  private static final String UPDATER_REPLACER = "ReplacerUpdater";
+  private static final String CHILDREN_PAYLOAD = "<div>payload</div>";
+
+  @Mock private HighLevelSimpleClient client;
+
+  @Mock private HTTPRequest request;
+
+  @Mock private ToadletContext context;
+
+  @Mock private SimpleToadletServer server;
+
+  @Mock private PushDataManager pushDataManager;
+
+  @Mock private BaseUpdateableElement element;
+
+  @Test
+  void path_whenCalled_expectUpdaterConstant() {
+    // Arrange
+    PushDataToadlet toadlet = new PushDataToadlet(client);
+
+    // Act
+    String path = toadlet.path();
+
+    // Assert
+    assertEquals(UpdaterConstants.dataPath, path);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'', ''",
+    "'noSpaces', 'noSpaces'",
+    "'a b', 'a+b'",
+    "'a  b', 'a++b'",
+    "'a+b', 'a+b'",
+    "' + ', '+++'"
+  })
+  void handleMethodGET_whenElementIdHasSpaces_expectPlusRestoredBeforeLookup(
+      String elementIdParam, String expectedLookupId) throws Exception {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(PushDataToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    try {
+      String requestId = "req-1";
+      CapturingPushDataToadlet toadlet = new CapturingPushDataToadlet(client);
+      when(request.getParam(PARAM_REQUEST_ID)).thenReturn(requestId);
+      when(request.getParam(PARAM_ELEMENT_ID)).thenReturn(elementIdParam);
+      when(context.getContainer()).thenReturn(server);
+      when(server.getPushDataManager()).thenReturn(pushDataManager);
+      when(pushDataManager.getRenderedElement(requestId, expectedLookupId)).thenReturn(element);
+      when(element.getUpdaterType()).thenReturn(UPDATER_REPLACER);
+      when(element.generateChildren()).thenReturn(CHILDREN_PAYLOAD);
+
+      // Act
+      toadlet.handleMethodGET(PUSH_DATA_URI, request, context);
+
+      // Assert
+      verify(pushDataManager).getRenderedElement(requestId, expectedLookupId);
+      assertEquals(1, toadlet.writeHtmlReplyCalls);
+      assertEquals(200, toadlet.capturedStatusCode);
+      assertEquals("OK", toadlet.capturedDescription);
+      assertEquals(expectedReply(UPDATER_REPLACER, CHILDREN_PAYLOAD), toadlet.capturedReply);
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenResponseGenerated_expectReplyIsUtf8Base64Encoded() throws Exception {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(PushDataToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    try {
+      String updaterType = "tÿpe✓";
+      String children = "<span>✓</span>";
+      CapturingPushDataToadlet toadlet = new CapturingPushDataToadlet(client);
+      when(request.getParam(PARAM_REQUEST_ID)).thenReturn("req-utf8");
+      when(request.getParam(PARAM_ELEMENT_ID)).thenReturn("Zg==");
+      when(context.getContainer()).thenReturn(server);
+      when(server.getPushDataManager()).thenReturn(pushDataManager);
+      when(pushDataManager.getRenderedElement("req-utf8", "Zg==")).thenReturn(element);
+      when(element.getUpdaterType()).thenReturn(updaterType);
+      when(element.generateChildren()).thenReturn(children);
+
+      // Act
+      toadlet.handleMethodGET(PUSH_DATA_URI, request, context);
+
+      // Assert
+      assertEquals(1, toadlet.writeHtmlReplyCalls);
+      assertSame(context, toadlet.capturedContext);
+      assertEquals(200, toadlet.capturedStatusCode);
+      assertEquals("OK", toadlet.capturedDescription);
+      assertEquals(expectedReply(updaterType, children), toadlet.capturedReply);
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenDebugEnabled_expectGenerateChildrenCalledTwice() throws Exception {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(PushDataToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
+    try {
+      CapturingPushDataToadlet toadlet = new CapturingPushDataToadlet(client);
+      when(request.getParam(PARAM_REQUEST_ID)).thenReturn("req-debug");
+      when(request.getParam(PARAM_ELEMENT_ID)).thenReturn("a b");
+      when(context.getContainer()).thenReturn(server);
+      when(server.getPushDataManager()).thenReturn(pushDataManager);
+      when(pushDataManager.getRenderedElement("req-debug", "a+b")).thenReturn(element);
+      when(element.getUpdaterType()).thenReturn(UPDATER_REPLACER);
+      when(element.generateChildren()).thenReturn("<div>debug</div>");
+
+      // Act
+      toadlet.handleMethodGET(PUSH_DATA_URI, request, context);
+
+      // Assert
+      verify(element, times(2)).generateChildren();
+      assertEquals(expectedReply(UPDATER_REPLACER, "<div>debug</div>"), toadlet.capturedReply);
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenRenderedElementIsMissing_expectNullPointerException() {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(PushDataToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    try {
+      PushDataToadlet toadlet = new PushDataToadlet(client);
+      when(request.getParam(PARAM_REQUEST_ID)).thenReturn("req-missing");
+      when(request.getParam(PARAM_ELEMENT_ID)).thenReturn("missing");
+      when(context.getContainer()).thenReturn(server);
+      when(server.getPushDataManager()).thenReturn(pushDataManager);
+      when(pushDataManager.getRenderedElement("req-missing", "missing")).thenReturn(null);
+
+      // Act
+      assertThrows(
+          NullPointerException.class,
+          () -> toadlet.handleMethodGET(PUSH_DATA_URI, request, context));
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenWriteHtmlReplyThrowsIOException_expectExceptionPropagates() {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(PushDataToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    try {
+      IOException failingIoException = new IOException("fail");
+      PushDataToadlet toadlet = new ThrowingPushDataToadlet(client, failingIoException);
+      when(request.getParam(PARAM_REQUEST_ID)).thenReturn("req-io");
+      when(request.getParam(PARAM_ELEMENT_ID)).thenReturn("Zg==");
+      when(context.getContainer()).thenReturn(server);
+      when(server.getPushDataManager()).thenReturn(pushDataManager);
+      when(pushDataManager.getRenderedElement("req-io", "Zg==")).thenReturn(element);
+      when(element.getUpdaterType()).thenReturn(UPDATER_REPLACER);
+      when(element.generateChildren()).thenReturn(CHILDREN_PAYLOAD);
+
+      // Act
+      IOException thrown =
+          assertThrows(
+              IOException.class, () -> toadlet.handleMethodGET(PUSH_DATA_URI, request, context));
+
+      // Assert
+      assertSame(failingIoException, thrown);
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  private static String expectedReply(String updaterType, String childrenHtml) {
+    return UpdaterConstants.SUCCESS
+        + UpdaterConstants.SEPARATOR
+        + Base64.encodeStandard(updaterType.getBytes(StandardCharsets.UTF_8))
+        + UpdaterConstants.SEPARATOR
+        + Base64.encodeStandard(childrenHtml.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static final class CapturingPushDataToadlet extends PushDataToadlet {
+    private int writeHtmlReplyCalls;
+    private ToadletContext capturedContext;
+    private int capturedStatusCode;
+    private String capturedDescription;
+    private String capturedReply;
+
+    private CapturingPushDataToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      writeHtmlReplyCalls++;
+      capturedContext = ctx;
+      capturedStatusCode = code;
+      capturedDescription = desc;
+      capturedReply = reply;
+    }
+  }
+
+  private static final class ThrowingPushDataToadlet extends PushDataToadlet {
+    private final IOException exceptionToThrow;
+
+    private ThrowingPushDataToadlet(HighLevelSimpleClient client, IOException exceptionToThrow) {
+      super(client);
+      this.exceptionToThrow = exceptionToThrow;
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply)
+        throws IOException {
+      throw exceptionToThrow;
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenContainerIsNotSimpleToadletServer_expectClassCastException() {
+    // Arrange
+    Logger logger = (Logger) LoggerFactory.getLogger(PushDataToadlet.class);
+    Level originalLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    try {
+      PushDataToadlet toadlet = new PushDataToadlet(client);
+      when(request.getParam(PARAM_REQUEST_ID)).thenReturn("req-cast");
+      when(request.getParam(PARAM_ELEMENT_ID)).thenReturn("abc");
+      when(context.getContainer())
+          .thenReturn(mock(network.crypta.clients.http.ToadletContainer.class));
+
+      // Act
+      assertThrows(
+          ClassCastException.class, () -> toadlet.handleMethodGET(PUSH_DATA_URI, request, context));
+    } finally {
+      logger.setLevel(originalLevel);
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/http/ajaxpush/PushFailoverToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ajaxpush/PushFailoverToadletTest.java
@@ -1,0 +1,163 @@
+package network.crypta.clients.http.ajaxpush;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.RedirectException;
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.clients.http.ToadletContainer;
+import network.crypta.clients.http.ToadletContext;
+import network.crypta.clients.http.ToadletContextClosedException;
+import network.crypta.clients.http.updateableelements.PushDataManager;
+import network.crypta.clients.http.updateableelements.UpdaterConstants;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PushFailoverToadletTest {
+
+  private static final String REQUEST_ID_PARAM = "requestId";
+  private static final String ORIGINAL_REQUEST_ID_PARAM = "originalRequestId";
+
+  private static final URI REQUEST_URI = URI.create("http://example.invalid/failover/");
+
+  private static final class CapturingPushFailoverToadlet extends PushFailoverToadlet {
+    private Integer lastCode;
+    private String lastDesc;
+    private String lastReply;
+
+    private CapturingPushFailoverToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      lastCode = code;
+      lastDesc = desc;
+      lastReply = reply;
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenFailoverSucceeds_writesSuccessReplyAndCallsFailover()
+      throws ToadletContextClosedException, IOException, RedirectException {
+    // Arrange
+    CapturingPushFailoverToadlet toadlet =
+        new CapturingPushFailoverToadlet(mock(HighLevelSimpleClient.class));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+
+    String requestId = "request-2";
+    String originalRequestId = "request-1";
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn(requestId);
+    when(request.getParam(ORIGINAL_REQUEST_ID_PARAM)).thenReturn(originalRequestId);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.failover(originalRequestId, requestId)).thenReturn(true);
+
+    // Act
+    toadlet.handleMethodGET(REQUEST_URI, request, context);
+
+    // Assert
+    verify(pushDataManager).failover(originalRequestId, requestId);
+    assertEquals(200, toadlet.lastCode);
+    assertEquals("OK", toadlet.lastDesc);
+    assertEquals(UpdaterConstants.SUCCESS, toadlet.lastReply);
+  }
+
+  @Test
+  void handleMethodGET_whenFailoverFails_writesFailureReplyAndCallsFailover()
+      throws ToadletContextClosedException, IOException, RedirectException {
+    // Arrange
+    CapturingPushFailoverToadlet toadlet =
+        new CapturingPushFailoverToadlet(mock(HighLevelSimpleClient.class));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+
+    String requestId = "new-request";
+    String originalRequestId = "old-request";
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn(requestId);
+    when(request.getParam(ORIGINAL_REQUEST_ID_PARAM)).thenReturn(originalRequestId);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.failover(originalRequestId, requestId)).thenReturn(false);
+
+    // Act
+    toadlet.handleMethodGET(REQUEST_URI, request, context);
+
+    // Assert
+    verify(pushDataManager).failover(originalRequestId, requestId);
+    assertEquals(UpdaterConstants.FAILURE, toadlet.lastReply);
+  }
+
+  @Test
+  void handleMethodGET_whenParamsMissing_passesEmptyStringsToFailover()
+      throws ToadletContextClosedException, IOException, RedirectException {
+    // Arrange
+    CapturingPushFailoverToadlet toadlet =
+        new CapturingPushFailoverToadlet(mock(HighLevelSimpleClient.class));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn("");
+    when(request.getParam(ORIGINAL_REQUEST_ID_PARAM)).thenReturn("");
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.failover("", "")).thenReturn(true);
+
+    // Act
+    toadlet.handleMethodGET(REQUEST_URI, request, context);
+
+    // Assert
+    verify(pushDataManager).failover("", "");
+    assertEquals(UpdaterConstants.SUCCESS, toadlet.lastReply);
+  }
+
+  @Test
+  void handleMethodGET_whenContainerNotSimpleToadletServer_throwsClassCastException() {
+    // Arrange
+    CapturingPushFailoverToadlet toadlet =
+        new CapturingPushFailoverToadlet(mock(HighLevelSimpleClient.class));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    ToadletContainer wrongContainer = mock(ToadletContainer.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn("request");
+    when(request.getParam(ORIGINAL_REQUEST_ID_PARAM)).thenReturn("original");
+    when(context.getContainer()).thenReturn(wrongContainer);
+
+    // Act + Assert
+    assertThrows(
+        ClassCastException.class, () -> toadlet.handleMethodGET(REQUEST_URI, request, context));
+    assertNull(toadlet.lastCode);
+    assertNull(toadlet.lastReply);
+  }
+
+  @Test
+  void path_whenCalled_returnsUpdaterFailoverPath() {
+    // Arrange
+    PushFailoverToadlet toadlet = new PushFailoverToadlet(mock(HighLevelSimpleClient.class));
+
+    // Act
+    String path = toadlet.path();
+
+    // Assert
+    assertEquals(UpdaterConstants.failoverPath, path);
+  }
+}

--- a/src/test/java/network/crypta/clients/http/ajaxpush/PushKeepaliveToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ajaxpush/PushKeepaliveToadletTest.java
@@ -1,0 +1,187 @@
+package network.crypta.clients.http.ajaxpush;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.stream.Stream;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.RedirectException;
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.clients.http.ToadletContainer;
+import network.crypta.clients.http.ToadletContext;
+import network.crypta.clients.http.ToadletContextClosedException;
+import network.crypta.clients.http.updateableelements.PushDataManager;
+import network.crypta.clients.http.updateableelements.UpdaterConstants;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PushKeepaliveToadletTest {
+
+  private static final String BASE_URL = "http://localhost";
+  private static final String PARAM_REQUEST_ID = "requestId";
+  private static final String REQUEST_ID = "req-1";
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private HTTPRequest request;
+  @Mock private ToadletContext context;
+  @Mock private SimpleToadletServer server;
+  @Mock private PushDataManager pushDataManager;
+
+  @Test
+  void path_whenCalled_expectKeepalivePath() {
+    // Arrange
+    PushKeepaliveToadlet toadlet = new PushKeepaliveToadlet(client);
+
+    // Act
+    String path = toadlet.path();
+
+    // Assert
+    assertEquals(UpdaterConstants.keepalivePath, path);
+  }
+
+  @ParameterizedTest(name = "success={0}")
+  @MethodSource("keepAliveOutcomes")
+  void handleMethodGET_whenKeepAliveProcessed_expectCorrespondingReply(
+      boolean success, String expectedBody)
+      throws ToadletContextClosedException, IOException, RedirectException {
+    // Arrange
+    URI uri = keepaliveUriWithRequestId();
+    when(request.getParam(PARAM_REQUEST_ID)).thenReturn(REQUEST_ID);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.keepAliveReceived(REQUEST_ID)).thenReturn(success);
+
+    CapturingPushKeepaliveToadlet toadlet = new CapturingPushKeepaliveToadlet(client);
+
+    // Act
+    toadlet.handleMethodGET(uri, request, context);
+
+    // Assert
+    assertEquals(200, toadlet.lastCode);
+    assertEquals("OK", toadlet.lastDescription);
+    assertEquals(expectedBody, toadlet.lastBody);
+    assertEquals(1, toadlet.writeCalls);
+
+    verify(request).getParam(PARAM_REQUEST_ID);
+    verify(context).getContainer();
+    verify(server).getPushDataManager();
+    verify(pushDataManager).keepAliveReceived(REQUEST_ID);
+    verifyNoMoreInteractions(request, context, server, pushDataManager);
+  }
+
+  static Stream<Arguments> keepAliveOutcomes() {
+    return Stream.of(
+        Arguments.of(true, UpdaterConstants.SUCCESS),
+        Arguments.of(false, UpdaterConstants.FAILURE));
+  }
+
+  @Test
+  void handleMethodGET_whenRequestIdMissing_expectNullPassedToManagerAndReplyWritten()
+      throws ToadletContextClosedException, IOException, RedirectException {
+    // Arrange
+    URI uri = keepaliveUri();
+    when(request.getParam(PARAM_REQUEST_ID)).thenReturn(null);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.keepAliveReceived(null)).thenReturn(true);
+
+    CapturingPushKeepaliveToadlet toadlet = new CapturingPushKeepaliveToadlet(client);
+
+    // Act
+    toadlet.handleMethodGET(uri, request, context);
+
+    // Assert
+    assertEquals(UpdaterConstants.SUCCESS, toadlet.lastBody);
+    assertEquals(context, toadlet.lastContext);
+    assertEquals(1, toadlet.writeCalls);
+
+    verify(request).getParam(PARAM_REQUEST_ID);
+    verify(context).getContainer();
+    verify(server).getPushDataManager();
+    verify(pushDataManager).keepAliveReceived(null);
+    verifyNoMoreInteractions(request, context, server, pushDataManager);
+  }
+
+  @Test
+  void handleMethodGET_whenContainerIsNotSimpleToadletServer_expectClassCastException() {
+    // Arrange
+    URI uri = keepaliveUri();
+    when(request.getParam(PARAM_REQUEST_ID)).thenReturn(REQUEST_ID);
+    ToadletContainer nonServerContainer = org.mockito.Mockito.mock(ToadletContainer.class);
+    when(context.getContainer()).thenReturn(nonServerContainer);
+
+    CapturingPushKeepaliveToadlet toadlet = new CapturingPushKeepaliveToadlet(client);
+
+    // Act + Assert
+    assertThrows(
+        ClassCastException.class,
+        () -> toadlet.handleMethodGET(uri, request, context),
+        "ToadletContext containers that are not SimpleToadletServer should fail fast.");
+
+    verify(request).getParam(PARAM_REQUEST_ID);
+    verify(context).getContainer();
+    verifyNoMoreInteractions(request, context);
+  }
+
+  @Test
+  void handleMethodGET_whenPushDataManagerIsNull_expectNullPointerException() {
+    // Arrange
+    URI uri = keepaliveUri();
+    when(request.getParam(PARAM_REQUEST_ID)).thenReturn(REQUEST_ID);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(null);
+
+    CapturingPushKeepaliveToadlet toadlet = new CapturingPushKeepaliveToadlet(client);
+
+    // Act + Assert
+    assertThrows(NullPointerException.class, () -> toadlet.handleMethodGET(uri, request, context));
+
+    verify(request).getParam(PARAM_REQUEST_ID);
+    verify(context).getContainer();
+    verify(server).getPushDataManager();
+    verifyNoMoreInteractions(request, context, server);
+  }
+
+  private static URI keepaliveUri() {
+    return URI.create(BASE_URL + UpdaterConstants.keepalivePath);
+  }
+
+  private static URI keepaliveUriWithRequestId() {
+    return URI.create(
+        BASE_URL + UpdaterConstants.keepalivePath + "?" + PARAM_REQUEST_ID + "=" + REQUEST_ID);
+  }
+
+  private static final class CapturingPushKeepaliveToadlet extends PushKeepaliveToadlet {
+    private int writeCalls;
+    private int lastCode = -1;
+    private String lastDescription;
+    private String lastBody;
+    private ToadletContext lastContext;
+
+    private CapturingPushKeepaliveToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      writeCalls++;
+      lastCode = code;
+      lastDescription = desc;
+      lastBody = reply;
+      lastContext = ctx;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/http/ajaxpush/PushLeavingToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ajaxpush/PushLeavingToadletTest.java
@@ -1,0 +1,178 @@
+package network.crypta.clients.http.ajaxpush;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.RedirectException;
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.clients.http.ToadletContainer;
+import network.crypta.clients.http.ToadletContext;
+import network.crypta.clients.http.ToadletContextClosedException;
+import network.crypta.clients.http.updateableelements.PushDataManager;
+import network.crypta.clients.http.updateableelements.UpdaterConstants;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PushLeavingToadletTest {
+
+  private static final String REQUEST_ID_PARAM = "requestId";
+
+  private static final URI REQUEST_URI = URI.create("http://example.invalid/leaving/");
+
+  private static final class CapturingPushLeavingToadlet extends PushLeavingToadlet {
+    private Integer lastCode;
+    private String lastDesc;
+    private String lastReply;
+
+    private CapturingPushLeavingToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      lastCode = code;
+      lastDesc = desc;
+      lastReply = reply;
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true", "false"})
+  void handleMethodGET_whenLeavingReturnsAnyValue_writesSuccessReplyAndCallsLeaving(boolean deleted)
+      throws ToadletContextClosedException, IOException, RedirectException {
+    // Arrange
+    CapturingPushLeavingToadlet toadlet =
+        new CapturingPushLeavingToadlet(mock(HighLevelSimpleClient.class));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+
+    String requestId = "request-1";
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn(requestId);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.leaving(requestId)).thenReturn(deleted);
+
+    // Act
+    toadlet.handleMethodGET(REQUEST_URI, request, context);
+
+    // Assert
+    verify(pushDataManager).leaving(requestId);
+    assertEquals(200, toadlet.lastCode);
+    assertEquals("OK", toadlet.lastDesc);
+    assertEquals(UpdaterConstants.SUCCESS, toadlet.lastReply);
+  }
+
+  @Test
+  void handleMethodGET_whenRequestIdIsNull_passesNullToLeavingAndWritesSuccessReply()
+      throws ToadletContextClosedException, IOException, RedirectException {
+    // Arrange
+    CapturingPushLeavingToadlet toadlet =
+        new CapturingPushLeavingToadlet(mock(HighLevelSimpleClient.class));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn(null);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.leaving(null)).thenReturn(true);
+
+    // Act
+    toadlet.handleMethodGET(REQUEST_URI, request, context);
+
+    // Assert
+    verify(pushDataManager).leaving(null);
+    assertEquals(UpdaterConstants.SUCCESS, toadlet.lastReply);
+  }
+
+  @Test
+  void handleMethodGET_whenContainerNotSimpleToadletServer_throwsClassCastException() {
+    // Arrange
+    CapturingPushLeavingToadlet toadlet =
+        new CapturingPushLeavingToadlet(mock(HighLevelSimpleClient.class));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    ToadletContainer wrongContainer = mock(ToadletContainer.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn("request");
+    when(context.getContainer()).thenReturn(wrongContainer);
+
+    // Act + Assert
+    assertThrows(
+        ClassCastException.class, () -> toadlet.handleMethodGET(REQUEST_URI, request, context));
+    assertNull(toadlet.lastCode);
+    assertNull(toadlet.lastReply);
+  }
+
+  @Test
+  void handleMethodGET_whenLeavingThrowsRuntimeException_propagatesAndDoesNotWriteReply() {
+    // Arrange
+    CapturingPushLeavingToadlet toadlet =
+        new CapturingPushLeavingToadlet(mock(HighLevelSimpleClient.class));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+
+    String requestId = "request-1";
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn(requestId);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.leaving(requestId)).thenThrow(new IllegalStateException("boom"));
+
+    // Act + Assert
+    assertThrows(
+        IllegalStateException.class, () -> toadlet.handleMethodGET(REQUEST_URI, request, context));
+    verify(pushDataManager).leaving(requestId);
+    assertNull(toadlet.lastCode);
+    assertNull(toadlet.lastReply);
+  }
+
+  @Test
+  void handleMethodGET_whenGetParamThrowsRuntimeException_propagatesAndDoesNotTouchContext() {
+    // Arrange
+    CapturingPushLeavingToadlet toadlet =
+        new CapturingPushLeavingToadlet(mock(HighLevelSimpleClient.class));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenThrow(new IllegalArgumentException("bad request"));
+
+    // Act + Assert
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> toadlet.handleMethodGET(REQUEST_URI, request, context));
+    verifyNoInteractions(context);
+    assertNull(toadlet.lastCode);
+    assertNull(toadlet.lastReply);
+  }
+
+  @Test
+  void path_whenCalled_returnsUpdaterLeavingPath() {
+    // Arrange
+    PushLeavingToadlet toadlet = new PushLeavingToadlet(mock(HighLevelSimpleClient.class));
+
+    // Act
+    String path = toadlet.path();
+
+    // Assert
+    assertEquals(UpdaterConstants.leavingPath, path);
+  }
+}

--- a/src/test/java/network/crypta/clients/http/ajaxpush/PushNotificationToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ajaxpush/PushNotificationToadletTest.java
@@ -1,0 +1,247 @@
+package network.crypta.clients.http.ajaxpush;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.RedirectException;
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.clients.http.ToadletContainer;
+import network.crypta.clients.http.ToadletContext;
+import network.crypta.clients.http.ToadletContextClosedException;
+import network.crypta.clients.http.updateableelements.PushDataManager;
+import network.crypta.clients.http.updateableelements.UpdaterConstants;
+import network.crypta.support.Base64;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PushNotificationToadletTest {
+
+  private static final URI REQUEST_URI = URI.create("http://localhost/pushnotifications/");
+  private static final String REQUEST_ID_PARAM = "requestId";
+  private static final String REQUEST_ID_1 = "request-1";
+
+  private static Stream<Arguments> successPayloadCases() {
+    return Stream.of(
+        Arguments.of("reqFromParam", "eventReq", "element-1"),
+        Arguments.of("ignored", "żółć", ""),
+        Arguments.of(null, "eventReq2", "element-3"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("successPayloadCases")
+  void handleMethodGET_whenUpdateEventPresent_writesSuccessPayloadFromEvent(
+      String requestIdParam, String eventRequestId, String elementId)
+      throws ToadletContextClosedException, IOException, RedirectException {
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    CapturingPushNotificationToadlet toadlet = new CapturingPushNotificationToadlet(client);
+
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+    PushDataManager.UpdateEvent event = mock(PushDataManager.UpdateEvent.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn(requestIdParam);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.getNextNotification(requestIdParam)).thenReturn(event);
+    when(event.getRequestId()).thenReturn(eventRequestId);
+    when(event.getElementId()).thenReturn(elementId);
+
+    toadlet.handleMethodGET(REQUEST_URI, request, context);
+
+    assertEquals(1, toadlet.replyCount);
+    assertEquals(200, toadlet.lastCode);
+    assertEquals("OK", toadlet.lastDescription);
+    assertNotNull(toadlet.lastContext);
+    assertEquals(context, toadlet.lastContext);
+
+    String expectedPayload =
+        UpdaterConstants.SUCCESS
+            + ":"
+            + Base64.encodeStandard(eventRequestId.getBytes(StandardCharsets.UTF_8))
+            + UpdaterConstants.SEPARATOR
+            + elementId;
+    assertEquals(expectedPayload, toadlet.lastReply);
+
+    verify(request).getParam(REQUEST_ID_PARAM);
+    verify(context).getContainer();
+    verify(server).getPushDataManager();
+    verify(pushDataManager).getNextNotification(requestIdParam);
+    verify(event).getRequestId();
+    verify(event).getElementId();
+    verifyNoMoreInteractions(request, context, server, pushDataManager, event);
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  void handleMethodGET_whenWriteHtmlReplyThrows_propagatesIOException() {
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    PushNotificationToadlet toadlet = new ThrowingPushNotificationToadlet(client);
+
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+    PushDataManager.UpdateEvent event = mock(PushDataManager.UpdateEvent.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn("req");
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.getNextNotification("req")).thenReturn(event);
+    when(event.getRequestId()).thenReturn("eventReq");
+    when(event.getElementId()).thenReturn("element-1");
+
+    assertThrows(IOException.class, () -> toadlet.handleMethodGET(REQUEST_URI, request, context));
+
+    verify(request).getParam(REQUEST_ID_PARAM);
+    verify(context).getContainer();
+    verify(server).getPushDataManager();
+    verify(pushDataManager).getNextNotification("req");
+    verify(event).getRequestId();
+    verify(event).getElementId();
+    verifyNoMoreInteractions(request, context, server, pushDataManager, event);
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  void handleMethodGET_whenUpdateEventMissing_writesFailurePayload()
+      throws ToadletContextClosedException, IOException, RedirectException {
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    CapturingPushNotificationToadlet toadlet = new CapturingPushNotificationToadlet(client);
+
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn(REQUEST_ID_1);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.getNextNotification(REQUEST_ID_1)).thenReturn(null);
+
+    toadlet.handleMethodGET(REQUEST_URI, request, context);
+
+    assertEquals(1, toadlet.replyCount);
+    assertEquals(200, toadlet.lastCode);
+    assertEquals("OK", toadlet.lastDescription);
+    assertEquals(UpdaterConstants.FAILURE, toadlet.lastReply);
+
+    verify(request).getParam(REQUEST_ID_PARAM);
+    verify(context).getContainer();
+    verify(server).getPushDataManager();
+    verify(pushDataManager).getNextNotification(REQUEST_ID_1);
+    verifyNoMoreInteractions(request, context, server, pushDataManager);
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  void handleMethodGET_whenRequestIdMissing_passesNullToPushManagerAndWritesFailure()
+      throws ToadletContextClosedException, IOException, RedirectException {
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    CapturingPushNotificationToadlet toadlet = new CapturingPushNotificationToadlet(client);
+
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+    PushDataManager pushDataManager = mock(PushDataManager.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn(null);
+    when(context.getContainer()).thenReturn(server);
+    when(server.getPushDataManager()).thenReturn(pushDataManager);
+    when(pushDataManager.getNextNotification(null)).thenReturn(null);
+
+    toadlet.handleMethodGET(REQUEST_URI, request, context);
+
+    assertEquals(1, toadlet.replyCount);
+    assertEquals(UpdaterConstants.FAILURE, toadlet.lastReply);
+
+    verify(request).getParam(REQUEST_ID_PARAM);
+    verify(context).getContainer();
+    verify(server).getPushDataManager();
+    verify(pushDataManager).getNextNotification(null);
+    verifyNoMoreInteractions(request, context, server, pushDataManager);
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  void handleMethodGET_whenContainerIsNotSimpleToadletServer_expectClassCastException() {
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    PushNotificationToadlet toadlet = new PushNotificationToadlet(client);
+
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext context = mock(ToadletContext.class);
+    ToadletContainer container = mock(ToadletContainer.class);
+
+    when(request.getParam(REQUEST_ID_PARAM)).thenReturn(REQUEST_ID_1);
+    when(context.getContainer()).thenReturn(container);
+
+    assertThrows(
+        ClassCastException.class, () -> toadlet.handleMethodGET(REQUEST_URI, request, context));
+
+    verify(request).getParam(REQUEST_ID_PARAM);
+    verify(context).getContainer();
+    verifyNoMoreInteractions(request, context);
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  void path_returnsNotificationPath() {
+    PushNotificationToadlet toadlet =
+        new PushNotificationToadlet(mock(HighLevelSimpleClient.class));
+
+    String result = toadlet.path();
+
+    assertEquals(UpdaterConstants.notificationPath, result);
+  }
+
+  private static final class CapturingPushNotificationToadlet extends PushNotificationToadlet {
+    private int replyCount;
+    private ToadletContext lastContext;
+    private int lastCode;
+    private String lastDescription;
+    private String lastReply;
+
+    private CapturingPushNotificationToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      replyCount++;
+      lastContext = ctx;
+      lastCode = code;
+      lastDescription = desc;
+      lastReply = reply;
+    }
+  }
+
+  private static final class ThrowingPushNotificationToadlet extends PushNotificationToadlet {
+    private ThrowingPushNotificationToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply)
+        throws IOException {
+      throw new IOException("boom");
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/http/ajaxpush/PushTesterToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ajaxpush/PushTesterToadletTest.java
@@ -1,0 +1,173 @@
+package network.crypta.clients.http.ajaxpush;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.PageMaker;
+import network.crypta.clients.http.PageMaker.RenderParameters;
+import network.crypta.clients.http.PageNode;
+import network.crypta.clients.http.RedirectException;
+import network.crypta.clients.http.ToadletContext;
+import network.crypta.clients.http.ToadletContextClosedException;
+import network.crypta.clients.http.updateableelements.TesterElement;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100") // Test method naming convention: method_whenCondition_expectOutcome
+@ExtendWith(MockitoExtension.class)
+class PushTesterToadletTest {
+
+  private static final String TITLE = "Push tester";
+
+  @SuppressWarnings("java:S1075")
+  private static final String TOADLET_PATH = "/pushtester/";
+
+  private static final int ELEMENT_COUNT = 600;
+  private static final int ELEMENT_MAX_STATUS = 100;
+  private static final String GENERATED_HTML = "<html>generated</html>";
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
+  @Mock private PageMaker pageMaker;
+  @Mock private PageNode pageNode;
+
+  private HTMLNode contentNode;
+
+  @Test
+  void path_whenCalled_expectStableMountPath() {
+    PushTesterToadlet toadlet = new PushTesterToadlet(client);
+
+    assertEquals(TOADLET_PATH, toadlet.path());
+  }
+
+  @Test
+  void handleMethodGET_whenInvoked_expectBuild600ElementsAndWriteOkHtmlReply()
+      throws ToadletContextClosedException, RedirectException, IOException {
+    // Arrange
+    CapturingPushTesterToadlet toadlet = new CapturingPushTesterToadlet(client);
+    URI uri = URI.create(TOADLET_PATH);
+    contentNode = stubPageTemplate();
+    List<List<Object>> constructedArguments = new ArrayList<>();
+
+    try (MockedConstruction<TesterElement> mockedConstruction =
+        mockConstruction(
+            TesterElement.class,
+            (mock, context) -> constructedArguments.add(List.copyOf(context.arguments())))) {
+      // Act
+      toadlet.handleMethodGET(uri, request, ctx);
+
+      // Assert (page chrome configuration)
+      ArgumentCaptor<RenderParameters> renderParamsCaptor =
+          ArgumentCaptor.forClass(RenderParameters.class);
+      verify(pageMaker).getPageNode(eq(TITLE), same(ctx), renderParamsCaptor.capture());
+      RenderParameters renderParameters = renderParamsCaptor.getValue();
+      assertNotNull(renderParameters);
+      assertFalse(renderParameters.isRenderNavigationLinks());
+      assertTrue(renderParameters.isRenderStatus());
+      assertTrue(renderParameters.isRenderModeSwitch());
+
+      // Assert (constructed elements are deterministic and bounded)
+      assertEquals(ELEMENT_COUNT, constructedArguments.size());
+      assertEquals(ELEMENT_COUNT, mockedConstruction.constructed().size());
+      assertEquals(ELEMENT_COUNT, contentNode.getChildren().size());
+      for (int i = 0; i < ELEMENT_COUNT; i++) {
+        List<?> args = constructedArguments.get(i);
+        assertEquals(3, args.size());
+        assertEquals(ctx, args.get(0));
+        assertEquals(String.valueOf(i), args.get(1));
+        assertEquals(ELEMENT_MAX_STATUS, args.get(2));
+      }
+
+      // Assert (HTTP reply)
+      assertEquals(1, toadlet.writeCount);
+      assertEquals(ctx, toadlet.lastContext);
+      assertEquals(200, toadlet.lastCode);
+      assertEquals("OK", toadlet.lastDescription);
+      assertEquals(GENERATED_HTML, toadlet.lastReply);
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenWriteHtmlReplyThrows_expectPropagatesIOException() {
+    // Arrange
+    PushTesterToadlet toadlet = new FailingWriteHtmlReplyPushTesterToadlet(client);
+    URI uri = URI.create(TOADLET_PATH);
+    stubPageTemplate();
+
+    try (MockedConstruction<TesterElement> mockedConstruction =
+        mockConstruction(TesterElement.class)) {
+      // Act
+      IOException thrown =
+          assertThrows(IOException.class, () -> toadlet.handleMethodGET(uri, request, ctx));
+
+      // Assert
+      assertEquals("write failed", thrown.getMessage());
+      assertEquals(ELEMENT_COUNT, mockedConstruction.constructed().size());
+    }
+  }
+
+  private HTMLNode stubPageTemplate() {
+    contentNode = new HTMLNode("div");
+
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(pageMaker.getPageNode(eq(TITLE), same(ctx), org.mockito.ArgumentMatchers.any()))
+        .thenReturn(pageNode);
+    when(pageNode.getContentNode()).thenReturn(contentNode);
+    when(pageNode.generate()).thenReturn(GENERATED_HTML);
+
+    return contentNode;
+  }
+
+  private static final class CapturingPushTesterToadlet extends PushTesterToadlet {
+    private int writeCount;
+    private ToadletContext lastContext;
+    private int lastCode;
+    private String lastDescription;
+    private String lastReply;
+
+    private CapturingPushTesterToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      writeCount++;
+      lastContext = ctx;
+      lastCode = code;
+      lastDescription = desc;
+      lastReply = reply;
+    }
+  }
+
+  private static final class FailingWriteHtmlReplyPushTesterToadlet extends PushTesterToadlet {
+    private FailingWriteHtmlReplyPushTesterToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply)
+        throws IOException {
+      throw new IOException("write failed");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add unit tests covering the Ajax-push HTTP toadlets (dismiss, log writeback, push data, failover, keepalive, leaving, notification, and the push tester endpoint).
- Expand/clarify Javadoc on the toadlets and switch debug logging to parameterized SLF4J formatting (no string concatenation).
- Tighten Spotless targeting to avoid scanning IDE metadata and generated build output.

## Testing
- `./gradlew test`

## Notes
- Behavior of the endpoints is unchanged; the main code changes are documentation/logging cleanups to make the new tests easier to reason about and to avoid unnecessary work when debug logging is disabled.