### PR TITLE
refactor(tools): harden CleanupTranslations

### DIFF
--- a/src/main/java/network/crypta/tools/CleanupTranslations.java
+++ b/src/main/java/network/crypta/tools/CleanupTranslations.java
@@ -3,92 +3,169 @@ package network.crypta.tools;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import network.crypta.support.Logging;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
+/**
+ * Command-line utility that cleans up translation property files under {@code src/freenet/l10n}.
+ *
+ * <p>This tool treats {@code crypta.l10n.en.properties} as the reference set of translation keys
+ * and rewrites other {@code crypta.l10n.*.properties} files to remove entries whose keys are no
+ * longer present in the English file. It is intended for repository maintenance (e.g., after
+ * renaming or deleting strings) so translators are not left with keys that are never looked up at
+ * runtime.
+ *
+ * <p><b>Notable behaviors</b>:
+ *
+ * <ul>
+ *   <li>Preserves the original line text for keys that are kept, including any value formatting.
+ *   <li>Requires translation files to terminate with a single {@code End} line and no trailing
+ *       content.
+ *   <li>Exits the JVM with a non-zero status for structural errors or I/O failures.
+ * </ul>
+ *
+ * <p>This class performs file I/O and is not designed for concurrent use across multiple processes
+ * targeting the same directory; it makes no attempt at locking or atomic multi-file updates.
+ *
+ * @see SimpleFieldSet
+ * @see Logging
+ */
 public class CleanupTranslations {
-  private static final Logger LOG = LoggerFactory.getLogger(CleanupTranslations.class);
+  private static final PrintWriter STDOUT =
+      new PrintWriter(
+          new OutputStreamWriter(new FileOutputStream(FileDescriptor.out), StandardCharsets.UTF_8),
+          true);
+  private static final PrintWriter STDERR =
+      new PrintWriter(
+          new OutputStreamWriter(new FileOutputStream(FileDescriptor.err), StandardCharsets.UTF_8),
+          true);
 
   /**
-   * @param args
-   * @throws IOException
+   * Removes translation keys that are no longer present in the English reference file.
+   *
+   * <p>The tool loads {@code src/freenet/l10n/crypta.l10n.en.properties} as a {@link
+   * SimpleFieldSet} and scans files in {@code src/freenet/l10n}. For each translation file, it
+   * keeps only key/value lines whose key exists in the English file and then rewrites the
+   * translation file if any orphaned keys were removed. Structural issues (such as missing {@code
+   * End} terminators) are treated as fatal and cause the JVM to exit with a non-zero status code.
+   *
+   * <p>This method performs filesystem reads and writes and is expected to be run as a single-shot
+   * CLI command. It is not idempotent with respect to formatting because it rewrites the file
+   * content exactly as it was read for kept lines.
+   *
+   * @param args command-line arguments, currently ignored by this maintenance utility
+   * @throws IOException if reading or writing translation files fails with an I/O error
    */
   public static void main(String[] args) throws IOException {
-    Logging.bootstrap(org.slf4j.event.Level.ERROR, "");
+    Logging.bootstrap(Level.ERROR, "");
     File engFile = new File("src/freenet/l10n/crypta.l10n.en.properties");
     SimpleFieldSet english = SimpleFieldSet.readFrom(engFile, false, true);
-    File[] translations = new File("src/freenet/l10n").listFiles();
-    for (File f : translations) {
-      String name = f.getName();
-      if (!name.startsWith("crypta.l10n.")) {
-        continue;
-      }
-      if (name.equals("crypta.1l0n.en.properties")) {
-        continue;
-      }
-      StringWriter sw = new StringWriter();
-      boolean changed = false;
-      try (FileInputStream fis = new FileInputStream(f);
-          InputStreamReader isr =
-              new InputStreamReader(new BufferedInputStream(fis), StandardCharsets.UTF_8);
-          BufferedReader br = new BufferedReader(isr)) {
-
-        while (true) {
-          String line = br.readLine();
-          if (line == null) {
-            System.err.println("File does not end in End: " + f);
-            System.exit(4);
-          }
-          int idx = line.indexOf('=');
-          if (idx == -1) {
-            // Last line
-            if (!line.equals("End")) {
-              System.err.println(
-                  "Line with no equals (file does not end in End???): "
-                      + f
-                      + " - \""
-                      + line
-                      + "\"");
-              System.exit(1);
+    File translationDir = new File("src/freenet/l10n");
+    File[] translations = translationDir.listFiles();
+    if (translations == null) {
+      fail(3, "Unable to list translation files in: " + translationDir);
+    } else {
+      for (File translation : translations) {
+        if (isTranslationFile(translation)) {
+          CleanupResult result = cleanupTranslationFile(translation, english);
+          if (result.changed()) {
+            try (FileOutputStream fos = new FileOutputStream(translation);
+                OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
+              osw.write(result.content());
             }
-            sw.append(line).append("\n");
-            line = br.readLine();
-            if (line != null) {
-              System.err.println("Content after End: \"" + line + "\"");
-              System.exit(2);
-            }
-            break;
+            STDOUT.println("Rewritten " + translation);
           }
-          String before = line.substring(0, idx);
-          // String after = line.substring(idx+1);
-          String s = english.get(before);
-          if (s == null) {
-            System.err.println("Orphaned string: \"" + before + "\" in " + f);
-            changed = true;
-            continue;
-          }
-          sw.append(line).append("\n");
         }
       }
-
-      if (!changed) {
-        continue;
-      }
-
-      try (FileOutputStream fos = new FileOutputStream(f);
-          OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
-        osw.write(sw.toString());
-      }
-      System.out.println("Rewritten " + f);
     }
   }
+
+  /**
+   * Creates a new instance.
+   *
+   * <p>This type is primarily used via its {@link #main(String[])} entry point and carries no
+   * instance state. The explicit constructor exists only to satisfy strict doclint checks for the
+   * public default constructor.
+   */
+  public CleanupTranslations() {
+    // Intentionally empty: this utility is invoked via main(...) and has no instance state.
+  }
+
+  private static boolean isTranslationFile(File file) {
+    String name = file.getName();
+    return name.startsWith("crypta.l10n.") && !name.equals("crypta.1l0n.en.properties");
+  }
+
+  private static CleanupResult cleanupTranslationFile(File file, SimpleFieldSet english)
+      throws IOException {
+    StringWriter output = new StringWriter();
+    boolean changed = false;
+
+    try (FileInputStream fis = new FileInputStream(file);
+        InputStreamReader isr =
+            new InputStreamReader(new BufferedInputStream(fis), StandardCharsets.UTF_8);
+        BufferedReader br = new BufferedReader(isr)) {
+      boolean finished = false;
+      while (!finished) {
+        String line = br.readLine();
+        if (line == null) {
+          fail(4, "File does not end in End: " + file);
+        } else {
+          int idx = line.indexOf('=');
+          if (idx == -1) {
+            finished = handleEndLine(line, br, output, file);
+          } else {
+            changed |= handleKeyLine(line, idx, english, output, file);
+          }
+        }
+      }
+    }
+
+    return new CleanupResult(changed, output.toString());
+  }
+
+  private static boolean handleEndLine(
+      String line, BufferedReader br, StringWriter output, File file) throws IOException {
+    if (!line.equals("End")) {
+      fail(1, "Line with no equals (file does not end in End???): " + file + " - \"" + line + "\"");
+    }
+
+    output.append(line).append("\n");
+    String extra = br.readLine();
+    if (extra != null) {
+      fail(2, "Content after End: \"" + extra + "\"");
+    }
+
+    return true;
+  }
+
+  private static boolean handleKeyLine(
+      String line, int equalsIndex, SimpleFieldSet english, StringWriter output, File file) {
+    String key = line.substring(0, equalsIndex);
+    if (english.get(key) == null) {
+      STDERR.println("Orphaned string: \"" + key + "\" in " + file);
+      return true;
+    }
+
+    output.append(line).append("\n");
+    return false;
+  }
+
+  private static void fail(int exitCode, String message) {
+    STDERR.println(message);
+    System.exit(exitCode);
+    throw new IllegalStateException(message);
+  }
+
+  private record CleanupResult(boolean changed, String content) {}
 }

--- a/src/test/java/network/crypta/tools/CleanupTranslationsTest.java
+++ b/src/test/java/network/crypta/tools/CleanupTranslationsTest.java
@@ -1,0 +1,180 @@
+package network.crypta.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class CleanupTranslationsTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void main_whenTranslationHasOrphanedKey_removesLineAndRewritesFile()
+      throws IOException, InterruptedException {
+    // Arrange
+    Path l10nDir = createL10nDir(tempDir);
+    writeEnglishKeys(l10nDir, List.of("known", "another"));
+    Path translation = l10nDir.resolve("crypta.l10n.fr.properties");
+    writeL10nFile(
+        translation,
+        List.of("known=Bonjour", "orphaned=ShouldBeRemoved", "another=Au revoir", "End"));
+
+    // Act
+    ProcessResult result = runCleanupTranslations(tempDir);
+
+    // Assert
+    assertEquals(0, result.exitCode());
+    assertTrue(
+        result.stderr().contains("Orphaned string: \"orphaned\""),
+        "Expected orphaned key to be reported on stderr");
+    assertTrue(
+        result.stdout().contains("Rewritten src/freenet/l10n/crypta.l10n.fr.properties"),
+        "Expected rewritten message on stdout");
+
+    String rewritten = Files.readString(translation, StandardCharsets.UTF_8);
+    assertEquals(
+        String.join("\n", List.of("known=Bonjour", "another=Au revoir", "End", "")),
+        rewritten,
+        "Expected orphaned line to be removed and file to remain newline-terminated");
+  }
+
+  @Test
+  void main_whenNoOrphanedKeys_expectNoRewrite() throws IOException, InterruptedException {
+    // Arrange
+    Path l10nDir = createL10nDir(tempDir);
+    writeEnglishKeys(l10nDir, List.of("onlyKey"));
+    Path translation = l10nDir.resolve("crypta.l10n.de.properties");
+    writeL10nFile(translation, List.of("onlyKey=Hallo", "End"));
+    String before = Files.readString(translation, StandardCharsets.UTF_8);
+
+    // Act
+    ProcessResult result = runCleanupTranslations(tempDir);
+
+    // Assert
+    assertEquals(0, result.exitCode());
+    assertFalse(result.stdout().contains("Rewritten"), "Expected no rewrite output when unchanged");
+    assertEquals(before, Files.readString(translation, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void main_whenNonTranslationFileInvalid_expectIgnoredAndStillSucceeds()
+      throws IOException, InterruptedException {
+    // Arrange
+    Path l10nDir = createL10nDir(tempDir);
+    writeEnglishKeys(l10nDir, List.of("k"));
+    writeL10nFile(l10nDir.resolve("crypta.l10n.es.properties"), List.of("k=Hola", "End"));
+    // Does not start with "crypta.l10n.", and does not end with "End" either; should be ignored.
+    writeUtf8File(l10nDir.resolve("crypta.1l0n.en.properties"), List.of("noEndHere"));
+
+    // Act
+    ProcessResult result = runCleanupTranslations(tempDir);
+
+    // Assert
+    assertEquals(0, result.exitCode());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("malformedTranslationCases")
+  void main_whenTranslationMalformed_expectExitCodeAndMessage(
+      String caseName, List<String> lines, int expectedExitCode, String expectedStderrSubstring)
+      throws IOException, InterruptedException {
+    // Arrange
+    Path l10nDir = createL10nDir(tempDir);
+    writeEnglishKeys(l10nDir, List.of("k"));
+    writeL10nFile(l10nDir.resolve("crypta.l10n.bad.properties"), lines);
+
+    // Act
+    ProcessResult result = runCleanupTranslations(tempDir);
+
+    // Assert
+    assertEquals(expectedExitCode, result.exitCode(), "Unexpected exit code for: " + caseName);
+    assertTrue(
+        result.stderr().contains(expectedStderrSubstring),
+        "Expected stderr to contain: " + expectedStderrSubstring);
+  }
+
+  private static Stream<Arguments> malformedTranslationCases() {
+    return Stream.of(
+        Arguments.of(
+            "missing End triggers exit code 4", List.of("k=v"), 4, "File does not end in End:"),
+        Arguments.of(
+            "line without equals triggers exit code 1",
+            List.of("ThisIsNotEnd", "End"),
+            1,
+            "Line with no equals"),
+        Arguments.of(
+            "content after End triggers exit code 2",
+            List.of("k=v", "End", "TrailingContent"),
+            2,
+            "Content after End:"));
+  }
+
+  private static Path createL10nDir(Path root) throws IOException {
+    Path l10nDir = root.resolve("src").resolve("freenet").resolve("l10n");
+    Files.createDirectories(l10nDir);
+    return l10nDir;
+  }
+
+  private static void writeEnglishKeys(Path l10nDir, List<String> keys) throws IOException {
+    Path english = l10nDir.resolve("crypta.l10n.en.properties");
+    java.util.ArrayList<String> lines = new java.util.ArrayList<>();
+    for (String key : keys) {
+      lines.add(key + "=EN");
+    }
+    lines.add("End");
+    writeL10nFile(english, lines);
+  }
+
+  private static void writeL10nFile(Path file, List<String> lines) throws IOException {
+    writeUtf8File(file, lines);
+  }
+
+  private static void writeUtf8File(Path file, List<String> lines) throws IOException {
+    String content = String.join("\n", lines) + "\n";
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, content, StandardCharsets.UTF_8);
+  }
+
+  private static ProcessResult runCleanupTranslations(Path workingDir)
+      throws IOException, InterruptedException {
+    String javaBin =
+        Path.of(System.getProperty("java.home")).resolve("bin").resolve("java").toString();
+
+    java.util.ArrayList<String> cmd = new java.util.ArrayList<>();
+    cmd.add(javaBin);
+    cmd.add("-cp");
+    cmd.add(System.getProperty("java.class.path"));
+    cmd.add("network.crypta.tools.CleanupTranslations");
+
+    Process process = new ProcessBuilder(cmd).directory(workingDir.toFile()).start();
+
+    boolean finished = process.waitFor(10, TimeUnit.SECONDS);
+    if (!finished) {
+      process.destroyForcibly();
+      throw new IllegalStateException("CleanupTranslations process did not exit within timeout");
+    }
+
+    String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+    return new ProcessResult(process.exitValue(), stdout, stderr);
+  }
+
+  private record ProcessResult(int exitCode, String stdout, String stderr) {}
+}


### PR DESCRIPTION
## Summary
- Refactors `CleanupTranslations` to make behavior more explicit/structured (fatal error helper, explicit stdout/stderr writers, null-check on l10n dir listing) and adds class-level Javadoc.
- Adds `CleanupTranslationsTest` covering orphan-key cleanup, no-op behavior, ignored non-translation file, and malformed translation cases.

## Notes
- Formatting applied via `./gradlew spotlessApply`.
- Tests were not run in this flow (only formatting).