### PR TITLE
Splitfile storage persistence refactor and allocator tests

### DIFF
--- a/src/main/java/network/crypta/client/async/SplitFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcher.java
@@ -260,7 +260,7 @@ public class SplitFileFetcher
       throws IOException, FetchException, MetadataParseException {
     ChecksumChecker checker = new CRCChecksumChecker();
     return new SplitFileFetcherStorage(
-        new SplitFileFetcherStorage.InitParams.Builder()
+        new SplitFileFetcherStorageInitParams.Builder()
             .metadata(metadata)
             .fetcher(this)
             .decompressors(decompressors)
@@ -695,7 +695,7 @@ public class SplitFileFetcher
       raf.onResume(context);
       this.storage =
           new SplitFileFetcherStorage(
-              new SplitFileFetcherStorage.ResumeParams.Builder()
+              new SplitFileFetcherStorageResumeParams.Builder()
                   .raf(raf)
                   .realTime(realTimeFlag)
                   .callback(this)

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherCrossSegmentAllocator.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherCrossSegmentAllocator.java
@@ -10,12 +10,55 @@ import org.slf4j.LoggerFactory;
 /**
  * Allocates cross-segment storage blocks for splitfile fetches.
  *
- * <p>Separates the random allocation logic from storage bookkeeping.
+ * <p>This utility builds the cross-segment layout used during fetch by choosing, per cross segment,
+ * a set of data and check blocks sourced from the per-segment storage structures. The allocation is
+ * driven by a deterministic random stream seeded from {@link Metadata} so a given metadata set
+ * yields the same allocation pattern while still spreading blocks across segments.
+ *
+ * <p>The allocator is intentionally stateless: it creates new {@link
+ * SplitFileFetcherCrossSegmentStorage} instances and mutates the provided {@link
+ * SplitFileFetcherSegmentStorage} instances to reserve blocks. Callers should treat the operation
+ * as single-threaded with exclusive ownership of the storage objects for the duration of the call.
+ * The method performs bounded randomized probes before falling back to a linear scan and throws an
+ * {@link IllegalStateException} if no block can be reserved.
+ *
+ * <ul>
+ *   <li>Creates cross-segment storage objects with correct per-segment sizing.
+ *   <li>Reserves data and check blocks in backing segment storages.
+ *   <li>Logs allocation progress for fetch diagnostics and troubleshooting.
+ * </ul>
+ *
+ * @see SplitFileFetcherCrossSegmentStorage
+ * @see SplitFileFetcherSegmentStorage
  */
 final class SplitFileFetcherCrossSegmentAllocator {
+  /** Logger for allocation progress and allocation failure diagnostics. */
   private static final Logger LOG =
       LoggerFactory.getLogger(SplitFileFetcherCrossSegmentAllocator.class);
 
+  /**
+   * Creates and populates cross-segment storages for a splitfile fetch.
+   *
+   * <p>When {@code crossCheckBlocks} is zero this returns an empty array without touching the
+   * segment storages. Otherwise, it seeds a deterministic random source from the metadata, creates
+   * one cross segment per input segment, and reserves {@code blocksPerSegment} data blocks and
+   * {@code crossCheckBlocks} check blocks for each cross segment. If the metadata indicates that
+   * blocks must be deducted, the size is reduced for the last {@code
+   * metadata.getDeductBlocksFromSegments()} segments. Allocation uses bounded random probes
+   * followed by a linear scan; failure to reserve any block results in {@link
+   * IllegalStateException}.
+   *
+   * @param owner fetcher storage that owns the cross-segment allocations; must be non-null
+   * @param metadata splitfile metadata supplying hashes and allocation adjustments; must be
+   *     non-null
+   * @param crossCheckBlocks number of check blocks per cross segment; zero disables cross segments
+   * @param blocksPerSegment number of data blocks per cross segment before deductions are applied
+   * @param segments per-segment storage array supplying allocators and block slots; must be
+   *     non-null
+   * @param fecCodec FEC codec used by cross segments for encoding and bookkeeping; must be non-null
+   * @return array of cross-segment storages; empty when crossCheckBlocks is zero
+   * @throws IllegalStateException if no segment can supply a required block after probing
+   */
   static SplitFileFetcherCrossSegmentStorage[] createCrossSegments(
       SplitFileFetcherStorage owner,
       Metadata metadata,
@@ -49,7 +92,18 @@ final class SplitFileFetcherCrossSegmentAllocator {
     return xSegments;
   }
 
-  /** Reserved for future use. */
+  /**
+   * Reserves one data block mapping for a cross segment.
+   *
+   * <p>The allocator first attempts up to ten randomized probes across the segment array, then
+   * scans linearly to find an available block. On success, it records the mapping in the cross
+   * segment; otherwise it fails fast to signal allocator exhaustion.
+   *
+   * @param segment cross-segment storage receiving the reserved data block mapping
+   * @param random random source used to select candidate segments for allocation
+   * @param segments backing segment storages that may supply a data block
+   * @throws IllegalStateException if no segment can provide a data block after probing
+   */
   private static void allocateCrossDataBlock(
       SplitFileFetcherCrossSegmentStorage segment,
       Random random,
@@ -77,7 +131,18 @@ final class SplitFileFetcherCrossSegmentAllocator {
     throw new IllegalStateException("Unable to allocate cross data block!");
   }
 
-  /** Reserved for future use. */
+  /**
+   * Reserves one check block mapping for a cross segment.
+   *
+   * <p>The allocator uses randomized probes followed by a linear scan to locate an available check
+   * block. Successful allocation records the mapping in the cross segment; failure indicates the
+   * allocator cannot satisfy the requested check block count.
+   *
+   * @param segment cross-segment storage receiving the reserved check block mapping
+   * @param random random source used to select candidate segments for allocation
+   * @param segments backing segment storages that may supply a check block
+   * @throws IllegalStateException if no segment can provide a check block after probing
+   */
   private static void allocateCrossCheckBlock(
       SplitFileFetcherCrossSegmentStorage segment,
       Random random,
@@ -105,5 +170,6 @@ final class SplitFileFetcherCrossSegmentAllocator {
     throw new IllegalStateException("Unable to allocate cross data block!");
   }
 
+  /** Prevents instantiation of this utility class. */
   private SplitFileFetcherCrossSegmentAllocator() {}
 }

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherCrossSegmentAllocator.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherCrossSegmentAllocator.java
@@ -1,0 +1,109 @@
+package network.crypta.client.async;
+
+import java.util.Random;
+import network.crypta.client.FECCodec;
+import network.crypta.client.Metadata;
+import network.crypta.support.math.MersenneTwister;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Allocates cross-segment storage blocks for splitfile fetches.
+ *
+ * <p>Separates the random allocation logic from storage bookkeeping.
+ */
+final class SplitFileFetcherCrossSegmentAllocator {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SplitFileFetcherCrossSegmentAllocator.class);
+
+  static SplitFileFetcherCrossSegmentStorage[] createCrossSegments(
+      SplitFileFetcherStorage owner,
+      Metadata metadata,
+      int crossCheckBlocks,
+      int blocksPerSegment,
+      SplitFileFetcherSegmentStorage[] segments,
+      FECCodec fecCodec) {
+    if (crossCheckBlocks == 0) return new SplitFileFetcherCrossSegmentStorage[0];
+    Random crossSegmentRandom =
+        MersenneTwister.createUnsynchronized(
+            Metadata.getCrossSegmentSeed(metadata.getHashes(), metadata.getHashThisLayerOnly()));
+    SplitFileFetcherCrossSegmentStorage[] xSegments =
+        new SplitFileFetcherCrossSegmentStorage[segments.length];
+    int segLen = blocksPerSegment;
+    int deductBlocksFromSegments = metadata.getDeductBlocksFromSegments();
+    for (int i = 0; i < xSegments.length; i++) {
+      LOG.info("Allocating blocks (on fetch) for cross segment {}", i);
+      if (segments.length - i == deductBlocksFromSegments) {
+        segLen--;
+      }
+      SplitFileFetcherCrossSegmentStorage seg =
+          new SplitFileFetcherCrossSegmentStorage(i, segLen, crossCheckBlocks, owner, fecCodec);
+      xSegments[i] = seg;
+      for (int j = 0; j < segLen; j++) {
+        allocateCrossDataBlock(seg, crossSegmentRandom, segments);
+      }
+      for (int j = 0; j < crossCheckBlocks; j++) {
+        allocateCrossCheckBlock(seg, crossSegmentRandom, segments);
+      }
+    }
+    return xSegments;
+  }
+
+  /** Reserved for future use. */
+  private static void allocateCrossDataBlock(
+      SplitFileFetcherCrossSegmentStorage segment,
+      Random random,
+      SplitFileFetcherSegmentStorage[] segments) {
+    int x = 0;
+    for (int i = 0; i < 10; i++) {
+      x = random.nextInt(segments.length);
+      SplitFileFetcherSegmentStorage seg = segments[x];
+      int blockNum = seg.allocateCrossDataBlock(segment, random);
+      if (blockNum >= 0) {
+        segment.addDataBlock(seg, blockNum);
+        return;
+      }
+    }
+    for (int i = 0; i < segments.length; i++) {
+      x++;
+      if (x == segments.length) x = 0;
+      SplitFileFetcherSegmentStorage seg = segments[x];
+      int blockNum = seg.allocateCrossDataBlock(segment, random);
+      if (blockNum >= 0) {
+        segment.addDataBlock(seg, blockNum);
+        return;
+      }
+    }
+    throw new IllegalStateException("Unable to allocate cross data block!");
+  }
+
+  /** Reserved for future use. */
+  private static void allocateCrossCheckBlock(
+      SplitFileFetcherCrossSegmentStorage segment,
+      Random random,
+      SplitFileFetcherSegmentStorage[] segments) {
+    int x = 0;
+    for (int i = 0; i < 10; i++) {
+      x = random.nextInt(segments.length);
+      SplitFileFetcherSegmentStorage seg = segments[x];
+      int blockNum = seg.allocateCrossCheckBlock(segment, random);
+      if (blockNum >= 0) {
+        segment.addDataBlock(seg, blockNum);
+        return;
+      }
+    }
+    for (int i = 0; i < segments.length; i++) {
+      x++;
+      if (x == segments.length) x = 0;
+      SplitFileFetcherSegmentStorage seg = segments[x];
+      int blockNum = seg.allocateCrossCheckBlock(segment, random);
+      if (blockNum >= 0) {
+        segment.addDataBlock(seg, blockNum);
+        return;
+      }
+    }
+    throw new IllegalStateException("Unable to allocate cross data block!");
+  }
+
+  private SplitFileFetcherCrossSegmentAllocator() {}
+}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
@@ -1,6 +1,5 @@
 package network.crypta.client.async;
 
-import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -12,7 +11,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FECCodec;
@@ -24,15 +22,11 @@ import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.Metadata;
 import network.crypta.client.Metadata.SplitfileAlgorithm;
 import network.crypta.client.MetadataParseException;
-import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.ChecksumFailedException;
-import network.crypta.crypt.HashType;
-import network.crypta.crypt.MultiHashOutputStream;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.ClientKey;
-import network.crypta.keys.FreenetURI;
 import network.crypta.keys.Key;
 import network.crypta.node.KeysFetchingLocally;
 import network.crypta.node.SendableRequestItem;
@@ -40,18 +34,13 @@ import network.crypta.node.SendableRequestItemKey;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.RandomArrayIterator;
 import network.crypta.support.Ticker;
-import network.crypta.support.api.Bucket;
-import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import network.crypta.support.api.LockableRandomAccessBuffer.RAFLock;
 import network.crypta.support.api.LockableRandomAccessBufferFactory;
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
-import network.crypta.support.io.ArrayBucketFactory;
-import network.crypta.support.io.BucketTools;
 import network.crypta.support.io.FileRandomAccessBufferFactory;
 import network.crypta.support.io.NativeThread;
 import network.crypta.support.io.StorageFormatException;
-import network.crypta.support.math.MersenneTwister;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -277,406 +266,29 @@ public class SplitFileFetcherStorage {
   private List<SplitFileFetcherSegmentStorage> segmentsToTryDecode;
 
   /**
-   * Builder-style constructor arguments for a fresh fetch session.
-   *
-   * <p>This holder captures all inputs required to initialise a brand-new storage instance when a
-   * splitfile fetch begins. It mirrors the metadata-driven structure of the file (segment keys,
-   * compression chain, client metadata) and also includes execution-time components such as
-   * schedulers, randomness and checksum policies. Instances are typically created via the nested
-   * {@link InitParams.Builder} and passed to the {@link
-   * SplitFileFetcherStorage#SplitFileFetcherStorage(InitParams)} constructor.
-   *
-   * <p>Thread-safety: {@code InitParams} is a simple data container; callers should publish it to a
-   * single thread and avoid mutation once built.
-   *
-   * @hidden
-   */
-  public static final class InitParams {
-    Metadata metadata;
-    SplitFileFetcherStorageCallback fetcher;
-    List<COMPRESSOR_TYPE> decompressors;
-    ClientMetadata clientMetadata;
-    boolean topDontCompress;
-    short topCompatibilityMode;
-    FetchContext origFetchContext;
-    boolean realTime;
-    KeySalter salt;
-    FreenetURI thisKey;
-    FreenetURI origKey;
-    boolean isFinalFetch;
-    byte[] clientDetails;
-    RandomSource random;
-    BucketFactory tempBucketFactory;
-    LockableRandomAccessBufferFactory rafFactory;
-    PersistentJobRunner exec;
-    Ticker ticker;
-    MemoryLimitedJobRunner memoryLimitedJobRunner;
-    ChecksumChecker checker;
-    boolean persistent;
-    File storageFile;
-    FileRandomAccessBufferFactory diskSpaceCheckingRAFFactory;
-    KeysFetchingLocally keysFetching;
-
-    /**
-     * Fluent builder for {@link InitParams}.
-     *
-     * <p>The builder performs no I/O and minimal validation. Typical usage sets the metadata,
-     * callback, decompression pipeline, factories, and execution helpers, then calls {@link
-     * #build()} to obtain an immutable {@link InitParams} snapshot.
-     *
-     * <p>Unless otherwise stated, all values are required. Optional values follow sensible defaults
-     * inside the storage constructor when omitted.
-     */
-    public static class Builder {
-      private Metadata metadata;
-      private SplitFileFetcherStorageCallback fetcher;
-      private List<COMPRESSOR_TYPE> decompressors;
-      private ClientMetadata clientMetadata;
-      private boolean topDontCompress;
-      private short topCompatibilityMode;
-      private FetchContext origFetchContext;
-      private boolean realTime;
-      private KeySalter salt;
-      private FreenetURI thisKey;
-      private FreenetURI origKey;
-      private boolean isFinalFetch;
-      private byte[] clientDetails;
-      private RandomSource random;
-      private BucketFactory tempBucketFactory;
-      private LockableRandomAccessBufferFactory rafFactory;
-      private PersistentJobRunner exec;
-      private Ticker ticker;
-      private MemoryLimitedJobRunner memoryLimitedJobRunner;
-      private ChecksumChecker checker;
-      private boolean persistent;
-      private File storageFile;
-      private FileRandomAccessBufferFactory diskSpaceCheckingRAFFactory;
-      private KeysFetchingLocally keysFetching;
-
-      /**
-       * Set the parsed splitfile {@link Metadata} required to plan the fetch.
-       *
-       * @param v metadata describing segments, blocks, and algorithms; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder metadata(Metadata v) {
-        this.metadata = v;
-        return this;
-      }
-
-      /**
-       * Set the fetcher callback that receives progress and completion events.
-       *
-       * @param v callback implementation used for notifications; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder fetcher(SplitFileFetcherStorageCallback v) {
-        this.fetcher = v;
-        return this;
-      }
-
-      /**
-       * Configure the decompressor pipeline to apply after block decode.
-       *
-       * @param v ordered list of compressor types; empty or singleton in most deployments.
-       * @return this builder for fluent chaining.
-       */
-      public Builder decompressors(List<COMPRESSOR_TYPE> v) {
-        this.decompressors = v;
-        return this;
-      }
-
-      /**
-       * Supply optional client metadata to attach to the completed object.
-       *
-       * @param v metadata such as MIME type and filename; may be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder clientMetadata(ClientMetadata v) {
-        this.clientMetadata = v;
-        return this;
-      }
-
-      /**
-       * Set whether the top-level container should avoid compression.
-       *
-       * @param v when {@code true}, skip attempting compression at the top level.
-       * @return this builder for fluent chaining.
-       */
-      public Builder topDontCompress(boolean v) {
-        this.topDontCompress = v;
-        return this;
-      }
-
-      /**
-       * Specify the minimum compatibility mode expected by the consumer.
-       *
-       * @param v numeric mode constant; affects padding and related behaviours.
-       * @return this builder for fluent chaining.
-       */
-      public Builder topCompatibilityMode(short v) {
-        this.topCompatibilityMode = v;
-        return this;
-      }
-
-      /**
-       * Provide the fetch context carrying retry and cooldown policy.
-       *
-       * @param v context with limits, timeouts, and priorities; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder fetchContext(FetchContext v) {
-        this.origFetchContext = v;
-        return this;
-      }
-
-      /**
-       * Indicate whether the fetch should prefer reduced buffering (real-time).
-       *
-       * @param v when {@code true}, configure for lower latency over throughput.
-       * @return this builder for fluent chaining.
-       */
-      public Builder realTime(boolean v) {
-        this.realTime = v;
-        return this;
-      }
-
-      /**
-       * Set the key salter used when deriving salted keys for requests.
-       *
-       * @param v optional salter strategy; may be {@code null} to disable salting.
-       * @return this builder for fluent chaining.
-       */
-      public Builder salt(KeySalter v) {
-        this.salt = v;
-        return this;
-      }
-
-      /**
-       * Set the primary request URI associated with this fetch.
-       *
-       * @param v the URI for the current object; used for logging and provenance.
-       * @return this builder for fluent chaining.
-       */
-      public Builder thisKey(FreenetURI v) {
-        this.thisKey = v;
-        return this;
-      }
-
-      /**
-       * Optionally record the original user-facing URI if different from {@link #thisKey}.
-       *
-       * @param v the original or canonical URI; may be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder origKey(FreenetURI v) {
-        this.origKey = v;
-        return this;
-      }
-
-      /**
-       * Indicate whether this fetch corresponds to the final content rather than metadata.
-       *
-       * @param v set {@code true} when fetching the actual payload, not intermediate data.
-       * @return this builder for fluent chaining.
-       */
-      public Builder isFinalFetch(boolean v) {
-        this.isFinalFetch = v;
-        return this;
-      }
-
-      /**
-       * Attach opaque client details preserved for callbacks and auditing.
-       *
-       * @param v optional byte array copied/stored as provided; may be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder clientDetails(byte[] v) {
-        this.clientDetails = v;
-        return this;
-      }
-
-      /**
-       * Provide the source of randomness used for key scheduling and shuffling.
-       *
-       * @param v randomness provider; must not be {@code null} in production use.
-       * @return this builder for fluent chaining.
-       */
-      public Builder random(RandomSource v) {
-        this.random = v;
-        return this;
-      }
-
-      /**
-       * Set the temporary bucket factory used to stage metadata before persistence.
-       *
-       * @param v factory for transient buffers; required when {@code persistent} is enabled.
-       * @return this builder for fluent chaining.
-       */
-      public Builder tempBucketFactory(BucketFactory v) {
-        this.tempBucketFactory = v;
-        return this;
-      }
-
-      /**
-       * Configure the random-access buffer factory that creates the backing store.
-       *
-       * @param v factory responsible for persistent RAF creation; must be compatible with the
-       *     chosen storage file.
-       * @return this builder for fluent chaining.
-       */
-      public Builder rafFactory(LockableRandomAccessBufferFactory v) {
-        this.rafFactory = v;
-        return this;
-      }
-
-      /**
-       * Provide the job runner used for off-thread work and callbacks.
-       *
-       * @param v persistent job runner implementation; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder exec(PersistentJobRunner v) {
-        this.exec = v;
-        return this;
-      }
-
-      /**
-       * Set the time source/scheduler used for delayed tasks and de-duplication.
-       *
-       * @param v ticker implementation; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder ticker(Ticker v) {
-        this.ticker = v;
-        return this;
-      }
-
-      /**
-       * Provide the memory-limited job runner used for heavy decode/encode work.
-       *
-       * @param v job runner aware of memory caps; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder memoryLimitedJobRunner(MemoryLimitedJobRunner v) {
-        this.memoryLimitedJobRunner = v;
-        return this;
-      }
-
-      /**
-       * Choose the checksum implementation and length used in persisted sections.
-       *
-       * @param v checker implementation which also provides the checksum length.
-       * @return this builder for fluent chaining.
-       */
-      public Builder checker(ChecksumChecker v) {
-        this.checker = v;
-        return this;
-      }
-
-      /**
-       * Enable or disable persistence of metadata and progress across restarts.
-       *
-       * @param v set {@code true} to persist enough state for resumption after a restart.
-       * @return this builder for fluent chaining.
-       */
-      public Builder persistent(boolean v) {
-        this.persistent = v;
-        return this;
-      }
-
-      /**
-       * Provide an explicit file for the backing store when truncation is desired.
-       *
-       * @param v target file path; when set, completion may use truncation optimisation.
-       * @return this builder for fluent chaining.
-       */
-      public Builder storageFile(File v) {
-        this.storageFile = v;
-        return this;
-      }
-
-      /**
-       * Configure a disk-space checking RAF factory for safer persistent allocations.
-       *
-       * @param v RAF factory that validates available space; optional but recommended.
-       * @return this builder for fluent chaining.
-       */
-      public Builder diskSpaceCheckingRAFFactory(FileRandomAccessBufferFactory v) {
-        this.diskSpaceCheckingRAFFactory = v;
-        return this;
-      }
-
-      /**
-       * Set the key-tracking helper that marks keys as fetching locally.
-       *
-       * @param v helper for cross-component key accounting; may be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder keysFetching(KeysFetchingLocally v) {
-        this.keysFetching = v;
-        return this;
-      }
-
-      /**
-       * Build an immutable snapshot of the current builder state.
-       *
-       * @return a fully-populated {@link InitParams} ready for storage construction.
-       */
-      public InitParams build() {
-        InitParams p = new InitParams();
-        p.metadata = metadata;
-        p.fetcher = fetcher;
-        p.decompressors = decompressors;
-        p.clientMetadata = clientMetadata;
-        p.topDontCompress = topDontCompress;
-        p.topCompatibilityMode = topCompatibilityMode;
-        p.origFetchContext = origFetchContext;
-        p.realTime = realTime;
-        p.salt = salt;
-        p.thisKey = thisKey;
-        p.origKey = origKey;
-        p.isFinalFetch = isFinalFetch;
-        p.clientDetails = clientDetails;
-        p.random = random;
-        p.tempBucketFactory = tempBucketFactory;
-        p.rafFactory = rafFactory;
-        p.exec = exec;
-        p.ticker = ticker;
-        p.memoryLimitedJobRunner = memoryLimitedJobRunner;
-        p.checker = checker;
-        p.persistent = persistent;
-        p.storageFile = storageFile;
-        p.diskSpaceCheckingRAFFactory = diskSpaceCheckingRAFFactory;
-        p.keysFetching = keysFetching;
-        return p;
-      }
-    }
-  }
-
-  /**
    * Create a new storage instance backed by a fresh on-disk layout.
    *
    * <p>This constructor interprets the supplied metadata, allocates segment/cross-segment state,
    * initialises Bloom filters and checksums, and wires asynchronous helpers. It does not block on
    * network I/O but may perform bounded file I/O to prepare the persistent structures when {@code
-   * persistent} is enabled in {@link InitParams}.
+   * persistent} is enabled in {@link SplitFileFetcherStorageInitParams}.
    *
    * <p>Callers normally place the instance under a coordinating fetcher which drives block request
    * scheduling. Once all segments finish and postconditions are met, the fetcher calls {@link
    * #streamGenerator()} to materialise the final byte stream.
    *
-   * @param p full set of immutable construction parameters created by {@link InitParams.Builder};
-   *     must reference the metadata for this splitfile and execution helpers such as {@code
-   *     jobRunner}, {@code ticker}, and checksum policy. May not be {@code null}.
+   * @param p full set of immutable construction parameters created by {@link
+   *     SplitFileFetcherStorageInitParams.Builder}; must reference the metadata for this splitfile
+   *     and execution helpers such as {@code jobRunner}, {@code ticker}, and checksum policy. May
+   *     not be {@code null}.
    * @throws FetchException if the fetch context indicates an unrecoverable configuration or policy
    *     error while preparing request state; this is not a network failure.
    * @throws MetadataParseException if the supplied {@link Metadata} cannot be interpreted into a
    *     valid splitfile layout (e.g., inconsistent block counts or unsupported algorithm).
    * @throws IOException if initial on-disk structures cannot be written or verified using the
-   *     configured {@link LockableRandomAccessBufferFactory} and {@link BucketFactory}.
+   *     configured {@link LockableRandomAccessBufferFactory} and temporary bucket factory.
    */
-  public SplitFileFetcherStorage(InitParams p)
+  public SplitFileFetcherStorage(SplitFileFetcherStorageInitParams p)
       throws FetchException, MetadataParseException, IOException {
     // Initialize immutable/basic fields.
     this.fetcher = p.fetcher;
@@ -788,7 +400,9 @@ public class SplitFileFetcherStorage {
     this.offsetKeyList = storedBlocksLength + storedCrossCheckBlocksLength;
     this.offsetSegmentStatus = offsetKeyList + acc.storedKeysLength;
 
-    byte[] generalProgress = encodeGeneralProgress();
+    byte[] generalProgress =
+        SplitFileFetcherStoragePersistence.encodeGeneralProgress(
+            checksumChecker, hasCheckedDatastore, errors);
 
     if (persistent) {
       offsetGeneralProgress = offsetSegmentStatus + acc.storedSegmentStatusLength;
@@ -820,20 +434,24 @@ public class SplitFileFetcherStorage {
 
     // Prepare metadata buffers and compute final layout lengths/offsets (assign finals here).
     long totalLength;
-    Bucket metadataTemp;
-    byte[] encodedURI;
+    SplitFileFetcherStoragePersistence.PreparedMetadata prepared = null;
     byte[] encodedBasicSettings;
     if (persistent) {
-      PersistentPreparation prep =
-          preparePersistent(
+      prepared =
+          SplitFileFetcherStoragePersistence.preparePersistent(
               p.metadata,
               p.tempBucketFactory,
-              new OriginalDetails(p.thisKey, p.origKey, p.clientDetails, p.isFinalFetch));
-      offsetOriginalDetails = prep.offsetOriginalDetails;
-      this.offsetBasicSettings = prep.offsetBasicSettings;
-      // Now we know encodedBasicSettings length, recompute totalLength accurately.
-      metadataTemp = prep.metadataTemp;
-      encodedURI = prep.encodedURI;
+              p.thisKey,
+              p.origKey,
+              p.clientDetails,
+              p.isFinalFetch,
+              offsetOriginalMetadata,
+              checksumChecker,
+              maxRetries,
+              cooldownTries,
+              cooldownLength);
+      offsetOriginalDetails = prepared.offsetOriginalDetails();
+      this.offsetBasicSettings = prepared.offsetBasicSettings();
       // Now offsets are final, we can encode the basic settings which embed them.
       encodedBasicSettings =
           encodeBasicSettings(
@@ -845,250 +463,15 @@ public class SplitFileFetcherStorage {
     } else {
       totalLength = offsetSegmentStatus;
       offsetOriginalDetails = offsetBasicSettings = offsetSegmentStatus;
-      metadataTemp = null;
-      encodedURI = encodedBasicSettings = null;
+      encodedBasicSettings = null;
     }
 
     // Create the actual LockableRandomAccessBuffer
     rafLength = totalLength;
     raf = createRAFOrThrow(p.storageFile, totalLength, p.rafFactory, p.diskSpaceCheckingRAFFactory);
-    writeToRAF(
-        segmentKeys, metadataTemp, encodedURI, encodedBasicSettings, totalLength, generalProgress);
+    writeToRAF(segmentKeys, prepared, encodedBasicSettings, totalLength, generalProgress);
     if (LOG.isDebugEnabled()) LOG.debug("Fetching {} on {} for {}", p.thisKey, this, fetcher);
     initAsyncHelpers();
-  }
-
-  /**
-   * Parameters needed to resume a previously persisted fetch session.
-   *
-   * <p>When storage was created in persistent mode, a restart rebuilds its in-memory state by
-   * reading and validating checksummed sections from the backing random access buffer. This holder
-   * conveys the environment required to do so, including the buffer itself, scheduling helpers and
-   * checksum implementation.
-   *
-   * <p>Unlike {@link InitParams}, these values are derived from the on-disk format rather than the
-   * metadata that initiated the fetch. Use the nested {@link ResumeParams.Builder} to construct an
-   * instance suitable for {@link SplitFileFetcherStorage#SplitFileFetcherStorage(ResumeParams)}.
-   *
-   * @hidden
-   */
-  public static final class ResumeParams {
-    LockableRandomAccessBuffer raf;
-    boolean realTime;
-    SplitFileFetcherStorageCallback callback;
-    FetchContext origContext;
-    RandomSource random;
-    PersistentJobRunner exec;
-    KeysFetchingLocally keysFetching;
-    Ticker ticker;
-    MemoryLimitedJobRunner memoryLimitedJobRunner;
-    ChecksumChecker checker;
-    boolean newSalt;
-    KeySalter salt;
-    boolean resumed;
-    boolean completeViaTruncation;
-
-    /**
-     * Fluent builder for {@link ResumeParams} used when reconstructing state from disk.
-     *
-     * <p>Callers provide the buffer to read from, runtime services (job/ticker), and flags
-     * indicating whether a new salt should be injected. The resulting {@link ResumeParams} is
-     * consumed by the resuming constructor.
-     */
-    public static class Builder {
-      private LockableRandomAccessBuffer raf;
-      private boolean realTime;
-      private SplitFileFetcherStorageCallback callback;
-      private FetchContext origContext;
-      private RandomSource random;
-      private PersistentJobRunner exec;
-      private KeysFetchingLocally keysFetching;
-      private Ticker ticker;
-      private MemoryLimitedJobRunner memoryLimitedJobRunner;
-      private ChecksumChecker checker;
-      private boolean newSalt;
-      private KeySalter salt;
-      private boolean resumed;
-      private boolean completeViaTruncation;
-
-      /**
-       * Set the random-access buffer to resume from.
-       *
-       * @param v buffer positioned at the previously persisted storage file.
-       * @return this builder for fluent chaining.
-       */
-      public Builder raf(LockableRandomAccessBuffer v) {
-        this.raf = v;
-        return this;
-      }
-
-      /**
-       * Configure whether resume should prefer real-time behaviour.
-       *
-       * @param v when {@code true}, optimises for latency over throughput.
-       * @return this builder for fluent chaining.
-       */
-      public Builder realTime(boolean v) {
-        this.realTime = v;
-        return this;
-      }
-
-      /**
-       * Set the callback used for notifications during the resumed session.
-       *
-       * @param v callback implementation; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder callback(SplitFileFetcherStorageCallback v) {
-        this.callback = v;
-        return this;
-      }
-
-      /**
-       * Provide the original fetch context to reapply scheduling policy.
-       *
-       * @param v fetch context used to derive retries and cooldown; non-null.
-       * @return this builder for fluent chaining.
-       */
-      public Builder context(FetchContext v) {
-        this.origContext = v;
-        return this;
-      }
-
-      /**
-       * Provide the randomness source used by resumed operations.
-       *
-       * @param v randomness provider; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder random(RandomSource v) {
-        this.random = v;
-        return this;
-      }
-
-      /**
-       * Set the job runner handling off-thread activity.
-       *
-       * @param v job runner for background tasks; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder exec(PersistentJobRunner v) {
-        this.exec = v;
-        return this;
-      }
-
-      /**
-       * Provide the helper used to mark keys as fetching locally.
-       *
-       * @param v optional accounting helper.
-       * @return this builder for fluent chaining.
-       */
-      public Builder keysFetching(KeysFetchingLocally v) {
-        this.keysFetching = v;
-        return this;
-      }
-
-      /**
-       * Set the ticker used for timed operations and coalescing.
-       *
-       * @param v ticker/scheduler implementation; non-null.
-       * @return this builder for fluent chaining.
-       */
-      public Builder ticker(Ticker v) {
-        this.ticker = v;
-        return this;
-      }
-
-      /**
-       * Provide the memory-limited job runner for heavy tasks.
-       *
-       * @param v job runner respecting memory caps; must not be {@code null}.
-       * @return this builder for fluent chaining.
-       */
-      public Builder memoryLimitedJobRunner(MemoryLimitedJobRunner v) {
-        this.memoryLimitedJobRunner = v;
-        return this;
-      }
-
-      /**
-       * Set the checksum implementation and length for persisted sections.
-       *
-       * @param v checker implementation; non-null.
-       * @return this builder for fluent chaining.
-       */
-      public Builder checker(ChecksumChecker v) {
-        this.checker = v;
-        return this;
-      }
-
-      /**
-       * Whether to inject a new salt when resuming, if supported.
-       *
-       * @param v set {@code true} to prefer re-salting.
-       * @return this builder for fluent chaining.
-       */
-      public Builder newSalt(boolean v) {
-        this.newSalt = v;
-        return this;
-      }
-
-      /**
-       * Provide the salter to use if {@link #newSalt(boolean)} is {@code true}.
-       *
-       * @param v salter implementation; may be {@code null} to disable.
-       * @return this builder for fluent chaining.
-       */
-      public Builder salt(KeySalter v) {
-        this.salt = v;
-        return this;
-      }
-
-      /**
-       * Mark that this session represents a true resume rather than a fresh start.
-       *
-       * @param v set {@code true} when resuming from persisted state.
-       * @return this builder for fluent chaining.
-       */
-      public Builder resumed(boolean v) {
-        this.resumed = v;
-        return this;
-      }
-
-      /**
-       * Enable completion via truncation when possible.
-       *
-       * @param v when {@code true}, prefer truncation optimisation at completion.
-       * @return this builder for fluent chaining.
-       */
-      public Builder completeViaTruncation(boolean v) {
-        this.completeViaTruncation = v;
-        return this;
-      }
-
-      /**
-       * Build a {@link ResumeParams} snapshot for resuming from disk.
-       *
-       * @return the constructed parameters object consumed by the resuming constructor.
-       */
-      public ResumeParams build() {
-        ResumeParams p = new ResumeParams();
-        p.raf = raf;
-        p.realTime = realTime;
-        p.callback = callback;
-        p.origContext = origContext;
-        p.random = random;
-        p.exec = exec;
-        p.keysFetching = keysFetching;
-        p.ticker = ticker;
-        p.memoryLimitedJobRunner = memoryLimitedJobRunner;
-        p.checker = checker;
-        p.newSalt = newSalt;
-        p.salt = salt;
-        p.resumed = resumed;
-        p.completeViaTruncation = completeViaTruncation;
-        return p;
-      }
-    }
   }
 
   /**
@@ -1098,15 +481,16 @@ public class SplitFileFetcherStorage {
    * section, and rebuilds segment state and Bloom filters. It also reattaches asynchronous helpers
    * and prepares any pending decode attempts when segment metadata indicates partial progress.
    *
-   * @param p environment and buffer required to resume; created via {@link ResumeParams.Builder}.
-   *     Must include a readable {@link LockableRandomAccessBuffer}.
+   * @param p environment and buffer required to resume; created via {@link
+   *     SplitFileFetcherStorageResumeParams.Builder}. Must include a readable {@link
+   *     LockableRandomAccessBuffer}.
    * @throws IOException if underlying storage cannot be accessed.
    * @throws StorageFormatException if the on-disk structure is corrupted or incompatible with the
    *     current format version.
    * @throws FetchException if the reconstructed state violates fetcher policy or cannot be
    *     reconciled with the provided runtime environment.
    */
-  public SplitFileFetcherStorage(ResumeParams p)
+  public SplitFileFetcherStorage(SplitFileFetcherStorageResumeParams p)
       throws IOException, StorageFormatException, FetchException {
     this.persistent = true;
     this.raf = p.raf;
@@ -1739,22 +1123,6 @@ public class SplitFileFetcherStorage {
     }
   }
 
-  private byte[] encodeGeneralProgress() {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try {
-      OutputStream ccos = checksumChecker.checksumWriterWithLength(baos, new ArrayBucketFactory());
-      DataOutputStream dos = new DataOutputStream(ccos);
-      long flags = 0;
-      if (hasCheckedDatastore) flags |= HAS_CHECKED_DATASTORE_FLAG;
-      dos.writeLong(flags);
-      errors.writeFixedLengthTo(dos);
-      dos.close();
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
-    return baos.toByteArray();
-  }
-
   /**
    * Start the storage layer.
    *
@@ -1926,21 +1294,6 @@ public class SplitFileFetcherStorage {
    * Write details needed to restart the download from scratch, and to identify whether it is useful
    * to do so.
    */
-  private byte[] encodeAndChecksumOriginalDetails(
-      FreenetURI thisKey, FreenetURI origKey, byte[] clientDetails, boolean isFinalFetch)
-      throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(baos);
-    dos.writeUTF(thisKey.toASCIIString());
-    dos.writeUTF(origKey.toASCIIString());
-    dos.writeBoolean(isFinalFetch);
-    dos.writeInt(clientDetails.length);
-    dos.write(clientDetails);
-    dos.writeInt(maxRetries);
-    dos.writeInt(cooldownTries);
-    dos.writeLong(cooldownLength);
-    return checksumChecker.appendChecksum(baos.toByteArray());
-  }
 
   /** Container for accumulated sizing information computed from segment keys and configuration. */
   private static final class AccumulatedSizes {
@@ -1962,20 +1315,6 @@ public class SplitFileFetcherStorage {
   }
 
   /** Bundles details needed to initialize persistent metadata sections. */
-  private static final class OriginalDetails {
-    final FreenetURI thisKey;
-    final FreenetURI origKey;
-    final byte[] clientDetails;
-    final boolean isFinalFetch;
-
-    OriginalDetails(
-        FreenetURI thisKey, FreenetURI origKey, byte[] clientDetails, boolean isFinalFetch) {
-      this.thisKey = thisKey;
-      this.origKey = origKey;
-      this.clientDetails = clientDetails;
-      this.isFinalFetch = isFinalFetch;
-    }
-  }
 
   /** Context needed to build segments and keys while computing offsets. */
   private static final class SegmentsBuildContext {
@@ -2026,74 +1365,9 @@ public class SplitFileFetcherStorage {
         splitfileDataBlocks, splitfileCheckBlocks, storedKeysLength, storedSegmentStatusLength);
   }
 
-  private static final class PersistentPreparation {
-    final Bucket metadataTemp;
-    final byte[] encodedURI;
-    final long totalLength;
-    final long offsetOriginalDetails;
-    final long offsetBasicSettings;
-
-    PersistentPreparation(
-        Bucket metadataTemp,
-        byte[] encodedURI,
-        long totalLength,
-        long offsetOriginalDetails,
-        long offsetBasicSettings) {
-      this.metadataTemp = metadataTemp;
-      this.encodedURI = encodedURI;
-      this.totalLength = totalLength;
-      this.offsetOriginalDetails = offsetOriginalDetails;
-      this.offsetBasicSettings = offsetBasicSettings;
-    }
-  }
-
-  private PersistentPreparation preparePersistent(
-      Metadata metadata, BucketFactory tempBucketFactory, OriginalDetails details)
-      throws FetchException, IOException {
-    Bucket metadataTemp = tempBucketFactory.makeBucket(-1);
-    try (OutputStream os = metadataTemp.getOutputStream();
-        OutputStream cos = checksumOutputStream(os);
-        BufferedOutputStream bos = new BufferedOutputStream(cos)) {
-      MultiHashOutputStream mos = new MultiHashOutputStream(bos, HashType.SHA256.bitmask);
-      metadata.writeTo(new DataOutputStream(mos));
-      mos.getResults()[0].writeTo(bos);
-    } catch (MetadataUnresolvedException e) {
-      throw new FetchException(
-          FetchExceptionMode.INTERNAL_ERROR,
-          "Metadata not resolved starting splitfile fetch?!: " + e,
-          e);
-    }
-    long metadataLength = metadataTemp.size();
-    long computedOffsetOriginalDetails = offsetOriginalMetadata + metadataLength;
-
-    byte[] encodedURI =
-        encodeAndChecksumOriginalDetails(
-            details.thisKey, details.origKey, details.clientDetails, details.isFinalFetch);
-    long computedOffsetBasicSettings = computedOffsetOriginalDetails + encodedURI.length;
-
-    //noinspection PointlessArithmeticExpression
-    long totalLength =
-        computedOffsetBasicSettings /* offset of basic settings */
-            + 0 /* encodedBasicSettings length (computed after assigning offsets) */
-            + 4 /* basic settings length */
-            + checksumLength /* footer checksum */
-            + 4 /* version */
-            + 4 /* flags */
-            + 2 /* checksum type */
-            + 8 /* magic */;
-
-    return new PersistentPreparation(
-        metadataTemp,
-        encodedURI,
-        totalLength,
-        computedOffsetOriginalDetails,
-        computedOffsetBasicSettings);
-  }
-
   private void writeToRAF(
       SplitFileSegmentKeys[] segmentKeys,
-      Bucket metadataTemp,
-      byte[] encodedURI,
+      SplitFileFetcherStoragePersistence.PreparedMetadata prepared,
       byte[] encodedBasicSettings,
       long totalLength,
       byte[] generalProgress)
@@ -2108,41 +1382,13 @@ public class SplitFileFetcherStorage {
         raf.pwrite(offsetGeneralProgress, generalProgress, 0, generalProgress.length);
         keyListener.innerWriteMainBloomFilter(offsetMainBloomFilter);
         keyListener.initialWriteSegmentBloomFilters(offsetSegmentBloomFilters);
-        BucketTools.copyTo(metadataTemp, raf, offsetOriginalMetadata, -1);
-        metadataTemp.free();
-        raf.pwrite(offsetOriginalDetails, encodedURI, 0, encodedURI.length);
-        raf.pwrite(offsetBasicSettings, encodedBasicSettings, 0, encodedBasicSettings.length);
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DataOutputStream dos = new DataOutputStream(baos);
-        dos.writeInt(encodedBasicSettings.length - checksumLength);
-        byte[] bufToWrite = baos.toByteArray();
-        baos = new ByteArrayOutputStream();
-        dos = new DataOutputStream(baos);
-        dos.writeInt(0);
-        dos.writeShort(checksumChecker.getChecksumTypeID());
-        dos.writeInt(VERSION);
-        byte[] version = baos.toByteArray();
-        byte[] bufToChecksum = Arrays.copyOf(bufToWrite, bufToWrite.length + version.length);
-        System.arraycopy(version, 0, bufToChecksum, bufToWrite.length, version.length);
-        byte[] checksum = checksumChecker.generateChecksum(bufToChecksum);
-        raf.pwrite(
-            offsetBasicSettings + encodedBasicSettings.length, bufToWrite, 0, bufToWrite.length);
-        raf.pwrite(
-            offsetBasicSettings + encodedBasicSettings.length + bufToWrite.length,
-            checksum,
-            0,
-            checksum.length);
-        raf.pwrite(
-            offsetBasicSettings + encodedBasicSettings.length + bufToWrite.length + checksum.length,
-            version,
-            0,
-            version.length);
-        baos = new ByteArrayOutputStream();
-        dos = new DataOutputStream(baos);
-        dos.writeLong(END_MAGIC);
-        byte[] buf = baos.toByteArray();
-        raf.pwrite(totalLength - 8, buf, 0, 8);
+        SplitFileFetcherStoragePersistence.writePersistentMetadata(
+            raf,
+            offsetOriginalMetadata,
+            prepared,
+            encodedBasicSettings,
+            checksumChecker,
+            totalLength);
       }
     }
   }
@@ -2332,85 +1578,8 @@ public class SplitFileFetcherStorage {
 
     keyListener.finishedSetup();
 
-    return createCrossSegments(ctx.metadata, ctx.crossCheckBlocks, ctx.blocksPerSegment);
-  }
-
-  private SplitFileFetcherCrossSegmentStorage[] createCrossSegments(
-      Metadata metadata, int crossCheckBlocks, int blocksPerSegment) {
-    SplitFileFetcherCrossSegmentStorage[] xSegments;
-    if (crossCheckBlocks == 0) return new SplitFileFetcherCrossSegmentStorage[0];
-    Random crossSegmentRandom =
-        MersenneTwister.createUnsynchronized(
-            Metadata.getCrossSegmentSeed(metadata.getHashes(), metadata.getHashThisLayerOnly()));
-    xSegments = new SplitFileFetcherCrossSegmentStorage[segments.length];
-    int segLen = blocksPerSegment;
-    int deductBlocksFromSegments = metadata.getDeductBlocksFromSegments();
-    for (int i = 0; i < xSegments.length; i++) {
-      LOG.info("Allocating blocks (on fetch) for cross segment {}", i);
-      if (segments.length - i == deductBlocksFromSegments) {
-        segLen--;
-      }
-      SplitFileFetcherCrossSegmentStorage seg =
-          new SplitFileFetcherCrossSegmentStorage(i, segLen, crossCheckBlocks, this, fecCodec);
-      xSegments[i] = seg;
-      for (int j = 0; j < segLen; j++) {
-        allocateCrossDataBlock(seg, crossSegmentRandom);
-      }
-      for (int j = 0; j < crossCheckBlocks; j++) {
-        allocateCrossCheckBlock(seg, crossSegmentRandom);
-      }
-    }
-    return xSegments;
-  }
-
-  /** Reserved for future use. */
-  private void allocateCrossDataBlock(SplitFileFetcherCrossSegmentStorage segment, Random random) {
-    int x = 0;
-    for (int i = 0; i < 10; i++) {
-      x = random.nextInt(segments.length);
-      SplitFileFetcherSegmentStorage seg = segments[x];
-      int blockNum = seg.allocateCrossDataBlock(segment, random);
-      if (blockNum >= 0) {
-        segment.addDataBlock(seg, blockNum);
-        return;
-      }
-    }
-    for (int i = 0; i < segments.length; i++) {
-      x++;
-      if (x == segments.length) x = 0;
-      SplitFileFetcherSegmentStorage seg = segments[x];
-      int blockNum = seg.allocateCrossDataBlock(segment, random);
-      if (blockNum >= 0) {
-        segment.addDataBlock(seg, blockNum);
-        return;
-      }
-    }
-    throw new IllegalStateException("Unable to allocate cross data block!");
-  }
-
-  /** Reserved for future use. */
-  private void allocateCrossCheckBlock(SplitFileFetcherCrossSegmentStorage segment, Random random) {
-    int x = 0;
-    for (int i = 0; i < 10; i++) {
-      x = random.nextInt(segments.length);
-      SplitFileFetcherSegmentStorage seg = segments[x];
-      int blockNum = seg.allocateCrossCheckBlock(segment, random);
-      if (blockNum >= 0) {
-        segment.addDataBlock(seg, blockNum);
-        return;
-      }
-    }
-    for (int i = 0; i < segments.length; i++) {
-      x++;
-      if (x == segments.length) x = 0;
-      SplitFileFetcherSegmentStorage seg = segments[x];
-      int blockNum = seg.allocateCrossCheckBlock(segment, random);
-      if (blockNum >= 0) {
-        segment.addDataBlock(seg, blockNum);
-        return;
-      }
-    }
-    throw new IllegalStateException("Unable to allocate cross data block!");
+    return SplitFileFetcherCrossSegmentAllocator.createCrossSegments(
+        this, ctx.metadata, ctx.crossCheckBlocks, ctx.blocksPerSegment, segments, fecCodec);
   }
 
   /**
@@ -2527,7 +1696,9 @@ public class SplitFileFetcherStorage {
       if (!dirtyGeneralProgress) return;
       dirtyGeneralProgress = false;
     }
-    byte[] generalProgress = encodeGeneralProgress();
+    byte[] generalProgress =
+        SplitFileFetcherStoragePersistence.encodeGeneralProgress(
+            checksumChecker, hasCheckedDatastore, errors);
     try {
       raf.pwrite(offsetGeneralProgress, generalProgress, 0, generalProgress.length);
     } catch (IOException e) {

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
@@ -1179,7 +1179,7 @@ public class SplitFileFetcherStorage {
   private boolean regenerateKeysAsync() {
     try {
       this.jobRunner.queue(
-          context -> {
+          _ -> {
             regenerateKeysJob();
             return false;
           },
@@ -1290,11 +1290,6 @@ public class SplitFileFetcherStorage {
     return baos.toByteArray();
   }
 
-  /**
-   * Write details needed to restart the download from scratch, and to identify whether it is useful
-   * to do so.
-   */
-
   /** Container for accumulated sizing information computed from segment keys and configuration. */
   private static final class AccumulatedSizes {
     final int splitfileDataBlocks;
@@ -1313,8 +1308,6 @@ public class SplitFileFetcherStorage {
       this.storedSegmentStatusLength = storedSegmentStatusLength;
     }
   }
-
-  /** Bundles details needed to initialize persistent metadata sections. */
 
   /** Context needed to build segments and keys while computing offsets. */
   private static final class SegmentsBuildContext {
@@ -1623,7 +1616,7 @@ public class SplitFileFetcherStorage {
 
   private void callSuccessOffThread() {
     jobRunner.queueNormalOrDrop(
-        context -> {
+        _ -> {
           synchronized (SplitFileFetcherStorage.this) {
             // Race conditions are possible, make sure we only call it once.
             if (succeeded) return false;
@@ -1708,7 +1701,7 @@ public class SplitFileFetcherStorage {
 
   private void initAsyncHelpers() {
     this.writeMetadataJob =
-        context -> {
+        _ -> {
           try {
             if (isFinishing()) return false;
             RAFLock lock = raf.lockOpen();
@@ -1778,7 +1771,7 @@ public class SplitFileFetcherStorage {
   /** Called on a normal non-truncation completion. Frees the storage file off-thread. */
   private void closeOffThread() {
     jobRunner.queueNormalOrDrop(
-        context -> {
+        _ -> {
           // ATOMICITY/DURABILITY: This will run after the checkpoint after completion.
           // So after restart, even if the checkpoint failed, we will be in a valid state.
           // This is why this is queue() not queueInternal().
@@ -1898,7 +1891,7 @@ public class SplitFileFetcherStorage {
   public void fail(final FetchException e) {
     if (LOG.isDebugEnabled()) LOG.debug("Failing {} with error {} and codes {}", this, e, errors);
     jobRunner.queueNormalOrDrop(
-        context -> {
+        _ -> {
           fetcher.fail(e);
           return true;
         });
@@ -1933,7 +1926,7 @@ public class SplitFileFetcherStorage {
   public void failOnDiskError(final IOException e) {
     LOG.error("Failing on disk error: {}", e, e);
     jobRunner.queueNormalOrDrop(
-        context -> {
+        _ -> {
           fetcher.failOnDiskError(e);
           return true;
         });
@@ -1950,7 +1943,7 @@ public class SplitFileFetcherStorage {
   public void failOnDiskError(final ChecksumFailedException e) {
     LOG.error("Failing on unrecoverable corrupt data: {}", e, e);
     jobRunner.queueNormalOrDrop(
-        context -> {
+        _ -> {
           fetcher.failOnDiskError(e);
           return true;
         });
@@ -2218,7 +2211,7 @@ public class SplitFileFetcherStorage {
    */
   public void failedBlock() {
     jobRunner.queueNormalOrDrop(
-        context -> {
+        _ -> {
           fetcher.onFailedBlock();
           return false;
         });
@@ -2243,7 +2236,7 @@ public class SplitFileFetcherStorage {
    */
   public void restartedAfterDataCorruption() {
     jobRunner.queueNormalOrDrop(
-        context -> {
+        _ -> {
           maybeClearCooldown();
           fetcher.restartedAfterDataCorruption();
           return false;
@@ -2260,7 +2253,7 @@ public class SplitFileFetcherStorage {
   void increaseCooldown(final long cooldownTime) {
     // Risky locking-wise, so run as a separate job.
     jobRunner.queueNormalOrDrop(
-        context -> {
+        _ -> {
           long now = System.currentTimeMillis();
           long wakeupTime;
           synchronized (cooldownLock) {

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
@@ -3,15 +3,10 @@ package network.crypta.client.async;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FECCodec;
 import network.crypta.client.FailureCodeTracker;
@@ -36,11 +31,9 @@ import network.crypta.support.RandomArrayIterator;
 import network.crypta.support.Ticker;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import network.crypta.support.api.LockableRandomAccessBuffer.RAFLock;
-import network.crypta.support.api.LockableRandomAccessBufferFactory;
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
-import network.crypta.support.io.FileRandomAccessBufferFactory;
-import network.crypta.support.io.NativeThread;
 import network.crypta.support.io.StorageFormatException;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -286,7 +279,8 @@ public class SplitFileFetcherStorage {
    * @throws MetadataParseException if the supplied {@link Metadata} cannot be interpreted into a
    *     valid splitfile layout (e.g., inconsistent block counts or unsupported algorithm).
    * @throws IOException if initial on-disk structures cannot be written or verified using the
-   *     configured {@link LockableRandomAccessBufferFactory} and temporary bucket factory.
+   *     configured {@link network.crypta.support.api.LockableRandomAccessBufferFactory} and
+   *     temporary bucket factory.
    */
   public SplitFileFetcherStorage(SplitFileFetcherStorageInitParams p)
       throws FetchException, MetadataParseException, IOException {
@@ -468,7 +462,9 @@ public class SplitFileFetcherStorage {
 
     // Create the actual LockableRandomAccessBuffer
     rafLength = totalLength;
-    raf = createRAFOrThrow(p.storageFile, totalLength, p.rafFactory, p.diskSpaceCheckingRAFFactory);
+    raf =
+        SplitFileFetcherStorageRafFactory.createRafOrThrow(
+            p.storageFile, totalLength, p.rafFactory, p.diskSpaceCheckingRAFFactory, random, LOG);
     writeToRAF(segmentKeys, prepared, encodedBasicSettings, totalLength, generalProgress);
     if (LOG.isDebugEnabled()) LOG.debug("Fetching {} on {} for {}", p.thisKey, this, fetcher);
     initAsyncHelpers();
@@ -524,36 +520,37 @@ public class SplitFileFetcherStorage {
     byte[] basicSettingsBuffer = readChecksummed(basicInfo.offset, basicInfo.length);
 
     ParsedBasicSettings parsed =
-        parseBasicSettings(basicSettingsBuffer, basicInfo.offset, p.completeViaTruncation);
+        SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+            basicSettingsBuffer, basicInfo.offset, p.completeViaTruncation, rafLength);
 
     // Assign parsed values to final fields
-    this.splitfileType = parsed.splitfileType;
+    this.splitfileType = parsed.getSplitfileType();
     this.fecCodec = FECCodec.getInstance(splitfileType);
-    this.splitfileSingleCryptoAlgorithm = parsed.splitfileSingleCryptoAlgorithm;
-    this.splitfileSingleCryptoKey = parsed.splitfileSingleCryptoKey;
-    this.finalLength = parsed.finalLength;
-    this.decompressedLength = parsed.decompressedLength;
-    this.clientMetadata = parsed.clientMetadata;
-    this.decompressors = parsed.decompressors;
-    this.offsetKeyList = parsed.offsetKeyList;
-    this.offsetSegmentStatus = parsed.offsetSegmentStatus;
-    this.offsetGeneralProgress = parsed.offsetGeneralProgress;
-    this.offsetMainBloomFilter = parsed.offsetMainBloomFilter;
-    this.offsetSegmentBloomFilters = parsed.offsetSegmentBloomFilters;
-    this.offsetOriginalMetadata = parsed.offsetOriginalMetadata;
-    this.offsetOriginalDetails = parsed.offsetOriginalDetails;
-    this.offsetBasicSettings = parsed.offsetBasicSettings;
-    this.finalMinCompatMode = parsed.finalMinCompatMode;
+    this.splitfileSingleCryptoAlgorithm = parsed.getSplitfileSingleCryptoAlgorithm();
+    this.splitfileSingleCryptoKey = parsed.getSplitfileSingleCryptoKey();
+    this.finalLength = parsed.getFinalLength();
+    this.decompressedLength = parsed.getDecompressedLength();
+    this.clientMetadata = parsed.getClientMetadata();
+    this.decompressors = parsed.getDecompressors();
+    this.offsetKeyList = parsed.getOffsetKeyList();
+    this.offsetSegmentStatus = parsed.getOffsetSegmentStatus();
+    this.offsetGeneralProgress = parsed.getOffsetGeneralProgress();
+    this.offsetMainBloomFilter = parsed.getOffsetMainBloomFilter();
+    this.offsetSegmentBloomFilters = parsed.getOffsetSegmentBloomFilters();
+    this.offsetOriginalMetadata = parsed.getOffsetOriginalMetadata();
+    this.offsetOriginalDetails = parsed.getOffsetOriginalDetails();
+    this.offsetBasicSettings = parsed.getOffsetBasicSettings();
+    this.finalMinCompatMode = parsed.getFinalMinCompatMode();
 
     // Allocate and assign segments array before constructing individual segments.
-    this.segments = new SplitFileFetcherSegmentStorage[parsed.segmentCount];
+    this.segments = new SplitFileFetcherSegmentStorage[parsed.getSegmentCount()];
     this.randomSegmentIterator = new RandomArrayIterator<>(segments);
     SegmentsInit segmentsInit =
         initSegmentsFromStream(
-            parsed.totalDataBlocks,
-            parsed.totalCheckBlocks,
-            parsed.totalCrossCheckBlocks,
-            parsed.settingsStream,
+            parsed.getTotalDataBlocks(),
+            parsed.getTotalCheckBlocks(),
+            parsed.getTotalCrossCheckBlocks(),
+            parsed.getSettingsStream(),
             p.completeViaTruncation,
             p.keysFetching,
             this.segments);
@@ -646,215 +643,6 @@ public class SplitFileFetcherStorage {
       throw new StorageFormatException("Basic settings checksum invalid");
     }
     return basicSettingsBuffer;
-  }
-
-  private ParsedBasicSettings parseBasicSettings(
-      byte[] basicSettingsBuffer, long basicSettingsOffset, boolean completeViaTruncation)
-      throws StorageFormatException {
-    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(basicSettingsBuffer));
-    try {
-      SplitfileAlgorithm splitfileAlgorithm = readSplitfileAlgorithm(dis);
-      CryptoInfo crypto = readCryptoInfo(dis, splitfileAlgorithm);
-      LengthsInfo lengths = readLengths(dis);
-      HeaderInfo header = new HeaderInfo(splitfileAlgorithm, crypto, lengths);
-      ClientMetadata cm = readClientMetadataSafe(dis);
-      List<COMPRESSOR_TYPE> decomps = readDecompressors(dis);
-      OffsetsInfo offsets = readOffsets(dis, basicSettingsOffset, completeViaTruncation);
-      CompatAndCounts compat = readCompatAndCounts(dis);
-      return new ParsedBasicSettings(header, cm, decomps, offsets, compat, dis);
-    } catch (IOException e) {
-      throw new StorageFormatException(
-          "Cannot read basic settings even though passed checksum: " + e, e);
-    }
-  }
-
-  private SplitfileAlgorithm readSplitfileAlgorithm(DataInputStream dis)
-      throws IOException, StorageFormatException {
-    short s = dis.readShort();
-    try {
-      return SplitfileAlgorithm.getByCode(s);
-    } catch (IllegalArgumentException _) {
-      throw new StorageFormatException("Invalid splitfile type " + s);
-    }
-  }
-
-  private static class CryptoInfo {
-    final byte algorithm;
-    final byte[] key;
-
-    CryptoInfo(byte algorithm, byte[] key) {
-      this.algorithm = algorithm;
-      this.key = key;
-    }
-  }
-
-  private CryptoInfo readCryptoInfo(DataInputStream dis, SplitfileAlgorithm splitfileAlgorithm)
-      throws IOException, StorageFormatException {
-    byte alg = dis.readByte();
-    if (!Metadata.isValidSplitfileCryptoAlgorithm(alg))
-      throw new StorageFormatException("Invalid splitfile crypto algorithm " + splitfileAlgorithm);
-    byte[] key = null;
-    if (dis.readBoolean()) {
-      key = new byte[32];
-      dis.readFully(key);
-    }
-    return new CryptoInfo(alg, key);
-  }
-
-  private static class LengthsInfo {
-    final long finalLength;
-    final long decompressedLength;
-
-    LengthsInfo(long finalLength, long decompressedLength) {
-      this.finalLength = finalLength;
-      this.decompressedLength = decompressedLength;
-    }
-  }
-
-  private static class HeaderInfo {
-    final SplitfileAlgorithm splitfileType;
-    final CryptoInfo crypto;
-    final LengthsInfo lengths;
-
-    HeaderInfo(SplitfileAlgorithm splitfileType, CryptoInfo crypto, LengthsInfo lengths) {
-      this.splitfileType = splitfileType;
-      this.crypto = crypto;
-      this.lengths = lengths;
-    }
-  }
-
-  private LengthsInfo readLengths(DataInputStream dis) throws IOException, StorageFormatException {
-    long finalLen = dis.readLong();
-    if (finalLen < 0) throw new StorageFormatException("Invalid final length " + finalLen);
-    long decompLen = dis.readLong();
-    if (decompLen < 0) throw new StorageFormatException("Invalid decompressed length " + decompLen);
-    return new LengthsInfo(finalLen, decompLen);
-  }
-
-  private ClientMetadata readClientMetadataSafe(DataInputStream dis)
-      throws IOException, StorageFormatException {
-    try {
-      return ClientMetadata.construct(dis);
-    } catch (MetadataParseException _) {
-      throw new StorageFormatException("Invalid MIME type");
-    }
-  }
-
-  private List<COMPRESSOR_TYPE> readDecompressors(DataInputStream dis)
-      throws IOException, StorageFormatException {
-    int decompressorCount = dis.readInt();
-    if (decompressorCount < 0)
-      throw new StorageFormatException("Invalid decompressor count " + decompressorCount);
-    List<COMPRESSOR_TYPE> decomps = new ArrayList<>(decompressorCount);
-    for (int i = 0; i < decompressorCount; i++) {
-      short type = dis.readShort();
-      COMPRESSOR_TYPE d = COMPRESSOR_TYPE.getCompressorByMetadataID(type);
-      if (d == null) throw new StorageFormatException("Invalid decompressor ID " + type);
-      decomps.add(d);
-    }
-    return decomps;
-  }
-
-  private static class OffsetsInfo {
-    final long offsetKeyList;
-    final long offsetSegmentStatus;
-    final long offsetGeneralProgress;
-    final long offsetMainBloomFilter;
-    final long offsetSegmentBloomFilters;
-    final long offsetOriginalMetadata;
-    final long offsetOriginalDetails;
-    final long offsetBasicSettings;
-
-    OffsetsInfo(long... offsets) {
-      this.offsetKeyList = offsets[0];
-      this.offsetSegmentStatus = offsets[1];
-      this.offsetGeneralProgress = offsets[2];
-      this.offsetMainBloomFilter = offsets[3];
-      this.offsetSegmentBloomFilters = offsets[4];
-      this.offsetOriginalMetadata = offsets[5];
-      this.offsetOriginalDetails = offsets[6];
-      this.offsetBasicSettings = offsets[7];
-    }
-  }
-
-  private OffsetsInfo readOffsets(
-      DataInputStream dis, long basicSettingsOffset, boolean completeViaTruncation)
-      throws IOException, StorageFormatException {
-    long keyListOff = readValidatedOffset(dis, "key list");
-    long segmentStatusOff = readValidatedOffset(dis, "segment status");
-    long generalProgressOff = readValidatedOffset(dis, "general progress");
-    long mainBloomOff = readValidatedOffset(dis, "main bloom filter");
-    long segmentBloomOff = readValidatedOffset(dis, "segment bloom filters");
-    long origMetaOff = readValidatedOffset(dis, "original metadata");
-    long origDetailsOff = readValidatedOffset(dis, "original metadata");
-    long basicSettingsOff = dis.readLong();
-    if (basicSettingsOff != basicSettingsOffset)
-      throw new StorageFormatException("Invalid basic settings offset (not the same as computed)");
-    if (completeViaTruncation != dis.readBoolean())
-      throw new StorageFormatException("Complete via truncation flag is wrong");
-    return new OffsetsInfo(
-        keyListOff,
-        segmentStatusOff,
-        generalProgressOff,
-        mainBloomOff,
-        segmentBloomOff,
-        origMetaOff,
-        origDetailsOff,
-        basicSettingsOff);
-  }
-
-  private long readValidatedOffset(DataInputStream dis, String what)
-      throws IOException, StorageFormatException {
-    long value = dis.readLong();
-    if (value < 0 || value > rafLength)
-      throw new StorageFormatException("Invalid offset (" + what + ")");
-    return value;
-  }
-
-  private static class CompatAndCounts {
-    final CompatibilityMode mode;
-    final int segmentCount;
-    final int totalDataBlocks;
-    final int totalCheckBlocks;
-    final int totalCrossCheckBlocks;
-
-    CompatAndCounts(
-        CompatibilityMode mode,
-        int segmentCount,
-        int totalDataBlocks,
-        int totalCheckBlocks,
-        int totalCrossCheckBlocks) {
-      this.mode = mode;
-      this.segmentCount = segmentCount;
-      this.totalDataBlocks = totalDataBlocks;
-      this.totalCheckBlocks = totalCheckBlocks;
-      this.totalCrossCheckBlocks = totalCrossCheckBlocks;
-    }
-  }
-
-  private CompatAndCounts readCompatAndCounts(DataInputStream dis)
-      throws IOException, StorageFormatException {
-    int compatMode = dis.readInt();
-    if (compatMode < 0 || compatMode > CompatibilityMode.values().length)
-      throw new StorageFormatException("Invalid compatibility mode " + compatMode);
-    CompatibilityMode finalMode = CompatibilityMode.values()[compatMode];
-    int segmentCount = dis.readInt();
-    if (segmentCount <= 0)
-      throw new StorageFormatException("Invalid segment count " + segmentCount);
-    int totalDataBlocks = dis.readInt();
-    if (totalDataBlocks < 0)
-      throw new StorageFormatException("Invalid total data blocks " + totalDataBlocks);
-    int totalCheckBlocks = dis.readInt();
-    if (totalCheckBlocks < 0)
-      throw new StorageFormatException("Invalid total check blocks " + totalDataBlocks);
-    int totalCrossCheckBlocks = dis.readInt();
-    if (totalCrossCheckBlocks < 0)
-      throw new StorageFormatException("Invalid total cross-check blocks " + totalDataBlocks);
-    if (totalDataBlocks + totalCheckBlocks + totalCrossCheckBlocks <= 0) {
-      throw new StorageFormatException("Total number of blocks in splitfile is non-positive");
-    }
-    return new CompatAndCounts(
-        finalMode, segmentCount, totalDataBlocks, totalCheckBlocks, totalCrossCheckBlocks);
   }
 
   private SegmentsInit initSegmentsFromStream(
@@ -1037,60 +825,6 @@ public class SplitFileFetcherStorage {
     }
   }
 
-  private static class ParsedBasicSettings {
-    final SplitfileAlgorithm splitfileType;
-    final byte splitfileSingleCryptoAlgorithm;
-    final byte[] splitfileSingleCryptoKey;
-    final long finalLength;
-    final long decompressedLength;
-    final ClientMetadata clientMetadata;
-    final List<COMPRESSOR_TYPE> decompressors;
-    final long offsetKeyList;
-    final long offsetSegmentStatus;
-    final long offsetGeneralProgress;
-    final long offsetMainBloomFilter;
-    final long offsetSegmentBloomFilters;
-    final long offsetOriginalMetadata;
-    final long offsetOriginalDetails;
-    final long offsetBasicSettings;
-    final CompatibilityMode finalMinCompatMode;
-    final int segmentCount;
-    final int totalDataBlocks;
-    final int totalCheckBlocks;
-    final int totalCrossCheckBlocks;
-    final DataInputStream settingsStream;
-
-    ParsedBasicSettings(
-        HeaderInfo header,
-        ClientMetadata clientMetadata,
-        List<COMPRESSOR_TYPE> decompressors,
-        OffsetsInfo offsets,
-        CompatAndCounts compat,
-        DataInputStream settingsStream) {
-      this.splitfileType = header.splitfileType;
-      this.splitfileSingleCryptoAlgorithm = header.crypto.algorithm;
-      this.splitfileSingleCryptoKey = header.crypto.key;
-      this.finalLength = header.lengths.finalLength;
-      this.decompressedLength = header.lengths.decompressedLength;
-      this.clientMetadata = clientMetadata;
-      this.decompressors = decompressors;
-      this.offsetKeyList = offsets.offsetKeyList;
-      this.offsetSegmentStatus = offsets.offsetSegmentStatus;
-      this.offsetGeneralProgress = offsets.offsetGeneralProgress;
-      this.offsetMainBloomFilter = offsets.offsetMainBloomFilter;
-      this.offsetSegmentBloomFilters = offsets.offsetSegmentBloomFilters;
-      this.offsetOriginalMetadata = offsets.offsetOriginalMetadata;
-      this.offsetOriginalDetails = offsets.offsetOriginalDetails;
-      this.offsetBasicSettings = offsets.offsetBasicSettings;
-      this.finalMinCompatMode = compat.mode;
-      this.segmentCount = compat.segmentCount;
-      this.totalDataBlocks = compat.totalDataBlocks;
-      this.totalCheckBlocks = compat.totalCheckBlocks;
-      this.totalCrossCheckBlocks = compat.totalCrossCheckBlocks;
-      this.settingsStream = settingsStream;
-    }
-  }
-
   private static class SegmentsInit {
     final SplitFileFetcherSegmentStorage[] segments;
     final SplitFileFetcherCrossSegmentStorage[] crossSegments;
@@ -1183,7 +917,7 @@ public class SplitFileFetcherStorage {
             regenerateKeysJob();
             return false;
           },
-          NativeThread.PriorityLevel.LOW_PRIORITY.value + 1);
+          REGENERATE_KEYS_PRIORITY);
     } catch (PersistenceDisabledException _) {
       // Ignore.
     }
@@ -1236,58 +970,8 @@ public class SplitFileFetcherStorage {
 
   private byte[] encodeBasicSettings(
       int totalDataBlocks, int totalCheckBlocks, int totalCrossCheckBlocks) {
-    return appendChecksum(
-        innerEncodeBasicSettings(totalDataBlocks, totalCheckBlocks, totalCrossCheckBlocks));
-  }
-
-  /** Encode the basic settings (number of blocks etc.) to a byte array */
-  private byte[] innerEncodeBasicSettings(
-      int totalDataBlocks, int totalCheckBlocks, int totalCrossCheckBlocks) {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(baos);
-    try {
-      dos.writeShort(splitfileType.code);
-      dos.writeByte(this.splitfileSingleCryptoAlgorithm);
-      dos.writeBoolean(this.splitfileSingleCryptoKey != null);
-      if (this.splitfileSingleCryptoKey != null) {
-        assert (splitfileSingleCryptoKey.length == 32);
-        dos.write(splitfileSingleCryptoKey);
-      }
-      dos.writeLong(this.finalLength);
-      dos.writeLong(this.decompressedLength);
-      clientMetadata.writeTo(dos);
-      // Record number of decompressors; any size constraints are enforced upstream.
-      dos.writeInt(decompressors.size());
-      for (COMPRESSOR_TYPE c : decompressors) dos.writeShort(c.metadataID);
-      dos.writeLong(offsetKeyList);
-      dos.writeLong(offsetSegmentStatus);
-      dos.writeLong(offsetGeneralProgress);
-      dos.writeLong(offsetMainBloomFilter);
-      dos.writeLong(offsetSegmentBloomFilters);
-      dos.writeLong(offsetOriginalMetadata);
-      dos.writeLong(offsetOriginalDetails);
-      dos.writeLong(offsetBasicSettings);
-      dos.writeBoolean(completeViaTruncation);
-      dos.writeInt(finalMinCompatMode.ordinal());
-      dos.writeInt(segments.length);
-      dos.writeInt(totalDataBlocks);
-      dos.writeInt(totalCheckBlocks);
-      dos.writeInt(totalCrossCheckBlocks);
-      for (SplitFileFetcherSegmentStorage segment : segments) {
-        segment.writeFixedMetadata(dos);
-      }
-      if (this.crossSegments == null) dos.writeInt(0);
-      else {
-        dos.writeInt(crossSegments.length);
-        for (SplitFileFetcherCrossSegmentStorage segment : crossSegments) {
-          segment.writeFixedMetadata(dos);
-        }
-      }
-      keyListener.writeStaticSettings(dos);
-    } catch (IOException e) {
-      throw new IllegalStateException(e); // Unexpected for in-memory buffer
-    }
-    return baos.toByteArray();
+    return SplitFileFetcherStorageSettingsCodec.encodeBasicSettings(
+        this, totalDataBlocks, totalCheckBlocks, totalCrossCheckBlocks);
   }
 
   /** Container for accumulated sizing information computed from segment keys and configuration. */
@@ -1365,7 +1049,7 @@ public class SplitFileFetcherStorage {
       long totalLength,
       byte[] generalProgress)
       throws IOException {
-    try (AutoCloseableRafLock ignored = autoLockOpen()) {
+    try (var _ = autoLockOpen()) {
       for (int i = 0; i < segments.length; i++) {
         SplitFileFetcherSegmentStorage segment = segments[i];
         segment.writeKeysWithChecksum(segmentKeys[i]);
@@ -1409,22 +1093,6 @@ public class SplitFileFetcherStorage {
       throw new FetchException(
           FetchExceptionMode.INVALID_METADATA,
           "Splitfile is " + checkLength + " bytes long but length is " + finalLength + " bytes");
-  }
-
-  private LockableRandomAccessBuffer createRAFOrThrow(
-      File storageFile,
-      long totalLength,
-      LockableRandomAccessBufferFactory rafFactory,
-      FileRandomAccessBufferFactory diskSpaceCheckingRAFFactory)
-      throws IOException {
-    if (storageFile != null) {
-      if (!storageFile.exists()) throw new IOException("Must have already created storage file");
-      if (storageFile.length() > 0) throw new IOException("Storage file must be empty");
-      LOG.info("Creating splitfile storage file for complete-via-truncation: {}", storageFile);
-      return diskSpaceCheckingRAFFactory.createNewRAF(storageFile, totalLength, random);
-    } else {
-      return rafFactory.makeRAF(totalLength);
-    }
   }
 
   private static void validateSegmentCount(int segmentCount) {
@@ -1657,7 +1325,7 @@ public class SplitFileFetcherStorage {
 
       @Override
       public void writeTo(OutputStream os, ClientContext context) throws IOException {
-        try (AutoCloseableRafLock ignored = autoLockOpen()) {
+        try (var _ = autoLockOpen()) {
           writeAllSegmentsToStream(os);
         }
       }
@@ -1680,7 +1348,9 @@ public class SplitFileFetcherStorage {
     }
   }
 
-  static final long LAZY_WRITE_METADATA_DELAY = TimeUnit.MINUTES.toMillis(5);
+  // Matches NativeThread.PriorityLevel.LOW_PRIORITY.value + 1.
+  private static final int REGENERATE_KEYS_PRIORITY = 4;
+  static final long LAZY_WRITE_METADATA_DELAY = 5L * 60 * 1000;
 
   private PersistentJob writeMetadataJob;
 
@@ -1735,7 +1405,7 @@ public class SplitFileFetcherStorage {
    */
   public void lazyWriteMetadata() {
     if (!persistent) return;
-    if (LAZY_WRITE_METADATA_DELAY != 0) {
+    if (LAZY_WRITE_METADATA_DELAY > 0 && !isFinishing()) {
       // The Runnable must be the same object for de-duplication.
       ticker.queueTimedJob(
           wrapLazyWriteMetadata,
@@ -2311,20 +1981,17 @@ public class SplitFileFetcherStorage {
 
   // Operations with checksums and storage access.
 
-  /** Append a CRC32 to a (short) byte[] */
-  private byte[] appendChecksum(byte[] data) {
-    return checksumChecker.appendChecksum(data);
-  }
-
   void preadChecksummed(long fileOffset, byte[] buf, int offset, int length)
       throws IOException, ChecksumFailedException {
     byte[] checksumBuf = new byte[checksumLength];
-    try (AutoCloseableRafLock ignored = autoLockOpen()) {
+    try (var _ = autoLockOpen()) {
       raf.pread(fileOffset, buf, offset, length);
       raf.pread(fileOffset + length, checksumBuf, 0, checksumLength);
     }
     if (!checksumChecker.checkChecksum(buf, offset, length, checksumBuf)) {
-      Arrays.fill(buf, offset, offset + length, (byte) 0);
+      for (int i = offset; i < offset + length; i++) {
+        buf[i] = 0;
+      }
       throw new ChecksumFailedException();
     }
   }
@@ -2335,7 +2002,7 @@ public class SplitFileFetcherStorage {
     byte[] lengthBuf = new byte[8];
     byte[] buf;
     int length;
-    try (AutoCloseableRafLock ignored = autoLockOpen()) {
+    try (var _ = autoLockOpen()) {
       raf.pread(fileOffset, lengthBuf, 0, lengthBuf.length);
       long len = new DataInputStream(new ByteArrayInputStream(lengthBuf)).readLong();
       if (len + fileOffset > rafLength || len > Integer.MAX_VALUE || len < 0)
@@ -2346,7 +2013,9 @@ public class SplitFileFetcherStorage {
       raf.pread(fileOffset + length + lengthBuf.length, checksumBuf, 0, checksumLength);
     }
     if (!checksumChecker.checkChecksum(buf, 0, length, checksumBuf)) {
-      Arrays.fill(buf, 0, length, (byte) 0);
+      for (int i = 0; i < length; i++) {
+        buf[i] = 0;
+      }
       throw new ChecksumFailedException();
     }
     return buf;
@@ -2366,11 +2035,25 @@ public class SplitFileFetcherStorage {
   OutputStream writeChecksummedTo(final long fileOffset, final int length) {
     final ByteArrayOutputStream baos = new ByteArrayOutputStream(length);
     OutputStream cos = checksumOutputStream(baos);
-    return new FilterOutputStream(cos) {
+    return new OutputStream() {
+      @Override
+      public void write(int b) throws IOException {
+        cos.write(b);
+      }
+
+      @Override
+      public void write(byte @NotNull [] b, int off, int len) throws IOException {
+        cos.write(b, off, len);
+      }
+
+      @Override
+      public void flush() throws IOException {
+        cos.flush();
+      }
 
       @Override
       public void close() throws IOException {
-        out.close();
+        cos.close();
         byte[] buf = baos.toByteArray();
         if (buf.length != length)
           throw new IllegalStateException(

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
@@ -38,66 +38,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Stores the state for a SplitFileFetcher, persisted to a LockableRandomAccessBuffer (i.e. a single
- * random access file), but with most of the metadata in memory. The data, and the larger metadata
- * such as the full keys, are read from disk when needed, and persisted to disk.
+ * Maintains persistent and in-memory state for a splitfile fetch.
  *
- * <p>On disk format goals:
+ * <p>This storage binds a {@link SplitFileFetcher} to a single {@link LockableRandomAccessBuffer},
+ * keeping hot metadata in memory while persisting block data, key lists, and progress so the fetch
+ * can resume after restarts. Segments may be stored in temporary FEC order; decoding reconstructs
+ * missing blocks and then rewrites data blocks into logical sequence. Callers create an instance
+ * for a new fetch or resume one from disk, then drive scheduling through the owning fetcher until
+ * completion.
  *
- * <ol>
- *   <li>Maximise robustness.
- *   <li>Minimise seeks.
- *   <li>Minimise disk usage.
- *   <li>Be as simple as realistically possible.
- * </ol>
+ * <p>The layout aims to minimize seeks and maximize robustness while tolerating recovery work after
+ * checksum failures. Callbacks into the fetcher run off-thread via job runners, and locking is
+ * shallow and taken last relative to segment locks. The storage itself is transient and recreated
+ * on startup; persisted sections carry enough state to rehydrate progress.
  *
- * <p>Overall on-disk structure: BLOCK STORAGE: Decoded data, one segment at a time (the last
- * segment's size is rounded up to a whole block). Within each segment, the number of blocks is
- * equal to the number of data blocks (plus the number of cross-check blocks if there are
- * cross-check blocks), but they are not necessarily actually data blocks (they may be check
- * blocks), and they may not be in the correct order. When we FEC decode, we read in the blocks,
- * construct the CHKs to see what keys they belong to, check that we still have enough valid keys
- * (update the metadata if the counts were wrong), do the decode, and write the data blocks back in
- * the correct order; the segment is finished. When all the segments are finished, we generate a
- * stream as usual, i.e. we still need to copy the file. It may be possible in future to simply
- * truncate the file but in many cases we need to decompress or filter, and there are significant
- * issues with code complexity and seeks during FEC decodes, see bug #6063.
+ * <p>On-disk sections include:
  *
- * <p>KEY LIST: The original key list. Not changed when a block is fetched. - Fixed and checksummed
- * (each segment has a checksum).
+ * <ul>
+ *   <li>Block storage for data and check blocks, organized per segment.
+ *   <li>Segment key lists with per-segment checksums.
+ *   <li>Segment status records with retry and block flags.
+ *   <li>Main and per-segment Bloom filters for key lookup.
+ *   <li>Original metadata/details and basic settings with a checksummed footer.
+ * </ul>
  *
- * <p>SEGMENT STATUS: The status of each segment, including the status of each block, including
- * flags and where it is in the block storage within the segment. - Checksummed per segment. So it
- * needs to be written as a whole segment. Can be regenerated from the block store and key list,
- * which happens routinely when FEC decoding.
- *
- * <p>BLOOM FILTERS: Main bloom filter. Segment bloom filters.
- *
- * <p>ORIGINAL METADATA: For extra robustness, keep the full original metadata.
- *
- * <p>ORIGINAL URL: If the original key is available, keep that too.
- *
- * <p>BASIC SETTINGS: Type of splitfile, length of file, overall decryption key, number of blocks
- * and check blocks per segment, etc. - Fixed and checksummed. Read as a block so we can check the
- * checksum.
- *
- * <p>FOOTER: Length of basic settings. (So we can seek back to get them) Version number. Checksum.
- * Magic value.
- *
- * <p>OTHER NOTES:
- *
- * <p>CHECKSUMS: 4-byte CRC32.
- *
- * <p>CONCURRENCY: Callbacks into fetcher should be run off-thread, as they will usually be inside a
- * MemoryLimitedJob.
- *
- * <p>LOCKING: Trivial or taken last. Hence, can be called inside e.g. RGA calls to getCooldownTime
- * etc.
- *
- * <p>PERSISTENCE: This whole class is transient. It is recreated on startup by the
- * SplitFileFetcher. Many of the fields are also transient, e.g. SplitFileFetcherSegmentStorage's
- * cooldown fields.
- *
+ * @see SplitFileFetcher
+ * @see SplitFileFetcherSegmentStorage
+ * @see SplitFileFetcherStoragePersistence
  * @author toad
  */
 public class SplitFileFetcherStorage {
@@ -209,7 +176,7 @@ public class SplitFileFetcherStorage {
   /** Offset to start of the key lists in bytes */
   final long offsetKeyList;
 
-  /** Offset to start of the segment status'es in bytes */
+  /** Offset to start of the segment status's in bytes */
   final long offsetSegmentStatus;
 
   /** Offset to start of the general progress section */
@@ -261,26 +228,22 @@ public class SplitFileFetcherStorage {
   /**
    * Create a new storage instance backed by a fresh on-disk layout.
    *
-   * <p>This constructor interprets the supplied metadata, allocates segment/cross-segment state,
-   * initialises Bloom filters and checksums, and wires asynchronous helpers. It does not block on
-   * network I/O but may perform bounded file I/O to prepare the persistent structures when {@code
-   * persistent} is enabled in {@link SplitFileFetcherStorageInitParams}.
+   * <p>This constructor interprets the supplied metadata, allocates segment and cross-segment
+   * state, initializes Bloom filters and checksums, and wires asynchronous helpers. It does not
+   * block on network I/O but may perform bounded file I/O to prepare the persistent structures when
+   * {@code persistent} is enabled in {@link SplitFileFetcherStorageInitParams}. On success the
+   * instance is ready to be driven by the owning fetcher and will contain computed offsets for all
+   * persistent sections.
    *
    * <p>Callers normally place the instance under a coordinating fetcher which drives block request
    * scheduling. Once all segments finish and postconditions are met, the fetcher calls {@link
-   * #streamGenerator()} to materialise the final byte stream.
+   * #streamGenerator()} to materialize the final byte stream.
    *
-   * @param p full set of immutable construction parameters created by {@link
-   *     SplitFileFetcherStorageInitParams.Builder}; must reference the metadata for this splitfile
-   *     and execution helpers such as {@code jobRunner}, {@code ticker}, and checksum policy. May
-   *     not be {@code null}.
-   * @throws FetchException if the fetch context indicates an unrecoverable configuration or policy
-   *     error while preparing request state; this is not a network failure.
-   * @throws MetadataParseException if the supplied {@link Metadata} cannot be interpreted into a
-   *     valid splitfile layout (e.g., inconsistent block counts or unsupported algorithm).
-   * @throws IOException if initial on-disk structures cannot be written or verified using the
-   *     configured {@link network.crypta.support.api.LockableRandomAccessBufferFactory} and
-   *     temporary bucket factory.
+   * @param p immutable parameters including metadata, factories, and execution helpers; must be
+   *     non-null.
+   * @throws FetchException when policy validation fails before any network activity begins.
+   * @throws MetadataParseException when metadata cannot describe a supported splitfile layout.
+   * @throws IOException when on-disk structures cannot be created or verified.
    */
   public SplitFileFetcherStorage(SplitFileFetcherStorageInitParams p)
       throws FetchException, MetadataParseException, IOException {
@@ -476,15 +439,13 @@ public class SplitFileFetcherStorage {
    * <p>This constructor validates footer magic, checksums, and version, locates each logical
    * section, and rebuilds segment state and Bloom filters. It also reattaches asynchronous helpers
    * and prepares any pending decode attempts when segment metadata indicates partial progress.
+   * Successful completion means the instance is ready for {@link #start(boolean)} with resume
+   * semantics and will reflect on-disk progress accurately.
    *
-   * @param p environment and buffer required to resume; created via {@link
-   *     SplitFileFetcherStorageResumeParams.Builder}. Must include a readable {@link
-   *     LockableRandomAccessBuffer}.
-   * @throws IOException if underlying storage cannot be accessed.
-   * @throws StorageFormatException if the on-disk structure is corrupted or incompatible with the
-   *     current format version.
-   * @throws FetchException if the reconstructed state violates fetcher policy or cannot be
-   *     reconciled with the provided runtime environment.
+   * @param p resume parameters including existing buffer and runtime helpers; must be non-null.
+   * @throws IOException when the underlying buffer cannot be read or locked.
+   * @throws StorageFormatException when checksums, version, or offsets are invalid.
+   * @throws FetchException when resumed state violates fetch policy or limits.
    */
   public SplitFileFetcherStorage(SplitFileFetcherStorageResumeParams p)
       throws IOException, StorageFormatException, FetchException {
@@ -858,12 +819,17 @@ public class SplitFileFetcherStorage {
   }
 
   /**
-   * Start the storage layer.
+   * Start the storage layer and enqueue any required recovery work.
    *
-   * @param resume True only if we are restarting without having serialized, i.e. from the file
-   *     only. In this case we will need to tell the parent how many blocks have been fetched.
-   * @return True if it should be scheduled immediately. If false, the storage layer will call back
-   *     into the fetcher later.
+   * <p>This method reattaches cross-segment helpers, schedules any deferred decode attempts, and
+   * optionally notifies the fetcher of resume statistics. When key Bloom filters are missing, it
+   * triggers asynchronous regeneration and returns {@code false} so the caller does not schedule
+   * requests prematurely. It performs no network I/O but may queue background work that later
+   * drives request scheduling through callbacks.
+   *
+   * @param resume {@code true} when resuming purely from disk state without memory snapshots.
+   * @return {@code true} when the caller may schedule immediately; {@code false} when callbacks
+   *     will schedule later.
    */
   public boolean start(boolean resume) {
     if (resume) onResumeInit();
@@ -1244,12 +1210,15 @@ public class SplitFileFetcherStorage {
   }
 
   /**
-   * Priority class forwarded to the request scheduler.
+   * Return the priority class forwarded to the request scheduler.
    *
    * <p>The class originates from the owning fetcher and influences how aggressively requests are
-   * scheduled relative to other work.
+   * scheduled relative to other work. The value is treated as a stable attribute of the fetch and
+   * is safe to query frequently; this method performs no synchronization beyond reading the cached
+   * field. Callers should avoid interpreting the numeric value directly and instead pass it through
+   * scheduler APIs that understand the range.
    *
-   * @return the priority class value defined by the fetcher.
+   * @return the fetcher's short priority class used by scheduling heuristics.
    */
   public short getPriorityClass() {
     return fetcher.getPriorityClass();
@@ -1261,10 +1230,10 @@ public class SplitFileFetcherStorage {
    * <p>When a segment finishes decoding, the storage checks whether all other segments have also
    * finished successfully. If so, completion is signaled and the success callback is scheduled. If
    * the fetcher requested a binary blob or truncation is in use, completion may be deferred until
-   * post-processing is done.
+   * post-processing is done. This method is safe to call multiple times for the same segment and
+   * will only trigger completion once.
    *
-   * @param segment the segment instance that has just reported success; must be one of {@link
-   *     #segments} and non-null. The parameter is used for logging and does not change behaviour.
+   * @param segment segment that just reported success, used only for diagnostics.
    */
   public void finishedSuccess(SplitFileFetcherSegmentStorage segment) {
     if (LOG.isDebugEnabled())
@@ -1303,11 +1272,14 @@ public class SplitFileFetcherStorage {
   }
 
   /**
-   * Create a {@link StreamGenerator} that materialises the final decoded data stream.
+   * Create a {@link StreamGenerator} that materializes the final decoded data stream.
    *
-   * <p>The returned generator emits the data blocks for all segments in logical order and applies
-   * any required transformations (e.g., decompression) declared by the metadata. The generator
-   * performs blocking file reads; callers should invoke it off the request-selection thread.
+   * <p>The returned generator emits data blocks for all segments in logical order and applies any
+   * required transformations (for example, decompression) declared by the metadata. The generator
+   * performs blocking file reads and may hold the RAF lock while streaming, so callers should
+   * invoke it off the request-selection thread and avoid concurrent mutation of segment state. It
+   * is intended for one logical consumer at a time; create a fresh generator for each output target
+   * if repeated streaming is required.
    *
    * <pre>{@code
    * // Example: write the reconstructed bytes to an OutputStream
@@ -1315,12 +1287,11 @@ public class SplitFileFetcherStorage {
    * gen.writeTo(outputStream, clientContext);
    * }</pre>
    *
-   * @return a generator that reads from the underlying storage and writes the complete payload on
-   *     demand. The instance is stateless between invocations of {@code writeTo} and not thread
-   *     safe.
+   * @return a generator that reads from underlying storage and writes the complete payload on
+   *     demand; it is not thread-safe.
    */
   public StreamGenerator streamGenerator() {
-    // Truncation optimisation can be added in future if safe.
+    // Truncation optimization can be added in future if safe.
     return new StreamGenerator() {
 
       @Override
@@ -1400,8 +1371,10 @@ public class SplitFileFetcherStorage {
    * Schedule a best-effort metadata write.
    *
    * <p>When running in persistent mode, metadata changes are checkpointed asynchronously to reduce
-   * contention and I/O overhead. Calls may coalesce when invoked in quick succession. In
-   * non-persistent mode this method is a no-op.
+   * contention and I/O overhead. Calls may coalesce when invoked in quick succession, so it is safe
+   * to call this after each state change without creating extra disk churn. In non-persistent mode
+   * this method is a no-op. The write occurs off-thread and does not guarantee immediate
+   * durability; callers that need a synchronous flush should use higher-level shutdown paths.
    */
   public void lazyWriteMetadata() {
     if (!persistent) return;
@@ -1423,7 +1396,8 @@ public class SplitFileFetcherStorage {
    *
    * <p>When both the fetcher and the encoder have finished (and truncation is not pending), the
    * storage closes its backing file off-thread. Repeated calls are safe and ignored after the first
-   * transition.
+   * transition. If truncation is requested, cleanup is deferred until encoding completes and the
+   * truncation path has run, ensuring the RAF remains available for late writes.
    */
   public void finishedFetcher() {
     synchronized (this) {
@@ -1524,7 +1498,7 @@ public class SplitFileFetcherStorage {
 
   /**
    * Called when a cross-segment has finished decoding. It doesn't necessarily have a "finished"
-   * state, except if it was cancelled.
+   * state, except if it was canceled.
    */
   void finishedEncoding(SplitFileFetcherCrossSegmentStorage segment) {
     if (LOG.isDebugEnabled())
@@ -1553,10 +1527,10 @@ public class SplitFileFetcherStorage {
    *
    * <p>Failure is posted to the job runner to avoid deadlocks with request-selection or decode
    * threads. The storage remains valid until the callback initiates shutdown, allowing callers to
-   * inspect error codes and progress.
+   * inspect error codes and progress. This method does not attempt retries or cancellation on its
+   * own; it simply forwards the provided {@link FetchException} to the fetcher.
    *
-   * @param e the failure cause describing mode and context; must not be {@code null}. The instance
-   *     is forwarded to the fetcher's {@code fail} callback without modification.
+   * @param e failure cause describing mode and context; must not be {@code null}.
    */
   public void fail(final FetchException e) {
     if (LOG.isDebugEnabled()) LOG.debug("Failing {} with error {} and codes {}", this, e, errors);
@@ -1571,9 +1545,11 @@ public class SplitFileFetcherStorage {
    * Abort the splitfile when a segment exhausts its retry budget.
    *
    * <p>This helper converts the condition into a consolidated {@link FetchException} and routes it
-   * through {@link #fail(FetchException)} so shutdown happens consistently.
+   * through {@link #fail(FetchException)} so shutdown happens consistently. It does not mutate the
+   * segment itself; segment state is expected to already reflect the terminal failure condition.
+   * Callers typically invoke this after a retry budget check fails.
    *
-   * @param segment the segment that can no longer make progress; used for logging only.
+   * @param segment segment that can no longer make progress, used only for logging.
    */
   public void failOnSegment(SplitFileFetcherSegmentStorage segment) {
     if (LOG.isDebugEnabled()) {
@@ -1589,9 +1565,11 @@ public class SplitFileFetcherStorage {
    * Report a non-recoverable disk I/O error to the fetcher.
    *
    * <p>Any failure during metadata or block persistence is considered fatal for the session. The
-   * notification occurs off-thread to avoid blocking callers inside I/O paths.
+   * notification occurs off-thread to avoid blocking callers inside I/O paths. The storage does not
+   * attempt to retry the failing operation; recovery decisions are left to the fetcher and its
+   * surrounding context.
    *
-   * @param e the I/O exception observed while reading or writing persistent state.
+   * @param e I/O exception observed while reading or writing persistent state.
    */
   public void failOnDiskError(final IOException e) {
     LOG.error("Failing on disk error: {}", e, e);
@@ -1606,9 +1584,10 @@ public class SplitFileFetcherStorage {
    * Report a checksum verification failure to the fetcher.
    *
    * <p>The storage zeroes the affected bytes and surfaces the failure via the callback. Depending
-   * on policy, the fetcher may propagate the error or attempt recovery using redundant blocks.
+   * on policy, the fetcher may propagate the error or attempt recovery using redundant blocks. This
+   * method only reports the condition; it does not initiate decoding or rebuilds directly.
    *
-   * @param e the checksum failure raised when verifying a checksummed section from disk.
+   * @param e checksum failure raised when verifying a checksummed section from disk.
    */
   public void failOnDiskError(final ChecksumFailedException e) {
     LOG.error("Failing on unrecoverable corrupt data: {}", e, e);
@@ -1623,7 +1602,9 @@ public class SplitFileFetcherStorage {
    * Count the number of not-yet-fetched keys across all segments.
    *
    * <p>The value includes keys that are currently cooling down or temporarily skipped. It is
-   * computed from in-memory segment state and does not perform disk I/O.
+   * computed from in-memory segment state and does not perform disk I/O. Use this for progress
+   * estimation rather than exact completion criteria; failed blocks and delayed retries can cause
+   * the count to oscillate.
    *
    * @return a non-negative count representing remaining work before decode can proceed.
    */
@@ -1638,6 +1619,7 @@ public class SplitFileFetcherStorage {
    *
    * <p>The returned array may be empty but never {@code null}. Keys are provided for diagnostic or
    * scheduling purposes and are not guaranteed to be immutable; callers should copy if retaining.
+   * On I/O failure the storage reports the disk error and returns an empty array.
    *
    * @return a possibly empty snapshot of outstanding {@link Key} instances.
    */
@@ -1655,8 +1637,9 @@ public class SplitFileFetcherStorage {
   /**
    * Count keys that are immediately eligible to send based on cooldown and retry limits.
    *
-   * <p>The result depends on the current time, retry counters and segment-level cooldown. It is
-   * intended for request schedulers to estimate near-term concurrency.
+   * <p>The result depends on the current time, retry counters, and segment-level cooldown. It is
+   * intended for request schedulers to estimate near-term concurrency rather than for strict
+   * accounting. The count is computed without disk I/O and may change rapidly as cooldowns expire.
    *
    * @return the number of keys that can be turned into outbound requests without waiting.
    */
@@ -1670,8 +1653,12 @@ public class SplitFileFetcherStorage {
    * Lightweight handle identifying a concrete block within a specific segment.
    *
    * <p>Instances are stable identifiers used by schedulers and callbacks to correlate request
-   * outcomes with storage state. Equality and hash semantics consider both the segment number and
-   * intra-segment block number.
+   * outcomes with storage state. The handle is immutable and embeds the owning storage, the segment
+   * index, and the block index so it can be used as a map key or queue token without additional
+   * lookups. It is not a cryptographic key; instead it is a positional reference that can be
+   * resolved to a {@link ClientKey} through {@link SplitFileFetcherStorage#getKey}. Equality and
+   * hash semantics incorporate the storage instance to avoid accidental collisions across
+   * concurrent fetches.
    */
   public static final class SplitFileFetcherStorageKey
       implements SendableRequestItem, SendableRequestItemKey {
@@ -1679,10 +1666,13 @@ public class SplitFileFetcherStorage {
     /**
      * Create a key handle for the given block and segment.
      *
-     * @param n zero-based block number within the segment; values outside the segment's range are
-     *     invalid and must not be supplied.
-     * @param segNo zero-based segment index inside the enclosing storage.
-     * @param storage the owning storage, used for lookups and logging; must not be {@code null}.
+     * <p>The constructor does not validate indices against segment bounds; callers must supply
+     * values obtained from segment state or scheduling helpers. The resulting instance is immutable
+     * and can be safely cached or used as a map key for the lifetime of the storage.
+     *
+     * @param n zero-based block index within the segment, must be in range.
+     * @param segNo zero-based segment index for the owning storage, must be valid.
+     * @param storage owning storage instance used for lookups and equality; must be non-null.
      */
     public SplitFileFetcherStorageKey(int n, int segNo, SplitFileFetcherStorage storage) {
       this.blockNumber = n;
@@ -1699,7 +1689,10 @@ public class SplitFileFetcherStorage {
     /**
      * Emit a debug dump of this key's computed request state.
      *
-     * <p>Intended for diagnostics and test support; output format is not part of the public API.
+     * <p>This implementation intentionally performs no work because the storage key carries only
+     * positional identifiers and has no derived state to emit. The method exists to satisfy the
+     * request-item interface and is safe to call from diagnostics or tests. Callers should not rely
+     * on side effects or output from this method.
      */
     @Override
     public void dump() {
@@ -1709,7 +1702,12 @@ public class SplitFileFetcherStorage {
     /**
      * Convert this handle into a request-layer key.
      *
-     * @return an immutable {@link SendableRequestItemKey} suitable for use by request senders.
+     * <p>This implementation returns {@code this} because the storage key already satisfies the
+     * request-layer contract. It avoids allocation and preserves identity semantics, which allows
+     * schedulers to compare or cache keys without additional wrapping. The returned instance is
+     * immutable for the lifetime of the storage.
+     *
+     * @return this instance as an immutable {@link SendableRequestItemKey} for scheduling.
      */
     @Override
     public SendableRequestItemKey getKey() {
@@ -1719,9 +1717,13 @@ public class SplitFileFetcherStorage {
     /**
      * Value equality based on segment and block indices.
      *
-     * @param o another object; equality holds when it is also a {@code SplitFileFetcherStorageKey}
-     *     with identical segment and block numbers.
-     * @return {@code true} when the two keys identify the same block, otherwise {@code false}.
+     * <p>Equality also requires the same owning storage instance, preventing collisions between
+     * concurrent fetches that may share segment numbering. This method is consistent with {@link
+     * #hashCode()} and is safe for use in hash-based collections. It performs a fast reference and
+     * primitive comparison without allocations.
+     *
+     * @param o candidate object to compare against this key for equality.
+     * @return {@code true} when the two keys identify the same storage block.
      */
     @Override
     public boolean equals(Object o) {
@@ -1733,7 +1735,11 @@ public class SplitFileFetcherStorage {
     /**
      * Hash code derived from the segment and block indices.
      *
-     * @return a stable hash suitable for use in hash-based collections.
+     * <p>The hash includes the owning storage reference to remain consistent with {@link #equals}.
+     * It is computed once at construction time and cached, so repeated calls are inexpensive. The
+     * value is stable for the lifetime of this key. No randomness is involved.
+     *
+     * @return a stable hash suitable for hash-based collections and caches.
      */
     public int hashCode() {
       return hashCode;
@@ -1751,6 +1757,11 @@ public class SplitFileFetcherStorage {
     /**
      * Human‑readable form for logging and diagnostics.
      *
+     * <p>The representation includes the segment and block indices and is intended for logs and
+     * debugging output. The exact format is not guaranteed to remain stable, so callers should not
+     * parse the string or depend on it for program logic. The output never includes key material or
+     * payload data.
+     *
      * @return a concise string containing the segment and block numbers.
      */
     public String toString() {
@@ -1762,10 +1773,11 @@ public class SplitFileFetcherStorage {
    * Choose a random eligible key from non-decoding, non-finished segments.
    *
    * <p>The selection uses a time‑varying seed to distribute requests and avoids segments currently
-   * decoding or ineligible due to cooldown/retry constraints. Returns {@code null} when no key is
-   * presently sendable.
+   * decoding or ineligible due to cooldown/retry constraints. The method synchronizes on the
+   * segment iterator to keep selection state consistent and may scan multiple segments before
+   * finding a candidate. Returns {@code null} when no key is presently sendable.
    *
-   * @return a randomly selected {@link SplitFileFetcherStorageKey} or {@code null} if none is
+   * @return a randomly selected {@link SplitFileFetcherStorageKey} or {@code null} when none is
    *     available.
    */
   public SplitFileFetcherStorageKey chooseRandomKey() {
@@ -1805,7 +1817,9 @@ public class SplitFileFetcherStorage {
    * Callback invoked after checking the local datastore for a candidate key.
    *
    * <p>When a check produces a definitive result the storage updates segment state and may schedule
-   * additional work. The method runs off-thread to avoid blocking request selection.
+   * additional work. The method runs off-thread to avoid blocking request selection. It increments
+   * the appropriate failure counters and notifies each segment that datastore probing has completed
+   * so retries can proceed. If all segments are already finished, the callback is a no-op.
    */
   public void finishedCheckingDatastoreOnLocalRequest() {
     // At this point, all the blocks will have been processed.
@@ -1829,10 +1843,12 @@ public class SplitFileFetcherStorage {
    * Record a non-fatal failure for a specific block request.
    *
    * <p>The error is accumulated in the failure tracker and the key is made retryable according to
-   * the configured policy. Persistent sessions schedule a metadata checkpoint.
+   * the configured policy. Persistent sessions schedule a metadata checkpoint. Callers should only
+   * invoke this for failures that may be retried; terminal failures should go through {@link
+   * #fail(FetchException)} or {@link #failOnSegment(SplitFileFetcherSegmentStorage)}.
    *
-   * @param key the key whose request failed; used to locate the segment and block counters.
-   * @param fe the reason for failure, including {@link FetchExceptionMode} and context.
+   * @param key handle whose request failed, used to locate segment and block.
+   * @param fe failure reason including mode and context for tracking.
    */
   public void onFailure(SplitFileFetcherStorageKey key, FetchException fe) {
     if (LOG.isDebugEnabled())
@@ -1850,11 +1866,12 @@ public class SplitFileFetcherStorage {
   /**
    * Resolve the client‑layer key for the given handle.
    *
-   * <p>On I/O failure the storage reports a disk error and returns {@code null}.
+   * <p>The lookup reads segment key data, so it may perform disk I/O and acquire the RAF lock. On
+   * I/O failure the storage reports a disk error and returns {@code null}. The call does not change
+   * segment state. Callers should treat the returned {@link ClientKey} as read-only.
    *
-   * @param key a handle returned by {@link #chooseRandomKey()} or constructed by a caller.
-   * @return the corresponding {@link ClientKey} when available; otherwise {@code null} on storage
-   *     failure.
+   * @param key handle identifying a block, usually from {@link #chooseRandomKey()}.
+   * @return client key for the block, or {@code null} on I/O failure.
    */
   public ClientKey getKey(SplitFileFetcherStorageKey key) {
     try {
@@ -1868,7 +1885,12 @@ public class SplitFileFetcherStorage {
   /**
    * Maximum number of per‑block retries permitted by policy.
    *
-   * @return a non‑negative limit; when reached a segment failure is raised and the splitfile fails.
+   * <p>The limit is derived from the originating {@link FetchContext} and remains fixed for the
+   * lifetime of the storage. When a block exceeds this count, its segment transitions to a failure
+   * state and the overall fetch eventually fails. A value of {@code -1} indicates unlimited
+   * retries.
+   *
+   * @return a non‑negative limit, or {@code -1} for unlimited retries.
    */
   public int maxRetries() {
     return maxRetries;
@@ -1877,7 +1899,10 @@ public class SplitFileFetcherStorage {
   /**
    * Notify the fetcher that a block has permanently failed.
    *
-   * <p>The notification is posted asynchronously. It does not modify storage state directly.
+   * <p>The notification is posted asynchronously to keep request-selection threads responsive. It
+   * does not modify storage state directly; callers should ensure segment bookkeeping has already
+   * transitioned the block into a terminal state before invoking this callback. Multiple calls may
+   * be coalesced by the fetcher.
    */
   public void failedBlock() {
     jobRunner.queueNormalOrDrop(
@@ -1890,8 +1915,11 @@ public class SplitFileFetcherStorage {
   /**
    * Indicate whether the final block may omit padding due to compatibility mode.
    *
-   * @return {@code true} when padding is not guaranteed for the last block, otherwise {@code
-   *     false}.
+   * <p>Some legacy compatibility modes allow a short final block without padding. Callers use this
+   * signal to decide whether to enforce padding checks during verification or decoding. The value
+   * is derived from the stored minimum compatibility mode and does not change after construction.
+   *
+   * @return {@code true} when padding is not guaranteed for the last block.
    */
   public boolean lastBlockMightNotBePadded() {
     return (finalMinCompatMode == CompatibilityMode.COMPAT_UNKNOWN
@@ -1902,7 +1930,9 @@ public class SplitFileFetcherStorage {
    * Called after a corruption recovery path has restarted the session.
    *
    * <p>Clears cooldown if appropriate and relays a notification to the fetcher on a background
-   * thread.
+   * thread. This method is used when metadata recovery or key regeneration succeeds, allowing the
+   * fetcher to resume scheduling without manual intervention. It does not re-run validation; it
+   * only signals that recovery work has completed.
    */
   public void restartedAfterDataCorruption() {
     jobRunner.queueNormalOrDrop(
@@ -1948,7 +1978,9 @@ public class SplitFileFetcherStorage {
    * Clear global cooldown when all segments have exited their individual cooldown windows.
    *
    * <p>This is safe to call frequently; it performs cheap checks and posts to the fetcher when the
-   * global flag changes.
+   * global flag changes. The method synchronizes on the cooldown lock and will reset the global
+   * wakeup time only when every segment reports a cleared cooldown. It does not schedule requests
+   * directly; that remains the fetcher's responsibility.
    */
   public void maybeClearCooldown() {
     synchronized (cooldownLock) {
@@ -1963,11 +1995,12 @@ public class SplitFileFetcherStorage {
    * Return the earliest time at which requests should resume after cooldown.
    *
    * <p>Returns {@code -1} when the overall request has finished. Otherwise, returns {@code 0} when
-   * there is no pending cooldown or a future epoch millisecond timestamp to wait until.
+   * there is no pending cooldown or a future epoch millisecond timestamp to wait until. The method
+   * updates the cached wakeup time to clear stale values and is safe to call from scheduling
+   * threads that only hold the request-selection lock.
    *
    * @param now the current epoch time in milliseconds used to clamp stale values.
-   * @return {@code -1} if finished, {@code 0} if no cooldown, or a future epoch millisecond
-   *     timestamp.
+   * @return negative one if finished, zero if no cooldown, else wakeup time.
    */
   public long getCooldownWakeupTime(long now) {
     // LOCKING: hasFinished() uses (this), separate from cooldownLock.
@@ -2095,7 +2128,12 @@ public class SplitFileFetcherStorage {
   /**
    * Mark that the local store has been checked at least once during this session.
    *
-   * @param context the execution context present when the check completed.
+   * <p>This updates the in-memory flag, marks general progress as dirty, and writes metadata
+   * immediately when persistence is enabled. The call is synchronized to ensure visibility across
+   * scheduler threads. Callers should pass the same {@link ClientContext} used for other storage
+   * checkpoint calls.
+   *
+   * @param context execution context available when the datastore check completed.
    */
   public synchronized void setHasCheckedStore(ClientContext context) {
     hasCheckedDatastore = true;
@@ -2107,7 +2145,12 @@ public class SplitFileFetcherStorage {
   /**
    * Whether a local datastore check has been performed in this session.
    *
-   * @return {@code true} once the first check has completed, otherwise {@code false}.
+   * <p>The flag is updated by {@link #setHasCheckedStore(ClientContext)} and is not persisted for
+   * transient sessions. It can be polled by schedulers to decide whether a datastore sweep should
+   * be attempted again after restarts. The value is read without additional I/O and is safe to
+   * query frequently.
+   *
+   * @return {@code true} once a datastore check has completed in this session.
    */
   public synchronized boolean hasCheckedStore() {
     return hasCheckedDatastore;

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageInitParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageInitParams.java
@@ -17,18 +17,29 @@ import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
 import network.crypta.support.io.FileRandomAccessBufferFactory;
 
 /**
- * Builder-style constructor arguments for a fresh fetch session.
+ * Holds the inputs required to initialize a splitfile fetch storage session.
  *
- * <p>This holder captures all inputs required to initialise a brand-new storage instance when a
- * splitfile fetch begins. It mirrors the metadata-driven structure of the file (segment keys,
- * compression chain, client metadata) and also includes execution-time components such as
- * schedulers, randomness and checksum policies. Instances are typically created via the nested
- * {@link Builder} and passed to the {@link
- * SplitFileFetcherStorage#SplitFileFetcherStorage(SplitFileFetcherStorageInitParams)} constructor.
+ * <p>This type is a simple data carrier that mirrors the parameters needed to start a new {@link
+ * SplitFileFetcherStorage} instance for a splitfile fetch. It captures parsed {@link Metadata}, the
+ * decompression pipeline, client metadata, and the various execution helpers (job runners, tickers,
+ * randomness, and checksum policy) that are supplied at runtime. Instances are typically produced
+ * via {@link Builder} and then passed directly to {@link
+ * SplitFileFetcherStorage#SplitFileFetcherStorage(SplitFileFetcherStorageInitParams)} without
+ * further transformation or validation.
  *
- * <p>Thread-safety: {@code SplitFileFetcherStorageInitParams} is a simple data container; callers
- * should publish it to a single thread and avoid mutation once built.
+ * <p>All fields are stored as references with no defensive copying, so callers should treat the
+ * built instance as immutable and avoid mutating supplied objects after {@link Builder#build()}.
+ * The container performs no I/O and is not thread-safe; publish it to a single thread or apply
+ * external synchronization if multiple threads may read it concurrently.
  *
+ * <ul>
+ *   <li>Captures metadata, keys, and compression settings for the fetch plan.
+ *   <li>Bundles execution-time helpers such as schedulers, RNG, and checksum policy.
+ *   <li>Provides a stable snapshot to hand to storage construction.
+ * </ul>
+ *
+ * @see SplitFileFetcherStorage
+ * @see SplitFileFetcherStorageInitParams.Builder
  * @hidden
  */
 public final class SplitFileFetcherStorageInitParams {
@@ -58,14 +69,22 @@ public final class SplitFileFetcherStorageInitParams {
   KeysFetchingLocally keysFetching;
 
   /**
-   * Fluent builder for {@link SplitFileFetcherStorageInitParams}.
+   * Builds {@link SplitFileFetcherStorageInitParams} instances through fluent, mutable setters.
    *
-   * <p>The builder performs no I/O and minimal validation. Typical usage sets the metadata,
-   * callback, decompression pipeline, factories, and execution helpers, then calls {@link #build()}
-   * to obtain an immutable {@link SplitFileFetcherStorageInitParams} snapshot.
+   * <p>This builder is a lightweight accumulator: each setter stores the provided reference and
+   * returns {@code this} for chaining. It performs no I/O, no validation, and no defensive copying.
+   * The final {@link #build()} call creates a new parameter snapshot containing the current
+   * references; subsequent setter calls do not affect already-built instances. Because the builder
+   * is mutable and unsynchronized, it should be confined to one thread or externally synchronized
+   * if shared.
    *
-   * <p>Unless otherwise stated, all values are required. Optional values follow sensible defaults
-   * inside the storage constructor when omitted.
+   * <ul>
+   *   <li>Set metadata, keys, and compression choices in a single place.
+   *   <li>Provide runtime helpers such as tickers, RNGs, and job runners.
+   *   <li>Create repeatable snapshots by reusing the same builder.
+   * </ul>
+   *
+   * @hidden
    */
   public static class Builder {
     private Metadata metadata;
@@ -94,10 +113,16 @@ public final class SplitFileFetcherStorageInitParams {
     private KeysFetchingLocally keysFetching;
 
     /**
-     * Set the parsed splitfile {@link Metadata} required to plan the fetch.
+     * Sets the parsed splitfile {@link Metadata} used to plan the fetch.
      *
-     * @param v metadata describing segments, blocks, and algorithms; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>This setter records the provided reference on the builder and performs no validation or
+     * copying. If invoked multiple times, the most recent value replaces any earlier one. Passing
+     * {@code null} clears the stored value, which may cause construction to fail later if storage
+     * logic requires metadata. Treat the supplied object as effectively immutable once {@link
+     * #build()} is called.
+     *
+     * @param v metadata describing segments and blocks; stored without defensive copy.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder metadata(Metadata v) {
       this.metadata = v;
@@ -105,10 +130,16 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Set the fetcher callback that receives progress and completion events.
+     * Sets the fetcher callback that receives progress and completion events.
      *
-     * @param v callback implementation used for notifications; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the callback reference without validation, copying, or lifecycle
+     * management. If the method is called more than once, the latest callback replaces the prior
+     * one. A {@code null} value clears the field and may defer failure until the storage
+     * constructor attempts to publish events. The stored reference is used as-is by downstream
+     * logic.
+     *
+     * @param v callback for progress and completion events; stored as provided.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder fetcher(SplitFileFetcherStorageCallback v) {
       this.fetcher = v;
@@ -116,10 +147,16 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Configure the decompressor pipeline to apply after block decode.
+     * Configures the decompressor pipeline to apply after block decode.
      *
-     * @param v ordered list of compressor types; empty or singleton in most deployments.
-     * @return this builder for fluent chaining.
+     * <p>The list is stored as a direct reference and is not copied or validated. Order matters:
+     * callers are responsible for supplying the correct sequence for the metadata they expect to
+     * decode. A {@code null} or empty list indicates no additional decompression steps beyond the
+     * mandatory decoding performed elsewhere. The last value provided wins when this setter is
+     * called repeatedly.
+     *
+     * @param v ordered compressor list to apply after decode; may be null.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder decompressors(List<COMPRESSOR_TYPE> v) {
       this.decompressors = v;
@@ -127,10 +164,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Supply optional client metadata to attach to the completed object.
+     * Supplies optional client metadata to attach to the completed object.
      *
-     * @param v metadata such as MIME type and filename; may be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>This setter records the provided metadata reference without validation or copying. It may
+     * be {@code null} to indicate the absence of client-side metadata, in which case downstream
+     * consumers decide on defaults. If you call this method multiple times, the most recent value
+     * replaces any previous one. Avoid mutating the supplied metadata after {@link #build()}.
+     *
+     * @param v optional client metadata for the final object; may be null.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder clientMetadata(ClientMetadata v) {
       this.clientMetadata = v;
@@ -138,10 +180,16 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Set whether the top-level container should avoid compression.
+     * Sets whether the top-level container should avoid compression.
      *
-     * @param v when {@code true}, skip attempting compression at the top level.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the flag value directly and does not enforce any compatibility checks.
+     * The flag influences how downstream code chooses compression behavior, but the builder itself
+     * does not interpret it. Repeated calls simply overwrite the previous value. When left at the
+     * default {@code false}, downstream components may still decide to skip compression based on
+     * their own rules.
+     *
+     * @param v flag indicating whether top-level compression is skipped.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder topDontCompress(boolean v) {
       this.topDontCompress = v;
@@ -149,10 +197,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Specify the minimum compatibility mode expected by the consumer.
+     * Specifies the minimum compatibility mode expected by the consumer.
      *
-     * @param v numeric mode constant; affects padding and related behaviours.
-     * @return this builder for fluent chaining.
+     * <p>The provided short value is stored without validation or normalization. The builder does
+     * not interpret the meaning of the mode; it simply passes it through to storage construction.
+     * Callers are responsible for selecting a value compatible with the metadata and protocol
+     * expectations in use. The last value set wins if this method is called more than once.
+     *
+     * @param v compatibility mode identifier stored as provided; not validated.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder topCompatibilityMode(short v) {
       this.topCompatibilityMode = v;
@@ -160,10 +213,16 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Provide the fetch context carrying retry and cooldown policy.
+     * Provides the fetch context carrying retry and cooldown policy.
      *
-     * @param v context with limits, timeouts, and priorities; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the supplied context reference as-is and does not attempt to validate
+     * timeouts, limits, or priorities. If called multiple times, the most recent value overwrites
+     * any earlier one. Supplying {@code null} clears the context and may lead to failures later if
+     * the storage logic requires a valid context. Callers should avoid mutating the context after
+     * {@link #build()}.
+     *
+     * @param v fetch context carrying retry and priority policy; stored as provided.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder fetchContext(FetchContext v) {
       this.origFetchContext = v;
@@ -171,10 +230,16 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Indicate whether the fetch should prefer reduced buffering (real-time).
+     * Indicates whether the fetch should prefer reduced buffering (real-time).
      *
-     * @param v when {@code true}, configure for lower latency over throughput.
-     * @return this builder for fluent chaining.
+     * <p>This setter records the boolean flag without additional validation or side effects. The
+     * meaning of real-time mode is interpreted by downstream scheduling and buffering logic rather
+     * than by the builder itself. Repeated calls simply overwrite the previously stored value. When
+     * left {@code false}, default buffering behavior is preserved unless other components override
+     * it.
+     *
+     * @param v flag selecting real-time scheduling preference for the fetch.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder realTime(boolean v) {
       this.realTime = v;
@@ -182,10 +247,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Set the key salter used when deriving salted keys for requests.
+     * Sets the key salter used when deriving salted keys for requests.
      *
-     * @param v optional salter strategy; may be {@code null} to disable salting.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the salter reference directly and does not validate its behavior. A
+     * {@code null} value indicates that salting should be skipped or handled elsewhere. If invoked
+     * multiple times, the most recent salter replaces any earlier one. Callers should ensure the
+     * provided instance has the desired lifetime and thread-safety properties for their context.
+     *
+     * @param v optional key-salter strategy; null disables salting.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder salt(KeySalter v) {
       this.salt = v;
@@ -193,10 +263,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Set the primary request URI associated with this fetch.
+     * Sets the primary request URI associated with this fetch.
      *
-     * @param v the URI for the current object; used for logging and provenance.
-     * @return this builder for fluent chaining.
+     * <p>The provided URI reference is stored without validation or copying. Downstream components
+     * may use the value for logging, provenance, or request key derivation. If this method is
+     * called multiple times, the latest value replaces the previous one. Passing {@code null}
+     * clears the field, which may cause storage initialization to fail if a key is required.
+     *
+     * @param v primary URI associated with this fetch; stored as provided.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder thisKey(FreenetURI v) {
       this.thisKey = v;
@@ -204,10 +279,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Optionally record the original user-facing URI if different from {@link #thisKey}.
+     * Optionally records the original user-facing URI if different from {@link #thisKey}.
      *
-     * @param v the original or canonical URI; may be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the reference as provided and does not compare it with {@code thisKey}
+     * or perform normalization. A {@code null} value indicates there is no distinct original key.
+     * If called multiple times, the last value wins. Downstream components may use this value to
+     * preserve provenance or to display canonical forms to users.
+     *
+     * @param v original or canonical URI for provenance; may be null.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder origKey(FreenetURI v) {
       this.origKey = v;
@@ -215,10 +295,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Indicate whether this fetch corresponds to the final content rather than metadata.
+     * Indicates whether this fetch corresponds to the final content rather than metadata.
      *
-     * @param v set {@code true} when fetching the actual payload, not intermediate data.
-     * @return this builder for fluent chaining.
+     * <p>The flag value is stored directly and is not interpreted by the builder itself. Downstream
+     * logic may treat {@code true} as a signal that the request targets final payload data, while
+     * {@code false} may indicate intermediate or metadata-only stages. If called multiple times,
+     * the latest value replaces the earlier one with no additional side effects.
+     *
+     * @param v flag marking whether this fetch targets final data.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder isFinalFetch(boolean v) {
       this.isFinalFetch = v;
@@ -226,10 +311,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Attach opaque client details preserved for callbacks and auditing.
+     * Attaches opaque client details preserved for callbacks and auditing.
      *
-     * @param v optional byte array copied/stored as provided; may be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>The byte array reference is stored directly and is not copied or validated. A {@code null}
+     * value indicates that no client details are supplied. If this setter is invoked multiple
+     * times, the most recent array reference replaces any prior one. Callers should avoid mutating
+     * the array contents after {@link #build()}, as the built parameters retain the same reference.
+     *
+     * @param v opaque client detail bytes; stored by reference, not copied.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder clientDetails(byte[] v) {
       this.clientDetails = v;
@@ -237,10 +327,16 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Provide the source of randomness used for key scheduling and shuffling.
+     * Provides the source of randomness used for key scheduling and shuffling.
      *
-     * @param v randomness provider; must not be {@code null} in production use.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the randomness provider reference without validation or wrapping. If
+     * called multiple times, the most recent provider replaces any earlier one. Supplying {@code
+     * null} clears the reference; downstream components may reject {@code null} depending on the
+     * execution mode. The builder does not assume ownership and will not close or otherwise manage
+     * the provider.
+     *
+     * @param v randomness source for scheduling or shuffling; may be null.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder random(RandomSource v) {
       this.random = v;
@@ -248,10 +344,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Set the temporary bucket factory used to stage metadata before persistence.
+     * Sets the temporary bucket factory used to stage metadata before persistence.
      *
-     * @param v factory for transient buffers; required when {@code persistent} is enabled.
-     * @return this builder for fluent chaining.
+     * <p>This setter records the factory reference with no validation or defensive copying. The
+     * builder does not create buckets or verify compatibility; it merely stores the supplier for
+     * later use. If invoked multiple times, the latest factory replaces the earlier one. When
+     * persistence is enabled, downstream logic may require a non-null factory to buffer metadata.
+     *
+     * @param v factory for temporary buckets used during persistence; may be null.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder tempBucketFactory(BucketFactory v) {
       this.tempBucketFactory = v;
@@ -259,11 +360,16 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Configure the random-access buffer factory that creates the backing store.
+     * Configures the random-access buffer factory that creates the backing store.
      *
-     * @param v factory responsible for persistent RAF creation; must be compatible with the chosen
-     *     storage file.
-     * @return this builder for fluent chaining.
+     * <p>The provided factory reference is stored as-is and is not validated or wrapped. The
+     * builder does not attempt to open files or allocate buffers; it only captures the factory for
+     * later use by storage construction. If set more than once, the most recent factory replaces
+     * the previous one. Callers should ensure the factory is compatible with any chosen storage
+     * file and persistence mode.
+     *
+     * @param v factory for persistent random-access buffers; stored without validation.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder rafFactory(LockableRandomAccessBufferFactory v) {
       this.rafFactory = v;
@@ -271,10 +377,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Provide the job runner used for off-thread work and callbacks.
+     * Provides the job runner used for off-thread work and callbacks.
      *
-     * @param v persistent job runner implementation; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the job runner reference without validation or lifecycle management. If
+     * called multiple times, the most recent runner replaces any earlier one. Supplying {@code
+     * null} clears the reference and may lead to failures later if asynchronous execution is
+     * required. The builder does not manage threads or scheduling; it merely captures the runner.
+     *
+     * @param v persistent job runner for async tasks; stored as provided.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder exec(PersistentJobRunner v) {
       this.exec = v;
@@ -282,10 +393,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Set the time source/scheduler used for delayed tasks and de-duplication.
+     * Sets the time source/scheduler used for delayed tasks and de-duplication.
      *
-     * @param v ticker implementation; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>The provided ticker reference is stored directly with no validation or wrapping. The
+     * builder does not schedule tasks or query time; it only retains the reference for later use.
+     * If set repeatedly, the newest value replaces the previous one. A {@code null} value clears
+     * the field and may cause failures if scheduling or de-duplication requires a ticker.
+     *
+     * @param v time source used for scheduling and de-duplication; stored.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder ticker(Ticker v) {
       this.ticker = v;
@@ -293,10 +409,16 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Provide the memory-limited job runner used for heavy decode/encode work.
+     * Provides the memory-limited job runner used for heavy decode/encode work.
      *
-     * @param v job runner aware of memory caps; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the provided runner reference without validation or configuration. The
+     * builder does not execute jobs or enforce memory limits itself; it merely captures the runner
+     * for later use by storage and decoding logic. If called more than once, the last runner
+     * replaces the earlier one. Supplying {@code null} may defer failure until heavy work is
+     * scheduled.
+     *
+     * @param v memory-aware job runner for heavy work; stored as provided.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder memoryLimitedJobRunner(MemoryLimitedJobRunner v) {
       this.memoryLimitedJobRunner = v;
@@ -304,10 +426,16 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Choose the checksum implementation and length used in persisted sections.
+     * Chooses the checksum implementation and length used in persisted sections.
      *
-     * @param v checker implementation which also provides the checksum length.
-     * @return this builder for fluent chaining.
+     * <p>The checker reference is stored without validation or defensive copying. The builder does
+     * not compute checksums or verify consistency; it only records the implementation to be used by
+     * storage and persistence code. If called multiple times, the latest checker replaces the
+     * previous one. A {@code null} value clears the field and may cause later failures if checksum
+     * verification is required.
+     *
+     * @param v checksum policy implementation including length; stored as provided.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder checker(ChecksumChecker v) {
       this.checker = v;
@@ -315,10 +443,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Enable or disable persistence of metadata and progress across restarts.
+     * Enables or disables persistence of metadata and progress across restarts.
      *
-     * @param v set {@code true} to persist enough state for resumption after a restart.
-     * @return this builder for fluent chaining.
+     * <p>This setter records the persistence flag without validation or side effects. The builder
+     * does not allocate storage or check disk space; it simply captures the intent to persist. When
+     * {@code true}, downstream logic may require additional factories and storage configuration to
+     * be present. If called repeatedly, the most recent value replaces the previous one.
+     *
+     * @param v flag enabling persistence of metadata and progress.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder persistent(boolean v) {
       this.persistent = v;
@@ -326,10 +459,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Provide an explicit file for the backing store when truncation is desired.
+     * Provides an explicit file for the backing store when truncation is desired.
      *
-     * @param v target file path; when set, completion may use truncation optimisation.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the file reference without creating or validating the file. Downstream
+     * storage code may use the file to place or truncate persistent data, but the builder does not
+     * touch the filesystem. A {@code null} value indicates that the storage layer should select its
+     * own file location. If called more than once, the latest file replaces the earlier one.
+     *
+     * @param v target file used for backing storage; may be null.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder storageFile(File v) {
       this.storageFile = v;
@@ -337,10 +475,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Configure a disk-space checking RAF factory for safer persistent allocations.
+     * Configures a disk-space checking RAF factory for safer persistent allocations.
      *
-     * @param v RAF factory that validates available space; optional but recommended.
-     * @return this builder for fluent chaining.
+     * <p>The provided factory reference is stored as-is and is not validated or wrapped. The
+     * builder does not check disk space itself; it merely captures the factory for later use by
+     * persistence logic. Passing {@code null} disables this additional safety check. If called
+     * multiple times, the last value replaces any earlier one.
+     *
+     * @param v factory that validates disk space for RAF allocations; optional.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder diskSpaceCheckingRAFFactory(FileRandomAccessBufferFactory v) {
       this.diskSpaceCheckingRAFFactory = v;
@@ -348,10 +491,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Set the key-tracking helper that marks keys as fetching locally.
+     * Sets the key-tracking helper that marks keys as fetching locally.
      *
-     * @param v helper for cross-component key accounting; may be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>This setter stores the helper reference without validation or copying. The builder does
+     * not register or unregister keys; it only supplies the helper to downstream components. A
+     * {@code null} value indicates that no local key tracking should be performed. If called
+     * multiple times, the most recent helper replaces any earlier one.
+     *
+     * @param v helper tracking keys fetched locally; may be null.
+     * @return this builder instance so further parameters can be chained.
      */
     public Builder keysFetching(KeysFetchingLocally v) {
       this.keysFetching = v;
@@ -359,10 +507,15 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Build an immutable snapshot of the current builder state.
+     * Builds a new snapshot of the current builder state.
      *
-     * @return a fully-populated {@link SplitFileFetcherStorageInitParams} ready for storage
-     *     construction.
+     * <p>This method allocates a fresh {@link SplitFileFetcherStorageInitParams} instance and
+     * copies the current builder references into it. No validation, normalization, or defensive
+     * copying is performed, so the returned snapshot directly reflects the values last provided to
+     * the setters. The builder remains mutable and may be reused to create additional snapshots;
+     * subsequent changes do not affect previously built instances but may share referenced objects.
+     *
+     * @return a new parameter snapshot holding the current builder references.
      */
     public SplitFileFetcherStorageInitParams build() {
       SplitFileFetcherStorageInitParams p = new SplitFileFetcherStorageInitParams();

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageInitParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageInitParams.java
@@ -1,0 +1,396 @@
+package network.crypta.client.async;
+
+import java.io.File;
+import java.util.List;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchContext;
+import network.crypta.client.Metadata;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.RandomSource;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.KeysFetchingLocally;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+
+/**
+ * Builder-style constructor arguments for a fresh fetch session.
+ *
+ * <p>This holder captures all inputs required to initialise a brand-new storage instance when a
+ * splitfile fetch begins. It mirrors the metadata-driven structure of the file (segment keys,
+ * compression chain, client metadata) and also includes execution-time components such as
+ * schedulers, randomness and checksum policies. Instances are typically created via the nested
+ * {@link Builder} and passed to the {@link
+ * SplitFileFetcherStorage#SplitFileFetcherStorage(SplitFileFetcherStorageInitParams)} constructor.
+ *
+ * <p>Thread-safety: {@code SplitFileFetcherStorageInitParams} is a simple data container; callers
+ * should publish it to a single thread and avoid mutation once built.
+ *
+ * @hidden
+ */
+public final class SplitFileFetcherStorageInitParams {
+  Metadata metadata;
+  SplitFileFetcherStorageCallback fetcher;
+  List<COMPRESSOR_TYPE> decompressors;
+  ClientMetadata clientMetadata;
+  boolean topDontCompress;
+  short topCompatibilityMode;
+  FetchContext origFetchContext;
+  boolean realTime;
+  KeySalter salt;
+  FreenetURI thisKey;
+  FreenetURI origKey;
+  boolean isFinalFetch;
+  byte[] clientDetails;
+  RandomSource random;
+  BucketFactory tempBucketFactory;
+  LockableRandomAccessBufferFactory rafFactory;
+  PersistentJobRunner exec;
+  Ticker ticker;
+  MemoryLimitedJobRunner memoryLimitedJobRunner;
+  ChecksumChecker checker;
+  boolean persistent;
+  File storageFile;
+  FileRandomAccessBufferFactory diskSpaceCheckingRAFFactory;
+  KeysFetchingLocally keysFetching;
+
+  /**
+   * Fluent builder for {@link SplitFileFetcherStorageInitParams}.
+   *
+   * <p>The builder performs no I/O and minimal validation. Typical usage sets the metadata,
+   * callback, decompression pipeline, factories, and execution helpers, then calls {@link #build()}
+   * to obtain an immutable {@link SplitFileFetcherStorageInitParams} snapshot.
+   *
+   * <p>Unless otherwise stated, all values are required. Optional values follow sensible defaults
+   * inside the storage constructor when omitted.
+   */
+  public static class Builder {
+    private Metadata metadata;
+    private SplitFileFetcherStorageCallback fetcher;
+    private List<COMPRESSOR_TYPE> decompressors;
+    private ClientMetadata clientMetadata;
+    private boolean topDontCompress;
+    private short topCompatibilityMode;
+    private FetchContext origFetchContext;
+    private boolean realTime;
+    private KeySalter salt;
+    private FreenetURI thisKey;
+    private FreenetURI origKey;
+    private boolean isFinalFetch;
+    private byte[] clientDetails;
+    private RandomSource random;
+    private BucketFactory tempBucketFactory;
+    private LockableRandomAccessBufferFactory rafFactory;
+    private PersistentJobRunner exec;
+    private Ticker ticker;
+    private MemoryLimitedJobRunner memoryLimitedJobRunner;
+    private ChecksumChecker checker;
+    private boolean persistent;
+    private File storageFile;
+    private FileRandomAccessBufferFactory diskSpaceCheckingRAFFactory;
+    private KeysFetchingLocally keysFetching;
+
+    /**
+     * Set the parsed splitfile {@link Metadata} required to plan the fetch.
+     *
+     * @param v metadata describing segments, blocks, and algorithms; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder metadata(Metadata v) {
+      this.metadata = v;
+      return this;
+    }
+
+    /**
+     * Set the fetcher callback that receives progress and completion events.
+     *
+     * @param v callback implementation used for notifications; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder fetcher(SplitFileFetcherStorageCallback v) {
+      this.fetcher = v;
+      return this;
+    }
+
+    /**
+     * Configure the decompressor pipeline to apply after block decode.
+     *
+     * @param v ordered list of compressor types; empty or singleton in most deployments.
+     * @return this builder for fluent chaining.
+     */
+    public Builder decompressors(List<COMPRESSOR_TYPE> v) {
+      this.decompressors = v;
+      return this;
+    }
+
+    /**
+     * Supply optional client metadata to attach to the completed object.
+     *
+     * @param v metadata such as MIME type and filename; may be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder clientMetadata(ClientMetadata v) {
+      this.clientMetadata = v;
+      return this;
+    }
+
+    /**
+     * Set whether the top-level container should avoid compression.
+     *
+     * @param v when {@code true}, skip attempting compression at the top level.
+     * @return this builder for fluent chaining.
+     */
+    public Builder topDontCompress(boolean v) {
+      this.topDontCompress = v;
+      return this;
+    }
+
+    /**
+     * Specify the minimum compatibility mode expected by the consumer.
+     *
+     * @param v numeric mode constant; affects padding and related behaviours.
+     * @return this builder for fluent chaining.
+     */
+    public Builder topCompatibilityMode(short v) {
+      this.topCompatibilityMode = v;
+      return this;
+    }
+
+    /**
+     * Provide the fetch context carrying retry and cooldown policy.
+     *
+     * @param v context with limits, timeouts, and priorities; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder fetchContext(FetchContext v) {
+      this.origFetchContext = v;
+      return this;
+    }
+
+    /**
+     * Indicate whether the fetch should prefer reduced buffering (real-time).
+     *
+     * @param v when {@code true}, configure for lower latency over throughput.
+     * @return this builder for fluent chaining.
+     */
+    public Builder realTime(boolean v) {
+      this.realTime = v;
+      return this;
+    }
+
+    /**
+     * Set the key salter used when deriving salted keys for requests.
+     *
+     * @param v optional salter strategy; may be {@code null} to disable salting.
+     * @return this builder for fluent chaining.
+     */
+    public Builder salt(KeySalter v) {
+      this.salt = v;
+      return this;
+    }
+
+    /**
+     * Set the primary request URI associated with this fetch.
+     *
+     * @param v the URI for the current object; used for logging and provenance.
+     * @return this builder for fluent chaining.
+     */
+    public Builder thisKey(FreenetURI v) {
+      this.thisKey = v;
+      return this;
+    }
+
+    /**
+     * Optionally record the original user-facing URI if different from {@link #thisKey}.
+     *
+     * @param v the original or canonical URI; may be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder origKey(FreenetURI v) {
+      this.origKey = v;
+      return this;
+    }
+
+    /**
+     * Indicate whether this fetch corresponds to the final content rather than metadata.
+     *
+     * @param v set {@code true} when fetching the actual payload, not intermediate data.
+     * @return this builder for fluent chaining.
+     */
+    public Builder isFinalFetch(boolean v) {
+      this.isFinalFetch = v;
+      return this;
+    }
+
+    /**
+     * Attach opaque client details preserved for callbacks and auditing.
+     *
+     * @param v optional byte array copied/stored as provided; may be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder clientDetails(byte[] v) {
+      this.clientDetails = v;
+      return this;
+    }
+
+    /**
+     * Provide the source of randomness used for key scheduling and shuffling.
+     *
+     * @param v randomness provider; must not be {@code null} in production use.
+     * @return this builder for fluent chaining.
+     */
+    public Builder random(RandomSource v) {
+      this.random = v;
+      return this;
+    }
+
+    /**
+     * Set the temporary bucket factory used to stage metadata before persistence.
+     *
+     * @param v factory for transient buffers; required when {@code persistent} is enabled.
+     * @return this builder for fluent chaining.
+     */
+    public Builder tempBucketFactory(BucketFactory v) {
+      this.tempBucketFactory = v;
+      return this;
+    }
+
+    /**
+     * Configure the random-access buffer factory that creates the backing store.
+     *
+     * @param v factory responsible for persistent RAF creation; must be compatible with the chosen
+     *     storage file.
+     * @return this builder for fluent chaining.
+     */
+    public Builder rafFactory(LockableRandomAccessBufferFactory v) {
+      this.rafFactory = v;
+      return this;
+    }
+
+    /**
+     * Provide the job runner used for off-thread work and callbacks.
+     *
+     * @param v persistent job runner implementation; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder exec(PersistentJobRunner v) {
+      this.exec = v;
+      return this;
+    }
+
+    /**
+     * Set the time source/scheduler used for delayed tasks and de-duplication.
+     *
+     * @param v ticker implementation; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder ticker(Ticker v) {
+      this.ticker = v;
+      return this;
+    }
+
+    /**
+     * Provide the memory-limited job runner used for heavy decode/encode work.
+     *
+     * @param v job runner aware of memory caps; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder memoryLimitedJobRunner(MemoryLimitedJobRunner v) {
+      this.memoryLimitedJobRunner = v;
+      return this;
+    }
+
+    /**
+     * Choose the checksum implementation and length used in persisted sections.
+     *
+     * @param v checker implementation which also provides the checksum length.
+     * @return this builder for fluent chaining.
+     */
+    public Builder checker(ChecksumChecker v) {
+      this.checker = v;
+      return this;
+    }
+
+    /**
+     * Enable or disable persistence of metadata and progress across restarts.
+     *
+     * @param v set {@code true} to persist enough state for resumption after a restart.
+     * @return this builder for fluent chaining.
+     */
+    public Builder persistent(boolean v) {
+      this.persistent = v;
+      return this;
+    }
+
+    /**
+     * Provide an explicit file for the backing store when truncation is desired.
+     *
+     * @param v target file path; when set, completion may use truncation optimisation.
+     * @return this builder for fluent chaining.
+     */
+    public Builder storageFile(File v) {
+      this.storageFile = v;
+      return this;
+    }
+
+    /**
+     * Configure a disk-space checking RAF factory for safer persistent allocations.
+     *
+     * @param v RAF factory that validates available space; optional but recommended.
+     * @return this builder for fluent chaining.
+     */
+    public Builder diskSpaceCheckingRAFFactory(FileRandomAccessBufferFactory v) {
+      this.diskSpaceCheckingRAFFactory = v;
+      return this;
+    }
+
+    /**
+     * Set the key-tracking helper that marks keys as fetching locally.
+     *
+     * @param v helper for cross-component key accounting; may be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder keysFetching(KeysFetchingLocally v) {
+      this.keysFetching = v;
+      return this;
+    }
+
+    /**
+     * Build an immutable snapshot of the current builder state.
+     *
+     * @return a fully-populated {@link SplitFileFetcherStorageInitParams} ready for storage
+     *     construction.
+     */
+    public SplitFileFetcherStorageInitParams build() {
+      SplitFileFetcherStorageInitParams p = new SplitFileFetcherStorageInitParams();
+      p.metadata = metadata;
+      p.fetcher = fetcher;
+      p.decompressors = decompressors;
+      p.clientMetadata = clientMetadata;
+      p.topDontCompress = topDontCompress;
+      p.topCompatibilityMode = topCompatibilityMode;
+      p.origFetchContext = origFetchContext;
+      p.realTime = realTime;
+      p.salt = salt;
+      p.thisKey = thisKey;
+      p.origKey = origKey;
+      p.isFinalFetch = isFinalFetch;
+      p.clientDetails = clientDetails;
+      p.random = random;
+      p.tempBucketFactory = tempBucketFactory;
+      p.rafFactory = rafFactory;
+      p.exec = exec;
+      p.ticker = ticker;
+      p.memoryLimitedJobRunner = memoryLimitedJobRunner;
+      p.checker = checker;
+      p.persistent = persistent;
+      p.storageFile = storageFile;
+      p.diskSpaceCheckingRAFFactory = diskSpaceCheckingRAFFactory;
+      p.keysFetching = keysFetching;
+      return p;
+    }
+  }
+}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStoragePersistence.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStoragePersistence.java
@@ -1,0 +1,219 @@
+package network.crypta.client.async;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.client.FailureCodeTracker;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.Metadata;
+import network.crypta.client.MetadataUnresolvedException;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.HashType;
+import network.crypta.crypt.MultiHashOutputStream;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.io.ArrayBucketFactory;
+import network.crypta.support.io.BucketTools;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Encapsulates persistence-related encoding and I/O for splitfile storage.
+ *
+ * <p>Owns bucket-based staging, checksum handling, and footer writes so the main storage class can
+ * focus on orchestration.
+ */
+final class SplitFileFetcherStoragePersistence {
+  /** Prepared metadata buffers and offsets for a persistent layout. */
+  record PreparedMetadata(
+      Bucket metadataTemp,
+      byte[] encodedURI,
+      long offsetOriginalDetails,
+      long offsetBasicSettings) {
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o
+          instanceof
+          PreparedMetadata(
+              Bucket otherMetadataTemp,
+              byte[] otherEncodedURI,
+              long otherOffsetOriginalDetails,
+              long otherOffsetBasicSettings))) {
+        return false;
+      }
+      return offsetOriginalDetails == otherOffsetOriginalDetails
+          && offsetBasicSettings == otherOffsetBasicSettings
+          && Objects.equals(metadataTemp, otherMetadataTemp)
+          && Arrays.equals(encodedURI, otherEncodedURI);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Objects.hash(metadataTemp, offsetOriginalDetails, offsetBasicSettings);
+      result = 31 * result + Arrays.hashCode(encodedURI);
+      return result;
+    }
+
+    @Override
+    public @NotNull String toString() {
+      return "PreparedMetadata[metadataTemp="
+          + metadataTemp
+          + ", encodedURI="
+          + Arrays.toString(encodedURI)
+          + ", offsetOriginalDetails="
+          + offsetOriginalDetails
+          + ", offsetBasicSettings="
+          + offsetBasicSettings
+          + "]";
+    }
+  }
+
+  static byte[] encodeGeneralProgress(
+      ChecksumChecker checksumChecker, boolean hasCheckedDatastore, FailureCodeTracker errors) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (OutputStream ccos =
+            checksumChecker.checksumWriterWithLength(baos, new ArrayBucketFactory());
+        DataOutputStream dos = new DataOutputStream(ccos)) {
+      long flags = hasCheckedDatastore ? SplitFileFetcherStorage.HAS_CHECKED_DATASTORE_FLAG : 0;
+      dos.writeLong(flags);
+      errors.writeFixedLengthTo(dos);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    return baos.toByteArray();
+  }
+
+  static PreparedMetadata preparePersistent(
+      Metadata metadata,
+      BucketFactory tempBucketFactory,
+      FreenetURI thisKey,
+      FreenetURI origKey,
+      byte[] clientDetails,
+      boolean isFinalFetch,
+      long offsetOriginalMetadata,
+      ChecksumChecker checksumChecker,
+      int maxRetries,
+      int cooldownTries,
+      long cooldownLength)
+      throws FetchException, IOException {
+    Bucket metadataTemp = tempBucketFactory.makeBucket(-1);
+    try (OutputStream os = metadataTemp.getOutputStream();
+        OutputStream cos = checksumChecker.checksumWriter(os);
+        BufferedOutputStream bos = new BufferedOutputStream(cos)) {
+      MultiHashOutputStream mos = new MultiHashOutputStream(bos, HashType.SHA256.bitmask);
+      metadata.writeTo(new DataOutputStream(mos));
+      mos.getResults()[0].writeTo(bos);
+    } catch (MetadataUnresolvedException e) {
+      throw new FetchException(
+          FetchExceptionMode.INTERNAL_ERROR,
+          "Metadata not resolved starting splitfile fetch?!: " + e,
+          e);
+    }
+    long metadataLength = metadataTemp.size();
+    long computedOffsetOriginalDetails = offsetOriginalMetadata + metadataLength;
+
+    byte[] encodedURI =
+        encodeAndChecksumOriginalDetails(
+            thisKey,
+            origKey,
+            clientDetails,
+            isFinalFetch,
+            checksumChecker,
+            maxRetries,
+            cooldownTries,
+            cooldownLength);
+    long computedOffsetBasicSettings = computedOffsetOriginalDetails + encodedURI.length;
+
+    return new PreparedMetadata(
+        metadataTemp, encodedURI, computedOffsetOriginalDetails, computedOffsetBasicSettings);
+  }
+
+  static void writePersistentMetadata(
+      LockableRandomAccessBuffer raf,
+      long offsetOriginalMetadata,
+      PreparedMetadata prepared,
+      byte[] encodedBasicSettings,
+      ChecksumChecker checksumChecker,
+      long totalLength)
+      throws IOException {
+    try (Bucket metadataTemp = prepared.metadataTemp()) {
+      BucketTools.copyTo(metadataTemp, raf, offsetOriginalMetadata, -1);
+    }
+    raf.pwrite(
+        prepared.offsetOriginalDetails(), prepared.encodedURI(), 0, prepared.encodedURI().length);
+    raf.pwrite(
+        prepared.offsetBasicSettings(), encodedBasicSettings, 0, encodedBasicSettings.length);
+
+    int checksumLength = checksumChecker.checksumLength();
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+    dos.writeInt(encodedBasicSettings.length - checksumLength);
+    byte[] bufToWrite = baos.toByteArray();
+    baos = new ByteArrayOutputStream();
+    dos = new DataOutputStream(baos);
+    dos.writeInt(0);
+    dos.writeShort(checksumChecker.getChecksumTypeID());
+    dos.writeInt(SplitFileFetcherStorage.VERSION);
+    byte[] versionBytes = baos.toByteArray();
+    byte[] bufToChecksum = Arrays.copyOf(bufToWrite, bufToWrite.length + versionBytes.length);
+    System.arraycopy(versionBytes, 0, bufToChecksum, bufToWrite.length, versionBytes.length);
+    byte[] checksum = checksumChecker.generateChecksum(bufToChecksum);
+    raf.pwrite(
+        prepared.offsetBasicSettings() + encodedBasicSettings.length,
+        bufToWrite,
+        0,
+        bufToWrite.length);
+    raf.pwrite(
+        prepared.offsetBasicSettings() + encodedBasicSettings.length + bufToWrite.length,
+        checksum,
+        0,
+        checksum.length);
+    raf.pwrite(
+        prepared.offsetBasicSettings()
+            + encodedBasicSettings.length
+            + bufToWrite.length
+            + checksum.length,
+        versionBytes,
+        0,
+        versionBytes.length);
+    baos = new ByteArrayOutputStream();
+    dos = new DataOutputStream(baos);
+    dos.writeLong(SplitFileFetcherStorage.END_MAGIC);
+    byte[] buf = baos.toByteArray();
+    raf.pwrite(totalLength - 8, buf, 0, 8);
+  }
+
+  private static byte[] encodeAndChecksumOriginalDetails(
+      FreenetURI thisKey,
+      FreenetURI origKey,
+      byte[] clientDetails,
+      boolean isFinalFetch,
+      ChecksumChecker checksumChecker,
+      int maxRetries,
+      int cooldownTries,
+      long cooldownLength)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+    dos.writeUTF(thisKey.toASCIIString());
+    dos.writeUTF(origKey.toASCIIString());
+    dos.writeBoolean(isFinalFetch);
+    dos.writeInt(clientDetails.length);
+    dos.write(clientDetails);
+    dos.writeInt(maxRetries);
+    dos.writeInt(cooldownTries);
+    dos.writeLong(cooldownLength);
+    return checksumChecker.appendChecksum(baos.toByteArray());
+  }
+
+  private SplitFileFetcherStoragePersistence() {}
+}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStoragePersistence.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStoragePersistence.java
@@ -26,11 +26,42 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Encapsulates persistence-related encoding and I/O for splitfile storage.
  *
- * <p>Owns bucket-based staging, checksum handling, and footer writes so the main storage class can
- * focus on orchestration.
+ * <p>This utility centralizes the byte-level layout used by {@link SplitFileFetcherStorage} when it
+ * persists splitfile fetch state. It stages metadata into a temporary {@link Bucket}, appends an
+ * SHA-256 digest, encodes original request details with checksum framing, and emits the footer
+ * fields that complete the on-disk structure. The methods are intentionally narrow and
+ * side-effect-free beyond writing to caller-supplied buffers, which keeps higher-level
+ * orchestration focused on scheduling and recovery rather than serialization minutiae. The class is
+ * stateless and therefore thread-safe as long as callers do not share the same buffers
+ * concurrently.
+ *
+ * <p>Notable responsibilities include:
+ *
+ * <ul>
+ *   <li>Prepare staged metadata and offsets for later persistent writes.
+ *   <li>Serialize progress flags and error trackers into a checksum-framed blob.
+ *   <li>Write encoded settings, checksums, and end markers to a random-access buffer.
+ * </ul>
+ *
+ * @see SplitFileFetcherStorage
+ * @see ChecksumChecker
  */
 final class SplitFileFetcherStoragePersistence {
-  /** Prepared metadata buffers and offsets for a persistent layout. */
+  /**
+   * Holds staged metadata bytes and computed offsets for the persistent layout.
+   *
+   * <p>The record is produced by {@link #preparePersistent} after metadata is serialized and the
+   * original request details are encoded with checksum framing. Offsets are byte positions relative
+   * to the same base used when writing the final layout, so callers should treat them as immutable
+   * coordinates. The {@link Bucket} is intentionally left open so it can be copied later; callers
+   * should either close it directly or pass the record to {@link #writePersistentMetadata}, which
+   * closes it after copying.
+   *
+   * @param metadataTemp temporary bucket containing encoded metadata and appended hash
+   * @param encodedURI encoded original details plus checksum for persistent layout
+   * @param offsetOriginalDetails byte offset of encoded original details within storage layout
+   * @param offsetBasicSettings byte offset of basic settings block within storage layout
+   */
   record PreparedMetadata(
       Bucket metadataTemp,
       byte[] encodedURI,
@@ -77,6 +108,26 @@ final class SplitFileFetcherStoragePersistence {
     }
   }
 
+  /**
+   * Serializes general fetch progress and error tracking into a checksum-framed byte array.
+   *
+   * <p>The method wraps a {@link DataOutputStream} in the {@link ChecksumChecker} framing returned
+   * by {@link ChecksumChecker#checksumWriterWithLength(OutputStream, BucketFactory)}. It writes a
+   * single flag word that currently records whether the datastore has been checked, followed by the
+   * fixed length representation of the {@link FailureCodeTracker}. Closing the stream finalizes the
+   * framing, and the resulting byte array is ready for persistence in the progress section.
+   *
+   * <pre>{@code
+   * byte[] payload = SplitFileFetcherStoragePersistence.encodeGeneralProgress(
+   *     checksumChecker, true, errorTracker);
+   * }</pre>
+   *
+   * @param checksumChecker non-null checksum provider used to frame the output bytes
+   * @param hasCheckedDatastore true when datastore validation already completed for this fetch
+   * @param errors non-null tracker written in fixed-length binary form
+   * @return byte array containing framed flags and serialized error data
+   * @throws IllegalStateException if the checksum writer reports an I/O failure
+   */
   static byte[] encodeGeneralProgress(
       ChecksumChecker checksumChecker, boolean hasCheckedDatastore, FailureCodeTracker errors) {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -92,6 +143,37 @@ final class SplitFileFetcherStoragePersistence {
     return baos.toByteArray();
   }
 
+  /**
+   * Stages metadata and computes offsets for a persistent splitfile layout.
+   *
+   * <p>The method serializes {@code metadata} into a temporary {@link Bucket}, appends the SHA-256
+   * digest produced by {@link MultiHashOutputStream}, and then computes where the original request
+   * details and basic settings should be written relative to {@code offsetOriginalMetadata}. It
+   * also encodes the original keys and client details with checksum framing so the caller can later
+   * write a contiguous structure without recomputing hashes. The returned record carries both the
+   * staged bucket and the computed offsets; the bucket remains open until it is copied.
+   *
+   * <pre>{@code
+   * PreparedMetadata prepared = SplitFileFetcherStoragePersistence.preparePersistent(
+   *     metadata, tempBucketFactory, thisKey, origKey, clientDetails, isFinalFetch,
+   *     offsetOriginalMetadata, checksumChecker, maxRetries, cooldownTries, cooldownLength);
+   * }</pre>
+   *
+   * @param metadata resolved metadata to serialize into the persistent layout
+   * @param tempBucketFactory factory used to allocate the temporary metadata bucket
+   * @param thisKey key of the fetch currently being persisted
+   * @param origKey original request key that seeded the fetch
+   * @param clientDetails non-null client detail bytes written verbatim to storage
+   * @param isFinalFetch true when the request is a final-fetch operation
+   * @param offsetOriginalMetadata base byte offset for metadata placement in storage
+   * @param checksumChecker checksum provider used for metadata and details framing
+   * @param maxRetries maximum retry count persisted for future resume logic
+   * @param cooldownTries number of retry attempts before cooldown applies
+   * @param cooldownLength cooldown duration in milliseconds for retry scheduling
+   * @return prepared metadata with staged bytes and computed offset positions
+   * @throws FetchException if metadata is unresolved or encoding fails internally
+   * @throws IOException if bucket I/O or checksum output cannot complete
+   */
   static PreparedMetadata preparePersistent(
       Metadata metadata,
       BucketFactory tempBucketFactory,
@@ -137,6 +219,23 @@ final class SplitFileFetcherStoragePersistence {
         metadataTemp, encodedURI, computedOffsetOriginalDetails, computedOffsetBasicSettings);
   }
 
+  /**
+   * Writes prepared metadata and footer fields into the persistent buffer.
+   *
+   * <p>The method copies the staged metadata bucket into {@code raf} at {@code
+   * offsetOriginalMetadata}, writes the encoded original details and the provided basic settings at
+   * the offsets held by {@code prepared}, and then appends a short footer that records the
+   * basic-settings length, checksum bytes, and version information. Finally, it writes the end
+   * marker at {@code totalLength - 8}. The prepared bucket is closed after the copy completes.
+   *
+   * @param raf non-null random access buffer that receives the persisted bytes
+   * @param offsetOriginalMetadata byte offset where metadata bytes are written
+   * @param prepared non-null staging record containing offsets and encoded details
+   * @param encodedBasicSettings non-null basic settings payload written verbatim
+   * @param checksumChecker checksum provider used to generate the footer checksum
+   * @param totalLength total byte length of the persistent layout buffer
+   * @throws IOException if any random-access writes or bucket copies fail
+   */
   static void writePersistentMetadata(
       LockableRandomAccessBuffer raf,
       long offsetOriginalMetadata,
@@ -192,6 +291,25 @@ final class SplitFileFetcherStoragePersistence {
     raf.pwrite(totalLength - 8, buf, 0, 8);
   }
 
+  /**
+   * Encodes original keys and retry settings, then appends a checksum.
+   *
+   * <p>The payload includes the current key, original key, a final-fetch flag, the client detail
+   * bytes with a length prefix, and the retry/cooldown settings in the order expected by the
+   * persistence layout. The returned byte array contains the encoded payload followed by the
+   * checksum bytes produced by {@link ChecksumChecker#appendChecksum(byte[])}.
+   *
+   * @param thisKey key of the fetch currently being persisted
+   * @param origKey original request key that seeded the fetch
+   * @param clientDetails non-null client detail bytes written verbatim to storage
+   * @param isFinalFetch true when the request is a final-fetch operation
+   * @param checksumChecker checksum provider used to append checksum bytes
+   * @param maxRetries maximum retry count persisted for future resume logic
+   * @param cooldownTries number of retry attempts before cooldown applies
+   * @param cooldownLength cooldown duration in milliseconds for retry scheduling
+   * @return encoded payload followed by checksum bytes for persistence
+   * @throws IOException if an unexpected stream write fails
+   */
   private static byte[] encodeAndChecksumOriginalDetails(
       FreenetURI thisKey,
       FreenetURI origKey,
@@ -215,5 +333,6 @@ final class SplitFileFetcherStoragePersistence {
     return checksumChecker.appendChecksum(baos.toByteArray());
   }
 
+  /** Prevents instantiation; this class exposes only static helpers. */
   private SplitFileFetcherStoragePersistence() {}
 }

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageRafFactory.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageRafFactory.java
@@ -1,0 +1,78 @@
+package network.crypta.client.async;
+
+import java.io.File;
+import java.io.IOException;
+import network.crypta.crypt.RandomSource;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import org.slf4j.Logger;
+
+/**
+ * Creates random-access buffers used by splitfile fetcher storage.
+ *
+ * <p>This utility encapsulates the decision between file-backed and in-memory {@link
+ * LockableRandomAccessBuffer} instances for fetch operations. Callers typically invoke {@link
+ * #createRafOrThrow(File, long, LockableRandomAccessBufferFactory, FileRandomAccessBufferFactory,
+ * RandomSource, Logger)} during fetcher initialization, after any on-disk storage file has been
+ * created. When a storage file is supplied, the factory enforces that it already exists and is
+ * empty, then delegates creation to a disk-space-checking factory; otherwise it delegates to the
+ * in-memory factory. The class is stateless and does not retain the returned buffer, so lifecycle
+ * management remains with the caller. It is safe to call concurrently as long as the provided
+ * factories are safe for the same usage.
+ *
+ * <ul>
+ *   <li>Selects file-backed or in-memory RAF creation based on inputs.
+ *   <li>Validates preconditions for complete-via-truncation file storage.
+ * </ul>
+ *
+ * @see LockableRandomAccessBufferFactory
+ * @see FileRandomAccessBufferFactory
+ */
+public final class SplitFileFetcherStorageRafFactory {
+  private SplitFileFetcherStorageRafFactory() {}
+
+  /**
+   * Creates a random-access buffer for splitfile fetch storage based on inputs.
+   *
+   * <p>The method chooses between file-backed and in-memory storage using {@code storageFile}. For
+   * file-backed storage, it requires an already-created, empty file, logs the creation event, and
+   * delegates to the disk-space-checking factory. For in-memory storage, it delegates to {@code
+   * rafFactory} without logging. The method performs no truncation or cleanup and does not cache
+   * the result; the caller owns the returned buffer and manages its lifecycle.
+   *
+   * <pre>{@code
+   * LockableRandomAccessBuffer raf =
+   *     SplitFileFetcherStorageRafFactory.createRafOrThrow(
+   *         storageFile, totalLength, memoryFactory, diskFactory, random, log);
+   * }</pre>
+   *
+   * @param storageFile optional on-disk file; when non-null triggers file-backed RAF creation
+   * @param totalLength length forwarded to the factory; units are defined by the factory
+   * @param rafFactory non-null factory for in-memory buffers when {@code storageFile} is null
+   * @param diskSpaceCheckingRafFactory non-null factory for file-backed RAFs when a file is used
+   * @param random randomness source forwarded to file-backed creation; null is not checked here
+   * @param log logger receiving a single info message for file-backed creation paths
+   * @return a newly created lockable RAF whose lifecycle is managed by the caller
+   * @throws IOException if preconditions fail or the selected factory cannot create storage
+   */
+  public static LockableRandomAccessBuffer createRafOrThrow(
+      File storageFile,
+      long totalLength,
+      LockableRandomAccessBufferFactory rafFactory,
+      FileRandomAccessBufferFactory diskSpaceCheckingRafFactory,
+      RandomSource random,
+      Logger log)
+      throws IOException {
+    if (storageFile != null) {
+      if (diskSpaceCheckingRafFactory == null) {
+        throw new IOException("Disk-space checking RAF factory required for file-backed storage");
+      }
+      if (!storageFile.exists()) throw new IOException("Must have already created storage file");
+      if (storageFile.length() > 0) throw new IOException("Storage file must be empty");
+      log.info("Creating splitfile storage file for complete-via-truncation: {}", storageFile);
+      return diskSpaceCheckingRafFactory.createNewRAF(storageFile, totalLength, random);
+    }
+    return rafFactory.makeRAF(totalLength);
+  }
+}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageResumeParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageResumeParams.java
@@ -75,9 +75,9 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Configure whether resume should prefer real-time behaviour.
+     * Configure whether resume should prefer real-time behavior.
      *
-     * @param v when {@code true}, optimises for latency over throughput.
+     * @param v when {@code true}, optimizes for latency over throughput.
      * @return this builder for fluent chaining.
      */
     public Builder realTime(boolean v) {
@@ -209,7 +209,7 @@ public final class SplitFileFetcherStorageResumeParams {
     /**
      * Enable completion via truncation when possible.
      *
-     * @param v when {@code true}, prefer truncation optimisation at completion.
+     * @param v when {@code true}, prefer truncation optimization at completion.
      * @return this builder for fluent chaining.
      */
     public Builder completeViaTruncation(boolean v) {

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageResumeParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageResumeParams.java
@@ -9,18 +9,30 @@ import network.crypta.support.Ticker;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 
 /**
- * Parameters needed to resume a previously persisted fetch session.
+ * Holds runtime services and flags needed to resume a persisted splitfile fetch.
  *
- * <p>When storage was created in persistent mode, a restart rebuilds its in-memory state by reading
- * and validating checksummed sections from the backing random access buffer. This holder conveys
- * the environment required to do so, including the buffer itself, scheduling helpers and checksum
- * implementation.
+ * <p>This parameter holder is populated during restart when persistent storage must reconstruct
+ * in-memory state from a backing random-access buffer and checksummed sections. It captures the
+ * runtime environment required by the resume constructor, such as scheduling helpers, randomness,
+ * and checksum validation logic, along with flags that influence resume behavior. Unlike {@link
+ * SplitFileFetcherStorageInitParams}, these values originate from the on-disk format and the
+ * persisted session state rather than the original request metadata.
  *
- * <p>Unlike {@link SplitFileFetcherStorageInitParams}, these values are derived from the on-disk
- * format rather than the metadata that initiated the fetch. Use the nested {@link Builder} to
- * construct an instance suitable for {@link
- * SplitFileFetcherStorage#SplitFileFetcherStorage(SplitFileFetcherStorageResumeParams)}.
+ * <p>The instance is intentionally lightweight: it stores references as-is, performs no validation,
+ * and is intended for single-threaded construction followed by immediate handoff to {@link
+ * SplitFileFetcherStorage#SplitFileFetcherStorage(SplitFileFetcherStorageResumeParams)}. Callers
+ * are responsible for providing compatible services and honoring nullability contracts expected by
+ * the resume path.
  *
+ * <ul>
+ *   <li>Holds the storage buffer and checksum checker for persisted sections.
+ *   <li>Provides schedulers, randomness, and accounting helpers used during resume.
+ *   <li>Captures resume flags such as real-time mode, salting, and truncation completion.
+ * </ul>
+ *
+ * @see SplitFileFetcherStorageResumeParams.Builder
+ * @see SplitFileFetcherStorageInitParams
+ * @see SplitFileFetcherStorage
  * @hidden
  */
 public final class SplitFileFetcherStorageResumeParams {
@@ -43,9 +55,27 @@ public final class SplitFileFetcherStorageResumeParams {
    * Fluent builder for {@link SplitFileFetcherStorageResumeParams} used when reconstructing state
    * from disk.
    *
-   * <p>Callers provide the buffer to read from, runtime services (job/ticker), and flags indicating
-   * whether a new salt should be injected. The resulting {@link
-   * SplitFileFetcherStorageResumeParams} is consumed by the resuming constructor.
+   * <p>The builder records the runtime dependencies and flags that the resume constructor expects.
+   * Each setter overwrites the previous value and returns the same builder for fluent chaining.
+   * Values are captured without validation or defensive copying; the {@link #build()} method
+   * transfers references into a new parameters instance. After construction, subsequent changes to
+   * the builder do not affect already-built objects.
+   *
+   * <p>Typical usage is to configure the buffer, schedulers, and checksum implementation based on
+   * the persisted state, then pass the resulting snapshot directly to {@link
+   * SplitFileFetcherStorage#SplitFileFetcherStorage(SplitFileFetcherStorageResumeParams)}. The
+   * builder is mutable and not thread-safe, so configure it on a single thread.
+   *
+   * <pre>{@code
+   * SplitFileFetcherStorageResumeParams params =
+   *     new SplitFileFetcherStorageResumeParams.Builder()
+   *         .raf(buffer)
+   *         .callback(callback)
+   *         .ticker(ticker)
+   *         .build();
+   * }</pre>
+   *
+   * @hidden
    */
   public static class Builder {
     private LockableRandomAccessBuffer raf;
@@ -64,10 +94,14 @@ public final class SplitFileFetcherStorageResumeParams {
     private boolean completeViaTruncation;
 
     /**
-     * Set the random-access buffer to resume from.
+     * Sets the random-access buffer to resume from.
      *
-     * @param v buffer positioned at the previously persisted storage file.
-     * @return this builder for fluent chaining.
+     * <p>This buffer is the backing store that contains the persisted splitfile metadata and
+     * checksummed sections. The builder records the reference exactly as provided; it does not
+     * validate position, size, or lock state. The last value set wins if invoked multiple times.
+     *
+     * @param v buffer positioned at the persisted storage file; may be {@code null}.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder raf(LockableRandomAccessBuffer v) {
       this.raf = v;
@@ -75,10 +109,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Configure whether resume should prefer real-time behavior.
+     * Configures whether resume should prefer real-time behavior.
      *
-     * @param v when {@code true}, optimizes for latency over throughput.
-     * @return this builder for fluent chaining.
+     * <p>This flag is a hint consumed by the resume logic to prefer lower latency to throughput
+     * where applicable. It is stored as-is without validation. Repeated calls replace the previous
+     * value; setting the same value again is idempotent.
+     *
+     * @param v {@code true} to favor latency; {@code false} to favor throughput.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder realTime(boolean v) {
       this.realTime = v;
@@ -86,10 +124,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Set the callback used for notifications during the resumed session.
+     * Sets the callback used for notifications during the resumed session.
      *
-     * @param v callback implementation; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>The callback is passed through to the resumed storage so it can emit progress or error
+     * notifications. The builder does not enforce non-nullity; the resume constructor may rely on
+     * callers to supply a valid implementation. Multiple invocations replace the previous callback.
+     *
+     * @param v callback implementation; may be {@code null} if the caller tolerates it.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder callback(SplitFileFetcherStorageCallback v) {
       this.callback = v;
@@ -97,10 +139,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Provide the original fetch context to reapply scheduling policy.
+     * Provides the original fetch context to reapply scheduling policy.
      *
-     * @param v fetch context used to derive retries and cooldown; non-null.
-     * @return this builder for fluent chaining.
+     * <p>The resume path may consult the original context to restore retry, cooldown, and queueing
+     * policies. This builder stores the reference directly and does not clone or sanitize it. The
+     * most recently supplied context wins if the method is called multiple times.
+     *
+     * @param v original fetch context reference; may be {@code null} if unavailable.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder context(FetchContext v) {
       this.origContext = v;
@@ -108,10 +154,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Provide the randomness source used by resumed operations.
+     * Provides the randomness source used by resumed operations.
      *
-     * @param v randomness provider; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>The resume path may rely on this source for randomized scheduling or salting decisions.
+     * The builder keeps the reference unchanged and does not enforce non-nullity. Calling this
+     * method repeatedly replaces the previous reference.
+     *
+     * @param v randomness provider reference; may be {@code null} if not available.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder random(RandomSource v) {
       this.random = v;
@@ -119,10 +169,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Set the job runner handling off-thread activity.
+     * Sets the job runner handling off-thread activity.
      *
-     * @param v job runner for background tasks; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>The resume logic may schedule work through this runner; this builder only stores the
+     * provided reference and does not validate its configuration. If invoked more than once, the
+     * last supplied runner is retained.
+     *
+     * @param v job runner for background tasks; may be {@code null} if not used.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder exec(PersistentJobRunner v) {
       this.exec = v;
@@ -130,10 +184,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Provide the helper used to mark keys as fetching locally.
+     * Provides the helper used to mark keys as fetching locally.
      *
-     * @param v optional accounting helper.
-     * @return this builder for fluent chaining.
+     * <p>This helper is optional and may be {@code null} when local key accounting is not desired
+     * or when the resume flow does not need to track local fetches. The builder records whatever
+     * reference is supplied, with later calls overwriting earlier ones.
+     *
+     * @param v helper for local fetch accounting; {@code null} disables the helper.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder keysFetching(KeysFetchingLocally v) {
       this.keysFetching = v;
@@ -141,10 +199,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Set the ticker used for timed operations and coalescing.
+     * Sets the ticker used for timed operations and coalescing.
      *
-     * @param v ticker/scheduler implementation; non-null.
-     * @return this builder for fluent chaining.
+     * <p>The ticker provides a scheduling and timing facility that the resume path can use for
+     * delays or periodic activity. The builder stores the reference as-is and performs no
+     * validation or wrapping. As with other setters, the most recent call wins.
+     *
+     * @param v ticker or scheduler implementation; may be {@code null} if unused.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder ticker(Ticker v) {
       this.ticker = v;
@@ -152,10 +214,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Provide the memory-limited job runner for heavy tasks.
+     * Provides the memory-limited job runner for heavy tasks.
      *
-     * @param v job runner respecting memory caps; must not be {@code null}.
-     * @return this builder for fluent chaining.
+     * <p>This runner is used when resume operations should respect memory caps. The builder keeps
+     * the supplied reference without validation, and later calls overwrite earlier values. The
+     * resume constructor is responsible for handling a {@code null} reference if provided.
+     *
+     * @param v job runner that enforces memory caps; may be {@code null} if unused.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder memoryLimitedJobRunner(MemoryLimitedJobRunner v) {
       this.memoryLimitedJobRunner = v;
@@ -163,10 +229,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Set the checksum implementation and length for persisted sections.
+     * Sets the checksum implementation used to validate persisted sections.
      *
-     * @param v checker implementation; non-null.
-     * @return this builder for fluent chaining.
+     * <p>The resume logic consults this checker when reading checksummed data from the backing
+     * buffer. This builder stores the reference exactly as provided and does not validate the
+     * checker’s configuration. Multiple calls replace the previous checker reference.
+     *
+     * @param v checksum checker implementation; may be {@code null} if not required.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder checker(ChecksumChecker v) {
       this.checker = v;
@@ -174,10 +244,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Whether to inject a new salt when resuming, if supported.
+     * Specifies whether to inject a new salt when resuming, if supported.
      *
-     * @param v set {@code true} to prefer re-salting.
-     * @return this builder for fluent chaining.
+     * <p>This flag signals a preference for re-salting during resume. It does not itself generate
+     * or validate salts, and it has no effect until consumed by the resume constructor. Repeated
+     * calls overwrite the previous value, and setting the same value again is idempotent.
+     *
+     * @param v {@code true} to request re-salting; {@code false} to keep existing salt.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder newSalt(boolean v) {
       this.newSalt = v;
@@ -185,10 +259,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Provide the salter to use if {@link #newSalt(boolean)} is {@code true}.
+     * Provides the salter to use if {@link #newSalt(boolean)} is {@code true}.
      *
-     * @param v salter implementation; may be {@code null} to disable.
-     * @return this builder for fluent chaining.
+     * <p>The salter reference is recorded without validation. It may be {@code null}, in which case
+     * the resume logic can decide to skip salting even if {@code newSalt} is requested. The most
+     * recently supplied salter replaces any prior value.
+     *
+     * @param v salter implementation reference; {@code null} disables salting support.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder salt(KeySalter v) {
       this.salt = v;
@@ -196,10 +274,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Mark that this session represents a true resume rather than a fresh start.
+     * Marks that this session represents a true resume rather than a fresh start.
      *
-     * @param v set {@code true} when resuming from persisted state.
-     * @return this builder for fluent chaining.
+     * <p>This flag allows the resume constructor to distinguish between reconstructed state and a
+     * newly initialized fetch. The builder records the value directly; repeated calls overwrite the
+     * prior value, and setting the same value again is idempotent.
+     *
+     * @param v {@code true} when resuming persisted state; {@code false} otherwise.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder resumed(boolean v) {
       this.resumed = v;
@@ -207,10 +289,14 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Enable completion via truncation when possible.
+     * Enables completion via truncation when possible.
      *
-     * @param v when {@code true}, prefer truncation optimization at completion.
-     * @return this builder for fluent chaining.
+     * <p>This flag indicates a preference for truncation-based completion optimizations at the end
+     * of the resumed fetch. The builder stores the preference as provided and does not validate
+     * compatibility. Later calls overwrite earlier ones.
+     *
+     * @param v {@code true} to prefer truncation completion; {@code false} to disable it.
+     * @return this builder instance for fluent chaining and continued configuration.
      */
     public Builder completeViaTruncation(boolean v) {
       this.completeViaTruncation = v;
@@ -218,9 +304,15 @@ public final class SplitFileFetcherStorageResumeParams {
     }
 
     /**
-     * Build a {@link SplitFileFetcherStorageResumeParams} snapshot for resuming from disk.
+     * Builds a {@link SplitFileFetcherStorageResumeParams} snapshot for resuming from disk.
      *
-     * @return the constructed parameters object consumed by the resuming constructor.
+     * <p>The returned instance is a shallow snapshot of the current builder state. References are
+     * copied as-is, so mutations to referenced objects are visible to the resume flow. The builder
+     * itself remains mutable and can be reused to build additional snapshots with different values.
+     * This method performs no validation; callers should ensure required fields are set before
+     * invoking the resume constructor.
+     *
+     * @return a new parameters object reflecting the builder’s current values and flags.
      */
     public SplitFileFetcherStorageResumeParams build() {
       SplitFileFetcherStorageResumeParams p = new SplitFileFetcherStorageResumeParams();

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageResumeParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageResumeParams.java
@@ -1,0 +1,244 @@
+package network.crypta.client.async;
+
+import network.crypta.client.FetchContext;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.KeysFetchingLocally;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+
+/**
+ * Parameters needed to resume a previously persisted fetch session.
+ *
+ * <p>When storage was created in persistent mode, a restart rebuilds its in-memory state by reading
+ * and validating checksummed sections from the backing random access buffer. This holder conveys
+ * the environment required to do so, including the buffer itself, scheduling helpers and checksum
+ * implementation.
+ *
+ * <p>Unlike {@link SplitFileFetcherStorageInitParams}, these values are derived from the on-disk
+ * format rather than the metadata that initiated the fetch. Use the nested {@link Builder} to
+ * construct an instance suitable for {@link
+ * SplitFileFetcherStorage#SplitFileFetcherStorage(SplitFileFetcherStorageResumeParams)}.
+ *
+ * @hidden
+ */
+public final class SplitFileFetcherStorageResumeParams {
+  LockableRandomAccessBuffer raf;
+  boolean realTime;
+  SplitFileFetcherStorageCallback callback;
+  FetchContext origContext;
+  RandomSource random;
+  PersistentJobRunner exec;
+  KeysFetchingLocally keysFetching;
+  Ticker ticker;
+  MemoryLimitedJobRunner memoryLimitedJobRunner;
+  ChecksumChecker checker;
+  boolean newSalt;
+  KeySalter salt;
+  boolean resumed;
+  boolean completeViaTruncation;
+
+  /**
+   * Fluent builder for {@link SplitFileFetcherStorageResumeParams} used when reconstructing state
+   * from disk.
+   *
+   * <p>Callers provide the buffer to read from, runtime services (job/ticker), and flags indicating
+   * whether a new salt should be injected. The resulting {@link
+   * SplitFileFetcherStorageResumeParams} is consumed by the resuming constructor.
+   */
+  public static class Builder {
+    private LockableRandomAccessBuffer raf;
+    private boolean realTime;
+    private SplitFileFetcherStorageCallback callback;
+    private FetchContext origContext;
+    private RandomSource random;
+    private PersistentJobRunner exec;
+    private KeysFetchingLocally keysFetching;
+    private Ticker ticker;
+    private MemoryLimitedJobRunner memoryLimitedJobRunner;
+    private ChecksumChecker checker;
+    private boolean newSalt;
+    private KeySalter salt;
+    private boolean resumed;
+    private boolean completeViaTruncation;
+
+    /**
+     * Set the random-access buffer to resume from.
+     *
+     * @param v buffer positioned at the previously persisted storage file.
+     * @return this builder for fluent chaining.
+     */
+    public Builder raf(LockableRandomAccessBuffer v) {
+      this.raf = v;
+      return this;
+    }
+
+    /**
+     * Configure whether resume should prefer real-time behaviour.
+     *
+     * @param v when {@code true}, optimises for latency over throughput.
+     * @return this builder for fluent chaining.
+     */
+    public Builder realTime(boolean v) {
+      this.realTime = v;
+      return this;
+    }
+
+    /**
+     * Set the callback used for notifications during the resumed session.
+     *
+     * @param v callback implementation; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder callback(SplitFileFetcherStorageCallback v) {
+      this.callback = v;
+      return this;
+    }
+
+    /**
+     * Provide the original fetch context to reapply scheduling policy.
+     *
+     * @param v fetch context used to derive retries and cooldown; non-null.
+     * @return this builder for fluent chaining.
+     */
+    public Builder context(FetchContext v) {
+      this.origContext = v;
+      return this;
+    }
+
+    /**
+     * Provide the randomness source used by resumed operations.
+     *
+     * @param v randomness provider; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder random(RandomSource v) {
+      this.random = v;
+      return this;
+    }
+
+    /**
+     * Set the job runner handling off-thread activity.
+     *
+     * @param v job runner for background tasks; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder exec(PersistentJobRunner v) {
+      this.exec = v;
+      return this;
+    }
+
+    /**
+     * Provide the helper used to mark keys as fetching locally.
+     *
+     * @param v optional accounting helper.
+     * @return this builder for fluent chaining.
+     */
+    public Builder keysFetching(KeysFetchingLocally v) {
+      this.keysFetching = v;
+      return this;
+    }
+
+    /**
+     * Set the ticker used for timed operations and coalescing.
+     *
+     * @param v ticker/scheduler implementation; non-null.
+     * @return this builder for fluent chaining.
+     */
+    public Builder ticker(Ticker v) {
+      this.ticker = v;
+      return this;
+    }
+
+    /**
+     * Provide the memory-limited job runner for heavy tasks.
+     *
+     * @param v job runner respecting memory caps; must not be {@code null}.
+     * @return this builder for fluent chaining.
+     */
+    public Builder memoryLimitedJobRunner(MemoryLimitedJobRunner v) {
+      this.memoryLimitedJobRunner = v;
+      return this;
+    }
+
+    /**
+     * Set the checksum implementation and length for persisted sections.
+     *
+     * @param v checker implementation; non-null.
+     * @return this builder for fluent chaining.
+     */
+    public Builder checker(ChecksumChecker v) {
+      this.checker = v;
+      return this;
+    }
+
+    /**
+     * Whether to inject a new salt when resuming, if supported.
+     *
+     * @param v set {@code true} to prefer re-salting.
+     * @return this builder for fluent chaining.
+     */
+    public Builder newSalt(boolean v) {
+      this.newSalt = v;
+      return this;
+    }
+
+    /**
+     * Provide the salter to use if {@link #newSalt(boolean)} is {@code true}.
+     *
+     * @param v salter implementation; may be {@code null} to disable.
+     * @return this builder for fluent chaining.
+     */
+    public Builder salt(KeySalter v) {
+      this.salt = v;
+      return this;
+    }
+
+    /**
+     * Mark that this session represents a true resume rather than a fresh start.
+     *
+     * @param v set {@code true} when resuming from persisted state.
+     * @return this builder for fluent chaining.
+     */
+    public Builder resumed(boolean v) {
+      this.resumed = v;
+      return this;
+    }
+
+    /**
+     * Enable completion via truncation when possible.
+     *
+     * @param v when {@code true}, prefer truncation optimisation at completion.
+     * @return this builder for fluent chaining.
+     */
+    public Builder completeViaTruncation(boolean v) {
+      this.completeViaTruncation = v;
+      return this;
+    }
+
+    /**
+     * Build a {@link SplitFileFetcherStorageResumeParams} snapshot for resuming from disk.
+     *
+     * @return the constructed parameters object consumed by the resuming constructor.
+     */
+    public SplitFileFetcherStorageResumeParams build() {
+      SplitFileFetcherStorageResumeParams p = new SplitFileFetcherStorageResumeParams();
+      p.raf = raf;
+      p.realTime = realTime;
+      p.callback = callback;
+      p.origContext = origContext;
+      p.random = random;
+      p.exec = exec;
+      p.keysFetching = keysFetching;
+      p.ticker = ticker;
+      p.memoryLimitedJobRunner = memoryLimitedJobRunner;
+      p.checker = checker;
+      p.newSalt = newSalt;
+      p.salt = salt;
+      p.resumed = resumed;
+      p.completeViaTruncation = completeViaTruncation;
+      return p;
+    }
+  }
+}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodec.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodec.java
@@ -6,7 +6,9 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.Metadata;
@@ -14,13 +16,38 @@ import network.crypta.client.Metadata.SplitfileAlgorithm;
 import network.crypta.client.MetadataParseException;
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
 import network.crypta.support.io.StorageFormatException;
+import org.jetbrains.annotations.NotNull;
 
-/** Encodes and decodes the basic settings section of splitfile fetcher storage persistence. */
+/**
+ * Encodes and decodes the basic settings section of splitfile fetcher persistence.
+ *
+ * <p>This utility reads and writes the fixed header portion that precedes per-segment metadata in
+ * the splitfile fetcher storage footer. Encoding gathers immutable settings and offsets from a
+ * fully initialized {@link SplitFileFetcherStorage} and produces a single byte array, including the
+ * checksum, that can be written to the storage file. Decoding consumes the corresponding byte
+ * block, validates structural invariants such as lengths, offsets, and compatibility modes, and
+ * exposes the parsed values for follow-on parsing.
+ *
+ * <p>The class is stateless and does not cache or retain input buffers; callers are responsible for
+ * synchronization around shared {@link SplitFileFetcherStorage} instances and for ensuring that the
+ * buffer represents the on-disk basic settings block they intend to parse. Parsing returns a {@link
+ * ParsedBasicSettings} that keeps the {@link DataInputStream} open and positioned after the fixed
+ * fields so callers can read segment metadata sequentially.
+ *
+ * <ul>
+ *   <li>Serializes splitfile algorithm, crypto parameters, lengths, and client metadata.
+ *   <li>Writes and validates offsets for subsequent storage sections.
+ *   <li>Records compatibility mode and block counts used for segment construction.
+ * </ul>
+ *
+ * @see SplitFileFetcherStorage
+ * @see ParsedBasicSettings
+ */
 public final class SplitFileFetcherStorageSettingsCodec {
   private SplitFileFetcherStorageSettingsCodec() {}
 
   /** Parse the basic settings block from the persisted splitfile storage format. */
-  public static ParsedBasicSettings parseBasicSettings(
+  static ParsedBasicSettings parseBasicSettings(
       byte[] basicSettingsBuffer,
       long basicSettingsOffset,
       boolean completeViaTruncation,
@@ -64,7 +91,31 @@ public final class SplitFileFetcherStorageSettingsCodec {
     }
   }
 
-  /** Encode the basic settings block (including checksum) for the current storage instance. */
+  /**
+   * Encodes the basic settings block, including the checksum, for splitfile fetcher persistence.
+   *
+   * <p>The method serializes the fixed header fields from {@code storage}, including crypto
+   * parameters, lengths, client metadata, offsets, compatibility mode, and the supplied block
+   * totals. It then writes fixed metadata for each segment, any cross-segment metadata, and the key
+   * listener's static settings before appending the checksum with the storage checker. The method
+   * does not perform additional validation of the block totals and assumes the offsets and lengths
+   * in {@code storage} are already computed.
+   *
+   * <pre>{@code
+   * byte[] settings =
+   *     SplitFileFetcherStorageSettingsCodec.encodeBasicSettings(
+   *         storage, dataBlocks, checkBlocks, crossBlocks);
+   * }</pre>
+   *
+   * @param storage storage instance providing offsets, metadata, and checksum checker; initialized
+   *     for serialization
+   * @param totalDataBlocks total count of data blocks across all segments; non-negative
+   * @param totalCheckBlocks total count of check blocks across all segments; non-negative
+   * @param totalCrossCheckBlocks total count of cross-check blocks across all segments;
+   *     non-negative
+   * @return byte array containing the encoded settings block with appended checksum
+   * @throws IllegalStateException if an unexpected I/O error occurs while encoding
+   */
   public static byte[] encodeBasicSettings(
       SplitFileFetcherStorage storage,
       int totalDataBlocks,
@@ -329,74 +380,157 @@ public final class SplitFileFetcherStorageSettingsCodec {
  * Parsed basic settings extracted from the persisted splitfile storage footer.
  *
  * <p>The {@code settingsStream} remains open and positioned at the first byte after the parsed
- * fields so callers can continue reading segment metadata without re-parsing the buffer.
+ * fields so callers can continue reading segment metadata without reparsing the buffer.
  */
-final class ParsedBasicSettings {
-  private final SplitfileAlgorithm splitfileType;
-  private final byte splitfileSingleCryptoAlgorithm;
-  private final byte[] splitfileSingleCryptoKey;
-  private final long finalLength;
-  private final long decompressedLength;
-  private final ClientMetadata clientMetadata;
-  private final List<COMPRESSOR_TYPE> decompressors;
-  private final long offsetKeyList;
-  private final long offsetSegmentStatus;
-  private final long offsetGeneralProgress;
-  private final long offsetMainBloomFilter;
-  private final long offsetSegmentBloomFilters;
-  private final long offsetOriginalMetadata;
-  private final long offsetOriginalDetails;
-  private final long offsetBasicSettings;
-  private final CompatibilityMode finalMinCompatMode;
-  private final int segmentCount;
-  private final int totalDataBlocks;
-  private final int totalCheckBlocks;
-  private final int totalCrossCheckBlocks;
-  private final DataInputStream settingsStream;
+record ParsedBasicSettings(
+    SplitfileAlgorithm splitfileType,
+    byte splitfileSingleCryptoAlgorithm,
+    byte[] splitfileSingleCryptoKey,
+    long finalLength,
+    long decompressedLength,
+    ClientMetadata clientMetadata,
+    List<COMPRESSOR_TYPE> decompressors,
+    long offsetKeyList,
+    long offsetSegmentStatus,
+    long offsetGeneralProgress,
+    long offsetMainBloomFilter,
+    long offsetSegmentBloomFilters,
+    long offsetOriginalMetadata,
+    long offsetOriginalDetails,
+    long offsetBasicSettings,
+    CompatibilityMode finalMinCompatMode,
+    int segmentCount,
+    int totalDataBlocks,
+    int totalCheckBlocks,
+    int totalCrossCheckBlocks,
+    DataInputStream settingsStream) {
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other
+        instanceof
+        ParsedBasicSettings(
+            var otherSplitfileType,
+            var otherSplitfileSingleCryptoAlgorithm,
+            var otherSplitfileSingleCryptoKey,
+            var otherFinalLength,
+            var otherDecompressedLength,
+            var otherClientMetadata,
+            var otherDecompressors,
+            var otherOffsetKeyList,
+            var otherOffsetSegmentStatus,
+            var otherOffsetGeneralProgress,
+            var otherOffsetMainBloomFilter,
+            var otherOffsetSegmentBloomFilters,
+            var otherOffsetOriginalMetadata,
+            var otherOffsetOriginalDetails,
+            var otherOffsetBasicSettings,
+            var otherFinalMinCompatMode,
+            var otherSegmentCount,
+            var otherTotalDataBlocks,
+            var otherTotalCheckBlocks,
+            var otherTotalCrossCheckBlocks,
+            var otherSettingsStream))) {
+      return false;
+    }
+    return splitfileSingleCryptoAlgorithm == otherSplitfileSingleCryptoAlgorithm
+        && finalLength == otherFinalLength
+        && decompressedLength == otherDecompressedLength
+        && offsetKeyList == otherOffsetKeyList
+        && offsetSegmentStatus == otherOffsetSegmentStatus
+        && offsetGeneralProgress == otherOffsetGeneralProgress
+        && offsetMainBloomFilter == otherOffsetMainBloomFilter
+        && offsetSegmentBloomFilters == otherOffsetSegmentBloomFilters
+        && offsetOriginalMetadata == otherOffsetOriginalMetadata
+        && offsetOriginalDetails == otherOffsetOriginalDetails
+        && offsetBasicSettings == otherOffsetBasicSettings
+        && segmentCount == otherSegmentCount
+        && totalDataBlocks == otherTotalDataBlocks
+        && totalCheckBlocks == otherTotalCheckBlocks
+        && totalCrossCheckBlocks == otherTotalCrossCheckBlocks
+        && Objects.equals(splitfileType, otherSplitfileType)
+        && Arrays.equals(splitfileSingleCryptoKey, otherSplitfileSingleCryptoKey)
+        && Objects.equals(clientMetadata, otherClientMetadata)
+        && Objects.equals(decompressors, otherDecompressors)
+        && Objects.equals(finalMinCompatMode, otherFinalMinCompatMode)
+        && Objects.equals(settingsStream, otherSettingsStream);
+  }
 
-  ParsedBasicSettings(
-      SplitfileAlgorithm splitfileType,
-      byte splitfileSingleCryptoAlgorithm,
-      byte[] splitfileSingleCryptoKey,
-      long finalLength,
-      long decompressedLength,
-      ClientMetadata clientMetadata,
-      List<COMPRESSOR_TYPE> decompressors,
-      long offsetKeyList,
-      long offsetSegmentStatus,
-      long offsetGeneralProgress,
-      long offsetMainBloomFilter,
-      long offsetSegmentBloomFilters,
-      long offsetOriginalMetadata,
-      long offsetOriginalDetails,
-      long offsetBasicSettings,
-      CompatibilityMode finalMinCompatMode,
-      int segmentCount,
-      int totalDataBlocks,
-      int totalCheckBlocks,
-      int totalCrossCheckBlocks,
-      DataInputStream settingsStream) {
-    this.splitfileType = splitfileType;
-    this.splitfileSingleCryptoAlgorithm = splitfileSingleCryptoAlgorithm;
-    this.splitfileSingleCryptoKey = splitfileSingleCryptoKey;
-    this.finalLength = finalLength;
-    this.decompressedLength = decompressedLength;
-    this.clientMetadata = clientMetadata;
-    this.decompressors = decompressors;
-    this.offsetKeyList = offsetKeyList;
-    this.offsetSegmentStatus = offsetSegmentStatus;
-    this.offsetGeneralProgress = offsetGeneralProgress;
-    this.offsetMainBloomFilter = offsetMainBloomFilter;
-    this.offsetSegmentBloomFilters = offsetSegmentBloomFilters;
-    this.offsetOriginalMetadata = offsetOriginalMetadata;
-    this.offsetOriginalDetails = offsetOriginalDetails;
-    this.offsetBasicSettings = offsetBasicSettings;
-    this.finalMinCompatMode = finalMinCompatMode;
-    this.segmentCount = segmentCount;
-    this.totalDataBlocks = totalDataBlocks;
-    this.totalCheckBlocks = totalCheckBlocks;
-    this.totalCrossCheckBlocks = totalCrossCheckBlocks;
-    this.settingsStream = settingsStream;
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            splitfileType,
+            splitfileSingleCryptoAlgorithm,
+            finalLength,
+            decompressedLength,
+            clientMetadata,
+            decompressors,
+            offsetKeyList,
+            offsetSegmentStatus,
+            offsetGeneralProgress,
+            offsetMainBloomFilter,
+            offsetSegmentBloomFilters,
+            offsetOriginalMetadata,
+            offsetOriginalDetails,
+            offsetBasicSettings,
+            finalMinCompatMode,
+            segmentCount,
+            totalDataBlocks,
+            totalCheckBlocks,
+            totalCrossCheckBlocks,
+            settingsStream);
+    return 31 * result + Arrays.hashCode(splitfileSingleCryptoKey);
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "ParsedBasicSettings["
+        + "splitfileType="
+        + splitfileType
+        + ", splitfileSingleCryptoAlgorithm="
+        + splitfileSingleCryptoAlgorithm
+        + ", splitfileSingleCryptoKey="
+        + Arrays.toString(splitfileSingleCryptoKey)
+        + ", finalLength="
+        + finalLength
+        + ", decompressedLength="
+        + decompressedLength
+        + ", clientMetadata="
+        + clientMetadata
+        + ", decompressors="
+        + decompressors
+        + ", offsetKeyList="
+        + offsetKeyList
+        + ", offsetSegmentStatus="
+        + offsetSegmentStatus
+        + ", offsetGeneralProgress="
+        + offsetGeneralProgress
+        + ", offsetMainBloomFilter="
+        + offsetMainBloomFilter
+        + ", offsetSegmentBloomFilters="
+        + offsetSegmentBloomFilters
+        + ", offsetOriginalMetadata="
+        + offsetOriginalMetadata
+        + ", offsetOriginalDetails="
+        + offsetOriginalDetails
+        + ", offsetBasicSettings="
+        + offsetBasicSettings
+        + ", finalMinCompatMode="
+        + finalMinCompatMode
+        + ", segmentCount="
+        + segmentCount
+        + ", totalDataBlocks="
+        + totalDataBlocks
+        + ", totalCheckBlocks="
+        + totalCheckBlocks
+        + ", totalCrossCheckBlocks="
+        + totalCrossCheckBlocks
+        + ", settingsStream="
+        + settingsStream
+        + "]";
   }
 
   SplitfileAlgorithm getSplitfileType() {

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodec.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodec.java
@@ -1,0 +1,485 @@
+package network.crypta.client.async;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.Metadata;
+import network.crypta.client.Metadata.SplitfileAlgorithm;
+import network.crypta.client.MetadataParseException;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import network.crypta.support.io.StorageFormatException;
+
+/** Encodes and decodes the basic settings section of splitfile fetcher storage persistence. */
+public final class SplitFileFetcherStorageSettingsCodec {
+  private SplitFileFetcherStorageSettingsCodec() {}
+
+  /** Parse the basic settings block from the persisted splitfile storage format. */
+  public static ParsedBasicSettings parseBasicSettings(
+      byte[] basicSettingsBuffer,
+      long basicSettingsOffset,
+      boolean completeViaTruncation,
+      long rafLength)
+      throws StorageFormatException {
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(basicSettingsBuffer));
+    try {
+      SplitfileAlgorithm splitfileAlgorithm = readSplitfileAlgorithm(dis);
+      CryptoInfo crypto = readCryptoInfo(dis, splitfileAlgorithm);
+      LengthsInfo lengths = readLengths(dis);
+      HeaderInfo header = new HeaderInfo(splitfileAlgorithm, crypto, lengths);
+      ClientMetadata cm = readClientMetadataSafe(dis);
+      List<COMPRESSOR_TYPE> decomps = readDecompressors(dis);
+      OffsetsInfo offsets = readOffsets(dis, basicSettingsOffset, completeViaTruncation, rafLength);
+      CompatAndCounts compat = readCompatAndCounts(dis);
+      return new ParsedBasicSettings(
+          header.splitfileType,
+          header.crypto.algorithm,
+          header.crypto.key,
+          header.lengths.finalLength,
+          header.lengths.decompressedLength,
+          cm,
+          decomps,
+          offsets.offsetKeyList,
+          offsets.offsetSegmentStatus,
+          offsets.offsetGeneralProgress,
+          offsets.offsetMainBloomFilter,
+          offsets.offsetSegmentBloomFilters,
+          offsets.offsetOriginalMetadata,
+          offsets.offsetOriginalDetails,
+          offsets.offsetBasicSettings,
+          compat.mode,
+          compat.segmentCount,
+          compat.totalDataBlocks,
+          compat.totalCheckBlocks,
+          compat.totalCrossCheckBlocks,
+          dis);
+    } catch (IOException e) {
+      throw new StorageFormatException(
+          "Cannot read basic settings even though passed checksum: " + e, e);
+    }
+  }
+
+  /** Encode the basic settings block (including checksum) for the current storage instance. */
+  public static byte[] encodeBasicSettings(
+      SplitFileFetcherStorage storage,
+      int totalDataBlocks,
+      int totalCheckBlocks,
+      int totalCrossCheckBlocks) {
+    byte[] raw =
+        innerEncodeBasicSettings(storage, totalDataBlocks, totalCheckBlocks, totalCrossCheckBlocks);
+    return storage.checksumChecker.appendChecksum(raw);
+  }
+
+  private static SplitfileAlgorithm readSplitfileAlgorithm(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    short code = dis.readShort();
+    try {
+      return SplitfileAlgorithm.getByCode(code);
+    } catch (IllegalArgumentException _) {
+      throw new StorageFormatException("Invalid splitfile type " + code);
+    }
+  }
+
+  private static CryptoInfo readCryptoInfo(
+      DataInputStream dis, SplitfileAlgorithm splitfileAlgorithm)
+      throws IOException, StorageFormatException {
+    byte alg = dis.readByte();
+    if (!Metadata.isValidSplitfileCryptoAlgorithm(alg)) {
+      throw new StorageFormatException("Invalid splitfile crypto algorithm " + splitfileAlgorithm);
+    }
+    byte[] key = null;
+    if (dis.readBoolean()) {
+      key = new byte[32];
+      dis.readFully(key);
+    }
+    return new CryptoInfo(alg, key);
+  }
+
+  private static LengthsInfo readLengths(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    long finalLen = dis.readLong();
+    if (finalLen < 0) throw new StorageFormatException("Invalid final length " + finalLen);
+    long decompLen = dis.readLong();
+    if (decompLen < 0) throw new StorageFormatException("Invalid decompressed length " + decompLen);
+    return new LengthsInfo(finalLen, decompLen);
+  }
+
+  private static ClientMetadata readClientMetadataSafe(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    try {
+      return ClientMetadata.construct(dis);
+    } catch (MetadataParseException _) {
+      throw new StorageFormatException("Invalid MIME type");
+    }
+  }
+
+  private static List<COMPRESSOR_TYPE> readDecompressors(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    int decompressorCount = dis.readInt();
+    if (decompressorCount < 0) {
+      throw new StorageFormatException("Invalid decompressor count " + decompressorCount);
+    }
+    List<COMPRESSOR_TYPE> decomps = new ArrayList<>(decompressorCount);
+    for (int i = 0; i < decompressorCount; i++) {
+      short type = dis.readShort();
+      COMPRESSOR_TYPE decompressor = COMPRESSOR_TYPE.getCompressorByMetadataID(type);
+      if (decompressor == null) {
+        throw new StorageFormatException("Invalid decompressor ID " + type);
+      }
+      decomps.add(decompressor);
+    }
+    return decomps;
+  }
+
+  private static OffsetsInfo readOffsets(
+      DataInputStream dis, long basicSettingsOffset, boolean completeViaTruncation, long rafLength)
+      throws IOException, StorageFormatException {
+    long keyListOffset = readValidatedOffset(dis, "key list", rafLength);
+    long segmentStatusOffset = readValidatedOffset(dis, "segment status", rafLength);
+    long generalProgressOffset = readValidatedOffset(dis, "general progress", rafLength);
+    long mainBloomOffset = readValidatedOffset(dis, "main bloom filter", rafLength);
+    long segmentBloomOffset = readValidatedOffset(dis, "segment bloom filters", rafLength);
+    long origMetaOffset = readValidatedOffset(dis, "original metadata", rafLength);
+    long origDetailsOffset = readValidatedOffset(dis, "original metadata", rafLength);
+    long basicSettingsOff = dis.readLong();
+    if (basicSettingsOff != basicSettingsOffset)
+      throw new StorageFormatException("Invalid basic settings offset (not the same as computed)");
+    if (completeViaTruncation != dis.readBoolean())
+      throw new StorageFormatException("Complete via truncation flag is wrong");
+    return new OffsetsInfo(
+        keyListOffset,
+        segmentStatusOffset,
+        generalProgressOffset,
+        mainBloomOffset,
+        segmentBloomOffset,
+        origMetaOffset,
+        origDetailsOffset,
+        basicSettingsOff);
+  }
+
+  private static long readValidatedOffset(DataInputStream dis, String what, long rafLength)
+      throws IOException, StorageFormatException {
+    long value = dis.readLong();
+    if (value < 0 || value > rafLength)
+      throw new StorageFormatException("Invalid offset (" + what + ")");
+    return value;
+  }
+
+  private static CompatAndCounts readCompatAndCounts(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    int compatMode = dis.readInt();
+    if (compatMode < 0 || compatMode > CompatibilityMode.values().length)
+      throw new StorageFormatException("Invalid compatibility mode " + compatMode);
+    CompatibilityMode finalMode = CompatibilityMode.values()[compatMode];
+    int segmentCount = dis.readInt();
+    if (segmentCount <= 0)
+      throw new StorageFormatException("Invalid segment count " + segmentCount);
+    int totalDataBlocks = dis.readInt();
+    if (totalDataBlocks < 0)
+      throw new StorageFormatException("Invalid total data blocks " + totalDataBlocks);
+    int totalCheckBlocks = dis.readInt();
+    if (totalCheckBlocks < 0)
+      throw new StorageFormatException("Invalid total check blocks " + totalDataBlocks);
+    int totalCrossCheckBlocks = dis.readInt();
+    if (totalCrossCheckBlocks < 0)
+      throw new StorageFormatException("Invalid total cross-check blocks " + totalDataBlocks);
+    if (totalDataBlocks + totalCheckBlocks + totalCrossCheckBlocks <= 0) {
+      throw new StorageFormatException("Total number of blocks in splitfile is non-positive");
+    }
+    return new CompatAndCounts(
+        finalMode, segmentCount, totalDataBlocks, totalCheckBlocks, totalCrossCheckBlocks);
+  }
+
+  private static byte[] innerEncodeBasicSettings(
+      SplitFileFetcherStorage storage,
+      int totalDataBlocks,
+      int totalCheckBlocks,
+      int totalCrossCheckBlocks) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+    try {
+      dos.writeShort(storage.splitfileType.code);
+      dos.writeByte(storage.splitfileSingleCryptoAlgorithm);
+      dos.writeBoolean(storage.splitfileSingleCryptoKey != null);
+      if (storage.splitfileSingleCryptoKey != null) {
+        assert (storage.splitfileSingleCryptoKey.length == 32);
+        dos.write(storage.splitfileSingleCryptoKey);
+      }
+      dos.writeLong(storage.finalLength);
+      dos.writeLong(storage.decompressedLength);
+      storage.clientMetadata.writeTo(dos);
+      dos.writeInt(storage.decompressors.size());
+      for (COMPRESSOR_TYPE compressor : storage.decompressors) {
+        dos.writeShort(compressor.metadataID);
+      }
+      dos.writeLong(storage.offsetKeyList);
+      dos.writeLong(storage.offsetSegmentStatus);
+      dos.writeLong(storage.offsetGeneralProgress);
+      dos.writeLong(storage.offsetMainBloomFilter);
+      dos.writeLong(storage.offsetSegmentBloomFilters);
+      dos.writeLong(storage.offsetOriginalMetadata);
+      dos.writeLong(storage.offsetOriginalDetails);
+      dos.writeLong(storage.offsetBasicSettings);
+      dos.writeBoolean(storage.completeViaTruncation);
+      dos.writeInt(storage.finalMinCompatMode.ordinal());
+      dos.writeInt(storage.segments.length);
+      dos.writeInt(totalDataBlocks);
+      dos.writeInt(totalCheckBlocks);
+      dos.writeInt(totalCrossCheckBlocks);
+      for (SplitFileFetcherSegmentStorage segment : storage.segments) {
+        segment.writeFixedMetadata(dos);
+      }
+      if (storage.crossSegments == null) {
+        dos.writeInt(0);
+      } else {
+        dos.writeInt(storage.crossSegments.length);
+        for (SplitFileFetcherCrossSegmentStorage segment : storage.crossSegments) {
+          segment.writeFixedMetadata(dos);
+        }
+      }
+      storage.keyListener.writeStaticSettings(dos);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    return baos.toByteArray();
+  }
+
+  private static final class CryptoInfo {
+    private final byte algorithm;
+    private final byte[] key;
+
+    private CryptoInfo(byte algorithm, byte[] key) {
+      this.algorithm = algorithm;
+      this.key = key;
+    }
+  }
+
+  private static final class LengthsInfo {
+    private final long finalLength;
+    private final long decompressedLength;
+
+    private LengthsInfo(long finalLength, long decompressedLength) {
+      this.finalLength = finalLength;
+      this.decompressedLength = decompressedLength;
+    }
+  }
+
+  private static final class HeaderInfo {
+    private final SplitfileAlgorithm splitfileType;
+    private final CryptoInfo crypto;
+    private final LengthsInfo lengths;
+
+    private HeaderInfo(SplitfileAlgorithm splitfileType, CryptoInfo crypto, LengthsInfo lengths) {
+      this.splitfileType = splitfileType;
+      this.crypto = crypto;
+      this.lengths = lengths;
+    }
+  }
+
+  private static final class OffsetsInfo {
+    private final long offsetKeyList;
+    private final long offsetSegmentStatus;
+    private final long offsetGeneralProgress;
+    private final long offsetMainBloomFilter;
+    private final long offsetSegmentBloomFilters;
+    private final long offsetOriginalMetadata;
+    private final long offsetOriginalDetails;
+    private final long offsetBasicSettings;
+
+    private OffsetsInfo(long... offsets) {
+      this.offsetKeyList = offsets[0];
+      this.offsetSegmentStatus = offsets[1];
+      this.offsetGeneralProgress = offsets[2];
+      this.offsetMainBloomFilter = offsets[3];
+      this.offsetSegmentBloomFilters = offsets[4];
+      this.offsetOriginalMetadata = offsets[5];
+      this.offsetOriginalDetails = offsets[6];
+      this.offsetBasicSettings = offsets[7];
+    }
+  }
+
+  private static final class CompatAndCounts {
+    private final CompatibilityMode mode;
+    private final int segmentCount;
+    private final int totalDataBlocks;
+    private final int totalCheckBlocks;
+    private final int totalCrossCheckBlocks;
+
+    private CompatAndCounts(
+        CompatibilityMode mode,
+        int segmentCount,
+        int totalDataBlocks,
+        int totalCheckBlocks,
+        int totalCrossCheckBlocks) {
+      this.mode = mode;
+      this.segmentCount = segmentCount;
+      this.totalDataBlocks = totalDataBlocks;
+      this.totalCheckBlocks = totalCheckBlocks;
+      this.totalCrossCheckBlocks = totalCrossCheckBlocks;
+    }
+  }
+}
+
+/**
+ * Parsed basic settings extracted from the persisted splitfile storage footer.
+ *
+ * <p>The {@code settingsStream} remains open and positioned at the first byte after the parsed
+ * fields so callers can continue reading segment metadata without re-parsing the buffer.
+ */
+final class ParsedBasicSettings {
+  private final SplitfileAlgorithm splitfileType;
+  private final byte splitfileSingleCryptoAlgorithm;
+  private final byte[] splitfileSingleCryptoKey;
+  private final long finalLength;
+  private final long decompressedLength;
+  private final ClientMetadata clientMetadata;
+  private final List<COMPRESSOR_TYPE> decompressors;
+  private final long offsetKeyList;
+  private final long offsetSegmentStatus;
+  private final long offsetGeneralProgress;
+  private final long offsetMainBloomFilter;
+  private final long offsetSegmentBloomFilters;
+  private final long offsetOriginalMetadata;
+  private final long offsetOriginalDetails;
+  private final long offsetBasicSettings;
+  private final CompatibilityMode finalMinCompatMode;
+  private final int segmentCount;
+  private final int totalDataBlocks;
+  private final int totalCheckBlocks;
+  private final int totalCrossCheckBlocks;
+  private final DataInputStream settingsStream;
+
+  ParsedBasicSettings(
+      SplitfileAlgorithm splitfileType,
+      byte splitfileSingleCryptoAlgorithm,
+      byte[] splitfileSingleCryptoKey,
+      long finalLength,
+      long decompressedLength,
+      ClientMetadata clientMetadata,
+      List<COMPRESSOR_TYPE> decompressors,
+      long offsetKeyList,
+      long offsetSegmentStatus,
+      long offsetGeneralProgress,
+      long offsetMainBloomFilter,
+      long offsetSegmentBloomFilters,
+      long offsetOriginalMetadata,
+      long offsetOriginalDetails,
+      long offsetBasicSettings,
+      CompatibilityMode finalMinCompatMode,
+      int segmentCount,
+      int totalDataBlocks,
+      int totalCheckBlocks,
+      int totalCrossCheckBlocks,
+      DataInputStream settingsStream) {
+    this.splitfileType = splitfileType;
+    this.splitfileSingleCryptoAlgorithm = splitfileSingleCryptoAlgorithm;
+    this.splitfileSingleCryptoKey = splitfileSingleCryptoKey;
+    this.finalLength = finalLength;
+    this.decompressedLength = decompressedLength;
+    this.clientMetadata = clientMetadata;
+    this.decompressors = decompressors;
+    this.offsetKeyList = offsetKeyList;
+    this.offsetSegmentStatus = offsetSegmentStatus;
+    this.offsetGeneralProgress = offsetGeneralProgress;
+    this.offsetMainBloomFilter = offsetMainBloomFilter;
+    this.offsetSegmentBloomFilters = offsetSegmentBloomFilters;
+    this.offsetOriginalMetadata = offsetOriginalMetadata;
+    this.offsetOriginalDetails = offsetOriginalDetails;
+    this.offsetBasicSettings = offsetBasicSettings;
+    this.finalMinCompatMode = finalMinCompatMode;
+    this.segmentCount = segmentCount;
+    this.totalDataBlocks = totalDataBlocks;
+    this.totalCheckBlocks = totalCheckBlocks;
+    this.totalCrossCheckBlocks = totalCrossCheckBlocks;
+    this.settingsStream = settingsStream;
+  }
+
+  SplitfileAlgorithm getSplitfileType() {
+    return splitfileType;
+  }
+
+  byte getSplitfileSingleCryptoAlgorithm() {
+    return splitfileSingleCryptoAlgorithm;
+  }
+
+  byte[] getSplitfileSingleCryptoKey() {
+    return splitfileSingleCryptoKey;
+  }
+
+  long getFinalLength() {
+    return finalLength;
+  }
+
+  long getDecompressedLength() {
+    return decompressedLength;
+  }
+
+  ClientMetadata getClientMetadata() {
+    return clientMetadata;
+  }
+
+  List<COMPRESSOR_TYPE> getDecompressors() {
+    return decompressors;
+  }
+
+  long getOffsetKeyList() {
+    return offsetKeyList;
+  }
+
+  long getOffsetSegmentStatus() {
+    return offsetSegmentStatus;
+  }
+
+  long getOffsetGeneralProgress() {
+    return offsetGeneralProgress;
+  }
+
+  long getOffsetMainBloomFilter() {
+    return offsetMainBloomFilter;
+  }
+
+  long getOffsetSegmentBloomFilters() {
+    return offsetSegmentBloomFilters;
+  }
+
+  long getOffsetOriginalMetadata() {
+    return offsetOriginalMetadata;
+  }
+
+  long getOffsetOriginalDetails() {
+    return offsetOriginalDetails;
+  }
+
+  long getOffsetBasicSettings() {
+    return offsetBasicSettings;
+  }
+
+  CompatibilityMode getFinalMinCompatMode() {
+    return finalMinCompatMode;
+  }
+
+  int getSegmentCount() {
+    return segmentCount;
+  }
+
+  int getTotalDataBlocks() {
+    return totalDataBlocks;
+  }
+
+  int getTotalCheckBlocks() {
+    return totalCheckBlocks;
+  }
+
+  int getTotalCrossCheckBlocks() {
+    return totalCrossCheckBlocks;
+  }
+
+  DataInputStream getSettingsStream() {
+    return settingsStream;
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherCrossSegmentAllocatorTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherCrossSegmentAllocatorTest.java
@@ -1,0 +1,296 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import network.crypta.client.FECCodec;
+import network.crypta.client.Metadata;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SplitFileFetcherCrossSegmentAllocatorTest {
+
+  private static Metadata metadataWithHash(byte[] hash, int deductBlocks) {
+    Metadata metadata = mock(Metadata.class);
+    when(metadata.getHashThisLayerOnly()).thenReturn(hash);
+    when(metadata.getHashes()).thenReturn(null);
+    when(metadata.getDeductBlocksFromSegments()).thenReturn(deductBlocks);
+    return metadata;
+  }
+
+  private static Metadata metadataWithoutHash() {
+    Metadata metadata = mock(Metadata.class);
+    when(metadata.getHashThisLayerOnly()).thenReturn(null);
+    when(metadata.getHashes()).thenReturn(null);
+    return metadata;
+  }
+
+  private static int[] readBlockNumbers(SplitFileFetcherCrossSegmentStorage cross) {
+    try {
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      DataOutputStream dos = new DataOutputStream(bos);
+      cross.writeFixedMetadata(dos);
+      dos.flush();
+      try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
+        int dataBlocks = dis.readInt();
+        int checkBlocks = dis.readInt();
+        int total = dataBlocks + checkBlocks;
+        int[] blockNumbers = new int[total];
+        for (int i = 0; i < total; i++) {
+          dis.readInt(); // segNo
+          blockNumbers[i] = dis.readInt();
+        }
+        return blockNumbers;
+      }
+    } catch (IOException e) {
+      throw new AssertionError("Failed to read fixed metadata", e);
+    }
+  }
+
+  @Test
+  void createCrossSegments_whenCrossCheckBlocksZero_returnsEmptyArrayAndSkipsAllocation() {
+    // Arrange
+    SplitFileFetcherStorage owner = mock(SplitFileFetcherStorage.class);
+    Metadata metadata = mock(Metadata.class);
+    SplitFileFetcherSegmentStorage seg1 = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage seg2 = mock(SplitFileFetcherSegmentStorage.class);
+    FECCodec codec = mock(FECCodec.class);
+
+    // Act
+    SplitFileFetcherCrossSegmentStorage[] result =
+        SplitFileFetcherCrossSegmentAllocator.createCrossSegments(
+            owner,
+            metadata,
+            /* crossCheckBlocks= */ 0,
+            /* blocksPerSegment= */ 3,
+            new SplitFileFetcherSegmentStorage[] {seg1, seg2},
+            codec);
+
+    // Assert
+    assertEquals(0, result.length);
+    verifyNoInteractions(owner, metadata, seg1, seg2, codec);
+  }
+
+  @Test
+  void createCrossSegments_whenMetadataMissingHashes_throwsIllegalArgumentException() {
+    // Arrange
+    Metadata metadata = metadataWithoutHash();
+    SplitFileFetcherStorage owner = mock(SplitFileFetcherStorage.class);
+    FECCodec codec = mock(FECCodec.class);
+    SplitFileFetcherSegmentStorage seg1 = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage seg2 = mock(SplitFileFetcherSegmentStorage.class);
+
+    // Act + Assert
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            SplitFileFetcherCrossSegmentAllocator.createCrossSegments(
+                owner,
+                metadata,
+                /* crossCheckBlocks= */ 1,
+                /* blocksPerSegment= */ 1,
+                new SplitFileFetcherSegmentStorage[] {seg1, seg2},
+                codec));
+    verifyNoInteractions(seg1, seg2);
+  }
+
+  @Test
+  void createCrossSegments_whenDeductBlocksFromSegments_adjustsDataBlockCountForTrailingSegments() {
+    // Arrange
+    Metadata metadata = metadataWithHash(new byte[] {1, 2, 3}, /* deductBlocks= */ 2);
+    SplitFileFetcherStorage owner = mock(SplitFileFetcherStorage.class);
+    FECCodec codec = mock(FECCodec.class);
+    SplitFileFetcherSegmentStorage[] segments =
+        new SplitFileFetcherSegmentStorage[] {
+          mock(SplitFileFetcherSegmentStorage.class),
+          mock(SplitFileFetcherSegmentStorage.class),
+          mock(SplitFileFetcherSegmentStorage.class)
+        };
+
+    AtomicInteger dataCalls = new AtomicInteger();
+    AtomicInteger checkCalls = new AtomicInteger();
+    for (SplitFileFetcherSegmentStorage segment : segments) {
+      doAnswer(
+              _ -> {
+                dataCalls.incrementAndGet();
+                return 0;
+              })
+          .when(segment)
+          .allocateCrossDataBlock(
+              any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class));
+      doAnswer(
+              _ -> {
+                checkCalls.incrementAndGet();
+                return 0;
+              })
+          .when(segment)
+          .allocateCrossCheckBlock(
+              any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class));
+    }
+
+    // Act
+    SplitFileFetcherCrossSegmentStorage[] result =
+        SplitFileFetcherCrossSegmentAllocator.createCrossSegments(
+            owner, metadata, /* crossCheckBlocks= */ 2, /* blocksPerSegment= */ 4, segments, codec);
+
+    // Assert
+    assertEquals(3, result.length);
+    assertEquals(4, result[0].dataBlockCount);
+    assertEquals(3, result[1].dataBlockCount);
+    assertEquals(3, result[2].dataBlockCount);
+    for (SplitFileFetcherCrossSegmentStorage cross : result) {
+      assertEquals(2, cross.crossCheckBlockCount);
+      assertEquals(cross.dataBlockCount + 2, cross.totalBlocks);
+    }
+    assertEquals(10, dataCalls.get());
+    assertEquals(6, checkCalls.get());
+  }
+
+  @Test
+  void createCrossSegments_whenDataAllocationFailsForAllSegments_throwsIllegalStateException() {
+    // Arrange
+    Metadata metadata = metadataWithHash(new byte[] {9}, /* deductBlocks= */ 0);
+    SplitFileFetcherStorage owner = mock(SplitFileFetcherStorage.class);
+    FECCodec codec = mock(FECCodec.class);
+    SplitFileFetcherSegmentStorage seg1 = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage seg2 = mock(SplitFileFetcherSegmentStorage.class);
+
+    when(seg1.allocateCrossDataBlock(
+            any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class)))
+        .thenReturn(-1);
+    when(seg2.allocateCrossDataBlock(
+            any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class)))
+        .thenReturn(-1);
+
+    // Act + Assert
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            SplitFileFetcherCrossSegmentAllocator.createCrossSegments(
+                owner,
+                metadata,
+                /* crossCheckBlocks= */ 1,
+                /* blocksPerSegment= */ 1,
+                new SplitFileFetcherSegmentStorage[] {seg1, seg2},
+                codec));
+    verify(seg1, never())
+        .allocateCrossCheckBlock(any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class));
+    verify(seg2, never())
+        .allocateCrossCheckBlock(any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class));
+  }
+
+  @Test
+  void createCrossSegments_whenCheckAllocationFailsForAllSegments_throwsIllegalStateException() {
+    // Arrange
+    Metadata metadata = metadataWithHash(new byte[] {4, 2}, /* deductBlocks= */ 0);
+    SplitFileFetcherStorage owner = mock(SplitFileFetcherStorage.class);
+    FECCodec codec = mock(FECCodec.class);
+    SplitFileFetcherSegmentStorage seg1 = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage seg2 = mock(SplitFileFetcherSegmentStorage.class);
+
+    when(seg1.allocateCrossCheckBlock(
+            any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class)))
+        .thenReturn(-1);
+    when(seg2.allocateCrossCheckBlock(
+            any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class)))
+        .thenReturn(-1);
+
+    // Act + Assert
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            SplitFileFetcherCrossSegmentAllocator.createCrossSegments(
+                owner,
+                metadata,
+                /* crossCheckBlocks= */ 1,
+                /* blocksPerSegment= */ 1,
+                new SplitFileFetcherSegmentStorage[] {seg1, seg2},
+                codec));
+  }
+
+  @Test
+  void createCrossSegments_whenRandomAttemptsFail_fallsBackToSequentialAllocationForDataBlock() {
+    // Arrange
+    Metadata metadata = metadataWithHash(new byte[] {7, 7, 7}, /* deductBlocks= */ 0);
+    SplitFileFetcherStorage owner = mock(SplitFileFetcherStorage.class);
+    FECCodec codec = mock(FECCodec.class);
+    SplitFileFetcherSegmentStorage segment = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[] {segment};
+
+    AtomicInteger dataCalls = new AtomicInteger();
+    doAnswer(
+            _ -> {
+              int call = dataCalls.incrementAndGet();
+              return call <= 10 ? -1 : 42;
+            })
+        .when(segment)
+        .allocateCrossDataBlock(any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class));
+    when(segment.allocateCrossCheckBlock(
+            any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class)))
+        .thenReturn(7);
+
+    // Act
+    SplitFileFetcherCrossSegmentStorage[] result =
+        SplitFileFetcherCrossSegmentAllocator.createCrossSegments(
+            owner, metadata, /* crossCheckBlocks= */ 1, /* blocksPerSegment= */ 1, segments, codec);
+
+    // Assert
+    assertEquals(1, result.length);
+    assertEquals(11, dataCalls.get());
+    int[] blockNumbers = readBlockNumbers(result[0]);
+    assertEquals(42, blockNumbers[0]);
+    assertEquals(7, blockNumbers[1]);
+  }
+
+  @Test
+  void createCrossSegments_whenCheckRandomAttemptsFail_fallsBackToSequentialAllocation() {
+    // Arrange
+    Metadata metadata = metadataWithHash(new byte[] {8, 8}, /* deductBlocks= */ 0);
+    SplitFileFetcherStorage owner = mock(SplitFileFetcherStorage.class);
+    FECCodec codec = mock(FECCodec.class);
+    SplitFileFetcherSegmentStorage segment = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[] {segment};
+
+    when(segment.allocateCrossDataBlock(
+            any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class)))
+        .thenReturn(3);
+
+    AtomicInteger checkCalls = new AtomicInteger();
+    doAnswer(
+            _ -> {
+              int call = checkCalls.incrementAndGet();
+              return call <= 10 ? -1 : 9;
+            })
+        .when(segment)
+        .allocateCrossCheckBlock(any(SplitFileFetcherCrossSegmentStorage.class), any(Random.class));
+
+    // Act
+    SplitFileFetcherCrossSegmentStorage[] result =
+        SplitFileFetcherCrossSegmentAllocator.createCrossSegments(
+            owner, metadata, /* crossCheckBlocks= */ 1, /* blocksPerSegment= */ 1, segments, codec);
+
+    // Assert
+    assertEquals(1, result.length);
+    assertEquals(11, checkCalls.get());
+    int[] blockNumbers = readBlockNumbers(result[0]);
+    assertEquals(3, blockNumbers[0]);
+    assertEquals(9, blockNumbers[1]);
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageInitParamsTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageInitParamsTest.java
@@ -1,0 +1,190 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.List;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchContext;
+import network.crypta.client.Metadata;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.RandomSource;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.KeysFetchingLocally;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SplitFileFetcherStorageInitParamsTest {
+
+  @Mock private Metadata metadata;
+  @Mock private SplitFileFetcherStorageCallback fetcher;
+  @Mock private ClientMetadata clientMetadata;
+  @Mock private FetchContext fetchContext;
+  @Mock private KeySalter keySalter;
+  @Mock private RandomSource random;
+  @Mock private BucketFactory tempBucketFactory;
+  @Mock private LockableRandomAccessBufferFactory rafFactory;
+  @Mock private PersistentJobRunner exec;
+  @Mock private Ticker ticker;
+  @Mock private MemoryLimitedJobRunner memoryLimitedJobRunner;
+  @Mock private ChecksumChecker checker;
+  @Mock private FileRandomAccessBufferFactory diskSpaceCheckingRAFFactory;
+  @Mock private KeysFetchingLocally keysFetching;
+
+  @Test
+  void build_whenNoValuesProvided_expectDefaults() {
+    // Arrange
+    SplitFileFetcherStorageInitParams.Builder builder =
+        new SplitFileFetcherStorageInitParams.Builder();
+
+    // Act
+    SplitFileFetcherStorageInitParams params = builder.build();
+
+    // Assert
+    assertNull(params.metadata);
+    assertNull(params.fetcher);
+    assertNull(params.decompressors);
+    assertNull(params.clientMetadata);
+    assertFalse(params.topDontCompress);
+    assertEquals((short) 0, params.topCompatibilityMode);
+    assertNull(params.origFetchContext);
+    assertFalse(params.realTime);
+    assertNull(params.salt);
+    assertNull(params.thisKey);
+    assertNull(params.origKey);
+    assertFalse(params.isFinalFetch);
+    assertNull(params.clientDetails);
+    assertNull(params.random);
+    assertNull(params.tempBucketFactory);
+    assertNull(params.rafFactory);
+    assertNull(params.exec);
+    assertNull(params.ticker);
+    assertNull(params.memoryLimitedJobRunner);
+    assertNull(params.checker);
+    assertFalse(params.persistent);
+    assertNull(params.storageFile);
+    assertNull(params.diskSpaceCheckingRAFFactory);
+    assertNull(params.keysFetching);
+  }
+
+  @Test
+  void build_whenAllValuesProvided_expectFieldsAssigned() {
+    // Arrange
+    List<COMPRESSOR_TYPE> decompressors = List.of(COMPRESSOR_TYPE.GZIP, COMPRESSOR_TYPE.BZIP2);
+    FreenetURI thisKey = new FreenetURI("CHK", "doc");
+    FreenetURI origKey = new FreenetURI("KSK", "orig");
+    byte[] clientDetails = new byte[] {1, 2, 3, 4};
+    File storageFile = new File("storage.dat");
+
+    SplitFileFetcherStorageInitParams.Builder builder =
+        new SplitFileFetcherStorageInitParams.Builder()
+            .metadata(metadata)
+            .fetcher(fetcher)
+            .decompressors(decompressors)
+            .clientMetadata(clientMetadata)
+            .topDontCompress(true)
+            .topCompatibilityMode((short) 7)
+            .fetchContext(fetchContext)
+            .realTime(true)
+            .salt(keySalter)
+            .thisKey(thisKey)
+            .origKey(origKey)
+            .isFinalFetch(true)
+            .clientDetails(clientDetails)
+            .random(random)
+            .tempBucketFactory(tempBucketFactory)
+            .rafFactory(rafFactory)
+            .exec(exec)
+            .ticker(ticker)
+            .memoryLimitedJobRunner(memoryLimitedJobRunner)
+            .checker(checker)
+            .persistent(true)
+            .storageFile(storageFile)
+            .diskSpaceCheckingRAFFactory(diskSpaceCheckingRAFFactory)
+            .keysFetching(keysFetching);
+
+    // Act
+    SplitFileFetcherStorageInitParams params = builder.build();
+
+    // Assert
+    assertSame(metadata, params.metadata);
+    assertSame(fetcher, params.fetcher);
+    assertEquals(decompressors, params.decompressors);
+    assertSame(clientMetadata, params.clientMetadata);
+    assertTrue(params.topDontCompress);
+    assertEquals((short) 7, params.topCompatibilityMode);
+    assertSame(fetchContext, params.origFetchContext);
+    assertTrue(params.realTime);
+    assertSame(keySalter, params.salt);
+    assertSame(thisKey, params.thisKey);
+    assertSame(origKey, params.origKey);
+    assertTrue(params.isFinalFetch);
+    assertArrayEquals(clientDetails, params.clientDetails);
+    assertSame(random, params.random);
+    assertSame(tempBucketFactory, params.tempBucketFactory);
+    assertSame(rafFactory, params.rafFactory);
+    assertSame(exec, params.exec);
+    assertSame(ticker, params.ticker);
+    assertSame(memoryLimitedJobRunner, params.memoryLimitedJobRunner);
+    assertSame(checker, params.checker);
+    assertTrue(params.persistent);
+    assertSame(storageFile, params.storageFile);
+    assertSame(diskSpaceCheckingRAFFactory, params.diskSpaceCheckingRAFFactory);
+    assertSame(keysFetching, params.keysFetching);
+  }
+
+  @Test
+  void build_whenBuilderReused_expectIndependentSnapshots() {
+    // Arrange
+    Metadata firstMetadata = metadata;
+    Metadata secondMetadata = org.mockito.Mockito.mock(Metadata.class);
+    SplitFileFetcherStorageInitParams.Builder builder =
+        new SplitFileFetcherStorageInitParams.Builder().metadata(firstMetadata);
+
+    // Act
+    SplitFileFetcherStorageInitParams firstParams = builder.build();
+    builder.metadata(secondMetadata);
+    SplitFileFetcherStorageInitParams secondParams = builder.build();
+
+    // Assert
+    assertSame(firstMetadata, firstParams.metadata);
+    assertSame(secondMetadata, secondParams.metadata);
+    assertNotSame(firstParams, secondParams);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true,true", "false,false", "true,false", "false,true"})
+  void build_whenBooleanFlagsProvided_expectValuesPropagated(
+      boolean topDontCompress, boolean persistent) {
+    // Arrange
+    SplitFileFetcherStorageInitParams.Builder builder =
+        new SplitFileFetcherStorageInitParams.Builder()
+            .topDontCompress(topDontCompress)
+            .persistent(persistent);
+
+    // Act
+    SplitFileFetcherStorageInitParams params = builder.build();
+
+    // Assert
+    assertEquals(topDontCompress, params.topDontCompress);
+    assertEquals(persistent, params.persistent);
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStoragePersistenceTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStoragePersistenceTest.java
@@ -1,0 +1,385 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FailureCodeTracker;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.Metadata;
+import network.crypta.client.Metadata.DocumentType;
+import network.crypta.client.MetadataUnresolvedException;
+import network.crypta.crypt.CRCChecksumChecker;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.HashType;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.io.ArrayBucketFactory;
+import network.crypta.support.io.BucketTools;
+import network.crypta.support.io.ByteArrayRandomAccessBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SplitFileFetcherStoragePersistenceTest {
+  private static final String WANNA_CHK_1 =
+      "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
+  private static final String WANNA_USK_1 =
+      "USK@5hH~39FtjA7A9~VXWtBKI~prUDTuJZURudDG0xFn3KA,GDgRGt5f6xqbmo-WraQtU54x4H~871Sho9Hz6hC-0RA,AQACAAE/Search/17/index_d51.xml";
+
+  private static Stream<Arguments> generalProgressFlagCases() {
+    return Stream.of(
+        Arguments.of(true, SplitFileFetcherStorage.HAS_CHECKED_DATASTORE_FLAG),
+        Arguments.of(false, 0L));
+  }
+
+  @Test
+  void preparedMetadata_whenSameContent_expectEqualsHashCodeAndToString() throws IOException {
+    BucketFactory bucketFactory = new ArrayBucketFactory();
+    Bucket sharedBucket = bucketFactory.makeBucket(-1);
+    byte[] encodedFirst = new byte[] {1, 2, 3};
+    byte[] encodedSecond = new byte[] {1, 2, 3};
+
+    SplitFileFetcherStoragePersistence.PreparedMetadata first =
+        new SplitFileFetcherStoragePersistence.PreparedMetadata(
+            sharedBucket, encodedFirst, 10L, 20L);
+    SplitFileFetcherStoragePersistence.PreparedMetadata second =
+        new SplitFileFetcherStoragePersistence.PreparedMetadata(
+            sharedBucket, encodedSecond, 10L, 20L);
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+    assertTrue(first.toString().contains("offsetOriginalDetails=10"));
+    assertTrue(first.toString().contains("offsetBasicSettings=20"));
+    assertTrue(first.toString().contains(Arrays.toString(encodedFirst)));
+
+    Bucket differentBucket = bucketFactory.makeBucket(-1);
+    SplitFileFetcherStoragePersistence.PreparedMetadata different =
+        new SplitFileFetcherStoragePersistence.PreparedMetadata(
+            differentBucket, encodedFirst, 10L, 20L);
+
+    assertNotEquals(first, different);
+  }
+
+  @ParameterizedTest
+  @MethodSource("generalProgressFlagCases")
+  void encodeGeneralProgress_whenHasCheckedDatastoreFlagMatches_expectPayloadRoundTrip(
+      boolean hasCheckedDatastore, long expectedFlags) throws Exception {
+    ChecksumChecker checksumChecker = new CRCChecksumChecker();
+    FailureCodeTracker errors = new FailureCodeTracker(false);
+    errors.inc(FetchExceptionMode.DATA_NOT_FOUND);
+    errors.inc(FetchExceptionMode.INTERNAL_ERROR);
+
+    byte[] encoded =
+        SplitFileFetcherStoragePersistence.encodeGeneralProgress(
+            checksumChecker, hasCheckedDatastore, errors);
+
+    long expectedPayloadLength = 8L + FailureCodeTracker.getFixedLength(false);
+    try (DataInputStream lengthStream = new DataInputStream(new ByteArrayInputStream(encoded))) {
+      assertEquals(expectedPayloadLength, lengthStream.readLong());
+    }
+    assertEquals(8 + expectedPayloadLength + checksumChecker.checksumLength(), encoded.length);
+
+    try (InputStream payloadStream =
+            checksumChecker.checksumReaderWithLength(
+                new ByteArrayInputStream(encoded),
+                new ArrayBucketFactory(),
+                expectedPayloadLength);
+        DataInputStream dis = new DataInputStream(payloadStream)) {
+      assertEquals(expectedFlags, dis.readLong());
+      FailureCodeTracker decoded = new FailureCodeTracker(false, dis);
+      assertEquals(1, decoded.getErrorCount(FetchExceptionMode.DATA_NOT_FOUND));
+      assertEquals(1, decoded.getErrorCount(FetchExceptionMode.INTERNAL_ERROR));
+      assertEquals(-1, payloadStream.read());
+    }
+  }
+
+  @Test
+  void encodeGeneralProgress_whenChecksumWriterFails_expectIllegalStateException()
+      throws IOException {
+    ChecksumChecker checksumChecker = Mockito.mock(ChecksumChecker.class);
+    FailureCodeTracker errors = new FailureCodeTracker(false);
+    IOException ioException = new IOException("boom");
+    doThrow(ioException)
+        .when(checksumChecker)
+        .checksumWriterWithLength(any(OutputStream.class), any(BucketFactory.class));
+
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                SplitFileFetcherStoragePersistence.encodeGeneralProgress(
+                    checksumChecker, true, errors));
+
+    assertSame(ioException, thrown.getCause());
+  }
+
+  private static Stream<Arguments> preparePersistentCases() {
+    return Stream.of(Arguments.of(true, 5, 3, 1234L, 64L), Arguments.of(false, 2, 1, 50L, 128L));
+  }
+
+  @ParameterizedTest
+  @MethodSource("preparePersistentCases")
+  void preparePersistent_whenMetadataWrites_expectOffsetsAndEncodedDetails(
+      boolean isFinalFetch, int maxRetries, int cooldownTries, long cooldownLength, long offset)
+      throws Exception {
+    ChecksumChecker checksumChecker = new CRCChecksumChecker();
+    BucketFactory bucketFactory = new ArrayBucketFactory();
+    Metadata metadata =
+        new Metadata(
+            DocumentType.SIMPLE_REDIRECT,
+            null,
+            null,
+            new FreenetURI(WANNA_CHK_1),
+            new ClientMetadata("text/plain"));
+    FreenetURI thisKey = new FreenetURI(WANNA_CHK_1);
+    FreenetURI origKey = new FreenetURI(WANNA_USK_1);
+    byte[] clientDetails = "client-details".getBytes(StandardCharsets.UTF_8);
+
+    SplitFileFetcherStoragePersistence.PreparedMetadata prepared =
+        SplitFileFetcherStoragePersistence.preparePersistent(
+            metadata,
+            bucketFactory,
+            thisKey,
+            origKey,
+            clientDetails,
+            isFinalFetch,
+            offset,
+            checksumChecker,
+            maxRetries,
+            cooldownTries,
+            cooldownLength);
+
+    byte[] metadataBytes = serializeMetadata(metadata);
+    byte[] bucketBytes = BucketTools.toByteArray(prepared.metadataTemp());
+    int checksumLength = checksumChecker.checksumLength();
+    assertEquals(
+        metadataBytes.length + HashType.SHA256.hashLength + checksumLength, bucketBytes.length);
+
+    MessageDigest digest = HashType.SHA256.get();
+    byte[] expectedHash = digest.digest(metadataBytes);
+    byte[] actualHash =
+        Arrays.copyOfRange(
+            bucketBytes, metadataBytes.length, metadataBytes.length + HashType.SHA256.hashLength);
+    assertArrayEquals(expectedHash, actualHash);
+
+    assertEquals(offset + bucketBytes.length, prepared.offsetOriginalDetails());
+    assertEquals(
+        prepared.offsetOriginalDetails() + prepared.encodedURI().length,
+        prepared.offsetBasicSettings());
+
+    verifyEncodedOriginalDetails(
+        prepared.encodedURI(),
+        checksumChecker,
+        thisKey,
+        origKey,
+        isFinalFetch,
+        clientDetails,
+        maxRetries,
+        cooldownTries,
+        cooldownLength);
+  }
+
+  @Test
+  void preparePersistent_whenMetadataUnresolved_expectFetchExceptionInternalError()
+      throws Exception {
+    ChecksumChecker checksumChecker = new CRCChecksumChecker();
+    BucketFactory bucketFactory = new ArrayBucketFactory();
+    Metadata metadata = Mockito.mock(Metadata.class);
+    MetadataUnresolvedException unresolved =
+        new MetadataUnresolvedException(new Metadata[0], "unresolved");
+    doThrow(unresolved).when(metadata).writeTo(any(DataOutputStream.class));
+
+    FetchException thrown =
+        assertThrows(
+            FetchException.class,
+            () ->
+                SplitFileFetcherStoragePersistence.preparePersistent(
+                    metadata,
+                    bucketFactory,
+                    new FreenetURI(WANNA_CHK_1),
+                    new FreenetURI(WANNA_USK_1),
+                    new byte[] {9},
+                    false,
+                    12L,
+                    checksumChecker,
+                    1,
+                    1,
+                    5L));
+
+    assertEquals(FetchExceptionMode.INTERNAL_ERROR, thrown.getMode());
+    assertSame(unresolved, thrown.getCause());
+  }
+
+  @Test
+  void writePersistentMetadata_whenCalled_writesSectionsAndFooter() throws Exception {
+    ChecksumChecker checksumChecker = new CRCChecksumChecker();
+    BucketFactory bucketFactory = new ArrayBucketFactory();
+    Metadata metadata =
+        new Metadata(
+            DocumentType.SIMPLE_REDIRECT,
+            null,
+            null,
+            new FreenetURI(WANNA_CHK_1),
+            new ClientMetadata("text/plain"));
+    SplitFileFetcherStoragePersistence.PreparedMetadata prepared =
+        SplitFileFetcherStoragePersistence.preparePersistent(
+            metadata,
+            bucketFactory,
+            new FreenetURI(WANNA_CHK_1),
+            new FreenetURI(WANNA_USK_1),
+            "client-details".getBytes(StandardCharsets.UTF_8),
+            true,
+            32L,
+            checksumChecker,
+            2,
+            1,
+            99L);
+
+    byte[] metadataBytes = BucketTools.toByteArray(prepared.metadataTemp());
+    byte[] basicPayload = "basic-settings".getBytes(StandardCharsets.UTF_8);
+    byte[] encodedBasicSettings = checksumChecker.appendChecksum(basicPayload);
+    int checksumLength = checksumChecker.checksumLength();
+    int versionBytesLength = 10;
+    long totalLength =
+        prepared.offsetBasicSettings()
+            + encodedBasicSettings.length
+            + Integer.BYTES
+            + checksumLength
+            + versionBytesLength
+            + Long.BYTES;
+    LockableRandomAccessBuffer raf = new ByteArrayRandomAccessBuffer((int) totalLength);
+
+    SplitFileFetcherStoragePersistence.writePersistentMetadata(
+        raf, 32L, prepared, encodedBasicSettings, checksumChecker, totalLength);
+
+    byte[] buffer = new byte[(int) totalLength];
+    raf.pread(0, buffer, 0, buffer.length);
+
+    assertArrayEquals(metadataBytes, slice(buffer, 32L, metadataBytes.length));
+    assertArrayEquals(
+        prepared.encodedURI(),
+        slice(buffer, prepared.offsetOriginalDetails(), prepared.encodedURI().length));
+    assertArrayEquals(
+        encodedBasicSettings,
+        slice(buffer, prepared.offsetBasicSettings(), encodedBasicSettings.length));
+
+    int footerOffset = (int) (prepared.offsetBasicSettings() + encodedBasicSettings.length);
+    try (DataInputStream dis =
+        new DataInputStream(
+            new ByteArrayInputStream(buffer, footerOffset, buffer.length - footerOffset))) {
+      int lengthWithoutChecksum = dis.readInt();
+      assertEquals(encodedBasicSettings.length - checksumLength, lengthWithoutChecksum);
+      byte[] checksum = dis.readNBytes(checksumLength);
+      byte[] versionBytes = new byte[versionBytesLength];
+      dis.readFully(versionBytes);
+
+      byte[] expectedVersionBytes = buildVersionBytes(checksumChecker);
+      assertArrayEquals(expectedVersionBytes, versionBytes);
+
+      byte[] expectedChecksum =
+          checksumChecker.generateChecksum(
+              concat(intToBytes(lengthWithoutChecksum), expectedVersionBytes));
+      assertArrayEquals(expectedChecksum, checksum);
+
+      long endMagic = dis.readLong();
+      assertEquals(SplitFileFetcherStorage.END_MAGIC, endMagic);
+      assertEquals(-1, dis.read());
+    }
+  }
+
+  private static byte[] serializeMetadata(Metadata metadata)
+      throws IOException, MetadataUnresolvedException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      metadata.writeTo(dos);
+    }
+    return baos.toByteArray();
+  }
+
+  @SuppressWarnings("java:S107")
+  private static void verifyEncodedOriginalDetails(
+      byte[] encoded,
+      ChecksumChecker checksumChecker,
+      FreenetURI thisKey,
+      FreenetURI origKey,
+      boolean isFinalFetch,
+      byte[] clientDetails,
+      int maxRetries,
+      int cooldownTries,
+      long cooldownLength)
+      throws IOException {
+    int checksumLength = checksumChecker.checksumLength();
+    byte[] payload = Arrays.copyOf(encoded, encoded.length - checksumLength);
+    byte[] checksum = Arrays.copyOfRange(encoded, payload.length, encoded.length);
+    assertTrue(checksumChecker.checkChecksum(payload, 0, payload.length, checksum));
+
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(payload))) {
+      assertEquals(thisKey.toASCIIString(), dis.readUTF());
+      assertEquals(origKey.toASCIIString(), dis.readUTF());
+      assertEquals(isFinalFetch, dis.readBoolean());
+      int detailsLength = dis.readInt();
+      byte[] details = new byte[detailsLength];
+      dis.readFully(details);
+      assertArrayEquals(clientDetails, details);
+      assertEquals(maxRetries, dis.readInt());
+      assertEquals(cooldownTries, dis.readInt());
+      assertEquals(cooldownLength, dis.readLong());
+      assertEquals(-1, dis.read());
+    }
+  }
+
+  private static byte[] slice(byte[] source, long offset, int length) {
+    return Arrays.copyOfRange(source, (int) offset, (int) offset + length);
+  }
+
+  private static byte[] buildVersionBytes(ChecksumChecker checksumChecker) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(0);
+      dos.writeShort(checksumChecker.getChecksumTypeID());
+      dos.writeInt(SplitFileFetcherStorage.VERSION);
+    }
+    return baos.toByteArray();
+  }
+
+  private static byte[] intToBytes(int value) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(value);
+    }
+    return baos.toByteArray();
+  }
+
+  private static byte[] concat(byte[] left, byte[] right) {
+    byte[] combined = Arrays.copyOf(left, left.length + right.length);
+    System.arraycopy(right, 0, combined, left.length, right.length);
+    return combined;
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageRafFactoryTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageRafFactoryTest.java
@@ -1,0 +1,201 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import network.crypta.crypt.RandomSource;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.PooledFileRandomAccessBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SplitFileFetcherStorageRafFactoryTest {
+  private static final String STORAGE_FILE_NAME = "storage.dat";
+  private static final String EXPECTED_IO_EXCEPTION_MESSAGE = "Expected IOException";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void createRafOrThrow_whenStorageFileNull_usesInMemoryFactory() throws Exception {
+    long totalLength = 128L;
+    LockableRandomAccessBuffer raf = mock(LockableRandomAccessBuffer.class);
+    CapturingRafFactory rafFactory = new CapturingRafFactory(raf);
+    CapturingFileRafFactory diskFactory =
+        new CapturingFileRafFactory(mock(PooledFileRandomAccessBuffer.class));
+    RandomSource random = mock(RandomSource.class);
+    Logger log = mock(Logger.class);
+
+    try (LockableRandomAccessBuffer result =
+        SplitFileFetcherStorageRafFactory.createRafOrThrow(
+            null, totalLength, rafFactory, diskFactory, random, log)) {
+      assertSame(raf, result);
+    }
+    assertEquals(1, rafFactory.callCount);
+    assertEquals(totalLength, rafFactory.lastSize);
+    assertEquals(0, diskFactory.callCount);
+  }
+
+  @Test
+  void createRafOrThrow_whenStorageFileProvidedWithoutDiskFactory_throwsIOException() {
+    long totalLength = 64L;
+    File storageFile = tempDir.resolve(STORAGE_FILE_NAME).toFile();
+    LockableRandomAccessBufferFactory rafFactory = mock(LockableRandomAccessBufferFactory.class);
+    RandomSource random = mock(RandomSource.class);
+    Logger log = mock(Logger.class);
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (LockableRandomAccessBuffer raf =
+                  SplitFileFetcherStorageRafFactory.createRafOrThrow(
+                      storageFile, totalLength, rafFactory, null, random, log)) {
+                fail(EXPECTED_IO_EXCEPTION_MESSAGE + ": " + raf);
+              }
+            });
+
+    assertEquals(
+        "Disk-space checking RAF factory required for file-backed storage", thrown.getMessage());
+  }
+
+  @Test
+  void createRafOrThrow_whenStorageFileMissing_throwsIOException() {
+    long totalLength = 64L;
+    File storageFile = tempDir.resolve("missing.dat").toFile();
+    CapturingRafFactory rafFactory =
+        new CapturingRafFactory(mock(LockableRandomAccessBuffer.class));
+    CapturingFileRafFactory diskFactory =
+        new CapturingFileRafFactory(mock(PooledFileRandomAccessBuffer.class));
+    RandomSource random = mock(RandomSource.class);
+    Logger log = mock(Logger.class);
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (LockableRandomAccessBuffer raf =
+                  SplitFileFetcherStorageRafFactory.createRafOrThrow(
+                      storageFile, totalLength, rafFactory, diskFactory, random, log)) {
+                fail(EXPECTED_IO_EXCEPTION_MESSAGE + ": " + raf);
+              }
+            });
+
+    assertEquals("Must have already created storage file", thrown.getMessage());
+    assertEquals(0, diskFactory.callCount);
+  }
+
+  @Test
+  void createRafOrThrow_whenStorageFileNotEmpty_throwsIOException() throws Exception {
+    long totalLength = 64L;
+    Path storagePath = tempDir.resolve(STORAGE_FILE_NAME);
+    Files.write(storagePath, new byte[] {1});
+    File storageFile = storagePath.toFile();
+    CapturingRafFactory rafFactory =
+        new CapturingRafFactory(mock(LockableRandomAccessBuffer.class));
+    CapturingFileRafFactory diskFactory =
+        new CapturingFileRafFactory(mock(PooledFileRandomAccessBuffer.class));
+    RandomSource random = mock(RandomSource.class);
+    Logger log = mock(Logger.class);
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (LockableRandomAccessBuffer raf =
+                  SplitFileFetcherStorageRafFactory.createRafOrThrow(
+                      storageFile, totalLength, rafFactory, diskFactory, random, log)) {
+                fail(EXPECTED_IO_EXCEPTION_MESSAGE + ": " + raf);
+              }
+            });
+
+    assertEquals("Storage file must be empty", thrown.getMessage());
+    assertEquals(0, diskFactory.callCount);
+  }
+
+  @Test
+  void createRafOrThrow_whenStorageFileEmpty_usesDiskFactory() throws Exception {
+    long totalLength = 512L;
+    Path storagePath = tempDir.resolve(STORAGE_FILE_NAME);
+    Files.createFile(storagePath);
+    File storageFile = storagePath.toFile();
+    CapturingRafFactory rafFactory =
+        new CapturingRafFactory(mock(LockableRandomAccessBuffer.class));
+    RandomSource random = mock(RandomSource.class);
+    Logger log = mock(Logger.class);
+    PooledFileRandomAccessBuffer raf = mock(PooledFileRandomAccessBuffer.class);
+    CapturingFileRafFactory diskFactory = new CapturingFileRafFactory(raf);
+
+    try (LockableRandomAccessBuffer result =
+        SplitFileFetcherStorageRafFactory.createRafOrThrow(
+            storageFile, totalLength, rafFactory, diskFactory, random, log)) {
+      assertSame(raf, result);
+    }
+    assertEquals(0, rafFactory.callCount);
+    assertEquals(1, diskFactory.callCount);
+    assertSame(storageFile, diskFactory.lastFile);
+    assertEquals(totalLength, diskFactory.lastSize);
+    assertSame(random, diskFactory.lastRandom);
+    verify(log)
+        .info("Creating splitfile storage file for complete-via-truncation: {}", storageFile);
+  }
+
+  private static final class CapturingRafFactory implements LockableRandomAccessBufferFactory {
+    private final LockableRandomAccessBuffer raf;
+    private int callCount;
+    private long lastSize = -1;
+
+    private CapturingRafFactory(LockableRandomAccessBuffer raf) {
+      this.raf = raf;
+    }
+
+    @Override
+    public LockableRandomAccessBuffer makeRAF(long size) {
+      callCount++;
+      lastSize = size;
+      return raf;
+    }
+
+    @Override
+    public LockableRandomAccessBuffer makeRAF(
+        byte[] initialContents, int offset, int size, boolean readOnly) {
+      throw new UnsupportedOperationException("Not needed for tests");
+    }
+  }
+
+  private static final class CapturingFileRafFactory implements FileRandomAccessBufferFactory {
+    private final PooledFileRandomAccessBuffer raf;
+    private int callCount;
+    private File lastFile;
+    private long lastSize;
+    private Random lastRandom;
+
+    private CapturingFileRafFactory(PooledFileRandomAccessBuffer raf) {
+      this.raf = raf;
+    }
+
+    @Override
+    public PooledFileRandomAccessBuffer createNewRAF(File file, long size, Random random) {
+      callCount++;
+      lastFile = file;
+      lastSize = size;
+      lastRandom = random;
+      return raf;
+    }
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageResumeParamsTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageResumeParamsTest.java
@@ -1,0 +1,121 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.client.FetchContext;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.KeysFetchingLocally;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SplitFileFetcherStorageResumeParamsTest {
+  @Mock private LockableRandomAccessBuffer raf;
+  @Mock private SplitFileFetcherStorageCallback callback;
+  @Mock private FetchContext origContext;
+  @Mock private RandomSource random;
+  @Mock private PersistentJobRunner exec;
+  @Mock private KeysFetchingLocally keysFetching;
+  @Mock private Ticker ticker;
+  @Mock private MemoryLimitedJobRunner memoryLimitedJobRunner;
+  @Mock private ChecksumChecker checker;
+  @Mock private KeySalter salt;
+
+  @Test
+  void build_whenNoValuesProvided_expectDefaultsNullAndFalse() {
+    SplitFileFetcherStorageResumeParams.Builder builder =
+        new SplitFileFetcherStorageResumeParams.Builder();
+
+    SplitFileFetcherStorageResumeParams params = builder.build();
+
+    assertAll(
+        "defaults",
+        () -> assertNull(params.raf),
+        () -> assertFalse(params.realTime),
+        () -> assertNull(params.callback),
+        () -> assertNull(params.origContext),
+        () -> assertNull(params.random),
+        () -> assertNull(params.exec),
+        () -> assertNull(params.keysFetching),
+        () -> assertNull(params.ticker),
+        () -> assertNull(params.memoryLimitedJobRunner),
+        () -> assertNull(params.checker),
+        () -> assertFalse(params.newSalt),
+        () -> assertNull(params.salt),
+        () -> assertFalse(params.resumed),
+        () -> assertFalse(params.completeViaTruncation));
+  }
+
+  @Test
+  void build_whenAllValuesProvided_expectSameReferencesAndFlags() {
+    SplitFileFetcherStorageResumeParams.Builder builder =
+        new SplitFileFetcherStorageResumeParams.Builder()
+            .raf(raf)
+            .realTime(true)
+            .callback(callback)
+            .context(origContext)
+            .random(random)
+            .exec(exec)
+            .keysFetching(keysFetching)
+            .ticker(ticker)
+            .memoryLimitedJobRunner(memoryLimitedJobRunner)
+            .checker(checker)
+            .newSalt(true)
+            .salt(salt)
+            .resumed(true)
+            .completeViaTruncation(true);
+
+    SplitFileFetcherStorageResumeParams params = builder.build();
+
+    assertAll(
+        "values",
+        () -> assertSame(raf, params.raf),
+        () -> assertTrue(params.realTime),
+        () -> assertSame(callback, params.callback),
+        () -> assertSame(origContext, params.origContext),
+        () -> assertSame(random, params.random),
+        () -> assertSame(exec, params.exec),
+        () -> assertSame(keysFetching, params.keysFetching),
+        () -> assertSame(ticker, params.ticker),
+        () -> assertSame(memoryLimitedJobRunner, params.memoryLimitedJobRunner),
+        () -> assertSame(checker, params.checker),
+        () -> assertTrue(params.newSalt),
+        () -> assertSame(salt, params.salt),
+        () -> assertTrue(params.resumed),
+        () -> assertTrue(params.completeViaTruncation));
+  }
+
+  @Test
+  void builderMethods_whenInvoked_expectSameBuilderInstance() {
+    SplitFileFetcherStorageResumeParams.Builder builder =
+        new SplitFileFetcherStorageResumeParams.Builder();
+
+    assertAll(
+        "fluent",
+        () -> assertSame(builder, builder.raf(raf)),
+        () -> assertSame(builder, builder.realTime(true)),
+        () -> assertSame(builder, builder.callback(callback)),
+        () -> assertSame(builder, builder.context(origContext)),
+        () -> assertSame(builder, builder.random(random)),
+        () -> assertSame(builder, builder.exec(exec)),
+        () -> assertSame(builder, builder.keysFetching(keysFetching)),
+        () -> assertSame(builder, builder.ticker(ticker)),
+        () -> assertSame(builder, builder.memoryLimitedJobRunner(memoryLimitedJobRunner)),
+        () -> assertSame(builder, builder.checker(checker)),
+        () -> assertSame(builder, builder.newSalt(true)),
+        () -> assertSame(builder, builder.salt(salt)),
+        () -> assertSame(builder, builder.resumed(true)),
+        () -> assertSame(builder, builder.completeViaTruncation(true)));
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodecTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodecTest.java
@@ -1,0 +1,538 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.Metadata.SplitfileAlgorithm;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import network.crypta.support.io.StorageFormatException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SplitFileFetcherStorageSettingsCodecTest {
+  private static final long RAF_LENGTH = 1_000L;
+  private static final int SENTINEL = 0xCAFEBABE;
+
+  @Test
+  void parseBasicSettings_whenValidBuffer_expectParsedValuesAndStreamPosition()
+      throws StorageFormatException, IOException {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.cryptoKey = fixedKey();
+    byte[] buffer = values.toBytes(trailingSentinelBytes());
+
+    ParsedBasicSettings parsed =
+        SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+            buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH);
+
+    assertParsedValues(values, parsed);
+
+    DataInputStream remainder = parsed.getSettingsStream();
+    assertNotNull(remainder);
+    assertEquals(SENTINEL, remainder.readInt());
+  }
+
+  @Test
+  void encodeBasicSettings_whenStorageProvided_expectSerializedValuesAndChecksummed()
+      throws StorageFormatException, IOException {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.cryptoKey = fixedKey();
+    values.decompressors = List.of(COMPRESSOR_TYPE.LZMA_NEW);
+    values.completeViaTruncation = true;
+    values.compatMode = CompatibilityMode.COMPAT_1251;
+    values.segmentCount = 2;
+    values.totalDataBlocks = 7;
+    values.totalCheckBlocks = 3;
+    values.totalCrossCheckBlocks = 1;
+
+    SplitFileFetcherSegmentStorage segment0 = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage segment1 = mock(SplitFileFetcherSegmentStorage.class);
+    doAnswer(
+            invocation -> {
+              DataOutputStream dos = invocation.getArgument(0);
+              dos.writeInt(1);
+              dos.writeInt(2);
+              dos.writeInt(3);
+              return null;
+            })
+        .when(segment0)
+        .writeFixedMetadata(any(DataOutputStream.class));
+    doAnswer(
+            invocation -> {
+              DataOutputStream dos = invocation.getArgument(0);
+              dos.writeInt(4);
+              dos.writeInt(5);
+              dos.writeInt(6);
+              return null;
+            })
+        .when(segment1)
+        .writeFixedMetadata(any(DataOutputStream.class));
+    SplitFileFetcherSegmentStorage[] segments =
+        new SplitFileFetcherSegmentStorage[] {segment0, segment1};
+
+    SplitFileFetcherCrossSegmentStorage crossSegment =
+        mock(SplitFileFetcherCrossSegmentStorage.class);
+    doAnswer(
+            invocation -> {
+              DataOutputStream dos = invocation.getArgument(0);
+              dos.writeInt(7);
+              dos.writeInt(8);
+              dos.writeInt(9);
+              dos.writeInt(10);
+              return null;
+            })
+        .when(crossSegment)
+        .writeFixedMetadata(any(DataOutputStream.class));
+    SplitFileFetcherCrossSegmentStorage[] crossSegments =
+        new SplitFileFetcherCrossSegmentStorage[] {crossSegment};
+
+    SplitFileFetcherKeyListener keyListener = mock(SplitFileFetcherKeyListener.class);
+    byte[] salt = new byte[32];
+    Arrays.fill(salt, (byte) 0x5A);
+    doAnswer(
+            invocation -> {
+              DataOutputStream dos = invocation.getArgument(0);
+              dos.write(salt);
+              dos.writeInt(111);
+              dos.writeInt(222);
+              dos.writeInt(333);
+              dos.writeInt(444);
+              return null;
+            })
+        .when(keyListener)
+        .writeStaticSettings(any(DataOutputStream.class));
+
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+    when(checksumChecker.appendChecksum(any(byte[].class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    SplitFileFetcherStorage storage =
+        newStorageForEncoding(values, segments, crossSegments, keyListener, checksumChecker);
+
+    byte[] encoded =
+        SplitFileFetcherStorageSettingsCodec.encodeBasicSettings(
+            storage, values.totalDataBlocks, values.totalCheckBlocks, values.totalCrossCheckBlocks);
+
+    verify(checksumChecker).appendChecksum(any(byte[].class));
+
+    ParsedBasicSettings parsed =
+        SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+            encoded, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH);
+
+    assertParsedValues(values, parsed);
+
+    DataInputStream remainder = parsed.getSettingsStream();
+    assertEncodedRemainder(remainder, salt);
+  }
+
+  @Test
+  void parseBasicSettings_whenInvalidSplitfileType_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.splitfileAlgorithmCodeOverride = (short) 99;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenInvalidCryptoAlgorithm_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.cryptoAlgorithm = (byte) 99;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenNegativeFinalLength_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.finalLength = -1L;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenInvalidClientMetadata_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.writeValidClientMetadata = false;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenNegativeDecompressorCount_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.decompressorCountOverride = -1;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenInvalidDecompressorId_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.decompressorIdsOverride = List.of((short) 999);
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenOffsetOutsideRafLength_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.offsetKeyList = RAF_LENGTH + 1;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenBasicSettingsOffsetMismatch_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings + 1, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenCompleteViaTruncationMismatch_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.completeViaTruncation = true;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, false, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenInvalidCompatMode_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.compatModeOrdinalOverride = CompatibilityMode.values().length + 1;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenSegmentCountNonPositive_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.segmentCount = 0;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  @Test
+  void parseBasicSettings_whenTotalBlocksNonPositive_expectStorageFormatException() {
+    BasicSettingsValues values = BasicSettingsValues.defaults();
+    values.totalDataBlocks = 0;
+    values.totalCheckBlocks = 0;
+    values.totalCrossCheckBlocks = 0;
+    byte[] buffer = values.toBytes(null);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+  }
+
+  private static byte[] fixedKey() {
+    byte[] key = new byte[32];
+    for (int i = 0; i < key.length; i++) {
+      key[i] = (byte) (i + 1);
+    }
+    return key;
+  }
+
+  private static byte[] trailingSentinelBytes() {
+    try {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      try (DataOutputStream dos = new DataOutputStream(baos)) {
+        dos.writeInt(SENTINEL);
+      }
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static void assertParsedValues(BasicSettingsValues values, ParsedBasicSettings parsed) {
+    assertEquals(values.splitfileAlgorithm, parsed.getSplitfileType());
+    assertEquals(values.cryptoAlgorithm, parsed.getSplitfileSingleCryptoAlgorithm());
+    assertArrayEquals(values.cryptoKey, parsed.getSplitfileSingleCryptoKey());
+    assertEquals(values.finalLength, parsed.getFinalLength());
+    assertEquals(values.decompressedLength, parsed.getDecompressedLength());
+    assertEquals(values.clientMetadata.getMIMEType(), parsed.getClientMetadata().getMIMEType());
+    assertEquals(values.decompressors, parsed.getDecompressors());
+    assertEquals(values.offsetKeyList, parsed.getOffsetKeyList());
+    assertEquals(values.offsetSegmentStatus, parsed.getOffsetSegmentStatus());
+    assertEquals(values.offsetGeneralProgress, parsed.getOffsetGeneralProgress());
+    assertEquals(values.offsetMainBloomFilter, parsed.getOffsetMainBloomFilter());
+    assertEquals(values.offsetSegmentBloomFilters, parsed.getOffsetSegmentBloomFilters());
+    assertEquals(values.offsetOriginalMetadata, parsed.getOffsetOriginalMetadata());
+    assertEquals(values.offsetOriginalDetails, parsed.getOffsetOriginalDetails());
+    assertEquals(values.offsetBasicSettings, parsed.getOffsetBasicSettings());
+    assertEquals(values.compatMode, parsed.getFinalMinCompatMode());
+    assertEquals(values.segmentCount, parsed.getSegmentCount());
+    assertEquals(values.totalDataBlocks, parsed.getTotalDataBlocks());
+    assertEquals(values.totalCheckBlocks, parsed.getTotalCheckBlocks());
+    assertEquals(values.totalCrossCheckBlocks, parsed.getTotalCrossCheckBlocks());
+  }
+
+  private static void assertEncodedRemainder(DataInputStream remainder, byte[] expectedSalt)
+      throws IOException {
+    assertNotNull(remainder);
+    assertArrayEquals(new int[] {1, 2, 3, 4, 5, 6, 1, 7, 8, 9, 10}, readInts(remainder, 11));
+    assertArrayEquals(expectedSalt, remainder.readNBytes(expectedSalt.length));
+    assertArrayEquals(new int[] {111, 222, 333, 444}, readInts(remainder, 4));
+  }
+
+  private static int[] readInts(DataInputStream remainder, int count) throws IOException {
+    int[] values = new int[count];
+    for (int i = 0; i < count; i++) {
+      values[i] = remainder.readInt();
+    }
+    return values;
+  }
+
+  private static SplitFileFetcherStorage newStorageForEncoding(
+      BasicSettingsValues values,
+      SplitFileFetcherSegmentStorage[] segments,
+      SplitFileFetcherCrossSegmentStorage[] crossSegments,
+      SplitFileFetcherKeyListener keyListener,
+      ChecksumChecker checksumChecker) {
+    try {
+      SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+      setField(storage, "splitfileType", values.splitfileAlgorithm);
+      setField(storage, "splitfileSingleCryptoAlgorithm", values.cryptoAlgorithm);
+      setField(storage, "splitfileSingleCryptoKey", values.cryptoKey);
+      setField(storage, "finalLength", values.finalLength);
+      setField(storage, "decompressedLength", values.decompressedLength);
+      setField(storage, "clientMetadata", values.clientMetadata);
+      setField(storage, "decompressors", values.decompressors);
+      setField(storage, "offsetKeyList", values.offsetKeyList);
+      setField(storage, "offsetSegmentStatus", values.offsetSegmentStatus);
+      setField(storage, "offsetGeneralProgress", values.offsetGeneralProgress);
+      setField(storage, "offsetMainBloomFilter", values.offsetMainBloomFilter);
+      setField(storage, "offsetSegmentBloomFilters", values.offsetSegmentBloomFilters);
+      setField(storage, "offsetOriginalMetadata", values.offsetOriginalMetadata);
+      setField(storage, "offsetOriginalDetails", values.offsetOriginalDetails);
+      setField(storage, "offsetBasicSettings", values.offsetBasicSettings);
+      setField(storage, "completeViaTruncation", values.completeViaTruncation);
+      setField(storage, "finalMinCompatMode", values.compatMode);
+      setField(storage, "segments", segments);
+      setField(storage, "crossSegments", crossSegments);
+      setField(storage, "keyListener", keyListener);
+      setField(storage, "checksumChecker", checksumChecker);
+      return storage;
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Unable to build storage instance", e);
+    }
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void setField(Object target, String name, Object value)
+      throws ReflectiveOperationException {
+    Field field = SplitFileFetcherStorage.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static final class BasicSettingsValues {
+    private final SplitfileAlgorithm splitfileAlgorithm = SplitfileAlgorithm.ONION_STANDARD;
+    private Short splitfileAlgorithmCodeOverride;
+    private byte cryptoAlgorithm = 0;
+    private byte[] cryptoKey;
+    private long finalLength = 123L;
+    private final long decompressedLength = 456L;
+    private final ClientMetadata clientMetadata = new ClientMetadata("text/plain");
+    private boolean writeValidClientMetadata = true;
+    private List<COMPRESSOR_TYPE> decompressors =
+        List.of(COMPRESSOR_TYPE.GZIP, COMPRESSOR_TYPE.BZIP2);
+    private Integer decompressorCountOverride;
+    private List<Short> decompressorIdsOverride;
+    private long offsetKeyList = 10L;
+    private final long offsetSegmentStatus = 20L;
+    private final long offsetGeneralProgress = 30L;
+    private final long offsetMainBloomFilter = 40L;
+    private final long offsetSegmentBloomFilters = 50L;
+    private final long offsetOriginalMetadata = 60L;
+    private final long offsetOriginalDetails = 70L;
+    private final long offsetBasicSettings = 80L;
+    private boolean completeViaTruncation = false;
+    private CompatibilityMode compatMode = CompatibilityMode.COMPAT_1250;
+    private Integer compatModeOrdinalOverride;
+    private int segmentCount = 2;
+    private int totalDataBlocks = 10;
+    private int totalCheckBlocks = 5;
+    private int totalCrossCheckBlocks = 0;
+
+    private static BasicSettingsValues defaults() {
+      return new BasicSettingsValues();
+    }
+
+    private byte[] toBytes(byte[] trailing) {
+      try {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.writeShort(resolveSplitfileAlgorithmCode());
+        writeCryptoInfo(dos);
+        dos.writeLong(finalLength);
+        dos.writeLong(decompressedLength);
+        writeClientMetadata(dos);
+        writeDecompressors(dos);
+        writeOffsets(dos);
+        dos.writeBoolean(completeViaTruncation);
+        dos.writeInt(resolveCompatModeOrdinal());
+        dos.writeInt(segmentCount);
+        dos.writeInt(totalDataBlocks);
+        dos.writeInt(totalCheckBlocks);
+        dos.writeInt(totalCrossCheckBlocks);
+        if (trailing != null) {
+          dos.write(trailing);
+        }
+        dos.flush();
+        return baos.toByteArray();
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    private short resolveSplitfileAlgorithmCode() {
+      return splitfileAlgorithmCodeOverride != null
+          ? splitfileAlgorithmCodeOverride
+          : splitfileAlgorithm.code;
+    }
+
+    private void writeCryptoInfo(DataOutputStream dos) throws IOException {
+      dos.writeByte(cryptoAlgorithm);
+      if (cryptoKey == null) {
+        dos.writeBoolean(false);
+        return;
+      }
+      if (cryptoKey.length != 32) {
+        throw new IllegalArgumentException("cryptoKey must be 32 bytes");
+      }
+      dos.writeBoolean(true);
+      dos.write(cryptoKey);
+    }
+
+    private void writeClientMetadata(DataOutputStream dos) throws IOException {
+      if (writeValidClientMetadata) {
+        clientMetadata.writeTo(dos);
+        return;
+      }
+      dos.writeInt(0x0BADBEEF);
+      dos.writeShort(1);
+      dos.writeBoolean(false);
+    }
+
+    private void writeDecompressors(DataOutputStream dos) throws IOException {
+      int count = resolveDecompressorCount();
+      dos.writeInt(count);
+      if (count <= 0) {
+        return;
+      }
+      for (short id : resolveDecompressorIds()) {
+        dos.writeShort(id);
+      }
+    }
+
+    private int resolveDecompressorCount() {
+      if (decompressorCountOverride != null) {
+        return decompressorCountOverride;
+      }
+      if (decompressorIdsOverride != null) {
+        return decompressorIdsOverride.size();
+      }
+      return decompressors.size();
+    }
+
+    private List<Short> resolveDecompressorIds() {
+      if (decompressorIdsOverride != null) {
+        return decompressorIdsOverride;
+      }
+      return decompressors.stream().map(compressor -> compressor.metadataID).toList();
+    }
+
+    private void writeOffsets(DataOutputStream dos) throws IOException {
+      dos.writeLong(offsetKeyList);
+      dos.writeLong(offsetSegmentStatus);
+      dos.writeLong(offsetGeneralProgress);
+      dos.writeLong(offsetMainBloomFilter);
+      dos.writeLong(offsetSegmentBloomFilters);
+      dos.writeLong(offsetOriginalMetadata);
+      dos.writeLong(offsetOriginalDetails);
+      dos.writeLong(offsetBasicSettings);
+    }
+
+    private int resolveCompatModeOrdinal() {
+      return compatModeOrdinalOverride != null ? compatModeOrdinalOverride : compatMode.ordinal();
+    }
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
@@ -1161,7 +1161,7 @@ class SplitFileFetcherStorageTest {
             }
           };
       return new SplitFileFetcherStorage(
-          new SplitFileFetcherStorage.InitParams.Builder()
+          new SplitFileFetcherStorageInitParams.Builder()
               .metadata(metadata)
               .fetcher(cb)
               .decompressors(NO_DECOMPRESSORS)
@@ -1203,7 +1203,7 @@ class SplitFileFetcherStorageTest {
         throws IOException, StorageFormatException, FetchException {
       assertTrue(persistent);
       return new SplitFileFetcherStorage(
-          new SplitFileFetcherStorage.ResumeParams.Builder()
+          new SplitFileFetcherStorageResumeParams.Builder()
               .raf(raf)
               .realTime(false)
               .callback(cb)


### PR DESCRIPTION
## Summary
- Refactor splitfile storage persistence into init/resume params, settings codec, and RAF factory helpers
- Add cross-segment allocator for splitfile storage and expand coverage
- Expand SplitFileFetcherStorage documentation and add persistence/resume tests

## Testing
- Not run (not requested)
