### PR TITLE
fix(pluginmanager): add factory creation and tests

### DIFF
--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -3328,7 +3328,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
 
     // Initialize the plugin manager
     LOG.info("Initializing Plugin Manager");
-    pluginManager = new PluginManager(this, lastVersion);
+    pluginManager = PluginManager.create(this, lastVersion);
 
     shutdownHook.addEarlyJob(
         new NativeThread("Shutdown plugins", NativeThread.PriorityLevel.HIGH_PRIORITY.value, true) {

--- a/src/main/java/network/crypta/pluginmanager/PluginManager.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginManager.java
@@ -10,11 +10,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
@@ -47,7 +47,6 @@ import network.crypta.node.RequestStarter;
 import network.crypta.node.useralerts.AbstractUserAlert;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginDescription;
-import network.crypta.pluginmanager.PluginManager.PluginProgress.ProgressState;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.HexUtil;
 import network.crypta.support.JarClassLoader;
@@ -62,8 +61,38 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tanukisoftware.wrapper.WrapperManager;
 
+/**
+ * Coordinates plugin download, loading, and lifecycle management for a {@link Node}.
+ *
+ * <p>This class provides the node-facing API for starting plugins from several kinds of
+ * specifications (official plugin name, Freenet URI, local file, or URL), tracking startup progress
+ * for UI/reporting, and wiring plugins into node services (HTTP handlers, configuration,
+ * localization, update management, and IP detector integrations).
+ *
+ * <p>Typical usage is:
+ *
+ * <ul>
+ *   <li>Create an instance via {@link #create(Node, int)} during node startup.
+ *   <li>Invoke {@link #start()} once configuration is ready; plugin startups are scheduled on the
+ *       node executor.
+ *   <li>On shutdown, call {@link #stop(long)} to request plugin termination and to wait until
+ *       plugins are unloaded or a timeout elapses.
+ * </ul>
+ *
+ * <p><strong>Threading:</strong> plugin operations are driven by the node executor and may involve
+ * callbacks into plugin code. This manager uses internal synchronization for shared state (such as
+ * the loaded plugin set and the HTTP handler registry), but callers should treat it as a
+ * single-owner node component: avoid calling lifecycle methods concurrently and avoid long-running
+ * work while holding locks that interact with other subsystems.
+ */
 public class PluginManager {
   private static final Logger LOG = LoggerFactory.getLogger(PluginManager.class);
+
+  private static final String L10N_PREFIX = "PluginManager.";
+  private static final String HTML_TAG_INPUT = "input";
+  private static final String HTML_ATTR_VALUE = "value";
+  private static final String CALLBACK_TASK_NAME = "Callback";
+  private static final String CALLBACK_THROWABLE_MESSAGE = "Caught Throwable in Callback";
 
   private final HashMap<String, FredPlugin> toadletList = new HashMap<>();
 
@@ -81,13 +110,44 @@ public class PluginManager {
 
   private final SerialExecutor executor;
 
-  private final boolean alwaysLoadOfficialPluginsFromCentralServer = false;
+  /**
+   * Creates and registers the singleton {@link PluginManager} instance for the current JVM.
+   *
+   * <p>The returned instance becomes the global {@code PluginManager} referenced by static helpers
+   * such as {@link #setLanguage(LANGUAGE)}. Callers should therefore prefer using this factory
+   * rather than invoking the constructor directly.
+   *
+   * <p>This method does not start plugins. Call {@link #start()} after construction to schedule
+   * plugin startup work.
+   *
+   * @param node owning node instance whose services and configuration are used by plugins
+   * @param lastVersion node build number used to apply upgrade-time compatibility adjustments
+   * @return the newly created plugin manager instance for {@code node}
+   */
+  public static PluginManager create(Node node, int lastVersion) {
+    PluginManager pluginManager = new PluginManager(node, lastVersion);
+    selfinstance = pluginManager;
+    return pluginManager;
+  }
 
   static final short PRIO = RequestStarter.INTERACTIVE_PRIORITY_CLASS;
 
   /** Is the plugin system enabled? Set at boot time only. Mainly for simulations. */
   private final boolean enabled;
 
+  /**
+   * Creates a plugin manager bound to the given node.
+   *
+   * <p>Construction wires configuration options, initializes the callback executor used for
+   * plugin-invoked operations, and captures the initial list of plugins to start from configuration
+   * (including legacy upgrade adjustments based on {@code lastVersion}).
+   *
+   * <p>This constructor does not start or load any plugin. Use {@link #start()} to schedule startup
+   * on the node executor once the node is ready.
+   *
+   * @param node node that owns this plugin manager and provides access to shared subsystems
+   * @param lastVersion previous node build number used for one-time migration behaviors
+   */
   public PluginManager(Node node, int lastVersion) {
 
     // config
@@ -122,9 +182,8 @@ public class PluginManager {
           }
 
           @Override
-          public void set(Boolean val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
-            if (enabled != val)
+          public synchronized void set(Boolean val) throws NodeNeedRestartException {
+            if (enabled != Boolean.TRUE.equals(val))
               throw new NodeNeedRestartException(l10n("changePluginManagerEnabledInConfig"));
           }
         });
@@ -148,8 +207,6 @@ public class PluginManager {
 
           @Override
           public void set(String[] val) throws InvalidConfigValueException {
-            // if(storeDir.equals(new File(val))) return;
-            // FIXME
             throw new InvalidConfigValueException(
                 NodeL10n.getBase().getString("PluginManager.cannotSetOnceLoaded"));
           }
@@ -165,15 +222,14 @@ public class PluginManager {
     if (lastVersion < 1237 && contains(toStart, "XMLLibrarian") && !contains(toStart, "Library")) {
       toStart = Arrays.copyOf(toStart, toStart.length + 1);
       toStart[toStart.length - 1] = "Library";
-      System.err.println(
-          "Loading Library plugin, replaces XMLLibrarian, when upgrading from pre-1237");
+      LOG.warn("Loading Library plugin, replaces XMLLibrarian, when upgrading from pre-1237");
     }
 
     if (contains(toStart, "KeyExplorer")) {
       for (int i = 0; i < toStart.length; i++) {
         if ("KeyExplorer".equals(toStart[i])) toStart[i] = "KeyUtils";
       }
-      System.err.println("KeyExplorer plugin renamed to KeyUtils");
+      LOG.warn("KeyExplorer plugin renamed to KeyUtils");
     }
 
     // ignore this in config files.
@@ -182,7 +238,6 @@ public class PluginManager {
     pmconfig.finishedInitialization();
 
     fproxyTheme = THEME.themeFromName(node.getConfig().get("fproxy").getString("css"));
-    selfinstance = this;
   }
 
   private boolean contains(String[] array, String string) {
@@ -194,6 +249,16 @@ public class PluginManager {
   private boolean stopping;
   private String[] toStart;
 
+  /**
+   * Starts all plugins configured to load on startup.
+   *
+   * <p>Startup is asynchronous: for each configured plugin entry, a task is scheduled on the node
+   * executor to resolve the specification and load the plugin. After all tasks signal completion,
+   * the manager marks itself as started and clears the startup list.
+   *
+   * <p>This method is idempotent. If the plugin system is disabled or already started, it returns
+   * without scheduling work.
+   */
   public void start() {
     if (!enabled) return;
     synchronized (loadedPlugins) {
@@ -223,50 +288,89 @@ public class PluginManager {
             });
   }
 
+  /**
+   * Stops all loaded (and still-starting) plugins, waiting up to the given time budget.
+   *
+   * <p>This method:
+   *
+   * <ul>
+   *   <li>Marks the manager as stopping to prevent new plugin loads.
+   *   <li>Requests cancellation for plugins that are still in the "starting" phase.
+   *   <li>Initiates shutdown for already loaded plugins and polls for completion until the timeout
+   *       elapses.
+   * </ul>
+   *
+   * <p>If the timeout elapses, the method logs the remaining plugins and returns; it does not throw
+   * an exception.
+   *
+   * @param maxWaitTime maximum time to wait in milliseconds for plugins to unload
+   */
   public void stop(long maxWaitTime) {
     if (!enabled) return;
+    markStopping();
+    killStartingPlugins();
+    startLoadedPluginsShutdown();
+
+    long deadline = System.currentTimeMillis() + maxWaitTime;
+    while (true) {
+      int remainingMillis = (int) (deadline - System.currentTimeMillis());
+      if (remainingMillis <= 0) {
+        logShutdownTimeout();
+        return;
+      }
+
+      finishShutdownIteration(remainingMillis);
+      if (!loadedPlugins.hasLoadedPlugins()) {
+        LOG.info("All plugins unloaded");
+        return;
+      }
+
+      logStillShuttingDown();
+    }
+  }
+
+  private void markStopping() {
     // Stop loading plugins.
     synchronized (loadedPlugins) {
       stopping = true;
     }
+  }
+
+  private void killStartingPlugins() {
     for (PluginProgress progress : loadedPlugins.getStartingPlugins()) {
       progress.kill();
     }
+  }
+
+  private void startLoadedPluginsShutdown() {
     // Stop already loaded plugins.
-    for (PluginInfoWrapper pi : loadedPlugins.getLoadedPlugins()) {
-      pi.startShutdownPlugin(this, false);
+    for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
+      pluginInfoWrapper.startShutdownPlugin(this, false);
     }
-    long now = System.currentTimeMillis();
-    long deadline = now + maxWaitTime;
-    while (true) {
-      int delta = (int) (deadline - now);
-      if (delta <= 0) {
-        String list = "";
-        try {
-          list = pluginList(loadedPlugins.getLoadedPlugins());
-          LOG.error("Plugins still shutting down at timeout:\n" + list);
-          System.err.println("Plugins still shutting down at timeout:\n" + list);
-        } catch (ConcurrentModificationException e) {
-          LOG.error("Error during shutdown: " + e);
-          LOG.error("Plugins still shutting down at timeout:\n" + list);
-        }
-      } else {
-        for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
-          System.out.println(
-              "Waiting for plugin to finish shutting down: " + pluginInfoWrapper.getFilename());
-          if (pluginInfoWrapper.finishShutdownPlugin(this, delta, false)) {
-            loadedPlugins.removeLoadedPlugin(pluginInfoWrapper);
-          }
-        }
-        if (!loadedPlugins.hasLoadedPlugins()) {
-          LOG.info("All plugins unloaded");
-          System.out.println("All plugins unloaded");
-          return;
-        }
-        String list = pluginList(loadedPlugins.getLoadedPlugins());
-        LOG.error("Plugins still shutting down:\n" + list);
-        System.err.println("Plugins still shutting down:\n" + list);
+  }
+
+  private void finishShutdownIteration(int remainingMillis) {
+    for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
+      LOG.info("Waiting for plugin to finish shutting down: {}", pluginInfoWrapper.getFilename());
+      if (pluginInfoWrapper.finishShutdownPlugin(this, remainingMillis, false)) {
+        loadedPlugins.removeLoadedPlugin(pluginInfoWrapper);
       }
+    }
+  }
+
+  private void logStillShuttingDown() {
+    String list = pluginList(loadedPlugins.getLoadedPlugins());
+    LOG.error("Plugins still shutting down:\n{}", list);
+  }
+
+  private void logShutdownTimeout() {
+    String list = "";
+    try {
+      list = pluginList(loadedPlugins.getLoadedPlugins());
+      LOG.error("Plugins still shutting down at timeout:\n{}", list);
+    } catch (ConcurrentModificationException e) {
+      LOG.error("Error during shutdown: {}", e, e);
+      LOG.error("Plugins still shutting down at timeout:\n{}", list);
     }
   }
 
@@ -296,13 +400,34 @@ public class PluginManager {
   /**
    * Returns a set of all currently starting plugins.
    *
-   * @return All currently starting plugins
+   * <p>The returned set is a snapshot copy and is safe to iterate without holding internal locks.
+   * Modifications to the returned set do not affect the plugin manager.
+   *
+   * @return snapshot copy of all currently starting plugin progress trackers
    */
   public Set<PluginProgress> getStartingPlugins() {
     return new HashSet<>(loadedPlugins.getStartingPlugins());
   }
 
-  // try to guess around...
+  /**
+   * Starts a plugin from an arbitrary specification, choosing an appropriate loader.
+   *
+   * <p>This method applies a heuristic resolution order:
+   *
+   * <ul>
+   *   <li>Official plugin name (as returned by {@link #isOfficialPlugin(String)}).
+   *   <li>Freenet URI (string accepted by {@link FreenetURI}).
+   *   <li>Existing local path (matched against the JVM's root directories).
+   *   <li>URL as a final fallback.
+   * </ul>
+   *
+   * <p>The returned {@link PluginInfoWrapper} is {@code null} when the plugin is already loaded or
+   * when startup fails in a way that the manager converts into a user alert and potential retry.
+   *
+   * @param pluginname plugin specification; may be an official name, key, file path, or URL
+   * @param store whether to persist configuration after attempting to start the plugin
+   * @return wrapper for the started plugin, or {@code null} when not started
+   */
   public PluginInfoWrapper startPluginAuto(final String pluginname, boolean store) {
 
     OfficialPluginDescription desc;
@@ -327,22 +452,49 @@ public class PluginManager {
     return startPluginURL(pluginname, store);
   }
 
+  /**
+   * Starts an official plugin by its short name.
+   *
+   * <p>The plugin content is retrieved using the official plugin loader and is subject to the
+   * official plugin descriptor configuration (including whether a fresh download is required).
+   *
+   * @param pluginname official plugin name as used in configuration and {@link OfficialPlugins}
+   * @param store whether to persist configuration after the load attempt completes
+   * @return wrapper for the started plugin, or {@code null} when not started
+   */
   public PluginInfoWrapper startPluginOfficial(final String pluginname, boolean store) {
     return startPluginOfficial(pluginname, store, officialPlugins.get(pluginname));
   }
 
   /**
-   * Use {@link #startPluginOfficial(String, boolean)}.
+   * Legacy overload kept for compatibility. Prefer {@link #startPluginOfficial(String, boolean)}.
    *
+   * <p>This overload accepts obsolete parameters that historically controlled loader behavior. The
+   * current implementation intentionally ignores them.
+   *
+   * @param pluginname official plugin name as used in configuration and {@link OfficialPlugins}
+   * @param store whether to persist configuration after the load attempt completes
    * @param force This parameter is ignored.
    * @param forceHTTPS This parameter is ignored.
+   * @return wrapper for the started plugin, or {@code null} when not started
    */
-  @Deprecated
+  @SuppressWarnings("unused")
   public PluginInfoWrapper startPluginOfficial(
       final String pluginname, boolean store, boolean force, boolean forceHTTPS) {
     return startPluginOfficial(pluginname, store);
   }
 
+  /**
+   * Starts an official plugin using an already resolved descriptor.
+   *
+   * <p>This overload is used when the caller has already looked up the {@link
+   * OfficialPluginDescription} and wants to avoid repeating that lookup.
+   *
+   * @param pluginname official plugin name as used in configuration and {@link OfficialPlugins}
+   * @param store whether to persist configuration after the load attempt completes
+   * @param desc descriptor for {@code pluginname}; must not be {@code null}
+   * @return wrapper for the started plugin, or {@code null} when not started
+   */
   public PluginInfoWrapper startPluginOfficial(
       final String pluginname, boolean store, OfficialPluginDescription desc) {
     return realStartPlugin(
@@ -353,12 +505,20 @@ public class PluginManager {
   }
 
   /**
-   * Use {@link #startPluginOfficial(String, boolean, OfficialPluginDescription)}.
+   * Legacy overload kept for compatibility. Prefer {@link #startPluginOfficial(String, boolean,
+   * OfficialPluginDescription)}.
    *
+   * <p>This overload accepts obsolete parameters that historically controlled loader behavior. The
+   * current implementation intentionally ignores them.
+   *
+   * @param pluginname official plugin name as used in configuration and {@link OfficialPlugins}
+   * @param store whether to persist configuration after the load attempt completes
+   * @param officialPluginDescription descriptor for the official plugin to load
    * @param force This parameter is ignored.
    * @param forceHTTPS This parameter is ignored.
+   * @return wrapper for the started plugin, or {@code null} when not started
    */
-  @Deprecated
+  @SuppressWarnings("unused")
   public PluginInfoWrapper startPluginOfficial(
       final String pluginname,
       boolean store,
@@ -368,19 +528,51 @@ public class PluginManager {
     return startPluginOfficial(pluginname, store, officialPluginDescription);
   }
 
+  /**
+   * Starts a plugin from a local file path.
+   *
+   * <p>The file is treated as a plugin JAR and loaded using the file-based plugin downloader.
+   *
+   * @param filename local filesystem path to the plugin JAR (absolute or relative to the process)
+   * @param store whether to persist configuration after the load attempt completes
+   * @return wrapper for the started plugin, or {@code null} when not started
+   */
   public PluginInfoWrapper startPluginFile(final String filename, boolean store) {
     return realStartPlugin(new PluginDownLoaderFile(), filename, store, false);
   }
 
+  /**
+   * Starts a plugin from a URL specification.
+   *
+   * <p>The URL is interpreted by the URL-based plugin downloader, which may download the plugin
+   * into the plugin directory. If caching is allowed and a cached copy exists, the downloader may
+   * reuse it.
+   *
+   * @param filename URL string for the plugin JAR to download and load
+   * @param store whether to persist configuration after the load attempt completes
+   * @return wrapper for the started plugin, or {@code null} when not started
+   */
   public PluginInfoWrapper startPluginURL(final String filename, boolean store) {
     return realStartPlugin(new PluginDownLoaderURL(), filename, store, false);
   }
 
+  /**
+   * Starts a plugin from a Freenet URI specification.
+   *
+   * <p>The provided string is expected to be a key that the Freenet-based downloader can resolve.
+   * Depending on downloader policy, the manager may keep cached copies in the plugin directory and
+   * may schedule retries when the plugin cannot be fetched immediately.
+   *
+   * @param filename freenet key string that identifies the plugin content
+   * @param store whether to persist configuration after the load attempt completes
+   * @return wrapper for the started plugin, or {@code null} when not started
+   */
   public PluginInfoWrapper startPluginFreenet(final String filename, boolean store) {
     return realStartPlugin(
         new PluginDownLoaderFreenet(client, node, false), filename, store, false);
   }
 
+  @SuppressWarnings("java:S1181")
   private PluginInfoWrapper realStartPlugin(
       final PluginDownLoader<?> pdl,
       final String filename,
@@ -390,62 +582,47 @@ public class PluginManager {
     if (filename.trim().isEmpty()) return null;
     final PluginProgress pluginProgress = new PluginProgress(filename, pdl);
     loadedPlugins.addStartingPlugin(pluginProgress);
-    LOG.info("Loading plugin: " + filename);
+    LOG.info("Loading plugin: {}", filename);
     FredPlugin plug;
     PluginInfoWrapper pi = null;
     try {
       plug = loadPlugin(pdl, filename, pluginProgress, alwaysDownload);
-      pluginProgress.setProgress(ProgressState.STARTING);
+      pluginProgress.setStarting();
       pi = new PluginInfoWrapper(node, plug, filename, pdl.isOfficialPluginLoader());
       PluginHandler.startPlugin(PluginManager.this, pi);
       loadedPlugins.addLoadedPlugin(pi);
       loadedPlugins.removeFailedPlugin(filename);
-      LOG.info("Plugin loaded: " + filename);
+      LOG.info("Plugin loaded: {}", filename);
     } catch (PluginAlreadyLoaded e) {
       return null;
     } catch (PluginNotFoundException e) {
-      LOG.info("Loading plugin failed (" + filename + ')', e);
-      boolean stillTrying = false;
-      if (pdl.isLoadingFromFreenet()) {
-        PluginDownLoaderFreenet downloader = (PluginDownLoaderFreenet) pdl;
-        if (!downloader.fatalFailure()
-            && !downloader.desperate
-            && !twoCopiesInStartingPlugins(filename)) {
-          // Retry forever...
-          final PluginDownLoader<?> retry = pdl.getRetryDownloader();
-          stillTrying = true;
-          node.getTicker().queueTimedJob(() -> realStartPlugin(retry, filename, store, true), 0);
-        }
-      }
+      LOG.info("Loading plugin failed ({})", filename, e);
+      boolean stillTrying = scheduleRetryAfterPluginNotFound(pdl, filename, store);
       PluginLoadFailedUserAlert newAlert =
           new PluginLoadFailedUserAlert(filename, pdl.isOfficialPluginLoader(), stillTrying, e);
       PluginLoadFailedUserAlert oldAlert = loadedPlugins.replaceUserAlert(filename, newAlert);
       core.getAlerts().register(newAlert);
       core.getAlerts().unregister(oldAlert);
     } catch (UnsupportedClassVersionError e) {
-      LOG.error("Could not load plugin " + filename + " : " + e, e);
-      System.err.println("Could not load plugin " + filename + " : " + e);
-      e.printStackTrace();
-      System.err.println("Plugin " + filename + " appears to require a later JVM");
-      LOG.error("Plugin " + filename + " appears to require a later JVM");
+      LOG.error("Could not load plugin {} : {}", filename, e, e);
+      LOG.error("Plugin {} appears to require a later JVM", filename);
       PluginLoadFailedUserAlert newAlert =
           new PluginLoadFailedUserAlert(
               filename,
               pdl.isOfficialPluginLoader(),
               false,
-              l10n("pluginReqNewerJVMTitle", "name", filename));
+              l10nName("pluginReqNewerJVMTitle", filename));
       PluginLoadFailedUserAlert oldAlert = loadedPlugins.replaceUserAlert(filename, newAlert);
       core.getAlerts().register(newAlert);
       core.getAlerts().unregister(oldAlert);
-    } catch (Throwable e) {
-      LOG.error("Could not load plugin " + filename + " : " + e, e);
-      System.err.println("Could not load plugin " + filename + " : " + e);
-      e.printStackTrace();
-      System.err.println(
-          "Plugin " + filename + " is broken, but we want to retry after next startup");
-      LOG.error("Plugin " + filename + " is broken, but we want to retry after next startup");
+    } catch (Throwable t) {
+      if (t instanceof VirtualMachineError vme) {
+        throw vme;
+      }
+      LOG.error("Could not load plugin {} : {}", filename, t, t);
+      LOG.error("Plugin {} is broken, but we want to retry after next startup", filename);
       PluginLoadFailedUserAlert newAlert =
-          new PluginLoadFailedUserAlert(filename, pdl.isOfficialPluginLoader(), false, e);
+          new PluginLoadFailedUserAlert(filename, pdl.isOfficialPluginLoader(), false, t);
       PluginLoadFailedUserAlert oldAlert = loadedPlugins.replaceUserAlert(filename, newAlert);
       core.getAlerts().register(newAlert);
       core.getAlerts().unregister(oldAlert);
@@ -458,6 +635,21 @@ public class PluginManager {
     }
     if (pi != null) node.getNodeUpdater().startPluginUpdater(filename);
     return pi;
+  }
+
+  private boolean scheduleRetryAfterPluginNotFound(
+      PluginDownLoader<?> pdl, String filename, boolean store) {
+    if (!pdl.isLoadingFromFreenet()) {
+      return false;
+    }
+    PluginDownLoaderFreenet downloader = (PluginDownLoaderFreenet) pdl;
+    if (downloader.fatalFailure() || downloader.desperate || twoCopiesInStartingPlugins(filename)) {
+      return false;
+    }
+    // Retry forever...
+    final PluginDownLoader<?> retry = pdl.getRetryDownloader();
+    node.getTicker().queueTimedJob(() -> realStartPlugin(retry, filename, store, true), 0);
+    return true;
   }
 
   private synchronized boolean twoCopiesInStartingPlugins(String filename) {
@@ -526,12 +718,7 @@ public class PluginManager {
     public HTMLNode getHTMLText() {
       HTMLNode div = new HTMLNode("div");
       HTMLNode p = div.addChild("p");
-      p.addChild(
-          "#",
-          l10n(
-              "pluginLoadingFailedWithMessage",
-              new String[] {"name", "message"},
-              new String[] {filename, message}));
+      p.addChild("#", l10nPluginLoadingFailedWithMessage(filename, message));
 
       if (stacktrace != null) {
         for (StackTraceElement e : stacktrace) {
@@ -554,16 +741,16 @@ public class PluginManager {
               div.addChild(
                   "form", new String[] {"action", "method"}, new String[] {"/plugins/", "post"});
           reloadForm.addChild(
-              "input",
-              new String[] {"type", "name", "value"},
+              HTML_TAG_INPUT,
+              new String[] {"type", "name", HTML_ATTR_VALUE},
               new String[] {"hidden", "formPassword", node.getClientCore().getFormPassword()});
           reloadForm.addChild(
-              "input",
-              new String[] {"type", "name", "value"},
+              HTML_TAG_INPUT,
+              new String[] {"type", "name", HTML_ATTR_VALUE},
               new String[] {"hidden", "plugin-name", filename});
           reloadForm.addChild(
-              "input",
-              new String[] {"type", "name", "value"},
+              HTML_TAG_INPUT,
+              new String[] {"type", "name", HTML_ATTR_VALUE},
               new String[] {
                 "submit", "submit-official", l10n("officialPluginLoadFailedTryAgainFreenet")
               });
@@ -580,15 +767,12 @@ public class PluginManager {
 
     @Override
     public String getShortText() {
-      return l10n("pluginLoadingFailedShort", "name", filename);
+      return l10nName("pluginLoadingFailedShort", filename);
     }
 
     @Override
     public String getText() {
-      return l10n(
-          "pluginLoadingFailedWithMessage",
-          new String[] {"name", "message"},
-          new String[] {filename, message});
+      return l10nPluginLoadingFailedWithMessage(filename, message);
     }
 
     @Override
@@ -606,7 +790,9 @@ public class PluginManager {
     }
 
     @Override
-    public void isValid(boolean validity) {}
+    public void isValid(boolean validity) {
+      // No-op: validity is derived from LoadedPlugins state via isValid().
+    }
 
     @Override
     public boolean shouldUnregisterOnDismiss() {
@@ -641,10 +827,9 @@ public class PluginManager {
       }
       if (pluginIsTryingToHijackNodeConfig) {
         LOG.warn(
-            "The plugin loaded from "
-                + pi.getFilename()
-                + " is attempting to hijack a node configuration page; refusing to register its"
-                + " ConfigToadlet");
+            "The plugin loaded from {} is attempting to hijack a node configuration page; refusing"
+                + " to register its ConfigToadlet",
+            pi.getFilename());
       } else {
         Toadlet toadlet = pi.getConfigToadlet();
         core.getToadletContainer()
@@ -669,8 +854,18 @@ public class PluginManager {
       node.getIpDetector().registerBandwidthIndicatorPlugin((FredPluginBandwidthIndicator) plug);
   }
 
+  /**
+   * Cancels in-flight load operations for a given plugin name.
+   *
+   * <p>This method iterates over the current "starting" set and requests cancellation for any
+   * matching entries except {@code exceptFor}. It also removes canceled entries from the starting
+   * set to avoid reporting them as still loading.
+   *
+   * @param filename plugin name to match against starting plugins
+   * @param exceptFor progress instance that should not be canceled, or {@code null} to cancel all
+   */
   public void cancelRunningLoads(String filename, PluginProgress exceptFor) {
-    LOG.info("Cancelling loads for plugin " + filename);
+    LOG.info("Cancelling loads for plugin {}", filename);
     for (PluginProgress progress : loadedPlugins.getStartingPlugins()) {
       if ((progress != exceptFor) && filename.equals(progress.name)) {
         progress.kill();
@@ -686,35 +881,45 @@ public class PluginManager {
    * @return The translation
    */
   static String l10n(String key) {
-    return NodeL10n.getBase().getString("PluginManager." + key);
-  }
-
-  private static String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("PluginManager." + key, pattern, value);
+    return NodeL10n.getBase().getString(L10N_PREFIX + key);
   }
 
   /**
-   * Returns the translation of the given key, replacing each occurence of <code>${<em>pattern</em>}
+   * Returns the translation of the given key, replacing each occurrence of <code>
+   * ${<em>pattern</em>}
    * </code> with <code>value</code>.
    *
    * @param key The key to fetch
-   * @param patterns The patterns to replace
-   * @param values The values to substitute
+   * @param name The value to substitute for the <code>${name}</code> pattern
    * @return The translation
    */
-  private String l10n(String key, String[] patterns, String[] values) {
-    return NodeL10n.getBase().getString("PluginManager." + key, patterns, values);
+  private static String l10nName(String key, String name) {
+    return NodeL10n.getBase().getString(L10N_PREFIX + key, "name", name);
+  }
+
+  private static String l10nPluginLoadingFailedWithMessage(String pluginName, String message) {
+    return NodeL10n.getBase()
+        .getString(
+            L10N_PREFIX + "pluginLoadingFailedWithMessage",
+            new String[] {"name", "message"},
+            new String[] {pluginName, message});
   }
 
   private void registerToadlet(FredPlugin pl) {
-    // toadletList.put(e.getStackTrace()[1].getClass().toString(), pl);
     synchronized (toadletList) {
       toadletList.put(pl.getClass().getName(), pl);
     }
-    LOG.info("Added HTTP handler for /plugins/" + pl.getClass().getName() + '/');
+    LOG.info("Added HTTP handler for /plugins/{}/", pl.getClass().getName());
   }
 
-  /** Remove a plugin from the plugin list. */
+  /**
+   * Removes a plugin from the loaded plugin set and persists configuration.
+   *
+   * <p>This method only updates the manager's bookkeeping and configuration; it does not stop a
+   * running plugin. Typical callers invoke it after the plugin has been shut down.
+   *
+   * @param pi wrapper for the plugin to remove from the loaded set
+   */
   public void removePlugin(PluginInfoWrapper pi) {
     synchronized (loadedPlugins) {
       if (!stopping && !loadedPlugins.hasLoadedPlugin(pi)) {
@@ -728,11 +933,11 @@ public class PluginManager {
   /**
    * Removes the cached copy of the given plugin from the plugins/ directory.
    *
-   * @param pluginSpecification The plugin specification
+   * @param pluginSpecification plugin identifier, path, or URL used to resolve the cached file
    */
   public void removeCachedCopy(String pluginSpecification) {
     if (pluginSpecification == null) {
-      // Will be null if the file for a given plugin can't be found, eg. if it has already been
+      // Will be null if the file for a given plugin can't be found, e.g. if it has already been
       // removed. Ignore it since the file isn't there anyway
       LOG.warn("Can't remove null from cache. Ignoring");
       return;
@@ -749,34 +954,52 @@ public class PluginManager {
       if (pluginSpecification.toLowerCase().endsWith(".jar")) pluginFilename = pluginSpecification;
       else pluginFilename = pluginSpecification + ".jar";
     } else pluginFilename = pluginSpecification.substring(lastSlash + 1);
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Delete plugin - plugname: " + pluginSpecification + " filename: " + pluginFilename,
-          new Exception("debug"));
+    LOG.debug("Delete plugin - plugname: {} filename: {}", pluginSpecification, pluginFilename);
     List<File> cachedFiles = getPreviousInstances(pluginDirectory, pluginFilename);
     for (File cachedFile : cachedFiles) {
-      if (!cachedFile.delete())
-        if (LOG.isDebugEnabled()) LOG.debug("Can't delete file " + cachedFile);
+      deleteFileIfExists(cachedFile);
     }
   }
 
+  private void deleteFileIfExists(File file) {
+    try {
+      boolean deleted = Files.deleteIfExists(file.toPath());
+      if (!deleted) {
+        LOG.debug("File already absent: {}", file);
+      }
+    } catch (IOException e) {
+      LOG.debug("Can't delete file {}", file, e);
+    }
+  }
+
+  /**
+   * Unregisters a plugin's HTTP handler mapping from the {@code /plugins/} namespace.
+   *
+   * <p>This method removes the plugin's class-name mapping from the internal handler registry. It
+   * is invoked as part of plugin unload, and can also be called defensively during cleanup.
+   *
+   * @param pi wrapper for the plugin whose handler entry should be removed
+   */
   public void unregisterPluginToadlet(PluginInfoWrapper pi) {
     synchronized (toadletList) {
       try {
         toadletList.remove(pi.getPluginClassName());
-        LOG.info(
-            "Removed HTTP handler for /plugins/" + pi.getPluginClassName() + '/',
-            new Exception("debug"));
-      } catch (Throwable ex) {
+        LOG.debug("Removed HTTP handler for /plugins/{}/", pi.getPluginClassName());
+      } catch (Exception ex) {
         LOG.error("removing Plugin", ex);
       }
     }
   }
 
   /**
-   * @deprecated will be removed in version 1473.
+   * Legacy method kept for compatibility.
+   *
+   * <p>This method removes any HTTP "symlink" mappings that point to the given plugin. It removes
+   * the aliases from the internal registry but does not alter the plugin itself.
+   *
+   * @param pi wrapper for the plugin whose alias mappings should be removed
    */
-  @Deprecated
+  @SuppressWarnings("unused")
   public void addToadletSymlinks(PluginInfoWrapper pi) {
     synchronized (toadletList) {
       try {
@@ -785,19 +1008,23 @@ public class PluginManager {
 
         for (String target : targets) {
           toadletList.remove(target);
-          LOG.info(
-              "Removed HTTP symlink: " + target + " => /plugins/" + pi.getPluginClassName() + '/');
+          LOG.info("Removed HTTP symlink: {} => /plugins/{}/", target, pi.getPluginClassName());
         }
-      } catch (Throwable ex) {
+      } catch (Exception ex) {
         LOG.error("removing Toadlet-link", ex);
       }
     }
   }
 
   /**
-   * @deprecated will be removed in version 1473.
+   * Legacy method kept for compatibility.
+   *
+   * <p>This method removes the aliases from the internal registry and asks the wrapper to forget
+   * each alias so it will not be restored on subsequent operations.
+   *
+   * @param pi wrapper for the plugin whose alias mappings should be removed
    */
-  @Deprecated
+  @SuppressWarnings("unused")
   public void removeToadletSymlinks(PluginInfoWrapper pi) {
     synchronized (toadletList) {
       String rm = null;
@@ -809,15 +1036,22 @@ public class PluginManager {
           rm = target;
           toadletList.remove(target);
           pi.removePluginToadletSymlink(target);
-          LOG.info(
-              "Removed HTTP symlink: " + target + " => /plugins/" + pi.getPluginClassName() + '/');
+          LOG.info("Removed HTTP symlink: {} => /plugins/{}/", target, pi.getPluginClassName());
         }
-      } catch (Throwable ex) {
-        LOG.error("removing Toadlet-link: " + rm, ex);
+      } catch (Exception ex) {
+        LOG.error("removing Toadlet-link: {}", rm, ex);
       }
     }
   }
 
+  /**
+   * Returns a human-readable summary of currently loaded plugins.
+   *
+   * <p>The returned string is primarily intended for diagnostics and may change format. Each line
+   * corresponds to a single {@link PluginInfoWrapper#toString()} value for a loaded plugin.
+   *
+   * @return multi-line summary of loaded plugins, or an empty string when none are loaded
+   */
   public String dumpPlugins() {
     StringBuilder out = new StringBuilder();
     for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
@@ -826,6 +1060,13 @@ public class PluginManager {
     return out.toString();
   }
 
+  /**
+   * Returns the current set of loaded plugins.
+   *
+   * <p>The returned set is a snapshot and may not reflect subsequent load/unload activity.
+   *
+   * @return sorted snapshot set of currently loaded plugin wrappers
+   */
   public Set<PluginInfoWrapper> getPlugins() {
     return new TreeSet<>(loadedPlugins.getLoadedPlugins());
   }
@@ -874,19 +1115,21 @@ public class PluginManager {
   /**
    * Look for PluginInfo for a Plugin with given classname or filename.
    *
-   * @return the PluginInfo or null if not found
-   * @deprecated This function was deprecated because the "or filename" part of the function
-   *     specification was NOT documented before it was deprecated. Thus it is possible that legacy
-   *     callers of the function did wrongly expect or not expect that. When removing this function,
-   *     please review the callers for correctness with regards to that.<br>
-   *     You might replace usage of this function with {@link #getPluginInfoByClassName(String)}.
+   * @param plugname plugin class name or plugin filename to search for
+   * @return the matching plugin info wrapper, or {@code null} if not found
    */
-  @Deprecated
+  @SuppressWarnings("unused")
   public PluginInfoWrapper getPluginInfo(String plugname) {
     return findPluginByIdentifier(plugname);
   }
 
   /**
+   * Returns the wrapper for the plugin whose main class matches the provided name.
+   *
+   * <p>This method performs an exact string match against {@link
+   * PluginInfoWrapper#getPluginClassName()}. It does not attempt suffix matching or filename
+   * matching; use {@link #findPluginByIdentifier(String)} if that behavior is required.
+   *
    * @param pluginClassName The name of the main class of the plugin - that is the class which
    *     implements {@link FredPlugin}.
    * @return The {@link PluginInfoWrapper} for the plugin with the given class name, or null if no
@@ -902,35 +1145,11 @@ public class PluginManager {
   }
 
   /**
-   * look for a FCPPlugin with given classname
-   *
-   * @param plugname
-   * @return the plugin or null if not found
-   * @deprecated The {@link FredPluginFCP} API, which this returns, was deprecated to be replaced by
-   *     {@link FredPluginFCPMessageHandler.ServerSideFCPMessageHandler}. Plugin authors should
-   *     implement the new interface instead of the old, and this codepath to support plugins which
-   *     implement the old interface should be removed one day. No new code will be needed then: The
-   *     code to use the new interface already exists in its own codepath - the equivalent function
-   *     for the new API is {link #getPluginFCPServer(String)}, and it is already being used
-   *     automatically for plugins which implement it.
-   */
-  @Deprecated
-  public FredPluginFCP getFCPPlugin(String plugname) {
-    for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
-      if (pluginInfoWrapper.isFCPPlugin()
-          && pluginInfoWrapper.getPluginClassName().equals(plugname)
-          && !pluginInfoWrapper.isStopping()) {
-        return (FredPluginFCP) pluginInfoWrapper.plug;
-      }
-    }
-    return null;
-  }
-
-  /**
    * Get the {@link FredPluginFCPMessageHandler.ServerSideFCPMessageHandler} of the plugin with the
    * given class name.
    *
    * @param pluginClassName See {@link #getPluginInfoByClassName(String)}.
+   * @return the server-side FCP handler provided by the specified plugin
    * @throws PluginNotFoundException If the specified plugin is not loaded or does not provide an
    *     FCP server.
    */
@@ -948,8 +1167,8 @@ public class PluginManager {
   /**
    * look for a Plugin with given classname
    *
-   * @param plugname
-   * @return the true if not found
+   * @param plugname plugin class name or plugin filename to search for
+   * @return {@code true} if the plugin is currently loaded, otherwise {@code false}
    */
   public boolean isPluginLoaded(String plugname) {
     for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
@@ -962,15 +1181,33 @@ public class PluginManager {
   }
 
   /**
+   * Checks whether a plugin is loaded, currently starting, or tracked as known.
+   *
+   * <p>This is a broader predicate than {@link #isPluginLoaded(String)}: it treats plugins as
+   * "known" if they are present in the starting set or have a recorded failure state, in addition
+   * to being fully loaded.
+   *
    * @param plugname The plugin filename e.g. "Library" for an official plugin.
-   * @return the true if not found
+   * @return {@code true} if the plugin is loaded, loading, or otherwise tracked as known
    */
   public boolean isPluginLoadedOrLoadingOrWantLoad(String plugname) {
     return loadedPlugins.isKnownPlugin(plugname);
   }
 
+  /**
+   * Dispatches an HTTP GET request to a plugin that implements {@link FredPluginHTTP}.
+   *
+   * <p>The manager temporarily sets the thread context class loader to the plugin's class loader so
+   * the plugin can resolve its own resources and dependencies during request handling. The original
+   * context class loader is restored before returning.
+   *
+   * @param plugin plugin identifier used as the handler key (typically the plugin main class name)
+   * @param request request wrapper containing the parsed HTTP request and parameters
+   * @return response body produced by the plugin, typically HTML content
+   * @throws PluginHTTPException if the plugin is not loaded or does not support HTTP handling
+   */
   public String handleHTTPGet(String plugin, HTTPRequest request) throws PluginHTTPException {
-    FredPlugin handler = null;
+    FredPlugin handler;
     synchronized (toadletList) {
       handler = toadletList.get(plugin);
     }
@@ -988,8 +1225,19 @@ public class PluginManager {
     }
   }
 
+  /**
+   * Dispatches an HTTP POST request to a plugin that implements {@link FredPluginHTTP}.
+   *
+   * <p>As with {@link #handleHTTPGet(String, HTTPRequest)}, the thread context class loader is
+   * temporarily switched to the plugin class loader for the duration of request handling.
+   *
+   * @param plugin plugin identifier used as the handler key (typically the plugin main class name)
+   * @param request request wrapper containing the parsed HTTP request and parameters
+   * @return response body produced by the plugin, typically HTML content
+   * @throws PluginHTTPException if the plugin is not loaded or does not support HTTP handling
+   */
   public String handleHTTPPost(String plugin, HTTPRequest request) throws PluginHTTPException {
-    FredPlugin handler = null;
+    FredPlugin handler;
     synchronized (toadletList) {
       handler = toadletList.get(plugin);
     }
@@ -1007,6 +1255,17 @@ public class PluginManager {
     throw new NotFoundPluginHTTPException("Plugin '" + plugin + "' not found!", "/plugins");
   }
 
+  /**
+   * Requests shutdown of a loaded plugin by its thread name.
+   *
+   * <p>This method searches the current loaded plugin set for a matching {@link
+   * PluginInfoWrapper#getThreadName()} and, if found, calls {@link
+   * PluginInfoWrapper#stopPlugin(PluginManager, long, boolean)} on that wrapper.
+   *
+   * @param name expected thread name of the plugin to stop
+   * @param maxWaitTime maximum time to wait in milliseconds for plugin shutdown
+   * @param reloading whether this stop is part of a reload operation
+   */
   public void killPlugin(String name, long maxWaitTime, boolean reloading) {
     for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
       if (pluginInfoWrapper.getThreadName().equals(name)) {
@@ -1016,6 +1275,16 @@ public class PluginManager {
     }
   }
 
+  /**
+   * Requests shutdown of a loaded plugin by its configured filename.
+   *
+   * <p>This is typically used for official plugins whose filename corresponds to their short name,
+   * but it also works for file-based plugins when the wrapper filename matches the supplied value.
+   *
+   * @param name plugin filename to match against {@link PluginInfoWrapper#getFilename()}
+   * @param maxWaitTime maximum time to wait in milliseconds for plugin shutdown
+   * @param reloading whether this stop is part of a reload operation
+   */
   public void killPluginByFilename(String name, long maxWaitTime, boolean reloading) {
     for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
       if (pluginInfoWrapper.getFilename().equals(name)) {
@@ -1025,6 +1294,15 @@ public class PluginManager {
     }
   }
 
+  /**
+   * Requests shutdown of a loaded plugin by its main class name.
+   *
+   * <p>If a matching plugin is found, it is stopped with {@code reloading=false}.
+   *
+   * @param name plugin main class name to match against {@link
+   *     PluginInfoWrapper#getPluginClassName()}
+   * @param maxWaitTime maximum time to wait in milliseconds for plugin shutdown
+   */
   public void killPluginByClass(String name, final long maxWaitTime) {
     for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
       if (pluginInfoWrapper.getPluginClassName().equals(name)) {
@@ -1034,6 +1312,14 @@ public class PluginManager {
     }
   }
 
+  /**
+   * Requests shutdown of a loaded plugin by plugin instance reference.
+   *
+   * <p>This performs reference equality against wrapper-held plugin instances.
+   *
+   * @param plugin plugin instance to stop, as previously returned by the plugin loader
+   * @param maxWaitTime maximum time to wait in milliseconds for plugin shutdown
+   */
   public void killPlugin(FredPlugin plugin, long maxWaitTime) {
     for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
       if (pluginInfoWrapper.plug == plugin) {
@@ -1043,10 +1329,24 @@ public class PluginManager {
     }
   }
 
+  /**
+   * Returns the descriptor for an official plugin by name.
+   *
+   * @param name official plugin name as used by {@link OfficialPlugins}
+   * @return descriptor for {@code name}, or {@code null} if no such plugin exists
+   */
   public OfficialPluginDescription getOfficialPlugin(String name) {
     return officialPlugins.get(name);
   }
 
+  /**
+   * Returns all known official plugin descriptors.
+   *
+   * <p>The returned collection is sourced from {@link OfficialPlugins} and is intended for UI and
+   * administrative tooling.
+   *
+   * @return collection view of all known official plugin descriptors
+   */
   public Collection<OfficialPluginDescription> getOfficialPlugins() {
     return officialPlugins.getAll();
   }
@@ -1058,11 +1358,19 @@ public class PluginManager {
    * @return A list of all available plugin names
    */
   public List<OfficialPluginDescription> findAvailablePlugins() {
-    List<OfficialPluginDescription> availablePlugins = new ArrayList<>();
-    availablePlugins.addAll(officialPlugins.getAll());
-    return availablePlugins;
+    return new ArrayList<>(officialPlugins.getAll());
   }
 
+  /**
+   * Checks whether a name refers to a known official plugin.
+   *
+   * <p>This performs a case-sensitive match against official plugin descriptors. Callers typically
+   * use this to decide whether to treat a plugin specification as an "official plugin name" versus
+   * a file path, Freenet key, or URL.
+   *
+   * @param name plugin name to validate; {@code null} and blank values return {@code null}
+   * @return descriptor for {@code name}, or {@code null} if {@code name} is not official
+   */
   public OfficialPluginDescription isOfficialPlugin(String name) {
     if ((name == null) || name.trim().isEmpty()) return null;
     List<OfficialPluginDescription> availablePlugins = findAvailablePlugins();
@@ -1080,14 +1388,24 @@ public class PluginManager {
   private final Object pluginLoadSyncObject = new Object();
 
   /**
-   * All plugin updates are on a single request client.
+   * Request client shared by all plugin updater fetches.
    *
-   * @deprecated Use {@link #getSingleUpdaterRequestClient()} instead of accessing this directly.
+   * <p>Plugin updates are intentionally funneled through a single {@link RequestClient} to bound
+   * concurrency and to make updater traffic easier to reason about. Callers should prefer accessing
+   * this via {@link #getSingleUpdaterRequestClient()} to keep the field usage localized.
    */
-  @Deprecated
-  /* It’s not the field that is deprecated but accessing it directly is. */
   public final RequestClient singleUpdaterRequestClient = new RequestClientBuilder().build();
 
+  /**
+   * Returns the expected on-disk filename for an official plugin name.
+   *
+   * <p>This method ensures that the plugin directory exists, and returns a {@link File} pointing to
+   * {@code <pluginDir>/<pluginName>.jar}. It does not validate that the file exists.
+   *
+   * @param pluginName short plugin name used as a base name (without {@code .jar})
+   * @return file pointing to the plugin JAR location, or {@code null} if the directory cannot be
+   *     used
+   */
   public File getPluginFilename(String pluginName) {
     File pluginDirectory = node.getPluginDir();
     if ((pluginDirectory.exists() && !pluginDirectory.isDirectory())
@@ -1101,7 +1419,7 @@ public class PluginManager {
    * If the name contains a complete url and the short file already exists in the plugin directory
    * it's loaded from the plugin directory, otherwise it's retrieved from the remote server.
    *
-   * @param pdl
+   * @param pdl downloader that resolves and fetches the plugin content, if needed
    * @param name The specification of the plugin
    * @param alwaysDownload If true, always download a new version anyway. This is especially
    *     important on Windows, where we will not usually be able to delete the file after
@@ -1124,66 +1442,98 @@ public class PluginManager {
         getTargetFileForPluginDownload(
             pluginDirectory, filename, !pdl.isCachingProhibited() && !alwaysDownload);
 
-    boolean downloadWasAttempted = false;
     /* check if file needs to be downloaded. */
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "plugin file "
-              + pluginFile.getAbsolutePath()
-              + " exists: "
-              + pluginFile.exists()
-              + " downloader "
-              + pdl
-              + " name "
-              + name);
-    int RETRIES = 5;
-    for (int i = 0; i < RETRIES; i++) {
+          "plugin file {} exists: {} downloader {} name {}",
+          pluginFile.getAbsolutePath(),
+          pluginFile.exists(),
+          pdl,
+          name);
+    return loadPluginWithRetries(pdl, name, progress, pluginDirectory, pluginFile);
+  }
+
+  private FredPlugin loadPluginWithRetries(
+      PluginDownLoader<?> pdl,
+      String name,
+      PluginProgress progress,
+      File pluginDirectory,
+      File pluginFile)
+      throws PluginNotFoundException, PluginAlreadyLoaded {
+    boolean downloadWasAttempted = false;
+    int retries = 5;
+
+    for (int attempt = 0; attempt < retries; attempt++) {
+      boolean retry = false;
       if (!pluginFile.exists() || pluginFile.length() == 0) {
-        try {
-          downloadWasAttempted = true;
-          System.err.println("Downloading plugin " + name);
-          WrapperManager.signalStarting((int) MINUTES.toMillis(5));
-          try {
-            downloadPluginFile(pdl, pluginDirectory, pluginFile, progress);
-            verifyDigest(pdl, pluginFile);
-          } catch (IOException ioe1) {
-            LOG.error("could not load plugin", ioe1);
-            throw new PluginNotFoundException("could not load plugin: " + ioe1.getMessage(), ioe1);
-          }
-        } catch (PluginNotFoundException e) {
-          if (i < RETRIES - 1) {
-            LOG.info("Failed to load plugin: " + e, e);
-            continue;
-          } else {
-            throw e;
-          }
-        }
+        downloadWasAttempted = true;
+        retry =
+            !downloadPluginForRetry(
+                pdl, name, pluginDirectory, pluginFile, progress, attempt, retries);
       }
 
-      cancelRunningLoads(name, progress);
-
-      // we do quite a lot inside the lock, use a dedicated one
-      synchronized (pluginLoadSyncObject) {
-        String pluginMainClassName;
+      if (!retry) {
+        cancelRunningLoads(name, progress);
         try {
-          pluginMainClassName = verifyJarFileAndGetPluginMainClass(pluginFile);
-          FredPlugin object =
-              loadPluginFromJarFile(
-                  name, pluginFile, pluginMainClassName, pdl.isOfficialPluginLoader());
-          if (object != null) {
-            return object;
-          }
+          return loadPluginFromFile(pdl, name, pluginFile);
         } catch (PluginNotFoundException e) {
-          LOG.error(e.getMessage());
-          pluginFile.delete();
-          if (!downloadWasAttempted) {
-            continue;
+          deleteFileIfExists(pluginFile);
+          retry = !downloadWasAttempted && attempt < retries - 1;
+          if (!retry) {
+            throw new PluginNotFoundException("could not load plugin: " + e.getMessage(), e);
           }
-          throw e;
         }
       }
     }
     return null;
+  }
+
+  private boolean downloadPluginForRetry(
+      PluginDownLoader<?> pluginDownLoader,
+      String name,
+      File pluginDirectory,
+      File pluginFile,
+      PluginProgress progress,
+      int attempt,
+      int retries)
+      throws PluginNotFoundException {
+    try {
+      downloadPluginFileAndVerify(pluginDownLoader, name, pluginDirectory, pluginFile, progress);
+      return true;
+    } catch (PluginNotFoundException e) {
+      if (attempt < retries - 1) {
+        LOG.info("Failed to load plugin: {}", e, e);
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  private FredPlugin loadPluginFromFile(PluginDownLoader<?> pdl, String name, File pluginFile)
+      throws PluginNotFoundException, PluginAlreadyLoaded {
+    // we do quite a lot inside the lock, use a dedicated one
+    synchronized (pluginLoadSyncObject) {
+      String pluginMainClassName = verifyJarFileAndGetPluginMainClass(pluginFile);
+      return loadPluginFromJarFile(
+          name, pluginFile, pluginMainClassName, pdl.isOfficialPluginLoader());
+    }
+  }
+
+  private void downloadPluginFileAndVerify(
+      PluginDownLoader<?> pluginDownLoader,
+      String name,
+      File pluginDirectory,
+      File pluginFile,
+      PluginProgress progress)
+      throws PluginNotFoundException {
+    LOG.info("Downloading plugin {}", name);
+    WrapperManager.signalStarting((int) MINUTES.toMillis(5));
+    try {
+      downloadPluginFile(pluginDownLoader, pluginDirectory, pluginFile, progress);
+      verifyDigest(pluginDownLoader, pluginFile);
+    } catch (IOException e) {
+      throw new PluginNotFoundException("could not load plugin: " + e.getMessage(), e);
+    }
   }
 
   private File getPluginDirectory() throws PluginNotFoundException {
@@ -1216,7 +1566,7 @@ public class PluginManager {
 
   private void deleteCachedVersions(List<File> filesInPluginDirectory) {
     for (File cachedFile : filesInPluginDirectory) {
-      cachedFile.delete();
+      deleteFileIfExists(cachedFile);
     }
   }
 
@@ -1234,7 +1584,7 @@ public class PluginManager {
 
       FileUtil.copy(pluginInputStream, pluginOutputStream, -1);
     } catch (IOException ioe1) {
-      tempPluginFile.delete();
+      deleteFileIfExists(tempPluginFile);
       throw ioe1;
     }
     if (tempPluginFile.length() == 0) {
@@ -1254,7 +1604,7 @@ public class PluginManager {
     }
     String testsum = getFileDigest(pluginFile);
     if (!(digest.equalsIgnoreCase(testsum))) {
-      LOG.error("Checksum verification failed, should be " + digest + " but was " + testsum);
+      LOG.error("Checksum verification failed, should be {} but was {}", digest, testsum);
       throw new PluginNotFoundException(
           "Checksum verification failed, should be " + digest + " but was " + testsum);
     }
@@ -1263,21 +1613,9 @@ public class PluginManager {
   private String verifyJarFileAndGetPluginMainClass(File pluginFile)
       throws PluginNotFoundException, PluginAlreadyLoaded {
     try (JarFile pluginJarFile = new JarFile(pluginFile)) {
-      Manifest manifest = pluginJarFile.getManifest();
-      if (manifest == null) {
-        throw new PluginNotFoundException("could not load manifest from plugin file");
-      }
-      Attributes mainAttributes = manifest.getMainAttributes();
-      if (mainAttributes == null) {
-        throw new PluginNotFoundException("manifest does not contain attributes");
-      }
-      String pluginMainClassName = mainAttributes.getValue("Plugin-Main-Class");
-      if (pluginMainClassName == null) {
-        throw new PluginNotFoundException(
-            "manifest does not contain a Plugin-Main-Class attribute");
-      }
+      String pluginMainClassName = getPluginMainClassNameFromManifest(pluginJarFile.getManifest());
       if (isPluginLoaded(pluginMainClassName)) {
-        LOG.error("Plugin already loaded: " + pluginFile.getName());
+        LOG.error("Plugin already loaded: {}", pluginFile.getName());
         throw new PluginAlreadyLoaded();
       }
       return pluginMainClassName;
@@ -1286,98 +1624,111 @@ public class PluginManager {
     }
   }
 
+  private static String getPluginMainClassNameFromManifest(Manifest manifest)
+      throws PluginNotFoundException {
+    if (manifest == null) {
+      throw new PluginNotFoundException("could not load manifest from plugin file");
+    }
+    Attributes mainAttributes = manifest.getMainAttributes();
+    if (mainAttributes == null) {
+      throw new PluginNotFoundException("manifest does not contain attributes");
+    }
+    String pluginMainClassName = mainAttributes.getValue("Plugin-Main-Class");
+    if (pluginMainClassName == null) {
+      throw new PluginNotFoundException("manifest does not contain a Plugin-Main-Class attribute");
+    }
+    return pluginMainClassName;
+  }
+
   private FredPlugin loadPluginFromJarFile(
       String name, File pluginFile, String pluginMainClassName, boolean isOfficialPlugin)
       throws PluginNotFoundException {
-    try {
-      JarClassLoader jarClassLoader = new JarClassLoader(pluginFile);
+    try (JarClassLoaderLease lease = new JarClassLoaderLease(pluginFile)) {
+      /*
+       * The plugin class loader must stay alive for the lifetime of the plugin: many plugins load
+       * additional classes/resources lazily during normal operation. We keep the JarClassLoader
+       * open on success, and it is closed later when the plugin is unloaded (see PluginInfoWrapper).
+       */
+      JarClassLoader jarClassLoader = lease.loader();
+
       Class<?> pluginMainClass = jarClassLoader.loadClass(pluginMainClassName);
-      Object object = pluginMainClass.getDeclaredConstructor().newInstance();
-      if (!(object instanceof FredPlugin)) {
+      Object pluginInstance = pluginMainClass.getDeclaredConstructor().newInstance();
+      if (!(pluginInstance instanceof FredPlugin plugin)) {
         throw new PluginNotFoundException("plugin main class is not a plugin");
       }
       if (isOfficialPlugin) {
-        verifyPluginVersion(name, jarClassLoader, (FredPlugin) object);
+        verifyPluginVersion(name, plugin);
       }
-      if (object instanceof FredPluginL10n l10n) {
+      if (pluginInstance instanceof FredPluginL10n l10n) {
         l10n.setLanguage(NodeL10n.getBase().getSelectedLanguage());
       }
-      if (object instanceof FredPluginBaseL10n l10n) {
+      if (pluginInstance instanceof FredPluginBaseL10n l10n) {
         l10n.setLanguage(NodeL10n.getBase().getSelectedLanguage());
       }
-      if (object instanceof FredPluginThemed themed) {
+      if (pluginInstance instanceof FredPluginThemed themed) {
         themed.setTheme(fproxyTheme);
       }
-      return (FredPlugin) object;
-    } catch (IOException ioe1) {
-      throw new PluginNotFoundException("could not load plugin", ioe1);
+      lease.keepOpen();
+      return plugin;
     } catch (ClassNotFoundException cnfe1) {
       throw new PluginNotFoundException(
           "could not find plugin class: \"" + cnfe1.getMessage() + "\"", cnfe1);
-    } catch (InstantiationException ie1) {
-      throw new PluginNotFoundException("could not instantiate plugin", ie1);
-    } catch (IllegalAccessException iae1) {
-      throw new PluginNotFoundException("could not access plugin main class", iae1);
     } catch (NoClassDefFoundError ncdfe1) {
       throw new PluginNotFoundException("could not find class def, may a missing lib?", ncdfe1);
-    } catch (Throwable t) {
-      throw new PluginNotFoundException("unexpected error while plugin loading " + t, t);
+    } catch (ReflectiveOperationException e) {
+      throw new PluginNotFoundException("could not instantiate plugin", e);
+    } catch (IOException ioe1) {
+      throw new PluginNotFoundException("could not load plugin", ioe1);
     }
   }
 
-  private void verifyPluginVersion(String name, JarClassLoader jarClassLoader, FredPlugin plugin)
-      throws PluginTooOldException {
-    System.err.println("Loading official plugin " + name);
-    // Check the version after loading it!
-    // FIXME IMPORTANT Build the version into the manifest. This is actually pretty easy and just
-    // involves changing build.xml.
-    // We already do similar things elsewhere.
+  private static final class JarClassLoaderLease implements AutoCloseable {
+    private final JarClassLoader loader;
+    private boolean keepOpen;
 
-    // Ugh, this is just as messy ... ideas???? Maybe we need to have OS
-    // detection and use grep/sed on unix and find on windows???
+    private JarClassLoaderLease(File pluginFile) throws IOException {
+      this.loader = new JarClassLoader(pluginFile);
+    }
+
+    private JarClassLoader loader() {
+      return loader;
+    }
+
+    private void keepOpen() {
+      keepOpen = true;
+    }
+
+    @Override
+    public void close() {
+      if (keepOpen) {
+        return;
+      }
+      try {
+        loader.close();
+      } catch (IOException ignored) {
+        // best-effort cleanup; load failure will be surfaced via the thrown exception
+      }
+    }
+  }
+
+  private void verifyPluginVersion(String name, FredPlugin plugin) throws PluginTooOldException {
+    LOG.info("Loading official plugin {}", name);
 
     OfficialPluginDescription desc = officialPlugins.get(name);
 
     long minVer = desc.minimumVersion;
     long ver = -1;
 
-    if (minVer != -1) {
-      if (plugin instanceof FredPluginRealVersioned versioned) {
-        ver = versioned.getRealVersion();
-      }
+    if (minVer != -1 && plugin instanceof FredPluginRealVersioned versioned) {
+      ver = versioned.getRealVersion();
     }
 
-    // FIXME l10n the PluginNotFoundException errors.
     if (ver < minVer) {
-      System.err.println(
-          "Failed to load plugin "
-              + name
-              + " : TOO OLD: need at least version "
-              + minVer
-              + " but is "
-              + ver);
       LOG.error(
-          "Failed to load plugin "
-              + name
-              + " : TOO OLD: need at least version "
-              + minVer
-              + " but is "
-              + ver);
-
-      // At this point, the constructor has run, so it's theoretically possible that the plugin has
-      // e.g. created some threads.
-      // However, it has not been able to use any of the node's services, because we haven't passed
-      // it the PluginRespirator.
-      // So there is no need to call runPlugin and terminate().
-      // And it doesn't matter all that much if the shutdown fails - we won't be able to delete the
-      // file on Windows anyway, we're relying on the ignoreOld logic.
-      // Plus, this will not cause a leak of more than one fd per plugin, even when it has started
-      // threads.
-      try {
-        jarClassLoader.close();
-      } catch (Throwable t) {
-        LOG.error("Failed to close jar classloader for plugin: " + t, t);
-      }
+          "Failed to load plugin {} : TOO OLD: need at least version {} but is {}",
+          name,
+          minVer,
+          ver);
       throw new PluginTooOldException(
           "plugin too old: need at least version " + minVer + " but is " + ver);
     }
@@ -1392,22 +1743,23 @@ public class PluginManager {
    * @return All cached instances
    */
   private List<File> getPreviousInstances(File pluginDirectory, final String filename) {
-    List<File> cachedFiles =
-        Arrays.asList(
-            pluginDirectory.listFiles(
-                pathname -> pathname.isFile() && pathname.getName().startsWith(filename)));
-    Collections.sort(
-        cachedFiles,
+    File[] matchingFiles =
+        pluginDirectory.listFiles(
+            pathname -> pathname.isFile() && pathname.getName().startsWith(filename));
+    if (matchingFiles == null) {
+      return List.of();
+    }
+
+    List<File> cachedFiles = new ArrayList<>(Arrays.asList(matchingFiles));
+    cachedFiles.sort(
         new Comparator<>() {
 
           @Override
           public int compare(File file1, File file2) {
-            return (int)
-                Math.min(
-                    Integer.MAX_VALUE,
-                    Math.max(
-                        Integer.MIN_VALUE,
-                        extractTimestamp(file2.getName()) - extractTimestamp(file1.getName())));
+            return Math.clamp(
+                extractTimestamp(file2.getName()) - extractTimestamp(file1.getName()),
+                Integer.MIN_VALUE,
+                Integer.MAX_VALUE);
           }
 
           private long extractTimestamp(String filename) {
@@ -1435,7 +1787,7 @@ public class PluginManager {
 
       // We compute the hash
       // http://java.sun.com/developer/TechTips/1998/tt0915.html#tip2
-      int len = 0;
+      int len;
       byte[] buffer = new byte[BUFFERSIZE];
       while ((len = bis.read(buffer)) > -1) {
         hash.update(buffer, 0, len);
@@ -1460,8 +1812,16 @@ public class PluginManager {
    */
   public static class PluginProgress {
 
-    enum ProgressState {
+    /**
+     * Represents the coarse-grained phase of a plugin load operation.
+     *
+     * <p>This enum is intentionally small and UI-friendly: it describes whether a plugin is still
+     * being fetched/verified or whether it has transitioned into in-process startup.
+     */
+    public enum ProgressState {
+      /** The plugin content is being fetched, cached, and verified. */
       DOWNLOADING,
+      /** The plugin class loader is active and the plugin is starting. */
       STARTING
     }
 
@@ -1492,7 +1852,7 @@ public class PluginManager {
      * Creates a new progress tracker for a plugin that is loaded by the given name.
      *
      * @param name The name by which the plugin is loaded
-     * @param pdl
+     * @param pdl downloader used for retrieval and cancellation of the in-flight load
      */
     PluginProgress(String name, PluginDownLoader<?> pdl) {
       this.name = name;
@@ -1500,6 +1860,12 @@ public class PluginManager {
       loader = pdl;
     }
 
+    /**
+     * Requests cancellation of the current load operation, if supported by the loader.
+     *
+     * <p>This method is a best-effort signal. The loader may ignore cancellation requests, and
+     * callers should still rely on higher-level shutdown timeouts where applicable.
+     */
     public void kill() {
       loader.tryCancel();
     }
@@ -1531,13 +1897,8 @@ public class PluginManager {
       return pluginProgress;
     }
 
-    /**
-     * Sets the current state of the plugin start procedure
-     *
-     * @param pluginProgress The current state
-     */
-    void setProgress(ProgressState state) {
-      this.pluginProgress = state;
+    void setStarting() {
+      this.pluginProgress = ProgressState.STARTING;
     }
 
     /**
@@ -1558,6 +1919,16 @@ public class PluginManager {
           + "]";
     }
 
+    /**
+     * Returns a localized HTML node describing the current progress.
+     *
+     * <p>The returned node is intended for embedding into existing UI tables. For downloading
+     * progress it delegates to {@link QueueToadlet#createProgressCell(boolean, boolean,
+     * ClientPut.COMPRESS_STATE, int, int, int, int, int, boolean, boolean)}; otherwise it returns a
+     * localized label for the current {@link ProgressState}.
+     *
+     * @return a {@link HTMLNode} describing the current load state for UI display
+     */
     public HTMLNode toLocalisedHTML() {
       if (pluginProgress == ProgressState.DOWNLOADING && total > 0) {
         return QueueToadlet.createProgressCell(
@@ -1580,6 +1951,20 @@ public class PluginManager {
       else return new HTMLNode("td", toString());
     }
 
+    /**
+     * Updates download progress counters for this plugin.
+     *
+     * <p>The supplied values are treated as raw counters whose exact unit is defined by the loader
+     * (for example bytes versus blocks). This method does not perform validation; callers should
+     * provide consistent values across calls.
+     *
+     * @param minSuccess minimum successful units required to treat the download as complete
+     * @param current currently completed units; uses the same unit as {@code total}
+     * @param total total units expected for the download, in loader-defined units
+     * @param failed number of units that failed but may still be retried or tolerated
+     * @param fatallyFailed number of units that failed in a non-recoverable way
+     * @param finalised whether {@code total} has been finalized and will not increase
+     */
     public void setDownloadProgress(
         int minSuccess, int current, int total, int failed, int fatallyFailed, boolean finalised) {
       this.pluginProgress = ProgressState.DOWNLOADING;
@@ -1591,14 +1976,32 @@ public class PluginManager {
       this.finalisedTotal = finalised;
     }
 
+    /**
+     * Marks the plugin as being in the downloading phase.
+     *
+     * <p>This does not reset counters; it only updates the phase marker.
+     */
     public void setDownloading() {
       this.pluginProgress = ProgressState.DOWNLOADING;
     }
 
+    /**
+     * Returns whether this load originated from an official plugin loader.
+     *
+     * @return {@code true} if the underlying loader is an official-plugin loader
+     */
     public boolean isOfficialPlugin() {
       return loader.isOfficialPluginLoader();
     }
 
+    /**
+     * Returns a localized plugin name when possible.
+     *
+     * <p>For official plugins this resolves the localized name from the node translation bundle;
+     * for non-official plugins it returns the raw load name.
+     *
+     * @return localized name for official plugins, otherwise the raw plugin name
+     */
     public String getLocalisedPluginName() {
       String pluginName = getName();
       if (isOfficialPlugin()) {
@@ -1611,29 +2014,42 @@ public class PluginManager {
     return l10n("pluginName." + pluginName);
   }
 
+  /**
+   * Updates the currently selected FProxy theme and notifies themed plugins.
+   *
+   * <p>The theme is applied to each loaded plugin's page maker. For plugins implementing {@link
+   * FredPluginThemed}, {@link FredPluginThemed#setTheme(THEME)} is invoked asynchronously on the
+   * callback executor.
+   *
+   * @param cssName theme selection to apply; must be a valid {@link THEME} value
+   */
   public void setFProxyTheme(final THEME cssName) {
-    // if (fproxyTheme.equals(cssName)) return;
     fproxyTheme = cssName;
     for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins.getLoadedPlugins()) {
       pluginInfoWrapper.pr.getPageMaker().setTheme(cssName);
       if (pluginInfoWrapper.isThemedPlugin()) {
         final FredPluginThemed plug = (FredPluginThemed) pluginInfoWrapper.plug;
         executor.execute(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  plug.setTheme(cssName);
-                } catch (Throwable t) {
-                  LOG.error("Caught Throwable in Callback", t);
-                }
+            () -> {
+              try {
+                plug.setTheme(cssName);
+              } catch (Exception e) {
+                LOG.error(CALLBACK_THROWABLE_MESSAGE, e);
               }
             },
-            "Callback");
+            CALLBACK_TASK_NAME);
       }
     }
   }
 
+  /**
+   * Sets the language on all loaded plugins that support localization.
+   *
+   * <p>This is a static convenience wrapper around the current singleton instance (created via
+   * {@link #create(Node, int)}). If no instance is registered, the call is ignored.
+   *
+   * @param lang language selection to apply to localization-capable plugins
+   */
   public static void setLanguage(LANGUAGE lang) {
     if (selfinstance == null) return;
     selfinstance.setPluginLanguage(lang);
@@ -1644,43 +2060,50 @@ public class PluginManager {
       if (pluginInfoWrapper.isL10nPlugin()) {
         final FredPluginL10n plug = (FredPluginL10n) (pluginInfoWrapper.plug);
         executor.execute(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  plug.setLanguage(lang);
-                } catch (Throwable t) {
-                  LOG.error("Caught Throwable in Callback", t);
-                }
+            () -> {
+              try {
+                plug.setLanguage(lang);
+              } catch (Exception e) {
+                LOG.error(CALLBACK_THROWABLE_MESSAGE, e);
               }
             },
-            "Callback");
+            CALLBACK_TASK_NAME);
       } else if (pluginInfoWrapper.isBaseL10nPlugin()) {
         final FredPluginBaseL10n plug = (FredPluginBaseL10n) (pluginInfoWrapper.plug);
         executor.execute(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  plug.setLanguage(lang);
-                } catch (Throwable t) {
-                  LOG.error("Caught Throwable in Callback", t);
-                }
+            () -> {
+              try {
+                plug.setLanguage(lang);
+              } catch (Exception e) {
+                LOG.error(CALLBACK_THROWABLE_MESSAGE, e);
               }
             },
-            "Callback");
+            CALLBACK_TASK_NAME);
       }
     }
   }
 
   /**
-   * @deprecated will be removed in version 1473.
+   * Legacy method kept for compatibility.
+   *
+   * @return currently configured FProxy theme value used for plugin-rendered pages
    */
-  @Deprecated
+  @SuppressWarnings("unused")
   public THEME getFProxyTheme() {
     return fproxyTheme;
   }
 
+  /**
+   * Unregisters a plugin from node subsystems during unload.
+   *
+   * <p>This removes plugin-provided toadlets, configuration pages, and auxiliary integrations (IP
+   * detector and port forwarding hooks). When not reloading, it also stops the plugin updater for
+   * the plugin file name.
+   *
+   * @param wrapper wrapper describing the plugin capabilities and registered components
+   * @param plug plugin instance being unloaded; used for type-specific unregister calls
+   * @param reloading whether this unload is part of a plugin reload operation
+   */
   public void unregisterPlugin(PluginInfoWrapper wrapper, FredPlugin plug, boolean reloading) {
     unregisterPluginToadlet(wrapper);
     if (wrapper.isConfigurablePlugin()) {
@@ -1695,6 +2118,14 @@ public class PluginManager {
     if (!reloading) node.getNodeUpdater().stopPluginUpdater(wrapper.getFilename());
   }
 
+  /**
+   * Returns whether the plugin system is enabled for this node.
+   *
+   * <p>This value is read from configuration at construction time and does not change until the
+   * node restarts.
+   *
+   * @return {@code true} if the plugin manager will load plugins, otherwise {@code false}
+   */
   public boolean isEnabled() {
     return enabled;
   }
@@ -1702,7 +2133,7 @@ public class PluginManager {
   private static class LoadedPlugins {
 
     private final Set<PluginProgress> startingPlugins = new HashSet<>();
-    private final Set<PluginInfoWrapper> loadedPlugins = new HashSet<>();
+    private final Set<PluginInfoWrapper> loadedPluginWrappers = new HashSet<>();
     private final Map<String, PluginLoadFailedUserAlert> failedPluginAlerts = new HashMap<>();
 
     public void addStartingPlugin(PluginProgress pluginProgress) {
@@ -1735,26 +2166,26 @@ public class PluginManager {
     public Collection<PluginInfoWrapper> getLoadedPlugins() {
       Set<PluginInfoWrapper> loadedPluginsCopy;
       synchronized (this) {
-        loadedPluginsCopy = new HashSet<>(loadedPlugins);
+        loadedPluginsCopy = new HashSet<>(loadedPluginWrappers);
       }
       return loadedPluginsCopy;
     }
 
     public void removeLoadedPlugin(PluginInfoWrapper pluginInfoWrapper) {
       synchronized (this) {
-        loadedPlugins.remove(pluginInfoWrapper);
+        loadedPluginWrappers.remove(pluginInfoWrapper);
       }
     }
 
     public boolean hasLoadedPlugin(PluginInfoWrapper pluginInfoWrapper) {
       synchronized (this) {
-        return loadedPlugins.contains(pluginInfoWrapper);
+        return loadedPluginWrappers.contains(pluginInfoWrapper);
       }
     }
 
     public boolean hasLoadedPlugins() {
       synchronized (this) {
-        return !loadedPlugins.isEmpty();
+        return !loadedPluginWrappers.isEmpty();
       }
     }
 
@@ -1766,7 +2197,7 @@ public class PluginManager {
 
     public void addLoadedPlugin(PluginInfoWrapper pluginInfoWrapper) {
       synchronized (this) {
-        loadedPlugins.add(pluginInfoWrapper);
+        loadedPluginWrappers.add(pluginInfoWrapper);
       }
     }
 
@@ -1799,7 +2230,7 @@ public class PluginManager {
             return true;
           }
         }
-        for (PluginInfoWrapper pluginInfoWrapper : loadedPlugins) {
+        for (PluginInfoWrapper pluginInfoWrapper : loadedPluginWrappers) {
           if (pluginInfoWrapper.getFilename().equals(pluginName)) {
             return true;
           }
@@ -1809,6 +2240,14 @@ public class PluginManager {
     }
   }
 
+  /**
+   * Returns the shared request client used for plugin updater activity.
+   *
+   * <p>Callers that schedule or perform plugin update fetches should use this client rather than
+   * creating their own, so that updater traffic remains bounded and consistent.
+   *
+   * @return the shared request client for plugin updater requests
+   */
   public RequestClient getSingleUpdaterRequestClient() {
     return singleUpdaterRequestClient;
   }

--- a/src/main/java/network/crypta/pluginmanager/PluginTalker.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginTalker.java
@@ -71,13 +71,21 @@ public class PluginTalker {
 
   protected WeakReference<FredPluginFCP> findPlugin(String pluginname2)
       throws PluginNotFoundException {
-    LOG.info("Searching fcp plugin: " + pluginname2);
-    FredPluginFCP plug = node.getPluginManager().getFCPPlugin(pluginname2);
+    LOG.info("Searching fcp plugin: {}", pluginname2);
+    FredPluginFCP plug = null;
+    for (PluginInfoWrapper pluginInfoWrapper : node.getPluginManager().getPlugins()) {
+      if (pluginInfoWrapper.getPluginClassName().equals(pluginname2)
+          && !pluginInfoWrapper.isStopping()
+          && pluginInfoWrapper.getPlugin() instanceof FredPluginFCP fcpPlugin) {
+        plug = fcpPlugin;
+        break;
+      }
+    }
     if (plug == null) {
-      LOG.error("Could not find fcp plugin: " + pluginname2);
+      LOG.error("Could not find fcp plugin: {}", pluginname2);
       throw new PluginNotFoundException();
     }
-    LOG.info("Found fcp plugin: " + pluginname2);
+    LOG.info("Found fcp plugin: {}", pluginname2);
     return new WeakReference<>(plug);
   }
 

--- a/src/test/java/network/crypta/pluginmanager/PluginManagerTest.java
+++ b/src/test/java/network/crypta/pluginmanager/PluginManagerTest.java
@@ -1,0 +1,537 @@
+package network.crypta.pluginmanager;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginDescription;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.api.StringCallback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // JUnit-style names: method_whenCondition_expectOutcome
+class PluginManagerTest {
+
+  @TempDir Path tempDir;
+
+  private static final String PLUGINS_TEMP_DIR = "plugins";
+  private static final String OFFICIAL_PLUGIN_HELLO_WORLD = "HelloWorld";
+  private static final String FPROXY_SUBCONFIG = "fproxy";
+  private static final String FPROXY_CSS_OPTION = "css";
+  private static final String THEME_CRYPTAFORGE = "cryptaforge";
+  private static final String FPROXY_CSS_SHORT_DESC = "fproxy.css";
+  private static final String FPROXY_CSS_LONG_DESC = "fproxy.cssLong";
+
+  @Test
+  void isOfficialPlugin_whenNullOrBlank_expectNull() {
+    PluginManager pluginManager = newPluginManagerWithRealConfig();
+
+    assertNull(pluginManager.isOfficialPlugin(null));
+    assertNull(pluginManager.isOfficialPlugin(""));
+    assertNull(pluginManager.isOfficialPlugin("   "));
+  }
+
+  @Test
+  void isOfficialPlugin_whenKnownPlugin_expectDescription() {
+    PluginManager pluginManager = newPluginManagerWithRealConfig();
+
+    OfficialPluginDescription desc = pluginManager.isOfficialPlugin(OFFICIAL_PLUGIN_HELLO_WORLD);
+
+    assertNotNull(desc);
+    assertEquals(OFFICIAL_PLUGIN_HELLO_WORLD, desc.name);
+  }
+
+  @Test
+  void findAvailablePlugins_whenCalled_expectContainsKnownPlugin() {
+    PluginManager pluginManager = newPluginManagerWithRealConfig();
+
+    List<OfficialPluginDescription> plugins = pluginManager.findAvailablePlugins();
+
+    Optional<OfficialPluginDescription> helloWorld =
+        plugins.stream().filter(p -> OFFICIAL_PLUGIN_HELLO_WORLD.equals(p.name)).findFirst();
+    assertTrue(helloWorld.isPresent());
+  }
+
+  @Test
+  void getPluginFilename_whenPluginDirIsFile_expectNull() throws IOException {
+    Path pluginDirFile = Files.createFile(tempDir.resolve("not-a-dir"));
+    PluginManager pluginManager = newPluginManagerWithRealConfig(pluginDirFile.toFile());
+
+    assertNull(pluginManager.getPluginFilename("Example"));
+  }
+
+  @Test
+  void getPluginFilename_whenPluginDirMissing_expectCreatesDirAndReturnsJarPath() {
+    File pluginDir = tempDir.resolve("plugins-missing").toFile();
+    PluginManager pluginManager = newPluginManagerWithRealConfig(pluginDir);
+
+    File jarPath = pluginManager.getPluginFilename("Example");
+
+    assertNotNull(jarPath);
+    assertTrue(pluginDir.isDirectory());
+    assertEquals(new File(pluginDir, "Example.jar"), jarPath);
+  }
+
+  @Test
+  void removeCachedCopy_whenNull_expectNoThrowAndNoDeletion() throws IOException {
+    File pluginDir = tempDir.resolve(PLUGINS_TEMP_DIR).toFile();
+    assertTrue(pluginDir.mkdirs());
+    Path keepFile = Files.createFile(pluginDir.toPath().resolve("KeepMe.jar"));
+    PluginManager pluginManager = newPluginManagerWithRealConfig();
+
+    assertDoesNotThrow(() -> pluginManager.removeCachedCopy(null));
+    assertTrue(Files.exists(keepFile));
+  }
+
+  @Test
+  void removeCachedCopy_whenNameWithoutExtension_expectDeletesMatchingCachedFiles()
+      throws IOException {
+    File pluginDir = tempDir.resolve(PLUGINS_TEMP_DIR).toFile();
+    assertTrue(pluginDir.mkdirs());
+    Path base = Files.createFile(pluginDir.toPath().resolve("MyPlugin.jar"));
+    Path v1 = Files.createFile(pluginDir.toPath().resolve("MyPlugin.jar-1"));
+    Path v2 = Files.createFile(pluginDir.toPath().resolve("MyPlugin.jar-2"));
+    Path other = Files.createFile(pluginDir.toPath().resolve("MyPlugin-Other.jar"));
+    PluginManager pluginManager = newPluginManagerWithRealConfig(pluginDir);
+
+    pluginManager.removeCachedCopy("MyPlugin");
+
+    assertTrue(Files.notExists(base));
+    assertTrue(Files.notExists(v1));
+    assertTrue(Files.notExists(v2));
+    assertTrue(Files.exists(other));
+  }
+
+  @Test
+  void removeCachedCopy_whenSpecificationContainsUnixPath_expectDeletesBasedOnBasename()
+      throws IOException {
+    File pluginDir = tempDir.resolve(PLUGINS_TEMP_DIR).toFile();
+    assertTrue(pluginDir.mkdirs());
+    Path base = Files.createFile(pluginDir.toPath().resolve("PathPlugin.jar"));
+    Path v1 = Files.createFile(pluginDir.toPath().resolve("PathPlugin.jar-99"));
+    PluginManager pluginManager = newPluginManagerWithRealConfig(pluginDir);
+
+    pluginManager.removeCachedCopy("/some/path/PathPlugin.jar");
+
+    assertTrue(Files.notExists(base));
+    assertTrue(Files.notExists(v1));
+  }
+
+  @Test
+  void removeCachedCopy_whenSpecificationContainsWindowsPath_expectDeletesBasedOnBasename()
+      throws IOException {
+    File pluginDir = tempDir.resolve(PLUGINS_TEMP_DIR).toFile();
+    assertTrue(pluginDir.mkdirs());
+    Path base = Files.createFile(pluginDir.toPath().resolve("WinPlugin.jar"));
+    Path v1 = Files.createFile(pluginDir.toPath().resolve("WinPlugin.jar-123"));
+    PluginManager pluginManager = newPluginManagerWithRealConfig(pluginDir);
+
+    pluginManager.removeCachedCopy("C:\\\\plugins\\\\WinPlugin.jar");
+
+    assertTrue(Files.notExists(base));
+    assertTrue(Files.notExists(v1));
+  }
+
+  @Test
+  void startPluginAuto_whenOfficialPluginName_expectRoutesToOfficial() {
+    TestablePluginManager pluginManager = newTestablePluginManagerWithRealConfig();
+
+    pluginManager.startPluginAuto(OFFICIAL_PLUGIN_HELLO_WORLD, false);
+
+    assertEquals(TestablePluginManager.Call.OFFICIAL, pluginManager.lastCall);
+    assertEquals(OFFICIAL_PLUGIN_HELLO_WORLD, pluginManager.lastName);
+    assertFalse(pluginManager.lastStore);
+  }
+
+  @Test
+  void startPluginAuto_whenFreenetUri_expectRoutesToFreenet() {
+    TestablePluginManager pluginManager = newTestablePluginManagerWithRealConfig();
+
+    String chk =
+        "CHK@r3SXUzFR-CjBjck0ZxoZ9mIUzGhSMq6Ap471njwvhAU,"
+            + "V0cQ6eJcCf-~XTwLvtgC2klbUx8CWFZoELM2RmEjSJo,"
+            + "AAMC--8/plugin-HelloWorld.jar";
+    pluginManager.startPluginAuto(chk, true);
+
+    assertEquals(TestablePluginManager.Call.FREENET, pluginManager.lastCall);
+    assertEquals(chk, pluginManager.lastName);
+    assertTrue(pluginManager.lastStore);
+  }
+
+  @Test
+  void startPluginAuto_whenExistingAbsoluteFilePath_expectRoutesToFile() throws IOException {
+    Path pluginJar = Files.createFile(tempDir.resolve("LocalPlugin.jar"));
+    TestablePluginManager pluginManager = newTestablePluginManagerWithRealConfig();
+
+    pluginManager.startPluginAuto(pluginJar.toAbsolutePath().toString(), false);
+
+    assertEquals(TestablePluginManager.Call.FILE, pluginManager.lastCall);
+    assertEquals(pluginJar.toAbsolutePath().toString(), pluginManager.lastName);
+  }
+
+  @Test
+  void startPluginAuto_whenNotOfficialNotFreenetNotFile_expectRoutesToUrl() {
+    TestablePluginManager pluginManager = newTestablePluginManagerWithRealConfig();
+
+    pluginManager.startPluginAuto("https://example.invalid/plugin.jar", true);
+
+    assertEquals(TestablePluginManager.Call.URL, pluginManager.lastCall);
+    assertEquals("https://example.invalid/plugin.jar", pluginManager.lastName);
+    assertTrue(pluginManager.lastStore);
+  }
+
+  @Test
+  void startPluginUrl_whenPluginsDisabled_expectIllegalStateException() {
+    PluginManager pluginManager = newPluginManagerWithDisabledPluginsConfig();
+
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> pluginManager.startPluginURL("https://example.invalid/p.jar", false));
+    assertEquals("Plugins disabled", exception.getMessage());
+  }
+
+  @Test
+  void loadPluginFromJarFile_whenPluginLoads_expectClassLoaderRemainsUsable() throws Exception {
+    PluginManager pluginManager = newPluginManagerWithRealConfig();
+    Path pluginJar = buildTestPluginJar(tempDir.resolve("test-plugin.jar"));
+
+    var method =
+        PluginManager.class.getDeclaredMethod(
+            "loadPluginFromJarFile", String.class, File.class, String.class, boolean.class);
+    method.setAccessible(true);
+
+    FredPlugin plugin =
+        (FredPlugin)
+            method.invoke(
+                pluginManager, "TestPlugin", pluginJar.toFile(), "testplugin.Main", false);
+
+    ClassLoader pluginLoader = plugin.getClass().getClassLoader();
+
+    assertDoesNotThrow(
+        () -> {
+          try {
+            pluginLoader.loadClass("testplugin.Helper");
+          } catch (ClassNotFoundException e) {
+            throw new AssertionError(e);
+          }
+        });
+    assertNotNull(pluginLoader.getResource("testplugin/resource.txt"));
+  }
+
+  private static Path buildTestPluginJar(Path jarPath) throws IOException {
+    Path workDir = jarPath.getParent().resolve("test-plugin-work");
+    Path srcDir = workDir.resolve("src");
+    Path classesDir = workDir.resolve("classes");
+    Files.createDirectories(srcDir);
+    Files.createDirectories(classesDir);
+
+    Path mainJava = srcDir.resolve("Main.java");
+    Path helperJava = srcDir.resolve("Helper.java");
+
+    Files.writeString(
+        mainJava,
+        """
+        package testplugin;
+
+        import network.crypta.pluginmanager.FredPlugin;
+        import network.crypta.pluginmanager.PluginRespirator;
+
+        public final class Main implements FredPlugin {
+          @Override
+          public void terminate() {}
+
+          @Override
+          public void runPlugin(PluginRespirator pr) {
+            // Intentionally empty; this plugin is used only for loader lifetime tests.
+          }
+        }
+        """);
+    Files.writeString(
+        helperJava,
+        """
+        package testplugin;
+
+        public final class Helper {
+          public static String hi() {
+            return "hi";
+          }
+        }
+        """);
+
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    assertNotNull(compiler, "JDK compiler not available (are tests running on a JRE?)");
+
+    List<String> options = new ArrayList<>();
+    options.add("--release");
+    options.add("21");
+    options.add("-classpath");
+    options.add(System.getProperty("java.class.path"));
+    options.add("-d");
+    options.add(classesDir.toString());
+
+    try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
+      Iterable<? extends JavaFileObject> sources =
+          fileManager.getJavaFileObjectsFromFiles(List.of(mainJava.toFile(), helperJava.toFile()));
+      boolean ok =
+          Boolean.TRUE.equals(
+              compiler.getTask(null, fileManager, null, options, null, sources).call());
+      assertTrue(ok, "Failed to compile test plugin sources");
+    }
+
+    Files.createDirectories(jarPath.getParent());
+
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+    manifest.getMainAttributes().putValue("Plugin-Main-Class", "testplugin.Main");
+
+    try (JarOutputStream jarOut = new JarOutputStream(Files.newOutputStream(jarPath), manifest)) {
+      try (var paths = Files.walk(classesDir)) {
+        paths
+            .filter(
+                path ->
+                    Files.isRegularFile(path) && path.getFileName().toString().endsWith(".class"))
+            .forEach(
+                path -> {
+                  String entryName =
+                      classesDir.relativize(path).toString().replace(File.separatorChar, '/');
+                  try {
+                    jarOut.putNextEntry(new JarEntry(entryName));
+                    jarOut.write(Files.readAllBytes(path));
+                    jarOut.closeEntry();
+                  } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                });
+      }
+
+      jarOut.putNextEntry(new JarEntry("testplugin/resource.txt"));
+      jarOut.write("ok\n".getBytes());
+      jarOut.closeEntry();
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+
+    return jarPath;
+  }
+
+  private PluginManager newPluginManagerWithRealConfig() {
+    Node node = mock(Node.class);
+
+    PersistentConfig config = new PersistentConfig(null);
+    SubConfig fproxy = config.createSubConfig(FPROXY_SUBCONFIG);
+    fproxy.register(
+        FPROXY_CSS_OPTION,
+        THEME_CRYPTAFORGE,
+        0,
+        true,
+        true,
+        FPROXY_CSS_SHORT_DESC,
+        FPROXY_CSS_LONG_DESC,
+        (StringCallback) null);
+    fproxy.finishedInitialization();
+    when(node.getConfig()).thenReturn(config);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(node.getClientCore()).thenReturn(core);
+    when(core.makeClient(PluginManager.PRIO, true, false))
+        .thenReturn(mock(HighLevelSimpleClient.class));
+
+    when(node.getExecutor()).thenReturn(new InlinePriorityAwareExecutor());
+
+    return new PluginManager(node, /* lastVersion= */ Integer.MAX_VALUE);
+  }
+
+  private PluginManager newPluginManagerWithRealConfig(File pluginDir) {
+    Node node = mock(Node.class);
+    when(node.getPluginDir()).thenReturn(pluginDir);
+
+    PersistentConfig config = new PersistentConfig(null);
+    SubConfig fproxy = config.createSubConfig(FPROXY_SUBCONFIG);
+    fproxy.register(
+        FPROXY_CSS_OPTION,
+        THEME_CRYPTAFORGE,
+        0,
+        true,
+        true,
+        FPROXY_CSS_SHORT_DESC,
+        FPROXY_CSS_LONG_DESC,
+        (StringCallback) null);
+    fproxy.finishedInitialization();
+    when(node.getConfig()).thenReturn(config);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(node.getClientCore()).thenReturn(core);
+    when(core.makeClient(PluginManager.PRIO, true, false))
+        .thenReturn(mock(HighLevelSimpleClient.class));
+
+    when(node.getExecutor()).thenReturn(new InlinePriorityAwareExecutor());
+
+    return new PluginManager(node, /* lastVersion= */ Integer.MAX_VALUE);
+  }
+
+  private TestablePluginManager newTestablePluginManagerWithRealConfig() {
+    Node node = mock(Node.class);
+
+    PersistentConfig config = new PersistentConfig(null);
+    SubConfig fproxy = config.createSubConfig(FPROXY_SUBCONFIG);
+    fproxy.register(
+        FPROXY_CSS_OPTION,
+        THEME_CRYPTAFORGE,
+        0,
+        true,
+        true,
+        FPROXY_CSS_SHORT_DESC,
+        FPROXY_CSS_LONG_DESC,
+        (StringCallback) null);
+    fproxy.finishedInitialization();
+    when(node.getConfig()).thenReturn(config);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(node.getClientCore()).thenReturn(core);
+    when(core.makeClient(PluginManager.PRIO, true, false))
+        .thenReturn(mock(HighLevelSimpleClient.class));
+
+    when(node.getExecutor()).thenReturn(new InlinePriorityAwareExecutor());
+
+    return new TestablePluginManager(node);
+  }
+
+  private PluginManager newPluginManagerWithDisabledPluginsConfig() {
+    Node node = mock(Node.class);
+
+    SubConfig pluginManagerConfig = mock(SubConfig.class);
+    when(pluginManagerConfig.getBoolean("enabled")).thenReturn(false);
+    when(pluginManagerConfig.getStringArr("loadplugin")).thenReturn(new String[0]);
+
+    SubConfig fproxy = mock(SubConfig.class);
+    when(fproxy.getString(FPROXY_CSS_OPTION)).thenReturn(THEME_CRYPTAFORGE);
+
+    PersistentConfig config = mock(PersistentConfig.class);
+    when(config.createSubConfig("pluginmanager")).thenReturn(pluginManagerConfig);
+    when(config.get(FPROXY_SUBCONFIG)).thenReturn(fproxy);
+    when(node.getConfig()).thenReturn(config);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(node.getClientCore()).thenReturn(core);
+    when(core.makeClient(PluginManager.PRIO, true, false))
+        .thenReturn(mock(HighLevelSimpleClient.class));
+
+    when(node.getExecutor()).thenReturn(new InlinePriorityAwareExecutor());
+
+    return new PluginManager(node, /* lastVersion= */ Integer.MAX_VALUE);
+  }
+
+  private static final class InlinePriorityAwareExecutor implements PriorityAwareExecutor {
+    @Override
+    public void execute(Runnable job) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName, boolean fromTicker) {
+      job.run();
+    }
+
+    @Override
+    public int[] waitingThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int[] runningThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int getWaitingThreadsCount() {
+      return 0;
+    }
+  }
+
+  private static final class TestablePluginManager extends PluginManager {
+    enum Call {
+      OFFICIAL,
+      FREENET,
+      FILE,
+      URL
+    }
+
+    Call lastCall;
+    String lastName;
+    boolean lastStore;
+
+    TestablePluginManager(Node node) {
+      super(node, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public PluginInfoWrapper startPluginOfficial(
+        String pluginname, boolean store, OfficialPluginDescription desc) {
+      lastCall = Call.OFFICIAL;
+      lastName = pluginname;
+      lastStore = store;
+      return mock(PluginInfoWrapper.class);
+    }
+
+    @Override
+    public PluginInfoWrapper startPluginFreenet(String filename, boolean store) {
+      lastCall = Call.FREENET;
+      lastName = filename;
+      lastStore = store;
+      return mock(PluginInfoWrapper.class);
+    }
+
+    @Override
+    public PluginInfoWrapper startPluginFile(String filename, boolean store) {
+      lastCall = Call.FILE;
+      lastName = filename;
+      lastStore = store;
+      return mock(PluginInfoWrapper.class);
+    }
+
+    @Override
+    public PluginInfoWrapper startPluginURL(String filename, boolean store) {
+      lastCall = Call.URL;
+      lastName = filename;
+      lastStore = store;
+      return mock(PluginInfoWrapper.class);
+    }
+  }
+}


### PR DESCRIPTION
Summary:
- Switch node startup to use `PluginManager.create(node, lastVersion)` instead of directly calling the constructor, centralizing singleton registration.
- Make `PluginTalker` resolve FCP plugins via the loaded plugin wrappers, ensuring we ignore stopping plugins and use structured logging.
- Add `PluginManagerTest` coverage for official plugin lookup, plugin filename/cached-copy handling, and startup path routing.

Notes:
- Formatting applied with `./gradlew spotlessApply`.
- I did not run the full test suite in this run (can run `./gradlew test` if you want).