### PR TITLE
test(junit): align test visibility and L10n helpers

### DIFF
--- a/src/test/java/network/crypta/client/CodeTest.java
+++ b/src/test/java/network/crypta/client/CodeTest.java
@@ -11,14 +11,14 @@ import com.onionnetworks.util.Util;
 import network.crypta.support.TestProperty;
 import org.junit.jupiter.api.Test;
 
-public class CodeTest {
+class CodeTest {
 
   public static final int KK = 192;
   public static final int PACKET_SIZE = 4096;
   public static FECMath fecMath = new FECMath(8);
 
   @Test
-  public void testBenchmark() {
+  void testBenchmark() {
     if (!TestProperty.BENCHMARK) {
       return;
     }
@@ -82,7 +82,7 @@ public class CodeTest {
   }
 
   @Test
-  public void testSimpleRev() {
+  void testSimpleRev() {
     int lim = fecMath.getGfSize() + 1;
     try (FECCode code = FECCodeFactory.getDefault().createFECCode(KK, lim);
         FECCode code2 = new PureCode(KK, lim)) {
@@ -98,7 +98,7 @@ public class CodeTest {
   }
 
   @Test
-  public void testSimple() {
+  void testSimple() {
     int lim = fecMath.getGfSize() + 1;
     try (FECCode code = FECCodeFactory.getDefault().createFECCode(KK, lim);
         FECCode code2 = new PureCode(KK, lim)) {
@@ -113,7 +113,7 @@ public class CodeTest {
   }
 
   @Test
-  public void testShifted() {
+  void testShifted() {
     int lim = fecMath.getGfSize() + 1;
     try (FECCode code = FECCodeFactory.getDefault().createFECCode(KK, lim);
         FECCode code2 = new PureCode(KK, lim)) {

--- a/src/test/java/network/crypta/client/filter/ContentFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/ContentFilterTest.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import network.crypta.client.filter.ContentFilter.FilterStatus;
 import network.crypta.clients.http.ExternalLinkToadlet;
-import network.crypta.l10n.BaseL10nTest;
+import network.crypta.l10n.L10nTestUtils;
 import network.crypta.support.Logging;
 import network.crypta.support.TestProperty;
 import network.crypta.support.io.ArrayBucket;
@@ -47,9 +47,9 @@ import org.slf4j.event.Level;
  */
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
-public class ContentFilterTest {
+class ContentFilterTest {
   static {
-    GenericReadFilterCallback.setBaseL10n(BaseL10nTest.createTestL10n(ENGLISH));
+    GenericReadFilterCallback.setBaseL10n(L10nTestUtils.createTestL10n(ENGLISH));
   }
 
   private static final String HTML_OPEN = "<html>";

--- a/src/test/java/network/crypta/client/filter/GenericReadFilterCallbackTest.java
+++ b/src/test/java/network/crypta/client/filter/GenericReadFilterCallbackTest.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
 import network.crypta.clients.http.ExternalLinkToadlet;
 import network.crypta.keys.FreenetURI;
-import network.crypta.l10n.BaseL10nTest;
+import network.crypta.l10n.L10nTestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +38,7 @@ class GenericReadFilterCallbackTest {
   @BeforeAll
   static void setupL10n() {
     // Ensure deterministic error messages during testing
-    GenericReadFilterCallback.setBaseL10n(BaseL10nTest.createTestL10n(ENGLISH));
+    GenericReadFilterCallback.setBaseL10n(L10nTestUtils.createTestL10n(ENGLISH));
   }
 
   private GenericReadFilterCallback newCallback(String base) throws URISyntaxException {

--- a/src/test/java/network/crypta/clients/fcp/FCPMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPMessageTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author <a href="mailto:david.roden@bietr.de">David Roden</a>
  */
-public class FCPMessageTest {
+class FCPMessageTest {
 
   private static final String LIST_REQUEST_IDENTIFIER = "ListRequestIdentifier";
   private static final String IDENTIFIER = "identifier";
@@ -29,25 +29,25 @@ public class FCPMessageTest {
   private final FCPMessage originalMessage = mock(FCPMessage.class);
 
   @Test
-  public void wrappingNullReturnsNull() {
+  void wrappingNullReturnsNull() {
     assertThat(FCPMessage.withListRequestIdentifier(null, LIST_REQUEST_IDENTIFIER), nullValue());
   }
 
   @Test
-  public void wrappingMessageAddsIdentifier() {
+  void wrappingMessageAddsIdentifier() {
     when(originalMessage.getFieldSet()).thenReturn(new SimpleFieldSet(true));
     FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
     assertThat(wrappedMessage.getFieldSet().get(LIST_REQUEST_IDENTIFIER), is(IDENTIFIER));
   }
 
   @Test
-  public void messageIsNotWrappedIfListRequestIdentifierIsNull() {
+  void messageIsNotWrappedIfListRequestIdentifierIsNull() {
     assertThat(
         FCPMessage.withListRequestIdentifier(originalMessage, null), sameInstance(originalMessage));
   }
 
   @Test
-  public void wrappedMessageDelegatesName() {
+  void wrappedMessageDelegatesName() {
     when(originalMessage.getName()).thenReturn(MESSAGE_NAME);
     FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
     assertThat(wrappedMessage.getName(), is(MESSAGE_NAME));
@@ -55,7 +55,7 @@ public class FCPMessageTest {
   }
 
   @Test
-  public void wrappedMessageDelegatesRun() throws MessageInvalidException {
+  void wrappedMessageDelegatesRun() throws MessageInvalidException {
     FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
     FCPConnectionHandler connectionHandler = mock(FCPConnectionHandler.class);
     Node node = mock(Node.class);
@@ -64,7 +64,7 @@ public class FCPMessageTest {
   }
 
   @Test
-  public void wrappedMessageDelegatesEndString() {
+  void wrappedMessageDelegatesEndString() {
     FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
     when(originalMessage.getEndString()).thenReturn(END_STRING);
     assertThat(wrappedMessage.getEndString(), is(END_STRING));
@@ -72,7 +72,7 @@ public class FCPMessageTest {
   }
 
   @Test
-  public void wrappedMessageDelegatesSend() throws IOException {
+  void wrappedMessageDelegatesSend() throws IOException {
     FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
     OutputStream outputStream = mock(OutputStream.class);
     wrappedMessage.send(outputStream);

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginMessageEncodeDecodeTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginMessageEncodeDecodeTest.java
@@ -25,14 +25,14 @@ import org.junit.jupiter.api.Test;
  * to be attached by network, not server plugins.<br>
  * See {@link FCPPluginConnectionImpl} for an overview of the architecture.
  */
-public final class FCPPluginMessageEncodeDecodeTest {
+final class FCPPluginMessageEncodeDecodeTest {
 
   /**
    * Creates different interesting types of {@link FCPPluginMessage}, whose actual encoding and
    * decoding is then tested using {@link #testEncodeDecode(FCPPluginMessage)}.
    */
   @Test
-  public void testEncodeDecode() throws MessageInvalidException, IOException, FSParseException {
+  void testEncodeDecode() throws MessageInvalidException, IOException, FSParseException {
     ArrayList<FCPPluginMessage> messages = new ArrayList<>();
 
     // Non-reply messages. Can either have a SimpleFieldSet, or a Bucket, or both. We don't use

--- a/src/test/java/network/crypta/clients/http/FilterCSSIdentifierTest.java
+++ b/src/test/java/network/crypta/clients/http/FilterCSSIdentifierTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
  * Tests that valid CSS identifiers without non-ASCII characters or escaped characters are
  * unchanged, and that invalid ones are changed as expected.
  */
-public class FilterCSSIdentifierTest {
+class FilterCSSIdentifierTest {
   @Test
-  public void testKnownValid() {
+  void testKnownValid() {
     String[] identifiers = {"sample_key-1", "-_", "-k_d", "_testing-key"};
 
     for (String identifier : identifiers) {
@@ -19,13 +19,13 @@ public class FilterCSSIdentifierTest {
   }
 
   @Test
-  public void testInvalidFirstDash() {
+  void testInvalidFirstDash() {
     assertEquals("-_things", PageMaker.filterCSSIdentifier("-9things"));
     assertEquals("-_", PageMaker.filterCSSIdentifier("--"));
   }
 
   @Test
-  public void testInvalidChar() {
+  void testInvalidChar() {
     assertEquals("__thing", PageMaker.filterCSSIdentifier("#$thing"));
   }
 }

--- a/src/test/java/network/crypta/clients/http/utils/PebbleUtilsTest.java
+++ b/src/test/java/network/crypta/clients/http/utils/PebbleUtilsTest.java
@@ -7,25 +7,24 @@ import static org.hamcrest.Matchers.equalTo;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import network.crypta.l10n.BaseL10nTest;
+import network.crypta.l10n.L10nTestUtils;
 import network.crypta.support.HTMLNode;
 import org.junit.jupiter.api.Test;
 
-public class PebbleUtilsTest {
+class PebbleUtilsTest {
 
   static {
-    PebbleUtils.setBaseL10n(BaseL10nTest.createTestL10n(ENGLISH));
+    PebbleUtils.setBaseL10n(L10nTestUtils.createTestL10n(ENGLISH));
   }
 
   @Test
-  public void addChildAddsCorrectlyEvaluatedSimpleTemplateToHtmlNode() throws IOException {
+  void addChildAddsCorrectlyEvaluatedSimpleTemplateToHtmlNode() throws IOException {
     PebbleUtils.addChild(emptyParentNode, "pebble-utils-test-simple", model, null);
     assertThat(normalizeEol(emptyParentNode.generate()), equalTo("Test!\n"));
   }
 
   @Test
-  public void addChildAddsCorrectlyEvaluatedTemplateWithL10nFunctionToHtmlNode()
-      throws IOException {
+  void addChildAddsCorrectlyEvaluatedTemplateWithL10nFunctionToHtmlNode() throws IOException {
     PebbleUtils.addChild(emptyParentNode, "pebble-utils-test-l10n", model, "pebble-utils-tests.");
     assertThat(emptyParentNode.generate(), equalTo("Test Value"));
   }

--- a/src/test/java/network/crypta/config/CryptadConfigExpandEdgeCasesTest.java
+++ b/src/test/java/network/crypta/config/CryptadConfigExpandEdgeCasesTest.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class CryptadConfigExpandEdgeCasesTest {
+class CryptadConfigExpandEdgeCasesTest {
 
   @TempDir Path tmp;
 
@@ -29,14 +29,14 @@ public class CryptadConfigExpandEdgeCasesTest {
   }
 
   @Test
-  public void leadingToken_backslashes_normalizesWithinBase() {
+  void leadingToken_backslashes_normalizesWithinBase() {
     Map<String, String> b = base();
     String out = CryptadConfig.expandValue("dataDir\\foo\\..\\bar", b);
     assertEquals(out, Path.of(b.get("dataDir"), "bar").toString());
   }
 
   @Test
-  public void leadingToken_posixSegments_normalizesWithinBase() {
+  void leadingToken_posixSegments_normalizesWithinBase() {
     Map<String, String> b = base();
     String out = CryptadConfig.expandValue("cacheDir/./tmp/../persist", b);
     assertEquals(out, Path.of(b.get("cacheDir"), "persist").toString());
@@ -45,35 +45,35 @@ public class CryptadConfigExpandEdgeCasesTest {
   // Mixed separators after a leading token should be handled uniformly.
   // This verifies cross-platform behavior when '/' and '\\' are interleaved.
   @Test
-  public void leadingToken_mixedSeparators_normalizesWithinBase() {
+  void leadingToken_mixedSeparators_normalizesWithinBase() {
     Map<String, String> b = base();
     String out = CryptadConfig.expandValue("dataDir/foo\\bar/baz", b);
     assertEquals(out, Path.of(b.get("dataDir"), "foo", "bar", "baz").toString());
   }
 
   @Test
-  public void placeholder_equality_resolvesToBase() {
+  void placeholder_equality_resolvesToBase() {
     Map<String, String> b = base();
     String out = CryptadConfig.expandValue("${logsDir}", b);
     assertEquals(out, Path.of(b.get("logsDir")).normalize().toString());
   }
 
   @Test
-  public void placeholder_windowsTraversal_rejectedWhenAnchored() {
+  void placeholder_windowsTraversal_rejectedWhenAnchored() {
     Map<String, String> b = base();
     assertThrows(
         IOException.class, () -> CryptadConfig.expandValue("${dataDir}\\..\\..\\etc\\passwd", b));
   }
 
   @Test
-  public void placeholder_inMiddle_isReplaced() {
+  void placeholder_inMiddle_isReplaced() {
     Map<String, String> b = base();
     String out = CryptadConfig.expandValue("prefix-${cacheDir}-suffix", b);
     assertEquals(out, "prefix-" + b.get("cacheDir") + "-suffix");
   }
 
   @Test
-  public void placeholder_inMiddle_withTraversal_rejected() {
+  void placeholder_inMiddle_withTraversal_rejected() {
     Map<String, String> b = base();
     assertThrows(
         IOException.class,
@@ -81,7 +81,7 @@ public class CryptadConfigExpandEdgeCasesTest {
   }
 
   @Test
-  public void leadingToken_backslashDot_normalizes() {
+  void leadingToken_backslashDot_normalizes() {
     Map<String, String> b = base();
     String out = CryptadConfig.expandValue("runDir\\.", b);
     assertEquals(out, Path.of(b.get("runDir")).normalize().toString());
@@ -91,7 +91,7 @@ public class CryptadConfigExpandEdgeCasesTest {
   // Windows ('\\') and POSIX ('/') separators should still anchor and
   // normalize correctly under that base.
   @Test
-  public void anchored_mixedSeparators_withWindowsStyleBase_normalizes() {
+  void anchored_mixedSeparators_withWindowsStyleBase_normalizes() {
     Map<String, String> b = new HashMap<>();
     b.put("dataDir", "C:\\base\\dir");
     String out = CryptadConfig.expandValue("C:/base/dir\\x/y\\z", b);
@@ -102,7 +102,7 @@ public class CryptadConfigExpandEdgeCasesTest {
   // Even with a POSIX-looking base, incoming backslashes are normalized in
   // comparisons and resolution so that anchoring and normalization are consistent.
   @Test
-  public void anchored_mixedSeparators_withPosixBase_normalizes() {
+  void anchored_mixedSeparators_withPosixBase_normalizes() {
     Map<String, String> b = base();
     String out = CryptadConfig.expandValue(b.get("dataDir") + "\\x\\y", b);
     assertEquals(out, Path.of(b.get("dataDir"), "x", "y").toString());
@@ -111,7 +111,7 @@ public class CryptadConfigExpandEdgeCasesTest {
   // Mixed traversal using interleaved separators must be rejected when it would
   // escape the base directory after normalization.
   @Test
-  public void leadingToken_mixedTraversal_rejected() {
+  void leadingToken_mixedTraversal_rejected() {
     Map<String, String> b = base();
     assertThrows(IOException.class, () -> CryptadConfig.expandValue("dataDir/..\\..\\evil", b));
   }

--- a/src/test/java/network/crypta/config/CryptadConfigExpandTest.java
+++ b/src/test/java/network/crypta/config/CryptadConfigExpandTest.java
@@ -6,9 +6,9 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-public class CryptadConfigExpandTest {
+class CryptadConfigExpandTest {
   @Test
-  public void expandsCurlyPlaceholders() {
+  void expandsCurlyPlaceholders() {
     Map<String, String> base = new HashMap<>();
     base.put("configDir", "/tmp/cfg");
     String out = CryptadConfig.expandValue("${configDir}", base);

--- a/src/test/java/network/crypta/config/CryptadConfigSecurityTest.java
+++ b/src/test/java/network/crypta/config/CryptadConfigSecurityTest.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class CryptadConfigSecurityTest {
+class CryptadConfigSecurityTest {
 
   @TempDir Path tmp;
 
@@ -29,20 +29,20 @@ public class CryptadConfigSecurityTest {
   }
 
   @Test
-  public void rejectsTraversal_inLeadingTokenForm() {
+  void rejectsTraversal_inLeadingTokenForm() {
     Map<String, String> b = base();
     assertThrows(IOException.class, () -> CryptadConfig.expandValue("dataDir/../../etc/passwd", b));
   }
 
   @Test
-  public void rejectsTraversal_inPlaceholderForm() {
+  void rejectsTraversal_inPlaceholderForm() {
     Map<String, String> b = base();
     assertThrows(
         IOException.class, () -> CryptadConfig.expandValue("${dataDir}/../../etc/passwd", b));
   }
 
   @Test
-  public void allowsNormalization_withinBase() throws IOException {
+  void allowsNormalization_withinBase() throws IOException {
     Map<String, String> b = base();
     String expanded = CryptadConfig.expandValue("dataDir/foo/../bar", b);
     assertEquals(expanded, Path.of(b.get("dataDir"), "bar").toString());

--- a/src/test/java/network/crypta/config/ShortOptionTest.java
+++ b/src/test/java/network/crypta/config/ShortOptionTest.java
@@ -75,7 +75,7 @@ class ShortOptionTest {
       @Mock ShortCallback cb) {
     // Arrange
     // Reset global translations to production bundle. Other tests may install
-    // a test-only bundle via BaseL10nTest.useTestTranslation(), which would
+    // a test-only bundle via L10nTestUtils.useTestTranslation(), which would
     // make this localized message assertion nondeterministic.
     //noinspection InstantiationOfUtilityClass
     new NodeL10n();

--- a/src/test/java/network/crypta/crypt/CryptUtilTest.java
+++ b/src/test/java/network/crypta/crypt/CryptUtilTest.java
@@ -10,10 +10,10 @@ import network.crypta.support.Fields;
 import network.crypta.support.math.MersenneTwister;
 import org.junit.jupiter.api.Test;
 
-public class CryptUtilTest {
+class CryptUtilTest {
 
   @Test
-  public void testRandomBytes() {
+  void testRandomBytes() {
     // two predictable pseudo-random sequence
     MersenneTwister mt1 = new MersenneTwister(Long.MAX_VALUE);
     MersenneTwister mt2 = new MersenneTwister(Long.MAX_VALUE);
@@ -31,7 +31,7 @@ public class CryptUtilTest {
   }
 
   @Test
-  public void testSecureRandomBytes() {
+  void testSecureRandomBytes() {
     SecureRandom r1;
     SecureRandom r2;
     try {

--- a/src/test/java/network/crypta/crypt/EncryptedRandomAccessBufferAltTest.java
+++ b/src/test/java/network/crypta/crypt/EncryptedRandomAccessBufferAltTest.java
@@ -8,7 +8,7 @@ import network.crypta.support.io.ByteArrayRandomAccessBuffer;
 import network.crypta.support.io.RandomAccessBufferTestBase;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
-public class EncryptedRandomAccessBufferAltTest extends RandomAccessBufferTestBase {
+class EncryptedRandomAccessBufferAltTest extends RandomAccessBufferTestBase {
 
   static {
     Security.addProvider(new BouncyCastleProvider());

--- a/src/test/java/network/crypta/crypt/TrivialPaddedBucketTest.java
+++ b/src/test/java/network/crypta/crypt/TrivialPaddedBucketTest.java
@@ -10,10 +10,10 @@ import network.crypta.support.io.FileUtil;
 import network.crypta.support.io.PaddedBucket;
 import org.junit.jupiter.api.Test;
 
-public class TrivialPaddedBucketTest {
+class TrivialPaddedBucketTest {
 
   @Test
-  public void testSimple() throws IOException {
+  void testSimple() throws IOException {
     checkSimple(4000, 4096);
     checkSimple(1, 1024);
     checkSimple((1 << 17) - 1, 1 << 17);

--- a/src/test/java/network/crypta/l10n/BaseL10nTest.java
+++ b/src/test/java/network/crypta/l10n/BaseL10nTest.java
@@ -28,16 +28,16 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings("java:S100") // allow descriptive test method names
-public class BaseL10nTest {
+class BaseL10nTest {
 
-  public static BaseL10n createL10n(LANGUAGE lang) {
+  static BaseL10n createL10n(LANGUAGE lang) {
     File overrideFile =
         new File(TestProperty.L10nPath_main, "crypta.l10n.${lang}.override.properties");
     return new BaseL10n(
         "network/crypta/l10n/", "crypta.l10n.${lang}.properties", overrideFile.getPath(), lang);
   }
 
-  public static BaseL10n createTestL10n(LANGUAGE lang) {
+  static BaseL10n createTestL10n(LANGUAGE lang) {
     File overrideFile =
         new File(TestProperty.L10nPath_test, "crypta.l10n.${lang}.override.properties");
     return new BaseL10n(
@@ -51,7 +51,7 @@ public class BaseL10nTest {
    * Installs a {@link #createTestL10n(LANGUAGE) BaseL10n} with translations read from the test
    * classpath into the global {@link NodeL10n}, allowing tests for translation keys.
    */
-  public static void useTestTranslation() {
+  static void useTestTranslation() {
     NodeL10n.setBase(createTestL10n(LANGUAGE.ENGLISH));
   }
 

--- a/src/test/java/network/crypta/l10n/L10nTestUtils.java
+++ b/src/test/java/network/crypta/l10n/L10nTestUtils.java
@@ -1,0 +1,40 @@
+package network.crypta.l10n;
+
+import java.io.File;
+import network.crypta.l10n.BaseL10n.LANGUAGE;
+import network.crypta.support.TestProperty;
+
+/**
+ * Shared helper for tests outside {@code network.crypta.l10n} that need {@link BaseL10n} instances
+ * or to install the test translation bundle. The utilities live in a dedicated class so tests can
+ * keep package-private visibility without exposing {@code BaseL10nTest} as public.
+ */
+public final class L10nTestUtils {
+
+  private L10nTestUtils() {}
+
+  public static BaseL10n createL10n(LANGUAGE lang) {
+    File overrideFile =
+        new File(TestProperty.L10nPath_main, "crypta.l10n.${lang}.override.properties");
+    return new BaseL10n(
+        "network/crypta/l10n/", "crypta.l10n.${lang}.properties", overrideFile.getPath(), lang);
+  }
+
+  public static BaseL10n createTestL10n(LANGUAGE lang) {
+    File overrideFile =
+        new File(TestProperty.L10nPath_test, "crypta.l10n.${lang}.override.properties");
+    return new BaseL10n(
+        "network/crypta/l10n/",
+        "crypta.l10n.${lang}.test.properties",
+        overrideFile.getPath(),
+        lang);
+  }
+
+  /**
+   * Installs a test {@link BaseL10n} with translations read from the test classpath into the global
+   * {@link NodeL10n}, allowing tests for translation keys.
+   */
+  public static void useTestTranslation() {
+    NodeL10n.setBase(createTestL10n(LANGUAGE.ENGLISH));
+  }
+}

--- a/src/test/java/network/crypta/l10n/NodeL10nTest.java
+++ b/src/test/java/network/crypta/l10n/NodeL10nTest.java
@@ -65,7 +65,7 @@ class NodeL10nTest {
   @Test
   void setBase_whenProvided_replacesGlobalInstance() {
     // Arrange: install a dedicated BaseL10n that uses test resources
-    BaseL10n custom = BaseL10nTest.createTestL10n(LANGUAGE.ENGLISH);
+    BaseL10n custom = L10nTestUtils.createTestL10n(LANGUAGE.ENGLISH);
 
     // Act
     NodeL10n.setBase(custom);

--- a/src/test/java/network/crypta/node/NodeAndClientLayerBlobTest.java
+++ b/src/test/java/network/crypta/node/NodeAndClientLayerBlobTest.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
-public class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
+class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
 
   @Test
-  public void testFetchPullBlobSingleNode()
+  void testFetchPullBlobSingleNode()
       throws NodeInitException,
           InsertException,
           FetchException,
@@ -101,7 +101,7 @@ public class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
   }
 
   @AfterEach
-  public void cleanUp() {
+  void cleanUp() {
     FileUtil.removeAll(dir);
   }
 

--- a/src/test/java/network/crypta/node/NodeAndClientLayerTest.java
+++ b/src/test/java/network/crypta/node/NodeAndClientLayerTest.java
@@ -30,10 +30,10 @@ import org.slf4j.event.Level;
  *
  * @author toad
  */
-public class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
+class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
 
   @Test
-  public void testFetchPullSingleNodeSsk()
+  void testFetchPullSingleNodeSsk()
       throws NodeInitException, InsertException, FetchException, IOException {
     if (!TestProperty.EXTENSIVE) {
       return;
@@ -45,7 +45,7 @@ public class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
   }
 
   @Test
-  public void testFetchPullSingleNodeUskEditionZero()
+  void testFetchPullSingleNodeUskEditionZero()
       throws NodeInitException, InsertException, FetchException, IOException {
     if (!TestProperty.EXTENSIVE) {
       return;
@@ -57,7 +57,7 @@ public class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
   }
 
   @AfterEach
-  public void cleanUp() {
+  void cleanUp() {
     FileUtil.removeAll(dir);
   }
 

--- a/src/test/java/network/crypta/node/NodeAndClientLayerTestBase.java
+++ b/src/test/java/network/crypta/node/NodeAndClientLayerTestBase.java
@@ -9,7 +9,7 @@ import network.crypta.keys.InsertableClientSSK;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.api.RandomAccessBucket;
 
-public class NodeAndClientLayerTestBase {
+class NodeAndClientLayerTestBase {
 
   static final int PORT = 2048;
   static final int FILE_SIZE = 1024 * 1024;

--- a/src/test/java/network/crypta/node/useralerts/UserAlertManagerTest.java
+++ b/src/test/java/network/crypta/node/useralerts/UserAlertManagerTest.java
@@ -28,7 +28,7 @@ import javax.xml.xpath.XPathFactory;
 import network.crypta.client.async.ClientContext;
 import network.crypta.clients.fcp.FCPConnectionHandler;
 import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.l10n.BaseL10nTest;
+import network.crypta.l10n.L10nTestUtils;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.HTMLNode;
@@ -57,7 +57,7 @@ class UserAlertManagerTest {
 
   @BeforeEach
   void setUp() {
-    BaseL10nTest.useTestTranslation();
+    L10nTestUtils.useTestTranslation();
     lenient().when(nodeClientCore.getNode()).thenReturn(node);
     lenient().when(node.getDarknetPubKeyHash()).thenReturn(new byte[] {1, 2, 3, 4});
     lenient().when(nodeClientCore.getClientContext()).thenReturn(clientContext);

--- a/src/test/java/network/crypta/store/SimplePubkeyCacheTest.java
+++ b/src/test/java/network/crypta/store/SimplePubkeyCacheTest.java
@@ -13,10 +13,10 @@ import network.crypta.support.ByteArrayWrapper;
 import network.crypta.support.math.MersenneTwister;
 import org.junit.jupiter.api.Test;
 
-public class SimplePubkeyCacheTest {
+class SimplePubkeyCacheTest {
 
   @Test
-  public void testSimple() {
+  void testSimple() {
     final int keys = 10;
     PubkeyStore pk = new PubkeyStore();
     new RAMFreenetStore<>(pk, keys);

--- a/src/test/java/network/crypta/support/FieldTrimSecondTest.java
+++ b/src/test/java/network/crypta/support/FieldTrimSecondTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
  * Tests parsing of bandwidth limits optionally specified with some indicator of "(bits) per
  * second."
  */
-public class FieldTrimSecondTest {
+class FieldTrimSecondTest {
 
   /** Bandwidth limit input with and without various "per second" specifiers and SI / IEC units. */
   private static final String[] input = {"50 KiB/s", "1.5 MiB/sec", "128 kbps", "20 KiB", "5800"};
@@ -19,7 +19,7 @@ public class FieldTrimSecondTest {
   };
 
   @Test
-  public void test() {
+  void test() {
     assert input.length == output.length;
 
     int parsed;

--- a/src/test/java/network/crypta/support/FieldsDurationTest.java
+++ b/src/test/java/network/crypta/support/FieldsDurationTest.java
@@ -8,7 +8,7 @@ import network.crypta.config.Dimension;
 import org.junit.jupiter.api.Test;
 
 /** Tests parsing of duration value. */
-public class FieldsDurationTest {
+class FieldsDurationTest {
 
   /** Duration input with and without various d|h|min|s. With correct result in millis */
   private static final Map<String, Integer> durations =
@@ -23,7 +23,7 @@ public class FieldsDurationTest {
       };
 
   @Test
-  public void test() {
+  void test() {
     durations.forEach(
         (duration, millis) -> {
           Integer parsed = Fields.parseInt(Fields.trimPerSecond(duration), Dimension.DURATION);

--- a/src/test/java/network/crypta/support/api/BooleanCallbackTest.java
+++ b/src/test/java/network/crypta/support/api/BooleanCallbackTest.java
@@ -8,10 +8,10 @@ import network.crypta.config.NodeNeedRestartException;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-public class BooleanCallbackTest {
+class BooleanCallbackTest {
 
   @Test
-  public void canCreateBooleanCallbackFromLambdas()
+  void canCreateBooleanCallbackFromLambdas()
       throws NodeNeedRestartException, InvalidConfigValueException {
     BooleanCallback callback = BooleanCallback.from(() -> true, (value) -> theValue = value);
     callback.set(true);
@@ -20,7 +20,7 @@ public class BooleanCallbackTest {
   }
 
   @Test
-  public void canThrowInvalidConfigValueException()
+  void canThrowInvalidConfigValueException()
       throws NodeNeedRestartException, InvalidConfigValueException {
     BooleanCallback callback =
         BooleanCallback.from(
@@ -32,7 +32,7 @@ public class BooleanCallbackTest {
   }
 
   @Test
-  public void canThrowNodeNeedRestartException()
+  void canThrowNodeNeedRestartException()
       throws NodeNeedRestartException, InvalidConfigValueException {
     BooleanCallback callback =
         BooleanCallback.from(
@@ -44,8 +44,7 @@ public class BooleanCallbackTest {
   }
 
   @Test
-  public void getGivesTheSetVariable()
-      throws NodeNeedRestartException, InvalidConfigValueException {
+  void getGivesTheSetVariable() throws NodeNeedRestartException, InvalidConfigValueException {
     BooleanCallback callback =
         BooleanCallback.from(
             () -> theValue,

--- a/src/test/java/network/crypta/support/compress/GzipCompressorTest.java
+++ b/src/test/java/network/crypta/support/compress/GzipCompressorTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author stuart martin &lt;wavey@freenetproject.org&gt;
  */
-public class GzipCompressorTest {
+class GzipCompressorTest {
 
   public static final String UNCOMPRESSED_DATA_1 =
       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -31,7 +31,7 @@ public class GzipCompressorTest {
 
   /** test GZIP compressor's identity and functionality */
   @Test
-  public void testGzipCompressor() {
+  void testGzipCompressor() {
     Compressor compressorZero = Compressor.COMPRESSOR_TYPE.getCompressorByMetadataID((short) 0);
 
     // check GZIP is the first compressor
@@ -39,7 +39,7 @@ public class GzipCompressorTest {
   }
 
   @Test
-  public void testCompress() throws IOException {
+  void testCompress() throws IOException {
     // do gzip compression
     byte[] compressedData = doCompress(UNCOMPRESSED_DATA_1.getBytes());
 
@@ -51,7 +51,7 @@ public class GzipCompressorTest {
   }
 
   @Test
-  public void testBucketDecompress() throws IOException {
+  void testBucketDecompress() throws IOException {
     // do gzip decompression with buckets
     byte[] uncompressedData = doBucketDecompress(COMPRESSED_DATA_1);
 
@@ -61,7 +61,7 @@ public class GzipCompressorTest {
   }
 
   @Test
-  public void testByteArrayDecompress() throws IOException {
+  void testByteArrayDecompress() throws IOException {
     // build 5k array
     byte[] originalUncompressedData = new byte[5 * 1024];
     Arrays.fill(originalUncompressedData, (byte) 1);
@@ -80,7 +80,7 @@ public class GzipCompressorTest {
   }
 
   @Test
-  public void testCompressException() throws IOException {
+  void testCompressException() throws IOException {
 
     byte[] uncompressedData = UNCOMPRESSED_DATA_1.getBytes();
     Bucket inBucket = new ArrayBucket(uncompressedData);
@@ -96,7 +96,7 @@ public class GzipCompressorTest {
   }
 
   @Test
-  public void testDecompressException() throws IOException {
+  void testDecompressException() throws IOException {
     // build 5k array
     byte[] uncompressedData = new byte[5 * 1024];
     Arrays.fill(uncompressedData, (byte) 1);

--- a/src/test/java/network/crypta/support/io/BucketTestBase.java
+++ b/src/test/java/network/crypta/support/io/BucketTestBase.java
@@ -36,7 +36,7 @@ public abstract class BucketTestBase {
   protected boolean canOverwrite = true;
 
   @Test
-  public void testReadEmpty() throws IOException {
+  void testReadEmpty() throws IOException {
     Bucket bucket = makeBucket(3);
     try {
       assertEquals(0, bucket.size(), "Size-0");
@@ -56,7 +56,7 @@ public abstract class BucketTestBase {
   }
 
   @Test
-  public void testReadExcess() throws IOException {
+  void testReadExcess() throws IOException {
     Bucket bucket = makeBucket(Math.max(DATA1.length, DATA2.length));
     try {
       assertEquals(0, bucket.size(), "Size-0");
@@ -85,7 +85,7 @@ public abstract class BucketTestBase {
   }
 
   @Test
-  public void testReadWrite() throws IOException {
+  void testReadWrite() throws IOException {
     Bucket bucket = makeBucket(Math.max(DATA1.length, DATA2.length));
     try {
       assertEquals(0, bucket.size(), "Size-0");
@@ -125,7 +125,7 @@ public abstract class BucketTestBase {
 
   // Write twice -- should overwrite, not append
   @Test
-  public void testReuse() throws IOException {
+  void testReuse() throws IOException {
     if (!canOverwrite) {
       return;
     }
@@ -165,7 +165,7 @@ public abstract class BucketTestBase {
   }
 
   @Test
-  public void testNegative() throws IOException {
+  void testNegative() throws IOException {
     Bucket bucket = makeBucket(Math.max(DATA1.length, DATA2.length));
     try {
       // Write
@@ -190,7 +190,7 @@ public abstract class BucketTestBase {
   }
 
   @Test
-  public void testLargeData() throws IOException {
+  void testLargeData() throws IOException {
 
     Bucket bucket = makeBucket(DATA_LONG.length * 16L);
     try {

--- a/src/test/java/network/crypta/support/io/RandomAccessBufferTestBase.java
+++ b/src/test/java/network/crypta/support/io/RandomAccessBufferTestBase.java
@@ -52,14 +52,14 @@ public abstract class RandomAccessBufferTestBase {
    * correct size.
    */
   @Test
-  public void testSize() throws IOException {
+  void testSize() throws IOException {
     for (long size : fullSizeList) {
       innerTestSize(size);
     }
   }
 
   @Test
-  public void testFormula() throws IOException {
+  void testFormula() throws IOException {
     Random r = new Random(2126);
     Formula modulo256 = offset -> (byte) offset;
     Formula modulo57 = offset -> (byte) (offset % 57);
@@ -71,7 +71,7 @@ public abstract class RandomAccessBufferTestBase {
 
   /** Test that we can't write or read after the size limit */
   @Test
-  public void testWriteOverLimit() throws IOException {
+  void testWriteOverLimit() throws IOException {
     Random r = new Random(21092506);
     innerTestWriteOverLimit(0L, 1);
     innerTestWriteOverLimit(1, 1);
@@ -91,7 +91,7 @@ public abstract class RandomAccessBufferTestBase {
   }
 
   @Test
-  public void testClose() throws IOException {
+  void testClose() throws IOException {
     // Try to cover any thresholds for e.g. moving to disk.
     // Implementations should add their own tests according to known thresholds (white box).
     for (long size : fullSizeList) {
@@ -100,7 +100,7 @@ public abstract class RandomAccessBufferTestBase {
   }
 
   @Test
-  public void testArray() throws IOException {
+  void testArray() throws IOException {
     Random r = new Random(21162506);
     for (int size : sizeList) {
       innerTestArray(size, r, false);

--- a/src/test/java/network/crypta/support/io/RandomAccessFileWrapperTest.java
+++ b/src/test/java/network/crypta/support/io/RandomAccessFileWrapperTest.java
@@ -14,24 +14,24 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class RandomAccessFileWrapperTest extends RandomAccessBufferTestBase {
+class RandomAccessFileWrapperTest extends RandomAccessBufferTestBase {
 
   public RandomAccessFileWrapperTest() {
     super(TEST_LIST);
   }
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     base.mkdir();
   }
 
   @AfterEach
-  public void tearDown() {
+  void tearDown() {
     FileUtil.removeAll(base);
   }
 
   @Test
-  public void testStoreTo() throws IOException, StorageFormatException, ResumeFailedException {
+  void testStoreTo() throws IOException, StorageFormatException, ResumeFailedException {
     File tempFile = File.createTempFile("test-storeto", ".tmp", base);
     byte[] buf = new byte[4096];
     Random r = new Random(1267612);

--- a/src/test/java/network/crypta/test/UTFUtil.java
+++ b/src/test/java/network/crypta/test/UTFUtil.java
@@ -1,16 +1,11 @@
 package network.crypta.test;
 
-import org.junit.jupiter.api.Test;
-
 /**
  * Utility class used throught test cases classes
  *
  * @author Alberto Bacchelli &lt;sback@freenetproject.org&gt;
  */
 public final class UTFUtil {
-
-  @Test
-  public void testFake() {}
 
   /**
    * Contains all unicode characters except the low and high surrogates (they are no valid


### PR DESCRIPTION
## Summary
- remove public modifiers from JUnit test classes and methods to satisfy JUnit 6 visibility guidance
- add `L10nTestUtils` as a shared helper for cross-package tests without exposing `BaseL10nTest`
- keep shared test base classes public where required by cross-package extensions

## Testing
- `./gradlew test`
