### PR TITLE
fix(sonar): wire junit report paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
+          SONAR_SCANNER_OPTS: >-
+            -Dsonar.scanner.dumpToFile=build/sonar/scanner-dump.properties
+            -Dsonar.verbose=true
         run: ./gradlew build sonar
 
       - name: Build (no Sonar token)

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -65,6 +65,11 @@ sonar {
       property("sonar.junit.reportsPath", primaryReportDir)
       property("sonar.surefire.reportsPath", primaryReportDir)
     }
+    // Dump scanner properties for CI debugging (without hard-coding absolute paths).
+    property(
+      "sonar.scanner.dumpToFile",
+      project.relativePath(layout.buildDirectory.file("sonar/scanner-dump.properties").get().asFile),
+    )
 
     // Avoid UTF-8 decode warnings on binary fixtures.
     property(
@@ -154,6 +159,24 @@ tasks
       logger.lifecycle(
         "Sonar debug: sampleReportFile=${sampleReport?.let { project.relativePath(it) } ?: "not found"}"
       )
+
+      val dumpFile = layout.buildDirectory.file("sonar/scanner-dump.properties").get().asFile
+      val dumpPath = project.relativePath(dumpFile)
+      logger.lifecycle("Sonar debug: scannerDumpPath=$dumpPath")
+      if (dumpFile.isFile) {
+        val sanitized =
+          dumpFile
+            .readLines()
+            .asSequence()
+            .filter { it.startsWith("sonar.") }
+            .filterNot { it.startsWith("sonar.token=") || it.startsWith("sonar.login=") }
+            .filterNot { it.startsWith("sonar.password=") }
+            .sorted()
+            .joinToString("\n")
+        logger.lifecycle("Sonar debug: scannerDumpProps\n$sanitized")
+      } else {
+        logger.lifecycle("Sonar debug: scannerDumpProps not available (file missing)")
+      }
     }
   }
 

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -27,6 +27,24 @@ sonar {
         .absolutePath
     property("sonar.coverage.jacoco.xmlReportPaths", jacocoXml)
 
+    // Ensure test sources and JUnit XML reports are discoverable during analysis.
+    val sourceSets = extensions.getByType<SourceSetContainer>()
+    val testSrcDirs =
+      sourceSets.getByName("test").allSource.srcDirs.map { it.absolutePath }.sorted()
+    if (testSrcDirs.isNotEmpty()) {
+      property("sonar.tests", testSrcDirs.joinToString(","))
+    }
+
+    val testReportDirs =
+      tasks
+        .withType<org.gradle.api.tasks.testing.Test>()
+        .map { it.reports.junitXml.outputLocation.get().asFile.absolutePath }
+        .distinct()
+        .sorted()
+    if (testReportDirs.isNotEmpty()) {
+      property("sonar.junit.reportPaths", testReportDirs.joinToString(","))
+    }
+
     // Read token from environment if provided to avoid passing on CLI (modern scanners read
     // sonar.token)
     providers.environmentVariable("SONAR_TOKEN").orNull?.let { token ->

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -163,6 +163,14 @@ tasks
       val dumpFile = layout.buildDirectory.file("sonar/scanner-dump.properties").get().asFile
       val dumpPath = project.relativePath(dumpFile)
       logger.lifecycle("Sonar debug: scannerDumpPath=$dumpPath")
+    }
+  }
+
+tasks
+  .matching { it.name == "sonar" }
+  .configureEach {
+    doLast {
+      val dumpFile = layout.buildDirectory.file("sonar/scanner-dump.properties").get().asFile
       if (dumpFile.isFile) {
         val sanitized =
           dumpFile

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -35,7 +35,7 @@ sonar {
     val mainSourceDirs =
       (sourceSets.getByName("main").java.srcDirs +
           (kotlinExt?.sourceSets?.getByName("main")?.kotlin?.srcDirs ?: emptySet()))
-        .map { it.absolutePath }
+        .map { project.relativePath(it) }
         .sorted()
     if (mainSourceDirs.isNotEmpty()) {
       property("sonar.sources", mainSourceDirs.joinToString(","))
@@ -44,7 +44,7 @@ sonar {
     val testSourceDirs =
       (sourceSets.getByName("test").java.srcDirs +
           (kotlinExt?.sourceSets?.getByName("test")?.kotlin?.srcDirs ?: emptySet()))
-        .map { it.absolutePath }
+        .map { project.relativePath(it) }
         .sorted()
     if (testSourceDirs.isNotEmpty()) {
       property("sonar.tests", testSourceDirs.joinToString(","))
@@ -53,9 +53,9 @@ sonar {
     val testReportDirs =
       tasks
         .withType<org.gradle.api.tasks.testing.Test>()
-        .map { it.reports.junitXml.outputLocation.get().asFile.absolutePath }
+        .map { project.relativePath(it.reports.junitXml.outputLocation.get().asFile) }
         .ifEmpty {
-          listOf(layout.buildDirectory.dir("test-results/test").get().asFile.absolutePath)
+          listOf(project.relativePath(layout.buildDirectory.dir("test-results/test").get().asFile))
         }
         .distinct()
         .sorted()

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -27,23 +27,58 @@ sonar {
         .absolutePath
     property("sonar.coverage.jacoco.xmlReportPaths", jacocoXml)
 
-    // Ensure test sources and JUnit XML reports are discoverable during analysis.
+    // Ensure test/main sources and JUnit XML reports are discoverable during analysis.
     val sourceSets = extensions.getByType<SourceSetContainer>()
-    val testSrcDirs =
-      sourceSets.getByName("test").allSource.srcDirs.map { it.absolutePath }.sorted()
-    if (testSrcDirs.isNotEmpty()) {
-      property("sonar.tests", testSrcDirs.joinToString(","))
+    val kotlinExt =
+      extensions.findByType(org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension::class.java)
+
+    val mainSourceDirs =
+      (sourceSets.getByName("main").java.srcDirs +
+          (kotlinExt?.sourceSets?.getByName("main")?.kotlin?.srcDirs ?: emptySet()))
+        .map { it.absolutePath }
+        .sorted()
+    if (mainSourceDirs.isNotEmpty()) {
+      property("sonar.sources", mainSourceDirs.joinToString(","))
+    }
+
+    val testSourceDirs =
+      (sourceSets.getByName("test").java.srcDirs +
+          (kotlinExt?.sourceSets?.getByName("test")?.kotlin?.srcDirs ?: emptySet()))
+        .map { it.absolutePath }
+        .sorted()
+    if (testSourceDirs.isNotEmpty()) {
+      property("sonar.tests", testSourceDirs.joinToString(","))
     }
 
     val testReportDirs =
       tasks
         .withType<org.gradle.api.tasks.testing.Test>()
         .map { it.reports.junitXml.outputLocation.get().asFile.absolutePath }
+        .ifEmpty {
+          listOf(layout.buildDirectory.dir("test-results/test").get().asFile.absolutePath)
+        }
         .distinct()
         .sorted()
-    if (testReportDirs.isNotEmpty()) {
-      property("sonar.junit.reportPaths", testReportDirs.joinToString(","))
-    }
+    property("sonar.junit.reportPaths", testReportDirs.joinToString(","))
+
+    // Avoid UTF-8 decode warnings on binary fixtures.
+    property(
+      "sonar.exclusions",
+      listOf(
+          "**/*.png",
+          "**/*.gif",
+          "**/*.bmp",
+          "**/*.webp",
+          "**/*.jpg",
+          "**/*.jpeg",
+          "**/*.ico",
+          "**/*.icns",
+          "**/*.pdf",
+          "**/*.zip",
+          "**/*.jar",
+        )
+        .joinToString(","),
+    )
 
     // Read token from environment if provided to avoid passing on CLI (modern scanners read
     // sonar.token)

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -65,10 +65,10 @@ sonar {
       property("sonar.junit.reportsPath", primaryReportDir)
       property("sonar.surefire.reportsPath", primaryReportDir)
     }
-    // Dump scanner properties for CI debugging (without hard-coding absolute paths).
+    // Dump scanner properties for CI debugging (path is computed, not hard-coded).
     property(
       "sonar.scanner.dumpToFile",
-      project.relativePath(layout.buildDirectory.file("sonar/scanner-dump.properties").get().asFile),
+      layout.buildDirectory.file("sonar/scanner-dump.properties").get().asFile.absolutePath,
     )
 
     // Avoid UTF-8 decode warnings on binary fixtures.
@@ -102,6 +102,11 @@ tasks
   .matching { it.name == "sonar" }
   .configureEach {
     doFirst {
+      val dumpFile = layout.buildDirectory.file("sonar/scanner-dump.properties").get().asFile
+      // SonarScanner reads dump config from system properties, not analysis properties.
+      System.setProperty("sonar.scanner.dumpToFile", dumpFile.absolutePath)
+      System.setProperty("sonar.verbose", "true")
+
       val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
       val kotlinExt =
         project.extensions.findByType(
@@ -160,7 +165,6 @@ tasks
         "Sonar debug: sampleReportFile=${sampleReport?.let { project.relativePath(it) } ?: "not found"}"
       )
 
-      val dumpFile = layout.buildDirectory.file("sonar/scanner-dump.properties").get().asFile
       val dumpPath = project.relativePath(dumpFile)
       logger.lifecycle("Sonar debug: scannerDumpPath=$dumpPath")
     }

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -88,6 +88,70 @@ sonar {
   }
 }
 
+tasks
+  .matching { it.name == "sonar" }
+  .configureEach {
+    doFirst {
+      val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
+      val kotlinExt =
+        project.extensions.findByType(
+          org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension::class.java
+        )
+
+      val mainSourceDirs =
+        (sourceSets.getByName("main").java.srcDirs +
+            (kotlinExt?.sourceSets?.getByName("main")?.kotlin?.srcDirs ?: emptySet()))
+          .toList()
+      val testSourceDirs =
+        (sourceSets.getByName("test").java.srcDirs +
+            (kotlinExt?.sourceSets?.getByName("test")?.kotlin?.srcDirs ?: emptySet()))
+          .toList()
+
+      val testReportDirs =
+        tasks
+          .withType<org.gradle.api.tasks.testing.Test>()
+          .map { it.reports.junitXml.outputLocation.get().asFile }
+          .ifEmpty { listOf(layout.buildDirectory.dir("test-results/test").get().asFile) }
+          .distinct()
+
+      val sampleClass = "network.crypta.support.compress.NewLzmaCompressorTest"
+      val sampleBase = sampleClass.replace('.', '/')
+      val sampleCandidates = listOf("$sampleBase.java", "$sampleBase.kt")
+      val sampleFound =
+        testSourceDirs.any { dir -> sampleCandidates.any { rel -> dir.resolve(rel).isFile } }
+      val sampleReport =
+        testReportDirs
+          .asSequence()
+          .flatMap { dir -> (dir.listFiles() ?: emptyArray()).asSequence() }
+          .firstOrNull { it.name.contains(sampleClass) && it.name.endsWith(".xml") }
+
+      val reportCount =
+        testReportDirs.sumOf { dir ->
+          dir
+            .listFiles { file -> file.name.startsWith("TEST-") && file.name.endsWith(".xml") }
+            ?.size ?: 0
+        }
+
+      logger.lifecycle("Sonar debug: projectDir=${project.projectDir}")
+      logger.lifecycle(
+        "Sonar debug: mainSourceDirs=${mainSourceDirs.joinToString(",") { project.relativePath(it) }}"
+      )
+      logger.lifecycle(
+        "Sonar debug: testSourceDirs=${testSourceDirs.joinToString(",") { project.relativePath(it) }}"
+      )
+      logger.lifecycle(
+        "Sonar debug: testReportDirs=${testReportDirs.joinToString(",") { project.relativePath(it) }}"
+      )
+      logger.lifecycle("Sonar debug: testReportXmlCount=$reportCount")
+      logger.lifecycle(
+        "Sonar debug: sampleTestSourceFound=$sampleFound sampleCandidates=${sampleCandidates.joinToString(",")}"
+      )
+      logger.lifecycle(
+        "Sonar debug: sampleReportFile=${sampleReport?.let { project.relativePath(it) } ?: "not found"}"
+      )
+    }
+  }
+
 // Minimal SonarLint configuration with optional file scoping via -Psonarlint.sources
 extensions.configure<SonarLintSettings>("sonarLint") {
   // default: don't fail builds on findings until CI is configured to be green

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -60,6 +60,11 @@ sonar {
         .distinct()
         .sorted()
     property("sonar.junit.reportPaths", testReportDirs.joinToString(","))
+    testReportDirs.firstOrNull()?.let { primaryReportDir ->
+      // Backward/compat properties used by older analyzers.
+      property("sonar.junit.reportsPath", primaryReportDir)
+      property("sonar.surefire.reportsPath", primaryReportDir)
+    }
 
     // Avoid UTF-8 decode warnings on binary fixtures.
     property(


### PR DESCRIPTION
## Summary
- add test source and JUnit XML report paths to Sonar properties
- ensure Sonar can map test reports to sources during CI analysis

## Testing
- ./gradlew spotlessApply