### PR TITLE
test(support): clarify URL encoder tests

### DIFF
--- a/src/test/java/network/crypta/support/URLEncoderDecoderTest.java
+++ b/src/test/java/network/crypta/support/URLEncoderDecoderTest.java
@@ -3,78 +3,132 @@ package network.crypta.support;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import network.crypta.test.UTFUtil;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link URLEncoder} and {@link URLDecoder} classes.
+ * Exercises URL encoding and decoding behavior against representative inputs and edge cases.
+ *
+ * <p>This test suite focuses on the contract between {@link URLEncoder} and {@link URLDecoder} by
+ * checking that round-trips preserve data across ASCII-safe characters, mixed printable ranges, and
+ * non-ASCII Unicode samples. It also validates how the encoder behaves when asked to force escaping
+ * of otherwise safe characters, and how the decoder reacts to malformed or borderline escape
+ * sequences. The goal is to keep observable behavior stable for both strict and tolerant decoding
+ * paths without asserting implementation details.
+ *
+ * <p>Because these tests operate only on in-memory strings, they are deterministic and
+ * side-effect-free. The class is not intended for concurrent access; JUnit creates a new instance
+ * per test by default. The inputs are fixed byte sequences sourced from {@link UTFUtil} so that
+ * regressions are easy to reproduce.
+ *
+ * <ul>
+ *   <li>Verify strict and tolerant decoding round-trip expected inputs.
+ *   <li>Assert forced escaping for all safe URL characters.
+ *   <li>Reject malformed escape sequences while allowing bare percent signs in tolerant mode.
+ * </ul>
  *
  * @author Alberto Bacchelli &lt;sback@freenetproject.org&gt;
  */
