### PR TITLE
refactor(launcher): clarify controller lifecycle

### DIFF
--- a/src/main/kotlin/network/crypta/launcher/LauncherController.kt
+++ b/src/main/kotlin/network/crypta/launcher/LauncherController.kt
@@ -1,11 +1,15 @@
 package network.crypta.launcher
 
 import java.awt.Desktop
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.RandomAccessFile
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.attribute.BasicFileAttributes
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
@@ -20,13 +24,36 @@ private const val TAIL_BASE_DELAY_MS: Long = 200
 private const val TAIL_MAX_DELAY_MS: Long = 1500
 private const val TAIL_READ_CHUNK: Int = 64 * 1024
 
-/** Controller for the Crypta launcher. Manages the daemon process and exposes state and logs. */
+/**
+ * Coordinates the launcher lifecycle for the Crypta daemon process and exposes UI-facing state.
+ *
+ * This controller resolves the wrapper script, starts the process, streams combined stdout/stderr,
+ * tails `wrapper.log` when available, and updates an in-memory [AppState] snapshot for the UI. It
+ * also extracts the FProxy port from log output to enable browser launch. Long-running work is
+ * dispatched onto the provided I/O dispatcher, while state updates are funneled through the
+ * supplied coroutine scope. The lifecycle is intentionally idempotent: repeated start/stop calls
+ * either return quickly or re-enter the same terminal states without throwing.
+ * <ul>
+ * <li>Start and stop the wrapper process with platform-specific behavior.</li>
+ * <li>Expose logs via a bounded shared flow for UI consumption.</li>
+ * <li>Track running state, shutdown intent, and detected HTTP port.</li>
+ * </ul>
+ *
+ * @param scope parent scope for launcher coroutines and UI-bound updates.
+ * @param io dispatcher used for process I/O and filesystem operations.
+ * @param cwd working directory used to resolve and launch the wrapper script.
+ */
 class LauncherController(
   private val scope: CoroutineScope,
   private val io: CoroutineDispatcher = Dispatchers.IO,
   private val cwd: Path = Paths.get(System.getProperty("user.dir")),
 ) {
   private val _state = MutableStateFlow(AppState())
+  /**
+   * Read-only stream of the latest [AppState] snapshot for UI rendering. The flow is eagerly
+   * started and always available, reflecting changes made by [start], [stop], and shutdown calls.
+   * Consumers should treat the state as immutable and use it as a point-in-time view only.
+   */
   val state: StateFlow<AppState> = _state.stateIn(scope, SharingStarted.Eagerly, _state.value)
 
   /**
@@ -44,15 +71,29 @@ class LauncherController(
       extraBufferCapacity = LOG_EXTRA_CAPACITY,
       onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
+  /**
+   * Bounded, drop-older log stream for launcher and daemon output. A small replay window is kept so
+   * late subscribers still receive recent lines; when buffers fill, older entries are dropped to
+   * stay memory-bounded. Emissions are best-effort and do not suspend the caller.
+   */
   val logs: SharedFlow<String> = _logs.asSharedFlow()
 
   private var process: Process? = null
   private var tailJob: Job? = null
   private var autoOpenedBrowser = false
   private var wrapperConfPath: Path? = null
-  // Separate shutdown scope so quit can proceed even if the UI scope is cancelled
+  // Separate shutdown scope so quit can proceed even if the UI scope is canceled
   private val shutdownScope: CoroutineScope = CoroutineScope(SupervisorJob() + io)
 
+  /**
+   * Launch the wrapper process if it is not already running.
+   *
+   * This method resolves the wrapper script from [cwd], validates that it is executable, and logs a
+   * readable command line for diagnostics. It starts the process with merged stdout/stderr and
+   * spins up coroutines to read output, detect the FProxy port, watch for exit, and optionally tail
+   * `wrapper.log`. The call returns immediately; all work happens asynchronously on [io]. Repeated
+   * calls while running are ignored.
+   */
   fun start() {
     if (_state.value.isRunning || process?.isAlive == true) return
     scope.launch(io) {
@@ -85,20 +126,28 @@ class LauncherController(
       process = p
 
       // Reader: combined stdout+stderr
-      scope.launch(io) { readProcessOutput(p) }
+      scope.launch { readProcessOutput(p) }
       // Watcher: termination
-      scope.launch(io) { watchProcess(p) }
+      scope.launch { watchProcess(p) }
       // Tail wrapper.log if present
       tailJob?.cancel()
       guessWrapperConfPathForCryptadScript(cryptadPath)?.let { conf ->
         wrapperConfPath = conf
         val logSpec = readWrapperProperty(conf, "wrapper.logfile")
         val logPath = computeWrapperLogPath(conf, logSpec)
-        tailJob = scope.launch(io) { tailFileWhileAlive(logPath) }
+        tailJob = scope.launch { tailFileWhileAlive(logPath) }
       }
     }
   }
 
+  /**
+   * Request a graceful stop of the wrapper process if it is running.
+   *
+   * The controller updates state to indicate a stop is in progress and then attempts platform
+   * appropriate shutdown (anchor-file signaling on Windows, signal escalation on Unix). The call
+   * returns immediately; waiting happens on [io] and is best-effort. If the process is already
+   * stopped, the state is normalized and the method exits without further work.
+   */
   fun stop() {
     val p = process ?: return
     if (!p.isAlive) {
@@ -115,6 +164,13 @@ class LauncherController(
     }
   }
 
+  /**
+   * Open the local FProxy URL in the default browser when a port is known.
+   *
+   * This method uses the desktop integration when available and falls back to platform-specific
+   * commands (`open`, `rundll32`, or `xdg-open`). If no port has been detected yet, it is a no-op.
+   * Errors are logged but do not propagate to the caller.
+   */
   fun launchBrowser() {
     val port = _state.value.knownPort ?: return
     val uri = URI.create("http://localhost:$port/")
@@ -141,6 +197,13 @@ class LauncherController(
     }
   }
 
+  /**
+   * Begin shutdown and return immediately.
+   *
+   * This method marks the controller as shutting down and initiates a stop on a dedicated shutdown
+   * scope so the request is honored even if the UI scope has been canceled. It is safe to call
+   * multiple times; subsequent calls are ignored once shutdown has started.
+   */
   fun shutdown() {
     if (_state.value.isShuttingDown) return
     updateState { it.copy(isShuttingDown = true) }
@@ -148,16 +211,19 @@ class LauncherController(
   }
 
   /**
-   * Shutdown and suspend until the wrapper process has exited (or been force-killed). Safe to call
-   * multiple times; subsequent calls return immediately.
+   * Suspend until the wrapper process has fully exited after shutdown is requested.
+   *
+   * If shutdown is already in progress, this method waits for the current process to terminate and
+   * returns. Otherwise, it marks shutdown, issues a graceful stop, and suspends on [io] until the
+   * process tree has exited or escalation completes. The method is idempotent and safe to call from
+   * repeated lifecycle paths such as window close handlers or test teardown hooks.
    */
   suspend fun shutdownAndWait() {
     if (_state.value.isShuttingDown) {
       // If already shutting down, just wait until not running
-      return withContext(io) {
-        val p = process
-        if (p != null && p.isAlive) stopProcessGracefully(p)
-      }
+      val p = process
+      if (p != null && p.isAlive) stopProcessGracefully(p)
+      return
     }
     updateState { it.copy(isShuttingDown = true) }
     withContext(io) { process?.let { p -> if (p.isAlive) stopProcessGracefully(p) } }
@@ -167,8 +233,7 @@ class LauncherController(
 
   private suspend fun readProcessOutput(p: Process) {
     withContext(io) {
-      val br =
-        java.io.BufferedReader(java.io.InputStreamReader(p.inputStream, StandardCharsets.UTF_8))
+      val br = BufferedReader(InputStreamReader(p.inputStream, StandardCharsets.UTF_8))
       var line: String?
       while (br.readLine().also { line = it } != null) {
         val s = line!!
@@ -209,100 +274,19 @@ class LauncherController(
     // Keep a single RAF open to avoid repeated open/close churn. Add exponential backoff when no
     // new data arrives to reduce filesystem pressure. Re-open on file rotation or truncation.
     withContext(io) {
-      var raf: java.io.RandomAccessFile? = null
-
-      fun closeQuietlyAndNull() {
-        val toClose = raf
-        raf = null
-        try {
-          toClose?.close()
-        } catch (_: Throwable) {
-          // best-effort close; ignore
-        }
-      }
-
-      var currentKey: Any? = null
-      var pos = 0L
-      var leftover = StringBuilder()
-      var idleCount = 0 // consecutive loops without new data
-
-      fun calcDelayMs(): Long {
-        val shifts = idleCount.coerceAtMost(3) // 200, 400, 800, 1600ms
-        val d = TAIL_BASE_DELAY_MS shl shifts
-        return d.coerceAtMost(TAIL_MAX_DELAY_MS)
-      }
-
+      val state = TailState()
       try {
         while (scope.isActive && (process?.isAlive == true)) {
           try {
-            if (!Files.exists(path)) {
-              closeQuietlyAndNull()
-              currentKey = null
-              idleCount++
-              delay(calcDelayMs())
-              continue
-            }
-
-            // Detect rotation by file key if available
-            val newKey =
-              try {
-                Files.readAttributes(path, java.nio.file.attribute.BasicFileAttributes::class.java)
-                  .fileKey()
-              } catch (_: Throwable) {
-                null
-              }
-
-            if (raf == null || (currentKey != null && newKey != null && currentKey != newKey)) {
-              // Open (or re-open after rotation). Start from end to avoid dumping historical logs.
-              closeQuietlyAndNull()
-              val opened = java.io.RandomAccessFile(path.toFile(), "r")
-              raf = opened
-              currentKey = newKey
-              val len = runCatching { opened.length() }.getOrDefault(0L)
-              pos = len
-            }
-
-            val handle = raf ?: continue
-
-            val len = runCatching { handle.length() }.getOrDefault(0L)
-            if (len < pos) pos = 0L // truncation
-
-            var madeProgress = false
-            if (len > pos) {
-              handle.seek(pos)
-              val toRead = (len - pos).coerceAtMost(TAIL_READ_CHUNK.toLong()).toInt()
-              val buf = ByteArray(toRead)
-              val r = runCatching { handle.read(buf) }.getOrDefault(-1)
-              if (r > 0) {
-                pos += r
-                val text = String(buf, 0, r, StandardCharsets.UTF_8)
-                val parts = text.split('\n')
-                if (parts.size == 1) {
-                  leftover.append(parts[0])
-                } else {
-                  val first = leftover.append(parts[0]).toString()
-                  if (first.isNotEmpty()) logLine(first)
-                  leftover = StringBuilder()
-                  for (i in 1 until parts.size - 1) logLine(parts[i])
-                  val last = parts.last()
-                  if (text.endsWith("\n")) logLine(last) else leftover.append(last)
-                }
-                madeProgress = true
-              }
-            }
-
-            if (madeProgress) idleCount = 0 else idleCount++
+            val madeProgress = tailOnce(path, state)
+            state.idleCount = if (madeProgress) 0 else state.idleCount + 1
           } catch (_: Throwable) {
-            // On any error, force re-open next loop.
-            closeQuietlyAndNull()
-            currentKey = null
-            idleCount++
+            resetTailOnError(state)
           }
-
-          delay(calcDelayMs())
+          delay(calcTailDelayMs(state.idleCount))
         }
       } finally {
-        closeQuietlyAndNull()
+        closeTailFile(state)
       }
     }
   }
@@ -437,16 +421,16 @@ class LauncherController(
           logLine(ts() + " WARN: Failed to delete anchor file at $anchorPath: ${it.message}")
         }
         .getOrDefault(false)
-    if (deleted) {
+    return if (deleted) {
       logLine(ts() + " Requested graceful shutdown via anchor: ${anchorPath.fileName} ...")
       // Give the wrapper time to observe deletion and stop the JVM
-      return waitForPidsToExit(allPids, 25_000)
+      waitForPidsToExit(allPids, 25_000)
     } else {
       logLine(
         ts() +
           " Anchor file not found or not deleted at $anchorPath; skipping wait for anchor stop."
       )
-      return false
+      false
     }
   }
 
@@ -454,7 +438,7 @@ class LauncherController(
     try {
       val conf = guessWrapperConfPathForCryptadScript(cryptadPath) ?: return
       if (!Files.isRegularFile(conf)) return
-      val lines = Files.readAllLines(conf, StandardCharsets.UTF_8)
+      val lines = Files.readAllLines(conf, StandardCharsets.UTF_8).toList()
       val props = parseWrapperProperties(lines)
       if (props["wrapper.console.flush"]?.equals("TRUE", ignoreCase = true) == true) return
       val updated = upsertWrapperProperty(lines, "wrapper.console.flush", "TRUE")
@@ -471,21 +455,115 @@ class LauncherController(
   private suspend fun readWrapperProperty(conf: Path, key: String): String? =
     withContext(io) {
       runCatching {
-          Files.newBufferedReader(conf, StandardCharsets.UTF_8).use { br ->
-            while (true) {
-              val raw = br.readLine() ?: break
-              val line = raw.trim()
-              if (line.isEmpty() || line.startsWith("#")) continue
-              val idx = line.indexOf('=')
-              if (idx <= 0) continue
-              val k = line.substringBefore('=', "").trim()
-              if (k == key) return@use line.substringAfter('=', "").trim()
-            }
-            null
+          Files.newBufferedReader(conf, StandardCharsets.UTF_8).useLines { lines ->
+            lines.firstNotNullOfOrNull { extractWrapperProperty(it, key) }
           }
         }
         .getOrNull()
     }
+
+  private fun extractWrapperProperty(raw: String, key: String): String? {
+    val line = raw.trim()
+    if (line.isEmpty() || line.startsWith("#")) return null
+    val idx = line.indexOf('=')
+    if (idx <= 0) return null
+    val k = line.substring(0, idx).trim()
+    if (k != key) return null
+    return line.substring(idx + 1).trim()
+  }
+
+  private class TailState {
+    var raf: RandomAccessFile? = null
+    var currentKey: Any? = null
+    var pos: Long = 0
+    var leftover: StringBuilder = StringBuilder()
+    var idleCount: Int = 0
+  }
+
+  private fun calcTailDelayMs(idleCount: Int): Long {
+    val shifts = idleCount.coerceAtMost(3) // 200, 400, 800, 1600ms
+    val d = TAIL_BASE_DELAY_MS shl shifts
+    return d.coerceAtMost(TAIL_MAX_DELAY_MS)
+  }
+
+  private fun resetTailOnError(state: TailState) {
+    closeTailFile(state)
+    state.currentKey = null
+    state.idleCount++
+  }
+
+  private fun closeTailFile(state: TailState) {
+    val toClose = state.raf
+    state.raf = null
+    try {
+      toClose?.close()
+    } catch (_: Throwable) {
+      // best-effort close; ignore
+    }
+  }
+
+  private fun tailOnce(path: Path, state: TailState): Boolean {
+    if (!Files.exists(path)) {
+      closeTailFile(state)
+      state.currentKey = null
+      return false
+    }
+
+    val newKey = readFileKey(path)
+    openTailFileIfNeeded(path, newKey, state)
+    val handle = state.raf ?: return false
+
+    val len = runCatching { handle.length() }.getOrDefault(0L)
+    if (len < state.pos) state.pos = 0L // truncation
+    if (len <= state.pos) return false
+
+    handle.seek(state.pos)
+    val toRead = (len - state.pos).coerceAtMost(TAIL_READ_CHUNK.toLong()).toInt()
+    val buf = ByteArray(toRead)
+    val r = runCatching { handle.read(buf) }.getOrDefault(-1)
+    if (r <= 0) return false
+
+    state.pos += r
+    emitTailText(state, String(buf, 0, r, StandardCharsets.UTF_8))
+    return true
+  }
+
+  private fun readFileKey(path: Path): Any? {
+    return try {
+      Files.readAttributes(path, BasicFileAttributes::class.java).fileKey()
+    } catch (_: Throwable) {
+      null
+    }
+  }
+
+  private fun openTailFileIfNeeded(path: Path, newKey: Any?, state: TailState) {
+    if (
+      state.raf == null ||
+        (state.currentKey != null && newKey != null && state.currentKey != newKey)
+    ) {
+      // Open (or re-open after rotation). Start from end to avoid dumping historical logs.
+      closeTailFile(state)
+      val opened = RandomAccessFile(path.toFile(), "r")
+      state.raf = opened
+      state.currentKey = newKey
+      state.pos = runCatching { opened.length() }.getOrDefault(0L)
+    }
+  }
+
+  private fun emitTailText(state: TailState, text: String) {
+    val parts = text.split('\n')
+    if (parts.size == 1) {
+      state.leftover.append(parts[0])
+      return
+    }
+
+    val first = state.leftover.append(parts[0]).toString()
+    if (first.isNotEmpty()) logLine(first)
+    state.leftover = StringBuilder()
+    for (i in 1 until parts.size - 1) logLine(parts[i])
+    val last = parts.last()
+    if (text.endsWith("\n")) logLine(last) else state.leftover.append(last)
+  }
 
   private fun updateState(block: (AppState) -> AppState) {
     _state.value = block(_state.value)

--- a/src/test/kotlin/network/crypta/launcher/LauncherControllerTest.kt
+++ b/src/test/kotlin/network/crypta/launcher/LauncherControllerTest.kt
@@ -1,0 +1,262 @@
+package network.crypta.launcher
+
+import java.awt.Desktop
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import network.crypta.fs.AppEnv
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.timeout
+import org.mockito.junit.jupiter.MockitoExtension
+
+@Suppress("java:S100", "kotlin:S100")
+@ExtendWith(MockitoExtension::class)
+internal class LauncherControllerTest {
+
+  @TempDir lateinit var tempDir: Path
+
+  private companion object {
+    private const val TEST_PORT = 8888
+  }
+
+  @Test
+  fun start_whenCryptadMissing_logsErrorAndDoesNotRun() = runBlocking {
+    val scope = newScope()
+    val controller = LauncherController(scope, Dispatchers.IO, tempDir)
+    val logs = startLogCollector(scope, controller)
+
+    try {
+      controller.start()
+
+      val line = awaitLog(logs.channel) { it.contains("Cannot find executable 'cryptad'") }
+      assertTrue(line.contains("ERROR: Cannot find executable 'cryptad'"))
+      assertFalse(controller.state.value.isRunning)
+    } finally {
+      logs.channel.close()
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun start_whenScriptRuns_updatesStateAndReadsPort() = runBlocking {
+    val scope = newScope()
+    val controller = LauncherController(scope, Dispatchers.IO, tempDir)
+    val logs = startLogCollector(scope, controller)
+    val wrapperConf = writeWrapperConf(tempDir)
+    writeCryptadScript(tempDir)
+    setPrivateField(controller, "autoOpenedBrowser", true)
+
+    try {
+      controller.start()
+
+      withTimeout(5_000) { controller.state.filter { it.isRunning }.first() }
+      val stateWithPort =
+        withTimeout(5_000) { controller.state.filter { it.knownPort == TEST_PORT }.first() }
+      assertEquals(TEST_PORT, stateWithPort.knownPort)
+
+      val stoppedState =
+        withTimeout(5_000) {
+          controller.state.filter { !it.isRunning && it.knownPort == TEST_PORT }.first()
+        }
+      assertFalse(stoppedState.isRunning)
+
+      awaitLog(logs.channel) { it.contains("Starting FProxy on") }
+      assertTrue(logs.lines.any { it.contains("Starting 'cryptad'") })
+      assertTrue(logs.lines.any { it.contains("exec:") })
+      assertTrue(logs.lines.any { it.contains("Starting FProxy on") })
+
+      val confLines = Files.readAllLines(wrapperConf, StandardCharsets.UTF_8).toList()
+      assertTrue(confLines.any { it.trim() == "wrapper.console.flush=TRUE" })
+    } finally {
+      logs.channel.close()
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun stop_whenProcessNotAlive_clearsRunningState() {
+    val scope = newScope()
+    val controller = LauncherController(scope, Dispatchers.IO, tempDir)
+    val process = mock(Process::class.java)
+    Mockito.`when`(process.isAlive).thenReturn(false)
+    setPrivateField(controller, "process", process)
+    setState(controller, AppState(isRunning = true))
+
+    try {
+      controller.stop()
+
+      val state = getPrivateState(controller)
+      assertFalse(state.isRunning)
+      assertFalse(state.isStopping)
+    } finally {
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun launchBrowser_whenDesktopSupported_invokesBrowse() {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    val controller = LauncherController(scope, Dispatchers.Unconfined, tempDir)
+    val desktop = mock(Desktop::class.java)
+    Mockito.`when`(desktop.isSupported(Desktop.Action.BROWSE)).thenReturn(true)
+    setState(controller, AppState(knownPort = 1234))
+
+    try {
+      mockStatic(Desktop::class.java).use { desktopStatic ->
+        desktopStatic.`when`<Boolean> { Desktop.isDesktopSupported() }.thenReturn(true)
+        desktopStatic.`when`<Desktop> { Desktop.getDesktop() }.thenReturn(desktop)
+
+        controller.launchBrowser()
+
+        Mockito.verify(desktop, timeout(1_000)).browse(URI.create("http://localhost:1234/"))
+      }
+    } finally {
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun shutdown_setsShuttingDownFlagAndIsIdempotent() {
+    val scope = newScope()
+    val controller = LauncherController(scope, Dispatchers.IO, tempDir)
+
+    try {
+      controller.shutdown()
+      assertTrue(getPrivateState(controller).isShuttingDown)
+
+      controller.shutdown()
+      assertTrue(getPrivateState(controller).isShuttingDown)
+    } finally {
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun shutdownAndWait_whenNoProcess_setsShuttingDownFlag() = runBlocking {
+    val scope = newScope()
+    val controller = LauncherController(scope, Dispatchers.IO, tempDir)
+
+    try {
+      controller.shutdownAndWait()
+
+      assertTrue(getPrivateState(controller).isShuttingDown)
+    } finally {
+      scope.cancel()
+    }
+  }
+
+  private fun newScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+  private fun startLogCollector(
+    scope: CoroutineScope,
+    controller: LauncherController,
+  ): LogCollector {
+    val channel = Channel<String>(Channel.UNLIMITED)
+    val lines = CopyOnWriteArrayList<String>()
+    scope.launch {
+      controller.logs.collect { line ->
+        lines.add(line)
+        channel.trySend(line)
+      }
+    }
+    return LogCollector(channel, lines)
+  }
+
+  private suspend fun awaitLog(channel: Channel<String>, predicate: (String) -> Boolean): String {
+    return withTimeout(5_000) { channel.receiveAsFlow().first { predicate(it) } }
+  }
+
+  private fun writeCryptadScript(baseDir: Path): Path {
+    val binDir = baseDir.resolve("bin")
+    Files.createDirectories(binDir)
+    val isWindows = AppEnv().isWindows()
+    val script = if (isWindows) binDir.resolve("cryptad.bat") else binDir.resolve("cryptad")
+    val content =
+      if (isWindows) {
+        """
+        @echo off
+        echo Starting FProxy on 127.0.0.1:$TEST_PORT
+        echo READY
+        ping -n 2 127.0.0.1 > nul
+        """
+          .trimIndent()
+      } else {
+        """
+        #!/usr/bin/env sh
+        echo "Starting FProxy on 127.0.0.1:$TEST_PORT"
+        echo "READY"
+        sleep 0.2
+        """
+          .trimIndent()
+      }
+    Files.writeString(script, content, StandardCharsets.UTF_8)
+    val executableSet = script.toFile().setExecutable(true)
+    if (!executableSet && !isWindows) {
+      error("Failed to mark cryptad script as executable: $script")
+    }
+    return script
+  }
+
+  private fun writeWrapperConf(baseDir: Path): Path {
+    val confDir = baseDir.resolve("conf")
+    val logsDir = baseDir.resolve("logs")
+    Files.createDirectories(confDir)
+    Files.createDirectories(logsDir)
+    val conf = confDir.resolve("wrapper.conf")
+    val lines = listOf("# wrapper.conf", "wrapper.logfile=../logs/wrapper.log")
+    Files.write(conf, lines, StandardCharsets.UTF_8)
+    Files.writeString(logsDir.resolve("wrapper.log"), "", StandardCharsets.UTF_8)
+    return conf
+  }
+
+  private fun setState(controller: LauncherController, state: AppState) {
+    val stateFlow = getStateFlow(controller)
+    stateFlow.value = state
+  }
+
+  private fun getPrivateState(controller: LauncherController): AppState {
+    return getStateFlow(controller).value
+  }
+
+  @Suppress("kotlin:S6518")
+  private fun setPrivateField(target: Any, fieldName: String, value: Any?) {
+    val field = target.javaClass.getDeclaredField(fieldName)
+    field.isAccessible = true
+    field.set(target, value)
+  }
+
+  @Suppress("kotlin:S6518")
+  private fun getStateFlow(controller: LauncherController): MutableStateFlow<AppState> {
+    val field = controller.javaClass.getDeclaredField("_state")
+    field.isAccessible = true
+    @Suppress("UNCHECKED_CAST")
+    return field.get(controller) as MutableStateFlow<AppState>
+  }
+
+  private data class LogCollector(
+    val channel: Channel<String>,
+    val lines: CopyOnWriteArrayList<String>,
+  )
+}


### PR DESCRIPTION
## Summary
- document launcher controller lifecycle and state/log flows
- extract wrapper.log tailing helpers and error handling
- add LauncherController test coverage for start/stop and shutdown

## Testing
- ./gradlew spotlessApply
- Not run (not requested)
