### PR TITLE
refactor(node): split PeerManager helpers and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -925,7 +925,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
       boolean advancedMode,
       long now) {
     double totalSelectionRate = 0.0;
-    PeerNodeStatus[] allPeerNodeStatuses = node.getPeers().getPeerNodeStatuses(true);
+    PeerNodeStatus[] allPeerNodeStatuses = node.getPeers().statusBook().getPeerNodeStatuses(true);
     for (PeerNodeStatus status : allPeerNodeStatuses) {
       totalSelectionRate += status.getSelectionRate();
     }

--- a/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -364,7 +364,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    */
   @Override
   protected PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
-    return node.getPeers().getDarknetPeerNodeStatuses(noHeavy);
+    return node.getPeers().statusBook().getDarknetPeerNodeStatuses(noHeavy);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
@@ -414,7 +414,7 @@ public class DiagnosticToadlet extends Toadlet {
 
   private void appendPeerStatistics(StringBuilder textBuilder) {
     textBuilder.append("Peer Statistics:\n");
-    PeerNodeStatus[] peerNodeStatuses = peers.getPeerNodeStatuses(true);
+    PeerNodeStatus[] peerNodeStatuses = peers.statusBook().getPeerNodeStatuses(true);
     Arrays.sort(peerNodeStatuses, Comparator.comparingInt(PeerNodeStatus::getStatusValue));
     appendPeerCount(
         textBuilder, peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED, "connectedShort");

--- a/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
@@ -136,7 +136,7 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
    */
   @Override
   protected PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
-    return node.getPeers().getOpennetPeerNodeStatuses(noHeavy);
+    return node.getPeers().statusBook().getOpennetPeerNodeStatuses(noHeavy);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/PageMaker.java
+++ b/src/main/java/network/crypta/clients/http/PageMaker.java
@@ -767,7 +767,7 @@ public final class PageMaker {
 
   private int countEnabledDarknetPeers() {
     int darknetTotal = 0;
-    for (DarknetPeerNode peer : node.getPeers().getDarknetPeers()) {
+    for (DarknetPeerNode peer : node.getPeers().roster().getDarknetPeers()) {
       if (peer != null && !peer.isDisabled()) {
         darknetTotal++;
       }

--- a/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
@@ -270,7 +270,7 @@ public class StatisticsToadlet extends Toadlet {
   }
 
   private PeerStatusSummary preparePeerStatusSummary() {
-    PeerNodeStatus[] peerNodeStatuses = peers.getPeerNodeStatuses(true);
+    PeerNodeStatus[] peerNodeStatuses = peers.statusBook().getPeerNodeStatuses(true);
     Arrays.sort(peerNodeStatuses, Comparator.comparingInt(PeerNodeStatus::getStatusValue));
 
     PeerStatusSummary summary = new PeerStatusSummary(peerNodeStatuses);

--- a/src/main/java/network/crypta/io/comm/IncomingPacketFilterImpl.java
+++ b/src/main/java/network/crypta/io/comm/IncomingPacketFilterImpl.java
@@ -123,7 +123,7 @@ public class IncomingPacketFilterImpl implements IncomingPacketFilter {
     // Mix a small amount of arrival-time entropy into the node RNG. The bias preserves legacy
     // behavior and balances entropy quality with performance.
     node.getRandom().acceptTimerEntropy(fnpTimingSource, 0.25);
-    PeerNode opn = node.getPeers().getByPeer(peer, mangler);
+    PeerNode opn = node.getPeers().roster().getByPeer(peer, mangler);
 
     if (opn == null) {
       LOG.info("Got packet from unknown address");

--- a/src/main/java/network/crypta/node/AnnounceSender.java
+++ b/src/main/java/network/crypta/node/AnnounceSender.java
@@ -241,6 +241,7 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
   private PeerNode chooseNextNode(HashSet<PeerNode> routed) {
     if (onlyNode == null) {
       return node.getPeers()
+          .routingSelector()
           .closerPeer(
               source,
               routed,

--- a/src/main/java/network/crypta/node/Announcer.java
+++ b/src/main/java/network/crypta/node/Announcer.java
@@ -125,8 +125,8 @@ public class Announcer {
    */
   protected void start() {
     if (!node.isOpennetEnabled()) return;
-    int darkPeers = node.getPeers().getDarknetPeers().length;
-    int openPeers = node.getPeers().getOpennetPeers().length;
+    int darkPeers = node.getPeers().roster().getDarknetPeers().length;
+    int openPeers = node.getPeers().roster().getOpennetPeers().length;
     int oldOpenPeers = om.countOldOpennetPeers();
     if (darkPeers + openPeers + oldOpenPeers == 0) {
       // Opennet is enabled and there are no peers. Connect to several seed nodes and announce.
@@ -180,7 +180,7 @@ public class Announcer {
 
     int count = connectSomeNodesInner(seeds);
     boolean stillConnecting;
-    List<SeedServerPeerNode> tryingSeeds = node.getPeers().getSeedServerPeersVector();
+    List<SeedServerPeerNode> tryingSeeds = node.getPeers().seedPeers().getSeedServerPeersVector();
     stillConnecting = hasUnannouncedTryingSeeds(tryingSeeds);
     debugCounts(count, stillConnecting);
     announceNow = handleNoMorePeers(count, stillConnecting);
@@ -538,11 +538,11 @@ public class Announcer {
     node.getExecutor()
         .execute(
             () -> {
-              for (OpennetPeerNode pn : node.getPeers().getOpennetPeers()) {
-                node.getPeers().disconnectAndRemove(pn, true, true, true);
+              for (OpennetPeerNode pn : node.getPeers().roster().getOpennetPeers()) {
+                node.getPeers().messenger().disconnectAndRemove(pn, true, true, true);
               }
-              for (SeedServerPeerNode pn : node.getPeers().getSeedServerPeersVector()) {
-                node.getPeers().disconnectAndRemove(pn, true, true, true);
+              for (SeedServerPeerNode pn : node.getPeers().seedPeers().getSeedServerPeersVector()) {
+                node.getPeers().messenger().disconnectAndRemove(pn, true, true, true);
               }
             });
   }
@@ -592,8 +592,9 @@ public class Announcer {
         running = runningAnnouncements;
       }
       if (enoughPeers()) {
-        for (SeedServerPeerNode pn : node.getPeers().getConnectedSeedServerPeersVector(null)) {
-          node.getPeers().disconnectAndRemove(pn, true, true, false);
+        for (SeedServerPeerNode pn :
+            node.getPeers().seedPeers().getConnectedSeedServerPeersVector(null)) {
+          node.getPeers().messenger().disconnectAndRemove(pn, true, true, false);
         }
         // Re-check every minute. Adverse conditions (e.g., CPU starvation) might require reseeding.
         node.getTicker()
@@ -689,7 +690,7 @@ public class Announcer {
 
   private void announceToAvailableSeeds() {
     List<SeedServerPeerNode> seeds =
-        node.getPeers().getConnectedSeedServerPeersVector(announcedToIdentities);
+        node.getPeers().seedPeers().getConnectedSeedServerPeersVector(announcedToIdentities);
     while (sentAnnouncements < WANT_ANNOUNCEMENTS && !seeds.isEmpty()) {
       final SeedServerPeerNode seed =
           ListUtils.removeRandomBySwapLastSimple(node.getRandom(), seeds);
@@ -839,7 +840,7 @@ public class Announcer {
                 // If disconnect takes longer than COOLING_OFF_PERIOD we might not reannounce to
                 // this seed immediately. Regardless, we cannot reannounce until the announced-to
                 // set is cleared, which is typically later than that period.
-                node.getPeers().disconnectAndRemove(seed, true, false, false);
+                node.getPeers().messenger().disconnectAndRemove(seed, true, false, false);
                 int shallow = node.maxHTL() - (totalAdded + totalNotWanted);
                 if (acceptedSomewhere)
                   LOG.atInfo()
@@ -958,7 +959,7 @@ public class Announcer {
           recentSentAnnouncements = sentAnnouncements;
           runningAnnouncementsLocal = Announcer.this.runningAnnouncements;
         }
-        List<SeedServerPeerNode> nodes = node.getPeers().getSeedServerPeersVector();
+        List<SeedServerPeerNode> nodes = node.getPeers().seedPeers().getSeedServerPeersVector();
         for (SeedServerPeerNode seed : nodes) {
           if (seed.isConnected()) connectedSeednodes++;
           else disconnectedSeednodes++;

--- a/src/main/java/network/crypta/node/BaseSender.java
+++ b/src/main/java/network/crypta/node/BaseSender.java
@@ -657,6 +657,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
 
   private PeerNode closerPeer(Set<PeerNode> exclude, long now) {
     return node.getPeers()
+        .routingSelector()
         .closerPeer(
             sourceForRouting(),
             exclude,

--- a/src/main/java/network/crypta/node/CHKInsertSender.java
+++ b/src/main/java/network/crypta/node/CHKInsertSender.java
@@ -619,6 +619,7 @@ public final class CHKInsertSender extends BaseSender
 
   private PeerNode findNextPeer() {
     return node.getPeers()
+        .routingSelector()
         .closerPeer(
             forkedRequestTag == null ? source : null,
             nodesRoutedTo,

--- a/src/main/java/network/crypta/node/FNPPacketMangler.java
+++ b/src/main/java/network/crypta/node/FNPPacketMangler.java
@@ -978,7 +978,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     sendJFKMessage4(params);
 
     if (dontWant) {
-      node.getPeers().disconnectAndRemove(params.pn, true, true, true);
+      node.getPeers().messenger().disconnectAndRemove(params.pn, true, true, true);
     } else {
       params.pn.maybeSendInitialMessages();
     }
@@ -1869,7 +1869,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   private void postHandshakeActionsJFK4(long newTrackerID, boolean dontWant, PeerNode pn) {
     if (newTrackerID >= 0) {
       if (dontWant) {
-        node.getPeers().disconnectAndRemove(pn, true, true, true);
+        node.getPeers().messenger().disconnectAndRemove(pn, true, true, true);
       } else {
         pn.maybeSendInitialMessages();
       }

--- a/src/main/java/network/crypta/node/LocationManager.java
+++ b/src/main/java/network/crypta/node/LocationManager.java
@@ -1166,7 +1166,7 @@ public class LocationManager implements ByteCounter {
     Message msg =
         DMT.createFNPLocChangeNotificationNew(
             getLocation(), node.getPeers().getPeerLocationDoubles(true));
-    node.getPeers().localBroadcast(msg, false, true, this);
+    node.getPeers().messenger().localBroadcast(msg, false, true, this);
     if (log) recordLocChange(randomReset, fromDupLocation);
   }
 

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -379,7 +379,7 @@ public class Node implements TimeSkewDetectorCallback {
       // reference
       SimpleFieldSet fs = new SimpleFieldSet(true);
       fs.putSingle("myName", myName);
-      peers.locallyBroadcastDiffNodeRef(fs, true, false);
+      peers.messenger().locallyBroadcastDiffNodeRef(fs, true, false);
       // We call the callback once again to ensure MeaningfulNodeNameUserAlert
       // has been unregistered ... see #1595
       get();
@@ -3966,12 +3966,14 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
 
     // IMPORTANT: Read the peers only after we have finished initializing Node.
     // Peer constructors are complex and can call methods on Node.
-    peers.tryReadPeers(
-        nodeDir.file("peers-" + getDarknetPortNumber()).getPath(),
-        darknetCrypto,
-        null,
-        false,
-        false);
+    peers
+        .persistence()
+        .tryReadPeers(
+            nodeDir.file("peers-" + getDarknetPortNumber()).getPath(),
+            darknetCrypto,
+            null,
+            false,
+            false);
     peers.updatePMUserAlert();
 
     dispatcher.start(nodeStats); // must be before usm
@@ -5427,7 +5429,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
 
     try {
       Message msg = DMT.createFNPDisconnect(false, false, -1, new ShortBuffer(new byte[0]));
-      peers.localBroadcast(msg, true, false, peers.ctrDisconn);
+      peers.messenger().localBroadcast(msg, true, false, peers.messenger().getDisconnCounter());
     } catch (Exception t) {
       try {
         // E.g. if we haven't finished startup
@@ -5454,7 +5456,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    * @return array of active darknet peers.
    */
   public DarknetPeerNode[] getDarknetConnections() {
-    return peers.getDarknetPeers();
+    return peers.roster().getDarknetPeers();
   }
 
   /**
@@ -5476,7 +5478,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    * @param pn peer to disconnect and remove.
    */
   public void removePeerConnection(PeerNode pn) {
-    peers.disconnectAndRemove(pn, true, false, false);
+    peers.messenger().disconnectAndRemove(pn, true, false, false);
   }
 
   public void onConnectedPeer() {
@@ -5778,7 +5780,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
           PeerParseException,
           ReferenceSignatureVerificationException,
           PeerTooOldException {
-    peers.connect(node.darknetCrypto.exportPublicFieldSet(), trust, visibility);
+    peers.connector().connect(node.darknetCrypto.exportPublicFieldSet(), trust, visibility);
   }
 
   public short maxHTL() {

--- a/src/main/java/network/crypta/node/NodeARKInserter.java
+++ b/src/main/java/network/crypta/node/NodeARKInserter.java
@@ -101,7 +101,9 @@ public class NodeARKInserter implements ClientPutCallback, RequestClient {
       SimpleFieldSet fs = new SimpleFieldSet(true);
       fs.putOverwrite(PHYSICAL_UDP, entries);
       if (LOG.isDebugEnabled()) LOG.debug("{} ref physical.udp={}", darknetOpennetString, fs);
-      node.getPeers().locallyBroadcastDiffNodeRef(fs, !crypto.isOpennet(), crypto.isOpennet());
+      node.getPeers()
+          .messenger()
+          .locallyBroadcastDiffNodeRef(fs, !crypto.isOpennet(), crypto.isOpennet());
     } else {
       if (LOG.isDebugEnabled()) LOG.debug("No physical.udp in {} ref", darknetOpennetString);
     }
@@ -314,7 +316,9 @@ public class NodeARKInserter implements ClientPutCallback, RequestClient {
       // Broadcast the new ARK edition to connected peers via a differential node reference.
       SimpleFieldSet fs = new SimpleFieldSet(true);
       fs.put("ark.number", crypto.getMyARKNumber());
-      node.getPeers().locallyBroadcastDiffNodeRef(fs, !crypto.isOpennet(), crypto.isOpennet());
+      node.getPeers()
+          .messenger()
+          .locallyBroadcastDiffNodeRef(fs, !crypto.isOpennet(), crypto.isOpennet());
     }
   }
 

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -2658,6 +2658,7 @@ public class NodeClientCore implements Persistable {
     // routing heuristics. If originator rules change, revisit this.
     short origHTL = node.decrementHTL(null, node.maxHTL());
     node.getPeers()
+        .routingSelector()
         .closerPeer(
             null,
             new HashSet<>(),

--- a/src/main/java/network/crypta/node/NodeCrypto.java
+++ b/src/main/java/network/crypta/node/NodeCrypto.java
@@ -580,8 +580,8 @@ public class NodeCrypto {
   @SuppressWarnings("java:S1168")
   public PeerNode[] getPeerNodes() {
     if (node.getPeers() == null) return null;
-    if (isOpennet) return node.getPeers().getOpennetAndSeedServerPeers();
-    else return node.getPeers().getDarknetPeers();
+    if (isOpennet) return node.getPeers().roster().getOpennetAndSeedServerPeers();
+    else return node.getPeers().roster().getDarknetPeers();
   }
 
   /**
@@ -598,7 +598,7 @@ public class NodeCrypto {
     // Disallow multiple connections to the same address.
     // TODO: For IPv6 consider a configurable same-/64 subnet rule instead of exact match.
     if (config.oneConnectionPerAddress()
-        && node.getPeers().anyConnectedPeerHasAddress(addr, pn)
+        && node.getPeers().roster().anyConnectedPeerHasAddress(addr, pn)
         && !detector.includes(addr)
         && addr.isRealInternetAddress(false, false, false)) {
       LOG.info("Skip handshake packets to {} for {}: same IP address as another node", addr, pn);
@@ -621,7 +621,7 @@ public class NodeCrypto {
     if (detector.includes(address)) return;
     if (!address.isRealInternetAddress(false, false, false)) return;
     java.util.List<PeerNode> possibleMatches =
-        node.getPeers().getAllConnectedByAddress(address, true);
+        node.getPeers().roster().getAllConnectedByAddress(address, true);
     if (possibleMatches == null) return;
     for (PeerNode pn : possibleMatches) {
       if (pn == peerNode || pn.equals(peerNode)) continue;
@@ -649,7 +649,9 @@ public class NodeCrypto {
           ((DarknetPeerNode) incomingPeer).getName(),
           address);
     }
-    node.getPeers().disconnectAndRemove(existingPeer, true, true, existingPeer.isOpennet());
+    node.getPeers()
+        .messenger()
+        .disconnectAndRemove(existingPeer, true, true, existingPeer.isOpennet());
   }
 
   /**

--- a/src/main/java/network/crypta/node/NodeDispatcher.java
+++ b/src/main/java/network/crypta/node/NodeDispatcher.java
@@ -675,7 +675,7 @@ public class NodeDispatcher implements Dispatcher, Runnable {
     // Otherwise, just dump all current connection state and keep trying to connect.
     boolean remove = m.getBoolean(DMT.REMOVE);
     if (remove) {
-      node.getPeers().disconnectAndRemove(source, false, false, false);
+      node.getPeers().messenger().disconnectAndRemove(source, false, false, false);
       if (source instanceof DarknetPeerNode peerNode)
         LOG.info(
             "Disconnecting permanently from your friend \"{}\" because they asked us to remove"
@@ -1264,6 +1264,7 @@ public class NodeDispatcher implements Dispatcher, Runnable {
     if (next == null)
       next =
           node.getPeers()
+              .routingSelector()
               .closerPeer(
                   pn,
                   ctx.routedTo,

--- a/src/main/java/network/crypta/node/NodeStats.java
+++ b/src/main/java/network/crypta/node/NodeStats.java
@@ -2827,7 +2827,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
     fs.put("RAMBucketPoolSize", node.getClientCore().getTempBucketFactory().getRamUsed());
 
     /* gather connection statistics */
-    PeerNodeStatus[] peerNodeStatuses = peers.getPeerNodeStatuses(true);
+    PeerNodeStatus[] peerNodeStatuses = peers.statusBook().getPeerNodeStatuses(true);
     int numberOfSeedServers = 0;
     int numberOfSeedClients = 0;
 

--- a/src/main/java/network/crypta/node/OpennetManager.java
+++ b/src/main/java/network/crypta/node/OpennetManager.java
@@ -459,13 +459,14 @@ public class OpennetManager {
     // Do this outside the constructor, since the constructor is called by the Node constructor, and
     // callbacks may make assumptions about data structures being ready.
     node.getPeers()
+        .persistence()
         .tryReadPeers(
             node.nodeDir().file("openpeers-" + crypto.getPortNumber()).toString(),
             crypto,
             this,
             true,
             false);
-    OpennetPeerNode[] nodes = node.getPeers().getOpennetPeers();
+    OpennetPeerNode[] nodes = node.getPeers().roster().getOpennetPeers();
     Arrays.sort(nodes, PEER_COMPARATOR);
     initLRUsFromExisting(nodes);
     if (LOG.isDebugEnabled()) {
@@ -479,6 +480,7 @@ public class OpennetManager {
     writeFile();
     // Read old peers
     node.getPeers()
+        .persistence()
         .tryReadPeers(
             node.nodeDir().file("openpeers-old-" + crypto.getPortNumber()).toString(),
             crypto,
@@ -520,7 +522,7 @@ public class OpennetManager {
       if (Location.isValid(opn.getLocation())) {
         lruQueue(opn).push(opn);
       } else {
-        node.getPeers().disconnectAndRemove(opn, false, false, false);
+        node.getPeers().messenger().disconnectAndRemove(opn, false, false, false);
       }
     }
   }
@@ -1067,7 +1069,7 @@ public class OpennetManager {
     for (OpennetPeerNode pn : result.dropList) {
       if (LOG.isDebugEnabled()) LOG.debug("Drop LRU opennet peer: {}", pn);
       pn.setAddedReason(null);
-      node.getPeers().disconnectAndRemove(pn, true, true, true);
+      node.getPeers().messenger().disconnectAndRemove(pn, true, true, true);
     }
   }
 
@@ -1079,7 +1081,7 @@ public class OpennetManager {
     // This does not check whether they are short or long as it is irrelevant for outdated peers.
     int maxTooOldPeers = maxOutdatedPeers();
     int count = 0;
-    OpennetPeerNode[] peers = node.getPeers().getOpennetPeers();
+    OpennetPeerNode[] peers = node.getPeers().roster().getOpennetPeers();
     for (OpennetPeerNode pn : peers) {
       if (pn.isUnroutableOlderVersion()) {
         count++;
@@ -1190,7 +1192,7 @@ public class OpennetManager {
         peersLRU.remove(toDrop);
       }
       if (LOG.isDebugEnabled()) LOG.debug("Drop {}", toDrop);
-      node.getPeers().disconnectAndRemove(toDrop, true, true, true);
+      node.getPeers().messenger().disconnectAndRemove(toDrop, true, true, true);
     }
   }
 
@@ -1365,7 +1367,7 @@ public class OpennetManager {
         false,
         ConnectionType.RECONNECT,
         distance)) { // Start at top as it just succeeded
-      node.getPeers().disconnectAndRemove(pn, true, false, true);
+      node.getPeers().messenger().disconnectAndRemove(pn, true, false, true);
     }
   }
 

--- a/src/main/java/network/crypta/node/PacketSender.java
+++ b/src/main/java/network/crypta/node/PacketSender.java
@@ -223,7 +223,7 @@ public class PacketSender implements Runnable {
         Math.max(pn.lastReceivedPacketTime(), lastReceivedPacketFromAnyNode);
     pn.maybeOnConnect();
     if (pn.shouldDisconnectAndRemoveNow() && !pn.isDisconnecting()) {
-      node.getPeers().disconnectAndRemove(pn, true, true, false);
+      node.getPeers().messenger().disconnectAndRemove(pn, true, true, false);
     }
   }
 
@@ -237,7 +237,9 @@ public class PacketSender implements Runnable {
       return;
     }
     if (shouldDisconnectDueToAcks(now, pn)) {
-      node.getPeers().disconnect(pn, true, true, false, true, false, SECONDS.toMillis(5));
+      node.getPeers()
+          .messenger()
+          .disconnect(pn, true, true, false, true, false, SECONDS.toMillis(5));
       return;
     }
     if (pn.isRoutable() && pn.noLongerRoutable()) {

--- a/src/main/java/network/crypta/node/PeerAlertCoordinator.java
+++ b/src/main/java/network/crypta/node/PeerAlertCoordinator.java
@@ -1,0 +1,134 @@
+package network.crypta.node;
+
+import network.crypta.node.useralerts.PeerManagerUserAlert;
+
+/**
+ * Updates and maintains the peer manager user alert based on current roster and status data.
+ *
+ * <p>This coordinator centralizes the mapping between live peer state and the user-facing alert
+ * object. Callers construct it with the node, roster, and status book that supply the underlying
+ * metrics, then invoke {@link #start()} once during node startup to create and register the alert.
+ * After startup, {@link #update()} should be called whenever peer connectivity or status counters
+ * change so the alert reflects the latest counts and flags.
+ *
+ * <p>The alert instance is created lazily in {@link #start()}, and {@link #update()} is a no-op
+ * until that initialization completes. Updates synchronize on an internal lock to ensure that the
+ * alert state is updated as a consistent snapshot. The coordinator itself is mutable and not
+ * intended to be externally synchronized; callers should avoid concurrent calls that race with
+ * startup or teardown.
+ *
+ * <p><strong>Responsibilities:</strong>
+ *
+ * <ul>
+ *   <li>Translate peer roster sizes and status counts into alert fields.
+ *   <li>Expose NAT and port-forwarding hints from darknet and opennet state.
+ *   <li>Trigger connected-peer notifications when any peer is connected.
+ * </ul>
+ *
+ * @see PeerManagerUserAlert
+ * @see PeerRoster
+ * @see PeerStatusBook
+ */
+public class PeerAlertCoordinator {
+  private final Node node;
+  private final PeerRoster roster;
+  private final PeerStatusBook statusBook;
+
+  private final Object uaLock = new Object();
+  private PeerManagerUserAlert alert;
+
+  /**
+   * Creates a coordinator that derives alert values from the provided node, roster, and status
+   * book.
+   *
+   * <p>The coordinator does not allocate or register the user alert until {@link #start()} is
+   * called. The supplied references are used directly; they are expected to remain valid for the
+   * lifetime of this instance. Passing {@code null} is not supported and will result in a {@link
+   * NullPointerException} at construction time.
+   *
+   * @param node owning node that exposes opennet/darknet state and alert registration
+   * @param roster peer roster used to compute current peer totals and connectivity
+   * @param statusBook peer status counters used to populate detailed alert fields
+   */
+  public PeerAlertCoordinator(Node node, PeerRoster roster, PeerStatusBook statusBook) {
+    this.node = node;
+    this.roster = roster;
+    this.statusBook = statusBook;
+  }
+
+  /**
+   * Initializes the user alert and registers it with the node's alert manager.
+   *
+   * <p>This method allocates the {@link PeerManagerUserAlert}, populates it with the current
+   * snapshot by calling {@link #update()}, and then registers it so it can be surfaced to users. It
+   * should be invoked once during startup and is not designed to be idempotent; calling it multiple
+   * times may overwrite the existing alert reference and cause duplicate registrations.
+   *
+   * <pre>{@code
+   * PeerAlertCoordinator coordinator = new PeerAlertCoordinator(node, roster, statusBook);
+   * coordinator.start();
+   * }</pre>
+   */
+  public void start() {
+    alert = new PeerManagerUserAlert(node.getNodeStats(), node.getNodeUpdater());
+    update();
+    node.getClientCore().getAlerts().register(alert);
+  }
+
+  /**
+   * Updates the alert state from the latest peer roster and status counters.
+   *
+   * <p>If the alert has not yet been initialized, this method returns without side effects. When
+   * initialized, it computes peer totals and connectivity counts, propagates NAT and port-forward
+   * hints, and updates alert counters within a synchronized block so values reflect a coherent
+   * snapshot. The method is safe to call frequently and is intended to run in response to changes
+   * in peer connectivity or status bookkeeping.
+   */
+  public void update() {
+    PeerManagerUserAlert ua = alert;
+    if (ua == null) return;
+
+    int darknetPeers = roster.getDarknetPeers().length;
+    int opennetPeers = roster.getOpennetPeers().length;
+    int peers = darknetPeers + opennetPeers;
+
+    OpennetManager om = node.getOpennet();
+    boolean opennetEnabled = om != null;
+    boolean opennetDefinitelyPortForwarded = om != null && om.getCrypto().definitelyPortForwarded();
+    boolean opennetAssumeNAT =
+        om != null && om.getCrypto().getConfig().alwaysHandshakeAggressively();
+    boolean darknetDefinitelyPortForwarded = node.darknetDefinitelyPortForwarded();
+    boolean darknetAssumeNAT = node.getDarknetCrypto().getConfig().alwaysHandshakeAggressively();
+
+    synchronized (uaLock) {
+      ua.setOpennetDefinitelyPortForwarded(opennetDefinitelyPortForwarded);
+      ua.setDarknetDefinitelyPortForwarded(darknetDefinitelyPortForwarded);
+      ua.setOpennetAssumeNAT(opennetAssumeNAT);
+      ua.setDarknetAssumeNAT(darknetAssumeNAT);
+      int darknetConnsVal =
+          statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, true)
+              + statusBook.getPeerNodeStatusSize(
+                  PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, true);
+      ua.setDarknetConns(darknetConnsVal);
+      ua.setConns(
+          statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false)
+              + statusBook.getPeerNodeStatusSize(
+                  PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, false));
+      ua.setDarknetPeers(darknetPeers);
+      ua.setDisconnDarknetPeers(darknetPeers - darknetConnsVal);
+      ua.setPeers(peers);
+      ua.setNeverConn(
+          statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED, true));
+      ua.setClockProblem(
+          statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM, false));
+      ua.setConnError(
+          statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONN_ERROR, true));
+      ua.setOpennetEnabled(opennetEnabled);
+      ua.setTooNewPeersDarknet(
+          statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, true));
+      ua.setTooNewPeersTotal(
+          statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, false));
+    }
+    if (roster.anyConnectedPeers()) node.onConnectedPeer();
+  }
+}

--- a/src/main/java/network/crypta/node/PeerConnector.java
+++ b/src/main/java/network/crypta/node/PeerConnector.java
@@ -1,0 +1,43 @@
+package network.crypta.node;
+
+import java.util.Arrays;
+import network.crypta.io.comm.PeerParseException;
+import network.crypta.io.comm.ReferenceSignatureVerificationException;
+import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
+import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.support.SimpleFieldSet;
+
+/** Handles creating and adding darknet peers from serialized references. */
+public class PeerConnector {
+  private final Node node;
+  private final PeerManager peerManager;
+
+  PeerConnector(Node node, PeerManager peerManager) {
+    this.node = node;
+    this.peerManager = peerManager;
+  }
+
+  /**
+   * Connects to a darknet peer from its serialized reference.
+   *
+   * <p>Creates a new {@link DarknetPeerNode} from the provided field set and adds it if a peer with
+   * the same public key hash is not already present.
+   *
+   * @throws FSParseException If the field set cannot be parsed.
+   * @throws PeerParseException If the noderef is syntactically invalid.
+   * @throws ReferenceSignatureVerificationException If the reference signature fails verification.
+   * @throws PeerTooOldException If the peer is older than the supported minimum.
+   */
+  public void connect(SimpleFieldSet noderef, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility)
+      throws FSParseException,
+          PeerParseException,
+          ReferenceSignatureVerificationException,
+          PeerTooOldException {
+    PeerNode pn = node.createNewDarknetNode(noderef, trust, visibility);
+    PeerNode[] peerList = peerManager.myPeers();
+    for (PeerNode mp : peerList) {
+      if (Arrays.equals(mp.peerECDSAPubKeyHash, pn.peerECDSAPubKeyHash)) return;
+    }
+    peerManager.addPeer(pn);
+  }
+}

--- a/src/main/java/network/crypta/node/PeerConnector.java
+++ b/src/main/java/network/crypta/node/PeerConnector.java
@@ -7,7 +7,31 @@ import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
 import network.crypta.support.SimpleFieldSet;
 
-/** Handles creating and adding darknet peers from serialized references. */
+/**
+ * Creates and registers darknet peers from serialized references.
+ *
+ * <p>This helper translates a {@link SimpleFieldSet} noderef into a {@link DarknetPeerNode} and
+ * adds it to the owning {@link PeerManager} when the peer is not already present. It is a small
+ * coordination layer that keeps the reference parsing, duplicate detection, and registration steps
+ * in one place so that callers do not need to know the peer list internals. Typical use is during
+ * UI-driven friend adds, configuration import, or any path that receives a noderef and needs to
+ * enroll it in the darknet peer set.
+ *
+ * <p>The duplicate check is based on the peer's ECDSA public-key hash, which is stable for the
+ * lifetime of a reference. If an existing peer shares that hash, the method performs no mutation
+ * and returns immediately. This class is intentionally state-light: it stores references to the
+ * owning {@link Node} and {@link PeerManager} but keeps no additional cache or lifecycle state.
+ *
+ * <p>Thread-safety depends on the {@link PeerManager} and {@link Node} implementations. This class
+ * performs a read of {@link PeerManager#myPeers()} followed by a conditional {@link
+ * PeerManager#addPeer(PeerNode)}; callers should ensure appropriate synchronization if peer list
+ * mutations can occur concurrently.
+ *
+ * <ul>
+ *   <li>Responsibilities: build a peer instance, detect duplicates, and register new peers.
+ *   <li>Notable behavior: duplicates are identified by public-key hash, not by noderef bytes.
+ * </ul>
+ */
 public class PeerConnector {
   private final Node node;
   private final PeerManager peerManager;
@@ -18,15 +42,30 @@ public class PeerConnector {
   }
 
   /**
-   * Connects to a darknet peer from its serialized reference.
+   * Connects to a darknet peer described by the provided noderef.
    *
-   * <p>Creates a new {@link DarknetPeerNode} from the provided field set and adds it if a peer with
-   * the same public key hash is not already present.
+   * <p>This method parses the {@code noderef} into a new {@link DarknetPeerNode} using the supplied
+   * trust and visibility settings, then checks the current peer list for an existing peer with the
+   * same ECDSA public-key hash. If a duplicate is found, the method performs no further work and
+   * returns without modifying the peer manager. Otherwise, it registers the newly created peer.
    *
-   * @throws FSParseException If the field set cannot be parsed.
-   * @throws PeerParseException If the noderef is syntactically invalid.
-   * @throws ReferenceSignatureVerificationException If the reference signature fails verification.
-   * @throws PeerTooOldException If the peer is older than the supported minimum.
+   * <p>The call is idempotent with respect to the peer's public-key hash: repeated calls with
+   * references that resolve to the same hash will not create additional peers. The method does not
+   * validate or normalize the {@link SimpleFieldSet} beyond what {@link Node#createNewDarknetNode}
+   * performs, and it does not retry on failures.
+   *
+   * <pre>{@code
+   * PeerConnector connector = new PeerConnector(node, peerManager);
+   * connector.connect(noderef, FRIEND_TRUST.NORMAL, FRIEND_VISIBILITY.YES);
+   * }</pre>
+   *
+   * @param noderef serialized noderef field set for the peer; must be parseable and non-null.
+   * @param trust trust level to assign for routing and policy decisions; must be non-null.
+   * @param visibility visibility preference to store for the peer; must be non-null.
+   * @throws FSParseException if the noderef fields cannot be parsed into required values.
+   * @throws PeerParseException if the noderef is syntactically invalid or inconsistent.
+   * @throws ReferenceSignatureVerificationException if a noderef signature is present but invalid.
+   * @throws PeerTooOldException if the peer's version is older than the supported minimum.
    */
   public void connect(SimpleFieldSet noderef, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility)
       throws FSParseException,

--- a/src/main/java/network/crypta/node/PeerManager.java
+++ b/src/main/java/network/crypta/node/PeerManager.java
@@ -1,45 +1,7 @@
 package network.crypta.node;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-
-import java.io.BufferedReader;
-import java.io.EOFException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import network.crypta.io.comm.AsyncMessageCallback;
-import network.crypta.io.comm.ByteCounter;
-import network.crypta.io.comm.DMT;
-import network.crypta.io.comm.FreenetInetAddress;
-import network.crypta.io.comm.Message;
-import network.crypta.io.comm.NotConnectedException;
-import network.crypta.io.comm.Peer;
-import network.crypta.io.comm.PeerParseException;
-import network.crypta.io.comm.ReferenceSignatureVerificationException;
-import network.crypta.keys.Key;
-import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
-import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.useralerts.DroppedOldPeersUserAlert;
-import network.crypta.node.useralerts.PeerManagerUserAlert;
-import network.crypta.support.ByteArrayWrapper;
-import network.crypta.support.ShortBuffer;
-import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.TimeUtil;
-import network.crypta.support.io.FileUtil;
-import network.crypta.support.io.NativeThread;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,94 +25,35 @@ public class PeerManager {
   /** Our Node */
   final Node node;
 
-  /** All the peers we want to connect to */
-  private PeerNode[] myPeers;
+  /** First time we got any connections since startup. */
+  long timeFirstAnyConnections = 0;
 
-  /** All the peers we are actually connected to */
-  private PeerNode[] connectedPeers;
+  /** Handles peer reference persistence and scheduling. */
+  private final PeerPersistence peerPersistence;
 
-  private String darkFilename;
-  private String openFilename;
-  private String oldOpennetPeersFilename;
-  // Note: Potential improvement: use a dedicated stable hash (not hashCode()).
-  // Note: Potential improvement: strip non-essential metadata; keep peer locations only.
-  private String darknetPeersStringCache = null;
-  private String opennetPeersStringCache = null;
-  private String oldOpennetPeersStringCache = null;
-  private PeerManagerUserAlert ua; // Peers stuff
-  private final Object uaLock = new Object();
+  /** Handles outbound peer connection requests. */
+  private final PeerConnector peerConnector;
 
-  /** age of oldest never connected peer (milliseconds) */
-  private long oldestNeverConnectedDarknetPeerAge;
+  /** Handles peer messaging and disconnect workflows. */
+  private final PeerMessenger peerMessenger;
 
-  /** Next time to update oldestNeverConnectedPeerAge */
-  private long nextOldestNeverConnectedDarknetPeerAgeUpdateTime = -1;
+  /** Handles queries for seed-server peers. */
+  private final SeedPeerQueries seedPeerQueries;
 
-  /** oldestNeverConnectedPeerAge update interval (milliseconds) */
-  private static final long OLDEST_NEVER_CONNECTED_DARKNET_PEER_AGE_UPDATE_INTERVAL = 5000;
+  /** Maintains peer lists and connected snapshots. */
+  private final PeerRoster roster;
 
-  /** Next time to log the PeerNode status summary */
-  private long nextPeerNodeStatusLogTime = -1;
+  /** Tracks peer status counts and backoff reasons. */
+  private final PeerStatusBook statusBook;
 
-  /** PeerNode status summary log interval (milliseconds) */
-  private static final long PEER_NODE_STATUS_LOG_INTERVAL = 5000;
+  /** Validates opennet admission rules for newly added peers. */
+  private final PeerOpennetGate opennetGate;
 
-  /** Statuses for all PeerNode's */
-  private final PeerStatusTracker<Integer> allPeersStatuses;
+  /** Performs routing peer selection. */
+  private final PeerRoutingSelector routingSelector;
 
-  /** Statuses for darknet PeerNode's */
-  private final PeerStatusTracker<Integer> darknetPeersStatuses;
-
-  /** PeerNode routing backoff reasons, by reason (realtime) */
-  private final PeerStatusTracker<String> peerNodeRoutingBackoffReasonsRT;
-
-  /** PeerNode routing backoff reasons, by reason (bulk) */
-  private final PeerStatusTracker<String> peerNodeRoutingBackoffReasonsBulk;
-
-  /** Next time to update routableConnectionStats */
-  private long nextRoutableConnectionStatsUpdateTime = -1;
-
-  /** routableConnectionStats update interval (milliseconds) */
-  private static final long ROUTABLE_CONNECTION_STATS_UPDATE_INTERVAL = SECONDS.toMillis(7);
-
-  /** Should update the peer-file ? */
-  private volatile boolean shouldWritePeersDarknet = false;
-
-  private volatile boolean shouldWritePeersOpennet = false;
-  private static final long MIN_WRITEPEERS_DELAY =
-      MINUTES.toMillis(5); // Urgent stuff calls write*PeersUrgent.
-  private final Runnable writePeersRunnable =
-      () -> {
-        try {
-          writePeersNow();
-        } finally {
-          scheduleWritePeersNextRun();
-        }
-      };
-
-  private void scheduleWritePeersNextRun() {
-    node.getTicker().queueTimedJob(writePeersRunnable, MIN_WRITEPEERS_DELAY);
-  }
-
-  protected void writePeersNow() {
-    // Non-urgent periodic write does not rotate backups.
-    writePeersDarknetNow(false);
-    writePeersOpennetNow(false);
-  }
-
-  private void writePeersDarknetNow(boolean rotateBackups) {
-    if (shouldWritePeersDarknet) {
-      shouldWritePeersDarknet = false;
-      writePeersInnerDarknet(rotateBackups);
-    }
-  }
-
-  private void writePeersOpennetNow(boolean rotateBackups) {
-    if (shouldWritePeersOpennet) {
-      shouldWritePeersOpennet = false;
-      writePeersInnerOpennet(rotateBackups);
-    }
-  }
+  /** Coordinates PeerManagerUserAlert updates. */
+  private final PeerAlertCoordinator alertCoordinator;
 
   public static final int PEER_NODE_STATUS_CONNECTED = 1;
   public static final int PEER_NODE_STATUS_ROUTING_BACKED_OFF = 2;
@@ -187,195 +90,53 @@ public class PeerManager {
    */
   public PeerManager(Node node, SemiOrderedShutdownHook shutdownHook) {
     LOG.info("PeerManager initialization start");
-    peerNodeRoutingBackoffReasonsRT = new PeerStatusTracker<>();
-    peerNodeRoutingBackoffReasonsBulk = new PeerStatusTracker<>();
-    allPeersStatuses = new PeerStatusTracker<>();
-    darknetPeersStatuses = new PeerStatusTracker<>();
-    LOG.info("PeerManager initialized");
-    myPeers = new PeerNode[0];
-    connectedPeers = new PeerNode[0];
     this.node = node;
-    shutdownHook.addEarlyJob(
-        new Thread(
-            () -> {
-              // Ensure we're not waiting 5mins here
-              writePeersDarknet();
-              writePeersOpennet();
-              writePeersNow();
-            }));
+    roster = new PeerRoster(node, this);
+    statusBook = new PeerStatusBook(roster, this);
+    opennetGate = new PeerOpennetGate(node);
+    peerPersistence = new PeerPersistence(node, this);
+    peerConnector = new PeerConnector(node, this);
+    peerMessenger = new PeerMessenger(node, this);
+    seedPeerQueries = new SeedPeerQueries(this);
+    routingSelector = new PeerRoutingSelector(node, roster, statusBook);
+    alertCoordinator = new PeerAlertCoordinator(node, roster, statusBook);
+    LOG.info("PeerManager initialized");
+    shutdownHook.addEarlyJob(new Thread(peerPersistence::flushOnShutdown));
   }
 
-  private static final String READ_PREFIX = "Read ";
-
-  /**
-   * Attempt to read a file full of noderefs. Try the file as named first, then the .bak if it is
-   * empty or otherwise doesn't work. WARNING: Only call this AFTER the Node constructor has
-   * completed! Methods may be called on Node!
-   *
-   * @param filename The filename to read from. If this doesn't work, we try the .bak file.
-   * @param crypto The cryptographic identity which these nodes are connected to.
-   * @param opennet The opennet manager for the nodes. Only needed (for constructing the nodes) if
-   *     isOpennet.
-   * @param isOpennet Whether the file contains opennet peers.
-   * @param oldOpennetPeers If true, don't add the nodes to the routing table, pass them to the
-   *     opennet manager as "old peers" i.e. inactive nodes which may try to reconnect.
-   */
-  void tryReadPeers(
-      String filename,
-      NodeCrypto crypto,
-      OpennetManager opennet,
-      boolean isOpennet,
-      boolean oldOpennetPeers) {
-    synchronized (writePeersSync) {
-      if (!oldOpennetPeers) {
-        if (isOpennet) {
-          openFilename = filename;
-        } else {
-          darkFilename = filename;
-        }
-      }
-    }
-    int maxBackups = isOpennet ? BACKUPS_OPENNET : BACKUPS_DARKNET;
-    for (int i = 0; i <= maxBackups; i++) {
-      File peersFile = this.getBackupFilename(filename, i);
-      // Try to read the node list from disk
-      if (peersFile.exists() && readPeers(peersFile, crypto, opennet, oldOpennetPeers)) {
-        String msg;
-        if (oldOpennetPeers) {
-          msg =
-              READ_PREFIX + opennet.countOldOpennetPeers() + " old-opennet-peers from " + peersFile;
-        } else if (isOpennet) {
-          msg = READ_PREFIX + getOpennetPeers().length + " opennet peers from " + peersFile;
-        } else {
-          msg = READ_PREFIX + getDarknetPeers().length + " darknet peers from " + peersFile;
-        }
-        LOG.info(msg);
-        return;
-      }
-    }
-    if (!isOpennet) {
-      LOG.info("No darknet peers file found.");
-    }
-    // The other cases are less important.
+  /** Returns the helper responsible for outbound peer connection requests. */
+  public PeerConnector connector() {
+    return peerConnector;
   }
 
-  @SuppressWarnings("java:S1181")
-  private boolean readPeers(
-      File peersFile, NodeCrypto crypto, OpennetManager opennet, boolean oldOpennetPeers) {
-    boolean someBroken;
-    File brokenPeersFile = new File(peersFile.getPath() + ".broken");
-    DroppedOldPeersUserAlert droppedOldPeers = new DroppedOldPeersUserAlert(brokenPeersFile);
-    List<SimpleFieldSet> peerEntries = new ArrayList<>();
-    // read the peers file
-    try (FileInputStream fis = new FileInputStream(peersFile);
-        InputStreamReader ris = new InputStreamReader(fis, StandardCharsets.UTF_8);
-        BufferedReader br = new BufferedReader(ris)) {
-      readPeerFieldSets(br, peerEntries);
-    } catch (FileNotFoundException _) {
-      LOG.info("Peers file not found: {}", peersFile);
-      return false;
-    } catch (IOException e3) {
-      LOG.error("Read error {} on {}", e3, peersFile, e3);
-    }
-
-    List<PeerNode> createdNodes =
-        createPeerNodesFromEntries(peerEntries, crypto, opennet, droppedOldPeers);
-    // Consider the file "broken" if we could not create all peers (parse errors or too-old entries)
-    someBroken = (createdNodes.size() != peerEntries.size());
-    applyCreatedNodes(createdNodes, opennet, oldOpennetPeers);
-    if (someBroken) {
-      try {
-        safeDeleteIfExists(brokenPeersFile);
-        try (FileOutputStream fos = new FileOutputStream(brokenPeersFile);
-            FileInputStream fis = new FileInputStream(peersFile)) {
-          FileUtil.copy(fis, fos, -1);
-        }
-        LOG.warn("Broken peers file copied to {}", brokenPeersFile);
-      } catch (IOException _) {
-        LOG.warn("Unable to copy broken peers file");
-      }
-    }
-    if (!droppedOldPeers.isEmpty()) {
-      try {
-        node.getClientCore().getAlerts().register(droppedOldPeers);
-        LOG.error(droppedOldPeers.getText());
-      } catch (Throwable t) {
-        // Startup MUST complete, don't let client layer problems kill it.
-        LOG.error("Caught error telling user about dropped peers", t);
-      }
-    }
-    return !someBroken;
+  /** Returns the helper responsible for peer messaging and disconnect workflows. */
+  public PeerMessenger messenger() {
+    return peerMessenger;
   }
 
-  private List<PeerNode> createPeerNodesFromEntries(
-      List<SimpleFieldSet> peerEntries,
-      NodeCrypto crypto,
-      OpennetManager opennet,
-      DroppedOldPeersUserAlert droppedOldPeers) {
-    List<PeerNode> created = new ArrayList<>();
-    for (SimpleFieldSet fs : peerEntries) {
-      try {
-        created.add(PeerNode.create(fs, node, crypto, opennet, this));
-      } catch (FSParseException
-          | PeerParseException
-          | ReferenceSignatureVerificationException
-          | RuntimeException e2) {
-        handlePeerCreationException(e2, fs);
-      } catch (PeerTooOldException e) {
-        if (crypto.isOpennet()) {
-          LOG.error("Dropping too-old opennet peer");
-        } else {
-          droppedOldPeers.add(e, fs.get("myName"));
-        }
-      }
-    }
-    // Always return successfully parsed peers; callers decide whether some entries were broken.
-    return created;
+  /** Returns the helper that provides seed-server peer queries. */
+  public SeedPeerQueries seedPeers() {
+    return seedPeerQueries;
   }
 
-  private void applyCreatedNodes(
-      List<PeerNode> createdNodes, OpennetManager opennet, boolean oldOpennetPeers) {
-    for (PeerNode pn : createdNodes) {
-      if (oldOpennetPeers) {
-        if (pn instanceof OpennetPeerNode opennetpeernode) {
-          opennet.addOldOpennetNode(opennetpeernode);
-        } else {
-          LOG.error("Darknet node in old opennet peers: {}", pn);
-        }
-      } else {
-        addPeer(pn, true, false);
-      }
-    }
+  /** Returns the peer roster for direct queries and snapshots. */
+  public PeerRoster roster() {
+    return roster;
   }
 
-  private void handlePeerCreationException(Exception e2, SimpleFieldSet fs) {
-    LOG.error("Peer parse error {} for {}", e2, fs, e2);
-    LOG.warn("Cannot parse friend from peers file: {}", e2, e2);
+  /** Returns the peer status tracker for status snapshots and backoff reasons. */
+  public PeerStatusBook statusBook() {
+    return statusBook;
   }
 
-  private static void readPeerFieldSets(BufferedReader br, List<SimpleFieldSet> out)
-      throws IOException {
-    for (SimpleFieldSet sfs = readNextPeerFieldSet(br);
-        sfs != null;
-        sfs = readNextPeerFieldSet(br)) {
-      out.add(sfs);
-    }
+  /** Returns the routing selector used for peer routing decisions. */
+  public PeerRoutingSelector routingSelector() {
+    return routingSelector;
   }
 
-  private static SimpleFieldSet readNextPeerFieldSet(BufferedReader br) throws IOException {
-    try {
-      return new SimpleFieldSet(br, false, true);
-    } catch (EOFException _) {
-      return null; // end-of-file reached
-    }
-  }
-
-  private static void safeDeleteIfExists(File file) {
-    try {
-      java.nio.file.Files.deleteIfExists(file.toPath());
-    } catch (IOException _) {
-      // best-effort
-    }
+  /** Returns the persistence helper used for peer file reads and writes. */
+  PeerPersistence persistence() {
+    return peerPersistence;
   }
 
   public boolean addPeer(PeerNode pn) {
@@ -395,30 +156,13 @@ public class PeerManager {
    */
   boolean addPeer(PeerNode pn, boolean ignoreOpennet, boolean reactivate) {
     assert (pn != null);
-    if (reactivate) pn.forceCancelDisconnecting();
-    synchronized (this) {
-      for (PeerNode myPeer : myPeers) {
-        if (myPeer.equals(pn)) {
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "Can't add peer {} because already have {}", pn, myPeer, new Exception("debug"));
-          return false;
-        }
-      }
-      myPeers = Arrays.copyOf(myPeers, myPeers.length + 1);
-      myPeers[myPeers.length - 1] = pn;
-      LOG.info("Added {}", pn);
-    }
-    if (pn.recordStatus()) addPeerNodeStatus(pn.getPeerNodeStatus(), pn);
+    boolean added = roster.addPeer(pn, reactivate);
+    if (!added) return false;
+    statusBook.onPeerAdded(pn);
     pn.setPeerNodeStatus(System.currentTimeMillis());
-    if ((!ignoreOpennet) && pn instanceof OpennetPeerNode peerNode) {
-      OpennetManager opennet = node.getOpennet();
-      if (opennet != null) opennet.forceAddPeer(peerNode, true);
-      else {
-        LOG.error("Adding opennet peer when opennet is disabled: {} - removing", pn);
-        removePeer(pn);
-        return false;
-      }
+    if (!opennetGate.allowPeer(pn, ignoreOpennet)) {
+      removePeer(pn);
+      return false;
     }
     notifyPeerStatusChangeListeners();
     if (!pn.isSeed()) {
@@ -429,24 +173,18 @@ public class PeerManager {
   }
 
   synchronized boolean havePeer(PeerNode pn) {
-    for (PeerNode myPeer : myPeers) {
-      if (myPeer == pn) return true;
-    }
-    return false;
+    return roster.havePeer(pn);
   }
 
   /** Remove a PeerNode. LOCKING: Caller should not hold locks on any PeerNode. */
   @SuppressWarnings("UnusedReturnValue")
-  private boolean removePeer(PeerNode pn) {
-    if (LOG.isDebugEnabled()) LOG.debug("Removing {}", pn);
+  boolean removePeer(PeerNode pn) {
     boolean isInPeers;
     synchronized (this) {
-      isInPeers = isPeerPresent(pn);
-      if (pn instanceof DarknetPeerNode peerNode) peerNode.removeExtraPeerDataDir();
+      isInPeers = roster.havePeer(pn);
       if (isInPeers) {
-        updateTrackersOnRemove(pn);
-        rebuildPeerArraysOnRemove(pn);
-        LOG.info("Removed {}", pn);
+        statusBook.onPeerRemoved(pn);
+        roster.removePeer(pn);
       }
     }
     pn.onRemove();
@@ -456,44 +194,10 @@ public class PeerManager {
     return true;
   }
 
-  private boolean isPeerPresent(PeerNode pn) {
-    // Delegate to the synchronized variant to avoid duplicate implementations.
-    return havePeer(pn);
-  }
-
-  private void updateTrackersOnRemove(PeerNode pn) {
-    int peerNodeStatus = pn.getPeerNodeStatus();
-    if (pn.recordStatus()) removePeerNodeStatus(peerNodeStatus, pn);
-    String prevReason = pn.getPreviousBackoffReason(true);
-    if (prevReason != null) removePeerNodeRoutingBackoffReason(prevReason, pn, true);
-    prevReason = pn.getPreviousBackoffReason(false);
-    if (prevReason != null) removePeerNodeRoutingBackoffReason(prevReason, pn, false);
-  }
-
-  private void rebuildPeerArraysOnRemove(PeerNode pn) {
-    ArrayList<PeerNode> a = new ArrayList<>();
-    for (PeerNode mp : myPeers) {
-      if ((mp != pn) && mp.isConnected() && mp.isRealConnection()) a.add(mp);
-    }
-    connectedPeers = a.toArray(new PeerNode[0]);
-
-    PeerNode[] newMyPeers = new PeerNode[myPeers.length - 1];
-    int positionInNewArray = 0;
-    for (PeerNode mp : myPeers) {
-      if (mp != pn) newMyPeers[positionInNewArray++] = mp;
-    }
-    myPeers = newMyPeers;
-  }
-
   @SuppressWarnings("UnusedReturnValue")
   public boolean removeAllPeers() {
     LOG.info("Removing all peers");
-    PeerNode[] oldPeers;
-    synchronized (this) {
-      oldPeers = myPeers;
-      myPeers = new PeerNode[0];
-      connectedPeers = new PeerNode[0];
-    }
+    PeerNode[] oldPeers = roster.removeAllPeers();
     for (PeerNode oldPeer : oldPeers) oldPeer.onRemove();
     notifyPeerStatusChangeListeners();
     return true;
@@ -506,30 +210,12 @@ public class PeerManager {
    * @return {@code true} if the peer was present in the connected set; otherwise {@code false}.
    */
   public boolean disconnected(PeerNode pn) {
-    synchronized (this) {
-      boolean isInPeers = false;
-      for (PeerNode connectedPeer : connectedPeers) {
-        if (connectedPeer == pn) {
-          isInPeers = true;
-          break;
-        }
-      }
-      if (!isInPeers) return false;
-      // removing from connectedPeers
-      ArrayList<PeerNode> a = new ArrayList<>();
-      for (PeerNode mp : myPeers) {
-        if ((mp != pn) && mp.isRoutable()) a.add(mp);
-      }
-      PeerNode[] newConnectedPeers = new PeerNode[a.size()];
-      newConnectedPeers = a.toArray(newConnectedPeers);
-      connectedPeers = newConnectedPeers;
-    }
+    boolean changed = roster.disconnected(pn);
+    if (!changed) return false;
     if (!pn.isSeed()) updatePMUserAlert();
     node.getLocationManager().announceLocChange();
     return true;
   }
-
-  long timeFirstAnyConnections = 0;
 
   /**
    * Returns the timestamp of the first successful connection since startup.
@@ -557,295 +243,12 @@ public class PeerManager {
     long now = System.currentTimeMillis();
     synchronized (this) {
       if (timeFirstAnyConnections == 0) timeFirstAnyConnections = now;
-      if (isAlreadyConnected(pn)) return;
-      ensurePeerPresent(pn);
-      addToConnectedPeers(pn);
     }
+    boolean added = roster.addConnectedPeer(pn, this::addPeer);
+    if (!added) return;
     if (!pn.isSeed()) updatePMUserAlert();
     node.getLocationManager().announceLocChange();
   }
-
-  private boolean isAlreadyConnected(PeerNode pn) {
-    for (PeerNode connectedPeer : connectedPeers) {
-      if (connectedPeer == pn) {
-        if (LOG.isDebugEnabled()) LOG.debug("Already connected: {}", pn);
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private void ensurePeerPresent(PeerNode pn) {
-    boolean inMyPeers = false;
-    for (PeerNode mp : myPeers) {
-      if (mp == pn) {
-        inMyPeers = true;
-        break;
-      }
-    }
-    if (!inMyPeers) {
-      LOG.error("Connecting to {} but not in peers", pn);
-      // Note: addPeer() called while holding PM lock; this mirrors historical behavior.
-      addPeer(pn);
-    }
-  }
-
-  private void addToConnectedPeers(PeerNode pn) {
-    if (LOG.isDebugEnabled()) LOG.debug("Connecting: {}", pn);
-    connectedPeers = Arrays.copyOf(connectedPeers, connectedPeers.length + 1);
-    connectedPeers[connectedPeers.length - 1] = pn;
-    if (LOG.isDebugEnabled()) LOG.debug("Connected peers: {}", connectedPeers.length);
-  }
-
-  /**
-   * Returns the peer matching the given {@code Peer} address (IP and port).
-   *
-   * <p>Used by {@link FNPPacketMangler} to quickly identify an incoming connection. Includes peers
-   * that are not real connections because they may still be connected.
-   *
-   * @param peer The transport-layer peer descriptor (contains IP and port).
-   * @return The matching {@link PeerNode}, or {@code null} if not found.
-   */
-  public PeerNode getByPeer(Peer peer) {
-    PeerNode[] peerList = myPeers();
-    for (PeerNode pn : peerList) {
-      if (pn.isDisabled()) continue;
-      if (pn.matchesPeerAndPort(peer)) return pn;
-    }
-    // Try a match by IP address if we can't match exactly by IP:port.
-    FreenetInetAddress addr = peer.getFreenetAddress();
-    for (PeerNode pn : peerList) {
-      if (pn.isDisabled()) continue;
-      if (pn.matchesIP(addr, false)) return pn;
-    }
-    return null;
-  }
-
-  /**
-   * Returns the peer that matches the given {@code Peer} address and outgoing mangler.
-   *
-   * <p>If an exact IP:port match is not found, falls back to an IP-only match. Only peers using the
-   * provided outgoing mangler are considered.
-   *
-   * @param peer The transport-layer peer descriptor (contains IP and port).
-   * @param mangler The expected outgoing packet mangler instance.
-   * @return The matching {@link PeerNode}, or {@code null} if not found.
-   */
-  public PeerNode getByPeer(Peer peer, FNPPacketMangler mangler) {
-    PeerNode[] peerList = myPeers();
-    for (PeerNode pn : peerList) {
-      if (pn.isDisabled()) continue;
-      if (pn.matchesPeerAndPort(peer) && pn.getOutgoingMangler() == mangler) return pn;
-    }
-    // Try a match by IP address if we can't match exactly by IP:port.
-    FreenetInetAddress addr = peer.getFreenetAddress();
-    for (PeerNode pn : peerList) {
-      if (pn.isDisabled()) continue;
-      if (pn.matchesIP(addr, false) && pn.getOutgoingMangler() == mangler) return pn;
-    }
-    return null;
-  }
-
-  /**
-   * Finds connected, routable peers with a given IP address.
-   *
-   * @param a IP address to match.
-   * @param strict When true, require an exact match; otherwise allow non-strict matches as defined
-   *     by {@link PeerNode#matchesIP(FreenetInetAddress, boolean)}.
-   * @return A list of matching peers (may be empty), or {@code null} if none found.
-   */
-  public List<PeerNode> getAllConnectedByAddress(FreenetInetAddress a, boolean strict) {
-    List<PeerNode> found = null;
-
-    PeerNode[] peerList = myPeers();
-    // Try a match by IP address if we can't match exactly by IP:port.
-    for (PeerNode pn : peerList) {
-      boolean eligible = pn.isConnected() && pn.isRoutable() && pn.matchesIP(a, strict);
-      if (eligible) {
-        if (found == null) found = new ArrayList<>();
-        found.add(pn);
-      }
-    }
-    return found;
-  }
-
-  /**
-   * Connects to a darknet peer from its serialized reference.
-   *
-   * <p>Creates a new {@link DarknetPeerNode} from the provided field set and adds it if a peer with
-   * the same public key hash is not already present.
-   *
-   * @param noderef Serialized darknet peer reference.
-   * @param trust Initial friend trust.
-   * @param visibility Initial friend visibility.
-   * @throws FSParseException If the field set cannot be parsed.
-   * @throws PeerParseException If the noderef is syntactically invalid.
-   * @throws ReferenceSignatureVerificationException If the reference signature fails verification.
-   * @throws PeerTooOldException If the peer is older than the supported minimum.
-   */
-  public void connect(SimpleFieldSet noderef, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility)
-      throws FSParseException,
-          PeerParseException,
-          ReferenceSignatureVerificationException,
-          PeerTooOldException {
-    PeerNode pn = node.createNewDarknetNode(noderef, trust, visibility);
-    PeerNode[] peerList = myPeers();
-    for (PeerNode mp : peerList) {
-      if (Arrays.equals(mp.peerECDSAPubKeyHash, pn.peerECDSAPubKeyHash)) return;
-    }
-    addPeer(pn);
-  }
-
-  /**
-   * Disconnects a peer and removes it from the routing table.
-   *
-   * @param pn Peer to disconnect.
-   * @param sendDisconnectMessage If true, send a protocol disconnect message.
-   * @param waitForAck If true, wait for the disconnect acknowledgment before removal.
-   * @param purge If true, request the remote to purge this node from old-peer state.
-   */
-  public void disconnectAndRemove(
-      final PeerNode pn, boolean sendDisconnectMessage, final boolean waitForAck, boolean purge) {
-    disconnect(pn, sendDisconnectMessage, waitForAck, purge, false, true, Node.MAX_PEER_INACTIVITY);
-  }
-
-  /**
-   * Disconnects from a specified node.
-   *
-   * @param pn Peer to disconnect.
-   * @param sendDisconnectMessage If false, do not send the protocol disconnect message.
-   * @param waitForAck If false, do not wait for the disconnect acknowledgment.
-   * @param purge If true, request the remote to purge this node from old-peer lists.
-   * @param dumpMessagesNow If true, drop queued messages immediately before completing disconnect.
-   * @param remove If true, remove the peer locally after disconnect.
-   * @param timeout Timeout in milliseconds to wait before completing removal if still
-   *     disconnecting.
-   */
-  public void disconnect(
-      final PeerNode pn,
-      boolean sendDisconnectMessage,
-      final boolean waitForAck,
-      boolean purge,
-      boolean dumpMessagesNow,
-      final boolean remove,
-      long timeout) {
-    if (LOG.isDebugEnabled()) LOG.debug("Disconnecting {}", pn.shortToString());
-    if (!shouldProceedWithDisconnect(pn, dumpMessagesNow)) return;
-    if (sendDisconnectMessage) {
-      Message msg = createDisconnectMessage(remove, purge);
-      try {
-        pn.sendAsync(msg, createDisconnectCallback(pn, remove, waitForAck), ctrDisconn);
-      } catch (NotConnectedException _) {
-        removePeerIfRequested(pn, remove);
-        return;
-      }
-      scheduleDisconnectTimeoutHandling(pn, remove, timeout);
-    } else {
-      if (remove) {
-        removePeer(pn);
-        if (!pn.isSeed()) writePeersUrgent(pn.isOpennet());
-      }
-    }
-  }
-
-  private AsyncMessageCallback createDisconnectCallback(
-      final PeerNode pn, final boolean remove, final boolean waitForAck) {
-    return new AsyncMessageCallback() {
-      boolean done = false;
-
-      @Override
-      public void acknowledged() {
-        markDone();
-      }
-
-      @Override
-      public void disconnected() {
-        markDone();
-      }
-
-      @Override
-      public void fatalError() {
-        markDone();
-      }
-
-      @Override
-      public void sent() {
-        if (!waitForAck) markDone();
-      }
-
-      void markDone() {
-        synchronized (this) {
-          if (done) return;
-          done = true;
-        }
-        if (remove) {
-          removePeer(pn);
-          if (!pn.isSeed()) writePeersUrgent(pn.isOpennet());
-        }
-      }
-    };
-  }
-
-  private boolean shouldProceedWithDisconnect(PeerNode pn, boolean dumpMessagesNow) {
-    synchronized (this) {
-      if (!havePeer(pn)) return false;
-    }
-    if (pn.notifyDisconnecting(dumpMessagesNow)) {
-      if (LOG.isDebugEnabled()) LOG.debug("Already disconnecting {}", pn.shortToString());
-      return false;
-    }
-    return true;
-  }
-
-  private static Message createDisconnectMessage(boolean remove, boolean purge) {
-    return DMT.createFNPDisconnect(remove, purge, -1, new ShortBuffer(new byte[0]));
-  }
-
-  private void removePeerIfRequested(PeerNode pn, boolean remove) {
-    if (remove && pn.isDisconnecting()) {
-      removePeer(pn);
-      if (!pn.isSeed()) {
-        writePeersUrgent(pn.isOpennet());
-      }
-    }
-  }
-
-  private void scheduleDisconnectTimeoutHandling(PeerNode pn, boolean remove, long timeout) {
-    if (pn.isSeed()) return;
-    node.getTicker()
-        .queueTimedJob(
-            () -> {
-              if (pn.isDisconnecting()) {
-                if (remove) {
-                  removePeer(pn);
-                  if (!pn.isSeed()) {
-                    writePeersUrgent(pn.isOpennet());
-                  }
-                }
-                pn.disconnected(true, true);
-              }
-            },
-            timeout);
-  }
-
-  final ByteCounter ctrDisconn =
-      new ByteCounter() {
-
-        @Override
-        public void receivedBytes(int x) {
-          node.getNodeStats().disconnBytesReceived(x);
-        }
-
-        @Override
-        public void sentBytes(int x) {
-          node.getNodeStats().disconnBytesSent(x);
-        }
-
-        @Override
-        public void sentPayload(int x) {
-          // Ignore
-        }
-      };
 
   /**
    * Returns the current locations of connected peers as doubles in [0.0, 1.0).
@@ -854,23 +257,7 @@ public class PeerManager {
    * @return A sorted array of peer locations, or an empty array when publishing is disabled.
    */
   public double[] getPeerLocationDoubles(boolean pruneBackedOffPeers) {
-    if (!node.shallWePublishOurPeersLocation()) return new double[0];
-    PeerNode[] conns = connectedPeers();
-    double[] locs = collectPeerLocations(conns, pruneBackedOffPeers);
-    Arrays.sort(locs);
-    return locs;
-  }
-
-  private static double[] collectPeerLocations(PeerNode[] peers, boolean pruneBackedOffPeers) {
-    java.util.ArrayList<Double> tmp = new java.util.ArrayList<>();
-    for (PeerNode conn : peers) {
-      if (conn.isRoutable() && (!pruneBackedOffPeers || !conn.shouldBeExcludedFromPeerList())) {
-        tmp.add(conn.getLocation());
-      }
-    }
-    double[] locs = new double[tmp.size()];
-    for (int i = 0; i < tmp.size(); i++) locs[i] = tmp.get(i);
-    return locs;
+    return roster.getPeerLocationDoubles(pruneBackedOffPeers);
   }
 
   /**
@@ -878,1041 +265,12 @@ public class PeerManager {
    *     NOT remove the "synchronized". See below for why.
    */
   public synchronized PeerNode getRandomPeer(PeerNode exclude) {
-    if (connectedPeers.length == 0) return null;
-    PeerNode candidate = attemptRandomRoutable(exclude);
-    if (candidate != null) return candidate;
-    int lengthWithoutExcluded = rebuildConnectedPeersExcluding(exclude);
-    if (lengthWithoutExcluded == 0) return null;
-    return connectedPeers[node.getRandom().nextInt(lengthWithoutExcluded)];
-  }
-
-  private PeerNode attemptRandomRoutable(PeerNode exclude) {
-    for (int i = 0; i < 5; i++) {
-      PeerNode pn = connectedPeers[node.getRandom().nextInt(connectedPeers.length)];
-      if (pn == exclude) continue;
-      if (pn.isRoutable()) return pn;
-    }
-    return null;
-  }
-
-  private int rebuildConnectedPeersExcluding(PeerNode exclude) {
-    ArrayList<PeerNode> v = new ArrayList<>(connectedPeers.length);
-    for (PeerNode pn : myPeers) {
-      if (pn == exclude) continue;
-      if (pn.isRoutable()) v.add(pn);
-      else if (LOG.isDebugEnabled()) LOG.debug("Excluding {}; disconnected", pn);
-    }
-    int lengthWithoutExcluded = v.size();
-    if ((exclude != null) && exclude.isRoutable()) v.add(exclude);
-    PeerNode[] newConnectedPeers = v.toArray(new PeerNode[0]);
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Connected peers in getRandomPeer: {} was {}",
-          newConnectedPeers.length,
-          connectedPeers.length);
-    connectedPeers = newConnectedPeers;
-    return lengthWithoutExcluded;
-  }
-
-  public void localBroadcast(
-      Message msg, boolean ignoreRoutability, boolean onlyRealConnections, ByteCounter ctr) {
-    localBroadcast(
-        msg, ignoreRoutability, onlyRealConnections, ctr, Integer.MIN_VALUE, Integer.MAX_VALUE);
-  }
-
-  /**
-   * Asynchronously sends a message to all eligible peers.
-   *
-   * @param msg Message to send.
-   * @param ignoreRoutability When true, send to connected peers even if not routable.
-   * @param onlyRealConnections When true, exclude non-real connections.
-   * @param ctr Counter to attribute bytes to.
-   * @param minVersion Minimum accepted build number (inclusive).
-   * @param maxVersion Maximum accepted build number (inclusive).
-   */
-  public void localBroadcast(
-      Message msg,
-      boolean ignoreRoutability,
-      boolean onlyRealConnections,
-      ByteCounter ctr,
-      int minVersion,
-      int maxVersion) {
-    // myPeers not connectedPeers as connectedPeers only contains
-    // ROUTABLE peers, and we may want to send to non-routable peers
-    PeerNode[] peers = myPeers();
-    for (PeerNode peer : peers) {
-      if (!shouldSendLocal(peer, ignoreRoutability, onlyRealConnections, minVersion, maxVersion))
-        continue;
-      try {
-        peer.sendAsync(msg, null, ctr);
-      } catch (NotConnectedException _) {
-        // Ignore
-      }
-    }
-  }
-
-  private static boolean shouldSendLocal(
-      PeerNode peer,
-      boolean ignoreRoutability,
-      boolean onlyRealConnections,
-      int minVersion,
-      int maxVersion) {
-    int version = peer.getBuildNumber();
-    boolean routableOrConnected = ignoreRoutability ? peer.isConnected() : peer.isRoutable();
-    return routableOrConnected
-        && (!onlyRealConnections || peer.isRealConnection())
-        && version >= minVersion
-        && version <= maxVersion;
-  }
-
-  /** Asynchronously sends a differential node reference to every connected peer. */
-  public void locallyBroadcastDiffNodeRef(
-      SimpleFieldSet fs, boolean toDarknetOnly, boolean toOpennetOnly) {
-    // myPeers not connectedPeers as connectedPeers only contains
-    // ROUTABLE peers, and we want to also send to non-routable peers
-    PeerNode[] peers = myPeers();
-    for (PeerNode peer : peers) {
-      boolean okDarknet = !toDarknetOnly || peer.isDarknet();
-      boolean okOpennet = !toOpennetOnly || peer.isOpennet();
-      if (peer.isConnected() && okDarknet && okOpennet) {
-        peer.sendNodeToNodeMessage(fs, Node.N2N_MESSAGE_TYPE_DIFFNODEREF, false, 0, false);
-      }
-    }
+    return roster.getRandomPeer(exclude);
   }
 
   /** Returns a random routable connected peer, or {@code null} if none. */
   public PeerNode getRandomPeer() {
     return getRandomPeer(null);
-  }
-
-  public PeerNode closerPeer(
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double loc,
-      boolean ignoreSelf,
-      boolean calculateMisrouting,
-      int minVersion,
-      List<Double> addUnpickedLocsTo,
-      Key key,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      boolean excludeMandatoryBackoff) {
-    return closerPeer(
-        pn,
-        routedTo,
-        loc,
-        ignoreSelf,
-        calculateMisrouting,
-        minVersion,
-        addUnpickedLocsTo,
-        2.0,
-        key,
-        outgoingHTL,
-        ignoreBackoffUnder,
-        isLocal,
-        realTime,
-        null,
-        false,
-        System.currentTimeMillis(),
-        excludeMandatoryBackoff);
-  }
-
-  /**
-   * Find the peer, if any, which is closer to the target location than we are, and is not included
-   * in the provided set. If ignoreSelf==false, and we are closer to the target than any peers, this
-   * function returns null. This function returns two values, the closest such peer which is backed
-   * off, and the same which is not backed off. It is possible for either to be null independent of
-   * the other, 'closest' is the closer of the two in either case, and will not be null if any of
-   * the other two return values is not null. LOCKING: This will briefly take various locks, try to
-   * avoid calling it with lots of locks held.
-   *
-   * @param addUnpickedLocsTo Add all locations we didn't choose which we could have routed to to
-   *     this array. Remove the location of the peer we pick from it.
-   * @param maxDistance If a node is further away from the target than this distance, ignore it.
-   * @param key The original key, if we have it, and if we want to consult with the FailureTable to
-   *     avoid routing to nodes which have recently failed for the same key.
-   * @param isLocal We don't just check pn == null because in some cases pn can be null here: If an
-   *     insert is forked, for a remote requests, we can route back to the originator, so we set pn
-   *     to null. Whereas for stats we want to know accurately whether this was originated remotely.
-   * @param recentlyFailed If non-null, we should check for recently failed: If we have routed to,
-   *     and got a failed response from, and are still connected to and within the timeout for, our
-   *     top two routing choices, *and* the same is true of at least 3 nodes, we fill in this object
-   *     and return null. This will cause a RecentlyFailed message to be returned to the originator,
-   *     allowing them to retry in a little while. Note: the scheduler is currently not designed to
-   *     retry immediately when that timeout elapses; re-evaluating this behavior may be beneficial
-   *     to avoid introducing a round-trip to the request originator.
-   */
-  public PeerNode closerPeer(
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double target,
-      boolean ignoreSelf,
-      boolean calculateMisrouting,
-      int minVersion,
-      List<Double> addUnpickedLocsTo,
-      double maxDistance,
-      Key key,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      RecentlyFailedReturn recentlyFailed,
-      boolean ignoreTimeout,
-      long now,
-      boolean newLoadManagement) {
-    CloserPeerContext ctx = initCloserPeerContext(pn, routedTo, target, ignoreSelf, key);
-    evaluateCandidatesInContext(
-        ctx,
-        pn,
-        routedTo,
-        minVersion,
-        now,
-        realTime,
-        ignoreTimeout,
-        outgoingHTL,
-        target,
-        maxDistance,
-        ignoreSelf,
-        addUnpickedLocsTo,
-        ignoreBackoffUnder,
-        newLoadManagement);
-
-    BestCandidate bestCand = selectBestCandidate(ctx.st, ctx.key);
-    if (recentlyFailed != null && LOG.isDebugEnabled())
-      LOG.debug("Count waiting: {}", ctx.st.countWaiting);
-
-    PeerNode best =
-        handleRecentlyFailedIfNeeded(
-            bestCand.best,
-            bestCand.bestDistance,
-            recentlyFailed,
-            ctx,
-            pn,
-            routedTo,
-            target,
-            ignoreSelf,
-            minVersion,
-            maxDistance,
-            outgoingHTL,
-            ignoreBackoffUnder,
-            isLocal,
-            realTime,
-            now,
-            newLoadManagement);
-    if (best == null) return null;
-
-    reportBackoffPercentIfNeeded(calculateMisrouting);
-    postSelectionUpdate(best, calculateMisrouting, addUnpickedLocsTo, ctx.st);
-    return best;
-  }
-
-  private void reportBackoffPercentIfNeeded(boolean calculateMisrouting) {
-    if (!calculateMisrouting) return;
-    int connected = getPeerNodeStatusSize(PEER_NODE_STATUS_CONNECTED, false);
-    int backedOff = getPeerNodeStatusSize(PEER_NODE_STATUS_ROUTING_BACKED_OFF, false);
-    if (backedOff + connected > 0)
-      node.getNodeStats()
-          .backedOffPercent
-          .report((double) backedOff / (double) (backedOff + connected));
-  }
-
-  private record SelectionRates(double[] rates, double total) {
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof SelectionRates(double[] rates1, double total1))) return false;
-      return Double.compare(total1, total) == 0 && java.util.Arrays.equals(rates, rates1);
-    }
-
-    @Override
-    public int hashCode() {
-      int result = java.util.Arrays.hashCode(rates);
-      result = 31 * result + Double.hashCode(total);
-      return result;
-    }
-
-    @Override
-    public @NotNull String toString() {
-      return "SelectionRates[rates=" + java.util.Arrays.toString(rates) + ", total=" + total + "]";
-    }
-  }
-
-  private static final class CloserPeerContext {
-    final PeerNode[] peers;
-    final Key key;
-    final double myLoc;
-    final double maxDiff;
-    final double prevLoc;
-    final TimedOutNodesList entry;
-    final SelectionRates selection;
-    final boolean enableFOAFMitigationHack;
-    final Set<Double> excludeLocations;
-    final PeerSelectionState st = new PeerSelectionState();
-
-    CloserPeerContext(
-        PeerNode[] peers,
-        Key key,
-        double myLoc,
-        double maxDiff,
-        double prevLoc,
-        TimedOutNodesList entry,
-        SelectionRates selection,
-        boolean enableFOAFMitigationHack,
-        Set<Double> excludeLocations) {
-      this.peers = peers;
-      this.key = key;
-      this.myLoc = myLoc;
-      this.maxDiff = maxDiff;
-      this.prevLoc = prevLoc;
-      this.entry = entry;
-      this.selection = selection;
-      this.enableFOAFMitigationHack = enableFOAFMitigationHack;
-      this.excludeLocations = excludeLocations;
-    }
-  }
-
-  private CloserPeerContext initCloserPeerContext(
-      PeerNode pn, Set<PeerNode> routedTo, double target, boolean ignoreSelf, Key key) {
-    PeerNode[] peers = connectedPeers();
-    Key effectiveKey = node.isEnablePerNodeFailureTables() ? key : null;
-    if (LOG.isDebugEnabled())
-      LOG.debug("Choosing closest peer (connectedPeers={}, key={})", peers.length, effectiveKey);
-
-    double myLoc = node.getLocation();
-    double maxDiff = ignoreSelf ? Double.MAX_VALUE : Location.distance(myLoc, target);
-    double prevLoc = (pn != null) ? pn.getLocation() : -1.0;
-    TimedOutNodesList entry =
-        (effectiveKey != null) ? node.getFailureTable().getTimedOutNodesList(effectiveKey) : null;
-    SelectionRates selection = computeSelectionRates(peers);
-    boolean enableFOAF = (peers.length >= PeerNode.SELECTION_MIN_PEERS) && (selection.total > 0.0);
-    Set<Double> exclude = buildExcludeLocations(myLoc, prevLoc, routedTo);
-    return new CloserPeerContext(
-        peers, effectiveKey, myLoc, maxDiff, prevLoc, entry, selection, enableFOAF, exclude);
-  }
-
-  private SelectionRates computeSelectionRates(PeerNode[] peers) {
-    double[] rates = new double[peers.length];
-    double total = 0.0;
-    for (int i = 0; i < peers.length; i++) {
-      rates[i] = peers[i].selectionRate();
-      total += rates[i];
-    }
-    return new SelectionRates(rates, total);
-  }
-
-  private void evaluateCandidatesInContext(
-      CloserPeerContext ctx,
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      int minVersion,
-      long now,
-      boolean realTime,
-      boolean ignoreTimeout,
-      short outgoingHTL,
-      double target,
-      double maxDistance,
-      boolean ignoreSelf,
-      List<Double> addUnpickedLocsTo,
-      long ignoreBackoffUnder,
-      boolean newLoadManagement) {
-    for (int i = 0; i < ctx.peers.length; i++) {
-      evaluateCandidate(
-          ctx.st,
-          ctx.peers[i],
-          i,
-          pn,
-          routedTo,
-          minVersion,
-          ctx.enableFOAFMitigationHack,
-          ctx.selection.rates,
-          ctx.selection.total,
-          now,
-          realTime,
-          ctx.entry,
-          ignoreTimeout,
-          outgoingHTL,
-          target,
-          ctx.excludeLocations,
-          maxDistance,
-          ignoreSelf,
-          ctx.maxDiff,
-          addUnpickedLocsTo,
-          ignoreBackoffUnder,
-          newLoadManagement);
-    }
-  }
-
-  private PeerNode handleRecentlyFailedIfNeeded(
-      PeerNode best,
-      double bestDistance,
-      RecentlyFailedReturn recentlyFailed,
-      CloserPeerContext ctx,
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double target,
-      boolean ignoreSelf,
-      int minVersion,
-      double maxDistance,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      long now,
-      boolean newLoadManagement) {
-    if (recentlyFailed == null) return best;
-    if (ctx.st.countWaiting < maxCountWaiting(ctx.peers)) return best;
-    if (!node.isEnableULPRDataPropagation()) return best;
-    return maybeHandleRecentlyFailed(
-        pn,
-        routedTo,
-        target,
-        ignoreSelf,
-        minVersion,
-        maxDistance,
-        ctx.key,
-        outgoingHTL,
-        ignoreBackoffUnder,
-        isLocal,
-        realTime,
-        now,
-        newLoadManagement,
-        ctx.entry,
-        ctx.st,
-        best,
-        bestDistance,
-        ctx.myLoc,
-        ctx.prevLoc,
-        recentlyFailed);
-  }
-
-  private static final class PeerSelectionState {
-    int countWaiting = 0;
-    long soonestTimeoutWakeup = Long.MAX_VALUE;
-    double closestDistance = Double.MAX_VALUE;
-    double closestRealDistance = Double.MAX_VALUE;
-    PeerNode closestBackedOff = null;
-    double closestBackedOffDistance = Double.MAX_VALUE;
-    double closestRealBackedOffDistance = Double.MAX_VALUE;
-    PeerNode closestNotBackedOff = null;
-    double closestNotBackedOffDistance = Double.MAX_VALUE;
-    double closestRealNotBackedOffDistance = Double.MAX_VALUE;
-    PeerNode leastRecentlyTimedOut = null;
-    long timeLeastRecentlyTimedOut = Long.MAX_VALUE;
-    double leastRecentlyTimedOutDistance = Double.MAX_VALUE;
-    PeerNode leastRecentlyTimedOutBackedOff = null;
-    long timeLeastRecentlyTimedOutBackedOff = Long.MAX_VALUE;
-    double leastRecentlyTimedOutBackedOffDistance = Double.MAX_VALUE;
-  }
-
-  private record BestCandidate(PeerNode best, double bestDistance) {}
-
-  private Set<Double> buildExcludeLocations(double myLoc, double prevLoc, Set<PeerNode> routedTo) {
-    Set<Double> excludeLocations = new HashSet<>();
-    excludeLocations.add(myLoc);
-    excludeLocations.add(prevLoc);
-    for (PeerNode routedToNode : routedTo) {
-      excludeLocations.add(routedToNode.getLocation());
-    }
-    return excludeLocations;
-  }
-
-  private void evaluateCandidate(
-      PeerSelectionState st,
-      PeerNode p,
-      int index,
-      PeerNode origin,
-      Set<PeerNode> routedTo,
-      int minVersion,
-      boolean enableFOAFMitigationHack,
-      double[] selectionRates,
-      double totalSelectionRate,
-      long now,
-      boolean realTime,
-      TimedOutNodesList entry,
-      boolean ignoreTimeout,
-      short outgoingHTL,
-      double target,
-      Set<Double> excludeLocations,
-      double maxDistance,
-      boolean ignoreSelf,
-      double maxDiff,
-      List<Double> addUnpickedLocsTo,
-      long ignoreBackoffUnder,
-      boolean newLoadManagement) {
-    if (shouldSkipCandidate(
-        p,
-        origin,
-        routedTo,
-        newLoadManagement,
-        realTime,
-        minVersion,
-        enableFOAFMitigationHack,
-        selectionRates,
-        totalSelectionRate,
-        index,
-        now)) return;
-
-    TimeoutInfo t = computeTimeoutInfo(st, entry, ignoreTimeout, now, outgoingHTL, p);
-    DiffInfo d = computeDiffInfo(p, target, outgoingHTL, excludeLocations);
-
-    if (d.diff > maxDistance) return;
-    if ((!ignoreSelf) && (d.diff > maxDiff)) {
-      if (LOG.isDebugEnabled()) LOG.debug("Ignore; farther than self; maxDiff={}", maxDiff);
-      return;
-    }
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "p.loc={}, target={}, d={} usedD={} timedOut={} for {}",
-          d.loc,
-          target,
-          Location.distance(d.loc, target),
-          d.diff,
-          t.timedOut,
-          p.getPeer());
-
-    boolean chosen =
-        updateBestTracking(st, p, d, t.timedOut, t.timeoutFT, ignoreBackoffUnder, realTime);
-    if (addUnpickedLocsTo != null && !chosen) {
-      Double locD = d.loc;
-      if (!addUnpickedLocsTo.contains(locD)) addUnpickedLocsTo.add(locD);
-    }
-  }
-
-  private boolean shouldSkipCandidate(
-      PeerNode p,
-      PeerNode origin,
-      Set<PeerNode> routedTo,
-      boolean newLoadManagement,
-      boolean realTime,
-      int minVersion,
-      boolean enableFOAFMitigationHack,
-      double[] selectionRates,
-      double totalSelectionRate,
-      int index,
-      long now) {
-    boolean skip = false;
-    skip |= isAlreadyRoutedTo(p, routedTo);
-    skip |= isOrigin(p, origin);
-    skip |= isNotRoutable(p);
-    skip |= isDisconnecting(p);
-    skip |= lacksLoadStats(p, newLoadManagement, realTime);
-    skip |= isOldVersion(p, minVersion);
-    skip |=
-        isOverSelectedPeer(enableFOAFMitigationHack, selectionRates, totalSelectionRate, index, p);
-    skip |= isInMandatoryBackoff(p, newLoadManagement, realTime, now);
-    return skip;
-  }
-
-  private boolean isAlreadyRoutedTo(PeerNode p, Set<PeerNode> routedTo) {
-    if (routedTo.contains(p)) {
-      if (LOG.isDebugEnabled()) LOG.debug("Skipping (already routed to): {}", p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private boolean isOrigin(PeerNode p, PeerNode origin) {
-    if (p == origin) {
-      if (LOG.isDebugEnabled()) LOG.debug("Skipping (req came from): {}", p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private boolean isNotRoutable(PeerNode p) {
-    if (!p.isRoutable()) {
-      if (LOG.isDebugEnabled()) LOG.debug("Skipping (not connected): {}", p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private boolean isDisconnecting(PeerNode p) {
-    if (p.isDisconnecting()) {
-      if (LOG.isDebugEnabled()) LOG.debug("Skipping (disconnecting): {}", p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private boolean lacksLoadStats(PeerNode p, boolean newLoadManagement, boolean realTime) {
-    if (newLoadManagement && p.outputLoadTracker(realTime).getLastIncomingLoadStats() == null) {
-      if (LOG.isDebugEnabled()) LOG.debug("Skipping (no load stats): {}", p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private boolean isOldVersion(PeerNode p, int minVersion) {
-    if (minVersion > 0
-        && !Version.isBuildAtLeast(
-            p.getNodeName(),
-            Version.parseBuildNumberFromVersionStr(p.getVersion(), -1),
-            minVersion)) {
-      if (LOG.isDebugEnabled()) LOG.debug("Skipping old version: {}", p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private boolean isOverSelectedPeer(
-      boolean enableFOAFMitigationHack,
-      double[] selectionRates,
-      double totalSelectionRate,
-      int index,
-      PeerNode p) {
-    if (enableFOAFMitigationHack) {
-      double selectionPercentage = 100.0 * selectionRates[index] / totalSelectionRate;
-      if (selectionPercentage > PeerNode.SELECTION_PERCENTAGE_WARNING) {
-        if (LOG.isDebugEnabled())
-          LOG.debug("Skipping over-selected peer({}%): {}", selectionPercentage, p.getPeer());
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private boolean isInMandatoryBackoff(
-      PeerNode p, boolean newLoadManagement, boolean realTime, long now) {
-    if (newLoadManagement && p.isInMandatoryBackoff(now, realTime)) {
-      if (LOG.isDebugEnabled()) LOG.debug("Skipping (mandatory backoff): {}", p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private record TimeoutInfo(boolean timedOut, long timeoutFT) {}
-
-  private TimeoutInfo computeTimeoutInfo(
-      PeerSelectionState st,
-      TimedOutNodesList entry,
-      boolean ignoreTimeout,
-      long now,
-      short outgoingHTL,
-      PeerNode p) {
-    long timeoutRF;
-    long timeoutFT = -1;
-    if (entry != null && !ignoreTimeout) {
-      timeoutFT = entry.getTimeoutTime(p, outgoingHTL, now, true);
-      timeoutRF = entry.getTimeoutTime(p, outgoingHTL, now, false);
-      if (timeoutRF > now) {
-        st.soonestTimeoutWakeup = Math.min(st.soonestTimeoutWakeup, timeoutRF);
-        st.countWaiting++;
-      }
-    }
-    boolean timedOut = timeoutFT > now;
-    return new TimeoutInfo(timedOut, timeoutFT);
-  }
-
-  private record DiffInfo(double loc, double diff, double realDiff, boolean direct) {}
-
-  private DiffInfo computeDiffInfo(
-      PeerNode p, double target, short outgoingHTL, Set<Double> excludeLocations) {
-    double loc = p.getLocation();
-    boolean direct = true;
-    double realDiff = Location.distance(loc, target);
-    double diff = realDiff;
-    if (p.shallWeRouteAccordingToOurPeersLocation(outgoingHTL)) {
-      double l = p.getClosestPeerLocation(target, excludeLocations);
-      if (!Double.isNaN(l)) {
-        double newDiff = Location.distance(l, target);
-        if (newDiff < diff) {
-          loc = l;
-          diff = newDiff;
-          direct = false;
-        }
-      }
-      if (LOG.isDebugEnabled())
-        LOG.debug("Peer {} publishes peer locations; closest candidate distance={}", p, diff);
-    }
-    return new DiffInfo(loc, diff, realDiff, direct);
-  }
-
-  private boolean updateBestTracking(
-      PeerSelectionState st,
-      PeerNode p,
-      DiffInfo d,
-      boolean timedOut,
-      long timeoutFT,
-      long ignoreBackoffUnder,
-      boolean realTime) {
-    boolean chosen = updateOverallBest(st, p, d);
-    boolean backedOff = p.isRoutingBackedOff(ignoreBackoffUnder, realTime);
-    chosen |= updateBestBackedOff(st, p, d, timedOut, backedOff);
-    chosen |= updateBestNotBackedOff(st, p, d, timedOut, backedOff);
-    updateTimedOutOrdering(st, p, d.diff, timeoutFT, timedOut, backedOff);
-    return chosen;
-  }
-
-  private boolean updateOverallBest(PeerSelectionState st, PeerNode p, DiffInfo d) {
-    if (d.diff < st.closestDistance
-        || (Math.abs(d.diff - st.closestDistance) < Double.MIN_VALUE * 2
-            && (d.direct || d.realDiff < st.closestRealDistance))) {
-      st.closestDistance = d.diff;
-      st.closestRealDistance = d.realDiff;
-      if (LOG.isDebugEnabled())
-        LOG.debug("New best distance={} at {} for {}", d.diff, d.loc, p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private boolean updateBestBackedOff(
-      PeerSelectionState st, PeerNode p, DiffInfo d, boolean timedOut, boolean backedOff) {
-    if (backedOff
-        && (d.diff < st.closestBackedOffDistance
-            || (Math.abs(d.diff - st.closestBackedOffDistance) < Double.MIN_VALUE * 2
-                && (d.direct || d.realDiff < st.closestRealBackedOffDistance)))
-        && !timedOut) {
-      st.closestBackedOffDistance = d.diff;
-      st.closestBackedOff = p;
-      st.closestRealBackedOffDistance = d.realDiff;
-      if (LOG.isDebugEnabled())
-        LOG.debug("New best-backed-off distance={} at {} for {}", d.diff, d.loc, p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private boolean updateBestNotBackedOff(
-      PeerSelectionState st, PeerNode p, DiffInfo d, boolean timedOut, boolean backedOff) {
-    if (!backedOff
-        && (d.diff < st.closestNotBackedOffDistance
-            || (Math.abs(d.diff - st.closestNotBackedOffDistance) < Double.MIN_VALUE * 2
-                && (d.direct || d.realDiff < st.closestRealNotBackedOffDistance)))
-        && !timedOut) {
-      st.closestNotBackedOffDistance = d.diff;
-      st.closestNotBackedOff = p;
-      st.closestRealNotBackedOffDistance = d.realDiff;
-      if (LOG.isDebugEnabled())
-        LOG.debug("New best-not-backed-off distance={} at {} for {}", d.diff, d.loc, p.getPeer());
-      return true;
-    }
-    return false;
-  }
-
-  private void updateTimedOutOrdering(
-      PeerSelectionState st,
-      PeerNode p,
-      double diff,
-      long timeoutFT,
-      boolean timedOut,
-      boolean backedOff) {
-    if (!timedOut) return;
-    if (!backedOff) {
-      if (timeoutFT < st.timeLeastRecentlyTimedOut) {
-        st.timeLeastRecentlyTimedOut = timeoutFT;
-        st.leastRecentlyTimedOut = p;
-        st.leastRecentlyTimedOutDistance = diff;
-      }
-    } else if (timeoutFT < st.timeLeastRecentlyTimedOutBackedOff) {
-      st.timeLeastRecentlyTimedOutBackedOff = timeoutFT;
-      st.leastRecentlyTimedOutBackedOff = p;
-      st.leastRecentlyTimedOutBackedOffDistance = diff;
-    }
-  }
-
-  private BestCandidate selectBestCandidate(PeerSelectionState st, Key key) {
-    PeerNode best = st.closestNotBackedOff;
-    double bestDistance = st.closestNotBackedOffDistance;
-    if (best == null) {
-      if (st.leastRecentlyTimedOut != null) {
-        best = st.leastRecentlyTimedOut;
-        bestDistance = st.leastRecentlyTimedOutDistance;
-        if (LOG.isDebugEnabled())
-          LOG.debug(
-              "Using least recently failed in-timeout-period peer for key: {} for {}",
-              best.shortToString(),
-              key);
-      } else if (st.closestBackedOff != null) {
-        best = st.closestBackedOff;
-        bestDistance = st.closestBackedOffDistance;
-        if (LOG.isDebugEnabled())
-          LOG.debug("Using best backed-off peer for key: {}", best.shortToString());
-      } else if (st.leastRecentlyTimedOutBackedOff != null) {
-        best = st.leastRecentlyTimedOutBackedOff;
-        bestDistance = st.leastRecentlyTimedOutBackedOffDistance;
-        if (LOG.isDebugEnabled())
-          LOG.debug(
-              "Using least recently failed in-timeout-period backed-off peer for key: {} for {}",
-              best.shortToString(),
-              key);
-      }
-    }
-    return new BestCandidate(best, bestDistance);
-  }
-
-  private PeerNode maybeHandleRecentlyFailed(
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double target,
-      boolean ignoreSelf,
-      int minVersion,
-      double maxDistance,
-      Key key,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      long now,
-      boolean newLoadManagement,
-      TimedOutNodesList entry,
-      PeerSelectionState st,
-      PeerNode best,
-      double bestDistance,
-      double myLoc,
-      double prevLoc,
-      RecentlyFailedReturn recentlyFailed) {
-    FirstSecondChoice choice =
-        computeFirstSecondChoice(
-            pn,
-            routedTo,
-            target,
-            ignoreSelf,
-            minVersion,
-            maxDistance,
-            key,
-            outgoingHTL,
-            ignoreBackoffUnder,
-            isLocal,
-            realTime,
-            now,
-            newLoadManagement,
-            entry);
-    if (choice == null) return best;
-    long until = computeUntil(choice.firstTime, choice.secondTime, st, now);
-    long check =
-        (best == st.closestNotBackedOff)
-            ? Long.MAX_VALUE
-            : checkBackoffsForRecentlyFailed(
-                connectedPeers(),
-                best,
-                target,
-                bestDistance,
-                myLoc,
-                prevLoc,
-                now,
-                entry,
-                outgoingHTL);
-    if (check < until) {
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "Reducing RecentlyFailed from {} ms to {} ms due to wake-up check",
-            until - now,
-            check - now);
-      until = check;
-    }
-    long decidedUntil = decideRecentlyFailedUntil(until, now, key);
-    if (decidedUntil >= 0) {
-      recentlyFailed.fail(decidedUntil);
-      return null;
-    } else {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Not sending RecentlyFailed because will wake up in {}ms", check - now);
-      return best;
-    }
-  }
-
-  private long computeUntil(long firstTime, long secondTime, PeerSelectionState st, long now) {
-    long until = Math.min(secondTime, firstTime);
-    if (st.countWaiting == maxCountWaiting(connectedPeers())) {
-      until = Math.min(until, st.soonestTimeoutWakeup);
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "Recently failed: {}ms",
-            (int) Math.min(Integer.MAX_VALUE, (st.soonestTimeoutWakeup - now)));
-    }
-    return until;
-  }
-
-  private long decideRecentlyFailedUntil(long until, long now, Key key) {
-    if (until <= now + MIN_DELTA) return -1L;
-    if (until > now + FailureTable.RECENTLY_FAILED_TIME) {
-      final long delay = until - now;
-      LOG.atError().addArgument(() -> TimeUtil.formatTime(delay)).log("Wake-up time too long: {}");
-      until = now + FailureTable.RECENTLY_FAILED_TIME;
-    }
-    return node.getFailureTable().hadAnyOffers(key) ? -1L : until;
-  }
-
-  private record FirstSecondChoice(
-      PeerNode first, long firstTime, PeerNode second, long secondTime) {}
-
-  private FirstSecondChoice computeFirstSecondChoice(
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double target,
-      boolean ignoreSelf,
-      int minVersion,
-      double maxDistance,
-      Key key,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      long now,
-      boolean newLoadManagement,
-      TimedOutNodesList entry) {
-    PeerNode first =
-        closerPeer(
-            pn,
-            routedTo,
-            target,
-            ignoreSelf,
-            false,
-            minVersion,
-            null,
-            maxDistance,
-            key,
-            outgoingHTL,
-            ignoreBackoffUnder,
-            isLocal,
-            realTime,
-            null,
-            true,
-            now,
-            newLoadManagement);
-    if (first == null) return null;
-    long firstTime = entry.getTimeoutTime(first, outgoingHTL, now, false);
-    if (firstTime <= now) return null;
-    if (LOG.isDebugEnabled()) LOG.debug("First choice timeout already passed");
-
-    HashSet<PeerNode> newRoutedTo = new HashSet<>(routedTo);
-    newRoutedTo.add(first);
-    PeerNode second =
-        closerPeer(
-            pn,
-            newRoutedTo,
-            target,
-            ignoreSelf,
-            false,
-            minVersion,
-            null,
-            maxDistance,
-            key,
-            outgoingHTL,
-            ignoreBackoffUnder,
-            isLocal,
-            realTime,
-            null,
-            true,
-            now,
-            newLoadManagement);
-    if (second == null) return null;
-    long secondTime = entry.getTimeoutTime(first, outgoingHTL, now, false);
-    if (secondTime <= now) return null;
-    return new FirstSecondChoice(first, firstTime, second, secondTime);
-  }
-
-  private void postSelectionUpdate(
-      PeerNode best,
-      boolean calculateMisrouting,
-      List<Double> addUnpickedLocsTo,
-      PeerSelectionState st) {
-    if (best == null) return;
-    if (calculateMisrouting) {
-      int numberOfConnected = getPeerNodeStatusSize(PEER_NODE_STATUS_CONNECTED, false);
-      int numberOfRoutingBackedOff =
-          getPeerNodeStatusSize(PEER_NODE_STATUS_ROUTING_BACKED_OFF, false);
-      if (numberOfRoutingBackedOff + numberOfConnected > 0)
-        node.getNodeStats()
-            .backedOffPercent
-            .report(
-                (double) numberOfRoutingBackedOff
-                    / (double) (numberOfRoutingBackedOff + numberOfConnected));
-    }
-    if (addUnpickedLocsTo != null
-        && st.closestNotBackedOff != null
-        && st.closestBackedOff != null) {
-      addUnpickedLocsTo.add(st.closestBackedOff.getLocation());
-    }
-  }
-
-  /**
-   * Computes the threshold count of peers waiting due to timeouts.
-   *
-   * @param peers Snapshot of peers to consider when computing the threshold.
-   * @return The minimum number of peers which are waiting for timeouts due to RecentlyFailed or
-   *     DNF's for which we will terminate the request with a RecentlyFailed of our own.
-   */
-  private int maxCountWaiting(PeerNode[] peers) {
-    int count = countConnectedPeers(peers);
-    return Math.clamp(count / 4, 3, 10);
-  }
-
-  static final int MIN_DELTA = 2000;
-
-  /**
-   * Check whether the routing situation will change soon because of a node coming out of backoff or
-   * of a FailureTable timeout.
-   *
-   * <p>If we have routed to a backed off node, or a node due to a failure-table timeout, there is a
-   * good chance that the ideal node will change shortly.
-   *
-   * @return The time at which there will be a different best location to route to for this key, or
-   *     Long.MAX_VALUE if we cannot predict a better peer after any amount of time.
-   */
-  private long checkBackoffsForRecentlyFailed(
-      PeerNode[] peers,
-      PeerNode best,
-      double target,
-      double bestDistance,
-      double myLoc,
-      double prevLoc,
-      long now,
-      TimedOutNodesList entry,
-      short outgoingHTL) {
-    long overallWakeup = Long.MAX_VALUE;
-    Set<Double> excludeLocations =
-        buildExcludeLocations(myLoc, prevLoc, java.util.Collections.emptySet());
-    for (PeerNode p : peers) {
-      long wake =
-          wakeupTimeIfBetterAlternative(
-              p, best, target, bestDistance, outgoingHTL, excludeLocations, now, entry);
-      if (wake == Long.MIN_VALUE) continue; // not eligible / no improvement
-      if (wake > now && wake < overallWakeup) overallWakeup = wake;
-    }
-    return overallWakeup;
-  }
-
-  private long wakeupTimeIfBetterAlternative(
-      PeerNode p,
-      PeerNode best,
-      double target,
-      double bestDistance,
-      short outgoingHTL,
-      Set<Double> excludeLocations,
-      long now,
-      TimedOutNodesList entry) {
-    if (p == best || !p.isRoutable()) return Long.MIN_VALUE;
-    DiffInfo d = computeDiffInfo(p, target, outgoingHTL, excludeLocations);
-    if (d.diff >= bestDistance) return Long.MIN_VALUE;
-    long wakeup = computeWakeupDeadline(entry, outgoingHTL, now, p);
-    if (wakeup <= now) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Better node available during RecentlyFailed check: {}", p);
-      return Long.MIN_VALUE;
-    }
-    if (LOG.isDebugEnabled()) LOG.debug("Peer {} exits backoff/timeout in {} ms", p, wakeup - now);
-    return wakeup;
-  }
-
-  private long computeWakeupDeadline(
-      TimedOutNodesList entry, short outgoingHTL, long now, PeerNode p) {
-    long wakeup = 0L;
-    long timeoutFT = entry.getTimeoutTime(p, outgoingHTL, now, true);
-    long timeoutRF = entry.getTimeoutTime(p, outgoingHTL, now, false);
-    if (timeoutFT > now) wakeup = Math.max(wakeup, timeoutFT);
-    if (timeoutRF > now) wakeup = Math.max(wakeup, timeoutRF);
-    long bulkBackoff = p.getRoutingBackedOffUntilBulk();
-    long rtBackoff = p.getRoutingBackedOffUntilRT();
-    long candidate = Long.MAX_VALUE;
-    if (bulkBackoff > now) candidate = bulkBackoff;
-    if (rtBackoff > now && rtBackoff < candidate) candidate = rtBackoff;
-    if (candidate != Long.MAX_VALUE) wakeup = Math.max(wakeup, candidate);
-    return wakeup;
   }
 
   /**
@@ -1921,19 +279,7 @@ public class PeerManager {
    * @return Multiline string, one line per peer status, sorted lexicographically.
    */
   public String getStatus() {
-    StringBuilder sb = new StringBuilder();
-    PeerNode[] peers = myPeers();
-    String[] status = new String[peers.length];
-    for (int i = 0; i < peers.length; i++) {
-      PeerNode pn = peers[i];
-      status[i] = pn.getStatus(true).toString();
-    }
-    Arrays.sort(status);
-    for (String s : status) {
-      sb.append(s);
-      sb.append('\n');
-    }
-    return sb.toString();
+    return roster.getStatus();
   }
 
   /**
@@ -1942,224 +288,23 @@ public class PeerManager {
    * @return Multiline string with TMCI peer info, sorted.
    */
   public String getTMCIPeerList() {
-    StringBuilder sb = new StringBuilder();
-    PeerNode[] peers = myPeers();
-    String[] peerList = new String[peers.length];
-    for (int i = 0; i < peers.length; i++) {
-      PeerNode pn = peers[i];
-      peerList[i] = pn.getTMCIPeerInfo();
-    }
-    Arrays.sort(peerList);
-    for (String p : peerList) {
-      sb.append(p);
-      sb.append('\n');
-    }
-    return sb.toString();
+    return roster.getTMCIPeerList();
   }
 
-  private final Object writePeersSync = new Object();
-  private final Object writePeerFileSync = new Object();
-
   void writePeers(boolean opennet) {
-    if (opennet) writePeersOpennet();
-    else writePeersDarknet();
+    peerPersistence.writePeers(opennet);
   }
 
   void writePeersUrgent(boolean opennet) {
-    if (opennet) writePeersOpennetUrgent();
-    else writePeersDarknetUrgent();
-  }
-
-  void writePeersOpennetUrgent() {
-    node.getExecutor()
-        .execute(
-            new PrioRunnable() {
-
-              @Override
-              public void run() {
-                writePeersOpennetNow(true);
-              }
-
-              @Override
-              public int getPriority() {
-                return NativeThread.PriorityLevel.HIGH_PRIORITY.value;
-              }
-            });
-  }
-
-  void writePeersDarknetUrgent() {
-    node.getExecutor()
-        .execute(
-            new PrioRunnable() {
-
-              @Override
-              public void run() {
-                writePeersDarknetNow(true);
-              }
-
-              @Override
-              public int getPriority() {
-                return NativeThread.PriorityLevel.HIGH_PRIORITY.value;
-              }
-            });
+    peerPersistence.writePeersUrgent(opennet);
   }
 
   void writePeersDarknet() {
-    shouldWritePeersDarknet = true;
+    peerPersistence.writePeers(false);
   }
 
-  void writePeersOpennet() {
-    shouldWritePeersOpennet = true;
-  }
-
-  protected String getDarknetPeersString() {
-    StringBuilder sb = new StringBuilder();
-    PeerNode[] peers = myPeers();
-    for (PeerNode pn : peers) {
-      if (pn instanceof DarknetPeerNode) sb.append(pn.exportDiskFieldSet().toOrderedString());
-    }
-
-    return sb.toString();
-  }
-
-  protected String getOpennetPeersString() {
-    StringBuilder sb = new StringBuilder();
-    PeerNode[] peers = myPeers();
-    for (PeerNode pn : peers) {
-      if (pn instanceof OpennetPeerNode) sb.append(pn.exportDiskFieldSet().toOrderedString());
-    }
-
-    return sb.toString();
-  }
-
-  protected String getOldOpennetPeersString(OpennetManager om) {
-    StringBuilder sb = new StringBuilder();
-    for (PeerNode pn : om.getOldPeers()) {
-      if (pn instanceof OpennetPeerNode) sb.append(pn.exportDiskFieldSet().toOrderedString());
-    }
-
-    return sb.toString();
-  }
-
-  private static final int BACKUPS_OPENNET = 1;
-  private static final int BACKUPS_DARKNET = 10;
-
-  private void writePeersInnerDarknet(boolean rotateBackups) {
-    String newDarknetPeersString = null;
-    synchronized (writePeersSync) {
-      if (darkFilename != null) newDarknetPeersString = getDarknetPeersString();
-    }
-    synchronized (writePeerFileSync) {
-      if (newDarknetPeersString != null && !newDarknetPeersString.equals(darknetPeersStringCache)) {
-        darknetPeersStringCache = newDarknetPeersString;
-        writePeersInner(darkFilename, darknetPeersStringCache, BACKUPS_DARKNET, rotateBackups);
-      }
-    }
-  }
-
-  private void writePeersInnerOpennet(boolean rotateBackups) {
-    String newOpennetPeersString = null;
-    String newOldOpennetPeersString = null;
-    synchronized (writePeersSync) {
-      OpennetManager om = node.getOpennet();
-      if (om != null) {
-        if (openFilename != null) newOpennetPeersString = getOpennetPeersString();
-        oldOpennetPeersFilename = om.getOldPeersFilename();
-        newOldOpennetPeersString = getOldOpennetPeersString(om);
-      }
-    }
-    synchronized (writePeerFileSync) {
-      if (newOpennetPeersString != null && !newOpennetPeersString.equals(opennetPeersStringCache)) {
-        opennetPeersStringCache = newOpennetPeersString;
-        writePeersInner(openFilename, opennetPeersStringCache, BACKUPS_OPENNET, rotateBackups);
-      }
-      if (newOldOpennetPeersString != null
-          && !newOldOpennetPeersString.equals(oldOpennetPeersStringCache)) {
-        oldOpennetPeersStringCache = newOldOpennetPeersString;
-        writePeersInner(
-            oldOpennetPeersFilename, oldOpennetPeersStringCache, BACKUPS_OPENNET, rotateBackups);
-      }
-    }
-  }
-
-  /**
-   * Write the peers file to disk
-   *
-   * @param rotateBackups If true, rotate backups. If false, just clobber the latest file.
-   */
-  private void writePeersInner(String filename, String sb, int maxBackups, boolean rotateBackups) {
-    assert (maxBackups >= 1);
-    synchronized (writePeerFileSync) {
-      File f;
-      File full = new File(filename).getAbsoluteFile();
-      try {
-        f = File.createTempFile(full.getName() + ".", ".tmp", full.getParentFile());
-      } catch (IOException e2) {
-        LOG.error("Cannot write peers to disk: temp file creation error={}", e2, e2);
-        return;
-      }
-
-      try (FileOutputStream fos = new FileOutputStream(f);
-          OutputStreamWriter w = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
-
-        w.write(sb);
-        w.flush();
-        fos.getFD().sync();
-
-        if (rotateBackups) {
-          rotateBackupFiles(filename, maxBackups, f);
-        } else {
-          FileUtil.moveTo(f, getBackupFilename(filename, 0));
-        }
-      } catch (FileNotFoundException e2) {
-        LOG.error("Cannot write peers to disk: cannot create {} (error={})", f, e2, e2);
-        try {
-          java.nio.file.Files.deleteIfExists(f.toPath());
-        } catch (IOException _) {
-          // best-effort
-        }
-      } catch (IOException e) {
-        LOG.error("I/O error writing peers file: {}", e, e);
-        try {
-          java.nio.file.Files.deleteIfExists(f.toPath());
-        } catch (IOException _) {
-          // best-effort
-        }
-        // don't overwrite old file!
-      } finally {
-        // Try-with-resources handles the stream cleanup
-        try {
-          java.nio.file.Files.deleteIfExists(f.toPath());
-        } catch (IOException _) {
-          // best-effort
-        }
-      }
-    }
-  }
-
-  private void rotateBackupFiles(String filename, int maxBackups, File newFile) {
-    File prevFile = null;
-    for (int i = maxBackups; i >= 0; i--) {
-      File thisFile = getBackupFilename(filename, i);
-      if (prevFile == null) {
-        try {
-          java.nio.file.Files.deleteIfExists(thisFile.toPath());
-        } catch (IOException _) {
-          // best-effort
-        }
-      } else if (thisFile.exists()) {
-        FileUtil.moveTo(thisFile, prevFile);
-      }
-      prevFile = thisFile;
-    }
-    if (prevFile == null) prevFile = getBackupFilename(filename, 0);
-    FileUtil.moveTo(newFile, prevFile);
-  }
-
-  private File getBackupFilename(String filename, int i) {
-    if (i == 0) return new File(filename);
-    if (i == 1) return new File(filename + ".bak");
-    return new File(filename + ".bak." + i);
+  void writePeersDarknetUrgent() {
+    peerPersistence.writePeersUrgent(false);
   }
 
   /**
@@ -2167,54 +312,7 @@ public class PeerManager {
    * onConnectedPeers() method if applicable. LOCKING: Do not call inside PeerNode lock.
    */
   public void updatePMUserAlert() {
-    if (ua == null) return;
-    int peers;
-    int darknetPeers;
-    int opennetPeers;
-    synchronized (this) {
-      darknetPeers = this.getDarknetPeers().length;
-      opennetPeers = this.getOpennetPeers().length;
-      peers = darknetPeers + opennetPeers; // Seednodes don't count.
-    }
-    OpennetManager om = node.getOpennet();
-
-    boolean opennetDefinitelyPortForwarded;
-    boolean opennetEnabled;
-    boolean opennetAssumeNAT;
-    if (om != null) {
-      opennetEnabled = true;
-      opennetDefinitelyPortForwarded = om.getCrypto().definitelyPortForwarded();
-      opennetAssumeNAT = om.getCrypto().getConfig().alwaysHandshakeAggressively();
-    } else {
-      opennetEnabled = false;
-      opennetDefinitelyPortForwarded = false;
-      opennetAssumeNAT = false;
-    }
-    boolean darknetDefinitelyPortForwarded = node.darknetDefinitelyPortForwarded();
-    boolean darknetAssumeNAT = node.getDarknetCrypto().getConfig().alwaysHandshakeAggressively();
-    synchronized (uaLock) {
-      ua.setOpennetDefinitelyPortForwarded(opennetDefinitelyPortForwarded);
-      ua.setDarknetDefinitelyPortForwarded(darknetDefinitelyPortForwarded);
-      ua.setOpennetAssumeNAT(opennetAssumeNAT);
-      ua.setDarknetAssumeNAT(darknetAssumeNAT);
-      int darknetConnsVal =
-          getPeerNodeStatusSize(PEER_NODE_STATUS_CONNECTED, true)
-              + getPeerNodeStatusSize(PEER_NODE_STATUS_ROUTING_BACKED_OFF, true);
-      ua.setDarknetConns(darknetConnsVal);
-      ua.setConns(
-          getPeerNodeStatusSize(PEER_NODE_STATUS_CONNECTED, false)
-              + getPeerNodeStatusSize(PEER_NODE_STATUS_ROUTING_BACKED_OFF, false));
-      ua.setDarknetPeers(darknetPeers);
-      ua.setDisconnDarknetPeers(darknetPeers - darknetConnsVal);
-      ua.setPeers(peers);
-      ua.setNeverConn(getPeerNodeStatusSize(PEER_NODE_STATUS_NEVER_CONNECTED, true));
-      ua.setClockProblem(getPeerNodeStatusSize(PEER_NODE_STATUS_CLOCK_PROBLEM, false));
-      ua.setConnError(getPeerNodeStatusSize(PEER_NODE_STATUS_CONN_ERROR, true));
-      ua.setOpennetEnabled(opennetEnabled);
-      ua.setTooNewPeersDarknet(getPeerNodeStatusSize(PEER_NODE_STATUS_TOO_NEW, true));
-      ua.setTooNewPeersTotal(getPeerNodeStatusSize(PEER_NODE_STATUS_TOO_NEW, false));
-    }
-    if (anyConnectedPeers()) node.onConnectedPeer();
+    alertCoordinator.update();
   }
 
   /**
@@ -2223,11 +321,7 @@ public class PeerManager {
    * @return {@code true} if at least one connected peer is routable; otherwise {@code false}.
    */
   public boolean anyConnectedPeers() {
-    PeerNode[] conns = connectedPeers();
-    for (PeerNode conn : conns) {
-      if (conn.isRoutable()) return true;
-    }
-    return false;
+    return roster.anyConnectedPeers();
   }
 
   /**
@@ -2236,30 +330,18 @@ public class PeerManager {
    * @return {@code true} when a darknet peer is connected; otherwise {@code false}.
    */
   public boolean anyDarknetPeers() {
-    PeerNode[] conns = connectedPeers();
-    for (PeerNode p : conns) if (p.isDarknet()) return true;
-    return false;
+    return roster.anyDarknetPeers();
   }
 
   /** Ask each PeerNode to read in its extra peer data */
   public void readExtraPeerData() {
-    DarknetPeerNode[] peers = getDarknetPeers();
-    for (DarknetPeerNode peer : peers) {
-      try {
-        peer.readExtraPeerData();
-      } catch (Exception e) {
-        LOG.error("Error reading extra peer data", e);
-      }
-    }
-    LOG.info("Extra peer data reading and processing completed");
+    roster.readExtraPeerData();
   }
 
   /** Initializes user alerts and schedules the first peer persistence write. */
   public void start() {
-    ua = new PeerManagerUserAlert(node.getNodeStats(), node.getNodeUpdater());
-    updatePMUserAlert();
-    node.getClientCore().getAlerts().register(ua);
-    node.getTicker().queueTimedJob(writePeersRunnable, 0);
+    alertCoordinator.start();
+    peerPersistence.scheduleInitialWrite();
   }
 
   /**
@@ -2269,205 +351,28 @@ public class PeerManager {
    * @return Number of connected peers not backed off.
    */
   public int countNonBackedOffPeers(boolean realTime) {
-    PeerNode[] peers = connectedPeers();
-    // even if myPeers peers are connected they won't be routed to
-    int countNoBackoff = 0;
-    for (PeerNode peer : peers) {
-      if (peer.isRoutable() && !peer.isRoutingBackedOff(realTime)) countNoBackoff++;
-    }
-    return countNoBackoff;
+    return roster.countNonBackedOffPeers(realTime);
   }
 
   // Stats stuff
   /** Update oldestNeverConnectedPeerAge if the timer has expired */
   public void maybeUpdateOldestNeverConnectedDarknetPeerAge(long now) {
-    PeerNode[] peerList;
-    synchronized (this) {
-      if (now <= nextOldestNeverConnectedDarknetPeerAgeUpdateTime) return;
-      nextOldestNeverConnectedDarknetPeerAgeUpdateTime =
-          now + OLDEST_NEVER_CONNECTED_DARKNET_PEER_AGE_UPDATE_INTERVAL;
-      peerList = myPeers;
-    }
-    oldestNeverConnectedDarknetPeerAge = 0;
-    for (PeerNode pn : peerList) {
-      if (!pn.isDarknet()) continue;
-      if (pn.getPeerNodeStatus() == PEER_NODE_STATUS_NEVER_CONNECTED
-          && (now - pn.getPeerAddedTime()) > oldestNeverConnectedDarknetPeerAge) {
-        oldestNeverConnectedDarknetPeerAge = now - pn.getPeerAddedTime();
-      }
-    }
-    if (oldestNeverConnectedDarknetPeerAge > 0 && LOG.isDebugEnabled())
-      LOG.debug("Oldest never connected peer is {}ms old", oldestNeverConnectedDarknetPeerAge);
-    nextOldestNeverConnectedDarknetPeerAgeUpdateTime =
-        now + OLDEST_NEVER_CONNECTED_DARKNET_PEER_AGE_UPDATE_INTERVAL;
+    statusBook.maybeUpdateOldestNeverConnectedDarknetPeerAge(now);
   }
 
   public long getOldestNeverConnectedDarknetPeerAge() {
-    return oldestNeverConnectedDarknetPeerAge;
+    return statusBook.getOldestNeverConnectedDarknetPeerAge();
   }
 
   /** Log the current PeerNode status summary if the timer has expired */
   public void maybeLogPeerNodeStatusSummary(long now) {
-    if (!shouldLogPeerStatus(now)) return;
-    PeerNode[] peers = this.myPeers();
-    PeerStatusSummary s = computePeerStatusSummary(peers);
-    logPeerStatusSummary(s);
-    nextPeerNodeStatusLogTime = now + PEER_NODE_STATUS_LOG_INTERVAL;
-  }
-
-  private boolean shouldLogPeerStatus(long now) {
-    if (now <= nextPeerNodeStatusLogTime) return false;
-    if ((now - nextPeerNodeStatusLogTime) > SECONDS.toMillis(10) && nextPeerNodeStatusLogTime > 0)
-      LOG.error(
-          "PeerNode status summary late by {} ms; PacketSender may be congested",
-          now - nextPeerNodeStatusLogTime);
-    return true;
-  }
-
-  private record PeerStatusSummary(
-      int connected,
-      int routingBackedOff,
-      int tooNew,
-      int tooOld,
-      int disconnected,
-      int neverConnected,
-      int disabled,
-      int bursting,
-      int listening,
-      int listenOnly,
-      int clockProblem,
-      int connError,
-      int disconnecting,
-      int routingDisabled,
-      int noLoadStats) {}
-
-  private PeerStatusSummary computePeerStatusSummary(PeerNode[] peers) {
-    int numberOfConnected = 0;
-    int numberOfRoutingBackedOff = 0;
-    int numberOfTooNew = 0;
-    int numberOfTooOld = 0;
-    int numberOfDisconnected = 0;
-    int numberOfNeverConnected = 0;
-    int numberOfDisabled = 0;
-    int numberOfListenOnly = 0;
-    int numberOfListening = 0;
-    int numberOfBursting = 0;
-    int numberOfClockProblem = 0;
-    int numberOfConnError = 0;
-    int numberOfDisconnecting = 0;
-    int numberOfRoutingDisabled = 0;
-    int numberOfNoLoadStats = 0;
-
-    for (PeerNode peer : peers) {
-      if (peer == null) {
-        LOG.error("Peer status list contains null entry");
-        continue;
-      }
-      int status = peer.getPeerNodeStatus();
-      switch (status) {
-        case PEER_NODE_STATUS_CONNECTED:
-          numberOfConnected++;
-          break;
-        case PEER_NODE_STATUS_ROUTING_BACKED_OFF:
-          numberOfRoutingBackedOff++;
-          break;
-        case PEER_NODE_STATUS_TOO_NEW:
-          numberOfTooNew++;
-          break;
-        case PEER_NODE_STATUS_TOO_OLD:
-          numberOfTooOld++;
-          break;
-        case PEER_NODE_STATUS_DISCONNECTED:
-          numberOfDisconnected++;
-          break;
-        case PEER_NODE_STATUS_NEVER_CONNECTED:
-          numberOfNeverConnected++;
-          break;
-        case PEER_NODE_STATUS_DISABLED:
-          numberOfDisabled++;
-          break;
-        case PEER_NODE_STATUS_LISTEN_ONLY:
-          numberOfListenOnly++;
-          break;
-        case PEER_NODE_STATUS_LISTENING:
-          numberOfListening++;
-          break;
-        case PEER_NODE_STATUS_BURSTING:
-          numberOfBursting++;
-          break;
-        case PEER_NODE_STATUS_CLOCK_PROBLEM:
-          numberOfClockProblem++;
-          break;
-        case PEER_NODE_STATUS_CONN_ERROR:
-          numberOfConnError++;
-          break;
-        case PEER_NODE_STATUS_DISCONNECTING:
-          numberOfDisconnecting++;
-          break;
-        case PEER_NODE_STATUS_ROUTING_DISABLED:
-          numberOfRoutingDisabled++;
-          break;
-        case PEER_NODE_STATUS_NO_LOAD_STATS:
-          numberOfNoLoadStats++;
-          break;
-        default:
-          LOG.error("Unknown peer status value: {}", status);
-          break;
-      }
-    }
-    return new PeerStatusSummary(
-        numberOfConnected,
-        numberOfRoutingBackedOff,
-        numberOfTooNew,
-        numberOfTooOld,
-        numberOfDisconnected,
-        numberOfNeverConnected,
-        numberOfDisabled,
-        numberOfBursting,
-        numberOfListening,
-        numberOfListenOnly,
-        numberOfClockProblem,
-        numberOfConnError,
-        numberOfDisconnecting,
-        numberOfRoutingDisabled,
-        numberOfNoLoadStats);
-  }
-
-  private void logPeerStatusSummary(PeerStatusSummary s) {
-    LOG.info(
-        "Connected={} RoutingBackedOff={} TooNew={} TooOld={} Disconnected={} NeverConnected={}"
-            + " Disabled={} Bursting={} Listening={} ListenOnly={} ClockProblem={}"
-            + " ConnectionProblem={} Disconnecting={} RoutingDisabled={} NoLoadStats={}",
-        s.connected,
-        s.routingBackedOff,
-        s.tooNew,
-        s.tooOld,
-        s.disconnected,
-        s.neverConnected,
-        s.disabled,
-        s.bursting,
-        s.listening,
-        s.listenOnly,
-        s.clockProblem,
-        s.connError,
-        s.disconnecting,
-        s.routingDisabled,
-        s.noLoadStats);
+    statusBook.maybeLogPeerNodeStatusSummary(now);
   }
 
   public void changePeerNodeStatus(
       PeerNode peerNode, int oldPeerNodeStatus, int peerNodeStatus, boolean noLog) {
-    this.allPeersStatuses.changePeerNodeStatus(peerNode, oldPeerNodeStatus, peerNodeStatus, noLog);
-    if (!peerNode.isOpennet())
-      this.darknetPeersStatuses.changePeerNodeStatus(
-          peerNode, oldPeerNodeStatus, peerNodeStatus, noLog);
+    statusBook.changePeerNodeStatus(peerNode, oldPeerNodeStatus, peerNodeStatus, noLog);
     node.getExecutor().execute(this::updatePMUserAlert);
-  }
-
-  /** Add a PeerNode status to the map. Used internally when a peer is added. */
-  private void addPeerNodeStatus(int pnStatus, PeerNode peerNode) {
-    this.allPeersStatuses.addStatus(pnStatus, peerNode, false);
-    if (!peerNode.isOpennet()) this.darknetPeersStatuses.addStatus(pnStatus, peerNode, false);
   }
 
   /**
@@ -2476,19 +381,7 @@ public class PeerManager {
    * @param darknet If true, only count darknet nodes, if false, count all nodes.
    */
   public int getPeerNodeStatusSize(int pnStatus, boolean darknet) {
-    if (darknet) return darknetPeersStatuses.statusSize(pnStatus);
-    else return allPeersStatuses.statusSize(pnStatus);
-  }
-
-  /**
-   * Removes a PeerNode status from the map when a peer is removed.
-   *
-   * @param pnStatus Status code being removed.
-   * @param peerNode Peer whose status is being removed.
-   */
-  private void removePeerNodeStatus(int pnStatus, PeerNode peerNode) {
-    this.allPeersStatuses.removeStatus(pnStatus, peerNode, false);
-    if (!peerNode.isOpennet()) this.darknetPeersStatuses.removeStatus(pnStatus, peerNode, false);
+    return statusBook.getPeerNodeStatusSize(pnStatus, darknet);
   }
 
   /** Add a PeerNode routing backoff reason to the map */
@@ -2502,79 +395,24 @@ public class PeerManager {
           new Exception("error"));
       return;
     }
-    PeerStatusTracker<String> peerNodeRoutingBackoffReasons =
-        realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
-    peerNodeRoutingBackoffReasons.addStatus(peerNodeRoutingBackoffReason, peerNode, false);
+    statusBook.addPeerNodeRoutingBackoffReason(peerNodeRoutingBackoffReason, peerNode, realTime);
   }
 
   /** What are the currently tracked PeerNode routing backoff reasons? */
   public String[] getPeerNodeRoutingBackoffReasons(boolean realTime) {
-    ArrayList<String> list = new ArrayList<>();
-    PeerStatusTracker<String> peerNodeRoutingBackoffReasons =
-        realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
-    peerNodeRoutingBackoffReasons.addStatusList(list);
-    return list.toArray(new String[0]);
+    return statusBook.getPeerNodeRoutingBackoffReasons(realTime);
   }
 
   /** How many PeerNodes have a particular routing backoff reason? */
   public int getPeerNodeRoutingBackoffReasonSize(
       String peerNodeRoutingBackoffReason, boolean realTime) {
-    PeerStatusTracker<String> peerNodeRoutingBackoffReasons =
-        realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
-    return peerNodeRoutingBackoffReasons.statusSize(peerNodeRoutingBackoffReason);
+    return statusBook.getPeerNodeRoutingBackoffReasonSize(peerNodeRoutingBackoffReason, realTime);
   }
 
   /** Remove a PeerNode routing backoff reason from the map */
   public void removePeerNodeRoutingBackoffReason(
       String peerNodeRoutingBackoffReason, PeerNode peerNode, boolean realTime) {
-    PeerStatusTracker<String> peerNodeRoutingBackoffReasons =
-        realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
-    peerNodeRoutingBackoffReasons.removeStatus(peerNodeRoutingBackoffReason, peerNode, false);
-  }
-
-  /**
-   * Returns a snapshot of statuses for all peers.
-   *
-   * @param noHeavy If true, skip expensive computations.
-   * @return Array of peer statuses.
-   */
-  public PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
-    PeerNode[] peers = myPeers();
-    PeerNodeStatus[] peerNodeStatuses = new PeerNodeStatus[peers.length];
-    for (int peerIndex = 0, peerCount = peers.length; peerIndex < peerCount; peerIndex++) {
-      peerNodeStatuses[peerIndex] = peers[peerIndex].getStatus(noHeavy);
-    }
-    return peerNodeStatuses;
-  }
-
-  /**
-   * Returns a snapshot of statuses for darknet peers.
-   *
-   * @param noHeavy If true, skip expensive computations.
-   * @return Array of darknet peer statuses.
-   */
-  public DarknetPeerNodeStatus[] getDarknetPeerNodeStatuses(boolean noHeavy) {
-    DarknetPeerNode[] peers = getDarknetPeers();
-    DarknetPeerNodeStatus[] peerNodeStatuses = new DarknetPeerNodeStatus[peers.length];
-    for (int peerIndex = 0, peerCount = peers.length; peerIndex < peerCount; peerIndex++) {
-      peerNodeStatuses[peerIndex] = (DarknetPeerNodeStatus) peers[peerIndex].getStatus(noHeavy);
-    }
-    return peerNodeStatuses;
-  }
-
-  /**
-   * Returns a snapshot of statuses for opennet peers.
-   *
-   * @param noHeavy If true, skip expensive computations.
-   * @return Array of opennet peer statuses.
-   */
-  public OpennetPeerNodeStatus[] getOpennetPeerNodeStatuses(boolean noHeavy) {
-    OpennetPeerNode[] peers = getOpennetPeers();
-    OpennetPeerNodeStatus[] peerNodeStatuses = new OpennetPeerNodeStatus[peers.length];
-    for (int peerIndex = 0, peerCount = peers.length; peerIndex < peerCount; peerIndex++) {
-      peerNodeStatuses[peerIndex] = (OpennetPeerNodeStatus) peers[peerIndex].getStatus(noHeavy);
-    }
-    return peerNodeStatuses;
+    statusBook.removePeerNodeRoutingBackoffReason(peerNodeRoutingBackoffReason, peerNode, realTime);
   }
 
   /**
@@ -2583,154 +421,19 @@ public class PeerManager {
    * <p>Increments sampling counters that feed routing-health statistics.
    */
   public void maybeUpdatePeerNodeRoutableConnectionStats(long now) {
-    PeerNode[] peersToUpdate = prepareRoutableStatsUpdate(now);
-    if (peersToUpdate.length == 0) return;
-    updatePeerNodeRoutableConnectionStats(peersToUpdate);
-  }
-
-  private void updatePeerNodeRoutableConnectionStats(PeerNode[] peerList) {
-    for (PeerNode pn : peerList) {
-      pn.checkRoutableConnectionStatus();
-    }
-  }
-
-  private PeerNode[] prepareRoutableStatsUpdate(long now) {
-    synchronized (this) {
-      if (now <= nextRoutableConnectionStatsUpdateTime) return new PeerNode[0];
-      nextRoutableConnectionStatsUpdateTime = now + ROUTABLE_CONNECTION_STATS_UPDATE_INTERVAL;
-      return myPeers;
-    }
-  }
-
-  /** Get the darknet peers list. Note: consider optimizing */
-  public DarknetPeerNode[] getDarknetPeers() {
-    PeerNode[] peers = myPeers();
-    // Note: consider optimizing by maintaining a separate list
-    List<DarknetPeerNode> v = new ArrayList<>(peers.length);
-    for (PeerNode peer : peers) {
-      if (peer instanceof DarknetPeerNode dnp) v.add(dnp);
-    }
-    return v.toArray(new DarknetPeerNode[0]);
-  }
-
-  /**
-   * Returns connected seed-server peers, excluding specified public key hashes.
-   *
-   * @param exclude Set of public key hashes to exclude (optional; may be {@code null}).
-   * @return List of connected seed-server peers.
-   */
-  public List<SeedServerPeerNode> getConnectedSeedServerPeersVector(Set<ByteArrayWrapper> exclude) {
-    PeerNode[] peers = myPeers();
-    ArrayList<SeedServerPeerNode> v = new ArrayList<>(peers.length);
-    for (PeerNode p : peers) {
-      if (p instanceof SeedServerPeerNode sspn && !shouldSkipSeedServerPeer(sspn, exclude)) {
-        v.add(sspn);
-      }
-    }
-    return v;
-  }
-
-  private boolean shouldSkipSeedServerPeer(SeedServerPeerNode sspn, Set<ByteArrayWrapper> exclude) {
-    if (exclude != null && exclude.contains(new ByteArrayWrapper(sspn.getPubKeyHash()))) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Excluded by filter (exclude set): {}", sspn.userToString());
-      return true;
-    }
-    if (!sspn.isConnected()) {
-      if (LOG.isDebugEnabled()) LOG.debug("Excluded; disconnected: {}", sspn.userToString());
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * Returns a snapshot of all seed-server peers (copy), connected or not.
-   *
-   * @return List of seed-server peers.
-   */
-  public List<SeedServerPeerNode> getSeedServerPeersVector() {
-    PeerNode[] peers = myPeers();
-    // Note: consider optimizing by maintaining a separate list
-    List<SeedServerPeerNode> v = new ArrayList<>(peers.length);
-    for (PeerNode peer : peers) {
-      if (peer instanceof SeedServerPeerNode peerNode) v.add(peerNode);
-    }
-    return v;
-  }
-
-  /** Get the opennet peers list. */
-  public OpennetPeerNode[] getOpennetPeers() {
-    PeerNode[] peers = myPeers();
-    // Note: consider optimizing by maintaining a separate list
-    List<OpennetPeerNode> v = new ArrayList<>(peers.length);
-    for (PeerNode peer : peers) {
-      if (peer instanceof OpennetPeerNode onp) v.add(onp);
-    }
-    return v.toArray(new OpennetPeerNode[0]);
-  }
-
-  /**
-   * Returns a snapshot of opennet and seed-server peers (copy).
-   *
-   * @return Array containing both opennet and seed-server peers.
-   */
-  public PeerNode[] getOpennetAndSeedServerPeers() {
-    PeerNode[] peers = myPeers();
-    // Note: consider optimizing by maintaining a separate list
-    ArrayList<PeerNode> v = new ArrayList<>(peers.length);
-    for (PeerNode peer : peers) {
-      if (peer instanceof OpennetPeerNode || peer instanceof SeedServerPeerNode) v.add(peer);
-    }
-    return v.toArray(new PeerNode[0]);
-  }
-
-  /**
-   * Checks whether any other connected real peer has the given address.
-   *
-   * @param addr Address to match.
-   * @param pn Peer to exclude from the check.
-   * @return {@code true} if a matching peer exists; otherwise {@code false}.
-   */
-  public boolean anyConnectedPeerHasAddress(FreenetInetAddress addr, PeerNode pn) {
-    PeerNode[] peers = myPeers();
-    for (PeerNode p : peers) {
-      boolean skip =
-          (p == pn)
-              || !p.isConnected()
-              || !p.isRealConnection()
-              || (p.isDarknet() && !pn.isDarknet());
-      if (skip) continue;
-      // If getPeer() is null then presumably !isConnected().
-      if (p.getPeer().getFreenetAddress().equals(addr)) return true;
-    }
-    return false;
+    statusBook.maybeUpdatePeerNodeRoutableConnectionStats(now);
   }
 
   /** Removes all opennet peers from the manager and updates alerts/listeners. */
   public void removeOpennetPeers() {
-    synchronized (this) {
-      ArrayList<PeerNode> keep = new ArrayList<>();
-      ArrayList<PeerNode> conn = new ArrayList<>();
-      for (PeerNode pn : myPeers) {
-        if (pn instanceof OpennetPeerNode) continue;
-        keep.add(pn);
-        if (pn.isConnected()) conn.add(pn);
-      }
-      myPeers = keep.toArray(new PeerNode[0]);
-      connectedPeers = keep.toArray(new PeerNode[conn.size()]);
-    }
+    roster.removeOpennetPeers();
     updatePMUserAlert();
     notifyPeerStatusChangeListeners();
   }
 
   @SuppressWarnings("unused")
   public PeerNode containsPeer(PeerNode pn) {
-    PeerNode[] peers = pn.isOpennet() ? getOpennetAndSeedServerPeers() : getDarknetPeers();
-
-    for (PeerNode peer : peers)
-      if (Arrays.equals(pn.getPubKeyHash(), peer.getPubKeyHash())) return peer;
-
-    return null;
+    return roster.containsPeer(pn);
   }
 
   /**
@@ -2739,15 +442,7 @@ public class PeerManager {
    * @return Number of connected darknet peers.
    */
   public int countConnectedDarknetPeers() {
-    int count = 0;
-    PeerNode[] peers = myPeers();
-    for (PeerNode peer : peers) {
-      if ((peer instanceof DarknetPeerNode) && !peer.isOpennet() && peer.isRoutable()) {
-        count++;
-      }
-    }
-    if (LOG.isDebugEnabled()) LOG.debug("countConnectedDarknetPeers() returning {}", count);
-    return count;
+    return roster.countConnectedDarknetPeers();
   }
 
   /**
@@ -2756,15 +451,7 @@ public class PeerManager {
    * @return Number of connected routable peers.
    */
   public int countConnectedPeers() {
-    return countConnectedPeers(myPeers());
-  }
-
-  private int countConnectedPeers(PeerNode[] peers) {
-    int count = 0;
-    for (PeerNode peer : peers) {
-      if (peer != null && peer.isRoutable()) count++;
-    }
-    return count;
+    return roster.countConnectedPeers();
   }
 
   /**
@@ -2773,14 +460,7 @@ public class PeerManager {
    * @return Number of connected darknet peers.
    */
   public int countAlmostConnectedDarknetPeers() {
-    int count = 0;
-    PeerNode[] peers = myPeers();
-    for (PeerNode peer : peers) {
-      if ((peer instanceof DarknetPeerNode) && !peer.isOpennet() && peer.isConnected()) {
-        count++;
-      }
-    }
-    return count;
+    return roster.countAlmostConnectedDarknetPeers();
   }
 
   /**
@@ -2789,17 +469,7 @@ public class PeerManager {
    * @return Number of compatible darknet peers.
    */
   public int countCompatibleDarknetPeers() {
-    int count = 0;
-    PeerNode[] peers = myPeers();
-    for (PeerNode peer : peers) {
-      if ((peer instanceof DarknetPeerNode)
-          && !peer.isOpennet()
-          && peer.isConnected()
-          && peer.isRoutingCompatible()) {
-        count++;
-      }
-    }
-    return count;
+    return roster.countCompatibleDarknetPeers();
   }
 
   /**
@@ -2808,17 +478,7 @@ public class PeerManager {
    * @return Number of compatible real peers.
    */
   public int countCompatibleRealPeers() {
-    int count = 0;
-    PeerNode[] peers = myPeers();
-    for (PeerNode peer : peers) {
-      if (peer != null
-          && peer.isRealConnection()
-          && peer.isConnected()
-          && peer.isRoutingCompatible()) {
-        count++;
-      }
-    }
-    return count;
+    return roster.countCompatibleRealPeers();
   }
 
   /**
@@ -2827,14 +487,7 @@ public class PeerManager {
    * @return Number of connected opennet peers.
    */
   public int countConnectedOpennetPeers() {
-    int count = 0;
-    PeerNode[] peers = connectedPeers();
-    for (PeerNode peer : peers) {
-      if ((peer instanceof OpennetPeerNode) && peer.isRoutable()) {
-        count++;
-      }
-    }
-    return count;
+    return roster.countConnectedOpennetPeers();
   }
 
   /**
@@ -2842,12 +495,7 @@ public class PeerManager {
    * etc.
    */
   public int countValidPeers() {
-    PeerNode[] peers = myPeers();
-    int count = 0;
-    for (PeerNode peer : peers) {
-      if (peer.isRealConnection() && !peer.isDisabled()) count++;
-    }
-    return count;
+    return roster.countValidPeers();
   }
 
   /**
@@ -2855,14 +503,7 @@ public class PeerManager {
    * etc.
    */
   public int countConnectiblePeers() {
-    PeerNode[] peers = myPeers();
-    int count = 0;
-    for (PeerNode peer : peers) {
-      boolean isListenOnlyDarknet =
-          (peer instanceof DarknetPeerNode peerNode) && peerNode.isListenOnly();
-      if (!peer.isDisabled() && !isListenOnlyDarknet) count++;
-    }
-    return count;
+    return roster.countConnectiblePeers();
   }
 
   /**
@@ -2871,11 +512,7 @@ public class PeerManager {
    * @return Number of seed nodes.
    */
   public int countSeednodes() {
-    int count = 0;
-    for (PeerNode peer : myPeers()) {
-      if (peer instanceof SeedServerPeerNode || peer instanceof SeedClientPeerNode) count++;
-    }
-    return count;
+    return roster.countSeednodes();
   }
 
   /**
@@ -2885,13 +522,7 @@ public class PeerManager {
    * @return Number of peers in backoff.
    */
   public int countBackedOffPeers(boolean realTime) {
-    PeerNode[] peers = myPeers();
-    int count = 0;
-    for (PeerNode peer : peers) {
-      if (peer.isRealConnection() && !peer.isDisabled() && peer.isRoutingBackedOff(realTime))
-        count++;
-    }
-    return count;
+    return roster.countBackedOffPeers(realTime);
   }
 
   /**
@@ -2901,23 +532,18 @@ public class PeerManager {
    * @return Matching peer or {@code null}.
    */
   public PeerNode getByPubKeyHash(byte[] pkHash) {
-    PeerNode[] peers = myPeers();
-    for (PeerNode peer : peers) {
-      if (Arrays.equals(peer.peerECDSAPubKeyHash, pkHash)) return peer;
-    }
-    return null;
+    return roster.getByPubKeyHash(pkHash);
   }
 
   void incrementSelectionSamples(PeerNode pn) {
-    // Note: consider reimplementing with a bit field to reduce memory usage
-    pn.incrementNumberOfSelections();
+    roster.incrementSelectionSamples(pn);
   }
 
   /** Notifies the listeners about status change */
   private void notifyPeerStatusChangeListeners() {
     for (PeerStatusChangeListener l : listeners) {
       l.onPeerStatusChange();
-      for (PeerNode pn : myPeers()) {
+      for (PeerNode pn : roster.myPeers()) {
         pn.registerPeerNodeStatusChangeListener(l);
       }
     }
@@ -2930,7 +556,7 @@ public class PeerManager {
    */
   public void addPeerStatusChangeListener(PeerStatusChangeListener listener) {
     listeners.add(listener);
-    for (PeerNode pn : myPeers()) {
+    for (PeerNode pn : roster.myPeers()) {
       pn.registerPeerNodeStatusChangeListener(listener);
     }
   }
@@ -2957,7 +583,7 @@ public class PeerManager {
    * node/ should use the copying getters (which are a little more expensive).
    */
   synchronized PeerNode[] myPeers() {
-    return myPeers;
+    return roster.myPeers();
   }
 
   /**
@@ -2968,7 +594,7 @@ public class PeerManager {
    * they use a copying method? I'm not sure how reliable updating of connectedPeers is ...
    */
   synchronized PeerNode[] connectedPeers() {
-    return connectedPeers;
+    return roster.connectedPeers();
   }
 
   /**
@@ -2976,12 +602,7 @@ public class PeerManager {
    * you should not call this if holding lots of locks!
    */
   public int countByStatus(int status) {
-    int count = 0;
-    PeerNode[] peers = myPeers();
-    for (PeerNode peer : peers) {
-      if (peer.getPeerNodeStatus() == status) count++;
-    }
-    return count;
+    return roster.countByStatus(status);
   }
 
   // We can't trust our strangers, so need a consensus.

--- a/src/main/java/network/crypta/node/PeerMessenger.java
+++ b/src/main/java/network/crypta/node/PeerMessenger.java
@@ -10,7 +10,32 @@ import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Handles peer messaging and disconnect workflows for {@link PeerManager}. */
+/**
+ * Coordinates outbound peer messaging and disconnect workflows for {@link PeerManager}.
+ *
+ * <p>This helper centralizes the common patterns used when disconnecting a {@link PeerNode} and
+ * when broadcasting local messages to connected peers. Typical usage is from the owning {@link
+ * Node} or {@link PeerManager} to either send protocol disconnect messages, schedule disconnect
+ * timeouts, or deliver node-to-node messages to eligible peers.
+ *
+ * <p>Notable behaviors include deferring removal until an acknowledgment (when requested),
+ * recording disconnect traffic with a dedicated {@link ByteCounter}, and filtering broadcast
+ * targets by routability, connection type, and build number. Timeouts are scheduled through the
+ * node ticker and only apply to non-seed peers.
+ *
+ * <p>Thread-safety: this class does not introduce additional synchronization. Callers must respect
+ * {@link PeerManager} and {@link PeerNode} concurrency requirements when invoking its methods.
+ *
+ * <ul>
+ *   <li>Disconnects may be immediate, acknowledged, or timeout-driven.
+ *   <li>Broadcasts are best-effort; disconnected peers are skipped.
+ *   <li>Removals optionally trigger urgent peer persistence writes.
+ * </ul>
+ *
+ * @see PeerManager
+ * @see PeerNode
+ * @see Node
+ */
 public class PeerMessenger {
   private static final Logger LOG = LoggerFactory.getLogger(PeerMessenger.class);
 
@@ -40,7 +65,16 @@ public class PeerMessenger {
     this.peerManager = peerManager;
   }
 
-  /** Returns the byte counter used for disconnect traffic. */
+  /**
+   * Returns the byte counter used for disconnect traffic accounting.
+   *
+   * <p>The returned counter reports received and sent disconnect bytes into {@link NodeStats},
+   * allowing disconnect message overhead to be tracked separately from normal traffic. The counter
+   * is owned by this instance and should be treated as read-only by callers; it is safe to reuse
+   * for multiple disconnect sends.
+   *
+   * @return the shared counter that attributes disconnect bytes to node statistics.
+   */
   public ByteCounter getDisconnCounter() {
     return disconnCounter;
   }
@@ -48,10 +82,15 @@ public class PeerMessenger {
   /**
    * Disconnects a peer and removes it from the routing table.
    *
-   * @param pn Peer to disconnect.
-   * @param sendDisconnectMessage If true, send a protocol disconnect message.
-   * @param waitForAck If true, wait for the disconnect acknowledgment before removal.
-   * @param purge If true, request the remote to purge this node from old-peer state.
+   * <p>This is a convenience wrapper that requests a disconnect message and removal using the
+   * default inactivity timeout. Removal can be immediate or deferred until an acknowledgment,
+   * depending on the {@code waitForAck} flag. If the peer is already disconnecting, the call is a
+   * no-op.
+   *
+   * @param pn peer to disconnect; must be non-null and known.
+   * @param sendDisconnectMessage whether to send the protocol disconnect message.
+   * @param waitForAck whether to wait for disconnect acknowledgment before removal.
+   * @param purge whether to request remote purge of old-peer state.
    */
   public void disconnectAndRemove(
       PeerNode pn, boolean sendDisconnectMessage, boolean waitForAck, boolean purge) {
@@ -61,14 +100,23 @@ public class PeerMessenger {
   /**
    * Disconnects from a specified node.
    *
-   * @param pn Peer to disconnect.
-   * @param sendDisconnectMessage If false, do not send the protocol disconnect message.
-   * @param waitForAck If false, do not wait for the disconnect acknowledgment.
-   * @param purge If true, request the remote to purge this node from old-peer lists.
-   * @param dumpMessagesNow If true, drop queued messages immediately before completing disconnect.
-   * @param remove If true, remove the peer locally after disconnect.
-   * @param timeout Timeout in milliseconds to wait before completing removal if still
-   *     disconnecting.
+   * <p>If {@code sendDisconnectMessage} is true, a disconnect message is sent asynchronously and
+   * removal is either immediate (when {@code waitForAck} is false) or deferred until the callback
+   * is acknowledged. If the peer is not connected, removal occurs only when the peer is already in
+   * a disconnecting state. When {@code sendDisconnectMessage} is false, removal is immediate if
+   * {@code remove} is true. Timeouts are scheduled via the node ticker and apply only to non-seed
+   * peers.
+   *
+   * <p>Typical usage is during peer shutdown or routing table cleanup. The method is idempotent for
+   * peers already in the disconnecting state.
+   *
+   * @param pn peer to disconnect; must be non-null and tracked.
+   * @param sendDisconnectMessage whether to send the protocol disconnect message.
+   * @param waitForAck whether to wait for disconnect acknowledgment before removal.
+   * @param purge whether to request remote purge of old-peer lists.
+   * @param dumpMessagesNow whether to drop queued messages immediately.
+   * @param remove whether to remove the peer after disconnect flow.
+   * @param timeout timeout in milliseconds before forced removal if disconnecting.
    */
   public void disconnect(
       PeerNode pn,
@@ -95,7 +143,19 @@ public class PeerMessenger {
     }
   }
 
-  /** Asynchronously sends a message to all eligible peers. */
+  /**
+   * Asynchronously sends a message to all eligible peers using unbounded version filters.
+   *
+   * <p>This overload forwards to {@link #localBroadcast(Message, boolean, boolean, ByteCounter,
+   * int, int)} with the minimum and maximum build numbers set to the full integer range. It is a
+   * best-effort broadcast; disconnected peers are skipped and connection loss during send is
+   * ignored.
+   *
+   * @param msg message to send; must be non-null and reusable.
+   * @param ignoreRoutability whether to treat connected peers as eligible.
+   * @param onlyRealConnections whether to exclude non-real connections.
+   * @param ctr counter used to attribute bytes to statistics.
+   */
   public void localBroadcast(
       Message msg, boolean ignoreRoutability, boolean onlyRealConnections, ByteCounter ctr) {
     localBroadcast(
@@ -105,12 +165,26 @@ public class PeerMessenger {
   /**
    * Asynchronously sends a message to all eligible peers.
    *
-   * @param msg Message to send.
-   * @param ignoreRoutability When true, send to connected peers even if not routable.
-   * @param onlyRealConnections When true, exclude non-real connections.
-   * @param ctr Counter to attribute bytes to.
-   * @param minVersion Minimum accepted build number (inclusive).
-   * @param maxVersion Maximum accepted build number (inclusive).
+   * <p>Eligibility is determined by connection/routability, connection type, and build number
+   * range. If {@code ignoreRoutability} is true, connected peers are eligible even when not
+   * routable. If {@code onlyRealConnections} is true, transient or non-real connections are
+   * excluded. Build numbers are compared inclusively against {@code minVersion} and {@code
+   * maxVersion}.
+   *
+   * <p>Not connected errors are ignored to keep the broadcast best-effort. The method does not
+   * retry or queue messages on failure.
+   *
+   * <pre>{@code
+   * // Example: send a message to all routable peers at or above a build.
+   * messenger.localBroadcast(msg, false, true, ctr, 1000, Integer.MAX_VALUE);
+   * }</pre>
+   *
+   * @param msg message to send; must be non-null and reusable.
+   * @param ignoreRoutability whether to include connected but non-routable peers.
+   * @param onlyRealConnections whether to exclude non-real connections.
+   * @param ctr counter used to attribute bytes to statistics.
+   * @param minVersion minimum accepted build number, inclusive.
+   * @param maxVersion maximum accepted build number, inclusive.
    */
   public void localBroadcast(
       Message msg,
@@ -133,7 +207,18 @@ public class PeerMessenger {
     }
   }
 
-  /** Asynchronously sends a differential node reference to every connected peer. */
+  /**
+   * Asynchronously sends a differential node reference to every matching connected peer.
+   *
+   * <p>This uses the N2N diff node reference message type and targets peers selected by darknet and
+   * opennet flags. When both {@code toDarknetOnly} and {@code toOpennetOnly} are false, all
+   * connected peers are eligible. The message is sent best-effort and is not queued for
+   * disconnected peers.
+   *
+   * @param fs field set containing the diff node reference payload.
+   * @param toDarknetOnly whether to restrict sending to darknet peers.
+   * @param toOpennetOnly whether to restrict sending to opennet peers.
+   */
   public void locallyBroadcastDiffNodeRef(
       SimpleFieldSet fs, boolean toDarknetOnly, boolean toOpennetOnly) {
     // myPeers not connectedPeers as connectedPeers only contains

--- a/src/main/java/network/crypta/node/PeerMessenger.java
+++ b/src/main/java/network/crypta/node/PeerMessenger.java
@@ -1,0 +1,242 @@
+package network.crypta.node;
+
+import network.crypta.io.comm.AsyncMessageCallback;
+import network.crypta.io.comm.ByteCounter;
+import network.crypta.io.comm.DMT;
+import network.crypta.io.comm.Message;
+import network.crypta.io.comm.NotConnectedException;
+import network.crypta.support.ShortBuffer;
+import network.crypta.support.SimpleFieldSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Handles peer messaging and disconnect workflows for {@link PeerManager}. */
+public class PeerMessenger {
+  private static final Logger LOG = LoggerFactory.getLogger(PeerMessenger.class);
+
+  private final Node node;
+  private final PeerManager peerManager;
+
+  private final ByteCounter disconnCounter =
+      new ByteCounter() {
+        @Override
+        public void receivedBytes(int x) {
+          node.getNodeStats().disconnBytesReceived(x);
+        }
+
+        @Override
+        public void sentBytes(int x) {
+          node.getNodeStats().disconnBytesSent(x);
+        }
+
+        @Override
+        public void sentPayload(int x) {
+          // Ignore
+        }
+      };
+
+  PeerMessenger(Node node, PeerManager peerManager) {
+    this.node = node;
+    this.peerManager = peerManager;
+  }
+
+  /** Returns the byte counter used for disconnect traffic. */
+  public ByteCounter getDisconnCounter() {
+    return disconnCounter;
+  }
+
+  /**
+   * Disconnects a peer and removes it from the routing table.
+   *
+   * @param pn Peer to disconnect.
+   * @param sendDisconnectMessage If true, send a protocol disconnect message.
+   * @param waitForAck If true, wait for the disconnect acknowledgment before removal.
+   * @param purge If true, request the remote to purge this node from old-peer state.
+   */
+  public void disconnectAndRemove(
+      PeerNode pn, boolean sendDisconnectMessage, boolean waitForAck, boolean purge) {
+    disconnect(pn, sendDisconnectMessage, waitForAck, purge, false, true, Node.MAX_PEER_INACTIVITY);
+  }
+
+  /**
+   * Disconnects from a specified node.
+   *
+   * @param pn Peer to disconnect.
+   * @param sendDisconnectMessage If false, do not send the protocol disconnect message.
+   * @param waitForAck If false, do not wait for the disconnect acknowledgment.
+   * @param purge If true, request the remote to purge this node from old-peer lists.
+   * @param dumpMessagesNow If true, drop queued messages immediately before completing disconnect.
+   * @param remove If true, remove the peer locally after disconnect.
+   * @param timeout Timeout in milliseconds to wait before completing removal if still
+   *     disconnecting.
+   */
+  public void disconnect(
+      PeerNode pn,
+      boolean sendDisconnectMessage,
+      boolean waitForAck,
+      boolean purge,
+      boolean dumpMessagesNow,
+      boolean remove,
+      long timeout) {
+    if (LOG.isDebugEnabled()) LOG.debug("Disconnecting {}", pn.shortToString());
+    if (!shouldProceedWithDisconnect(pn, dumpMessagesNow)) return;
+    if (sendDisconnectMessage) {
+      Message msg = createDisconnectMessage(remove, purge);
+      try {
+        pn.sendAsync(msg, createDisconnectCallback(pn, remove, waitForAck), disconnCounter);
+      } catch (NotConnectedException _) {
+        removePeerIfRequested(pn, remove);
+        return;
+      }
+      scheduleDisconnectTimeoutHandling(pn, remove, timeout);
+    } else if (remove) {
+      peerManager.removePeer(pn);
+      if (!pn.isSeed()) peerManager.writePeersUrgent(pn.isOpennet());
+    }
+  }
+
+  /** Asynchronously sends a message to all eligible peers. */
+  public void localBroadcast(
+      Message msg, boolean ignoreRoutability, boolean onlyRealConnections, ByteCounter ctr) {
+    localBroadcast(
+        msg, ignoreRoutability, onlyRealConnections, ctr, Integer.MIN_VALUE, Integer.MAX_VALUE);
+  }
+
+  /**
+   * Asynchronously sends a message to all eligible peers.
+   *
+   * @param msg Message to send.
+   * @param ignoreRoutability When true, send to connected peers even if not routable.
+   * @param onlyRealConnections When true, exclude non-real connections.
+   * @param ctr Counter to attribute bytes to.
+   * @param minVersion Minimum accepted build number (inclusive).
+   * @param maxVersion Maximum accepted build number (inclusive).
+   */
+  public void localBroadcast(
+      Message msg,
+      boolean ignoreRoutability,
+      boolean onlyRealConnections,
+      ByteCounter ctr,
+      int minVersion,
+      int maxVersion) {
+    // myPeers not connectedPeers as connectedPeers only contains
+    // ROUTABLE peers, and we may want to send to non-routable peers
+    PeerNode[] peers = peerManager.myPeers();
+    for (PeerNode peer : peers) {
+      if (!shouldSendLocal(peer, ignoreRoutability, onlyRealConnections, minVersion, maxVersion))
+        continue;
+      try {
+        peer.sendAsync(msg, null, ctr);
+      } catch (NotConnectedException _) {
+        // Ignore
+      }
+    }
+  }
+
+  /** Asynchronously sends a differential node reference to every connected peer. */
+  public void locallyBroadcastDiffNodeRef(
+      SimpleFieldSet fs, boolean toDarknetOnly, boolean toOpennetOnly) {
+    // myPeers not connectedPeers as connectedPeers only contains
+    // ROUTABLE peers, and we want to also send to non-routable peers
+    PeerNode[] peers = peerManager.myPeers();
+    for (PeerNode peer : peers) {
+      boolean okDarknet = !toDarknetOnly || peer.isDarknet();
+      boolean okOpennet = !toOpennetOnly || peer.isOpennet();
+      if (peer.isConnected() && okDarknet && okOpennet) {
+        peer.sendNodeToNodeMessage(fs, Node.N2N_MESSAGE_TYPE_DIFFNODEREF, false, 0, false);
+      }
+    }
+  }
+
+  private AsyncMessageCallback createDisconnectCallback(
+      PeerNode pn, boolean remove, boolean waitForAck) {
+    return new AsyncMessageCallback() {
+      boolean done = false;
+
+      @Override
+      public void acknowledged() {
+        markDone();
+      }
+
+      @Override
+      public void disconnected() {
+        markDone();
+      }
+
+      @Override
+      public void fatalError() {
+        markDone();
+      }
+
+      @Override
+      public void sent() {
+        if (!waitForAck) markDone();
+      }
+
+      void markDone() {
+        synchronized (this) {
+          if (done) return;
+          done = true;
+        }
+        if (remove) {
+          peerManager.removePeer(pn);
+          if (!pn.isSeed()) peerManager.writePeersUrgent(pn.isOpennet());
+        }
+      }
+    };
+  }
+
+  private boolean shouldProceedWithDisconnect(PeerNode pn, boolean dumpMessagesNow) {
+    if (!peerManager.havePeer(pn)) return false;
+    if (pn.notifyDisconnecting(dumpMessagesNow)) {
+      if (LOG.isDebugEnabled()) LOG.debug("Already disconnecting {}", pn.shortToString());
+      return false;
+    }
+    return true;
+  }
+
+  private static Message createDisconnectMessage(boolean remove, boolean purge) {
+    return DMT.createFNPDisconnect(remove, purge, -1, new ShortBuffer(new byte[0]));
+  }
+
+  private void removePeerIfRequested(PeerNode pn, boolean remove) {
+    if (remove && pn.isDisconnecting()) {
+      peerManager.removePeer(pn);
+      if (!pn.isSeed()) {
+        peerManager.writePeersUrgent(pn.isOpennet());
+      }
+    }
+  }
+
+  private void scheduleDisconnectTimeoutHandling(PeerNode pn, boolean remove, long timeout) {
+    if (pn.isSeed()) return;
+    node.getTicker()
+        .queueTimedJob(
+            () -> {
+              if (pn.isDisconnecting()) {
+                if (remove) {
+                  peerManager.removePeer(pn);
+                  if (!pn.isSeed()) {
+                    peerManager.writePeersUrgent(pn.isOpennet());
+                  }
+                }
+                pn.disconnected(true, true);
+              }
+            },
+            timeout);
+  }
+
+  private static boolean shouldSendLocal(
+      PeerNode peer,
+      boolean ignoreRoutability,
+      boolean onlyRealConnections,
+      int minVersion,
+      int maxVersion) {
+    int version = peer.getBuildNumber();
+    boolean routableOrConnected = ignoreRoutability ? peer.isConnected() : peer.isRoutable();
+    return routableOrConnected
+        && (!onlyRealConnections || peer.isRealConnection())
+        && version >= minVersion
+        && version <= maxVersion;
+  }
+}

--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -4751,8 +4751,8 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
   }
 
   /**
-   * Does this peernode want to be returned by for example PeerManager.getByPeer() ? False =
-   * seednode etc., never going to be routable.
+   * Should this peer be returned by roster lookups (for example {@link PeerRoster#getByPeer})?
+   * False means seed nodes or other entries that are never routed.
    */
   public abstract boolean isRealConnection();
 

--- a/src/main/java/network/crypta/node/PeerOpennetGate.java
+++ b/src/main/java/network/crypta/node/PeerOpennetGate.java
@@ -1,0 +1,41 @@
+package network.crypta.node;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles opennet admission checks for peers that are being added.
+ *
+ * <p>Encapsulates the dependency on {@link OpennetManager} so callers do not need to reference
+ * opennet-specific types when deciding whether a peer may be accepted.
+ */
+public class PeerOpennetGate {
+  private static final Logger LOG = LoggerFactory.getLogger(PeerOpennetGate.class);
+
+  private final Node node;
+
+  public PeerOpennetGate(Node node) {
+    this.node = node;
+  }
+
+  /**
+   * Validates opennet peers when opennet handling is enabled.
+   *
+   * @param peer candidate peer.
+   * @param ignoreOpennet if true, skip opennet checks entirely.
+   * @return true if the peer may remain, false if it must be removed.
+   */
+  public boolean allowPeer(PeerNode peer, boolean ignoreOpennet) {
+    if (ignoreOpennet) return true;
+    if (!(peer instanceof OpennetPeerNode)) return true;
+
+    OpennetManager opennet = node.getOpennet();
+    if (opennet != null) {
+      opennet.forceAddPeer((OpennetPeerNode) peer, true);
+      return true;
+    }
+
+    LOG.error("Adding opennet peer when opennet is disabled: {} - removing", peer);
+    return false;
+  }
+}

--- a/src/main/java/network/crypta/node/PeerOpennetGate.java
+++ b/src/main/java/network/crypta/node/PeerOpennetGate.java
@@ -4,16 +4,48 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handles opennet admission checks for peers that are being added.
+ * Gates admission of peers based on opennet policy for the current node.
  *
- * <p>Encapsulates the dependency on {@link OpennetManager} so callers do not need to reference
- * opennet-specific types when deciding whether a peer may be accepted.
+ * <p>This helper provides a single, focused entry point for deciding whether a newly discovered
+ * peer should be retained when opennet logic is in play. Callers supply the candidate peer and a
+ * flag that can bypass opennet checks; the gate then applies opennet-specific rules only when the
+ * peer is an {@link OpennetPeerNode} and opennet support is available. The class hides the direct
+ * {@link OpennetManager} dependency so other components do not need to reference opennet types to
+ * make basic admission decisions.
+ *
+ * <p>Lifecycle and state are intentionally simple: the instance is bound to a {@link Node} and
+ * remains valid as long as that node reference is valid. It has no internal mutable state beyond
+ * the node reference and performs no caching; each call evaluates the current opennet manager
+ * availability. Concurrency is limited to the thread-safety of the supplied {@link Node} and its
+ * opennet manager; this class itself is stateless and safe to share between threads when the node
+ * is safe.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Applying opt-in opennet admission rules for {@link OpennetPeerNode} instances.
+ *   <li>Delegating to {@link OpennetManager} when opennet is enabled.
+ *   <li>Rejecting opennet peers when opennet support is absent or disabled.
+ * </ul>
+ *
+ * @see OpennetManager
+ * @see OpennetPeerNode
  */
 public class PeerOpennetGate {
   private static final Logger LOG = LoggerFactory.getLogger(PeerOpennetGate.class);
 
   private final Node node;
 
+  /**
+   * Creates a gate that evaluates opennet admission against the given node.
+   *
+   * <p>The provided {@link Node} supplies the opennet manager reference used to validate opennet
+   * peers. The gate does not take ownership of the node and performs no defensive copying; callers
+   * should pass the same node instance used by their peer-management workflow. This constructor is
+   * side-effect free and does not perform any opennet checks by itself.
+   *
+   * @param node node instance that supplies opennet configuration and manager access.
+   */
   public PeerOpennetGate(Node node) {
     this.node = node;
   }
@@ -21,9 +53,16 @@ public class PeerOpennetGate {
   /**
    * Validates opennet peers when opennet handling is enabled.
    *
-   * @param peer candidate peer.
-   * @param ignoreOpennet if true, skip opennet checks entirely.
-   * @return true if the peer may remain, false if it must be removed.
+   * <p>This method returns {@code true} for non-opennet peers or when opennet checks are explicitly
+   * bypassed. For opennet peers, it consults the current {@link OpennetManager} from the associated
+   * {@link Node} and, when available, delegates admission to the manager. If opennet is disabled or
+   * unavailable, the peer is rejected and an error is logged. The method is deterministic and
+   * idempotent with respect to non-opennet peers; it may have side effects when delegating to the
+   * manager for opennet peers.
+   *
+   * @param peer candidate peer to evaluate for opennet admission; non-opennet peers are accepted.
+   * @param ignoreOpennet if true, bypass all opennet checks and accept the peer immediately.
+   * @return {@code true} if the peer may remain, or {@code false} if it must be removed.
    */
   public boolean allowPeer(PeerNode peer, boolean ignoreOpennet) {
     if (ignoreOpennet) return true;

--- a/src/main/java/network/crypta/node/PeerPersistence.java
+++ b/src/main/java/network/crypta/node/PeerPersistence.java
@@ -24,37 +24,81 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handles peer reference persistence for {@link PeerManager}.
+ * Coordinates persistence of peer references for {@link PeerManager}.
  *
- * <p>Responsible for reading peer files, writing updated peer lists, rotating backups, and caching
- * serialized peers. The manager owns the scheduling and synchronization for disk I/O.
+ * <p>This helper encapsulates the disk I/O for reading peer reference files on startup and
+ * periodically writing updated snapshots for darknet, opennet, and old opennet peers. It is created
+ * and owned by {@link PeerManager}; callers schedule work or mark peers dirty, while the class
+ * handles serialization, backup rotation, and best-effort recovery when files are missing or
+ * partially corrupt. Cached snapshots of the last written state prevent redundant writes and reduce
+ * churn on the filesystem.
+ *
+ * <p>Concurrency: callers may invoke write/mark methods from different threads. This class uses
+ * lightweight synchronization and volatile flags to coordinate state, while actual I/O happens on
+ * the ticker or executor threads provided by {@link Node}. It does not expose external
+ * thread-safety guarantees beyond those internal guards.
+ *
+ * <ul>
+ *   <li>Read peer reference files, with backup fallback and error reporting.
+ *   <li>Write snapshots with optional backup rotation and atomic replacement.
+ *   <li>Track old opennet peers separately for reconnection attempts.
+ * </ul>
  */
 class PeerPersistence {
+  /** Logger for persistence I/O, parsing, and recovery diagnostics. */
   private static final Logger LOG = LoggerFactory.getLogger(PeerPersistence.class);
+
+  /** Read-log prefix used by {@link #buildReadMessage(File, OpennetManager, boolean, boolean)}. */
   private static final String READ_PREFIX = "Read ";
+
+  /** Number of backup generations retained for opennet peer files. */
   private static final int BACKUPS_OPENNET = 1;
+
+  /** Number of backup generations retained for darknet peer files. */
   private static final int BACKUPS_DARKNET = 10;
+
+  /** Minimum delay between scheduled non-urgent peer writes, in milliseconds. */
   private static final long MIN_WRITEPEERS_DELAY = MINUTES.toMillis(5);
 
+  /** Owning node, used for scheduling, alerts, and access to opennet services. */
   private final Node node;
+
+  /** Peer manager that owns the peer roster and accepts newly parsed peers. */
   private final PeerManager peerManager;
 
+  /** Guards access to filenames and cached serialized snapshots during writes. */
   private final Object writePeersSync = new Object();
+
+  /** Serializes file-system writes and backup rotations. */
   private final Object writePeerFileSync = new Object();
 
+  /** Dirty flag for pending darknet writes, set by requests and cleared on write. */
   private volatile boolean shouldWritePeersDarknet = false;
+
+  /** Dirty flag for pending opennet writes, set by requests and cleared on write. */
   private volatile boolean shouldWritePeersOpennet = false;
 
+  /** Current filename for the darknet peers file, or {@code null} until known. */
   private String darkFilename;
+
+  /** Current filename for the opennet peers file, or {@code null} until known. */
   private String openFilename;
+
+  /** Current filename for the old-opennet peers file, or {@code null} until known. */
   private String oldOpennetPeersFilename;
 
   // Note: Potential improvement: use a dedicated stable hash (not hashCode()).
   // Note: Potential improvement: strip non-essential metadata; keep peer locations only.
+  /** Serialized snapshot of the last written darknet peers, for change detection. */
   private String darknetPeersStringCache = null;
+
+  /** Serialized snapshot of the last written opennet peers, for change detection. */
   private String opennetPeersStringCache = null;
+
+  /** Serialized snapshot of the last written old-opennet peers, for change detection. */
   private String oldOpennetPeersStringCache = null;
 
+  /** Periodic write runnable that writes peers and re-schedules itself. */
   private final Runnable writePeersRunnable =
       () -> {
         try {
@@ -64,17 +108,40 @@ class PeerPersistence {
         }
       };
 
+  /**
+   * Create a new persistence helper bound to a node and its peer manager.
+   *
+   * <p>The instance is lightweight and does not perform I/O until scheduled. Callers typically
+   * invoke {@link #scheduleInitialWrite()} during startup and {@link #flushOnShutdown()} during
+   * shutdown to ensure files are flushed. This class assumes the provided components remain valid
+   * for the life of the node and does not attempt to outlive them.
+   *
+   * @param node owning node used for scheduling, alerts, and opennet access; must not be {@code
+   *     null}
+   * @param peerManager peer manager that owns the peer roster; must not be {@code null}
+   */
   PeerPersistence(Node node, PeerManager peerManager) {
     this.node = node;
     this.peerManager = peerManager;
   }
 
-  /** Schedule the periodic peer persistence job to run immediately. */
+  /**
+   * Schedule the periodic peer persistence job to run immediately.
+   *
+   * <p>This is normally invoked during startup once the node has completed construction. The
+   * runnable performs a best-effort write if peers are marked dirty, then re-schedules itself using
+   * {@link #scheduleWritePeersNextRun()} so the periodic cycle continues.
+   */
   void scheduleInitialWrite() {
     node.getTicker().queueTimedJob(writePeersRunnable, 0);
   }
 
-  /** Flush peer files during shutdown to avoid waiting for the periodic write interval. */
+  /**
+   * Flush peer files during shutdown to avoid waiting for the periodic write interval.
+   *
+   * <p>This marks both darknet and opennet peer lists as dirty and then writes them synchronously
+   * on the current thread. The write is best-effort: failures are logged but do not abort shutdown.
+   */
   void flushOnShutdown() {
     markWriteDarknet();
     markWriteOpennet();
@@ -86,13 +153,17 @@ class PeerPersistence {
    * empty or otherwise doesn't work. WARNING: Only call this AFTER the Node constructor has
    * completed! Methods may be called on Node!
    *
-   * @param filename The filename to read from. If this doesn't work, we try the .bak file.
-   * @param crypto The cryptographic identity which these nodes are connected to.
-   * @param opennet The opennet manager for the nodes. Only needed (for constructing the nodes) if
-   *     isOpennet.
-   * @param isOpennet Whether the file contains opennet peers.
-   * @param oldOpennetPeers If true, don't add the nodes to the routing table, pass them to the
-   *     opennet manager as "old peers" i.e. inactive nodes which may try to reconnect.
+   * <p>The method attempts the primary file first and then tries backup files in order, stopping at
+   * the first successful parse. If entries are unparseable or too old, they are skipped and the
+   * original file is copied to a {@code .broken} file for inspection. When reading old opennet
+   * peers, entries are routed to the opennet manager instead of the routing table. This method does
+   * not throw; all failures are logged and treated as a non-fatal startup condition.
+   *
+   * @param filename path to the peers file; backups are derived from this name
+   * @param crypto cryptographic identity for peers being loaded; must not be {@code null}
+   * @param opennet opennet manager used for opennet peers; may be {@code null} if not opennet
+   * @param isOpennet whether the file contains opennet peers instead of darknet peers
+   * @param oldOpennetPeers when {@code true}, treat entries as old peers for reconnection attempts
    */
   void tryReadPeers(
       String filename,
@@ -100,6 +171,79 @@ class PeerPersistence {
       OpennetManager opennet,
       boolean isOpennet,
       boolean oldOpennetPeers) {
+    recordPeerFilename(filename, isOpennet, oldOpennetPeers);
+    int maxBackups = isOpennet ? BACKUPS_OPENNET : BACKUPS_DARKNET;
+    for (int i = 0; i <= maxBackups; i++) {
+      File peersFile = getBackupFilename(filename, i);
+      // Try to read the node list from disk
+      if (peersFile.exists() && readPeers(peersFile, crypto, opennet, oldOpennetPeers)) {
+        if (LOG.isInfoEnabled()) {
+          LOG.info(buildReadMessage(peersFile, opennet, isOpennet, oldOpennetPeers));
+        }
+        return;
+      }
+    }
+    logMissingPeers(isOpennet);
+    // The other cases are less important.
+  }
+
+  /**
+   * Mark a peer list write request so the next periodic run persists it.
+   *
+   * <p>This is a low-priority, coalesced update. The flag is checked on the periodic runnable; if
+   * multiple calls arrive before the next tick, only one write occurs. Use {@link
+   * #writePeersUrgent(boolean)} for immediate persistence on a high-priority executor thread.
+   *
+   * @param opennet {@code true} to mark opennet peers; {@code false} for darknet peers
+   */
+  void writePeers(boolean opennet) {
+    if (opennet) markWriteOpennet();
+    else markWriteDarknet();
+  }
+
+  /**
+   * Write peers immediately on a high-priority executor thread.
+   *
+   * <p>This bypasses the periodic delay and triggers an immediate write with backup rotation. The
+   * write is still serialized with other disk writes to avoid concurrent file operations.
+   *
+   * @param opennet {@code true} to write opennet peers; {@code false} for darknet peers
+   */
+  void writePeersUrgent(boolean opennet) {
+    if (opennet) writePeersOpennetUrgent();
+    else writePeersDarknetUrgent();
+  }
+
+  /**
+   * Schedule the next periodic peer write after the configured delay.
+   *
+   * <p>This keeps the persistence loop running even if the previous write encountered errors. The
+   * delay is fixed and expressed in milliseconds by {@link #MIN_WRITEPEERS_DELAY}.
+   */
+  private void scheduleWritePeersNextRun() {
+    node.getTicker().queueTimedJob(writePeersRunnable, MIN_WRITEPEERS_DELAY);
+  }
+
+  /**
+   * Write any pending peer lists immediately without rotating backups.
+   *
+   * <p>This method performs the periodic, non-urgent write path. It clears dirty flags and writes
+   * only if the cached snapshot differs from the current serialized state.
+   */
+  private void writePeersNow() {
+    // Non-urgent periodic write does not rotate backups.
+    writePeersDarknetNow(false);
+    writePeersOpennetNow(false);
+  }
+
+  /**
+   * Record the current peer filename for later write operations.
+   *
+   * @param filename path to the peer file to remember for future writes
+   * @param isOpennet {@code true} if the filename is for opennet peers
+   * @param oldOpennetPeers {@code true} when the filename is for old opennet peers
+   */
+  private void recordPeerFilename(String filename, boolean isOpennet, boolean oldOpennetPeers) {
     synchronized (writePeersSync) {
       if (!oldOpennetPeers) {
         if (isOpennet) {
@@ -109,60 +253,65 @@ class PeerPersistence {
         }
       }
     }
-    int maxBackups = isOpennet ? BACKUPS_OPENNET : BACKUPS_DARKNET;
-    for (int i = 0; i <= maxBackups; i++) {
-      File peersFile = getBackupFilename(filename, i);
-      // Try to read the node list from disk
-      if (peersFile.exists() && readPeers(peersFile, crypto, opennet, oldOpennetPeers)) {
-        String msg;
-        if (oldOpennetPeers) {
-          int oldPeers = opennet == null ? 0 : opennet.countOldOpennetPeers();
-          msg = READ_PREFIX + oldPeers + " old-opennet-peers from " + peersFile;
-        } else if (isOpennet) {
-          msg =
-              READ_PREFIX
-                  + peerManager.roster().getOpennetPeers().length
-                  + " opennet peers from "
-                  + peersFile;
-        } else {
-          msg =
-              READ_PREFIX
-                  + peerManager.roster().getDarknetPeers().length
-                  + " darknet peers from "
-                  + peersFile;
-        }
-        LOG.info(msg);
-        return;
-      }
+  }
+
+  /**
+   * Build a human-readable message describing the most recent peer read.
+   *
+   * @param peersFile file that was read successfully
+   * @param opennet opennet manager for old-peers count, or {@code null} when absent
+   * @param isOpennet {@code true} if the file contained opennet peers
+   * @param oldOpennetPeers {@code true} if the file contained old opennet peers
+   * @return formatted log message describing the peer counts and source file
+   */
+  private String buildReadMessage(
+      File peersFile, OpennetManager opennet, boolean isOpennet, boolean oldOpennetPeers) {
+    if (oldOpennetPeers) {
+      int oldPeers = opennet == null ? 0 : opennet.countOldOpennetPeers();
+      return READ_PREFIX + oldPeers + " old-opennet-peers from " + peersFile;
     }
+    if (isOpennet) {
+      return READ_PREFIX + getOpennetPeerCount() + " opennet peers from " + peersFile;
+    }
+    return READ_PREFIX + getDarknetPeerCount() + " darknet peers from " + peersFile;
+  }
+
+  /**
+   * Log when expected peer files are missing during startup.
+   *
+   * @param isOpennet {@code true} if the missing file is for opennet peers
+   */
+  private void logMissingPeers(boolean isOpennet) {
     if (!isOpennet) {
       LOG.info("No darknet peers file found.");
     }
-    // The other cases are less important.
   }
 
-  /** Marks a peer list write request so the next periodic run persists it. */
-  void writePeers(boolean opennet) {
-    if (opennet) markWriteOpennet();
-    else markWriteDarknet();
+  /**
+   * Return the current opennet peer count based on the roster snapshot.
+   *
+   * @return number of opennet peers currently known to the roster
+   */
+  private int getOpennetPeerCount() {
+    PeerRoster roster = peerManager.roster();
+    return roster == null ? 0 : roster.getOpennetPeers().length;
   }
 
-  /** Writes peers immediately on a high-priority executor thread. */
-  void writePeersUrgent(boolean opennet) {
-    if (opennet) writePeersOpennetUrgent();
-    else writePeersDarknetUrgent();
+  /**
+   * Return the current darknet peer count based on the roster snapshot.
+   *
+   * @return number of darknet peers currently known to the roster
+   */
+  private int getDarknetPeerCount() {
+    PeerRoster roster = peerManager.roster();
+    return roster == null ? 0 : roster.getDarknetPeers().length;
   }
 
-  private void scheduleWritePeersNextRun() {
-    node.getTicker().queueTimedJob(writePeersRunnable, MIN_WRITEPEERS_DELAY);
-  }
-
-  private void writePeersNow() {
-    // Non-urgent periodic write does not rotate backups.
-    writePeersDarknetNow(false);
-    writePeersOpennetNow(false);
-  }
-
+  /**
+   * Write darknet peers immediately if they have been marked dirty.
+   *
+   * @param rotateBackups whether to rotate backup files instead of overwriting the primary file
+   */
   private void writePeersDarknetNow(boolean rotateBackups) {
     if (shouldWritePeersDarknet) {
       shouldWritePeersDarknet = false;
@@ -170,6 +319,11 @@ class PeerPersistence {
     }
   }
 
+  /**
+   * Write opennet peers immediately if they have been marked dirty.
+   *
+   * @param rotateBackups whether to rotate backup files instead of overwriting the primary file
+   */
   private void writePeersOpennetNow(boolean rotateBackups) {
     if (shouldWritePeersOpennet) {
       shouldWritePeersOpennet = false;
@@ -177,6 +331,11 @@ class PeerPersistence {
     }
   }
 
+  /**
+   * Dispatch an urgent opennet write on the executor with high priority.
+   *
+   * <p>This path rotates backups and runs outside the ticker to reduce latency.
+   */
   private void writePeersOpennetUrgent() {
     node.getExecutor()
         .execute(
@@ -193,6 +352,11 @@ class PeerPersistence {
             });
   }
 
+  /**
+   * Dispatch an urgent darknet write on the executor with high priority.
+   *
+   * <p>This path rotates backups and runs outside the ticker to reduce latency.
+   */
   private void writePeersDarknetUrgent() {
     node.getExecutor()
         .execute(
@@ -209,14 +373,21 @@ class PeerPersistence {
             });
   }
 
+  /** Mark the darknet peers as dirty so the next write persists them. */
   private void markWriteDarknet() {
     shouldWritePeersDarknet = true;
   }
 
+  /** Mark the opennet peers as dirty so the next write persists them. */
   private void markWriteOpennet() {
     shouldWritePeersOpennet = true;
   }
 
+  /**
+   * Serialize current darknet peers to an ordered field set string.
+   *
+   * @return serialized representation of darknet peers, possibly empty but never {@code null}
+   */
   private String getDarknetPeersString() {
     StringBuilder sb = new StringBuilder();
     PeerNode[] peers = peerManager.myPeers();
@@ -226,6 +397,11 @@ class PeerPersistence {
     return sb.toString();
   }
 
+  /**
+   * Serialize current opennet peers to an ordered field set string.
+   *
+   * @return serialized representation of opennet peers, possibly empty but never {@code null}
+   */
   private String getOpennetPeersString() {
     StringBuilder sb = new StringBuilder();
     PeerNode[] peers = peerManager.myPeers();
@@ -235,6 +411,12 @@ class PeerPersistence {
     return sb.toString();
   }
 
+  /**
+   * Serialize the current old opennet peers to an ordered field set string.
+   *
+   * @param om opennet manager providing the old-peer collection; must not be {@code null}
+   * @return serialized representation of old opennet peers, possibly empty but never {@code null}
+   */
   private String getOldOpennetPeersString(OpennetManager om) {
     StringBuilder sb = new StringBuilder();
     for (PeerNode pn : om.getOldPeers()) {
@@ -243,6 +425,11 @@ class PeerPersistence {
     return sb.toString();
   }
 
+  /**
+   * Write the darknet peers file if the serialized snapshot changed.
+   *
+   * @param rotateBackups whether to rotate backup files instead of overwriting the primary file
+   */
   private void writePeersInnerDarknet(boolean rotateBackups) {
     String newDarknetPeersString;
     synchronized (writePeersSync) {
@@ -256,6 +443,11 @@ class PeerPersistence {
     }
   }
 
+  /**
+   * Write opennet and old-opennet peer files if their snapshots changed.
+   *
+   * @param rotateBackups whether to rotate backup files instead of overwriting the primary file
+   */
   private void writePeersInnerOpennet(boolean rotateBackups) {
     String newOpennetPeersString = null;
     String newOldOpennetPeersString = null;
@@ -282,9 +474,17 @@ class PeerPersistence {
   }
 
   /**
-   * Write the peers file to disk.
+   * Write a serialized peers file to disk.
    *
-   * @param rotateBackups If true, rotate backups. If false, just clobber the latest file.
+   * <p>The write uses a temporary file, flushes and syncs it, then either rotates backups or
+   * replaces the primary file. This method is synchronized to prevent concurrent writes from
+   * interleaving or corrupting the backup chain. Errors are logged and the previous file is left
+   * intact when possible.
+   *
+   * @param filename target filename to write, not {@code null}
+   * @param sb serialized peers content, in UTF-8, not {@code null}
+   * @param maxBackups number of backup generations to retain; must be at least 1
+   * @param rotateBackups if {@code true}, rotate backups; otherwise overwrite the primary file
    */
   private void writePeersInner(String filename, String sb, int maxBackups, boolean rotateBackups) {
     assert (maxBackups >= 1);
@@ -323,6 +523,13 @@ class PeerPersistence {
     }
   }
 
+  /**
+   * Rotate backup files and install the new peers file as the latest generation.
+   *
+   * @param filename base filename used to compute backup paths
+   * @param maxBackups maximum number of backup generations to keep
+   * @param newFile temporary file containing the new peers content
+   */
   private void rotateBackupFiles(String filename, int maxBackups, File newFile) {
     File prevFile = null;
     for (int i = maxBackups; i >= 0; i--) {
@@ -338,12 +545,33 @@ class PeerPersistence {
     FileUtil.moveTo(newFile, prevFile);
   }
 
+  /**
+   * Resolve the backup filename for a given generation index.
+   *
+   * @param filename base filename for peers
+   * @param i backup index, where {@code 0} is the primary and {@code 1} is {@code .bak}
+   * @return the resolved backup file path for the given index
+   */
   private File getBackupFilename(String filename, int i) {
     if (i == 0) return new File(filename);
     if (i == 1) return new File(filename + ".bak");
     return new File(filename + ".bak." + i);
   }
 
+  /**
+   * Read and parse peers from a file, returning whether the read was fully successful.
+   *
+   * <p>If parsing fails for some entries, a copy of the original file is written to a {@code
+   * .broken} suffix for later inspection. Old opennet peers are routed to the opennet manager,
+   * while darknet peers are added directly to the peer manager. Exceptions are logged and treated
+   * as non-fatal so startup can continue.
+   *
+   * @param peersFile file to read and parse
+   * @param crypto cryptographic identity used to validate parsed peers
+   * @param opennet opennet manager, required when parsing opennet peers
+   * @param oldOpennetPeers {@code true} when parsing old opennet peers instead of active peers
+   * @return {@code true} if all entries were parsed and applied successfully
+   */
   @SuppressWarnings("java:S1181")
   private boolean readPeers(
       File peersFile, NodeCrypto crypto, OpennetManager opennet, boolean oldOpennetPeers) {
@@ -392,6 +620,15 @@ class PeerPersistence {
     return !someBroken;
   }
 
+  /**
+   * Convert serialized field sets into peer nodes, skipping entries that fail validation.
+   *
+   * @param peerEntries parsed field sets for peers, in file order
+   * @param crypto cryptographic identity used to validate peer references
+   * @param opennet opennet manager used when creating opennet peers
+   * @param droppedOldPeers user alert collector for too-old peers
+   * @return list of successfully created peer nodes, possibly empty
+   */
   private List<PeerNode> createPeerNodesFromEntries(
       List<SimpleFieldSet> peerEntries,
       NodeCrypto crypto,
@@ -418,6 +655,13 @@ class PeerPersistence {
     return created;
   }
 
+  /**
+   * Apply created peers to either the opennet manager or the peer manager.
+   *
+   * @param createdNodes peers successfully created from the input file
+   * @param opennet opennet manager used for old-opennet peers, may be {@code null}
+   * @param oldOpennetPeers {@code true} to add to old-opennet storage instead of routing table
+   */
   private void applyCreatedNodes(
       List<PeerNode> createdNodes, OpennetManager opennet, boolean oldOpennetPeers) {
     for (PeerNode pn : createdNodes) {
@@ -437,11 +681,24 @@ class PeerPersistence {
     }
   }
 
+  /**
+   * Log peer creation failures with both error and warning messages.
+   *
+   * @param e2 exception thrown while parsing or verifying a peer entry
+   * @param fs serialized field set that caused the parse failure
+   */
   private void handlePeerCreationException(Exception e2, SimpleFieldSet fs) {
     LOG.error("Peer parse error {} for {}", e2, fs, e2);
     LOG.warn("Cannot parse friend from peers file: {}", e2, e2);
   }
 
+  /**
+   * Read all peer field sets from a buffered reader.
+   *
+   * @param br reader positioned at the start of the peers file
+   * @param out destination list for parsed field sets
+   * @throws IOException if an I/O error occurs while reading from the stream
+   */
   private void readPeerFieldSets(BufferedReader br, List<SimpleFieldSet> out) throws IOException {
     for (SimpleFieldSet sfs = readNextPeerFieldSet(br);
         sfs != null;
@@ -450,6 +707,13 @@ class PeerPersistence {
     }
   }
 
+  /**
+   * Read the next peer field set from the stream.
+   *
+   * @param br reader positioned at the next field set
+   * @return parsed field set, or {@code null} when end-of-file is reached
+   * @throws IOException if an I/O error occurs while reading from the stream
+   */
   private SimpleFieldSet readNextPeerFieldSet(BufferedReader br) throws IOException {
     try {
       return new SimpleFieldSet(br, false, true);
@@ -458,6 +722,11 @@ class PeerPersistence {
     }
   }
 
+  /**
+   * Delete a file if it exists, ignoring I/O errors.
+   *
+   * @param file file to delete, possibly {@code null} if no temp file was created
+   */
   private static void safeDeleteIfExists(File file) {
     try {
       java.nio.file.Files.deleteIfExists(file.toPath());

--- a/src/main/java/network/crypta/node/PeerPersistence.java
+++ b/src/main/java/network/crypta/node/PeerPersistence.java
@@ -1,0 +1,468 @@
+package network.crypta.node;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+import java.io.BufferedReader;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.io.comm.PeerParseException;
+import network.crypta.io.comm.ReferenceSignatureVerificationException;
+import network.crypta.node.useralerts.DroppedOldPeersUserAlert;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.NativeThread;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles peer reference persistence for {@link PeerManager}.
+ *
+ * <p>Responsible for reading peer files, writing updated peer lists, rotating backups, and caching
+ * serialized peers. The manager owns the scheduling and synchronization for disk I/O.
+ */
+class PeerPersistence {
+  private static final Logger LOG = LoggerFactory.getLogger(PeerPersistence.class);
+  private static final String READ_PREFIX = "Read ";
+  private static final int BACKUPS_OPENNET = 1;
+  private static final int BACKUPS_DARKNET = 10;
+  private static final long MIN_WRITEPEERS_DELAY = MINUTES.toMillis(5);
+
+  private final Node node;
+  private final PeerManager peerManager;
+
+  private final Object writePeersSync = new Object();
+  private final Object writePeerFileSync = new Object();
+
+  private volatile boolean shouldWritePeersDarknet = false;
+  private volatile boolean shouldWritePeersOpennet = false;
+
+  private String darkFilename;
+  private String openFilename;
+  private String oldOpennetPeersFilename;
+
+  // Note: Potential improvement: use a dedicated stable hash (not hashCode()).
+  // Note: Potential improvement: strip non-essential metadata; keep peer locations only.
+  private String darknetPeersStringCache = null;
+  private String opennetPeersStringCache = null;
+  private String oldOpennetPeersStringCache = null;
+
+  private final Runnable writePeersRunnable =
+      () -> {
+        try {
+          writePeersNow();
+        } finally {
+          scheduleWritePeersNextRun();
+        }
+      };
+
+  PeerPersistence(Node node, PeerManager peerManager) {
+    this.node = node;
+    this.peerManager = peerManager;
+  }
+
+  /** Schedule the periodic peer persistence job to run immediately. */
+  void scheduleInitialWrite() {
+    node.getTicker().queueTimedJob(writePeersRunnable, 0);
+  }
+
+  /** Flush peer files during shutdown to avoid waiting for the periodic write interval. */
+  void flushOnShutdown() {
+    markWriteDarknet();
+    markWriteOpennet();
+    writePeersNow();
+  }
+
+  /**
+   * Attempt to read a file full of noderefs. Try the file as named first, then the .bak if it is
+   * empty or otherwise doesn't work. WARNING: Only call this AFTER the Node constructor has
+   * completed! Methods may be called on Node!
+   *
+   * @param filename The filename to read from. If this doesn't work, we try the .bak file.
+   * @param crypto The cryptographic identity which these nodes are connected to.
+   * @param opennet The opennet manager for the nodes. Only needed (for constructing the nodes) if
+   *     isOpennet.
+   * @param isOpennet Whether the file contains opennet peers.
+   * @param oldOpennetPeers If true, don't add the nodes to the routing table, pass them to the
+   *     opennet manager as "old peers" i.e. inactive nodes which may try to reconnect.
+   */
+  void tryReadPeers(
+      String filename,
+      NodeCrypto crypto,
+      OpennetManager opennet,
+      boolean isOpennet,
+      boolean oldOpennetPeers) {
+    synchronized (writePeersSync) {
+      if (!oldOpennetPeers) {
+        if (isOpennet) {
+          openFilename = filename;
+        } else {
+          darkFilename = filename;
+        }
+      }
+    }
+    int maxBackups = isOpennet ? BACKUPS_OPENNET : BACKUPS_DARKNET;
+    for (int i = 0; i <= maxBackups; i++) {
+      File peersFile = getBackupFilename(filename, i);
+      // Try to read the node list from disk
+      if (peersFile.exists() && readPeers(peersFile, crypto, opennet, oldOpennetPeers)) {
+        String msg;
+        if (oldOpennetPeers) {
+          int oldPeers = opennet == null ? 0 : opennet.countOldOpennetPeers();
+          msg = READ_PREFIX + oldPeers + " old-opennet-peers from " + peersFile;
+        } else if (isOpennet) {
+          msg =
+              READ_PREFIX
+                  + peerManager.roster().getOpennetPeers().length
+                  + " opennet peers from "
+                  + peersFile;
+        } else {
+          msg =
+              READ_PREFIX
+                  + peerManager.roster().getDarknetPeers().length
+                  + " darknet peers from "
+                  + peersFile;
+        }
+        LOG.info(msg);
+        return;
+      }
+    }
+    if (!isOpennet) {
+      LOG.info("No darknet peers file found.");
+    }
+    // The other cases are less important.
+  }
+
+  /** Marks a peer list write request so the next periodic run persists it. */
+  void writePeers(boolean opennet) {
+    if (opennet) markWriteOpennet();
+    else markWriteDarknet();
+  }
+
+  /** Writes peers immediately on a high-priority executor thread. */
+  void writePeersUrgent(boolean opennet) {
+    if (opennet) writePeersOpennetUrgent();
+    else writePeersDarknetUrgent();
+  }
+
+  private void scheduleWritePeersNextRun() {
+    node.getTicker().queueTimedJob(writePeersRunnable, MIN_WRITEPEERS_DELAY);
+  }
+
+  private void writePeersNow() {
+    // Non-urgent periodic write does not rotate backups.
+    writePeersDarknetNow(false);
+    writePeersOpennetNow(false);
+  }
+
+  private void writePeersDarknetNow(boolean rotateBackups) {
+    if (shouldWritePeersDarknet) {
+      shouldWritePeersDarknet = false;
+      writePeersInnerDarknet(rotateBackups);
+    }
+  }
+
+  private void writePeersOpennetNow(boolean rotateBackups) {
+    if (shouldWritePeersOpennet) {
+      shouldWritePeersOpennet = false;
+      writePeersInnerOpennet(rotateBackups);
+    }
+  }
+
+  private void writePeersOpennetUrgent() {
+    node.getExecutor()
+        .execute(
+            new PrioRunnable() {
+              @Override
+              public void run() {
+                writePeersOpennetNow(true);
+              }
+
+              @Override
+              public int getPriority() {
+                return NativeThread.PriorityLevel.HIGH_PRIORITY.value;
+              }
+            });
+  }
+
+  private void writePeersDarknetUrgent() {
+    node.getExecutor()
+        .execute(
+            new PrioRunnable() {
+              @Override
+              public void run() {
+                writePeersDarknetNow(true);
+              }
+
+              @Override
+              public int getPriority() {
+                return NativeThread.PriorityLevel.HIGH_PRIORITY.value;
+              }
+            });
+  }
+
+  private void markWriteDarknet() {
+    shouldWritePeersDarknet = true;
+  }
+
+  private void markWriteOpennet() {
+    shouldWritePeersOpennet = true;
+  }
+
+  private String getDarknetPeersString() {
+    StringBuilder sb = new StringBuilder();
+    PeerNode[] peers = peerManager.myPeers();
+    for (PeerNode pn : peers) {
+      if (pn instanceof DarknetPeerNode) sb.append(pn.exportDiskFieldSet().toOrderedString());
+    }
+    return sb.toString();
+  }
+
+  private String getOpennetPeersString() {
+    StringBuilder sb = new StringBuilder();
+    PeerNode[] peers = peerManager.myPeers();
+    for (PeerNode pn : peers) {
+      if (pn instanceof OpennetPeerNode) sb.append(pn.exportDiskFieldSet().toOrderedString());
+    }
+    return sb.toString();
+  }
+
+  private String getOldOpennetPeersString(OpennetManager om) {
+    StringBuilder sb = new StringBuilder();
+    for (PeerNode pn : om.getOldPeers()) {
+      if (pn instanceof OpennetPeerNode) sb.append(pn.exportDiskFieldSet().toOrderedString());
+    }
+    return sb.toString();
+  }
+
+  private void writePeersInnerDarknet(boolean rotateBackups) {
+    String newDarknetPeersString;
+    synchronized (writePeersSync) {
+      newDarknetPeersString = darkFilename != null ? getDarknetPeersString() : null;
+    }
+    synchronized (writePeerFileSync) {
+      if (newDarknetPeersString != null && !newDarknetPeersString.equals(darknetPeersStringCache)) {
+        darknetPeersStringCache = newDarknetPeersString;
+        writePeersInner(darkFilename, darknetPeersStringCache, BACKUPS_DARKNET, rotateBackups);
+      }
+    }
+  }
+
+  private void writePeersInnerOpennet(boolean rotateBackups) {
+    String newOpennetPeersString = null;
+    String newOldOpennetPeersString = null;
+    synchronized (writePeersSync) {
+      OpennetManager om = node.getOpennet();
+      if (om != null) {
+        if (openFilename != null) newOpennetPeersString = getOpennetPeersString();
+        oldOpennetPeersFilename = om.getOldPeersFilename();
+        newOldOpennetPeersString = getOldOpennetPeersString(om);
+      }
+    }
+    synchronized (writePeerFileSync) {
+      if (newOpennetPeersString != null && !newOpennetPeersString.equals(opennetPeersStringCache)) {
+        opennetPeersStringCache = newOpennetPeersString;
+        writePeersInner(openFilename, opennetPeersStringCache, BACKUPS_OPENNET, rotateBackups);
+      }
+      if (newOldOpennetPeersString != null
+          && !newOldOpennetPeersString.equals(oldOpennetPeersStringCache)) {
+        oldOpennetPeersStringCache = newOldOpennetPeersString;
+        writePeersInner(
+            oldOpennetPeersFilename, oldOpennetPeersStringCache, BACKUPS_OPENNET, rotateBackups);
+      }
+    }
+  }
+
+  /**
+   * Write the peers file to disk.
+   *
+   * @param rotateBackups If true, rotate backups. If false, just clobber the latest file.
+   */
+  private void writePeersInner(String filename, String sb, int maxBackups, boolean rotateBackups) {
+    assert (maxBackups >= 1);
+    synchronized (writePeerFileSync) {
+      File f;
+      File full = new File(filename).getAbsoluteFile();
+      try {
+        f = File.createTempFile(full.getName() + ".", ".tmp", full.getParentFile());
+      } catch (IOException e2) {
+        LOG.error("Cannot write peers to disk: temp file creation error={}", e2, e2);
+        return;
+      }
+
+      try (FileOutputStream fos = new FileOutputStream(f);
+          OutputStreamWriter w = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
+        w.write(sb);
+        w.flush();
+        fos.getFD().sync();
+
+        if (rotateBackups) {
+          rotateBackupFiles(filename, maxBackups, f);
+        } else {
+          FileUtil.moveTo(f, getBackupFilename(filename, 0));
+        }
+      } catch (FileNotFoundException e2) {
+        LOG.error("Cannot write peers to disk: cannot create {} (error={})", f, e2, e2);
+        safeDeleteIfExists(f);
+      } catch (IOException e) {
+        LOG.error("I/O error writing peers file: {}", e, e);
+        safeDeleteIfExists(f);
+        // don't overwrite old file!
+      } finally {
+        // Try-with-resources handles the stream cleanup
+        safeDeleteIfExists(f);
+      }
+    }
+  }
+
+  private void rotateBackupFiles(String filename, int maxBackups, File newFile) {
+    File prevFile = null;
+    for (int i = maxBackups; i >= 0; i--) {
+      File thisFile = getBackupFilename(filename, i);
+      if (prevFile == null) {
+        safeDeleteIfExists(thisFile);
+      } else if (thisFile.exists()) {
+        FileUtil.moveTo(thisFile, prevFile);
+      }
+      prevFile = thisFile;
+    }
+    if (prevFile == null) prevFile = getBackupFilename(filename, 0);
+    FileUtil.moveTo(newFile, prevFile);
+  }
+
+  private File getBackupFilename(String filename, int i) {
+    if (i == 0) return new File(filename);
+    if (i == 1) return new File(filename + ".bak");
+    return new File(filename + ".bak." + i);
+  }
+
+  @SuppressWarnings("java:S1181")
+  private boolean readPeers(
+      File peersFile, NodeCrypto crypto, OpennetManager opennet, boolean oldOpennetPeers) {
+    boolean someBroken;
+    File brokenPeersFile = new File(peersFile.getPath() + ".broken");
+    DroppedOldPeersUserAlert droppedOldPeers = new DroppedOldPeersUserAlert(brokenPeersFile);
+    List<SimpleFieldSet> peerEntries = new ArrayList<>();
+    // read the peers file
+    try (FileInputStream fis = new FileInputStream(peersFile);
+        InputStreamReader ris = new InputStreamReader(fis, StandardCharsets.UTF_8);
+        BufferedReader br = new BufferedReader(ris)) {
+      readPeerFieldSets(br, peerEntries);
+    } catch (FileNotFoundException _) {
+      LOG.info("Peers file not found: {}", peersFile);
+      return false;
+    } catch (IOException e3) {
+      LOG.error("Read error {} on {}", e3, peersFile, e3);
+    }
+
+    List<PeerNode> createdNodes =
+        createPeerNodesFromEntries(peerEntries, crypto, opennet, droppedOldPeers);
+    // Consider the file "broken" if we could not create all peers (parse errors or too-old entries)
+    someBroken = (createdNodes.size() != peerEntries.size());
+    applyCreatedNodes(createdNodes, opennet, oldOpennetPeers);
+    if (someBroken) {
+      try {
+        safeDeleteIfExists(brokenPeersFile);
+        try (FileOutputStream fos = new FileOutputStream(brokenPeersFile);
+            FileInputStream fis = new FileInputStream(peersFile)) {
+          FileUtil.copy(fis, fos, -1);
+        }
+        LOG.warn("Broken peers file copied to {}", brokenPeersFile);
+      } catch (IOException _) {
+        LOG.warn("Unable to copy broken peers file");
+      }
+    }
+    if (!droppedOldPeers.isEmpty()) {
+      try {
+        node.getClientCore().getAlerts().register(droppedOldPeers);
+        LOG.error(droppedOldPeers.getText());
+      } catch (Throwable t) {
+        // Startup MUST complete, don't let client layer problems kill it.
+        LOG.error("Caught error telling user about dropped peers", t);
+      }
+    }
+    return !someBroken;
+  }
+
+  private List<PeerNode> createPeerNodesFromEntries(
+      List<SimpleFieldSet> peerEntries,
+      NodeCrypto crypto,
+      OpennetManager opennet,
+      DroppedOldPeersUserAlert droppedOldPeers) {
+    List<PeerNode> created = new ArrayList<>();
+    for (SimpleFieldSet fs : peerEntries) {
+      try {
+        created.add(PeerNode.create(fs, node, crypto, opennet, peerManager));
+      } catch (FSParseException
+          | PeerParseException
+          | ReferenceSignatureVerificationException
+          | RuntimeException e2) {
+        handlePeerCreationException(e2, fs);
+      } catch (PeerTooOldException e) {
+        if (crypto.isOpennet()) {
+          LOG.error("Dropping too-old opennet peer");
+        } else {
+          droppedOldPeers.add(e, fs.get("myName"));
+        }
+      }
+    }
+    // Always return successfully parsed peers; callers decide whether some entries were broken.
+    return created;
+  }
+
+  private void applyCreatedNodes(
+      List<PeerNode> createdNodes, OpennetManager opennet, boolean oldOpennetPeers) {
+    for (PeerNode pn : createdNodes) {
+      if (oldOpennetPeers) {
+        if (pn instanceof OpennetPeerNode opennetPeerNode) {
+          if (opennet != null) {
+            opennet.addOldOpennetNode(opennetPeerNode);
+          } else {
+            LOG.error("Opennet manager missing for old opennet peer: {}", pn);
+          }
+        } else {
+          LOG.error("Darknet node in old opennet peers: {}", pn);
+        }
+      } else {
+        peerManager.addPeer(pn, true, false);
+      }
+    }
+  }
+
+  private void handlePeerCreationException(Exception e2, SimpleFieldSet fs) {
+    LOG.error("Peer parse error {} for {}", e2, fs, e2);
+    LOG.warn("Cannot parse friend from peers file: {}", e2, e2);
+  }
+
+  private void readPeerFieldSets(BufferedReader br, List<SimpleFieldSet> out) throws IOException {
+    for (SimpleFieldSet sfs = readNextPeerFieldSet(br);
+        sfs != null;
+        sfs = readNextPeerFieldSet(br)) {
+      out.add(sfs);
+    }
+  }
+
+  private SimpleFieldSet readNextPeerFieldSet(BufferedReader br) throws IOException {
+    try {
+      return new SimpleFieldSet(br, false, true);
+    } catch (EOFException _) {
+      return null; // end-of-file reached
+    }
+  }
+
+  private static void safeDeleteIfExists(File file) {
+    try {
+      java.nio.file.Files.deleteIfExists(file.toPath());
+    } catch (IOException _) {
+      // best-effort
+    }
+  }
+}

--- a/src/main/java/network/crypta/node/PeerRoster.java
+++ b/src/main/java/network/crypta/node/PeerRoster.java
@@ -598,7 +598,7 @@ public class PeerRoster {
       }
       PeerNode[] keepArray = keep.toArray(new PeerNode[0]);
       myPeers = keepArray;
-      connectedPeers = Arrays.copyOf(keepArray, conn.size());
+      connectedPeers = conn.toArray(new PeerNode[0]);
     }
   }
 

--- a/src/main/java/network/crypta/node/PeerRoster.java
+++ b/src/main/java/network/crypta/node/PeerRoster.java
@@ -1,0 +1,603 @@
+package network.crypta.node;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import network.crypta.io.comm.FreenetInetAddress;
+import network.crypta.io.comm.Peer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Maintains the active peer roster and connected peer snapshots for a node.
+ *
+ * <p>This class encapsulates peer list mutations, lookups, and related counts while delegating
+ * higher-level coordination (alerts, routing, persistence) to the owning {@link PeerManager}.
+ */
+public class PeerRoster {
+  private static final Logger LOG = LoggerFactory.getLogger(PeerRoster.class);
+
+  private final Node node;
+  private final Object lock;
+
+  private PeerNode[] myPeers = new PeerNode[0];
+  private PeerNode[] connectedPeers = new PeerNode[0];
+
+  public PeerRoster(Node node, Object lock) {
+    this.node = node;
+    this.lock = lock;
+  }
+
+  /** Returns a non-copied snapshot of all peers (synchronized on the manager lock). */
+  public PeerNode[] myPeers() {
+    synchronized (lock) {
+      return myPeers;
+    }
+  }
+
+  /** Returns the last known connected-peer snapshot (synchronized on the manager lock). */
+  public PeerNode[] connectedPeers() {
+    synchronized (lock) {
+      return connectedPeers;
+    }
+  }
+
+  /** Returns whether the given peer instance is present in the roster (identity check). */
+  public boolean havePeer(PeerNode peer) {
+    synchronized (lock) {
+      for (PeerNode existing : myPeers) {
+        if (existing == peer) return true;
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Adds a peer to the roster if absent.
+   *
+   * @param peer the peer to add.
+   * @param reactivate if true, cancel any disconnecting state before adding.
+   * @return true if the peer was added, false if it was already present.
+   */
+  public boolean addPeer(PeerNode peer, boolean reactivate) {
+    if (reactivate) peer.forceCancelDisconnecting();
+    synchronized (lock) {
+      for (PeerNode existing : myPeers) {
+        if (existing == peer) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                "Can't add peer {} because already have {}",
+                peer,
+                existing,
+                new Exception("debug"));
+          }
+          return false;
+        }
+      }
+      myPeers = Arrays.copyOf(myPeers, myPeers.length + 1);
+      myPeers[myPeers.length - 1] = peer;
+      LOG.info("Added {}", peer);
+    }
+    return true;
+  }
+
+  /**
+   * Removes the given peer from the roster.
+   *
+   * @return true if the peer was present and removed, false otherwise.
+   */
+  public boolean removePeer(PeerNode peer) {
+    if (LOG.isDebugEnabled()) LOG.debug("Removing {}", peer);
+    synchronized (lock) {
+      boolean isInPeers = false;
+      for (PeerNode existing : myPeers) {
+        if (existing == peer) {
+          isInPeers = true;
+          break;
+        }
+      }
+      if (peer instanceof DarknetPeerNode) {
+        ((DarknetPeerNode) peer).removeExtraPeerDataDir();
+      }
+      if (isInPeers) {
+        rebuildPeerArraysOnRemove(peer);
+        LOG.info("Removed {}", peer);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Removes all peers and returns the previous peer snapshot for cleanup. */
+  public PeerNode[] removeAllPeers() {
+    synchronized (lock) {
+      PeerNode[] oldPeers = myPeers;
+      myPeers = new PeerNode[0];
+      connectedPeers = new PeerNode[0];
+      return oldPeers;
+    }
+  }
+
+  private void rebuildPeerArraysOnRemove(PeerNode peer) {
+    ArrayList<PeerNode> connected = new ArrayList<>();
+    for (PeerNode mp : myPeers) {
+      if (mp != peer && mp.isConnected() && mp.isRealConnection()) connected.add(mp);
+    }
+    connectedPeers = connected.toArray(new PeerNode[0]);
+
+    PeerNode[] newMyPeers = new PeerNode[myPeers.length - 1];
+    int position = 0;
+    for (PeerNode mp : myPeers) {
+      if (mp != peer) {
+        newMyPeers[position++] = mp;
+      }
+    }
+    myPeers = newMyPeers;
+  }
+
+  /**
+   * Updates the connected peers list when a peer disconnects.
+   *
+   * @return true if the peer was present in the connected set; false otherwise.
+   */
+  public boolean disconnected(PeerNode peer) {
+    synchronized (lock) {
+      boolean isInPeers = false;
+      for (PeerNode connectedPeer : connectedPeers) {
+        if (connectedPeer == peer) {
+          isInPeers = true;
+          break;
+        }
+      }
+      if (!isInPeers) return false;
+      ArrayList<PeerNode> peers = new ArrayList<>();
+      for (PeerNode mp : myPeers) {
+        if (mp != peer && mp.isRoutable()) peers.add(mp);
+      }
+      connectedPeers = peers.toArray(new PeerNode[0]);
+    }
+    return true;
+  }
+
+  /**
+   * Adds a peer to the connected set if it is a real, connected peer.
+   *
+   * @param peerAdder callback used when the peer is not present in the roster.
+   * @return true if the connected set changed, false otherwise.
+   */
+  public boolean addConnectedPeer(PeerNode peer, PeerAdder peerAdder) {
+    if (!peer.isRealConnection()) {
+      if (LOG.isDebugEnabled()) LOG.debug("Not a real connection: {}", peer);
+      return false;
+    }
+    if (!peer.isConnected()) {
+      if (LOG.isDebugEnabled()) LOG.debug("Not connected: {}", peer);
+      return false;
+    }
+    synchronized (lock) {
+      for (PeerNode connectedPeer : connectedPeers) {
+        if (connectedPeer == peer) {
+          if (LOG.isDebugEnabled()) LOG.debug("Already connected: {}", peer);
+          return false;
+        }
+      }
+      ensurePeerPresent(peer, peerAdder);
+      if (LOG.isDebugEnabled()) LOG.debug("Connecting: {}", peer);
+      connectedPeers = Arrays.copyOf(connectedPeers, connectedPeers.length + 1);
+      connectedPeers[connectedPeers.length - 1] = peer;
+      if (LOG.isDebugEnabled()) LOG.debug("Connected peers: {}", connectedPeers.length);
+    }
+    return true;
+  }
+
+  private void ensurePeerPresent(PeerNode peer, PeerAdder peerAdder) {
+    boolean inMyPeers = false;
+    for (PeerNode mp : myPeers) {
+      if (mp == peer) {
+        inMyPeers = true;
+        break;
+      }
+    }
+    if (!inMyPeers) {
+      LOG.error("Connecting to {} but not in peers", peer);
+      peerAdder.add(peer);
+    }
+  }
+
+  /** Finds a peer by transport address, falling back to IP-only matches. */
+  public PeerNode getByPeer(Peer peer) {
+    PeerNode[] peerList = myPeers();
+    for (PeerNode pn : peerList) {
+      if (pn.isDisabled()) continue;
+      if (pn.matchesPeerAndPort(peer)) return pn;
+    }
+    FreenetInetAddress addr = peer.getFreenetAddress();
+    for (PeerNode pn : peerList) {
+      if (pn.isDisabled()) continue;
+      if (pn.matchesIP(addr, false)) return pn;
+    }
+    return null;
+  }
+
+  /** Finds a peer by transport address and outgoing mangler, falling back to IP-only matches. */
+  public PeerNode getByPeer(Peer peer, FNPPacketMangler mangler) {
+    PeerNode[] peerList = myPeers();
+    for (PeerNode pn : peerList) {
+      if (pn.isDisabled()) continue;
+      if (pn.matchesPeerAndPort(peer) && pn.getOutgoingMangler() == mangler) return pn;
+    }
+    FreenetInetAddress addr = peer.getFreenetAddress();
+    for (PeerNode pn : peerList) {
+      if (pn.isDisabled()) continue;
+      if (pn.matchesIP(addr, false) && pn.getOutgoingMangler() == mangler) return pn;
+    }
+    return null;
+  }
+
+  /** Finds connected, routable peers that match the given address. */
+  public List<PeerNode> getAllConnectedByAddress(FreenetInetAddress addr, boolean strict) {
+    List<PeerNode> found = null;
+    PeerNode[] peerList = myPeers();
+    for (PeerNode pn : peerList) {
+      boolean eligible = pn.isConnected() && pn.isRoutable() && pn.matchesIP(addr, strict);
+      if (eligible) {
+        if (found == null) found = new ArrayList<>();
+        found.add(pn);
+      }
+    }
+    return found;
+  }
+
+  /** Returns the peer with the given public key hash, if present. */
+  public PeerNode getByPubKeyHash(byte[] pkHash) {
+    PeerNode[] peers = myPeers();
+    for (PeerNode peer : peers) {
+      if (Arrays.equals(peer.peerECDSAPubKeyHash, pkHash)) return peer;
+    }
+    return null;
+  }
+
+  /** Returns a random routable connected peer, or null if none. */
+  public PeerNode getRandomPeer() {
+    return getRandomPeer(null);
+  }
+
+  /** Returns a random routable connected peer, or null if none. */
+  public PeerNode getRandomPeer(PeerNode exclude) {
+    synchronized (lock) {
+      if (connectedPeers.length == 0) return null;
+      PeerNode candidate = attemptRandomRoutable(exclude);
+      if (candidate != null) return candidate;
+      int lengthWithoutExcluded = rebuildConnectedPeersExcluding(exclude);
+      if (lengthWithoutExcluded == 0) return null;
+      return connectedPeers[node.getRandom().nextInt(lengthWithoutExcluded)];
+    }
+  }
+
+  private PeerNode attemptRandomRoutable(PeerNode exclude) {
+    for (int i = 0; i < 5; i++) {
+      PeerNode pn = connectedPeers[node.getRandom().nextInt(connectedPeers.length)];
+      if (pn == exclude) continue;
+      if (pn.isRoutable()) return pn;
+    }
+    return null;
+  }
+
+  private int rebuildConnectedPeersExcluding(PeerNode exclude) {
+    ArrayList<PeerNode> v = new ArrayList<>(connectedPeers.length);
+    for (PeerNode pn : myPeers) {
+      if (pn == exclude) continue;
+      if (pn.isRoutable()) v.add(pn);
+      else if (LOG.isDebugEnabled()) LOG.debug("Excluding {}; disconnected", pn);
+    }
+    int lengthWithoutExcluded = v.size();
+    if (exclude != null && exclude.isRoutable()) v.add(exclude);
+    PeerNode[] newConnectedPeers = v.toArray(new PeerNode[0]);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(
+          "Connected peers in getRandomPeer: {} was {}",
+          newConnectedPeers.length,
+          connectedPeers.length);
+    }
+    connectedPeers = newConnectedPeers;
+    return lengthWithoutExcluded;
+  }
+
+  /** Returns the current locations of connected peers as doubles in [0.0, 1.0). */
+  public double[] getPeerLocationDoubles(boolean pruneBackedOffPeers) {
+    if (!node.shallWePublishOurPeersLocation()) return new double[0];
+    PeerNode[] conns = connectedPeers();
+    double[] locs = collectPeerLocations(conns, pruneBackedOffPeers);
+    Arrays.sort(locs);
+    return locs;
+  }
+
+  private double[] collectPeerLocations(PeerNode[] peers, boolean pruneBackedOffPeers) {
+    ArrayList<Double> tmp = new ArrayList<>();
+    for (PeerNode peer : peers) {
+      if (peer.isRoutable() && (!pruneBackedOffPeers || !peer.shouldBeExcludedFromPeerList())) {
+        tmp.add(peer.getLocation());
+      }
+    }
+    double[] locs = new double[tmp.size()];
+    for (int i = 0; i < tmp.size(); i++) {
+      locs[i] = tmp.get(i);
+    }
+    return locs;
+  }
+
+  /** Returns whether any peer is currently routable. */
+  public boolean anyConnectedPeers() {
+    PeerNode[] conns = connectedPeers();
+    for (PeerNode conn : conns) {
+      if (conn.isRoutable()) return true;
+    }
+    return false;
+  }
+
+  /** Returns whether any connected peer is a darknet peer. */
+  public boolean anyDarknetPeers() {
+    PeerNode[] conns = connectedPeers();
+    for (PeerNode peer : conns) {
+      if (peer.isDarknet()) return true;
+    }
+    return false;
+  }
+
+  /** Returns the current list of darknet peers. */
+  public DarknetPeerNode[] getDarknetPeers() {
+    PeerNode[] peers = myPeers();
+    ArrayList<DarknetPeerNode> v = new ArrayList<>(peers.length);
+    for (PeerNode peer : peers) {
+      if (peer instanceof DarknetPeerNode) v.add((DarknetPeerNode) peer);
+    }
+    return v.toArray(new DarknetPeerNode[0]);
+  }
+
+  /** Returns the current list of opennet peers. */
+  public OpennetPeerNode[] getOpennetPeers() {
+    PeerNode[] peers = myPeers();
+    ArrayList<OpennetPeerNode> v = new ArrayList<>(peers.length);
+    for (PeerNode peer : peers) {
+      if (peer instanceof OpennetPeerNode) v.add((OpennetPeerNode) peer);
+    }
+    return v.toArray(new OpennetPeerNode[0]);
+  }
+
+  /** Returns opennet and seed-server peers. */
+  public PeerNode[] getOpennetAndSeedServerPeers() {
+    PeerNode[] peers = myPeers();
+    ArrayList<PeerNode> v = new ArrayList<>(peers.length);
+    for (PeerNode peer : peers) {
+      if (peer instanceof OpennetPeerNode || peer instanceof SeedServerPeerNode) v.add(peer);
+    }
+    return v.toArray(new PeerNode[0]);
+  }
+
+  /** Removes all opennet peers from the roster. */
+  public void removeOpennetPeers() {
+    synchronized (lock) {
+      ArrayList<PeerNode> keep = new ArrayList<>();
+      ArrayList<PeerNode> conn = new ArrayList<>();
+      for (PeerNode pn : myPeers) {
+        if (pn instanceof OpennetPeerNode) continue;
+        keep.add(pn);
+        if (pn.isConnected()) conn.add(pn);
+      }
+      PeerNode[] keepArray = keep.toArray(new PeerNode[0]);
+      myPeers = keepArray;
+      connectedPeers = Arrays.copyOf(keepArray, conn.size());
+    }
+  }
+
+  /** Finds a peer by public key hash within the relevant peer set. */
+  public PeerNode containsPeer(PeerNode peer) {
+    PeerNode[] peers = peer.isOpennet() ? getOpennetAndSeedServerPeers() : getDarknetPeers();
+    for (PeerNode candidate : peers) {
+      if (Arrays.equals(peer.peerECDSAPubKeyHash, candidate.peerECDSAPubKeyHash)) return candidate;
+    }
+    return null;
+  }
+
+  /** Checks whether any other connected real peer has the given address. */
+  public boolean anyConnectedPeerHasAddress(FreenetInetAddress addr, PeerNode peer) {
+    PeerNode[] peers = myPeers();
+    for (PeerNode p : peers) {
+      boolean skip =
+          p == peer
+              || !p.isConnected()
+              || !p.isRealConnection()
+              || (p.isDarknet() && !peer.isDarknet());
+      if (skip) continue;
+      if (p.getPeer().getFreenetAddress().equals(addr)) return true;
+    }
+    return false;
+  }
+
+  /** Counts peers that are routable and not in backoff for the given traffic class. */
+  public int countNonBackedOffPeers(boolean realTime) {
+    PeerNode[] peers = connectedPeers();
+    int count = 0;
+    for (PeerNode peer : peers) {
+      if (peer.isRoutable() && !peer.isRoutingBackedOff(realTime)) count++;
+    }
+    return count;
+  }
+
+  /** Counts connected darknet peers that are routable and not opennet. */
+  public int countConnectedDarknetPeers() {
+    int count = 0;
+    PeerNode[] peers = myPeers();
+    for (PeerNode peer : peers) {
+      if (peer instanceof DarknetPeerNode && !peer.isOpennet() && peer.isRoutable()) count++;
+    }
+    if (LOG.isDebugEnabled()) LOG.debug("countConnectedDarknetPeers() returning {}", count);
+    return count;
+  }
+
+  /** Counts all connected and routable peers. */
+  public int countConnectedPeers() {
+    return countConnectedPeers(myPeers());
+  }
+
+  private int countConnectedPeers(PeerNode[] peers) {
+    int count = 0;
+    for (PeerNode peer : peers) {
+      if (peer.isRoutable()) count++;
+    }
+    return count;
+  }
+
+  /** Counts darknet peers that are connected (regardless of routability). */
+  public int countAlmostConnectedDarknetPeers() {
+    int count = 0;
+    PeerNode[] peers = myPeers();
+    for (PeerNode peer : peers) {
+      if (peer instanceof DarknetPeerNode && !peer.isOpennet() && peer.isConnected()) count++;
+    }
+    return count;
+  }
+
+  /** Counts darknet peers that are connected and routing-compatible. */
+  public int countCompatibleDarknetPeers() {
+    int count = 0;
+    PeerNode[] peers = myPeers();
+    for (PeerNode peer : peers) {
+      if (peer instanceof DarknetPeerNode
+          && !peer.isOpennet()
+          && peer.isConnected()
+          && peer.isRoutingCompatible()) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** Counts peers with a real connection that are connected and routing-compatible. */
+  public int countCompatibleRealPeers() {
+    int count = 0;
+    PeerNode[] peers = myPeers();
+    for (PeerNode peer : peers) {
+      if (peer.isRealConnection() && peer.isConnected() && peer.isRoutingCompatible()) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** Counts connected opennet peers that are routable. */
+  public int countConnectedOpennetPeers() {
+    int count = 0;
+    PeerNode[] peers = connectedPeers();
+    for (PeerNode peer : peers) {
+      if (peer instanceof OpennetPeerNode && peer.isRoutable()) count++;
+    }
+    return count;
+  }
+
+  /** Counts peers that actually may connect (excluding seednodes and disabled peers). */
+  public int countValidPeers() {
+    int count = 0;
+    PeerNode[] peers = myPeers();
+    for (PeerNode peer : peers) {
+      if (peer.isRealConnection() && !peer.isDisabled()) count++;
+    }
+    return count;
+  }
+
+  /** Counts peers that may connect, excluding listen-only darknet peers. */
+  public int countConnectiblePeers() {
+    int count = 0;
+    PeerNode[] peers = myPeers();
+    for (PeerNode peer : peers) {
+      boolean isListenOnlyDarknet =
+          (peer instanceof DarknetPeerNode) && ((DarknetPeerNode) peer).isListenOnly();
+      if (!peer.isDisabled() && !isListenOnlyDarknet) count++;
+    }
+    return count;
+  }
+
+  /** Counts peers that are seed servers or seed clients. */
+  public int countSeednodes() {
+    int count = 0;
+    for (PeerNode peer : myPeers()) {
+      if (peer instanceof SeedServerPeerNode || peer instanceof SeedClientPeerNode) count++;
+    }
+    return count;
+  }
+
+  /** Counts peers currently in routing backoff. */
+  public int countBackedOffPeers(boolean realTime) {
+    int count = 0;
+    PeerNode[] peers = myPeers();
+    for (PeerNode peer : peers) {
+      if (peer.isRealConnection() && !peer.isDisabled() && peer.isRoutingBackedOff(realTime)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** Count peers by current status value. */
+  public int countByStatus(int status) {
+    int count = 0;
+    PeerNode[] peers = myPeers();
+    for (PeerNode peer : peers) {
+      if (peer.getPeerNodeStatus() == status) count++;
+    }
+    return count;
+  }
+
+  /** Returns a textual status list for all peers. */
+  public String getStatus() {
+    StringBuilder sb = new StringBuilder();
+    PeerNode[] peers = myPeers();
+    String[] status = new String[peers.length];
+    for (int i = 0; i < peers.length; i++) {
+      status[i] = peers[i].getStatus(true).toString();
+    }
+    Arrays.sort(status);
+    for (String s : status) {
+      sb.append(s).append('\n');
+    }
+    return sb.toString();
+  }
+
+  /** Returns a textual list of TMCI peers. */
+  public String getTMCIPeerList() {
+    StringBuilder sb = new StringBuilder();
+    PeerNode[] peers = myPeers();
+    String[] peerList = new String[peers.length];
+    for (int i = 0; i < peers.length; i++) {
+      peerList[i] = peers[i].getTMCIPeerInfo();
+    }
+    Arrays.sort(peerList);
+    for (String p : peerList) {
+      sb.append(p).append('\n');
+    }
+    return sb.toString();
+  }
+
+  /** Ask each DarknetPeerNode to read in its extra peer data. */
+  public void readExtraPeerData() {
+    DarknetPeerNode[] peers = getDarknetPeers();
+    for (DarknetPeerNode peer : peers) {
+      try {
+        peer.readExtraPeerData();
+      } catch (Exception e) {
+        LOG.error("Error reading extra peer data", e);
+      }
+    }
+    LOG.info("Extra peer data reading and processing completed");
+  }
+
+  /** Increments the selection sample counter for a peer. */
+  public void incrementSelectionSamples(PeerNode peer) {
+    peer.incrementNumberOfSelections();
+  }
+
+  @FunctionalInterface
+  public interface PeerAdder {
+    void add(PeerNode peer);
+  }
+}

--- a/src/main/java/network/crypta/node/PeerRoster.java
+++ b/src/main/java/network/crypta/node/PeerRoster.java
@@ -112,7 +112,7 @@ public class PeerRoster {
   /**
    * Adds a peer to the roster if it is not already present.
    *
-   * <p>This method performs an identity-based check under the shared lock. When {@code reactivate}
+   * <p>This method performs an equality-based check under the shared lock. When {@code reactivate}
    * is {@code true}, it first cancels any disconnecting state on the peer before acquiring the
    * lock. Adding a peer only updates the roster snapshot; it does not implicitly mark the peer as
    * connected or modify the connected-peers snapshot.
@@ -125,7 +125,7 @@ public class PeerRoster {
     if (reactivate) peer.forceCancelDisconnecting();
     synchronized (lock) {
       for (PeerNode existing : myPeers) {
-        if (existing == peer) {
+        if (existing.equals(peer)) {
           if (LOG.isDebugEnabled()) {
             LOG.debug(
                 "Can't add peer {} because already have {}",

--- a/src/main/java/network/crypta/node/PeerRoster.java
+++ b/src/main/java/network/crypta/node/PeerRoster.java
@@ -11,8 +11,27 @@ import org.slf4j.LoggerFactory;
 /**
  * Maintains the active peer roster and connected peer snapshots for a node.
  *
- * <p>This class encapsulates peer list mutations, lookups, and related counts while delegating
- * higher-level coordination (alerts, routing, persistence) to the owning {@link PeerManager}.
+ * <p>The roster is a small, synchronized registry that tracks known peers, their connected view,
+ * and a set of common queries used by routing and status reporting. It is intentionally narrow in
+ * scope: the class focuses on array-backed storage, identity checks, and lightweight lookups,
+ * leaving higher-level coordination (alerts, routing policy, persistence) to {@link PeerManager}
+ * and {@link Node}. Arrays are replaced atomically under a shared manager lock, so callers should
+ * treat returned arrays as snapshots that can become stale immediately after the lock is released.
+ *
+ * <p>This design favors low-overhead reads and predictable allocation patterns, but it means
+ * multistep operations must re-check state under the same lock if consistency is required.
+ * Thread-safety is provided by synchronizing on the supplied lock; the returned arrays are mutable
+ * and must not be modified by callers.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> add/remove peers, track connected peers, and answer
+ *       summary queries.
+ *   <li><strong>Notable behavior:</strong> connected snapshots are rebuilt from roster state and
+ *       routability checks.
+ * </ul>
+ *
+ * @see PeerManager
+ * @see PeerNode
  */
 public class PeerRoster {
   private static final Logger LOG = LoggerFactory.getLogger(PeerRoster.class);
@@ -23,26 +42,64 @@ public class PeerRoster {
   private PeerNode[] myPeers = new PeerNode[0];
   private PeerNode[] connectedPeers = new PeerNode[0];
 
+  /**
+   * Creates a roster bound to the owning node and its shared synchronization lock.
+   *
+   * <p>The roster stores references to the supplied node and lock; it does not take ownership of
+   * either object and does not perform any synchronization during construction. Callers should
+   * provide the same lock that guards peer management in {@link PeerManager} so that roster updates
+   * remain consistent with other peer-related state transitions.
+   *
+   * @param node the owning node instance used for random selection and policy checks.
+   * @param lock the shared manager lock guarding all roster mutations and snapshots.
+   */
   public PeerRoster(Node node, Object lock) {
     this.node = node;
     this.lock = lock;
   }
 
-  /** Returns a non-copied snapshot of all peers (synchronized on the manager lock). */
+  /**
+   * Returns the current roster snapshot without making a defensive copy.
+   *
+   * <p>The returned array is the internal snapshot captured under the shared lock. Its contents
+   * represent the roster state at the time of the call, but the array may be replaced immediately
+   * afterward by subsequent mutations. Callers must not modify the array and should copy it if they
+   * require a stable, caller-owned view.
+   *
+   * @return the internal array snapshot of all known peers, potentially empty.
+   */
   public PeerNode[] myPeers() {
     synchronized (lock) {
       return myPeers;
     }
   }
 
-  /** Returns the last known connected-peer snapshot (synchronized on the manager lock). */
+  /**
+   * Returns the last known connected-peer snapshot without a defensive copy.
+   *
+   * <p>The returned array is the internal connected-peers snapshot captured under the shared lock.
+   * It may include only peers that were connected and routable when the snapshot was built, and it
+   * can become stale as soon as the lock is released. Callers must not mutate the array and should
+   * copy it for long-lived iteration.
+   *
+   * @return the internal array snapshot of connected peers, possibly empty.
+   */
   public PeerNode[] connectedPeers() {
     synchronized (lock) {
       return connectedPeers;
     }
   }
 
-  /** Returns whether the given peer instance is present in the roster (identity check). */
+  /**
+   * Returns whether the given peer instance is present in the roster by identity.
+   *
+   * <p>This method performs a reference-equality check against the current roster snapshot. It does
+   * not consult peer identity fields or keys, and it does not modify any roster state. The check is
+   * performed under the shared lock to provide a consistent view of the array.
+   *
+   * @param peer the peer instance to test for presence; if {@code null} this returns {@code false}.
+   * @return {@code true} if the exact instance is present, otherwise {@code false}.
+   */
   public boolean havePeer(PeerNode peer) {
     synchronized (lock) {
       for (PeerNode existing : myPeers) {
@@ -53,11 +110,16 @@ public class PeerRoster {
   }
 
   /**
-   * Adds a peer to the roster if absent.
+   * Adds a peer to the roster if it is not already present.
    *
-   * @param peer the peer to add.
-   * @param reactivate if true, cancel any disconnecting state before adding.
-   * @return true if the peer was added, false if it was already present.
+   * <p>This method performs an identity-based check under the shared lock. When {@code reactivate}
+   * is {@code true}, it first cancels any disconnecting state on the peer before acquiring the
+   * lock. Adding a peer only updates the roster snapshot; it does not implicitly mark the peer as
+   * connected or modify the connected-peers snapshot.
+   *
+   * @param peer the peer instance to add to the roster snapshot.
+   * @param reactivate whether to cancel disconnecting state before the add attempt.
+   * @return {@code true} if the peer was newly added; {@code false} if already present.
    */
   public boolean addPeer(PeerNode peer, boolean reactivate) {
     if (reactivate) peer.forceCancelDisconnecting();
@@ -82,9 +144,16 @@ public class PeerRoster {
   }
 
   /**
-   * Removes the given peer from the roster.
+   * Removes the given peer from the roster by identity.
    *
-   * @return true if the peer was present and removed, false otherwise.
+   * <p>The method checks whether the exact peer instance is present, updates the roster snapshot,
+   * and rebuilds the connected-peers snapshot from the remaining routable real connections. If the
+   * peer is a {@link DarknetPeerNode}, its extra peer data directory is removed as part of the
+   * cleanup. The method does not attempt to close network connections; it only updates local
+   * snapshots.
+   *
+   * @param peer the peer instance to remove from the roster snapshot.
+   * @return {@code true} if the peer was present and removed; {@code false} otherwise.
    */
   public boolean removePeer(PeerNode peer) {
     if (LOG.isDebugEnabled()) LOG.debug("Removing {}", peer);
@@ -96,8 +165,8 @@ public class PeerRoster {
           break;
         }
       }
-      if (peer instanceof DarknetPeerNode) {
-        ((DarknetPeerNode) peer).removeExtraPeerDataDir();
+      if (peer instanceof DarknetPeerNode darknetPeer) {
+        darknetPeer.removeExtraPeerDataDir();
       }
       if (isInPeers) {
         rebuildPeerArraysOnRemove(peer);
@@ -108,7 +177,15 @@ public class PeerRoster {
     return false;
   }
 
-  /** Removes all peers and returns the previous peer snapshot for cleanup. */
+  /**
+   * Removes all peers and returns the previous roster snapshot for cleanup.
+   *
+   * <p>Both the roster and connected-peers snapshots are cleared under the shared lock. The method
+   * does not close network connections or alter peer state; it simply drops the local references so
+   * the caller can perform any necessary cleanup with the returned array.
+   *
+   * @return the previous roster snapshot that was cleared from this roster.
+   */
   public PeerNode[] removeAllPeers() {
     synchronized (lock) {
       PeerNode[] oldPeers = myPeers;
@@ -136,9 +213,15 @@ public class PeerRoster {
   }
 
   /**
-   * Updates the connected peers list when a peer disconnects.
+   * Updates the connected-peers snapshot when a peer disconnects.
    *
-   * @return true if the peer was present in the connected set; false otherwise.
+   * <p>If the peer is present in the connected snapshot, this method rebuilds the connected list by
+   * scanning the roster and retaining only peers that are currently routable. The roster itself is
+   * not modified. The update is performed under the shared lock to avoid races with other snapshot
+   * updates.
+   *
+   * @param peer the peer instance that is transitioning to a disconnected state.
+   * @return {@code true} if the peer was found in the connected snapshot; {@code false} otherwise.
    */
   public boolean disconnected(PeerNode peer) {
     synchronized (lock) {
@@ -160,10 +243,16 @@ public class PeerRoster {
   }
 
   /**
-   * Adds a peer to the connected set if it is a real, connected peer.
+   * Adds a peer to the connected snapshot when it is real and already connected.
    *
-   * @param peerAdder callback used when the peer is not present in the roster.
-   * @return true if the connected set changed, false otherwise.
+   * <p>The method rejects non-real or disconnected peers early and returns {@code false} without
+   * modifying any state. When the peer is eligible, it verifies that the peer exists in the roster;
+   * if not, it logs a diagnostic and invokes the provided {@link PeerAdder} to add it. The
+   * connected snapshot is then updated under the shared lock using identity equality.
+   *
+   * @param peer the peer to consider for inclusion in the connected snapshot.
+   * @param peerAdder callback used to insert the peer if missing from the roster.
+   * @return {@code true} if the connected snapshot changed; {@code false} otherwise.
    */
   public boolean addConnectedPeer(PeerNode peer, PeerAdder peerAdder) {
     if (!peer.isRealConnection()) {
@@ -204,7 +293,17 @@ public class PeerRoster {
     }
   }
 
-  /** Finds a peer by transport address, falling back to IP-only matches. */
+  /**
+   * Finds a peer by transport address, falling back to IP-only matches.
+   *
+   * <p>The roster is scanned twice: first for peers whose transport address and port match the
+   * supplied {@link Peer}, and then for peers whose IP matches the same address regardless of port.
+   * Disabled peers are skipped. The method returns the first matching peer and does not modify
+   * roster state.
+   *
+   * @param peer the transport address descriptor to match against the roster.
+   * @return the first matching peer, or {@code null} if no match is found.
+   */
   public PeerNode getByPeer(Peer peer) {
     PeerNode[] peerList = myPeers();
     for (PeerNode pn : peerList) {
@@ -219,7 +318,17 @@ public class PeerRoster {
     return null;
   }
 
-  /** Finds a peer by transport address and outgoing mangler, falling back to IP-only matches. */
+  /**
+   * Finds a peer by transport address and outgoing mangler, with an IP-only fallback.
+   *
+   * <p>This method mirrors {@link #getByPeer(Peer)} but additionally requires the peer's outgoing
+   * {@link FNPPacketMangler} to match the supplied {@code mangler}. Disabled peers are skipped. The
+   * method returns the first matching peer and does not modify roster state.
+   *
+   * @param peer the transport address descriptor to match against the roster.
+   * @param mangler the outgoing mangler instance that must match the peer configuration.
+   * @return the first matching peer, or {@code null} if no match is found.
+   */
   public PeerNode getByPeer(Peer peer, FNPPacketMangler mangler) {
     PeerNode[] peerList = myPeers();
     for (PeerNode pn : peerList) {
@@ -234,7 +343,18 @@ public class PeerRoster {
     return null;
   }
 
-  /** Finds connected, routable peers that match the given address. */
+  /**
+   * Finds connected, routable peers that match the given address.
+   *
+   * <p>The roster snapshot is scanned for peers that are connected, routable, and whose IP matches
+   * the provided address using the {@code strict} flag. The method returns {@code null} when no
+   * peers match to avoid allocating an empty list. When matches exist, the returned list preserves
+   * the roster iteration order and is owned by the caller.
+   *
+   * @param addr the address to match against each peer's IP.
+   * @param strict whether to request strict matching semantics from {@code matchesIP}.
+   * @return a list of matching peers, or {@code null} if no peers match.
+   */
   public List<PeerNode> getAllConnectedByAddress(FreenetInetAddress addr, boolean strict) {
     List<PeerNode> found = null;
     PeerNode[] peerList = myPeers();
@@ -248,7 +368,17 @@ public class PeerRoster {
     return found;
   }
 
-  /** Returns the peer with the given public key hash, if present. */
+  /**
+   * Returns the peer with the given public key hash, if present.
+   *
+   * <p>The roster is scanned linearly and each peer's public key hash is compared using {@link
+   * Arrays#equals(byte[], byte[])}. The method returns the first matching peer or {@code null} if
+   * none are present. The provided hash array is not copied or stored, and the comparison is a raw
+   * byte match without normalization or decoding.
+   *
+   * @param pkHash the peer public-key hash bytes to match against roster entries.
+   * @return the first peer with a matching hash, or {@code null} when absent.
+   */
   public PeerNode getByPubKeyHash(byte[] pkHash) {
     PeerNode[] peers = myPeers();
     for (PeerNode peer : peers) {
@@ -257,12 +387,31 @@ public class PeerRoster {
     return null;
   }
 
-  /** Returns a random routable connected peer, or null if none. */
+  /**
+   * Returns a random routable connected peer, or {@code null} if none exist.
+   *
+   * <p>This is a convenience wrapper around {@link #getRandomPeer(PeerNode)} with no exclusion. The
+   * selection is based on the connected snapshot and may rebuild that snapshot if needed to ensure
+   * routability. The method does not guarantee stable distribution across calls.
+   *
+   * @return a random routable connected peer, or {@code null} if none are available.
+   */
   public PeerNode getRandomPeer() {
     return getRandomPeer(null);
   }
 
-  /** Returns a random routable connected peer, or null if none. */
+  /**
+   * Returns a random routable connected peer, optionally excluding one peer.
+   *
+   * <p>The method first tries a small number of random selections from the current connected
+   * snapshot, skipping the excluded peer and any unroutable entries. If those attempts fail, it
+   * rebuilds the connected snapshot from the roster, optionally excluding the provided peer from
+   * selection, and then chooses uniformly from the rebuilt list. The connected snapshot may be
+   * modified as a side effect.
+   *
+   * @param exclude a peer instance to avoid returning; {@code null} allows any.
+   * @return a routable connected peer, or {@code null} when none are eligible.
+   */
   public PeerNode getRandomPeer(PeerNode exclude) {
     synchronized (lock) {
       if (connectedPeers.length == 0) return null;
@@ -303,7 +452,17 @@ public class PeerRoster {
     return lengthWithoutExcluded;
   }
 
-  /** Returns the current locations of connected peers as doubles in [0.0, 1.0). */
+  /**
+   * Returns the current locations of connected peers as doubles in {@code [0.0, 1.0)}.
+   *
+   * <p>If the node is not configured to publish its peers' locations, this method returns an empty
+   * array. Otherwise, it collects locations from connected, routable peers, optionally pruning
+   * peers that should be excluded from published lists, and sorts the resulting values in ascending
+   * order. The returned array is a new allocation owned by the caller.
+   *
+   * @param pruneBackedOffPeers whether to exclude peers that should be pruned from peer lists.
+   * @return a sorted array of peer locations, or an empty array when publishing is disabled.
+   */
   public double[] getPeerLocationDoubles(boolean pruneBackedOffPeers) {
     if (!node.shallWePublishOurPeersLocation()) return new double[0];
     PeerNode[] conns = connectedPeers();
@@ -326,7 +485,16 @@ public class PeerRoster {
     return locs;
   }
 
-  /** Returns whether any peer is currently routable. */
+  /**
+   * Returns whether any connected peer is currently routable.
+   *
+   * <p>This method scans the connected snapshot and checks routability on each peer. It does not
+   * alter roster state and returns immediately on the first routable peer found. The snapshot used
+   * for scanning is retrieved atomically but can become stale once the method returns. It is a
+   * lightweight read-only query intended for fast status checks.
+   *
+   * @return {@code true} if any connected peer is routable; {@code false} otherwise.
+   */
   public boolean anyConnectedPeers() {
     PeerNode[] conns = connectedPeers();
     for (PeerNode conn : conns) {
@@ -335,7 +503,16 @@ public class PeerRoster {
     return false;
   }
 
-  /** Returns whether any connected peer is a darknet peer. */
+  /**
+   * Returns whether any connected peer is a darknet peer.
+   *
+   * <p>The check is performed against the current connected snapshot and does not modify any roster
+   * state. It returns as soon as a connected darknet peer is found and does not attempt to
+   * revalidate connectivity or routability beyond what the snapshot already captured. Use this for
+   * quick UI or reporting decisions rather than authoritative membership checks.
+   *
+   * @return {@code true} if any connected peer is a darknet peer; {@code false} otherwise.
+   */
   public boolean anyDarknetPeers() {
     PeerNode[] conns = connectedPeers();
     for (PeerNode peer : conns) {
@@ -344,27 +521,54 @@ public class PeerRoster {
     return false;
   }
 
-  /** Returns the current list of darknet peers. */
+  /**
+   * Returns the current list of darknet peers in the roster.
+   *
+   * <p>The method builds a new array containing only {@link DarknetPeerNode} instances found in the
+   * roster snapshot. The snapshot is not filtered by connectivity, routability, or disabled state,
+   * so the caller should apply additional checks if needed. The iteration order matches the roster
+   * snapshot order, and the returned array is owned by the caller and can be modified safely.
+   *
+   * @return an array of darknet peers for callers, possibly empty.
+   */
   public DarknetPeerNode[] getDarknetPeers() {
     PeerNode[] peers = myPeers();
     ArrayList<DarknetPeerNode> v = new ArrayList<>(peers.length);
     for (PeerNode peer : peers) {
-      if (peer instanceof DarknetPeerNode) v.add((DarknetPeerNode) peer);
+      if (peer instanceof DarknetPeerNode darknetPeer) v.add(darknetPeer);
     }
     return v.toArray(new DarknetPeerNode[0]);
   }
 
-  /** Returns the current list of opennet peers. */
+  /**
+   * Returns the current list of opennet peers in the roster.
+   *
+   * <p>The method builds a new array containing only {@link OpennetPeerNode} instances found in the
+   * roster snapshot. The snapshot is not filtered by connectivity, routability, or disabled state,
+   * so the caller should apply additional checks if needed. The iteration order matches the roster
+   * snapshot order, and the returned array is owned by the caller and can be modified safely.
+   *
+   * @return an array of opennet peers, possibly empty.
+   */
   public OpennetPeerNode[] getOpennetPeers() {
     PeerNode[] peers = myPeers();
     ArrayList<OpennetPeerNode> v = new ArrayList<>(peers.length);
     for (PeerNode peer : peers) {
-      if (peer instanceof OpennetPeerNode) v.add((OpennetPeerNode) peer);
+      if (peer instanceof OpennetPeerNode opennetPeer) v.add(opennetPeer);
     }
     return v.toArray(new OpennetPeerNode[0]);
   }
 
-  /** Returns opennet and seed-server peers. */
+  /**
+   * Returns opennet peers and seed-server peers from the roster.
+   *
+   * <p>The method scans the roster snapshot and collects peers that are either {@link
+   * OpennetPeerNode} instances or {@link SeedServerPeerNode} instances. The snapshot is not
+   * filtered by connection state or disabled flag, so the result is purely type-based. The returned
+   * array is a new allocation owned by the caller and ordered by the roster iteration order.
+   *
+   * @return an array of opennet and seed-server peers, possibly empty.
+   */
   public PeerNode[] getOpennetAndSeedServerPeers() {
     PeerNode[] peers = myPeers();
     ArrayList<PeerNode> v = new ArrayList<>(peers.length);
@@ -374,7 +578,15 @@ public class PeerRoster {
     return v.toArray(new PeerNode[0]);
   }
 
-  /** Removes all opennet peers from the roster. */
+  /**
+   * Removes all opennet peers from the roster.
+   *
+   * <p>The method rebuilds both the roster snapshot and the connected snapshot under the shared
+   * lock, keeping only non-opennet peers. Connected peers are retained only if they remain
+   * connected after the filtering. The method is idempotent and does not otherwise modify peer
+   * state or attempt to close connections. Callers should expect the connected snapshot to shrink
+   * as a result of removing opennet entries.
+   */
   public void removeOpennetPeers() {
     synchronized (lock) {
       ArrayList<PeerNode> keep = new ArrayList<>();
@@ -390,7 +602,18 @@ public class PeerRoster {
     }
   }
 
-  /** Finds a peer by public key hash within the relevant peer set. */
+  /**
+   * Finds a peer by public key hash within the relevant peer set.
+   *
+   * <p>The search scope depends on the supplied peer's network type: opennet peers are matched
+   * against opennet and seed-server peers, while darknet peers are matched against the darknet
+   * roster. Peers are compared by their public-key hash bytes, so the result may be a different
+   * instance than the one supplied if another peer shares the same hash. The method performs a
+   * linear scan and returns the first match in snapshot order.
+   *
+   * @param peer the peer whose network type and hash define the search scope.
+   * @return the matching peer instance, or {@code null} if no match is found.
+   */
   public PeerNode containsPeer(PeerNode peer) {
     PeerNode[] peers = peer.isOpennet() ? getOpennetAndSeedServerPeers() : getDarknetPeers();
     for (PeerNode candidate : peers) {
@@ -399,7 +622,20 @@ public class PeerRoster {
     return null;
   }
 
-  /** Checks whether any other connected real peer has the given address. */
+  /**
+   * Checks whether any other connected real peer has the given address.
+   *
+   * <p>The scan ignores the provided peer instance, peers that are not connected, and peers that
+   * are not real connections. Additionally, darknet peers are skipped when the reference peer is
+   * not a darknet peer, preventing cross-network address comparisons. Address equality uses {@link
+   * FreenetInetAddress#equals(Object)} for comparison, and the method returns immediately on the
+   * first match found.
+   *
+   * @param addr the address to match against other connected peers.
+   * @param peer the peer to exclude from matching and to infer network scope.
+   * @return {@code true} if another connected real peer shares the address; {@code false}
+   *     otherwise.
+   */
   public boolean anyConnectedPeerHasAddress(FreenetInetAddress addr, PeerNode peer) {
     PeerNode[] peers = myPeers();
     for (PeerNode p : peers) {
@@ -414,7 +650,17 @@ public class PeerRoster {
     return false;
   }
 
-  /** Counts peers that are routable and not in backoff for the given traffic class. */
+  /**
+   * Counts connected peers that are routable and not in routing backoff.
+   *
+   * <p>The method scans the connected snapshot and counts peers that are routable and not backed
+   * off for the requested traffic class. It does not modify roster state and performs no
+   * allocations other than local counters. The result is a snapshot and should not be treated as a
+   * stable capacity guarantee.
+   *
+   * @param realTime whether to apply the real-time traffic backoff classification.
+   * @return the number of connected peers that are routable and not backed off.
+   */
   public int countNonBackedOffPeers(boolean realTime) {
     PeerNode[] peers = connectedPeers();
     int count = 0;
@@ -424,7 +670,15 @@ public class PeerRoster {
     return count;
   }
 
-  /** Counts connected darknet peers that are routable and not opennet. */
+  /**
+   * Counts connected darknet peers that are routable and not opennet.
+   *
+   * <p>The roster snapshot is scanned for {@link DarknetPeerNode} instances that are not opennet
+   * and are currently routable. This count is independent of the connected snapshot and reflects
+   * the roster's current view at the time of the scan. It does not inspect backoff status.
+   *
+   * @return the number of connected, routable darknet peers that are not opennet.
+   */
   public int countConnectedDarknetPeers() {
     int count = 0;
     PeerNode[] peers = myPeers();
@@ -435,7 +689,17 @@ public class PeerRoster {
     return count;
   }
 
-  /** Counts all connected and routable peers. */
+  /**
+   * Counts all routable peers in the roster snapshot.
+   *
+   * <p>This method counts routable peers from the roster snapshot rather than the connected
+   * snapshot, mirroring historical behavior and allowing the roster to include peers that are
+   * considered routable even if not currently in the connected list. The count is a best-effort
+   * snapshot and may change immediately after the call returns. No allocations are performed beyond
+   * a counter.
+   *
+   * @return the number of routable peers present in the roster snapshot.
+   */
   public int countConnectedPeers() {
     return countConnectedPeers(myPeers());
   }
@@ -448,7 +712,15 @@ public class PeerRoster {
     return count;
   }
 
-  /** Counts darknet peers that are connected (regardless of routability). */
+  /**
+   * Counts darknet peers that are connected, regardless of routability.
+   *
+   * <p>The roster snapshot is scanned for {@link DarknetPeerNode} instances that are not opennet
+   * and that report themselves as connected. Routability is not considered in this count, so peers
+   * in backoff may still be included. The count is a transient view of roster state.
+   *
+   * @return the number of connected darknet peers, regardless of routability.
+   */
   public int countAlmostConnectedDarknetPeers() {
     int count = 0;
     PeerNode[] peers = myPeers();
@@ -458,7 +730,16 @@ public class PeerRoster {
     return count;
   }
 
-  /** Counts darknet peers that are connected and routing-compatible. */
+  /**
+   * Counts darknet peers that are connected and routing-compatible.
+   *
+   * <p>The roster snapshot is scanned for {@link DarknetPeerNode} instances that are connected, not
+   * opennet, and routing-compatible. This is a stricter filter than simply checking connectivity or
+   * routability alone and is often used for eligibility gating. The count is based solely on
+   * current peer-reported flags.
+   *
+   * @return the number of connected darknet peers that are routing-compatible.
+   */
   public int countCompatibleDarknetPeers() {
     int count = 0;
     PeerNode[] peers = myPeers();
@@ -473,7 +754,16 @@ public class PeerRoster {
     return count;
   }
 
-  /** Counts peers with a real connection that are connected and routing-compatible. */
+  /**
+   * Counts peers with a real connection that are connected and routing-compatible.
+   *
+   * <p>The roster snapshot is scanned for peers that report a real connection, are connected, and
+   * are routing-compatible. This count includes both darknet and opennet peers that satisfy the
+   * criteria and does not distinguish between them. The result is a snapshot and may change as
+   * peers connect or disconnect.
+   *
+   * @return the number of real, connected peers that are routing-compatible.
+   */
   public int countCompatibleRealPeers() {
     int count = 0;
     PeerNode[] peers = myPeers();
@@ -485,7 +775,15 @@ public class PeerRoster {
     return count;
   }
 
-  /** Counts connected opennet peers that are routable. */
+  /**
+   * Counts connected opennet peers that are routable.
+   *
+   * <p>The connected snapshot is scanned for {@link OpennetPeerNode} instances that are routable.
+   * This uses the connected snapshot rather than the roster snapshot and therefore reflects the
+   * last connection update rather than a live connection probe. The count is best-effort.
+   *
+   * @return the number of connected opennet peers that are routable.
+   */
   public int countConnectedOpennetPeers() {
     int count = 0;
     PeerNode[] peers = connectedPeers();
@@ -495,7 +793,16 @@ public class PeerRoster {
     return count;
   }
 
-  /** Counts peers that actually may connect (excluding seednodes and disabled peers). */
+  /**
+   * Counts peers that may connect, excluding disabled peers and non-real connections.
+   *
+   * <p>The roster snapshot is scanned for peers that represent real connections and are not
+   * disabled. Seed nodes are excluded implicitly because they do not qualify as real connections.
+   * The count is a snapshot and may change as peers are added or removed. This method does not
+   * attempt any network operations.
+   *
+   * @return the number of peers that may connect based on current roster state.
+   */
   public int countValidPeers() {
     int count = 0;
     PeerNode[] peers = myPeers();
@@ -505,19 +812,35 @@ public class PeerRoster {
     return count;
   }
 
-  /** Counts peers that may connect, excluding listen-only darknet peers. */
+  /**
+   * Counts peers that may connect, excluding listen-only darknet peers.
+   *
+   * <p>The roster snapshot is scanned for peers that are not disabled and are not listen-only
+   * darknet peers. This provides a count of peers that can actively participate in connections and
+   * does not require any connectivity checks. The count treats opennet peers uniformly.
+   *
+   * @return the number of peers that may connect under current roster conditions.
+   */
   public int countConnectiblePeers() {
     int count = 0;
     PeerNode[] peers = myPeers();
     for (PeerNode peer : peers) {
       boolean isListenOnlyDarknet =
-          (peer instanceof DarknetPeerNode) && ((DarknetPeerNode) peer).isListenOnly();
+          (peer instanceof DarknetPeerNode darknetPeer) && darknetPeer.isListenOnly();
       if (!peer.isDisabled() && !isListenOnlyDarknet) count++;
     }
     return count;
   }
 
-  /** Counts peers that are seed servers or seed clients. */
+  /**
+   * Counts peers that are seed servers or seed clients.
+   *
+   * <p>The roster snapshot is scanned for {@link SeedServerPeerNode} and {@link SeedClientPeerNode}
+   * instances. This count does not inspect connectivity or routability, so it remains stable even
+   * when peer connection states fluctuate. The scan is linear in roster size.
+   *
+   * @return the number of seed server or seed client peers in the roster.
+   */
   public int countSeednodes() {
     int count = 0;
     for (PeerNode peer : myPeers()) {
@@ -526,7 +849,17 @@ public class PeerRoster {
     return count;
   }
 
-  /** Counts peers currently in routing backoff. */
+  /**
+   * Counts peers currently in routing backoff.
+   *
+   * <p>The roster snapshot is scanned for peers that represent real connections, are not disabled,
+   * and are currently backed off for the given traffic class. This count helps to route policy
+   * assess available capacity without triggering any network operations. The result is a snapshot
+   * and may change as backoff timers expire.
+   *
+   * @param realTime whether to apply the real-time traffic backoff classification.
+   * @return the number of peers in routing backoff for the requested traffic class.
+   */
   public int countBackedOffPeers(boolean realTime) {
     int count = 0;
     PeerNode[] peers = myPeers();
@@ -538,7 +871,17 @@ public class PeerRoster {
     return count;
   }
 
-  /** Count peers by current status value. */
+  /**
+   * Counts peers by their current status value.
+   *
+   * <p>The roster snapshot is scanned and each peer's status is compared to the supplied status
+   * code. No normalization or translation is performed; the integer is compared directly, so the
+   * caller should use the exact status constants expected by {@link PeerNode#getPeerNodeStatus()}.
+   * The scan is linear and does not allocate.
+   *
+   * @param status the raw status value to match against each peer's status code.
+   * @return the number of peers whose status matches the supplied value.
+   */
   public int countByStatus(int status) {
     int count = 0;
     PeerNode[] peers = myPeers();
@@ -548,7 +891,16 @@ public class PeerRoster {
     return count;
   }
 
-  /** Returns a textual status list for all peers. */
+  /**
+   * Returns a textual status list for all peers.
+   *
+   * <p>The method collects each peer's status string with verbose detail, sorts the resulting
+   * entries, and joins them with newline separators. The returned string ends with a trailing
+   * newline if at least one entry is present. When there are no peers, the method returns an empty
+   * string without a trailing newline. The ordering is purely lexical after sorting.
+   *
+   * @return a sorted, newline-delimited list of peer status entries.
+   */
   public String getStatus() {
     StringBuilder sb = new StringBuilder();
     PeerNode[] peers = myPeers();
@@ -563,7 +915,16 @@ public class PeerRoster {
     return sb.toString();
   }
 
-  /** Returns a textual list of TMCI peers. */
+  /**
+   * Returns a textual list of TMCI peers.
+   *
+   * <p>The method collects each peer's TMCI information string, sorts the resulting entries, and
+   * joins them with newline separators. The returned string ends with a trailing newline if at
+   * least one entry is present. When there are no peers, the method returns an empty string. The
+   * list is intended for display and is not a structured serialization format.
+   *
+   * @return a sorted, newline-delimited list of TMCI peer entries.
+   */
   public String getTMCIPeerList() {
     StringBuilder sb = new StringBuilder();
     PeerNode[] peers = myPeers();
@@ -578,7 +939,14 @@ public class PeerRoster {
     return sb.toString();
   }
 
-  /** Ask each DarknetPeerNode to read in its extra peer data. */
+  /**
+   * Asks each darknet peer to read and process its extra peer data.
+   *
+   * <p>The method iterates over the current darknet peers and invokes their extra data reader.
+   * Exceptions are caught and logged so that a failure on one peer does not block processing of
+   * others. A completion message is logged after the scan finishes, and no exceptions are
+   * propagated to callers.
+   */
   public void readExtraPeerData() {
     DarknetPeerNode[] peers = getDarknetPeers();
     for (DarknetPeerNode peer : peers) {
@@ -591,13 +959,38 @@ public class PeerRoster {
     LOG.info("Extra peer data reading and processing completed");
   }
 
-  /** Increments the selection sample counter for a peer. */
+  /**
+   * Increments the selection sample counter for a peer.
+   *
+   * <p>This is a thin delegation to the peer's selection counter used for sampling and weighting.
+   * The roster itself does not maintain any additional state for this operation, and the method
+   * does not acquire the roster lock because it does not modify roster snapshots. Callers should
+   * ensure the peer reference is valid for the current roster lifecycle.
+   *
+   * @param peer the peer whose selection counter should be incremented.
+   */
   public void incrementSelectionSamples(PeerNode peer) {
     peer.incrementNumberOfSelections();
   }
 
+  /**
+   * Callback for inserting a peer into the roster when a connection is observed first.
+   *
+   * <p>This interface is used by {@link #addConnectedPeer(PeerNode, PeerAdder)} to ensure that
+   * connected peers are also present in the roster. Implementations should perform the minimal
+   * roster mutation and avoid blocking operations, because the call may occur while holding the
+   * shared manager lock.
+   */
   @FunctionalInterface
   public interface PeerAdder {
+    /**
+     * Adds the given peer to the roster.
+     *
+     * <p>The implementation is expected to register the peer with the roster and any surrounding
+     * peer-management infrastructure without performing long-running work.
+     *
+     * @param peer the peer instance to add to the roster.
+     */
     void add(PeerNode peer);
   }
 }

--- a/src/main/java/network/crypta/node/PeerRoutingSelector.java
+++ b/src/main/java/network/crypta/node/PeerRoutingSelector.java
@@ -1,0 +1,980 @@
+package network.crypta.node;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import network.crypta.keys.Key;
+import network.crypta.support.TimeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Selects routing peers based on closeness and peer status.
+ *
+ * <p>This encapsulates the routing-selection logic formerly embedded in {@link PeerManager}.
+ */
+public class PeerRoutingSelector {
+  private static final Logger LOG = LoggerFactory.getLogger(PeerRoutingSelector.class);
+
+  private final Node node;
+  private final PeerRoster roster;
+  private final PeerStatusBook statusBook;
+
+  public PeerRoutingSelector(Node node, PeerRoster roster, PeerStatusBook statusBook) {
+    this.node = node;
+    this.roster = roster;
+    this.statusBook = statusBook;
+  }
+
+  public PeerNode closerPeer(
+      PeerNode pn,
+      Set<PeerNode> routedTo,
+      double target,
+      boolean ignoreSelf,
+      boolean calculateMisrouting,
+      int minVersion,
+      List<Double> addUnpickedLocsTo,
+      Key key,
+      short outgoingHTL,
+      long ignoreBackoffUnder,
+      boolean isLocal,
+      boolean realTime,
+      boolean excludeMandatoryBackoff) {
+    return closerPeer(
+        pn,
+        routedTo,
+        target,
+        ignoreSelf,
+        calculateMisrouting,
+        minVersion,
+        addUnpickedLocsTo,
+        2.0,
+        key,
+        outgoingHTL,
+        ignoreBackoffUnder,
+        isLocal,
+        realTime,
+        null,
+        false,
+        System.currentTimeMillis(),
+        excludeMandatoryBackoff);
+  }
+
+  public PeerNode closerPeer(
+      PeerNode pn,
+      Set<PeerNode> routedTo,
+      double target,
+      boolean ignoreSelf,
+      boolean calculateMisrouting,
+      int minVersion,
+      List<Double> addUnpickedLocsTo,
+      double maxDistance,
+      Key key,
+      short outgoingHTL,
+      long ignoreBackoffUnder,
+      boolean isLocal,
+      boolean realTime,
+      RecentlyFailedReturn recentlyFailed,
+      boolean ignoreTimeout,
+      long now,
+      boolean newLoadManagement) {
+    CloserPeerContext ctx = initCloserPeerContext(pn, routedTo, target, ignoreSelf, key);
+    evaluateCandidatesInContext(
+        ctx,
+        pn,
+        routedTo,
+        minVersion,
+        now,
+        realTime,
+        ignoreTimeout,
+        outgoingHTL,
+        target,
+        maxDistance,
+        ignoreSelf,
+        addUnpickedLocsTo,
+        ignoreBackoffUnder,
+        newLoadManagement);
+
+    BestCandidate bestCand = selectBestCandidate(ctx.st, ctx.key);
+    if (recentlyFailed != null && LOG.isDebugEnabled()) {
+      LOG.debug("Count waiting: {}", ctx.st.countWaiting);
+    }
+
+    PeerNode best =
+        handleRecentlyFailedIfNeeded(
+            bestCand.best,
+            bestCand.bestDistance,
+            recentlyFailed,
+            ctx,
+            pn,
+            routedTo,
+            target,
+            ignoreSelf,
+            minVersion,
+            maxDistance,
+            outgoingHTL,
+            ignoreBackoffUnder,
+            isLocal,
+            realTime,
+            now,
+            newLoadManagement);
+    if (best == null) return null;
+
+    reportBackoffPercentIfNeeded(calculateMisrouting);
+    postSelectionUpdate(best, calculateMisrouting, addUnpickedLocsTo, ctx.st);
+    return best;
+  }
+
+  private void reportBackoffPercentIfNeeded(boolean calculateMisrouting) {
+    if (!calculateMisrouting) return;
+    int connected = statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false);
+    int backedOff =
+        statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, false);
+    if (backedOff + connected > 0) {
+      node.getNodeStats()
+          .backedOffPercent
+          .report(((double) backedOff) / ((double) backedOff + (double) connected));
+    }
+  }
+
+  private static final class SelectionRates {
+    private final double[] rates;
+    private final double total;
+
+    private SelectionRates(double[] rates, double total) {
+      this.rates = rates;
+      this.total = total;
+    }
+  }
+
+  private static final class CloserPeerContext {
+    private final PeerNode[] peers;
+    private final Key key;
+    private final double myLoc;
+    private final double maxDiff;
+    private final double prevLoc;
+    private final TimedOutNodesList entry;
+    private final SelectionRates selection;
+    private final boolean enableFOAFMitigationHack;
+    private final Set<Double> excludeLocations;
+    private final PeerSelectionState st = new PeerSelectionState();
+
+    private CloserPeerContext(
+        PeerNode[] peers,
+        Key key,
+        double myLoc,
+        double maxDiff,
+        double prevLoc,
+        TimedOutNodesList entry,
+        SelectionRates selection,
+        boolean enableFOAFMitigationHack,
+        Set<Double> excludeLocations) {
+      this.peers = peers;
+      this.key = key;
+      this.myLoc = myLoc;
+      this.maxDiff = maxDiff;
+      this.prevLoc = prevLoc;
+      this.entry = entry;
+      this.selection = selection;
+      this.enableFOAFMitigationHack = enableFOAFMitigationHack;
+      this.excludeLocations = excludeLocations;
+    }
+  }
+
+  private CloserPeerContext initCloserPeerContext(
+      PeerNode pn, Set<PeerNode> routedTo, double target, boolean ignoreSelf, Key key) {
+    PeerNode[] peers = roster.connectedPeers();
+    Key effectiveKey = node.isEnablePerNodeFailureTables() ? key : null;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Choosing closest peer (connectedPeers={}, key={})", peers.length, effectiveKey);
+    }
+
+    double myLoc = node.getLocation();
+    double maxDiff = ignoreSelf ? Double.MAX_VALUE : Location.distance(myLoc, target);
+    double prevLoc = pn != null ? pn.getLocation() : -1.0;
+    TimedOutNodesList entry =
+        effectiveKey != null ? node.getFailureTable().getTimedOutNodesList(effectiveKey) : null;
+    SelectionRates selection = computeSelectionRates(peers);
+    boolean enableFOAF = peers.length >= PeerNode.SELECTION_MIN_PEERS && selection.total > 0.0;
+    Set<Double> exclude = buildExcludeLocations(myLoc, prevLoc, routedTo);
+    return new CloserPeerContext(
+        peers, effectiveKey, myLoc, maxDiff, prevLoc, entry, selection, enableFOAF, exclude);
+  }
+
+  private SelectionRates computeSelectionRates(PeerNode[] peers) {
+    double[] rates = new double[peers.length];
+    double total = 0.0;
+    for (int i = 0; i < peers.length; i++) {
+      rates[i] = peers[i].selectionRate();
+      total += rates[i];
+    }
+    return new SelectionRates(rates, total);
+  }
+
+  private void evaluateCandidatesInContext(
+      CloserPeerContext ctx,
+      PeerNode pn,
+      Set<PeerNode> routedTo,
+      int minVersion,
+      long now,
+      boolean realTime,
+      boolean ignoreTimeout,
+      short outgoingHTL,
+      double target,
+      double maxDistance,
+      boolean ignoreSelf,
+      List<Double> addUnpickedLocsTo,
+      long ignoreBackoffUnder,
+      boolean newLoadManagement) {
+    for (int i = 0; i < ctx.peers.length; i++) {
+      evaluateCandidate(
+          ctx.st,
+          ctx.peers[i],
+          i,
+          pn,
+          routedTo,
+          minVersion,
+          ctx.enableFOAFMitigationHack,
+          ctx.selection.rates,
+          ctx.selection.total,
+          now,
+          realTime,
+          ctx.entry,
+          ignoreTimeout,
+          outgoingHTL,
+          target,
+          ctx.excludeLocations,
+          maxDistance,
+          ignoreSelf,
+          ctx.maxDiff,
+          addUnpickedLocsTo,
+          ignoreBackoffUnder,
+          newLoadManagement);
+    }
+  }
+
+  private PeerNode handleRecentlyFailedIfNeeded(
+      PeerNode best,
+      double bestDistance,
+      RecentlyFailedReturn recentlyFailed,
+      CloserPeerContext ctx,
+      PeerNode pn,
+      Set<PeerNode> routedTo,
+      double target,
+      boolean ignoreSelf,
+      int minVersion,
+      double maxDistance,
+      short outgoingHTL,
+      long ignoreBackoffUnder,
+      boolean isLocal,
+      boolean realTime,
+      long now,
+      boolean newLoadManagement) {
+    if (recentlyFailed == null) return best;
+    if (ctx.st.countWaiting < maxCountWaiting(ctx.peers)) return best;
+    if (!node.isEnableULPRDataPropagation()) return best;
+    return maybeHandleRecentlyFailed(
+        pn,
+        routedTo,
+        target,
+        ignoreSelf,
+        minVersion,
+        maxDistance,
+        ctx.key,
+        outgoingHTL,
+        ignoreBackoffUnder,
+        isLocal,
+        realTime,
+        now,
+        newLoadManagement,
+        ctx.entry,
+        ctx.st,
+        best,
+        bestDistance,
+        ctx.myLoc,
+        ctx.prevLoc,
+        recentlyFailed);
+  }
+
+  private static final class PeerSelectionState {
+    private int countWaiting = 0;
+    private long soonestTimeoutWakeup = Long.MAX_VALUE;
+    private double closestDistance = Double.MAX_VALUE;
+    private double closestRealDistance = Double.MAX_VALUE;
+    private PeerNode closestBackedOff = null;
+    private double closestBackedOffDistance = Double.MAX_VALUE;
+    private double closestRealBackedOffDistance = Double.MAX_VALUE;
+    private PeerNode closestNotBackedOff = null;
+    private double closestNotBackedOffDistance = Double.MAX_VALUE;
+    private double closestRealNotBackedOffDistance = Double.MAX_VALUE;
+    private PeerNode leastRecentlyTimedOut = null;
+    private long timeLeastRecentlyTimedOut = Long.MAX_VALUE;
+    private double leastRecentlyTimedOutDistance = Double.MAX_VALUE;
+    private PeerNode leastRecentlyTimedOutBackedOff = null;
+    private long timeLeastRecentlyTimedOutBackedOff = Long.MAX_VALUE;
+    private double leastRecentlyTimedOutBackedOffDistance = Double.MAX_VALUE;
+  }
+
+  private static final class BestCandidate {
+    private final PeerNode best;
+    private final double bestDistance;
+
+    private BestCandidate(PeerNode best, double bestDistance) {
+      this.best = best;
+      this.bestDistance = bestDistance;
+    }
+  }
+
+  private Set<Double> buildExcludeLocations(double myLoc, double prevLoc, Set<PeerNode> routedTo) {
+    Set<Double> excludeLocations = new HashSet<>();
+    excludeLocations.add(myLoc);
+    excludeLocations.add(prevLoc);
+    for (PeerNode routedToNode : routedTo) {
+      excludeLocations.add(routedToNode.getLocation());
+    }
+    return excludeLocations;
+  }
+
+  private void evaluateCandidate(
+      PeerSelectionState st,
+      PeerNode p,
+      int index,
+      PeerNode origin,
+      Set<PeerNode> routedTo,
+      int minVersion,
+      boolean enableFOAFMitigationHack,
+      double[] selectionRates,
+      double totalSelectionRate,
+      long now,
+      boolean realTime,
+      TimedOutNodesList entry,
+      boolean ignoreTimeout,
+      short outgoingHTL,
+      double target,
+      Set<Double> excludeLocations,
+      double maxDistance,
+      boolean ignoreSelf,
+      double maxDiff,
+      List<Double> addUnpickedLocsTo,
+      long ignoreBackoffUnder,
+      boolean newLoadManagement) {
+    if (shouldSkipCandidate(
+        p,
+        origin,
+        routedTo,
+        newLoadManagement,
+        realTime,
+        minVersion,
+        enableFOAFMitigationHack,
+        selectionRates,
+        totalSelectionRate,
+        index,
+        now)) {
+      return;
+    }
+
+    TimeoutInfo t = computeTimeoutInfo(st, entry, ignoreTimeout, now, outgoingHTL, p);
+    DiffInfo d = computeDiffInfo(p, target, outgoingHTL, excludeLocations);
+
+    if (d.diff > maxDistance) return;
+    if (!ignoreSelf && d.diff > maxDiff) {
+      if (LOG.isDebugEnabled()) LOG.debug("Ignore; farther than self; maxDiff={}", maxDiff);
+      return;
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(
+          "p.loc={}, target={}, d={} usedD={} timedOut={} for {}",
+          d.loc,
+          target,
+          Location.distance(d.loc, target),
+          d.diff,
+          t.timedOut,
+          p.getPeer());
+    }
+
+    boolean chosen =
+        updateBestTracking(st, p, d, t.timedOut, t.timeoutFT, ignoreBackoffUnder, realTime);
+    if (addUnpickedLocsTo != null && !chosen) {
+      double locD = d.loc;
+      if (!addUnpickedLocsTo.contains(locD)) addUnpickedLocsTo.add(locD);
+    }
+  }
+
+  private boolean shouldSkipCandidate(
+      PeerNode p,
+      PeerNode origin,
+      Set<PeerNode> routedTo,
+      boolean newLoadManagement,
+      boolean realTime,
+      int minVersion,
+      boolean enableFOAFMitigationHack,
+      double[] selectionRates,
+      double totalSelectionRate,
+      int index,
+      long now) {
+    boolean skip = false;
+    skip = skip || isAlreadyRoutedTo(p, routedTo);
+    skip = skip || isOrigin(p, origin);
+    skip = skip || isNotRoutable(p);
+    skip = skip || isDisconnecting(p);
+    skip = skip || lacksLoadStats(p, newLoadManagement, realTime);
+    skip = skip || isOldVersion(p, minVersion);
+    skip =
+        skip
+            || isOverSelectedPeer(
+                enableFOAFMitigationHack, selectionRates, totalSelectionRate, index, p);
+    skip = skip || isInMandatoryBackoff(p, newLoadManagement, realTime, now);
+    return skip;
+  }
+
+  private boolean isAlreadyRoutedTo(PeerNode p, Set<PeerNode> routedTo) {
+    if (routedTo.contains(p)) {
+      if (LOG.isDebugEnabled()) LOG.debug("Skipping (already routed to): {}", p.getPeer());
+      return true;
+    }
+    return false;
+  }
+
+  private boolean isOrigin(PeerNode p, PeerNode origin) {
+    if (p == origin) {
+      if (LOG.isDebugEnabled()) LOG.debug("Skipping (req came from): {}", p.getPeer());
+      return true;
+    }
+    return false;
+  }
+
+  private boolean isNotRoutable(PeerNode p) {
+    if (!p.isRoutable()) {
+      if (LOG.isDebugEnabled()) LOG.debug("Skipping (not connected): {}", p.getPeer());
+      return true;
+    }
+    return false;
+  }
+
+  private boolean isDisconnecting(PeerNode p) {
+    if (p.isDisconnecting()) {
+      if (LOG.isDebugEnabled()) LOG.debug("Skipping (disconnecting): {}", p.getPeer());
+      return true;
+    }
+    return false;
+  }
+
+  private boolean lacksLoadStats(PeerNode p, boolean newLoadManagement, boolean realTime) {
+    if (newLoadManagement && p.outputLoadTracker(realTime).getLastIncomingLoadStats() == null) {
+      if (LOG.isDebugEnabled()) LOG.debug("Skipping (no load stats): {}", p.getPeer());
+      return true;
+    }
+    return false;
+  }
+
+  private boolean isOldVersion(PeerNode p, int minVersion) {
+    if (minVersion > 0
+        && !Version.isBuildAtLeast(
+            p.getNodeName(),
+            Version.parseBuildNumberFromVersionStr(p.getVersion(), -1),
+            minVersion)) {
+      if (LOG.isDebugEnabled()) LOG.debug("Skipping old version: {}", p.getPeer());
+      return true;
+    }
+    return false;
+  }
+
+  private boolean isOverSelectedPeer(
+      boolean enableFOAFMitigationHack,
+      double[] selectionRates,
+      double totalSelectionRate,
+      int index,
+      PeerNode p) {
+    if (enableFOAFMitigationHack) {
+      double selectionPercentage = 100.0 * selectionRates[index] / totalSelectionRate;
+      if (selectionPercentage > PeerNode.SELECTION_PERCENTAGE_WARNING) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Skipping over-selected peer({}%): {}", selectionPercentage, p.getPeer());
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isInMandatoryBackoff(
+      PeerNode p, boolean newLoadManagement, boolean realTime, long now) {
+    if (newLoadManagement && p.isInMandatoryBackoff(now, realTime)) {
+      if (LOG.isDebugEnabled()) LOG.debug("Skipping (mandatory backoff): {}", p.getPeer());
+      return true;
+    }
+    return false;
+  }
+
+  private static final class TimeoutInfo {
+    private final boolean timedOut;
+    private final long timeoutFT;
+
+    private TimeoutInfo(boolean timedOut, long timeoutFT) {
+      this.timedOut = timedOut;
+      this.timeoutFT = timeoutFT;
+    }
+  }
+
+  private TimeoutInfo computeTimeoutInfo(
+      PeerSelectionState st,
+      TimedOutNodesList entry,
+      boolean ignoreTimeout,
+      long now,
+      short outgoingHTL,
+      PeerNode p) {
+    long timeoutRF;
+    long timeoutFT = -1L;
+    if (entry != null && !ignoreTimeout) {
+      timeoutFT = entry.getTimeoutTime(p, outgoingHTL, now, true);
+      timeoutRF = entry.getTimeoutTime(p, outgoingHTL, now, false);
+      if (timeoutRF > now) {
+        st.soonestTimeoutWakeup = Math.min(st.soonestTimeoutWakeup, timeoutRF);
+        st.countWaiting++;
+      }
+    }
+    boolean timedOut = timeoutFT > now;
+    return new TimeoutInfo(timedOut, timeoutFT);
+  }
+
+  private static final class DiffInfo {
+    private final double loc;
+    private final double diff;
+    private final double realDiff;
+    private final boolean direct;
+
+    private DiffInfo(double loc, double diff, double realDiff, boolean direct) {
+      this.loc = loc;
+      this.diff = diff;
+      this.realDiff = realDiff;
+      this.direct = direct;
+    }
+  }
+
+  private DiffInfo computeDiffInfo(
+      PeerNode p, double target, short outgoingHTL, Set<Double> excludeLocations) {
+    double loc = p.getLocation();
+    boolean direct = true;
+    double realDiff = Location.distance(loc, target);
+    double diff = realDiff;
+    if (p.shallWeRouteAccordingToOurPeersLocation((int) outgoingHTL)) {
+      double l = p.getClosestPeerLocation(target, excludeLocations);
+      if (!Double.isNaN(l)) {
+        double newDiff = Location.distance(l, target);
+        if (newDiff < diff) {
+          loc = l;
+          diff = newDiff;
+          direct = false;
+        }
+      }
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Peer {} publishes peer locations; closest candidate distance={}", p, diff);
+      }
+    }
+    return new DiffInfo(loc, diff, realDiff, direct);
+  }
+
+  private boolean updateBestTracking(
+      PeerSelectionState st,
+      PeerNode p,
+      DiffInfo d,
+      boolean timedOut,
+      long timeoutFT,
+      long ignoreBackoffUnder,
+      boolean realTime) {
+    boolean chosen = updateOverallBest(st, p, d);
+    boolean backedOff = p.isRoutingBackedOff(ignoreBackoffUnder, realTime);
+    chosen = chosen || updateBestBackedOff(st, p, d, timedOut, backedOff);
+    chosen = chosen || updateBestNotBackedOff(st, p, d, timedOut, backedOff);
+    updateTimedOutOrdering(st, p, d.diff, timeoutFT, timedOut, backedOff);
+    return chosen;
+  }
+
+  private boolean updateOverallBest(PeerSelectionState st, PeerNode p, DiffInfo d) {
+    if (d.diff < st.closestDistance
+        || (Math.abs(d.diff - st.closestDistance) < Double.MIN_VALUE * 2
+            && (d.direct || d.realDiff < st.closestRealDistance))) {
+      st.closestDistance = d.diff;
+      st.closestRealDistance = d.realDiff;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("New best distance={} at {} for {}", d.diff, d.loc, p.getPeer());
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private boolean updateBestBackedOff(
+      PeerSelectionState st, PeerNode p, DiffInfo d, boolean timedOut, boolean backedOff) {
+    if (backedOff
+        && (d.diff < st.closestBackedOffDistance
+            || (Math.abs(d.diff - st.closestBackedOffDistance) < Double.MIN_VALUE * 2
+                && (d.direct || d.realDiff < st.closestRealBackedOffDistance)))
+        && !timedOut) {
+      st.closestBackedOffDistance = d.diff;
+      st.closestBackedOff = p;
+      st.closestRealBackedOffDistance = d.realDiff;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("New best-backed-off distance={} at {} for {}", d.diff, d.loc, p.getPeer());
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private boolean updateBestNotBackedOff(
+      PeerSelectionState st, PeerNode p, DiffInfo d, boolean timedOut, boolean backedOff) {
+    if (!backedOff
+        && (d.diff < st.closestNotBackedOffDistance
+            || (Math.abs(d.diff - st.closestNotBackedOffDistance) < Double.MIN_VALUE * 2
+                && (d.direct || d.realDiff < st.closestRealNotBackedOffDistance)))
+        && !timedOut) {
+      st.closestNotBackedOffDistance = d.diff;
+      st.closestNotBackedOff = p;
+      st.closestRealNotBackedOffDistance = d.realDiff;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("New best-not-backed-off distance={} at {} for {}", d.diff, d.loc, p.getPeer());
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private void updateTimedOutOrdering(
+      PeerSelectionState st,
+      PeerNode p,
+      double diff,
+      long timeoutFT,
+      boolean timedOut,
+      boolean backedOff) {
+    if (!timedOut) return;
+    if (!backedOff) {
+      if (timeoutFT < st.timeLeastRecentlyTimedOut) {
+        st.timeLeastRecentlyTimedOut = timeoutFT;
+        st.leastRecentlyTimedOut = p;
+        st.leastRecentlyTimedOutDistance = diff;
+      }
+    } else if (timeoutFT < st.timeLeastRecentlyTimedOutBackedOff) {
+      st.timeLeastRecentlyTimedOutBackedOff = timeoutFT;
+      st.leastRecentlyTimedOutBackedOff = p;
+      st.leastRecentlyTimedOutBackedOffDistance = diff;
+    }
+  }
+
+  private BestCandidate selectBestCandidate(PeerSelectionState st, Key key) {
+    PeerNode best = st.closestNotBackedOff;
+    double bestDistance = st.closestNotBackedOffDistance;
+    if (best == null) {
+      if (st.leastRecentlyTimedOut != null) {
+        best = st.leastRecentlyTimedOut;
+        bestDistance = st.leastRecentlyTimedOutDistance;
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
+              "Using least recently failed in-timeout-period peer for key: {} for {}",
+              best.shortToString(),
+              key);
+        }
+      } else if (st.closestBackedOff != null) {
+        best = st.closestBackedOff;
+        bestDistance = st.closestBackedOffDistance;
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Using best backed-off peer for key: {}", best.shortToString());
+        }
+      } else if (st.leastRecentlyTimedOutBackedOff != null) {
+        best = st.leastRecentlyTimedOutBackedOff;
+        bestDistance = st.leastRecentlyTimedOutBackedOffDistance;
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
+              "Using least recently failed in-timeout-period backed-off peer for key: {} for {}",
+              best.shortToString(),
+              key);
+        }
+      }
+    }
+    return new BestCandidate(best, bestDistance);
+  }
+
+  private PeerNode maybeHandleRecentlyFailed(
+      PeerNode pn,
+      Set<PeerNode> routedTo,
+      double target,
+      boolean ignoreSelf,
+      int minVersion,
+      double maxDistance,
+      Key key,
+      short outgoingHTL,
+      long ignoreBackoffUnder,
+      boolean isLocal,
+      boolean realTime,
+      long now,
+      boolean newLoadManagement,
+      TimedOutNodesList entry,
+      PeerSelectionState st,
+      PeerNode best,
+      double bestDistance,
+      double myLoc,
+      double prevLoc,
+      RecentlyFailedReturn recentlyFailed) {
+    FirstSecondChoice choice =
+        computeFirstSecondChoice(
+            pn,
+            routedTo,
+            target,
+            ignoreSelf,
+            minVersion,
+            maxDistance,
+            key,
+            outgoingHTL,
+            ignoreBackoffUnder,
+            isLocal,
+            realTime,
+            now,
+            newLoadManagement,
+            entry);
+    if (choice == null) return best;
+    long until = computeUntil(choice.firstTime, choice.secondTime, st, now);
+    long check =
+        best == st.closestNotBackedOff
+            ? Long.MAX_VALUE
+            : checkBackoffsForRecentlyFailed(
+                roster.connectedPeers(),
+                best,
+                target,
+                bestDistance,
+                myLoc,
+                prevLoc,
+                now,
+                entry,
+                outgoingHTL);
+    if (check < until) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Reducing RecentlyFailed from {} ms to {} ms due to wake-up check",
+            until - now,
+            check - now);
+      }
+      until = check;
+    }
+    long decidedUntil = decideRecentlyFailedUntil(until, now, key);
+    if (decidedUntil >= 0) {
+      recentlyFailed.fail(decidedUntil);
+      return null;
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Not sending RecentlyFailed because will wake up in {}ms", check - now);
+    }
+    return best;
+  }
+
+  private long computeUntil(long firstTime, long secondTime, PeerSelectionState st, long now) {
+    long until = Math.min(secondTime, firstTime);
+    if (st.countWaiting == maxCountWaiting(roster.connectedPeers())) {
+      until = Math.min(until, st.soonestTimeoutWakeup);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Recently failed: {}ms",
+            Math.min((long) Integer.MAX_VALUE, st.soonestTimeoutWakeup - now));
+      }
+    }
+    return until;
+  }
+
+  private long decideRecentlyFailedUntil(long until, long now, Key key) {
+    if (until <= now + MIN_DELTA) return -1L;
+    long decidedUntil = until;
+    if (decidedUntil > now + FailureTable.RECENTLY_FAILED_TIME) {
+      long delay = decidedUntil - now;
+      LOG.error("Wake-up time too long: {}", TimeUtil.formatTime(delay));
+      decidedUntil = now + FailureTable.RECENTLY_FAILED_TIME;
+    }
+    return key != null && node.getFailureTable().hadAnyOffers(key) ? -1L : decidedUntil;
+  }
+
+  private static final class FirstSecondChoice {
+    private final PeerNode first;
+    private final long firstTime;
+    private final PeerNode second;
+    private final long secondTime;
+
+    private FirstSecondChoice(PeerNode first, long firstTime, PeerNode second, long secondTime) {
+      this.first = first;
+      this.firstTime = firstTime;
+      this.second = second;
+      this.secondTime = secondTime;
+    }
+  }
+
+  private FirstSecondChoice computeFirstSecondChoice(
+      PeerNode pn,
+      Set<PeerNode> routedTo,
+      double target,
+      boolean ignoreSelf,
+      int minVersion,
+      double maxDistance,
+      Key key,
+      short outgoingHTL,
+      long ignoreBackoffUnder,
+      boolean isLocal,
+      boolean realTime,
+      long now,
+      boolean newLoadManagement,
+      TimedOutNodesList entry) {
+    if (entry == null) return null;
+    PeerNode first =
+        closerPeer(
+            pn,
+            routedTo,
+            target,
+            ignoreSelf,
+            false,
+            minVersion,
+            null,
+            maxDistance,
+            key,
+            outgoingHTL,
+            ignoreBackoffUnder,
+            isLocal,
+            realTime,
+            null,
+            true,
+            now,
+            newLoadManagement);
+    if (first == null) return null;
+    long firstTime = entry.getTimeoutTime(first, outgoingHTL, now, false);
+    if (firstTime <= now) return null;
+    if (LOG.isDebugEnabled()) LOG.debug("First choice timeout already passed");
+
+    HashSet<PeerNode> newRoutedTo = new HashSet<>(routedTo);
+    newRoutedTo.add(first);
+    PeerNode second =
+        closerPeer(
+            pn,
+            newRoutedTo,
+            target,
+            ignoreSelf,
+            false,
+            minVersion,
+            null,
+            maxDistance,
+            key,
+            outgoingHTL,
+            ignoreBackoffUnder,
+            isLocal,
+            realTime,
+            null,
+            true,
+            now,
+            newLoadManagement);
+    if (second == null) return null;
+    long secondTime = entry.getTimeoutTime(first, outgoingHTL, now, false);
+    if (secondTime <= now) return null;
+    return new FirstSecondChoice(first, firstTime, second, secondTime);
+  }
+
+  private void postSelectionUpdate(
+      PeerNode best,
+      boolean calculateMisrouting,
+      List<Double> addUnpickedLocsTo,
+      PeerSelectionState st) {
+    if (best == null) return;
+    if (calculateMisrouting) {
+      int numberOfConnected =
+          statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false);
+      int numberOfRoutingBackedOff =
+          statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, false);
+      if (numberOfRoutingBackedOff + numberOfConnected > 0) {
+        node.getNodeStats()
+            .backedOffPercent
+            .report(
+                ((double) numberOfRoutingBackedOff)
+                    / ((double) numberOfRoutingBackedOff + (double) numberOfConnected));
+      }
+    }
+    if (addUnpickedLocsTo != null
+        && st.closestNotBackedOff != null
+        && st.closestBackedOff != null) {
+      addUnpickedLocsTo.add(st.closestBackedOff.getLocation());
+    }
+  }
+
+  private int maxCountWaiting(PeerNode[] peers) {
+    int count = countConnectedPeers(peers);
+    return clamp(count / 4, 3, 10);
+  }
+
+  private int countConnectedPeers(PeerNode[] peers) {
+    int count = 0;
+    for (PeerNode peer : peers) {
+      if (peer.isRoutable()) count++;
+    }
+    return count;
+  }
+
+  private long checkBackoffsForRecentlyFailed(
+      PeerNode[] peers,
+      PeerNode best,
+      double target,
+      double bestDistance,
+      double myLoc,
+      double prevLoc,
+      long now,
+      TimedOutNodesList entry,
+      short outgoingHTL) {
+    if (entry == null) return Long.MAX_VALUE;
+    long overallWakeup = Long.MAX_VALUE;
+    Set<Double> excludeLocations = buildExcludeLocations(myLoc, prevLoc, Set.of());
+    for (PeerNode p : peers) {
+      long wake =
+          wakeupTimeIfBetterAlternative(
+              p, best, target, bestDistance, outgoingHTL, excludeLocations, now, entry);
+      if (wake == Long.MIN_VALUE) continue;
+      if (wake > now && wake < overallWakeup) overallWakeup = wake;
+    }
+    return overallWakeup;
+  }
+
+  private long wakeupTimeIfBetterAlternative(
+      PeerNode p,
+      PeerNode best,
+      double target,
+      double bestDistance,
+      short outgoingHTL,
+      Set<Double> excludeLocations,
+      long now,
+      TimedOutNodesList entry) {
+    if (p == best || !p.isRoutable()) return Long.MIN_VALUE;
+    DiffInfo d = computeDiffInfo(p, target, outgoingHTL, excludeLocations);
+    if (d.diff >= bestDistance) return Long.MIN_VALUE;
+    long wakeup = computeWakeupDeadline(entry, outgoingHTL, now, p);
+    if (wakeup <= now) {
+      if (LOG.isDebugEnabled())
+        LOG.debug("Better node available during RecentlyFailed check: {}", p);
+      return Long.MIN_VALUE;
+    }
+    if (LOG.isDebugEnabled()) LOG.debug("Peer {} exits backoff/timeout in {} ms", p, wakeup - now);
+    return wakeup;
+  }
+
+  private long computeWakeupDeadline(
+      TimedOutNodesList entry, short outgoingHTL, long now, PeerNode p) {
+    long wakeup = 0L;
+    long timeoutFT = entry.getTimeoutTime(p, outgoingHTL, now, true);
+    long timeoutRF = entry.getTimeoutTime(p, outgoingHTL, now, false);
+    if (timeoutFT > now) wakeup = Math.max(wakeup, timeoutFT);
+    if (timeoutRF > now) wakeup = Math.max(wakeup, timeoutRF);
+    long bulkBackoff = p.routingBackedOffUntilBulk;
+    long rtBackoff = p.routingBackedOffUntilRT;
+    long candidate = Long.MAX_VALUE;
+    if (bulkBackoff > now) candidate = bulkBackoff;
+    if (rtBackoff > now && rtBackoff < candidate) candidate = rtBackoff;
+    if (candidate != Long.MAX_VALUE) wakeup = Math.max(wakeup, candidate);
+    return wakeup;
+  }
+
+  private int clamp(int value, int minValue, int maxValue) {
+    if (value < minValue) return minValue;
+    return Math.min(value, maxValue);
+  }
+
+  private static final long MIN_DELTA = 2000L;
+}

--- a/src/main/java/network/crypta/node/PeerRoutingSelector.java
+++ b/src/main/java/network/crypta/node/PeerRoutingSelector.java
@@ -9,9 +9,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Selects routing peers based on closeness and peer status.
+ * Selects routing peers based on location closeness and peer status signals.
  *
- * <p>This encapsulates the routing-selection logic formerly embedded in {@link PeerManager}.
+ * <p>This class centralizes the peer-selection policy that was previously spread across {@link
+ * PeerManager}. Callers provide the candidate set and routing context, and the selector evaluates
+ * peer distance, routing backoff state, timeouts, and optional recently-failed handling to produce
+ * a single best peer. The selector does not mutate peer state directly; instead it reports
+ * selection statistics and returns the chosen {@link PeerNode} for the caller to route to.
+ *
+ * <p>Selection is stateful only within a single call and is safe for repeated use as long as
+ * callers provide consistent inputs. The implementation assumes that the provided peer roster and
+ * status book are kept up to date by the surrounding node lifecycle. Thread safety is delegated to
+ * those collaborators; this class itself is immutable after construction.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Filtering peers by eligibility (version, backoff, routing status).
+ *   <li>Computing distance and load-based weighting.
+ *   <li>Optionally incorporating recently-failed retry timing.
+ * </ul>
  */
 public class PeerRoutingSelector {
   private static final Logger LOG = LoggerFactory.getLogger(PeerRoutingSelector.class);
@@ -20,12 +37,47 @@ public class PeerRoutingSelector {
   private final PeerRoster roster;
   private final PeerStatusBook statusBook;
 
+  /**
+   * Creates a selector that draws candidates from the provided node services.
+   *
+   * <p>The selector keeps references to the node, roster, and status book so it can evaluate peer
+   * availability, distance, and routing backoff state during selection. The constructor does not
+   * validate these collaborators beyond storing them, so callers should ensure they are non-null
+   * and fully initialized before invoking selection methods.
+   *
+   * @param node owning node used for configuration and statistics reporting
+   * @param roster source of the currently connected peer set
+   * @param statusBook snapshot provider for peer routing status counts
+   */
   public PeerRoutingSelector(Node node, PeerRoster roster, PeerStatusBook statusBook) {
     this.node = node;
     this.roster = roster;
     this.statusBook = statusBook;
   }
 
+  /**
+   * Selects the closest eligible peer using default selection parameters.
+   *
+   * <p>This overload provides a simplified entry point for common routing decisions. It applies a
+   * default maximum distance of {@code 2.0}, uses the current wall-clock time for timeout checks,
+   * and does not request recently-failed handling. The method is side-effect free with respect to
+   * peer state; it only reports backoff statistics when requested.
+   *
+   * @param pn the origin peer for this routing decision, or {@code null}
+   * @param routedTo peers already selected for this request path
+   * @param target target location on the ring, in normalized location units
+   * @param ignoreSelf whether to ignore the local node when selecting
+   * @param calculateMisrouting whether to record misrouting and backoff metrics
+   * @param minVersion minimum acceptable peer version, inclusive, in build units
+   * @param addUnpickedLocsTo optional list to collect alternative locations
+   * @param key key for per-node failure tracking, or {@code null}
+   * @param outgoingHTL hop-to-live for the outgoing request, in hops
+   * @param ignoreBackoffUnder backoff window to ignore, in milliseconds
+   * @param isLocal whether the request originates locally, affecting policy
+   * @param realTime whether to enforce real-time routing constraints
+   * @param excludeMandatoryBackoff whether to exclude mandatory-backoff peers from selection
+   * @return the selected peer, or {@code null} if none qualifies
+   */
   public PeerNode closerPeer(
       PeerNode pn,
       Set<PeerNode> routedTo,
@@ -60,6 +112,34 @@ public class PeerRoutingSelector {
         excludeMandatoryBackoff);
   }
 
+  /**
+   * Selects the closest eligible peer using fully specified routing parameters.
+   *
+   * <p>This method evaluates all connected peers against distance, routing backoff, timeout, and
+   * load-management constraints to produce a single best candidate. It can optionally integrate
+   * recently-failed information to delay retries until an appropriate wake-up time. The selection
+   * is deterministic for the given inputs and does not mutate peers; callers remain responsible for
+   * updating per-request state and for respecting a {@code null} result.
+   *
+   * @param pn the origin peer for this routing decision, or {@code null}
+   * @param routedTo peers already selected for this request path
+   * @param target target location on the ring, in normalized location units
+   * @param ignoreSelf whether to ignore the local node when selecting
+   * @param calculateMisrouting whether to record misrouting and backoff metrics
+   * @param minVersion minimum acceptable peer version, inclusive, in build units
+   * @param addUnpickedLocsTo optional list to collect alternative locations
+   * @param maxDistance maximum allowable distance from the target location
+   * @param key key for per-node failure tracking, or {@code null}
+   * @param outgoingHTL hop-to-live for the outgoing request, in hops
+   * @param ignoreBackoffUnder backoff window to ignore, in milliseconds
+   * @param isLocal whether the request originates locally, affecting policy
+   * @param realTime whether to enforce real-time routing constraints
+   * @param recentlyFailed optional holder for recently-failed timing feedback
+   * @param ignoreTimeout whether to ignore timeout-based exclusion checks
+   * @param now current time in milliseconds used for timeout comparisons
+   * @param newLoadManagement whether to use new load-management heuristics
+   * @return the selected peer, or {@code null} if none qualifies
+   */
   public PeerNode closerPeer(
       PeerNode pn,
       Set<PeerNode> routedTo,
@@ -131,9 +211,7 @@ public class PeerRoutingSelector {
     int backedOff =
         statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, false);
     if (backedOff + connected > 0) {
-      node.getNodeStats()
-          .backedOffPercent
-          .report(((double) backedOff) / ((double) backedOff + (double) connected));
+      node.getNodeStats().backedOffPercent.report((double) backedOff / (backedOff + connected));
     }
   }
 
@@ -412,8 +490,7 @@ public class PeerRoutingSelector {
       double totalSelectionRate,
       int index,
       long now) {
-    boolean skip = false;
-    skip = skip || isAlreadyRoutedTo(p, routedTo);
+    boolean skip = isAlreadyRoutedTo(p, routedTo);
     skip = skip || isOrigin(p, origin);
     skip = skip || isNotRoutable(p);
     skip = skip || isDisconnecting(p);
@@ -557,7 +634,7 @@ public class PeerRoutingSelector {
     boolean direct = true;
     double realDiff = Location.distance(loc, target);
     double diff = realDiff;
-    if (p.shallWeRouteAccordingToOurPeersLocation((int) outgoingHTL)) {
+    if (p.shallWeRouteAccordingToOurPeersLocation(outgoingHTL)) {
       double l = p.getClosestPeerLocation(target, excludeLocations);
       if (!Double.isNaN(l)) {
         double newDiff = Location.distance(l, target);
@@ -772,8 +849,7 @@ public class PeerRoutingSelector {
       until = Math.min(until, st.soonestTimeoutWakeup);
       if (LOG.isDebugEnabled()) {
         LOG.debug(
-            "Recently failed: {}ms",
-            Math.min((long) Integer.MAX_VALUE, st.soonestTimeoutWakeup - now));
+            "Recently failed: {}ms", Math.min(Integer.MAX_VALUE, st.soonestTimeoutWakeup - now));
       }
     }
     return until;
@@ -784,22 +860,20 @@ public class PeerRoutingSelector {
     long decidedUntil = until;
     if (decidedUntil > now + FailureTable.RECENTLY_FAILED_TIME) {
       long delay = decidedUntil - now;
-      LOG.error("Wake-up time too long: {}", TimeUtil.formatTime(delay));
+      if (LOG.isErrorEnabled()) {
+        LOG.error("Wake-up time too long: {}", TimeUtil.formatTime(delay));
+      }
       decidedUntil = now + FailureTable.RECENTLY_FAILED_TIME;
     }
     return key != null && node.getFailureTable().hadAnyOffers(key) ? -1L : decidedUntil;
   }
 
   private static final class FirstSecondChoice {
-    private final PeerNode first;
     private final long firstTime;
-    private final PeerNode second;
     private final long secondTime;
 
-    private FirstSecondChoice(PeerNode first, long firstTime, PeerNode second, long secondTime) {
-      this.first = first;
+    private FirstSecondChoice(long firstTime, long secondTime) {
       this.firstTime = firstTime;
-      this.second = second;
       this.secondTime = secondTime;
     }
   }
@@ -866,9 +940,9 @@ public class PeerRoutingSelector {
             now,
             newLoadManagement);
     if (second == null) return null;
-    long secondTime = entry.getTimeoutTime(first, outgoingHTL, now, false);
+    long secondTime = entry.getTimeoutTime(second, outgoingHTL, now, false);
     if (secondTime <= now) return null;
-    return new FirstSecondChoice(first, firstTime, second, secondTime);
+    return new FirstSecondChoice(firstTime, secondTime);
   }
 
   private void postSelectionUpdate(
@@ -886,8 +960,7 @@ public class PeerRoutingSelector {
         node.getNodeStats()
             .backedOffPercent
             .report(
-                ((double) numberOfRoutingBackedOff)
-                    / ((double) numberOfRoutingBackedOff + (double) numberOfConnected));
+                (double) numberOfRoutingBackedOff / (numberOfRoutingBackedOff + numberOfConnected));
       }
     }
     if (addUnpickedLocsTo != null
@@ -899,7 +972,7 @@ public class PeerRoutingSelector {
 
   private int maxCountWaiting(PeerNode[] peers) {
     int count = countConnectedPeers(peers);
-    return clamp(count / 4, 3, 10);
+    return clampCountWaiting(count / 4);
   }
 
   private int countConnectedPeers(PeerNode[] peers) {
@@ -971,10 +1044,12 @@ public class PeerRoutingSelector {
     return wakeup;
   }
 
-  private int clamp(int value, int minValue, int maxValue) {
-    if (value < minValue) return minValue;
-    return Math.min(value, maxValue);
+  private int clampCountWaiting(int value) {
+    if (value < MIN_COUNT_WAITING) return MIN_COUNT_WAITING;
+    return Math.min(value, MAX_COUNT_WAITING);
   }
 
   private static final long MIN_DELTA = 2000L;
+  private static final int MIN_COUNT_WAITING = 3;
+  private static final int MAX_COUNT_WAITING = 10;
 }

--- a/src/main/java/network/crypta/node/PeerStatusBook.java
+++ b/src/main/java/network/crypta/node/PeerStatusBook.java
@@ -1,0 +1,338 @@
+package network.crypta.node;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks peer status counters, routing backoff reasons, and periodic status summaries.
+ *
+ * <p>This class centralizes status bookkeeping to keep {@link PeerManager} focused on coordination
+ * rather than tracking details.
+ */
+public class PeerStatusBook {
+  private static final Logger LOG = LoggerFactory.getLogger(PeerStatusBook.class);
+
+  private final PeerRoster roster;
+  private final Object lock;
+
+  private final PeerStatusTracker<Integer> allPeersStatuses = new PeerStatusTracker<>();
+  private final PeerStatusTracker<Integer> darknetPeersStatuses = new PeerStatusTracker<>();
+  private final PeerStatusTracker<String> peerNodeRoutingBackoffReasonsRT =
+      new PeerStatusTracker<>();
+  private final PeerStatusTracker<String> peerNodeRoutingBackoffReasonsBulk =
+      new PeerStatusTracker<>();
+
+  private long oldestNeverConnectedDarknetPeerAge = 0L;
+  private long nextOldestNeverConnectedDarknetPeerAgeUpdateTime = -1L;
+  private long nextPeerNodeStatusLogTime = -1L;
+  private long nextRoutableConnectionStatsUpdateTime = -1L;
+
+  public PeerStatusBook(PeerRoster roster, Object lock) {
+    this.roster = roster;
+    this.lock = lock;
+  }
+
+  /** Adds initial status tracking for a newly added peer. */
+  public void onPeerAdded(PeerNode peer) {
+    if (peer.recordStatus()) addPeerNodeStatus(peer.getPeerNodeStatus(), peer);
+  }
+
+  /** Removes tracked status and routing backoff entries for a removed peer. */
+  public void onPeerRemoved(PeerNode peer) {
+    int peerNodeStatus = peer.getPeerNodeStatus();
+    if (peer.recordStatus()) removePeerNodeStatus(peerNodeStatus, peer);
+    String prevReasonRt = peer.getPreviousBackoffReason(true);
+    if (prevReasonRt != null) removePeerNodeRoutingBackoffReason(prevReasonRt, peer, true);
+    String prevReasonBulk = peer.getPreviousBackoffReason(false);
+    if (prevReasonBulk != null) removePeerNodeRoutingBackoffReason(prevReasonBulk, peer, false);
+  }
+
+  /** Updates status counts when a peer changes status. */
+  public void changePeerNodeStatus(PeerNode peer, int oldStatus, int newStatus, boolean noLog) {
+    allPeersStatuses.changePeerNodeStatus(peer, oldStatus, newStatus, noLog);
+    if (!peer.isOpennet()) {
+      darknetPeersStatuses.changePeerNodeStatus(peer, oldStatus, newStatus, noLog);
+    }
+  }
+
+  /** Adds a PeerNode status to the trackers. */
+  private void addPeerNodeStatus(int status, PeerNode peer) {
+    allPeersStatuses.addStatus(status, peer, false);
+    if (!peer.isOpennet()) darknetPeersStatuses.addStatus(status, peer, false);
+  }
+
+  /** Removes a PeerNode status from the trackers. */
+  private void removePeerNodeStatus(int status, PeerNode peer) {
+    allPeersStatuses.removeStatus(status, peer, false);
+    if (!peer.isOpennet()) darknetPeersStatuses.removeStatus(status, peer, false);
+  }
+
+  /** Counts PeerNodes with a particular status. */
+  public int getPeerNodeStatusSize(int status, boolean darknet) {
+    return darknet ? darknetPeersStatuses.statusSize(status) : allPeersStatuses.statusSize(status);
+  }
+
+  /** Adds a routing backoff reason for a peer. */
+  public void addPeerNodeRoutingBackoffReason(String reason, PeerNode peer, boolean realTime) {
+    PeerStatusTracker<String> tracker =
+        realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
+    tracker.addStatus(reason, peer, false);
+  }
+
+  /** Removes a routing backoff reason for a peer. */
+  public void removePeerNodeRoutingBackoffReason(String reason, PeerNode peer, boolean realTime) {
+    PeerStatusTracker<String> tracker =
+        realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
+    tracker.removeStatus(reason, peer, false);
+  }
+
+  /** Returns the currently tracked routing backoff reasons. */
+  public String[] getPeerNodeRoutingBackoffReasons(boolean realTime) {
+    List<String> list = new ArrayList<>();
+    PeerStatusTracker<String> tracker =
+        realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
+    tracker.addStatusList(list);
+    return list.toArray(new String[0]);
+  }
+
+  /** Returns the count of peers with a specific routing backoff reason. */
+  public int getPeerNodeRoutingBackoffReasonSize(String reason, boolean realTime) {
+    PeerStatusTracker<String> tracker =
+        realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
+    return tracker.statusSize(reason);
+  }
+
+  /** Returns a snapshot of statuses for all peers. */
+  public PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
+    PeerNode[] peers = roster.myPeers();
+    PeerNodeStatus[] statuses = new PeerNodeStatus[peers.length];
+    for (int i = 0; i < peers.length; i++) {
+      statuses[i] = peers[i].getStatus(noHeavy);
+    }
+    return statuses;
+  }
+
+  /** Returns a snapshot of statuses for darknet peers. */
+  public DarknetPeerNodeStatus[] getDarknetPeerNodeStatuses(boolean noHeavy) {
+    DarknetPeerNode[] peers = roster.getDarknetPeers();
+    DarknetPeerNodeStatus[] statuses = new DarknetPeerNodeStatus[peers.length];
+    for (int i = 0; i < peers.length; i++) {
+      statuses[i] = (DarknetPeerNodeStatus) peers[i].getStatus(noHeavy);
+    }
+    return statuses;
+  }
+
+  /** Returns a snapshot of statuses for opennet peers. */
+  public OpennetPeerNodeStatus[] getOpennetPeerNodeStatuses(boolean noHeavy) {
+    OpennetPeerNode[] peers = roster.getOpennetPeers();
+    OpennetPeerNodeStatus[] statuses = new OpennetPeerNodeStatus[peers.length];
+    for (int i = 0; i < peers.length; i++) {
+      statuses[i] = (OpennetPeerNodeStatus) peers[i].getStatus(noHeavy);
+    }
+    return statuses;
+  }
+
+  /** Update oldest never-connected darknet peer age if the timer has expired. */
+  public void maybeUpdateOldestNeverConnectedDarknetPeerAge(long now) {
+    PeerNode[] peerList;
+    synchronized (lock) {
+      if (now <= nextOldestNeverConnectedDarknetPeerAgeUpdateTime) return;
+      nextOldestNeverConnectedDarknetPeerAgeUpdateTime =
+          now + OLDEST_NEVER_CONNECTED_DARKNET_PEER_AGE_UPDATE_INTERVAL;
+      peerList = roster.myPeers();
+    }
+    oldestNeverConnectedDarknetPeerAge = 0L;
+    for (PeerNode peer : peerList) {
+      if (!peer.isDarknet()) continue;
+      if (peer.getPeerNodeStatus() == PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED) {
+        long age = now - peer.getPeerAddedTime();
+        if (age > oldestNeverConnectedDarknetPeerAge) oldestNeverConnectedDarknetPeerAge = age;
+      }
+    }
+    if (oldestNeverConnectedDarknetPeerAge > 0 && LOG.isDebugEnabled()) {
+      LOG.debug("Oldest never connected peer is {}ms old", oldestNeverConnectedDarknetPeerAge);
+    }
+    nextOldestNeverConnectedDarknetPeerAgeUpdateTime =
+        now + OLDEST_NEVER_CONNECTED_DARKNET_PEER_AGE_UPDATE_INTERVAL;
+  }
+
+  /** Returns the cached age of the oldest never-connected darknet peer. */
+  public long getOldestNeverConnectedDarknetPeerAge() {
+    return oldestNeverConnectedDarknetPeerAge;
+  }
+
+  /** Log the current PeerNode status summary if the timer has expired. */
+  public void maybeLogPeerNodeStatusSummary(long now) {
+    if (!shouldLogPeerStatus(now)) return;
+    PeerNode[] peers = roster.myPeers();
+    PeerStatusSummary summary = computePeerStatusSummary(peers);
+    logPeerStatusSummary(summary);
+    nextPeerNodeStatusLogTime = now + PEER_NODE_STATUS_LOG_INTERVAL;
+  }
+
+  private boolean shouldLogPeerStatus(long now) {
+    if (now <= nextPeerNodeStatusLogTime) return false;
+    if ((now - nextPeerNodeStatusLogTime) > TimeUnit.SECONDS.toMillis(10)
+        && nextPeerNodeStatusLogTime > 0) {
+      LOG.error(
+          "PeerNode status summary late by {} ms; PacketSender may be congested",
+          now - nextPeerNodeStatusLogTime);
+    }
+    return true;
+  }
+
+  private static final class PeerStatusSummary {
+    private final int connected;
+    private final int routingBackedOff;
+    private final int tooNew;
+    private final int tooOld;
+    private final int disconnected;
+    private final int neverConnected;
+    private final int disabled;
+    private final int bursting;
+    private final int listening;
+    private final int listenOnly;
+    private final int clockProblem;
+    private final int connError;
+    private final int disconnecting;
+    private final int routingDisabled;
+    private final int noLoadStats;
+
+    private PeerStatusSummary(
+        int connected,
+        int routingBackedOff,
+        int tooNew,
+        int tooOld,
+        int disconnected,
+        int neverConnected,
+        int disabled,
+        int bursting,
+        int listening,
+        int listenOnly,
+        int clockProblem,
+        int connError,
+        int disconnecting,
+        int routingDisabled,
+        int noLoadStats) {
+      this.connected = connected;
+      this.routingBackedOff = routingBackedOff;
+      this.tooNew = tooNew;
+      this.tooOld = tooOld;
+      this.disconnected = disconnected;
+      this.neverConnected = neverConnected;
+      this.disabled = disabled;
+      this.bursting = bursting;
+      this.listening = listening;
+      this.listenOnly = listenOnly;
+      this.clockProblem = clockProblem;
+      this.connError = connError;
+      this.disconnecting = disconnecting;
+      this.routingDisabled = routingDisabled;
+      this.noLoadStats = noLoadStats;
+    }
+  }
+
+  private PeerStatusSummary computePeerStatusSummary(PeerNode[] peers) {
+    int numberOfConnected = 0;
+    int numberOfRoutingBackedOff = 0;
+    int numberOfTooNew = 0;
+    int numberOfTooOld = 0;
+    int numberOfDisconnected = 0;
+    int numberOfNeverConnected = 0;
+    int numberOfDisabled = 0;
+    int numberOfListenOnly = 0;
+    int numberOfListening = 0;
+    int numberOfBursting = 0;
+    int numberOfClockProblem = 0;
+    int numberOfConnError = 0;
+    int numberOfDisconnecting = 0;
+    int numberOfRoutingDisabled = 0;
+    int numberOfNoLoadStats = 0;
+
+    for (PeerNode peer : peers) {
+      int status = peer.getPeerNodeStatus();
+      switch (status) {
+        case PeerManager.PEER_NODE_STATUS_CONNECTED -> numberOfConnected++;
+        case PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF -> numberOfRoutingBackedOff++;
+        case PeerManager.PEER_NODE_STATUS_TOO_NEW -> numberOfTooNew++;
+        case PeerManager.PEER_NODE_STATUS_TOO_OLD -> numberOfTooOld++;
+        case PeerManager.PEER_NODE_STATUS_DISCONNECTED -> numberOfDisconnected++;
+        case PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED -> numberOfNeverConnected++;
+        case PeerManager.PEER_NODE_STATUS_DISABLED -> numberOfDisabled++;
+        case PeerManager.PEER_NODE_STATUS_LISTEN_ONLY -> numberOfListenOnly++;
+        case PeerManager.PEER_NODE_STATUS_LISTENING -> numberOfListening++;
+        case PeerManager.PEER_NODE_STATUS_BURSTING -> numberOfBursting++;
+        case PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM -> numberOfClockProblem++;
+        case PeerManager.PEER_NODE_STATUS_CONN_ERROR -> numberOfConnError++;
+        case PeerManager.PEER_NODE_STATUS_DISCONNECTING -> numberOfDisconnecting++;
+        case PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED -> numberOfRoutingDisabled++;
+        case PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS -> numberOfNoLoadStats++;
+        default -> LOG.error("Unknown peer status value: {}", status);
+      }
+    }
+
+    return new PeerStatusSummary(
+        numberOfConnected,
+        numberOfRoutingBackedOff,
+        numberOfTooNew,
+        numberOfTooOld,
+        numberOfDisconnected,
+        numberOfNeverConnected,
+        numberOfDisabled,
+        numberOfBursting,
+        numberOfListening,
+        numberOfListenOnly,
+        numberOfClockProblem,
+        numberOfConnError,
+        numberOfDisconnecting,
+        numberOfRoutingDisabled,
+        numberOfNoLoadStats);
+  }
+
+  private void logPeerStatusSummary(PeerStatusSummary summary) {
+    LOG.info(
+        "Connected={} RoutingBackedOff={} TooNew={} TooOld={} Disconnected={} NeverConnected={}"
+            + " Disabled={} Bursting={} Listening={} ListenOnly={} ClockProblem={}"
+            + " ConnectionProblem={} Disconnecting={} RoutingDisabled={} NoLoadStats={}",
+        summary.connected,
+        summary.routingBackedOff,
+        summary.tooNew,
+        summary.tooOld,
+        summary.disconnected,
+        summary.neverConnected,
+        summary.disabled,
+        summary.bursting,
+        summary.listening,
+        summary.listenOnly,
+        summary.clockProblem,
+        summary.connError,
+        summary.disconnecting,
+        summary.routingDisabled,
+        summary.noLoadStats);
+  }
+
+  /** Updates per-peer routable-connection counters when the timer elapses. */
+  public void maybeUpdatePeerNodeRoutableConnectionStats(long now) {
+    PeerNode[] peersToUpdate = prepareRoutableStatsUpdate(now);
+    if (peersToUpdate.length == 0) return;
+    for (PeerNode peer : peersToUpdate) {
+      peer.checkRoutableConnectionStatus();
+    }
+  }
+
+  private PeerNode[] prepareRoutableStatsUpdate(long now) {
+    synchronized (lock) {
+      if (now <= nextRoutableConnectionStatsUpdateTime) return new PeerNode[0];
+      nextRoutableConnectionStatsUpdateTime = now + ROUTABLE_CONNECTION_STATS_UPDATE_INTERVAL;
+      return roster.myPeers();
+    }
+  }
+
+  private static final long OLDEST_NEVER_CONNECTED_DARKNET_PEER_AGE_UPDATE_INTERVAL = 5000L;
+  private static final long PEER_NODE_STATUS_LOG_INTERVAL = 5000L;
+  private static final long ROUTABLE_CONNECTION_STATS_UPDATE_INTERVAL =
+      TimeUnit.SECONDS.toMillis(7);
+}

--- a/src/main/java/network/crypta/node/PeerStatusBook.java
+++ b/src/main/java/network/crypta/node/PeerStatusBook.java
@@ -9,8 +9,28 @@ import org.slf4j.LoggerFactory;
 /**
  * Tracks peer status counters, routing backoff reasons, and periodic status summaries.
  *
- * <p>This class centralizes status bookkeeping to keep {@link PeerManager} focused on coordination
- * rather than tracking details.
+ * <p>This class centralizes bookkeeping for {@link PeerNode} status transitions, routing backoff
+ * reasons, and timed summary snapshots so that {@link PeerManager} can focus on coordination rather
+ * than on per-peer accounting. Typical usage is that the manager calls {@link
+ * #onPeerAdded(PeerNode)} when a peer joins, {@link #onPeerRemoved(PeerNode)} when it leaves, and
+ * invokes the periodic methods from a scheduler or main loop to refresh cached summaries.
+ *
+ * <p>State is maintained in in-memory trackers keyed by status values or reason strings. Timed
+ * updates are guarded by a shared lock supplied by the caller to keep roster snapshots and timer
+ * checks consistent, but the per-status trackers are synchronized internally. The class does not
+ * mutate {@link PeerNode} state; it only reads from peers and keeps derived counters and snapshots.
+ *
+ * <p>Notable behaviors include:
+ *
+ * <ul>
+ *   <li>Separate tracking for all peers versus darknet-only peers.
+ *   <li>Distinct routing backoff reason sets for real-time and bulk streams.
+ *   <li>Cached computations that update on fixed millisecond intervals.
+ * </ul>
+ *
+ * @see PeerManager
+ * @see PeerRoster
+ * @see PeerStatusTracker
  */
 public class PeerStatusBook {
   private static final Logger LOG = LoggerFactory.getLogger(PeerStatusBook.class);
@@ -30,17 +50,53 @@ public class PeerStatusBook {
   private long nextPeerNodeStatusLogTime = -1L;
   private long nextRoutableConnectionStatsUpdateTime = -1L;
 
+  /**
+   * Creates a status book bound to a roster and shared lock.
+   *
+   * <p>The provided roster supplies peer snapshots for status queries and periodic summaries. The
+   * lock must be the same monitor used by the owning manager when it mutates or snapshots the
+   * roster; this ensures that time-gated updates observe a consistent roster and timer state. The
+   * instance starts with empty counters and inactive timers; first updates occur on the first
+   * relevant method call.
+   *
+   * <pre>{@code
+   * var book = new PeerStatusBook(roster, managerLock);
+   * book.onPeerAdded(peer);
+   * }</pre>
+   *
+   * @param roster peer roster used to obtain peer snapshots; must be non-null
+   * @param lock shared monitor guarding roster snapshots and timer updates; must be non-null
+   */
   public PeerStatusBook(PeerRoster roster, Object lock) {
     this.roster = roster;
     this.lock = lock;
   }
 
-  /** Adds initial status tracking for a newly added peer. */
+  /**
+   * Adds initial status tracking for a newly added peer.
+   *
+   * <p>This method inspects the peer's current status and, when {@link PeerNode#recordStatus()}
+   * indicates that status should be tracked, registers it in the internal counters. Darknet peers
+   * contribute to both the global tracker and the darknet-only tracker, while opennet peers only
+   * affect the global tracker. The call is idempotent from the perspective of the trackers, though
+   * duplicate additions may be logged by the underlying status tracker.
+   *
+   * @param peer peer instance whose current status is registered; must be non-null
+   */
   public void onPeerAdded(PeerNode peer) {
     if (peer.recordStatus()) addPeerNodeStatus(peer.getPeerNodeStatus(), peer);
   }
 
-  /** Removes tracked status and routing backoff entries for a removed peer. */
+  /**
+   * Removes tracked status and routing backoff entries for a removed peer.
+   *
+   * <p>The method removes the peer from the status trackers when {@link PeerNode#recordStatus()} is
+   * true and also removes any previously recorded routing backoff reasons for both real-time and
+   * bulk streams. If no prior reason is recorded, the removal step is skipped. This call does not
+   * mutate peer state; it only removes bookkeeping data held by this instance.
+   *
+   * @param peer peer instance being removed; must be non-null and previously tracked
+   */
   public void onPeerRemoved(PeerNode peer) {
     int peerNodeStatus = peer.getPeerNodeStatus();
     if (peer.recordStatus()) removePeerNodeStatus(peerNodeStatus, peer);
@@ -50,7 +106,19 @@ public class PeerStatusBook {
     if (prevReasonBulk != null) removePeerNodeRoutingBackoffReason(prevReasonBulk, peer, false);
   }
 
-  /** Updates status counts when a peer changes status. */
+  /**
+   * Updates status counters when a peer changes status.
+   *
+   * <p>This method moves the peer from its old status bucket to the new status bucket in the global
+   * tracker, and in the darknet-only tracker when the peer is not an opennet peer. The operation is
+   * performed atomically within each tracker. When {@code noLog} is {@code true}, duplicate or
+   * absent membership messages from the tracker are suppressed.
+   *
+   * @param peer peer whose status has changed; must be non-null
+   * @param oldStatus previous status value, typically a {@link PeerManager} constant
+   * @param newStatus new status value, typically a {@link PeerManager} constant
+   * @param noLog when true, suppresses duplicate and missing-status error logs
+   */
   public void changePeerNodeStatus(PeerNode peer, int oldStatus, int newStatus, boolean noLog) {
     allPeersStatuses.changePeerNodeStatus(peer, oldStatus, newStatus, noLog);
     if (!peer.isOpennet()) {
@@ -70,26 +138,66 @@ public class PeerStatusBook {
     if (!peer.isOpennet()) darknetPeersStatuses.removeStatus(status, peer, false);
   }
 
-  /** Counts PeerNodes with a particular status. */
+  /**
+   * Counts peers with a particular status in the requested tracker.
+   *
+   * <p>The count is derived from a weakly referenced set, so it reflects the current bookkeeping
+   * snapshot and may shrink if peers become only weakly reachable. The method is read-only and does
+   * not trigger any updates or logging.
+   *
+   * @param status status key to count, usually from {@link PeerManager} constants
+   * @param darknet when true, use the darknet-only tracker instead of global
+   * @return number of peers currently recorded with the requested status
+   */
   public int getPeerNodeStatusSize(int status, boolean darknet) {
     return darknet ? darknetPeersStatuses.statusSize(status) : allPeersStatuses.statusSize(status);
   }
 
-  /** Adds a routing backoff reason for a peer. */
+  /**
+   * Adds a routing backoff reason for a peer.
+   *
+   * <p>The reason string is tracked independently for real-time and bulk streams. If the same peer
+   * is added twice for the same reason, the underlying tracker treats it as a duplicate and may log
+   * an error unless suppressed elsewhere. This method does not interpret or normalize the reason
+   * text; it uses the provided string as the key.
+   *
+   * @param reason backoff reason identifier; must be non-null and stable for grouping
+   * @param peer peer instance associated with the reason; must be non-null
+   * @param realTime true for real-time routing, false for bulk routing
+   */
   public void addPeerNodeRoutingBackoffReason(String reason, PeerNode peer, boolean realTime) {
     PeerStatusTracker<String> tracker =
         realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
     tracker.addStatus(reason, peer, false);
   }
 
-  /** Removes a routing backoff reason for a peer. */
+  /**
+   * Removes a routing backoff reason for a peer.
+   *
+   * <p>The removal affects only the tracker selected by {@code realTime}. If the peer is not
+   * currently associated with the reason, the underlying tracker may log an error. The reason key
+   * is removed entirely when no peers remain associated with it.
+   *
+   * @param reason backoff reason identifier; must match the previously added key
+   * @param peer peer instance associated with the reason; must be non-null
+   * @param realTime true for real-time routing, false for bulk routing
+   */
   public void removePeerNodeRoutingBackoffReason(String reason, PeerNode peer, boolean realTime) {
     PeerStatusTracker<String> tracker =
         realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
     tracker.removeStatus(reason, peer, false);
   }
 
-  /** Returns the currently tracked routing backoff reasons. */
+  /**
+   * Returns the currently tracked routing backoff reasons.
+   *
+   * <p>The returned array contains the distinct reason keys currently known to the selected
+   * tracker. No ordering is guaranteed because the keys are derived from a hash map. The snapshot
+   * is taken at call time and is not backed by the underlying data structures.
+   *
+   * @param realTime true to query real-time routing reasons, false for bulk
+   * @return array of distinct reason identifiers, possibly empty but never null
+   */
   public String[] getPeerNodeRoutingBackoffReasons(boolean realTime) {
     List<String> list = new ArrayList<>();
     PeerStatusTracker<String> tracker =
@@ -98,14 +206,34 @@ public class PeerStatusBook {
     return list.toArray(new String[0]);
   }
 
-  /** Returns the count of peers with a specific routing backoff reason. */
+  /**
+   * Returns the count of peers with a specific routing backoff reason.
+   *
+   * <p>The count reflects the current tracker snapshot and may change as peers are added or
+   * removed. The reason key is matched exactly; this method does not normalize or interpret the
+   * string.
+   *
+   * @param reason backoff reason identifier to count; must be non-null
+   * @param realTime true to query real-time routing reasons, false for bulk
+   * @return number of peers recorded for the provided reason key
+   */
   public int getPeerNodeRoutingBackoffReasonSize(String reason, boolean realTime) {
     PeerStatusTracker<String> tracker =
         realTime ? peerNodeRoutingBackoffReasonsRT : peerNodeRoutingBackoffReasonsBulk;
     return tracker.statusSize(reason);
   }
 
-  /** Returns a snapshot of statuses for all peers. */
+  /**
+   * Returns a snapshot of statuses for all peers in the roster.
+   *
+   * <p>The method iterates over the current roster snapshot and calls {@link
+   * PeerNode#getStatus(boolean)} on each peer. The resulting array preserves the roster order and
+   * is independent of subsequent roster changes. The method performs no filtering beyond the roster
+   * snapshot it receives.
+   *
+   * @param noHeavy whether to omit heavy-weight fields from the status snapshot
+   * @return array of status snapshots, one per peer in roster order
+   */
   public PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
     PeerNode[] peers = roster.myPeers();
     PeerNodeStatus[] statuses = new PeerNodeStatus[peers.length];
@@ -115,7 +243,17 @@ public class PeerStatusBook {
     return statuses;
   }
 
-  /** Returns a snapshot of statuses for darknet peers. */
+  /**
+   * Returns a snapshot of statuses for darknet peers.
+   *
+   * <p>The method selects only darknet peers from the roster and returns their status snapshots in
+   * the same order as the filtered roster. It expects each returned status to be a {@link
+   * DarknetPeerNodeStatus} instance because it invokes {@link PeerNode#getStatus(boolean)} on a
+   * {@link DarknetPeerNode}.
+   *
+   * @param noHeavy whether to omit heavy-weight fields from the status snapshot
+   * @return array of darknet peer status snapshots, possibly empty but never null
+   */
   public DarknetPeerNodeStatus[] getDarknetPeerNodeStatuses(boolean noHeavy) {
     DarknetPeerNode[] peers = roster.getDarknetPeers();
     DarknetPeerNodeStatus[] statuses = new DarknetPeerNodeStatus[peers.length];
@@ -125,7 +263,17 @@ public class PeerStatusBook {
     return statuses;
   }
 
-  /** Returns a snapshot of statuses for opennet peers. */
+  /**
+   * Returns a snapshot of statuses for opennet peers.
+   *
+   * <p>The method filters the roster to opennet peers and returns their status snapshots in the
+   * same order as the filtered roster. Each status is expected to be an {@link
+   * OpennetPeerNodeStatus} because the snapshots are created from {@link OpennetPeerNode}
+   * instances.
+   *
+   * @param noHeavy whether to omit heavy-weight fields from the status snapshot
+   * @return array of opennet peer status snapshots, possibly empty but never null
+   */
   public OpennetPeerNodeStatus[] getOpennetPeerNodeStatuses(boolean noHeavy) {
     OpennetPeerNode[] peers = roster.getOpennetPeers();
     OpennetPeerNodeStatus[] statuses = new OpennetPeerNodeStatus[peers.length];
@@ -135,7 +283,17 @@ public class PeerStatusBook {
     return statuses;
   }
 
-  /** Update oldest never-connected darknet peer age if the timer has expired. */
+  /**
+   * Updates the cached oldest never-connected darknet peer age when the timer elapses.
+   *
+   * <p>The method checks the last update time under the shared lock and returns early if the
+   * interval has not expired. When an update is due, it scans the current roster snapshot and
+   * computes the maximum {@code now - peerAddedTime} among darknet peers that are in {@link
+   * PeerManager#PEER_NODE_STATUS_NEVER_CONNECTED}. The cached value is expressed in milliseconds
+   * and is reset to {@code 0} when no matching peers are found.
+   *
+   * @param now current time in milliseconds, typically {@code System.currentTimeMillis()}
+   */
   public void maybeUpdateOldestNeverConnectedDarknetPeerAge(long now) {
     PeerNode[] peerList;
     synchronized (lock) {
@@ -159,12 +317,29 @@ public class PeerStatusBook {
         now + OLDEST_NEVER_CONNECTED_DARKNET_PEER_AGE_UPDATE_INTERVAL;
   }
 
-  /** Returns the cached age of the oldest never-connected darknet peer. */
+  /**
+   * Returns the cached age of the oldest never-connected darknet peer.
+   *
+   * <p>The value is updated only when {@link #maybeUpdateOldestNeverConnectedDarknetPeerAge(long)}
+   * runs and the update interval has elapsed. The age is measured in milliseconds and is zero when
+   * no qualifying peers exist or when the cache has not yet been populated.
+   *
+   * @return cached age in milliseconds; zero when no matching peers are present
+   */
   public long getOldestNeverConnectedDarknetPeerAge() {
     return oldestNeverConnectedDarknetPeerAge;
   }
 
-  /** Log the current PeerNode status summary if the timer has expired. */
+  /**
+   * Logs the current peer status summary when the timer has expired.
+   *
+   * <p>The method checks whether the periodic interval has elapsed and, if so, collects a roster
+   * snapshot and computes a count of peers in each status bucket. It then emits a single summary
+   * log line containing all counts. If the logging schedule is significantly late, it also emits an
+   * error indicating potential congestion in the sender loop.
+   *
+   * @param now current time in milliseconds, typically {@code System.currentTimeMillis()}
+   */
   public void maybeLogPeerNodeStatusSummary(long now) {
     if (!shouldLogPeerStatus(now)) return;
     PeerNode[] peers = roster.myPeers();
@@ -314,10 +489,18 @@ public class PeerStatusBook {
         summary.noLoadStats);
   }
 
-  /** Updates per-peer routable-connection counters when the timer elapses. */
+  /**
+   * Updates per-peer routable-connection counters when the timer elapses.
+   *
+   * <p>The method first checks the update interval under the shared lock. When an update is due, it
+   * retrieves a roster snapshot and invokes {@link PeerNode#checkRoutableConnectionStatus()} on
+   * each peer. If the interval has not elapsed, no peer methods are called and the roster is not
+   * read, keeping the method cheap for frequent polling.
+   *
+   * @param now current time in milliseconds, typically {@code System.currentTimeMillis()}
+   */
   public void maybeUpdatePeerNodeRoutableConnectionStats(long now) {
     PeerNode[] peersToUpdate = prepareRoutableStatsUpdate(now);
-    if (peersToUpdate.length == 0) return;
     for (PeerNode peer : peersToUpdate) {
       peer.checkRoutableConnectionStatus();
     }

--- a/src/main/java/network/crypta/node/RequestSender.java
+++ b/src/main/java/network/crypta/node/RequestSender.java
@@ -340,6 +340,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     // Route it
     next =
         node.getPeers()
+            .routingSelector()
             .closerPeer(
                 source,
                 nodesRoutedTo,

--- a/src/main/java/network/crypta/node/SSKInsertSender.java
+++ b/src/main/java/network/crypta/node/SSKInsertSender.java
@@ -240,6 +240,7 @@ public class SSKInsertSender extends BaseSender
 
   private PeerNode findNextPeer() {
     return node.getPeers()
+        .routingSelector()
         .closerPeer(
             forkedRequestTag == null ? source : null,
             nodesRoutedTo,

--- a/src/main/java/network/crypta/node/SecurityLevels.java
+++ b/src/main/java/network/crypta/node/SecurityLevels.java
@@ -431,7 +431,7 @@ public class SecurityLevels {
 
   private HTMLNode handleHighOrMaximum(
       HTMLNode parent, NETWORK_THREAT_LEVEL newThreatLevel, String checkboxName) {
-    if (node.getPeers().getDarknetPeers().length == 0) {
+    if (node.getPeers().roster().getDarknetPeers().length == 0) {
       parent.addChild("p", l10n("noFriendsWarning"));
       if (newThreatLevel == NETWORK_THREAT_LEVEL.MAXIMUM) {
         HTMLNode p = parent.addChild("p");
@@ -452,7 +452,7 @@ public class SecurityLevels {
           l10n(
               "noConnectedFriendsWarning",
               new String[] {"added"},
-              new String[] {Integer.toString(node.getPeers().getDarknetPeers().length)}));
+              new String[] {Integer.toString(node.getPeers().roster().getDarknetPeers().length)}));
       if (newThreatLevel == NETWORK_THREAT_LEVEL.MAXIMUM) {
         HTMLNode p = parent.addChild("p");
         NodeL10n.getBase()
@@ -474,7 +474,7 @@ public class SecurityLevels {
               new String[] {"connected", "added"},
               new String[] {
                 Integer.toString(node.getPeers().countConnectedDarknetPeers()),
-                Integer.toString(node.getPeers().getDarknetPeers().length)
+                Integer.toString(node.getPeers().roster().getDarknetPeers().length)
               }));
       if (newThreatLevel == NETWORK_THREAT_LEVEL.MAXIMUM) {
         HTMLNode p = parent.addChild("p");

--- a/src/main/java/network/crypta/node/SeedClientPeerNode.java
+++ b/src/main/java/network/crypta/node/SeedClientPeerNode.java
@@ -159,7 +159,7 @@ public class SeedClientPeerNode extends PeerNode {
   @Override
   public boolean disconnected(boolean dumpMessageQueue, boolean dumpTrackers) {
     boolean ret = super.disconnected(true, true);
-    node.getPeers().disconnectAndRemove(this, false, false, false);
+    node.getPeers().messenger().disconnectAndRemove(this, false, false, false);
     return ret;
   }
 

--- a/src/main/java/network/crypta/node/SeedPeerQueries.java
+++ b/src/main/java/network/crypta/node/SeedPeerQueries.java
@@ -7,12 +7,46 @@ import network.crypta.support.ByteArrayWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Provides seed-server peer queries derived from the current peer snapshot. */
+/**
+ * Provides read-only queries for seed-server peers derived from the current peer snapshot.
+ *
+ * <p>This helper wraps a {@link PeerManager} snapshot lookup and filters for {@link
+ * SeedServerPeerNode} instances. It is intended for callers that need a consistent, short-lived
+ * view of seed peers without mutating the underlying peer roster. Typical usage is to fetch a list,
+ * iterate immediately, and then discard it; the results should not be cached across network events
+ * because the peer roster may change concurrently.
+ *
+ * <p>All methods return new {@link java.util.ArrayList} instances that contain the matching peers
+ * in the order provided by the manager snapshot. The class itself is stateless aside from its
+ * reference to the manager and therefore is safe for concurrent use as long as the underlying
+ * manager provides a safe snapshot. Filtering is conservative: peers are excluded if they are not
+ * currently connected or if their public key hash is explicitly filtered by the caller.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Filtering connected seed peers while honoring an optional exclude set.
+ *   <li>Returning a complete seed-peer snapshot without connection filtering.
+ * </ul>
+ *
+ * @see PeerManager
+ * @see SeedServerPeerNode
+ */
 public class SeedPeerQueries {
   private static final Logger LOG = LoggerFactory.getLogger(SeedPeerQueries.class);
 
   private final PeerManager peerManager;
 
+  /**
+   * Creates query helpers bound to the provided peer manager snapshot API.
+   *
+   * <p>The manager reference is stored and used for subsequent snapshot reads. Callers typically
+   * obtain this instance via {@link PeerManager#seedPeers()} rather than constructing it directly.
+   * This constructor performs no I/O and does not copy peer state; all data is read on demand from
+   * the manager.
+   *
+   * @param peerManager manager that supplies the current peer snapshot; must not be {@code null}
+   */
   SeedPeerQueries(PeerManager peerManager) {
     this.peerManager = peerManager;
   }
@@ -20,8 +54,22 @@ public class SeedPeerQueries {
   /**
    * Returns connected seed-server peers, excluding specified public key hashes.
    *
-   * @param exclude Set of public key hashes to exclude (optional; may be {@code null}).
-   * @return List of connected seed-server peers.
+   * <p>The method walks the current peer snapshot returned by the manager and retains only {@link
+   * SeedServerPeerNode} instances that are connected at the time of evaluation. If an {@code
+   * exclude} set is provided, any seed peer whose public key hash matches a member of the set is
+   * filtered out. The returned list is a new mutable list that reflects the snapshot order; later
+   * changes to connectivity or peer membership are not reflected in the list.
+   *
+   * <p>Edge cases: a {@code null} exclude set is treated as empty; disconnected peers are always
+   * omitted; non-seed peers are ignored. This operation is read-only and safe to call repeatedly.
+   *
+   * <pre>{@code
+   * List<SeedServerPeerNode> seeds = peerManager.seedPeers()
+   *     .getConnectedSeedServerPeersVector(null);
+   * }</pre>
+   *
+   * @param exclude set of public key hashes to exclude; {@code null} means no exclusions apply
+   * @return mutable snapshot list of connected seed peers, never {@code null} and possibly empty
    */
   public List<SeedServerPeerNode> getConnectedSeedServerPeersVector(Set<ByteArrayWrapper> exclude) {
     PeerNode[] peers = peerManager.myPeers();
@@ -35,9 +83,21 @@ public class SeedPeerQueries {
   }
 
   /**
-   * Returns a snapshot of all seed-server peers (copy), connected or not.
+   * Returns a snapshot list of all seed-server peers, connected or not.
    *
-   * @return List of seed-server peers.
+   * <p>This method filters the current peer snapshot for {@link SeedServerPeerNode} instances only,
+   * without applying any connection checks. The returned list is a new mutable list, ordered to
+   * match the manager snapshot at the time of the call. The list does not update if the peer roster
+   * changes later.
+   *
+   * <p>Edge cases: if there are no seed peers, the returned list is empty; non-seed peers are
+   * ignored. This is a read-only operation intended for quick iteration.
+   *
+   * <pre>{@code
+   * List<SeedServerPeerNode> allSeeds = peerManager.seedPeers().getSeedServerPeersVector();
+   * }</pre>
+   *
+   * @return mutable snapshot list of seed peers, never {@code null} and possibly empty
    */
   public List<SeedServerPeerNode> getSeedServerPeersVector() {
     PeerNode[] peers = peerManager.myPeers();

--- a/src/main/java/network/crypta/node/SeedPeerQueries.java
+++ b/src/main/java/network/crypta/node/SeedPeerQueries.java
@@ -1,0 +1,64 @@
+package network.crypta.node;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import network.crypta.support.ByteArrayWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Provides seed-server peer queries derived from the current peer snapshot. */
+public class SeedPeerQueries {
+  private static final Logger LOG = LoggerFactory.getLogger(SeedPeerQueries.class);
+
+  private final PeerManager peerManager;
+
+  SeedPeerQueries(PeerManager peerManager) {
+    this.peerManager = peerManager;
+  }
+
+  /**
+   * Returns connected seed-server peers, excluding specified public key hashes.
+   *
+   * @param exclude Set of public key hashes to exclude (optional; may be {@code null}).
+   * @return List of connected seed-server peers.
+   */
+  public List<SeedServerPeerNode> getConnectedSeedServerPeersVector(Set<ByteArrayWrapper> exclude) {
+    PeerNode[] peers = peerManager.myPeers();
+    List<SeedServerPeerNode> result = new ArrayList<>(peers.length);
+    for (PeerNode peer : peers) {
+      if (peer instanceof SeedServerPeerNode sspn && !shouldSkipSeedServerPeer(sspn, exclude)) {
+        result.add(sspn);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Returns a snapshot of all seed-server peers (copy), connected or not.
+   *
+   * @return List of seed-server peers.
+   */
+  public List<SeedServerPeerNode> getSeedServerPeersVector() {
+    PeerNode[] peers = peerManager.myPeers();
+    // Note: consider optimizing by maintaining a separate list
+    List<SeedServerPeerNode> result = new ArrayList<>(peers.length);
+    for (PeerNode peer : peers) {
+      if (peer instanceof SeedServerPeerNode peerNode) result.add(peerNode);
+    }
+    return result;
+  }
+
+  private boolean shouldSkipSeedServerPeer(SeedServerPeerNode sspn, Set<ByteArrayWrapper> exclude) {
+    if (exclude != null && exclude.contains(new ByteArrayWrapper(sspn.getPubKeyHash()))) {
+      if (LOG.isDebugEnabled())
+        LOG.debug("Excluded by filter (exclude set): {}", sspn.userToString());
+      return true;
+    }
+    if (!sspn.isConnected()) {
+      if (LOG.isDebugEnabled()) LOG.debug("Excluded; disconnected: {}", sspn.userToString());
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/java/network/crypta/node/SeedServerPeerNode.java
+++ b/src/main/java/network/crypta/node/SeedServerPeerNode.java
@@ -136,7 +136,7 @@ public class SeedServerPeerNode extends PeerNode {
     final OpennetManager om = node.getOpennet();
     if (om == null) {
       LOG.info("Opennet turned off while connecting to seednodes");
-      node.getPeers().disconnectAndRemove(this, true, true, true);
+      node.getPeers().messenger().disconnectAndRemove(this, true, true, true);
     } else {
       // Delay announcements: another node may connect first; avoid biasing toward the
       // fastest initial connection.
@@ -202,7 +202,7 @@ public class SeedServerPeerNode extends PeerNode {
   @Override
   public boolean disconnected(boolean dumpMessageQueue, boolean dumpTrackers) {
     boolean ret = super.disconnected(dumpMessageQueue, dumpTrackers);
-    node.getPeers().disconnectAndRemove(this, false, false, false);
+    node.getPeers().messenger().disconnectAndRemove(this, false, false, false);
     return ret;
   }
 

--- a/src/main/java/network/crypta/node/TextModeClientInterface.java
+++ b/src/main/java/network/crypta/node/TextModeClientInterface.java
@@ -1732,7 +1732,7 @@ public class TextModeClientInterface implements Runnable {
    * success as boolean
    */
   private boolean disablePeer(String nodeIdentifier) {
-    for (DarknetPeerNode pn : n.getPeers().getDarknetPeers()) {
+    for (DarknetPeerNode pn : n.getPeers().roster().getDarknetPeers()) {
       Peer peer = pn.getPeer();
       String nodeIpAndPort = "";
       if (peer != null) {
@@ -1755,7 +1755,7 @@ public class TextModeClientInterface implements Runnable {
    * success as boolean
    */
   private boolean enablePeer(String nodeIdentifier) {
-    for (DarknetPeerNode pn : n.getPeers().getDarknetPeers()) {
+    for (DarknetPeerNode pn : n.getPeers().roster().getDarknetPeers()) {
       Peer peer = pn.getPeer();
       String nodeIpAndPort = "";
       if (peer != null) {
@@ -1778,7 +1778,7 @@ public class TextModeClientInterface implements Runnable {
    * existence as boolean
    */
   private boolean havePeer(String nodeIdentifier) {
-    for (DarknetPeerNode pn : n.getPeers().getDarknetPeers()) {
+    for (DarknetPeerNode pn : n.getPeers().roster().getDarknetPeers()) {
       Peer peer = pn.getPeer();
       String nodeIpAndPort = "";
       if (peer != null) {
@@ -1801,7 +1801,7 @@ public class TextModeClientInterface implements Runnable {
    */
   private boolean removePeer(String nodeIdentifier) {
     LOG.info("Removing peer from node for: {}", nodeIdentifier);
-    for (DarknetPeerNode pn : n.getPeers().getDarknetPeers()) {
+    for (DarknetPeerNode pn : n.getPeers().roster().getDarknetPeers()) {
       Peer peer = pn.getPeer();
       String nodeIpAndPort = "";
       if (peer != null) {

--- a/src/main/java/network/crypta/node/simulator/BootstrapSeedTest.java
+++ b/src/main/java/network/crypta/node/simulator/BootstrapSeedTest.java
@@ -69,7 +69,7 @@ public class BootstrapSeedTest {
     while (seconds < 600) {
       Thread.sleep(1000);
       int seeds = node.getPeers().countSeednodes();
-      int seedConns = node.getPeers().getConnectedSeedServerPeersVector(null).size();
+      int seedConns = node.getPeers().seedPeers().getConnectedSeedServerPeersVector(null).size();
       int opennetPeers = node.getPeers().countValidPeers();
       int opennetConns = node.getPeers().countConnectedOpennetPeers();
       LOG.error(

--- a/src/main/java/network/crypta/node/simulator/SeednodePingTest.java
+++ b/src/main/java/network/crypta/node/simulator/SeednodePingTest.java
@@ -275,7 +275,8 @@ public class SeednodePingTest extends RealNodeTest {
   private static PingLoopResult pingConnectedSeednodes(Node node, int pingIdStart) {
     int pingId = pingIdStart;
     int countConnectedSeednodes = 0;
-    for (SeedServerPeerNode seednode : node.getPeers().getConnectedSeedServerPeersVector(null)) {
+    for (SeedServerPeerNode seednode :
+        node.getPeers().seedPeers().getConnectedSeedServerPeersVector(null)) {
       if (pingSeednode(seednode, pingId)) {
         countConnectedSeednodes++;
         pingId++;

--- a/src/main/java/network/crypta/node/simulator/TestUtil.java
+++ b/src/main/java/network/crypta/node/simulator/TestUtil.java
@@ -43,7 +43,7 @@ public class TestUtil {
     while (seconds < 600) {
       Thread.sleep(1000);
       int seeds = node.getPeers().countSeednodes();
-      int seedConns = node.getPeers().getConnectedSeedServerPeersVector(null).size();
+      int seedConns = node.getPeers().seedPeers().getConnectedSeedServerPeersVector(null).size();
       int opennetPeers = node.getPeers().countValidPeers();
       int opennetConns = node.getPeers().countConnectedOpennetPeers();
       LOG.info(

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -490,6 +490,7 @@ public class NodeUpdateManager {
       LOG.debug("Broadcasting UOM announcements");
     }
     node.getPeers()
+        .messenger()
         .localBroadcast(msg, true, true, getByteCounter(), TRANSITION_VERSION, Integer.MAX_VALUE);
   }
 

--- a/src/main/java/network/crypta/node/useralerts/IPUndetectedUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/IPUndetectedUserAlert.java
@@ -157,7 +157,7 @@ public class IPUndetectedUserAlert extends AbstractUserAlert {
             new String[] {"link"},
             new HTMLNode[] {HTMLNode.link("/config/" + sc.getPrefix())});
 
-    int peers = node.getPeers().getDarknetPeers().length;
+    int peers = node.getPeers().roster().getDarknetPeers().length;
     if (peers > 0)
       textNode.addChild("p", l10n("noIPMaybeFromPeers", "number", Integer.toString(peers)));
 

--- a/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
@@ -27,6 +27,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.OpennetPeerNodeStatus;
 import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNodeStatus;
+import network.crypta.node.PeerStatusBook;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;
@@ -45,6 +46,7 @@ class OpennetConnectionsToadletTest {
   @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient client;
   @Mock private PeerManager peerManager;
+  @Mock private PeerStatusBook statusBook;
   @Mock private SimpleFieldSet noderef;
 
   private OpennetConnectionsToadlet toadlet;
@@ -75,13 +77,15 @@ class OpennetConnectionsToadletTest {
     OpennetPeerNodeStatus[] statuses =
         new OpennetPeerNodeStatus[] {mock(OpennetPeerNodeStatus.class)};
     when(node.getPeers()).thenReturn(peerManager);
-    when(peerManager.getOpennetPeerNodeStatuses(false)).thenReturn(statuses);
+    when(peerManager.statusBook()).thenReturn(statusBook);
+    when(statusBook.getOpennetPeerNodeStatuses(false)).thenReturn(statuses);
 
     PeerNodeStatus[] result = toadlet.getPeerNodeStatuses(false);
 
     assertSame(statuses, result);
     verify(node, atLeastOnce()).getPeers();
-    verify(peerManager).getOpennetPeerNodeStatuses(false);
+    verify(peerManager).statusBook();
+    verify(statusBook).getOpennetPeerNodeStatuses(false);
   }
 
   @Test

--- a/src/test/java/network/crypta/io/comm/IncomingPacketFilterImplTest.java
+++ b/src/test/java/network/crypta/io/comm/IncomingPacketFilterImplTest.java
@@ -21,6 +21,7 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeCrypto;
 import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNode;
+import network.crypta.node.PeerRoster;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +40,7 @@ class IncomingPacketFilterImplTest {
   @Mock private Node node;
   @Mock private NodeCrypto crypto;
   @Mock private PeerManager peerManager;
+  @Mock private PeerRoster roster;
   @Mock private RandomSource randomSource;
 
   private IncomingPacketFilterImpl filter;
@@ -85,8 +87,9 @@ class IncomingPacketFilterImplTest {
     // Node wiring used by the filter
     when(node.getRandom()).thenReturn(randomSource);
     when(node.getPeers()).thenReturn(peerManager);
+    when(peerManager.roster()).thenReturn(roster);
     PeerNode opn = Mockito.mock(PeerNode.class);
-    when(peerManager.getByPeer(peer, mangler)).thenReturn(opn);
+    when(roster.getByPeer(peer, mangler)).thenReturn(opn);
     when(opn.handleReceivedPacket(buf, 0, buf.length, now, peer)).thenReturn(true);
 
     DECODED result = filter.process(buf, 0, buf.length, peer, now);
@@ -102,7 +105,8 @@ class IncomingPacketFilterImplTest {
   void process_whenUnknownAddress_callsManglerWithNullPeerNode_andReturnsManglerResult() {
     when(node.getRandom()).thenReturn(randomSource);
     when(node.getPeers()).thenReturn(peerManager);
-    when(peerManager.getByPeer(peer, mangler)).thenReturn(null);
+    when(peerManager.roster()).thenReturn(roster);
+    when(roster.getByPeer(peer, mangler)).thenReturn(null);
     when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.DECODED);
 
     DECODED result = filter.process(buf, 0, buf.length, peer, now);
@@ -118,7 +122,8 @@ class IncomingPacketFilterImplTest {
   void process_whenManglerNotDecoded_thenFallbackPeersHandle_returnsDecoded() {
     when(node.getRandom()).thenReturn(randomSource);
     when(node.getPeers()).thenReturn(peerManager);
-    when(peerManager.getByPeer(peer, mangler)).thenReturn(null);
+    when(peerManager.roster()).thenReturn(roster);
+    when(roster.getByPeer(peer, mangler)).thenReturn(null);
     when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.NOT_DECODED);
 
     PeerNode pn1 = Mockito.mock(PeerNode.class);
@@ -139,7 +144,8 @@ class IncomingPacketFilterImplTest {
   void process_whenManglerNotDecoded_andNoPeerHandles_returnsNotDecoded() {
     when(node.getRandom()).thenReturn(randomSource);
     when(node.getPeers()).thenReturn(peerManager);
-    when(peerManager.getByPeer(peer, mangler)).thenReturn(null);
+    when(peerManager.roster()).thenReturn(roster);
+    when(roster.getByPeer(peer, mangler)).thenReturn(null);
     when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.NOT_DECODED);
 
     PeerNode pn1 = Mockito.mock(PeerNode.class);
@@ -160,7 +166,8 @@ class IncomingPacketFilterImplTest {
   void process_whenManglerReturnsShuttingDown_returnsShuttingDown_withoutFallback() {
     when(node.getRandom()).thenReturn(randomSource);
     when(node.getPeers()).thenReturn(peerManager);
-    when(peerManager.getByPeer(peer, mangler)).thenReturn(null);
+    when(peerManager.roster()).thenReturn(roster);
+    when(roster.getByPeer(peer, mangler)).thenReturn(null);
     when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.SHUTTING_DOWN);
 
     DECODED result = filter.process(buf, 0, buf.length, peer, now);

--- a/src/test/java/network/crypta/node/AnnounceSenderTest.java
+++ b/src/test/java/network/crypta/node/AnnounceSenderTest.java
@@ -49,6 +49,7 @@ class AnnounceSenderTest {
   @Mock private NodeCrypto crypto;
   @Mock private PriorityAwareExecutor executor;
   @Mock private PeerManager peers;
+  @Mock private PeerRoutingSelector routingSelector;
 
   private static final long FIXED_UID = 777L;
 
@@ -171,10 +172,12 @@ class AnnounceSenderTest {
 
   @Test
   void run_whenNoOnlyNodeAndNoPeerChosen_expectNoMoreNodes() {
-    // Arrange: onlyNode == null, peers.closerPeer() returns null so we RNF with next == null
+    // Arrange: onlyNode == null, routingSelector.closerPeer() returns null so we RNF with next ==
+    // null
     when(node.getPeers()).thenReturn(peers);
+    when(peers.routingSelector()).thenReturn(routingSelector);
     when(node.decrementHTL(isNull(), anyShort())).thenReturn((short) 1);
-    when(peers.closerPeer(
+    when(routingSelector.closerPeer(
             isNull(),
             anySet(),
             anyDouble(),
@@ -215,10 +218,11 @@ class AnnounceSenderTest {
   void updateHtl_usesLastPeerAfterSendFailure() throws Exception {
     // Arrange: multi-peer routing (onlyNode == null)
     when(node.getPeers()).thenReturn(peers);
+    when(peers.routingSelector()).thenReturn(routingSelector);
 
     PeerNode p1 = Mockito.mock(PeerNode.class);
     PeerNode p2 = Mockito.mock(PeerNode.class);
-    when(peers.closerPeer(
+    when(routingSelector.closerPeer(
             isNull(),
             anySet(),
             anyDouble(),

--- a/src/test/java/network/crypta/node/NodeARKInserterTest.java
+++ b/src/test/java/network/crypta/node/NodeARKInserterTest.java
@@ -44,6 +44,7 @@ class NodeARKInserterTest {
   @Mock private NodeCrypto crypto;
   @Mock private NodeIPPortDetector detector;
   @Mock private PeerManager peerManager;
+  @Mock private PeerMessenger peerMessenger;
   @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient hlsc;
   @Mock private ClientContext clientContext;
@@ -86,6 +87,7 @@ class NodeARKInserterTest {
 
     when(node.getExecutor()).thenReturn(inlineExecutor);
     org.mockito.Mockito.lenient().when(node.getPeers()).thenReturn(peerManager);
+    org.mockito.Mockito.lenient().when(peerManager.messenger()).thenReturn(peerMessenger);
     org.mockito.Mockito.lenient().when(node.getClientCore()).thenReturn(core);
     org.mockito.Mockito.lenient().when(core.getClientContext()).thenReturn(clientContext);
 
@@ -175,7 +177,7 @@ class NodeARKInserterTest {
     // Assert
     // Broadcast differential noderef with physical.udp
     ArgumentCaptor<SimpleFieldSet> sfsCaptor = ArgumentCaptor.forClass(SimpleFieldSet.class);
-    verify(peerManager).locallyBroadcastDiffNodeRef(sfsCaptor.capture(), eq(true), eq(false));
+    verify(peerMessenger).locallyBroadcastDiffNodeRef(sfsCaptor.capture(), eq(true), eq(false));
     assertEquals("127.0.0.1:12345", sfsCaptor.getValue().get("physical.udp"));
 
     // Insert started
@@ -231,7 +233,7 @@ class NodeARKInserterTest {
     verify(node, never()).writeOpennetFile();
 
     ArgumentCaptor<SimpleFieldSet> sfsCaptor = ArgumentCaptor.forClass(SimpleFieldSet.class);
-    verify(peerManager).locallyBroadcastDiffNodeRef(sfsCaptor.capture(), eq(true), eq(false));
+    verify(peerMessenger).locallyBroadcastDiffNodeRef(sfsCaptor.capture(), eq(true), eq(false));
     assertEquals(7L, Long.parseLong(sfsCaptor.getValue().get("ark.number")));
   }
 
@@ -253,7 +255,7 @@ class NodeARKInserterTest {
     verify(node, never()).writeNodeFile();
 
     ArgumentCaptor<SimpleFieldSet> sfsCaptor = ArgumentCaptor.forClass(SimpleFieldSet.class);
-    verify(peerManager).locallyBroadcastDiffNodeRef(sfsCaptor.capture(), eq(false), eq(true));
+    verify(peerMessenger).locallyBroadcastDiffNodeRef(sfsCaptor.capture(), eq(false), eq(true));
     assertEquals(3L, Long.parseLong(sfsCaptor.getValue().get("ark.number")));
   }
 
@@ -272,7 +274,7 @@ class NodeARKInserterTest {
     verify(crypto, never()).setMyARKNumber(any(Long.class));
     verify(node, never()).writeNodeFile();
     verify(node, never()).writeOpennetFile();
-    verifyNoInteractions(peerManager);
+    verifyNoInteractions(peerMessenger);
   }
 
   @Test

--- a/src/test/java/network/crypta/node/NodeCryptoTest.java
+++ b/src/test/java/network/crypta/node/NodeCryptoTest.java
@@ -298,7 +298,9 @@ class NodeCryptoTest {
     FNPPacketMangler mangler = (FNPPacketMangler) getField(nc, "packetMangler");
 
     PeerManager pm = mock(PeerManager.class);
+    PeerRoster roster = mock(PeerRoster.class);
     when(node.getPeers()).thenReturn(pm);
+    when(pm.roster()).thenReturn(roster);
 
     PeerNode a = mock(PeerNode.class);
     when(a.handshakeUnknownInitiator()).thenReturn(true);
@@ -342,7 +344,9 @@ class NodeCryptoTest {
     when(cfg.oneConnectionPerAddress()).thenReturn(true);
 
     PeerManager pm = mock(PeerManager.class);
+    PeerRoster roster = mock(PeerRoster.class);
     when(node.getPeers()).thenReturn(pm);
+    when(pm.roster()).thenReturn(roster);
 
     FreenetInetAddress addr = new FreenetInetAddress(InetAddress.getByName("203.0.113.5"));
     PeerNode peer = mock(PeerNode.class);
@@ -352,7 +356,7 @@ class NodeCryptoTest {
     // Real internet address
     assertTrue(addr.isRealInternetAddress(false, false, false));
 
-    when(pm.anyConnectedPeerHasAddress(addr, peer)).thenReturn(true);
+    when(roster.anyConnectedPeerHasAddress(addr, peer)).thenReturn(true);
 
     boolean res = nc.allowConnection(peer, addr);
     assertFalse(res);
@@ -368,7 +372,11 @@ class NodeCryptoTest {
 
     // Prepare PeerManager with a conflicting Darknet peer
     PeerManager pm = mock(PeerManager.class);
+    PeerMessenger messenger = mock(PeerMessenger.class);
+    PeerRoster roster = mock(PeerRoster.class);
     when(node.getPeers()).thenReturn(pm);
+    when(pm.messenger()).thenReturn(messenger);
+    when(pm.roster()).thenReturn(roster);
 
     DarknetPeerNode conflicting = mock(DarknetPeerNode.class);
     // Make the inner crypto's config return oneConnectionPerAddress=true
@@ -379,7 +387,7 @@ class NodeCryptoTest {
     setPeerNodeCrypto(conflicting, otherCrypto);
 
     when(conflicting.isOpennet()).thenReturn(false);
-    when(pm.getAllConnectedByAddress(address, true))
+    when(roster.getAllConnectedByAddress(address, true))
         .thenReturn(new ArrayList<>(List.of(conflicting)));
 
     // Caller peer is also darknet, so the conflict applies
@@ -387,7 +395,7 @@ class NodeCryptoTest {
 
     nc.maybeBootConnection(caller, address);
 
-    verify(pm).disconnectAndRemove(eq(conflicting), eq(true), eq(true), anyBoolean());
+    verify(messenger).disconnectAndRemove(eq(conflicting), eq(true), eq(true), anyBoolean());
   }
 
   @Test

--- a/src/test/java/network/crypta/node/NodeDispatcherTest.java
+++ b/src/test/java/network/crypta/node/NodeDispatcherTest.java
@@ -252,7 +252,9 @@ class NodeDispatcherTest {
     m = withSource(m, src);
 
     PeerManager pm = mock(PeerManager.class);
+    PeerMessenger messenger = mock(PeerMessenger.class);
     when(node.getPeers()).thenReturn(pm);
+    when(pm.messenger()).thenReturn(messenger);
 
     boolean handled = dispatcher.handleMessage(m);
     assertTrue(handled);
@@ -261,7 +263,7 @@ class NodeDispatcherTest {
     scheduled.get().run();
 
     verify(src).disconnected(true, true);
-    verify(pm).disconnectAndRemove(src, false, false, false);
+    verify(messenger).disconnectAndRemove(src, false, false, false);
     verify(node).receivedNodeToNodeMessage(eq(src), eq(9), any(ShortBuffer.class), eq(true));
   }
 

--- a/src/test/java/network/crypta/node/PeerAlertCoordinatorTest.java
+++ b/src/test/java/network/crypta/node/PeerAlertCoordinatorTest.java
@@ -1,0 +1,216 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.node.useralerts.PeerManagerUserAlert;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerAlertCoordinatorTest {
+
+  @Mock private Node node;
+  @Mock private PeerRoster roster;
+  @Mock private PeerStatusBook statusBook;
+  @Mock private NodeClientCore clientCore;
+  @Mock private UserAlertManager alertManager;
+  @Mock private NodeStats nodeStats;
+  @Mock private NodeUpdateManager nodeUpdateManager;
+
+  @Test
+  void update_whenAlertNotInitialized_expectNoInteractions() {
+    // Arrange
+    PeerAlertCoordinator coordinator = new PeerAlertCoordinator(node, roster, statusBook);
+
+    // Act
+    coordinator.update();
+
+    // Assert
+    verifyNoInteractions(node, roster, statusBook);
+  }
+
+  @Test
+  void update_whenOpennetDisabled_expectCountersSetAndNoNotification() {
+    // Arrange
+    PeerAlertCoordinator coordinator = new PeerAlertCoordinator(node, roster, statusBook);
+    PeerManagerUserAlert alert = mock(PeerManagerUserAlert.class);
+    setAlert(coordinator, alert);
+
+    when(roster.getDarknetPeers()).thenReturn(new DarknetPeerNode[2]);
+    when(roster.getOpennetPeers()).thenReturn(new OpennetPeerNode[1]);
+    when(roster.anyConnectedPeers()).thenReturn(false);
+
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, true))
+        .thenReturn(1);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, true))
+        .thenReturn(1);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false))
+        .thenReturn(2);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, false))
+        .thenReturn(0);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED, true))
+        .thenReturn(4);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM, false))
+        .thenReturn(1);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONN_ERROR, true))
+        .thenReturn(3);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, true))
+        .thenReturn(2);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, false))
+        .thenReturn(5);
+
+    when(node.getOpennet()).thenReturn(null);
+
+    NodeCrypto darknetCrypto = mock(NodeCrypto.class);
+    NodeCryptoConfig darknetConfig = mock(NodeCryptoConfig.class);
+    when(node.getDarknetCrypto()).thenReturn(darknetCrypto);
+    when(darknetCrypto.getConfig()).thenReturn(darknetConfig);
+    when(darknetConfig.alwaysHandshakeAggressively()).thenReturn(true);
+    when(node.darknetDefinitelyPortForwarded()).thenReturn(true);
+
+    // Act
+    coordinator.update();
+
+    // Assert
+    verify(alert).setOpennetDefinitelyPortForwarded(false);
+    verify(alert).setDarknetDefinitelyPortForwarded(true);
+    verify(alert).setOpennetAssumeNAT(false);
+    verify(alert).setDarknetAssumeNAT(true);
+    verify(alert).setDarknetConns(2);
+    verify(alert).setConns(2);
+    verify(alert).setDarknetPeers(2);
+    verify(alert).setDisconnDarknetPeers(0);
+    verify(alert).setPeers(3);
+    verify(alert).setNeverConn(4);
+    verify(alert).setClockProblem(1);
+    verify(alert).setConnError(3);
+    verify(alert).setOpennetEnabled(false);
+    verify(alert).setTooNewPeersDarknet(2);
+    verify(alert).setTooNewPeersTotal(5);
+    verify(node, never()).onConnectedPeer();
+  }
+
+  @Test
+  void update_whenOpennetEnabledAndPeersConnected_expectOpennetFlagsAndNotify() {
+    // Arrange
+    PeerAlertCoordinator coordinator = new PeerAlertCoordinator(node, roster, statusBook);
+    PeerManagerUserAlert alert = mock(PeerManagerUserAlert.class);
+    setAlert(coordinator, alert);
+
+    when(roster.getDarknetPeers()).thenReturn(new DarknetPeerNode[1]);
+    when(roster.getOpennetPeers()).thenReturn(new OpennetPeerNode[2]);
+    when(roster.anyConnectedPeers()).thenReturn(true);
+
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, true))
+        .thenReturn(1);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, true))
+        .thenReturn(0);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false))
+        .thenReturn(2);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, false))
+        .thenReturn(1);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED, true))
+        .thenReturn(0);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM, false))
+        .thenReturn(0);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONN_ERROR, true))
+        .thenReturn(0);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, true))
+        .thenReturn(1);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, false))
+        .thenReturn(2);
+
+    OpennetManager opennet = mock(OpennetManager.class);
+    NodeCrypto opennetCrypto = mock(NodeCrypto.class);
+    NodeCryptoConfig opennetConfig = mock(NodeCryptoConfig.class);
+    when(node.getOpennet()).thenReturn(opennet);
+    when(opennet.getCrypto()).thenReturn(opennetCrypto);
+    when(opennetCrypto.definitelyPortForwarded()).thenReturn(true);
+    when(opennetCrypto.getConfig()).thenReturn(opennetConfig);
+    when(opennetConfig.alwaysHandshakeAggressively()).thenReturn(true);
+
+    NodeCrypto darknetCrypto = mock(NodeCrypto.class);
+    NodeCryptoConfig darknetConfig = mock(NodeCryptoConfig.class);
+    when(node.getDarknetCrypto()).thenReturn(darknetCrypto);
+    when(darknetCrypto.getConfig()).thenReturn(darknetConfig);
+    when(darknetConfig.alwaysHandshakeAggressively()).thenReturn(false);
+    when(node.darknetDefinitelyPortForwarded()).thenReturn(false);
+
+    // Act
+    coordinator.update();
+
+    // Assert
+    verify(alert).setOpennetEnabled(true);
+    verify(alert).setOpennetDefinitelyPortForwarded(true);
+    verify(alert).setOpennetAssumeNAT(true);
+    verify(alert).setDarknetDefinitelyPortForwarded(false);
+    verify(alert).setDarknetAssumeNAT(false);
+    verify(alert).setDarknetConns(1);
+    verify(alert).setConns(3);
+    verify(alert).setDarknetPeers(1);
+    verify(alert).setDisconnDarknetPeers(0);
+    verify(alert).setPeers(3);
+    verify(alert).setTooNewPeersDarknet(1);
+    verify(alert).setTooNewPeersTotal(2);
+    verify(node, times(1)).onConnectedPeer();
+  }
+
+  @Test
+  void start_whenCalled_expectRegistersAlertAndUpdates() {
+    // Arrange
+    PeerAlertCoordinator coordinator = new PeerAlertCoordinator(node, roster, statusBook);
+
+    when(node.getNodeStats()).thenReturn(nodeStats);
+    when(node.getNodeUpdater()).thenReturn(nodeUpdateManager);
+    when(node.getClientCore()).thenReturn(clientCore);
+    when(clientCore.getAlerts()).thenReturn(alertManager);
+
+    when(roster.getDarknetPeers()).thenReturn(new DarknetPeerNode[0]);
+    when(roster.getOpennetPeers()).thenReturn(new OpennetPeerNode[0]);
+    when(roster.anyConnectedPeers()).thenReturn(false);
+
+    NodeCrypto darknetCrypto = mock(NodeCrypto.class);
+    NodeCryptoConfig darknetConfig = mock(NodeCryptoConfig.class);
+    when(node.getDarknetCrypto()).thenReturn(darknetCrypto);
+    when(darknetCrypto.getConfig()).thenReturn(darknetConfig);
+    when(darknetConfig.alwaysHandshakeAggressively()).thenReturn(false);
+
+    // Act
+    coordinator.start();
+
+    // Assert
+    ArgumentCaptor<UserAlert> alertCaptor = ArgumentCaptor.forClass(UserAlert.class);
+    verify(alertManager).register(alertCaptor.capture());
+    assertNotNull(alertCaptor.getValue());
+    assertInstanceOf(PeerManagerUserAlert.class, alertCaptor.getValue());
+    verify(statusBook).getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, true);
+    verify(roster).getDarknetPeers();
+    verify(roster).getOpennetPeers();
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void setAlert(PeerAlertCoordinator coordinator, PeerManagerUserAlert alert) {
+    try {
+      Field alertField = PeerAlertCoordinator.class.getDeclaredField("alert");
+      alertField.setAccessible(true);
+      alertField.set(coordinator, alert);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Unable to set PeerAlertCoordinator alert", e);
+    }
+  }
+}

--- a/src/test/java/network/crypta/node/PeerConnectorTest.java
+++ b/src/test/java/network/crypta/node/PeerConnectorTest.java
@@ -1,0 +1,129 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import network.crypta.io.comm.PeerParseException;
+import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
+import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerConnectorTest {
+
+  @Test
+  void connect_whenPeerNotPresent_addsPeer() throws Exception {
+    // Arrange
+    Node node = mock(Node.class);
+    PeerManager peerManager = mock(PeerManager.class);
+    SimpleFieldSet noderef = mock(SimpleFieldSet.class);
+    DarknetPeerNode newPeer = mock(DarknetPeerNode.class);
+    PeerNode existingPeer = mock(PeerNode.class);
+    byte[] newPeerHash = new byte[] {1, 2, 3};
+    byte[] existingPeerHash = new byte[] {9, 9, 9};
+    setPeerHash(newPeer, newPeerHash);
+    setPeerHash(existingPeer, existingPeerHash);
+
+    FRIEND_TRUST trust = FRIEND_TRUST.NORMAL;
+    FRIEND_VISIBILITY visibility = FRIEND_VISIBILITY.YES;
+
+    when(node.createNewDarknetNode(noderef, trust, visibility)).thenReturn(newPeer);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[] {existingPeer});
+
+    PeerConnector connector = new PeerConnector(node, peerManager);
+
+    // Act
+    connector.connect(noderef, trust, visibility);
+
+    // Assert
+    verify(peerManager).addPeer(newPeer);
+  }
+
+  @Test
+  void connect_whenPeerAlreadyPresent_doesNotAddPeer() throws Exception {
+    // Arrange
+    Node node = mock(Node.class);
+    PeerManager peerManager = mock(PeerManager.class);
+    SimpleFieldSet noderef = mock(SimpleFieldSet.class);
+    DarknetPeerNode newPeer = mock(DarknetPeerNode.class);
+    PeerNode existingPeer = mock(PeerNode.class);
+    byte[] peerHash = new byte[] {4, 5, 6};
+    setPeerHash(newPeer, peerHash);
+    setPeerHash(existingPeer, peerHash);
+
+    FRIEND_TRUST trust = FRIEND_TRUST.HIGH;
+    FRIEND_VISIBILITY visibility = FRIEND_VISIBILITY.NAME_ONLY;
+
+    when(node.createNewDarknetNode(noderef, trust, visibility)).thenReturn(newPeer);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[] {existingPeer});
+
+    PeerConnector connector = new PeerConnector(node, peerManager);
+
+    // Act
+    connector.connect(noderef, trust, visibility);
+
+    // Assert
+    verify(peerManager, never()).addPeer(newPeer);
+  }
+
+  @Test
+  void connect_whenPeerListEmpty_addsPeer() throws Exception {
+    // Arrange
+    Node node = mock(Node.class);
+    PeerManager peerManager = mock(PeerManager.class);
+    SimpleFieldSet noderef = mock(SimpleFieldSet.class);
+    DarknetPeerNode newPeer = mock(DarknetPeerNode.class);
+    setPeerHash(newPeer, new byte[] {7, 8, 9});
+
+    FRIEND_TRUST trust = FRIEND_TRUST.LOW;
+    FRIEND_VISIBILITY visibility = FRIEND_VISIBILITY.NO;
+
+    when(node.createNewDarknetNode(noderef, trust, visibility)).thenReturn(newPeer);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[0]);
+
+    PeerConnector connector = new PeerConnector(node, peerManager);
+
+    // Act
+    connector.connect(noderef, trust, visibility);
+
+    // Assert
+    verify(peerManager).addPeer(newPeer);
+  }
+
+  @Test
+  void connect_whenCreateNewDarknetNodeThrows_propagatesAndSkipsPeerManager() throws Exception {
+    // Arrange
+    Node node = mock(Node.class);
+    PeerManager peerManager = mock(PeerManager.class);
+    SimpleFieldSet noderef = mock(SimpleFieldSet.class);
+
+    FRIEND_TRUST trust = FRIEND_TRUST.NORMAL;
+    FRIEND_VISIBILITY visibility = FRIEND_VISIBILITY.YES;
+
+    PeerParseException failure = new PeerParseException("bad noderef");
+    when(node.createNewDarknetNode(noderef, trust, visibility)).thenThrow(failure);
+
+    PeerConnector connector = new PeerConnector(node, peerManager);
+
+    // Act & Assert
+    assertThrows(PeerParseException.class, () -> connector.connect(noderef, trust, visibility));
+
+    verifyNoInteractions(peerManager);
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void setPeerHash(PeerNode peer, byte[] hash) throws Exception {
+    Field field = PeerNode.class.getField("peerECDSAPubKeyHash");
+    field.setAccessible(true);
+    field.set(peer, hash);
+  }
+}

--- a/src/test/java/network/crypta/node/PeerManagerTest.java
+++ b/src/test/java/network/crypta/node/PeerManagerTest.java
@@ -191,16 +191,16 @@ class PeerManagerTest {
     pm.addPeer(p4);
 
     // only p1 qualifies
-    pm.localBroadcast(msg, false, true, ctr, Integer.MIN_VALUE, Integer.MAX_VALUE);
+    pm.messenger().localBroadcast(msg, false, true, ctr, Integer.MIN_VALUE, Integer.MAX_VALUE);
     verify(p1, times(1)).sendAsync(msg, null, ctr);
 
     // minVersion excludes all (since min=101 and p1..p3 have 100; p4 not connected)
-    pm.localBroadcast(msg, true, false, ctr, 101, Integer.MAX_VALUE);
+    pm.messenger().localBroadcast(msg, true, false, ctr, 101, Integer.MAX_VALUE);
     verify(p1, times(1)).sendAsync(msg, null, ctr); // unchanged
 
     // throwing NotConnectedException is ignored
     doThrow(new NotConnectedException()).when(p1).sendAsync(msg, null, ctr);
-    pm.localBroadcast(msg, false, true, ctr, Integer.MIN_VALUE, Integer.MAX_VALUE);
+    pm.messenger().localBroadcast(msg, false, true, ctr, Integer.MIN_VALUE, Integer.MAX_VALUE);
     // no exception thrown
   }
 
@@ -219,13 +219,13 @@ class PeerManagerTest {
     pm.addPeer(open);
     pm.addPeer(disconnected);
 
-    pm.locallyBroadcastDiffNodeRef(fs, true, false); // toDarknetOnly
+    pm.messenger().locallyBroadcastDiffNodeRef(fs, true, false); // toDarknetOnly
     verify(dark, times(1))
         .sendNodeToNodeMessage(fs, Node.N2N_MESSAGE_TYPE_DIFFNODEREF, false, 0L, false);
     verify(open, times(0))
         .sendNodeToNodeMessage(any(), anyInt(), anyBoolean(), anyLong(), anyBoolean());
 
-    pm.locallyBroadcastDiffNodeRef(fs, false, true); // toOpennetOnly
+    pm.messenger().locallyBroadcastDiffNodeRef(fs, false, true); // toOpennetOnly
     verify(open, times(1))
         .sendNodeToNodeMessage(fs, Node.N2N_MESSAGE_TYPE_DIFFNODEREF, false, 0L, false);
   }
@@ -242,11 +242,11 @@ class PeerManagerTest {
     pm.addPeer(pn);
 
     when(pn.matchesPeerAndPort(peer)).thenReturn(true);
-    assertEquals(pn, pm.getByPeer(peer));
+    assertEquals(pn, pm.roster().getByPeer(peer));
 
     when(pn.matchesPeerAndPort(peer)).thenReturn(false);
     when(pn.matchesIP(addr, false)).thenReturn(true);
-    assertEquals(pn, pm.getByPeer(peer));
+    assertEquals(pn, pm.roster().getByPeer(peer));
   }
 
   @Test
@@ -269,13 +269,13 @@ class PeerManagerTest {
     pm.addPeer(pn1);
     pm.addPeer(pn2);
 
-    assertEquals(pn1, pm.getByPeer(peer, mangler));
+    assertEquals(pn1, pm.roster().getByPeer(peer, mangler));
 
     // Fallback by IP + matching mangler
     when(pn1.matchesPeerAndPort(peer)).thenReturn(false);
     when(pn2.matchesPeerAndPort(peer)).thenReturn(false);
     when(pn1.matchesIP(addr, false)).thenReturn(true);
-    assertEquals(pn1, pm.getByPeer(peer, mangler));
+    assertEquals(pn1, pm.roster().getByPeer(peer, mangler));
   }
 
   @Test
@@ -294,7 +294,7 @@ class PeerManagerTest {
     pm.addPeer(p3);
     pm.addPeer(p4);
 
-    List<PeerNode> found = pm.getAllConnectedByAddress(addr, true);
+    List<PeerNode> found = pm.roster().getAllConnectedByAddress(addr, true);
     assertNotNull(found);
     assertEquals(1, found.size());
     assertEquals(p1, found.getFirst());

--- a/src/test/java/network/crypta/node/PeerMessengerTest.java
+++ b/src/test/java/network/crypta/node/PeerMessengerTest.java
@@ -1,0 +1,283 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.io.comm.AsyncMessageCallback;
+import network.crypta.io.comm.ByteCounter;
+import network.crypta.io.comm.Message;
+import network.crypta.io.comm.NotConnectedException;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerMessengerTest {
+  @Mock private Node node;
+  @Mock private PeerManager peerManager;
+  @Mock private NodeStats nodeStats;
+  @Mock private Ticker ticker;
+  @Mock private PeerNode peerNode;
+  @Mock private Message message;
+  @Mock private ByteCounter byteCounter;
+
+  @Captor private ArgumentCaptor<AsyncMessageCallback> callbackCaptor;
+  @Captor private ArgumentCaptor<Runnable> runnableCaptor;
+
+  private PeerMessenger messenger;
+
+  @BeforeEach
+  void setUp() {
+    messenger = new PeerMessenger(node, peerManager);
+  }
+
+  @Test
+  void getDisconnCounter_whenBytesReported_updatesNodeStats() {
+    when(node.getNodeStats()).thenReturn(nodeStats);
+    ByteCounter counter = messenger.getDisconnCounter();
+
+    counter.receivedBytes(10);
+    counter.sentBytes(12);
+    counter.sentPayload(5);
+
+    verify(nodeStats).disconnBytesReceived(10);
+    verify(nodeStats).disconnBytesSent(12);
+    verifyNoMoreInteractions(nodeStats);
+  }
+
+  @Test
+  void disconnectAndRemove_whenCalled_delegatesToDisconnectWithDefaults() {
+    PeerMessenger spy = Mockito.spy(new PeerMessenger(node, peerManager));
+    doNothing()
+        .when(spy)
+        .disconnect(peerNode, true, false, true, false, true, Node.MAX_PEER_INACTIVITY);
+
+    spy.disconnectAndRemove(peerNode, true, false, true);
+
+    verify(spy).disconnect(peerNode, true, false, true, false, true, Node.MAX_PEER_INACTIVITY);
+  }
+
+  @Test
+  void disconnect_whenPeerMissing_noActionTaken() {
+    when(peerManager.havePeer(peerNode)).thenReturn(false);
+
+    messenger.disconnect(peerNode, true, true, false, false, true, 1000L);
+
+    verify(peerManager).havePeer(peerNode);
+    verify(peerNode, never()).notifyDisconnecting(anyBoolean());
+    verifyNoMoreInteractions(peerManager);
+  }
+
+  @Test
+  void disconnect_whenAlreadyDisconnecting_noFurtherWork() throws Exception {
+    when(peerManager.havePeer(peerNode)).thenReturn(true);
+    when(peerNode.notifyDisconnecting(true)).thenReturn(true);
+
+    messenger.disconnect(peerNode, true, true, false, true, true, 1000L);
+
+    verify(peerManager).havePeer(peerNode);
+    verify(peerNode).notifyDisconnecting(true);
+    verify(peerManager, never()).removePeer(peerNode);
+    verify(peerManager, never()).writePeersUrgent(anyBoolean());
+    verify(peerNode, never()).sendAsync(any(Message.class), any(AsyncMessageCallback.class), any());
+  }
+
+  @Test
+  void disconnect_whenNotConnected_removesPeerIfRequestedAndDisconnecting() throws Exception {
+    when(peerManager.havePeer(peerNode)).thenReturn(true);
+    when(peerNode.notifyDisconnecting(false)).thenReturn(false);
+    when(peerNode.isDisconnecting()).thenReturn(true);
+    when(peerNode.isSeed()).thenReturn(false);
+    when(peerNode.isOpennet()).thenReturn(true);
+    doThrow(new NotConnectedException())
+        .when(peerNode)
+        .sendAsync(any(Message.class), any(AsyncMessageCallback.class), any(ByteCounter.class));
+
+    messenger.disconnect(peerNode, true, true, false, false, true, 1000L);
+
+    verify(peerManager).removePeer(peerNode);
+    verify(peerManager).writePeersUrgent(true);
+    verify(ticker, never()).queueTimedJob(any(Runnable.class), anyLong());
+  }
+
+  @Test
+  void disconnect_whenWaitForAckFalse_removesOnSentCallback() throws Exception {
+    when(peerManager.havePeer(peerNode)).thenReturn(true);
+    when(peerNode.notifyDisconnecting(false)).thenReturn(false);
+    when(peerNode.isSeed()).thenReturn(false);
+    when(peerNode.isOpennet()).thenReturn(false);
+    when(node.getTicker()).thenReturn(ticker);
+    when(peerNode.sendAsync(any(Message.class), callbackCaptor.capture(), any(ByteCounter.class)))
+        .thenReturn(null);
+
+    messenger.disconnect(peerNode, true, false, false, false, true, 500L);
+
+    verify(ticker).queueTimedJob(runnableCaptor.capture(), eq(500L));
+    callbackCaptor.getValue().sent();
+
+    verify(peerManager).removePeer(peerNode);
+    verify(peerManager).writePeersUrgent(false);
+  }
+
+  @Test
+  void disconnect_whenWaitForAckTrue_removesOnAcknowledged() throws Exception {
+    when(peerManager.havePeer(peerNode)).thenReturn(true);
+    when(peerNode.notifyDisconnecting(false)).thenReturn(false);
+    when(peerNode.isSeed()).thenReturn(false);
+    when(peerNode.isOpennet()).thenReturn(true);
+    when(node.getTicker()).thenReturn(ticker);
+    when(peerNode.sendAsync(any(Message.class), callbackCaptor.capture(), any(ByteCounter.class)))
+        .thenReturn(null);
+
+    messenger.disconnect(peerNode, true, true, false, false, true, 500L);
+
+    callbackCaptor.getValue().sent();
+
+    verify(peerManager, never()).removePeer(peerNode);
+    verify(peerManager, never()).writePeersUrgent(anyBoolean());
+
+    callbackCaptor.getValue().acknowledged();
+
+    verify(peerManager).removePeer(peerNode);
+    verify(peerManager).writePeersUrgent(true);
+  }
+
+  @Test
+  void disconnect_whenSendDisconnectMessageFalse_removesImmediately() throws Exception {
+    when(peerManager.havePeer(peerNode)).thenReturn(true);
+    when(peerNode.notifyDisconnecting(false)).thenReturn(false);
+    when(peerNode.isSeed()).thenReturn(false);
+    when(peerNode.isOpennet()).thenReturn(true);
+
+    messenger.disconnect(peerNode, false, true, false, false, true, 1000L);
+
+    verify(peerManager).removePeer(peerNode);
+    verify(peerManager).writePeersUrgent(true);
+    verify(peerNode, never()).sendAsync(any(Message.class), any(AsyncMessageCallback.class), any());
+  }
+
+  @Test
+  void disconnect_whenTimeoutJobRuns_disconnectsAndRemoves() throws Exception {
+    when(peerManager.havePeer(peerNode)).thenReturn(true);
+    when(peerNode.notifyDisconnecting(false)).thenReturn(false);
+    when(peerNode.isSeed()).thenReturn(false);
+    when(peerNode.isOpennet()).thenReturn(false);
+    when(peerNode.isDisconnecting()).thenReturn(true);
+    when(node.getTicker()).thenReturn(ticker);
+    when(peerNode.sendAsync(
+            any(Message.class), any(AsyncMessageCallback.class), any(ByteCounter.class)))
+        .thenReturn(null);
+
+    messenger.disconnect(peerNode, true, true, false, false, true, 250L);
+
+    verify(ticker).queueTimedJob(runnableCaptor.capture(), eq(250L));
+
+    runnableCaptor.getValue().run();
+
+    verify(peerManager).removePeer(peerNode);
+    verify(peerManager).writePeersUrgent(false);
+    verify(peerNode).disconnected(true, true);
+  }
+
+  @Test
+  void localBroadcast_whenFilteringByRoutabilityAndVersion_sendsToEligiblePeers() throws Exception {
+    PeerNode eligible = Mockito.mock(PeerNode.class);
+    PeerNode tooOld = Mockito.mock(PeerNode.class);
+    PeerNode notRoutable = Mockito.mock(PeerNode.class);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[] {eligible, tooOld, notRoutable});
+
+    when(eligible.getBuildNumber()).thenReturn(10);
+    when(eligible.isRoutable()).thenReturn(true);
+    when(eligible.isRealConnection()).thenReturn(true);
+
+    when(tooOld.getBuildNumber()).thenReturn(3);
+    when(tooOld.isRoutable()).thenReturn(true);
+    when(tooOld.isRealConnection()).thenReturn(true);
+
+    when(notRoutable.getBuildNumber()).thenReturn(12);
+    when(notRoutable.isRoutable()).thenReturn(false);
+
+    messenger.localBroadcast(message, false, true, byteCounter, 5, 15);
+
+    verify(eligible).sendAsync(message, null, byteCounter);
+    verify(tooOld, never()).sendAsync(any(Message.class), any(), any());
+    verify(notRoutable, never()).sendAsync(any(Message.class), any(), any());
+  }
+
+  @Test
+  void localBroadcast_whenIgnoreRoutability_sendsOnlyToRealConnectedPeers() throws Exception {
+    PeerNode connectedReal = Mockito.mock(PeerNode.class);
+    PeerNode connectedNotReal = Mockito.mock(PeerNode.class);
+    PeerNode disconnected = Mockito.mock(PeerNode.class);
+    when(peerManager.myPeers())
+        .thenReturn(new PeerNode[] {connectedReal, connectedNotReal, disconnected});
+
+    when(connectedReal.getBuildNumber()).thenReturn(42);
+    when(connectedReal.isConnected()).thenReturn(true);
+    when(connectedReal.isRealConnection()).thenReturn(true);
+
+    when(connectedNotReal.getBuildNumber()).thenReturn(42);
+    when(connectedNotReal.isConnected()).thenReturn(true);
+    when(connectedNotReal.isRealConnection()).thenReturn(false);
+
+    when(disconnected.getBuildNumber()).thenReturn(42);
+    when(disconnected.isConnected()).thenReturn(false);
+
+    doThrow(new NotConnectedException())
+        .when(connectedReal)
+        .sendAsync(any(Message.class), any(), any(ByteCounter.class));
+
+    assertDoesNotThrow(() -> messenger.localBroadcast(message, true, true, byteCounter, 0, 100));
+
+    verify(connectedReal).sendAsync(message, null, byteCounter);
+    verify(connectedNotReal, never()).sendAsync(any(Message.class), any(), any());
+    verify(disconnected, never()).sendAsync(any(Message.class), any(), any());
+  }
+
+  @Test
+  void locallyBroadcastDiffNodeRef_whenFlagsSet_targetsMatchingConnectedPeers() {
+    PeerNode darknet = Mockito.mock(PeerNode.class);
+    PeerNode opennet = Mockito.mock(PeerNode.class);
+    PeerNode disconnected = Mockito.mock(PeerNode.class);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[] {darknet, opennet, disconnected});
+
+    when(darknet.isConnected()).thenReturn(true);
+    when(darknet.isDarknet()).thenReturn(true);
+
+    when(opennet.isConnected()).thenReturn(true);
+    when(opennet.isDarknet()).thenReturn(false);
+
+    when(disconnected.isConnected()).thenReturn(false);
+
+    SimpleFieldSet fieldSet = new SimpleFieldSet(false);
+
+    messenger.locallyBroadcastDiffNodeRef(fieldSet, true, false);
+
+    verify(darknet)
+        .sendNodeToNodeMessage(fieldSet, Node.N2N_MESSAGE_TYPE_DIFFNODEREF, false, 0, false);
+    verify(opennet, never())
+        .sendNodeToNodeMessage(
+            any(SimpleFieldSet.class), anyInt(), anyBoolean(), anyLong(), anyBoolean());
+    verify(disconnected, never())
+        .sendNodeToNodeMessage(
+            any(SimpleFieldSet.class), anyInt(), anyBoolean(), anyLong(), anyBoolean());
+  }
+}

--- a/src/test/java/network/crypta/node/PeerOpennetGateTest.java
+++ b/src/test/java/network/crypta/node/PeerOpennetGateTest.java
@@ -1,0 +1,65 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerOpennetGateTest {
+  @Mock private Node node;
+  @Mock private OpennetManager opennet;
+  @Mock private OpennetPeerNode opennetPeer;
+  @Mock private PeerNode nonOpennetPeer;
+
+  @Test
+  void allowPeer_whenIgnoreOpennetTrue_expectTrue() {
+    PeerOpennetGate gate = new PeerOpennetGate(node);
+
+    boolean allowed = gate.allowPeer(opennetPeer, true);
+
+    assertTrue(allowed);
+    verifyNoInteractions(node);
+  }
+
+  @Test
+  void allowPeer_whenPeerNotOpennet_expectTrue() {
+    PeerOpennetGate gate = new PeerOpennetGate(node);
+
+    boolean allowed = gate.allowPeer(nonOpennetPeer, false);
+
+    assertTrue(allowed);
+    verifyNoInteractions(node);
+  }
+
+  @Test
+  void allowPeer_whenOpennetEnabled_expectTrueAndForceAdd() {
+    PeerOpennetGate gate = new PeerOpennetGate(node);
+    when(node.getOpennet()).thenReturn(opennet);
+
+    boolean allowed = gate.allowPeer(opennetPeer, false);
+
+    assertTrue(allowed);
+    verify(node).getOpennet();
+    verify(opennet).forceAddPeer(opennetPeer, true);
+  }
+
+  @Test
+  void allowPeer_whenOpennetDisabled_expectFalse() {
+    PeerOpennetGate gate = new PeerOpennetGate(node);
+    when(node.getOpennet()).thenReturn(null);
+
+    boolean allowed = gate.allowPeer(opennetPeer, false);
+
+    assertFalse(allowed);
+    verify(node).getOpennet();
+    verifyNoInteractions(opennet);
+  }
+}

--- a/src/test/java/network/crypta/node/PeerPersistenceTest.java
+++ b/src/test/java/network/crypta/node/PeerPersistenceTest.java
@@ -1,0 +1,201 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerPersistenceTest {
+
+  @Mock private Node node;
+  @Mock private PeerManager peerManager;
+  @Mock private Ticker ticker;
+
+  @Test
+  void scheduleInitialWrite_whenCalled_queuesImmediateJob() {
+    when(node.getTicker()).thenReturn(ticker);
+    PeerPersistence persistence = new PeerPersistence(node, peerManager);
+
+    persistence.scheduleInitialWrite();
+
+    verify(ticker).queueTimedJob(any(Runnable.class), eq(0L));
+  }
+
+  @Test
+  void writePeersUrgent_whenDarknetMarked_rotatesAndWrites(@TempDir Path tempDir)
+      throws IOException {
+    Path darknetFile = tempDir.resolve("darknet.peers");
+    Files.writeString(darknetFile, "", StandardCharsets.UTF_8);
+
+    PeerPersistence persistence = new PeerPersistence(node, peerManager);
+
+    NodeCrypto crypto = org.mockito.Mockito.mock(NodeCrypto.class);
+    persistence.tryReadPeers(darknetFile.toString(), crypto, null, false, false);
+
+    DarknetPeerNode darknetPeer = org.mockito.Mockito.mock(DarknetPeerNode.class);
+    SimpleFieldSet newFieldSet = simpleFieldSet("new-peer");
+    when(darknetPeer.exportDiskFieldSet()).thenReturn(newFieldSet);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[] {darknetPeer});
+
+    network.crypta.support.PriorityAwareExecutor executor =
+        org.mockito.Mockito.mock(network.crypta.support.PriorityAwareExecutor.class);
+    when(node.getExecutor()).thenReturn(executor);
+
+    persistence.writePeers(false);
+    persistence.writePeersUrgent(false);
+
+    ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor).execute(runnableCaptor.capture());
+    runnableCaptor.getValue().run();
+
+    Path backupFile = tempDir.resolve("darknet.peers.bak");
+    assertAll(
+        () ->
+            assertEquals(
+                newFieldSet.toOrderedString(),
+                Files.readString(darknetFile, StandardCharsets.UTF_8)),
+        () -> assertTrue(Files.exists(backupFile)),
+        () -> assertEquals("", Files.readString(backupFile, StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void flushOnShutdown_whenCalled_writesDarknetAndOpennetWithoutRotation(@TempDir Path tempDir)
+      throws IOException {
+    Path darknetFile = tempDir.resolve("darknet.peers");
+    Path opennetFile = tempDir.resolve("opennet.peers");
+    Path darknetBackup = tempDir.resolve("darknet.peers.bak");
+    Path opennetBackup = tempDir.resolve("opennet.peers.bak");
+    Files.writeString(darknetFile, "", StandardCharsets.UTF_8);
+    Files.writeString(opennetFile, "", StandardCharsets.UTF_8);
+    Files.writeString(darknetBackup, "keep-darknet\n", StandardCharsets.UTF_8);
+    Files.writeString(opennetBackup, "keep-opennet\n", StandardCharsets.UTF_8);
+
+    PeerPersistence persistence = new PeerPersistence(node, peerManager);
+    NodeCrypto crypto = org.mockito.Mockito.mock(NodeCrypto.class);
+    persistence.tryReadPeers(darknetFile.toString(), crypto, null, false, false);
+    persistence.tryReadPeers(opennetFile.toString(), crypto, null, true, false);
+
+    DarknetPeerNode darknetPeer = org.mockito.Mockito.mock(DarknetPeerNode.class);
+    OpennetPeerNode opennetPeer = org.mockito.Mockito.mock(OpennetPeerNode.class);
+    SimpleFieldSet darknetFieldSet = simpleFieldSet("darknet");
+    SimpleFieldSet opennetFieldSet = simpleFieldSet("opennet");
+    when(darknetPeer.exportDiskFieldSet()).thenReturn(darknetFieldSet);
+    when(opennetPeer.exportDiskFieldSet()).thenReturn(opennetFieldSet);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[] {darknetPeer, opennetPeer});
+
+    OpennetManager opennetManager = org.mockito.Mockito.mock(OpennetManager.class);
+    Path oldOpennetFile = tempDir.resolve("old-opennet.peers");
+    when(opennetManager.getOldPeersFilename()).thenReturn(oldOpennetFile.toString());
+    when(opennetManager.getOldPeers()).thenReturn(new OpennetPeerNode[] {opennetPeer});
+    when(node.getOpennet()).thenReturn(opennetManager);
+
+    persistence.flushOnShutdown();
+
+    assertAll(
+        () ->
+            assertEquals(
+                darknetFieldSet.toOrderedString(),
+                Files.readString(darknetFile, StandardCharsets.UTF_8)),
+        () ->
+            assertEquals(
+                opennetFieldSet.toOrderedString(),
+                Files.readString(opennetFile, StandardCharsets.UTF_8)),
+        () ->
+            assertEquals(
+                opennetFieldSet.toOrderedString(),
+                Files.readString(oldOpennetFile, StandardCharsets.UTF_8)),
+        () ->
+            assertEquals("keep-darknet\n", Files.readString(darknetBackup, StandardCharsets.UTF_8)),
+        () ->
+            assertEquals(
+                "keep-opennet\n", Files.readString(opennetBackup, StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void tryReadPeers_whenOldOpennetPeers_addsOldOpennetNode(@TempDir Path tempDir)
+      throws IOException {
+    Path opennetFile = tempDir.resolve("opennet.peers");
+    SimpleFieldSet peerFieldSet = simpleFieldSet("peer");
+    Files.writeString(opennetFile, peerFieldSet.toOrderedString(), StandardCharsets.UTF_8);
+
+    PeerPersistence persistence = new PeerPersistence(node, peerManager);
+    NodeCrypto crypto = org.mockito.Mockito.mock(NodeCrypto.class);
+
+    OpennetManager opennetManager = org.mockito.Mockito.mock(OpennetManager.class);
+    OpennetPeerNode opennetPeer = org.mockito.Mockito.mock(OpennetPeerNode.class);
+    try (MockedStatic<PeerNode> peerNodeMock = mockStatic(PeerNode.class)) {
+      peerNodeMock
+          .when(
+              () ->
+                  PeerNode.create(
+                      any(SimpleFieldSet.class),
+                      eq(node),
+                      eq(crypto),
+                      eq(opennetManager),
+                      eq(peerManager)))
+          .thenReturn(opennetPeer);
+
+      persistence.tryReadPeers(opennetFile.toString(), crypto, opennetManager, true, true);
+    }
+
+    verify(opennetManager).addOldOpennetNode(opennetPeer);
+  }
+
+  @Test
+  void tryReadPeers_whenPeerParseFails_createsBrokenCopy(@TempDir Path tempDir) throws IOException {
+    Path opennetFile = tempDir.resolve("opennet.peers");
+    SimpleFieldSet peerFieldSet = simpleFieldSet("peer");
+    String peerContent = peerFieldSet.toOrderedString();
+    Files.writeString(opennetFile, peerContent, StandardCharsets.UTF_8);
+
+    PeerPersistence persistence = new PeerPersistence(node, peerManager);
+    NodeCrypto crypto = org.mockito.Mockito.mock(NodeCrypto.class);
+
+    OpennetManager opennetManager = org.mockito.Mockito.mock(OpennetManager.class);
+    try (MockedStatic<PeerNode> peerNodeMock = mockStatic(PeerNode.class)) {
+      peerNodeMock
+          .when(
+              () ->
+                  PeerNode.create(
+                      any(SimpleFieldSet.class),
+                      eq(node),
+                      eq(crypto),
+                      eq(opennetManager),
+                      eq(peerManager)))
+          .thenThrow(new network.crypta.io.comm.PeerParseException("bad"));
+
+      persistence.tryReadPeers(opennetFile.toString(), crypto, opennetManager, true, false);
+    }
+
+    Path brokenFile = tempDir.resolve("opennet.peers.broken");
+    assertAll(
+        () -> assertTrue(Files.exists(brokenFile)),
+        () -> assertEquals(peerContent, Files.readString(brokenFile, StandardCharsets.UTF_8)));
+  }
+
+  private static SimpleFieldSet simpleFieldSet(String name) {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("myName", name);
+    return fieldSet;
+  }
+}

--- a/src/test/java/network/crypta/node/PeerRosterTest.java
+++ b/src/test/java/network/crypta/node/PeerRosterTest.java
@@ -1,0 +1,969 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.util.List;
+import network.crypta.crypt.RandomSource;
+import network.crypta.io.comm.FreenetInetAddress;
+import network.crypta.io.comm.Peer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerRosterTest {
+
+  @Test
+  void myPeers_whenEmpty_expectEmptyArray() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+
+    // Act
+    PeerNode[] peers = roster.myPeers();
+
+    // Assert
+    assertEquals(0, peers.length);
+  }
+
+  @Test
+  void addPeer_whenReactivateTrue_expectAddedAndForceCancelCalled() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+
+    // Act
+    boolean added = roster.addPeer(peer, true);
+
+    // Assert
+    assertTrue(added);
+    assertSame(peer, roster.myPeers()[0]);
+    verify(peer).forceCancelDisconnecting();
+  }
+
+  @Test
+  void addPeer_whenAlreadyPresent_expectFalseAndNoDuplicate() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    roster.addPeer(peer, false);
+
+    // Act
+    boolean added = roster.addPeer(peer, false);
+
+    // Assert
+    assertFalse(added);
+    assertEquals(1, roster.myPeers().length);
+  }
+
+  @Test
+  void removePeer_whenPresent_expectRemovedAndConnectedRebuilt() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode remove = mock(PeerNode.class);
+    PeerNode connected = mock(PeerNode.class);
+    when(connected.isConnected()).thenReturn(true);
+    when(connected.isRealConnection()).thenReturn(true);
+    addPeers(roster, remove, connected);
+    addConnectedPeers(roster, remove, connected);
+
+    // Act
+    boolean removed = roster.removePeer(remove);
+
+    // Assert
+    assertTrue(removed);
+    assertArrayEquals(new PeerNode[] {connected}, roster.myPeers());
+    assertArrayEquals(new PeerNode[] {connected}, roster.connectedPeers());
+  }
+
+  @Test
+  void removePeer_whenDarknetNotPresent_expectFalseButExtraDataRemoved() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode darknet = mock(DarknetPeerNode.class);
+
+    // Act
+    boolean removed = roster.removePeer(darknet);
+
+    // Assert
+    assertFalse(removed);
+    verify(darknet).removeExtraPeerDataDir();
+  }
+
+  @Test
+  void removeAllPeers_whenCalled_expectClearsAndReturnsOld() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    addPeers(roster, peer);
+    addConnectedPeers(roster, peer);
+
+    // Act
+    PeerNode[] oldPeers = roster.removeAllPeers();
+
+    // Assert
+    assertArrayEquals(new PeerNode[] {peer}, oldPeers);
+    assertEquals(0, roster.myPeers().length);
+    assertEquals(0, roster.connectedPeers().length);
+  }
+
+  @Test
+  void disconnected_whenPeerPresent_expectConnectedPeersRebuilt() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode disconnecting = mock(PeerNode.class);
+    PeerNode routable = mock(PeerNode.class);
+    PeerNode notRoutable = mock(PeerNode.class);
+    when(routable.isRoutable()).thenReturn(true);
+    when(notRoutable.isRoutable()).thenReturn(false);
+    addPeers(roster, disconnecting, routable, notRoutable);
+    addConnectedPeers(roster, disconnecting, routable);
+
+    // Act
+    boolean updated = roster.disconnected(disconnecting);
+
+    // Assert
+    assertTrue(updated);
+    assertArrayEquals(new PeerNode[] {routable}, roster.connectedPeers());
+  }
+
+  @Test
+  void disconnected_whenPeerAbsent_expectFalse() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    addConnectedPeers(roster, mock(PeerNode.class));
+
+    // Act
+    boolean updated = roster.disconnected(peer);
+
+    // Assert
+    assertFalse(updated);
+  }
+
+  @Test
+  void addConnectedPeer_whenNotRealConnection_expectFalse() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    when(peer.isRealConnection()).thenReturn(false);
+    PeerRoster.PeerAdder peerAdder = mock(PeerRoster.PeerAdder.class);
+
+    // Act
+    boolean added = roster.addConnectedPeer(peer, peerAdder);
+
+    // Assert
+    assertFalse(added);
+    verify(peerAdder, never()).add(peer);
+  }
+
+  @Test
+  void addConnectedPeer_whenNotConnected_expectFalse() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    when(peer.isRealConnection()).thenReturn(true);
+    when(peer.isConnected()).thenReturn(false);
+    PeerRoster.PeerAdder peerAdder = mock(PeerRoster.PeerAdder.class);
+
+    // Act
+    boolean added = roster.addConnectedPeer(peer, peerAdder);
+
+    // Assert
+    assertFalse(added);
+    verify(peerAdder, never()).add(peer);
+  }
+
+  @Test
+  void addConnectedPeer_whenNotInRoster_expectPeerAdderCalledAndAdded() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    when(peer.isRealConnection()).thenReturn(true);
+    when(peer.isConnected()).thenReturn(true);
+    PeerRoster.PeerAdder peerAdder = mock(PeerRoster.PeerAdder.class);
+
+    // Act
+    boolean added = roster.addConnectedPeer(peer, peerAdder);
+
+    // Assert
+    assertTrue(added);
+    assertArrayEquals(new PeerNode[] {peer}, roster.connectedPeers());
+    verify(peerAdder).add(peer);
+  }
+
+  @Test
+  void addConnectedPeer_whenAlreadyConnected_expectFalse() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    when(peer.isRealConnection()).thenReturn(true);
+    when(peer.isConnected()).thenReturn(true);
+    addConnectedPeers(roster, peer);
+    PeerRoster.PeerAdder peerAdder = mock(PeerRoster.PeerAdder.class);
+
+    // Act
+    boolean added = roster.addConnectedPeer(peer, peerAdder);
+
+    // Assert
+    assertFalse(added);
+  }
+
+  @Test
+  void getByPeer_whenMatchesPeerAndPort_expectMatchReturned() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    Peer peer = mock(Peer.class);
+    PeerNode disabled = mock(PeerNode.class);
+    PeerNode match = mock(PeerNode.class);
+    when(disabled.isDisabled()).thenReturn(true);
+    when(match.isDisabled()).thenReturn(false);
+    when(match.matchesPeerAndPort(peer)).thenReturn(true);
+    addPeers(roster, disabled, match);
+
+    // Act
+    PeerNode found = roster.getByPeer(peer);
+
+    // Assert
+    assertSame(match, found);
+  }
+
+  @Test
+  void getByPeer_whenMatchesIpOnly_expectFallbackMatch() throws Exception {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    FreenetInetAddress address = new FreenetInetAddress(InetAddress.getByName("127.0.0.1"));
+    Peer peer = mock(Peer.class);
+    when(peer.getFreenetAddress()).thenReturn(address);
+    PeerNode peerNode = mock(PeerNode.class);
+    when(peerNode.isDisabled()).thenReturn(false);
+    when(peerNode.matchesPeerAndPort(peer)).thenReturn(false);
+    when(peerNode.matchesIP(address, false)).thenReturn(true);
+    addPeers(roster, peerNode);
+
+    // Act
+    PeerNode found = roster.getByPeer(peer);
+
+    // Assert
+    assertSame(peerNode, found);
+  }
+
+  @Test
+  void getByPeer_withMangler_expectMatchReturned() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    Peer peer = mock(Peer.class);
+    FNPPacketMangler mangler = mock(FNPPacketMangler.class);
+    PeerNode peerNode = mock(PeerNode.class);
+    when(peerNode.isDisabled()).thenReturn(false);
+    when(peerNode.matchesPeerAndPort(peer)).thenReturn(true);
+    when(peerNode.getOutgoingMangler()).thenReturn(mangler);
+    addPeers(roster, peerNode);
+
+    // Act
+    PeerNode found = roster.getByPeer(peer, mangler);
+
+    // Assert
+    assertSame(peerNode, found);
+  }
+
+  @Test
+  void getAllConnectedByAddress_whenMatches_expectListReturned() throws Exception {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    FreenetInetAddress address = new FreenetInetAddress(InetAddress.getByName("127.0.0.3"));
+    PeerNode match = mock(PeerNode.class);
+    PeerNode noMatch = mock(PeerNode.class);
+    when(match.isConnected()).thenReturn(true);
+    when(match.isRoutable()).thenReturn(true);
+    when(match.matchesIP(address, true)).thenReturn(true);
+    when(noMatch.isConnected()).thenReturn(true);
+    when(noMatch.isRoutable()).thenReturn(true);
+    when(noMatch.matchesIP(address, true)).thenReturn(false);
+    addPeers(roster, match, noMatch);
+
+    // Act
+    List<PeerNode> found = roster.getAllConnectedByAddress(address, true);
+
+    // Assert
+    assertEquals(1, found.size());
+    assertSame(match, found.getFirst());
+  }
+
+  @Test
+  void getAllConnectedByAddress_whenNone_expectNull() throws Exception {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    FreenetInetAddress address = new FreenetInetAddress(InetAddress.getByName("127.0.0.4"));
+    PeerNode peer = mock(PeerNode.class);
+    when(peer.isConnected()).thenReturn(false);
+    addPeers(roster, peer);
+
+    // Act
+    List<PeerNode> found = roster.getAllConnectedByAddress(address, false);
+
+    // Assert
+    assertNull(found);
+  }
+
+  @Test
+  void getByPubKeyHash_whenMatch_expectPeer() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    byte[] hash = new byte[] {1, 2, 3};
+    setPeerKeyHash(peer, hash);
+    addPeers(roster, peer);
+
+    // Act
+    PeerNode found = roster.getByPubKeyHash(hash);
+
+    // Assert
+    assertSame(peer, found);
+  }
+
+  @Test
+  void getByPubKeyHash_whenNoMatch_expectNull() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    setPeerKeyHash(peer, new byte[] {9, 9, 9});
+    addPeers(roster, peer);
+
+    // Act
+    PeerNode found = roster.getByPubKeyHash(new byte[] {1, 2, 3});
+
+    // Assert
+    assertNull(found);
+  }
+
+  @Test
+  void getRandomPeer_whenNoConnectedPeers_expectNull() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+
+    // Act
+    PeerNode found = roster.getRandomPeer();
+
+    // Assert
+    assertNull(found);
+  }
+
+  @Test
+  void getRandomPeer_whenRoutableAvailable_expectSelected() {
+    // Arrange
+    RandomSource random = mock(RandomSource.class);
+    when(random.nextInt(anyInt())).thenReturn(0);
+    PeerRoster roster = newRoster(random, true);
+    PeerNode peer = mock(PeerNode.class);
+    when(peer.isRoutable()).thenReturn(true);
+    addConnectedPeers(roster, peer);
+
+    // Act
+    PeerNode found = roster.getRandomPeer();
+
+    // Assert
+    assertSame(peer, found);
+  }
+
+  @Test
+  void getRandomPeer_whenExcludeOnlyRoutable_expectNull() {
+    // Arrange
+    RandomSource random = mock(RandomSource.class);
+    when(random.nextInt(anyInt())).thenReturn(0);
+    PeerRoster roster = newRoster(random, true);
+    PeerNode peer = mock(PeerNode.class);
+    when(peer.isRoutable()).thenReturn(true);
+    addPeers(roster, peer);
+    addConnectedPeers(roster, peer);
+
+    // Act
+    PeerNode found = roster.getRandomPeer(peer);
+
+    // Assert
+    assertNull(found);
+  }
+
+  @Test
+  void getRandomPeer_whenConnectedNotRoutable_expectRebuildAndSelect() {
+    // Arrange
+    RandomSource random = mock(RandomSource.class);
+    when(random.nextInt(anyInt())).thenReturn(0);
+    PeerRoster roster = newRoster(random, true);
+    PeerNode notRoutable = mock(PeerNode.class);
+    PeerNode routable = mock(PeerNode.class);
+    when(notRoutable.isRoutable()).thenReturn(false);
+    when(routable.isRoutable()).thenReturn(true);
+    addConnectedPeers(roster, notRoutable);
+    addPeers(roster, notRoutable, routable);
+
+    // Act
+    PeerNode found = roster.getRandomPeer();
+
+    // Assert
+    assertSame(routable, found);
+  }
+
+  @Test
+  void getPeerLocationDoubles_whenPublishingDisabled_expectEmpty() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), false);
+
+    // Act
+    double[] locations = roster.getPeerLocationDoubles(false);
+
+    // Assert
+    assertEquals(0, locations.length);
+  }
+
+  @Test
+  void getPeerLocationDoubles_whenPruneFalse_expectSortedAll() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode first = mock(PeerNode.class);
+    PeerNode second = mock(PeerNode.class);
+    when(first.isRoutable()).thenReturn(true);
+    when(second.isRoutable()).thenReturn(true);
+    when(first.getLocation()).thenReturn(0.8);
+    when(second.getLocation()).thenReturn(0.2);
+    addConnectedPeers(roster, first, second);
+
+    // Act
+    double[] locations = roster.getPeerLocationDoubles(false);
+
+    // Assert
+    assertArrayEquals(new double[] {0.2, 0.8}, locations, 0.0);
+  }
+
+  @Test
+  void getPeerLocationDoubles_whenPruneTrue_expectFiltered() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode included = mock(PeerNode.class);
+    PeerNode excluded = mock(PeerNode.class);
+    when(included.isRoutable()).thenReturn(true);
+    when(excluded.isRoutable()).thenReturn(true);
+    when(included.shouldBeExcludedFromPeerList()).thenReturn(false);
+    when(excluded.shouldBeExcludedFromPeerList()).thenReturn(true);
+    when(included.getLocation()).thenReturn(0.4);
+    addConnectedPeers(roster, included, excluded);
+
+    // Act
+    double[] locations = roster.getPeerLocationDoubles(true);
+
+    // Assert
+    assertArrayEquals(new double[] {0.4}, locations, 0.0);
+  }
+
+  @Test
+  void anyConnectedPeers_whenRoutablePresent_expectTrue() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    when(peer.isRoutable()).thenReturn(true);
+    addConnectedPeers(roster, peer);
+
+    // Act
+    boolean any = roster.anyConnectedPeers();
+
+    // Assert
+    assertTrue(any);
+  }
+
+  @Test
+  void anyDarknetPeers_whenDarknetConnected_expectTrue() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+    when(peer.isDarknet()).thenReturn(true);
+    addConnectedPeers(roster, peer);
+
+    // Act
+    boolean any = roster.anyDarknetPeers();
+
+    // Assert
+    assertTrue(any);
+  }
+
+  @Test
+  void getDarknetPeers_whenMixed_expectOnlyDarknet() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode darknet = mock(DarknetPeerNode.class);
+    OpennetPeerNode opennet = mock(OpennetPeerNode.class);
+    addPeers(roster, darknet, opennet);
+
+    // Act
+    DarknetPeerNode[] peers = roster.getDarknetPeers();
+
+    // Assert
+    assertArrayEquals(new DarknetPeerNode[] {darknet}, peers);
+  }
+
+  @Test
+  void getOpennetPeers_whenMixed_expectOnlyOpennet() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode darknet = mock(DarknetPeerNode.class);
+    OpennetPeerNode opennet = mock(OpennetPeerNode.class);
+    addPeers(roster, darknet, opennet);
+
+    // Act
+    OpennetPeerNode[] peers = roster.getOpennetPeers();
+
+    // Assert
+    assertArrayEquals(new OpennetPeerNode[] {opennet}, peers);
+  }
+
+  @Test
+  void getOpennetAndSeedServerPeers_whenMixed_expectFiltered() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    OpennetPeerNode opennet = mock(OpennetPeerNode.class);
+    SeedServerPeerNode seedServer = mock(SeedServerPeerNode.class);
+    DarknetPeerNode darknet = mock(DarknetPeerNode.class);
+    addPeers(roster, opennet, seedServer, darknet);
+
+    // Act
+    PeerNode[] peers = roster.getOpennetAndSeedServerPeers();
+
+    // Assert
+    assertArrayEquals(new PeerNode[] {opennet, seedServer}, peers);
+  }
+
+  @Test
+  void removeOpennetPeers_whenCalled_expectOpennetRemoved() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode darknet = mock(DarknetPeerNode.class);
+    SeedServerPeerNode seedServer = mock(SeedServerPeerNode.class);
+    OpennetPeerNode opennet = mock(OpennetPeerNode.class);
+    when(darknet.isConnected()).thenReturn(true);
+    when(seedServer.isConnected()).thenReturn(true);
+    addPeers(roster, darknet, opennet, seedServer);
+    addConnectedPeers(roster, darknet, opennet, seedServer);
+
+    // Act
+    roster.removeOpennetPeers();
+
+    // Assert
+    assertArrayEquals(new PeerNode[] {darknet, seedServer}, roster.myPeers());
+    assertArrayEquals(new PeerNode[] {darknet, seedServer}, roster.connectedPeers());
+  }
+
+  @Test
+  void containsPeer_whenOpennetMatchOnHash_expectPeer() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    OpennetPeerNode existing = mock(OpennetPeerNode.class);
+    setPeerKeyHash(existing, new byte[] {7, 7, 7});
+    addPeers(roster, existing);
+    PeerNode probe = mock(PeerNode.class);
+    when(probe.isOpennet()).thenReturn(true);
+    setPeerKeyHash(probe, new byte[] {7, 7, 7});
+
+    // Act
+    PeerNode found = roster.containsPeer(probe);
+
+    // Assert
+    assertSame(existing, found);
+  }
+
+  @Test
+  void containsPeer_whenDarknetNoMatch_expectNull() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode existing = mock(DarknetPeerNode.class);
+    setPeerKeyHash(existing, new byte[] {1, 1, 1});
+    addPeers(roster, existing);
+    PeerNode probe = mock(PeerNode.class);
+    when(probe.isOpennet()).thenReturn(false);
+    setPeerKeyHash(probe, new byte[] {2, 2, 2});
+
+    // Act
+    PeerNode found = roster.containsPeer(probe);
+
+    // Assert
+    assertNull(found);
+  }
+
+  @Test
+  void anyConnectedPeerHasAddress_whenMatchAndEligible_expectTrue() throws Exception {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    FreenetInetAddress address = new FreenetInetAddress(InetAddress.getByName("127.0.0.5"));
+    PeerNode peer = mock(PeerNode.class);
+    PeerNode other = mock(PeerNode.class);
+    Peer otherPeer = mock(Peer.class);
+    when(peer.isDarknet()).thenReturn(true);
+    when(other.isDarknet()).thenReturn(true);
+    when(other.isConnected()).thenReturn(true);
+    when(other.isRealConnection()).thenReturn(true);
+    when(otherPeer.getFreenetAddress()).thenReturn(address);
+    when(other.getPeer()).thenReturn(otherPeer);
+    addPeers(roster, peer, other);
+
+    // Act
+    boolean found = roster.anyConnectedPeerHasAddress(address, peer);
+
+    // Assert
+    assertTrue(found);
+  }
+
+  @Test
+  void anyConnectedPeerHasAddress_whenDarknetMismatch_expectFalse() throws Exception {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    FreenetInetAddress address = new FreenetInetAddress(InetAddress.getByName("127.0.0.6"));
+    PeerNode peer = mock(PeerNode.class);
+    PeerNode other = mock(PeerNode.class);
+    when(peer.isDarknet()).thenReturn(false);
+    when(other.isDarknet()).thenReturn(true);
+    when(other.isConnected()).thenReturn(true);
+    when(other.isRealConnection()).thenReturn(true);
+    addPeers(roster, peer, other);
+
+    // Act
+    boolean found = roster.anyConnectedPeerHasAddress(address, peer);
+
+    // Assert
+    assertFalse(found);
+  }
+
+  @Test
+  void countNonBackedOffPeers_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode included = mock(PeerNode.class);
+    PeerNode excluded = mock(PeerNode.class);
+    when(included.isRoutable()).thenReturn(true);
+    when(included.isRoutingBackedOff(true)).thenReturn(false);
+    when(excluded.isRoutable()).thenReturn(true);
+    when(excluded.isRoutingBackedOff(true)).thenReturn(true);
+    addConnectedPeers(roster, included, excluded);
+
+    // Act
+    int count = roster.countNonBackedOffPeers(true);
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countConnectedDarknetPeers_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode included = mock(DarknetPeerNode.class);
+    DarknetPeerNode excluded = mock(DarknetPeerNode.class);
+    when(included.isOpennet()).thenReturn(false);
+    when(included.isRoutable()).thenReturn(true);
+    when(excluded.isOpennet()).thenReturn(true);
+    addPeers(roster, included, excluded);
+
+    // Act
+    int count = roster.countConnectedDarknetPeers();
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countConnectedPeers_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode routable = mock(PeerNode.class);
+    PeerNode notRoutable = mock(PeerNode.class);
+    when(routable.isRoutable()).thenReturn(true);
+    when(notRoutable.isRoutable()).thenReturn(false);
+    addPeers(roster, routable, notRoutable);
+
+    // Act
+    int count = roster.countConnectedPeers();
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countAlmostConnectedDarknetPeers_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode included = mock(DarknetPeerNode.class);
+    DarknetPeerNode excluded = mock(DarknetPeerNode.class);
+    when(included.isOpennet()).thenReturn(false);
+    when(included.isConnected()).thenReturn(true);
+    when(excluded.isOpennet()).thenReturn(false);
+    when(excluded.isConnected()).thenReturn(false);
+    addPeers(roster, included, excluded);
+
+    // Act
+    int count = roster.countAlmostConnectedDarknetPeers();
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countCompatibleDarknetPeers_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode included = mock(DarknetPeerNode.class);
+    DarknetPeerNode excluded = mock(DarknetPeerNode.class);
+    when(included.isOpennet()).thenReturn(false);
+    when(included.isConnected()).thenReturn(true);
+    when(included.isRoutingCompatible()).thenReturn(true);
+    when(excluded.isOpennet()).thenReturn(false);
+    when(excluded.isConnected()).thenReturn(true);
+    when(excluded.isRoutingCompatible()).thenReturn(false);
+    addPeers(roster, included, excluded);
+
+    // Act
+    int count = roster.countCompatibleDarknetPeers();
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countCompatibleRealPeers_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode included = mock(PeerNode.class);
+    PeerNode excluded = mock(PeerNode.class);
+    when(included.isRealConnection()).thenReturn(true);
+    when(included.isConnected()).thenReturn(true);
+    when(included.isRoutingCompatible()).thenReturn(true);
+    when(excluded.isRealConnection()).thenReturn(false);
+    addPeers(roster, included, excluded);
+
+    // Act
+    int count = roster.countCompatibleRealPeers();
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countConnectedOpennetPeers_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    OpennetPeerNode included = mock(OpennetPeerNode.class);
+    OpennetPeerNode excluded = mock(OpennetPeerNode.class);
+    when(included.isRoutable()).thenReturn(true);
+    when(excluded.isRoutable()).thenReturn(false);
+    addConnectedPeers(roster, included, excluded);
+
+    // Act
+    int count = roster.countConnectedOpennetPeers();
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countValidPeers_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode included = mock(PeerNode.class);
+    PeerNode excluded = mock(PeerNode.class);
+    when(included.isRealConnection()).thenReturn(true);
+    when(included.isDisabled()).thenReturn(false);
+    when(excluded.isRealConnection()).thenReturn(true);
+    when(excluded.isDisabled()).thenReturn(true);
+    addPeers(roster, included, excluded);
+
+    // Act
+    int count = roster.countValidPeers();
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countConnectiblePeers_whenListenOnlyDarknet_expectExcluded() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode listenOnly = mock(DarknetPeerNode.class);
+    PeerNode included = mock(PeerNode.class);
+    when(listenOnly.isDisabled()).thenReturn(false);
+    when(listenOnly.isListenOnly()).thenReturn(true);
+    when(included.isDisabled()).thenReturn(false);
+    addPeers(roster, listenOnly, included);
+
+    // Act
+    int count = roster.countConnectiblePeers();
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countSeednodes_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    SeedServerPeerNode server = mock(SeedServerPeerNode.class);
+    SeedClientPeerNode client = mock(SeedClientPeerNode.class);
+    PeerNode other = mock(PeerNode.class);
+    addPeers(roster, server, client, other);
+
+    // Act
+    int count = roster.countSeednodes();
+
+    // Assert
+    assertEquals(2, count);
+  }
+
+  @Test
+  void countBackedOffPeers_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode included = mock(PeerNode.class);
+    PeerNode excluded = mock(PeerNode.class);
+    when(included.isRealConnection()).thenReturn(true);
+    when(included.isDisabled()).thenReturn(false);
+    when(included.isRoutingBackedOff(false)).thenReturn(true);
+    when(excluded.isRealConnection()).thenReturn(true);
+    when(excluded.isDisabled()).thenReturn(false);
+    when(excluded.isRoutingBackedOff(false)).thenReturn(false);
+    addPeers(roster, included, excluded);
+
+    // Act
+    int count = roster.countBackedOffPeers(false);
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countByStatus_whenMixed_expectCount() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode included = mock(PeerNode.class);
+    PeerNode excluded = mock(PeerNode.class);
+    when(included.getPeerNodeStatus()).thenReturn(3);
+    when(excluded.getPeerNodeStatus()).thenReturn(4);
+    addPeers(roster, included, excluded);
+
+    // Act
+    int count = roster.countByStatus(3);
+
+    // Assert
+    assertEquals(1, count);
+  }
+
+  @Test
+  void getStatus_whenUnsorted_expectSortedLines() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode first = mock(PeerNode.class);
+    PeerNode second = mock(PeerNode.class);
+    PeerNodeStatus statusA = mock(PeerNodeStatus.class);
+    PeerNodeStatus statusB = mock(PeerNodeStatus.class);
+    when(statusA.toString()).thenReturn("B-status");
+    when(statusB.toString()).thenReturn("A-status");
+    when(first.getStatus(true)).thenReturn(statusA);
+    when(second.getStatus(true)).thenReturn(statusB);
+    addPeers(roster, first, second);
+
+    // Act
+    String status = roster.getStatus();
+
+    // Assert
+    assertEquals("A-status\nB-status\n", status);
+  }
+
+  @Test
+  void getTMCIPeerList_whenUnsorted_expectSortedLines() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode first = mock(PeerNode.class);
+    PeerNode second = mock(PeerNode.class);
+    when(first.getTMCIPeerInfo()).thenReturn("peer-b");
+    when(second.getTMCIPeerInfo()).thenReturn("peer-a");
+    addPeers(roster, first, second);
+
+    // Act
+    String list = roster.getTMCIPeerList();
+
+    // Assert
+    assertEquals("peer-a\npeer-b\n", list);
+  }
+
+  @Test
+  void readExtraPeerData_whenOneThrows_expectContinues() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    DarknetPeerNode first = mock(DarknetPeerNode.class);
+    DarknetPeerNode second = mock(DarknetPeerNode.class);
+    doThrow(new IllegalStateException("boom")).when(first).readExtraPeerData();
+    addPeers(roster, first, second);
+
+    // Act
+    roster.readExtraPeerData();
+
+    // Assert
+    verify(first).readExtraPeerData();
+    verify(second).readExtraPeerData();
+  }
+
+  @Test
+  void incrementSelectionSamples_whenCalled_expectDelegates() {
+    // Arrange
+    PeerRoster roster = newRoster(mock(RandomSource.class), true);
+    PeerNode peer = mock(PeerNode.class);
+
+    // Act
+    roster.incrementSelectionSamples(peer);
+
+    // Assert
+    verify(peer).incrementNumberOfSelections();
+  }
+
+  private static PeerRoster newRoster(RandomSource random, boolean publish) {
+    Node node = mock(Node.class);
+    lenient().when(node.getRandom()).thenReturn(random);
+    lenient().when(node.shallWePublishOurPeersLocation()).thenReturn(publish);
+    return new PeerRoster(node, new Object());
+  }
+
+  private static void addPeers(PeerRoster roster, PeerNode... peers) {
+    for (PeerNode peer : peers) {
+      roster.addPeer(peer, false);
+    }
+  }
+
+  private static void addConnectedPeers(PeerRoster roster, PeerNode... peers) {
+    PeerRoster.PeerAdder noOp = _ -> {};
+    for (PeerNode peer : peers) {
+      when(peer.isRealConnection()).thenReturn(true);
+      when(peer.isConnected()).thenReturn(true);
+      roster.addPeer(peer, false);
+      roster.addConnectedPeer(peer, noOp);
+    }
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void setPeerKeyHash(PeerNode peer, byte[] hash) {
+    try {
+      Field field = PeerNode.class.getDeclaredField("peerECDSAPubKeyHash");
+      field.setAccessible(true);
+      field.set(peer, hash);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to set peer key hash", e);
+    }
+  }
+}

--- a/src/test/java/network/crypta/node/PeerRoutingSelectorTest.java
+++ b/src/test/java/network/crypta/node/PeerRoutingSelectorTest.java
@@ -1,0 +1,735 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import network.crypta.keys.Key;
+import network.crypta.node.NodeStats.PeerLoadStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PeerRoutingSelectorTest {
+
+  private static final long NOW = 1_000_000L;
+  private static final short OUTGOING_HTL = 5;
+  private static final double TARGET = 0.25;
+
+  @Mock private Node node;
+  @Mock private PeerRoster roster;
+  @Mock private PeerStatusBook statusBook;
+
+  private PeerRoutingSelector selector;
+
+  @BeforeEach
+  void setUp() {
+    selector = new PeerRoutingSelector(node, roster, statusBook);
+    when(node.getLocation()).thenReturn(0.0);
+    when(node.isEnablePerNodeFailureTables()).thenReturn(false);
+  }
+
+  @Test
+  void closerPeer_whenNoConnectedPeers_expectNull() {
+    // Arrange
+    when(roster.connectedPeers()).thenReturn(new PeerNode[0]);
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertNull(selected);
+  }
+
+  @Test
+  void closerPeer_whenSingleEligiblePeer_expectNull() {
+    // Arrange
+    PeerNode onlyPeer = routablePeerAt(0.80);
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {onlyPeer});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertNull(selected);
+  }
+
+  @Test
+  void closerPeer_whenTwoEligiblePeers_expectSecondClosestSelected() {
+    // Arrange
+    PeerNode closest = routablePeerAt(0.24);
+    PeerNode secondClosest = routablePeerAt(0.30);
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closest, secondClosest});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertEquals(secondClosest, selected);
+  }
+
+  @Test
+  void closerPeer_whenIgnoreSelfFalseAndOnlyPeersBeyondSelf_expectNull() {
+    // Arrange
+    when(node.getLocation()).thenReturn(0.0); // self distance to target=0.25 is 0.25
+
+    PeerNode closerBeyondSelf = routablePeerAt(0.60); // diff=0.35 (> 0.25)
+    PeerNode fartherBeyondSelf = routablePeerAt(0.80); // diff=0.45 (> 0.25)
+
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closerBeyondSelf, fartherBeyondSelf});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            false,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertNull(selected);
+  }
+
+  @Test
+  void closerPeer_whenIgnoreSelfTrueAndOnlyPeersBeyondSelf_expectSelectsSecond() {
+    // Arrange
+    when(node.getLocation()).thenReturn(0.0); // self distance to target=0.25 is 0.25
+
+    PeerNode closerBeyondSelf = routablePeerAt(0.60); // diff=0.35
+    PeerNode fartherBeyondSelf = routablePeerAt(0.80); // diff=0.45
+
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closerBeyondSelf, fartherBeyondSelf});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertEquals(fartherBeyondSelf, selected);
+  }
+
+  @Test
+  void closerPeer_whenNewLoadManagementAndMissingLoadStats_expectSkipsPeer() {
+    // Arrange
+    PeerNode missingStats = routablePeerAt(0.24);
+    stubLoadStats(missingStats, null);
+
+    PeerNode ignored = routablePeerAt(0.27);
+    stubLoadStats(ignored, mock(PeerLoadStats.class));
+
+    PeerNode selectedExpected = routablePeerAt(0.30);
+    stubLoadStats(selectedExpected, mock(PeerLoadStats.class));
+
+    when(roster.connectedPeers())
+        .thenReturn(new PeerNode[] {missingStats, ignored, selectedExpected});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            true,
+            null,
+            false,
+            NOW,
+            true);
+
+    // Assert
+    assertEquals(selectedExpected, selected);
+  }
+
+  @Test
+  void closerPeer_whenMandatoryBackoff_expectSkipsPeer() {
+    // Arrange
+    PeerNode inMandatoryBackoff = routablePeerAt(0.24);
+    stubLoadStats(inMandatoryBackoff, mock(PeerLoadStats.class));
+    when(inMandatoryBackoff.isInMandatoryBackoff(NOW, true)).thenReturn(true);
+
+    PeerNode ignored = routablePeerAt(0.27);
+    stubLoadStats(ignored, mock(PeerLoadStats.class));
+
+    PeerNode selectedExpected = routablePeerAt(0.30);
+    stubLoadStats(selectedExpected, mock(PeerLoadStats.class));
+
+    when(roster.connectedPeers())
+        .thenReturn(new PeerNode[] {inMandatoryBackoff, ignored, selectedExpected});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            true,
+            null,
+            false,
+            NOW,
+            true);
+
+    // Assert
+    assertEquals(selectedExpected, selected);
+  }
+
+  @Test
+  void closerPeer_whenPeerIsOverSelected_expectSkipped() {
+    // Arrange
+    PeerNode overSelected = routablePeerAt(0.24);
+    when(overSelected.selectionRate()).thenReturn(100.0);
+
+    PeerNode ignored = routablePeerAt(0.27);
+    when(ignored.selectionRate()).thenReturn(1.0);
+
+    PeerNode selectedExpected = routablePeerAt(0.30);
+    when(selectedExpected.selectionRate()).thenReturn(1.0);
+
+    PeerNode other1 = routablePeerAt(0.35);
+    PeerNode other2 = routablePeerAt(0.40);
+    when(other1.selectionRate()).thenReturn(1.0);
+    when(other2.selectionRate()).thenReturn(1.0);
+
+    when(roster.connectedPeers())
+        .thenReturn(new PeerNode[] {overSelected, ignored, selectedExpected, other1, other2});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertEquals(selectedExpected, selected);
+  }
+
+  @Test
+  void closerPeer_whenMinVersionRejectsOldFred_expectSkipsPeer() {
+    // Arrange
+    int minVersion = 1_000;
+
+    PeerNode oldFred = routablePeerAt(0.24);
+    when(oldFred.getNodeName()).thenReturn("Fred");
+    when(oldFred.getVersion()).thenReturn("Fred,0.7,1.0,999");
+
+    PeerNode ignored = routablePeerAt(0.27);
+    when(ignored.getNodeName()).thenReturn("Fred");
+    when(ignored.getVersion()).thenReturn("Fred,0.7,1.0,1000");
+
+    PeerNode selectedExpected = routablePeerAt(0.30);
+    when(selectedExpected.getNodeName()).thenReturn("Fred");
+    when(selectedExpected.getVersion()).thenReturn("Fred,0.7,1.0,1001");
+
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {oldFred, ignored, selectedExpected});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            minVersion,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertEquals(selectedExpected, selected);
+  }
+
+  @Test
+  void closerPeer_whenPeerPublishesCloserPeerLocation_expectInfluencesMaxDistance() {
+    // Arrange
+    when(node.getLocation()).thenReturn(0.0);
+    PeerNode origin = mock(PeerNode.class);
+    when(origin.getLocation()).thenReturn(0.10);
+
+    PeerNode indirect = routablePeerAt(0.90);
+    when(indirect.shallWeRouteAccordingToOurPeersLocation(OUTGOING_HTL)).thenReturn(true);
+    when(indirect.getClosestPeerLocation(eq(TARGET), any())).thenReturn(0.21); // diff=0.04
+
+    PeerNode direct = routablePeerAt(0.20); // diff=0.05
+
+    double maxDistance = 0.06;
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {indirect, direct});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            origin,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            maxDistance,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertEquals(direct, selected);
+    verify(indirect)
+        .getClosestPeerLocation(
+            eq(TARGET),
+            argThat(
+                (Set<Double> exclude) ->
+                    exclude != null
+                        && exclude.contains(0.0)
+                        && exclude.contains(0.10)
+                        && exclude.size() == 2));
+  }
+
+  @Test
+  void closerPeer_whenAllCandidatesBackedOff_expectReturnsSecondClosestBackedOff() {
+    // Arrange
+    PeerNode closestBackedOff = routablePeerAt(0.24);
+    when(closestBackedOff.isRoutingBackedOff(anyLong(), anyBoolean())).thenReturn(true);
+
+    PeerNode secondBackedOff = routablePeerAt(0.30);
+    when(secondBackedOff.isRoutingBackedOff(anyLong(), anyBoolean())).thenReturn(true);
+
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closestBackedOff, secondBackedOff});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertEquals(secondBackedOff, selected);
+  }
+
+  @Test
+  void closerPeer_whenAddUnpickedLocsToProvided_expectCollectsUnpickedAndBackedOff() {
+    // Arrange
+    PeerNode closest = routablePeerAt(0.22); // diff=0.03 (ignored)
+    PeerNode selectedExpected = routablePeerAt(0.20); // diff=0.05
+
+    PeerNode backedOff = routablePeerAt(0.19); // diff=0.06
+    when(backedOff.isRoutingBackedOff(anyLong(), anyBoolean())).thenReturn(true);
+
+    PeerNode unpicked = routablePeerAt(0.10); // diff=0.15
+
+    when(roster.connectedPeers())
+        .thenReturn(new PeerNode[] {closest, selectedExpected, backedOff, unpicked});
+
+    List<Double> addUnpickedLocsTo = new ArrayList<>();
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            addUnpickedLocsTo,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertEquals(selectedExpected, selected);
+    assertEquals(Set.of(0.10, 0.19), Set.copyOf(addUnpickedLocsTo));
+  }
+
+  @Test
+  void closerPeer_whenRecentlyFailedAndUnderWaitingThreshold_expectDoesNotFail() {
+    // Arrange
+    when(node.isEnablePerNodeFailureTables()).thenReturn(true);
+
+    FailureTable failureTable = mock(FailureTable.class);
+    when(node.getFailureTable()).thenReturn(failureTable);
+
+    Key key = mock(Key.class);
+    TimedOutNodesList entry = mock(TimedOutNodesList.class);
+    when(failureTable.getTimedOutNodesList(key)).thenReturn(entry);
+
+    PeerNode closest = routablePeerAt(0.24);
+    PeerNode selectedExpected = routablePeerAt(0.27);
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closest, selectedExpected});
+
+    when(entry.getTimeoutTime(closest, OUTGOING_HTL, NOW, true)).thenReturn(NOW - 1);
+    when(entry.getTimeoutTime(selectedExpected, OUTGOING_HTL, NOW, true)).thenReturn(NOW - 1);
+
+    when(entry.getTimeoutTime(closest, OUTGOING_HTL, NOW, false)).thenReturn(NOW + 10_000);
+    when(entry.getTimeoutTime(selectedExpected, OUTGOING_HTL, NOW, false)).thenReturn(NOW - 1);
+
+    RecentlyFailedReturn recentlyFailed = new RecentlyFailedReturn();
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            key,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            recentlyFailed,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertEquals(selectedExpected, selected);
+    assertEquals(-1L, recentlyFailed.recentlyFailed());
+  }
+
+  @Test
+  void closerPeer_whenRecentlyFailedAndWaitingThresholdReached_expectFailsAndReturnsNull() {
+    // Arrange
+    when(node.isEnablePerNodeFailureTables()).thenReturn(true);
+    when(node.isEnableULPRDataPropagation()).thenReturn(true);
+
+    FailureTable failureTable = mock(FailureTable.class);
+    when(node.getFailureTable()).thenReturn(failureTable);
+
+    Key key = mock(Key.class);
+    TimedOutNodesList entry = mock(TimedOutNodesList.class);
+    when(failureTable.getTimedOutNodesList(key)).thenReturn(entry);
+    when(failureTable.hadAnyOffers(key)).thenReturn(false);
+
+    PeerNode closest = routablePeerAt(0.24);
+    PeerNode middle = routablePeerAt(0.27);
+    PeerNode farthest = routablePeerAt(0.30);
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closest, middle, farthest});
+
+    for (PeerNode peer : List.of(closest, middle, farthest)) {
+      when(entry.getTimeoutTime(peer, OUTGOING_HTL, NOW, true)).thenReturn(NOW - 1);
+      when(entry.getTimeoutTime(peer, OUTGOING_HTL, NOW, false)).thenReturn(NOW + 10_000);
+    }
+
+    RecentlyFailedReturn recentlyFailed = new RecentlyFailedReturn();
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            key,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            recentlyFailed,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertNull(selected);
+    assertEquals(NOW + 10_000, recentlyFailed.recentlyFailed());
+  }
+
+  @Test
+  void closerPeer_whenCalculateMisroutingAndNoPeersCounted_expectNoNodeStatsReport() {
+    // Arrange
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false))
+        .thenReturn(0);
+    when(statusBook.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, false))
+        .thenReturn(0);
+
+    PeerNode closest = routablePeerAt(0.24);
+    PeerNode selectedExpected = routablePeerAt(0.27);
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closest, selectedExpected});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            true,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
+    // Assert
+    assertEquals(selectedExpected, selected);
+    verify(statusBook, atLeastOnce())
+        .getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false);
+    verify(statusBook, atLeastOnce())
+        .getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF, false);
+    verify(node, never()).getNodeStats();
+  }
+
+  @Test
+  void closerPeer_whenRoutedToIsNull_expectNullPointerException() {
+    // Arrange
+    when(roster.connectedPeers()).thenReturn(new PeerNode[0]);
+
+    // Act + Assert
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            selector.closerPeer(
+                null,
+                null,
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
+  }
+
+  @Test
+  void closerPeer_whenUsingConvenienceOverload_expectSameSelectionRulesApply() {
+    // Arrange
+    PeerNode closest = routablePeerAt(0.24);
+    PeerNode selectedExpected = routablePeerAt(0.30);
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closest, selectedExpected});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            null,
+            identityPeerSet(),
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            false);
+
+    // Assert
+    assertEquals(selectedExpected, selected);
+  }
+
+  private static Set<PeerNode> identityPeerSet() {
+    return Collections.newSetFromMap(new IdentityHashMap<>());
+  }
+
+  private PeerNode routablePeerAt(double location) {
+    PeerNode peer = mock(PeerNode.class);
+    lenient().when(peer.getLocation()).thenReturn(location);
+    when(peer.selectionRate()).thenReturn(1.0);
+    when(peer.isRoutable()).thenReturn(true);
+    when(peer.isDisconnecting()).thenReturn(false);
+    lenient().when(peer.isRoutingBackedOff(anyLong(), anyBoolean())).thenReturn(false);
+    lenient().when(peer.shallWeRouteAccordingToOurPeersLocation(anyInt())).thenReturn(false);
+    return peer;
+  }
+
+  private void stubLoadStats(PeerNode peer, PeerLoadStats statsOrNull) {
+    PeerNode.OutputLoadTracker tracker = mock(PeerNode.OutputLoadTracker.class);
+    when(tracker.getLastIncomingLoadStats()).thenReturn(statsOrNull);
+    when(peer.outputLoadTracker(true)).thenReturn(tracker);
+  }
+}

--- a/src/test/java/network/crypta/node/PeerStatusBookTest.java
+++ b/src/test/java/network/crypta/node/PeerStatusBookTest.java
@@ -1,0 +1,239 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PeerStatusBookTest {
+  private static final long NOW = 10_000L;
+
+  private final Object lock = new Object();
+
+  @Mock private PeerRoster roster;
+  @Mock private PeerNode peer;
+
+  private PeerStatusBook book;
+
+  @BeforeEach
+  void setUp() {
+    book = new PeerStatusBook(roster, lock);
+  }
+
+  @Test
+  void onPeerAdded_whenRecordStatusTrue_tracksAllAndDarknetStatuses() {
+    when(peer.recordStatus()).thenReturn(true);
+    when(peer.getPeerNodeStatus()).thenReturn(PeerManager.PEER_NODE_STATUS_CONNECTED);
+    when(peer.isOpennet()).thenReturn(false);
+
+    book.onPeerAdded(peer);
+
+    assertEquals(1, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false));
+    assertEquals(1, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, true));
+  }
+
+  @Test
+  void onPeerAdded_whenRecordStatusFalse_doesNotTrackStatuses() {
+    when(peer.recordStatus()).thenReturn(false);
+
+    book.onPeerAdded(peer);
+
+    assertEquals(0, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false));
+    assertEquals(0, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, true));
+  }
+
+  @Test
+  void onPeerRemoved_whenStatusAndReasonsPresent_clearsAllTracking() {
+    when(peer.recordStatus()).thenReturn(true);
+    when(peer.getPeerNodeStatus()).thenReturn(PeerManager.PEER_NODE_STATUS_TOO_NEW);
+    when(peer.isOpennet()).thenReturn(false);
+    when(peer.getPreviousBackoffReason(true)).thenReturn("rt");
+    when(peer.getPreviousBackoffReason(false)).thenReturn("bulk");
+
+    book.onPeerAdded(peer);
+    book.addPeerNodeRoutingBackoffReason("rt", peer, true);
+    book.addPeerNodeRoutingBackoffReason("bulk", peer, false);
+
+    book.onPeerRemoved(peer);
+
+    assertEquals(0, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, false));
+    assertEquals(0, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, true));
+    assertEquals(0, book.getPeerNodeRoutingBackoffReasonSize("rt", true));
+    assertEquals(0, book.getPeerNodeRoutingBackoffReasonSize("bulk", false));
+  }
+
+  @Test
+  void changePeerNodeStatus_whenDarknet_movesCountsBetweenStatuses() {
+    when(peer.recordStatus()).thenReturn(true);
+    when(peer.getPeerNodeStatus()).thenReturn(PeerManager.PEER_NODE_STATUS_DISCONNECTED);
+    when(peer.isOpennet()).thenReturn(false);
+
+    book.onPeerAdded(peer);
+    book.changePeerNodeStatus(
+        peer,
+        PeerManager.PEER_NODE_STATUS_DISCONNECTED,
+        PeerManager.PEER_NODE_STATUS_CONNECTED,
+        false);
+
+    assertEquals(0, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_DISCONNECTED, false));
+    assertEquals(1, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, false));
+    assertEquals(0, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_DISCONNECTED, true));
+    assertEquals(1, book.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_CONNECTED, true));
+  }
+
+  @Test
+  void getPeerNodeRoutingBackoffReasons_whenTracked_returnsDistinctReasonsPerStream() {
+    book.addPeerNodeRoutingBackoffReason("reason-a", peer, true);
+    book.addPeerNodeRoutingBackoffReason("reason-b", peer, true);
+    book.addPeerNodeRoutingBackoffReason("bulk-only", peer, false);
+
+    Set<String> realtimeReasons =
+        new HashSet<>(Arrays.asList(book.getPeerNodeRoutingBackoffReasons(true)));
+    Set<String> bulkReasons =
+        new HashSet<>(Arrays.asList(book.getPeerNodeRoutingBackoffReasons(false)));
+
+    assertEquals(Set.of("reason-a", "reason-b"), realtimeReasons);
+    assertEquals(Set.of("bulk-only"), bulkReasons);
+  }
+
+  @Test
+  void getPeerNodeStatuses_whenRequested_returnsSnapshotInRosterOrder() {
+    PeerNode first = peer;
+    PeerNode second = org.mockito.Mockito.mock(PeerNode.class);
+    PeerNodeStatus firstStatus = org.mockito.Mockito.mock(PeerNodeStatus.class);
+    PeerNodeStatus secondStatus = org.mockito.Mockito.mock(PeerNodeStatus.class);
+    when(roster.myPeers()).thenReturn(new PeerNode[] {first, second});
+    when(first.getStatus(true)).thenReturn(firstStatus);
+    when(second.getStatus(true)).thenReturn(secondStatus);
+
+    PeerNodeStatus[] statuses = book.getPeerNodeStatuses(true);
+
+    assertEquals(2, statuses.length);
+    assertSame(firstStatus, statuses[0]);
+    assertSame(secondStatus, statuses[1]);
+    verify(first).getStatus(true);
+    verify(second).getStatus(true);
+  }
+
+  @Test
+  void getDarknetPeerNodeStatuses_whenRequested_returnsDarknetSnapshots() {
+    DarknetPeerNode darknetPeer = org.mockito.Mockito.mock(DarknetPeerNode.class);
+    DarknetPeerNodeStatus status = org.mockito.Mockito.mock(DarknetPeerNodeStatus.class);
+    when(roster.getDarknetPeers()).thenReturn(new DarknetPeerNode[] {darknetPeer});
+    when(darknetPeer.getStatus(false)).thenReturn(status);
+
+    DarknetPeerNodeStatus[] statuses = book.getDarknetPeerNodeStatuses(false);
+
+    assertEquals(1, statuses.length);
+    assertSame(status, statuses[0]);
+    verify(darknetPeer).getStatus(false);
+  }
+
+  @Test
+  void getOpennetPeerNodeStatuses_whenRequested_returnsOpennetSnapshots() {
+    OpennetPeerNode opennetPeer = org.mockito.Mockito.mock(OpennetPeerNode.class);
+    OpennetPeerNodeStatus status = org.mockito.Mockito.mock(OpennetPeerNodeStatus.class);
+    when(roster.getOpennetPeers()).thenReturn(new OpennetPeerNode[] {opennetPeer});
+    when(opennetPeer.getStatus(false)).thenReturn(status);
+
+    OpennetPeerNodeStatus[] statuses = book.getOpennetPeerNodeStatuses(false);
+
+    assertEquals(1, statuses.length);
+    assertSame(status, statuses[0]);
+    verify(opennetPeer).getStatus(false);
+  }
+
+  @Test
+  void maybeUpdateOldestNeverConnectedDarknetPeerAge_whenIntervalElapsed_updatesMaxAge() {
+    PeerNode first = org.mockito.Mockito.mock(PeerNode.class);
+    PeerNode second = org.mockito.Mockito.mock(PeerNode.class);
+    PeerNode third = org.mockito.Mockito.mock(PeerNode.class);
+
+    when(first.isDarknet()).thenReturn(true);
+    when(first.getPeerNodeStatus()).thenReturn(PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED);
+    when(first.getPeerAddedTime()).thenReturn(NOW - 1_000L);
+
+    when(second.isDarknet()).thenReturn(true);
+    when(second.getPeerNodeStatus()).thenReturn(PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED);
+    when(second.getPeerAddedTime()).thenReturn(NOW - 2_000L);
+
+    when(third.isDarknet()).thenReturn(false);
+
+    PeerNode[] initialPeers = new PeerNode[] {first, second, third};
+    PeerNode[] updatedPeers = new PeerNode[] {second, third};
+
+    when(roster.myPeers()).thenReturn(initialPeers, updatedPeers);
+
+    book.maybeUpdateOldestNeverConnectedDarknetPeerAge(NOW);
+
+    assertEquals(2_000L, book.getOldestNeverConnectedDarknetPeerAge());
+
+    book.maybeUpdateOldestNeverConnectedDarknetPeerAge(NOW + 4_999L);
+
+    assertEquals(2_000L, book.getOldestNeverConnectedDarknetPeerAge());
+
+    book.maybeUpdateOldestNeverConnectedDarknetPeerAge(NOW + 5_001L);
+
+    assertEquals(7_001L, book.getOldestNeverConnectedDarknetPeerAge());
+    verify(roster, times(2)).myPeers();
+  }
+
+  @Test
+  void maybeUpdateOldestNeverConnectedDarknetPeerAge_whenNoMatchingPeers_returnsZero() {
+    PeerNode nonDarknet = org.mockito.Mockito.mock(PeerNode.class);
+    when(nonDarknet.isDarknet()).thenReturn(false);
+    when(roster.myPeers()).thenReturn(new PeerNode[] {nonDarknet});
+
+    book.maybeUpdateOldestNeverConnectedDarknetPeerAge(NOW);
+
+    assertEquals(0L, book.getOldestNeverConnectedDarknetPeerAge());
+  }
+
+  @Test
+  void maybeLogPeerNodeStatusSummary_whenCalledTwiceWithinInterval_logsOnce() {
+    when(roster.myPeers()).thenReturn(new PeerNode[] {peer});
+    when(peer.getPeerNodeStatus()).thenReturn(PeerManager.PEER_NODE_STATUS_CONNECTED);
+
+    book.maybeLogPeerNodeStatusSummary(NOW);
+    book.maybeLogPeerNodeStatusSummary(NOW);
+
+    verify(roster, times(1)).myPeers();
+    verify(peer, times(1)).getPeerNodeStatus();
+  }
+
+  @Test
+  void maybeUpdatePeerNodeRoutableConnectionStats_whenIntervalElapsed_updatesPeers() {
+    PeerNode first = peer;
+    PeerNode second = org.mockito.Mockito.mock(PeerNode.class);
+    when(roster.myPeers()).thenReturn(new PeerNode[] {first, second});
+
+    book.maybeUpdatePeerNodeRoutableConnectionStats(NOW);
+    book.maybeUpdatePeerNodeRoutableConnectionStats(NOW + 6_999L);
+
+    verify(first, times(1)).checkRoutableConnectionStatus();
+    verify(second, times(1)).checkRoutableConnectionStatus();
+  }
+
+  @Test
+  void maybeUpdatePeerNodeRoutableConnectionStats_whenIntervalNotElapsed_skipsPeers() {
+    when(roster.myPeers()).thenReturn(new PeerNode[] {peer});
+
+    book.maybeUpdatePeerNodeRoutableConnectionStats(NOW);
+    book.maybeUpdatePeerNodeRoutableConnectionStats(NOW + 1_000L);
+
+    verify(peer, times(1)).checkRoutableConnectionStatus();
+    verify(roster, times(1)).myPeers();
+  }
+}

--- a/src/test/java/network/crypta/node/SecurityLevelsTest.java
+++ b/src/test/java/network/crypta/node/SecurityLevelsTest.java
@@ -32,12 +32,14 @@ class SecurityLevelsTest {
 
   @Mock private Node node;
   @Mock private PeerManager peers;
+  @Mock private PeerRoster roster;
 
   @BeforeEach
   void setup() {
     // Ensure Node.getPeers() returns our mock for tests that need it; lenient to avoid strict
     // stubbing failures in tests that don't call getConfirmWarning().
     org.mockito.Mockito.lenient().when(node.getPeers()).thenReturn(peers);
+    org.mockito.Mockito.lenient().when(peers.roster()).thenReturn(roster);
   }
 
   // --- Helpers ---
@@ -60,7 +62,7 @@ class SecurityLevelsTest {
 
   private void stubPeers(int added, int connected) {
     org.mockito.Mockito.lenient()
-        .when(peers.getDarknetPeers())
+        .when(roster.getDarknetPeers())
         .thenReturn(new DarknetPeerNode[Math.max(added, 0)]);
     org.mockito.Mockito.lenient()
         .when(peers.countConnectedDarknetPeers())

--- a/src/test/java/network/crypta/node/SeedClientPeerNodeTest.java
+++ b/src/test/java/network/crypta/node/SeedClientPeerNodeTest.java
@@ -39,6 +39,7 @@ import org.mockito.quality.Strictness;
 class SeedClientPeerNodeTest {
 
   @Mock private PeerManager peerManager;
+  @Mock private PeerMessenger peerMessenger;
 
   @Mock private Node node;
 
@@ -62,6 +63,8 @@ class SeedClientPeerNodeTest {
     MessageCore usm = mock(MessageCore.class);
     doNothing().when(usm).onDisconnect(any());
     when(node.getUSM()).thenReturn(usm);
+
+    when(peerManager.messenger()).thenReturn(peerMessenger);
 
     RequestTracker tracker = mock(RequestTracker.class);
     doNothing().when(tracker).onRestartOrDisconnect(any());
@@ -212,7 +215,7 @@ class SeedClientPeerNodeTest {
     // In override: super.disconnected(true,true) returns prior connected state. New peers start
     // disconnected, so false is expected.
     assertFalse(ret);
-    verify(peerManager, times(1)).disconnectAndRemove(c, false, false, false);
+    verify(peerMessenger, times(1)).disconnectAndRemove(c, false, false, false);
   }
 
   @Test

--- a/src/test/java/network/crypta/node/SeedPeerQueriesTest.java
+++ b/src/test/java/network/crypta/node/SeedPeerQueriesTest.java
@@ -1,0 +1,86 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import network.crypta.support.ByteArrayWrapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SeedPeerQueriesTest {
+
+  @Test
+  void getConnectedSeedServerPeersVector_whenExcludeNull_returnsOnlyConnectedSeedServerPeers() {
+    PeerManager peerManager = mock(PeerManager.class);
+    SeedServerPeerNode connectedSeed = mockSeedServerPeer();
+    SeedServerPeerNode disconnectedSeed = mockSeedServerPeer();
+    PeerNode regularPeer = mock(PeerNode.class);
+    when(connectedSeed.isConnected()).thenReturn(true);
+    when(disconnectedSeed.isConnected()).thenReturn(false);
+    when(peerManager.myPeers())
+        .thenReturn(new PeerNode[] {connectedSeed, disconnectedSeed, regularPeer});
+    SeedPeerQueries queries = new SeedPeerQueries(peerManager);
+
+    List<SeedServerPeerNode> result = queries.getConnectedSeedServerPeersVector(null);
+
+    assertEquals(1, result.size());
+    assertSame(connectedSeed, result.getFirst());
+  }
+
+  @Test
+  void getConnectedSeedServerPeersVector_whenExcludeContainsHash_excludesMatchingPeer() {
+    PeerManager peerManager = mock(PeerManager.class);
+    byte[] hash1 = new byte[] {9, 9, 9};
+    byte[] hash2 = new byte[] {8, 8, 8};
+    SeedServerPeerNode excludedSeed = mockSeedServerPeer();
+    SeedServerPeerNode includedSeed = mockSeedServerPeer();
+    doReturn(hash1).when(excludedSeed).getPubKeyHash();
+    doReturn(hash2).when(includedSeed).getPubKeyHash();
+    when(includedSeed.isConnected()).thenReturn(true);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[] {excludedSeed, includedSeed});
+    SeedPeerQueries queries = new SeedPeerQueries(peerManager);
+    Set<ByteArrayWrapper> exclude = Set.of(new ByteArrayWrapper(hash1));
+
+    List<SeedServerPeerNode> result = queries.getConnectedSeedServerPeersVector(exclude);
+
+    assertEquals(List.of(includedSeed), result);
+  }
+
+  @Test
+  void getSeedServerPeersVector_whenMixedPeers_returnsAllSeedServerPeersInOrder() {
+    PeerManager peerManager = mock(PeerManager.class);
+    SeedServerPeerNode firstSeed = mockSeedServerPeer();
+    SeedServerPeerNode secondSeed = mockSeedServerPeer();
+    PeerNode regularPeer = mock(PeerNode.class);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[] {firstSeed, regularPeer, secondSeed});
+    SeedPeerQueries queries = new SeedPeerQueries(peerManager);
+
+    List<SeedServerPeerNode> result = queries.getSeedServerPeersVector();
+
+    assertIterableEquals(List.of(firstSeed, secondSeed), result);
+  }
+
+  @Test
+  void getSeedServerPeersVector_whenNoPeers_returnsEmptyList() {
+    PeerManager peerManager = mock(PeerManager.class);
+    when(peerManager.myPeers()).thenReturn(new PeerNode[0]);
+    SeedPeerQueries queries = new SeedPeerQueries(peerManager);
+
+    List<SeedServerPeerNode> result = queries.getSeedServerPeersVector();
+
+    assertEquals(List.of(), result);
+  }
+
+  private static SeedServerPeerNode mockSeedServerPeer() {
+    return mock(SeedServerPeerNode.class);
+  }
+}

--- a/src/test/java/network/crypta/node/simulator/TestUtilTest.java
+++ b/src/test/java/network/crypta/node/simulator/TestUtilTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import network.crypta.node.Node;
 import network.crypta.node.OpennetManager;
 import network.crypta.node.PeerManager;
+import network.crypta.node.SeedPeerQueries;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -25,11 +26,13 @@ class TestUtilTest {
     Node node = mock(Node.class);
     OpennetManager opennet = mock(OpennetManager.class);
     PeerManager peers = mock(PeerManager.class);
+    SeedPeerQueries seedPeers = mock(SeedPeerQueries.class);
     when(node.getOpennet()).thenReturn(opennet);
     when(opennet.getAnnouncementThreshold()).thenReturn(3);
     when(node.getPeers()).thenReturn(peers);
+    when(peers.seedPeers()).thenReturn(seedPeers);
     when(peers.countSeednodes()).thenReturn(1);
-    when(peers.getConnectedSeedServerPeersVector(null)).thenReturn(List.of());
+    when(seedPeers.getConnectedSeedServerPeersVector(null)).thenReturn(List.of());
     when(peers.countValidPeers()).thenReturn(2);
     when(peers.countConnectedOpennetPeers()).thenReturn(3);
 
@@ -41,7 +44,7 @@ class TestUtilTest {
     verify(peers).countConnectedOpennetPeers();
     verify(peers).countSeednodes();
     verify(peers).countValidPeers();
-    verify(peers).getConnectedSeedServerPeersVector(null);
+    verify(seedPeers).getConnectedSeedServerPeersVector(null);
   }
 
   @Test

--- a/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
+++ b/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
@@ -30,6 +30,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeFile;
 import network.crypta.node.NodeStats;
 import network.crypta.node.PeerManager;
+import network.crypta.node.PeerMessenger;
 import network.crypta.node.PeerNode;
 import network.crypta.node.ProgramDirectory;
 import network.crypta.node.Version;
@@ -59,6 +60,7 @@ class NodeUpdateManagerTest {
   @Mock NodeClientCore nodeCore;
   @Mock UserAlertManager alerts;
   @Mock PeerManager peerManager;
+  @Mock PeerMessenger peerMessenger;
   @Mock NodeStats nodeStats;
   @Mock PluginManager pluginManager;
 
@@ -80,6 +82,7 @@ class NodeUpdateManagerTest {
     when(nodeCore.getPersistentTempDir()).thenReturn(persistentTmpDir);
     when(nodeCore.getAlerts()).thenReturn(alerts);
     when(node.getPeers()).thenReturn(peerManager);
+    when(peerManager.messenger()).thenReturn(peerMessenger);
     when(node.getNodeStats()).thenReturn(nodeStats);
     when(node.getPluginManager()).thenReturn(pluginManager);
     when(pluginManager.getOfficialPlugins()).thenReturn(Collections.emptyList());
@@ -220,7 +223,7 @@ class NodeUpdateManagerTest {
     assertTrue(manager.isBlown());
 
     // Announcement broadcasted via PeerManager
-    verify(peerManager, times(1))
+    verify(peerMessenger, times(1))
         .localBroadcast(
             any(Message.class),
             eq(true),

--- a/src/test/java/network/crypta/node/useralerts/IPUndetectedUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/IPUndetectedUserAlertTest.java
@@ -16,6 +16,7 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeIPDetector;
 import network.crypta.node.PeerManager;
+import network.crypta.node.PeerRoster;
 import network.crypta.support.HTMLNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,7 @@ class IPUndetectedUserAlertTest {
   @Mock private Node node;
   @Mock private NodeIPDetector ipDetector;
   @Mock private PeerManager peers;
+  @Mock private PeerRoster roster;
   @Mock private NodeClientCore clientCore;
   @Mock private PersistentConfig config;
   @Mock private SubConfig nodeSubConfig;
@@ -50,6 +52,7 @@ class IPUndetectedUserAlertTest {
     // Common stubs used by multiple tests
     lenient().when(node.getIpDetector()).thenReturn(ipDetector);
     lenient().when(node.getPeers()).thenReturn(peers);
+    lenient().when(peers.roster()).thenReturn(roster);
     lenient().when(node.getDarknetPortNumber()).thenReturn(12345);
     lenient().when(node.getOpennetFNPPort()).thenReturn(-1);
     lenient().when(node.isOpennetEnabled()).thenReturn(false);
@@ -205,7 +208,7 @@ class IPUndetectedUserAlertTest {
     when(ipDetector.isDetecting()).thenReturn(false);
     when(ipDetector.noDetectPlugins()).thenReturn(false);
     when(ipDetector.hasJSTUN()).thenReturn(true);
-    when(peers.getDarknetPeers()).thenReturn(new network.crypta.node.DarknetPeerNode[1]);
+    when(roster.getDarknetPeers()).thenReturn(new network.crypta.node.DarknetPeerNode[1]);
 
     HTMLNode html = alert.getHTMLText();
     assertNotNull(html);
@@ -263,7 +266,7 @@ class IPUndetectedUserAlertTest {
   void htmlText_whenNoPlugins_includesLoadDetectPluginsMessageAndLinks() {
     when(ipDetector.noDetectPlugins()).thenReturn(true);
     when(ipDetector.isDetecting()).thenReturn(false);
-    when(peers.getDarknetPeers()).thenReturn(new network.crypta.node.DarknetPeerNode[0]);
+    when(roster.getDarknetPeers()).thenReturn(new network.crypta.node.DarknetPeerNode[0]);
 
     String out = alert.getHTMLText().generate();
     // Verify links for plugins and config are present; message is rendered via substitutions
@@ -277,7 +280,7 @@ class IPUndetectedUserAlertTest {
     when(ipDetector.noDetectPlugins()).thenReturn(false);
     when(ipDetector.isDetecting()).thenReturn(false);
     when(ipDetector.hasJSTUN()).thenReturn(false);
-    when(peers.getDarknetPeers()).thenReturn(new network.crypta.node.DarknetPeerNode[0]);
+    when(roster.getDarknetPeers()).thenReturn(new network.crypta.node.DarknetPeerNode[0]);
 
     String out = alert.getHTMLText().generate();
     // Ensure the plugins link is present for loading JSTUN


### PR DESCRIPTION
## Summary
- split PeerManager into focused helpers (connector, messenger, routing selector, status book, persistence, roster)
- route callers to new PeerManager subcomponents across node + HTTP paths
- add unit test coverage for new helpers, persistence, roster, routing selection, and seed queries

## Testing
- not run (not requested)
