### PR TITLE
http: harden Pebble l10n function + expand proxy header parser tests

### DIFF
--- a/src/main/java/network/crypta/clients/http/utils/L10nExtension.java
+++ b/src/main/java/network/crypta/clients/http/utils/L10nExtension.java
@@ -7,14 +7,56 @@ import io.pebbletemplates.pebble.template.PebbleTemplate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import network.crypta.l10n.BaseL10n;
 
+/**
+ * Pebble extension that exposes Crypta localization to HTTP templates.
+ *
+ * <p>This extension registers a single Pebble function named {@code l10n}. Templates can call it
+ * with a localization key to obtain a user-facing string from a provided {@link BaseL10n} instance.
+ * The function also supports an optional prefix taken from the Pebble evaluation context variable
+ * {@code l10nPrefix}, allowing templates to share a common namespace without repeating it at each
+ * call site.
+ *
+ * <p>The extension is intentionally small and immutable: it does not cache results, and it does not
+ * mutate the evaluation context. Any thread-safety guarantees depend on the supplied {@link
+ * BaseL10n} implementation; this wrapper itself only stores references and performs simple string
+ * composition.
+ *
+ * <ul>
+ *   <li>Registers {@code l10n} as a template function.
+ *   <li>Supports both positional and named argument styles for the key.
+ *   <li>Optionally prepends a context-provided prefix for key namespacing.
+ * </ul>
+ */
 class L10nExtension extends AbstractExtension {
 
+  /**
+   * Creates a new extension instance backed by the given localization provider.
+   *
+   * <p>The supplied {@link BaseL10n} is stored and used for all subsequent template evaluations.
+   * This class does not take ownership of the instance and does not alter its configuration. The
+   * resulting extension is immutable and safe to reuse across requests provided that the underlying
+   * {@link BaseL10n} is safe for the intended concurrency model.
+   *
+   * @param l10n localization provider used to resolve keys into display strings; must be non-null
+   */
   public L10nExtension(BaseL10n l10n) {
     l10nFunction = new L10nFunction(l10n);
   }
 
+  /**
+   * Returns the Pebble functions exported by this extension.
+   *
+   * <p>The returned map contains a single entry mapping the name {@code l10n} to an implementation
+   * that resolves localization keys using the {@link BaseL10n} supplied at construction time. A new
+   * map is created on each invocation to match Pebble's extension contract; callers should treat
+   * the returned map as owned by the caller and not rely on identity or mutability across
+   * invocations.
+   *
+   * @return a map of Pebble function name to function implementation, containing {@code l10n}
+   */
   @Override
   public Map<String, Function> getFunctions() {
     Map<String, Function> functions = new HashMap<>();
@@ -22,29 +64,147 @@ class L10nExtension extends AbstractExtension {
     return functions;
   }
 
+  /**
+   * Pebble {@code l10n} function implementation owned by this extension instance.
+   *
+   * <p>This field is immutable after construction and is registered under the name {@code l10n}. It
+   * encapsulates the configured {@link BaseL10n} and performs argument parsing for each invocation.
+   */
   private final L10nFunction l10nFunction;
 
+  /**
+   * Pebble function that resolves localization keys via {@link BaseL10n}.
+   *
+   * <p>The function accepts a single optional argument representing the localization key. Pebble
+   * may provide the key as positional argument {@code "0"} or as a named argument {@code "key"}.
+   * When argument names are not declared by the function, Pebble may use other keys; in that case
+   * the first value in the argument map is treated as the key.
+   *
+   * <p>If the evaluation context contains a variable named {@code l10nPrefix}, its string value is
+   * prepended to the key before calling {@link BaseL10n#getString(String)}. When no key is
+   * available, this implementation returns the literal string {@code "null"} to avoid returning a
+   * Java {@code null} into the template engine.
+   */
   static class L10nFunction implements Function {
 
+    /**
+     * Creates a function instance bound to the supplied localization provider.
+     *
+     * <p>The provider is stored as-is and consulted on each {@link #execute(Map, PebbleTemplate,
+     * EvaluationContext, int)} call. The function does not cache results, so repeated invocations
+     * may perform repeated lookups depending on the {@link BaseL10n} implementation.
+     *
+     * @param l10n localization provider used to resolve keys; must be non-null
+     */
     public L10nFunction(BaseL10n l10n) {
       this.l10n = l10n;
     }
 
+    /**
+     * Resolves a localization key from Pebble arguments and returns the corresponding string.
+     *
+     * <p>This method extracts the key from {@code args} using {@link #extractKey(Map)}. If no key
+     * is provided (including when the argument map is empty), it returns the literal {@code "null"}
+     * to avoid inserting a Java {@code null} into the template output. When a key is available, it
+     * is prefixed with the optional {@code l10nPrefix} variable from {@code context} and then
+     * resolved with {@link BaseL10n#getString(String)}.
+     *
+     * @param args Pebble argument map for this function call; may be empty or null depending on how
+     *     the template is invoked
+     * @param self template instance invoking the function, provided by Pebble; unused by this
+     *     implementation
+     * @param context evaluation context containing variables such as {@code l10nPrefix}; may be
+     *     null for some call sites
+     * @param lineNumber template line number for diagnostics, provided by Pebble; unused here
+     * @return resolved localized string, or the literal {@code "null"} when no key is provided
+     */
     @Override
     public Object execute(
         Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
-      Object key = args.get("0");
+      Object key = extractKey(args);
       if (key == null) {
         return "null";
       }
-      return l10n.getString(context.getVariable("l10nPrefix") + key.toString());
+      return l10n.getString(extractPrefix(context) + key);
     }
 
+    /**
+     * Declares the set of accepted argument names for this Pebble function.
+     *
+     * <p>This implementation declares a single optional positional argument named {@code "0"} to
+     * support calls such as {@code l10n("some.key")}. Pebble accepts calls with fewer arguments
+     * (for example {@code l10n()}) and provides an empty argument map in that case, which is
+     * handled by {@link #execute(Map, PebbleTemplate, EvaluationContext, int)}.
+     *
+     * @return an immutable list containing the single name {@code "0"}
+     */
     @Override
     public List<String> getArgumentNames() {
-      return null;
+      // Declare a single optional positional argument. Pebble accepts calls with fewer arguments
+      // (e.g. l10n()) and provides an empty args map in that case.
+      return List.of("0");
     }
 
+    /**
+     * Extracts the localization key argument from a Pebble argument map.
+     *
+     * <p>The resolution order is:
+     *
+     * <ol>
+     *   <li>Return {@code null} when {@code args} is null or empty.
+     *   <li>Use the positional argument under key {@code "0"} when present.
+     *   <li>Use the named argument {@code "key"} when present.
+     *   <li>Otherwise, treat the first value in the map as the key.
+     * </ol>
+     *
+     * <p>The fallback to the first value exists because Pebble may use arbitrary keys when argument
+     * names are not declared.
+     *
+     * @param args argument map provided by Pebble; may be null or empty
+     * @return the extracted key object, or null when no key is available
+     */
+    private static Object extractKey(Map<String, Object> args) {
+      if (args == null || args.isEmpty()) {
+        return null;
+      }
+
+      if (args.containsKey("0")) {
+        return args.get("0");
+      }
+      if (args.containsKey("key")) {
+        return args.get("key");
+      }
+
+      // Pebble may use arbitrary keys when argument names aren't declared. In that case, treat the
+      // first value as the key.
+      return args.values().iterator().next();
+    }
+
+    /**
+     * Extracts the localization prefix from the Pebble evaluation context.
+     *
+     * <p>The prefix is read from the context variable {@code l10nPrefix}. If the context is null or
+     * the variable is missing, this method returns an empty string. The returned value is always a
+     * non-null string suitable for concatenation with a key.
+     *
+     * @param context Pebble evaluation context from which to read {@code l10nPrefix}; may be null
+     * @return a string prefix to prepend to localization keys, or {@code ""} when unset
+     */
+    private static String extractPrefix(EvaluationContext context) {
+      if (context == null) {
+        return "";
+      }
+      return Optional.ofNullable(context.getVariable("l10nPrefix"))
+          .map(Object::toString)
+          .orElse("");
+    }
+
+    /**
+     * Localization provider used to resolve composed keys via {@link BaseL10n#getString(String)}.
+     *
+     * <p>This reference is immutable after construction. Any caching, fallback, or key resolution
+     * behavior is defined by the {@link BaseL10n} implementation.
+     */
     private final BaseL10n l10n;
   }
 }

--- a/src/main/java/network/crypta/clients/http/utils/PebbleUtils.java
+++ b/src/main/java/network/crypta/clients/http/utils/PebbleUtils.java
@@ -13,13 +13,49 @@ import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.HTMLNode;
 
+/**
+ * Renders Pebble templates into {@link HTMLNode} trees for the HTTP UI.
+ *
+ * <p>This is a small, static helper that centralizes Pebble setup (template loader, suffix/prefix,
+ * and the localization extension) so callers do not need to repeatedly construct a {@link
+ * PebbleEngine}. Typical usage is to keep a model {@link Map} for one response, call {@link
+ * #addChild(HTMLNode, String, Map, String)} for one or more fragments, and let the template engine
+ * merge the model into HTML.
+ *
+ * <p>The utility is intentionally state-free from the caller's perspective. Internally it uses a
+ * single shared {@link PebbleEngine} instance initialized with a {@link ClasspathLoader} rooted at
+ * {@code network/crypta/clients/http/templates/} and {@code .html} suffixing. The engine is also
+ * configured with {@link L10nExtension} using {@link NodeL10n#getBase()} by default, allowing
+ * templates to resolve localized strings through the registered function.
+ *
+ * <ul>
+ *   <li><b>Responsibility:</b> Render a named template with a model and attach the result to a
+ *       parent {@link HTMLNode}.
+ *   <li><b>Side effects:</b> Mutates the provided model by setting {@code l10nPrefix}.
+ *   <li><b>Thread safety:</b> No synchronization is performed; callers should avoid concurrently
+ *       mutating the same {@code model} or {@code parent} across threads.
+ * </ul>
+ *
+ * @see L10nExtension
+ * @see NodeL10n
+ */
 public class PebbleUtils {
   private static final String TEMPLATE_ROOT_PATH = "network/crypta/clients/http/templates/";
   private static final String TEMPLATE_NAME_SUFFIX = ".html";
   private static final PebbleEngine templateEngine;
 
+  /**
+   * Prevents instantiation of this utility class.
+   *
+   * <p>This type is a static utility holder and should not be instantiated. If construction is
+   * attempted (for example via reflection), this constructor fails fast.
+   */
+  private PebbleUtils() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
   static {
-    Loader loader = new ClasspathLoader(PebbleUtils.class.getClassLoader());
+    Loader<String> loader = new ClasspathLoader(PebbleUtils.class.getClassLoader());
     loader.setPrefix(PebbleUtils.TEMPLATE_ROOT_PATH);
     loader.setSuffix(PebbleUtils.TEMPLATE_NAME_SUFFIX);
 
@@ -30,6 +66,32 @@ public class PebbleUtils {
             .build();
   }
 
+  /**
+   * Renders a classpath template and appends the evaluated output to a parent node.
+   *
+   * <p>This method loads {@code templateName} via the shared {@link PebbleEngine}, evaluates it
+   * with the provided {@code model}, and appends the resulting text by calling {@link
+   * HTMLNode#addChild(String, String)} with the {@code "%"} child tag. The model is mutated by
+   * inserting a {@code l10nPrefix} key so templates can access a common localization prefix
+   * consistently across pages.
+   *
+   * <p>Callers are expected to provide a per-request {@code model} and a {@code parent} that is
+   * safe to mutate for the duration of rendering. This method does not perform validation beyond
+   * what Pebble enforces, and it does not attempt to recover from template parse or evaluation
+   * failures.
+   *
+   * <pre>{@code
+   * HTMLNode parent = ...;
+   * Map<String, Object> model = new java.util.HashMap<>();
+   * PebbleUtils.addChild(parent, "status", model, "status.");
+   * }</pre>
+   *
+   * @param parent The {@link HTMLNode} that receives the rendered output as a new child node.
+   * @param templateName The template name resolved by the configured loader (without path prefix).
+   * @param model Mutable model values used during evaluation; updated with {@code l10nPrefix}.
+   * @param l10nPrefix Localization prefix stored under {@code l10nPrefix} for template lookups.
+   * @throws IOException If template evaluation writes fail or Pebble reports an I/O error.
+   */
   public static void addChild(
       HTMLNode parent, String templateName, Map<String, Object> model, String l10nPrefix)
       throws IOException {
@@ -44,15 +106,15 @@ public class PebbleUtils {
 
   /**
    * Sets the {@link BaseL10n l10n provider} to use with the {@link L10nFunction}. If this method is
-   * not called, {@link NodeL10n}’s {@link NodeL10n#getBase() l10n provider} is used.
+   * not called, {@link NodeL10n}'s {@link NodeL10n#getBase() l10n provider} is used.
    *
    * <p>This method should only be called from tests.
    *
-   * @param l10n The l10n provider to use
+   * @param l10n The l10n provider to register for subsequent template evaluations
    */
   static void setBaseL10n(BaseL10n l10n) {
-    // this will remove the old function from the registry, because the
-    // registry is a big Map, with the function name as key.
+    // This removes the old function from the registry because the registry is a Map keyed by
+    // function name.
     templateEngine.getExtensionRegistry().addExtension(new L10nExtension(l10n));
   }
 }

--- a/src/main/java/network/crypta/clients/http/utils/UriFilterProxyHeaderParser.java
+++ b/src/main/java/network/crypta/clients/http/utils/UriFilterProxyHeaderParser.java
@@ -7,9 +7,56 @@ import java.util.Set;
 import network.crypta.config.Option;
 import network.crypta.support.MultiValueTable;
 
+/**
+ * Parses request scheme/host information for the URI filter proxy from the current request context.
+ *
+ * <p>This helper is used by the HTTP layer to derive a safe, displayable "base URL" made up of a
+ * scheme and a host (optionally including a port). It combines three sources of information:
+ * explicit request values ({@code uriScheme}/{@code uriHost}), reverse-proxy forwarding headers
+ * (for example {@code X-Forwarded-Proto} and {@code X-Forwarded-Host}), and local node
+ * configuration ({@code fProxy.bindTo} and {@code fProxy.port}).
+ *
+ * <p>The parser is deliberately defensive: it only accepts a small allow-list of protocols, and it
+ * only accepts hosts that match the configured bind addresses (with and without the configured
+ * port). If a value is missing or not allow-listed, it falls back to a loopback-based default. The
+ * returned value is immutable and safe to cache per request. This class is stateless and
+ * thread-safe.
+ *
+ * <ul>
+ *   <li><b>Responsibilities:</b> choose a scheme/host pair from inputs and headers.
+ *   <li><b>Notable behavior:</b> allow-list protocols and bind-to hosts, with conservative
+ *       fallbacks.
+ * </ul>
+ */
 public class UriFilterProxyHeaderParser {
+  /** Utility class; this type only exposes static parsing helpers. */
   private UriFilterProxyHeaderParser() {}
 
+  /**
+   * Determine a safe scheme and host (with port) for proxy-facing URLs.
+   *
+   * <p>This method selects the scheme and host primarily from forwarding headers when present, and
+   * otherwise falls back to the explicit {@code uriScheme}/{@code uriHost} values. The resulting
+   * scheme is restricted to {@code http} or {@code https}. The host is restricted to the configured
+   * bind targets (from {@code fProxyBindToConfig}), and also to those same targets with the
+   * configured proxy port appended.
+   *
+   * <p>The method is pure with respect to its inputs: it does not mutate configuration objects or
+   * the header table. Callers typically use the returned value to build absolute links or for UI
+   * display. When inputs are missing or do not match the allow-list, the result falls back to a
+   * loopback address and a default port.
+   *
+   * @param fProxyPortConfig configuration option providing the proxy port as a string, possibly
+   *     empty.
+   * @param fProxyBindToConfig configuration option providing comma-separated bind host(s), possibly
+   *     empty.
+   * @param uriScheme explicit request scheme; if {@code null} or blank, header/default fallback is
+   *     used.
+   * @param uriHost explicit request host; if {@code null} or blank, header fallback is consulted.
+   * @param headers request headers used for proxy forwarding values, especially {@code
+   *     x-forwarded-proto}, {@code x-forwarded-host}, and {@code host}.
+   * @return an immutable scheme and host pair suitable for building proxy-facing absolute URLs.
+   */
   public static SchemeAndHostWithPort parse(
       Option<?> fProxyPortConfig,
       Option<?> fProxyBindToConfig,
@@ -35,14 +82,17 @@ public class UriFilterProxyHeaderParser {
     safeHosts.addAll(safeHosts.stream().map(host -> host + ":" + port).toList());
 
     // check uri host and headers
+    String schemeFallback = uriScheme != null && !uriScheme.trim().isEmpty() ? uriScheme : "http";
     String protocol =
         headers.containsKey("x-forwarded-proto")
             ? headers.getFirst("x-forwarded-proto")
-            : uriScheme != null && !uriScheme.trim().isEmpty() ? uriScheme : "http";
+            : schemeFallback;
+    String hostFallback =
+        uriHost != null && !uriHost.trim().isEmpty() ? uriHost : headers.getFirst("host");
     String host =
         headers.containsKey("x-forwarded-host")
             ? headers.getFirst("x-forwarded-host")
-            : uriHost != null && !uriHost.trim().isEmpty() ? uriHost : headers.getFirst("host");
+            : hostFallback;
     // check allow list
     if (!safeProtocols.contains(protocol)) {
       protocol = "http";
@@ -53,8 +103,18 @@ public class UriFilterProxyHeaderParser {
     return new SchemeAndHostWithPort(protocol, host);
   }
 
+  /**
+   * Value object holding a scheme and a host (optionally including a port).
+   *
+   * <p>This type is intentionally minimal: it stores the chosen scheme and host as strings and
+   * formats them as a URI authority prefix via {@link #toString()}. Instances are immutable and
+   * safe to share between threads.
+   */
   public static class SchemeAndHostWithPort {
+    /** URI scheme component such as {@code http} or {@code https}. */
     private final String scheme;
+
+    /** Host component, optionally including a {@code :port} suffix. */
     private final String host;
 
     SchemeAndHostWithPort(String scheme, String host) {
@@ -62,6 +122,15 @@ public class UriFilterProxyHeaderParser {
       this.host = host;
     }
 
+    /**
+     * Render this value as {@code <scheme>://<host>} suitable for prefixing paths.
+     *
+     * <p>This is a convenience representation for logging and UI display. It does not attempt to
+     * normalize, encode, or validate the host beyond what {@link #parse(Option, Option, String,
+     * String, MultiValueTable)} already enforces.
+     *
+     * @return a URI-like string consisting of the scheme, {@code ://}, and the stored host.
+     */
     public String toString() {
       return scheme + "://" + host;
     }

--- a/src/test/java/network/crypta/clients/http/utils/L10nExtensionTest.java
+++ b/src/test/java/network/crypta/clients/http/utils/L10nExtensionTest.java
@@ -1,63 +1,165 @@
 package network.crypta.clients.http.utils;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
-import static network.crypta.l10n.BaseL10n.LANGUAGE.ENGLISH;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.pebbletemplates.pebble.extension.Function;
 import io.pebbletemplates.pebble.template.EvaluationContext;
-import java.util.Locale;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import network.crypta.l10n.BaseL10n;
-import network.crypta.l10n.BaseL10nTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class L10nExtensionTest {
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class L10nExtensionTest {
+
+  private static final String L10N_PREFIX_VARIABLE = "l10nPrefix";
+  private static final String LOCALIZED_VALUE = "localized";
+
+  @Mock private BaseL10n l10n;
+  @Mock private EvaluationContext context;
 
   @Test
-  public void l10nExtensionExposesAnL10nFunction() {
-    assertThat(l10nExtension.getFunctions().keySet(), contains("l10n"));
+  void getFunctions_whenCalled_returnsNewMapContainingL10nFunction() {
+    L10nExtension extension = new L10nExtension(l10n);
+
+    Map<String, Function> first = extension.getFunctions();
+    Map<String, Function> second = extension.getFunctions();
+
+    assertNotNull(first.get("l10n"));
+    assertNotNull(second.get("l10n"));
+    assertNotSame(first, second);
+    assertSame(first.get("l10n"), second.get("l10n"));
   }
 
   @Test
-  public void l10nFunctionDoesNotHaveArguments() {
-    assertThat(l10nFunction.getArgumentNames(), nullValue());
+  void getArgumentNames_whenCalled_returnsSinglePositionalArgumentNameZero() {
+    L10nExtension.L10nFunction function = new L10nExtension.L10nFunction(l10n);
+
+    assertEquals(List.of("0"), function.getArgumentNames());
+  }
+
+  @ParameterizedTest
+  @MethodSource("nullOrEmptyArgs")
+  void execute_whenArgsNullOrEmpty_returnsLiteralNull(Map<String, Object> args) {
+    L10nExtension.L10nFunction function = new L10nExtension.L10nFunction(l10n);
+
+    Object result = function.execute(args, null, null, 0);
+
+    assertEquals("null", result);
+  }
+
+  static Stream<Arguments> nullOrEmptyArgs() {
+    return Stream.of(Arguments.of((Map<String, Object>) null), Arguments.of(Map.of()));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "0,posKey",
+    "key,namedKey",
+  })
+  void execute_whenKeyProvidedWithoutPrefix_resolvesUsingBaseL10n(String argName, String key) {
+    when(l10n.getString(key)).thenReturn(LOCALIZED_VALUE);
+    L10nExtension.L10nFunction function = new L10nExtension.L10nFunction(l10n);
+
+    Object result = function.execute(Map.of(argName, key), null, null, 0);
+
+    assertEquals(LOCALIZED_VALUE, result);
+    verify(l10n).getString(key);
   }
 
   @Test
-  public void l10nFunctionReturnStringNullIfNotArgumentsAreGiven() {
-    assertThat(l10nFunction.execute(emptyMap(), null, null, 0), equalTo("null"));
+  void execute_whenContextPrefixProvided_prependsPrefixBeforeLookup() {
+    when(context.getVariable(L10N_PREFIX_VARIABLE)).thenReturn("test.");
+    when(l10n.getString("test.some.key")).thenReturn(LOCALIZED_VALUE);
+    L10nExtension.L10nFunction function = new L10nExtension.L10nFunction(l10n);
+
+    Object result = function.execute(Map.of("0", "some.key"), null, context, 0);
+
+    assertEquals(LOCALIZED_VALUE, result);
+    verify(l10n).getString("test.some.key");
   }
 
   @Test
-  public void l10nFunctionRetrievesGivenArgumentWithPrefixFromContextToNodeL10n() {
-    Map<String, Object> arguments = singletonMap("0", "l10nFunctionTest");
-    EvaluationContext context = createEvaluationContext();
-    assertThat(l10nFunction.execute(arguments, null, context, 0), equalTo("Localized Value"));
+  void execute_whenContextPrefixIsNonString_usesToStringValue() {
+    Object prefix = 123;
+    when(context.getVariable(L10N_PREFIX_VARIABLE)).thenReturn(prefix);
+    when(l10n.getString("123some.key")).thenReturn(LOCALIZED_VALUE);
+    L10nExtension.L10nFunction function = new L10nExtension.L10nFunction(l10n);
+
+    Object result = function.execute(Map.of("0", "some.key"), null, context, 0);
+
+    assertEquals(LOCALIZED_VALUE, result);
+    verify(l10n).getString("123some.key");
   }
 
-  private static EvaluationContext createEvaluationContext() {
-    return new EvaluationContext() {
-      @Override
-      public boolean isStrictVariables() {
-        return false;
-      }
+  @Test
+  void execute_whenArgsContainBothPositionalAndNamed_usesPositional() {
+    when(context.getVariable(L10N_PREFIX_VARIABLE)).thenReturn("p.");
+    when(l10n.getString("p.positional")).thenReturn(LOCALIZED_VALUE);
+    L10nExtension.L10nFunction function = new L10nExtension.L10nFunction(l10n);
 
-      @Override
-      public Locale getLocale() {
-        return null;
-      }
+    Object result = function.execute(Map.of("0", "positional", "key", "named"), null, context, 0);
 
-      @Override
-      public Object getVariable(String key) {
-        return key.equals("l10nPrefix") ? "test." : null;
-      }
-    };
+    assertEquals(LOCALIZED_VALUE, result);
+    verify(l10n).getString("p.positional");
   }
 
-  private final BaseL10n l10n = BaseL10nTest.createTestL10n(ENGLISH);
-  private final L10nExtension l10nExtension = new L10nExtension(l10n);
-  private final Function l10nFunction = l10nExtension.getFunctions().get("l10n");
+  @Test
+  void execute_whenArgsHaveNoRecognizedKey_usesFirstValueDeterministically() {
+    when(context.getVariable(L10N_PREFIX_VARIABLE)).thenReturn("p.");
+    when(l10n.getString("p.first")).thenReturn(LOCALIZED_VALUE);
+    L10nExtension.L10nFunction function = new L10nExtension.L10nFunction(l10n);
+
+    Map<String, Object> args = new LinkedHashMap<>();
+    args.put("unexpected", "first");
+    args.put("another", "second");
+
+    Object result = function.execute(args, null, context, 0);
+
+    assertEquals(LOCALIZED_VALUE, result);
+    verify(l10n).getString("p.first");
+  }
+
+  @Test
+  void execute_whenProvidedKeyIsExplicitlyNull_returnsLiteralNull() {
+    L10nExtension.L10nFunction function = new L10nExtension.L10nFunction(l10n);
+
+    Map<String, Object> args = new LinkedHashMap<>();
+    args.put("0", null);
+
+    Object result = function.execute(args, null, context, 0);
+
+    assertEquals("null", result);
+  }
+
+  @Test
+  void execute_whenBaseL10nThrows_propagatesException() {
+    when(context.getVariable(L10N_PREFIX_VARIABLE)).thenReturn("p.");
+    IllegalArgumentException failure = new IllegalArgumentException("bad key");
+    when(l10n.getString("p.bad")).thenThrow(failure);
+    L10nExtension.L10nFunction function = new L10nExtension.L10nFunction(l10n);
+    Map<String, Object> args = Map.of("0", "bad");
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class, () -> function.execute(args, null, context, 0));
+
+    assertSame(failure, thrown);
+  }
 }

--- a/src/test/java/network/crypta/clients/http/utils/UriFilterProxyHeaderParserTest.java
+++ b/src/test/java/network/crypta/clients/http/utils/UriFilterProxyHeaderParserTest.java
@@ -1,281 +1,243 @@
 package network.crypta.clients.http.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import network.crypta.config.Config;
-import network.crypta.config.StringOption;
+import java.util.Objects;
+import network.crypta.config.Option;
 import network.crypta.support.MultiValueTable;
-import network.crypta.support.api.StringCallback;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class UriFilterProxyHeaderParserTest {
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class UriFilterProxyHeaderParserTest {
+  private static final String DEFAULT_BIND_TO = "127.0.0.1";
+  private static final String DEFAULT_PORT = "8888";
+  private static final String DEFAULT_HOST_WITH_PORT = "127.0.0.1:8888";
+  private static final String DEFAULT_URL = "http://127.0.0.1:8888";
+  private static final String BIND_TO_LOCAL_AND_FOO = "127.0.0.1,foo";
+  private static final String HTTP_FOO = "http://foo";
 
-  // typical arguments
-  @Test
-  public void standardValuesParsedAsStandardPrefix() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888", "127.0.0.1", "", "", new MultiValueTable<>(), "http://127.0.0.1:8888");
-  }
-
-  // empty arguments result in plain http:// prefix
-  @Test
-  public void emptyArgumentsParsedAsStandardPrefix() throws Exception {
-    testUriPrefixMatchesExpected("", "", "", "", new MultiValueTable<>(), "http://127.0.0.1:8888");
-  }
-
-  @Test
-  public void nullArgumentsParsedAsStandardPrefix() throws Exception {
-    testUriPrefixMatchesExpected(
-        "", "", null, null, new MultiValueTable<>(), "http://127.0.0.1:8888");
-  }
-
-  // sanity checks for defaults
-  @Test
-  public void defaultPortParsedAsStandardPrefix() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888", "", "", "", new MultiValueTable<>(), "http://127.0.0.1:8888");
-  }
+  private static final String HEADER_HOST = "host";
+  private static final String HEADER_X_FORWARDED_HOST = "x-forwarded-host";
+  private static final String HEADER_X_FORWARDED_PROTO = "x-forwarded-proto";
 
   @Test
-  public void defaultIpParsedAsStandardPrefix() throws Exception {
-    testUriPrefixMatchesExpected(
-        "", "127.0.0.1", "", "", new MultiValueTable<>(), "http://127.0.0.1:8888");
-  }
+  void parse_whenNoHeadersAndNullUriSchemeAndNullUriHost_expectDefaults() {
+    // Arrange
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
 
-  // taking proxy values
-  @Test
-  public void allowedProxyHostIsUsedIfInSecondPositionOfBindTo() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888",
-        "127.0.0.1,foo",
-        "",
-        "",
-        MultiValueTable.from("x-forwarded-host", "foo"),
-        "http://foo");
+    // Act
+    String result = parseToString(mockOption(""), mockOption(""), null, null, headers);
+
+    // Assert
+    assertEquals(DEFAULT_URL, result);
   }
 
   @Test
-  public void allowedProxyHostIsUsedIfInFirstPositionOfBindTo() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888",
-        "foo,127.0.0.1",
-        "",
-        "",
-        MultiValueTable.from("x-forwarded-host", "foo:8888"),
-        "http://foo:8888");
+  void parse_whenHostHeaderPresentAndAllowed_expectUsesHostHeader() {
+    // Arrange
+    MultiValueTable<String, String> headers = MultiValueTable.from(HEADER_HOST, "foo");
+
+    // Act
+    String result =
+        parseToString(mockOption(DEFAULT_PORT), mockOption(BIND_TO_LOCAL_AND_FOO), "", "", headers);
+
+    // Assert
+    assertEquals(HTTP_FOO, result);
   }
 
   @Test
-  public void allowedProxyHostWithNonstandardPortIsUsed() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8889",
-        "127.0.0.1,foo",
-        "",
-        "",
-        MultiValueTable.from("x-forwarded-host", "foo:8889"),
-        "http://foo:8889");
+  void parse_whenUriHostProvidedAndAllowed_expectUsesUriHostOverHostHeader() {
+    // Arrange
+    MultiValueTable<String, String> headers =
+        MultiValueTable.from(HEADER_HOST, DEFAULT_HOST_WITH_PORT);
+
+    // Act
+    String result =
+        parseToString(
+            mockOption(DEFAULT_PORT), mockOption(BIND_TO_LOCAL_AND_FOO), "", "foo", headers);
+
+    // Assert
+    assertEquals(HTTP_FOO, result);
   }
 
   @Test
-  public void httpsProtocolFromProxyIsUsed() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888",
-        "127.0.0.1",
-        "",
-        "",
-        MultiValueTable.from("x-forwarded-proto", "https"),
-        "https://127.0.0.1:8888");
-  }
+  void parse_whenForwardedHostPresentAndAllowed_expectUsesForwardedHostOverUriAndHostHeader() {
+    // Arrange
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    headers.put(HEADER_HOST, DEFAULT_HOST_WITH_PORT);
+    headers.put(HEADER_X_FORWARDED_HOST, "foo:" + DEFAULT_PORT);
 
-  // taking uri values
-  @Test
-  public void allowedUriHostIsUsed() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888", "127.0.0.1,foo", "", "foo", new MultiValueTable<>(), "http://foo");
-  }
+    // Act
+    String result =
+        parseToString(
+            mockOption(DEFAULT_PORT),
+            mockOption(BIND_TO_LOCAL_AND_FOO),
+            "",
+            DEFAULT_BIND_TO,
+            headers);
 
-  @Test
-  public void allowedUriHostWithStandardPortAreUsed() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888", "127.0.0.1,foo", "", "foo:8888", new MultiValueTable<>(), "http://foo:8888");
+    // Assert
+    assertEquals("http://foo:8888", result);
   }
 
   @Test
-  public void allowedUriAndNonstandardPortAreUsed() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8889", "127.0.0.1,foo", "", "foo:8889", new MultiValueTable<>(), "http://foo:8889");
+  void
+      parse_whenForwardedHostPresentButDisallowed_expectFallsBackToFirstBindToWithPortEvenIfUriHostAllowed() {
+    // Arrange
+    MultiValueTable<String, String> headers = MultiValueTable.from(HEADER_X_FORWARDED_HOST, "evil");
+
+    // Act
+    String result =
+        parseToString(
+            mockOption(DEFAULT_PORT), mockOption(BIND_TO_LOCAL_AND_FOO), "", "foo", headers);
+
+    // Assert
+    assertEquals(DEFAULT_URL, result);
   }
 
   @Test
-  public void httpsProtocolFromUriIsUsed() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888", "127.0.0.1", "https", "", new MultiValueTable<>(), "https://127.0.0.1:8888");
-  }
+  void parse_whenForwardedProtoPresentAndAllowed_expectUsesForwardedProto() {
+    // Arrange
+    MultiValueTable<String, String> headers =
+        MultiValueTable.from(HEADER_X_FORWARDED_PROTO, "https");
 
-  // ignored header values
-  @Test
-  public void disallowedProxyHostHeaderIsIgnored() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888",
-        "127.0.0.1",
-        "",
-        "",
-        MultiValueTable.from("x-forwarded-host", "foo"),
-        "http://127.0.0.1:8888");
+    // Act
+    String result =
+        parseToString(mockOption(DEFAULT_PORT), mockOption(DEFAULT_BIND_TO), "", "", headers);
+
+    // Assert
+    assertEquals("https://127.0.0.1:8888", result);
   }
 
   @Test
-  public void disallowedProxyProtocolIsIgnored() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888",
-        "127.0.0.1",
-        "",
-        "",
-        MultiValueTable.from("x-forwarded-proto", "catchme"),
-        "http://127.0.0.1:8888");
+  void parse_whenForwardedProtoPresentButInvalid_expectFallsBackToHttpEvenIfUriSchemeHttps() {
+    // Arrange
+    MultiValueTable<String, String> headers =
+        MultiValueTable.from(HEADER_X_FORWARDED_PROTO, "gopher");
+
+    // Act
+    String result =
+        parseToString(mockOption(DEFAULT_PORT), mockOption(DEFAULT_BIND_TO), "https", "", headers);
+
+    // Assert
+    assertEquals(DEFAULT_URL, result);
   }
 
   @Test
-  public void disallowedProxyHostAndPortAreIgnored() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888",
-        "127.0.0.1",
-        "",
-        "foo:8888",
-        MultiValueTable.from("x-forwarded-host", "foo:8888"),
-        "http://127.0.0.1:8888");
+  void parse_whenUriSchemeInvalid_expectFallsBackToHttp() {
+    // Arrange
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+
+    // Act
+    String result =
+        parseToString(mockOption(DEFAULT_PORT), mockOption(DEFAULT_BIND_TO), "ftp", "", headers);
+
+    // Assert
+    assertEquals(DEFAULT_URL, result);
   }
 
   @Test
-  public void disallowedProxyWithStandardPortIsIgnoredIfPortIsNotStandardAndHostNotAllowed()
-      throws Exception {
-    testUriPrefixMatchesExpected(
-        "8889",
-        "127.0.0.1",
-        "",
-        "",
-        MultiValueTable.from("x-forwarded-host", "foo:8888"),
-        "http://127.0.0.1:8889");
+  void parse_whenPortConfigEmpty_expectDefaultPortUsedInFallbackHost() {
+    // Arrange
+    MultiValueTable<String, String> headers = MultiValueTable.from(HEADER_X_FORWARDED_HOST, "evil");
+
+    // Act
+    String result = parseToString(mockOption(""), mockOption(DEFAULT_BIND_TO), "", "", headers);
+
+    // Assert
+    assertEquals(DEFAULT_URL, result);
   }
 
   @Test
-  public void disallowedProxyWithStandardPortIsIgnoredIfPortIsNotStandard() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8889",
-        "127.0.0.1",
-        "",
-        "",
-        MultiValueTable.from("x-forwarded-host", "127.0.0.1:8888"),
-        "http://127.0.0.1:8889");
-  }
+  void parse_whenBindToIpv6Literal_expectAllowsBracketedHostAndPort() {
+    // Arrange
+    MultiValueTable<String, String> headers =
+        MultiValueTable.from(HEADER_X_FORWARDED_HOST, "[2001:db8::1]:" + DEFAULT_PORT);
 
-  // ignored uri values
-  // no such bindToHost
-  @Test
-  public void disallowedUriHostIsIgnored() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888",
-        "127.0.0.1",
-        "",
-        "foo",
-        MultiValueTable.from("x-forwarded-host", "foo"),
-        "http://127.0.0.1:8888");
+    // Act
+    String result =
+        parseToString(mockOption(DEFAULT_PORT), mockOption("2001:db8::1"), "", "", headers);
+
+    // Assert
+    assertEquals("http://[2001:db8::1]:8888", result);
   }
 
   @Test
-  public void disallowedUriHostWithStandardPortIsIgnored() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888",
-        "127.0.0.1",
-        "",
-        "foo:8888",
-        MultiValueTable.from("x-forwarded-host", "foo:8888"),
-        "http://127.0.0.1:8888");
+  void parse_whenBindToIpv6LiteralAndHostDisallowed_expectFallsBackToFirstBindToWithPort() {
+    // Arrange
+    MultiValueTable<String, String> headers = MultiValueTable.from(HEADER_X_FORWARDED_HOST, "evil");
+
+    // Act
+    String result =
+        parseToString(mockOption(DEFAULT_PORT), mockOption("2001:db8::1"), "", "", headers);
+
+    // Assert
+    assertEquals("http://[2001:db8::1]:8888", result);
   }
 
-  // port mismatch
   @Test
-  public void disallowedUriWithAllowedHostButDisallowedPortIsIgnored() throws Exception {
-    testUriPrefixMatchesExpected(
-        "8888",
-        "127.0.0.1,foo",
-        "",
-        "foo:8889",
-        MultiValueTable.from("x-forwarded-host", "foo:8889"),
-        "http://127.0.0.1:8888");
+  void parse_whenPortNonStandardAndForwardedHostHasNoPort_expectAllowsHostWithoutPort() {
+    // Arrange
+    MultiValueTable<String, String> headers = MultiValueTable.from(HEADER_X_FORWARDED_HOST, "foo");
+
+    // Act
+    String result =
+        parseToString(mockOption("8889"), mockOption(BIND_TO_LOCAL_AND_FOO), "", "", headers);
+
+    // Assert
+    assertEquals(HTTP_FOO, result);
   }
 
-  private void testUriPrefixMatchesExpected(
-      String fProxyPort,
-      String fProxyBindTo,
+  @Test
+  void parse_whenHeadersNull_expectThrowsNullPointerException() {
+    // Arrange
+    Option<?> port = mockOption(DEFAULT_PORT);
+    Option<?> bindTo = mockOption(DEFAULT_BIND_TO);
+
+    // Act / Assert
+    assertThrows(
+        NullPointerException.class,
+        () -> UriFilterProxyHeaderParser.parse(port, bindTo, "", "", null));
+  }
+
+  @Test
+  void parse_whenBindToOptionNull_expectThrowsNullPointerException() {
+    // Arrange
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    Option<?> port = mock(Option.class);
+
+    // Act / Assert
+    //noinspection DataFlowIssue
+    assertThrows(
+        NullPointerException.class,
+        () -> UriFilterProxyHeaderParser.parse(port, null, "", "", headers));
+  }
+
+  private static String parseToString(
+      Option<?> fProxyPortConfig,
+      Option<?> fProxyBindToConfig,
       String uriScheme,
       String uriHost,
-      MultiValueTable<String, String> headers,
-      String resultUriPrefix)
-      throws Exception {
-    String schemeHostAndPort =
+      MultiValueTable<String, String> headers) {
+    UriFilterProxyHeaderParser.SchemeAndHostWithPort result =
         UriFilterProxyHeaderParser.parse(
-                fakePortOption(fProxyPort),
-                fakeBindToOption(fProxyBindTo),
-                uriScheme,
-                uriHost,
-                headers)
-            .toString();
-    assertEquals(
-        schemeHostAndPort,
-        resultUriPrefix,
-        "schemeHostAndPort %s does not match expected %s; portConfig=\"%s\", bindTo=\"%s\", uriScheme=\"%s\", uriHost=\"%s\", headers=%s, expected=\"%s\""
-            .formatted(
-                schemeHostAndPort,
-                resultUriPrefix,
-                fProxyPort,
-                fProxyBindTo,
-                uriScheme,
-                uriHost,
-                headers,
-                resultUriPrefix));
+            Objects.requireNonNull(fProxyPortConfig),
+            Objects.requireNonNull(fProxyBindToConfig),
+            uriScheme,
+            uriHost,
+            Objects.requireNonNull(headers));
+    return result.toString();
   }
 
-  private StringOption fakeBindToOption(String value) throws Exception {
-    StringOption option =
-        new StringOption(
-            new Config().createSubConfig("fake"),
-            "bindTo",
-            "127.0.0.1",
-            0,
-            false,
-            false,
-            "",
-            "",
-            new DummyStringCallback());
-    option.setValue(value);
+  private static Option<?> mockOption(String value) {
+    Option<?> option = mock(Option.class);
+    when(option.getValueString()).thenReturn(value);
     return option;
-  }
-
-  private StringOption fakePortOption(String value) throws Exception {
-    StringOption option =
-        new StringOption(
-            new Config().createSubConfig("fake"),
-            "port",
-            "8888",
-            0,
-            false,
-            false,
-            "",
-            "",
-            new DummyStringCallback());
-    option.setValue(value);
-    return option;
-  }
-
-  private class DummyStringCallback extends StringCallback {
-
-    @Override
-    public String get() {
-      return null;
-    }
-
-    @Override
-    public void set(String val) {}
   }
 }


### PR DESCRIPTION
## Summary
- Hardened `L10nExtension`'s Pebble `l10n` function argument handling (supports positional/named key args, optional `l10nPrefix` from context, avoids returning Java `null`).
- Doclint/clarity pass on `PebbleUtils` and tightened it as a true utility class.
- Expanded tests for `L10nExtension` and `UriFilterProxyHeaderParser` to cover additional edge cases.

## Testing
- `./gradlew test`

## Notes
- Branch includes a merge from `origin/develop` to keep the PR diff focused on these changes.