### PR TITLE
fix(test): correct upstream bandwidth mock

### DIFF
--- a/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthRateTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthRateTest.java
@@ -281,7 +281,7 @@ class BandwidthRateTest {
     FredPluginBandwidthIndicator indicator = mock(FredPluginBandwidthIndicator.class);
     when(ipDetector.getBandwidthIndicator()).thenReturn(indicator);
     when(indicator.getDownstreamMaxBitRate()).thenReturn(8_000_000);
-    when(indicator.getUpstramMaxBitRate()).thenReturn(1_000_000);
+    when(indicator.getUpstreamMaxBitRate()).thenReturn(1_000_000);
 
     BandwidthRate step = new TestableBandwidthRate(core, config, null);
 


### PR DESCRIPTION
## Summary
- fix a typo in BandwidthRateTest so the mocked bandwidth indicator uses the real upstream accessor

## Testing
- ./gradlew spotlessApply
- ./gradlew compileTestJava
- ./gradlew test --tests *BandwidthRateTest