### PR TITLE
test(support): simplify BooleanCallbackTest lambdas

### DIFF
--- a/src/test/java/network/crypta/support/api/BooleanCallbackTest.java
+++ b/src/test/java/network/crypta/support/api/BooleanCallbackTest.java
@@ -13,31 +13,29 @@ class BooleanCallbackTest {
   @Test
   void canCreateBooleanCallbackFromLambdas()
       throws NodeNeedRestartException, InvalidConfigValueException {
-    BooleanCallback callback = BooleanCallback.from(() -> true, (value) -> theValue = value);
+    BooleanCallback callback = BooleanCallback.from(() -> true, value -> theValue = value);
     callback.set(true);
 
     assertThat(theValue, Matchers.is(true));
   }
 
   @Test
-  void canThrowInvalidConfigValueException()
-      throws NodeNeedRestartException, InvalidConfigValueException {
+  void canThrowInvalidConfigValueException() {
     BooleanCallback callback =
         BooleanCallback.from(
             () -> true,
-            (value) -> {
+            _ -> {
               throw new InvalidConfigValueException("invalid");
             });
     assertThrows(InvalidConfigValueException.class, () -> callback.set(true));
   }
 
   @Test
-  void canThrowNodeNeedRestartException()
-      throws NodeNeedRestartException, InvalidConfigValueException {
+  void canThrowNodeNeedRestartException() {
     BooleanCallback callback =
         BooleanCallback.from(
             () -> true,
-            (value) -> {
+            _ -> {
               throw new NodeNeedRestartException("needs restart");
             });
     assertThrows(NodeNeedRestartException.class, () -> callback.set(true));
@@ -45,12 +43,7 @@ class BooleanCallbackTest {
 
   @Test
   void getGivesTheSetVariable() throws NodeNeedRestartException, InvalidConfigValueException {
-    BooleanCallback callback =
-        BooleanCallback.from(
-            () -> theValue,
-            (value -> {
-              theValue = value;
-            }));
+    BooleanCallback callback = BooleanCallback.from(() -> theValue, value -> theValue = value);
     callback.set(true);
     boolean trueValue = callback.get();
     callback.set(false);


### PR DESCRIPTION
## Summary
- simplify BooleanCallbackTest lambda usage and exception tests
- drop unused checked-exception declarations in test helpers
- keep test intent unchanged with more compact callbacks

## Testing
- ./gradlew spotlessApply
