### PR TITLE
build: target Java 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
         default: main
       jdk-version:
         type: string
-        default: '21'
+        default: '25'
     outputs:
       artifact-id:
         description: The artifact-id for built cryptad.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         distribution: [temurin]
-        java: [17]
+        java: [25]
 
     runs-on: '${{ matrix.os }}'
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ Refactoring guidance
 
 ## Environment Setup
 
-- Java version: 21 or higher
+- Java version: 25 or higher
     - Java runtime has been installed in the environment. So you can run java and gradle related commands without issues
 - Kotlin version: 2.3.0 or higher (matches `gradle/libs.versions.toml`)
     - The ki shell is installed in the environment.
@@ -298,7 +298,7 @@ Tip: If GitHub API rate limits are hit during builds, set `GITHUB_TOKEN` in the 
 ## Build System
 
 - Gradle with Kotlin DSL
-- Targets Java 21+
+- Targets Java 25+
 - Kotlin components present alongside Java
 - Dependency verification is configured and typically strict (temporarily set to lenient only when updating metadata)
 - Version info (`Version.kt`) generated with current build number and git revision
@@ -474,7 +474,7 @@ Notes
 
 ## Important Notes
 
-- Requires Java 21+ to compile and run
+- Requires Java 25+ to compile and run
 - Updater supports automatic updates and includes legacy-related utilities
 - Custom crypto implementations; avoid changes without review
 - Network protocol changes must consider backward compatibility

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://www.gnu.org/licenses/gpl-3.0">
     <img alt="License: GPLv3" src="https://img.shields.io/badge/license-GPLv3-blue.svg" />
   </a>
-  <img alt="Java 21+" src="https://img.shields.io/badge/Java-21%2B-007396?logo=openjdk" />
+  <img alt="Java 25+" src="https://img.shields.io/badge/Java-25%2B-007396?logo=openjdk" />
   <img alt="Kotlin 2.3.0+" src="https://img.shields.io/badge/Kotlin-2.3.0%2B-7F52FF?logo=kotlin" />
   <img alt="Gradle" src="https://img.shields.io/badge/Build-Gradle-02303A?logo=gradle" />
 </p>
@@ -147,7 +147,7 @@ wrapper, you can build immediately.
 
 Prerequisites:
 
-- Java 21 or newer
+- Java 25 or newer
 - Kotlin 2.3.0+ (tooling; the project includes Kotlin Gradle plugins)
 - A POSIX shell or Windows terminal
 
@@ -427,8 +427,8 @@ cd build/jpackage/Crypta.app/Contents
 
 ## Dependencies
 
-- Runtime: Java 21+
-- Language/Tooling: Kotlin 2.2.20+, Gradle Wrapper (provided in this repo)
+- Runtime: Java 25+
+- Language/Tooling: Kotlin 2.3.0+, Gradle Wrapper (provided in this repo)
 - External libraries are managed via Gradle.
 - Dependency verification is enabled. When adding or updating libraries:
   - Declare versions in `gradle/libs.versions.toml` and add usages in `build.gradle.kts`.

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 java {
-  // Use Java 21 toolchain for build logic
+  // Keep build-logic compatible with Gradle's embedded Kotlin
   toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }
   sourceCompatibility = JavaVersion.VERSION_21
   targetCompatibility = JavaVersion.VERSION_21
@@ -36,7 +36,7 @@ dependencies {
   )
 }
 
-// Align Kotlin JVM target with Java 21 for build-logic itself
 tasks.withType<KotlinCompile>().configureEach {
+  // Keep build-logic compatible with Gradle's embedded Kotlin
   compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
 }

--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -8,13 +8,14 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   java
-  id("org.jetbrains.kotlin.jvm")
+  kotlin("jvm")
   jacoco
 }
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_21
-  targetCompatibility = JavaVersion.VERSION_21
+  toolchain { languageVersion.set(JavaLanguageVersion.of(25)) }
+  sourceCompatibility = JavaVersion.VERSION_25
+  targetCompatibility = JavaVersion.VERSION_25
 }
 
 repositories {
@@ -60,7 +61,7 @@ tasks.withType<Javadoc>().configureEach {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-  compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+  compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25)
 }
 
 // Ensure Kotlin sources compile before Java when Java depends on Kotlin types

