### PR TITLE
test(geoip): add coverage + doclint-clean docs

### DIFF
--- a/src/main/java/network/crypta/clients/http/geoip/Cache.java
+++ b/src/main/java/network/crypta/clients/http/geoip/Cache.java
@@ -1,18 +1,82 @@
 package network.crypta.clients.http.geoip;
 
+/**
+ * In-memory GeoIP lookup table backing {@link IPConverter}.
+ *
+ * <p>This class is a lightweight container for two parallel primitive arrays used during IPv4
+ * lookups: an {@code int[]} of table entries (often interpreted as unsigned 32-bit values) and a
+ * {@code short[]} of country identifiers stored as {@link IPConverter.Country} ordinals. The data
+ * is typically produced by parsing a downloaded database file once and then re-used for many
+ * lookups without allocating per-query objects.
+ *
+ * <p>The constructor stores references to the provided arrays directly, and the getters return the
+ * same live backing arrays. This avoids copies, but it also means callers must maintain the
+ * expected invariants themselves: index alignment between arrays, any required sort order, and
+ * treating the arrays as effectively immutable once shared across threads. This class performs no
+ * validation and does not provide any synchronization.
+ *
+ * <ul>
+ *   <li>Responsibility: hold decoded range table data in memory.
+ *   <li>Behavior: expose the backing arrays without defensive copies.
+ *   <li>Threading: safe for concurrent reads if arrays are not mutated.
+ * </ul>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * Cache table = new Cache(codes, ips);
+ * short[] countryOrdinals = table.getCodes();
+ * int[] ipTable = table.getIps();
+ * }</pre>
+ *
+ * @see IPConverter
+ */
 public class Cache {
   short[] codes;
   int[] ips;
 
+  /**
+   * Creates a new cache backed by the provided arrays.
+   *
+   * <p>This constructor does not copy or validate its inputs. The {@code codes} and {@code ips}
+   * references are stored as-is and will be returned verbatim by {@link #getCodes()} and {@link
+   * #getIps()}. Mutating either array after construction will therefore be observed through this
+   * instance, which is convenient for tests but usually undesirable in production usage.
+   *
+   * @param codes array of country ordinals aligned by index with {@code ips}; may be {@code null}
+   *     to represent an intentionally absent table.
+   * @param ips array of IPv4 table entries aligned by index with {@code codes}; may be {@code null}
+   *     to represent an intentionally absent table.
+   */
   public Cache(short[] codes, int[] ips) {
     this.codes = codes;
     this.ips = ips;
   }
 
+  /**
+   * Returns the country code table associated with this cache.
+   *
+   * <p>The returned array is the live backing {@code short[]} provided to the constructor; it is
+   * not a defensive copy. Each element is typically an {@link IPConverter.Country} ordinal, with
+   * negative values sometimes used by callers to indicate "unknown". Treat the array as read-only
+   * once the cache is in use, especially if it may be accessed concurrently.
+   *
+   * @return the live backing {@code short[]} of country ordinals, or {@code null} if none exists.
+   */
   public short[] getCodes() {
     return codes;
   }
 
+  /**
+   * Returns the IP table associated with this cache.
+   *
+   * <p>The returned array is the live backing {@code int[]} provided to the constructor; it is not
+   * a defensive copy. Values are commonly compared as unsigned 32-bit integers (for example via
+   * {@code value & 0xffffffffL}) when looking up an IPv4 address represented as a {@code long}.
+   * Mutating the array affects all readers of this cache instance.
+   *
+   * @return the live backing {@code int[]} of IPv4 table entries, or {@code null} if none exists.
+   */
   public int[] getIps() {
     return ips;
   }

--- a/src/main/java/network/crypta/clients/http/geoip/IPConverter.java
+++ b/src/main/java/network/crypta/clients/http/geoip/IPConverter.java
@@ -5,27 +5,43 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.ref.SoftReference;
-import java.lang.ref.WeakReference;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import network.crypta.clients.http.StaticToadlet;
-import network.crypta.node.Node;
 import network.crypta.support.HTMLNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Converts IP addresses to an approximate country or region code using an on-disk GeoIP range
+ * table.
+ *
+ * <p>This helper is used by the HTTP UI layer to turn an IP address (typically the peer address or
+ * a remote client address) into a {@link Country} enum value that can be rendered as a
+ * human-friendly label and, when available, a flag icon. It is intentionally lightweight: it reads
+ * a compact encoded range list from a local database file, builds an in-memory search structure,
+ * and then performs a binary search for lookups. Results are memoized in a small LRU-like cache to
+ * avoid repeated searches for the same address.
+ *
+ * <p>The database file is treated as an optional, best-effort input. If the file is missing,
+ * corrupted, or contains unknown country codes, lookups return {@code null} rather than failing the
+ * caller. The instance keeps a soft reference to the full decoded table so the JVM may reclaim it
+ * under memory pressure and the next lookup will reload it.
+ *
+ * <p><b>Thread-safety:</b> instances have mutable caches and are not designed for concurrent access
+ * without external synchronization.
+ */
 public class IPConverter {
   private static final Logger LOG = LoggerFactory.getLogger(IPConverter.class);
 
   // Regex indicating ipranges start
   private static final String START = "##start##";
-  final int MAX_ENTRIES = 100;
+  private static final int MAX_ENTRIES = 100;
 
   // Local cache
-  @SuppressWarnings("serial")
   private final HashMap<Integer, Country> cache =
       new LinkedHashMap<>() {
         @Override
@@ -42,263 +58,534 @@ public class IPConverter {
   private final File dbFile;
   private boolean dbFileCorrupt;
 
+  /**
+   * Enumeration of GeoIP country/region codes used by the IP range database.
+   *
+   * <p>Each constant name corresponds to a two-character code embedded in the database file. The
+   * associated display name is a user-facing label that can be shown in the UI and can optionally
+   * be accompanied by a flag icon if a matching static resource exists.
+   *
+   * <p><b>Notable behaviors:</b>
+   *
+   * <ul>
+   *   <li>Some values represent non-country concepts such as local addresses or proxies.
+   *   <li>Flag availability is cached per enum constant to avoid repeated filesystem checks.
+   * </ul>
+   */
   public enum Country {
+    /** GeoIP code {@code L0} ({@code localhost}). */
     L0("localhost"),
+    /** GeoIP code {@code I0} ({@code IntraNet}). */
     I0("IntraNet"),
+    /** GeoIP code {@code A1} ({@code Anonymous Proxy}). */
     A1("Anonymous Proxy"),
+    /** GeoIP code {@code A2} ({@code Satellite Provider}). */
     A2("Satellite Provider"),
+    /** GeoIP code {@code AP} ({@code AP Asia/Pacific Region}). */
     AP("AP Asia/Pacific Region"),
+    /** GeoIP code {@code AF} ({@code AFGHANISTAN}). */
     AF("AFGHANISTAN"),
+    /** GeoIP code {@code AX} ({@code ALAND ISLANDS}). */
     AX("ALAND ISLANDS"),
+    /** GeoIP code {@code AL} ({@code ALBANIA}). */
     AL("ALBANIA"),
+    /** GeoIP code {@code AN} ({@code NETHERLANDS ANTILLES}). */
     AN("NETHERLANDS ANTILLES"),
+    /** GeoIP code {@code DZ} ({@code ALGERIA}). */
     DZ("ALGERIA"),
+    /** GeoIP code {@code AS} ({@code AMERICAN SAMOA}). */
     AS("AMERICAN SAMOA"),
+    /** GeoIP code {@code AD} ({@code ANDORRA}). */
     AD("ANDORRA"),
+    /** GeoIP code {@code AO} ({@code ANGOLA}). */
     AO("ANGOLA"),
+    /** GeoIP code {@code AI} ({@code ANGUILLA}). */
     AI("ANGUILLA"),
+    /** GeoIP code {@code AQ} ({@code ANTARCTICA}). */
     AQ("ANTARCTICA"),
+    /** GeoIP code {@code AG} ({@code ANTIGUA AND BARBUDA}). */
     AG("ANTIGUA AND BARBUDA"),
+    /** GeoIP code {@code AR} ({@code ARGENTINA}). */
     AR("ARGENTINA"),
+    /** GeoIP code {@code AM} ({@code ARMENIA}). */
     AM("ARMENIA"),
+    /** GeoIP code {@code AW} ({@code ARUBA}). */
     AW("ARUBA"),
+    /** GeoIP code {@code AU} ({@code AUSTRALIA}). */
     AU("AUSTRALIA"),
+    /** GeoIP code {@code AT} ({@code AUSTRIA}). */
     AT("AUSTRIA"),
+    /** GeoIP code {@code AZ} ({@code AZERBAIJAN}). */
     AZ("AZERBAIJAN"),
+    /** GeoIP code {@code BS} ({@code BAHAMAS}). */
     BS("BAHAMAS"),
+    /** GeoIP code {@code BH} ({@code BAHRAIN}). */
     BH("BAHRAIN "),
+    /** GeoIP code {@code BD} ({@code BANGLADESH}). */
     BD("BANGLADESH "),
+    /** GeoIP code {@code BB} ({@code BARBADOS}). */
     BB("BARBADOS "),
+    /** GeoIP code {@code BY} ({@code BELARUS}). */
     BY("BELARUS "),
+    /** GeoIP code {@code BE} ({@code BELGIUM}). */
     BE("BELGIUM "),
+    /** GeoIP code {@code BZ} ({@code BELIZE}). */
     BZ("BELIZE "),
+    /** GeoIP code {@code BJ} ({@code BENIN}). */
     BJ("BENIN "),
+    /** GeoIP code {@code BM} ({@code BERMUDA}). */
     BM("BERMUDA "),
+    /** GeoIP code {@code BT} ({@code BHUTAN}). */
     BT("BHUTAN "),
+    /** GeoIP code {@code BO} ({@code BOLIVIA, PLURINATIONAL STATE OF}). */
     BO("BOLIVIA, PLURINATIONAL STATE OF "),
+    /** GeoIP code {@code BQ} ({@code BONAIRE, SAINT EUSTATIUS AND SABA}). */
     BQ("BONAIRE, SAINT EUSTATIUS AND SABA "),
+    /** GeoIP code {@code BA} ({@code BOSNIA AND HERZEGOVINA}). */
     BA("BOSNIA AND HERZEGOVINA "),
+    /** GeoIP code {@code BW} ({@code BOTSWANA}). */
     BW("BOTSWANA "),
+    /** GeoIP code {@code BV} ({@code BOUVET ISLAND}). */
     BV("BOUVET ISLAND "),
+    /** GeoIP code {@code BR} ({@code BRAZIL}). */
     BR("BRAZIL "),
+    /** GeoIP code {@code IO} ({@code BRITISH INDIAN OCEAN TERRITORY}). */
     IO("BRITISH INDIAN OCEAN TERRITORY "),
+    /** GeoIP code {@code BN} ({@code BRUNEI DARUSSALAM}). */
     BN("BRUNEI DARUSSALAM "),
+    /** GeoIP code {@code BG} ({@code BULGARIA}). */
     BG("BULGARIA "),
+    /** GeoIP code {@code BF} ({@code BURKINA FASO}). */
     BF("BURKINA FASO "),
+    /** GeoIP code {@code BI} ({@code BURUNDI}). */
     BI("BURUNDI "),
+    /** GeoIP code {@code KH} ({@code CAMBODIA}). */
     KH("CAMBODIA "),
+    /** GeoIP code {@code CM} ({@code CAMEROON}). */
     CM("CAMEROON "),
+    /** GeoIP code {@code CA} ({@code CANADA}). */
     CA("CANADA "),
+    /** GeoIP code {@code CV} ({@code CAPE VERDE}). */
     CV("CAPE VERDE "),
+    /** GeoIP code {@code KY} ({@code CAYMAN ISLANDS}). */
     KY("CAYMAN ISLANDS "),
+    /** GeoIP code {@code CF} ({@code CENTRAL AFRICAN REPUBLIC}). */
     CF("CENTRAL AFRICAN REPUBLIC "),
+    /** GeoIP code {@code TD} ({@code CHAD}). */
     TD("CHAD "),
+    /** GeoIP code {@code CL} ({@code CHILE}). */
     CL("CHILE "),
+    /** GeoIP code {@code CN} ({@code CHINA}). */
     CN("CHINA "),
+    /** GeoIP code {@code CX} ({@code CHRISTMAS ISLAND}). */
     CX("CHRISTMAS ISLAND "),
+    /** GeoIP code {@code CC} ({@code COCOS (KEELING) ISLANDS}). */
     CC("COCOS (KEELING) ISLANDS "),
+    /** GeoIP code {@code CO} ({@code COLOMBIA}). */
     CO("COLOMBIA "),
+    /** GeoIP code {@code KM} ({@code COMOROS}). */
     KM("COMOROS "),
+    /** GeoIP code {@code CG} ({@code CONGO}). */
     CG("CONGO "),
+    /** GeoIP code {@code CD} ({@code CONGO, THE DEMOCRATIC REPUBLIC OF THE}). */
     CD("CONGO, THE DEMOCRATIC REPUBLIC OF THE "),
+    /** GeoIP code {@code CK} ({@code COOK ISLANDS}). */
     CK("COOK ISLANDS "),
+    /** GeoIP code {@code CR} ({@code COSTA RICA}). */
     CR("COSTA RICA "),
+    /** GeoIP code {@code CI} ({@code COTE D'IVOIRE}). */
     CI("COTE D'IVOIRE "),
+    /** GeoIP code {@code HR} ({@code CROATIA}). */
     HR("CROATIA "),
+    /** GeoIP code {@code CU} ({@code CUBA}). */
     CU("CUBA "),
+    /** GeoIP code {@code CW} ({@code CURACAO}). */
     CW("CURACAO "),
+    /** GeoIP code {@code CY} ({@code CYPRUS}). */
     CY("CYPRUS "),
+    /** GeoIP code {@code CZ} ({@code CZECH REPUBLIC}). */
     CZ("CZECH REPUBLIC "),
+    /** GeoIP code {@code DK} ({@code DENMARK}). */
     DK("DENMARK "),
+    /** GeoIP code {@code DJ} ({@code DJIBOUTI}). */
     DJ("DJIBOUTI "),
+    /** GeoIP code {@code DM} ({@code DOMINICA}). */
     DM("DOMINICA "),
+    /** GeoIP code {@code DO} ({@code DOMINICAN REPUBLIC}). */
     DO("DOMINICAN REPUBLIC "),
+    /** GeoIP code {@code EC} ({@code ECUADOR}). */
     EC("ECUADOR "),
+    /** GeoIP code {@code EG} ({@code EGYPT}). */
     EG("EGYPT "),
+    /** GeoIP code {@code SV} ({@code EL SALVADOR}). */
     SV("EL SALVADOR "),
+    /** GeoIP code {@code GQ} ({@code EQUATORIAL GUINEA}). */
     GQ("EQUATORIAL GUINEA "),
+    /** GeoIP code {@code ER} ({@code ERITREA}). */
     ER("ERITREA "),
+    /** GeoIP code {@code EE} ({@code ESTONIA}). */
     EE("ESTONIA "),
+    /** GeoIP code {@code ET} ({@code ETHIOPIA}). */
     ET("ETHIOPIA "),
+    /** GeoIP code {@code FK} ({@code FALKLAND ISLANDS (MALVINAS)}). */
     FK("FALKLAND ISLANDS (MALVINAS) "),
+    /** GeoIP code {@code FO} ({@code FAROE ISLANDS}). */
     FO("FAROE ISLANDS "),
+    /** GeoIP code {@code FJ} ({@code FIJI}). */
     FJ("FIJI "),
+    /** GeoIP code {@code FI} ({@code FINLAND}). */
     FI("FINLAND "),
+    /** GeoIP code {@code FR} ({@code FRANCE}). */
     FR("FRANCE "),
+    /** GeoIP code {@code GF} ({@code FRENCH GUIANA}). */
     GF("FRENCH GUIANA "),
+    /** GeoIP code {@code PF} ({@code FRENCH POLYNESIA}). */
     PF("FRENCH POLYNESIA "),
+    /** GeoIP code {@code TF} ({@code FRENCH SOUTHERN TERRITORIES}). */
     TF("FRENCH SOUTHERN TERRITORIES "),
+    /** GeoIP code {@code GA} ({@code GABON}). */
     GA("GABON "),
+    /** GeoIP code {@code GM} ({@code GAMBIA}). */
     GM("GAMBIA "),
+    /** GeoIP code {@code GE} ({@code GEORGIA}). */
     GE("GEORGIA "),
+    /** GeoIP code {@code DE} ({@code GERMANY}). */
     DE("GERMANY "),
+    /** GeoIP code {@code GH} ({@code GHANA}). */
     GH("GHANA "),
+    /** GeoIP code {@code GI} ({@code GIBRALTAR}). */
     GI("GIBRALTAR "),
+    /** GeoIP code {@code GR} ({@code GREECE}). */
     GR("GREECE "),
+    /** GeoIP code {@code GL} ({@code GREENLAND}). */
     GL("GREENLAND "),
+    /** GeoIP code {@code GD} ({@code GRENADA}). */
     GD("GRENADA "),
+    /** GeoIP code {@code GP} ({@code GUADELOUPE}). */
     GP("GUADELOUPE "),
+    /** GeoIP code {@code GU} ({@code GUAM}). */
     GU("GUAM "),
+    /** GeoIP code {@code GT} ({@code GUATEMALA}). */
     GT("GUATEMALA "),
+    /** GeoIP code {@code GG} ({@code GUERNSEY}). */
     GG("GUERNSEY "),
+    /** GeoIP code {@code GN} ({@code GUINEA}). */
     GN("GUINEA "),
+    /** GeoIP code {@code GW} ({@code GUINEA-BISSAU}). */
     GW("GUINEA-BISSAU "),
+    /** GeoIP code {@code GY} ({@code GUYANA}). */
     GY("GUYANA "),
+    /** GeoIP code {@code HT} ({@code HAITI}). */
     HT("HAITI "),
+    /** GeoIP code {@code HM} ({@code HEARD ISLAND AND MCDONALD ISLANDS}). */
     HM("HEARD ISLAND AND MCDONALD ISLANDS "),
+    /** GeoIP code {@code VA} ({@code HOLY SEE (VATICAN CITY STATE)}). */
     VA("HOLY SEE (VATICAN CITY STATE) "),
+    /** GeoIP code {@code HN} ({@code HONDURAS}). */
     HN("HONDURAS "),
+    /** GeoIP code {@code HK} ({@code HONG KONG}). */
     HK("HONG KONG "),
+    /** GeoIP code {@code HU} ({@code HUNGARY}). */
     HU("HUNGARY "),
+    /** GeoIP code {@code IS} ({@code ICELAND}). */
     IS("ICELAND "),
+    /** GeoIP code {@code IN} ({@code INDIA}). */
     IN("INDIA "),
+    /** GeoIP code {@code ID} ({@code INDONESIA}). */
     ID("INDONESIA "),
+    /** GeoIP code {@code IR} ({@code IRAN, ISLAMIC REPUBLIC OF}). */
     IR("IRAN, ISLAMIC REPUBLIC OF "),
+    /** GeoIP code {@code IQ} ({@code IRAQ}). */
     IQ("IRAQ "),
+    /** GeoIP code {@code IE} ({@code IRELAND}). */
     IE("IRELAND "),
+    /** GeoIP code {@code IM} ({@code ISLE OF MAN}). */
     IM("ISLE OF MAN "),
+    /** GeoIP code {@code IL} ({@code ISRAEL}). */
     IL("ISRAEL "),
+    /** GeoIP code {@code IT} ({@code ITALY}). */
     IT("ITALY "),
+    /** GeoIP code {@code JM} ({@code JAMAICA}). */
     JM("JAMAICA "),
+    /** GeoIP code {@code JP} ({@code JAPAN}). */
     JP("JAPAN "),
+    /** GeoIP code {@code JE} ({@code JERSEY}). */
     JE("JERSEY "),
+    /** GeoIP code {@code JO} ({@code JORDAN}). */
     JO("JORDAN "),
+    /** GeoIP code {@code KZ} ({@code KAZAKHSTAN}). */
     KZ("KAZAKHSTAN "),
+    /** GeoIP code {@code KE} ({@code KENYA}). */
     KE("KENYA "),
+    /** GeoIP code {@code KI} ({@code KIRIBATI}). */
     KI("KIRIBATI "),
+    /** GeoIP code {@code KP} ({@code KOREA, DEMOCRATIC PEOPLE'S REPUBLIC OF}). */
     KP("KOREA, DEMOCRATIC PEOPLE'S REPUBLIC OF "),
+    /** GeoIP code {@code KR} ({@code KOREA, REPUBLIC OF}). */
     KR("KOREA, REPUBLIC OF "),
+    /** GeoIP code {@code KW} ({@code KUWAIT}). */
     KW("KUWAIT "),
+    /** GeoIP code {@code KG} ({@code KYRGYZSTAN}). */
     KG("KYRGYZSTAN "),
+    /** GeoIP code {@code LA} ({@code LAO PEOPLE'S DEMOCRATIC REPUBLIC}). */
     LA("LAO PEOPLE'S DEMOCRATIC REPUBLIC "),
+    /** GeoIP code {@code LV} ({@code LATVIA}). */
     LV("LATVIA "),
+    /** GeoIP code {@code LB} ({@code LEBANON}). */
     LB("LEBANON "),
+    /** GeoIP code {@code LS} ({@code LESOTHO}). */
     LS("LESOTHO "),
+    /** GeoIP code {@code LR} ({@code LIBERIA}). */
     LR("LIBERIA "),
+    /** GeoIP code {@code LY} ({@code LIBYAN ARAB JAMAHIRIYA}). */
     LY("LIBYAN ARAB JAMAHIRIYA "),
+    /** GeoIP code {@code LI} ({@code LIECHTENSTEIN}). */
     LI("LIECHTENSTEIN "),
+    /** GeoIP code {@code LT} ({@code LITHUANIA}). */
     LT("LITHUANIA "),
+    /** GeoIP code {@code LU} ({@code LUXEMBOURG}). */
     LU("LUXEMBOURG "),
+    /** GeoIP code {@code MO} ({@code MACAO}). */
     MO("MACAO "),
+    /** GeoIP code {@code MK} ({@code MACEDONIA, THE FORMER YUGOSLAV REPUBLIC OF}). */
     MK("MACEDONIA, THE FORMER YUGOSLAV REPUBLIC OF "),
+    /** GeoIP code {@code MG} ({@code MADAGASCAR}). */
     MG("MADAGASCAR "),
+    /** GeoIP code {@code MW} ({@code MALAWI}). */
     MW("MALAWI "),
+    /** GeoIP code {@code MY} ({@code MALAYSIA}). */
     MY("MALAYSIA "),
+    /** GeoIP code {@code MV} ({@code MALDIVES}). */
     MV("MALDIVES "),
+    /** GeoIP code {@code ML} ({@code MALI}). */
     ML("MALI "),
+    /** GeoIP code {@code MT} ({@code MALTA}). */
     MT("MALTA "),
+    /** GeoIP code {@code MH} ({@code MARSHALL ISLANDS}). */
     MH("MARSHALL ISLANDS "),
+    /** GeoIP code {@code MQ} ({@code MARTINIQUE}). */
     MQ("MARTINIQUE "),
+    /** GeoIP code {@code MR} ({@code MAURITANIA}). */
     MR("MAURITANIA "),
+    /** GeoIP code {@code MU} ({@code MAURITIUS}). */
     MU("MAURITIUS "),
+    /** GeoIP code {@code YT} ({@code MAYOTTE}). */
     YT("MAYOTTE "),
+    /** GeoIP code {@code MX} ({@code MEXICO}). */
     MX("MEXICO "),
+    /** GeoIP code {@code FM} ({@code MICRONESIA, FEDERATED STATES OF}). */
     FM("MICRONESIA, FEDERATED STATES OF "),
+    /** GeoIP code {@code MD} ({@code MOLDOVA, REPUBLIC OF}). */
     MD("MOLDOVA, REPUBLIC OF "),
+    /** GeoIP code {@code MC} ({@code MONACO}). */
     MC("MONACO "),
+    /** GeoIP code {@code MN} ({@code MONGOLIA}). */
     MN("MONGOLIA "),
+    /** GeoIP code {@code ME} ({@code MONTENEGRO}). */
     ME("MONTENEGRO "),
+    /** GeoIP code {@code MS} ({@code MONTSERRAT}). */
     MS("MONTSERRAT "),
+    /** GeoIP code {@code MA} ({@code MOROCCO}). */
     MA("MOROCCO "),
+    /** GeoIP code {@code MZ} ({@code MOZAMBIQUE}). */
     MZ("MOZAMBIQUE "),
+    /** GeoIP code {@code MM} ({@code MYANMAR}). */
     MM("MYANMAR "),
+    /** GeoIP code {@code NA} ({@code NAMIBIA}). */
     NA("NAMIBIA "),
+    /** GeoIP code {@code NR} ({@code NAURU}). */
     NR("NAURU "),
+    /** GeoIP code {@code NP} ({@code NEPAL}). */
     NP("NEPAL "),
+    /** GeoIP code {@code NL} ({@code NETHERLANDS}). */
     NL("NETHERLANDS "),
+    /** GeoIP code {@code NC} ({@code NEW CALEDONIA}). */
     NC("NEW CALEDONIA "),
+    /** GeoIP code {@code NZ} ({@code NEW ZEALAND}). */
     NZ("NEW ZEALAND "),
+    /** GeoIP code {@code NI} ({@code NICARAGUA}). */
     NI("NICARAGUA "),
+    /** GeoIP code {@code NE} ({@code NIGER}). */
     NE("NIGER "),
+    /** GeoIP code {@code NG} ({@code NIGERIA}). */
     NG("NIGERIA "),
+    /** GeoIP code {@code NU} ({@code NIUE}). */
     NU("NIUE "),
+    /** GeoIP code {@code NF} ({@code NORFOLK ISLAND}). */
     NF("NORFOLK ISLAND "),
+    /** GeoIP code {@code MP} ({@code NORTHERN MARIANA ISLANDS}). */
     MP("NORTHERN MARIANA ISLANDS "),
+    /** GeoIP code {@code NO} ({@code NORWAY}). */
     NO("NORWAY "),
+    /** GeoIP code {@code OM} ({@code OMAN}). */
     OM("OMAN "),
+    /** GeoIP code {@code PK} ({@code PAKISTAN}). */
     PK("PAKISTAN "),
+    /** GeoIP code {@code PW} ({@code PALAU}). */
     PW("PALAU "),
+    /** GeoIP code {@code PS} ({@code PALESTINIAN TERRITORY, OCCUPIED}). */
     PS("PALESTINIAN TERRITORY, OCCUPIED "),
+    /** GeoIP code {@code PA} ({@code PANAMA}). */
     PA("PANAMA "),
+    /** GeoIP code {@code PG} ({@code PAPUA NEW GUINEA}). */
     PG("PAPUA NEW GUINEA "),
+    /** GeoIP code {@code PY} ({@code PARAGUAY}). */
     PY("PARAGUAY "),
+    /** GeoIP code {@code PE} ({@code PERU}). */
     PE("PERU "),
+    /** GeoIP code {@code PH} ({@code PHILIPPINES}). */
     PH("PHILIPPINES "),
+    /** GeoIP code {@code PN} ({@code PITCAIRN}). */
     PN("PITCAIRN "),
+    /** GeoIP code {@code PL} ({@code POLAND}). */
     PL("POLAND "),
+    /** GeoIP code {@code PT} ({@code PORTUGAL}). */
     PT("PORTUGAL "),
+    /** GeoIP code {@code PR} ({@code PUERTO RICO}). */
     PR("PUERTO RICO "),
+    /** GeoIP code {@code QA} ({@code QATAR}). */
     QA("QATAR "),
+    /** GeoIP code {@code RE} ({@code REUNION}). */
     RE("REUNION "),
+    /** GeoIP code {@code RO} ({@code ROMANIA}). */
     RO("ROMANIA "),
+    /** GeoIP code {@code RU} ({@code RUSSIAN FEDERATION}). */
     RU("RUSSIAN FEDERATION "),
+    /** GeoIP code {@code RW} ({@code RWANDA}). */
     RW("RWANDA "),
+    /** GeoIP code {@code BL} ({@code SAINT BARTHELEMY}). */
     BL("SAINT BARTHELEMY "),
+    /** GeoIP code {@code SH} ({@code SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA}). */
     SH("SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA "),
+    /** GeoIP code {@code KN} ({@code SAINT KITTS AND NEVIS}). */
     KN("SAINT KITTS AND NEVIS "),
+    /** GeoIP code {@code LC} ({@code SAINT LUCIA}). */
     LC("SAINT LUCIA "),
+    /** GeoIP code {@code MF} ({@code SAINT MARTIN (FRENCH PART)}). */
     MF("SAINT MARTIN (FRENCH PART) "),
+    /** GeoIP code {@code PM} ({@code SAINT PIERRE AND MIQUELON}). */
     PM("SAINT PIERRE AND MIQUELON "),
+    /** GeoIP code {@code VC} ({@code SAINT VINCENT AND THE GRENADINES}). */
     VC("SAINT VINCENT AND THE GRENADINES "),
+    /** GeoIP code {@code WS} ({@code SAMOA}). */
     WS("SAMOA "),
+    /** GeoIP code {@code SM} ({@code SAN MARINO}). */
     SM("SAN MARINO "),
+    /** GeoIP code {@code ST} ({@code SAO TOME AND PRINCIPE}). */
     ST("SAO TOME AND PRINCIPE "),
+    /** GeoIP code {@code SA} ({@code SAUDI ARABIA}). */
     SA("SAUDI ARABIA "),
+    /** GeoIP code {@code SN} ({@code SENEGAL}). */
     SN("SENEGAL "),
+    /** GeoIP code {@code RS} ({@code SERBIA}). */
     RS("SERBIA "),
+    /** GeoIP code {@code SC} ({@code SEYCHELLES}). */
     SC("SEYCHELLES "),
+    /** GeoIP code {@code SL} ({@code SIERRA LEONE}). */
     SL("SIERRA LEONE "),
+    /** GeoIP code {@code SG} ({@code SINGAPORE}). */
     SG("SINGAPORE "),
+    /** GeoIP code {@code SX} ({@code SINT MAARTEN (DUTCH PART)}). */
     SX("SINT MAARTEN (DUTCH PART) "),
+    /** GeoIP code {@code SK} ({@code SLOVAKIA}). */
     SK("SLOVAKIA "),
+    /** GeoIP code {@code SI} ({@code SLOVENIA}). */
     SI("SLOVENIA "),
+    /** GeoIP code {@code SB} ({@code SOLOMON ISLANDS}). */
     SB("SOLOMON ISLANDS "),
+    /** GeoIP code {@code SO} ({@code SOMALIA}). */
     SO("SOMALIA "),
+    /** GeoIP code {@code ZA} ({@code SOUTH AFRICA}). */
     ZA("SOUTH AFRICA "),
+    /** GeoIP code {@code GS} ({@code SOUTH GEORGIA AND THE SOUTH SANDWICH ISLANDS}). */
     GS("SOUTH GEORGIA AND THE SOUTH SANDWICH ISLANDS "),
+    /** GeoIP code {@code SS} ({@code SOUTH SUDAN}). */
     SS("SOUTH SUDAN"),
+    /** GeoIP code {@code ES} ({@code SPAIN}). */
     ES("SPAIN "),
+    /** GeoIP code {@code LK} ({@code SRI LANKA}). */
     LK("SRI LANKA "),
+    /** GeoIP code {@code SD} ({@code SUDAN}). */
     SD("SUDAN "),
+    /** GeoIP code {@code SR} ({@code SURINAME}). */
     SR("SURINAME "),
+    /** GeoIP code {@code SJ} ({@code SVALBARD AND JAN MAYEN}). */
     SJ("SVALBARD AND JAN MAYEN "),
+    /** GeoIP code {@code SZ} ({@code SWAZILAND}). */
     SZ("SWAZILAND "),
+    /** GeoIP code {@code SE} ({@code SWEDEN}). */
     SE("SWEDEN "),
+    /** GeoIP code {@code CH} ({@code SWITZERLAND}). */
     CH("SWITZERLAND "),
+    /** GeoIP code {@code SY} ({@code SYRIAN ARAB REPUBLIC}). */
     SY("SYRIAN ARAB REPUBLIC "),
+    /** GeoIP code {@code TW} ({@code TAIWAN, PROVINCE OF CHINA}). */
     TW("TAIWAN, PROVINCE OF CHINA "),
+    /** GeoIP code {@code TJ} ({@code TAJIKISTAN}). */
     TJ("TAJIKISTAN "),
+    /** GeoIP code {@code TZ} ({@code TANZANIA, UNITED REPUBLIC OF}). */
     TZ("TANZANIA, UNITED REPUBLIC OF "),
+    /** GeoIP code {@code TH} ({@code THAILAND}). */
     TH("THAILAND "),
+    /** GeoIP code {@code TL} ({@code TIMOR-LESTE}). */
     TL("TIMOR-LESTE "),
+    /** GeoIP code {@code TG} ({@code TOGO}). */
     TG("TOGO "),
+    /** GeoIP code {@code TK} ({@code TOKELAU}). */
     TK("TOKELAU "),
+    /** GeoIP code {@code TO} ({@code TONGA}). */
     TO("TONGA "),
+    /** GeoIP code {@code TT} ({@code TRINIDAD AND TOBAGO}). */
     TT("TRINIDAD AND TOBAGO "),
+    /** GeoIP code {@code TN} ({@code TUNISIA}). */
     TN("TUNISIA "),
+    /** GeoIP code {@code TR} ({@code TURKEY}). */
     TR("TURKEY "),
+    /** GeoIP code {@code TM} ({@code TURKMENISTAN}). */
     TM("TURKMENISTAN "),
+    /** GeoIP code {@code TC} ({@code TURKS AND CAICOS ISLANDS}). */
     TC("TURKS AND CAICOS ISLANDS "),
+    /** GeoIP code {@code TV} ({@code TUVALU}). */
     TV("TUVALU "),
+    /** GeoIP code {@code UG} ({@code UGANDA}). */
     UG("UGANDA "),
+    /** GeoIP code {@code UA} ({@code UKRAINE}). */
     UA("UKRAINE "),
+    /** GeoIP code {@code AE} ({@code UNITED ARAB EMIRATES}). */
     AE("UNITED ARAB EMIRATES "),
+    /** GeoIP code {@code GB} ({@code UNITED KINGDOM}). */
     GB("UNITED KINGDOM "),
+    /** GeoIP code {@code US} ({@code UNITED STATES}). */
     US("UNITED STATES "),
+    /** GeoIP code {@code UM} ({@code UNITED STATES MINOR OUTLYING ISLANDS}). */
     UM("UNITED STATES MINOR OUTLYING ISLANDS "),
+    /** GeoIP code {@code UY} ({@code URUGUAY}). */
     UY("URUGUAY "),
+    /** GeoIP code {@code UZ} ({@code UZBEKISTAN}). */
     UZ("UZBEKISTAN "),
+    /** GeoIP code {@code VU} ({@code VANUATU}). */
     VU("VANUATU "),
+    /** GeoIP code {@code VE} ({@code VENEZUELA, BOLIVARIAN REPUBLIC OF}). */
     VE("VENEZUELA, BOLIVARIAN REPUBLIC OF "),
+    /** GeoIP code {@code VN} ({@code VIET NAM}). */
     VN("VIET NAM "),
+    /** GeoIP code {@code VG} ({@code VIRGIN ISLANDS, BRITISH}). */
     VG("VIRGIN ISLANDS, BRITISH "),
+    /** GeoIP code {@code VI} ({@code VIRGIN ISLANDS, U.S.}). */
     VI("VIRGIN ISLANDS, U.S. "),
+    /** GeoIP code {@code WF} ({@code WALLIS AND FUTUNA}). */
     WF("WALLIS AND FUTUNA "),
+    /** GeoIP code {@code EH} ({@code WESTERN SAHARA}). */
     EH("WESTERN SAHARA "),
+    /** GeoIP code {@code YE} ({@code YEMEN}). */
     YE("YEMEN "),
+    /** GeoIP code {@code ZM} ({@code ZAMBIA}). */
     ZM("ZAMBIA "),
+    /** GeoIP code {@code ZW} ({@code ZIMBABWE}). */
     ZW("ZIMBABWE "),
+    /** GeoIP code {@code ZZ} ({@code NA}). */
     ZZ("NA"),
+    /** GeoIP code {@code EU} ({@code European Union}). */
     EU("European Union");
     private final String name;
     private boolean hasFlag;
@@ -308,10 +595,28 @@ public class IPConverter {
       this.name = name;
     }
 
+    /**
+     * Returns the display name for this country/region code.
+     *
+     * <p>This value is intended for UI display and comes from the database-provided mapping used by
+     * {@link IPConverter}. It is not guaranteed to match any specific external naming standard and
+     * should not be used as a stable identifier; use {@link #name()} when a stable code is needed.
+     *
+     * @return human-readable label for this entry, suitable for UI rendering.
+     */
     public String getName() {
       return name;
     }
 
+    /**
+     * Adds an {@code <img>} element for this entry's flag icon, when available.
+     *
+     * <p>The icon is resolved relative to the static files root (see {@link StaticToadlet}) and the
+     * presence check is cached per enum constant. If no icon exists, this method performs no
+     * modification to {@code parent}.
+     *
+     * @param parent HTML node to append an icon element to; must be non-null and mutable.
+     */
     public void renderFlagIcon(HTMLNode parent) {
       String flagPath = getFlagIconPath();
       if (flagPath != null)
@@ -321,16 +626,31 @@ public class IPConverter {
             new String[] {StaticToadlet.ROOT_URL + flagPath, "flag", getName()});
     }
 
+    /**
+     * Returns whether a flag icon exists for this country/region code.
+     *
+     * <p>This method is a convenience wrapper around {@link #getFlagIconPath()}. The result is
+     * cached and will not reflect filesystem changes after the first check in the current process.
+     *
+     * @return {@code true} if a static flag icon file exists; {@code false} otherwise.
+     */
     public boolean hasFlagIcon() {
       return getFlagIconPath() != null;
     }
 
-    /** Doesn't check whether it exists. Relative to the top of staticfiles. */
+    /** Does not check whether it exists. Relative to the top of static files. */
     private String flagIconPath() {
       return "icon/flags/" + toString().toLowerCase() + ".png";
     }
 
-    /** Relative to top of static files */
+    /**
+     * Returns the static path for this entry's flag icon, or {@code null} when unavailable.
+     *
+     * <p>The returned value is a relative path under the static files root (for example, {@code
+     * icon/flags/us.png}). The method caches both the existence check and the result.
+     *
+     * @return relative static path to the flag icon, or {@code null} if none exists.
+     */
     public String getFlagIconPath() {
       String flagPath = flagIconPath();
       synchronized (this) {
@@ -354,51 +674,70 @@ public class IPConverter {
     'v', 'w', 'x', 'y', 'z', '.', ',', ';', '\'', '"', '`', '<', '>', '{', '}', '[', ']', '=', '+',
     '-', '~', '*', '@', '#', '%', '$', '&', '!', '?'
   };
-  private static final int base = base85.length;
+  private static final int BASE = base85.length;
   // XXX this is actually base86, not base85!
   private static final byte[] base85inv = new byte[128 - 32];
 
   static {
     Arrays.fill(base85inv, (byte) -1);
     for (int i = 0; i < base85.length; i++) {
-      assert (base85[i] >= (char) 32 && base85[i] < (char) 128);
-      base85inv[(int) base85[i] - 32] = (byte) i;
+      base85inv[base85[i] - 32] = (byte) i;
     }
   }
 
   /**
-   * Constructs a new {@link IPConverter}
+   * Constructs a new {@link IPConverter} bound to a specific GeoIP database file.
    *
-   * @param node reference to freenet {@link Node}
+   * <p>The file is treated as an optional input: callers may create an instance before the file is
+   * present, and lookups will return {@code null} until a readable and parseable database exists.
+   *
+   * @param dbFile file containing the encoded IP range table; must not be {@code null}.
    */
   private IPConverter(File dbFile) {
     this.dbFile = dbFile;
   }
 
   /**
-   * Returns the reference to singleton object of this class.
+   * Returns a singleton {@link IPConverter} instance for the provided database file.
    *
-   * @return singleton object
+   * <p>If the current singleton is {@code null} or was created for a different {@code file}, a new
+   * instance is created and replaces the previous singleton reference.
+   *
+   * <p><b>Thread-safety:</b> this method is not synchronized. Concurrent callers may observe races
+   * when swapping the singleton; all created instances should be functionally equivalent for a
+   * given file path.
+   *
+   * @param file database file that should back the singleton instance; must not be {@code null}.
+   * @return singleton instance configured to read from {@code file}.
    */
   public static IPConverter getInstance(File file) {
-    if (instance == null) {
-      instance = new IPConverter(file);
-    } else if (!instance.getDBFile().equals(file)) {
+    if (instance == null || !instance.getDBFile().equals(file)) {
       instance = new IPConverter(file);
     }
     return instance;
   }
 
+  private static short countryOrdinalOrUnknown(String code) {
+    try {
+      return (short) Country.valueOf(code).ordinal();
+    } catch (IllegalArgumentException e) {
+      // Does not invalidate the whole file, just means the country list is out of date.
+      LOG.error("Country not in list: {}", code);
+      return (short) -1;
+    }
+  }
+
   /**
-   * Copies all IP ranges from given String to memory as a {@link WeakReference}.
+   * Reads and decodes the GeoIP range table from {@link #dbFile}.
    *
-   * @param line {@link String} containing IP ranges
-   * @throws IOException
+   * <p>This method scans the file until it finds the {@link #START} marker, decodes the compact
+   * range representation into two parallel arrays, and returns them wrapped in a {@link Cache}. Any
+   * read or parse failure is handled internally and results in a {@code null} return value.
+   *
+   * @return decoded cache, or {@code null} when the file is missing or cannot be parsed.
    */
   private Cache readRanges() {
-    RandomAccessFile raf;
-    try {
-      raf = new RandomAccessFile(dbFile, "r");
+    try (RandomAccessFile raf = new RandomAccessFile(dbFile, "r")) {
       String line;
       do {
         line = raf.readLine();
@@ -417,37 +756,32 @@ public class IPConverter {
         // Ip
         String ipcode = line.substring(offset + 2, offset + 7);
         long ip = decodeBase85(ipcode.getBytes(StandardCharsets.ISO_8859_1));
-        try {
-          Country country = Country.valueOf(code);
-          codes[i] = (short) country.ordinal();
-        } catch (IllegalArgumentException e) {
-          // Does not invalidate the whole file, just means the country list is out of date.
-          LOG.error("Country not in list: " + code);
-          codes[i] = (short) -1;
-        }
+        codes[i] = countryOrdinalOrUnknown(code);
         ips[i] = (int) ip;
       }
-      raf.close();
       return new Cache(codes, ips);
     } catch (FileNotFoundException e) {
       // Not downloaded yet
-      LOG.warn("Database file not found!", e);
+      LOG.warn("Database file not found.", e);
     } catch (IOException e) {
       LOG.error(e.getMessage());
     } catch (IPConverterParseException e) {
-      LOG.error("IP to country datbase file is corrupt: " + e, e);
+      LOG.error("IP-to-country database file is corrupt: {}", e, e);
       // Don't try again until next restart.
-      // FIXME add a callback to clear the flag when we download a new copy.
       dbFileCorrupt = true;
     }
     return null;
   }
 
   /**
-   * Converts a given IP4 in a long number
+   * Converts an IPv4 address from dotted-decimal notation to a numeric value.
    *
-   * @param ip IP in "XX.XX.XX.XX" format
-   * @return IP in long format
+   * <p>The returned value is the 32-bit IPv4 address interpreted as an unsigned integer and stored
+   * in the low 32 bits of the returned {@code long}. Each octet is parsed as a decimal integer and
+   * reduced modulo 256 to obtain a byte value.
+   *
+   * @param ip IPv4 address in dotted-decimal form (for example, {@code 192.0.2.1}).
+   * @return numeric value for the address, suitable for {@link #locateIP(long)} lookups.
    * @throws NumberFormatException If the string is not an IP address.
    */
   public long ip2num(String ip) {
@@ -455,8 +789,8 @@ public class IPConverter {
     if (split.length != 4) throw new NumberFormatException();
     long num = 0;
     long coef = (256 << 16);
-    for (int i = 0; i < split.length; i++) {
-      long modulo = Integer.parseInt(split[i]) % 256;
+    for (String s : split) {
+      long modulo = Integer.parseInt(s) % 256;
       num += (modulo * coef);
       coef >>= 8;
     }
@@ -464,12 +798,17 @@ public class IPConverter {
   }
 
   /**
-   * Returns a {@link Country} respecting given IP4.
+   * Locates the {@link Country} for an IPv4 address provided as a string.
    *
-   * @param ip IP in "XX.XX.XX.XX" format
-   * @return {@link Country} of given IP, or null if the passed in string is not an IP address or we
-   *     fail to load the ip to country data file.
-   * @throws IOException
+   * <p>This is a convenience overload that parses the dotted-decimal IPv4 string and then performs
+   * a lookup against the current in-memory cache. If the database file cannot be loaded or the
+   * input string is not a valid IPv4 address, this method returns {@code null}.
+   *
+   * <p>This method does not perform network I/O; it reads only from the on-disk database file when
+   * the decoded table is not currently cached in memory.
+   *
+   * @param ip IPv4 address in dotted-decimal form; may be {@code null}.
+   * @return matched country/region, or {@code null} if unknown or unavailable.
    */
   public Country locateIP(String ip) {
     if (ip == null) return null;
@@ -482,6 +821,17 @@ public class IPConverter {
     return locateIP(longip);
   }
 
+  /**
+   * Locates the {@link Country} for an IP address provided as raw bytes.
+   *
+   * <p>This overload accepts either an IPv4 address (4 bytes) or an IPv6 address (16 bytes). For a
+   * subset of IPv6 transition mechanisms (for example, 6to4 and Teredo), it attempts to derive an
+   * embedded IPv4 address and then performs an IPv4 lookup. Other IPv6 addresses are not currently
+   * handled and result in {@code null}.
+   *
+   * @param ip raw address bytes in network byte order; may be {@code null}.
+   * @return matched country/region, or {@code null} if unsupported, unknown, or unavailable.
+   */
   public Country locateIP(byte[] ip) {
     if (ip == null) return null;
     if (ip.length == 16) {
@@ -560,9 +910,14 @@ public class IPConverter {
   }
 
   /**
-   * Returns {@link Cache} containing IPranges
+   * Returns the decoded GeoIP range table, loading it if necessary.
    *
-   * @return {@link Cache}
+   * <p>The decoded range table is stored behind a {@link SoftReference}. This allows the JVM to
+   * reclaim the arrays under memory pressure, trading memory for occasional reload cost. If the
+   * database file has previously been marked as corrupt in this process, this method returns {@code
+   * null} without retrying.
+   *
+   * @return decoded range table cache, or {@code null} if unavailable.
    */
   private Cache getCache() {
     Cache memCache = null;
@@ -570,34 +925,42 @@ public class IPConverter {
       if (fullCache != null) memCache = fullCache.get();
       if (memCache == null) {
         if (dbFileCorrupt) return null;
-        fullCache = new SoftReference<>(memCache = readRanges());
+        memCache = readRanges();
+        fullCache = new SoftReference<>(memCache);
       }
     }
     return memCache;
   }
 
   /**
-   * Decodes a ASCII85 code into a long number.
+   * Decodes a 5-byte base-N encoded value into a numeric address boundary.
    *
-   * @param code encoded bytes
-   * @return decoded long
-   * @throws IPConverterParseException
+   * <p>The GeoIP range table stores compact address boundaries using an alphabet defined by {@link
+   * #base85}. This method validates the input against {@link #base85inv} and computes the
+   * corresponding value as an unsigned integer stored in the returned {@code long}.
+   *
+   * @param code encoded bytes; must contain exactly 5 ASCII characters from the supported alphabet.
+   * @return decoded numeric value suitable for comparison with {@code longip}.
+   * @throws IPConverterParseException if {@code code} is the wrong length or contains invalid
+   *     bytes.
    */
   private long decodeBase85(byte[] code) throws IPConverterParseException {
     long result = 0;
     if (code.length != 5) throw new IPConverterParseException();
-    for (int i = 0; i < code.length; i++) {
-      if (code[i] < (byte) 32 || base85inv[code[i] - 32] < (byte) 0)
-        throw new IPConverterParseException();
-      result = (result * base) + base85inv[code[i] - 32];
+    for (byte b : code) {
+      if (b < (byte) 32 || base85inv[b - 32] < (byte) 0) throw new IPConverterParseException();
+      result = (result * BASE) + base85inv[b - 32];
     }
     return result;
   }
 
   /**
-   * Returns database file containing IP ranges
+   * Returns the database file containing encoded IP ranges.
    *
-   * @return database file
+   * <p>This accessor is primarily used to decide whether the singleton instance should be replaced
+   * by {@link #getInstance(File)}.
+   *
+   * @return file backing this converter instance.
    */
   File getDBFile() {
     return this.dbFile;

--- a/src/main/java/network/crypta/clients/http/geoip/IPConverterParseException.java
+++ b/src/main/java/network/crypta/clients/http/geoip/IPConverterParseException.java
@@ -1,5 +1,47 @@
 package network.crypta.clients.http.geoip;
 
+import java.io.Serial;
+
+/**
+ * Signals that a textual IP address could not be parsed or converted into a usable representation.
+ *
+ * <p>This exception is part of the GeoIP-related HTTP implementation and is intended to represent
+ * failures that happen at the boundary between untrusted input (for example, query parameters or
+ * headers) and the code that consumes an IP address for subsequent processing. It gives callers a
+ * dedicated, domain-specific signal that the input did not meet the syntactic expectations of the
+ * converter, instead of overloading more general exceptions.
+ *
+ * <p>Instances of this type are immutable after construction and safe to share across threads in
+ * the same way as {@link Exception}; the only mutable state is the standard stack trace managed by
+ * the JVM. This exception carries no additional fields beyond what {@link Exception} provides, so
+ * callers should rely on the detail message (when present) and the cause chain to convey parse
+ * context.
+ *
+ * <p><b>Notable behaviors</b>
+ *
+ * <ul>
+ *   <li>Represents input-shape problems (parse/convert failures) rather than downstream I/O or
+ *       lookup failures.
+ *   <li>Does not attempt recovery; callers decide whether to reject, sanitize, or fallback to a
+ *       default.
+ * </ul>
+ */
 public class IPConverterParseException extends Exception {
-  static final long serialVersionUID = 8465371657927636643L;
+  /**
+   * Creates a new exception without a detail message or a cause.
+   *
+   * <p>This constructor exists to explicitly document the default constructor for doclint. The
+   * resulting instance has a {@code null} detail message and a {@code null} cause, and it is
+   * otherwise equivalent to the compiler-generated no-argument constructor that would be provided
+   * for this class.
+   *
+   * <p>Use this constructor when the call site already has an out-of-band mechanism to report parse
+   * context (for example, returning a structured error response to an HTTP client) and the
+   * exception itself is only used as a control-flow signal to abort the conversion.
+   */
+  public IPConverterParseException() {
+    super();
+  }
+
+  @Serial private static final long serialVersionUID = 8465371657927636643L;
 }

--- a/src/main/java/network/crypta/clients/http/geoip/package-info.java
+++ b/src/main/java/network/crypta/clients/http/geoip/package-info.java
@@ -1,7 +1,39 @@
 /**
- * Classes to look up what country an IP address is likely to be in, based on a file downloaded by
- * the auto-update system, originally from software77.com/geo-ip/. Currently this is only used by
- * fproxy to show what countries your peers are in, but in future it might be used to e.g. limit the
- * number of opennet peers by country.
+ * GeoIP lookup helpers for the HTTP UI.
+ *
+ * <p>This package provides a small, best-effort utility layer that maps an IP address to an
+ * approximate country or region code by consulting an on-disk IP range table. The table is expected
+ * to be downloaded and refreshed by the node's update system, and the lookup logic is written to
+ * tolerate missing or corrupted inputs: when the database is unavailable or cannot be parsed,
+ * callers typically receive no location information rather than a hard failure.
+ *
+ * <p>The primary entry point is {@code IPConverter}, which loads the database file, builds a
+ * compact in-memory representation, and performs lookups via binary search. Lookups may be memoized
+ * in a small cache to reduce repeated work for common addresses. The in-memory table representation
+ * is carried by {@code Cache}, which intentionally stores and exposes primitive arrays without
+ * defensive copies for efficiency.
+ *
+ * <p><b>Intended usage and constraints</b>
+ *
+ * <ul>
+ *   <li>This is used by the HTTP interface (for example, the peer UI) to display approximate
+ *       locations such as a country label and, when resources exist, a corresponding flag icon.
+ *   <li>Results are derived from a third-party range database and are not authoritative; they
+ *       should not be treated as an identity or security boundary.
+ *   <li>Threading expectations are conservative: the converter and its caches are mutable and are
+ *       generally intended for single-threaded use unless callers provide their own
+ *       synchronization.
+ * </ul>
+ *
+ * <p>Example flow:
+ *
+ * <pre>{@code
+ * File dbFile = new File("/path/to/geoip-range-table");
+ * IPConverter converter = IPConverter.getInstance(dbFile);
+ * IPConverter.Country country = converter.locateIP("203.0.113.7");
+ * // country may be null when the database is missing or the address is unknown.
+ * }</pre>
+ *
+ * <p>Input parsing errors may be reported via {@code IPConverterParseException}.
  */
 package network.crypta.clients.http.geoip;

--- a/src/test/java/network/crypta/clients/http/geoip/CacheTest.java
+++ b/src/test/java/network/crypta/clients/http/geoip/CacheTest.java
@@ -1,0 +1,77 @@
+package network.crypta.clients.http.geoip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link Cache}. */
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // test naming: method_whenCondition_expectOutcome
+class CacheTest {
+
+  @ParameterizedTest(name = "{index}: {2}")
+  @MethodSource("constructorCases")
+  @DisplayName("getCodes()/getIps() return the exact arrays provided to the constructor")
+  void constructor_whenAnyArraysProvided_gettersReturnSameReferences(
+      short[] codes, int[] ips, String description) {
+    // Arrange
+
+    // Act
+    Cache cache = new Cache(codes, ips);
+
+    // Assert
+    assertSame(
+        codes,
+        cache.getCodes(),
+        () -> "Expected getCodes() to return the same reference (" + description + ")");
+    assertSame(
+        ips,
+        cache.getIps(),
+        () -> "Expected getIps() to return the same reference (" + description + ")");
+  }
+
+  private static Stream<Arguments> constructorCases() {
+    return Stream.of(
+        Arguments.of(new short[] {1, 2, 3}, new int[] {0x01020304, 0x0a000001}, "non-null arrays"),
+        Arguments.of(null, new int[] {1}, "null codes array"),
+        Arguments.of(new short[] {1}, null, "null ips array"),
+        Arguments.of(null, null, "both arrays null"),
+        Arguments.of(new short[0], new int[0], "empty arrays"));
+  }
+
+  @Test
+  @DisplayName("Mutating the codes array is visible through getCodes() (live backing array)")
+  void getCodes_whenBackingArrayMutated_reflectsMutation() {
+    // Arrange
+    short[] codes = new short[] {10};
+    Cache cache = new Cache(codes, new int[] {123});
+
+    // Act
+    codes[0] = 42;
+
+    // Assert
+    assertEquals((short) 42, cache.getCodes()[0]);
+  }
+
+  @Test
+  @DisplayName("Mutating the ips array is visible through getIps() (live backing array)")
+  void getIps_whenBackingArrayMutated_reflectsMutation() {
+    // Arrange
+    int[] ips = new int[] {123};
+    Cache cache = new Cache(new short[] {10}, ips);
+
+    // Act
+    ips[0] = 456;
+
+    // Assert
+    assertEquals(456, cache.getIps()[0]);
+  }
+}

--- a/src/test/java/network/crypta/clients/http/geoip/IPConverterTest.java
+++ b/src/test/java/network/crypta/clients/http/geoip/IPConverterTest.java
@@ -1,0 +1,435 @@
+package network.crypta.clients.http.geoip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("java:S100")
+class IPConverterTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void getInstance_whenCalledTwiceWithSameFile_expectSameSingletonInstance() throws IOException {
+    // Arrange
+    Path dbFile = tempDir.resolve(DB_FILE_NAME);
+    Files.writeString(dbFile, START_MARKER, StandardCharsets.ISO_8859_1);
+
+    // Act
+    IPConverter first = IPConverter.getInstance(dbFile.toFile());
+    IPConverter second = IPConverter.getInstance(dbFile.toFile());
+
+    // Assert
+    assertSame(first, second);
+  }
+
+  @Test
+  void getInstance_whenCalledWithDifferentFiles_expectRecreatedInstance() throws IOException {
+    // Arrange
+    Path firstDb = tempDir.resolve("geoip-1.dat");
+    Path secondDb = tempDir.resolve("geoip-2.dat");
+    Files.writeString(firstDb, START_MARKER, StandardCharsets.ISO_8859_1);
+    Files.writeString(secondDb, START_MARKER, StandardCharsets.ISO_8859_1);
+
+    // Act
+    IPConverter first = IPConverter.getInstance(firstDb.toFile());
+    IPConverter second = IPConverter.getInstance(secondDb.toFile());
+
+    // Assert
+    assertNotSame(first, second);
+  }
+
+  @Test
+  void ip2num_whenValidIPv4_expectConvertedLong() {
+    // Arrange
+    IPConverter converter = newConverterWithMissingDb();
+
+    // Act
+    long result = converter.ip2num(ipv4(1, 2, 3, 4));
+
+    // Assert
+    assertEquals(0x01020304L, result);
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidIpv4Inputs")
+  void ip2num_whenNotValidIPv4_expectThrowsNumberFormatException(String ip) {
+    // Arrange
+    IPConverter converter = newConverterWithMissingDb();
+
+    // Act / Assert
+    assertThrows(NumberFormatException.class, () -> converter.ip2num(ip));
+  }
+
+  @Test
+  void ip2num_whenOctetsExceedByte_expectAppliesModulo256() {
+    // Arrange
+    IPConverter converter = newConverterWithMissingDb();
+
+    // Act
+    long wrapped = converter.ip2num(ipv4(257, 0, 0, 0));
+    long zeroed = converter.ip2num(ipv4(256, 0, 0, 0));
+
+    // Assert
+    assertEquals(1L << 24, wrapped);
+    assertEquals(0L, zeroed);
+  }
+
+  @Test
+  void locateIP_whenIpIsNull_expectNull() {
+    // Arrange
+    IPConverter converter = newConverterWithMissingDb();
+
+    // Act
+    IPConverter.Country result = converter.locateIP((String) null);
+
+    // Assert
+    assertNull(result);
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidLocateIpInputs")
+  void locateIP_whenIpIsNotIPv4_expectNull(String ip) {
+    // Arrange
+    IPConverter converter = newConverterWithMissingDb();
+
+    // Act
+    IPConverter.Country result = converter.locateIP(ip);
+
+    // Assert
+    assertNull(result);
+  }
+
+  @Test
+  void locateIP_whenDbFileDoesNotExist_expectNull() {
+    // Arrange
+    Path missingDbFile = tempDir.resolve(MISSING_DB_FILE_NAME);
+    IPConverter converter = IPConverter.getInstance(missingDbFile.toFile());
+
+    // Act
+    IPConverter.Country result = converter.locateIP(ipv4WithLastOctet(150));
+
+    // Assert
+    assertNull(result);
+  }
+
+  @Test
+  void locateIP_whenDbIsValid_expectCountryForIPv4String() throws IOException {
+    // Arrange
+    Path dbFile = tempDir.resolve(DB_FILE_NAME);
+    writeDbFile(
+        dbFile,
+        List.of(
+            new DbEntry("US", 2), // 2..8
+            new DbEntry("DE", 1), // 1
+            new DbEntry("FR", 0) // 0
+            ));
+    IPConverter converter = IPConverter.getInstance(dbFile.toFile());
+
+    // Act
+    IPConverter.Country us = converter.locateIP(ipv4WithLastOctet(3));
+    IPConverter.Country de = converter.locateIP(ipv4WithLastOctet(1));
+    IPConverter.Country fr = converter.locateIP(ipv4WithLastOctet(0));
+
+    // Assert
+    assertEquals(IPConverter.Country.US, us);
+    assertEquals(IPConverter.Country.DE, de);
+    assertEquals(IPConverter.Country.FR, fr);
+  }
+
+  @Test
+  void locateIP_whenDbIsValid_expectCountryForIPv4Bytes() throws IOException {
+    // Arrange
+    Path dbFile = tempDir.resolve(DB_FILE_NAME);
+    writeDbFile(
+        dbFile,
+        List.of(
+            new DbEntry("US", 2), // 2..8
+            new DbEntry("DE", 1), // 1
+            new DbEntry("FR", 0) // 0
+            ));
+    IPConverter converter = IPConverter.getInstance(dbFile.toFile());
+
+    // Act
+    IPConverter.Country result = converter.locateIP(new byte[] {0, 0, 0, (byte) 1});
+
+    // Assert
+    assertEquals(IPConverter.Country.DE, result);
+  }
+
+  @Test
+  void locateIP_whenDbHasUnknownCountryCode_expectNullForThatRange() throws IOException {
+    // Arrange
+    Path dbFile = tempDir.resolve(DB_FILE_NAME);
+    writeDbFile(
+        dbFile,
+        List.of(
+            new DbEntry("QQ", 2), // unknown country => stored as -1 => null results
+            new DbEntry("DE", 1),
+            new DbEntry("FR", 0)));
+    IPConverter converter = IPConverter.getInstance(dbFile.toFile());
+
+    // Act
+    IPConverter.Country unknown = converter.locateIP(ipv4WithLastOctet(3));
+    IPConverter.Country known = converter.locateIP(ipv4WithLastOctet(1));
+
+    // Assert
+    assertNull(unknown);
+    assertEquals(IPConverter.Country.DE, known);
+  }
+
+  @Test
+  void locateIP_whenDbCorrupt_expectNullAndNoRetryUntilRestart() throws IOException {
+    // Arrange
+    Path dbFile = tempDir.resolve(DB_FILE_NAME);
+    // Corrupt: invalid base85 chars (spaces) will trip decodeBase85 => dbFileCorrupt=true.
+    Files.writeString(dbFile, START_MARKER + "US     ", StandardCharsets.ISO_8859_1);
+    IPConverter converter = IPConverter.getInstance(dbFile.toFile());
+
+    // Act
+    IPConverter.Country firstAttempt = converter.locateIP(ipv4WithLastOctet(1));
+    writeDbFile(dbFile, List.of(new DbEntry("US", 0), new DbEntry("US", 0), new DbEntry("US", 0)));
+    IPConverter.Country secondAttemptAfterFix = converter.locateIP(ipv4WithLastOctet(1));
+
+    // Assert
+    assertNull(firstAttempt);
+    assertNull(secondAttemptAfterFix);
+  }
+
+  @Test
+  void locateIP_whenByteArrayIsNull_expectNull() {
+    // Arrange
+    IPConverter converter = newConverterWithMissingDb();
+
+    // Act
+    IPConverter.Country result = converter.locateIP((byte[]) null);
+
+    // Assert
+    assertNull(result);
+  }
+
+  @Test
+  void locateIP_whenByteArrayLengthIsUnsupported_expectNull() {
+    // Arrange
+    IPConverter converter = newConverterWithMissingDb();
+
+    // Act
+    IPConverter.Country result = converter.locateIP(new byte[] {1, 2, 3});
+
+    // Assert
+    assertNull(result);
+  }
+
+  @Test
+  void locateIP_whenIpv6Is6to4_expectConvertedAndLocated() throws IOException {
+    // Arrange
+    Path dbFile = tempDir.resolve(DB_FILE_NAME);
+    writeDbFile(dbFile, List.of(new DbEntry("US", 2), new DbEntry("DE", 1), new DbEntry("FR", 0)));
+    IPConverter converter = IPConverter.getInstance(dbFile.toFile());
+
+    byte[] ipv6 =
+        new byte[] {
+          0x20, 0x02, // 2002::/16 prefix
+          0, 0, 0, (byte) 1, // embedded IPv4 bytes
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        };
+
+    // Act
+    IPConverter.Country result = converter.locateIP(ipv6);
+
+    // Assert
+    assertEquals(IPConverter.Country.DE, result);
+  }
+
+  @Test
+  void locateIP_whenIpv6IsIpv4Compatible_expectConvertedAndLocated() throws IOException {
+    // Arrange
+    Path dbFile = tempDir.resolve(DB_FILE_NAME);
+    writeDbFile(dbFile, List.of(new DbEntry("US", 2), new DbEntry("DE", 1), new DbEntry("FR", 0)));
+    IPConverter converter = IPConverter.getInstance(dbFile.toFile());
+
+    byte[] ipv6 = new byte[16];
+    ipv6[12] = 0;
+    ipv6[13] = 0;
+    ipv6[14] = 0;
+    ipv6[15] = (byte) 1;
+
+    // Act
+    IPConverter.Country result = converter.locateIP(ipv6);
+
+    // Assert
+    assertEquals(IPConverter.Country.DE, result);
+  }
+
+  @Test
+  void locateIP_whenIpv6IsTeredo_expectDeinvertedAndLocated() throws IOException {
+    // Arrange
+    Path dbFile = tempDir.resolve(DB_FILE_NAME);
+    writeDbFile(dbFile, List.of(new DbEntry("US", 2), new DbEntry("DE", 1), new DbEntry("FR", 0)));
+    IPConverter converter = IPConverter.getInstance(dbFile.toFile());
+
+    byte[] ipv6 = new byte[16];
+    ipv6[0] = 0x20;
+    ipv6[1] = 0x01;
+    ipv6[2] = 0x00;
+    ipv6[3] = 0x00;
+    // 12..15: client address (inverted)
+    ipv6[12] = (byte) 0xff;
+    ipv6[13] = (byte) 0xff;
+    ipv6[14] = (byte) 0xff;
+    ipv6[15] = (byte) (1 ^ 0xff);
+
+    // Act
+    IPConverter.Country result = converter.locateIP(ipv6);
+
+    // Assert
+    assertEquals(IPConverter.Country.DE, result);
+  }
+
+  @Test
+  void locateIP_whenIpv6IsNotConvertible_expectNull() {
+    // Arrange
+    IPConverter converter = newConverterWithMissingDb();
+    byte[] ipv6 = new byte[16];
+    ipv6[0] = 0x20;
+    ipv6[1] = 0x01;
+    ipv6[2] = 0x0d;
+    ipv6[3] = (byte) 0xb8; // 2001:db8::/32, documentation prefix
+
+    // Act
+    IPConverter.Country result = converter.locateIP(ipv6);
+
+    // Assert
+    assertNull(result);
+  }
+
+  @Test
+  void country_hasFlagIcon_whenResourceExists_expectTrue() {
+    // Arrange / Act
+    boolean hasFlag = IPConverter.Country.US.hasFlagIcon();
+
+    // Assert
+    assertTrue(hasFlag);
+  }
+
+  @Test
+  void country_getFlagIconPath_whenResourceExists_expectRelativePath() {
+    // Arrange / Act
+    String path = IPConverter.Country.US.getFlagIconPath();
+
+    // Assert
+    assertEquals("icon/flags/us.png", path);
+  }
+
+  @Test
+  void country_getFlagIconPath_whenResourceMissing_expectNull() {
+    // Arrange / Act
+    String path = IPConverter.Country.ZZ.getFlagIconPath();
+
+    // Assert
+    assertNull(path);
+  }
+
+  @Test
+  void country_renderFlagIcon_whenResourceExists_expectImgChildWithExpectedAttributes() {
+    // Arrange
+    HTMLNode parent = new HTMLNode("div");
+
+    // Act
+    IPConverter.Country.US.renderFlagIcon(parent);
+
+    // Assert
+    assertEquals(1, parent.getChildren().size());
+    HTMLNode img = parent.getChildren().getFirst();
+    assertEquals("img", img.getName());
+    assertEquals("flag", img.getAttribute("class"));
+    assertEquals(IPConverter.Country.US.getName(), img.getAttribute("title"));
+    assertNotNull(img.getAttribute("src"));
+    assertTrue(img.getAttribute("src").endsWith("/icon/flags/us.png"));
+  }
+
+  @Test
+  void country_renderFlagIcon_whenResourceMissing_expectNoChildAdded() {
+    // Arrange
+    HTMLNode parent = new HTMLNode("div");
+
+    // Act
+    IPConverter.Country.ZZ.renderFlagIcon(parent);
+
+    // Assert
+    assertTrue(parent.getChildren().isEmpty());
+  }
+
+  private IPConverter newConverterWithMissingDb() {
+    Path missingDbFile = tempDir.resolve(MISSING_DB_FILE_NAME);
+    return IPConverter.getInstance(missingDbFile.toFile());
+  }
+
+  private static void writeDbFile(Path dbFile, List<DbEntry> entries) throws IOException {
+    List<DbEntry> stableEntries = new ArrayList<>(entries.size() + 1);
+    // IPConverter's binary search never selects index 0, so real databases include an unused
+    // "top" entry. Add a deterministic sentinel so small synthetic tables behave like production.
+    stableEntries.add(new DbEntry("ZZ", 9));
+    stableEntries.addAll(entries);
+    stableEntries.sort((a, b) -> Long.compare(b.ipValue(), a.ipValue()));
+
+    StringBuilder data = new StringBuilder(START_MARKER);
+    for (DbEntry entry : stableEntries) {
+      if (entry.countryCode().length() != 2) {
+        throw new IllegalArgumentException(
+            "countryCode must be exactly 2 chars: " + entry.countryCode());
+      }
+      data.append(entry.countryCode());
+      data.append(encodeBase85SmallValue(entry.ipValue()));
+    }
+    Files.writeString(dbFile, data.toString(), StandardCharsets.ISO_8859_1);
+  }
+
+  private static String encodeBase85SmallValue(long value) {
+    if (value < 0 || value > 9) {
+      throw new IllegalArgumentException(
+          "Test DB only supports base85 encoding for values 0..9: " + value);
+    }
+    // For any base >= 10 (true for IPConverter's alphabet), values 0..9 encode as a single digit.
+    // decodeBase85() interprets "0000X" as X.
+    return "0000" + (char) ('0' + (int) value);
+  }
+
+  private record DbEntry(String countryCode, long ipValue) {}
+
+  private static final String DB_FILE_NAME = "geoip.dat";
+  private static final String MISSING_DB_FILE_NAME = "missing-geoip.dat";
+  private static final String START_MARKER = "##start##";
+
+  private static String ipv4(int octet0, int octet1, int octet2, int octet3) {
+    return octet0 + "." + octet1 + "." + octet2 + "." + octet3;
+  }
+
+  private static String ipv4WithLastOctet(int lastOctet) {
+    return "0.0.0." + lastOctet;
+  }
+
+  private static List<String> invalidIpv4Inputs() {
+    return List.of("", "1.2.3", String.join(".", "1", "2", "3", "4", "5"), "not-an-ip", "1..2.3");
+  }
+
+  private static List<String> invalidLocateIpInputs() {
+    return List.of("not-an-ip", "1.2.3", String.join(".", "1", "2", "3", "4", "5"));
+  }
+}


### PR DESCRIPTION
Summary:
- Adds unit tests for GeoIP cache/table behavior (`CacheTest`) and IP parsing/lookup paths (`IPConverterTest`).
- Expands GeoIP package/class Javadoc and makes `IPConverterParseException` doclint-clean.
- No intended runtime behavior changes; logic changes are formatting/cleanup only.

Tests:
- `./gradlew test --tests '*CacheTest' --tests '*IPConverterTest'`