-public class URLEncoderDecoderTest {
-
-  public static final String prtblAscii = new String(UTFUtil.PRINTABLE_ASCII);
-  public static final String stressedUTF_8Chars = new String(UTFUtil.STRESSED_UTF);
-  public static final String allCharsExceptNull =
-      new String(UTFUtil.ALL_CHARACTERS).replace("\u0000", "");
-  public static final String allChars = new String(UTFUtil.ALL_CHARACTERS);
+class URLEncoderDecoderTest {
 
   /**
-   * Encodes a string of ALL unicode characters except the 0-character and tests whether it is
-   * decoded correctly.
+   * Creates a test instance with no mutable state.
+   *
+   * <p>JUnit constructs a new instance per test method, so the constructor intentionally performs
+   * no work beyond default initialization.
+   */
+  URLEncoderDecoderTest() {}
+
+  /** Printable US-ASCII sample used to validate safe-path encoding and decoding. */
+  static final String PRINTABLE_ASCII = new String(UTFUtil.PRINTABLE_ASCII);
+
+  /** Stress sample containing non-ASCII characters to exercise UTF-8 percent encoding paths. */
+  static final String STRESSED_UTF_8_CHARS = new String(UTFUtil.STRESSED_UTF);
+
+  /**
+   * Full Unicode sample with the null character removed, used to ensure round-trip safety in strict
+   * decoding mode.
+   */
+  static final String ALL_CHARS_EXCEPT_NULL =
+      new String(UTFUtil.ALL_CHARACTERS).replace("\u0000", "");
+
+  /** Full Unicode sample including null, used when testing URI acceptance of encoded output. */
+  static final String ALL_CHARS = new String(UTFUtil.ALL_CHARACTERS);
+
+  /**
+   * Encodes a full Unicode sample without the null character and validates strict and tolerant
+   * decoding round-trips.
+   *
+   * <p>This test uses the widest sample that does not contain {@code '\u0000'} because the encoder
+   * rejects a null code point. The encoded output is then decoded in both strict and tolerant modes
+   * to ensure the original string is preserved.
+   *
+   * @throws URLEncodedFormatException if strict decoding rejects a generated escape sequence
    */
   @Test
-  public void testEncodeDecodeString_allChars() throws URLEncodedFormatException {
-    assertTrue(areCorrectlyEncodedDecoded(new String[] {allCharsExceptNull}, true));
-    assertTrue(areCorrectlyEncodedDecoded(new String[] {allCharsExceptNull}, false));
+  void encodeDecode_whenAllCharsExceptNull_expectRoundTrip() throws URLEncodedFormatException {
+    String[] toEncode = {ALL_CHARS_EXCEPT_NULL};
+
+    boolean strictResult = areCorrectlyEncodedDecoded(toEncode, true);
+    boolean tolerantResult = areCorrectlyEncodedDecoded(toEncode, false);
+
+    assertTrue(strictResult);
+    assertTrue(tolerantResult);
   }
 
   /**
-   * Tests if URLEncode.encode(String) and URLDecode.decode(String,boolean) methods work correctly
-   * together, both with safe characters and not safe "base" (i.e. ASCII) chars .
+   * Verifies strict and tolerant round-trips for safe URL characters and ASCII-base inputs.
+   *
+   * <p>The sample includes the full safe-character set, a printable ASCII range, a sequence of
+   * percent signs that would be invalid if incorrectly encoded, and an empty string to confirm
+   * zero-length handling. The test uses both decoding modes to ensure consistency.
    */
   @Test
-  public void testEncodeDecodeString_notSafeBaseChars() {
+  void encodeDecode_whenSafeAndAsciiBaseChars_expectRoundTrip() {
     String[] toEncode = {
       // safe chars
       URLEncoder.safeURLCharacters,
-      prtblAscii,
+      PRINTABLE_ASCII,
       // triple % char, if badly encoded it will generate an exception
       "%%%",
       // no chars
       ""
     };
-    try {
-      assertTrue(areCorrectlyEncodedDecoded(toEncode, true));
-      assertTrue(areCorrectlyEncodedDecoded(toEncode, false));
-    } catch (URLEncodedFormatException anException) {
-      fail("Not expected exception thrown : " + anException.getMessage());
-    }
+
+    boolean strictResult = assertDoesNotThrow(() -> areCorrectlyEncodedDecoded(toEncode, true));
+    boolean tolerantResult = assertDoesNotThrow(() -> areCorrectlyEncodedDecoded(toEncode, false));
+
+    assertTrue(strictResult);
+    assertTrue(tolerantResult);
   }
 
   /**
-   * Tests if URLEncode.encode(String) and URLDecode.decode(String,boolean) methods work correctly
-   * together, both with safe characters and not safe "advanced" (i.e. not ASCII) chars .
+   * Verifies strict and tolerant round-trips for non-ASCII inputs.
+   *
+   * <p>The stressed UTF-8 sample includes characters that must be percent encoded. The test
+   * confirms that both decoding paths produce the original string without loss or truncation.
    */
   @Test
-  public void testEncodeDecodeString_notSafeAdvChars() {
-    String[] toEncode = {stressedUTF_8Chars};
-    try {
-      assertTrue(areCorrectlyEncodedDecoded(toEncode, true));
-      assertTrue(areCorrectlyEncodedDecoded(toEncode, false));
-    } catch (URLEncodedFormatException anException) {
-      fail("Not expected exception thrown : " + anException.getMessage());
-    }
+  void encodeDecode_whenNonAsciiChars_expectRoundTrip() {
+    String[] toEncode = {STRESSED_UTF_8_CHARS};
+
+    boolean strictResult = assertDoesNotThrow(() -> areCorrectlyEncodedDecoded(toEncode, true));
+    boolean tolerantResult = assertDoesNotThrow(() -> areCorrectlyEncodedDecoded(toEncode, false));
+
+    assertTrue(strictResult);
+    assertTrue(tolerantResult);
   }
 
   /**
-   * Tests encode(String,String,boolean) method to verify if the force parameter is well-managed for
-   * each safeURLCharacter, with both true and false ascii-flag.
+   * Forces encoding of safe characters and checks for consistent percent-encoding output.
+   *
+   * <p>Each safe character is encoded twice, once with ASCII letters preserved and once with
+   * uppercase hex letters forced. The expected output is the percent-encoded US-ASCII byte for the
+   * character, so both modes should yield the same sequence.
    */
   @Test
-  public void testEncodeForced() {
+  void encode_whenForceOnSafeChars_expectPercentEncoded() {
     for (int i = 0; i < URLEncoder.safeURLCharacters.length(); i++) {
       char eachChar = URLEncoder.safeURLCharacters.charAt(i);
       String toEncode = String.valueOf(eachChar);
@@ -83,65 +137,91 @@ public class URLEncoderDecoderTest {
               + HexUtil.bytesToHex(
                   // since safe chars are only US-ASCII
                   toEncode.getBytes(StandardCharsets.US_ASCII));
-      assertEquals(expectedResult, URLEncoder.encode(toEncode, toEncode, false));
-      assertEquals(expectedResult, URLEncoder.encode(toEncode, toEncode, true));
+
+      String encodedWithoutLetters = URLEncoder.encode(toEncode, toEncode, false);
+      String encodedWithLetters = URLEncoder.encode(toEncode, toEncode, true);
+
+      assertEquals(expectedResult, encodedWithoutLetters);
+      assertEquals(expectedResult, encodedWithLetters);
     }
   }
 
   /**
-   * Tests decode(String,boolean) method using not valid encoded String to verifies if it raises an
-   * exception
+   * Ensures strict decoding rejects a null byte encoded as {@code %00}.
+   *
+   * <p>Null bytes are disallowed by the decoder, so a strict decode is expected to raise an {@link
+   * URLEncodedFormatException}.
    */
   @Test
-  public void testDecodeWrongString() {
+  void decode_whenNullCharPercentEncoded_expectException() {
     String toDecode = "%00";
-    assertTrue(isDecodeRaisingEncodedException(toDecode, false));
+
+    boolean exceptionRaised = isDecodeRaisingEncodedException(toDecode);
+
+    assertTrue(exceptionRaised);
   }
 
   /**
-   * Tests decode(String,boolean) method using not valid hex values String to verifies if it raises
-   * an exception
+   * Ensures strict decoding rejects invalid percent-escape sequences.
+   *
+   * <p>Each candidate string is formed with a percent sign and a single invalid character, so the
+   * decoder must detect the malformed escape and raise an {@link URLEncodedFormatException}.
    */
   @Test
-  public void testDecodeWrongHex() {
-    String toDecode = "123456789abcde" + prtblAscii + stressedUTF_8Chars;
+  void decode_whenInvalidHexDigits_expectException() {
+    String toDecode = "123456789abcde" + PRINTABLE_ASCII + STRESSED_UTF_8_CHARS;
 
     for (int i = 0; i < toDecode.length(); i++) {
-      assertTrue(isDecodeRaisingEncodedException("%" + toDecode.charAt(i), false));
+      String invalidEncoded = "%" + toDecode.charAt(i);
+
+      boolean exceptionRaised = isDecodeRaisingEncodedException(invalidEncoded);
+
+      assertTrue(exceptionRaised);
     }
   }
 
   /**
-   * Tests decode(String,boolean) method trying the boolean argument, to verify if it work correctly
-   * as a hack to allow users to paste in URLs containing %'s.
+   * Verifies tolerant decoding preserves bare percent characters without throwing.
+   *
+   * <p>Tolerant mode is intended to accept user-pasted URLs that include percent signs not part of
+   * valid escapes, so the decoder should return the original input unchanged.
    */
   @Test
-  public void testTolerantDecoding() {
+  void decode_whenTolerantAndBarePercents_expectOriginal() {
     String toDecode = "%%%";
 
-    try {
-      assertEquals(URLDecoder.decode(toDecode, true), toDecode);
-    } catch (URLEncodedFormatException anException) {
-      fail("Not expected exception thrown : " + anException.getMessage());
-    }
-  }
+    String decoded = assertDoesNotThrow(() -> URLDecoder.decode(toDecode, true));
 
-  /** Tests whether all URL-encoded characters are acceptable to the java.net.URI constructor. */
-  @Test
-  public void testEncodedUsableInURI() {
-    try {
-      new URI("#" + URLEncoder.encode(allChars, false));
-    } catch (URISyntaxException e) {
-      fail("URLEncoder output rejected by URI constructor");
-    }
+    assertEquals(toDecode, decoded);
   }
 
   /**
-   * Verifies if a string is the same after being processed by encoding and decoding methods
+   * Confirms that a fully encoded Unicode string produces a URI-safe fragment.
    *
-   * @param toEncode String to Encode
-   * @return true means to be tolerant of bogus escapes
-   * @throws URLEncodedFormatException
+   * <p>The {@link URI} constructor is a strict parser for allowed characters. This test wraps the
+   * encoded output in a fragment prefix and asserts that it is accepted without error.
+   */
+  @Test
+  void encode_whenAllChars_expectUriAcceptsEncodedOutput() {
+    String encoded = URLEncoder.encode(ALL_CHARS, false);
+
+    assertDoesNotThrow(() -> new URI("#" + encoded));
+  }
+
+  /**
+   * Encodes each input string and verifies that decoding returns the original value.
+   *
+   * <p>This helper method runs a two-phase check: it first encodes each input string and then
+   * decodes the encoded value using the specified decoding mode. When a mismatch is detected, it
+   * performs a character-by-character comparison to surface the first divergence and returns {@code
+   * false} without throwing. The method is deterministic and has no side effects beyond the
+   * returned boolean.
+   *
+   * @param toEncode array of input strings to encode and then decode in order
+   * @param withLetters whether the encoder and decoder should allow ASCII letters in escapes
+   * @return {@code true} when every input round-trips to the original value, otherwise {@code
+   *     false}
+   * @throws URLEncodedFormatException if decoding rejects an encoded value in strict mode
    */
   private boolean areCorrectlyEncodedDecoded(String[] toEncode, boolean withLetters)
       throws URLEncodedFormatException {
@@ -158,8 +238,11 @@ public class URLEncoderDecoderTest {
       if (!orig.equals(decoded)) {
         for (int c = 0; c < orig.length(); ++c) {
           final char origChar = orig.charAt(c);
+          if (c >= decoded.length()) {
+            return false; // Set your debugger breakpoint here
+          }
           final char decodedChar = decoded.charAt(c);
-          if (c > decoded.length() || origChar != decodedChar) {
+          if (origChar != decodedChar) {
             return false; // Set your debugger breakpoint here
           }
         }
@@ -170,17 +253,19 @@ public class URLEncoderDecoderTest {
   }
 
   /**
-   * Verifies if a URLEncodedFormatException is raised when decoding the provided String
+   * Attempts strict decoding and reports whether a {@link URLEncodedFormatException} is raised.
    *
-   * @param toDecode the String to decode
-   * @param tolerant whether the decoding should be tolerant with
-   * @return
+   * <p>This helper only exercises the strict decoding path. It catches the expected exception and
+   * returns a boolean so tests can remain explicit about the failure condition being asserted.
+   *
+   * @param toDecode the raw string to decode, expected to contain malformed escapes
+   * @return {@code true} if strict decoding throws, otherwise {@code false}
    */
-  private boolean isDecodeRaisingEncodedException(String toDecode, boolean tolerant) {
+  private boolean isDecodeRaisingEncodedException(String toDecode) {
     boolean retValue = false;
     try {
-      System.out.println(URLDecoder.decode(toDecode, false));
-    } catch (URLEncodedFormatException anException) {
+      URLDecoder.decode(toDecode, false);
+    } catch (URLEncodedFormatException _) {
       retValue = true;
     }
     return retValue;


### PR DESCRIPTION
## Summary
- improve test naming and documentation around URL encoding/decoding expectations
- make strict vs tolerant decoding assertions explicit and remove noisy debug output

## Testing
- ./gradlew spotlessApply