### PR TITLE
refactor(tools): make MergeSFS stream-based

### DIFF
--- a/src/main/java/network/crypta/tools/MergeSFS.java
+++ b/src/main/java/network/crypta/tools/MergeSFS.java
@@ -2,43 +2,153 @@ package network.crypta.tools;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import network.crypta.support.SimpleFieldSet;
 
+/**
+ * Merge a {@link SimpleFieldSet} “override” file into a “source” file.
+ *
+ * <p>This tool reads two SimpleFieldSet (SFS) documents, applies all keys from the override onto
+ * the source using {@link SimpleFieldSet#putAllOverwrite(SimpleFieldSet)}, and writes the merged
+ * result back in deterministic key order. It is primarily a small command-line utility, but the
+ * core behavior is exposed as stream-based methods so it can be exercised in unit tests without
+ * creating temporary files.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Encoding is treated as UTF-8 for both reading and writing.
+ *   <li>The merge is an overwrite merge: if a key exists in both inputs, the override wins.
+ *   <li>Output uses {@link SimpleFieldSet#writeToOrdered(Writer)} for stable ordering.
+ * </ul>
+ *
+ * <p>Thread-safety and mutability: this class is stateless. The {@link #merge(InputStream,
+ * InputStream, OutputStream)} method creates new {@link SimpleFieldSet} instances from the input
+ * streams. The {@link #mergeInPlace(SimpleFieldSet, SimpleFieldSet)} method mutates the provided
+ * {@code source} instance.
+ */
 public class MergeSFS {
 
+  private MergeSFS() {}
+
   /**
-   * @param args
-   * @throws IOException
+   * Run the command-line merge tool.
+   *
+   * <p>This method expects two file paths: the source file to merge into and an override file whose
+   * keys overwrite matching keys in the source. If a third argument equal to {@code --stdout} is
+   * provided, the merged result is written to standard output; otherwise the source file is
+   * overwritten in place. When the arguments are invalid, usage information is written and the
+   * method returns without modifying any file.
+   *
+   * @param args command-line arguments: {@code source-file override-file [--stdout]} in that order.
+   * @throws IOException if reading either file or writing the merged output fails.
    */
   public static void main(String[] args) throws IOException {
     if (args.length < 2 || args.length > 3) {
-      System.out.println("Merges changes made in a SFS override file to a SFS source file.");
-      System.out.println("Usage: source-file override-file [--stdout]");
-      System.out.println("    By default the merged file is written to source-file.");
-      System.out.println("    --stdout writes to standard output instead.");
+      try (OutputStream out = stdoutOutputStream()) {
+        printUsage(out);
+      }
       return;
     }
     File f1 = new File(args[0]);
     File f2 = new File(args[1]);
-    SimpleFieldSet fs1 = SimpleFieldSet.readFrom(f1, false, true);
-    SimpleFieldSet fs2 = SimpleFieldSet.readFrom(f2, false, true);
-    fs1.putAllOverwrite(fs2);
-    // Force output to UTF-8. A PrintStream is still an OutputStream.
-    // These files are always UTF-8, and stdout is likely to be redirected into one.
-    final OutputStream os;
-    if (args.length == 3 && args[2].equals("--stdout")) {
-      os = System.out;
-    } else {
-      os = new FileOutputStream(f1);
+    boolean useStdout = args.length == 3 && "--stdout".equals(args[2]);
+
+    if (useStdout) {
+      try (InputStream sourceIn = new FileInputStream(f1);
+          InputStream overrideIn = new FileInputStream(f2);
+          OutputStream out = stdoutOutputStream()) {
+        merge(sourceIn, overrideIn, out);
+      }
+      return;
     }
-    Writer w = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
-    fs1.writeToOrdered(w);
+
+    try (InputStream sourceIn = new FileInputStream(f1);
+        InputStream overrideIn = new FileInputStream(f2);
+        OutputStream out = new FileOutputStream(f1)) {
+      merge(sourceIn, overrideIn, out);
+    }
+  }
+
+  /**
+   * Merge two UTF-8 encoded SFS streams and write the merged field set in deterministic order to
+   * the given output stream.
+   *
+   * <p>This method does not close {@code out}. Note that {@link
+   * SimpleFieldSet#readFrom(InputStream, boolean, boolean)} closes its {@link InputStream}
+   * argument, so both {@code sourceIn} and {@code overrideIn} are closed as part of parsing.
+   *
+   * <p>The merge is performed by overwriting keys in the parsed source with keys from the parsed
+   * override and then emitting the result via {@link SimpleFieldSet#writeToOrdered(Writer)}. The
+   * output always includes the trailing end marker line (typically {@code End}).
+   *
+   * <pre>{@code
+   * byte[] sourceBytes = "a=1\nEnd\n".getBytes(StandardCharsets.UTF_8);
+   * byte[] overrideBytes = "b=2\nEnd\n".getBytes(StandardCharsets.UTF_8);
+   * ByteArrayOutputStream out = new ByteArrayOutputStream();
+   * MergeSFS.merge(new ByteArrayInputStream(sourceBytes), new ByteArrayInputStream(overrideBytes), out);
+   * }</pre>
+   *
+   * @param sourceIn source SFS content to parse and then merge into, read and then closed.
+   * @param overrideIn override SFS content whose keys overwrite the source, read and then closed.
+   * @param out destination for the merged SFS text encoded as UTF-8, not closed by this method.
+   * @throws IOException if parsing either input or writing the merged result fails.
+   */
+  public static void merge(InputStream sourceIn, InputStream overrideIn, OutputStream out)
+      throws IOException {
+    SimpleFieldSet source = SimpleFieldSet.readFrom(sourceIn, false, true);
+    SimpleFieldSet override = SimpleFieldSet.readFrom(overrideIn, false, true);
+    mergeInPlace(source, override);
+
+    // Force output to UTF-8.
+    Writer w = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+    source.writeToOrdered(w);
     w.flush();
+  }
+
+  /**
+   * Apply all keys from {@code override} onto {@code source}, overwriting existing keys.
+   *
+   * <p>This is a small convenience wrapper around {@link
+   * SimpleFieldSet#putAllOverwrite(SimpleFieldSet)}. It mutates {@code source} in place and returns
+   * the same instance for fluent call sites. If {@code override} is {@code null}, no changes are
+   * made.
+   *
+   * @param source base field set to modify in place; must not be {@code null}.
+   * @param override overrides to apply on top of {@code source}; {@code null} performs no merge.
+   * @return the same {@code source} instance after applying all override keys.
+   */
+  public static SimpleFieldSet mergeInPlace(SimpleFieldSet source, SimpleFieldSet override) {
+    if (override != null) {
+      source.putAllOverwrite(override);
+    }
+    return source;
+  }
+
+  private static void printUsage(OutputStream out) throws IOException {
+    Writer w = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+    w.write("Merges changes made in a SFS override file to a SFS source file.\n");
+    w.write("Usage: source-file override-file [--stdout]\n");
+    w.write("    By default the merged file is written to source-file.\n");
+    w.write("    --stdout writes to standard output instead.\n");
+    w.flush();
+  }
+
+  private static OutputStream stdoutOutputStream() {
+    return new FilterOutputStream(new FileOutputStream(FileDescriptor.out)) {
+      @Override
+      public void close() throws IOException {
+        flush();
+      }
+    };
   }
 }

--- a/src/main/java/network/crypta/tools/MergeSFS.java
+++ b/src/main/java/network/crypta/tools/MergeSFS.java
@@ -72,10 +72,19 @@ public class MergeSFS {
       return;
     }
 
+    // Important: Do not open the output stream to f1 until after the source has been parsed.
+    // Constructing FileOutputStream(f1) truncates f1 immediately, which would otherwise zero the
+    // source file before we read it, resulting in a merge that only contains the override.
+    SimpleFieldSet source;
+    SimpleFieldSet override;
     try (InputStream sourceIn = new FileInputStream(f1);
-        InputStream overrideIn = new FileInputStream(f2);
-        OutputStream out = new FileOutputStream(f1)) {
-      merge(sourceIn, overrideIn, out);
+        InputStream overrideIn = new FileInputStream(f2)) {
+      source = SimpleFieldSet.readFrom(sourceIn, false, true);
+      override = SimpleFieldSet.readFrom(overrideIn, false, true);
+    }
+    mergeInPlace(source, override);
+    try (OutputStream out = new FileOutputStream(f1)) {
+      writeToOrderedUtf8(source, out);
     }
   }
 
