### PR TITLE
fix(tools): improve AddRef CLI and add tests

### DIFF
--- a/src/main/java/network/crypta/tools/AddRef.java
+++ b/src/main/java/network/crypta/tools/AddRef.java
@@ -1,8 +1,13 @@
 package network.crypta.tools;
 
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.filter.LevelFilter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.spi.FilterReply;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.SocketException;
@@ -13,100 +18,146 @@ import network.crypta.clients.fcp.MessageInvalidException;
 import network.crypta.clients.fcp.NodeHelloMessage;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.LineReadingInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Command-line tool that adds a darknet reference to a running local node via FCP.
+ *
+ * <p>This class is intended to be invoked from the command line with a single argument pointing to
+ * a reference file. It connects to the local {@link network.crypta.clients.fcp.FCPServer} on the
+ * default port, performs a minimal FCP handshake (sending {@code ClientHello} and validating the
+ * node responds with {@code NodeHello}), and then sends the parsed reference fields using the
+ * {@code AddPeer} message.
+ *
+ * <p>The implementation is intentionally small and synchronous: it opens one TCP connection, sends
+ * a small number of messages, and exits. It logs user-facing output to stdout/stderr and, for
+ * historical compatibility with existing scripts, exits the JVM with a non-zero code on common
+ * failure paths (invalid arguments, connection failures, or I/O errors). This tool is not designed
+ * for concurrent use; each invocation operates independently and has no shared mutable state.
+ *
+ * <ul>
+ *   <li><b>Inputs:</b> a readable file containing a serialized {@link SimpleFieldSet} reference
+ *   <li><b>Outputs:</b> a best-effort attempt to add the reference, reported via logs
+ *   <li><b>Failure modes:</b> validation errors, socket errors, or malformed message data
+ * </ul>
+ *
+ * @see network.crypta.clients.fcp.FCPMessage
+ * @see network.crypta.clients.fcp.NodeHelloMessage
+ * @see network.crypta.clients.fcp.AddPeer
+ */
 public class AddRef {
+  private static final Logger LOG = LoggerFactory.getLogger(AddRef.class);
+
+  private AddRef() {}
 
   /**
-   * Connects to a FCP server and adds a reference
+   * Runs the AddRef command-line entry point, validating arguments and executing the add flow.
    *
-   * @param args
+   * <p>This method configures console logging suitable for standalone execution, validates that a
+   * reference file path is provided and readable, and then attempts to connect to the local FCP
+   * server to submit the reference. On invalid arguments the process exits immediately; on network
+   * or I/O failures, errors are logged and the process exits with a non-zero status. The tool
+   * intentionally sleeps briefly at shutdown to make user-facing console output easier to observe
+   * when launched from wrappers that may close quickly.
+   *
+   * @param args command-line arguments where {@code args[0]} is a readable reference file path
+   *     suitable for {@link SimpleFieldSet#readFrom(File, boolean, boolean)}.
    */
   public static void main(String[] args) {
+    configureStandaloneConsoleLogging();
     if (args.length < 1) {
-      System.err.println("Please provide a file name as the first argument.");
+      LOG.error("Please provide a file name as the first argument.");
       System.exit(-1);
     }
 
     final File reference = new File(args[0]);
-    if ((reference == null) || !(reference.isFile()) || !(reference.canRead())) {
-      System.err.println("Please provide a file name as the first argument.");
+    if (!reference.isFile() || !reference.canRead()) {
+      LOG.error("Please provide a file name as the first argument.");
       System.exit(-1);
     }
 
-    new AddRef(reference);
+    addRef(reference);
   }
 
-  AddRef(File reference) {
-    Socket fcpSocket = null;
-
-    FCPMessage fcpm;
-    SimpleFieldSet sfs = new SimpleFieldSet(true);
-
+  private static void addRef(File reference) {
     try {
-      fcpSocket = new Socket("127.0.0.1", FCPServer.DEFAULT_FCP_PORT);
-      fcpSocket.setSoTimeout(2000);
-
-      InputStream is = fcpSocket.getInputStream();
-      LineReadingInputStream lis = new LineReadingInputStream(is);
-      OutputStream os = fcpSocket.getOutputStream();
-
-      try {
-        sfs.putSingle("Name", "AddRef");
-        sfs.putSingle("ExpectedVersion", "2.0");
-        fcpm = FCPMessage.create("ClientHello", sfs);
-        fcpm.send(os);
-        os.flush();
-
-        String messageName = lis.readLine(128, 128, true);
-        sfs = getMessage(lis);
-        fcpm = FCPMessage.create(messageName, sfs);
-        if (!(fcpm instanceof NodeHelloMessage)) {
-          System.err.println("Not a valid FRED node!");
-          System.exit(1);
-        }
-      } catch (MessageInvalidException me) {
-        me.printStackTrace();
+      try (Socket fcpSocket = new Socket("127.0.0.1", FCPServer.DEFAULT_FCP_PORT);
+          LineReadingInputStream lis = new LineReadingInputStream(fcpSocket.getInputStream());
+          OutputStream os = fcpSocket.getOutputStream()) {
+        fcpSocket.setSoTimeout(2000);
+        sendClientHelloAndValidateNode(lis, os);
+        sendReference(reference, os);
       }
-
-      try {
-        sfs = SimpleFieldSet.readFrom(reference, false, true);
-        fcpm = FCPMessage.create(AddPeer.NAME, sfs);
-        fcpm.send(os);
-        os.flush();
-
-        // TODO: We ought to do stricter checking!
-        // FIXME: some checks even
-      } catch (MessageInvalidException me) {
-        System.err.println("Invalid reference file!" + me);
-        me.printStackTrace();
-      }
-
-      lis.close();
-      is.close();
-      os.close();
-      fcpSocket.close();
-      System.out.println("That reference has been added");
+      LOG.info("That reference has been added");
     } catch (SocketException se) {
-      System.err.println(se);
-      se.printStackTrace();
+      LOG.error("Failed to connect to FCP server.", se);
       System.exit(1);
     } catch (IOException ioe) {
-      System.err.println(ioe);
-      ioe.printStackTrace();
+      LOG.error("I/O error while communicating with the FCP server.", ioe);
       System.exit(2);
     } finally {
-      try {
-        Thread.sleep(3000);
-      } catch (InterruptedException e) {
+      sleepAtShutdown();
+    }
+  }
+
+  private static void sendClientHelloAndValidateNode(LineReadingInputStream lis, OutputStream os)
+      throws IOException {
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    sfs.putSingle("Name", "AddRef");
+    sfs.putSingle("ExpectedVersion", "2.0");
+    try {
+      FCPMessage fcpm = FCPMessage.create("ClientHello", sfs);
+      fcpm.send(os);
+      os.flush();
+
+      String messageName = lis.readLine(128, 128, true);
+      sfs = getMessage(lis);
+      fcpm = FCPMessage.create(messageName, sfs);
+      if (!(fcpm instanceof NodeHelloMessage)) {
+        LOG.error("Not a valid FRED node!");
+        System.exit(1);
       }
+    } catch (MessageInvalidException e) {
+      LOG.error("Received an invalid FCP message during node handshake.", e);
+    }
+  }
+
+  private static void sendReference(File reference, OutputStream os) throws IOException {
+    try {
+      SimpleFieldSet sfs = SimpleFieldSet.readFrom(reference, false, true);
+      FCPMessage fcpm = FCPMessage.create(AddPeer.NAME, sfs);
+      fcpm.send(os);
+      os.flush();
+    } catch (MessageInvalidException e) {
+      LOG.error("Invalid reference file.", e);
+    }
+  }
+
+  private static void sleepAtShutdown() {
+    try {
+      Thread.sleep(3000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 
   /**
-   * @param lis
-   * @return
+   * Reads an FCP message body from the provided line reader into a {@link SimpleFieldSet}.
+   *
+   * <p>This helper performs a best-effort parse of {@code key=value} lines that follow an FCP
+   * message name. Reading stops when the stream reports no more available bytes, when a line begins
+   * with {@code End}, or when a line cannot be split on {@code '='}. The returned field set may be
+   * empty or partially populated if the peer closes the connection early or an I/O error occurs.
+   *
+   * <p>This method does not throw checked exceptions. If an {@link IOException} occurs while
+   * reading, the error is logged and the fields collected so far are returned.
+   *
+   * @param lis line-oriented view of the underlying FCP socket input, positioned at the start of
+   *     the message field lines.
+   * @return a {@link SimpleFieldSet} containing any successfully parsed fields, possibly empty.
    */
-  protected SimpleFieldSet getMessage(LineReadingInputStream lis) {
+  protected static SimpleFieldSet getMessage(LineReadingInputStream lis) {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
     try {
       while (lis.available() > 0) {
@@ -116,9 +167,69 @@ public class AddRef {
         sfs.putSingle(line.substring(0, index), line.substring(index + 1));
       }
     } catch (IOException e) {
+      LOG.error("Failed while reading an FCP message.", e);
       return sfs;
     }
 
     return sfs;
+  }
+
+  /**
+   * Ensures AddRef emits user-facing output to stdout/stderr (plain text) when running as a
+   * standalone tool.
+   *
+   * <p>In particular, tests execute AddRef in a separate JVM where the default Logback
+   * configuration may route console logs to stdout only. This method configures the AddRef logger
+   * to emit INFO to stdout and ERROR to stderr, matching historical behavior.
+   */
+  private static void configureStandaloneConsoleLogging() {
+    if (!(LoggerFactory.getILoggerFactory() instanceof LoggerContext context)) {
+      return;
+    }
+
+    ch.qos.logback.classic.Logger logger = context.getLogger(AddRef.class);
+    if (logger.getAppender("ADDREF_OUT") != null || logger.getAppender("ADDREF_ERR") != null) {
+      return;
+    }
+
+    logger.setAdditive(false);
+    logger.detachAndStopAllAppenders();
+
+    ConsoleAppender<ILoggingEvent> stdout = new ConsoleAppender<>();
+    stdout.setName("ADDREF_OUT");
+    stdout.setContext(context);
+    stdout.setTarget("System.out");
+    stdout.setEncoder(newConsoleEncoder(context, "%msg%n"));
+    stdout.addFilter(levelOnlyFilter(ch.qos.logback.classic.Level.INFO));
+    stdout.start();
+    logger.addAppender(stdout);
+
+    ConsoleAppender<ILoggingEvent> stderr = new ConsoleAppender<>();
+    stderr.setName("ADDREF_ERR");
+    stderr.setContext(context);
+    stderr.setTarget("System.err");
+    stderr.setEncoder(newConsoleEncoder(context, "%msg%n%ex{full}"));
+    stderr.addFilter(levelOnlyFilter(ch.qos.logback.classic.Level.ERROR));
+    stderr.start();
+    logger.addAppender(stderr);
+
+    logger.setLevel(ch.qos.logback.classic.Level.INFO);
+  }
+
+  private static PatternLayoutEncoder newConsoleEncoder(LoggerContext context, String pattern) {
+    PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+    encoder.setContext(context);
+    encoder.setPattern(pattern);
+    encoder.start();
+    return encoder;
+  }
+
+  private static LevelFilter levelOnlyFilter(ch.qos.logback.classic.Level level) {
+    LevelFilter filter = new LevelFilter();
+    filter.setLevel(level);
+    filter.setOnMatch(FilterReply.ACCEPT);
+    filter.setOnMismatch(FilterReply.DENY);
+    filter.start();
+    return filter;
   }
 }

--- a/src/test/java/network/crypta/tools/AddRefTest.java
+++ b/src/test/java/network/crypta/tools/AddRefTest.java
@@ -1,0 +1,149 @@
+package network.crypta.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.io.LineReadingInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class AddRefTest {
+
+  private static final String USAGE_MESSAGE = "Please provide a file name as the first argument.";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void getMessage_whenInputIsEmpty_expectEmptyFieldSet() {
+    LineReadingInputStream lis = new LineReadingInputStream(new ByteArrayInputStream(new byte[0]));
+
+    SimpleFieldSet result = AddRef.getMessage(lis);
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void getMessage_whenInputHasKeyValuePairs_expectParsedFieldSet() {
+    String payload = "Foo=bar\nBaz=qux\nEndMessage\n";
+    LineReadingInputStream lis =
+        new LineReadingInputStream(
+            new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8)));
+
+    SimpleFieldSet result = AddRef.getMessage(lis);
+
+    assertEquals("bar", result.get("Foo"));
+    assertEquals("qux", result.get("Baz"));
+  }
+
+  @Test
+  void getMessage_whenLineHasNoEquals_expectStopsAndReturnsPreviouslyParsedFields() {
+    String payload = "Foo=bar\nNoEqualsHere\nBaz=qux\nEndMessage\n";
+    LineReadingInputStream lis =
+        new LineReadingInputStream(
+            new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8)));
+
+    SimpleFieldSet result = AddRef.getMessage(lis);
+
+    assertEquals("bar", result.get("Foo"));
+    assertNull(result.get("Baz"));
+  }
+
+  @Test
+  void getMessage_whenLineStartsWithEnd_expectStopsBeforeParsingFurther() {
+    String payload = "Foo=bar\nEndMessage\nBaz=qux\n";
+    LineReadingInputStream lis =
+        new LineReadingInputStream(
+            new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8)));
+
+    SimpleFieldSet result = AddRef.getMessage(lis);
+
+    assertEquals("bar", result.get("Foo"));
+    assertNull(result.get("Baz"));
+  }
+
+  @Test
+  void getMessage_whenReadLineThrowsIOException_expectEmptyFieldSet() throws IOException {
+    LineReadingInputStream lis = mock(LineReadingInputStream.class);
+    when(lis.available()).thenReturn(1);
+    doThrow(new IOException("boom")).when(lis).readLine(128, 128, true);
+
+    SimpleFieldSet result = AddRef.getMessage(lis);
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    verify(lis, times(1)).readLine(128, 128, true);
+  }
+
+  @Test
+  void main_whenNoArgs_expectExitCode255AndUsageMessageToStderr()
+      throws IOException, InterruptedException {
+    ProcessResult result = runAddRef();
+
+    assertEquals(255, result.exitCode());
+    assertTrue(result.stderr().contains(USAGE_MESSAGE));
+  }
+
+  @Test
+  void main_whenPathIsDirectory_expectExitCode255AndUsageMessageToStderr()
+      throws IOException, InterruptedException {
+    ProcessResult result = runAddRef(tempDir.toString());
+
+    assertEquals(255, result.exitCode());
+    assertTrue(result.stderr().contains(USAGE_MESSAGE));
+  }
+
+  @Test
+  void main_whenPathDoesNotExist_expectExitCode255AndUsageMessageToStderr()
+      throws IOException, InterruptedException {
+    ProcessResult result = runAddRef(tempDir.resolve("missing.ref").toString());
+
+    assertEquals(255, result.exitCode());
+    assertTrue(result.stderr().contains(USAGE_MESSAGE));
+  }
+
+  private static ProcessResult runAddRef(String... args) throws IOException, InterruptedException {
+    String javaBin =
+        Path.of(System.getProperty("java.home")).resolve("bin").resolve("java").toString();
+
+    List<String> cmd = new java.util.ArrayList<>();
+    cmd.add(javaBin);
+    cmd.add("-cp");
+    cmd.add(System.getProperty("java.class.path"));
+    cmd.add("network.crypta.tools.AddRef");
+    cmd.addAll(List.of(args));
+
+    Process process = new ProcessBuilder(cmd).start();
+
+    boolean finished = process.waitFor(10, TimeUnit.SECONDS);
+    if (!finished) {
+      process.destroyForcibly();
+      throw new IllegalStateException("AddRef process did not exit within timeout");
+    }
+
+    // Drain streams after the process exits; AddRef should only emit small amounts of output.
+    process.getInputStream().readAllBytes();
+    String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+    return new ProcessResult(process.exitValue(), stderr);
+  }
+
+  private record ProcessResult(int exitCode, String stderr) {}
+}


### PR DESCRIPTION
Changes:
- Refactors `network.crypta.tools.AddRef` to be a more robust CLI tool (argument validation, clearer logging, structured flow) while preserving behavior.
- Adds JUnit tests for parsing and CLI error handling (`AddRefTest`).

Notes:
- Branch contains a single commit: `8d75b2554b`.
- No uncommitted/untracked files at PR creation time.

How to test:
- `./gradlew test --tests network.crypta.tools.AddRefTest`