### PR TITLE
refactor(useralerts): clarify alert manager

### DIFF
--- a/src/main/java/network/crypta/node/useralerts/UserAlertManager.java
+++ b/src/main/java/network/crypta/node/useralerts/UserAlertManager.java
@@ -4,12 +4,13 @@ import static java.util.Arrays.stream;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -35,9 +36,41 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-/** Collection of UserAlert's. */
+/**
+ * Manages the lifecycle, ordering, and presentation of {@link UserAlert} instances for a node.
+ *
+ * <p>This class registers and unregisters alerts, keeps the latest {@link UserEvent} per event
+ * type, and exposes rendering helpers for HTML summaries and Atom feed output. Typical usage is to
+ * create one manager per {@link NodeClientCore}, register alerts as they occur, and query snapshots
+ * for rendering in web or FCP contexts. Alerts are stored in a mutable set and sorted on demand
+ * using a deterministic comparator, so callers should treat returned arrays as snapshots.
+ *
+ * <p>Concurrency: registration and state updates synchronize on internal collections, while
+ * subscriber notifications are dispatched asynchronously to avoid blocking alert updates. The
+ * manager is mutable and not thread-safe for external iteration; call {@link #getAlerts()} to
+ * obtain a stable array.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Maintaining alert and event registries with dismissal semantics
+ *   <li>Generating HTML fragments and summary lines for UI integration
+ *   <li>Producing an Atom feed that mirrors the current alert state
+ * </ul>
+ *
+ * @see UserAlert
+ * @see UserEvent
+ */
 public class UserAlertManager implements Comparator<UserAlert> {
   private static final Logger LOG = LoggerFactory.getLogger(UserAlertManager.class);
+  private static final char PATH_SEPARATOR = '/';
+  private static final String ALERTS_PATH_SEGMENT = "alerts";
+  private static final String ALERTS_PATH = PATH_SEPARATOR + ALERTS_PATH_SEGMENT + PATH_SEPARATOR;
+  private static final String ALERT_LEVEL_ERROR = "error";
+  private static final String ATTR_CLASS = "class";
+  private static final String ATTR_VALUE = "value";
+  private static final String INPUT_TAG = "input";
+  private static final String INPUT_TYPE_HIDDEN = "hidden";
 
   // No point keeping them sorted as some alerts can change priority.
   private final Set<UserAlert> alerts;
@@ -47,15 +80,34 @@ public class UserAlertManager implements Comparator<UserAlert> {
   private final Set<UserEvent.Type> unregisteredEventTypes;
   private long lastUpdated;
 
+  /**
+   * Creates a manager bound to the given core and initializes empty alert state.
+   *
+   * <p>The manager stores alerts in mutable collections, tracks the most recent update time, and
+   * prepares to notify FCP subscribers asynchronously. Callers should typically construct this once
+   * during node startup and reuse it for the lifetime of the {@link NodeClientCore}.
+   *
+   * @param core the owning core used for executors, localization, and passwords
+   */
   public UserAlertManager(NodeClientCore core) {
     this.core = core;
     alerts = new HashSet<>();
     subscribers = new CopyOnWriteArraySet<>();
-    events = new HashMap<>();
+    events = new EnumMap<>(UserEvent.Type.class);
     unregisteredEventTypes = new HashSet<>();
     lastUpdated = System.currentTimeMillis();
   }
 
+  /**
+   * Registers a new alert and notifies subscribers if it is newly added.
+   *
+   * <p>If the alert is also a {@link UserEvent}, this method delegates to {@link
+   * #register(UserEvent)} to enforce the "latest event only" invariant. For non-event alerts,
+   * registration is idempotent: the alert is added only if it is not already present. Successful
+   * registration updates the manager timestamp and schedules asynchronous FCP notifications.
+   *
+   * @param alert the alert to register; must be a non-null alert instance
+   */
   public void register(UserAlert alert) {
     if (alert instanceof UserEvent event) register(event);
     synchronized (alerts) {
@@ -67,6 +119,15 @@ public class UserAlertManager implements Comparator<UserAlert> {
     }
   }
 
+  /**
+   * Registers an event alert, replacing any previously registered event of the same type.
+   *
+   * <p>Events are treated specially: only the newest {@link UserEvent} for a given type is kept in
+   * the alerts list. If the event type has been permanently unregistered, this call is ignored.
+   * Registration updates the timestamp and sends an asynchronous FCP notification to subscribers.
+   *
+   * @param event the event to register; its type determines replacement behavior
+   */
   public void register(UserEvent event) {
     // The event is ignored if it has been indefinitely unregistered
     synchronized (unregisteredEventTypes) {
@@ -98,6 +159,16 @@ public class UserAlertManager implements Comparator<UserAlert> {
             "UserAlertManager callback executor");
   }
 
+  /**
+   * Unregisters a non-event alert or forwards to event-type unregistration.
+   *
+   * <p>If the alert is a {@link UserEvent}, this method delegates to {@link
+   * #unregister(UserEvent.Type)} to enforce the event registry rules. For other alerts, it simply
+   * removes the alert from the internal set. Passing {@code null} is a no-op. This method does not
+   * invoke {@link UserAlert#onDismiss()} or alter the alert's validity flag.
+   *
+   * @param alert the alert to remove from the active alert set, or {@code null}
+   */
   public void unregister(UserAlert alert) {
     if (alert == null) return;
     if (alert instanceof UserEvent event) unregister(event.getEventType());
@@ -106,6 +177,16 @@ public class UserAlertManager implements Comparator<UserAlert> {
     }
   }
 
+  /**
+   * Unregisters the latest event alert for the given event type.
+   *
+   * <p>If the event type supports indefinite unregistration, the type is remembered so future
+   * events of the same type are ignored. Any existing alert for the type is removed from both the
+   * event registry and the alert set. This method is safe to call even if the event type is not
+   * currently registered.
+   *
+   * @param eventType the event type to remove and optionally disable permanently
+   */
   public void unregister(UserEvent.Type eventType) {
     if (eventType.unregisterIndefinitely())
       synchronized (unregisteredEventTypes) {
@@ -122,27 +203,42 @@ public class UserAlertManager implements Comparator<UserAlert> {
   }
 
   /**
-   * Tries to find the user alert with the given hash code and dismisses it, if found.
+   * Dismisses a user-dismissable alert that matches the provided hash code.
    *
+   * <p>This method scans the current snapshot of alerts and checks each candidate for matching
+   * {@code hashCode} as well as {@link UserAlert#userCanDismiss()}. When a match is found, it
+   * applies the alert's dismissal policy: alerts that request unregistration are removed and have
+   * their {@link UserAlert#onDismiss()} callback invoked; others are simply marked invalid. The
+   * operation is best-effort and ignores non-dismissable alerts.
+   *
+   * @param alertHashCode the hash code identifying the alert to dismiss
    * @see #unregister(UserAlert)
-   * @param alertHashCode The hash code of the user alert to dismiss
    */
   public void dismissAlert(int alertHashCode) {
     UserAlert[] userAlerts = getAlerts();
     for (UserAlert userAlert : userAlerts) {
-      if (userAlert.hashCode() == alertHashCode) {
-        if (userAlert.userCanDismiss()) {
-          if (userAlert.shouldUnregisterOnDismiss()) {
-            userAlert.onDismiss();
-            unregister(userAlert);
-          } else {
-            userAlert.isValid(false);
-          }
-        }
+      if (userAlert.hashCode() != alertHashCode || !userAlert.userCanDismiss()) {
+        continue;
+      }
+      if (userAlert.shouldUnregisterOnDismiss()) {
+        userAlert.onDismiss();
+        unregister(userAlert);
+      } else {
+        userAlert.isValid(false);
       }
     }
   }
 
+  /**
+   * Returns a sorted snapshot of all current alerts.
+   *
+   * <p>The returned array is a stable snapshot at the time of call and is sorted using the manager
+   * comparator. It is safe for callers to iterate without holding locks, but the snapshot will not
+   * reflect subsequent registrations or dismissals. Callers should not mutate or retain elements
+   * expecting live updates.
+   *
+   * @return a newly allocated array sorted by alert priority and recency
+   */
   public UserAlert[] getAlerts() {
     UserAlert[] a;
     synchronized (alerts) {
@@ -152,56 +248,92 @@ public class UserAlertManager implements Comparator<UserAlert> {
     return a;
   }
 
+  /**
+   * Orders alerts by priority, event status, class hash, update time, and hash code.
+   *
+   * <p>Higher-priority alerts (lower numeric priority class) come first. Non-event alerts are
+   * ordered before event notifications, then by class hash for stable grouping, followed by
+   * descending updated time, and finally by {@code hashCode} to break remaining ties. This
+   * comparator is consistent with identity checks and provides deterministic ordering for
+   * snapshots.
+   *
+   * @param a0 the first alert to compare; must be a non-null alert
+   * @param a1 the second alert to compare; must be a non-null alert
+   * @return a negative, zero, or positive value per the ordering described above
+   */
   @Override
   public int compare(UserAlert a0, UserAlert a1) {
     if (a0 == a1)
       return 0; // common case, also we should be consistent with == even with proxyuseralert's
-    short prio0 = a0.getPriorityClass();
-    short prio1 = a1.getPriorityClass();
-    if (prio0 - prio1 == 0) {
-      boolean isEvent0 = a0.isEventNotification();
-      boolean isEvent1 = a1.isEventNotification();
-      if (isEvent0 && !isEvent1) return 1;
-      if ((!isEvent0) && isEvent1) return -1;
-      // First go by class
-      int classHash0 = a0.getClass().hashCode();
-      int classHash1 = a1.getClass().hashCode();
-      if (classHash0 > classHash1) return 1;
-      else if (classHash0 < classHash1) return -1;
-      // Then go by time (newest first)
-      if (a0.getUpdatedTime() < a1.getUpdatedTime()) return 1;
-      else if (a0.getUpdatedTime() > a1.getUpdatedTime()) return -1;
-      // And finally by object hashCode
-      int hash0 = a0.hashCode();
-      int hash1 = a1.hashCode();
-      if (hash0 > hash1) return 1;
-      if (hash1 > hash0) return -1;
-      return 0;
-    } else {
-      if (prio0 > prio1) return 1;
-      else return -1;
+    int priorityComparison = Short.compare(a0.getPriorityClass(), a1.getPriorityClass());
+    if (priorityComparison != 0) {
+      return priorityComparison;
     }
+    int eventComparison = compareEventNotifications(a0, a1);
+    if (eventComparison != 0) {
+      return eventComparison;
+    }
+    int classComparison = Integer.compare(a0.getClass().hashCode(), a1.getClass().hashCode());
+    if (classComparison != 0) {
+      return classComparison;
+    }
+    int timeComparison = Long.compare(a1.getUpdatedTime(), a0.getUpdatedTime());
+    if (timeComparison != 0) {
+      return timeComparison;
+    }
+    return Integer.compare(a0.hashCode(), a1.hashCode());
   }
 
+  private int compareEventNotifications(UserAlert a0, UserAlert a1) {
+    boolean isEvent0 = a0.isEventNotification();
+    boolean isEvent1 = a1.isEventNotification();
+    if (isEvent0 == isEvent1) {
+      return 0;
+    }
+    return isEvent0 ? 1 : -1;
+  }
+
+  /**
+   * Creates an HTML fragment containing only error-level alerts.
+   *
+   * <p>This convenience overload delegates to {@link #createAlerts(boolean)} with {@code
+   * showOnlyErrors=true}. It is commonly used by status views that want to avoid rendering
+   * lower-severity information, while still providing a consistent HTML structure.
+   *
+   * @return an HTML node containing error-level alerts, or an empty marker node
+   */
+  @SuppressWarnings("unused")
   public HTMLNode createAlerts() {
     return createAlerts(true);
   }
 
-  /** Write the alerts as HTML. */
+  /**
+   * Renders alert entries as an HTML container.
+   *
+   * <p>The container includes anchors for each alert, with content generated by {@link
+   * #renderAlert(UserAlert)}. When {@code showOnlyErrors} is true, the method only renders alerts
+   * at or above {@link UserAlert#ERROR}, and it guards rendering with a catch-all to avoid breaking
+   * the UI when an alert misbehaves. When false, all valid alerts are rendered and exceptions are
+   * allowed to propagate.
+   *
+   * @param showOnlyErrors whether to include only error-level alerts in the output
+   * @return the root HTML node for the rendered alerts, or an empty marker node
+   */
   public HTMLNode createAlerts(boolean showOnlyErrors) {
     HTMLNode alertsNode = new HTMLNode("div");
     int totalNumber = 0;
     for (UserAlert alert : getAlerts()) {
-      if (showOnlyErrors && alert.getPriorityClass() > UserAlert.ERROR) continue;
-      if (!alert.isValid()) continue;
+      if (shouldSkipAlert(alert, showOnlyErrors)) {
+        continue;
+      }
       totalNumber++;
       alertsNode.addChild("a", "name", alert.anchor());
       if (showOnlyErrors) {
         // Paranoia. Don't break the web interface no matter what.
         try {
           alertsNode.addChild(renderAlert(alert));
-        } catch (Throwable t) {
-          LOG.error("FAILED TO RENDER ALERT: " + alert + " : " + t, t);
+        } catch (Exception e) {
+          LOG.error("FAILED TO RENDER ALERT: {} : {}", alert, e, e);
         }
       } else {
         // Alerts toadlet itself can error, that's OK.
@@ -214,160 +346,130 @@ public class UserAlertManager implements Comparator<UserAlert> {
     return alertsNode;
   }
 
+  private boolean shouldSkipAlert(UserAlert alert, boolean showOnlyErrors) {
+    return (!alert.isValid()) || (showOnlyErrors && alert.getPriorityClass() > UserAlert.ERROR);
+  }
+
   /**
-   * Renders the given alert and returns the rendered HTML node.
+   * Renders a single alert as an HTML block with header, content, and dismissal controls.
    *
-   * @param userAlert The user alert to render
-   * @return The rendered HTML node
+   * <p>The generated node includes CSS classes based on the alert priority class, the localized
+   * title as a header, and the full HTML body from the alert. If the alert is dismissable, a
+   * standard dismiss form is appended. This method does not catch exceptions from the alert
+   * implementation; callers should guard if failures must not propagate.
+   *
+   * @param userAlert the alert to render; must be non-null and already validated
+   * @return an HTML node representing the alert content and controls
    */
   public HTMLNode renderAlert(UserAlert userAlert) {
-    HTMLNode userAlertNode = null;
+    HTMLNode userAlertNode;
     short level = userAlert.getPriorityClass();
-    userAlertNode = new HTMLNode("div", "class", "infobox infobox-" + getAlertLevelName(level));
+    userAlertNode = new HTMLNode("div", ATTR_CLASS, "infobox infobox-" + getAlertLevelName(level));
 
-    userAlertNode.addChild("div", "class", "infobox-header", userAlert.getTitle());
-    HTMLNode alertContentNode = userAlertNode.addChild("div", "class", "infobox-content");
+    userAlertNode.addChild("div", ATTR_CLASS, "infobox-header", userAlert.getTitle());
+    HTMLNode alertContentNode = userAlertNode.addChild("div", ATTR_CLASS, "infobox-content");
     alertContentNode.addChild(userAlert.getHTMLText());
     alertContentNode.addChild(renderDismissButton(userAlert, null));
 
     return userAlertNode;
   }
 
+  /**
+   * Builds a dismiss button form for a given alert.
+   *
+   * <p>If the alert can be dismissed, this method generates a form that posts to the alerts
+   * endpoint with the alert hash code and form password. An optional redirect target can be
+   * provided to return users to the originating page after dismissal. Non-dismissable alerts return
+   * an empty container.
+   *
+   * @param userAlert the alert whose dismissal form should be generated
+   * @param redirectToAfterDisable optional redirect target after dismissal, or {@code null}
+   * @return a container HTML node that may include a dismissal form
+   */
   public HTMLNode renderDismissButton(UserAlert userAlert, String redirectToAfterDisable) {
     HTMLNode result = new HTMLNode("div");
     if (userAlert.userCanDismiss()) {
       HTMLNode dismissFormNode =
           result
               .addChild(
-                  "form", new String[] {"action", "method"}, new String[] {"/alerts/", "post"})
+                  "form", new String[] {"action", "method"}, new String[] {ALERTS_PATH, "post"})
               .addChild("div");
       dismissFormNode.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "disable", String.valueOf(userAlert.hashCode())});
+          INPUT_TAG,
+          new String[] {"type", "name", ATTR_VALUE},
+          new String[] {INPUT_TYPE_HIDDEN, "disable", String.valueOf(userAlert.hashCode())});
       dismissFormNode.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "formPassword", core.getFormPassword()});
+          INPUT_TAG,
+          new String[] {"type", "name", ATTR_VALUE},
+          new String[] {INPUT_TYPE_HIDDEN, "formPassword", core.getFormPassword()});
       dismissFormNode.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
+          INPUT_TAG,
+          new String[] {"type", "name", ATTR_VALUE},
           new String[] {"submit", "dismiss-user-alert", userAlert.dismissButtonText()});
 
       if (redirectToAfterDisable != null) {
         dismissFormNode.addChild(
-            "input",
-            new String[] {"type", "name", "value"},
-            new String[] {"hidden", "redirectToAfterDisable", redirectToAfterDisable});
+            INPUT_TAG,
+            new String[] {"type", "name", ATTR_VALUE},
+            new String[] {INPUT_TYPE_HIDDEN, "redirectToAfterDisable", redirectToAfterDisable});
       }
     }
     return result;
   }
 
   private String getAlertLevelName(short level) {
-    if (level <= UserAlert.CRITICAL_ERROR) return "error";
-    else if (level <= UserAlert.ERROR) return "alert";
-    else if (level <= UserAlert.WARNING) return "warning";
-    else if (level <= UserAlert.MINOR) return "minor";
+    if (level <= UserAlert.CRITICAL_ERROR) return ALERT_LEVEL_ERROR;
+    else if (level == UserAlert.ERROR) return "alert";
+    else if (level == UserAlert.WARNING) return "warning";
+    else if (level == UserAlert.MINOR) return "minor";
     else {
       LOG.error("Unknown alert level: {}", level);
-      return "error";
+      return ALERT_LEVEL_ERROR;
     }
   }
 
+  /**
+   * Creates a summary fragment intended for status views.
+   *
+   * <p>This overload delegates to {@link #createAlerts(boolean)} with error-only filtering. It is
+   * used by status bar and summary pages that only display higher-severity messages and do not
+   * require the full alert list.
+   *
+   * @return an HTML fragment containing error-level alerts, or an empty marker node
+   */
   public HTMLNode createSummary() {
     // This method is called by the toadlets when they want to show
     // a summary of alerts. With a status bar, we only show full errors here.
     return createAlerts(true);
   }
 
-  static final HTMLNode ALERTS_LINK = new HTMLNode("a", "href", "/alerts/").setReadOnly();
+  static final HTMLNode ALERTS_LINK = new HTMLNode("a", "href", ALERTS_PATH).setReadOnly();
 
-  /** Write the alert summary as HTML to a StringBuilder */
+  /**
+   * Builds a textual summary of the current alerts and returns it as an HTML infobox.
+   *
+   * <p>The summary aggregates counts by severity and formats them either as a single line or as a
+   * multipart infobox, depending on {@code oneLine}. When there are no alerts to display, an empty
+   * marker node is returned. In one-line mode, the summary can be suppressed entirely for
+   * low-severity alerts; in that case, this method returns {@code null}.
+   *
+   * @param oneLine whether to emit a compact single-line summary instead of a full infobox
+   * @return the summary infobox node, an empty marker node, or {@code null} when suppressed
+   */
   public HTMLNode createSummary(boolean oneLine) {
-    short highestLevel = 99;
-    int numberOfCriticalError = 0;
-    int numberOfError = 0;
-    int numberOfWarning = 0;
-    int numberOfMinor = 0;
-    int totalNumber = 0;
-    for (UserAlert alert : getAlerts()) {
-      if (!alert.isValid()) continue;
-      short level = alert.getPriorityClass();
-      if (level < highestLevel) highestLevel = level;
-      if (level <= UserAlert.CRITICAL_ERROR) numberOfCriticalError++;
-      else if (level <= UserAlert.ERROR) numberOfError++;
-      else if (level <= UserAlert.WARNING) numberOfWarning++;
-      else if (level <= UserAlert.MINOR) numberOfMinor++;
-      totalNumber++;
+    SummaryStats stats = collectSummaryStats();
+    if (stats.shouldHideSummary(oneLine)) {
+      return null;
+    }
+    if (stats.totalNumber == 0) {
+      return new HTMLNode("#", "");
     }
 
-    if (numberOfMinor == 0 && numberOfWarning == 0 && oneLine) return null;
-
-    if (totalNumber == 0) return new HTMLNode("#", "");
-
-    boolean separatorNeeded = false;
     String separator = oneLine ? ", " : " | ";
-    int messageTypes = 0;
-    StringBuilder alertSummaryString = new StringBuilder(1024);
-    if (numberOfCriticalError != 0 && !oneLine) {
-      alertSummaryString
-          .append(l10n("criticalErrorCountLabel"))
-          .append(' ')
-          .append(numberOfCriticalError);
-      separatorNeeded = true;
-      messageTypes++;
-    }
-    if (numberOfError != 0 && !oneLine) {
-      if (separatorNeeded) alertSummaryString.append(separator);
-      alertSummaryString.append(l10n("errorCountLabel")).append(' ').append(numberOfError);
-      separatorNeeded = true;
-      messageTypes++;
-    }
-    if (numberOfWarning != 0) {
-      if (separatorNeeded) alertSummaryString.append(separator);
-      if (oneLine) {
-        alertSummaryString
-            .append(numberOfWarning)
-            .append(' ')
-            .append(l10n("warningCountLabel").replace(":", ""));
-      } else {
-        alertSummaryString.append(l10n("warningCountLabel")).append(' ').append(numberOfWarning);
-      }
-      separatorNeeded = true;
-      messageTypes++;
-    }
-    if (numberOfMinor != 0) {
-      if (separatorNeeded) alertSummaryString.append(separator);
-      if (oneLine) {
-        alertSummaryString
-            .append(numberOfMinor)
-            .append(' ')
-            .append(l10n("minorCountLabel").replace(":", ""));
-      } else {
-        alertSummaryString.append(l10n("minorCountLabel")).append(' ').append(numberOfMinor);
-      }
-      separatorNeeded = true;
-      messageTypes++;
-    }
-    if (messageTypes != 1 && !oneLine) {
-      if (separatorNeeded) alertSummaryString.append(separator);
-      alertSummaryString.append(l10n("totalLabel")).append(' ').append(totalNumber);
-    }
-    HTMLNode summaryBox = null;
-
-    String classes = oneLine ? "alerts-line contains-" : "infobox infobox-";
-
-    if (highestLevel <= UserAlert.CRITICAL_ERROR && !oneLine)
-      summaryBox = new HTMLNode("div", "class", classes + "error");
-    else if (highestLevel <= UserAlert.ERROR && !oneLine)
-      summaryBox = new HTMLNode("div", "class", classes + "alert");
-    else if (highestLevel <= UserAlert.WARNING)
-      summaryBox = new HTMLNode("div", "class", classes + "warning");
-    else if (highestLevel <= UserAlert.MINOR)
-      summaryBox = new HTMLNode("div", "class", classes + "information");
-    summaryBox.addChild("div", "class", "infobox-header", l10n("alertsTitle"));
-    HTMLNode summaryContent = summaryBox.addChild("div", "class", "infobox-content");
+    StringBuilder alertSummaryString = buildAlertSummaryString(stats, oneLine, separator);
+    HTMLNode summaryBox = createSummaryBox(stats.highestLevel, oneLine);
+    summaryBox.addChild("div", ATTR_CLASS, "infobox-header", l10n("alertsTitle"));
+    HTMLNode summaryContent = summaryBox.addChild("div", ATTR_CLASS, "infobox-content");
     if (!oneLine) {
       summaryContent.addChild("#", alertSummaryString + separator + " ");
       NodeL10n.getBase()
@@ -380,27 +482,84 @@ public class UserAlertManager implements Comparator<UserAlert> {
       summaryContent.addChild(
           "a",
           "href",
-          "/alerts/",
+          ALERTS_PATH,
           NodeL10n.getBase().getString("StatusBar.alerts") + " " + alertSummaryString);
     }
     summaryBox.addAttribute("id", "messages-summary-box");
     return summaryBox;
   }
 
+  private SummaryStats collectSummaryStats() {
+    SummaryStats stats = new SummaryStats();
+    for (UserAlert alert : getAlerts()) {
+      if (!alert.isValid()) {
+        continue;
+      }
+      stats.recordAlert(alert);
+    }
+    return stats;
+  }
+
+  private StringBuilder buildAlertSummaryString(
+      SummaryStats stats, boolean oneLine, String separator) {
+    StringBuilder alertSummaryString = new StringBuilder(1024);
+    SummaryTextBuilder builder = new SummaryTextBuilder(stats, alertSummaryString, separator);
+    builder.appendIfPresent(stats.numberOfCriticalError, !oneLine, l10n("criticalErrorCountLabel"));
+    builder.appendIfPresent(stats.numberOfError, !oneLine, l10n("errorCountLabel"));
+    builder.appendWarningCount(stats.numberOfWarning, oneLine);
+    builder.appendMinorCount(stats.numberOfMinor, oneLine);
+    builder.appendTotal(stats.totalNumber, oneLine);
+    return alertSummaryString;
+  }
+
+  private HTMLNode createSummaryBox(short highestLevel, boolean oneLine) {
+    String classes = oneLine ? "alerts-line contains-" : "infobox infobox-";
+    if (highestLevel <= UserAlert.CRITICAL_ERROR && !oneLine) {
+      return new HTMLNode("div", ATTR_CLASS, classes + ALERT_LEVEL_ERROR);
+    }
+    if (highestLevel <= UserAlert.ERROR && !oneLine) {
+      return new HTMLNode("div", ATTR_CLASS, classes + "alert");
+    }
+    if (highestLevel <= UserAlert.WARNING) {
+      return new HTMLNode("div", ATTR_CLASS, classes + "warning");
+    }
+    return new HTMLNode("div", ATTR_CLASS, classes + "information");
+  }
+
   private String l10n(String key) {
     return NodeL10n.getBase().getString("UserAlertManager." + key);
   }
 
-  public void dumpEvents(HashSet<String> toDump) {
+  /**
+   * Dismisses event alerts whose anchors appear in the supplied set.
+   *
+   * <p>This method iterates over a snapshot of current alerts and, for each event notification
+   * whose anchor is present in {@code toDump}, unregisters the alert and invokes its dismissal
+   * callback. Non-event alerts are ignored. The operation is best-effort and does not report which
+   * alerts were removed.
+   *
+   * @param toDump the set of alert anchor strings to dismiss when matched
+   */
+  public void dumpEvents(Set<String> toDump) {
     // An iterator might be faster, but we don't want to call methods on the alert within the lock.
     for (UserAlert alert : getAlerts()) {
-      if (!alert.isEventNotification()) continue;
-      if (!toDump.contains(alert.anchor())) continue;
-      unregister(alert);
-      alert.onDismiss();
+      if (alert.isEventNotification() && toDump.contains(alert.anchor())) {
+        unregister(alert);
+        alert.onDismiss();
+      }
     }
   }
 
+  /**
+   * Registers a subscriber and immediately sends the current valid alerts.
+   *
+   * <p>The subscriber is added to the internal subscriber set and then receives a snapshot of all
+   * valid alerts via asynchronous FCP callbacks. The snapshot is taken at execution time on the
+   * executor, so it reflects the state at that moment. Registering the same subscriber multiple
+   * times is safe because the set de-duplicates entries.
+   *
+   * @param subscriber the FCP connection that should receive alert notifications
+   */
   public void watch(final FCPConnectionHandler subscriber) {
     subscribers.add(subscriber);
     // Run off-thread, because of locking, and because client
@@ -416,6 +575,14 @@ public class UserAlertManager implements Comparator<UserAlert> {
     subscribers.add(subscriber);
   }
 
+  /**
+   * Unregisters a subscriber so it no longer receives alert notifications.
+   *
+   * <p>This method removes the subscriber from the internal set. It does not attempt to cancel any
+   * in-flight asynchronous notifications already queued on the executor.
+   *
+   * @param subscriber the FCP connection to remove from the subscriber list
+   */
   public void unwatch(FCPConnectionHandler subscriber) {
     subscribers.remove(subscriber);
   }
@@ -428,8 +595,19 @@ public class UserAlertManager implements Comparator<UserAlert> {
     return date.substring(0, 22) + ":" + date.substring(22);
   }
 
+  /**
+   * Builds an Atom feed document containing the current alerts.
+   *
+   * <p>The feed uses the provided start URI as the base for links to the alerts page and is updated
+   * with the most recent alert timestamp. Each valid alert becomes a feed entry containing its
+   * title, summary, and full text. The generated XML is intended for lightweight status polling and
+   * does not include pagination or history beyond the current alert snapshot.
+   *
+   * @param startURI the base URI used to construct alert and feed links
+   * @return a serialized Atom feed containing the current alert snapshot
+   */
   public String getAtom(String startURI) {
-    String messagesURI = startURI + "/alerts/";
+    String messagesURI = startURI + ALERTS_PATH;
     String feedURI = startURI + "/feed/";
 
     XmlBuilder xmlBuilder = new XmlBuilder();
@@ -452,24 +630,23 @@ public class UserAlertManager implements Comparator<UserAlert> {
           stream(getAlerts())
               .filter(UserAlert::isValid)
               .forEach(
-                  alert -> {
-                    feed.addElement(
-                        "entry",
-                        entry -> {
-                          entry.addElement("id", "urn:feed:" + alert.anchor());
-                          entry.addElement(
-                              "link",
-                              link ->
-                                  link.setAttribute("href", messagesURI + "#" + alert.anchor()));
-                          entry.addElement("updated", formatTime(alert.getUpdatedTime()));
-                          entry.addElement("title", alert.getTitle());
-                          entry.addElement("summary", alert.getShortText());
-                          entry.addElement(
-                              "content",
-                              alert.getText(),
-                              content -> content.setAttribute("type", "text"));
-                        });
-                  });
+                  alert ->
+                      feed.addElement(
+                          "entry",
+                          entry -> {
+                            entry.addElement("id", "urn:feed:" + alert.anchor());
+                            entry.addElement(
+                                "link",
+                                link ->
+                                    link.setAttribute("href", messagesURI + "#" + alert.anchor()));
+                            entry.addElement("updated", formatTime(alert.getUpdatedTime()));
+                            entry.addElement("title", alert.getTitle());
+                            entry.addElement("summary", alert.getShortText());
+                            entry.addElement(
+                                "content",
+                                alert.getText(),
+                                content -> content.setAttribute("type", "text"));
+                          }));
         });
     return xmlBuilder.generate();
   }
@@ -480,13 +657,10 @@ public class UserAlertManager implements Comparator<UserAlert> {
 
     void addElement(String name, String content, Consumer<ElementBuilder> elementBuilder);
 
-    void addNamespaceElement(
-        String namespace, String name, Consumer<ElementBuilder> elementBuilder);
-
     void setAttribute(String name, String value);
 
     default void addElement(String name, String content) {
-      addElement(name, content, elementBuilder -> {});
+      addElement(name, content, _ -> {});
     }
   }
 
@@ -494,25 +668,24 @@ public class UserAlertManager implements Comparator<UserAlert> {
 
     @Override
     public void addElement(String name, Consumer<ElementBuilder> elementBuilder) {
-      Element element = document.createElement(name);
-      elementBuilder.accept(new XmlBuilder(document, element));
-      ((this.element == null) ? document : this.element).appendChild(element);
+      Element childElement = document.createElement(name);
+      elementBuilder.accept(new XmlBuilder(document, childElement));
+      ((this.element == null) ? document : this.element).appendChild(childElement);
     }
 
     @Override
     public void addElement(String name, String content, Consumer<ElementBuilder> elementBuilder) {
-      Element element = document.createElement(name);
-      element.setTextContent(content);
-      elementBuilder.accept(new XmlBuilder(document, element));
-      ((this.element == null) ? document : this.element).appendChild(element);
+      Element childElement = document.createElement(name);
+      childElement.setTextContent(content);
+      elementBuilder.accept(new XmlBuilder(document, childElement));
+      ((this.element == null) ? document : this.element).appendChild(childElement);
     }
 
-    @Override
     public void addNamespaceElement(
         String namespace, String name, Consumer<ElementBuilder> elementBuilder) {
-      Element element = document.createElementNS(namespace, name);
-      elementBuilder.accept(new XmlBuilder(document, element));
-      ((this.element == null) ? document : this.element).appendChild(element);
+      Element childElement = document.createElementNS(namespace, name);
+      elementBuilder.accept(new XmlBuilder(document, childElement));
+      ((this.element == null) ? document : this.element).appendChild(childElement);
     }
 
     @Override
@@ -528,8 +701,10 @@ public class UserAlertManager implements Comparator<UserAlert> {
         StreamResult result = new StreamResult(stringWriter);
         transformer.transform(source, result);
         return stringWriter.toString();
-      } catch (TransformerException | IOException e) {
-        throw new RuntimeException(e);
+      } catch (TransformerException e) {
+        throw new IllegalStateException("Failed to render user alerts feed.", e);
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to write user alerts feed.", e);
       }
     }
 
@@ -555,7 +730,103 @@ public class UserAlertManager implements Comparator<UserAlert> {
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xalan}indent-amount", "2");
       } catch (ParserConfigurationException | TransformerConfigurationException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException("Failed to initialize alert feed generator.", e);
+      }
+    }
+  }
+
+  private static final class SummaryStats {
+    private short highestLevel = Short.MAX_VALUE;
+    private int numberOfCriticalError;
+    private int numberOfError;
+    private int numberOfWarning;
+    private int numberOfMinor;
+    private int totalNumber;
+    private int messageTypes;
+
+    private void recordAlert(UserAlert alert) {
+      short level = alert.getPriorityClass();
+      if (level < highestLevel) {
+        highestLevel = level;
+      }
+      if (level <= UserAlert.CRITICAL_ERROR) {
+        numberOfCriticalError++;
+      } else if (level == UserAlert.ERROR) {
+        numberOfError++;
+      } else if (level == UserAlert.WARNING) {
+        numberOfWarning++;
+      } else if (level == UserAlert.MINOR) {
+        numberOfMinor++;
+      }
+      totalNumber++;
+    }
+
+    private boolean shouldHideSummary(boolean oneLine) {
+      return oneLine && numberOfMinor == 0 && numberOfWarning == 0;
+    }
+  }
+
+  private final class SummaryTextBuilder {
+    private final SummaryStats stats;
+    private final StringBuilder builder;
+    private final String separator;
+    private boolean separatorNeeded;
+
+    private SummaryTextBuilder(SummaryStats stats, StringBuilder builder, String separator) {
+      this.stats = stats;
+      this.builder = builder;
+      this.separator = separator;
+    }
+
+    private void appendIfPresent(int count, boolean include, String label) {
+      if (count == 0 || !include) {
+        return;
+      }
+      appendSeparatorIfNeeded();
+      builder.append(label).append(' ').append(count);
+      separatorNeeded = true;
+      stats.messageTypes++;
+    }
+
+    private void appendWarningCount(int count, boolean oneLine) {
+      if (count == 0) {
+        return;
+      }
+      appendSeparatorIfNeeded();
+      if (oneLine) {
+        builder.append(count).append(' ').append(l10n("warningCountLabel").replace(":", ""));
+      } else {
+        builder.append(l10n("warningCountLabel")).append(' ').append(count);
+      }
+      separatorNeeded = true;
+      stats.messageTypes++;
+    }
+
+    private void appendMinorCount(int count, boolean oneLine) {
+      if (count == 0) {
+        return;
+      }
+      appendSeparatorIfNeeded();
+      if (oneLine) {
+        builder.append(count).append(' ').append(l10n("minorCountLabel").replace(":", ""));
+      } else {
+        builder.append(l10n("minorCountLabel")).append(' ').append(count);
+      }
+      separatorNeeded = true;
+      stats.messageTypes++;
+    }
+
+    private void appendTotal(int totalNumber, boolean oneLine) {
+      if (stats.messageTypes == 1 || oneLine) {
+        return;
+      }
+      appendSeparatorIfNeeded();
+      builder.append(l10n("totalLabel")).append(' ').append(totalNumber);
+    }
+
+    private void appendSeparatorIfNeeded() {
+      if (separatorNeeded) {
+        builder.append(separator);
       }
     }
   }

--- a/src/test/java/network/crypta/node/useralerts/UserAlertManagerTest.java
+++ b/src/test/java/network/crypta/node/useralerts/UserAlertManagerTest.java
@@ -1,44 +1,771 @@
 package network.crypta.node.useralerts;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.matchesPattern;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
+import java.util.Set;
 import java.util.TimeZone;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import network.crypta.client.async.ClientContext;
+import network.crypta.clients.fcp.FCPConnectionHandler;
+import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.l10n.BaseL10nTest;
+import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.PriorityAwareExecutor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
-public class UserAlertManagerTest {
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // allow descriptive test method names
+class UserAlertManagerTest {
 
-  private static final XPath xPath = XPathFactory.newInstance().newXPath();
-  private final NodeClientCore nodeClientCore = mock(NodeClientCore.class, RETURNS_DEEP_STUBS);
-  private final UserAlertManager userAlertManager = new UserAlertManager(nodeClientCore);
+  private static final XPath X_PATH = XPathFactory.newInstance().newXPath();
 
-  {
-    when(nodeClientCore.getNode().getDarknetPubKeyHash()).thenReturn(new byte[] {1, 2, 3, 4});
+  @Mock private NodeClientCore nodeClientCore;
+  @Mock private Node node;
+  @Mock private ClientContext clientContext;
+  @Mock private PriorityAwareExecutor executor;
+
+  private UserAlertManager userAlertManager;
+
+  @BeforeEach
+  void setUp() {
+    BaseL10nTest.useTestTranslation();
+    lenient().when(nodeClientCore.getNode()).thenReturn(node);
+    lenient().when(node.getDarknetPubKeyHash()).thenReturn(new byte[] {1, 2, 3, 4});
+    lenient().when(nodeClientCore.getClientContext()).thenReturn(clientContext);
+    lenient().when(clientContext.getMainExecutor()).thenReturn(executor);
+    lenient().when(nodeClientCore.getFormPassword()).thenReturn("form-password");
+    lenient()
+        .doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(0);
+              runnable.run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class), anyString());
+    lenient()
+        .doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(0);
+              runnable.run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class));
+    userAlertManager = new UserAlertManager(nodeClientCore);
+  }
+
+  @Test
+  void getAtom_whenGenerated_expectFeedMetadataPresent() throws Exception {
+    // Arrange
+    String atom = userAlertManager.getAtom("http://test");
+
+    // Act
+    Document atomXml = parseAtomXml(atom);
+
+    // Assert
+    assertEquals("UserAlertManager.feedTitle", X_PATH.evaluate("/feed/title", atomXml));
+    assertEquals("http://test/feed/", X_PATH.evaluate("/feed/link[@rel='self']/@href", atomXml));
+    assertEquals("http://test", X_PATH.evaluate("/feed/link[count(@rel)=0]/@href", atomXml));
+    assertTrue(
+        X_PATH
+            .evaluate("/feed/updated", atomXml)
+            .matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}[+-]\\d{2}:\\d{2}"));
+    assertEquals("urn:node:AQIDBA", X_PATH.evaluate("/feed/id", atomXml));
+    assertEquals("/favicon.ico", X_PATH.evaluate("/feed/logo", atomXml));
+  }
+
+  @Test
+  void getAtom_whenAlertsPresent_expectEntriesMatchAlerts() throws Exception {
+    // Arrange
+    TestAlert firstAlert =
+        new TestAlert(
+            true,
+            "Alert 1",
+            "Text 1",
+            "Short 1",
+            UserAlert.ERROR,
+            true,
+            true,
+            false,
+            1_000L,
+            "anchor-1");
+    TestAlert secondAlert =
+        new TestAlert(
+            true,
+            "Alert 2",
+            "Text 2",
+            "Short 2",
+            UserAlert.ERROR,
+            true,
+            true,
+            false,
+            2_000L,
+            "anchor-2");
+    userAlertManager.register(secondAlert);
+    userAlertManager.register(firstAlert);
+
+    // Act
+    Document atomXml = parseAtomXml(userAlertManager.getAtom("http://test"));
+    List<EntrySnapshot> entries = getEntrySnapshots(atomXml);
+
+    // Assert
+    assertEquals(2, entries.size());
+    assertTrue(entries.contains(entryFor(firstAlert)));
+    assertTrue(entries.contains(entryFor(secondAlert)));
+  }
+
+  @Test
+  void getAtom_whenAlertHasXmlCharacters_expectEscapedContent() throws Exception {
+    // Arrange
+    TestAlert alert =
+        new TestAlert(
+            true,
+            "Alert <",
+            "Contains a <.",
+            "Short <",
+            UserAlert.ERROR,
+            true,
+            true,
+            false,
+            1_234L,
+            "alert-xml");
+    userAlertManager.register(alert);
+
+    // Act
+    Document atomXml = parseAtomXml(userAlertManager.getAtom("http://test"));
+    List<EntrySnapshot> entries = getEntrySnapshots(atomXml);
+
+    // Assert
+    assertEquals(1, entries.size());
+    assertEquals(entryFor(alert), entries.getFirst());
+  }
+
+  @Test
+  void getAtom_whenAlertInvalid_expectExcludedFromFeed() throws Exception {
+    // Arrange
+    TestAlert validAlert =
+        new TestAlert(
+            true,
+            "Alert 1",
+            "Text 1",
+            "Short 1",
+            UserAlert.ERROR,
+            true,
+            true,
+            false,
+            1_000L,
+            "valid");
+    TestAlert invalidAlert =
+        new TestAlert(
+            true,
+            "Alert 2",
+            "Text 2",
+            "Short 2",
+            UserAlert.ERROR,
+            false,
+            true,
+            false,
+            2_000L,
+            "invalid");
+    userAlertManager.register(invalidAlert);
+    userAlertManager.register(validAlert);
+
+    // Act
+    Document atomXml = parseAtomXml(userAlertManager.getAtom("http://test"));
+    List<EntrySnapshot> entries = getEntrySnapshots(atomXml);
+
+    // Assert
+    assertEquals(1, entries.size());
+    assertEquals(entryFor(validAlert), entries.getFirst());
+  }
+
+  @Test
+  void getAtom_whenCustomAnchor_expectIdUsesAnchor() throws Exception {
+    // Arrange
+    TestAlert userAlert =
+        new TestAlert(
+            true,
+            "Alert 1",
+            "Text 1",
+            "Short 1",
+            UserAlert.ERROR,
+            true,
+            true,
+            false,
+            1_000L,
+            "test-anchor");
+    userAlertManager.register(userAlert);
+
+    // Act
+    Document atomXml = parseAtomXml(userAlertManager.getAtom("http://test"));
+    List<EntrySnapshot> entries = getEntrySnapshots(atomXml);
+
+    // Assert
+    assertEquals("urn:feed:test-anchor", entries.getFirst().id());
+  }
+
+  @Test
+  void register_whenAlertDuplicate_expectSingleEntry() {
+    // Arrange
+    TestAlert alert =
+        new TestAlert(
+            true,
+            "Title",
+            "Text",
+            "Short",
+            UserAlert.ERROR,
+            true,
+            true,
+            false,
+            1_000L,
+            "duplicate");
+
+    // Act
+    userAlertManager.register(alert);
+    userAlertManager.register(alert);
+
+    // Assert
+    UserAlert[] alerts = userAlertManager.getAlerts();
+    assertArrayEquals(new UserAlert[] {alert}, alerts);
+  }
+
+  @Test
+  void register_whenUserEventSameType_expectLatestEventKept() {
+    // Arrange
+    TestEvent firstEvent =
+        new TestEvent(
+            UserEvent.Type.GET_COMPLETED,
+            true,
+            "First",
+            "Text",
+            "Short",
+            UserAlert.WARNING,
+            true,
+            true,
+            true,
+            1_000L,
+            "event-first");
+    TestEvent secondEvent =
+        new TestEvent(
+            UserEvent.Type.GET_COMPLETED,
+            true,
+            "Second",
+            "Text",
+            "Short",
+            UserAlert.WARNING,
+            true,
+            true,
+            true,
+            2_000L,
+            "event-second");
+
+    // Act
+    userAlertManager.register(firstEvent);
+    userAlertManager.register(secondEvent);
+
+    // Assert
+    UserAlert[] alerts = userAlertManager.getAlerts();
+    assertArrayEquals(new UserAlert[] {secondEvent}, alerts);
+  }
+
+  @Test
+  void unregister_whenEventTypeUnregistersIndefinitely_expectFutureEventsIgnored() {
+    // Arrange
+    userAlertManager.unregister(UserEvent.Type.ANNOUNCER);
+    TestEvent announcerEvent =
+        new TestEvent(
+            UserEvent.Type.ANNOUNCER,
+            true,
+            "Announce",
+            "Text",
+            "Short",
+            UserAlert.MINOR,
+            true,
+            true,
+            true,
+            1_000L,
+            "announcer");
+
+    // Act
+    userAlertManager.register(announcerEvent);
+
+    // Assert
+    assertEquals(0, userAlertManager.getAlerts().length);
+  }
+
+  @Test
+  void unregister_whenAlertNull_expectNoInteraction() {
+    // Arrange
+    TestAlert existing =
+        new TestAlert(
+            true, "Title", "Text", "Short", UserAlert.WARNING, true, true, false, 1_000L, "keep");
+    userAlertManager.register(existing);
+
+    // Act
+    userAlertManager.unregister((UserAlert) null);
+
+    // Assert
+    assertArrayEquals(new UserAlert[] {existing}, userAlertManager.getAlerts());
+  }
+
+  @Test
+  void dismissAlert_whenUnregisterOnDismiss_expectRemovedAndDismissed() {
+    // Arrange
+    TestAlert alert =
+        new TestAlert(
+            true,
+            "Title",
+            "Text",
+            "Short",
+            UserAlert.ERROR,
+            true,
+            true,
+            false,
+            1_000L,
+            "dismiss-me");
+    userAlertManager.register(alert);
+
+    // Act
+    userAlertManager.dismissAlert(alert.hashCode());
+
+    // Assert
+    assertTrue(alert.dismissed());
+    assertEquals(0, userAlertManager.getAlerts().length);
+  }
+
+  @Test
+  void dismissAlert_whenKeepRegistered_expectInvalidated() {
+    // Arrange
+    TestAlert alert =
+        new TestAlert(
+            true,
+            "Title",
+            "Text",
+            "Short",
+            UserAlert.ERROR,
+            true,
+            false,
+            false,
+            1_000L,
+            "keep-registered");
+    userAlertManager.register(alert);
+
+    // Act
+    userAlertManager.dismissAlert(alert.hashCode());
+
+    // Assert
+    assertFalse(alert.isValid());
+    assertArrayEquals(new UserAlert[] {alert}, userAlertManager.getAlerts());
+  }
+
+  @Test
+  void dismissAlert_whenUserCannotDismiss_expectIgnored() {
+    // Arrange
+    TestAlert alert =
+        new TestAlert(
+            false,
+            "Title",
+            "Text",
+            "Short",
+            UserAlert.ERROR,
+            true,
+            true,
+            false,
+            1_000L,
+            "cannot-dismiss");
+    userAlertManager.register(alert);
+
+    // Act
+    userAlertManager.dismissAlert(alert.hashCode());
+
+    // Assert
+    assertTrue(alert.isValid());
+    assertFalse(alert.dismissed());
+  }
+
+  @Test
+  void getAlerts_whenSamePriorityWithEvent_expectEventSortedAfterNonEvent() {
+    // Arrange
+    TestAlert nonEvent =
+        new TestAlert(
+            true,
+            "Non-event",
+            "Text",
+            "Short",
+            UserAlert.WARNING,
+            true,
+            true,
+            false,
+            1_000L,
+            "non-event");
+    TestAlert event =
+        new TestAlert(
+            true, "Event", "Text", "Short", UserAlert.WARNING, true, true, true, 2_000L, "event");
+    userAlertManager.register(event);
+    userAlertManager.register(nonEvent);
+
+    // Act
+    UserAlert[] alerts = userAlertManager.getAlerts();
+
+    // Assert
+    assertArrayEquals(new UserAlert[] {nonEvent, event}, alerts);
+  }
+
+  @Test
+  void compare_whenSameClassDifferentUpdatedTime_expectNewestFirst() {
+    // Arrange
+    TestAlert older =
+        new TestAlert(
+            true, "Old", "Text", "Short", UserAlert.WARNING, true, true, false, 1_000L, "older");
+    TestAlert newer =
+        new TestAlert(
+            true, "New", "Text", "Short", UserAlert.WARNING, true, true, false, 2_000L, "newer");
+
+    // Act
+    int result = userAlertManager.compare(newer, older);
+
+    // Assert
+    assertEquals(-1, result);
+  }
+
+  @Test
+  void createAlerts_whenOnlyErrors_expectReturnsErrorsOnly() {
+    // Arrange
+    TestAlert errorAlert =
+        new TestAlert(
+            true, "Error", "Text", "Short", UserAlert.ERROR, true, true, false, 1_000L, "error");
+    TestAlert warningAlert =
+        new TestAlert(
+            true,
+            "Warning",
+            "Text",
+            "Short",
+            UserAlert.WARNING,
+            true,
+            true,
+            false,
+            1_000L,
+            "warning");
+    userAlertManager.register(errorAlert);
+    userAlertManager.register(warningAlert);
+
+    // Act
+    HTMLNode alerts = userAlertManager.createAlerts(true);
+
+    // Assert
+    String html = alerts.generate();
+    assertTrue(html.contains("Error"));
+    assertFalse(html.contains("Warning"));
+  }
+
+  @Test
+  void createAlerts_whenNoValidAlerts_expectEmptyNode() {
+    // Arrange
+    TestAlert invalidAlert =
+        new TestAlert(
+            true,
+            "Invalid",
+            "Text",
+            "Short",
+            UserAlert.ERROR,
+            false,
+            true,
+            false,
+            1_000L,
+            "invalid");
+    userAlertManager.register(invalidAlert);
+
+    // Act
+    HTMLNode alerts = userAlertManager.createAlerts(true);
+
+    // Assert
+    assertEquals("", alerts.generate());
+  }
+
+  @Test
+  void renderAlert_whenUnknownLevel_expectErrorClass() {
+    // Arrange
+    TestAlert alert =
+        new TestAlert(
+            true, "Title", "Text", "Short", (short) 9, true, true, false, 1_000L, "unknown-level");
+
+    // Act
+    HTMLNode alertNode = userAlertManager.renderAlert(alert);
+
+    // Assert
+    assertTrue(alertNode.generate().contains("infobox infobox-error"));
+  }
+
+  @Test
+  void renderDismissButton_whenDismissibleWithRedirect_expectHiddenFields() {
+    // Arrange
+    TestAlert alert =
+        new TestAlert(
+            true,
+            "Title",
+            "Text",
+            "Short",
+            UserAlert.WARNING,
+            true,
+            true,
+            false,
+            1_000L,
+            "dismissable");
+
+    // Act
+    HTMLNode dismissNode = userAlertManager.renderDismissButton(alert, "/redirect");
+
+    // Assert
+    String html = dismissNode.generate();
+    assertTrue(html.contains("formPassword"));
+    assertTrue(html.contains("form-password"));
+    assertTrue(html.contains("redirectToAfterDisable"));
+  }
+
+  @Test
+  void renderDismissButton_whenNotDismissible_expectNoForm() {
+    // Arrange
+    TestAlert alert =
+        new TestAlert(
+            false,
+            "Title",
+            "Text",
+            "Short",
+            UserAlert.WARNING,
+            true,
+            true,
+            false,
+            1_000L,
+            "non-dismissable");
+
+    // Act
+    HTMLNode dismissNode = userAlertManager.renderDismissButton(alert, null);
+
+    // Assert
+    assertFalse(dismissNode.generate().contains("form"));
+  }
+
+  @Test
+  void createSummary_whenOneLineWithOnlyErrors_expectNull() {
+    // Arrange
+    TestAlert errorAlert =
+        new TestAlert(
+            true, "Error", "Text", "Short", UserAlert.ERROR, true, true, false, 1_000L, "error");
+    userAlertManager.register(errorAlert);
+
+    // Act
+    HTMLNode summary = userAlertManager.createSummary(true);
+
+    // Assert
+    assertNull(summary);
+  }
+
+  @Test
+  void createSummary_whenWarningOneLine_expectWarningClass() {
+    // Arrange
+    TestAlert warningAlert =
+        new TestAlert(
+            true,
+            "Warning",
+            "Text",
+            "Short",
+            UserAlert.WARNING,
+            true,
+            true,
+            false,
+            1_000L,
+            "warning");
+    userAlertManager.register(warningAlert);
+
+    // Act
+    HTMLNode summary = userAlertManager.createSummary(true);
+
+    // Assert
+    assertNotNull(summary);
+    String html = summary.generate();
+    assertTrue(html.contains("alerts-line contains-warning"));
+    assertTrue(html.contains("messages-summary-box"));
+  }
+
+  @Test
+  void createSummary_whenNoAlerts_expectEmptyNode() {
+    // Arrange
+    // No alerts registered
+
+    // Act
+    HTMLNode summary = userAlertManager.createSummary(false);
+
+    // Assert
+    assertEquals("", summary.generate());
+  }
+
+  @Test
+  void dumpEvents_whenAnchorsMatch_expectDismissedAndRemoved() {
+    // Arrange
+    TestEvent event =
+        new TestEvent(
+            UserEvent.Type.PUT_COMPLETED,
+            true,
+            "Event",
+            "Text",
+            "Short",
+            UserAlert.MINOR,
+            true,
+            true,
+            true,
+            1_000L,
+            "event-anchor");
+    TestAlert nonEvent =
+        new TestAlert(
+            true,
+            "Alert",
+            "Text",
+            "Short",
+            UserAlert.WARNING,
+            true,
+            true,
+            false,
+            1_000L,
+            "non-event");
+    userAlertManager.register(event);
+    userAlertManager.register(nonEvent);
+    Set<String> toDump = new HashSet<>();
+    toDump.add("event-anchor");
+
+    // Act
+    userAlertManager.dumpEvents(new HashSet<>(toDump));
+
+    // Assert
+    assertTrue(event.dismissed());
+    assertArrayEquals(new UserAlert[] {nonEvent}, userAlertManager.getAlerts());
+  }
+
+  @Test
+  void watch_whenExistingValidAlerts_expectSubscriberReceivesMessages() {
+    // Arrange
+    TestAlert validAlert =
+        new TestAlert(
+            true, "Valid", "Text", "Short", UserAlert.ERROR, true, true, false, 1_000L, "valid");
+    TestAlert invalidAlert =
+        new TestAlert(
+            true,
+            "Invalid",
+            "Text",
+            "Short",
+            UserAlert.ERROR,
+            false,
+            true,
+            false,
+            1_000L,
+            "invalid");
+    userAlertManager.register(validAlert);
+    userAlertManager.register(invalidAlert);
+    FCPConnectionHandler subscriber = mock(FCPConnectionHandler.class);
+
+    // Act
+    userAlertManager.watch(subscriber);
+
+    // Assert
+    verify(subscriber).send(validAlert.getFCPMessage());
+    verify(subscriber, never()).send(invalidAlert.getFCPMessage());
+  }
+
+  @Test
+  void watch_whenNewAlertRegistered_expectSubscriberNotified() {
+    // Arrange
+    FCPConnectionHandler subscriber = mock(FCPConnectionHandler.class);
+    userAlertManager.watch(subscriber);
+    TestAlert alert =
+        new TestAlert(
+            true, "Title", "Text", "Short", UserAlert.ERROR, true, true, false, 1_000L, "notify");
+
+    // Act
+    userAlertManager.register(alert);
+
+    // Assert
+    verify(subscriber).send(alert.getFCPMessage());
+  }
+
+  @Test
+  void unwatch_whenSubscriberRemoved_expectNoFurtherNotifications() {
+    // Arrange
+    FCPConnectionHandler subscriber = mock(FCPConnectionHandler.class);
+    userAlertManager.watch(subscriber);
+    userAlertManager.unwatch(subscriber);
+    TestAlert alert =
+        new TestAlert(
+            true, "Title", "Text", "Short", UserAlert.ERROR, true, true, false, 1_000L, "notify");
+
+    // Act
+    userAlertManager.register(alert);
+
+    // Assert
+    verifyNoInteractions(subscriber);
+  }
+
+  private static Document parseAtomXml(String atom) throws Exception {
+    return DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder()
+        .parse(new InputSource(new StringReader(atom)));
+  }
+
+  private static List<EntrySnapshot> getEntrySnapshots(Document atomXml) throws Exception {
+    NodeList nodeList = (NodeList) X_PATH.evaluate("/feed/entry", atomXml, XPathConstants.NODESET);
+    List<EntrySnapshot> entries = new ArrayList<>();
+    for (int index = 0; index < nodeList.getLength(); index++) {
+      entries.add(entrySnapshot(nodeList.item(index)));
+    }
+    return entries;
+  }
+
+  private static EntrySnapshot entrySnapshot(org.w3c.dom.Node node) throws Exception {
+    return new EntrySnapshot(
+        X_PATH.evaluate("id", node),
+        X_PATH.evaluate("link/@href", node),
+        X_PATH.evaluate("updated", node),
+        X_PATH.evaluate("title", node),
+        X_PATH.evaluate("summary", node),
+        X_PATH.evaluate("content[@type='text']", node));
+  }
+
+  private static EntrySnapshot entryFor(TestAlert alert) {
+    return new EntrySnapshot(
+        "urn:feed:" + alert.anchor(),
+        "http://test/alerts/#" + alert.anchor(),
+        formatTime(alert.getUpdatedTime()),
+        alert.getTitle(),
+        alert.getShortText(),
+        alert.getText());
   }
 
   private static String formatTime(long time) {
@@ -49,179 +776,102 @@ public class UserAlertManagerTest {
             MILLISECONDS.toMinutes(TimeZone.getDefault().getOffset(time)) % 60);
   }
 
-  @Test
-  public void generatedAtomContainsTitle() throws Exception {
-    BaseL10nTest.useTestTranslation();
-    verifyStringPropertyInGeneratedAtom("/feed/title", equalTo("UserAlertManager.feedTitle"));
-  }
+  private static class TestAlert extends AbstractUserAlert {
+    private final boolean eventNotification;
+    private final long updatedTime;
+    private final String anchor;
+    private final FCPMessage fcpMessage;
+    private boolean dismissed;
 
-  @Test
-  public void generatedAtomContainsLinkToItself() throws Exception {
-    verifyStringPropertyInGeneratedAtom(
-        "/feed/link[@rel='self']/@href", equalTo("http://test/feed/"));
-  }
-
-  @Test
-  public void generatedAtomContainsLinkToContext() throws Exception {
-    verifyStringPropertyInGeneratedAtom("/feed/link[count(@rel)=0]/@href", equalTo("http://test"));
-  }
-
-  @Test
-  public void generatedAtomContainsLastUpdateTime() throws Exception {
-    verifyStringPropertyInGeneratedAtom(
-        "/feed/updated",
-        matchesPattern("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}[+-]\\d{2}:\\d{2}"));
-  }
-
-  @Test
-  public void generatedAtomContainsNodeId() throws Exception {
-    verifyStringPropertyInGeneratedAtom("/feed/id", equalTo("urn:node:AQIDBA"));
-  }
-
-  @Test
-  public void generatedAtomContainsLogoUrl() throws Exception {
-    verifyStringPropertyInGeneratedAtom("/feed/logo", equalTo("/favicon.ico"));
-  }
-
-  @Test
-  public void generatedAtomContainsUserAlerts() throws Exception {
-    SimpleUserAlert alert =
-        new SimpleUserAlert(true, "Alert Title", "This is an alert!", "It’s an alert!", (short) 0);
-    userAlertManager.register(alert);
-    List<Node> nodes = getEntryNodes(createAtomXml());
-    assertThat(nodes, contains(representsUserAlert(alert)));
-  }
-
-  @Test
-  public void generatedAtomContainsUserAlertWithCharactersThatAreNotValidInXml() throws Exception {
-    SimpleUserAlert userAlert =
-        new SimpleUserAlert(true, "Alert <", "Contains a <.", "It’s <!", (short) 0);
-    userAlertManager.register(userAlert);
-    List<Node> nodes = getEntryNodes(createAtomXml());
-    assertThat(nodes, contains(representsUserAlert(userAlert)));
-  }
-
-  @Test
-  public void generatedAtomContainsMultipleUserAlerts() throws Exception {
-    SimpleUserAlert firstAlert =
-        new SimpleUserAlert(true, "Alert 1", "Text 1", "Short 1", (short) 0);
-    SimpleUserAlert secondAlert =
-        new SimpleUserAlert(true, "Alert 2", "Text 2", "Short 2", (short) 0);
-    userAlertManager.register(secondAlert);
-    userAlertManager.register(firstAlert);
-    List<Node> entryNodes = getEntryNodes(createAtomXml());
-    assertThat(
-        entryNodes,
-        containsInAnyOrder(representsUserAlert(firstAlert), representsUserAlert(secondAlert)));
-  }
-
-  @Test
-  public void generatedAtomDoesNotContainInvalidUserAlerts() throws Exception {
-    SimpleUserAlert firstAlert =
-        new SimpleUserAlert(true, "Alert 1", "Text 1", "Short 1", (short) 0);
-    SimpleUserAlert secondAlert =
-        new SimpleUserAlert(true, "Alert 2", "Text 2", "Short 2", (short) 0) {
-          @Override
-          public boolean isValid() {
-            return false;
-          }
-        };
-    userAlertManager.register(secondAlert);
-    userAlertManager.register(firstAlert);
-    List<Node> entryNodes = getEntryNodes(createAtomXml());
-    assertThat(entryNodes, containsInAnyOrder(representsUserAlert(firstAlert)));
-  }
-
-  @Test
-  public void generatedAtomEntriesUseAnchorForId() throws Exception {
-    SimpleUserAlert userAlert =
-        new SimpleUserAlert(true, "Alert 1", "Text 1", "Short 1", (short) 0) {
-          @Override
-          public String anchor() {
-            return "test-anchor";
-          }
-        };
-    userAlertManager.register(userAlert);
-    Node node = getEntryNodes(createAtomXml()).getFirst();
-    assertThat(xPath.evaluate("id", node), equalTo("urn:feed:test-anchor"));
-  }
-
-  private List<Node> getEntryNodes(Document atomXml) throws Exception {
-    List<Node> nodes = new ArrayList<>();
-    NodeList nodeList = (NodeList) xPath.evaluate("/feed/entry", atomXml, XPathConstants.NODESET);
-    for (int index = 0; index < nodeList.getLength(); index++) {
-      nodes.add(nodeList.item(index));
+    private TestAlert(
+        boolean canDismiss,
+        String title,
+        String text,
+        String shortText,
+        short priority,
+        boolean valid,
+        boolean unregisterOnDismiss,
+        boolean eventNotification,
+        long updatedTime,
+        String anchor) {
+      super(
+          canDismiss,
+          title,
+          Body.of(text, shortText, new HTMLNode("div", text)),
+          priority,
+          valid,
+          new DismissOptions("Dismiss", unregisterOnDismiss));
+      this.eventNotification = eventNotification;
+      this.updatedTime = updatedTime;
+      this.anchor = anchor;
+      this.fcpMessage = mock(FCPMessage.class);
     }
-    return nodes;
+
+    @Override
+    public boolean isEventNotification() {
+      return eventNotification;
+    }
+
+    @Override
+    public long getUpdatedTime() {
+      return updatedTime;
+    }
+
+    @Override
+    public String anchor() {
+      return anchor;
+    }
+
+    @Override
+    public FCPMessage getFCPMessage() {
+      return fcpMessage;
+    }
+
+    @Override
+    public void onDismiss() {
+      dismissed = true;
+    }
+
+    boolean dismissed() {
+      return dismissed;
+    }
   }
 
-  private Matcher<Node> representsUserAlert(UserAlert userAlert) {
-    return new TypeSafeDiagnosingMatcher<>() {
-      @Override
-      public void describeTo(Description description) {
-        description.appendText("is user alert ").appendValue(userAlert);
-      }
+  private static final class TestEvent extends TestAlert implements UserEvent {
+    private final Type eventType;
 
-      @Override
-      protected boolean matchesSafely(Node node, Description mismatchDescription) {
-        try {
-          if (!Objects.equals(xPath.evaluate("id", node), "urn:feed:" + userAlert.anchor())) {
-            mismatchDescription.appendText("id was ").appendValue(xPath.evaluate("id", node));
-            return false;
-          }
-          if (!Objects.equals(
-              xPath.evaluate("link/@href", node), "http://test/alerts/#" + userAlert.anchor())) {
-            mismatchDescription
-                .appendText("link was ")
-                .appendValue(xPath.evaluate("link/@href", node));
-            return false;
-          }
-          if (!Objects.equals(
-              xPath.evaluate("updated", node), formatTime(userAlert.getUpdatedTime()))) {
-            mismatchDescription
-                .appendText("updated was ")
-                .appendValue(xPath.evaluate("updated", node));
-            return false;
-          }
-          if (!Objects.equals(xPath.evaluate("title", node), userAlert.getTitle())) {
-            mismatchDescription.appendText("title was ").appendValue(xPath.evaluate("title", node));
-            return false;
-          }
-          if (!Objects.equals(xPath.evaluate("summary", node), userAlert.getShortText())) {
-            mismatchDescription
-                .appendText("summary was ")
-                .appendValue(xPath.evaluate("summary", node));
-            return false;
-          }
-          if (!Objects.equals(xPath.evaluate("content[@type='text']", node), userAlert.getText())) {
-            mismatchDescription
-                .appendText("content was ")
-                .appendValue(xPath.evaluate("content[@type='text']", node));
-            return false;
-          }
-        } catch (XPathExpressionException e) {
-          throw new RuntimeException(e);
-        }
-        return true;
-      }
-    };
+    private TestEvent(
+        Type eventType,
+        boolean canDismiss,
+        String title,
+        String text,
+        String shortText,
+        short priority,
+        boolean valid,
+        boolean unregisterOnDismiss,
+        boolean eventNotification,
+        long updatedTime,
+        String anchor) {
+      super(
+          canDismiss,
+          title,
+          text,
+          shortText,
+          priority,
+          valid,
+          unregisterOnDismiss,
+          eventNotification,
+          updatedTime,
+          anchor);
+      this.eventType = eventType;
+    }
+
+    @Override
+    public Type getEventType() {
+      return eventType;
+    }
   }
 
-  private void verifyStringPropertyInGeneratedAtom(
-      String xpathExpression, Matcher<String> valueMatcher) throws Exception {
-    verifyStringPropertyInAtom(createAtomXml(), xpathExpression, valueMatcher);
-  }
-
-  private void verifyStringPropertyInAtom(
-      Document atomXml, String xpathExpression, Matcher<String> valueMatcher) throws Exception {
-    String value = xPath.evaluate(xpathExpression, atomXml);
-    assertThat(value, valueMatcher);
-  }
-
-  private Document createAtomXml() throws Exception {
-    String atom = userAlertManager.getAtom("http://test");
-    return DocumentBuilderFactory.newInstance()
-        .newDocumentBuilder()
-        .parse(new InputSource(new StringReader(atom)));
-  }
+  private record EntrySnapshot(
+      String id, String link, String updated, String title, String summary, String content) {}
 }


### PR DESCRIPTION
## Summary
- document and refactor UserAlertManager responsibilities
- streamline ordering, summary stats, and dismiss/render handling
- expand UserAlertManager tests for ordering, summaries, and feeds

## Testing
- `./gradlew spotlessApply`