@@ -108,11 +117,7 @@ public class MergeSFS {
     SimpleFieldSet source = SimpleFieldSet.readFrom(sourceIn, false, true);
     SimpleFieldSet override = SimpleFieldSet.readFrom(overrideIn, false, true);
     mergeInPlace(source, override);
-
-    // Force output to UTF-8.
-    Writer w = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
-    source.writeToOrdered(w);
-    w.flush();
+    writeToOrderedUtf8(source, out);
   }
 
   /**
@@ -140,6 +145,14 @@ public class MergeSFS {
     w.write("Usage: source-file override-file [--stdout]\n");
     w.write("    By default the merged file is written to source-file.\n");
     w.write("    --stdout writes to standard output instead.\n");
+    w.flush();
+  }
+
+  private static void writeToOrderedUtf8(SimpleFieldSet fieldSet, OutputStream out)
+      throws IOException {
+    // Force output to UTF-8.
+    Writer w = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+    fieldSet.writeToOrdered(w);
     w.flush();
   }
 

--- a/src/main/java/network/crypta/tools/MergeSFS.java
+++ b/src/main/java/network/crypta/tools/MergeSFS.java
@@ -2,7 +2,6 @@ package network.crypta.tools;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FilterOutputStream;
@@ -156,8 +155,12 @@ public class MergeSFS {
     w.flush();
   }
 
+  @SuppressWarnings("java:S106")
   private static OutputStream stdoutOutputStream() {
-    return new FilterOutputStream(new FileOutputStream(FileDescriptor.out)) {
+    // Wrap System.out so try-with-resources callers can "close" it without closing stdout (FD 1).
+    // Do not create a new FileOutputStream(FileDescriptor.out) here: if the stream is not closed,
+    // its cleaner/finalizer may eventually close the shared stdout file descriptor during GC.
+    return new FilterOutputStream(System.out) {
       @Override
       public void close() throws IOException {
         flush();

--- a/src/main/java/network/crypta/tools/package-info.java
+++ b/src/main/java/network/crypta/tools/package-info.java
@@ -1,6 +1,30 @@
 /**
- * Command-line tools bundled with Freenet which can be called separately from the node by using
- * java -cp ... classname. Some of these are only of interest to devs, but @see AddRef is used on
- * Windows to handle .fref files (sending them to the node as darknet references).
+ * Command-line tools bundled with the Crypta node distribution.
+ *
+ * <p>This package contains small, standalone entry points intended to be invoked from the command
+ * line (for example with {@code java -cp ... network.crypta.tools.AddRef}). Unlike the long-running
+ * node daemon, these utilities typically perform a narrow task and then exit: importing or
+ * transforming data, validating or rewriting local files, or assisting with developer and operator
+ * workflows. They are designed to be script-friendly rather than a stable, embeddable library API.
+ *
+ * <p>Most tools follow a simple lifecycle: parse arguments, perform the required file/network I/O,
+ * report a concise status message, and terminate with an appropriate process exit code. Each
+ * invocation is self-contained and generally has no shared mutable state, so thread-safety is
+ * typically not a concern unless a tool explicitly uses concurrency internally.
+ *
+ * <p><b>Notable tools:</b>
+ *
+ * <ul>
+ *   <li>{@link network.crypta.tools.AddRef} — imports a peer reference into a running node
+ *       (commonly used on Windows for handling {@code .fref} files).
+ *   <li>{@link network.crypta.tools.MergeSFS} — merges SimpleFieldSet documents for maintenance and
+ *       troubleshooting workflows.
+ *   <li>{@link network.crypta.tools.CleanupTranslations} — normalizes translation property files in
+ *       the source tree.
+ * </ul>
+ *
+ * @see network.crypta.tools.AddRef
+ * @see network.crypta.tools.MergeSFS
+ * @see network.crypta.tools.CleanupTranslations
  */
 package network.crypta.tools;

