### PR TITLE
chore(logging): downgrade native priority failure log

### DIFF
--- a/src/main/java/network/crypta/support/io/NativeThread.java
+++ b/src/main/java/network/crypta/support/io/NativeThread.java
@@ -234,7 +234,7 @@ public class NativeThread extends Thread {
   @Override
   public final void run() {
     if (!setNativePriority(currentPriority))
-      LOG.warn("setNativePriority({}) has failed!", currentPriority);
+      LOG.info("setNativePriority({}) has failed!", currentPriority);
     super.run();
     realRun();
   }


### PR DESCRIPTION
## Summary
- lower NativeThread native-priority failure log from WARN to INFO to reduce CI noise

## Testing
- not run (logging level change only)
