### PR TITLE
chore(test): enable native access

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -78,6 +78,7 @@ tasks.withType<Test>().configureEach {
     jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
     jvmArgs("--add-opens=java.base/java.io=ALL-UNNAMED")
     jvmArgs("--add-opens=java.base/java.util.zip=ALL-UNNAMED")
+    jvmArgs("--enable-native-access=ALL-UNNAMED")
   }
   // Allow dynamic agent loading for Mockito inline mock-maker (JEP 451).
   jvmArgs("-XX:+EnableDynamicAgentLoading")


### PR DESCRIPTION
## Summary
- allow the test JVM to use `--enable-native-access=ALL-UNNAMED`
- align test JVM flags with runtime wrapper settings to silence bcprov native access warnings

## Testing
- `./gradlew testClasses`
- `./gradlew spotlessApply`