--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -198,10 +198,10 @@ fun iconPathForOs(): String =
     else -> project.file("src/jpackage/linux/cryptad.png").absolutePath
   }
 
-/** Resolves the `jpackage` executable from the Java 21 toolchain. */
+/** Resolves the `jpackage` executable from the Java 25 toolchain. */
 fun resolveJpackageExecutable(): File {
   val toolchains = project.extensions.getByType(JavaToolchainService::class.java)
-  val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+  val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
   val javaHome = launcher.get().metadata.installationPath.asFile
   val exe =
     javaHome.resolve(
@@ -674,7 +674,7 @@ val jpackageInstallerRpm by
           "--install-dir",
           "/opt/cryptad",
         )
-      // jpackage (JDK 21) does not accept linux post-install flags here; use template.spec
+      // jpackage (JDK 25) does not accept linux post-install flags here; use template.spec
       // override.
       args.addAll(listOf("--icon", iconPathForOs()))
       if (providers.gradleProperty("jpackageDebug").orNull == "true") args += "--verbose"

--- a/build-logic/src/main/kotlin/cryptad.runtime.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.runtime.gradle.kts
@@ -134,10 +134,10 @@ val computeJlinkModules by
     modulesFile.set(layout.buildDirectory.file("jlink/modules.list"))
 
     // Toolchain + baseline
-    javaLanguageVersion.set(21)
+    javaLanguageVersion.set(25)
     // Resolve toolchain at configuration time and pass JDK home path as input
     val toolchains = project.serviceOf<JavaToolchainService>()
-    val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+    val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
     javaHomePath.set(launcher.map { it.metadata.installationPath.asFile.absolutePath })
     baselineModules.set(
       listOf(
@@ -163,7 +163,7 @@ val createJreImage by
     dependsOn(computeJlinkModules)
     // Resolve toolchain and static inputs at configuration time to avoid Task.project access
     val toolchains = project.serviceOf<JavaToolchainService>()
-    val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+    val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
     val javaHomePath = launcher.map { it.metadata.installationPath.asFile.absolutePath }
     val jreDirProvider = layout.buildDirectory.dir("jre")
     val modulesFileProvider = layout.buildDirectory.dir("jlink").map { it.file("modules.list") }

--- a/tools/generator/README.md
+++ b/tools/generator/README.md
@@ -57,7 +57,7 @@ Only attempt if you genuinely need to change the client helpers and understand G
 4. Verify the UI loads and push updates work (status bar messages, progress bars, keepalive) before committing.
 
 Notes:
-- Expect toolchain friction on modern JDKs; you may need to build with an older Java version that the GWT compiler supports, then run the daemon with Java 21+.
+- Expect toolchain friction on modern JDKs; you may need to build with an older Java version that the GWT compiler supports, then run the daemon with Java 25+.
 - Keep the output exactly under the `freenetjs/` directory to match URL paths the server emits.
 
 ## Testing Hints
@@ -69,4 +69,3 @@ Notes:
 
 - Security/maintenance: GWT hosted/dev mode and older permutations are not maintained; prefer minimal changes.
 - Backward compatibility: Any change to the generated assets can affect the HTTP client behavior; test thoroughly across the UI.
-


### PR DESCRIPTION
## Summary
- Targets Java 25 for main project compilation (toolchain + Kotlin `jvmTarget=25`).
- Updates jlink/jpackage toolchains to use Java 25.
- Updates docs to state Java 25+ requirements.
- Updates GitHub Actions workflows to run on Java 25.

## Notes
- The included build `build-logic/` stays on Java 21 to remain compatible with Gradle’s embedded Kotlin.

## Verification
- `./gradlew spotlessApply`
- `./gradlew test`
