### PR TITLE
refactor(crypt): remove deprecated PCFBMode.create

### DIFF
--- a/src/main/java/network/crypta/crypt/PCFBMode.java
+++ b/src/main/java/network/crypta/crypt/PCFBMode.java
@@ -34,22 +34,6 @@ public class PCFBMode {
   protected int registerPointer;
 
   /**
-   * Creates a PCFB instance without an IV.
-   *
-   * <p>The internal register is initialized to zeros and will be encrypted on first use. Callers
-   * should prefer the {@code create(BlockCipher, byte[])} or {@code create(BlockCipher, byte[],
-   * int)} factory and provide a unique IV. Reusing an IV with the same key is insecure.
-   *
-   * @param c the underlying block cipher
-   * @return a new PCFB instance
-   * @deprecated Prefer {@link #create(BlockCipher, byte[])} with an explicit IV.
-   */
-  @Deprecated(since = "1")
-  public static PCFBMode create(BlockCipher c) {
-    return new PCFBMode(c);
-  }
-
-  /**
    * Creates a PCFB instance with an explicit IV starting at offset {@code 0}.
    *
    * <p>The register pointer is positioned at the end so the next operation re-encrypts the register

--- a/src/main/java/network/crypta/keys/ClientCHKBlock.java
+++ b/src/main/java/network/crypta/keys/ClientCHKBlock.java
@@ -211,7 +211,6 @@ public class ClientCHKBlock implements ClientKeyBlock {
    * @throws IOException if allocating or writing the output bucket fails.
    * @throws UnsupportedOperationException if the block does not use the legacy algorithm.
    */
-  @SuppressWarnings("deprecation")
   public Bucket decodeOld(BucketFactory bf, int maxLength, boolean dontCompress)
       throws CHKDecodeException, IOException {
     // Overall hash already verified, so first job is to decrypt.
@@ -228,7 +227,8 @@ public class ClientCHKBlock implements ClientKeyBlock {
     if (cryptoKey.length < Node.SYMMETRIC_KEY_LENGTH)
       throw new CHKDecodeException("Crypto key too short");
     cipher.initialize(key.cryptoKey);
-    PCFBMode pcfb = PCFBMode.create(cipher);
+    byte[] zeroIv = new byte[PCFBMode.lengthIV(cipher)];
+    PCFBMode pcfb = PCFBMode.create(cipher, zeroIv);
     byte[] headers = block.headers;
     byte[] data = block.data;
     byte[] hbuf = Arrays.copyOfRange(headers, 2, headers.length);
@@ -850,8 +850,8 @@ public class ClientCHKBlock implements ClientKeyBlock {
      * keystream segment on every block.
      */
 
-    @SuppressWarnings("deprecation")
-    PCFBMode pcfb = PCFBMode.create(cipher);
+    byte[] zeroIv = new byte[PCFBMode.lengthIV(cipher)];
+    PCFBMode pcfb = PCFBMode.create(cipher, zeroIv);
     pcfb.blockEncipher(header, 2, header.length - 2);
     pcfb.blockEncipher(data, 0, data.length);
 

--- a/src/main/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
@@ -421,10 +421,9 @@ public class PaddedEphemerallyEncryptedBucket implements Bucket, Serializable {
   public PCFBMode getPCFB() {
     Rijndael aes = getRijndael();
     if (iv != null) return PCFBMode.create(aes, iv);
-    else
-      // Crypto note: when iv==null we fall back to zero-IV PCFB; keys are unique per bucket.
-      // TODO: Replace deprecated zero-IV PCFB factory; prefer supplying an IV or migrating mode.
-      return PCFBMode.create(aes);
+    // Crypto note: when iv==null we fall back to zero-IV PCFB; keys are unique per bucket.
+    byte[] zeroIv = new byte[PCFBMode.lengthIV(aes)];
+    return PCFBMode.create(aes, zeroIv);
   }
 
   /**

--- a/src/test/java/network/crypta/crypt/PCFBModeTest.java
+++ b/src/test/java/network/crypta/crypt/PCFBModeTest.java
@@ -198,7 +198,7 @@ class PCFBModeTest {
   @Test
   void lengthIV_matchesCipherBlockSizeBytes() {
     BlockCipher c = new ToyCipher(128);
-    PCFBMode pcfb = PCFBMode.create(c);
+    PCFBMode pcfb = createZeroIv(c);
     assertEquals(16, PCFBMode.lengthIV(c));
     assertEquals(16, pcfb.lengthIV());
   }
@@ -239,7 +239,7 @@ class PCFBModeTest {
   @Test
   void writeIV_whenCalled_writesRandomIVAndSetsState() throws IOException {
     BlockCipher c = new ToyCipher(128);
-    PCFBMode p = PCFBMode.create(c);
+    PCFBMode p = createZeroIv(c);
     DeterministicRandom rs = new DeterministicRandom((byte) 0x5A);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     p.writeIV(rs, out);
@@ -258,7 +258,7 @@ class PCFBModeTest {
     BlockCipher c = new ToyCipher(128);
     byte[] iv = new byte[16];
     for (int i = 0; i < iv.length; i++) iv[i] = (byte) (0x20 + i);
-    PCFBMode p = PCFBMode.create(c);
+    PCFBMode p = createZeroIv(c);
     p.readIV(new ByteArrayInputStream(iv));
     PCFBMode q = PCFBMode.create(c, iv);
     assertEquals(q.encipher(0x00), p.encipher(0x00));
@@ -443,5 +443,9 @@ class PCFBModeTest {
       // (no files, sockets, or threads) that need releasing. Keeping it empty avoids unnecessary
       // complexity in test helpers while complying with the RandomSource contract.
     }
+  }
+
+  private static PCFBMode createZeroIv(BlockCipher c) {
+    return PCFBMode.create(c, new byte[PCFBMode.lengthIV(c)]);
   }
 }


### PR DESCRIPTION
## Summary
- remove the deprecated PCFBMode zero-IV factory
- update legacy zero-IV call sites to pass an explicit zero IV
- adjust PCFBMode tests to use a shared zero-IV helper

## Testing
- ./gradlew test