--- a/src/test/java/network/crypta/tools/MergeSFSTest.java
+++ b/src/test/java/network/crypta/tools/MergeSFSTest.java
@@ -1,10 +1,13 @@
 package network.crypta.tools;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -58,5 +61,45 @@ class MergeSFSTest {
     MergeSFS.main(new String[] {sourceFile.toString(), overrideFile.toString()});
 
     assertEquals("a=1\nb=2\nEnd\n", Files.readString(sourceFile, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void main_whenUsingStdout_expectNotToCloseSystemOut(@TempDir Path tempDir) throws IOException {
+    Path sourceFile = tempDir.resolve("source.sfs");
+    Path overrideFile = tempDir.resolve("override.sfs");
+
+    Files.writeString(sourceFile, "b=2\nEnd\n", StandardCharsets.UTF_8);
+    Files.writeString(overrideFile, "a=1\nEnd\n", StandardCharsets.UTF_8);
+
+    PrintStream originalOut = System.out;
+    CloseDetectingOutputStream capturingOut = new CloseDetectingOutputStream();
+    try (PrintStream redirectedOut = new PrintStream(capturingOut, true, StandardCharsets.UTF_8)) {
+      System.setOut(redirectedOut);
+      MergeSFS.main(new String[] {sourceFile.toString(), overrideFile.toString(), "--stdout"});
+      assertFalse(capturingOut.isClosed);
+      System.out.print("still-open");
+      System.out.flush();
+      //noinspection ConstantValue
+      assertFalse(capturingOut.isClosed);
+    } finally {
+      System.setOut(originalOut);
+    }
+  }
+
+  private static final class CloseDetectingOutputStream extends OutputStream {
+
+    private boolean isClosed;
+
+    @Override
+    public void write(int b) throws IOException {
+      if (isClosed) {
+        throw new IOException("OutputStream is closed");
+      }
+    }
+
+    @Override
+    public void close() {
+      isClosed = true;
+    }
   }
 }

--- a/src/test/java/network/crypta/tools/MergeSFSTest.java
+++ b/src/test/java/network/crypta/tools/MergeSFSTest.java
@@ -6,9 +6,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.stream.Stream;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,5 +44,19 @@ class MergeSFSTest {
     SimpleFieldSet source = new SimpleFieldSet("a=1\nEnd\n", false, true, false);
     MergeSFS.mergeInPlace(source, null);
     assertEquals("a=1\nEnd\n", source.toOrderedString());
+  }
+
+  @Test
+  void main_whenMergingInPlace_expectSourceNotTruncatedBeforeMerge(@TempDir Path tempDir)
+      throws IOException {
+    Path sourceFile = tempDir.resolve("source.sfs");
+    Path overrideFile = tempDir.resolve("override.sfs");
+
+    Files.writeString(sourceFile, "b=2\nEnd\n", StandardCharsets.UTF_8);
+    Files.writeString(overrideFile, "a=1\nEnd\n", StandardCharsets.UTF_8);
+
+    MergeSFS.main(new String[] {sourceFile.toString(), overrideFile.toString()});
+
+    assertEquals("a=1\nb=2\nEnd\n", Files.readString(sourceFile, StandardCharsets.UTF_8));
   }
 }

--- a/src/test/java/network/crypta/tools/MergeSFSTest.java
+++ b/src/test/java/network/crypta/tools/MergeSFSTest.java
@@ -1,0 +1,45 @@
+package network.crypta.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MergeSFSTest {
+
+  @ParameterizedTest
+  @MethodSource("mergeCases")
+  void merge_whenVariousInputs_expectMergedInDeterministicOrder(
+      String sourceSfs, String overrideSfs, String expectedMergedSfs) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    MergeSFS.merge(
+        new ByteArrayInputStream(sourceSfs.getBytes(StandardCharsets.UTF_8)),
+        new ByteArrayInputStream(overrideSfs.getBytes(StandardCharsets.UTF_8)),
+        out);
+
+    assertEquals(expectedMergedSfs, out.toString(StandardCharsets.UTF_8));
+  }
+
+  private static Stream<Arguments> mergeCases() {
+    return Stream.of(
+        Arguments.of("b=2\nEnd\n", "a=1\nEnd\n", "a=1\nb=2\nEnd\n"),
+        Arguments.of("a=1\nEnd\n", "a=2\nEnd\n", "a=2\nEnd\n"),
+        Arguments.of(
+            "greeting=こんにちは\nEnd\n", "emoji=🙂\nEnd\n", "emoji=🙂\ngreeting=こんにちは\nEnd\n"));
+  }
+
+  @Test
+  void mergeInPlace_whenOverrideNull_expectNoChange() throws IOException {
+    SimpleFieldSet source = new SimpleFieldSet("a=1\nEnd\n", false, true, false);
+    MergeSFS.mergeInPlace(source, null);
+    assertEquals("a=1\nEnd\n", source.toOrderedString());
+  }
+}


### PR DESCRIPTION
## Summary
- Refactors `network.crypta.tools.MergeSFS` to expose stream-based merge helpers (enables testability without temp files).
- Keeps the CLI behavior (merge override into source, deterministic ordered output), with explicit `--stdout` support.
- Expands `network.crypta.tools` package documentation.

## Details
- Adds `MergeSFS.merge(InputStream, InputStream, OutputStream)` and `MergeSFS.mergeInPlace(SimpleFieldSet, SimpleFieldSet)`.
- Writes output using UTF-8 and `SimpleFieldSet#writeToOrdered(...)` for stable ordering.
- Adds `MergeSFSTest` coverage for overwrite semantics, deterministic ordering, and Unicode round-tripping.

## Testing
- Not run in this environment.
- Suggested: `./gradlew test` (or scope to the new test class if preferred).
