### PR TITLE
fix(crypt): avoid null hash results

### DIFF
--- a/src/main/java/network/crypta/client/Metadata.java
+++ b/src/main/java/network/crypta/client/Metadata.java
@@ -853,7 +853,9 @@ public class Metadata implements Serializable {
     }
     if (orig.hashes != null) {
       this.hashes = new HashResult[orig.hashes.length];
-      for (int i = 0; i < this.hashes.length; i++) this.hashes[i] = orig.hashes[i].clone();
+      for (int i = 0; i < this.hashes.length; i++) {
+        this.hashes[i] = new HashResult(orig.hashes[i]);
+      }
     }
     if (orig.manifestEntries != null) {
       this.manifestEntries = HashMap.newHashMap(orig.manifestEntries.size());

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -336,7 +336,9 @@ class SingleFileInserter implements ClientPutState, Serializable {
     long origSize = block.getData().size();
     byte[] hashThisLayerOnly = null;
     if (hashes != null && metadata) {
-      hashThisLayerOnly = HashResult.get(hashes, HashType.SHA256);
+      if (HashResult.contains(hashes, HashType.SHA256)) {
+        hashThisLayerOnly = HashResult.get(hashes, HashType.SHA256);
+      }
       hashes = null; // Inherit origHashes
     }
     if (hashes != null) {
@@ -402,6 +404,9 @@ class SingleFileInserter implements ClientPutState, Serializable {
   private record KeyKind(int blockSize, int oneBlockCompressedSize, boolean isCHK, boolean isUSK) {}
 
   private KeyKind computeKeyKind(FreenetURI uri) throws InsertException {
+    if (uri == null) {
+      throw new InsertException(InsertExceptionMode.INVALID_URI, "Null key type", null);
+    }
     boolean isCHK = false;
     boolean isUSK = uri.getKeyType().equals("USK");
     int blockSize;
@@ -746,6 +751,9 @@ class SingleFileInserter implements ClientPutState, Serializable {
 
   private void tryCompress(ClientContext context) throws InsertException {
     RandomAccessBucket origData = block.getData();
+    if (block.desiredURI == null) {
+      throw new InsertException(InsertExceptionMode.INVALID_URI, "Null key type", null);
+    }
     BlockSizes sizes = determineBlockSizes(block.desiredURI.getKeyType().toUpperCase());
     long origSize = origData.size();
     long wantHashes = computeWantedHashes(origData.size());
@@ -923,6 +931,9 @@ class SingleFileInserter implements ClientPutState, Serializable {
       throws InsertException {
 
     FreenetURI uri = block.desiredURI;
+    if (uri == null) {
+      throw new InsertException(InsertExceptionMode.INVALID_URI, "Null key type", null);
+    }
     uri.checkInsertURI(); // will throw an exception if needed
 
     if (uri.getKeyType().equals("USK")) {

--- a/src/main/java/network/crypta/crypt/HashResult.java
+++ b/src/main/java/network/crypta/crypt/HashResult.java
@@ -8,16 +8,49 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.security.MessageDigest;
 import java.util.Arrays;
+import java.util.Objects;
 import network.crypta.support.HexUtil;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HashResult implements Comparable<HashResult>, Cloneable, Serializable {
+/**
+ * Holds a hash type identifier and its corresponding raw hash bytes.
+ *
+ * <p>This class is a small value object used when a call needs to transport both the hash algorithm
+ * identity and the computed digest. It is intentionally lightweight: it stores the {@link HashType}
+ * and the byte array as-is, provides serialization-friendly readers/writers, and orders instances
+ * by the hash type bitmask so callers can build stable collections and bitmasks. Typical usage is
+ * to read a set of hashes from a stream, compare them to expected values, or write them back in the
+ * canonical order.
+ *
+ * <p>Instances are effectively immutable by convention, but the underlying byte array is stored and
+ * returned directly. Callers must treat the bytes as read-only to preserve invariants. Because of
+ * that shared storage, concurrent reads are safe only if the array is not mutated elsewhere.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Serialization reads and writes hash bytes without a per-hash length prefix.
+ *   <li>{@link #write(HashResult[], DataOutputStream)} sorts the input array in place.
+ *   <li>{@link #copy(HashResult[])} performs a shallow copy that shares hash bytes.
+ * </ul>
+ */
+public class HashResult implements Comparable<HashResult>, Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(HashResult.class);
+  private static final HashResult[] EMPTY_HASHES = new HashResult[0];
+  private static final byte[] EMPTY_BYTES = new byte[0];
+  private static final String RESULT_MESSAGE = "result";
 
   @Serial private static final long serialVersionUID = 1L;
 
-  /** The type of hash. */
+  /**
+   * Identifies the hash algorithm associated with {@link #result}.
+   *
+   * <p>This value is treated as a stable identifier for ordering and bitmasking. It should be
+   * non-null for normal instances and match the byte length of the stored digest. Consumers rely on
+   * it to select the correct hash length and to compare or serialize results deterministically.
+   */
   public final HashType type;
 
   /** The result of the hash. Immutable. */
@@ -26,26 +59,81 @@ public class HashResult implements Comparable<HashResult>, Cloneable, Serializab
   /** Cached HashType.values(). Never modify or pass this array to outside code! */
   private static final HashType[] HashType_values = HashType.values();
 
+  /**
+   * Creates a hash result with the provided type and raw digest bytes.
+   *
+   * <p>The bytes are stored directly without copying. Callers should pass a buffer of exactly
+   * {@code hashType.hashLength} bytes and must not mutate the array after construction. This
+   * constructor does not perform defensive validation beyond the internal assertion used by the
+   * delegated constructor, so misuse can surface later during comparisons or serialization.
+   *
+   * @param hashType identifies the hash algorithm; expected to be non-null and stable
+   * @param bs raw digest bytes; expected length matches {@code hashType.hashLength} and non-null
+   */
   public HashResult(HashType hashType, byte[] bs) {
     this(hashType, bs, false);
   }
 
-  // Protected constructor for unit testing
+  /**
+   * Creates a copy of the provided {@link HashResult}.
+   *
+   * <p>This constructor preserves the historical shallow-copy behavior of {@code clone()} by
+   * reusing the source byte array. As a result, the new instance shares the underlying bytes with
+   * {@code source}. Treat the array as read-only and avoid mutating either instance when used
+   * across threads or stored in shared collections.
+   *
+   * @param source source hash result to copy; expected non-null and fully initialized
+   */
+  public HashResult(HashResult source) {
+    this.type = source.type;
+    this.result = source.result;
+  }
+
+  /**
+   * Creates a hash result with optional validation for unit tests.
+   *
+   * <p>When {@code testing} is {@code true}, callers may bypass the length assertion; otherwise an
+   * assertion checks that {@code bs.length} matches the declared hash length. This constructor is
+   * protected so tests can create intentionally malformed instances without exposing that behavior
+   * to normal callers.
+   *
+   * @param hashType identifies the hash algorithm; expected non-null for non-test use
+   * @param bs raw digest bytes to store directly; may be null only for serialization tests
+   * @param testing whether to bypass the length assertion for test-only scenarios
+   */
   protected HashResult(HashType hashType, byte[] bs, boolean testing) {
     this.type = hashType;
     this.result = bs;
     assert testing || (bs.length == type.hashLength);
   }
 
+  /**
+   * Creates an uninitialized instance for serialization frameworks.
+   *
+   * <p>This constructor leaves fields null so that the deserialization machinery can populate them.
+   * Normal code should use the public constructors instead of this entry point.
+   */
   protected HashResult() {
     // For serialization.
     type = null;
     result = null;
   }
 
+  /**
+   * Reads a set of hash results from the provided stream.
+   *
+   * <p>The method consumes a 32-bit bitmask followed by the raw bytes for each hash type present in
+   * the bitmask. The order is defined by the current {@link HashType#values()} array, which
+   * provides a stable, deterministic sequence in this codebase. When the bitmask is zero, a shared
+   * empty array is returned instead of {@code null}.
+   *
+   * @param dis input stream positioned at the hash bitmask; must be non-null and readable
+   * @return an array of hash results in canonical order; never {@code null}
+   * @throws IOException if the stream cannot be read or does not contain enough bytes
+   */
   public static HashResult[] readHashes(DataInputStream dis) throws IOException {
     int bitmask = dis.readInt();
-    if (bitmask == 0) return null;
+    if (bitmask == 0) return EMPTY_HASHES;
     int count = 0;
     for (HashType h : HashType_values) {
       if ((bitmask & h.bitmask) == h.bitmask) {
@@ -68,8 +156,21 @@ public class HashResult implements Comparable<HashResult>, Cloneable, Serializab
     return new HashResult(h, buf);
   }
 
+  /**
+   * Writes a set of hash results to the provided stream.
+   *
+   * <p>The method emits a 32-bit bitmask and then the raw bytes for each hash in ascending type
+   * order. To enforce that order, the input array is sorted in place. Callers who need to preserve
+   * the original ordering must pass a copy. Duplicate hash types are rejected to keep the encoding
+   * unambiguous.
+   *
+   * @param hashes hash results to write; {@code null} is treated as an empty array
+   * @param dos output stream that receives the bitmask and digest bytes; must be non-null
+   * @throws IOException if the stream cannot be written to
+   * @throws IllegalArgumentException if multiple hashes share the same type bitmask
+   */
   public static void write(HashResult[] hashes, DataOutputStream dos) throws IOException {
-    if (hashes == null) hashes = new HashResult[0];
+    if (hashes == null) hashes = EMPTY_HASHES;
     int bitmask = 0;
     for (HashResult hash : hashes) bitmask |= hash.type.bitmask;
     dos.writeInt(bitmask);
@@ -83,83 +184,180 @@ public class HashResult implements Comparable<HashResult>, Cloneable, Serializab
     for (HashResult h : hashes) h.writeTo(dos);
   }
 
+  /**
+   * Writes the raw digest bytes for this hash result.
+   *
+   * <p>No length prefix is written because the hash type already defines the expected length.
+   * Callers must ensure the corresponding {@link HashType} is serialized or known separately. The
+   * method writes exactly {@code type.hashLength} bytes from the internal buffer.
+   *
+   * @param dos output stream that receives the digest bytes; must be non-null
+   * @throws IOException if the stream cannot be written to
+   * @throws NullPointerException if the result bytes are not initialized
+   */
   public void writeTo(OutputStream dos) throws IOException {
     // Any given hash type has a fixed hash length, so just push the bytes.
+    Objects.requireNonNull(result, RESULT_MESSAGE);
     dos.write(result);
   }
 
+  /**
+   * Compares this instance to another by hash type bitmask.
+   *
+   * <p>The comparison establishes a stable ordering used by serialization and array sorting. It
+   * ignores the digest bytes and only inspects the {@link HashType} bitmask. The method requires
+   * both instances and their types to be non-null.
+   *
+   * @param h other hash result to compare; must be non-null and initialized
+   * @return a negative, zero, or positive value based on the type bitmask ordering
+   * @throws NullPointerException if {@code h} or either hash type is null
+   */
   @Override
-  public int compareTo(HashResult h) {
-    if (type.bitmask == h.type.bitmask) return 0;
-    if (type.bitmask > h.type.bitmask) return 1;
-    /* else if(type.bitmask < h.type.bitmask) */ return -1;
+  public int compareTo(@NotNull HashResult h) {
+    Objects.requireNonNull(type, "type");
+    Objects.requireNonNull(h, "hashResult");
+    Objects.requireNonNull(h.type, "type");
+    return Integer.compare(type.bitmask, h.type.bitmask);
   }
 
+  /**
+   * Builds a bitmask representing the types present in the array.
+   *
+   * <p>Each hash type contributes its {@link HashType#bitmask} bit to the returned value. The
+   * method performs no validation and assumes each array entry is non-null and initialized. It is
+   * intended for compact storage or quick membership checks.
+   *
+   * @param hashes array of hash results to inspect; expected non-null and fully populated
+   * @return bitmask with one bit set for each hash type present
+   * @throws NullPointerException if {@code hashes} or any entry is null
+   */
   public static long makeBitmask(HashResult[] hashes) {
     long l = 0;
     for (HashResult hash : hashes) l |= hash.type.bitmask;
     return l;
   }
 
+  /**
+   * Compares two arrays for strict equality of type ordering and hash bytes.
+   *
+   * <p>The arrays must have the same length and be ordered identically by hash type. The method
+   * compares types by identity and by name to tolerate classloader differences, then compares the
+   * raw digest bytes. Any mismatch is logged at error level. This is a diagnostic helper; it does
+   * not attempt to reorder or normalize inputs.
+   *
+   * @param results expected results array; must be non-null and aligned by type
+   * @param hashes actual results array; must be non-null and aligned by type
+   * @return {@code true} when every type and byte array matches in order; {@code false} otherwise
+   * @throws NullPointerException if either array or any entry is null
+   */
   public static boolean strictEquals(HashResult[] results, HashResult[] hashes) {
     if (results.length != hashes.length) {
-      LOG.error("Hashes not equal: " + results.length + " hashes vs " + hashes.length + " hashes");
+      LOG.error("Hashes not equal: {} hashes vs {} hashes", results.length, hashes.length);
       return false;
     }
     for (int i = 0; i < results.length; i++) {
-      if (results[i].type != hashes[i].type) {
-        // FIXME Db4o kludge
-        if (HashType.valueOf(results[i].type.name()) != HashType.valueOf(hashes[i].type.name())) {
-          LOG.error(
-              "Hashes not the same type: "
-                  + results[i].type.name()
-                  + " vs "
-                  + hashes[i].type.name());
-          return false;
-        }
+      if (results[i].type != hashes[i].type
+          && HashType.valueOf(results[i].type.name()) != HashType.valueOf(hashes[i].type.name())) {
+        LOG.error(
+            "Hashes not the same type: {} vs {}", results[i].type.name(), hashes[i].type.name());
+        return false;
       }
       if (!Arrays.equals(results[i].result, hashes[i].result)) {
-        LOG.error("Hash " + results[i].type.name() + " not equal");
+        LOG.error("Hash {} not equal", results[i].type.name());
         return false;
       }
     }
     return true;
   }
 
+  /**
+   * Determines whether the provided array contains a hash of the given type.
+   *
+   * <p>Type matching is performed by identity and by name to accommodate different enum instances
+   * from separate classloaders. A {@code null} array yields {@code false}. The method does not
+   * validate contents beyond reading the type field.
+   *
+   * @param hashes array of hash results to scan; {@code null} is treated as empty
+   * @param type hash type to locate; expected non-null and stable
+   * @return {@code true} if a matching type is present; {@code false} otherwise
+   * @throws NullPointerException if {@code type} is null and the array is non-null
+   */
   public static boolean contains(HashResult[] hashes, HashType type) {
+    if (hashes == null) {
+      return false;
+    }
     for (HashResult res : hashes)
       if (res.type == type || type.name().equals(res.type.name())) return true;
     return false;
   }
 
+  /**
+   * Returns the raw digest bytes for the requested hash type.
+   *
+   * <p>The returned array is the internal storage of the matching {@link HashResult}, not a copy.
+   * Callers must treat it as read-only. When the array is {@code null} or no match is found, a
+   * shared empty array is returned.
+   *
+   * @param hashes array of hash results to scan; {@code null} is treated as empty
+   * @param type hash type to locate; expected non-null and stable
+   * @return the stored digest bytes for the matching type, or an empty array if absent
+   * @throws NullPointerException if {@code type} is null and the array is non-null
+   */
   public static byte[] get(HashResult[] hashes, HashType type) {
+    if (hashes == null) {
+      return EMPTY_BYTES;
+    }
     for (HashResult res : hashes)
       if (res.type == type || type.name().equals(res.type.name())) return res.result;
-    return null;
+    return EMPTY_BYTES;
   }
 
+  /**
+   * Returns a shallow copy of the provided hash result array.
+   *
+   * <p>Each element is copied using {@link #HashResult(HashResult)}, which preserves the original
+   * byte arrays. The returned array is safe to reorder, but the contained {@code HashResult}
+   * instances still share their digest storage with the originals. A {@code null} or empty input
+   * yields a shared empty array.
+   *
+   * @param hashes array of hash results to copy; {@code null} is treated as empty
+   * @return a new array containing shallow copies, or a shared empty array when no entries exist
+   */
   public static HashResult[] copy(HashResult[] hashes) {
-    if (hashes == null) return null;
+    if (hashes == null || hashes.length == 0) return EMPTY_HASHES;
     HashResult[] out = new HashResult[hashes.length];
     for (int i = 0; i < hashes.length; i++) {
-      out[i] = hashes[i].clone();
+      out[i] = new HashResult(hashes[i]);
     }
     return out;
   }
 
-  @Override
-  public HashResult clone() {
-    try {
-      return (HashResult) super.clone();
-    } catch (CloneNotSupportedException e) {
-      throw new Error(e);
-    }
-  }
-
+  /**
+   * Returns the digest bytes as a lowercase hexadecimal string.
+   *
+   * <p>The conversion uses {@link HexUtil} and does not alter the stored bytes. This is typically
+   * used for logging, debugging, or textual comparisons where a stable encoding is required.
+   *
+   * @return hex-encoded digest string for this hash result
+   * @throws NullPointerException if the result bytes are not initialized
+   */
   public String hashAsHex() {
+    Objects.requireNonNull(result, RESULT_MESSAGE);
     return HexUtil.bytesToHex(result);
   }
 
+  /**
+   * Tests this hash result for equality with another object.
+   *
+   * <p>Two instances are considered equal when they share the same {@link HashType} reference and
+   * their digest bytes compare equal using {@link MessageDigest#isEqual(byte[], byte[])}. The
+   * comparison is byte-for-byte and does not normalize or copy arrays. This method is safe for hash
+   * comparisons where timing side channels are a concern because the digest comparison uses a
+   * constant-time helper.
+   *
+   * @param otherObject object to compare against; {@code null} or other types return {@code false}
+   * @return {@code true} when type and digest bytes match; {@code false} otherwise
+   */
   @Override
   public boolean equals(Object otherObject) {
     if (!(otherObject instanceof HashResult otherHash)) {
@@ -173,12 +371,25 @@ public class HashResult implements Comparable<HashResult>, Cloneable, Serializab
     return MessageDigest.isEqual(result, otherHash.result);
   }
 
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash code combines the hash type and the digest bytes using {@link Arrays#hashCode}.
+   * This is stable for a given byte array content but will change if the underlying digest bytes
+   * are mutated. Callers must treat the digest array as read-only to preserve hashing behavior in
+   * maps and sets.
+   *
+   * @return a hash code derived from the type and digest bytes
+   * @throws NullPointerException if the type or digest bytes are uninitialized
+   */
   @Override
   public int hashCode() {
     int hash = 1;
 
+    Objects.requireNonNull(type, "type");
+    Objects.requireNonNull(result, RESULT_MESSAGE);
     hash *= 31 + type.hashCode();
-    hash *= 31 + result.hashCode();
+    hash *= 31 + Arrays.hashCode(result);
 
     return hash;
   }

--- a/src/test/java/network/crypta/crypt/HashResultTest.java
+++ b/src/test/java/network/crypta/crypt/HashResultTest.java
@@ -1,0 +1,373 @@
+package network.crypta.crypt;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class HashResultTest {
+  private static byte[] bytesFor(HashType type, int seed) {
+    byte[] bytes = new byte[type.hashLength];
+    for (int i = 0; i < bytes.length; i++) {
+      bytes[i] = (byte) (seed + i);
+    }
+    return bytes;
+  }
+
+  private static byte[] resultBytes(HashResult hashResult) {
+    return HashResult.get(new HashResult[] {hashResult}, hashResult.type);
+  }
+
+  @Test
+  void readHashes_whenBitmaskZero_expectEmptyArray() throws IOException {
+    // Arrange
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
+
+    // Act
+    HashResult.write(null, dataOutputStream);
+    DataInputStream dataInputStream =
+        new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+    HashResult[] results = HashResult.readHashes(dataInputStream);
+
+    // Assert
+    assertArrayEquals(new HashResult[0], results);
+  }
+
+  @Test
+  void writeAndRead_whenMultipleTypes_expectRoundTripInEnumOrder() throws IOException {
+    // Arrange
+    byte[] sha512Bytes = bytesFor(HashType.SHA512, 10);
+    byte[] sha1Bytes = bytesFor(HashType.SHA1, 20);
+    byte[] md5Bytes = bytesFor(HashType.MD5, 30);
+    HashResult[] input =
+        new HashResult[] {
+          new HashResult(HashType.SHA512, sha512Bytes),
+          new HashResult(HashType.SHA1, sha1Bytes),
+          new HashResult(HashType.MD5, md5Bytes)
+        };
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
+
+    // Act
+    HashResult.write(input, dataOutputStream);
+    DataInputStream dataInputStream =
+        new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+    HashResult[] results = HashResult.readHashes(dataInputStream);
+
+    // Assert
+    assertNotNull(results);
+    assertEquals(3, results.length);
+    assertEquals(HashType.SHA1, results[0].type);
+    assertEquals(HashType.MD5, results[1].type);
+    assertEquals(HashType.SHA512, results[2].type);
+    assertArrayEquals(sha1Bytes, HashResult.get(results, HashType.SHA1));
+    assertArrayEquals(md5Bytes, HashResult.get(results, HashType.MD5));
+    assertArrayEquals(sha512Bytes, HashResult.get(results, HashType.SHA512));
+  }
+
+  @Test
+  void write_whenDuplicateTypes_expectIllegalArgumentException() {
+    // Arrange
+    HashResult first = new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1));
+    HashResult second = new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 2));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
+
+    // Act
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> HashResult.write(new HashResult[] {first, second}, dataOutputStream));
+
+    // Assert
+    assertEquals("Multiple hashes of the same type!", ex.getMessage());
+  }
+
+  @Test
+  void makeBitmask_whenMultipleHashes_expectCombinedBitmask() {
+    // Arrange
+    HashResult sha1 = new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1));
+    HashResult md5 = new HashResult(HashType.MD5, bytesFor(HashType.MD5, 2));
+
+    // Act
+    long bitmask = HashResult.makeBitmask(new HashResult[] {sha1, md5});
+
+    // Assert
+    assertEquals(HashType.SHA1.bitmask | HashType.MD5.bitmask, bitmask);
+  }
+
+  @Test
+  void strictEquals_whenLengthsDiffer_expectFalse() {
+    // Arrange
+    HashResult[] results =
+        new HashResult[] {new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1))};
+    HashResult[] hashes =
+        new HashResult[] {
+          new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1)),
+          new HashResult(HashType.MD5, bytesFor(HashType.MD5, 2))
+        };
+
+    // Act
+    boolean equal = HashResult.strictEquals(results, hashes);
+
+    // Assert
+    assertFalse(equal);
+  }
+
+  @Test
+  void strictEquals_whenTypeMismatch_expectFalse() {
+    // Arrange
+    HashResult[] results =
+        new HashResult[] {new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1))};
+    HashResult[] hashes =
+        new HashResult[] {new HashResult(HashType.MD5, bytesFor(HashType.MD5, 1))};
+
+    // Act
+    boolean equal = HashResult.strictEquals(results, hashes);
+
+    // Assert
+    assertFalse(equal);
+  }
+
+  @Test
+  void strictEquals_whenByteMismatch_expectFalse() {
+    // Arrange
+    HashResult[] results =
+        new HashResult[] {new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1))};
+    HashResult[] hashes =
+        new HashResult[] {new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 2))};
+
+    // Act
+    boolean equal = HashResult.strictEquals(results, hashes);
+
+    // Assert
+    assertFalse(equal);
+  }
+
+  @Test
+  void strictEquals_whenSameTypeAndBytes_expectTrue() {
+    // Arrange
+    byte[] bytes = bytesFor(HashType.SHA1, 1);
+    HashResult[] results = new HashResult[] {new HashResult(HashType.SHA1, bytes)};
+    HashResult[] hashes =
+        new HashResult[] {new HashResult(HashType.SHA1, Arrays.copyOf(bytes, bytes.length))};
+
+    // Act
+    boolean equal = HashResult.strictEquals(results, hashes);
+
+    // Assert
+    assertTrue(equal);
+  }
+
+  @Test
+  void contains_whenTypePresent_expectTrue() {
+    // Arrange
+    HashResult[] hashes =
+        new HashResult[] {new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1))};
+
+    // Act
+    boolean contains = HashResult.contains(hashes, HashType.SHA1);
+
+    // Assert
+    assertTrue(contains);
+  }
+
+  @Test
+  void contains_whenTypeAbsent_expectFalse() {
+    // Arrange
+    HashResult[] hashes =
+        new HashResult[] {new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1))};
+
+    // Act
+    boolean contains = HashResult.contains(hashes, HashType.MD5);
+
+    // Assert
+    assertFalse(contains);
+  }
+
+  @Test
+  void get_whenTypePresent_expectByteArray() {
+    // Arrange
+    byte[] bytes = bytesFor(HashType.SHA1, 1);
+    HashResult[] hashes = new HashResult[] {new HashResult(HashType.SHA1, bytes)};
+
+    // Act
+    byte[] found = HashResult.get(hashes, HashType.SHA1);
+
+    // Assert
+    assertArrayEquals(bytes, found);
+  }
+
+  @Test
+  void get_whenTypeAbsent_expectEmptyArray() {
+    // Arrange
+    HashResult[] hashes =
+        new HashResult[] {new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1))};
+
+    // Act
+    byte[] found = HashResult.get(hashes, HashType.MD5);
+
+    // Assert
+    assertArrayEquals(new byte[0], found);
+  }
+
+  @Test
+  void copy_whenNull_expectEmptyArray() {
+    // Arrange
+    HashResult[] hashes = null;
+
+    // Act
+    //noinspection ConstantValue
+    HashResult[] copy = HashResult.copy(hashes);
+
+    // Assert
+    assertArrayEquals(new HashResult[0], copy);
+  }
+
+  @Test
+  void copy_whenArrayProvided_expectClonedElements() {
+    // Arrange
+    HashResult original = new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1));
+    HashResult[] hashes = new HashResult[] {original};
+
+    // Act
+    HashResult[] copy = HashResult.copy(hashes);
+
+    // Assert
+    assertNotNull(copy);
+    assertNotSame(hashes, copy);
+    assertEquals(1, copy.length);
+    assertNotSame(original, copy[0]);
+    assertEquals(original.type, copy[0].type);
+    assertSame(resultBytes(original), resultBytes(copy[0]));
+  }
+
+  @Test
+  void copyConstructor_whenInvoked_expectDistinctInstanceAndSharedResultArray() {
+    // Arrange
+    HashResult original = new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1));
+
+    // Act
+    HashResult cloned = new HashResult(original);
+
+    // Assert
+    assertNotSame(original, cloned);
+    assertEquals(original.type, cloned.type);
+    assertSame(resultBytes(original), resultBytes(cloned));
+  }
+
+  @Test
+  void hashAsHex_whenBytesProvided_expectLowercaseHex() {
+    // Arrange
+    byte[] bytes = new byte[HashType.MD5.hashLength];
+    bytes[0] = 0x00;
+    bytes[1] = 0x0f;
+    bytes[2] = (byte) 0xa5;
+    HashResult hashResult = new HashResult(HashType.MD5, bytes);
+
+    // Act
+    String hex = hashResult.hashAsHex();
+
+    // Assert
+    assertEquals("000fa5" + "00".repeat(HashType.MD5.hashLength - 3), hex);
+  }
+
+  @Test
+  void equals_whenSameTypeAndBytes_expectTrue() {
+    // Arrange
+    byte[] bytes = bytesFor(HashType.SHA1, 1);
+    HashResult first = new HashResult(HashType.SHA1, bytes);
+    HashResult second = new HashResult(HashType.SHA1, Arrays.copyOf(bytes, bytes.length));
+
+    // Act
+    boolean equal = first.equals(second);
+
+    // Assert
+    assertTrue(equal);
+  }
+
+  @Test
+  void equals_whenDifferentType_expectFalse() {
+    // Arrange
+    HashResult first = new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1));
+    HashResult second = new HashResult(HashType.MD5, bytesFor(HashType.MD5, 1));
+
+    // Act
+    boolean equal = first.equals(second);
+
+    // Assert
+    assertFalse(equal);
+  }
+
+  @Test
+  void equals_whenDifferentBytes_expectFalse() {
+    // Arrange
+    HashResult first = new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 1));
+    HashResult second = new HashResult(HashType.SHA1, bytesFor(HashType.SHA1, 2));
+
+    // Act
+    boolean equal = first.equals(second);
+
+    // Assert
+    assertFalse(equal);
+  }
+
+  @Test
+  void hashCode_whenCalledMultipleTimes_expectStableValue() {
+    // Arrange
+    byte[] bytes = bytesFor(HashType.SHA1, 1);
+    HashResult hashResult = new HashResult(HashType.SHA1, bytes);
+    HashResult cloned = new HashResult(hashResult);
+
+    // Act
+    int first = hashResult.hashCode();
+    int second = hashResult.hashCode();
+
+    // Assert
+    assertEquals(first, second);
+    assertEquals(first, cloned.hashCode());
+  }
+
+  @ParameterizedTest(name = "compareTo {0} vs {1} -> {2}")
+  @MethodSource("compareToCases")
+  void compareTo_whenBitmaskOrder_expectSignedComparison(
+      HashType leftType, HashType rightType, int expectedSign) {
+    // Arrange
+    HashResult left = new HashResult(leftType, bytesFor(leftType, 1));
+    HashResult right = new HashResult(rightType, bytesFor(rightType, 2));
+
+    // Act
+    int comparison = Integer.signum(left.compareTo(right));
+
+    // Assert
+    assertEquals(expectedSign, comparison);
+  }
+
+  private static Stream<Arguments> compareToCases() {
+    return Stream.of(
+        Arguments.of(HashType.SHA1, HashType.SHA1, 0),
+        Arguments.of(HashType.SHA1, HashType.MD5, -1),
+        Arguments.of(HashType.SHA512, HashType.SHA1, 1));
+  }
+}


### PR DESCRIPTION
## Summary
- return shared empty arrays/bytes for missing hash results
- replace clone usage with a shallow copy constructor and document HashResult behavior
- add HashResult tests covering ordering, equality, and empty results

## Testing
- `./gradlew spotlessApply`
