### PR TITLE
fix(io): harden persistent temp bucket factory

### DIFF
--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -719,7 +719,6 @@ public class NodeClientCore implements Persistable {
       return new PersistentTempBucketFactory(
           persistentTempDir.dir(),
           "freenet-temp-",
-          node.getRandom(),
           node.getFastWeakRandom(),
           nodeConfig.getBoolean(CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS));
     } catch (IOException e) {

--- a/src/main/java/network/crypta/support/io/PersistentTempBucketFactory.java
+++ b/src/main/java/network/crypta/support/io/PersistentTempBucketFactory.java
@@ -2,47 +2,56 @@ package network.crypta.support.io;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Random;
 import network.crypta.crypt.EncryptedRandomAccessBucket;
 import network.crypta.crypt.MasterSecret;
-import network.crypta.crypt.RandomSource;
-import network.crypta.keys.CHKBlock;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handles persistent temp files. These are used for e.g. persistent downloads. These are temporary
- * files in the directory specified for the PersistentFileTracker (which supports changing the
- * directory, i.e. moving the files).
+ * Manages persistent temporary buckets stored on disk for restart-safe workflows.
  *
- * <p>These temporary files are encrypted using an ephemeral key (unless the node is configured not
- * to encrypt temporary files as happens with physical security level LOW). FIXME NO CRYPTO AT THE
- * MOMENT.
+ * <p>This factory creates {@link RandomAccessBucket} instances backed by files under a directory
+ * managed by {@link PersistentFileTracker}. It is used for long-lived temporary data such as
+ * persistent downloads: callers allocate buckets, register the resulting files on startup, and
+ * allow the factory to delete unclaimed files once initialization completes. Buckets can be
+ * encrypted with an ephemeral key when configured, and encryption can be toggled for newly created
+ * buckets without rewriting existing files.
  *
- * <p>Note that the files are only deleted *after* the transaction containing their deletion reaches
- * disk - so we should not leak temporary files, or forget that we deleted a bucket and try to reuse
- * it, if there is an unclean shutdown.
+ * <p>The deletion lifecycle is coordinated with persistence: buckets are freed only after the
+ * transaction recording their deletion is durably committed. The factory is recreated on startup
+ * and relies on callers to re-register their files, which prevents reuse after an unclean shutdown.
+ * This class is thread-safe; it synchronizes around mutable state and uses a dedicated lock for
+ * encryption settings.
  *
- * <p>PERSISTENCE: This class is involved in persistence but is not itself Serializable; it is
- * recreated on every startup, and persistent Bucket's register themselves with it.
+ * <p><strong>Notable behaviors:</strong>
+ *
+ * <ul>
+ *   <li>Tracks unclaimed files seen at startup and deletes them after {@link #completedInit()}.
+ *   <li>Defers file deletion until after {@link #finishDelayedFree(DelayedFree[])} is called.
+ *   <li>Wraps buckets with encryption and delayed-free layers when configured.
+ * </ul>
  */
 public class PersistentTempBucketFactory implements BucketFactory, PersistentFileTracker {
   private static final Logger LOG = LoggerFactory.getLogger(PersistentTempBucketFactory.class);
 
   /**
    * Original contents of directory. This used to be used to delete any files that we can't account
-   * for. However at the moment we do not support garbage collection for non-blob persistent temp
-   * files. When we implement it it will probably not use this structure... FIXME!
+   * for. However, at the moment we do not support garbage collection for non-blob persistent temp
+   * files. When we implement it, it will probably not use this structure.
    */
   private HashSet<File> originalFiles;
 
   /**
-   * Filename generator. Tracks the directory and the prefix for temp files, can move them if these
-   * change, generates filenames.
+   * Filename generator used for persistent temp files. It tracks the active directory and prefix,
+   * supports directory moves initiated by the tracker, and produces unique filenames for new
+   * buckets. The reference is immutable, but its internal configuration can change as the tracked
+   * directory changes.
    */
   public final FilenameGenerator fg;
 
@@ -63,33 +72,29 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
 
   private long commitID;
 
-  static final int BLOB_SIZE = CHKBlock.DATA_LENGTH;
-
-  static {
-  }
-
   /**
-   * Create a temporary bucket factory.
+   * Creates a persistent temporary bucket factory rooted at a specific directory.
    *
-   * @param dir Where to put it.
-   * @param prefix Prefix for temporary file names.
-   * @param strongPRNG Cryptographically strong random number generator, for making keys etc.
-   * @param weakPRNG Weak but fast random number generator.
-   * @param encrypt Whether to encrypt temporary files.
-   * @throws IOException If we are unable to read the directory, etc.
+   * <p>The factory scans the directory for pre-existing files matching the provided prefix and
+   * records them as candidates for cleanup during {@link #completedInit()}. The supplied random
+   * generator is used only for filename construction and need not be cryptographically strong.
+   * Encryption configuration affects only buckets created after construction; existing buckets are
+   * left unchanged.
+   *
+   * @param dir directory that stores persistent temporary files; must exist or be creatable.
+   * @param prefix filename prefix used to recognize and generate persistent temp files.
+   * @param weakPRNG fast, non-cryptographic random source for filename generation.
+   * @param encrypt whether to encrypt newly created temporary buckets.
+   * @throws IOException if the directory cannot be created, listed, or is not a directory.
    */
   public PersistentTempBucketFactory(
-      File dir, final String prefix, RandomSource strongPRNG, Random weakPRNG, boolean encrypt)
-      throws IOException {
-    /** Cryptographically strong random number generator */
-    /** Weak but fast random number generator. */
+      File dir, final String prefix, Random weakPRNG, boolean encrypt) throws IOException {
+    /* Cryptographically strong random number generator */
+    /* Weak but fast random number generator. */
     this.encrypt = encrypt;
     this.fg = new FilenameGenerator(weakPRNG, false, dir, prefix);
-    if (!dir.exists()) {
-      dir.mkdir();
-      if (!dir.exists()) {
-        throw new IOException("Directory does not exist and cannot be created: " + dir);
-      }
+    if (!dir.exists() && !dir.mkdir()) {
+      throw new IOException("Directory does not exist and cannot be created: " + dir);
     }
     if (!dir.isDirectory()) throw new IOException("Directory is not a directory: " + dir);
     originalFiles = new HashSet<>();
@@ -100,9 +105,12 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
               String name = pathname.getName();
               return name.startsWith(prefix);
             });
+    if (files == null) {
+      throw new IOException("Unable to list files in directory: " + dir);
+    }
     for (File f : files) {
       f = FileUtil.getCanonicalFile(f);
-      if (LOG.isDebugEnabled()) LOG.debug("Found " + f);
+      if (LOG.isDebugEnabled()) LOG.debug("Found {}", f);
       originalFiles.add(f);
     }
 
@@ -110,10 +118,31 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
     commitID = 1; // Must start > 0.
   }
 
+  /**
+   * Installs the disk space checker consulted by {@link #checkDiskSpace(File, int, int)}.
+   *
+   * <p>This method simply replaces the active checker reference and performs no validation. It is
+   * typically called during wiring at startup before any buckets are created. Callers should ensure
+   * the provided checker is thread-safe because it may be invoked concurrently by bucket writes.
+   *
+   * @param checker implementation to use for disk space validation; must not be {@code null}.
+   */
   public void setDiskSpaceChecker(DiskSpaceChecker checker) {
     this.checker = checker;
   }
 
+  /**
+   * Sets the master secret used when encrypting new persistent temporary buckets.
+   *
+   * <p>The secret is stored under the encryption lock to keep updates consistent with {@link
+   * #makeBucket(long)}. Changing the secret does not re-encrypt existing buckets; it only affects
+   * buckets created after the update while encryption is enabled. Callers typically set the secret
+   * during startup before creating any buckets to avoid inconsistent encryption settings across a
+   * single run.
+   *
+   * @param secret master secret used to derive ephemeral encryption keys; may be {@code null} only
+   *     if encryption is disabled.
+   */
   public void setMasterSecret(MasterSecret secret) {
     synchronized (encryptLock) {
       this.secret = secret;
@@ -121,8 +150,16 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
   }
 
   /**
-   * Notify the bucket factory that a file is a temporary file, and not to be deleted. FIXME this is
-   * not currently used. @see #completedInit()
+   * Records a temporary file as in-use so it is not deleted during initialization cleanup.
+   *
+   * <p>Callers should invoke this during startup for every persisted bucket that still exists. The
+   * method removes the canonical file from the startup snapshot taken by the constructor. If {@link
+   * #completedInit()} has already been called, this method throws an {@link IllegalStateException}
+   * because cleanup is complete.
+   *
+   * @param file temporary bucket file to preserve; must resolve to an existing file.
+   * @throws IllegalStateException if initialization has already completed.
+   * @see #completedInit()
    */
   @Override
   public void register(File file) {
@@ -135,30 +172,45 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
     }
   }
 
-  /** Called when boot-up is complete. Deletes any old temp files still unclaimed. */
+  /**
+   * Finalizes startup cleanup by deleting any unclaimed temporary files.
+   *
+   * <p>After this method runs, the startup snapshot is discarded and later calls to {@link
+   * #register(File)} are rejected. Deletions are best-effort: failures are logged and do not abort
+   * startup. This method is synchronized to prevent concurrent cleanup with registration. It should
+   * be invoked once, after all persisted buckets have had a chance to register.
+   */
   public synchronized void completedInit() {
     if (originalFiles == null) {
       LOG.error("Completed init called twice");
       return;
     }
     for (File f : originalFiles) {
-      if (LOG.isDebugEnabled()) LOG.debug("Deleting old tempfile " + f);
-      f.delete();
+      if (LOG.isDebugEnabled()) LOG.debug("Deleting old tempfile {}", f);
+      try {
+        Files.deleteIfExists(f.toPath());
+      } catch (IOException e) {
+        LOG.warn("Failed to delete old tempfile {}", f, e);
+      }
     }
     originalFiles = null;
   }
 
   /**
-   * Create a persistent temporary bucket. Encrypted if appropriate. Wrapped in a DelayedFreeBucket
-   * so that they will not be deleted until after the transaction deleting them in the database
-   * commits.
+   * Creates a persistent temporary bucket with delayed deletion semantics.
+   *
+   * <p>The returned bucket is file-backed and may be wrapped with padding and encryption when
+   * enabled. It is also wrapped in a delayed-free layer so that {@link #delayedFree(DelayedFree,
+   * long)} can defer deletion until a transaction commit is durably recorded. The {@code size}
+   * parameter is accepted for interface compatibility and does not preallocate storage.
+   *
+   * @param size desired bucket size in bytes; used for accounting only and may be ignored.
+   * @return a new persistent, delayed-free random access bucket.
+   * @throws IOException if the backing file cannot be created or initialized.
    */
   @Override
   public RandomAccessBucket makeBucket(long size) throws IOException {
-    RandomAccessBucket rawBucket = null;
-    boolean mustWrap = true;
-    if (rawBucket == null)
-      rawBucket = new PersistentTempFileBucket(fg.makeRandomFilename(), fg, this);
+    RandomAccessBucket rawBucket = new PersistentTempFileBucket(fg.makeRandomFilename(), fg, this);
     synchronized (encryptLock) {
       if (encrypt) {
         rawBucket = new PaddedRandomAccessBucket(rawBucket);
@@ -166,11 +218,21 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
             new EncryptedRandomAccessBucket(TempBucketFactory.CRYPT_TYPE, rawBucket, secret);
       }
     }
-    if (mustWrap) rawBucket = new DelayedFreeRandomAccessBucket(this, rawBucket);
+    rawBucket = new DelayedFreeRandomAccessBucket(this, rawBucket);
     return rawBucket;
   }
 
-  /** Free an allocated bucket, but only after the change has been written to disk. */
+  /**
+   * Schedules a bucket for deletion once the commit boundary has advanced.
+   *
+   * <p>If the bucket was created in the current commit, the method frees it immediately. Otherwise,
+   * it enqueues the bucket so the caller can flush the pending frees and later invoke {@link
+   * #finishDelayedFree(DelayedFree[])} after the corresponding transaction has been persisted. This
+   * method is thread-safe and may be called concurrently.
+   *
+   * @param b bucket wrapper that can be freed after a durable commit.
+   * @param createdCommitID commit identifier captured when the bucket was created.
+   */
   @Override
   public void delayedFree(DelayedFree b, long createdCommitID) {
     synchronized (this) {
@@ -183,12 +245,18 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
   }
 
   /**
-   * Returns a list of buckets to free. The caller should write the buckets to the checkpoint, and
-   * free them after the checkpoint has written successfully, by calling postCommit().
+   * Returns the buckets pending deletion and advances the commit identifier.
+   *
+   * <p>The returned array is a snapshot of the current delayed-free queue and is safe for the
+   * caller to persist alongside a checkpoint. After the checkpoint is durably written, the caller
+   * should invoke {@link #finishDelayedFree(DelayedFree[])} with the same array. Each invocation
+   * clears the queue and increments the commit identifier.
+   *
+   * @return array of buckets to free, or an empty array if none are pending.
    */
   public DelayedFree[] grabBucketsToFree() {
     synchronized (this) {
-      if (bucketsToFree.isEmpty()) return null;
+      if (bucketsToFree.isEmpty()) return new DelayedFree[0];
       DelayedFree[] buckets = bucketsToFree.toArray(new DelayedFree[0]);
       bucketsToFree.clear();
       commitID++;
@@ -196,24 +264,58 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
     }
   }
 
+  /**
+   * Returns the current commit identifier used for delayed-free coordination.
+   *
+   * <p>The identifier starts at {@code 1} and increments each time {@link #grabBucketsToFree()} is
+   * called. Callers should treat the value as a monotonically increasing token that scopes when a
+   * bucket may be freed. The value has process-local meaning only and should not be persisted
+   * across restarts.
+   *
+   * @return the current commit identifier.
+   */
   @Override
   public synchronized long commitID() {
     return commitID;
   }
 
-  /** Get the directory we are creating temporary files in */
+  /**
+   * Returns the directory where persistent temporary files are created.
+   *
+   * <p>This value reflects the current directory tracked by {@link #fg}. Callers should avoid
+   * caching the value across directory changes and instead query when needed. The directory is
+   * expected to exist and be writable when buckets are created.
+   *
+   * @return the active directory for persistent temporary files.
+   */
   @Override
   public File dir() {
     return fg.getDir();
   }
 
-  /** Get the FilenameGenerator */
+  /**
+   * Returns the filename generator responsible for persistent temp file naming.
+   *
+   * <p>The generator exposes the current directory and prefix and can relocate files when the
+   * tracked directory changes. Callers should not mutate its configuration directly and should rely
+   * on the factory methods to create new filenames.
+   *
+   * @return the filename generator used by this factory.
+   */
   @Override
   public FilenameGenerator getGenerator() {
     return fg;
   }
 
-  /** Are we encrypting temporary files? */
+  /**
+   * Reports whether newly created temporary buckets are encrypted.
+   *
+   * <p>The value is guarded by the encryption lock and reflects only the configuration for new
+   * buckets. Existing buckets are not rewritten if encryption settings change. Callers that need to
+   * reason about existing data should track encryption state externally.
+   *
+   * @return {@code true} if new buckets will be encrypted; {@code false} otherwise.
+   */
   public boolean isEncrypting() {
     synchronized (encryptLock) {
       return encrypt;
@@ -221,8 +323,14 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
   }
 
   /**
-   * Set whether to encrypt new persistent temp buckets. Note that we do not encrypt/decrypt old
-   * ones when this changes.
+   * Sets whether to encrypt new persistent temporary buckets.
+   *
+   * <p>This setting affects buckets created after the update and does not re-encrypt or decrypt
+   * existing files. Callers should set the {@link MasterSecret} first when enabling encryption to
+   * avoid creating unencrypted buckets unexpectedly. Disabling encryption does not remove padding
+   * or other wrappers from previously created buckets.
+   *
+   * @param encrypt {@code true} to encrypt new buckets, {@code false} to leave them unencrypted.
    */
   public void setEncryption(boolean encrypt) {
     synchronized (encryptLock) {
@@ -230,19 +338,41 @@ public class PersistentTempBucketFactory implements BucketFactory, PersistentFil
     }
   }
 
-  /** Delete the buckets. */
+  /**
+   * Finalizes deletion for previously delayed buckets.
+   *
+   * <p>The method iterates over the provided array and frees buckets that are still eligible for
+   * deletion. It is safe to pass {@code null} or an empty array. Exceptions from individual bucket
+   * frees are logged and do not halt the loop. This method does not retry failures; the caller may
+   * choose to requeue a bucket if needed.
+   *
+   * @param buckets buckets previously returned by {@link #grabBucketsToFree()}, or {@code null}.
+   */
   public void finishDelayedFree(DelayedFree[] buckets) {
     if (buckets != null) {
       for (DelayedFree bucket : buckets) {
         try {
           if (bucket.toFree()) bucket.realFree();
-        } catch (Throwable t) {
-          LOG.error("Caught " + t + " freeing bucket " + bucket + " after transaction commit", t);
+        } catch (Exception e) {
+          LOG.error("Caught {} freeing bucket {} after transaction commit", e, bucket, e);
         }
       }
     }
   }
 
+  /**
+   * Delegates disk space checks to the configured {@link DiskSpaceChecker}.
+   *
+   * <p>This method does not apply additional logic beyond delegation and may throw a {@link
+   * NullPointerException} if no checker has been configured. Callers should set the checker during
+   * startup to ensure write paths can validate available space. The return value is used directly
+   * by bucket writers to decide whether to proceed.
+   *
+   * @param file file that will be written; used to resolve the target filesystem.
+   * @param toWrite number of bytes expected to be written in the current operation.
+   * @param bufferSize write buffer size in bytes used by the caller.
+   * @return {@code true} if the checker reports adequate space; {@code false} otherwise.
+   */
   @Override
   public boolean checkDiskSpace(File file, int toWrite, int bufferSize) {
     return checker.checkDiskSpace(file, toWrite, bufferSize);

--- a/src/test/java/network/crypta/support/io/PersistentTempBucketFactoryTest.java
+++ b/src/test/java/network/crypta/support/io/PersistentTempBucketFactoryTest.java
@@ -1,0 +1,259 @@
+package network.crypta.support.io;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import network.crypta.crypt.EncryptedRandomAccessBucket;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PersistentTempBucketFactoryTest {
+
+  @TempDir Path tempDir;
+
+  private static final String PREFIX = "ptbf-";
+
+  private static SecureRandom seededSecureRandom(long seed) throws NoSuchAlgorithmException {
+    SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+    random.setSeed(seed);
+    return random;
+  }
+
+  @Test
+  void constructor_whenDirectoryMissingParent_expectIOException() {
+    // Arrange
+    File missingParentDir = tempDir.resolve("missing-parent").resolve("child").toFile();
+
+    // Act & Assert
+    assertThrows(
+        IOException.class,
+        () ->
+            new PersistentTempBucketFactory(
+                missingParentDir, PREFIX, seededSecureRandom(1L), false));
+  }
+
+  @Test
+  void constructor_whenDirectoryIsFile_expectIOException() throws Exception {
+    // Arrange
+    Path filePath = Files.createFile(tempDir.resolve("not-a-dir"));
+
+    // Act & Assert
+    assertThrows(
+        IOException.class,
+        () ->
+            new PersistentTempBucketFactory(
+                filePath.toFile(), PREFIX, seededSecureRandom(2L), false));
+  }
+
+  @Test
+  void registerAndCompletedInit_whenUnclaimedFilesExist_deletesOnlyUnregistered() throws Exception {
+    // Arrange
+    Path dir = Files.createDirectory(tempDir.resolve("ptbf"));
+    Path keepFile = Files.createFile(dir.resolve(PREFIX + "keep"));
+    Path deleteFile = Files.createFile(dir.resolve(PREFIX + "delete"));
+    Path otherFile = Files.createFile(dir.resolve("other"));
+    Files.createDirectory(dir.resolve(PREFIX + "dir"));
+
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(dir.toFile(), PREFIX, seededSecureRandom(3L), false);
+
+    // Act
+    factory.register(keepFile.toFile());
+    factory.completedInit();
+
+    // Assert
+    assertTrue(Files.exists(keepFile), "Registered file should be retained");
+    assertFalse(Files.exists(deleteFile), "Unregistered prefixed file should be deleted");
+    assertTrue(Files.exists(otherFile), "Non-prefixed file should be retained");
+    assertTrue(Files.isDirectory(dir.resolve(PREFIX + "dir")), "Directories should be retained");
+  }
+
+  @Test
+  void register_whenCompletedInitAlreadyCalled_throwsIllegalStateException() throws Exception {
+    // Arrange
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(4L), false);
+    factory.completedInit();
+    Path file = Files.createFile(tempDir.resolve(PREFIX + "late"));
+    File lateFile = file.toFile();
+
+    // Act & Assert
+    assertThrows(IllegalStateException.class, () -> factory.register(lateFile));
+  }
+
+  @Test
+  void makeBucket_whenEncryptionDisabled_returnsDelayedFreeWithPersistentTempFileBucket()
+      throws Exception {
+    // Arrange
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(5L), false);
+
+    // Act
+    RandomAccessBucket bucket = factory.makeBucket(128);
+
+    // Assert
+    DelayedFreeRandomAccessBucket wrapper =
+        assertInstanceOf(DelayedFreeRandomAccessBucket.class, bucket);
+    PersistentTempFileBucket underlying =
+        assertInstanceOf(PersistentTempFileBucket.class, wrapper.getUnderlying());
+    assertTrue(underlying.getFile().exists(), "Backing file should exist");
+    assertEquals(
+        tempDir.toFile(), underlying.getFile().getParentFile(), "File should live in temp dir");
+  }
+
+  @Test
+  void makeBucket_whenEncryptionEnabled_wrapsEncryptedAndPaddedBucket() throws Exception {
+    // Arrange
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(6L), true);
+    factory.setMasterSecret(new MasterSecret(new byte[64]));
+
+    // Act
+    RandomAccessBucket bucket = factory.makeBucket(256);
+
+    // Assert
+    DelayedFreeRandomAccessBucket wrapper =
+        assertInstanceOf(DelayedFreeRandomAccessBucket.class, bucket);
+    EncryptedRandomAccessBucket encrypted =
+        assertInstanceOf(EncryptedRandomAccessBucket.class, wrapper.getUnderlying());
+    PaddedRandomAccessBucket padded =
+        assertInstanceOf(PaddedRandomAccessBucket.class, encrypted.getUnderlying());
+    PersistentTempFileBucket base =
+        assertInstanceOf(PersistentTempFileBucket.class, padded.getUnderlying());
+    assertTrue(base.getFile().exists(), "Backing file should exist for encrypted bucket");
+  }
+
+  @Test
+  void delayedFree_whenCommitIdMatches_callsRealFreeImmediately() throws Exception {
+    // Arrange
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(7L), false);
+    DelayedFree bucket = mock(DelayedFree.class);
+
+    // Act
+    factory.delayedFree(bucket, factory.commitID());
+
+    // Assert
+    verify(bucket).realFree();
+    DelayedFree[] queued = factory.grabBucketsToFree();
+    assertNotNull(queued, "No buckets should be queued");
+    assertEquals(0, queued.length, "No buckets should be queued");
+  }
+
+  @Test
+  void delayedFree_whenCommitIdDiffers_queuesAndGrabBucketsToFreeAdvancesCommitId()
+      throws Exception {
+    // Arrange
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(8L), false);
+    DelayedFree bucket = mock(DelayedFree.class);
+    long originalCommit = factory.commitID();
+
+    // Act
+    factory.delayedFree(bucket, 0L);
+    DelayedFree[] queued = factory.grabBucketsToFree();
+
+    // Assert
+    verify(bucket, never()).realFree();
+    assertNotNull(queued, "Queued buckets should be returned");
+    assertEquals(1, queued.length, "Exactly one bucket should be queued");
+    assertEquals(bucket, queued[0], "Queued bucket should be the original instance");
+    assertEquals(originalCommit + 1, factory.commitID(), "Commit ID should advance after grab");
+  }
+
+  @Test
+  void grabBucketsToFree_whenEmpty_returnsEmptyArray() throws Exception {
+    // Arrange
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(9L), false);
+
+    // Act
+    DelayedFree[] queued = factory.grabBucketsToFree();
+
+    // Assert
+    assertNotNull(queued);
+    assertEquals(0, queued.length);
+  }
+
+  @Test
+  void finishDelayedFree_whenToFreeFalse_skipsRealFree() throws Exception {
+    // Arrange
+    DelayedFree bucket = mock(DelayedFree.class);
+    when(bucket.toFree()).thenReturn(false);
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(10L), false);
+
+    // Act
+    factory.finishDelayedFree(new DelayedFree[] {bucket});
+
+    // Assert
+    verify(bucket, never()).realFree();
+  }
+
+  @Test
+  void finishDelayedFree_whenRealFreeThrows_doesNotPropagate() throws Exception {
+    // Arrange
+    DelayedFree bucket = mock(DelayedFree.class);
+    when(bucket.toFree()).thenReturn(true);
+    RuntimeException failure = new RuntimeException("boom");
+    doThrow(failure).when(bucket).realFree();
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(11L), false);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> factory.finishDelayedFree(new DelayedFree[] {bucket}));
+  }
+
+  @Test
+  void checkDiskSpace_whenCheckerSet_delegatesToChecker() throws Exception {
+    // Arrange
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(13L), false);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    factory.setDiskSpaceChecker(checker);
+    File target = tempDir.resolve("target").toFile();
+    when(checker.checkDiskSpace(target, 10, 4096)).thenReturn(true);
+
+    // Act
+    boolean allowed = factory.checkDiskSpace(target, 10, 4096);
+
+    // Assert
+    assertTrue(allowed);
+    verify(checker).checkDiskSpace(target, 10, 4096);
+  }
+
+  @Test
+  void setEncryption_whenToggled_updatesIsEncrypting() throws Exception {
+    // Arrange
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(12L), false);
+
+    // Act
+    factory.setEncryption(true);
+
+    // Assert
+    assertTrue(factory.isEncrypting());
+  }
+}

--- a/src/test/java/network/crypta/support/io/PersistentTempFileBucketTest.java
+++ b/src/test/java/network/crypta/support/io/PersistentTempFileBucketTest.java
@@ -248,7 +248,7 @@ class PersistentTempFileBucketTest {
       PersistentTempBucketFactory ptbfSpy =
           spy(
               new PersistentTempBucketFactory(
-                  tempDir.toFile(), "ctx-", null, seededSecureRandom(3), false));
+                  tempDir.toFile(), "ctx-", seededSecureRandom(3), false));
 
       // Rebuild context with ptbfSpy to ensure persistentFileTracker is our spy and persistentFG is
       // generator


### PR DESCRIPTION
## Summary
- tighten PersistentTempBucketFactory cleanup and error handling
- simplify bucket creation and delayed-free queue behavior
- add/adjust tests for constructor and queue semantics

## Testing
- ./gradlew spotlessApply