### PR TITLE
refactor(node): split client core wiring

### DIFF
--- a/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
+++ b/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
@@ -836,7 +836,7 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
     ctx.setAllowedMIMETypes(allowedTypes);
     final ClientGetter get =
         new ClientGetter(nullCallback, uri, ctx, prio, new NullBucket(), null, null);
-    core.getTicker().queueTimedJob(() -> get.cancel(core.getClientContext()), timeout);
+    core.getNode().getTicker().queueTimedJob(() -> get.cancel(core.getClientContext()), timeout);
     try {
       core.getClientContext().start(get);
     } catch (FetchException | PersistenceDisabledException _) {

--- a/src/main/java/network/crypta/client/async/ClientLayerPersister.java
+++ b/src/main/java/network/crypta/client/async/ClientLayerPersister.java
@@ -145,6 +145,29 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     this.bandwidthStatsPutter = stats;
   }
 
+  /**
+   * Constructs a persistence coordinator using a new bandwidth stats collector.
+   *
+   * <p>This overload creates a dedicated {@link PersistentStatsPutter} instance so callers do not
+   * need to supply one explicitly.
+   */
+  public ClientLayerPersister(
+      PriorityAwareExecutor executor,
+      Ticker ticker,
+      Node node,
+      NodeClientCore core,
+      PersistentTempBucketFactory persistentTempFactory,
+      TempBucketFactory tempBucketFactory) {
+    this(
+        executor,
+        ticker,
+        node,
+        core,
+        persistentTempFactory,
+        tempBucketFactory,
+        new PersistentStatsPutter());
+  }
+
   private void loadAllVariants(
       PartialLoad loaded,
       File dir,
@@ -932,6 +955,16 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
    */
   public synchronized File getWriteFilename() {
     return writeToFilename;
+  }
+
+  /**
+   * Returns the persistent bandwidth statistics collector.
+   *
+   * <p>The returned instance accumulates bandwidth and uptime data across restarts when the client
+   * persistence layer is enabled.
+   */
+  public PersistentStatsPutter getBandwidthStatsPutter() {
+    return bandwidthStatsPutter;
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/OfferedKeysList.java
+++ b/src/main/java/network/crypta/client/async/OfferedKeysList.java
@@ -242,9 +242,9 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
   /**
    * Provides a sender that performs a short-lived asynchronous get for a chosen offered key.
    *
-   * <p>The sender invokes {@code NodeClientCore.asyncGet(...)} with parameters suitable for an
-   * opportunistic attempt: it checks the datastore and briefly accepts peer offers; it does not
-   * escalate into a full client request and does not write to the client cache. Upon completion
+   * <p>The sender invokes {@code NodeClientCoreTransfers.asyncGet(...)} with parameters suitable
+   * for an opportunistic attempt: it checks the datastore and briefly accepts peer offers; it does
+   * not escalate into a full client request and does not write to the client cache. Upon completion
    * (success or failure) the sender removes the key from the fetching set and wakes the starter so
    * other work can proceed.
    *
@@ -268,35 +268,36 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
         // We check the datastore, take up offers if any (on a short timeout), and then quit if we
         // still haven't fetched the data.
         // Obviously this may have a marginal impact on load, but it should only be marginal.
-        core.asyncGet(
-            key,
-            true,
-            new RequestCompletionListener() {
+        core.getTransfers()
+            .asyncGet(
+                key,
+                true,
+                new RequestCompletionListener() {
 
-              @Override
-              public void onSucceeded() {
-                // We don't use ChosenBlockImpl so have to remove the keys from the fetching set
-                // ourselves.
-                sched.removeFetchingKey(key);
-                sched.wakeStarter();
-              }
+                  @Override
+                  public void onSucceeded() {
+                    // We don't use ChosenBlockImpl so have to remove the keys from the fetching set
+                    // ourselves.
+                    sched.removeFetchingKey(key);
+                    sched.wakeStarter();
+                  }
 
-              @Override
-              public void onFailed(LowLevelGetException e) {
-                // We don't use ChosenBlockImpl so have to remove the keys from the fetching set
-                // ourselves.
-                sched.removeFetchingKey(key);
-                // Something might be waiting for a request to complete (e.g. if we have two
-                // requests for the same key),
-                // so wake the starter thread.
-                sched.wakeStarter();
-              }
-            },
-            true,
-            false,
-            realTimeFlag,
-            false,
-            false);
+                  @Override
+                  public void onFailed(LowLevelGetException e) {
+                    // We don't use ChosenBlockImpl so have to remove the keys from the fetching set
+                    // ourselves.
+                    sched.removeFetchingKey(key);
+                    // Something might be waiting for a request to complete (e.g. if we have two
+                    // requests for the same key),
+                    // so wake the starter thread.
+                    sched.wakeStarter();
+                  }
+                },
+                true,
+                false,
+                realTimeFlag,
+                false,
+                false);
         // canWriteClientCache remains false intentionally here.
         return true;
       }

--- a/src/main/java/network/crypta/client/async/SingleBlockInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleBlockInserter.java
@@ -796,13 +796,14 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
         throw new LowLevelPutException(collided);
       }
     else
-      core.realPut(
-          b,
-          req.canWriteClientCache,
-          req.forkOnCacheable,
-          Node.PREFER_INSERT_DEFAULT,
-          Node.IGNORE_LOW_BACKOFF_DEFAULT,
-          req.realTimeFlag);
+      core.getTransfers()
+          .realPut(
+              b,
+              req.canWriteClientCache,
+              req.forkOnCacheable,
+              Node.PREFER_INSERT_DEFAULT,
+              Node.IGNORE_LOW_BACKOFF_DEFAULT,
+              req.realTimeFlag);
   }
 
   private boolean handleCollision(

--- a/src/main/java/network/crypta/client/async/SplitFileInserterSender.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterSender.java
@@ -247,13 +247,14 @@ public class SplitFileInserterSender extends SendableInsert {
         if (request.localRequestOnly) {
           storeLocally(node, block, request.canWriteClientCache);
         } else {
-          node.realPut(
-              block,
-              request.canWriteClientCache,
-              request.forkOnCacheable,
-              Node.PREFER_INSERT_DEFAULT,
-              Node.IGNORE_LOW_BACKOFF_DEFAULT,
-              request.realTimeFlag);
+          node.getTransfers()
+              .realPut(
+                  block,
+                  request.canWriteClientCache,
+                  request.forkOnCacheable,
+                  Node.PREFER_INSERT_DEFAULT,
+                  Node.IGNORE_LOW_BACKOFF_DEFAULT,
+                  request.realTimeFlag);
         }
         request.onInsertSuccess(key, context);
       } catch (final LowLevelPutException e) {

--- a/src/main/java/network/crypta/client/async/USKManager.java
+++ b/src/main/java/network/crypta/client/async/USKManager.java
@@ -136,7 +136,7 @@ public class USKManager {
     backgroundFetchersByClearUSK = new TreeMap<>(USK.FAST_COMPARATOR);
     temporaryBackgroundFetchersLRU = LRUMap.createSafeMap(USK.FAST_COMPARATOR);
     temporaryBackgroundFetchersPrefetch = new WeakHashMap<>();
-    executor = core.getExecutor();
+    executor = core.getNode().getExecutor();
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -768,6 +768,7 @@ public abstract class ClientRequest implements Serializable {
     } else {
       server
           .getCore()
+          .getNode()
           .getExecutor()
           .execute(
               new PrioRunnable() {

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -288,7 +288,7 @@ public class FCPServer implements Runnable, DownloadCache {
 
     @Override
     public Integer get() {
-      return node.getFCPServer().port;
+      return node.getEndpoints().getFCPServer().port;
     }
 
     @Override
@@ -314,7 +314,7 @@ public class FCPServer implements Runnable, DownloadCache {
 
     @Override
     public Boolean get() {
-      return node.getFCPServer().enabled;
+      return node.getEndpoints().getFCPServer().enabled;
     }
 
     // Changing the enabled flag at runtime is not supported.
@@ -374,14 +374,14 @@ public class FCPServer implements Runnable, DownloadCache {
 
     @Override
     public String get() {
-      return node.getFCPServer().bindTo;
+      return node.getEndpoints().getFCPServer().bindTo;
     }
 
     @Override
     public void set(String val) throws InvalidConfigValueException {
       String oldValue = get();
       if (!val.equals(oldValue)) {
-        FCPServer server = node.getFCPServer();
+        FCPServer server = node.getEndpoints().getFCPServer();
 
         String[] failedAddresses = server.networkInterface.setBindTo(val, true);
         if (failedAddresses != null) {
@@ -413,7 +413,7 @@ public class FCPServer implements Runnable, DownloadCache {
 
     @Override
     public String get() {
-      FCPServer server = node.getFCPServer();
+      FCPServer server = node.getEndpoints().getFCPServer();
       if (server == null) return NetworkInterface.DEFAULT_BIND_TO;
       NetworkInterface netIface = server.networkInterface;
       return (netIface == null ? NetworkInterface.DEFAULT_BIND_TO : netIface.getAllowedHosts());
@@ -423,7 +423,7 @@ public class FCPServer implements Runnable, DownloadCache {
     public void set(String val) throws InvalidConfigValueException {
       if (!val.equals(get())) {
         try {
-          node.getFCPServer().networkInterface.setAllowedHosts(val);
+          node.getEndpoints().getFCPServer().networkInterface.setAllowedHosts(val);
         } catch (IllegalArgumentException e) {
           throw new InvalidConfigValueException(e);
         }
@@ -440,14 +440,14 @@ public class FCPServer implements Runnable, DownloadCache {
 
     @Override
     public String get() {
-      return node.getFCPServer().allowedHostsFullAccess.getAllowedHosts();
+      return node.getEndpoints().getFCPServer().allowedHostsFullAccess.getAllowedHosts();
     }
 
     @Override
     public void set(String val) throws InvalidConfigValueException {
       if (!val.equals(get())) {
         try {
-          node.getFCPServer().allowedHostsFullAccess.setAllowedHosts(val);
+          node.getEndpoints().getFCPServer().allowedHostsFullAccess.setAllowedHosts(val);
         } catch (IllegalArgumentException e) {
           throw new InvalidConfigValueException(e);
         }

--- a/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
@@ -188,7 +188,8 @@ public class ModifyPersistentRequest extends FCPMessage {
         handler.send(msg);
       }
     } else {
-      req.modifyRequest(clientToken, priorityClass, node.getClientCore().getFCPServer());
+      req.modifyRequest(
+          clientToken, priorityClass, node.getClientCore().getEndpoints().getFCPServer());
     }
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/WatchGlobal.java
+++ b/src/main/java/network/crypta/clients/fcp/WatchGlobal.java
@@ -129,7 +129,8 @@ public class WatchGlobal extends FCPMessage {
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler
         .getRebootClient()
-        .setWatchGlobal(enabled, verbosityMask, node.getClientCore().getFCPServer())) {
+        .setWatchGlobal(
+            enabled, verbosityMask, node.getClientCore().getEndpoints().getFCPServer())) {
       FCPMessage err =
           new ProtocolErrorMessage(
               ProtocolErrorMessage.PERSISTENCE_DISABLED, false, "Persistence disabled", null, true);

--- a/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
@@ -540,7 +540,7 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
         null,
         null,
         null,
-        core.getLinkFilterExceptionProvider());
+        core.getEndpoints().getToadletContainer());
   }
 
   private void validateOperation(FilterOperation operation) {

--- a/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
@@ -137,7 +137,7 @@ public class DiagnosticToadlet extends Toadlet {
       return;
     }
 
-    node.getClientCore().getBandwidthStatsPutter().updateData(node);
+    node.getClientCore().getClientLayerPersister().getBandwidthStatsPutter().updateData(node);
 
     final SubConfig nodeConfig = node.getConfig().get("node");
 
@@ -532,7 +532,7 @@ public class DiagnosticToadlet extends Toadlet {
       throw new NullPointerException();
     }
     BandwidthStatsContainer bandwidthStats =
-        node.getClientCore().getBandwidthStatsPutter().getLatestBWData();
+        node.getClientCore().getClientLayerPersister().getBandwidthStatsPutter().getLatestBWData();
     if (bandwidthStats == null) {
       throw new NullPointerException();
     }

--- a/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
@@ -131,7 +131,8 @@ public class ExternalLinkToadlet extends Toadlet {
 
     // Confirm whether the user really means to access an HTTP link.
     // Only render status and navigation bars if the user has completed the wizard.
-    boolean renderBars = node.getClientCore().getToadletContainer().fproxyHasCompletedWizard();
+    boolean renderBars =
+        node.getClientCore().getEndpoints().getToadletContainer().fproxyHasCompletedWizard();
     PageNode page =
         ctx.getPageMaker()
             .getPageNode(

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -79,7 +79,7 @@ final class FProxyRegistrar {
             new RequestClientBuilder().realTime().build());
 
     FProxyToadlet fproxy = new FProxyToadlet(client, core, fetchTracker);
-    core.setFProxy(fproxy);
+    core.getEndpoints().setFProxy(fproxy);
 
     server.registerMenu(
         "/", FProxyToadlet.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing", null);
@@ -135,7 +135,8 @@ final class FProxyRegistrar {
         true,
         null);
 
-    QueueToadlet downloadToadlet = new QueueToadlet(core, core.getFCPServer(), client, false);
+    QueueToadlet downloadToadlet =
+        new QueueToadlet(core, core.getEndpoints().getFCPServer(), client, false);
     server.register(
         downloadToadlet,
         FProxyToadlet.CATEGORY_QUEUE,
@@ -149,7 +150,8 @@ final class FProxyRegistrar {
         new LocalDownloadDirectoryToadlet(core, client, QueueToadlet.PATH_DOWNLOADS);
     server.register(
         localDownloadDirectoryToadlet, null, localDownloadDirectoryToadlet.path(), true, false);
-    QueueToadlet uploadToadlet = new QueueToadlet(core, core.getFCPServer(), client, true);
+    QueueToadlet uploadToadlet =
+        new QueueToadlet(core, core.getEndpoints().getFCPServer(), client, true);
     server.register(
         uploadToadlet,
         FProxyToadlet.CATEGORY_QUEUE,
@@ -315,7 +317,8 @@ final class FProxyRegistrar {
         true,
         null);
 
-    DiagnosticToadlet diagnosticToadlet = new DiagnosticToadlet(node, core.getFCPServer(), client);
+    DiagnosticToadlet diagnosticToadlet =
+        new DiagnosticToadlet(node, core.getEndpoints().getFCPServer(), client);
     server.register(
         diagnosticToadlet,
         FProxyToadlet.CATEGORY_STATUS,

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -803,7 +803,8 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       }
       if (container.isFProxyWebPushingEnabled()) {
         fctx.setTagReplacer(
-            new PushingTagReplacerCallback(core.getFProxy().fetchTracker, defaultMaxSize, ctx));
+            new PushingTagReplacerCallback(
+                core.getEndpoints().getFProxy().fetchTracker, defaultMaxSize, ctx));
       }
     }
 

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
@@ -168,7 +168,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
 
   private void showForm(ToadletContext ctx, Map<String, Object> model)
       throws IOException, ToadletContextClosedException {
-    model.put("formPassword", core.getToadletContainer().getFormPassword());
+    model.put("formPassword", core.getEndpoints().getToadletContainer().getFormPassword());
     PageNode page =
         ctx.getPageMaker()
             .getPageNode(

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -4541,7 +4541,9 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     }
 
     private void saveCompletedIdentifiersOffThread() {
-      core.getExecutor().execute(this::saveCompletedIdentifiers, "Save completed identifiers");
+      core.getNode()
+          .getExecutor()
+          .execute(this::saveCompletedIdentifiers, "Save completed identifiers");
     }
 
     private void loadCompletedIdentifiers() throws PersistenceDisabledException {

--- a/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
@@ -251,7 +251,7 @@ public class StatisticsToadlet extends Toadlet {
       return;
     }
 
-    node.getClientCore().getBandwidthStatsPutter().updateData(node);
+    node.getClientCore().getClientLayerPersister().getBandwidthStatsPutter().updateData(node);
 
     PageNode page = ctx.getPageMaker().getPageNode(l10n("fullTitle"), ctx);
 
@@ -460,7 +460,11 @@ public class StatisticsToadlet extends Toadlet {
       drawOverviewBox(
           overviewInfobox,
           nodeUptimeSeconds,
-          node.getClientCore().getBandwidthStatsPutter().getLatestUptimeData().getTotalUptime(),
+          node.getClientCore()
+              .getClientLayerPersister()
+              .getBandwidthStatsPutter()
+              .getLatestUptimeData()
+              .getTotalUptime(),
           now,
           swaps,
           noSwaps);
@@ -1030,7 +1034,11 @@ public class StatisticsToadlet extends Toadlet {
     if (totalAccess == null) {
       return 0;
     }
-    return node.getClientCore().getBandwidthStatsPutter().getLatestUptimeData().getTotalUptime();
+    return node.getClientCore()
+        .getClientLayerPersister()
+        .getBandwidthStatsPutter()
+        .getLatestUptimeData()
+        .getTotalUptime();
   }
 
   private String formatTotalValue(StoreAccessStats totalAccess, long totalValue) {
@@ -1411,7 +1419,7 @@ public class StatisticsToadlet extends Toadlet {
     long totalPayloadRate = totalPayload / nodeUptimeSeconds;
     if (node.getClientCore() == null) throw new NullPointerException();
     BandwidthStatsContainer stats =
-        node.getClientCore().getBandwidthStatsPutter().getLatestBWData();
+        node.getClientCore().getClientLayerPersister().getBandwidthStatsPutter().getLatestBWData();
     if (stats == null) throw new NullPointerException();
     long overallTotalOut = stats.getTotalBytesOut();
     long overallTotalIn = stats.getTotalBytesIn();

--- a/src/main/java/network/crypta/node/ClientContextResources.java
+++ b/src/main/java/network/crypta/node/ClientContextResources.java
@@ -1,0 +1,23 @@
+package network.crypta.node;
+
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.async.HealingQueue;
+
+/** Bundles resources required to initialize a {@link network.crypta.client.async.ClientContext}. */
+public final class ClientContextResources {
+  private final ArchiveManager archiveManager;
+  private final HealingQueue healingQueue;
+
+  public ClientContextResources(ArchiveManager archiveManager, HealingQueue healingQueue) {
+    this.archiveManager = archiveManager;
+    this.healingQueue = healingQueue;
+  }
+
+  public ArchiveManager getArchiveManager() {
+    return archiveManager;
+  }
+
+  public HealingQueue getHealingQueue() {
+    return healingQueue;
+  }
+}

--- a/src/main/java/network/crypta/node/ClientContextResources.java
+++ b/src/main/java/network/crypta/node/ClientContextResources.java
@@ -3,20 +3,55 @@ package network.crypta.node;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.async.HealingQueue;
 
-/** Bundles resources required to initialize a {@link network.crypta.client.async.ClientContext}. */
-public final class ClientContextResources {
-  private final ArchiveManager archiveManager;
-  private final HealingQueue healingQueue;
-
-  public ClientContextResources(ArchiveManager archiveManager, HealingQueue healingQueue) {
-    this.archiveManager = archiveManager;
-    this.healingQueue = healingQueue;
-  }
-
+/**
+ * Bundles resources required to initialize a {@link network.crypta.client.async.ClientContext}.
+ *
+ * <p>This record groups the core collaborators that client-layer components need when wiring a
+ * {@code ClientContext}. It acts as a simple, immutable carrier for prebuilt services so callers
+ * can pass a single value through setup paths rather than a long parameter list. Instances are
+ * typically created during node startup and shared with persistence and request orchestration code,
+ * which then reads the references without mutation. The record does not validate, copy, or lazily
+ * create its components; it merely stores the references provided at construction time. As a
+ * result, any lifecycle, ownership, or concurrency guarantees are inherited from those supplied
+ * objects.
+ *
+ * <ul>
+ *   <li>Provides a stable container for archive and healing services.
+ *   <li>Allows construction-time composition without hidden side effects.
+ *   <li>Delegates thread-safety to the referenced implementations.
+ * </ul>
+ *
+ * @param archiveManager archive extraction/cache service; may be {@code null} if unavailable
+ * @param healingQueue background healing queue; may be {@code null} if not configured
+ * @see ArchiveManager
+ * @see HealingQueue
+ */
+public record ClientContextResources(ArchiveManager archiveManager, HealingQueue healingQueue) {
+  /**
+   * Returns the archive manager reference configured for this client context.
+   *
+   * <p>This accessor returns exactly the instance supplied to the record constructor without
+   * performing validation or defensive copying. The method is idempotent and has no side effects.
+   * Callers should expect the same reference for the lifetime of this record and handle a {@code
+   * null} value if the resource was intentionally omitted by the creator. Thread-safety and
+   * mutability are determined solely by the referenced {@link ArchiveManager} implementation.
+   *
+   * @return the configured archive manager instance, or {@code null} when absent
+   */
   public ArchiveManager getArchiveManager() {
     return archiveManager;
   }
 
+  /**
+   * Returns the healing queue reference configured for this client context.
+   *
+   * <p>This accessor exposes the stored queue reference as provided at construction time. It does
+   * not create or wrap the queue, and it performs no synchronization or validation. The method is
+   * safe to call repeatedly and will always return the same reference for this record instance.
+   * Callers should be prepared for {@code null} when healing is disabled or not wired yet.
+   *
+   * @return the configured healing queue instance, or {@code null} when absent
+   */
   public HealingQueue getHealingQueue() {
     return healingQueue;
   }

--- a/src/main/java/network/crypta/node/ClientEndpoints.java
+++ b/src/main/java/network/crypta/node/ClientEndpoints.java
@@ -42,6 +42,19 @@ public final class ClientEndpoints {
   private UserAlert startingUpAlert;
 
   /**
+   * Result wrapper for {@link #create(Node, NodeClientCore, NodeClientCoreInit,
+   * NodeClientPersistence, ClientContext)}.
+   *
+   * <p>The returned direct TMCI is created but not started. Callers must publish it via {@link
+   * #setDirectTMCI(TextModeClientInterface)} and schedule it on the node executor only after the
+   * {@link NodeClientCore} has completed endpoint assignment.
+   *
+   * @param endpoints fully constructed client endpoints bundle.
+   * @param directTMCI direct text-mode interface instance, or {@code null} when disabled.
+   */
+  public record InitResult(ClientEndpoints endpoints, TextModeClientInterface directTMCI) {}
+
+  /**
    * Creates a new bundle from the provided endpoint instances.
    *
    * <p>The constructor stores the references without validation or defensive copying, so the caller
@@ -279,13 +292,15 @@ public final class ClientEndpoints {
    * the persistence layer, and registers that server as the download cache in the client context.
    * If the node has not killed its database, it loads persistent requests immediately. No endpoints
    * are started by this method; callers typically invoke {@link #maybeStart()} once the node is
-   * ready. The returned instance captures the created references and does not perform any
-   * additional initialization beyond the steps described above.
+   * ready. When direct TMCI is enabled, it is created but not started; callers must register it on
+   * the endpoints bundle and schedule it after {@link NodeClientCore#getEndpoints()} is assigned.
+   * The returned instance captures the created references and does not perform any additional
+   * initialization beyond the steps described above.
    *
    * <pre>{@code
-   * ClientEndpoints endpoints =
+   * ClientEndpoints.InitResult initResult =
    *     ClientEndpoints.create(node, core, init, persistence, clientContext);
-   * endpoints.maybeStart();
+   * initResult.endpoints().maybeStart();
    * }</pre>
    *
    * @param node node instance used for endpoint creation and configuration.
@@ -293,21 +308,24 @@ public final class ClientEndpoints {
    * @param init initializer providing configuration and toadlet container access.
    * @param persistence persistence layer responsible for creating the FCP server.
    * @param clientContext client context updated with the FCP download cache.
-   * @return a new {@link ClientEndpoints} instance with initialized components attached.
+   * @return an {@link InitResult} containing the endpoints bundle and optional direct TMCI
+   *     instance.
    */
-  public static ClientEndpoints create(
+  public static InitResult create(
       Node node,
       NodeClientCore core,
       NodeClientCoreInit init,
       NodeClientPersistence persistence,
       ClientContext clientContext) {
-    TextModeClientInterfaceServer tmci =
+    TextModeClientInterfaceServer.InitResult tmciInit =
         TextModeClientInterfaceServer.maybeCreate(node, core, init.config());
+    TextModeClientInterfaceServer tmci = tmciInit.server();
     FCPServer fcpServer = persistence.createFcpServer(node, core);
     clientContext.setDownloadCache(fcpServer);
     if (!core.killedDatabase()) {
       fcpServer.load();
     }
-    return new ClientEndpoints(fcpServer, tmci, init.toadlets());
+    return new InitResult(
+        new ClientEndpoints(fcpServer, tmci, init.toadlets()), tmciInit.directTMCI());
   }
 }

--- a/src/main/java/network/crypta/node/ClientEndpoints.java
+++ b/src/main/java/network/crypta/node/ClientEndpoints.java
@@ -1,0 +1,112 @@
+package network.crypta.node;
+
+import network.crypta.client.async.ClientContext;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.http.FProxyToadlet;
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.io.TempBucketFactory;
+
+/** Bundles client-facing endpoints (FCP, TMCI, and HTTP toadlet container) and their lifecycle. */
+public final class ClientEndpoints {
+  private final FCPServer fcpServer;
+  private final TextModeClientInterfaceServer tmci;
+  private final SimpleToadletServer toadletContainer;
+  private volatile TextModeClientInterface directTMCI;
+  private volatile FProxyToadlet fproxy;
+  private UserAlert startingUpAlert;
+
+  public ClientEndpoints(
+      FCPServer fcpServer,
+      TextModeClientInterfaceServer tmci,
+      SimpleToadletServer toadletContainer) {
+    this.fcpServer = fcpServer;
+    this.tmci = tmci;
+    this.toadletContainer = toadletContainer;
+  }
+
+  public FCPServer getFCPServer() {
+    return fcpServer;
+  }
+
+  public FProxyToadlet getFProxy() {
+    return fproxy;
+  }
+
+  public void setFProxy(FProxyToadlet fproxy) {
+    this.fproxy = fproxy;
+  }
+
+  public SimpleToadletServer getToadletContainer() {
+    return toadletContainer;
+  }
+
+  public TextModeClientInterfaceServer getTextModeClientInterface() {
+    return tmci;
+  }
+
+  public TextModeClientInterface getDirectTMCI() {
+    return directTMCI;
+  }
+
+  public void setDirectTMCI(TextModeClientInterface tmci) {
+    this.directTMCI = tmci;
+  }
+
+  public void loadPersistentRequestsIfNeeded() {
+    fcpServer.load();
+  }
+
+  public void maybeStart() {
+    fcpServer.maybeStart();
+    if (tmci != null) {
+      tmci.start();
+    }
+  }
+
+  public void configureBucketFactory(TempBucketFactory tempBucketFactory) {
+    toadletContainer.setBucketFactory(tempBucketFactory);
+  }
+
+  public void registerStartupAlerts(
+      UserAlertManager alerts,
+      NodeClientCore core,
+      String title,
+      String longText,
+      String shortText) {
+    UserAlert alert = NodeClientCoreSupport.createStartingUpAlert(title, longText, shortText);
+    NodeClientCoreSupport.registerFProxyAlerts(alerts, core, alert);
+    startingUpAlert = alert;
+  }
+
+  public void unregisterStartupAlert(UserAlertManager alerts) {
+    if (startingUpAlert != null) {
+      alerts.unregister(startingUpAlert);
+    }
+  }
+
+  public boolean isAdvancedModeEnabled() {
+    return toadletContainer.isAdvancedModeEnabled();
+  }
+
+  public boolean isFProxyJavascriptEnabled() {
+    return toadletContainer.isFProxyJavascriptEnabled();
+  }
+
+  public static ClientEndpoints create(
+      Node node,
+      NodeClientCore core,
+      NodeClientCoreInit init,
+      NodeClientPersistence persistence,
+      ClientContext clientContext) {
+    TextModeClientInterfaceServer tmci =
+        TextModeClientInterfaceServer.maybeCreate(node, core, init.getConfig());
+    FCPServer fcpServer = persistence.createFcpServer(node, core);
+    clientContext.setDownloadCache(fcpServer);
+    if (!core.killedDatabase()) {
+      fcpServer.load();
+    }
+    return new ClientEndpoints(fcpServer, tmci, init.getToadlets());
+  }
+}

--- a/src/main/java/network/crypta/node/ClientEndpoints.java
+++ b/src/main/java/network/crypta/node/ClientEndpoints.java
@@ -101,12 +101,12 @@ public final class ClientEndpoints {
       NodeClientPersistence persistence,
       ClientContext clientContext) {
     TextModeClientInterfaceServer tmci =
-        TextModeClientInterfaceServer.maybeCreate(node, core, init.getConfig());
+        TextModeClientInterfaceServer.maybeCreate(node, core, init.config());
     FCPServer fcpServer = persistence.createFcpServer(node, core);
     clientContext.setDownloadCache(fcpServer);
     if (!core.killedDatabase()) {
       fcpServer.load();
     }
-    return new ClientEndpoints(fcpServer, tmci, init.getToadlets());
+    return new ClientEndpoints(fcpServer, tmci, init.toadlets());
   }
 }

--- a/src/main/java/network/crypta/node/ClientEndpoints.java
+++ b/src/main/java/network/crypta/node/ClientEndpoints.java
@@ -1,5 +1,6 @@
 package network.crypta.node;
 
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.async.ClientContext;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.http.FProxyToadlet;
@@ -8,15 +9,52 @@ import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.io.TempBucketFactory;
 
-/** Bundles client-facing endpoints (FCP, TMCI, and HTTP toadlet container) and their lifecycle. */
+/**
+ * Bundles client-facing endpoints (FCP, TMCI, and HTTP toadlet container) and their lifecycle.
+ *
+ * <p>This type centralizes the node's externally visible interfaces so callers can wire them
+ * consistently during startup and expose simple accessors during runtime. It holds the FCP server,
+ * the optional text-mode interface, and the HTTP toadlet container, and it exposes a small set of
+ * methods that delegate to those collaborators. Typical usage is to build an instance during node
+ * initialization, register any startup alerts, and then start the endpoints once the core is ready.
+ *
+ * <p>Thread-safety is limited to safe publication of a small set of references via atomic holders;
+ * the underlying endpoint implementations define their own concurrency guarantees. Callers should
+ * avoid mutating endpoint state concurrently unless the respective component documents that it is
+ * safe to do so.
+ *
+ * <ul>
+ *   <li>Holds the endpoint instances and exposes read-only accessors.
+ *   <li>Coordinates simple lifecycle steps such as load and start.
+ *   <li>Registers and unregisters a startup alert during initialization.
+ * </ul>
+ *
+ * @see FCPServer
+ * @see SimpleToadletServer
+ * @see TextModeClientInterfaceServer
+ */
 public final class ClientEndpoints {
   private final FCPServer fcpServer;
   private final TextModeClientInterfaceServer tmci;
   private final SimpleToadletServer toadletContainer;
-  private volatile TextModeClientInterface directTMCI;
-  private volatile FProxyToadlet fproxy;
+  private final AtomicReference<TextModeClientInterface> directTMCI = new AtomicReference<>();
+  private final AtomicReference<FProxyToadlet> fproxy = new AtomicReference<>();
   private UserAlert startingUpAlert;
 
+  /**
+   * Creates a new bundle from the provided endpoint instances.
+   *
+   * <p>The constructor stores the references without validation or defensive copying, so the caller
+   * must supply fully initialized instances that remain valid for the lifetime of this bundle. The
+   * text-mode interface may be {@code null} when that endpoint is disabled; all other parameters
+   * are expected to be non-null in normal operation. Construction has no side effects beyond
+   * storing the references, and it does not perform any lifecycle work such as starting servers or
+   * registering alerts.
+   *
+   * @param fcpServer FCP server instance to expose and manage for the node.
+   * @param tmci text-mode client interface server, or {@code null} when disabled.
+   * @param toadletContainer HTTP toadlet container used for browser-facing endpoints.
+   */
   public ClientEndpoints(
       FCPServer fcpServer,
       TextModeClientInterfaceServer tmci,
@@ -26,38 +64,123 @@ public final class ClientEndpoints {
     this.toadletContainer = toadletContainer;
   }
 
+  /**
+   * Returns the FCP server associated with this bundle.
+   *
+   * <p>The returned reference is the same instance supplied at construction time and is not wrapped
+   * or proxied. The call is inexpensive and side-effect free, and it does not guarantee that the
+   * server has been started or loaded. Use it when wiring other components that already manage the
+   * server lifecycle.
+   *
+   * @return the FCP server instance owned by this bundle.
+   */
   public FCPServer getFCPServer() {
     return fcpServer;
   }
 
+  /**
+   * Returns the currently configured FProxy toadlet, if any.
+   *
+   * <p>This value may be {@code null} when no FProxy has been installed or before configuration
+   * occurs. The reference is stored in an atomic holder for safe publication across threads, but it
+   * does not imply that the toadlet implementation itself is thread-safe. The returned reference is
+   * the direct instance currently published by this bundle.
+   *
+   * @return the current FProxy toadlet, or {@code null} when not set.
+   */
   public FProxyToadlet getFProxy() {
-    return fproxy;
+    return fproxy.get();
   }
 
+  /**
+   * Sets the FProxy toadlet reference to expose via {@link #getFProxy()}.
+   *
+   * <p>The provided reference is stored as-is and can be {@code null} to clear a previous value. No
+   * additional registration or lifecycle actions are performed by this method, so callers must
+   * ensure the toadlet is registered with the container elsewhere if required. The update becomes
+   * visible to other threads via the atomic reference.
+   *
+   * @param fproxy FProxy toadlet instance to publish, or {@code null} to clear.
+   */
   public void setFProxy(FProxyToadlet fproxy) {
-    this.fproxy = fproxy;
+    this.fproxy.set(fproxy);
   }
 
+  /**
+   * Returns the HTTP toadlet container used by this bundle.
+   *
+   * <p>The container is expected to be non-null and shared with other components that register
+   * toadlets. This method simply returns the stored reference without modification and does not
+   * guarantee any specific initialization state of the container. Callers should consult the
+   * container itself for lifecycle details and concurrency guarantees.
+   *
+   * @return the toadlet container instance for HTTP endpoints and requests.
+   */
   public SimpleToadletServer getToadletContainer() {
     return toadletContainer;
   }
 
+  /**
+   * Returns the text-mode client interface server, if one was created.
+   *
+   * <p>The text-mode interface is optional and may be {@code null} when disabled by configuration.
+   * Callers must handle the absence of this endpoint and should not attempt to start it directly
+   * without checking for {@code null}. The returned instance is the same object provided to the
+   * constructor.
+   *
+   * @return the text-mode client interface server, or {@code null} when unavailable.
+   */
   public TextModeClientInterfaceServer getTextModeClientInterface() {
     return tmci;
   }
 
+  /**
+   * Returns the directly configured text-mode client interface, if any.
+   *
+   * <p>This reference is separate from the server returned by {@link #getTextModeClientInterface()}
+   * and is published atomically. It may be {@code null} until configured. The method only returns
+   * the stored reference and does not create or start a client interface. Callers must handle a
+   * {@code null} result.
+   *
+   * @return the direct text-mode client interface, or {@code null} when not set.
+   */
   public TextModeClientInterface getDirectTMCI() {
-    return directTMCI;
+    return directTMCI.get();
   }
 
+  /**
+   * Sets the direct text-mode client interface reference.
+   *
+   * <p>The reference is stored as-is for later access and may be {@code null} to clear a previous
+   * value. No network listeners are started or stopped by this call, and the method does not alter
+   * any configuration associated with the interface. It is purely a setter.
+   *
+   * @param tmci direct text-mode client interface to publish, or {@code null} to clear.
+   */
   public void setDirectTMCI(TextModeClientInterface tmci) {
-    this.directTMCI = tmci;
+    directTMCI.set(tmci);
   }
 
+  /**
+   * Loads persistent requests through the FCP server.
+   *
+   * <p>This method delegates directly to {@link FCPServer#load()} without checking any additional
+   * conditions. It is up to the caller to decide whether loading is required for the current node
+   * state, such as skipping it when a database has been intentionally reset. The method itself does
+   * not cache or record whether loading has been performed.
+   */
   public void loadPersistentRequestsIfNeeded() {
     fcpServer.load();
   }
 
+  /**
+   * Starts the client-facing endpoints when appropriate.
+   *
+   * <p>The FCP server is asked to start via {@link FCPServer#maybeStart()}, and the text-mode
+   * interface server is started only if it is present. This method does not create new endpoints
+   * and performs no retries; it simply forwards to the underlying components. It is safe to call
+   * multiple times if the underlying components implement idempotent start logic.
+   */
   public void maybeStart() {
     fcpServer.maybeStart();
     if (tmci != null) {
@@ -65,10 +188,36 @@ public final class ClientEndpoints {
     }
   }
 
+  /**
+   * Configures the bucket factory used by the HTTP toadlet container.
+   *
+   * <p>The provided factory is passed directly to {@link SimpleToadletServer#setBucketFactory} and
+   * becomes the source of temporary buckets for future requests. The method does not validate the
+   * factory beyond the container's own checks, and it does not create any buckets immediately.
+   * Configuration applies to subsequent requests only.
+   *
+   * @param tempBucketFactory bucket factory to install for temporary storage.
+   */
   public void configureBucketFactory(TempBucketFactory tempBucketFactory) {
     toadletContainer.setBucketFactory(tempBucketFactory);
   }
 
+  /**
+   * Creates and registers the startup alert shown while the node is initializing.
+   *
+   * <p>The alert is created via {@link NodeClientCoreSupport#createStartingUpAlert} and registered
+   * with the alert manager using {@link NodeClientCoreSupport#registerFProxyAlerts}. The newly
+   * created alert reference is stored so {@link #unregisterStartupAlert(UserAlertManager)} can
+   * remove it later. If this method is called multiple times, the stored reference is overwritten
+   * without automatically unregistering the previous alert, so callers should explicitly unregister
+   * when replacing an existing startup alert.
+   *
+   * @param alerts alert manager used to register the startup alert instance.
+   * @param core node client core associated with the alert registration.
+   * @param title alert title text to display to the user.
+   * @param longText long-form alert description shown in detailed views.
+   * @param shortText short-form alert description shown in compact views.
+   */
   public void registerStartupAlerts(
       UserAlertManager alerts,
       NodeClientCore core,
@@ -80,20 +229,72 @@ public final class ClientEndpoints {
     startingUpAlert = alert;
   }
 
+  /**
+   * Unregisters the previously registered startup alert, if present.
+   *
+   * <p>If no startup alert has been registered, this method performs no action. The stored alert
+   * reference is not cleared here; the caller should avoid reusing stale references or should clear
+   * its own tracking when appropriate. No other alerts are affected.
+   *
+   * @param alerts alert manager used to unregister the stored startup alert.
+   */
   public void unregisterStartupAlert(UserAlertManager alerts) {
     if (startingUpAlert != null) {
       alerts.unregister(startingUpAlert);
     }
   }
 
+  /**
+   * Returns whether the toadlet container is in advanced mode.
+   *
+   * <p>This is a simple delegation to {@link SimpleToadletServer#isAdvancedModeEnabled()} and has
+   * no side effects. The returned value reflects the container's current configuration and may
+   * change if that configuration is updated elsewhere. It does not imply any access control
+   * changes. It is read-only.
+   *
+   * @return {@code true} when advanced mode is enabled, otherwise {@code false}.
+   */
   public boolean isAdvancedModeEnabled() {
     return toadletContainer.isAdvancedModeEnabled();
   }
 
+  /**
+   * Returns whether FProxy JavaScript support is enabled.
+   *
+   * <p>This is a direct delegation to {@link SimpleToadletServer#isFProxyJavascriptEnabled()} and
+   * does not alter the container state. The return value is a snapshot of the container's current
+   * configuration at the time of the call. It does not enable or disable scripts. It is
+   * informational only.
+   *
+   * @return {@code true} when FProxy JavaScript is enabled, otherwise {@code false}.
+   */
   public boolean isFProxyJavascriptEnabled() {
     return toadletContainer.isFProxyJavascriptEnabled();
   }
 
+  /**
+   * Builds a fully wired {@link ClientEndpoints} instance from core node components.
+   *
+   * <p>The method conditionally creates the text-mode interface server, creates an FCP server via
+   * the persistence layer, and registers that server as the download cache in the client context.
+   * If the node has not killed its database, it loads persistent requests immediately. No endpoints
+   * are started by this method; callers typically invoke {@link #maybeStart()} once the node is
+   * ready. The returned instance captures the created references and does not perform any
+   * additional initialization beyond the steps described above.
+   *
+   * <pre>{@code
+   * ClientEndpoints endpoints =
+   *     ClientEndpoints.create(node, core, init, persistence, clientContext);
+   * endpoints.maybeStart();
+   * }</pre>
+   *
+   * @param node node instance used for endpoint creation and configuration.
+   * @param core client core used by endpoint factories and alert registration.
+   * @param init initializer providing configuration and toadlet container access.
+   * @param persistence persistence layer responsible for creating the FCP server.
+   * @param clientContext client context updated with the FCP download cache.
+   * @return a new {@link ClientEndpoints} instance with initialized components attached.
+   */
   public static ClientEndpoints create(
       Node node,
       NodeClientCore core,

--- a/src/main/java/network/crypta/node/DarknetPeerNode.java
+++ b/src/main/java/network/crypta/node/DarknetPeerNode.java
@@ -1267,8 +1267,8 @@ public class DarknetPeerNode extends PeerNode {
     public void accept() {
       acceptedOrRejected = true;
       final String baseFilename = "direct-" + FileUtil.sanitize(getName()) + "-" + filename;
-      final File dest = node.getClientCore().downloadsDir().file(baseFilename + ".part");
-      destination = node.getClientCore().downloadsDir().file(baseFilename);
+      final File dest = new File(node.getClientCore().getDownloadsDir(), baseFilename + ".part");
+      destination = new File(node.getClientCore().getDownloadsDir(), baseFilename);
       try {
         data = new FileRandomAccessBuffer(dest, size, false);
       } catch (IOException e) {
@@ -1292,7 +1292,8 @@ public class DarknetPeerNode extends PeerNode {
                       onReceiveFailure();
                     } else {
                       data.close();
-                      if (!dest.renameTo(node.getClientCore().downloadsDir().file(baseFilename))) {
+                      if (!dest.renameTo(
+                          new File(node.getClientCore().getDownloadsDir(), baseFilename))) {
                         LOG.error("Failed to rename {} to remove .part suffix.", dest.getName());
                       }
                       onReceiveSuccess();
@@ -1571,6 +1572,7 @@ public class DarknetPeerNode extends PeerNode {
           // Hopefully we will have a container when this function is called!
           HTMLNode form =
               node.getClientCore()
+                  .getEndpoints()
                   .getToadletContainer()
                   .addFormChild(div, "/friends/", "f2fFileOfferAcceptForm");
 

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -2217,17 +2217,11 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeStats = new NodeStats(this, sortOrder, config.createSubConfig("node.load"));
 
     // clientCore needs new load management and other settings from stats.
+    NodeClientCoreInit clientCoreInit =
+        new NodeClientCoreInit(config, nodeConfig, installConfig, toadlets);
     clientCore =
         new NodeClientCore(
-            this,
-            config,
-            nodeConfig,
-            installConfig,
-            getDarknetPortNumber(),
-            sortOrder,
-            toadlets,
-            databaseKey,
-            persistentSecret);
+            this, clientCoreInit, getDarknetPortNumber(), sortOrder, databaseKey, persistentSecret);
     toadlets.setCore(clientCore);
 
     if (JVMVersion.isEOL()) {
@@ -3625,7 +3619,14 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
         public HTMLNode getHTMLText() {
           HTMLNode content = new HTMLNode("div");
           SecurityLevelsToadlet.generatePasswordFormPage(
-              false, clientCore.getToadletContainer(), content, false, false, false, null, null);
+              false,
+              clientCore.getEndpoints().getToadletContainer(),
+              content,
+              false,
+              false,
+              false,
+              null,
+              null);
           return content;
         }
 

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -5665,7 +5665,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
   }
 
   public void queueRandomReinsert(KeyBlock block) {
-    clientCore.queueRandomReinsert(block);
+    clientCore.getTransfers().queueRandomReinsert(block);
   }
 
   public String getExtraPeerDataDir() {

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -4,12 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.HashSet;
-import network.crypta.client.ArchiveManager;
 import network.crypta.client.FECCodec;
 import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
@@ -17,46 +12,21 @@ import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientLayerPersister;
-import network.crypta.client.async.ClientRequestScheduler;
 import network.crypta.client.async.DatastoreChecker;
-import network.crypta.client.async.HealingDecisionSupplier;
-import network.crypta.client.async.HealingQueue;
-import network.crypta.client.async.PersistentStatsPutter;
-import network.crypta.client.async.SimpleHealingQueue;
 import network.crypta.client.async.USKManager;
-import network.crypta.client.events.SimpleEventProducer;
-import network.crypta.client.filter.FilterCallback;
-import network.crypta.client.filter.FoundURICallback;
-import network.crypta.client.filter.GenericReadFilterCallback;
-import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.ClientRequest;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.PersistentRequestRoot;
-import network.crypta.clients.http.FProxyToadlet;
-import network.crypta.clients.http.SimpleToadletServer;
-import network.crypta.clients.http.bookmark.BookmarkManager;
-import network.crypta.config.Config;
-import network.crypta.config.Dimension;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
-import network.crypta.config.SubConfig;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
-import network.crypta.fs.AppDirs;
-import network.crypta.fs.AppEnv;
-import network.crypta.fs.Resolved;
-import network.crypta.fs.ServiceDirs;
 import network.crypta.io.xfer.AbortedException;
 import network.crypta.io.xfer.PartiallyReceivedBlock;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKVerifyException;
 import network.crypta.keys.ClientCHK;
-import network.crypta.keys.ClientCHKBlock;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.ClientKeyBlock;
 import network.crypta.keys.ClientSSK;
-import network.crypta.keys.ClientSSKBlock;
-import network.crypta.keys.FreenetURI;
 import network.crypta.keys.Key;
 import network.crypta.keys.KeyBlock;
 import network.crypta.keys.NodeSSK;
@@ -64,10 +34,6 @@ import network.crypta.keys.SSKBlock;
 import network.crypta.keys.SSKVerifyException;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
-import network.crypta.node.useralerts.DatastoreTooSmallAlert;
-import network.crypta.node.useralerts.DiskSpaceUserAlert;
-import network.crypta.node.useralerts.SimpleUserAlert;
-import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.pluginmanager.PluginRespirator;
 import network.crypta.pluginmanager.PluginStores;
@@ -75,23 +41,17 @@ import network.crypta.store.KeyCollisionException;
 import network.crypta.support.Base64;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MemoryLimitedJobRunner;
-import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.SizeUtil;
-import network.crypta.support.Ticker;
 import network.crypta.support.api.BooleanCallback;
 import network.crypta.support.api.IntCallback;
 import network.crypta.support.api.LongCallback;
 import network.crypta.support.api.StringArrCallback;
-import network.crypta.support.compress.Compressor;
 import network.crypta.support.compress.RealCompressor;
-import network.crypta.support.io.DiskSpaceCheckingRandomAccessBufferFactory;
 import network.crypta.support.io.FileUtil;
 import network.crypta.support.io.FilenameGenerator;
-import network.crypta.support.io.MaybeEncryptedRandomAccessBufferFactory;
 import network.crypta.support.io.NativeThread;
 import network.crypta.support.io.PersistentTempBucketFactory;
-import network.crypta.support.io.PooledFileRandomAccessBufferFactory;
 import network.crypta.support.io.TempBucketFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,22 +86,11 @@ public class NodeClientCore implements Persistable {
   // barely succeed.
   private static final int MAX_RUNNING_HEALING_INSERTS = 8192;
 
-  /** Puts persistent bandwidth statistics. Access via {@link #getBandwidthStatsPutter()}. */
-  private final PersistentStatsPutter bandwidthStatsPutter;
-
   /** Manages USK state. Access via {@link #getUskManager()}. */
   private final USKManager uskManager;
 
-  /**
-   * Manages archive handlers and caches to read container formats efficiently. Immutable after
-   * construction.
-   */
-  public final ArchiveManager archiveManager;
-
   /** Request starter group. Access via {@link #getRequestStarters()}. */
   private final RequestStarterGroup requestStarters;
-
-  private final HealingQueue healingQueue;
 
   /**
    * Runs memory-bound background jobs (e.g., FEC decode) within a configured capacity and thread
@@ -159,7 +108,7 @@ public class NodeClientCore implements Persistable {
    */
   private final String formPassword;
 
-  final ProgramDirectory downloadsDir;
+  final File downloadsDir;
   private File[] downloadAllowedDirs;
   private boolean includeDownloadDir;
   private boolean downloadAllowedEverywhere;
@@ -167,10 +116,10 @@ public class NodeClientCore implements Persistable {
   private File[] uploadAllowedDirs;
   private boolean uploadAllowedEverywhere;
 
-  /** Temp filename generator. Access via {@link #getTempFilenameGenerator()}. */
+  /** Temp filename generator for ephemeral bucket file names. */
   private final FilenameGenerator tempFilenameGenerator;
 
-  /** Persistent filename generator. Access via {@link #getPersistentFilenameGenerator()}. */
+  /** Persistent filename generator for restart-safe bucket file names. */
   private final FilenameGenerator persistentFilenameGenerator;
 
   /** Temp bucket factory. Access via {@link #getTempBucketFactory()}. */
@@ -179,13 +128,8 @@ public class NodeClientCore implements Persistable {
   /** Persistent temp bucket factory. Access via {@link #getPersistentTempBucketFactory()}. */
   private final PersistentTempBucketFactory persistentTempBucketFactory;
 
-  private final DiskSpaceCheckingRandomAccessBufferFactory persistentDiskChecker;
-
-  /**
-   * RandomAccessBuffer factory for persistent storage that can transparently enable encryption
-   * based on the current security level and configuration.
-   */
-  public final MaybeEncryptedRandomAccessBufferFactory persistentRAFFactory;
+  /** Persistence wiring for throttles, FCP root, and disk checks. */
+  private final NodeClientPersistence persistence;
 
   /** Persists and reloads client-layer state such as throttles and pending requests. */
   private final ClientLayerPersister clientLayerPersister;
@@ -193,35 +137,20 @@ public class NodeClientCore implements Persistable {
   /** Back-reference to the owning {@link Node}. Access via {@link #getNode()}. */
   private final Node node;
 
-  /** Tracks request UIDs and related lifecycle events used by senders and listeners. */
-  public final RequestTracker tracker;
-
-  private final NodeStats nodeStats;
-
   /** Random source for request IDs and other non-cryptographic needs. */
   private final RandomSource random;
 
-  final ProgramDirectory tempDir; // Temporary buckets (non-persistent)
-  final ProgramDirectory persistentTempDir;
+  final File tempDir; // Temporary buckets (non-persistent)
+  final File persistentTempDir;
 
   /** User alert manager. Access via {@link #getAlerts()}. */
   private final UserAlertManager alerts;
 
-  final TextModeClientInterfaceServer tmci;
-
-  /** Direct Text Mode Client Interface. Access via {@link #getDirectTMCI()}. */
-  private TextModeClientInterface directTMCI;
-
-  private final PersistentRequestRoot fcpPersistentRoot;
-  final FCPServer fcpServer;
-  FProxyToadlet fproxyServlet;
-  final SimpleToadletServer toadletContainer;
+  /** Client-facing endpoints (TMCI, FCP, and FProxy wiring). */
+  private final ClientEndpoints endpoints;
 
   /** Compressor implementation used for network transfers and storage. */
   public final RealCompressor compressor;
-
-  /** Persists client throttles and schedules resume at startup. */
-  private final Persister persister;
 
   /** Datastore consistency checker. Access via {@link #getStoreChecker()}. */
   private final DatastoreChecker storeChecker;
@@ -248,7 +177,6 @@ public class NodeClientCore implements Persistable {
   static final long MAX_ARCHIVED_FILE_SIZE = 1024L * 1024; // arbitrary
   static final int MAX_CACHED_ELEMENTS =
       256 * 1024; // equally arbitrary; hopefully we can cache many of these though
-  private final UserAlert startingUpAlert;
   private boolean alwaysCommit;
   private final PluginStores pluginStores;
   private boolean lazyStartDatastoreChecker;
@@ -258,22 +186,17 @@ public class NodeClientCore implements Persistable {
 
   NodeClientCore(
       Node node,
-      Config config,
-      SubConfig nodeConfig,
-      SubConfig installConfig,
+      NodeClientCoreInit init,
       int portNumber,
       int sortOrder,
-      SimpleToadletServer toadlets,
       DatabaseKey databaseKey,
       MasterSecret persistentSecret)
       throws NodeInitException {
     this.node = node;
-    this.tracker = node.getTracker();
-    this.nodeStats = node.getNodeStats();
     this.random = node.getRandom();
-    this.pluginStores = new PluginStores(node, installConfig);
+    this.pluginStores = new PluginStores(node, init.getInstallConfig());
 
-    sortOrder = registerLazyStartDatastoreChecker(nodeConfig, sortOrder);
+    sortOrder = registerLazyStartDatastoreChecker(init, sortOrder);
 
     storeChecker =
         new DatastoreChecker(
@@ -283,21 +206,10 @@ public class NodeClientCore implements Persistable {
     compressor = new RealCompressor();
     this.formPassword = Base64.encode(pwdBuf);
     alerts = new UserAlertManager(this);
-    persister =
-        new ConfigurablePersister(
-            this,
-            nodeConfig,
-            "clientThrottleFile",
-            "client-throttle.dat",
-            sortOrder++,
-            true,
-            false,
-            "NodeClientCore.fileForClientStats",
-            "NodeClientCore.fileForClientStatsLong",
-            node.getTicker(),
-            node.getRunDir());
+    persistence = new NodeClientPersistence(this, init.getNodeConfig(), node, sortOrder);
+    sortOrder = persistence.getSortOrderAfter();
 
-    SimpleFieldSet throttleFS = persister.read();
+    SimpleFieldSet throttleFS = persistence.readThrottle();
     if (LOG.isDebugEnabled()) LOG.debug("Read throttleFS:\n{}", throttleFS);
 
     if (LOG.isDebugEnabled()) LOG.debug("Serializing RequestStarterGroup from:\n{}", throttleFS);
@@ -305,14 +217,15 @@ public class NodeClientCore implements Persistable {
     // Temp files
 
     // Adaptive default: cacheDir/tmp
-    Path defaultCacheDir = resolveDefaultCacheDir();
-    Path defaultDataDir = resolveDefaultDataDir();
+    File defaultCacheDir = NodeClientCoreSupport.resolveDefaultCacheDir();
+    File defaultDataDir = NodeClientCoreSupport.resolveDefaultDataDir();
 
     this.tempDir =
-        node.setupProgramDir(
-            installConfig,
+        NodeClientCoreSupport.setupProgramDirFile(
+            node,
+            init.getInstallConfig(),
             "tempDir",
-            defaultCacheDir.resolve("tmp").toString(),
+            new File(defaultCacheDir, "tmp").getPath(),
             "NodeClientCore.tempDir",
             "NodeClientCore.tempDirLong");
 
@@ -326,18 +239,18 @@ public class NodeClientCore implements Persistable {
     uskManager = new USKManager(this);
 
     // Persistent temp files
-    sortOrder = registerEncryptPersistentTempBuckets(nodeConfig, sortOrder);
+    sortOrder = registerEncryptPersistentTempBuckets(init, sortOrder);
 
     this.persistentTempDir =
-        node.setupProgramDir(
-            installConfig,
+        NodeClientCoreSupport.setupProgramDirFile(
+            node,
+            init.getInstallConfig(),
             "persistentTempDir",
-            defaultCacheDir.resolve("persistent-temp").toString(),
+            new File(defaultCacheDir, "persistent-temp").getPath(),
             "NodeClientCore.persistentTempDir",
             "NodeClientCore.persistentTempDirLong");
 
-    fcpPersistentRoot = new PersistentRequestRoot();
-    PersistentTempBucketFactory ptbf = createPersistentTempBucketFactory(nodeConfig);
+    PersistentTempBucketFactory ptbf = createPersistentTempBucketFactory(init);
     this.persistentTempBucketFactory = ptbf;
     this.persistentFilenameGenerator = ptbf.fg;
 
@@ -350,26 +263,24 @@ public class NodeClientCore implements Persistable {
     // Max bucket size is 5% of the pool, minimum 32 KiB (one block; typical case).
     long maxBucketSize = Math.max(32768, (defaultRamBucketPoolSize * 1024 * 1024) / 20);
 
-    sortOrder = registerMaxRamBucketSize(nodeConfig, sortOrder, maxBucketSize);
+    sortOrder = registerMaxRamBucketSize(init, sortOrder, maxBucketSize);
 
-    sortOrder = registerRamBucketPoolSize(nodeConfig, sortOrder, defaultRamBucketPoolSize);
+    sortOrder = registerRamBucketPoolSize(init, sortOrder, defaultRamBucketPoolSize);
 
-    sortOrder = registerEncryptTempBuckets(nodeConfig, sortOrder);
+    sortOrder = registerEncryptTempBuckets(init, sortOrder);
 
-    initDiskSpaceLimits(nodeConfig, sortOrder);
+    initDiskSpaceLimits(init, sortOrder);
 
     MasterSecret cryptoSecretTransient = new MasterSecret();
     tempBucketFactory =
         new TempBucketFactory(
             node.getExecutor(),
             tempFilenameGenerator,
-            nodeConfig.getLong("maxRAMBucketSize"),
-            nodeConfig.getLong("RAMBucketPoolSize"),
-            nodeConfig.getBoolean("encryptTempBuckets"),
+            init.getNodeConfig().getLong("maxRAMBucketSize"),
+            init.getNodeConfig().getLong("RAMBucketPoolSize"),
+            init.getNodeConfig().getBoolean("encryptTempBuckets"),
             minDiskFreeShortTerm,
             cryptoSecretTransient);
-
-    bandwidthStatsPutter = new PersistentStatsPutter();
 
     clientLayerPersister =
         new ClientLayerPersister(
@@ -378,53 +289,53 @@ public class NodeClientCore implements Persistable {
             node,
             this,
             persistentTempBucketFactory,
-            tempBucketFactory,
-            bandwidthStatsPutter);
+            tempBucketFactory);
 
     SemiOrderedShutdownHook shutdownHook = SemiOrderedShutdownHook.get();
     installCoreShutdownHooks(shutdownHook);
 
-    archiveManager = createArchiveManager();
-    healingQueue = createHealingQueue();
+    ClientContextResources clientContextResources =
+        NodeClientCoreSupport.createClientContextResources(
+            node,
+            tempBucketFactory,
+            MAX_ARCHIVE_HANDLERS,
+            MAX_CACHED_ARCHIVE_DATA,
+            MAX_ARCHIVED_FILE_SIZE,
+            MAX_CACHED_ELEMENTS,
+            MAX_RUNNING_HEALING_INSERTS);
 
-    PooledFileRandomAccessBufferFactory raff =
-        new PooledFileRandomAccessBufferFactory(persistentFilenameGenerator);
-    persistentDiskChecker =
-        new DiskSpaceCheckingRandomAccessBufferFactory(
-            raff, persistentTempDir.dir(), minDiskFreeLongTerm + tempBucketFactory.getMaxRamUsed());
-    persistentRAFFactory =
-        new MaybeEncryptedRandomAccessBufferFactory(
-            persistentDiskChecker, nodeConfig.getBoolean(CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS));
-    persistentTempBucketFactory.setDiskSpaceChecker(persistentDiskChecker);
+    persistence.initDiskChecker(
+        persistentFilenameGenerator,
+        persistentTempDir,
+        minDiskFreeLongTerm,
+        tempBucketFactory,
+        init.getNodeConfig().getBoolean(CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS));
+    persistence.installDiskChecker(persistentTempBucketFactory);
     HighLevelSimpleClient client = makeClient((short) 0, false, false);
     FetchContext defaultFetchContext = client.getFetchContext();
     InsertContext defaultInsertContext = client.getInsertContext(false);
     int maxMemoryLimitedJobThreads = computeMaxMemoryLimitedJobThreads();
-    sortOrder =
-        registerMemoryLimitedJobThreadLimit(nodeConfig, sortOrder, maxMemoryLimitedJobThreads);
+    sortOrder = registerMemoryLimitedJobThreadLimit(init, sortOrder, maxMemoryLimitedJobThreads);
     long overallMemoryLimit = NodeStarter.getMemoryLimitBytes();
     long defaultMemoryLimitedJobMemoryLimit =
         computeDefaultMemoryLimitedJobMemoryLimit(overallMemoryLimit);
     sortOrder =
-        registerMemoryLimitedJobMemoryLimit(
-            nodeConfig, sortOrder, defaultMemoryLimitedJobMemoryLimit);
+        registerMemoryLimitedJobMemoryLimit(init, sortOrder, defaultMemoryLimitedJobMemoryLimit);
     memoryLimitedJobRunner =
         new MemoryLimitedJobRunner(
-            nodeConfig.getLong("memoryLimitedJobMemoryLimit"),
-            nodeConfig.getInt("memoryLimitedJobThreadLimit"),
+            init.getNodeConfig().getLong("memoryLimitedJobMemoryLimit"),
+            init.getNodeConfig().getInt("memoryLimitedJobThreadLimit"),
             node.getExecutor(),
             RequestStarter.NUMBER_OF_PRIORITY_CLASSES);
     installFecShutdownHooks(shutdownHook);
     clientContext =
-        new ClientContext(
-            node.getBootId(),
+        persistence.createClientContext(
+            node,
             clientLayerPersister,
             node.getExecutor(),
-            archiveManager,
+            clientContextResources,
             persistentTempBucketFactory,
             tempBucketFactory,
-            persistentTempBucketFactory,
-            healingQueue,
             uskManager,
             random,
             node.getFastWeakRandom(),
@@ -433,22 +344,19 @@ public class NodeClientCore implements Persistable {
             tempFilenameGenerator,
             persistentFilenameGenerator,
             tempBucketFactory,
-            persistentRAFFactory,
+            persistence.getPersistentRafFactory(),
             tempBucketFactory.getUnderlyingRAFFactory(),
-            persistentDiskChecker,
             compressor,
             storeChecker,
-            fcpPersistentRoot,
             cryptoSecretTransient,
-            toadlets,
+            init,
             defaultFetchContext,
-            defaultInsertContext,
-            config);
+            defaultInsertContext);
     compressor.setClientContext(getClientContext());
     storeChecker.setContext(getClientContext());
     getClientLayerPersister().start(getClientContext());
 
-    requestStarters = createRequestStarters(node, portNumber, config, throttleFS);
+    requestStarters = createRequestStarters(node, portNumber, init, throttleFS);
 
     clientContext.init(requestStarters, alerts);
 
@@ -459,43 +367,41 @@ public class NodeClientCore implements Persistable {
     // Downloads directory
 
     this.downloadsDir =
-        node.setupProgramDir(
-            nodeConfig,
+        NodeClientCoreSupport.setupProgramDirFile(
+            node,
+            init.getNodeConfig(),
             "downloadsDir",
-            defaultDataDir.resolve(DOWNLOADS_DIR_NAME).toString(),
+            new File(defaultDataDir, DOWNLOADS_DIR_NAME).getPath(),
             "NodeClientCore.downloadsDir",
             "NodeClientCore.downloadsDirLong",
             l10n("couldNotFindOrCreateDir"));
 
     // Downloads allowed, uploads allowed
 
-    sortOrder = registerDownloadAllowedDirs(nodeConfig, sortOrder);
+    sortOrder = registerDownloadAllowedDirs(init, sortOrder);
 
-    sortOrder = registerUploadAllowedDirs(nodeConfig, sortOrder);
+    sortOrder = registerUploadAllowedDirs(init, sortOrder);
 
     LOG.info("Initializing USK Manager");
     uskManager.init(getClientContext());
 
-    sortOrder = registerMaxBackgroundUSKFetchers(nodeConfig, sortOrder);
+    sortOrder = registerMaxBackgroundUSKFetchers(init, sortOrder);
 
     // This is all part of construction, not of start().
     // Some plugins depend on it, so it needs to be *created* before they are started.
 
     // TMCI and FCP (including persistent requests so needs to start before FProxy)
-    tmci = initTmci(config);
-    fcpServer = initFcp(node);
+    endpoints = ClientEndpoints.create(node, this, init, persistence, clientContext);
 
     // FProxy
     // Note: This wiring is a stopgap; plugins should handle this in the future.
-    startingUpAlert = createStartingUpAlert();
-    registerFProxyAlerts();
-    toadletContainer = toadlets;
-    toadletContainer.setBucketFactory(tempBucketFactory);
+    endpoints.registerStartupAlerts(
+        alerts, this, l10n("startingUpTitle"), l10n("startingUp"), l10n("startingUpShort"));
+    endpoints.configureBucketFactory(tempBucketFactory);
 
-    registerAlwaysCommit(nodeConfig, sortOrder);
-    alwaysCommit = nodeConfig.getBoolean("alwaysCommit");
-    alerts.register(new DiskSpaceUserAlert(this));
-    alerts.register(new DatastoreTooSmallAlert(this));
+    registerAlwaysCommit(init, sortOrder);
+    alwaysCommit = init.getNodeConfig().getBoolean("alwaysCommit");
+    NodeClientCoreSupport.registerStorageAlerts(alerts, this);
   }
 
   /**
@@ -507,91 +413,93 @@ public class NodeClientCore implements Persistable {
   protected void updatePersistentRAFSpaceLimit() {
     // The temp bucket factory may have to migrate everything to disk.
     // So we add the RAM limit for the temp factory to the disk limit for the persistent one.
-    if (persistentRAFFactory != null) {
+    if (persistence.hasPersistentRafFactory()) {
       long size;
       synchronized (this) {
         size = minDiskFreeLongTerm;
       }
       size += tempBucketFactory.getMaxRamUsed();
-      persistentDiskChecker.setMinDiskSpace(size);
+      persistence.updateMinDiskSpace(size);
     }
   }
 
-  private void initDiskSpaceLimits(SubConfig nodeConfig, int sortOrder) {
-    nodeConfig.register(
-        "minDiskFreeLongTerm",
-        "1G",
-        sortOrder++,
-        true,
-        true,
-        "NodeClientCore.minDiskFreeLongTerm",
-        "NodeClientCore.minDiskFreeLongTermLong",
-        new LongCallback() {
+  private void initDiskSpaceLimits(NodeClientCoreInit init, int sortOrder) {
+    init.getNodeConfig()
+        .register(
+            "minDiskFreeLongTerm",
+            "1G",
+            sortOrder++,
+            true,
+            true,
+            "NodeClientCore.minDiskFreeLongTerm",
+            "NodeClientCore.minDiskFreeLongTermLong",
+            new LongCallback() {
 
-          @Override
-          public Long get() {
-            synchronized (NodeClientCore.this) {
-              return minDiskFreeLongTerm;
-            }
-          }
+              @Override
+              public Long get() {
+                synchronized (NodeClientCore.this) {
+                  return minDiskFreeLongTerm;
+                }
+              }
 
-          @Override
-          public void set(Long val) throws InvalidConfigValueException {
-            synchronized (NodeClientCore.this) {
-              if (val < 0) throw new InvalidConfigValueException(l10n("minDiskFreeMustBePositive"));
-              minDiskFreeLongTerm = val;
-            }
-            updatePersistentRAFSpaceLimit();
-          }
-        },
-        true);
-    minDiskFreeLongTerm = nodeConfig.getLong("minDiskFreeLongTerm");
+              @Override
+              public void set(Long val) throws InvalidConfigValueException {
+                synchronized (NodeClientCore.this) {
+                  if (val < 0)
+                    throw new InvalidConfigValueException(l10n("minDiskFreeMustBePositive"));
+                  minDiskFreeLongTerm = val;
+                }
+                updatePersistentRAFSpaceLimit();
+              }
+            },
+            true);
+    minDiskFreeLongTerm = init.getNodeConfig().getLong("minDiskFreeLongTerm");
 
-    nodeConfig.register(
-        "minDiskFreeShortTerm",
-        "512M",
-        sortOrder + 1,
-        true,
-        true,
-        "NodeClientCore.minDiskFreeShortTerm",
-        "NodeClientCore.minDiskFreeShortTermLong",
-        new LongCallback() {
+    init.getNodeConfig()
+        .register(
+            "minDiskFreeShortTerm",
+            "512M",
+            sortOrder + 1,
+            true,
+            true,
+            "NodeClientCore.minDiskFreeShortTerm",
+            "NodeClientCore.minDiskFreeShortTermLong",
+            new LongCallback() {
 
-          @Override
-          public Long get() {
-            synchronized (NodeClientCore.this) {
-              return minDiskFreeShortTerm;
-            }
-          }
+              @Override
+              public Long get() {
+                synchronized (NodeClientCore.this) {
+                  return minDiskFreeShortTerm;
+                }
+              }
 
-          @Override
-          public void set(Long val) throws InvalidConfigValueException {
-            synchronized (NodeClientCore.this) {
-              if (val < 0) throw new InvalidConfigValueException(l10n("minDiskFreeMustBePositive"));
-              minDiskFreeShortTerm = val;
-            }
-            tempBucketFactory.setMinDiskSpace(val);
-          }
-        },
-        true);
-    minDiskFreeShortTerm = nodeConfig.getLong("minDiskFreeShortTerm");
+              @Override
+              public void set(Long val) throws InvalidConfigValueException {
+                synchronized (NodeClientCore.this) {
+                  if (val < 0)
+                    throw new InvalidConfigValueException(l10n("minDiskFreeMustBePositive"));
+                  minDiskFreeShortTerm = val;
+                }
+                tempBucketFactory.setMinDiskSpace(val);
+              }
+            },
+            true);
+    minDiskFreeShortTerm = init.getNodeConfig().getLong("minDiskFreeShortTerm");
     // Do not register the UserAlert yet, since we haven't finished constructing stuff it uses.
   }
 
   boolean lateInitDatabase(DatabaseKey databaseKey) {
     LOG.info("Late database initialisation: starting middle phase");
-    try {
-      initStorage(databaseKey);
-    } catch (MasterKeysWrongPasswordException _) {
-      LOG.warn(
-          "Late database initialisation failed: wrong master key/password provided (hasKey={}).",
-          databaseKey != null);
-      return false;
+    if (initStorage(databaseKey)) {
+      // Don't actually start the database thread yet, messy concurrency issues.
+      endpoints.loadPersistentRequestsIfNeeded();
+      LOG.info("Late database initialisation completed.");
+      return true;
     }
-    // Don't actually start the database thread yet, messy concurrency issues.
-    fcpServer.load();
-    LOG.info("Late database initialisation completed.");
-    return true;
+    LOG.warn(
+        "Late database initialisation failed: wrong master key/password provided (hasKey={}).",
+        databaseKey != null);
+    return false;
   }
 
   /**
@@ -599,17 +507,23 @@ public class NodeClientCore implements Persistable {
    * can also be called afterward to change where to write to.
    *
    * @param databaseKey The encryption key.
-   * @throws MasterKeysWrongPasswordException If it needs an encryption key.
+   * @return {@code true} if storage was initialized; {@code false} if the key was missing or
+   *     invalid.
    */
-  private void initStorage(DatabaseKey databaseKey) throws MasterKeysWrongPasswordException {
-    getClientLayerPersister()
-        .setFilesAndLoad(
-            node.getNodeDir(),
-            "client.dat",
-            node.wantEncryptedDatabase(),
-            node.wantNoPersistentDatabase(),
-            databaseKey,
-            requestStarters);
+  private boolean initStorage(DatabaseKey databaseKey) {
+    try {
+      getClientLayerPersister()
+          .setFilesAndLoad(
+              node.getNodeDir(),
+              "client.dat",
+              node.wantEncryptedDatabase(),
+              node.wantNoPersistentDatabase(),
+              databaseKey,
+              requestStarters);
+      return true;
+    } catch (MasterKeysWrongPasswordException _) {
+      return false;
+    }
   }
 
   /** Must only be called after we have loaded master.keys */
@@ -682,16 +596,18 @@ public class NodeClientCore implements Persistable {
           rs.getTotalSentBytes(),
           rs.getTotalReceivedBytes(),
           status);
-    (isSSK ? nodeStats.localSskFetchBytesSentAverage : nodeStats.localChkFetchBytesSentAverage)
+    (isSSK
+            ? node.getNodeStats().localSskFetchBytesSentAverage
+            : node.getNodeStats().localChkFetchBytesSentAverage)
         .report(rs.getTotalSentBytes());
     (isSSK
-            ? nodeStats.localSskFetchBytesReceivedAverage
-            : nodeStats.localChkFetchBytesReceivedAverage)
+            ? node.getNodeStats().localSskFetchBytesReceivedAverage
+            : node.getNodeStats().localChkFetchBytesReceivedAverage)
         .report(rs.getTotalReceivedBytes());
     if (status == RequestSender.SUCCESS)
       (isSSK
-              ? nodeStats.successfulSskFetchBytesReceivedAverage
-              : nodeStats.successfulChkFetchBytesReceivedAverage)
+              ? node.getNodeStats().successfulSskFetchBytesReceivedAverage
+              : node.getNodeStats().successfulChkFetchBytesReceivedAverage)
           .report(rs.getTotalReceivedBytes());
   }
 
@@ -713,14 +629,14 @@ public class NodeClientCore implements Persistable {
     }
   }
 
-  private PersistentTempBucketFactory createPersistentTempBucketFactory(SubConfig nodeConfig)
+  private PersistentTempBucketFactory createPersistentTempBucketFactory(NodeClientCoreInit init)
       throws NodeInitException {
     try {
       return new PersistentTempBucketFactory(
-          persistentTempDir.dir(),
+          persistentTempDir,
           "freenet-temp-",
           node.getFastWeakRandom(),
-          nodeConfig.getBoolean(CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS));
+          init.getNodeConfig().getBoolean(CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS));
     } catch (IOException e) {
       String msg = "Could not find or create persistent temporary directory: " + e;
       LOG.error(msg, e);
@@ -729,7 +645,7 @@ public class NodeClientCore implements Persistable {
   }
 
   private void deleteOldPersistentBlobIfPresent() {
-    File oldBlobFile = new File(persistentTempDir.dir(), "persistent-blob.tmp");
+    File oldBlobFile = new File(persistentTempDir, "persistent-blob.tmp");
     if (oldBlobFile.exists()) {
       LOG.info("Deleting {}", oldBlobFile);
       if (persistentTempBucketFactory.isEncrypting()) {
@@ -741,7 +657,7 @@ public class NodeClientCore implements Persistable {
         }
       } else {
         try {
-          Files.delete(oldBlobFile.toPath());
+          NodeClientCoreSupport.deleteFile(oldBlobFile);
         } catch (IOException e) {
           LOG.warn("Unable to delete old blob file {}: {}", oldBlobFile, e.toString());
         }
@@ -818,35 +734,6 @@ public class NodeClientCore implements Persistable {
     }
   }
 
-  private ArchiveManager createArchiveManager() {
-    return new ArchiveManager(
-        MAX_ARCHIVE_HANDLERS,
-        MAX_CACHED_ARCHIVE_DATA,
-        MAX_ARCHIVED_FILE_SIZE,
-        MAX_CACHED_ELEMENTS,
-        tempBucketFactory);
-  }
-
-  private HealingQueue createHealingQueue() {
-    return new SimpleHealingQueue(
-        new InsertContext(
-            0,
-            2,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            Node.FORK_ON_CACHEABLE_DEFAULT,
-            false,
-            Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_DEFAULT),
-        RequestStarter.PREFETCH_PRIORITY_CLASS,
-        MAX_RUNNING_HEALING_INSERTS,
-        new HealingDecisionSupplier(node::getLocation, node::isOpennetEnabled));
-  }
-
   private int computeMaxMemoryLimitedJobThreads() {
     int maxThreads = Runtime.getRuntime().availableProcessors() / 2;
     maxThreads = Math.min(maxThreads, node.getNodeStats().getThreadLimit() / 20);
@@ -862,11 +749,11 @@ public class NodeClientCore implements Persistable {
   }
 
   private RequestStarterGroup createRequestStarters(
-      Node node, int portNumber, Config config, SimpleFieldSet throttleFS)
+      Node node, int portNumber, NodeClientCoreInit init, SimpleFieldSet throttleFS)
       throws NodeInitException {
     try {
       return new RequestStarterGroup(
-          node, this, portNumber, random, config, throttleFS, clientContext);
+          node, this, portNumber, random, init.getConfig(), throttleFS, clientContext);
     } catch (InvalidConfigValueException e1) {
       throw new NodeInitException(NodeInitException.EXIT_BAD_CONFIG, e1.toString());
     }
@@ -876,18 +763,16 @@ public class NodeClientCore implements Persistable {
     if (persistentSecret != null) {
       setupMasterSecret(persistentSecret);
     }
-    try {
-      initStorage(databaseKey);
-    } catch (MasterKeysWrongPasswordException _) {
-      LOG.warn("Cannot load persistent requests, awaiting password ...");
-      node.setDatabaseAwaitingPassword();
+    if (initStorage(databaseKey)) {
+      return;
     }
+    LOG.warn("Cannot load persistent requests, awaiting password ...");
+    node.setDatabaseAwaitingPassword();
   }
 
   private void installPhysicalThreatLevelListener() {
     node.getSecurityLevels()
-        .addPhysicalThreatLevelListener(
-            (oldLevel, newLevel) -> onPhysicalThreatLevelChanged(newLevel));
+        .addPhysicalThreatLevelListener((_, newLevel) -> onPhysicalThreatLevelChanged(newLevel));
   }
 
   private void onPhysicalThreatLevelChanged(PHYSICAL_THREAT_LEVEL newLevel) {
@@ -904,17 +789,16 @@ public class NodeClientCore implements Persistable {
         && persistentTempBucketFactory.isEncrypting() != enable) {
       persistentTempBucketFactory.setEncryption(enable);
     }
-    persistentRAFFactory.setEncryption(enable);
+    persistence.setPersistentRafEncryption(enable);
   }
 
   private void maybeReloadStorageAfterThreatChange() {
     if (!getClientLayerPersister().hasLoaded()) return;
-    try {
-      // May need to change filenames for client.dat* or even create them.
-      initStorage(NodeClientCore.this.getNode().getDatabaseKey());
-    } catch (MasterKeysWrongPasswordException _) {
-      NodeClientCore.this.getNode().setDatabaseAwaitingPassword();
+    // May need to change filenames for client.dat* or even create them.
+    if (initStorage(NodeClientCore.this.getNode().getDatabaseKey())) {
+      return;
     }
+    NodeClientCore.this.getNode().setDatabaseAwaitingPassword();
   }
 
   private void installFecShutdownHooks(SemiOrderedShutdownHook shutdownHook) {
@@ -972,346 +856,305 @@ public class NodeClientCore implements Persistable {
         });
   }
 
-  private SimpleUserAlert createStartingUpAlert() {
-    return new SimpleUserAlert(
-        true,
-        l10n("startingUpTitle"),
-        l10n("startingUp"),
-        l10n("startingUpShort"),
-        UserAlert.ERROR);
-  }
-
-  private void registerFProxyAlerts() {
-    this.alerts.register(startingUpAlert);
-    this.alerts.register(
-        new SimpleUserAlert(
+  private static int registerMaxBackgroundUSKFetchers(NodeClientCoreInit init, int sortOrder) {
+    init.getNodeConfig()
+        .register(
+            "maxBackgroundUSKFetchers",
+            64,
+            sortOrder,
             true,
-            NodeL10n.getBase().getString("QueueToadlet.persistenceBrokenTitle"),
-            NodeL10n.getBase()
-                .getString(
-                    "QueueToadlet.persistenceBroken",
-                    new String[] {"TEMPDIR", "DBFILE"},
-                    new String[] {
-                      new File(FileUtil.getCanonicalFile(getPersistentTempDir()), File.separator)
-                          .toString(),
-                      new File(FileUtil.getCanonicalFile(node.getUserDir()), "client.dat")
-                          .toString()
-                    }),
-            NodeL10n.getBase().getString("QueueToadlet.persistenceBrokenShortAlert"),
-            UserAlert.CRITICAL_ERROR) {
-          @Override
-          public boolean isValid() {
-            synchronized (NodeClientCore.this) {
-              if (!killedDatabase()) return false;
-            }
-            if (NodeClientCore.this.node.awaitingPassword()) return false;
-            return !NodeClientCore.this.node.isStopping();
-          }
+            false,
+            "NodeClientCore.maxUSKFetchers",
+            "NodeClientCore.maxUSKFetchersLong",
+            new IntCallback() {
 
-          @Override
-          public boolean userCanDismiss() {
-            return false;
-          }
-        });
-  }
+              @Override
+              public Integer get() {
+                return maxBackgroundUSKFetchers;
+              }
 
-  private TextModeClientInterfaceServer initTmci(Config config) {
-    return TextModeClientInterfaceServer.maybeCreate(node, this, config);
-  }
-
-  private FCPServer initFcp(Node node) throws NodeInitException {
-    FCPServer server = FCPServer.maybeCreate(node, this, node.getConfig(), fcpPersistentRoot);
-    getClientContext().setDownloadCache(server);
-    if (!killedDatabase()) server.load();
-    return server;
-  }
-
-  private static int registerMaxBackgroundUSKFetchers(SubConfig nodeConfig, int sortOrder) {
-    nodeConfig.register(
-        "maxBackgroundUSKFetchers",
-        "64",
-        sortOrder,
-        true,
-        false,
-        "NodeClientCore.maxUSKFetchers",
-        "NodeClientCore.maxUSKFetchersLong",
-        new IntCallback() {
-
-          @Override
-          public Integer get() {
-            return maxBackgroundUSKFetchers;
-          }
-
-          @Override
-          public void set(Integer uskFetch) throws InvalidConfigValueException {
-            if (uskFetch <= 0)
-              throw new InvalidConfigValueException(l10n("maxUSKFetchersMustBeGreaterThanZero"));
-            maxBackgroundUSKFetchers = uskFetch;
-          }
-        },
-        Dimension.NOT);
-    maxBackgroundUSKFetchers = nodeConfig.getInt("maxBackgroundUSKFetchers");
+              @Override
+              public void set(Integer uskFetch) throws InvalidConfigValueException {
+                if (uskFetch <= 0)
+                  throw new InvalidConfigValueException(
+                      l10n("maxUSKFetchersMustBeGreaterThanZero"));
+                maxBackgroundUSKFetchers = uskFetch;
+              }
+            },
+            false);
+    maxBackgroundUSKFetchers = init.getNodeConfig().getInt("maxBackgroundUSKFetchers");
     return sortOrder + 1;
   }
 
-  private int registerDownloadAllowedDirs(SubConfig nodeConfig, int sortOrder) {
-    nodeConfig.register(
-        "downloadAllowedDirs",
-        new String[] {"all"},
-        sortOrder,
-        true,
-        true,
-        "NodeClientCore.downloadAllowedDirs",
-        "NodeClientCore.downloadAllowedDirsLong",
-        new StringArrCallback() {
+  private int registerDownloadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
+    init.getNodeConfig()
+        .register(
+            "downloadAllowedDirs",
+            new String[] {"all"},
+            sortOrder,
+            true,
+            true,
+            "NodeClientCore.downloadAllowedDirs",
+            "NodeClientCore.downloadAllowedDirsLong",
+            new StringArrCallback() {
 
-          @Override
-          public String[] get() {
-            synchronized (NodeClientCore.this) {
-              if (downloadAllowedEverywhere) return new String[] {"all"};
-              String[] dirs = new String[downloadAllowedDirs.length + (includeDownloadDir ? 1 : 0)];
-              for (int i = 0; i < downloadAllowedDirs.length; i++)
-                dirs[i] = downloadAllowedDirs[i].getPath();
-              if (includeDownloadDir) dirs[downloadAllowedDirs.length] = DOWNLOADS_DIR_NAME;
-              return dirs;
-            }
-          }
+              @Override
+              public String[] get() {
+                synchronized (NodeClientCore.this) {
+                  if (downloadAllowedEverywhere) return new String[] {"all"};
+                  String[] dirs =
+                      new String[downloadAllowedDirs.length + (includeDownloadDir ? 1 : 0)];
+                  for (int i = 0; i < downloadAllowedDirs.length; i++)
+                    dirs[i] = downloadAllowedDirs[i].getPath();
+                  if (includeDownloadDir) dirs[downloadAllowedDirs.length] = DOWNLOADS_DIR_NAME;
+                  return dirs;
+                }
+              }
 
-          @Override
-          public void set(String[] val) {
-            setDownloadAllowedDirs(val);
-          }
-        });
-    setDownloadAllowedDirs(nodeConfig.getStringArr("downloadAllowedDirs"));
+              @Override
+              public void set(String[] val) {
+                setDownloadAllowedDirs(val);
+              }
+            });
+    setDownloadAllowedDirs(init.getNodeConfig().getStringArr("downloadAllowedDirs"));
     return sortOrder + 1;
   }
 
-  private int registerUploadAllowedDirs(SubConfig nodeConfig, int sortOrder) {
-    nodeConfig.register(
-        "uploadAllowedDirs",
-        new String[] {"all"},
-        sortOrder,
-        true,
-        true,
-        "NodeClientCore.uploadAllowedDirs",
-        "NodeClientCore.uploadAllowedDirsLong",
-        new StringArrCallback() {
+  private int registerUploadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
+    init.getNodeConfig()
+        .register(
+            "uploadAllowedDirs",
+            new String[] {"all"},
+            sortOrder,
+            true,
+            true,
+            "NodeClientCore.uploadAllowedDirs",
+            "NodeClientCore.uploadAllowedDirsLong",
+            new StringArrCallback() {
 
-          @Override
-          public String[] get() {
-            synchronized (NodeClientCore.this) {
-              if (uploadAllowedEverywhere) return new String[] {"all"};
-              String[] dirs = new String[uploadAllowedDirs.length];
-              for (int i = 0; i < uploadAllowedDirs.length; i++)
-                dirs[i] = uploadAllowedDirs[i].getPath();
-              return dirs;
-            }
-          }
+              @Override
+              public String[] get() {
+                synchronized (NodeClientCore.this) {
+                  if (uploadAllowedEverywhere) return new String[] {"all"};
+                  String[] dirs = new String[uploadAllowedDirs.length];
+                  for (int i = 0; i < uploadAllowedDirs.length; i++)
+                    dirs[i] = uploadAllowedDirs[i].getPath();
+                  return dirs;
+                }
+              }
 
-          @Override
-          public void set(String[] val) {
-            setUploadAllowedDirs(val);
-          }
-        });
-    setUploadAllowedDirs(nodeConfig.getStringArr("uploadAllowedDirs"));
+              @Override
+              public void set(String[] val) {
+                setUploadAllowedDirs(val);
+              }
+            });
+    setUploadAllowedDirs(init.getNodeConfig().getStringArr("uploadAllowedDirs"));
     return sortOrder + 1;
   }
 
   private int registerMemoryLimitedJobThreadLimit(
-      SubConfig nodeConfig, int sortOrder, int maxMemoryLimitedJobThreads) {
-    nodeConfig.register(
-        "memoryLimitedJobThreadLimit",
-        maxMemoryLimitedJobThreads,
-        sortOrder,
-        true,
-        false,
-        "NodeClientCore.memoryLimitedJobThreadLimit",
-        "NodeClientCore.memoryLimitedJobThreadLimitLong",
-        new IntCallback() {
+      NodeClientCoreInit init, int sortOrder, int maxMemoryLimitedJobThreads) {
+    init.getNodeConfig()
+        .register(
+            "memoryLimitedJobThreadLimit",
+            maxMemoryLimitedJobThreads,
+            sortOrder,
+            true,
+            false,
+            "NodeClientCore.memoryLimitedJobThreadLimit",
+            "NodeClientCore.memoryLimitedJobThreadLimitLong",
+            new IntCallback() {
 
-          @Override
-          public Integer get() {
-            return memoryLimitedJobRunner.getMaxThreads();
-          }
+              @Override
+              public Integer get() {
+                return memoryLimitedJobRunner.getMaxThreads();
+              }
 
-          @Override
-          public void set(Integer val) throws InvalidConfigValueException {
-            if (val < 1)
-              throw new InvalidConfigValueException(l10n("memoryLimitedJobThreadLimitMustBe1Plus"));
-            memoryLimitedJobRunner.setMaxThreads(val);
-          }
-        },
-        false);
+              @Override
+              public void set(Integer val) throws InvalidConfigValueException {
+                if (val < 1)
+                  throw new InvalidConfigValueException(
+                      l10n("memoryLimitedJobThreadLimitMustBe1Plus"));
+                memoryLimitedJobRunner.setMaxThreads(val);
+              }
+            },
+            false);
     return sortOrder + 1;
   }
 
   private int registerMemoryLimitedJobMemoryLimit(
-      SubConfig nodeConfig, int sortOrder, long defaultMemoryLimitedJobMemoryLimit) {
-    nodeConfig.register(
-        "memoryLimitedJobMemoryLimit",
-        defaultMemoryLimitedJobMemoryLimit,
-        sortOrder,
-        true,
-        false,
-        "NodeClientCore.memoryLimitedJobMemoryLimit",
-        "NodeClientCore.memoryLimitedJobMemoryLimitLong",
-        new LongCallback() {
+      NodeClientCoreInit init, int sortOrder, long defaultMemoryLimitedJobMemoryLimit) {
+    init.getNodeConfig()
+        .register(
+            "memoryLimitedJobMemoryLimit",
+            defaultMemoryLimitedJobMemoryLimit,
+            sortOrder,
+            true,
+            false,
+            "NodeClientCore.memoryLimitedJobMemoryLimit",
+            "NodeClientCore.memoryLimitedJobMemoryLimitLong",
+            new LongCallback() {
 
-          @Override
-          public Long get() {
-            return memoryLimitedJobRunner.getCapacity();
-          }
+              @Override
+              public Long get() {
+                return memoryLimitedJobRunner.getCapacity();
+              }
 
-          @Override
-          public void set(Long val) throws InvalidConfigValueException {
-            if (val < FECCodec.MIN_MEMORY_ALLOCATION)
-              throw new InvalidConfigValueException(
-                  NodeL10n.getBase()
-                      .getString(
-                          "NodeClientCore.memoryLimitedJobMemoryLimitMustBeAtLeast",
-                          "min",
-                          SizeUtil.formatSize(FECCodec.MIN_MEMORY_ALLOCATION)));
-            memoryLimitedJobRunner.setCapacity(val);
-          }
-        },
-        true);
+              @Override
+              public void set(Long val) throws InvalidConfigValueException {
+                if (val < FECCodec.MIN_MEMORY_ALLOCATION)
+                  throw new InvalidConfigValueException(
+                      NodeL10n.getBase()
+                          .getString(
+                              "NodeClientCore.memoryLimitedJobMemoryLimitMustBeAtLeast",
+                              "min",
+                              SizeUtil.formatSize(FECCodec.MIN_MEMORY_ALLOCATION)));
+                memoryLimitedJobRunner.setCapacity(val);
+              }
+            },
+            true);
     return sortOrder + 1;
   }
 
   @SuppressWarnings("UnusedReturnValue")
-  private int registerAlwaysCommit(SubConfig nodeConfig, int sortOrder) {
-    nodeConfig.register(
-        "alwaysCommit",
-        false,
-        sortOrder,
-        true,
-        false,
-        "NodeClientCore.alwaysCommit",
-        "NodeClientCore.alwaysCommitLong",
-        new BooleanCallback() {
+  private int registerAlwaysCommit(NodeClientCoreInit init, int sortOrder) {
+    init.getNodeConfig()
+        .register(
+            "alwaysCommit",
+            false,
+            sortOrder,
+            true,
+            false,
+            "NodeClientCore.alwaysCommit",
+            "NodeClientCore.alwaysCommitLong",
+            new BooleanCallback() {
 
-          @Override
-          public Boolean get() {
-            return alwaysCommit;
-          }
+              @Override
+              public Boolean get() {
+                return alwaysCommit;
+              }
 
-          @Override
-          public void set(Boolean val) {
-            alwaysCommit = val;
-          }
-        });
+              @Override
+              public void set(Boolean val) {
+                alwaysCommit = val;
+              }
+            });
     return sortOrder + 1;
   }
 
-  private int registerMaxRamBucketSize(SubConfig nodeConfig, int sortOrder, long maxBucketSize) {
-    nodeConfig.register(
-        "maxRAMBucketSize",
-        SizeUtil.formatSizeWithoutSpace(maxBucketSize),
-        sortOrder,
-        true,
-        false,
-        "NodeClientCore.maxRAMBucketSize",
-        "NodeClientCore.maxRAMBucketSizeLong",
-        new LongCallback() {
+  private int registerMaxRamBucketSize(NodeClientCoreInit init, int sortOrder, long maxBucketSize) {
+    init.getNodeConfig()
+        .register(
+            "maxRAMBucketSize",
+            SizeUtil.formatSizeWithoutSpace(maxBucketSize),
+            sortOrder,
+            true,
+            false,
+            "NodeClientCore.maxRAMBucketSize",
+            "NodeClientCore.maxRAMBucketSizeLong",
+            new LongCallback() {
 
-          @Override
-          public Long get() {
-            return (tempBucketFactory == null ? 0 : tempBucketFactory.getMaxRAMBucketSize());
-          }
+              @Override
+              public Long get() {
+                return (tempBucketFactory == null ? 0 : tempBucketFactory.getMaxRAMBucketSize());
+              }
 
-          @Override
-          public void set(Long val) {
-            if (get().equals(val) || (tempBucketFactory == null)) return;
-            tempBucketFactory.setMaxRAMBucketSize(val);
-          }
-        },
-        true);
+              @Override
+              public void set(Long val) {
+                if (get().equals(val) || (tempBucketFactory == null)) return;
+                tempBucketFactory.setMaxRAMBucketSize(val);
+              }
+            },
+            true);
     return sortOrder + 1;
   }
 
   private int registerRamBucketPoolSize(
-      SubConfig nodeConfig, int sortOrder, int defaultRamBucketPoolSize) {
-    nodeConfig.register(
-        "RAMBucketPoolSize",
-        defaultRamBucketPoolSize + "MiB",
-        sortOrder,
-        true,
-        false,
-        "NodeClientCore.ramBucketPoolSize",
-        "NodeClientCore.ramBucketPoolSizeLong",
-        new LongCallback() {
+      NodeClientCoreInit init, int sortOrder, int defaultRamBucketPoolSize) {
+    init.getNodeConfig()
+        .register(
+            "RAMBucketPoolSize",
+            defaultRamBucketPoolSize + "MiB",
+            sortOrder,
+            true,
+            false,
+            "NodeClientCore.ramBucketPoolSize",
+            "NodeClientCore.ramBucketPoolSizeLong",
+            new LongCallback() {
 
-          @Override
-          public Long get() {
-            return (tempBucketFactory == null ? 0 : tempBucketFactory.getMaxRamUsed());
-          }
+              @Override
+              public Long get() {
+                return (tempBucketFactory == null ? 0 : tempBucketFactory.getMaxRamUsed());
+              }
 
-          @Override
-          public void set(Long val) {
-            if (get().equals(val) || (tempBucketFactory == null)) return;
-            tempBucketFactory.setMaxRamUsed(val);
-            updatePersistentRAFSpaceLimit();
-          }
-        },
-        true);
+              @Override
+              public void set(Long val) {
+                if (get().equals(val) || (tempBucketFactory == null)) return;
+                tempBucketFactory.setMaxRamUsed(val);
+                updatePersistentRAFSpaceLimit();
+              }
+            },
+            true);
     return sortOrder + 1;
   }
 
-  private int registerEncryptTempBuckets(SubConfig nodeConfig, int sortOrder) {
-    nodeConfig.register(
-        "encryptTempBuckets",
-        true,
-        sortOrder,
-        true,
-        false,
-        "NodeClientCore.encryptTempBuckets",
-        "NodeClientCore.encryptTempBucketsLong",
-        new BooleanCallback() {
+  private int registerEncryptTempBuckets(NodeClientCoreInit init, int sortOrder) {
+    init.getNodeConfig()
+        .register(
+            "encryptTempBuckets",
+            true,
+            sortOrder,
+            true,
+            false,
+            "NodeClientCore.encryptTempBuckets",
+            "NodeClientCore.encryptTempBucketsLong",
+            new BooleanCallback() {
 
-          @Override
-          public Boolean get() {
-            return (tempBucketFactory == null || tempBucketFactory.isEncrypting());
-          }
+              @Override
+              public Boolean get() {
+                return (tempBucketFactory == null || tempBucketFactory.isEncrypting());
+              }
 
-          @Override
-          public void set(Boolean val) {
-            if (get().equals(val) || (tempBucketFactory == null)) return;
-            tempBucketFactory.setEncryption(val);
-          }
-        });
+              @Override
+              public void set(Boolean val) {
+                if (get().equals(val) || (tempBucketFactory == null)) return;
+                tempBucketFactory.setEncryption(val);
+              }
+            });
     return sortOrder + 1;
   }
 
-  private int registerEncryptPersistentTempBuckets(SubConfig nodeConfig, int sortOrder) {
-    nodeConfig.register(
-        CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS,
-        true,
-        sortOrder,
-        true,
-        false,
-        "NodeClientCore.encryptPersistentTempBuckets",
-        "NodeClientCore.encryptPersistentTempBucketsLong",
-        new BooleanCallback() {
+  private int registerEncryptPersistentTempBuckets(NodeClientCoreInit init, int sortOrder) {
+    init.getNodeConfig()
+        .register(
+            CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS,
+            true,
+            sortOrder,
+            true,
+            false,
+            "NodeClientCore.encryptPersistentTempBuckets",
+            "NodeClientCore.encryptPersistentTempBucketsLong",
+            new BooleanCallback() {
 
-          @Override
-          public Boolean get() {
-            return (persistentTempBucketFactory == null
-                || persistentTempBucketFactory.isEncrypting());
-          }
+              @Override
+              public Boolean get() {
+                return (persistentTempBucketFactory == null
+                    || persistentTempBucketFactory.isEncrypting());
+              }
 
-          @Override
-          public void set(Boolean val) {
-            if (get().equals(val) || (persistentTempBucketFactory == null)) return;
-            persistentTempBucketFactory.setEncryption(val);
-            persistentRAFFactory.setEncryption(val);
-          }
-        });
+              @Override
+              public void set(Boolean val) {
+                if (get().equals(val) || (persistentTempBucketFactory == null)) return;
+                persistentTempBucketFactory.setEncryption(val);
+                persistence.setPersistentRafEncryption(val);
+              }
+            });
     return sortOrder + 1;
   }
 
   private void deleteLegacyTempDirIfPresent(Node node) {
     File oldTemp = node.runDir().file("temp-" + node.getDarknetPortNumber());
-    if (oldTemp.exists() && oldTemp.isDirectory() && !FileUtil.equals(tempDir.dir, oldTemp)) {
+    if (oldTemp.exists() && oldTemp.isDirectory() && !FileUtil.equals(tempDir, oldTemp)) {
       LOG.info("Deleting old temporary dir: {}", oldTemp);
       try {
         FileUtil.secureDeleteAll(oldTemp);
@@ -1321,63 +1164,38 @@ public class NodeClientCore implements Persistable {
     }
   }
 
-  private Path resolveDefaultCacheDir() {
-    AppEnv appEnv = new AppEnv();
-    if (appEnv.isServiceMode()) {
-      ServiceDirs serviceDirs = new ServiceDirs();
-      Resolved resolved = serviceDirs.resolve();
-      return resolved.getCacheDir();
-    } else {
-      AppDirs dirs = new AppDirs();
-      Resolved resolved = dirs.resolve();
-      return resolved.getCacheDir();
-    }
-  }
+  private int registerLazyStartDatastoreChecker(NodeClientCoreInit init, int sortOrder) {
+    init.getNodeConfig()
+        .register(
+            "lazyStartDatastoreChecker",
+            false,
+            sortOrder,
+            true,
+            false,
+            "NodeClientCore.lazyStartDatastoreChecker",
+            "NodeClientCore.lazyStartDatastoreCheckerLong",
+            new BooleanCallback() {
 
-  private Path resolveDefaultDataDir() {
-    AppEnv appEnv = new AppEnv();
-    if (appEnv.isServiceMode()) {
-      ServiceDirs serviceDirs = new ServiceDirs();
-      Resolved resolved = serviceDirs.resolve();
-      return resolved.getDataDir();
-    } else {
-      AppDirs dirs = new AppDirs();
-      Resolved resolved = dirs.resolve();
-      return resolved.getDataDir();
-    }
-  }
-
-  private int registerLazyStartDatastoreChecker(SubConfig nodeConfig, int sortOrder) {
-    nodeConfig.register(
-        "lazyStartDatastoreChecker",
-        false,
-        sortOrder,
-        true,
-        false,
-        "NodeClientCore.lazyStartDatastoreChecker",
-        "NodeClientCore.lazyStartDatastoreCheckerLong",
-        new BooleanCallback() {
-
-          @Override
-          public Boolean get() {
-            synchronized (NodeClientCore.this) {
-              return lazyStartDatastoreChecker;
-            }
-          }
-
-          @Override
-          public void set(Boolean val) throws NodeNeedRestartException {
-            synchronized (NodeClientCore.this) {
-              final boolean newValue = Boolean.TRUE.equals(val);
-              if (newValue != lazyStartDatastoreChecker) {
-                lazyStartDatastoreChecker = newValue;
-                throw new NodeNeedRestartException(
-                    l10n("lazyStartDatastoreCheckerMustRestartNode"));
+              @Override
+              public Boolean get() {
+                synchronized (NodeClientCore.this) {
+                  return lazyStartDatastoreChecker;
+                }
               }
-            }
-          }
-        });
-    lazyStartDatastoreChecker = nodeConfig.getBoolean("lazyStartDatastoreChecker");
+
+              @Override
+              public void set(Boolean val) throws NodeNeedRestartException {
+                synchronized (NodeClientCore.this) {
+                  final boolean newValue = Boolean.TRUE.equals(val);
+                  if (newValue != lazyStartDatastoreChecker) {
+                    lazyStartDatastoreChecker = newValue;
+                    throw new NodeNeedRestartException(
+                        l10n("lazyStartDatastoreCheckerMustRestartNode"));
+                  }
+                }
+              }
+            });
+    lazyStartDatastoreChecker = init.getNodeConfig().getBoolean("lazyStartDatastoreChecker");
     return sortOrder + 1;
   }
 
@@ -1455,15 +1273,14 @@ public class NodeClientCore implements Persistable {
    */
   public void start() {
 
-    persister.start();
+    persistence.startThrottle();
 
     requestStarters.start();
 
     storeChecker.start();
-    if (fcpServer != null) fcpServer.maybeStart();
+    endpoints.maybeStart();
     node.getPluginManager().start();
     node.getIpDetector().ipDetectorManager.start();
-    if (tmci != null) tmci.start();
 
     node.getExecutor()
         .execute(
@@ -1481,7 +1298,7 @@ public class NodeClientCore implements Persistable {
                   }
                 }
                 LOG.info("Completed startup: All persistent requests resumed or restarted");
-                alerts.unregister(startingUpAlert);
+                endpoints.unregisterStartupAlert(alerts);
               }
 
               @Override
@@ -1537,7 +1354,7 @@ public class NodeClientCore implements Persistable {
     final boolean isSSK = key instanceof NodeSSK;
     final RequestTag tag =
         new RequestTag(isSSK, RequestTag.START.ASYNC_GET, null, realTimeFlag, uid, node);
-    if (!tracker.lockUID(uid, isSSK, false, false, true, realTimeFlag, tag)) {
+    if (!node.getTracker().lockUID(uid, isSSK, false, false, true, realTimeFlag, tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       listener.onFailed(
           new LowLevelGetException(
@@ -1555,10 +1372,60 @@ public class NodeClientCore implements Persistable {
       if (LOG.isDebugEnabled()) LOG.debug("Using old HTL for GetOfferedKey: {}", htl);
     }
     final long startTime = System.currentTimeMillis();
-    asyncGet(
+    startAsyncGet(
         key,
         offersOnly,
         uid,
+        listener,
+        tag,
+        canReadClientCache,
+        canWriteClientCache,
+        htl,
+        realTimeFlag,
+        localOnly,
+        ignoreStore,
+        isSSK,
+        startTime);
+  }
+
+  /**
+   * Start an asynchronous fetch of the key in question, which will complete to the datastore. It
+   * will not decode the data because we don't provide a ClientKey. It will not return anything and
+   * will run asynchronously. Caller is responsible for unlocking the UID.
+   *
+   * @param key The key being fetched.
+   * @param offersOnly If true, only fetch the key from nodes that have offered it, using
+   *     GetOfferedKeys, don't do a normal fetch for it.
+   * @param uid The UID of the request. This should already be locked before calling.
+   * @param requestTag The RequestTag for the request; used for request lifecycle callbacks.
+   * @param listener Will be called by the request sender, if a request is started. However, for
+   *     example, if we fetch it from the store, it will be returned via the tripPendingKeys
+   *     mechanism.
+   * @param canReadClientCache Can this request read the client-cache?
+   * @param canWriteClientCache Can this request write the client-cache?
+   * @param htl The HTL to start the request at. See the caller, this can be modified in the case of
+   *     fetching an offered key.
+   * @param realTimeFlag Is this a real-time request? False = this is a bulk request.
+   * @param localOnly If true, only check the datastore, don't create a request if nothing is found.
+   * @param ignoreStore If true, don't check the datastore, create a request immediately.
+   */
+  @SuppressWarnings("java:S1181")
+  private void startAsyncGet(
+      Key key,
+      boolean offersOnly,
+      long uid,
+      RequestCompletionListener listener,
+      Object requestTag,
+      boolean canReadClientCache,
+      boolean canWriteClientCache,
+      short htl,
+      boolean realTimeFlag,
+      boolean localOnly,
+      boolean ignoreStore,
+      boolean isSSK,
+      long startTime) {
+    RequestTag tag = (RequestTag) requestTag;
+    RequestSenderListener senderListener =
         new RequestSenderListener() {
 
           private boolean rejectedOverload;
@@ -1610,51 +1477,7 @@ public class NodeClientCore implements Persistable {
               listener.onFailed(
                   new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND_IN_STORE));
           }
-        },
-        tag,
-        canReadClientCache,
-        canWriteClientCache,
-        htl,
-        realTimeFlag,
-        localOnly,
-        ignoreStore);
-  }
-
-  /**
-   * Start an asynchronous fetch of the key in question, which will complete to the datastore. It
-   * will not decode the data because we don't provide a ClientKey. It will not return anything and
-   * will run asynchronously. Caller is responsible for unlocking the UID.
-   *
-   * @param key The key being fetched.
-   * @param offersOnly If true, only fetch the key from nodes that have offered it, using
-   *     GetOfferedKeys, don't do a normal fetch for it.
-   * @param uid The UID of the request. This should already be locked, see the tag.
-   * @param tag The RequestTag for the request. In case of an error when starting it we will unlock
-   *     it, but in other cases the listener should unlock it.
-   * @param listener Will be called by the request sender, if a request is started. However, for
-   *     example, if we fetch it from the store, it will be returned via the tripPendingKeys
-   *     mechanism.
-   * @param canReadClientCache Can this request read the client-cache?
-   * @param canWriteClientCache Can this request write the client-cache?
-   * @param htl The HTL to start the request at. See the caller, this can be modified in the case of
-   *     fetching an offered key.
-   * @param realTimeFlag Is this a real-time request? False = this is a bulk request.
-   * @param localOnly If true, only check the datastore, don't create a request if nothing is found.
-   * @param ignoreStore If true, don't check the datastore, create a request immediately.
-   */
-  @SuppressWarnings("java:S1181")
-  void asyncGet(
-      Key key,
-      boolean offersOnly,
-      long uid,
-      RequestSenderListener listener,
-      RequestTag tag,
-      boolean canReadClientCache,
-      boolean canWriteClientCache,
-      short htl,
-      boolean realTimeFlag,
-      boolean localOnly,
-      boolean ignoreStore) {
+        };
     try {
       Object o =
           node.makeRequestSender(
@@ -1672,22 +1495,22 @@ public class NodeClientCore implements Persistable {
                   realTimeFlag));
       if (o instanceof KeyBlock) {
         tag.setServedFromDatastore();
-        listener.onDataFoundLocally();
+        senderListener.onDataFoundLocally();
         return; // Already have it.
       }
       if (o == null) {
-        listener.onNotStarted(false);
+        senderListener.onNotStarted(false);
         tag.unlockHandler();
         return;
       }
       RequestSender rs = (RequestSender) o;
-      rs.addListener(listener);
+      rs.addListener(senderListener);
       if (rs.uid != uid) tag.unlockHandler();
       // Else it has started a request.
       if (LOG.isDebugEnabled()) LOG.debug("Started {} for {} for {}", o, uid, key);
     } catch (RuntimeException | Error e) {
       LOG.error("Caught error trying to start request: {}", e, e);
-      listener.onNotStarted(true);
+      senderListener.onNotStarted(true);
     }
   }
 
@@ -1734,11 +1557,11 @@ public class NodeClientCore implements Persistable {
    *     client cache are always allowed for local requests; some callers disable writes to avoid
    *     cache pollution.
    * @param realTimeFlag {@code true} for latency-optimized routing; {@code false} for bulk.
-   * @return the verified client CHK block.
+   * @return the verified client block.
    * @throws LowLevelGetException if the data is not found, recently failed, transfer fails, verify
    *     fails, or on internal error.
    */
-  ClientCHKBlock realGetCHK(
+  ClientKeyBlock realGetCHK(
       ClientCHK key,
       boolean localOnly,
       boolean ignoreStore,
@@ -1748,7 +1571,7 @@ public class NodeClientCore implements Persistable {
     long startTime = System.currentTimeMillis();
     long uid = makeUID();
     RequestTag tag = new RequestTag(false, RequestTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!tracker.lockUID(uid, false, false, false, true, realTimeFlag, tag)) {
+    if (!node.getTracker().lockUID(uid, false, false, false, true, realTimeFlag, tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
     }
@@ -1767,7 +1590,7 @@ public class NodeClientCore implements Persistable {
       if (o instanceof CHKBlock block)
         try {
           tag.setServedFromDatastore();
-          return new ClientCHKBlock(block, key);
+          return NodeClientCoreSupport.buildClientChkBlock(block, key);
         } catch (CHKVerifyException e) {
           LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
           throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
@@ -1780,7 +1603,7 @@ public class NodeClientCore implements Persistable {
     }
   }
 
-  private ClientCHKBlock processChkRequestLoop(
+  private ClientKeyBlock processChkRequestLoop(
       RequestSender rs, ClientCHK key, long startTime, boolean realTimeFlag)
       throws LowLevelGetException {
     boolean rejectedOverload = false;
@@ -1802,7 +1625,7 @@ public class NodeClientCore implements Persistable {
             false, realTimeFlag, startTime, key.getNodeCHK(), rs, status, rejectedOverload);
       }
 
-      ClientCHKBlock maybe = tryReturnChkBlock(rs, key, status);
+      ClientKeyBlock maybe = tryReturnChkBlock(rs, key, status);
       if (maybe != null) return maybe;
       throwForGetStatus(status, rs);
     }
@@ -1838,11 +1661,12 @@ public class NodeClientCore implements Persistable {
     }
   }
 
-  private ClientCHKBlock tryReturnChkBlock(RequestSender rs, ClientCHK key, int status)
+  private ClientKeyBlock tryReturnChkBlock(RequestSender rs, ClientCHK key, int status)
       throws LowLevelGetException {
     if (status == RequestSender.SUCCESS)
       try {
-        return new ClientCHKBlock(rs.getPRB().getBlock(), rs.getHeaders(), key, true);
+        return NodeClientCoreSupport.buildClientChkBlock(
+            rs.getPRB().getBlock(), rs.getHeaders(), key);
       } catch (CHKVerifyException e) {
         LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
         throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
@@ -1877,7 +1701,7 @@ public class NodeClientCore implements Persistable {
     }
   }
 
-  ClientSSKBlock realGetSSK(
+  ClientKeyBlock realGetSSK(
       ClientSSK key,
       boolean localOnly,
       boolean ignoreStore,
@@ -1887,7 +1711,7 @@ public class NodeClientCore implements Persistable {
     long startTime = System.currentTimeMillis();
     long uid = makeUID();
     RequestTag tag = new RequestTag(true, RequestTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!tracker.lockUID(uid, true, false, false, true, realTimeFlag, tag)) {
+    if (!node.getTracker().lockUID(uid, true, false, false, true, realTimeFlag, tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
     }
@@ -1907,7 +1731,7 @@ public class NodeClientCore implements Persistable {
         try {
           tag.setServedFromDatastore();
           key.setPublicKey(block.getPubKey());
-          return ClientSSKBlock.construct(block, key);
+          return NodeClientCoreSupport.buildClientSskBlock(block, key);
         } catch (SSKVerifyException e) {
           LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
           throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
@@ -1920,7 +1744,7 @@ public class NodeClientCore implements Persistable {
     }
   }
 
-  private ClientSSKBlock processSskRequestLoop(
+  private ClientKeyBlock processSskRequestLoop(
       RequestSender rs, ClientSSK key, long startTime, boolean realTimeFlag)
       throws LowLevelGetException {
     boolean rejectedOverload = false;
@@ -1946,7 +1770,7 @@ public class NodeClientCore implements Persistable {
         try {
           SSKBlock block = rs.getSSKBlock();
           key.setPublicKey(block.getPubKey());
-          return ClientSSKBlock.construct(block, key);
+          return NodeClientCoreSupport.buildClientSskBlock(block, key);
         } catch (SSKVerifyException e) {
           LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
           throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
@@ -2018,7 +1842,7 @@ public class NodeClientCore implements Persistable {
     CHKInsertSender is;
     long uid = makeUID();
     InsertTag tag = new InsertTag(false, InsertTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!tracker.lockUID(uid, false, true, false, true, realTimeFlag, tag)) {
+    if (!node.getTracker().lockUID(uid, false, true, false, true, realTimeFlag, tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
     }
@@ -2084,10 +1908,10 @@ public class NodeClientCore implements Persistable {
       int received = is.getTotalReceivedBytes();
       if (LOG.isDebugEnabled())
         LOG.debug("Local CHK insert cost {}/{}" + LOG_BYTES_OPEN + "{})", sent, received, status);
-      nodeStats.localChkInsertBytesSentAverage.report(sent);
-      nodeStats.localChkInsertBytesReceivedAverage.report(received);
+      node.getNodeStats().localChkInsertBytesSentAverage.report(sent);
+      node.getNodeStats().localChkInsertBytesReceivedAverage.report(received);
       if (status == CHKInsertSender.SUCCESS)
-        nodeStats.successfulChkInsertBytesSentAverage.report(sent);
+        node.getNodeStats().successfulChkInsertBytesSentAverage.report(sent);
     }
   }
 
@@ -2187,7 +2011,7 @@ public class NodeClientCore implements Persistable {
     SSKInsertSender is;
     long uid = makeUID();
     InsertTag tag = new InsertTag(true, InsertTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!tracker.lockUID(uid, true, true, false, true, realTimeFlag, tag)) {
+    if (!node.getTracker().lockUID(uid, true, true, false, true, realTimeFlag, tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
     }
@@ -2290,10 +2114,10 @@ public class NodeClientCore implements Persistable {
       int received = is.getTotalReceivedBytes();
       if (LOG.isDebugEnabled())
         LOG.debug("Local SSK insert cost {}/{}" + LOG_BYTES_OPEN + "{})", sent, received, status);
-      nodeStats.localSskInsertBytesSentAverage.report(sent);
-      nodeStats.localSskInsertBytesReceivedAverage.report(received);
+      node.getNodeStats().localSskInsertBytesSentAverage.report(sent);
+      node.getNodeStats().localSskInsertBytesReceivedAverage.report(received);
       if (status == SSKInsertSender.SUCCESS)
-        nodeStats.successfulSskInsertBytesSentAverage.report(sent);
+        node.getNodeStats().successfulSskInsertBytesSentAverage.report(sent);
     }
   }
 
@@ -2387,65 +2211,14 @@ public class NodeClientCore implements Persistable {
         realTimeFlag);
   }
 
-  /** Returns the FCP server, or {@code null} when disabled. */
-  public FCPServer getFCPServer() {
-    return fcpServer;
-  }
-
-  /** Returns the FProxy toadlet when available. */
-  public FProxyToadlet getFProxy() {
-    return fproxyServlet;
-  }
-
-  /** Returns the HTTP toadlet container for client UI endpoints. */
-  public SimpleToadletServer getToadletContainer() {
-    return toadletContainer;
-  }
-
-  /**
-   * Returns the link filter exception provider of the node. At the moment this is the {@link
-   * #getToadletContainer() toadlet container}.
-   *
-   * @return The link filter exception provider
-   */
-  public LinkFilterExceptionProvider getLinkFilterExceptionProvider() {
-    return toadletContainer;
-  }
-
-  /** Returns the Text Mode Client Interface (TMCI) server, or {@code null} when disabled. */
-  public TextModeClientInterfaceServer getTextModeClientInterface() {
-    return tmci;
-  }
-
-  /** Sets the active FProxy toadlet instance. */
-  public void setFProxy(FProxyToadlet fproxy) {
-    this.fproxyServlet = fproxy;
-  }
-
-  /** Returns the direct (in-process) TMCI instance, if set. */
-  public TextModeClientInterface getDirectTMCI() {
-    return directTMCI;
-  }
-
-  /** Sets the direct (in-process) TMCI instance. */
-  public void setDirectTMCI(TextModeClientInterface i) {
-    this.directTMCI = i;
+  /** Returns client endpoints (FCP, TMCI, and HTTP toadlet container). */
+  public ClientEndpoints getEndpoints() {
+    return endpoints;
   }
 
   /** Returns the configured downloads directory. */
   public File getDownloadsDir() {
-    return downloadsDir.dir();
-  }
-
-  /** Returns the program-directory wrapper for the downloads directory. */
-  public ProgramDirectory downloadsDir() {
     return downloadsDir;
-  }
-
-  /** Returns the queue used for healing reinserts. */
-  @SuppressWarnings("unused")
-  public HealingQueue getHealingQueue() {
-    return healingQueue;
   }
 
   public void queueRandomReinsert(KeyBlock block) {
@@ -2469,29 +2242,17 @@ public class NodeClientCore implements Persistable {
 
   /** Returns whether advanced-mode UI features are enabled in FProxy. */
   public boolean isAdvancedModeEnabled() {
-    return (getToadletContainer() != null) && getToadletContainer().isAdvancedModeEnabled();
+    return endpoints.isAdvancedModeEnabled();
   }
 
   /** Returns whether JavaScript is enabled in FProxy. */
   public boolean isFProxyJavascriptEnabled() {
-    return (getToadletContainer() != null) && getToadletContainer().isFProxyJavascriptEnabled();
+    return endpoints.isFProxyJavascriptEnabled();
   }
 
   /** Returns the node's user-visible name. */
   public String getMyName() {
     return node.getMyName();
-  }
-
-  /**
-   * Creates a read filter callback bound to the HTTP UI context.
-   *
-   * @param uri source URI for the filter.
-   * @param cb sink invoked for each found URI.
-   * @return a {@link FilterCallback} suitable for content filtering.
-   */
-  public FilterCallback createFilterCallback(URI uri, FoundURICallback cb) {
-    if (LOG.isDebugEnabled()) LOG.debug("Creating filter callback: {}, {}", uri, cb);
-    return new GenericReadFilterCallback(uri, cb, null, toadletContainer);
   }
 
   /** Returns the configured maximum number of background USK fetchers. */
@@ -2567,24 +2328,14 @@ public class NodeClientCore implements Persistable {
     return requestStarters.persistToFieldSet();
   }
 
-  /** Returns the node's shared ticker for timing and scheduling. */
-  public Ticker getTicker() {
-    return node.getTicker();
-  }
-
-  /** Returns the node's priority-aware executor for background tasks. */
-  public PriorityAwareExecutor getExecutor() {
-    return node.getExecutor();
-  }
-
   /** Returns the directory used for persistent temporary buckets. */
   public File getPersistentTempDir() {
-    return persistentTempDir.dir();
+    return persistentTempDir;
   }
 
   /** Returns the directory used for ephemeral temporary buckets. */
   public File getTempDir() {
-    return tempDir.dir();
+    return tempDir;
   }
 
   /**
@@ -2594,28 +2345,15 @@ public class NodeClientCore implements Persistable {
    * @param realTime whether to queue on the real-time scheduler.
    */
   public void queueOfferedKey(Key key, boolean realTime) {
-    ClientRequestScheduler sched =
-        requestStarters.getScheduler(key instanceof NodeSSK, false, realTime);
-    sched.queueOfferedKey(key, realTime);
+    requestStarters
+        .getScheduler(key instanceof NodeSSK, false, realTime)
+        .queueOfferedKey(key, realTime);
   }
 
   /** Removes a previously queued offered key from both bulk and real-time schedulers. */
   public void dequeueOfferedKey(Key key) {
-    ClientRequestScheduler sched =
-        requestStarters.getScheduler(key instanceof NodeSSK, false, false);
-    sched.dequeueOfferedKey(key);
-    sched = requestStarters.getScheduler(key instanceof NodeSSK, false, true);
-    sched.dequeueOfferedKey(key);
-  }
-
-  /** Returns the bookmark manager used by the HTTP UI. */
-  public BookmarkManager getBookmarkManager() {
-    return toadletContainer.getBookmarks();
-  }
-
-  /** Returns the list of configured bookmark URIs. */
-  public FreenetURI[] getBookmarkURIs() {
-    return toadletContainer.getBookmarkURIs();
+    requestStarters.getScheduler(key instanceof NodeSSK, false, false).dequeueOfferedKey(key);
+    requestStarters.getScheduler(key instanceof NodeSSK, false, true).dequeueOfferedKey(key);
   }
 
   /** Returns the total number of requests currently queued across schedulers. */
@@ -2653,31 +2391,7 @@ public class NodeClientCore implements Persistable {
    * @return a non-negative value indicating how recently the key failed (units are internal).
    */
   public long checkRecentlyFailed(Key key, boolean realTime) {
-    RecentlyFailedReturn r = new RecentlyFailedReturn();
-    // Mirror originator behavior by decrementing HTL here so results match RequestSender’s
-    // routing heuristics. If originator rules change, revisit this.
-    short origHTL = node.decrementHTL(null, node.maxHTL());
-    node.getPeers()
-        .routingSelector()
-        .closerPeer(
-            null,
-            new HashSet<>(),
-            key.toNormalizedDouble(),
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            key,
-            origHTL,
-            0,
-            true,
-            realTime,
-            r,
-            false,
-            System.currentTimeMillis(),
-            node.enableNewLoadManagement(realTime));
-    return r.recentlyFailed();
+    return NodeClientCoreSupport.checkRecentlyFailed(node, key, realTime);
   }
 
   /** Returns the plugin stores accessor for this node. */
@@ -2706,7 +2420,7 @@ public class NodeClientCore implements Persistable {
 
   /** Returns the set of currently persisted FCP requests. */
   public ClientRequest[] getPersistentRequests() {
-    return fcpPersistentRoot.getPersistentRequests();
+    return persistence.getPersistentRequests();
   }
 
   /**
@@ -2718,7 +2432,7 @@ public class NodeClientCore implements Persistable {
     if (getClientContext().getPersistentMasterSecret() == null)
       getClientContext().setPersistentMasterSecret(persistentSecret);
     getPersistentTempBucketFactory().setMasterSecret(persistentSecret);
-    persistentRAFFactory.setMasterSecret(persistentSecret);
+    persistence.setPersistentRafMasterSecret(persistentSecret);
   }
 
   /** Returns whether the client-layer database has been loaded. */
@@ -2727,10 +2441,6 @@ public class NodeClientCore implements Persistable {
   }
 
   /** Returns the component that persists bandwidth statistics. */
-  public PersistentStatsPutter getBandwidthStatsPutter() {
-    return bandwidthStatsPutter;
-  }
-
   /** Returns the USK manager. */
   public USKManager getUskManager() {
     return uskManager;
@@ -2744,16 +2454,6 @@ public class NodeClientCore implements Persistable {
   /** Returns the anti-CSRF token expected by HTTP handlers. */
   public String getFormPassword() {
     return formPassword;
-  }
-
-  /** Returns the generator used for temporary filenames. */
-  public FilenameGenerator getTempFilenameGenerator() {
-    return tempFilenameGenerator;
-  }
-
-  /** Returns the generator used for persistent temporary filenames. */
-  public FilenameGenerator getPersistentFilenameGenerator() {
-    return persistentFilenameGenerator;
   }
 
   /** Returns the factory for ephemeral temporary buckets. */
@@ -2774,11 +2474,6 @@ public class NodeClientCore implements Persistable {
   /** Returns the owning node. */
   public Node getNode() {
     return node;
-  }
-
-  /** Returns the node statistics sink used for reporting costs and outcomes. */
-  public NodeStats getNodeStats() {
-    return nodeStats;
   }
 
   /** Returns the non-cryptographic random source used by this component. */

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -49,6 +49,12 @@ import org.slf4j.LoggerFactory;
  * run on node executor threads; accessors that expose mutable configuration state are synchronized
  * to provide a stable snapshot.
  *
+ * <p>State is mostly immutable after construction, with explicit setters for download and upload
+ * allowlists and disk-threshold configuration. Long-lived services such as the persister, request
+ * starters, and datastore checker are owned by the node lifecycle; callers obtain shared references
+ * but should not shut them down directly. Thread-safety is achieved via final fields, synchronized
+ * accessors for mutable policy, and executor-managed background tasks rather than external locking.
+ *
  * <ul>
  *   <li>Provide client-layer factories and shared services for request handlers.
  *   <li>Gate disk usage and security policy for downloads and uploads.
@@ -82,9 +88,11 @@ public class NodeClientCore implements Persistable {
   private final NodeClientCoreTransfers transfers;
 
   /**
-   * Runs memory-bounded background jobs such as FEC decoding within configured capacity and thread
-   * limits. The runner is shared by client operations, so callers should treat it as a long-lived
-   * service and avoid shutting it down directly; lifecycle is owned by the core.
+   * Runs memory-bounded background jobs such as FEC decoding.
+   *
+   * <p>The runner enforces configured memory and thread ceilings for long-lived background work
+   * shared across client operations. It is owned by the core for the node lifetime, so callers
+   * should not shut it down or reconfigure limits outside the managed settings callbacks.
    */
   public final MemoryLimitedJobRunner memoryLimitedJobRunner;
 
@@ -131,8 +139,9 @@ public class NodeClientCore implements Persistable {
   /**
    * Compressor used for network transfers and stored blocks.
    *
-   * <p>The instance is created during construction and is shared across requests. Callers should
-   * treat it as a core-owned component and avoid reconfiguring it outside managed setup.
+   * <p>The instance is created during construction and shared across requests for the lifetime of
+   * the node. It is configured by the core and wired to the {@link ClientContext}; callers should
+   * treat it as read-only infrastructure and avoid calling {@link RealCompressor#shutdown()}.
    */
   public final RealCompressor compressor;
 
@@ -409,8 +418,10 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The calculation adds the current RAM-backed temp bucket allowance to the configured
    * long-term free-space requirement so the persistent RAF factory can accommodate a migration of
-   * temporary data to disk. It updates the persisted factory only when one is present and uses the
-   * current in-memory configuration snapshot to compute the threshold.
+   * temporary data to disk. It synchronizes on this core to read the latest long-term threshold,
+   * then applies the derived value only when a persistent factory is present. Calling it multiple
+   * times with unchanged configuration is effectively idempotent and performs no I/O beyond the
+   * factory update.
    */
   protected void updatePersistentRAFSpaceLimit() {
     // The temp bucket factory may have to migrate everything to disk.
@@ -995,9 +1006,11 @@ public class NodeClientCore implements Persistable {
    * <p>Recognized entries include {@code "all"} to allow any destination and {@code "downloads"} to
    * allow the configured downloads directory. Any other string is treated as a filesystem path and
    * stored as a {@link File}. Passing an empty array disables downloads entirely. The configuration
-   * is applied immediately and affects subsequent permission checks.
+   * is applied immediately and affects subsequent permission checks. The method updates in-memory
+   * policy only, does not create directories, and does not validate that paths exist. Reapplying
+   * the same list yields equivalent policy without additional side effects.
    *
-   * @param val allowlist entries describing special tokens or absolute/relative paths.
+   * @param val allowlist entries describing tokens or absolute/relative filesystem paths.
    */
   protected synchronized void setDownloadAllowedDirs(String[] val) {
     transferPolicy.setDownloadAllowedDirs(val);
@@ -1009,9 +1022,10 @@ public class NodeClientCore implements Persistable {
    * <p>Recognized entries include {@code "all"} to allow any source. Any other string is treated as
    * a filesystem path and stored as a {@link File}. The configuration is applied immediately and
    * affects subsequent permission checks for upload sources. The method performs no I/O and updates
-   * in-memory policy.
+   * in-memory policy. Calling it repeatedly with the same values is effectively idempotent, but
+   * callers should provide normalized paths if they expect deterministic matching.
    *
-   * @param val allowlist entries describing special tokens or filesystem paths.
+   * @param val allowlist entries describing tokens or filesystem source paths.
    */
   protected synchronized void setUploadAllowedDirs(String[] val) {
     transferPolicy.setUploadAllowedDirs(val);
@@ -1024,7 +1038,9 @@ public class NodeClientCore implements Persistable {
    * plugins, then schedules a low-priority completion task to migrate persistent temporary buckets
    * and resume pending requests. Call it during node startup after construction has finished
    * wiring. Exceptions during migration are logged and do not prevent the remaining services from
-   * running.
+   * running. The startup sequence is asynchronous: it returns immediately after scheduling the
+   * completion task, so callers should not assume persistent requests are resumed when it returns.
+   * The method is intended to be called once per node lifecycle.
    */
   public void start() {
 
@@ -1071,13 +1087,13 @@ public class NodeClientCore implements Persistable {
    * source so its requests are scheduled and accounted for with the node. The client respects the
    * provided priority class and real-time flag, which influence routing and throttling behavior.
    * This method does not start network activity by itself; it only constructs a configured client
-   * instance.
+   * instance. Repeated calls create independent client instances that share the same underlying
+   * services and are safe to use concurrently.
    *
-   * @param prioClass priority class assigned to requests from the client.
-   * @param forceDontIgnoreTooManyPathComponents whether to disable path-component pruning for
-   *     overly long paths.
-   * @param realTimeFlag true for latency-optimized requests; false for bulk requests.
-   * @return configured {@link HighLevelSimpleClient} bound to this core and context.
+   * @param prioClass priority class assigned to requests issued by the client.
+   * @param forceDontIgnoreTooManyPathComponents whether to disable pruning for overly long paths.
+   * @param realTimeFlag true for latency-optimized requests, false for bulk requests.
+   * @return configured client instance bound to this core and shared context.
    */
   public HighLevelSimpleClient makeClient(
       short prioClass, boolean forceDontIgnoreTooManyPathComponents, boolean realTimeFlag) {
@@ -1095,10 +1111,12 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The returned {@link ClientEndpoints} instance owns the lifecycle of the FCP and TMCI servers
    * and the HTTP toadlet container for this node. It is created during construction and remains
-   * shared across the node lifecycle. Callers should treat it as core-owned and avoid stopping
-   * endpoints outside managed shutdown paths.
+   * shared across the node lifecycle. The accessor performs no I/O and returns the shared reference
+   * immediately. Callers should treat it as core-owned and avoid stopping or reconfiguring
+   * endpoints outside managed shutdown paths; startup and shutdown are controlled by the node
+   * lifecycle.
    *
-   * @return the shared {@link ClientEndpoints} instance for this node.
+   * @return shared {@link ClientEndpoints} instance for the current node lifecycle.
    */
   public ClientEndpoints getEndpoints() {
     return endpoints;
@@ -1109,7 +1127,8 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The directory is resolved during initialization and represents the default location used
    * when downloads are permitted. The returned {@link File} is the internal instance used by the
-   * core, so callers should treat it as shared and avoid mutating configuration through it.
+   * core, so callers should treat it as shared and avoid mutating configuration through it. The
+   * accessor performs no I/O and simply returns the current configuration snapshot.
    *
    * @return configured downloads directory {@link File} used by permission checks.
    */
@@ -1123,7 +1142,8 @@ public class NodeClientCore implements Persistable {
    * <p>This triggers the node configuration store to write its current values to the configured
    * storage location. The operation invokes the write immediately, but the underlying storage
    * subsystem controls any buffering or durability semantics. Call it after changing configuration
-   * values that must survive restart.
+   * values that must survive restart. The method is side-effecting, but it does not block on
+   * network activity; any errors are handled by the configuration subsystem.
    */
   public void storeConfig() {
     LOG.info("Trying to write config to disk");
@@ -1134,9 +1154,10 @@ public class NodeClientCore implements Persistable {
    * Returns whether the node runs in testnet mode.
    *
    * <p>This is a global setting that affects network compatibility and routing behavior. The value
-   * is determined by node configuration and is not modified by this method. Use it to gate features
-   * that should only operate on a test network. The accessor performs no I/O and does not modify
-   * state.
+   * is determined by node configuration and is not modified by this method. The accessor performs
+   * no I/O and does not cache beyond the call, so changes in configuration are reflected on
+   * subsequent invocations. Use it to gate features or UI elements that should only operate on a
+   * test network. The method is thread-safe and side-effect free.
    *
    * @return {@code true} if the node is configured for testnet operation.
    */
@@ -1151,7 +1172,8 @@ public class NodeClientCore implements Persistable {
    * <p>This flag is provided by the client endpoints configuration and controls whether advanced UI
    * features are exposed in the HTTP interface. It reflects the current configuration snapshot and
    * may change at runtime if settings are updated. The accessor performs no I/O and simply returns
-   * the current flag.
+   * the current flag, making it safe to call from UI rendering code. It has no side effects and
+   * does not influence endpoint state.
    *
    * @return {@code true} if advanced-mode UI features are enabled in FProxy.
    */
@@ -1165,7 +1187,8 @@ public class NodeClientCore implements Persistable {
    * <p>This flag reflects HTTP UI configuration and indicates whether the toadlet container should
    * render pages that depend on client-side scripting. It is a snapshot of current settings and may
    * change at runtime when configuration is updated. The accessor performs no I/O and simply
-   * returns the current flag.
+   * returns the current flag; it does not alter rendering behavior by itself. Callers can use it to
+   * decide whether to emit script-dependent UI elements.
    *
    * @return {@code true} if JavaScript is enabled for the HTTP UI.
    */
@@ -1178,7 +1201,8 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The name is managed by the {@link Node} configuration and can be displayed in UI surfaces or
    * status messages. The value is a snapshot and may be empty if the user has not configured a
-   * custom name. The accessor performs no I/O and returns the current in-memory value.
+   * custom name. The accessor performs no I/O and returns the current in-memory value; it does not
+   * trigger configuration reloads. Callers should treat it as presentation data only.
    *
    * @return current user-visible node name, which may be empty.
    */
@@ -1191,7 +1215,8 @@ public class NodeClientCore implements Persistable {
    *
    * <p>This limit is loaded from configuration and is used by USK scheduling to cap concurrent
    * background fetch activity. The value is a snapshot and can change if configuration is updated
-   * at runtime. Callers can use it to size background queues and avoid oversubscription.
+   * at runtime. The accessor performs no I/O and simply returns the current configuration value.
+   * Callers can use it to size background queues and avoid oversubscription.
    *
    * @return configured maximum number of concurrent background USK fetchers.
    */
@@ -1206,10 +1231,11 @@ public class NodeClientCore implements Persistable {
    * <p>This check enforces the current physical threat level and the configured download allowlist,
    * including the downloads directory when enabled. If downloads are disabled by configuration, no
    * target is accepted. The check uses parent-path matching and does not create directories or
-   * touch the filesystem beyond path comparisons.
+   * touch the filesystem beyond path comparisons. It is a pure policy check that can be called
+   * frequently without side effects.
    *
-   * @param filename target file path to validate against download allowlist.
-   * @return {@code true} if the path is allowed under current policy.
+   * @param filename file path to validate against the download allowlist.
+   * @return {@code true} when the path is allowed by current policy.
    */
   public boolean allowDownloadTo(File filename) {
     return transferPolicy.allowDownloadTo(filename);
@@ -1221,10 +1247,10 @@ public class NodeClientCore implements Persistable {
    * <p>This check uses the configured upload allowlist and does not verify file existence. The
    * result is a snapshot of current configuration and is used to gate upload requests before any
    * I/O occurs. Paths are matched by parent-directory containment. The method does not read file
-   * contents and only evaluates path hierarchy.
+   * contents and only evaluates path hierarchy. It is a pure policy check that has no side effects.
    *
-   * @param filename source file path to validate against upload allowlist.
-   * @return {@code true} if the path is allowed as an upload source.
+   * @param filename file path to validate against the upload allowlist.
+   * @return {@code true} when the path is allowed as an upload source.
    */
   public synchronized boolean allowUploadFrom(File filename) {
     return transferPolicy.allowUploadFrom(filename);
@@ -1235,9 +1261,10 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The returned array contains the configured directories used for permission checks. It is a
    * direct reference to internal state, so callers should not modify the array or its elements. The
-   * allowlist may be empty when downloads are disabled. No defensive copy is made.
+   * allowlist may be empty when downloads are disabled. No defensive copy is made, and the
+   * reference may change when configuration is updated.
    *
-   * @return current allowlist array; entries are internal references, not copies.
+   * @return current allowlist array with shared directory references and entries.
    */
   public synchronized File[] getAllowedDownloadDirs() {
     return transferPolicy.getAllowedDownloadDirs();
@@ -1248,9 +1275,10 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The returned array contains the configured directories used for permission checks. It is a
    * direct reference to internal state, so callers should not modify the array or its elements. The
-   * allowlist may be empty when no explicit sources are configured. No defensive copy is made.
+   * allowlist may be empty when no explicit sources are configured. No defensive copy is made, and
+   * the reference may change when configuration is updated.
    *
-   * @return current allowlist array; entries are internal references, not copies.
+   * @return current allowlist array with shared directory references and entries.
    */
   public synchronized File[] getAllowedUploadDirs() {
     return transferPolicy.getAllowedUploadDirs();
@@ -1262,7 +1290,9 @@ public class NodeClientCore implements Persistable {
    * <p>The returned {@link SimpleFieldSet} captures the current throttling configuration for
    * request starters and schedulers so it can be written to persistent storage. The snapshot is
    * intended for persistence and reload, not for direct mutation by callers. The method performs no
-   * I/O and only builds an in-memory structure.
+   * I/O and only builds an in-memory structure. Calling it repeatedly without changing throttles is
+   * effectively idempotent and produces equivalent output. It is safe to call from executor threads
+   * as part of periodic persistence.
    *
    * @return throttles encoded as a {@link SimpleFieldSet} snapshot for persistence.
    */
@@ -1277,9 +1307,10 @@ public class NodeClientCore implements Persistable {
    * <p>This directory is created during initialization and is used for restart-safe temporary
    * storage. The returned {@link File} is the internal instance used by the core, so callers should
    * treat it as shared and avoid changing its contents outside managed cleanup. The accessor
-   * performs no I/O and returns the current configuration value.
+   * performs no I/O and returns the current configuration value, which can change only via
+   * configuration updates.
    *
-   * @return directory used for persistent temporary bucket storage.
+   * @return directory used for persistent temporary bucket storage on disk.
    */
   public File getPersistentTempDir() {
     return persistentTempDir;
@@ -1291,9 +1322,10 @@ public class NodeClientCore implements Persistable {
    * <p>This directory is created during initialization and is used for short-lived temporary
    * storage. The returned {@link File} is the internal instance used by the core, so callers should
    * treat it as shared and avoid changing its contents outside managed cleanup. The accessor
-   * performs no I/O and returns the current configuration value.
+   * performs no I/O and returns the current configuration value, which can change only via
+   * configuration updates.
    *
-   * @return directory used for non-persistent temporary bucket storage.
+   * @return directory used for non-persistent temporary bucket storage on disk.
    */
   public File getTempDir() {
     return tempDir;
@@ -1304,10 +1336,12 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The key is placed on the scheduler corresponding to its type (SSK vs CHK) and the selected
    * real-time or bulk queue. This operation is asynchronous; it only enqueues the key and returns.
-   * It is typically used when peers advertise availability via offered-key mechanisms.
+   * It is typically used when peers advertise availability via offered-key mechanisms. Behavior for
+   * already-queued keys is determined by the scheduler implementation. The method performs no
+   * network I/O and returns immediately.
    *
    * @param key offered key to enqueue for opportunistic fetching.
-   * @param realTime whether to enqueue on the real-time scheduler.
+   * @param realTime true to enqueue on the real-time scheduler.
    */
   public void queueOfferedKey(Key key, boolean realTime) {
     requestStarters
@@ -1320,7 +1354,8 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The removal is applied to both queue variants to avoid stale scheduling. If the key is not
    * present, the operation has no observable effect and returns immediately. The method does not
-   * block on network activity or disk I/O. It only updates scheduler queues in memory.
+   * block on network activity or disk I/O. It only updates scheduler queues in memory, so repeated
+   * calls are effectively idempotent.
    *
    * @param key offered key to remove from scheduler queues.
    */
@@ -1334,9 +1369,10 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The count includes both real-time and bulk queues for CHK and SSK schedulers. The value is a
    * snapshot of current state and can change immediately as requests are queued or completed. The
-   * method performs no blocking operations and returns immediately.
+   * method performs no blocking operations and returns immediately, so it is suitable for
+   * monitoring and UI counters. No guarantees are made about consistency across concurrent updates.
    *
-   * @return total queued request count across all schedulers.
+   * @return total queued request count across all schedulers currently.
    */
   public long countQueuedRequests() {
     return requestStarters.countQueuedRequests();
@@ -1348,9 +1384,9 @@ public class NodeClientCore implements Persistable {
    * <p>This static value is loaded from configuration during initialization. It is used by USK
    * scheduling to limit concurrent background fetch activity across the node. The accessor performs
    * no I/O and returns the current configured value. Callers typically use it to size background
-   * queues and avoid oversubscription.
+   * queues and avoid oversubscription. The value may change when configuration is reloaded.
    *
-   * @return configured maximum number of background USK fetchers.
+   * @return configured maximum number of background USK fetchers allowed.
    */
   public static int getMaxBackgroundUSKFetchers() {
     return maxBackgroundUSKFetchers;
@@ -1363,7 +1399,8 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The method checks both real-time and bulk fetch schedulers for the key type (SSK vs CHK). It
    * is used to decide whether to keep or forward offered keys and to avoid redundant work. The
-   * result is a snapshot and may change as scheduling state evolves.
+   * result is a snapshot and may change as scheduling state evolves. The method performs no I/O and
+   * does not enqueue the key; it only queries scheduler state.
    *
    * @param key key to test for scheduler interest.
    * @return {@code true} if any scheduler currently wants the key.
@@ -1380,7 +1417,8 @@ public class NodeClientCore implements Persistable {
    * <p>This performs a local probe equivalent to how {@link RequestSender} considers recent
    * failures for a key at the originator, ensuring comparable behavior to running requests. The
    * returned value is an internal metric and should only be used for relative comparisons in
-   * routing heuristics, not for display.
+   * routing heuristics, not for display. The method performs no network I/O and returns
+   * immediately.
    *
    * @param key target key to probe for recent failures.
    * @param realTime whether to use real-time routing heuristics or bulk.
@@ -1394,11 +1432,11 @@ public class NodeClientCore implements Persistable {
    * Returns the plugin stores accessor for this node.
    *
    * <p>The returned {@link PluginStores} instance provides access to plugin-managed storage and is
-   * created during core initialization. It is shared across the node lifecycle, so callers should
-   * treat it as core-owned and avoid replacing or shutting it down directly. The accessor performs
-   * no I/O and returns the existing instance.
+   * created during core initialization. It is shared across the node lifecycle and may be used by
+   * multiple threads, so callers should treat it as core-owned and avoid replacing or shutting it
+   * down directly. The accessor performs no I/O and returns the existing reference immediately.
    *
-   * @return shared {@link PluginStores} instance used for plugin storage.
+   * @return shared plugin stores instance used by plugin storage.
    */
   public PluginStores getPluginStores() {
     return pluginStores;
@@ -1409,7 +1447,8 @@ public class NodeClientCore implements Persistable {
    *
    * <p>This value is configured via node settings and is used to gate operations with unpredictable
    * duration, such as large downloads. The value is a snapshot and may change when configuration is
-   * updated at runtime. The accessor performs no I/O and returns the current threshold.
+   * updated at runtime. The accessor is synchronized to provide a consistent view with other disk
+   * limit updates and performs no I/O. Use it to decide whether to admit long-running requests.
    *
    * @return minimum free-disk threshold for long-running jobs, in bytes.
    */
@@ -1422,7 +1461,8 @@ public class NodeClientCore implements Persistable {
    *
    * <p>This value is configured via node settings and is used to gate operations such as completing
    * downloads. The value is a snapshot and may change when configuration is updated at runtime. The
-   * accessor performs no I/O and returns the current threshold.
+   * accessor is synchronized to provide a consistent view with other disk limit updates and
+   * performs no I/O. Use it to decide whether to admit short, disk-intensive work.
    *
    * @return minimum free-disk threshold for short disk-heavy jobs, in bytes.
    */
@@ -1436,7 +1476,7 @@ public class NodeClientCore implements Persistable {
    * <p>This reflects the {@link ClientLayerPersister} state and indicates whether persistence is
    * unavailable for client-layer data. It can be used to gate operations that require persisted
    * state or to display warnings in UI surfaces. The accessor performs no I/O and simply reflects
-   * persister state.
+   * persister state; it is a snapshot and may change as persistence loads or shuts down.
    *
    * @return {@code true} if persistence is unavailable for client-layer data.
    */
@@ -1449,9 +1489,10 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The returned array is a snapshot of persisted request state at the time of the call. It may
    * be empty if persistence is disabled or if no requests are stored. Callers should treat the
-   * array as read-only. The accessor performs no I/O and returns the in-memory snapshot.
+   * array as read-only and avoid modifying its elements. The accessor performs no I/O and returns
+   * the in-memory snapshot immediately.
    *
-   * @return snapshot array of persisted {@link ClientRequest} entries.
+   * @return snapshot array of persisted {@link ClientRequest} entries at call time.
    */
   public ClientRequest[] getPersistentRequests() {
     return persistence.getPersistentRequests();
@@ -1462,7 +1503,8 @@ public class NodeClientCore implements Persistable {
    *
    * <p>If the client context does not already have a persistent secret, this method installs the
    * provided secret and wires it into the persistent temp bucket factory and RAF persistence. It
-   * does not generate a secret; callers must supply one that is already initialized.
+   * does not generate a secret; callers must supply one that is already initialized. The method
+   * performs no I/O and does not validate the secret beyond wiring it into dependent components.
    *
    * @param persistentSecret master secret to use for persistent encryption state.
    */
@@ -1479,7 +1521,7 @@ public class NodeClientCore implements Persistable {
    * <p>This reflects whether the {@link ClientLayerPersister} has completed loading persistent
    * state. It can be used to gate operations that depend on restored request queues or throttles.
    * The accessor performs no I/O and simply reflects persister state. It does not trigger loading
-   * and does not alter persistence state.
+   * and does not alter persistence state; callers should poll or listen for updates as needed.
    *
    * @return {@code true} if the client-layer database has been loaded.
    */
@@ -1492,7 +1534,8 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The returned {@link USKManager} instance coordinates USK state and scheduling for this core.
    * It is initialized during construction and is shared for the life of the node, so callers should
-   * treat it as core-owned. The accessor performs no I/O and returns the existing instance.
+   * treat it as core-owned. The accessor performs no I/O and returns the existing instance, which
+   * may be used concurrently by multiple request paths.
    *
    * @return shared {@link USKManager} instance for this core.
    */
@@ -1504,9 +1547,10 @@ public class NodeClientCore implements Persistable {
    * Returns the client transfer operations for fetch/insert paths.
    *
    * <p>The returned {@link NodeClientCoreTransfers} instance encapsulates key transfer logic and is
-   * bound to this core. Callers should treat it as core-owned state.
+   * bound to this core. Callers should treat it as core-owned state and avoid replacing or shutting
+   * it down directly. The accessor performs no I/O and returns the existing instance.
    *
-   * @return shared transfer operations instance.
+   * @return shared transfer operations instance bound to this core.
    */
   public NodeClientCoreTransfers getTransfers() {
     return transfers;
@@ -1518,9 +1562,9 @@ public class NodeClientCore implements Persistable {
    * <p>The {@link RequestStarterGroup} coordinates routing, throttling, and queue management for
    * both fetch and insert operations. The returned instance is shared and should be treated as
    * core-owned state managed by the node lifecycle. The accessor performs no I/O and returns the
-   * existing instance.
+   * existing instance, which may be accessed concurrently by multiple request paths.
    *
-   * @return shared {@link RequestStarterGroup} coordinating request starts.
+   * @return shared {@link RequestStarterGroup} coordinating request starts for this node.
    */
   public RequestStarterGroup getRequestStarters() {
     return requestStarters;
@@ -1532,7 +1576,7 @@ public class NodeClientCore implements Persistable {
    * <p>The token is generated during initialization and is used by HTTP forms to protect
    * state-changing requests. Callers should treat it as sensitive within UI contexts and avoid
    * exposing it outside expected request handling flows. The accessor performs no I/O and returns
-   * the stored token.
+   * the stored token immediately; it does not regenerate or rotate the value.
    *
    * @return anti-CSRF token string used by HTTP handlers and forms.
    */
@@ -1546,9 +1590,9 @@ public class NodeClientCore implements Persistable {
    * <p>The returned {@link TempBucketFactory} manages non-persistent temporary storage for client
    * operations. It is configured during initialization and shared across requests, so callers
    * should avoid modifying its lifecycle outside managed shutdown. The accessor performs no I/O and
-   * returns the existing instance.
+   * returns the existing instance, which may be used concurrently by client operations.
    *
-   * @return shared {@link TempBucketFactory} for ephemeral buckets.
+   * @return shared {@link TempBucketFactory} for ephemeral buckets used by clients.
    */
   public TempBucketFactory getTempBucketFactory() {
     return tempBucketFactory;
@@ -1560,9 +1604,9 @@ public class NodeClientCore implements Persistable {
    * <p>The returned {@link PersistentTempBucketFactory} manages restart-safe temporary storage for
    * client operations. It is configured during initialization and shared across requests, so
    * callers should avoid modifying its lifecycle outside managed shutdown. The accessor performs no
-   * I/O and returns the existing instance.
+   * I/O and returns the existing instance, which may be used concurrently by client operations.
    *
-   * @return shared {@link PersistentTempBucketFactory} for persistent buckets.
+   * @return shared {@link PersistentTempBucketFactory} for persistent buckets used by clients.
    */
   public PersistentTempBucketFactory getPersistentTempBucketFactory() {
     return persistentTempBucketFactory;
@@ -1574,9 +1618,9 @@ public class NodeClientCore implements Persistable {
    * <p>The {@link ClientLayerPersister} is responsible for loading and saving client-layer state
    * such as throttles and persistent requests. The returned instance is shared and should be
    * treated as core-owned service infrastructure. The accessor performs no I/O and returns the
-   * existing instance.
+   * existing instance, which may be used concurrently by persistence-related components.
    *
-   * @return shared {@link ClientLayerPersister} instance for persistence.
+   * @return shared {@link ClientLayerPersister} instance for client-layer persistence tasks here.
    */
   public ClientLayerPersister getClientLayerPersister() {
     return clientLayerPersister;
@@ -1588,9 +1632,9 @@ public class NodeClientCore implements Persistable {
    * <p>This provides access to the {@link Node} that created and owns this core. The node manages
    * lifecycle and executor resources, so callers should treat it as shared and avoid altering its
    * state except through supported APIs. The accessor performs no I/O and returns the existing
-   * instance.
+   * instance immediately.
    *
-   * @return owning {@link Node} instance for this core.
+   * @return owning {@link Node} instance for this core and lifecycle.
    */
   public Node getNode() {
     return node;
@@ -1601,9 +1645,10 @@ public class NodeClientCore implements Persistable {
    *
    * <p>The returned {@link RandomSource} is used for request IDs and other non-cryptographic needs.
    * It is shared across the core and should not be replaced or reseeded by callers. The accessor
-   * performs no I/O and returns the existing instance. Use it only for non-cryptographic purposes.
+   * performs no I/O and returns the existing instance. Use it only for non-cryptographic purposes
+   * and assume concurrent access from multiple request paths.
    *
-   * @return shared non-cryptographic {@link RandomSource} used by the core.
+   * @return shared non-cryptographic {@link RandomSource} instance used by the core.
    */
   public RandomSource getRandom() {
     return random;
@@ -1615,9 +1660,9 @@ public class NodeClientCore implements Persistable {
    * <p>The returned {@link UserAlertManager} coordinates user-facing alerts emitted by client
    * components. It is created during initialization and shared for the life of the node. The
    * accessor performs no I/O and returns the existing instance. Use it to register or clear alerts
-   * as needed by client-facing components.
+   * as needed by client-facing components, without attempting to manage its lifecycle directly.
    *
-   * @return shared {@link UserAlertManager} instance used for alerts.
+   * @return shared {@link UserAlertManager} instance used for client alerts lifecycle.
    */
   public UserAlertManager getAlerts() {
     return alerts;
@@ -1629,9 +1674,9 @@ public class NodeClientCore implements Persistable {
    * <p>The {@link DatastoreChecker} validates datastore health and is started during core startup.
    * The returned instance is shared and should be treated as core-owned service state. The accessor
    * performs no I/O and returns the existing instance. Use it to coordinate datastore checking
-   * tasks when needed.
+   * tasks when needed; lifecycle control is managed by the node.
    *
-   * @return shared {@link DatastoreChecker} instance for datastore checks.
+   * @return shared {@link DatastoreChecker} instance for datastore check tasks and lifecycle.
    */
   public DatastoreChecker getStoreChecker() {
     return storeChecker;
@@ -1643,9 +1688,9 @@ public class NodeClientCore implements Persistable {
    * <p>The {@link ClientContext} bundles shared configuration, caches, and schedulers used by
    * client requests. It is created during construction and is central to request execution, so
    * callers should treat it as shared, mutable state managed by the core. The accessor performs no
-   * I/O and returns the existing instance.
+   * I/O and returns the existing instance immediately; callers should not replace or shut it down.
    *
-   * @return shared {@link ClientContext} instance used by client APIs.
+   * @return shared {@link ClientContext} instance used by client APIs here.
    */
   public ClientContext getClientContext() {
     return clientContext;

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -403,7 +403,14 @@ public class NodeClientCore implements Persistable {
     // Some plugins depend on it, so it needs to be *created* before they are started.
 
     // TMCI and FCP (including persistent requests so needs to start before FProxy)
-    endpoints = ClientEndpoints.create(node, this, init, persistence, clientContext);
+    ClientEndpoints.InitResult endpointsInit =
+        ClientEndpoints.create(node, this, init, persistence, clientContext);
+    endpoints = endpointsInit.endpoints();
+    TextModeClientInterface directTMCI = endpointsInit.directTMCI();
+    if (directTMCI != null) {
+      endpoints.setDirectTMCI(directTMCI);
+      node.getExecutor().execute(directTMCI, "Direct text mode interface");
+    }
 
     // FProxy
     // Note: This wiring is a stopgap; plugins should handle this in the future.

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -57,17 +57,27 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Bridges the {@link Node} and the client layer.
+ * Coordinates the client-facing services layered on top of a {@link Node}.
  *
- * <p>This component wires and coordinates client-facing services such as request scheduling,
- * client-layer persistence, USK management, healing, FCP/TMCI endpoints, and the HTTP toadlet
- * container. It owns factories for temporary and persistent buckets, exposes a {@link
- * ClientContext} for higher-level APIs, and reports per-request costs to {@link NodeStats}.
+ * <p>{@code NodeClientCore} wires persistence, request scheduling, USK management, client
+ * endpoints, and temporary storage so higher-level APIs can operate against a single, consistent
+ * context. It builds and exposes a {@link ClientContext}, configures bucket factories for in-memory
+ * and on-disk use, and integrates with {@link NodeStats} to report per-request costs. Startup is
+ * multiphase: construction performs registration and wiring, while {@link #start()} activates
+ * background services and resumes persisted requests on a separate executor task. Most entry points
+ * run on node executor threads; accessors that expose mutable configuration state are synchronized
+ * to provide a stable snapshot.
  *
- * <p>Threading: methods are generally invoked from the node's executor threads; selected getters
- * are synchronized where they expose mutable state. Startup is multiphased: the constructor
- * performs wiring, {@link #start()} activates services and resumes persistent requests on a
- * background task.
+ * <ul>
+ *   <li>Provide client-layer factories and shared services for request handlers.
+ *   <li>Gate disk usage and security policy for downloads and uploads.
+ *   <li>Bridge persistence and throttling with node lifecycle events.
+ * </ul>
+ *
+ * @see Node
+ * @see ClientContext
+ * @see ClientEndpoints
+ * @see RequestStarterGroup
  */
 public class NodeClientCore implements Persistable {
   private static final Logger LOG = LoggerFactory.getLogger(NodeClientCore.class);
@@ -93,8 +103,9 @@ public class NodeClientCore implements Persistable {
   private final RequestStarterGroup requestStarters;
 
   /**
-   * Runs memory-bound background jobs (e.g., FEC decode) within a configured capacity and thread
-   * limit. Exposed for components that need to schedule such work explicitly.
+   * Runs memory-bounded background jobs such as FEC decoding within configured capacity and thread
+   * limits. The runner is shared by client operations, so callers should treat it as a long-lived
+   * service and avoid shutting it down directly; lifecycle is owned by the core.
    */
   public final MemoryLimitedJobRunner memoryLimitedJobRunner;
 
@@ -115,12 +126,6 @@ public class NodeClientCore implements Persistable {
   private boolean downloadDisabled;
   private File[] uploadAllowedDirs;
   private boolean uploadAllowedEverywhere;
-
-  /** Temp filename generator for ephemeral bucket file names. */
-  private final FilenameGenerator tempFilenameGenerator;
-
-  /** Persistent filename generator for restart-safe bucket file names. */
-  private final FilenameGenerator persistentFilenameGenerator;
 
   /** Temp bucket factory. Access via {@link #getTempBucketFactory()}. */
   private final TempBucketFactory tempBucketFactory;
@@ -149,7 +154,12 @@ public class NodeClientCore implements Persistable {
   /** Client-facing endpoints (TMCI, FCP, and FProxy wiring). */
   private final ClientEndpoints endpoints;
 
-  /** Compressor implementation used for network transfers and storage. */
+  /**
+   * Compressor used for network transfers and stored blocks.
+   *
+   * <p>The instance is created during construction and is shared across requests. Callers should
+   * treat it as a core-owned component and avoid reconfiguring it outside managed setup.
+   */
   public final RealCompressor compressor;
 
   /** Datastore consistency checker. Access via {@link #getStoreChecker()}. */
@@ -234,7 +244,8 @@ public class NodeClientCore implements Persistable {
 
     FileUtil.setOwnerRWX(getTempDir());
 
-    tempFilenameGenerator = createTempFilenameGeneratorOrThrow();
+    // Temp filename generator for ephemeral bucket file names.
+    FilenameGenerator tempFilenameGenerator = createTempFilenameGeneratorOrThrow();
 
     uskManager = new USKManager(this);
 
@@ -252,7 +263,8 @@ public class NodeClientCore implements Persistable {
 
     PersistentTempBucketFactory ptbf = createPersistentTempBucketFactory(init);
     this.persistentTempBucketFactory = ptbf;
-    this.persistentFilenameGenerator = ptbf.fg;
+    // Persistent filename generator for restart-safe bucket file names.
+    FilenameGenerator persistentFilenameGenerator = ptbf.fg;
 
     // Remove legacy persistent-blob file to reclaim space for migration.
     deleteOldPersistentBlobIfPresent();
@@ -407,8 +419,10 @@ public class NodeClientCore implements Persistable {
   /**
    * Recomputes the minimum free-disk threshold for the persistent RAF factory.
    *
-   * <p>Includes RAM-backed temp usage in the persistent threshold to account for possible migration
-   * of temporary data to disk.
+   * <p>The calculation adds the current RAM-backed temp bucket allowance to the configured
+   * long-term free-space requirement so the persistent RAF factory can accommodate a migration of
+   * temporary data to disk. It updates the persisted factory only when one is present and uses the
+   * current in-memory configuration snapshot to compute the threshold.
    */
   protected void updatePersistentRAFSpaceLimit() {
     // The temp bucket factory may have to migrate everything to disk.
@@ -1202,9 +1216,12 @@ public class NodeClientCore implements Persistable {
   /**
    * Returns whether downloads are globally disabled by configuration.
    *
-   * <p>When disabled, no target directory is considered eligible, regardless of the allowlist.
+   * <p>This flag is derived from the current allowlist configuration. When disabled, directory
+   * checks are short-circuited and no target is considered eligible, even if it matches an
+   * allowlisted path. The value is a snapshot and can change when configuration is updated at
+   * runtime.
    *
-   * @return {@code true} when all downloads are disabled.
+   * @return {@code true} if downloads are disabled and all targets are rejected.
    */
   public boolean isDownloadDisabled() {
     return downloadDisabled;
@@ -1213,12 +1230,12 @@ public class NodeClientCore implements Persistable {
   /**
    * Configures directories where downloads may be written.
    *
-   * <p>Recognized entries: - {@code "all"}: allow any destination. - {@code downloads}: allow the
-   * configured downloads directory. - any other string is treated as a filesystem path.
+   * <p>Recognized entries include {@code "all"} to allow any destination and {@code "downloads"} to
+   * allow the configured downloads directory. Any other string is treated as a filesystem path and
+   * stored as a {@link File}. Passing an empty array disables downloads entirely. The configuration
+   * is applied immediately and affects subsequent permission checks.
    *
-   * <p>Passing an empty array disables downloads.
-   *
-   * @param val allowlist entries as described above.
+   * @param val allowlist entries describing special tokens or absolute/relative paths.
    */
   protected synchronized void setDownloadAllowedDirs(String[] val) {
     int x = 0;
@@ -1244,10 +1261,12 @@ public class NodeClientCore implements Persistable {
   /**
    * Configures directories from which uploads may read.
    *
-   * <p>Recognized entries: - {@code "all"}: allow any source. - any other string is treated as a
-   * filesystem path.
+   * <p>Recognized entries include {@code "all"} to allow any source. Any other string is treated as
+   * a filesystem path and stored as a {@link File}. The configuration is applied immediately and
+   * affects subsequent permission checks for upload sources. The method performs no I/O and updates
+   * in-memory policy.
    *
-   * @param val allowlist entries as described above.
+   * @param val allowlist entries describing special tokens or filesystem paths.
    */
   protected synchronized void setUploadAllowedDirs(String[] val) {
     int x = 0;
@@ -1267,9 +1286,11 @@ public class NodeClientCore implements Persistable {
   /**
    * Starts client-layer services and resumes persisted requests.
    *
-   * <p>Side effects: - Starts request starters, the datastore checker, FCP/TMCI servers (when
-   * configured), and plugins. - Schedules asynchronous completion to migrate legacy buckets and
-   * resume pending requests.
+   * <p>This method activates request starters, the datastore checker, client endpoints, and
+   * plugins, then schedules a low-priority completion task to migrate persistent temporary buckets
+   * and resume pending requests. Call it during node startup after construction has finished
+   * wiring. Exceptions during migration are logged and do not prevent the remaining services from
+   * running.
    */
   public void start() {
 
@@ -1325,21 +1346,21 @@ public class NodeClientCore implements Persistable {
   /**
    * Starts an asynchronous fetch for a key.
    *
-   * <p>If the data is found locally the listener is notified and no network request is started. If
-   * a request is started, the listener receives completion or failure callbacks; some successful
-   * outcomes may be delivered via the pending-keys mechanism instead of the listener.
+   * <p>If the data is found locally the listener is notified and no network request is started.
+   * Otherwise, a request sender is created and the listener receives completion or failure
+   * callbacks; some successful outcomes may be delivered via the pending-keys mechanism instead of
+   * the listener. The call is non-blocking and returns after scheduling work using a freshly
+   * generated UID. Store access is controlled by {@code localOnly} and {@code ignoreStore}; when
+   * both are {@code false} the datastore is checked first and routing proceeds on miss.
    *
-   * @param key key to fetch.
-   * @param offersOnly when {@code true}, fetch only from nodes that have offered the key (via
-   *     GetOfferedKeys); no regular routing is used.
-   * @param listener callback for completion and most failure cases.
-   * @param canReadClientCache whether the request may read the client cache.
-   * @param canWriteClientCache whether the request may write the client cache.
-   * @param realTimeFlag {@code true} for latency-optimized requests; {@code false} for
-   *     throughput-optimized (bulk) requests.
-   * @param localOnly when {@code true}, check only the datastore and do not create a network
-   *     request on miss.
-   * @param ignoreStore when {@code true}, skip the datastore and create a request immediately.
+   * @param key key to fetch; typically a {@code CHK} or {@link NodeSSK}.
+   * @param offersOnly when true, fetch only from offered-key sources.
+   * @param listener callback notified on completion or failure of the request.
+   * @param canReadClientCache whether this request may read from the client cache.
+   * @param canWriteClientCache whether this request may write into the client cache.
+   * @param realTimeFlag true for latency-optimized routing; false for bulk throughput.
+   * @param localOnly true to check only local store and skip routing.
+   * @param ignoreStore true to bypass datastore and always create a request.
    */
   public void asyncGet(
       final Key key,
@@ -1408,6 +1429,8 @@ public class NodeClientCore implements Persistable {
    * @param realTimeFlag Is this a real-time request? False = this is a bulk request.
    * @param localOnly If true, only check the datastore, don't create a request if nothing is found.
    * @param ignoreStore If true, don't check the datastore, create a request immediately.
+   * @param isSSK Whether the request targets an SSK key type.
+   * @param startTime Start time in milliseconds since epoch for metrics.
    */
   @SuppressWarnings("java:S1181")
   private void startAsyncGet(
@@ -1456,6 +1479,7 @@ public class NodeClientCore implements Persistable {
            * @param status The completion status code reported by the sender.
            * @param fromOfferedKey {@code true} if this completion originated from an offered-key
            *     fetch path (GetOfferedKeys); {@code false} for a normal fetch.
+           * @param rs The sender that completed and reported the status.
            */
           @Override
           public void onRequestSenderFinished(
@@ -1517,17 +1541,19 @@ public class NodeClientCore implements Persistable {
   /**
    * Synchronously fetches a block for a client key.
    *
-   * <p>Depending on {@code localOnly} and {@code ignoreStore}, this may read from the datastore or
-   * perform a network request. On success, returns a verified client block.
+   * <p>This method blocks until the fetch completes or fails. Depending on {@code localOnly} and
+   * {@code ignoreStore}, it may read from the datastore or issue a routed request through the
+   * network. It returns a verified client block on success and throws a {@link
+   * LowLevelGetException} on any failure. The request uses an internally generated UID and releases
+   * tracking resources before returning.
    *
-   * @param key client key (CHK or SSK).
-   * @param localOnly when {@code true}, check only the datastore and do not create a network
-   *     request on miss.
-   * @param ignoreStore when {@code true}, skip the datastore and create a request immediately.
-   * @param canWriteClientCache whether the request may write the client cache.
-   * @param realTimeFlag {@code true} for latency-optimized requests; {@code false} for bulk.
-   * @return verified client block.
-   * @throws LowLevelGetException on not found, transfer failure, verify failure, or internal error.
+   * @param key client key to fetch; must be {@link ClientCHK} or {@link ClientSSK}.
+   * @param localOnly true to consult only the datastore and stop on miss.
+   * @param ignoreStore true to bypass datastore and route immediately.
+   * @param canWriteClientCache whether the request may write to the client cache.
+   * @param realTimeFlag true for latency-optimized routing; false for bulk routing.
+   * @return verified client block, owned by the caller for use.
+   * @throws LowLevelGetException when not found, verify fails, or internal errors occur.
    */
   public ClientKeyBlock realGetKey(
       ClientKey key,
@@ -1787,16 +1813,18 @@ public class NodeClientCore implements Persistable {
   /**
    * Inserts a block into the network.
    *
-   * <p>Accepts either CHK or SSK blocks. Reinserts may be performed depending on the block type and
-   * flags.
+   * <p>This entry point accepts either CHK or SSK blocks and dispatches to the appropriate insert
+   * path. It performs local bookkeeping, records costs, and may store the block locally according
+   * to caching rules. The call blocks until the insert completes or fails. Failures are mapped to
+   * {@link LowLevelPutException} codes describing routing, overload, or collision outcomes.
    *
-   * @param block block to insert.
+   * @param block block to insert; must be a {@link CHKBlock} or {@link SSKBlock}.
    * @param canWriteClientCache whether the insert may update the client cache.
    * @param forkOnCacheable whether to fork when the block is cacheable.
-   * @param preferInsert whether to prefer insert to other strategies when applicable.
+   * @param preferInsert whether to prefer insert when multiple strategies apply.
    * @param ignoreLowBackoff whether to ignore low backoff during routing.
-   * @param realTimeFlag {@code true} for latency-optimized; {@code false} for bulk.
-   * @throws LowLevelPutException on route failure, overload, or internal error.
+   * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
+   * @throws LowLevelPutException when routing fails, overload occurs, or an internal error arises.
    */
   public void realPut(
       KeyBlock block,
@@ -1827,6 +1855,22 @@ public class NodeClientCore implements Persistable {
     }
   }
 
+  /**
+   * Inserts a CHK block into the network and optionally caches it locally.
+   *
+   * <p>This variant constructs a CHK insert sender, waits for completion, reports costs, and stores
+   * the block according to cache policy. It blocks until the insert completes and throws a {@link
+   * LowLevelPutException} on routing failure, overload, or internal errors. The method generates
+   * and locks a request UID internally and releases it before returning.
+   *
+   * @param block CHK block to insert and potentially store locally.
+   * @param canWriteClientCache whether the insert may update the client cache.
+   * @param forkOnCacheable whether to fork when the block is cacheable.
+   * @param preferInsert whether to prefer insert when multiple strategies apply.
+   * @param ignoreLowBackoff whether to ignore low backoff during routing.
+   * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
+   * @throws LowLevelPutException when routing fails, overload occurs, or internal errors arise.
+   */
   public void realPutCHK(
       CHKBlock block,
       boolean canWriteClientCache,
@@ -1992,13 +2036,18 @@ public class NodeClientCore implements Persistable {
   /**
    * Inserts an SSK block.
    *
-   * @param block SSK block to insert.
+   * <p>This method performs a local collision check using the client cache, then starts an SSK
+   * insert sender and waits for completion. It reports costs, stores the block when appropriate,
+   * and throws {@link LowLevelPutException} for collisions, routing failures, overload, or internal
+   * errors. The call blocks until the insert completes and always releases the request UID.
+   *
+   * @param block SSK block to insert and potentially store locally.
    * @param canWriteClientCache whether the insert may update the client cache.
    * @param forkOnCacheable whether to fork when the block is cacheable.
-   * @param preferInsert whether to prefer insert to other strategies when applicable.
+   * @param preferInsert whether to prefer insert when multiple strategies apply.
    * @param ignoreLowBackoff whether to ignore low backoff during routing.
-   * @param realTimeFlag {@code true} for latency-optimized; {@code false} for bulk.
-   * @throws LowLevelPutException on collision, route failure, overload, or internal error.
+   * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
+   * @throws LowLevelPutException on collision, routing failure, overload, or internal error.
    */
   public void realPutSSK(
       SSKBlock block,
@@ -2192,13 +2241,17 @@ public class NodeClientCore implements Persistable {
   /**
    * Creates a high-level client bound to this core.
    *
-   * @param prioClass priority class for requests started by the client.
+   * <p>The returned client shares this core's {@link ClientContext}, bucket factories, and random
+   * source so its requests are scheduled and accounted for with the node. The client respects the
+   * provided priority class and real-time flag, which influence routing and throttling behavior.
+   * This method does not start network activity by itself; it only constructs a configured client
+   * instance.
+   *
+   * @param prioClass priority class assigned to requests from the client.
    * @param forceDontIgnoreTooManyPathComponents whether to disable path-component pruning for
-   *     requests that would otherwise ignore excessive path components.
-   * @param realTimeFlag {@code true} for latency-optimized requests; {@code false} for
-   *     throughput-optimized (bulk) requests. Fewer latency-optimized requests are accepted, but
-   *     they tend to complete faster; bulk requests may run more continuously.
-   * @return a configured {@link HighLevelSimpleClient} instance.
+   *     overly long paths.
+   * @param realTimeFlag true for latency-optimized requests; false for bulk requests.
+   * @return configured {@link HighLevelSimpleClient} bound to this core and context.
    */
   public HighLevelSimpleClient makeClient(
       short prioClass, boolean forceDontIgnoreTooManyPathComponents, boolean realTimeFlag) {
@@ -2211,16 +2264,43 @@ public class NodeClientCore implements Persistable {
         realTimeFlag);
   }
 
-  /** Returns client endpoints (FCP, TMCI, and HTTP toadlet container). */
+  /**
+   * Returns client endpoints (FCP, TMCI, and HTTP toadlet container).
+   *
+   * <p>The returned {@link ClientEndpoints} instance owns the lifecycle of the FCP and TMCI servers
+   * and the HTTP toadlet container for this node. It is created during construction and remains
+   * shared across the node lifecycle. Callers should treat it as core-owned and avoid stopping
+   * endpoints outside managed shutdown paths.
+   *
+   * @return the shared {@link ClientEndpoints} instance for this node.
+   */
   public ClientEndpoints getEndpoints() {
     return endpoints;
   }
 
-  /** Returns the configured downloads directory. */
+  /**
+   * Returns the configured downloads directory.
+   *
+   * <p>The directory is resolved during initialization and represents the default location used
+   * when downloads are permitted. The returned {@link File} is the internal instance used by the
+   * core, so callers should treat it as shared and avoid mutating configuration through it.
+   *
+   * @return configured downloads directory {@link File} used by permission checks.
+   */
   public File getDownloadsDir() {
     return downloadsDir;
   }
 
+  /**
+   * Queues a low-priority reinsert of a key block.
+   *
+   * <p>The block is wrapped in a {@link SimpleSendableInsert} and scheduled on the request starters
+   * at the maximum priority class for reinserts. The operation is asynchronous; it enqueues work
+   * and returns immediately without waiting for completion. Use it to refresh availability for
+   * already known data.
+   *
+   * @param block key block to reinsert and schedule for background routing.
+   */
   public void queueRandomReinsert(KeyBlock block) {
     SimpleSendableInsert ssi =
         new SimpleSendableInsert(this, block, RequestStarter.MAXIMUM_PRIORITY_CLASS);
@@ -2228,34 +2308,84 @@ public class NodeClientCore implements Persistable {
     ssi.schedule();
   }
 
-  /** Persists the current configuration to disk. */
+  /**
+   * Persists the current configuration to disk.
+   *
+   * <p>This triggers the node configuration store to write its current values to the configured
+   * storage location. The operation invokes the write immediately, but the underlying storage
+   * subsystem controls any buffering or durability semantics. Call it after changing configuration
+   * values that must survive restart.
+   */
   public void storeConfig() {
     LOG.info("Trying to write config to disk");
     node.getConfig().store();
   }
 
-  /** Returns whether the node runs in testnet mode. */
+  /**
+   * Returns whether the node runs in testnet mode.
+   *
+   * <p>This is a global setting that affects network compatibility and routing behavior. The value
+   * is determined by node configuration and is not modified by this method. Use it to gate features
+   * that should only operate on a test network. The accessor performs no I/O and does not modify
+   * state.
+   *
+   * @return {@code true} if the node is configured for testnet operation.
+   */
   @SuppressWarnings("unused")
   public boolean isTestnetEnabled() {
     return Node.isTestnetEnabled();
   }
 
-  /** Returns whether advanced-mode UI features are enabled in FProxy. */
+  /**
+   * Returns whether advanced-mode UI features are enabled in FProxy.
+   *
+   * <p>This flag is provided by the client endpoints configuration and controls whether advanced UI
+   * features are exposed in the HTTP interface. It reflects the current configuration snapshot and
+   * may change at runtime if settings are updated. The accessor performs no I/O and simply returns
+   * the current flag.
+   *
+   * @return {@code true} if advanced-mode UI features are enabled in FProxy.
+   */
   public boolean isAdvancedModeEnabled() {
     return endpoints.isAdvancedModeEnabled();
   }
 
-  /** Returns whether JavaScript is enabled in FProxy. */
+  /**
+   * Returns whether JavaScript is enabled in FProxy.
+   *
+   * <p>This flag reflects HTTP UI configuration and indicates whether the toadlet container should
+   * render pages that depend on client-side scripting. It is a snapshot of current settings and may
+   * change at runtime when configuration is updated. The accessor performs no I/O and simply
+   * returns the current flag.
+   *
+   * @return {@code true} if JavaScript is enabled for the HTTP UI.
+   */
   public boolean isFProxyJavascriptEnabled() {
     return endpoints.isFProxyJavascriptEnabled();
   }
 
-  /** Returns the node's user-visible name. */
+  /**
+   * Returns the node's user-visible name.
+   *
+   * <p>The name is managed by the {@link Node} configuration and can be displayed in UI surfaces or
+   * status messages. The value is a snapshot and may be empty if the user has not configured a
+   * custom name. The accessor performs no I/O and returns the current in-memory value.
+   *
+   * @return current user-visible node name, which may be empty.
+   */
   public String getMyName() {
     return node.getMyName();
   }
 
-  /** Returns the configured maximum number of background USK fetchers. */
+  /**
+   * Returns the configured maximum number of background USK fetchers.
+   *
+   * <p>This limit is loaded from configuration and is used by USK scheduling to cap concurrent
+   * background fetch activity. The value is a snapshot and can change if configuration is updated
+   * at runtime. Callers can use it to size background queues and avoid oversubscription.
+   *
+   * @return configured maximum number of concurrent background USK fetchers.
+   */
   @SuppressWarnings("unused")
   public int maxBackgroundUSKFetchers() {
     return maxBackgroundUSKFetchers;
@@ -2264,11 +2394,13 @@ public class NodeClientCore implements Persistable {
   /**
    * Returns whether a file path is permitted as a download target.
    *
-   * <p>Respects the physical threat level (denies at {@code MAXIMUM}) and the configured allowlist
-   * including the downloads directory when enabled.
+   * <p>This check enforces the current physical threat level and the configured download allowlist,
+   * including the downloads directory when enabled. If downloads are disabled by configuration, no
+   * target is accepted. The check uses parent-path matching and does not create directories or
+   * touch the filesystem beyond path comparisons.
    *
-   * @param filename target file path.
-   * @return {@code true} when writing under {@code filename} is allowed.
+   * @param filename target file path to validate against download allowlist.
+   * @return {@code true} if the path is allowed under current policy.
    */
   public boolean allowDownloadTo(File filename) {
     PHYSICAL_THREAT_LEVEL physicalThreatLevel = node.getSecurityLevels().getPhysicalThreatLevel();
@@ -2289,11 +2421,15 @@ public class NodeClientCore implements Persistable {
   }
 
   /**
-   * Returns whether a file path is permitted as an upload source according to the configured
-   * allowlist.
+   * Returns whether a file path is permitted as an upload source.
    *
-   * @param filename source file path.
-   * @return {@code true} when reading from {@code filename} is allowed.
+   * <p>This check uses the configured upload allowlist and does not verify file existence. The
+   * result is a snapshot of current configuration and is used to gate upload requests before any
+   * I/O occurs. Paths are matched by parent-directory containment. The method does not read file
+   * contents and only evaluates path hierarchy.
+   *
+   * @param filename source file path to validate against upload allowlist.
+   * @return {@code true} if the path is allowed as an upload source.
    */
   public synchronized boolean allowUploadFrom(File filename) {
     if (uploadAllowedEverywhere) return true;
@@ -2308,12 +2444,28 @@ public class NodeClientCore implements Persistable {
     return false;
   }
 
-  /** Returns the current allowlist for download destinations. */
+  /**
+   * Returns the current allowlist for download destinations.
+   *
+   * <p>The returned array contains the configured directories used for permission checks. It is a
+   * direct reference to internal state, so callers should not modify the array or its elements. The
+   * allowlist may be empty when downloads are disabled. No defensive copy is made.
+   *
+   * @return current allowlist array; entries are internal references, not copies.
+   */
   public synchronized File[] getAllowedDownloadDirs() {
     return downloadAllowedDirs;
   }
 
-  /** Returns the current allowlist for upload sources. */
+  /**
+   * Returns the current allowlist for upload sources.
+   *
+   * <p>The returned array contains the configured directories used for permission checks. It is a
+   * direct reference to internal state, so callers should not modify the array or its elements. The
+   * allowlist may be empty when no explicit sources are configured. No defensive copy is made.
+   *
+   * @return current allowlist array; entries are internal references, not copies.
+   */
   public synchronized File[] getAllowedUploadDirs() {
     return uploadAllowedDirs;
   }
@@ -2321,19 +2473,42 @@ public class NodeClientCore implements Persistable {
   /**
    * Serializes client throttle state to a field set for persistence.
    *
-   * @return throttles encoded as a {@link SimpleFieldSet}.
+   * <p>The returned {@link SimpleFieldSet} captures the current throttling configuration for
+   * request starters and schedulers so it can be written to persistent storage. The snapshot is
+   * intended for persistence and reload, not for direct mutation by callers. The method performs no
+   * I/O and only builds an in-memory structure.
+   *
+   * @return throttles encoded as a {@link SimpleFieldSet} snapshot for persistence.
    */
   @Override
   public SimpleFieldSet persistThrottlesToFieldSet() {
     return requestStarters.persistToFieldSet();
   }
 
-  /** Returns the directory used for persistent temporary buckets. */
+  /**
+   * Returns the directory used for persistent temporary buckets.
+   *
+   * <p>This directory is created during initialization and is used for restart-safe temporary
+   * storage. The returned {@link File} is the internal instance used by the core, so callers should
+   * treat it as shared and avoid changing its contents outside managed cleanup. The accessor
+   * performs no I/O and returns the current configuration value.
+   *
+   * @return directory used for persistent temporary bucket storage.
+   */
   public File getPersistentTempDir() {
     return persistentTempDir;
   }
 
-  /** Returns the directory used for ephemeral temporary buckets. */
+  /**
+   * Returns the directory used for ephemeral temporary buckets.
+   *
+   * <p>This directory is created during initialization and is used for short-lived temporary
+   * storage. The returned {@link File} is the internal instance used by the core, so callers should
+   * treat it as shared and avoid changing its contents outside managed cleanup. The accessor
+   * performs no I/O and returns the current configuration value.
+   *
+   * @return directory used for non-persistent temporary bucket storage.
+   */
   public File getTempDir() {
     return tempDir;
   }
@@ -2341,8 +2516,12 @@ public class NodeClientCore implements Persistable {
   /**
    * Queues a key that has been offered by peers to be fetched opportunistically.
    *
-   * @param key key to queue.
-   * @param realTime whether to queue on the real-time scheduler.
+   * <p>The key is placed on the scheduler corresponding to its type (SSK vs CHK) and the selected
+   * real-time or bulk queue. This operation is asynchronous; it only enqueues the key and returns.
+   * It is typically used when peers advertise availability via offered-key mechanisms.
+   *
+   * @param key offered key to enqueue for opportunistic fetching.
+   * @param realTime whether to enqueue on the real-time scheduler.
    */
   public void queueOfferedKey(Key key, boolean realTime) {
     requestStarters
@@ -2350,18 +2529,43 @@ public class NodeClientCore implements Persistable {
         .queueOfferedKey(key, realTime);
   }
 
-  /** Removes a previously queued offered key from both bulk and real-time schedulers. */
+  /**
+   * Removes a previously queued offered key from both bulk and real-time schedulers.
+   *
+   * <p>The removal is applied to both queue variants to avoid stale scheduling. If the key is not
+   * present, the operation has no observable effect and returns immediately. The method does not
+   * block on network activity or disk I/O. It only updates scheduler queues in memory.
+   *
+   * @param key offered key to remove from scheduler queues.
+   */
   public void dequeueOfferedKey(Key key) {
     requestStarters.getScheduler(key instanceof NodeSSK, false, false).dequeueOfferedKey(key);
     requestStarters.getScheduler(key instanceof NodeSSK, false, true).dequeueOfferedKey(key);
   }
 
-  /** Returns the total number of requests currently queued across schedulers. */
+  /**
+   * Returns the total number of requests currently queued across schedulers.
+   *
+   * <p>The count includes both real-time and bulk queues for CHK and SSK schedulers. The value is a
+   * snapshot of current state and can change immediately as requests are queued or completed. The
+   * method performs no blocking operations and returns immediately.
+   *
+   * @return total queued request count across all schedulers.
+   */
   public long countQueuedRequests() {
     return requestStarters.countQueuedRequests();
   }
 
-  /** Returns the global cap on background USK fetchers. */
+  /**
+   * Returns the global cap on background USK fetchers.
+   *
+   * <p>This static value is loaded from configuration during initialization. It is used by USK
+   * scheduling to limit concurrent background fetch activity across the node. The accessor performs
+   * no I/O and returns the current configured value. Callers typically use it to size background
+   * queues and avoid oversubscription.
+   *
+   * @return configured maximum number of background USK fetchers.
+   */
   public static int getMaxBackgroundUSKFetchers() {
     return maxBackgroundUSKFetchers;
   }
@@ -2371,8 +2575,12 @@ public class NodeClientCore implements Persistable {
   /**
    * Returns whether any fetch scheduler wants the given key.
    *
-   * @param key key to test.
-   * @return {@code true} if either real-time or bulk scheduler wants the key.
+   * <p>The method checks both real-time and bulk fetch schedulers for the key type (SSK vs CHK). It
+   * is used to decide whether to keep or forward offered keys and to avoid redundant work. The
+   * result is a snapshot and may change as scheduling state evolves.
+   *
+   * @param key key to test for scheduler interest.
+   * @return {@code true} if any scheduler currently wants the key.
    */
   public boolean wantKey(Key key) {
     boolean isSSK = key instanceof NodeSSK;
@@ -2383,28 +2591,55 @@ public class NodeClientCore implements Persistable {
   /**
    * Estimates the recency of failures for routing decisions.
    *
-   * <p>Performs a local probe equivalent to how {@link RequestSender} considers recent failures for
-   * a key at the originator, ensuring comparable behavior to running requests.
+   * <p>This performs a local probe equivalent to how {@link RequestSender} considers recent
+   * failures for a key at the originator, ensuring comparable behavior to running requests. The
+   * returned value is an internal metric and should only be used for relative comparisons in
+   * routing heuristics, not for display.
    *
-   * @param key target key.
-   * @param realTime when {@code true}, use real-time routing heuristics; otherwise bulk.
-   * @return a non-negative value indicating how recently the key failed (units are internal).
+   * @param key target key to probe for recent failures.
+   * @param realTime whether to use real-time routing heuristics or bulk.
+   * @return non-negative value indicating how recently the key failed.
    */
   public long checkRecentlyFailed(Key key, boolean realTime) {
     return NodeClientCoreSupport.checkRecentlyFailed(node, key, realTime);
   }
 
-  /** Returns the plugin stores accessor for this node. */
+  /**
+   * Returns the plugin stores accessor for this node.
+   *
+   * <p>The returned {@link PluginStores} instance provides access to plugin-managed storage and is
+   * created during core initialization. It is shared across the node lifecycle, so callers should
+   * treat it as core-owned and avoid replacing or shutting it down directly. The accessor performs
+   * no I/O and returns the existing instance.
+   *
+   * @return shared {@link PluginStores} instance used for plugin storage.
+   */
   public PluginStores getPluginStores() {
     return pluginStores;
   }
 
-  /** Minimum free-disk threshold for long-running jobs, in bytes. */
+  /**
+   * Returns the minimum free-disk threshold for long-running jobs, in bytes.
+   *
+   * <p>This value is configured via node settings and is used to gate operations with unpredictable
+   * duration, such as large downloads. The value is a snapshot and may change when configuration is
+   * updated at runtime. The accessor performs no I/O and returns the current threshold.
+   *
+   * @return minimum free-disk threshold for long-running jobs, in bytes.
+   */
   public synchronized long getMinDiskFreeLongTerm() {
     return minDiskFreeLongTerm;
   }
 
-  /** Minimum free-disk threshold for short, disk-heavy jobs, in bytes. */
+  /**
+   * Returns the minimum free-disk threshold for short, disk-heavy jobs, in bytes.
+   *
+   * <p>This value is configured via node settings and is used to gate operations such as completing
+   * downloads. The value is a snapshot and may change when configuration is updated at runtime. The
+   * accessor performs no I/O and returns the current threshold.
+   *
+   * @return minimum free-disk threshold for short disk-heavy jobs, in bytes.
+   */
   public synchronized long getMinDiskFreeShortTerm() {
     return minDiskFreeShortTerm;
   }
@@ -2412,13 +2647,26 @@ public class NodeClientCore implements Persistable {
   /**
    * Returns whether the client-layer database has been killed or not loaded.
    *
-   * @return {@code true} if persistence is unavailable.
+   * <p>This reflects the {@link ClientLayerPersister} state and indicates whether persistence is
+   * unavailable for client-layer data. It can be used to gate operations that require persisted
+   * state or to display warnings in UI surfaces. The accessor performs no I/O and simply reflects
+   * persister state.
+   *
+   * @return {@code true} if persistence is unavailable for client-layer data.
    */
   public boolean killedDatabase() {
     return this.getClientLayerPersister().isKilledOrNotLoaded();
   }
 
-  /** Returns the set of currently persisted FCP requests. */
+  /**
+   * Returns the set of currently persisted FCP requests.
+   *
+   * <p>The returned array is a snapshot of persisted request state at the time of the call. It may
+   * be empty if persistence is disabled or if no requests are stored. Callers should treat the
+   * array as read-only. The accessor performs no I/O and returns the in-memory snapshot.
+   *
+   * @return snapshot array of persisted {@link ClientRequest} entries.
+   */
   public ClientRequest[] getPersistentRequests() {
     return persistence.getPersistentRequests();
   }
@@ -2426,7 +2674,11 @@ public class NodeClientCore implements Persistable {
   /**
    * Installs the persistent master secret for encrypted resources and factories.
    *
-   * @param persistentSecret master secret to use.
+   * <p>If the client context does not already have a persistent secret, this method installs the
+   * provided secret and wires it into the persistent temp bucket factory and RAF persistence. It
+   * does not generate a secret; callers must supply one that is already initialized.
+   *
+   * @param persistentSecret master secret to use for persistent encryption state.
    */
   public void setupMasterSecret(MasterSecret persistentSecret) {
     if (getClientContext().getPersistentMasterSecret() == null)
@@ -2435,63 +2687,168 @@ public class NodeClientCore implements Persistable {
     persistence.setPersistentRafMasterSecret(persistentSecret);
   }
 
-  /** Returns whether the client-layer database has been loaded. */
+  /**
+   * Returns whether the client-layer database has been loaded.
+   *
+   * <p>This reflects whether the {@link ClientLayerPersister} has completed loading persistent
+   * state. It can be used to gate operations that depend on restored request queues or throttles.
+   * The accessor performs no I/O and simply reflects persister state. It does not trigger loading
+   * and does not alter persistence state.
+   *
+   * @return {@code true} if the client-layer database has been loaded.
+   */
   public boolean loadedDatabase() {
     return getClientLayerPersister().hasLoaded();
   }
 
-  /** Returns the component that persists bandwidth statistics. */
-  /** Returns the USK manager. */
+  /**
+   * Returns the USK manager.
+   *
+   * <p>The returned {@link USKManager} instance coordinates USK state and scheduling for this core.
+   * It is initialized during construction and is shared for the life of the node, so callers should
+   * treat it as core-owned. The accessor performs no I/O and returns the existing instance.
+   *
+   * @return shared {@link USKManager} instance for this core.
+   */
   public USKManager getUskManager() {
     return uskManager;
   }
 
-  /** Returns the group of request starters and schedulers. */
+  /**
+   * Returns the group of request starters and schedulers.
+   *
+   * <p>The {@link RequestStarterGroup} coordinates routing, throttling, and queue management for
+   * both fetch and insert operations. The returned instance is shared and should be treated as
+   * core-owned state managed by the node lifecycle. The accessor performs no I/O and returns the
+   * existing instance.
+   *
+   * @return shared {@link RequestStarterGroup} coordinating request starts.
+   */
   public RequestStarterGroup getRequestStarters() {
     return requestStarters;
   }
 
-  /** Returns the anti-CSRF token expected by HTTP handlers. */
+  /**
+   * Returns the anti-CSRF token expected by HTTP handlers.
+   *
+   * <p>The token is generated during initialization and is used by HTTP forms to protect
+   * state-changing requests. Callers should treat it as sensitive within UI contexts and avoid
+   * exposing it outside expected request handling flows. The accessor performs no I/O and returns
+   * the stored token.
+   *
+   * @return anti-CSRF token string used by HTTP handlers and forms.
+   */
   public String getFormPassword() {
     return formPassword;
   }
 
-  /** Returns the factory for ephemeral temporary buckets. */
+  /**
+   * Returns the factory for ephemeral temporary buckets.
+   *
+   * <p>The returned {@link TempBucketFactory} manages non-persistent temporary storage for client
+   * operations. It is configured during initialization and shared across requests, so callers
+   * should avoid modifying its lifecycle outside managed shutdown. The accessor performs no I/O and
+   * returns the existing instance.
+   *
+   * @return shared {@link TempBucketFactory} for ephemeral buckets.
+   */
   public TempBucketFactory getTempBucketFactory() {
     return tempBucketFactory;
   }
 
-  /** Returns the factory for persistent temporary buckets. */
+  /**
+   * Returns the factory for persistent temporary buckets.
+   *
+   * <p>The returned {@link PersistentTempBucketFactory} manages restart-safe temporary storage for
+   * client operations. It is configured during initialization and shared across requests, so
+   * callers should avoid modifying its lifecycle outside managed shutdown. The accessor performs no
+   * I/O and returns the existing instance.
+   *
+   * @return shared {@link PersistentTempBucketFactory} for persistent buckets.
+   */
   public PersistentTempBucketFactory getPersistentTempBucketFactory() {
     return persistentTempBucketFactory;
   }
 
-  /** Returns the client-layer persister. */
+  /**
+   * Returns the client-layer persister.
+   *
+   * <p>The {@link ClientLayerPersister} is responsible for loading and saving client-layer state
+   * such as throttles and persistent requests. The returned instance is shared and should be
+   * treated as core-owned service infrastructure. The accessor performs no I/O and returns the
+   * existing instance.
+   *
+   * @return shared {@link ClientLayerPersister} instance for persistence.
+   */
   public ClientLayerPersister getClientLayerPersister() {
     return clientLayerPersister;
   }
 
-  /** Returns the owning node. */
+  /**
+   * Returns the owning node.
+   *
+   * <p>This provides access to the {@link Node} that created and owns this core. The node manages
+   * lifecycle and executor resources, so callers should treat it as shared and avoid altering its
+   * state except through supported APIs. The accessor performs no I/O and returns the existing
+   * instance.
+   *
+   * @return owning {@link Node} instance for this core.
+   */
   public Node getNode() {
     return node;
   }
 
-  /** Returns the non-cryptographic random source used by this component. */
+  /**
+   * Returns the non-cryptographic random source used by this component.
+   *
+   * <p>The returned {@link RandomSource} is used for request IDs and other non-cryptographic needs.
+   * It is shared across the core and should not be replaced or reseeded by callers. The accessor
+   * performs no I/O and returns the existing instance. Use it only for non-cryptographic purposes.
+   *
+   * @return shared non-cryptographic {@link RandomSource} used by the core.
+   */
   public RandomSource getRandom() {
     return random;
   }
 
-  /** Returns the user-alert manager. */
+  /**
+   * Returns the user-alert manager.
+   *
+   * <p>The returned {@link UserAlertManager} coordinates user-facing alerts emitted by client
+   * components. It is created during initialization and shared for the life of the node. The
+   * accessor performs no I/O and returns the existing instance. Use it to register or clear alerts
+   * as needed by client-facing components.
+   *
+   * @return shared {@link UserAlertManager} instance used for alerts.
+   */
   public UserAlertManager getAlerts() {
     return alerts;
   }
 
-  /** Returns the datastore consistency checker. */
+  /**
+   * Returns the datastore consistency checker.
+   *
+   * <p>The {@link DatastoreChecker} validates datastore health and is started during core startup.
+   * The returned instance is shared and should be treated as core-owned service state. The accessor
+   * performs no I/O and returns the existing instance. Use it to coordinate datastore checking
+   * tasks when needed.
+   *
+   * @return shared {@link DatastoreChecker} instance for datastore checks.
+   */
   public DatastoreChecker getStoreChecker() {
     return storeChecker;
   }
 
-  /** Returns the client context shared with higher-level client APIs. */
+  /**
+   * Returns the client context shared with higher-level client APIs.
+   *
+   * <p>The {@link ClientContext} bundles shared configuration, caches, and schedulers used by
+   * client requests. It is created during construction and is central to request execution, so
+   * callers should treat it as shared, mutable state managed by the core. The accessor performs no
+   * I/O and returns the existing instance.
+   *
+   * @return shared {@link ClientContext} instance used by client APIs.
+   */
   public ClientContext getClientContext() {
     return clientContext;
   }

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -194,7 +194,7 @@ public class NodeClientCore implements Persistable {
       throws NodeInitException {
     this.node = node;
     this.random = node.getRandom();
-    this.pluginStores = new PluginStores(node, init.getInstallConfig());
+    this.pluginStores = new PluginStores(node, init.installConfig());
 
     sortOrder = registerLazyStartDatastoreChecker(init, sortOrder);
 
@@ -206,7 +206,7 @@ public class NodeClientCore implements Persistable {
     compressor = new RealCompressor();
     this.formPassword = Base64.encode(pwdBuf);
     alerts = new UserAlertManager(this);
-    persistence = new NodeClientPersistence(this, init.getNodeConfig(), node, sortOrder);
+    persistence = new NodeClientPersistence(this, init.nodeConfig(), node, sortOrder);
     sortOrder = persistence.getSortOrderAfter();
 
     SimpleFieldSet throttleFS = persistence.readThrottle();
@@ -223,7 +223,7 @@ public class NodeClientCore implements Persistable {
     this.tempDir =
         NodeClientCoreSupport.setupProgramDirFile(
             node,
-            init.getInstallConfig(),
+            init.installConfig(),
             "tempDir",
             new File(defaultCacheDir, "tmp").getPath(),
             "NodeClientCore.tempDir",
@@ -244,7 +244,7 @@ public class NodeClientCore implements Persistable {
     this.persistentTempDir =
         NodeClientCoreSupport.setupProgramDirFile(
             node,
-            init.getInstallConfig(),
+            init.installConfig(),
             "persistentTempDir",
             new File(defaultCacheDir, "persistent-temp").getPath(),
             "NodeClientCore.persistentTempDir",
@@ -276,9 +276,9 @@ public class NodeClientCore implements Persistable {
         new TempBucketFactory(
             node.getExecutor(),
             tempFilenameGenerator,
-            init.getNodeConfig().getLong("maxRAMBucketSize"),
-            init.getNodeConfig().getLong("RAMBucketPoolSize"),
-            init.getNodeConfig().getBoolean("encryptTempBuckets"),
+            init.nodeConfig().getLong("maxRAMBucketSize"),
+            init.nodeConfig().getLong("RAMBucketPoolSize"),
+            init.nodeConfig().getBoolean("encryptTempBuckets"),
             minDiskFreeShortTerm,
             cryptoSecretTransient);
 
@@ -309,7 +309,7 @@ public class NodeClientCore implements Persistable {
         persistentTempDir,
         minDiskFreeLongTerm,
         tempBucketFactory,
-        init.getNodeConfig().getBoolean(CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS));
+        init.nodeConfig().getBoolean(CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS));
     persistence.installDiskChecker(persistentTempBucketFactory);
     HighLevelSimpleClient client = makeClient((short) 0, false, false);
     FetchContext defaultFetchContext = client.getFetchContext();
@@ -323,8 +323,8 @@ public class NodeClientCore implements Persistable {
         registerMemoryLimitedJobMemoryLimit(init, sortOrder, defaultMemoryLimitedJobMemoryLimit);
     memoryLimitedJobRunner =
         new MemoryLimitedJobRunner(
-            init.getNodeConfig().getLong("memoryLimitedJobMemoryLimit"),
-            init.getNodeConfig().getInt("memoryLimitedJobThreadLimit"),
+            init.nodeConfig().getLong("memoryLimitedJobMemoryLimit"),
+            init.nodeConfig().getInt("memoryLimitedJobThreadLimit"),
             node.getExecutor(),
             RequestStarter.NUMBER_OF_PRIORITY_CLASSES);
     installFecShutdownHooks(shutdownHook);
@@ -369,7 +369,7 @@ public class NodeClientCore implements Persistable {
     this.downloadsDir =
         NodeClientCoreSupport.setupProgramDirFile(
             node,
-            init.getNodeConfig(),
+            init.nodeConfig(),
             "downloadsDir",
             new File(defaultDataDir, DOWNLOADS_DIR_NAME).getPath(),
             "NodeClientCore.downloadsDir",
@@ -400,7 +400,7 @@ public class NodeClientCore implements Persistable {
     endpoints.configureBucketFactory(tempBucketFactory);
 
     registerAlwaysCommit(init, sortOrder);
-    alwaysCommit = init.getNodeConfig().getBoolean("alwaysCommit");
+    alwaysCommit = init.nodeConfig().getBoolean("alwaysCommit");
     NodeClientCoreSupport.registerStorageAlerts(alerts, this);
   }
 
@@ -424,7 +424,7 @@ public class NodeClientCore implements Persistable {
   }
 
   private void initDiskSpaceLimits(NodeClientCoreInit init, int sortOrder) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "minDiskFreeLongTerm",
             "1G",
@@ -453,9 +453,9 @@ public class NodeClientCore implements Persistable {
               }
             },
             true);
-    minDiskFreeLongTerm = init.getNodeConfig().getLong("minDiskFreeLongTerm");
+    minDiskFreeLongTerm = init.nodeConfig().getLong("minDiskFreeLongTerm");
 
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "minDiskFreeShortTerm",
             "512M",
@@ -484,7 +484,7 @@ public class NodeClientCore implements Persistable {
               }
             },
             true);
-    minDiskFreeShortTerm = init.getNodeConfig().getLong("minDiskFreeShortTerm");
+    minDiskFreeShortTerm = init.nodeConfig().getLong("minDiskFreeShortTerm");
     // Do not register the UserAlert yet, since we haven't finished constructing stuff it uses.
   }
 
@@ -636,7 +636,7 @@ public class NodeClientCore implements Persistable {
           persistentTempDir,
           "freenet-temp-",
           node.getFastWeakRandom(),
-          init.getNodeConfig().getBoolean(CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS));
+          init.nodeConfig().getBoolean(CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS));
     } catch (IOException e) {
       String msg = "Could not find or create persistent temporary directory: " + e;
       LOG.error(msg, e);
@@ -753,7 +753,7 @@ public class NodeClientCore implements Persistable {
       throws NodeInitException {
     try {
       return new RequestStarterGroup(
-          node, this, portNumber, random, init.getConfig(), throttleFS, clientContext);
+          node, this, portNumber, random, init.config(), throttleFS, clientContext);
     } catch (InvalidConfigValueException e1) {
       throw new NodeInitException(NodeInitException.EXIT_BAD_CONFIG, e1.toString());
     }
@@ -857,7 +857,7 @@ public class NodeClientCore implements Persistable {
   }
 
   private static int registerMaxBackgroundUSKFetchers(NodeClientCoreInit init, int sortOrder) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "maxBackgroundUSKFetchers",
             64,
@@ -882,12 +882,12 @@ public class NodeClientCore implements Persistable {
               }
             },
             false);
-    maxBackgroundUSKFetchers = init.getNodeConfig().getInt("maxBackgroundUSKFetchers");
+    maxBackgroundUSKFetchers = init.nodeConfig().getInt("maxBackgroundUSKFetchers");
     return sortOrder + 1;
   }
 
   private int registerDownloadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "downloadAllowedDirs",
             new String[] {"all"},
@@ -916,12 +916,12 @@ public class NodeClientCore implements Persistable {
                 setDownloadAllowedDirs(val);
               }
             });
-    setDownloadAllowedDirs(init.getNodeConfig().getStringArr("downloadAllowedDirs"));
+    setDownloadAllowedDirs(init.nodeConfig().getStringArr("downloadAllowedDirs"));
     return sortOrder + 1;
   }
 
   private int registerUploadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "uploadAllowedDirs",
             new String[] {"all"},
@@ -948,13 +948,13 @@ public class NodeClientCore implements Persistable {
                 setUploadAllowedDirs(val);
               }
             });
-    setUploadAllowedDirs(init.getNodeConfig().getStringArr("uploadAllowedDirs"));
+    setUploadAllowedDirs(init.nodeConfig().getStringArr("uploadAllowedDirs"));
     return sortOrder + 1;
   }
 
   private int registerMemoryLimitedJobThreadLimit(
       NodeClientCoreInit init, int sortOrder, int maxMemoryLimitedJobThreads) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "memoryLimitedJobThreadLimit",
             maxMemoryLimitedJobThreads,
@@ -984,7 +984,7 @@ public class NodeClientCore implements Persistable {
 
   private int registerMemoryLimitedJobMemoryLimit(
       NodeClientCoreInit init, int sortOrder, long defaultMemoryLimitedJobMemoryLimit) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "memoryLimitedJobMemoryLimit",
             defaultMemoryLimitedJobMemoryLimit,
@@ -1018,7 +1018,7 @@ public class NodeClientCore implements Persistable {
 
   @SuppressWarnings("UnusedReturnValue")
   private int registerAlwaysCommit(NodeClientCoreInit init, int sortOrder) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "alwaysCommit",
             false,
@@ -1043,7 +1043,7 @@ public class NodeClientCore implements Persistable {
   }
 
   private int registerMaxRamBucketSize(NodeClientCoreInit init, int sortOrder, long maxBucketSize) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "maxRAMBucketSize",
             SizeUtil.formatSizeWithoutSpace(maxBucketSize),
@@ -1071,7 +1071,7 @@ public class NodeClientCore implements Persistable {
 
   private int registerRamBucketPoolSize(
       NodeClientCoreInit init, int sortOrder, int defaultRamBucketPoolSize) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "RAMBucketPoolSize",
             defaultRamBucketPoolSize + "MiB",
@@ -1099,7 +1099,7 @@ public class NodeClientCore implements Persistable {
   }
 
   private int registerEncryptTempBuckets(NodeClientCoreInit init, int sortOrder) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "encryptTempBuckets",
             true,
@@ -1125,7 +1125,7 @@ public class NodeClientCore implements Persistable {
   }
 
   private int registerEncryptPersistentTempBuckets(NodeClientCoreInit init, int sortOrder) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS,
             true,
@@ -1165,7 +1165,7 @@ public class NodeClientCore implements Persistable {
   }
 
   private int registerLazyStartDatastoreChecker(NodeClientCoreInit init, int sortOrder) {
-    init.getNodeConfig()
+    init.nodeConfig()
         .register(
             "lazyStartDatastoreChecker",
             false,
@@ -1195,7 +1195,7 @@ public class NodeClientCore implements Persistable {
                 }
               }
             });
-    lazyStartDatastoreChecker = init.getNodeConfig().getBoolean("lazyStartDatastoreChecker");
+    lazyStartDatastoreChecker = init.nodeConfig().getBoolean("lazyStartDatastoreChecker");
     return sortOrder + 1;
   }
 

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -1,14 +1,9 @@
 package network.crypta.node;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import network.crypta.client.FECCodec;
 import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientLayerPersister;
@@ -19,25 +14,12 @@ import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
-import network.crypta.io.xfer.AbortedException;
-import network.crypta.io.xfer.PartiallyReceivedBlock;
-import network.crypta.keys.CHKBlock;
-import network.crypta.keys.CHKVerifyException;
-import network.crypta.keys.ClientCHK;
-import network.crypta.keys.ClientKey;
-import network.crypta.keys.ClientKeyBlock;
-import network.crypta.keys.ClientSSK;
 import network.crypta.keys.Key;
-import network.crypta.keys.KeyBlock;
 import network.crypta.keys.NodeSSK;
-import network.crypta.keys.SSKBlock;
-import network.crypta.keys.SSKVerifyException;
-import network.crypta.l10n.NodeL10n;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.pluginmanager.PluginRespirator;
 import network.crypta.pluginmanager.PluginStores;
-import network.crypta.store.KeyCollisionException;
 import network.crypta.support.Base64;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MemoryLimitedJobRunner;
@@ -46,7 +28,6 @@ import network.crypta.support.SizeUtil;
 import network.crypta.support.api.BooleanCallback;
 import network.crypta.support.api.IntCallback;
 import network.crypta.support.api.LongCallback;
-import network.crypta.support.api.StringArrCallback;
 import network.crypta.support.compress.RealCompressor;
 import network.crypta.support.io.FileUtil;
 import network.crypta.support.io.FilenameGenerator;
@@ -83,11 +64,6 @@ public class NodeClientCore implements Persistable {
   private static final Logger LOG = LoggerFactory.getLogger(NodeClientCore.class);
   private static final String CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS = "encryptPersistentTempBuckets";
   private static final String DOWNLOADS_DIR_NAME = "downloads";
-  private static final String LOG_BYTES_OPEN = " bytes (";
-  private static final String MSG_CANNOT_LOCK_UID = "Could not lock UID just randomly generated: ";
-  private static final String MSG_BROKEN_PRNG = " - probably indicates broken PRNG";
-  private static final String LOG_DOES_NOT_VERIFY = "Does not verify: ";
-
   // Maximum number of healing inserts. If a 320 MiB file barely succeeds,
   // it has ~10,000 blocks eligible for healing (10,000 × 32 KiB).
   // Large-file lifetime is currently 7–14 days; with a 10,000-key cap a 320 MiB file
@@ -101,6 +77,9 @@ public class NodeClientCore implements Persistable {
 
   /** Request starter group. Access via {@link #getRequestStarters()}. */
   private final RequestStarterGroup requestStarters;
+
+  /** Fetch/insert operations bound to this core. Access via {@link #getTransfers()}. */
+  private final NodeClientCoreTransfers transfers;
 
   /**
    * Runs memory-bounded background jobs such as FEC decoding within configured capacity and thread
@@ -120,12 +99,7 @@ public class NodeClientCore implements Persistable {
   private final String formPassword;
 
   final File downloadsDir;
-  private File[] downloadAllowedDirs;
-  private boolean includeDownloadDir;
-  private boolean downloadAllowedEverywhere;
-  private boolean downloadDisabled;
-  private File[] uploadAllowedDirs;
-  private boolean uploadAllowedEverywhere;
+  private final NodeClientCoreTransferPolicy transferPolicy;
 
   /** Temp bucket factory. Access via {@link #getTempBucketFactory()}. */
   private final TempBucketFactory tempBucketFactory;
@@ -330,9 +304,10 @@ public class NodeClientCore implements Persistable {
     sortOrder = registerMemoryLimitedJobThreadLimit(init, sortOrder, maxMemoryLimitedJobThreads);
     long overallMemoryLimit = NodeStarter.getMemoryLimitBytes();
     long defaultMemoryLimitedJobMemoryLimit =
-        computeDefaultMemoryLimitedJobMemoryLimit(overallMemoryLimit);
+        NodeClientCoreSupport.computeDefaultMemoryLimitedJobMemoryLimit(overallMemoryLimit);
     sortOrder =
-        registerMemoryLimitedJobMemoryLimit(init, sortOrder, defaultMemoryLimitedJobMemoryLimit);
+        NodeClientCoreSupport.registerMemoryLimitedJobMemoryLimit(
+            init, sortOrder, defaultMemoryLimitedJobMemoryLimit, this);
     memoryLimitedJobRunner =
         new MemoryLimitedJobRunner(
             init.nodeConfig().getLong("memoryLimitedJobMemoryLimit"),
@@ -369,6 +344,7 @@ public class NodeClientCore implements Persistable {
     getClientLayerPersister().start(getClientContext());
 
     requestStarters = createRequestStarters(node, portNumber, init, throttleFS);
+    transfers = new NodeClientCoreTransfers(this);
 
     clientContext.init(requestStarters, alerts);
 
@@ -386,13 +362,14 @@ public class NodeClientCore implements Persistable {
             new File(defaultDataDir, DOWNLOADS_DIR_NAME).getPath(),
             "NodeClientCore.downloadsDir",
             "NodeClientCore.downloadsDirLong",
-            l10n("couldNotFindOrCreateDir"));
+            NodeClientCoreSupport.l10n("couldNotFindOrCreateDir"));
+    this.transferPolicy = new NodeClientCoreTransferPolicy(node, downloadsDir);
 
     // Downloads allowed, uploads allowed
 
-    sortOrder = registerDownloadAllowedDirs(init, sortOrder);
+    sortOrder = transferPolicy.registerDownloadAllowedDirs(init, sortOrder);
 
-    sortOrder = registerUploadAllowedDirs(init, sortOrder);
+    sortOrder = transferPolicy.registerUploadAllowedDirs(init, sortOrder);
 
     LOG.info("Initializing USK Manager");
     uskManager.init(getClientContext());
@@ -415,7 +392,11 @@ public class NodeClientCore implements Persistable {
     // FProxy
     // Note: This wiring is a stopgap; plugins should handle this in the future.
     endpoints.registerStartupAlerts(
-        alerts, this, l10n("startingUpTitle"), l10n("startingUp"), l10n("startingUpShort"));
+        alerts,
+        this,
+        NodeClientCoreSupport.l10n("startingUpTitle"),
+        NodeClientCoreSupport.l10n("startingUp"),
+        NodeClientCoreSupport.l10n("startingUpShort"));
     endpoints.configureBucketFactory(tempBucketFactory);
 
     registerAlwaysCommit(init, sortOrder);
@@ -467,7 +448,8 @@ public class NodeClientCore implements Persistable {
               public void set(Long val) throws InvalidConfigValueException {
                 synchronized (NodeClientCore.this) {
                   if (val < 0)
-                    throw new InvalidConfigValueException(l10n("minDiskFreeMustBePositive"));
+                    throw new InvalidConfigValueException(
+                        NodeClientCoreSupport.l10n("minDiskFreeMustBePositive"));
                   minDiskFreeLongTerm = val;
                 }
                 updatePersistentRAFSpaceLimit();
@@ -498,7 +480,8 @@ public class NodeClientCore implements Persistable {
               public void set(Long val) throws InvalidConfigValueException {
                 synchronized (NodeClientCore.this) {
                   if (val < 0)
-                    throw new InvalidConfigValueException(l10n("minDiskFreeMustBePositive"));
+                    throw new InvalidConfigValueException(
+                        NodeClientCoreSupport.l10n("minDiskFreeMustBePositive"));
                   minDiskFreeShortTerm = val;
                 }
                 tempBucketFactory.setMinDiskSpace(val);
@@ -566,79 +549,20 @@ public class NodeClientCore implements Persistable {
     }
   }
 
-  private static String l10n(String key) {
-    return NodeL10n.getBase().getString("NodeClientCore." + key);
-  }
-
   // Note: Use NodeL10n.getBase().getString("NodeClientCore.<key>", pattern, value) directly
   // when parameter substitution is needed.
 
-  private void handleAsyncGetFinished(
-      boolean isSSK,
-      RequestCompletionListener listener,
-      long startTime,
-      Key key,
-      boolean realTimeFlag,
-      RequestSender rs,
-      boolean rejectedOverload) {
-    int status = rs.getStatus();
-    if (status == RequestSender.NOT_FINISHED) {
-      LOG.error("Bogus status in onRequestSenderFinished for {}", rs, new Exception("error"));
-      listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
-      return;
+  /**
+   * Generates a random UID for requests.
+   *
+   * <p>Note: {@code -1} is reserved internally and is never returned. If a peer uses {@code -1} it
+   * is merely scheduled more slowly (round-robin with no-UID messages).
+   */
+  long makeUID() {
+    while (true) {
+      long uid = random.nextLong();
+      if (uid != -1) return uid;
     }
-
-    if (isNonErrorStatus(status)) reportFetchCosts(isSSK, rs, status);
-
-    if (status == RequestSender.TIMED_OUT || status == RequestSender.GENERATED_REJECTED_OVERLOAD) {
-      handleTimeoutOrRejected(isSSK, realTimeFlag, startTime, key, rejectedOverload);
-    } else if (rs.hasForwarded() && isForwardedTerminalStatus(status)) {
-      handleForwardedStatuses(isSSK, realTimeFlag, startTime, key, status);
-    }
-
-    if (status == RequestSender.SUCCESS) {
-      listener.onSucceeded();
-      return;
-    }
-    handleStatusResult(isSSK, listener, rs, status);
-  }
-
-  private boolean isNonErrorStatus(int status) {
-    return status != RequestSender.TIMED_OUT
-        && status != RequestSender.GENERATED_REJECTED_OVERLOAD
-        && status != RequestSender.INTERNAL_ERROR;
-  }
-
-  private void reportFetchCosts(boolean isSSK, RequestSender rs, int status) {
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "{} fetch cost {}/{}" + LOG_BYTES_OPEN + "{})",
-          isSSK ? "SSK" : "CHK",
-          rs.getTotalSentBytes(),
-          rs.getTotalReceivedBytes(),
-          status);
-    (isSSK
-            ? node.getNodeStats().localSskFetchBytesSentAverage
-            : node.getNodeStats().localChkFetchBytesSentAverage)
-        .report(rs.getTotalSentBytes());
-    (isSSK
-            ? node.getNodeStats().localSskFetchBytesReceivedAverage
-            : node.getNodeStats().localChkFetchBytesReceivedAverage)
-        .report(rs.getTotalReceivedBytes());
-    if (status == RequestSender.SUCCESS)
-      (isSSK
-              ? node.getNodeStats().successfulSskFetchBytesReceivedAverage
-              : node.getNodeStats().successfulChkFetchBytesReceivedAverage)
-          .report(rs.getTotalReceivedBytes());
-  }
-
-  private boolean isForwardedTerminalStatus(int status) {
-    return status == RequestSender.DATA_NOT_FOUND
-        || status == RequestSender.RECENTLY_FAILED
-        || status == RequestSender.SUCCESS
-        || status == RequestSender.ROUTE_NOT_FOUND
-        || status == RequestSender.VERIFY_FAILURE
-        || status == RequestSender.GET_OFFER_VERIFY_FAILURE;
   }
 
   private FilenameGenerator createTempFilenameGeneratorOrThrow() throws NodeInitException {
@@ -694,79 +618,10 @@ public class NodeClientCore implements Persistable {
     return sz;
   }
 
-  private void handleTimeoutOrRejected(
-      boolean isSSK, boolean realTimeFlag, long startTime, Key key, boolean rejectedOverload) {
-    if (rejectedOverload) return;
-    requestStarters.rejectedOverload(isSSK, false, realTimeFlag);
-    long rtt = System.currentTimeMillis() - startTime;
-    double targetLocation = key.toNormalizedDouble();
-    if (isSSK) node.getNodeStats().reportSSKOutcome(rtt, false, realTimeFlag);
-    else node.getNodeStats().reportCHKOutcome(rtt, false, targetLocation, realTimeFlag);
-  }
-
-  private void handleForwardedStatuses(
-      boolean isSSK, boolean realTimeFlag, long startTime, Key key, int status) {
-    long rtt = System.currentTimeMillis() - startTime;
-    double targetLocation = key.toNormalizedDouble();
-    requestStarters.requestCompleted(isSSK, false, key, realTimeFlag);
-    requestStarters.getThrottle(isSSK, false, realTimeFlag).successfulCompletion(rtt);
-    if (isSSK)
-      node.getNodeStats().reportSSKOutcome(rtt, status == RequestSender.SUCCESS, realTimeFlag);
-    else
-      node.getNodeStats()
-          .reportCHKOutcome(rtt, status == RequestSender.SUCCESS, targetLocation, realTimeFlag);
-    if (status == RequestSender.SUCCESS) {
-      LOG.debug("Successful {} fetch took {}", isSSK ? "SSK" : "CHK", rtt);
-    }
-  }
-
-  private void handleStatusResult(
-      boolean isSSK, RequestCompletionListener listener, RequestSender rs, int status) {
-    switch (status) {
-      case RequestSender.NOT_FINISHED:
-        LOG.error("RS still running in get{}!: {}", isSSK ? "SSK" : "CHK", rs);
-        listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
-        return;
-      case RequestSender.DATA_NOT_FOUND:
-        listener.onFailed(new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND));
-        return;
-      case RequestSender.RECENTLY_FAILED:
-        listener.onFailed(new LowLevelGetException(LowLevelGetException.RECENTLY_FAILED));
-        return;
-      case RequestSender.ROUTE_NOT_FOUND:
-        listener.onFailed(new LowLevelGetException(LowLevelGetException.ROUTE_NOT_FOUND));
-        return;
-      case RequestSender.TRANSFER_FAILED, RequestSender.GET_OFFER_TRANSFER_FAILED:
-        listener.onFailed(new LowLevelGetException(LowLevelGetException.TRANSFER_FAILED));
-        return;
-      case RequestSender.VERIFY_FAILURE, RequestSender.GET_OFFER_VERIFY_FAILURE:
-        listener.onFailed(new LowLevelGetException(LowLevelGetException.VERIFY_FAILED));
-        return;
-      case RequestSender.GENERATED_REJECTED_OVERLOAD, RequestSender.TIMED_OUT:
-        listener.onFailed(new LowLevelGetException(LowLevelGetException.REJECTED_OVERLOAD));
-        return;
-      case RequestSender.INTERNAL_ERROR:
-        listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
-        return;
-      default:
-        LOG.error(
-            "Unknown RequestSender code in get{}: {} on {}", isSSK ? "SSK" : "CHK", status, rs);
-        listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
-    }
-  }
-
   private int computeMaxMemoryLimitedJobThreads() {
     int maxThreads = Runtime.getRuntime().availableProcessors() / 2;
     maxThreads = Math.min(maxThreads, node.getNodeStats().getThreadLimit() / 20);
     return Math.max(1, maxThreads);
-  }
-
-  private long computeDefaultMemoryLimitedJobMemoryLimit(long overallMemoryLimit) {
-    long limit = FECCodec.MIN_MEMORY_ALLOCATION;
-    if (overallMemoryLimit > 512L * 1024 * 1024) {
-      limit += (overallMemoryLimit - 512L * 1024 * 1024) / 20;
-    }
-    return limit;
   }
 
   private RequestStarterGroup createRequestStarters(
@@ -898,78 +753,12 @@ public class NodeClientCore implements Persistable {
               public void set(Integer uskFetch) throws InvalidConfigValueException {
                 if (uskFetch <= 0)
                   throw new InvalidConfigValueException(
-                      l10n("maxUSKFetchersMustBeGreaterThanZero"));
+                      NodeClientCoreSupport.l10n("maxUSKFetchersMustBeGreaterThanZero"));
                 maxBackgroundUSKFetchers = uskFetch;
               }
             },
             false);
     maxBackgroundUSKFetchers = init.nodeConfig().getInt("maxBackgroundUSKFetchers");
-    return sortOrder + 1;
-  }
-
-  private int registerDownloadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
-    init.nodeConfig()
-        .register(
-            "downloadAllowedDirs",
-            new String[] {"all"},
-            sortOrder,
-            true,
-            true,
-            "NodeClientCore.downloadAllowedDirs",
-            "NodeClientCore.downloadAllowedDirsLong",
-            new StringArrCallback() {
-
-              @Override
-              public String[] get() {
-                synchronized (NodeClientCore.this) {
-                  if (downloadAllowedEverywhere) return new String[] {"all"};
-                  String[] dirs =
-                      new String[downloadAllowedDirs.length + (includeDownloadDir ? 1 : 0)];
-                  for (int i = 0; i < downloadAllowedDirs.length; i++)
-                    dirs[i] = downloadAllowedDirs[i].getPath();
-                  if (includeDownloadDir) dirs[downloadAllowedDirs.length] = DOWNLOADS_DIR_NAME;
-                  return dirs;
-                }
-              }
-
-              @Override
-              public void set(String[] val) {
-                setDownloadAllowedDirs(val);
-              }
-            });
-    setDownloadAllowedDirs(init.nodeConfig().getStringArr("downloadAllowedDirs"));
-    return sortOrder + 1;
-  }
-
-  private int registerUploadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
-    init.nodeConfig()
-        .register(
-            "uploadAllowedDirs",
-            new String[] {"all"},
-            sortOrder,
-            true,
-            true,
-            "NodeClientCore.uploadAllowedDirs",
-            "NodeClientCore.uploadAllowedDirsLong",
-            new StringArrCallback() {
-
-              @Override
-              public String[] get() {
-                synchronized (NodeClientCore.this) {
-                  if (uploadAllowedEverywhere) return new String[] {"all"};
-                  String[] dirs = new String[uploadAllowedDirs.length];
-                  for (int i = 0; i < uploadAllowedDirs.length; i++)
-                    dirs[i] = uploadAllowedDirs[i].getPath();
-                  return dirs;
-                }
-              }
-
-              @Override
-              public void set(String[] val) {
-                setUploadAllowedDirs(val);
-              }
-            });
-    setUploadAllowedDirs(init.nodeConfig().getStringArr("uploadAllowedDirs"));
     return sortOrder + 1;
   }
 
@@ -995,45 +784,11 @@ public class NodeClientCore implements Persistable {
               public void set(Integer val) throws InvalidConfigValueException {
                 if (val < 1)
                   throw new InvalidConfigValueException(
-                      l10n("memoryLimitedJobThreadLimitMustBe1Plus"));
+                      NodeClientCoreSupport.l10n("memoryLimitedJobThreadLimitMustBe1Plus"));
                 memoryLimitedJobRunner.setMaxThreads(val);
               }
             },
             false);
-    return sortOrder + 1;
-  }
-
-  private int registerMemoryLimitedJobMemoryLimit(
-      NodeClientCoreInit init, int sortOrder, long defaultMemoryLimitedJobMemoryLimit) {
-    init.nodeConfig()
-        .register(
-            "memoryLimitedJobMemoryLimit",
-            defaultMemoryLimitedJobMemoryLimit,
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.memoryLimitedJobMemoryLimit",
-            "NodeClientCore.memoryLimitedJobMemoryLimitLong",
-            new LongCallback() {
-
-              @Override
-              public Long get() {
-                return memoryLimitedJobRunner.getCapacity();
-              }
-
-              @Override
-              public void set(Long val) throws InvalidConfigValueException {
-                if (val < FECCodec.MIN_MEMORY_ALLOCATION)
-                  throw new InvalidConfigValueException(
-                      NodeL10n.getBase()
-                          .getString(
-                              "NodeClientCore.memoryLimitedJobMemoryLimitMustBeAtLeast",
-                              "min",
-                              SizeUtil.formatSize(FECCodec.MIN_MEMORY_ALLOCATION)));
-                memoryLimitedJobRunner.setCapacity(val);
-              }
-            },
-            true);
     return sortOrder + 1;
   }
 
@@ -1211,7 +966,7 @@ public class NodeClientCore implements Persistable {
                   if (newValue != lazyStartDatastoreChecker) {
                     lazyStartDatastoreChecker = newValue;
                     throw new NodeNeedRestartException(
-                        l10n("lazyStartDatastoreCheckerMustRestartNode"));
+                        NodeClientCoreSupport.l10n("lazyStartDatastoreCheckerMustRestartNode"));
                   }
                 }
               }
@@ -1231,7 +986,7 @@ public class NodeClientCore implements Persistable {
    * @return {@code true} if downloads are disabled and all targets are rejected.
    */
   public boolean isDownloadDisabled() {
-    return downloadDisabled;
+    return transferPolicy.isDownloadDisabled();
   }
 
   /**
@@ -1245,24 +1000,7 @@ public class NodeClientCore implements Persistable {
    * @param val allowlist entries describing special tokens or absolute/relative paths.
    */
   protected synchronized void setDownloadAllowedDirs(String[] val) {
-    int x = 0;
-    downloadAllowedEverywhere = false;
-    includeDownloadDir = false;
-    downloadDisabled = false;
-    int i;
-    downloadAllowedDirs = new File[val.length];
-    for (i = 0; i < downloadAllowedDirs.length; i++) {
-      String s = val[i];
-      if (s.equals(DOWNLOADS_DIR_NAME)) includeDownloadDir = true;
-      else if (s.equals("all")) downloadAllowedEverywhere = true;
-      else downloadAllowedDirs[x++] = new File(val[i]);
-    }
-    if (x != i) {
-      downloadAllowedDirs = Arrays.copyOf(downloadAllowedDirs, x);
-    }
-    if (i == 0) {
-      downloadDisabled = true;
-    }
+    transferPolicy.setDownloadAllowedDirs(val);
   }
 
   /**
@@ -1276,18 +1014,7 @@ public class NodeClientCore implements Persistable {
    * @param val allowlist entries describing special tokens or filesystem paths.
    */
   protected synchronized void setUploadAllowedDirs(String[] val) {
-    int x = 0;
-    int i;
-    uploadAllowedEverywhere = false;
-    uploadAllowedDirs = new File[val.length];
-    for (i = 0; i < uploadAllowedDirs.length; i++) {
-      String s = val[i];
-      if (s.equals("all")) uploadAllowedEverywhere = true;
-      else uploadAllowedDirs[x++] = new File(val[i]);
-    }
-    if (x != i) {
-      uploadAllowedDirs = Arrays.copyOf(uploadAllowedDirs, x);
-    }
+    transferPolicy.setUploadAllowedDirs(val);
   }
 
   /**
@@ -1338,914 +1065,6 @@ public class NodeClientCore implements Persistable {
   }
 
   /**
-   * Generates a random UID for requests.
-   *
-   * <p>Note: {@code -1} is reserved internally and is never returned. If a peer uses {@code -1} it
-   * is merely scheduled more slowly (round-robin with no-UID messages).
-   */
-  long makeUID() {
-    while (true) {
-      long uid = random.nextLong();
-      if (uid != -1) return uid;
-    }
-  }
-
-  /**
-   * Starts an asynchronous fetch for a key.
-   *
-   * <p>If the data is found locally the listener is notified and no network request is started.
-   * Otherwise, a request sender is created and the listener receives completion or failure
-   * callbacks; some successful outcomes may be delivered via the pending-keys mechanism instead of
-   * the listener. The call is non-blocking and returns after scheduling work using a freshly
-   * generated UID. Store access is controlled by {@code localOnly} and {@code ignoreStore}; when
-   * both are {@code false} the datastore is checked first and routing proceeds on miss.
-   *
-   * @param key key to fetch; typically a {@code CHK} or {@link NodeSSK}.
-   * @param offersOnly when true, fetch only from offered-key sources.
-   * @param listener callback notified on completion or failure of the request.
-   * @param canReadClientCache whether this request may read from the client cache.
-   * @param canWriteClientCache whether this request may write into the client cache.
-   * @param realTimeFlag true for latency-optimized routing; false for bulk throughput.
-   * @param localOnly true to check only local store and skip routing.
-   * @param ignoreStore true to bypass datastore and always create a request.
-   */
-  public void asyncGet(
-      final Key key,
-      boolean offersOnly,
-      final RequestCompletionListener listener,
-      boolean canReadClientCache,
-      boolean canWriteClientCache,
-      final boolean realTimeFlag,
-      boolean localOnly,
-      boolean ignoreStore) {
-    final long uid = makeUID();
-    final boolean isSSK = key instanceof NodeSSK;
-    final RequestTag tag =
-        new RequestTag(isSSK, RequestTag.START.ASYNC_GET, null, realTimeFlag, uid, node);
-    if (!node.getTracker().lockUID(uid, isSSK, false, false, true, realTimeFlag, tag)) {
-      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
-      listener.onFailed(
-          new LowLevelGetException(
-              LowLevelGetException.INTERNAL_ERROR,
-              "Could not lock random UID - serious PRNG problem???"));
-      return;
-    }
-    tag.setAccepted();
-    short htl = node.maxHTL();
-    // If another node requested it within the ULPR period at a lower HTL, that may allow
-    // us to cache it in the datastore. Find the lowest HTL fetching the key in that period,
-    // and use that for purposes of deciding whether to cache it in the store.
-    if (offersOnly) {
-      htl = node.getFailureTable().minOfferedHTL(key, htl);
-      if (LOG.isDebugEnabled()) LOG.debug("Using old HTL for GetOfferedKey: {}", htl);
-    }
-    final long startTime = System.currentTimeMillis();
-    startAsyncGet(
-        key,
-        offersOnly,
-        uid,
-        listener,
-        tag,
-        canReadClientCache,
-        canWriteClientCache,
-        htl,
-        realTimeFlag,
-        localOnly,
-        ignoreStore,
-        isSSK,
-        startTime);
-  }
-
-  /**
-   * Start an asynchronous fetch of the key in question, which will complete to the datastore. It
-   * will not decode the data because we don't provide a ClientKey. It will not return anything and
-   * will run asynchronously. Caller is responsible for unlocking the UID.
-   *
-   * @param key The key being fetched.
-   * @param offersOnly If true, only fetch the key from nodes that have offered it, using
-   *     GetOfferedKeys, don't do a normal fetch for it.
-   * @param uid The UID of the request. This should already be locked before calling.
-   * @param requestTag The RequestTag for the request; used for request lifecycle callbacks.
-   * @param listener Will be called by the request sender, if a request is started. However, for
-   *     example, if we fetch it from the store, it will be returned via the tripPendingKeys
-   *     mechanism.
-   * @param canReadClientCache Can this request read the client-cache?
-   * @param canWriteClientCache Can this request write the client-cache?
-   * @param htl The HTL to start the request at. See the caller, this can be modified in the case of
-   *     fetching an offered key.
-   * @param realTimeFlag Is this a real-time request? False = this is a bulk request.
-   * @param localOnly If true, only check the datastore, don't create a request if nothing is found.
-   * @param ignoreStore If true, don't check the datastore, create a request immediately.
-   * @param isSSK Whether the request targets an SSK key type.
-   * @param startTime Start time in milliseconds since epoch for metrics.
-   */
-  @SuppressWarnings("java:S1181")
-  private void startAsyncGet(
-      Key key,
-      boolean offersOnly,
-      long uid,
-      RequestCompletionListener listener,
-      Object requestTag,
-      boolean canReadClientCache,
-      boolean canWriteClientCache,
-      short htl,
-      boolean realTimeFlag,
-      boolean localOnly,
-      boolean ignoreStore,
-      boolean isSSK,
-      long startTime) {
-    RequestTag tag = (RequestTag) requestTag;
-    RequestSenderListener senderListener =
-        new RequestSenderListener() {
-
-          private boolean rejectedOverload;
-
-          @Override
-          public void onCHKTransferBegins() {
-            // Ignore
-          }
-
-          @Override
-          public void onReceivedRejectOverload() {
-            synchronized (this) {
-              if (rejectedOverload) return;
-              rejectedOverload = true;
-            }
-            requestStarters.rejectedOverload(isSSK, false, realTimeFlag);
-          }
-
-          @Override
-          public void onDataFoundLocally() {
-            tag.unlockHandler();
-            listener.onSucceeded();
-          }
-
-          /**
-           * The RequestSender finished.
-           *
-           * @param status The completion status code reported by the sender.
-           * @param fromOfferedKey {@code true} if this completion originated from an offered-key
-           *     fetch path (GetOfferedKeys); {@code false} for a normal fetch.
-           * @param rs The sender that completed and reported the status.
-           */
-          @Override
-          public void onRequestSenderFinished(
-              int status, boolean fromOfferedKey, RequestSender rs) {
-            tag.unlockHandler();
-            boolean rejectedOverloadLocal;
-            synchronized (this) {
-              rejectedOverloadLocal = this.rejectedOverload;
-            }
-            handleAsyncGetFinished(
-                isSSK, listener, startTime, key, realTimeFlag, rs, rejectedOverloadLocal);
-          }
-
-          @Override
-          public void onNotStarted(boolean internalError) {
-            if (internalError)
-              listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
-            else
-              listener.onFailed(
-                  new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND_IN_STORE));
-          }
-        };
-    try {
-      Object o =
-          node.makeRequestSender(
-              key,
-              htl,
-              uid,
-              tag,
-              null,
-              Node.RequestSenderOptions.of(
-                  localOnly,
-                  ignoreStore,
-                  offersOnly,
-                  canReadClientCache,
-                  canWriteClientCache,
-                  realTimeFlag));
-      if (o instanceof KeyBlock) {
-        tag.setServedFromDatastore();
-        senderListener.onDataFoundLocally();
-        return; // Already have it.
-      }
-      if (o == null) {
-        senderListener.onNotStarted(false);
-        tag.unlockHandler();
-        return;
-      }
-      RequestSender rs = (RequestSender) o;
-      rs.addListener(senderListener);
-      if (rs.uid != uid) tag.unlockHandler();
-      // Else it has started a request.
-      if (LOG.isDebugEnabled()) LOG.debug("Started {} for {} for {}", o, uid, key);
-    } catch (RuntimeException | Error e) {
-      LOG.error("Caught error trying to start request: {}", e, e);
-      senderListener.onNotStarted(true);
-    }
-  }
-
-  /**
-   * Synchronously fetches a block for a client key.
-   *
-   * <p>This method blocks until the fetch completes or fails. Depending on {@code localOnly} and
-   * {@code ignoreStore}, it may read from the datastore or issue a routed request through the
-   * network. It returns a verified client block on success and throws a {@link
-   * LowLevelGetException} on any failure. The request uses an internally generated UID and releases
-   * tracking resources before returning.
-   *
-   * @param key client key to fetch; must be {@link ClientCHK} or {@link ClientSSK}.
-   * @param localOnly true to consult only the datastore and stop on miss.
-   * @param ignoreStore true to bypass datastore and route immediately.
-   * @param canWriteClientCache whether the request may write to the client cache.
-   * @param realTimeFlag true for latency-optimized routing; false for bulk routing.
-   * @return verified client block, owned by the caller for use.
-   * @throws LowLevelGetException when not found, verify fails, or internal errors occur.
-   */
-  public ClientKeyBlock realGetKey(
-      ClientKey key,
-      boolean localOnly,
-      boolean ignoreStore,
-      boolean canWriteClientCache,
-      boolean realTimeFlag)
-      throws LowLevelGetException {
-    return switch (key) {
-      case ClientCHK hK ->
-          realGetCHK(hK, localOnly, ignoreStore, canWriteClientCache, realTimeFlag);
-      case ClientSSK sK ->
-          realGetSSK(sK, localOnly, ignoreStore, canWriteClientCache, realTimeFlag);
-      default -> throw new IllegalArgumentException("Not a CHK or SSK: " + key);
-    };
-  }
-
-  /**
-   * Fetches a CHK block, optionally via the network.
-   *
-   * @param key the client CHK to fetch.
-   * @param localOnly when {@code true}, check only the datastore and do not create a network
-   *     request on miss.
-   * @param ignoreStore when {@code true}, skip the datastore and create a network request
-   *     immediately.
-   * @param canWriteClientCache whether the request may write the client cache. Reads from the
-   *     client cache are always allowed for local requests; some callers disable writes to avoid
-   *     cache pollution.
-   * @param realTimeFlag {@code true} for latency-optimized routing; {@code false} for bulk.
-   * @return the verified client block.
-   * @throws LowLevelGetException if the data is not found, recently failed, transfer fails, verify
-   *     fails, or on internal error.
-   */
-  ClientKeyBlock realGetCHK(
-      ClientCHK key,
-      boolean localOnly,
-      boolean ignoreStore,
-      boolean canWriteClientCache,
-      boolean realTimeFlag)
-      throws LowLevelGetException {
-    long startTime = System.currentTimeMillis();
-    long uid = makeUID();
-    RequestTag tag = new RequestTag(false, RequestTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!node.getTracker().lockUID(uid, false, false, false, true, realTimeFlag, tag)) {
-      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
-      throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
-    }
-    tag.setAccepted();
-    RequestSender rs;
-    try {
-      Object o =
-          node.makeRequestSender(
-              key.getNodeCHK(),
-              node.maxHTL(),
-              uid,
-              tag,
-              null,
-              Node.RequestSenderOptions.of(
-                  localOnly, ignoreStore, false, true, canWriteClientCache, realTimeFlag));
-      if (o instanceof CHKBlock block)
-        try {
-          tag.setServedFromDatastore();
-          return NodeClientCoreSupport.buildClientChkBlock(block, key);
-        } catch (CHKVerifyException e) {
-          LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
-          throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
-        }
-      if (o == null) throw new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND_IN_STORE);
-      rs = (RequestSender) o;
-      return processChkRequestLoop(rs, key, startTime, realTimeFlag);
-    } finally {
-      tag.unlockHandler();
-    }
-  }
-
-  private ClientKeyBlock processChkRequestLoop(
-      RequestSender rs, ClientCHK key, long startTime, boolean realTimeFlag)
-      throws LowLevelGetException {
-    boolean rejectedOverload = false;
-    short waitStatus = 0;
-    while (true) {
-      waitStatus = rs.waitUntilStatusChange(waitStatus);
-      rejectedOverload =
-          checkAndReportRejectedOverload(rejectedOverload, waitStatus, false, realTimeFlag);
-
-      int status = rs.getStatus();
-      if (status == RequestSender.NOT_FINISHED) continue;
-
-      maybeReportFetchCosts(false, rs, status);
-
-      if (status == RequestSender.TIMED_OUT
-          || status == RequestSender.GENERATED_REJECTED_OVERLOAD
-          || (rs.hasForwarded() && isForwardedTerminalStatus(status))) {
-        maybeHandleTimeoutOrForwarded(
-            false, realTimeFlag, startTime, key.getNodeCHK(), rs, status, rejectedOverload);
-      }
-
-      ClientKeyBlock maybe = tryReturnChkBlock(rs, key, status);
-      if (maybe != null) return maybe;
-      throwForGetStatus(status, rs);
-    }
-  }
-
-  private boolean checkAndReportRejectedOverload(
-      boolean alreadyRejected, short waitStatus, boolean isSSK, boolean realTimeFlag) {
-    if (!alreadyRejected && (waitStatus & RequestSender.WAIT_REJECTED_OVERLOAD) != 0) {
-      requestStarters.rejectedOverload(isSSK, false, realTimeFlag);
-      return true;
-    }
-    return alreadyRejected;
-  }
-
-  private void maybeReportFetchCosts(boolean isSSK, RequestSender rs, int status) {
-    if (isNonErrorStatus(status)) {
-      reportFetchCosts(isSSK, rs, status);
-    }
-  }
-
-  private void maybeHandleTimeoutOrForwarded(
-      boolean isSSK,
-      boolean realTimeFlag,
-      long startTime,
-      Key key,
-      RequestSender rs,
-      int status,
-      boolean rejectedOverload) {
-    if (status == RequestSender.TIMED_OUT || status == RequestSender.GENERATED_REJECTED_OVERLOAD) {
-      handleTimeoutOrRejected(isSSK, realTimeFlag, startTime, key, rejectedOverload);
-    } else if (rs.hasForwarded() && isForwardedTerminalStatus(status)) {
-      handleForwardedStatuses(isSSK, realTimeFlag, startTime, key, status);
-    }
-  }
-
-  private ClientKeyBlock tryReturnChkBlock(RequestSender rs, ClientCHK key, int status)
-      throws LowLevelGetException {
-    if (status == RequestSender.SUCCESS)
-      try {
-        return NodeClientCoreSupport.buildClientChkBlock(
-            rs.getPRB().getBlock(), rs.getHeaders(), key);
-      } catch (CHKVerifyException e) {
-        LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
-        throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
-      } catch (AbortedException e) {
-        LOG.error("Impossible: {}", e, e);
-        throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
-      }
-    return null;
-  }
-
-  private void throwForGetStatus(int status, RequestSender rs) throws LowLevelGetException {
-    switch (status) {
-      case RequestSender.NOT_FINISHED:
-        LOG.error("RS still running in get!: {}", rs);
-        throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
-      case RequestSender.DATA_NOT_FOUND:
-        throw new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND);
-      case RequestSender.RECENTLY_FAILED:
-        throw new LowLevelGetException(LowLevelGetException.RECENTLY_FAILED);
-      case RequestSender.ROUTE_NOT_FOUND:
-        throw new LowLevelGetException(LowLevelGetException.ROUTE_NOT_FOUND);
-      case RequestSender.TRANSFER_FAILED, RequestSender.GET_OFFER_TRANSFER_FAILED:
-        throw new LowLevelGetException(LowLevelGetException.TRANSFER_FAILED);
-      case RequestSender.VERIFY_FAILURE, RequestSender.GET_OFFER_VERIFY_FAILURE:
-        throw new LowLevelGetException(LowLevelGetException.VERIFY_FAILED);
-      case RequestSender.GENERATED_REJECTED_OVERLOAD, RequestSender.TIMED_OUT:
-        throw new LowLevelGetException(LowLevelGetException.REJECTED_OVERLOAD);
-      case RequestSender.INTERNAL_ERROR:
-      default:
-        LOG.error("Unknown RequestSender code in get: {} on {}", status, rs);
-        throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
-    }
-  }
-
-  ClientKeyBlock realGetSSK(
-      ClientSSK key,
-      boolean localOnly,
-      boolean ignoreStore,
-      boolean canWriteClientCache,
-      boolean realTimeFlag)
-      throws LowLevelGetException {
-    long startTime = System.currentTimeMillis();
-    long uid = makeUID();
-    RequestTag tag = new RequestTag(true, RequestTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!node.getTracker().lockUID(uid, true, false, false, true, realTimeFlag, tag)) {
-      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
-      throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
-    }
-    tag.setAccepted();
-    RequestSender rs;
-    try {
-      Object o =
-          node.makeRequestSender(
-              key.getNodeKey(true),
-              node.maxHTL(),
-              uid,
-              tag,
-              null,
-              Node.RequestSenderOptions.of(
-                  localOnly, ignoreStore, false, true, canWriteClientCache, realTimeFlag));
-      if (o instanceof SSKBlock block)
-        try {
-          tag.setServedFromDatastore();
-          key.setPublicKey(block.getPubKey());
-          return NodeClientCoreSupport.buildClientSskBlock(block, key);
-        } catch (SSKVerifyException e) {
-          LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
-          throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
-        }
-      if (o == null) throw new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND_IN_STORE);
-      rs = (RequestSender) o;
-      return processSskRequestLoop(rs, key, startTime, realTimeFlag);
-    } finally {
-      tag.unlockHandler();
-    }
-  }
-
-  private ClientKeyBlock processSskRequestLoop(
-      RequestSender rs, ClientSSK key, long startTime, boolean realTimeFlag)
-      throws LowLevelGetException {
-    boolean rejectedOverload = false;
-    short waitStatus = 0;
-    while (true) {
-      waitStatus = rs.waitUntilStatusChange(waitStatus);
-      rejectedOverload =
-          checkAndReportRejectedOverload(rejectedOverload, waitStatus, true, realTimeFlag);
-
-      int status = rs.getStatus();
-      if (status == RequestSender.NOT_FINISHED) continue;
-
-      maybeReportFetchCosts(true, rs, status);
-
-      if (status == RequestSender.TIMED_OUT
-          || status == RequestSender.GENERATED_REJECTED_OVERLOAD
-          || (rs.hasForwarded() && isForwardedTerminalStatus(status))) {
-        maybeHandleTimeoutOrForwarded(
-            true, realTimeFlag, startTime, key.getNodeKey(true), rs, status, rejectedOverload);
-      }
-
-      if (status == RequestSender.SUCCESS) {
-        try {
-          SSKBlock block = rs.getSSKBlock();
-          key.setPublicKey(block.getPubKey());
-          return NodeClientCoreSupport.buildClientSskBlock(block, key);
-        } catch (SSKVerifyException e) {
-          LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
-          throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
-        }
-      }
-      if (status == RequestSender.TRANSFER_FAILED
-          || status == RequestSender.GET_OFFER_TRANSFER_FAILED) {
-        LOG.error("Unexpected transfer failure on an SSK for uid {}", (Object) null);
-      }
-      throwForGetStatus(status, rs);
-    }
-  }
-
-  /**
-   * Inserts a block into the network.
-   *
-   * <p>This entry point accepts either CHK or SSK blocks and dispatches to the appropriate insert
-   * path. It performs local bookkeeping, records costs, and may store the block locally according
-   * to caching rules. The call blocks until the insert completes or fails. Failures are mapped to
-   * {@link LowLevelPutException} codes describing routing, overload, or collision outcomes.
-   *
-   * @param block block to insert; must be a {@link CHKBlock} or {@link SSKBlock}.
-   * @param canWriteClientCache whether the insert may update the client cache.
-   * @param forkOnCacheable whether to fork when the block is cacheable.
-   * @param preferInsert whether to prefer insert when multiple strategies apply.
-   * @param ignoreLowBackoff whether to ignore low backoff during routing.
-   * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
-   * @throws LowLevelPutException when routing fails, overload occurs, or an internal error arises.
-   */
-  public void realPut(
-      KeyBlock block,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      boolean preferInsert,
-      boolean ignoreLowBackoff,
-      boolean realTimeFlag)
-      throws LowLevelPutException {
-    switch (block) {
-      case CHKBlock kBlock1 ->
-          realPutCHK(
-              kBlock1,
-              canWriteClientCache,
-              forkOnCacheable,
-              preferInsert,
-              ignoreLowBackoff,
-              realTimeFlag);
-      case SSKBlock kBlock ->
-          realPutSSK(
-              kBlock,
-              canWriteClientCache,
-              forkOnCacheable,
-              preferInsert,
-              ignoreLowBackoff,
-              realTimeFlag);
-      default -> throw new IllegalArgumentException("Unknown put type " + block.getClass());
-    }
-  }
-
-  /**
-   * Inserts a CHK block into the network and optionally caches it locally.
-   *
-   * <p>This variant constructs a CHK insert sender, waits for completion, reports costs, and stores
-   * the block according to cache policy. It blocks until the insert completes and throws a {@link
-   * LowLevelPutException} on routing failure, overload, or internal errors. The method generates
-   * and locks a request UID internally and releases it before returning.
-   *
-   * @param block CHK block to insert and potentially store locally.
-   * @param canWriteClientCache whether the insert may update the client cache.
-   * @param forkOnCacheable whether to fork when the block is cacheable.
-   * @param preferInsert whether to prefer insert when multiple strategies apply.
-   * @param ignoreLowBackoff whether to ignore low backoff during routing.
-   * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
-   * @throws LowLevelPutException when routing fails, overload occurs, or internal errors arise.
-   */
-  public void realPutCHK(
-      CHKBlock block,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      boolean preferInsert,
-      boolean ignoreLowBackoff,
-      boolean realTimeFlag)
-      throws LowLevelPutException {
-    byte[] data = block.getData();
-    byte[] headers = block.getHeaders();
-    PartiallyReceivedBlock prb =
-        new PartiallyReceivedBlock(Node.PACKETS_IN_BLOCK, Node.PACKET_SIZE, data);
-    CHKInsertSender is;
-    long uid = makeUID();
-    InsertTag tag = new InsertTag(false, InsertTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!node.getTracker().lockUID(uid, false, true, false, true, realTimeFlag, tag)) {
-      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
-      throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
-    }
-    tag.setAccepted();
-    try {
-      long startTime = System.currentTimeMillis();
-      is =
-          node.makeInsertSender(
-              block.getKey(),
-              node.maxHTL(),
-              uid,
-              tag,
-              null,
-              Node.ChkInsertOptions.of(headers, prb)
-                  .withFromStore(false)
-                  .withCanWriteClientCache(canWriteClientCache)
-                  .withForkOnCacheable(forkOnCacheable)
-                  .withPreferInsert(preferInsert)
-                  .withIgnoreLowBackoff(ignoreLowBackoff)
-                  .withRealTimeFlag(realTimeFlag));
-      boolean hasReceivedRejectedOverload = awaitChkCompletion(is, realTimeFlag);
-
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "Completed {} overload={} {}", uid, hasReceivedRejectedOverload, is.getStatusString());
-
-      maybeReportChkCompleted(is, uid, startTime, realTimeFlag, block);
-
-      // Get status explicitly, *after* completed(), so that it will be RECEIVE_FAILED if the
-      // receive failed.
-      int status = is.getStatus();
-      reportChkInsertCosts(status, is);
-      storeChkLocally(is, block, canWriteClientCache);
-
-      logChkInsertResult(status, is, block);
-      if (status != CHKInsertSender.SUCCESS) {
-        throwForChkPutStatus(is);
-      }
-    } finally {
-      tag.unlockHandler();
-    }
-  }
-
-  private void maybeReportChkCompleted(
-      CHKInsertSender is, long uid, long startTime, boolean realTimeFlag, CHKBlock block) {
-    if (is.sentRequest()
-        && (is.uid == uid)
-        && ((is.getStatus() == CHKInsertSender.ROUTE_NOT_FOUND)
-            || (is.getStatus() == CHKInsertSender.SUCCESS))) {
-      long endTime = System.currentTimeMillis();
-      long len = endTime - startTime;
-      requestStarters.getThrottle(false, true, realTimeFlag).successfulCompletion(len);
-      requestStarters.requestCompleted(false, true, block.getKey(), realTimeFlag);
-    }
-  }
-
-  private void reportChkInsertCosts(int status, CHKInsertSender is) {
-    if (status != CHKInsertSender.TIMED_OUT
-        && status != CHKInsertSender.GENERATED_REJECTED_OVERLOAD
-        && status != CHKInsertSender.INTERNAL_ERROR
-        && status != CHKInsertSender.ROUTE_REALLY_NOT_FOUND) {
-      int sent = is.getTotalSentBytes();
-      int received = is.getTotalReceivedBytes();
-      if (LOG.isDebugEnabled())
-        LOG.debug("Local CHK insert cost {}/{}" + LOG_BYTES_OPEN + "{})", sent, received, status);
-      node.getNodeStats().localChkInsertBytesSentAverage.report(sent);
-      node.getNodeStats().localChkInsertBytesReceivedAverage.report(received);
-      if (status == CHKInsertSender.SUCCESS)
-        node.getNodeStats().successfulChkInsertBytesSentAverage.report(sent);
-    }
-  }
-
-  private void storeChkLocally(CHKInsertSender is, CHKBlock block, boolean canWriteClientCache) {
-    boolean deep =
-        node.shouldStoreDeep(block.getKey(), null, is == null ? new PeerNode[0] : is.getRoutedTo());
-    try {
-      node.store(block, deep, canWriteClientCache, false, false);
-    } catch (KeyCollisionException _) {
-      // CHKs don't collide
-    }
-  }
-
-  private void logChkInsertResult(int status, CHKInsertSender is, CHKBlock block) {
-    if (status == CHKInsertSender.SUCCESS) {
-      LOG.info("Succeeded inserting {}", block);
-    } else {
-      String msg = "Failed inserting " + block + " : " + is.getStatusString();
-      if (status == CHKInsertSender.ROUTE_NOT_FOUND)
-        msg +=
-            " - this is normal on small networks; the data will still be propagated, but it can't"
-                + " find the 20+ nodes needed for full success";
-      if (is.getStatus() != CHKInsertSender.ROUTE_NOT_FOUND) LOG.error(msg);
-      else LOG.info(msg);
-    }
-  }
-
-  private boolean awaitChkCompletion(CHKInsertSender is, boolean realTimeFlag) {
-    boolean overloaded = awaitChkInitialStatus(is, realTimeFlag);
-    return awaitChkFinalCompletion(is, realTimeFlag, overloaded);
-  }
-
-  private boolean awaitChkInitialStatus(CHKInsertSender is, boolean realTimeFlag) {
-    boolean hasReceivedRejectedOverload = false;
-    while (true) {
-      if (is.getStatus() == CHKInsertSender.NOT_FINISHED) {
-        is.waitIfNotFinished(SECONDS.toMillis(5));
-      }
-      if (is.getStatus() != CHKInsertSender.NOT_FINISHED) break;
-      if ((!hasReceivedRejectedOverload) && is.receivedRejectedOverload()) {
-        hasReceivedRejectedOverload = true;
-        requestStarters.rejectedOverload(false, true, realTimeFlag);
-      }
-    }
-    return hasReceivedRejectedOverload;
-  }
-
-  private boolean awaitChkFinalCompletion(
-      CHKInsertSender is, boolean realTimeFlag, boolean hasReceivedRejectedOverload) {
-    while (!is.completed()) {
-      is.waitIfNotCompleted(SECONDS.toMillis(10));
-      if (is.anyTransfersFailed() && (!hasReceivedRejectedOverload)) {
-        hasReceivedRejectedOverload = true; // not strictly true but same effect
-        requestStarters.rejectedOverload(false, true, realTimeFlag);
-      }
-    }
-    return hasReceivedRejectedOverload;
-  }
-
-  private void throwForChkPutStatus(CHKInsertSender is) throws LowLevelPutException {
-    switch (is.getStatus()) {
-      case CHKInsertSender.NOT_FINISHED:
-        LOG.error("IS still running in putCHK!: {}", is);
-        throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
-      case CHKInsertSender.GENERATED_REJECTED_OVERLOAD, CHKInsertSender.TIMED_OUT:
-        throw new LowLevelPutException(LowLevelPutException.REJECTED_OVERLOAD);
-      case CHKInsertSender.ROUTE_NOT_FOUND:
-        throw new LowLevelPutException(LowLevelPutException.ROUTE_NOT_FOUND);
-      case CHKInsertSender.ROUTE_REALLY_NOT_FOUND:
-        throw new LowLevelPutException(LowLevelPutException.ROUTE_REALLY_NOT_FOUND);
-      case CHKInsertSender.INTERNAL_ERROR:
-      default:
-        LOG.error("Unknown CHKInsertSender code in putCHK: {} on {}", is.getStatus(), is);
-        throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
-    }
-  }
-
-  /**
-   * Inserts an SSK block.
-   *
-   * <p>This method performs a local collision check using the client cache, then starts an SSK
-   * insert sender and waits for completion. It reports costs, stores the block when appropriate,
-   * and throws {@link LowLevelPutException} for collisions, routing failures, overload, or internal
-   * errors. The call blocks until the insert completes and always releases the request UID.
-   *
-   * @param block SSK block to insert and potentially store locally.
-   * @param canWriteClientCache whether the insert may update the client cache.
-   * @param forkOnCacheable whether to fork when the block is cacheable.
-   * @param preferInsert whether to prefer insert when multiple strategies apply.
-   * @param ignoreLowBackoff whether to ignore low backoff during routing.
-   * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
-   * @throws LowLevelPutException on collision, routing failure, overload, or internal error.
-   */
-  public void realPutSSK(
-      SSKBlock block,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      boolean preferInsert,
-      boolean ignoreLowBackoff,
-      boolean realTimeFlag)
-      throws LowLevelPutException {
-    SSKInsertSender is;
-    long uid = makeUID();
-    InsertTag tag = new InsertTag(true, InsertTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!node.getTracker().lockUID(uid, true, true, false, true, realTimeFlag, tag)) {
-      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
-      throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
-    }
-    tag.setAccepted();
-    try {
-      long startTime = System.currentTimeMillis();
-      // Be consistent: use the client cache to check for collisions as this is a local insert.
-      SSKBlock altBlock =
-          node.fetch(block.getKey(), false, true, canWriteClientCache, false, false, null);
-      if (altBlock != null && !altBlock.equals(block)) throw new LowLevelPutException(altBlock);
-      is =
-          node.makeInsertSender(
-              block,
-              node.maxHTL(),
-              uid,
-              tag,
-              null,
-              Node.SskInsertOptions.of()
-                  .withFromStore(false)
-                  .withCanWriteClientCache(canWriteClientCache)
-                  .withCanWriteDatastore(false)
-                  .withForkOnCacheable(forkOnCacheable)
-                  .withPreferInsert(preferInsert)
-                  .withIgnoreLowBackoff(ignoreLowBackoff)
-                  .withRealTimeFlag(realTimeFlag));
-      boolean hasReceivedRejectedOverload = awaitSskCompletion(is, realTimeFlag);
-
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "Completed {} overload={} {}", uid, hasReceivedRejectedOverload, is.getStatusString());
-
-      // Finished?
-      maybeReportSskCompleted(is, uid, startTime, realTimeFlag, block, hasReceivedRejectedOverload);
-
-      int status = is.getStatus();
-
-      reportSskInsertCosts(status, is);
-      handleSskCollisionOrStore(is, block, canWriteClientCache);
-
-      logSskInsertResult(status, is, block);
-      if (status != SSKInsertSender.SUCCESS) {
-        throwForSskPutStatus(is);
-      }
-    } finally {
-      tag.unlockHandler();
-    }
-  }
-
-  private boolean awaitSskCompletion(SSKInsertSender is, boolean realTimeFlag) {
-    boolean overloaded = awaitSskInitialStatus(is, realTimeFlag);
-    return awaitSskFinalCompletion(is, overloaded);
-  }
-
-  private boolean awaitSskInitialStatus(SSKInsertSender is, boolean realTimeFlag) {
-    boolean hasReceivedRejectedOverload = false;
-    while (true) {
-      if (is.getStatus() == SSKInsertSender.NOT_FINISHED) {
-        is.waitIfNotFinished(SECONDS.toMillis(5));
-      }
-      if (is.getStatus() != SSKInsertSender.NOT_FINISHED) break;
-      if ((!hasReceivedRejectedOverload) && is.receivedRejectedOverload()) {
-        hasReceivedRejectedOverload = true;
-        requestStarters.rejectedOverload(true, true, realTimeFlag);
-      }
-    }
-    return hasReceivedRejectedOverload;
-  }
-
-  private boolean awaitSskFinalCompletion(SSKInsertSender is, boolean hasReceivedRejectedOverload) {
-    while (is.getStatus() == SSKInsertSender.NOT_FINISHED) {
-      is.waitIfNotFinished(SECONDS.toMillis(10));
-    }
-    return hasReceivedRejectedOverload;
-  }
-
-  private void throwForSskPutStatus(SSKInsertSender is) throws LowLevelPutException {
-    switch (is.getStatus()) {
-      case SSKInsertSender.NOT_FINISHED:
-        LOG.error("IS still running in putCHK!: {}", is);
-        throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
-      case SSKInsertSender.GENERATED_REJECTED_OVERLOAD, SSKInsertSender.TIMED_OUT:
-        throw new LowLevelPutException(LowLevelPutException.REJECTED_OVERLOAD);
-      case SSKInsertSender.ROUTE_NOT_FOUND:
-        throw new LowLevelPutException(LowLevelPutException.ROUTE_NOT_FOUND);
-      case SSKInsertSender.ROUTE_REALLY_NOT_FOUND:
-        throw new LowLevelPutException(LowLevelPutException.ROUTE_REALLY_NOT_FOUND);
-      case SSKInsertSender.INTERNAL_ERROR:
-      default:
-        LOG.error("Unknown CHKInsertSender code in putSSK: {} on {}", is.getStatus(), is);
-        throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
-    }
-  }
-
-  private void reportSskInsertCosts(int status, SSKInsertSender is) {
-    if (status != CHKInsertSender.TIMED_OUT
-        && status != CHKInsertSender.GENERATED_REJECTED_OVERLOAD
-        && status != CHKInsertSender.INTERNAL_ERROR
-        && status != CHKInsertSender.ROUTE_REALLY_NOT_FOUND) {
-      int sent = is.getTotalSentBytes();
-      int received = is.getTotalReceivedBytes();
-      if (LOG.isDebugEnabled())
-        LOG.debug("Local SSK insert cost {}/{}" + LOG_BYTES_OPEN + "{})", sent, received, status);
-      node.getNodeStats().localSskInsertBytesSentAverage.report(sent);
-      node.getNodeStats().localSskInsertBytesReceivedAverage.report(received);
-      if (status == SSKInsertSender.SUCCESS)
-        node.getNodeStats().successfulSskInsertBytesSentAverage.report(sent);
-    }
-  }
-
-  private void maybeReportSskCompleted(
-      SSKInsertSender is,
-      long uid,
-      long startTime,
-      boolean realTimeFlag,
-      SSKBlock block,
-      boolean hasReceivedRejectedOverload) {
-    if (!hasReceivedRejectedOverload
-        && is.sentRequest()
-        && (is.uid == uid)
-        && ((is.getStatus() == SSKInsertSender.ROUTE_NOT_FOUND)
-            || (is.getStatus() == SSKInsertSender.SUCCESS))) {
-      long endTime = System.currentTimeMillis();
-      long rtt = endTime - startTime;
-      requestStarters.requestCompleted(true, true, block.getKey(), realTimeFlag);
-      requestStarters.getThrottle(true, true, realTimeFlag).successfulCompletion(rtt);
-    }
-  }
-
-  private void handleSskCollisionOrStore(
-      SSKInsertSender is, SSKBlock block, boolean canWriteClientCache) throws LowLevelPutException {
-    boolean deep =
-        node.shouldStoreDeep(block.getKey(), null, is == null ? new PeerNode[0] : is.getRoutedTo());
-
-    if (is != null && is.hasCollided()) {
-      SSKBlock collided = is.getBlock();
-      try {
-        node.storeInsert(collided, deep, true, canWriteClientCache, false);
-      } catch (KeyCollisionException e) {
-        LOG.info("collision race? is={}", is, e);
-      }
-      throw new LowLevelPutException(collided);
-    }
-    try {
-      node.storeInsert(block, deep, false, canWriteClientCache, false);
-    } catch (KeyCollisionException e) {
-      NodeSSK key = block.getKey();
-      KeyBlock collided = node.fetch(key, true, canWriteClientCache, false, false, null);
-      if (collided == null) {
-        LOG.error("Collided but no key?!");
-        try {
-          node.store(block, false, canWriteClientCache, false, false);
-        } catch (KeyCollisionException _) {
-          LOG.error("Collided but no key and still collided!");
-          throw new LowLevelPutException(
-              LowLevelPutException.INTERNAL_ERROR,
-              "Collided, can't find block, but still collides!",
-              e);
-        }
-      }
-      throw new LowLevelPutException(collided);
-    }
-  }
-
-  private void logSskInsertResult(int status, SSKInsertSender is, SSKBlock block) {
-    if (status == SSKInsertSender.SUCCESS) {
-      LOG.info("Succeeded inserting {}", block);
-    } else {
-      String msg = "Failed inserting " + block + " : " + is.getStatusString();
-      if (status == CHKInsertSender.ROUTE_NOT_FOUND)
-        msg +=
-            " - this is normal on small networks; the data will still be propagated, but it can't"
-                + " find the 20+ nodes needed for full success";
-      if (is.getStatus() != SSKInsertSender.ROUTE_NOT_FOUND) LOG.error(msg);
-      else LOG.info(msg);
-    }
-  }
-
-  /**
    * Creates a high-level client bound to this core.
    *
    * <p>The returned client shares this core's {@link ClientContext}, bucket factories, and random
@@ -2262,7 +1081,7 @@ public class NodeClientCore implements Persistable {
    */
   public HighLevelSimpleClient makeClient(
       short prioClass, boolean forceDontIgnoreTooManyPathComponents, boolean realTimeFlag) {
-    return new HighLevelSimpleClientImpl(
+    return NodeClientCoreSupport.createHighLevelClient(
         this,
         tempBucketFactory,
         random,
@@ -2296,23 +1115,6 @@ public class NodeClientCore implements Persistable {
    */
   public File getDownloadsDir() {
     return downloadsDir;
-  }
-
-  /**
-   * Queues a low-priority reinsert of a key block.
-   *
-   * <p>The block is wrapped in a {@link SimpleSendableInsert} and scheduled on the request starters
-   * at the maximum priority class for reinserts. The operation is asynchronous; it enqueues work
-   * and returns immediately without waiting for completion. Use it to refresh availability for
-   * already known data.
-   *
-   * @param block key block to reinsert and schedule for background routing.
-   */
-  public void queueRandomReinsert(KeyBlock block) {
-    SimpleSendableInsert ssi =
-        new SimpleSendableInsert(this, block, RequestStarter.MAXIMUM_PRIORITY_CLASS);
-    if (LOG.isDebugEnabled()) LOG.debug("Queueing random reinsert for {} : {}", block, ssi);
-    ssi.schedule();
   }
 
   /**
@@ -2410,21 +1212,7 @@ public class NodeClientCore implements Persistable {
    * @return {@code true} if the path is allowed under current policy.
    */
   public boolean allowDownloadTo(File filename) {
-    PHYSICAL_THREAT_LEVEL physicalThreatLevel = node.getSecurityLevels().getPhysicalThreatLevel();
-    if (physicalThreatLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM) return false;
-    synchronized (this) {
-      if (downloadAllowedEverywhere) return true;
-      if (includeDownloadDir && FileUtil.isParent(getDownloadsDir(), filename)) return true;
-      for (File dir : downloadAllowedDirs) {
-        if (dir == null) {
-          // Debug mysterious NPE...
-          LOG.error("Null in upload allowed dirs???");
-          continue;
-        }
-        if (FileUtil.isParent(dir, filename)) return true;
-      }
-      return false;
-    }
+    return transferPolicy.allowDownloadTo(filename);
   }
 
   /**
@@ -2439,16 +1227,7 @@ public class NodeClientCore implements Persistable {
    * @return {@code true} if the path is allowed as an upload source.
    */
   public synchronized boolean allowUploadFrom(File filename) {
-    if (uploadAllowedEverywhere) return true;
-    for (File dir : uploadAllowedDirs) {
-      if (dir == null) {
-        // Debug mysterious NPE...
-        LOG.error("Null in upload allowed dirs???");
-        continue;
-      }
-      if (FileUtil.isParent(dir, filename)) return true;
-    }
-    return false;
+    return transferPolicy.allowUploadFrom(filename);
   }
 
   /**
@@ -2461,7 +1240,7 @@ public class NodeClientCore implements Persistable {
    * @return current allowlist array; entries are internal references, not copies.
    */
   public synchronized File[] getAllowedDownloadDirs() {
-    return downloadAllowedDirs;
+    return transferPolicy.getAllowedDownloadDirs();
   }
 
   /**
@@ -2474,7 +1253,7 @@ public class NodeClientCore implements Persistable {
    * @return current allowlist array; entries are internal references, not copies.
    */
   public synchronized File[] getAllowedUploadDirs() {
-    return uploadAllowedDirs;
+    return transferPolicy.getAllowedUploadDirs();
   }
 
   /**
@@ -2719,6 +1498,18 @@ public class NodeClientCore implements Persistable {
    */
   public USKManager getUskManager() {
     return uskManager;
+  }
+
+  /**
+   * Returns the client transfer operations for fetch/insert paths.
+   *
+   * <p>The returned {@link NodeClientCoreTransfers} instance encapsulates key transfer logic and is
+   * bound to this core. Callers should treat it as core-owned state.
+   *
+   * @return shared transfer operations instance.
+   */
+  public NodeClientCoreTransfers getTransfers() {
+    return transfers;
   }
 
   /**

--- a/src/main/java/network/crypta/node/NodeClientCoreInit.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreInit.java
@@ -1,0 +1,37 @@
+package network.crypta.node;
+
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.config.Config;
+import network.crypta.config.SubConfig;
+
+/** Bundles configuration inputs required to initialize {@link NodeClientCore}. */
+public final class NodeClientCoreInit {
+  private final Config config;
+  private final SubConfig nodeConfig;
+  private final SubConfig installConfig;
+  private final SimpleToadletServer toadlets;
+
+  public NodeClientCoreInit(
+      Config config, SubConfig nodeConfig, SubConfig installConfig, SimpleToadletServer toadlets) {
+    this.config = config;
+    this.nodeConfig = nodeConfig;
+    this.installConfig = installConfig;
+    this.toadlets = toadlets;
+  }
+
+  public Config getConfig() {
+    return config;
+  }
+
+  public SubConfig getNodeConfig() {
+    return nodeConfig;
+  }
+
+  public SubConfig getInstallConfig() {
+    return installConfig;
+  }
+
+  public SimpleToadletServer getToadlets() {
+    return toadlets;
+  }
+}

--- a/src/main/java/network/crypta/node/NodeClientCoreInit.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreInit.java
@@ -4,34 +4,43 @@ import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.config.Config;
 import network.crypta.config.SubConfig;
 
-/** Bundles configuration inputs required to initialize {@link NodeClientCore}. */
-public final class NodeClientCoreInit {
-  private final Config config;
-  private final SubConfig nodeConfig;
-  private final SubConfig installConfig;
-  private final SimpleToadletServer toadlets;
-
-  public NodeClientCoreInit(
-      Config config, SubConfig nodeConfig, SubConfig installConfig, SimpleToadletServer toadlets) {
-    this.config = config;
-    this.nodeConfig = nodeConfig;
-    this.installConfig = installConfig;
-    this.toadlets = toadlets;
-  }
-
-  public Config getConfig() {
-    return config;
-  }
-
-  public SubConfig getNodeConfig() {
-    return nodeConfig;
-  }
-
-  public SubConfig getInstallConfig() {
-    return installConfig;
-  }
-
-  public SimpleToadletServer getToadlets() {
-    return toadlets;
-  }
-}
+/**
+ * Bundles configuration inputs required to initialize {@link NodeClientCore}.
+ *
+ * <p>This record is a small, immutable carrier for the configuration objects and server wiring
+ * needed during client-core startup. It keeps related inputs together so call sites can pass a
+ * single value through initialization flows without threading multiple parameters across several
+ * methods. Typical usage is to construct it once, then pass it to initialization helpers that read
+ * the accessors to configure persistence, networking, and client-facing endpoints.
+ *
+ * <p>The record itself is shallowly immutable: its component references never change after
+ * construction, but the referenced objects may still be mutable and managed elsewhere. Callers may
+ * supply {@code null} components when a particular subsystem is intentionally absent; consumers
+ * must handle such cases explicitly.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Holding the root {@link Config} and relevant {@link SubConfig} sections.
+ *   <li>Providing access to the {@link SimpleToadletServer} used by HTTP toadlets.
+ *   <li>Keeping startup wiring cohesive and easy to pass across layers.
+ * </ul>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * NodeClientCoreInit init =
+ *     new NodeClientCoreInit(config, nodeConfig, installConfig, toadlets);
+ * Config root = init.config();
+ * }</pre>
+ *
+ * @param config root configuration container used by client-core subsystems; may be {@code null}
+ * @param nodeConfig node-specific sub-configuration used during initialization; may be {@code null}
+ * @param installConfig installation sub-configuration for path and store setup; may be {@code null}
+ * @param toadlets HTTP toadlet server instance used for client endpoints; may be {@code null}
+ * @see NodeClientCore
+ * @see NodeClientPersistence
+ * @see ClientEndpoints
+ */
+public record NodeClientCoreInit(
+    Config config, SubConfig nodeConfig, SubConfig installConfig, SimpleToadletServer toadlets) {}

--- a/src/main/java/network/crypta/node/NodeClientCoreSupport.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreSupport.java
@@ -5,15 +5,21 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.HashSet;
 import network.crypta.client.ArchiveManager;
+import network.crypta.client.FECCodec;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.HealingDecisionSupplier;
 import network.crypta.client.async.SimpleHealingQueue;
 import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.SubConfig;
+import network.crypta.crypt.RandomSource;
 import network.crypta.fs.AppDirs;
 import network.crypta.fs.AppEnv;
 import network.crypta.fs.Resolved;
 import network.crypta.fs.ServiceDirs;
+import network.crypta.io.xfer.PartiallyReceivedBlock;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKVerifyException;
 import network.crypta.keys.ClientCHK;
@@ -30,6 +36,8 @@ import network.crypta.node.useralerts.DiskSpaceUserAlert;
 import network.crypta.node.useralerts.SimpleUserAlert;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.SizeUtil;
+import network.crypta.support.api.LongCallback;
 import network.crypta.support.compress.Compressor;
 import network.crypta.support.io.FileUtil;
 import network.crypta.support.io.TempBucketFactory;
@@ -116,6 +124,94 @@ public final class NodeClientCoreSupport {
     return new ClientContextResources(archiveManager, healingQueue);
   }
 
+  /**
+   * Creates a high-level client bound to the provided core.
+   *
+   * <p>The returned client shares the core's context and bucket factories and honors the provided
+   * priority class and real-time flag.
+   */
+  public static HighLevelSimpleClient createHighLevelClient(
+      NodeClientCore core,
+      TempBucketFactory tempBucketFactory,
+      RandomSource random,
+      short prioClass,
+      boolean forceDontIgnoreTooManyPathComponents,
+      boolean realTimeFlag) {
+    return new HighLevelSimpleClientImpl(
+        core,
+        tempBucketFactory,
+        random,
+        prioClass,
+        forceDontIgnoreTooManyPathComponents,
+        realTimeFlag);
+  }
+
+  /**
+   * Computes the default memory limit for memory-limited jobs given the overall JVM memory limit.
+   *
+   * <p>The default starts at the minimum required by FEC decoding and scales with available memory
+   * beyond 512 MiB. This mirrors the previous in-core calculation and keeps the same effective
+   * defaults.
+   *
+   * @param overallMemoryLimit total memory limit in bytes.
+   * @return computed default memory limit for memory-limited jobs.
+   */
+  public static long computeDefaultMemoryLimitedJobMemoryLimit(long overallMemoryLimit) {
+    long limit = FECCodec.MIN_MEMORY_ALLOCATION;
+    if (overallMemoryLimit > 512L * 1024 * 1024) {
+      limit += (overallMemoryLimit - 512L * 1024 * 1024) / 20;
+    }
+    return limit;
+  }
+
+  /**
+   * Registers the memory-limited job memory cap setting.
+   *
+   * <p>Validation enforces the minimum FEC allocation and updates the shared runner at runtime.
+   *
+   * @param init initialization context containing node configuration.
+   * @param sortOrder current config sort order.
+   * @param defaultMemoryLimitedJobMemoryLimit default memory cap in bytes.
+   * @param core owning core used to access the shared runner.
+   * @return updated sort order.
+   */
+  public static int registerMemoryLimitedJobMemoryLimit(
+      NodeClientCoreInit init,
+      int sortOrder,
+      long defaultMemoryLimitedJobMemoryLimit,
+      NodeClientCore core) {
+    init.nodeConfig()
+        .register(
+            "memoryLimitedJobMemoryLimit",
+            defaultMemoryLimitedJobMemoryLimit,
+            sortOrder,
+            true,
+            false,
+            "NodeClientCore.memoryLimitedJobMemoryLimit",
+            "NodeClientCore.memoryLimitedJobMemoryLimitLong",
+            new LongCallback() {
+
+              @Override
+              public Long get() {
+                return core.memoryLimitedJobRunner.getCapacity();
+              }
+
+              @Override
+              public void set(Long val) throws InvalidConfigValueException {
+                if (val < FECCodec.MIN_MEMORY_ALLOCATION)
+                  throw new InvalidConfigValueException(
+                      NodeL10n.getBase()
+                          .getString(
+                              "NodeClientCore.memoryLimitedJobMemoryLimitMustBeAtLeast",
+                              "min",
+                              SizeUtil.formatSize(FECCodec.MIN_MEMORY_ALLOCATION)));
+                core.memoryLimitedJobRunner.setCapacity(val);
+              }
+            },
+            true);
+    return sortOrder + 1;
+  }
+
   /** Builds a client CHK block from an encoded block and key. */
   public static ClientKeyBlock buildClientChkBlock(CHKBlock block, ClientCHK key)
       throws CHKVerifyException {
@@ -132,6 +228,31 @@ public final class NodeClientCoreSupport {
   public static ClientKeyBlock buildClientSskBlock(SSKBlock block, ClientSSK key)
       throws SSKVerifyException {
     return ClientSSKBlock.construct(block, key);
+  }
+
+  /**
+   * Builds CHK insert options for the local insert path.
+   *
+   * <p>This creates the {@link PartiallyReceivedBlock} wrapper and applies the same option
+   * configuration previously assembled in {@link NodeClientCore}.
+   */
+  public static Node.ChkInsertOptions buildChkInsertOptions(
+      byte[] headers,
+      byte[] data,
+      boolean canWriteClientCache,
+      boolean forkOnCacheable,
+      boolean preferInsert,
+      boolean ignoreLowBackoff,
+      boolean realTimeFlag) {
+    PartiallyReceivedBlock prb =
+        new PartiallyReceivedBlock(Node.PACKETS_IN_BLOCK, Node.PACKET_SIZE, data);
+    return Node.ChkInsertOptions.of(headers, prb)
+        .withFromStore(false)
+        .withCanWriteClientCache(canWriteClientCache)
+        .withForkOnCacheable(forkOnCacheable)
+        .withPreferInsert(preferInsert)
+        .withIgnoreLowBackoff(ignoreLowBackoff)
+        .withRealTimeFlag(realTimeFlag);
   }
 
   /**
@@ -190,6 +311,15 @@ public final class NodeClientCoreSupport {
   public static void registerStorageAlerts(UserAlertManager alerts, NodeClientCore core) {
     alerts.register(new DiskSpaceUserAlert(core));
     alerts.register(new DatastoreTooSmallAlert(core));
+  }
+
+  /**
+   * Returns a localized string for NodeClientCore settings.
+   *
+   * <p>Use {@link NodeL10n#getBase()} directly when parameter substitution is required.
+   */
+  public static String l10n(String key) {
+    return NodeL10n.getBase().getString("NodeClientCore." + key);
   }
 
   private static UserAlert createPersistenceBrokenAlert(NodeClientCore core) {

--- a/src/main/java/network/crypta/node/NodeClientCoreSupport.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreSupport.java
@@ -36,6 +36,9 @@ import network.crypta.support.io.TempBucketFactory;
 
 /** Helper methods that keep NodeClientCore wiring focused while preserving existing behavior. */
 public final class NodeClientCoreSupport {
+  /** Lock used when evaluating persistence alert validity to avoid synchronizing on parameters. */
+  private static final Object PERSISTENCE_ALERT_LOCK = new Object();
+
   private NodeClientCoreSupport() {}
 
   /** Returns the default cache directory for the current environment (service or desktop). */
@@ -152,7 +155,7 @@ public final class NodeClientCoreSupport {
         .routingSelector()
         .closerPeer(
             null,
-            new HashSet<PeerNode>(),
+            new HashSet<>(),
             key.toNormalizedDouble(),
             true,
             false,
@@ -206,7 +209,7 @@ public final class NodeClientCoreSupport {
         UserAlert.CRITICAL_ERROR) {
       @Override
       public boolean isValid() {
-        synchronized (core) {
+        synchronized (PERSISTENCE_ALERT_LOCK) {
           if (!core.killedDatabase()) return false;
         }
         if (node.awaitingPassword()) return false;

--- a/src/main/java/network/crypta/node/NodeClientCoreSupport.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreSupport.java
@@ -1,0 +1,227 @@
+package network.crypta.node;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashSet;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.HealingDecisionSupplier;
+import network.crypta.client.async.SimpleHealingQueue;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.config.SubConfig;
+import network.crypta.fs.AppDirs;
+import network.crypta.fs.AppEnv;
+import network.crypta.fs.Resolved;
+import network.crypta.fs.ServiceDirs;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.CHKVerifyException;
+import network.crypta.keys.ClientCHK;
+import network.crypta.keys.ClientCHKBlock;
+import network.crypta.keys.ClientKeyBlock;
+import network.crypta.keys.ClientSSK;
+import network.crypta.keys.ClientSSKBlock;
+import network.crypta.keys.Key;
+import network.crypta.keys.SSKBlock;
+import network.crypta.keys.SSKVerifyException;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.useralerts.DatastoreTooSmallAlert;
+import network.crypta.node.useralerts.DiskSpaceUserAlert;
+import network.crypta.node.useralerts.SimpleUserAlert;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.compress.Compressor;
+import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.TempBucketFactory;
+
+/** Helper methods that keep NodeClientCore wiring focused while preserving existing behavior. */
+public final class NodeClientCoreSupport {
+  private NodeClientCoreSupport() {}
+
+  /** Returns the default cache directory for the current environment (service or desktop). */
+  public static File resolveDefaultCacheDir() {
+    return resolveDefaultDirs().getCacheDir().toFile();
+  }
+
+  /** Returns the default data directory for the current environment (service or desktop). */
+  public static File resolveDefaultDataDir() {
+    return resolveDefaultDirs().getDataDir().toFile();
+  }
+
+  /** Returns the resolved program directory as a {@link File}. */
+  public static File setupProgramDirFile(
+      Node node,
+      SubConfig installConfig,
+      String cfgKey,
+      String defaultValue,
+      String shortDesc,
+      String longDesc)
+      throws NodeInitException {
+    return setupProgramDirFile(
+        node, installConfig, cfgKey, defaultValue, shortDesc, longDesc, null);
+  }
+
+  /** Returns the resolved program directory as a {@link File}. */
+  public static File setupProgramDirFile(
+      Node node,
+      SubConfig installConfig,
+      String cfgKey,
+      String defaultValue,
+      String shortDesc,
+      String longDesc,
+      String moveErrMsg)
+      throws NodeInitException {
+    return node.setupProgramDir(
+            installConfig, cfgKey, defaultValue, shortDesc, longDesc, moveErrMsg)
+        .dir();
+  }
+
+  /** Creates archive and healing resources required for client context initialization. */
+  public static ClientContextResources createClientContextResources(
+      Node node,
+      TempBucketFactory tempBucketFactory,
+      int maxArchiveHandlers,
+      long maxCachedArchiveData,
+      long maxArchivedFileSize,
+      int maxCachedElements,
+      int maxRunningHealingInserts) {
+    ArchiveManager archiveManager =
+        new ArchiveManager(
+            maxArchiveHandlers,
+            maxCachedArchiveData,
+            maxArchivedFileSize,
+            maxCachedElements,
+            tempBucketFactory);
+    SimpleHealingQueue healingQueue =
+        new SimpleHealingQueue(
+            new InsertContext(
+                0,
+                2,
+                0,
+                0,
+                new SimpleEventProducer(),
+                false,
+                Node.FORK_ON_CACHEABLE_DEFAULT,
+                false,
+                Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
+                0,
+                0,
+                InsertContext.CompatibilityMode.COMPAT_DEFAULT),
+            RequestStarter.PREFETCH_PRIORITY_CLASS,
+            maxRunningHealingInserts,
+            new HealingDecisionSupplier(node::getLocation, node::isOpennetEnabled));
+    return new ClientContextResources(archiveManager, healingQueue);
+  }
+
+  /** Builds a client CHK block from an encoded block and key. */
+  public static ClientKeyBlock buildClientChkBlock(CHKBlock block, ClientCHK key)
+      throws CHKVerifyException {
+    return new ClientCHKBlock(block, key);
+  }
+
+  /** Builds a client CHK block from raw data and headers. */
+  public static ClientKeyBlock buildClientChkBlock(byte[] data, byte[] header, ClientCHK key)
+      throws CHKVerifyException {
+    return new ClientCHKBlock(data, header, key, true);
+  }
+
+  /** Builds a client SSK block from an encoded block and key. */
+  public static ClientKeyBlock buildClientSskBlock(SSKBlock block, ClientSSK key)
+      throws SSKVerifyException {
+    return ClientSSKBlock.construct(block, key);
+  }
+
+  /**
+   * Deletes the provided file, mirroring NodeClientCore's previous deletion behavior.
+   *
+   * @throws IOException if deletion fails
+   */
+  public static void deleteFile(File file) throws IOException {
+    Files.delete(file.toPath());
+  }
+
+  /**
+   * Computes the most recent failure timing for routing decisions.
+   *
+   * <p>Mirrors the originator behavior by decrementing HTL before invoking the routing selector.
+   */
+  public static long checkRecentlyFailed(Node node, Key key, boolean realTime) {
+    RecentlyFailedReturn result = new RecentlyFailedReturn();
+    short origHtl = node.decrementHTL(null, node.maxHTL());
+    node.getPeers()
+        .routingSelector()
+        .closerPeer(
+            null,
+            new HashSet<PeerNode>(),
+            key.toNormalizedDouble(),
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            key,
+            origHtl,
+            0,
+            true,
+            realTime,
+            result,
+            false,
+            System.currentTimeMillis(),
+            node.enableNewLoadManagement(realTime));
+    return result.recentlyFailed();
+  }
+
+  /** Creates the startup alert displayed until the node finishes initialization. */
+  public static UserAlert createStartingUpAlert(String title, String longText, String shortText) {
+    return new SimpleUserAlert(true, title, longText, shortText, UserAlert.ERROR);
+  }
+
+  /** Registers the core FProxy alerts, including the persistence-broken warning. */
+  public static void registerFProxyAlerts(
+      UserAlertManager alerts, NodeClientCore core, UserAlert startingUpAlert) {
+    alerts.register(startingUpAlert);
+    alerts.register(createPersistenceBrokenAlert(core));
+  }
+
+  /** Registers disk-space related user alerts. */
+  public static void registerStorageAlerts(UserAlertManager alerts, NodeClientCore core) {
+    alerts.register(new DiskSpaceUserAlert(core));
+    alerts.register(new DatastoreTooSmallAlert(core));
+  }
+
+  private static UserAlert createPersistenceBrokenAlert(NodeClientCore core) {
+    Node node = core.getNode();
+    String tempDir =
+        new File(FileUtil.getCanonicalFile(core.getPersistentTempDir()), File.separator).toString();
+    String dbFile = new File(FileUtil.getCanonicalFile(node.getUserDir()), "client.dat").toString();
+    return new SimpleUserAlert(
+        true,
+        NodeL10n.getBase().getString("QueueToadlet.persistenceBrokenTitle"),
+        NodeL10n.getBase()
+            .getString(
+                "QueueToadlet.persistenceBroken",
+                new String[] {"TEMPDIR", "DBFILE"},
+                new String[] {tempDir, dbFile}),
+        NodeL10n.getBase().getString("QueueToadlet.persistenceBrokenShortAlert"),
+        UserAlert.CRITICAL_ERROR) {
+      @Override
+      public boolean isValid() {
+        synchronized (core) {
+          if (!core.killedDatabase()) return false;
+        }
+        if (node.awaitingPassword()) return false;
+        return !node.isStopping();
+      }
+
+      @Override
+      public boolean userCanDismiss() {
+        return false;
+      }
+    };
+  }
+
+  private static Resolved resolveDefaultDirs() {
+    AppEnv appEnv = new AppEnv();
+    return appEnv.isServiceMode() ? new ServiceDirs().resolve() : new AppDirs().resolve();
+  }
+}

--- a/src/main/java/network/crypta/node/NodeClientCoreSupport.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreSupport.java
@@ -42,24 +42,77 @@ import network.crypta.support.compress.Compressor;
 import network.crypta.support.io.FileUtil;
 import network.crypta.support.io.TempBucketFactory;
 
-/** Helper methods that keep NodeClientCore wiring focused while preserving existing behavior. */
+/**
+ * Provides wiring helpers that keep {@link NodeClientCore} focused on orchestration logic.
+ *
+ * <p>This utility exposes stateless factories and registration helpers used during node startup and
+ * client setup. It resolves default directories based on the runtime environment, builds client
+ * context resources, assembles insert options, and wires user alerts and localization. The helpers
+ * intentionally mirror previous in-core defaults to preserve behavior while keeping the
+ * implementation centralized and testable. The class is safe to call from multiple threads because
+ * it holds no mutable state; the only shared guard is a dedicated lock that protects
+ * persistence-alert validity checks.
+ *
+ * <ul>
+ *   <li>Maps configuration inputs to existing node setup methods.
+ *   <li>Constructs client-facing helper objects with preserved defaults.
+ *   <li>Registers alert wiring for storage and startup status.
+ * </ul>
+ *
+ * @see NodeClientCore
+ * @see Node
+ */
 public final class NodeClientCoreSupport {
   /** Lock used when evaluating persistence alert validity to avoid synchronizing on parameters. */
   private static final Object PERSISTENCE_ALERT_LOCK = new Object();
 
   private NodeClientCoreSupport() {}
 
-  /** Returns the default cache directory for the current environment (service or desktop). */
+  /**
+   * Resolves the default cache directory for the current runtime environment.
+   *
+   * <p>This helper selects the appropriate directory layout by consulting the environment detector
+   * and then returns the cache directory from the resolved layout. It does not create or validate
+   * the directory; callers typically use it as a default when initializing configuration or when no
+   * explicit override is provided.
+   *
+   * @return default cache directory for the current environment, as a {@link File}.
+   */
   public static File resolveDefaultCacheDir() {
     return resolveDefaultDirs().getCacheDir().toFile();
   }
 
-  /** Returns the default data directory for the current environment (service or desktop). */
+  /**
+   * Resolves the default data directory for the current runtime environment.
+   *
+   * <p>This helper chooses between service-mode and desktop directory layouts and then returns the
+   * data directory from the resolved layout. It does not create or validate the directory; it
+   * simply exposes the conventional location used by the node when a configuration override is
+   * absent.
+   *
+   * @return default data directory for the current environment, as a {@link File}.
+   */
   public static File resolveDefaultDataDir() {
     return resolveDefaultDirs().getDataDir().toFile();
   }
 
-  /** Returns the resolved program directory as a {@link File}. */
+  /**
+   * Resolves the program directory from configuration and returns it as a {@link File}.
+   *
+   * <p>This overload delegates to the full variant with a {@code null} move-error message. It is
+   * typically used during installation configuration to bind a configuration key and default value
+   * to a directory path while preserving the existing {@link Node} setup behavior. Use this
+   * overload when no custom move error message is needed.
+   *
+   * @param node owning node used to perform directory setup work.
+   * @param installConfig configuration section that stores the directory setting.
+   * @param cfgKey configuration key that identifies the directory entry.
+   * @param defaultValue default path string used when no value present.
+   * @param shortDesc short description key for UI or config text.
+   * @param longDesc long description key for UI or config text.
+   * @return resolved program directory as a {@link File} for further use.
+   * @throws NodeInitException if directory resolution or validation fails.
+   */
   public static File setupProgramDirFile(
       Node node,
       SubConfig installConfig,
@@ -72,7 +125,25 @@ public final class NodeClientCoreSupport {
         node, installConfig, cfgKey, defaultValue, shortDesc, longDesc, null);
   }
 
-  /** Returns the resolved program directory as a {@link File}. */
+  /**
+   * Resolves the program directory from configuration and returns it as a {@link File}.
+   *
+   * <p>This overload delegates to {@link Node#setupProgramDir(SubConfig, String, String, String,
+   * String, String)} and exposes the resulting directory as a {@link File}. The optional move error
+   * message allows callers to customize the error text when a directory move fails while preserving
+   * the underlying setup semantics. Provide a custom message only when the caller must surface a
+   * specific migration hint.
+   *
+   * @param node owning node used to perform directory setup work.
+   * @param installConfig configuration section that stores the directory setting.
+   * @param cfgKey configuration key that identifies the directory entry.
+   * @param defaultValue default path string used when no value present.
+   * @param shortDesc short description key for UI or config text.
+   * @param longDesc long description key for UI or config text.
+   * @param moveErrMsg optional move error message or {@code null} to use defaults.
+   * @return resolved program directory as a {@link File} for further use.
+   * @throws NodeInitException if directory resolution or validation fails.
+   */
   public static File setupProgramDirFile(
       Node node,
       SubConfig installConfig,
@@ -87,7 +158,24 @@ public final class NodeClientCoreSupport {
         .dir();
   }
 
-  /** Creates archive and healing resources required for client context initialization. */
+  /**
+   * Creates archive and healing resources required for client context initialization.
+   *
+   * <p>This method builds an {@link ArchiveManager} configured with the provided limits and
+   * temporary bucket factory, then constructs a {@link SimpleHealingQueue} using an {@link
+   * InsertContext} aligned with the legacy defaults. Healing decisions are backed by the node's
+   * location and opennet state. The returned resources are not registered automatically; callers
+   * retain ownership and are responsible for wiring them into the client context.
+   *
+   * @param node node providing location and opennet state for healing decisions.
+   * @param tempBucketFactory temporary bucket factory used for archive extraction buffers.
+   * @param maxArchiveHandlers maximum concurrent archive handlers allowed by the archive manager.
+   * @param maxCachedArchiveData cap on cached archive data bytes kept in memory.
+   * @param maxArchivedFileSize maximum permitted archived file size, in bytes.
+   * @param maxCachedElements maximum number of cached archive elements retained.
+   * @param maxRunningHealingInserts upper bound for concurrent healing insert operations.
+   * @return resources containing the configured archive manager and healing queue.
+   */
   public static ClientContextResources createClientContextResources(
       Node node,
       TempBucketFactory tempBucketFactory,
@@ -127,8 +215,20 @@ public final class NodeClientCoreSupport {
   /**
    * Creates a high-level client bound to the provided core.
    *
-   * <p>The returned client shares the core's context and bucket factories and honors the provided
-   * priority class and real-time flag.
+   * <p>The returned {@link HighLevelSimpleClient} shares the core's client context and uses the
+   * provided temporary bucket factory and random source. The priority class and flags are passed
+   * through unchanged, allowing the caller to control scheduling and path-component behavior. This
+   * method always constructs a new instance and performs no caching; callers manage the lifecycle
+   * of the returned client.
+   *
+   * @param core core that provides the shared client context and settings.
+   * @param tempBucketFactory temporary bucket factory used by the client.
+   * @param random random source used for client-side operations.
+   * @param prioClass priority class value used for request scheduling.
+   * @param forceDontIgnoreTooManyPathComponents flag controlling path-component handling behavior
+   *     during requests.
+   * @param realTimeFlag whether the client should run in real-time mode.
+   * @return newly constructed high-level client bound to the provided core.
    */
   public static HighLevelSimpleClient createHighLevelClient(
       NodeClientCore core,
@@ -149,12 +249,13 @@ public final class NodeClientCoreSupport {
   /**
    * Computes the default memory limit for memory-limited jobs given the overall JVM memory limit.
    *
-   * <p>The default starts at the minimum required by FEC decoding and scales with available memory
-   * beyond 512 MiB. This mirrors the previous in-core calculation and keeps the same effective
-   * defaults.
+   * <p>The calculation starts at {@link FECCodec#MIN_MEMORY_ALLOCATION} and then adds one twentieth
+   * of any memory beyond 512 MiB. This mirrors the previous in-core formula, keeping the same
+   * effective defaults for legacy behavior. The result is deterministic, does not allocate memory,
+   * and depends only on the supplied limit.
    *
-   * @param overallMemoryLimit total memory limit in bytes.
-   * @return computed default memory limit for memory-limited jobs.
+   * @param overallMemoryLimit total memory limit in bytes for the JVM.
+   * @return default memory cap in bytes for memory-limited jobs.
    */
   public static long computeDefaultMemoryLimitedJobMemoryLimit(long overallMemoryLimit) {
     long limit = FECCodec.MIN_MEMORY_ALLOCATION;
@@ -167,13 +268,17 @@ public final class NodeClientCoreSupport {
   /**
    * Registers the memory-limited job memory cap setting.
    *
-   * <p>Validation enforces the minimum FEC allocation and updates the shared runner at runtime.
+   * <p>This registers the {@code memoryLimitedJobMemoryLimit} configuration key using the provided
+   * default and sort order. The associated {@link LongCallback} enforces {@link
+   * FECCodec#MIN_MEMORY_ALLOCATION} and updates the shared runner capacity when the value changes.
+   * Callers should use the returned sort order when registering subsequent settings to preserve
+   * stable UI ordering.
    *
-   * @param init initialization context containing node configuration.
-   * @param sortOrder current config sort order.
-   * @param defaultMemoryLimitedJobMemoryLimit default memory cap in bytes.
-   * @param core owning core used to access the shared runner.
-   * @return updated sort order.
+   * @param init initialization helper providing access to node configuration.
+   * @param sortOrder current sort order index used for config registration.
+   * @param defaultMemoryLimitedJobMemoryLimit default memory cap in bytes when unset.
+   * @param core core providing the shared memory-limited job runner.
+   * @return next sort order value after registering this setting.
    */
   public static int registerMemoryLimitedJobMemoryLimit(
       NodeClientCoreInit init,
@@ -212,19 +317,56 @@ public final class NodeClientCoreSupport {
     return sortOrder + 1;
   }
 
-  /** Builds a client CHK block from an encoded block and key. */
+  /**
+   * Builds a client CHK block from an encoded block and key.
+   *
+   * <p>This is a convenience wrapper around {@link ClientCHKBlock} construction that preserves the
+   * legacy creation path used by {@link NodeClientCore}. Verification is performed during
+   * construction, so invalid inputs surface as a checked exception. The returned {@link
+   * ClientKeyBlock} can be passed to higher-level client APIs that operate on verified blocks.
+   *
+   * @param block encoded CHK block data to verify and wrap.
+   * @param key client CHK key describing block parameters and verification.
+   * @return client key block representing the verified CHK payload.
+   * @throws CHKVerifyException if block verification fails for the provided key.
+   */
   public static ClientKeyBlock buildClientChkBlock(CHKBlock block, ClientCHK key)
       throws CHKVerifyException {
     return new ClientCHKBlock(block, key);
   }
 
-  /** Builds a client CHK block from raw data and headers. */
+  /**
+   * Builds a client CHK block from raw data and headers.
+   *
+   * <p>This variant accepts raw payload and header buffers and forwards them to the {@link
+   * ClientCHKBlock} constructor along with the supplied key. Verification happens during
+   * construction, and invalid inputs result in a checked exception. Use this helper when the
+   * encoded block has already been split into data and header components by upstream logic.
+   *
+   * @param data raw data bytes of the CHK payload.
+   * @param header raw header bytes associated with the CHK payload.
+   * @param key client CHK key used to verify and interpret inputs.
+   * @return client key block representing the verified CHK payload.
+   * @throws CHKVerifyException if verification fails for the provided data and key.
+   */
   public static ClientKeyBlock buildClientChkBlock(byte[] data, byte[] header, ClientCHK key)
       throws CHKVerifyException {
     return new ClientCHKBlock(data, header, key, true);
   }
 
-  /** Builds a client SSK block from an encoded block and key. */
+  /**
+   * Builds a client SSK block from an encoded block and key.
+   *
+   * <p>This helper delegates to {@link ClientSSKBlock#construct(SSKBlock, ClientSSK)} to create a
+   * verified client key block. It preserves the same construction behavior used by the legacy core,
+   * including validation and failure signaling via a checked exception. The returned block is ready
+   * for client-side processing and validation-aware flows.
+   *
+   * @param block encoded SSK block data to verify and wrap.
+   * @param key client SSK key describing block parameters and verification.
+   * @return client key block representing the verified SSK payload.
+   * @throws SSKVerifyException if block verification fails for the provided key.
+   */
   public static ClientKeyBlock buildClientSskBlock(SSKBlock block, ClientSSK key)
       throws SSKVerifyException {
     return ClientSSKBlock.construct(block, key);
@@ -234,7 +376,19 @@ public final class NodeClientCoreSupport {
    * Builds CHK insert options for the local insert path.
    *
    * <p>This creates the {@link PartiallyReceivedBlock} wrapper and applies the same option
-   * configuration previously assembled in {@link NodeClientCore}.
+   * configuration previously assembled in {@link NodeClientCore}. The headers and data are used to
+   * populate the options and the payload wrapper, while the boolean flags control cache behavior,
+   * fork-on-cacheable handling, insertion preference, low-backoff handling, and real-time
+   * scheduling. A fresh options instance is returned each time.
+   *
+   * @param headers encoded block header bytes to associate with the insert.
+   * @param data block payload bytes used to populate the insert wrapper.
+   * @param canWriteClientCache whether client cache writes are permitted.
+   * @param forkOnCacheable whether to fork on cacheable inserts.
+   * @param preferInsert whether to prefer insertion to fetch behavior.
+   * @param ignoreLowBackoff whether low-backoff limits should be ignored.
+   * @param realTimeFlag whether to schedule this insert as real-time.
+   * @return insert options configured for local CHK insertion.
    */
   public static Node.ChkInsertOptions buildChkInsertOptions(
       byte[] headers,
@@ -258,7 +412,13 @@ public final class NodeClientCoreSupport {
   /**
    * Deletes the provided file, mirroring NodeClientCore's previous deletion behavior.
    *
-   * @throws IOException if deletion fails
+   * <p>This is a thin wrapper around {@link Files#delete(java.nio.file.Path)} that propagates any
+   * {@link IOException} thrown by the underlying file system operation. It performs no retries or
+   * fallback logic, so callers should handle failures explicitly when deletion is optional or when
+   * user-facing messaging is required.
+   *
+   * @param file file to delete; passed directly to {@link Files#delete}.
+   * @throws IOException if the underlying delete operation fails.
    */
   public static void deleteFile(File file) throws IOException {
     Files.delete(file.toPath());
@@ -267,7 +427,15 @@ public final class NodeClientCoreSupport {
   /**
    * Computes the most recent failure timing for routing decisions.
    *
-   * <p>Mirrors the originator behavior by decrementing HTL before invoking the routing selector.
+   * <p>Mirrors the originator behavior by decrementing HTL before invoking the routing selector. It
+   * performs a selector probe using the same parameters as the in-core path and returns the {@code
+   * recentlyFailed} value captured from the selector callback. Callers use the returned value to
+   * inform routing backoff decisions without reimplementing the selector call sequence.
+   *
+   * @param node node providing routing selector and HTL configuration.
+   * @param key routing key used to select the closest peers.
+   * @param realTime whether to apply real-time scheduling constraints.
+   * @return recently-failed value reported by the routing selector.
    */
   public static long checkRecentlyFailed(Node node, Key key, boolean realTime) {
     RecentlyFailedReturn result = new RecentlyFailedReturn();
@@ -295,19 +463,51 @@ public final class NodeClientCoreSupport {
     return result.recentlyFailed();
   }
 
-  /** Creates the startup alert displayed until the node finishes initialization. */
+  /**
+   * Creates the startup alert displayed until the node finishes initialization.
+   *
+   * <p>The supplied title and text values are used verbatim, and the alert is created with error
+   * severity to communicate that the node is still initializing. Callers typically register the
+   * alert at startup and remove or replace it once initialization completes.
+   *
+   * @param title localized title shown in the alerts list.
+   * @param longText detailed message describing the startup state.
+   * @param shortText short message used for condensed alert displays.
+   * @return newly constructed user alert for startup status.
+   */
   public static UserAlert createStartingUpAlert(String title, String longText, String shortText) {
     return new SimpleUserAlert(true, title, longText, shortText, UserAlert.ERROR);
   }
 
-  /** Registers the core FProxy alerts, including the persistence-broken warning. */
+  /**
+   * Registers the core FProxy alerts, including the persistence-broken warning.
+   *
+   * <p>This registers the provided startup alert and then adds the persistence-broken alert that is
+   * derived from the core's state. It centralizes the alert wiring sequence so the calling code can
+   * remain focused on higher-level initialization flow. It does not remove or replace existing
+   * alerts.
+   *
+   * @param alerts alert manager that receives the registrations.
+   * @param core core used to build the persistence-broken alert.
+   * @param startingUpAlert startup alert to register first.
+   */
   public static void registerFProxyAlerts(
       UserAlertManager alerts, NodeClientCore core, UserAlert startingUpAlert) {
     alerts.register(startingUpAlert);
     alerts.register(createPersistenceBrokenAlert(core));
   }
 
-  /** Registers disk-space related user alerts. */
+  /**
+   * Registers disk-space related user alerts.
+   *
+   * <p>This method wires both the disk-space warning and datastore-too-small warning alerts into
+   * the provided manager. It does not perform any evaluation itself; the alert instances handle
+   * their own validation and message updates once registered. Registration order matches the legacy
+   * sequence used in the core.
+   *
+   * @param alerts alert manager that receives the registrations.
+   * @param core core used by the alert implementations to query state.
+   */
   public static void registerStorageAlerts(UserAlertManager alerts, NodeClientCore core) {
     alerts.register(new DiskSpaceUserAlert(core));
     alerts.register(new DatastoreTooSmallAlert(core));
@@ -316,7 +516,13 @@ public final class NodeClientCoreSupport {
   /**
    * Returns a localized string for NodeClientCore settings.
    *
-   * <p>Use {@link NodeL10n#getBase()} directly when parameter substitution is required.
+   * <p>This helper prefixes the provided key with {@code "NodeClientCore."} and looks it up using
+   * {@link NodeL10n#getBase()}. It is intended for simple string lookups without parameter
+   * substitution; callers that need substitutions should obtain the base bundle directly. It does
+   * not perform caching; each call performs a bundle lookup.
+   *
+   * @param key key suffix appended to the {@code NodeClientCore.} prefix.
+   * @return localized string for the composed NodeClientCore key.
    */
   public static String l10n(String key) {
     return NodeL10n.getBase().getString("NodeClientCore." + key);

--- a/src/main/java/network/crypta/node/NodeClientCoreTransferPolicy.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreTransferPolicy.java
@@ -9,34 +9,106 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handles download/upload allowlists and file permission checks for {@link NodeClientCore}.
+ * Tracks configured transfer allowlists for {@link NodeClientCore} and evaluates file path
+ * permissions.
  *
- * <p>This helper owns mutable allowlist state and encapsulates the configuration callbacks that
- * update it. It keeps policy logic cohesive and reduces the core's direct dependencies.
+ * <p>This helper owns the mutable download and upload allowlists derived from node configuration.
+ * It registers configuration callbacks, normalizes special tokens such as {@code "all"} and {@code
+ * "downloads"}, and answers permission checks against candidate paths. Typical usage is to
+ * construct the policy during client-core initialization, call the registration methods to wire it
+ * into {@link NodeClientCoreInit}, and then consult {@link #allowDownloadTo(File)} or {@link
+ * #allowUploadFrom(File)} before initiating file I/O.
+ *
+ * <p>The policy is stateful and thread-safe for its own fields: mutations and reads of allowlist
+ * arrays are synchronized on {@code this}. Permission checks never create directories or touch the
+ * filesystem beyond parent-path comparisons, but download checks also honor the current physical
+ * threat level from {@link SecurityLevels}. Changes take effect immediately for subsequent calls.
+ *
+ * <ul>
+ *   <li>Maintains normalized download and upload allowlists.
+ *   <li>Registers configuration callbacks to update policy state.
+ *   <li>Answers permission checks for transfer source and destination paths.
+ * </ul>
+ *
+ * @see NodeClientCore
+ * @see NodeClientCoreInit
+ * @see SecurityLevels
  */
 final class NodeClientCoreTransferPolicy {
+  /** Logger used for unexpected allowlist state; avoids throwing on anomalies. */
   private static final Logger LOG = LoggerFactory.getLogger(NodeClientCoreTransferPolicy.class);
+
+  /** Token used in configuration to include the configured downloads directory. */
   private static final String DOWNLOADS_DIR_NAME = "downloads";
 
+  /** Node providing security levels that gate download permissions. */
   private final Node node;
+
+  /** Downloads directory used when the {@code "downloads"} token is present. */
   private final File downloadsDir;
 
+  /** Normalized list of explicit directories allowed as download destinations. */
   private File[] downloadAllowedDirs = new File[0];
+
+  /** Whether the {@code "downloads"} token is currently enabled. */
   private boolean includeDownloadDir;
+
+  /** Whether downloads are allowed to any destination regardless of path. */
   private boolean downloadAllowedEverywhere;
+
+  /** Whether configuration supplied no download entries and thus disabled downloads. */
   private boolean downloadDisabled;
+
+  /** Normalized list of explicit directories allowed as upload sources. */
   private File[] uploadAllowedDirs = new File[0];
+
+  /** Whether uploads are allowed from any source regardless of path. */
   private boolean uploadAllowedEverywhere;
 
+  /**
+   * Creates a transfer policy bound to a node and downloads directory.
+   *
+   * <p>The instance starts with empty allowlists and no implied permissions until either the
+   * registration helpers or the setter methods are invoked. The provided downloads directory is
+   * used only for parent-path checks; it is not created or validated here. Callers typically
+   * construct this policy once during client-core initialization and reuse it for subsequent
+   * permission checks.
+   *
+   * @param node owning node used to read security levels; must be non-null.
+   * @param downloadsDir downloads directory used for {@code "downloads"} resolution.
+   */
   NodeClientCoreTransferPolicy(Node node, File downloadsDir) {
     this.node = node;
     this.downloadsDir = downloadsDir;
   }
 
+  /**
+   * Reports whether downloads are disabled by the last configuration update.
+   *
+   * <p>The flag is set when {@link #setDownloadAllowedDirs(String[])} is called with an empty
+   * array. It reflects configuration intent and does not consult the filesystem. Other checks, such
+   * as {@link #allowDownloadTo(File)}, still apply their own logic independently.
+   *
+   * @return {@code true} when the most recent download allowlist was empty.
+   */
   boolean isDownloadDisabled() {
     return downloadDisabled;
   }
 
+  /**
+   * Registers the download allowlist option and binds its update callback.
+   *
+   * <p>This method wires a {@code String[]} option into the node configuration so that changes
+   * immediately update this policy. After registration, it applies the current stored value, so
+   * subsequent permission checks reflect persisted settings. Callers typically chain the returned
+   * sort order when registering additional options. Re-registering the same option would attempt to
+   * add a duplicate and is not supported.
+   *
+   * @param init initialization bundle providing the node configuration to register.
+   * @param sortOrder sort order used for UI display; incremented for return.
+   * @return next sort order value to chain for further registrations.
+   * @throws NullPointerException if {@code init} or its nodeConfig is null.
+   */
   int registerDownloadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
     init.nodeConfig()
         .register(
@@ -71,6 +143,20 @@ final class NodeClientCoreTransferPolicy {
     return sortOrder + 1;
   }
 
+  /**
+   * Registers the upload allowlist option and binds its update callback.
+   *
+   * <p>This method wires a {@code String[]} option into the node configuration so that changes
+   * immediately update this policy. After registration, it applies the current stored value, so
+   * subsequent permission checks reflect persisted settings. Callers typically chain the returned
+   * sort order when registering additional options. Re-registering the same option would attempt to
+   * add a duplicate and is not supported.
+   *
+   * @param init initialization bundle providing the node configuration to register.
+   * @param sortOrder sort order used for UI display; incremented for return.
+   * @return next sort order value to chain for further registrations.
+   * @throws NullPointerException if {@code init} or its nodeConfig is null.
+   */
   int registerUploadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
     init.nodeConfig()
         .register(
@@ -108,7 +194,11 @@ final class NodeClientCoreTransferPolicy {
    *
    * <p>Recognized entries include {@code "all"} to allow any destination and {@code "downloads"} to
    * allow the configured downloads directory. Any other string is treated as a filesystem path and
-   * stored as a {@link File}. Passing an empty array disables downloads entirely.
+   * stored as a {@link File}. Passing an empty array disables downloads entirely. The update is
+   * applied immediately and affects subsequent permission checks.
+   *
+   * @param val array of directory entries; may include {@code "all"} or {@code "downloads"} tokens.
+   * @throws NullPointerException if {@code val} contains a null entry.
    */
   synchronized void setDownloadAllowedDirs(String[] val) {
     int x = 0;
@@ -137,6 +227,9 @@ final class NodeClientCoreTransferPolicy {
    * <p>Recognized entries include {@code "all"} to allow any source. Any other string is treated as
    * a filesystem path and stored as a {@link File}. The configuration is applied immediately and
    * affects subsequent permission checks for upload sources.
+   *
+   * @param val array of directory entries; may include {@code "all"} token.
+   * @throws NullPointerException if {@code val} contains a null entry.
    */
   synchronized void setUploadAllowedDirs(String[] val) {
     int x = 0;
@@ -154,15 +247,16 @@ final class NodeClientCoreTransferPolicy {
   }
 
   /**
-   * Returns whether a file path is permitted as a download target.
+   * Determines whether a target file path is permitted for downloads.
    *
-   * <p>This check enforces the current physical threat level and the configured download allowlist,
-   * including the downloads directory when enabled. If downloads are disabled by configuration, no
-   * target is accepted. The check uses parent-path matching and does not create directories or
-   * touch the filesystem beyond path comparisons.
+   * <p>The check first consults the node's physical threat level and denies all downloads at {@link
+   * PHYSICAL_THREAT_LEVEL#MAXIMUM}. It then compares the candidate path against the current
+   * allowlist, including the configured downloads directory when enabled. Matches are evaluated by
+   * parent-directory containment and do not create files or directories. Supplying an empty
+   * allowlist disables downloads by making every path fail this check.
    *
-   * @param filename target file path to validate against download allowlist.
-   * @return {@code true} if the path is allowed under current policy.
+   * @param filename candidate path to evaluate; must be non-null.
+   * @return {@code true} when the path is within an allowed parent directory.
    */
   boolean allowDownloadTo(File filename) {
     PHYSICAL_THREAT_LEVEL physicalThreatLevel = node.getSecurityLevels().getPhysicalThreatLevel();
@@ -183,14 +277,15 @@ final class NodeClientCoreTransferPolicy {
   }
 
   /**
-   * Returns whether a file path is permitted as an upload source.
+   * Determines whether a source file path is permitted for uploads.
    *
-   * <p>This check uses the configured upload allowlist and does not verify file existence. The
-   * result is a snapshot of current configuration and is used to gate upload requests before any
-   * I/O occurs. Paths are matched by parent-directory containment.
+   * <p>The check compares the candidate path against the current upload allowlist and does not
+   * verify file existence. The result is a snapshot of configuration at call time and is used to
+   * gate upload requests before any I/O occurs. Paths are matched by parent-directory containment;
+   * when {@code "all"} is configured, any path is accepted.
    *
-   * @param filename source file path to validate against upload allowlist.
-   * @return {@code true} if the path is allowed as an upload source.
+   * @param filename candidate source path to evaluate; must be non-null.
+   * @return {@code true} when the path is within an allowed parent directory.
    */
   synchronized boolean allowUploadFrom(File filename) {
     if (uploadAllowedEverywhere) return true;
@@ -209,9 +304,11 @@ final class NodeClientCoreTransferPolicy {
    * Returns the current allowlist for download destinations.
    *
    * <p>The returned array contains the configured directories used for permission checks. It is a
-   * direct reference to internal state, so callers should not modify the array or its elements.
+   * direct reference to internal state, so callers should not modify the array or its elements. The
+   * contents may be empty when no explicit directories are configured. Callers should treat the
+   * array and its entries as read-only snapshots.
    *
-   * @return current allowlist array; entries are internal references, not copies.
+   * @return current allowlist array reference; entries are not defensive copies.
    */
   synchronized File[] getAllowedDownloadDirs() {
     return downloadAllowedDirs;
@@ -221,9 +318,11 @@ final class NodeClientCoreTransferPolicy {
    * Returns the current allowlist for upload sources.
    *
    * <p>The returned array contains the configured directories used for permission checks. It is a
-   * direct reference to internal state, so callers should not modify the array or its elements.
+   * direct reference to internal state, so callers should not modify the array or its elements. The
+   * contents may be empty when no explicit directories are configured. Callers should treat the
+   * array and its entries as read-only snapshots.
    *
-   * @return current allowlist array; entries are internal references, not copies.
+   * @return current allowlist array reference; entries are not defensive copies.
    */
   synchronized File[] getAllowedUploadDirs() {
     return uploadAllowedDirs;

--- a/src/main/java/network/crypta/node/NodeClientCoreTransferPolicy.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreTransferPolicy.java
@@ -1,0 +1,231 @@
+package network.crypta.node;
+
+import java.io.File;
+import java.util.Arrays;
+import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.support.api.StringArrCallback;
+import network.crypta.support.io.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles download/upload allowlists and file permission checks for {@link NodeClientCore}.
+ *
+ * <p>This helper owns mutable allowlist state and encapsulates the configuration callbacks that
+ * update it. It keeps policy logic cohesive and reduces the core's direct dependencies.
+ */
+final class NodeClientCoreTransferPolicy {
+  private static final Logger LOG = LoggerFactory.getLogger(NodeClientCoreTransferPolicy.class);
+  private static final String DOWNLOADS_DIR_NAME = "downloads";
+
+  private final Node node;
+  private final File downloadsDir;
+
+  private File[] downloadAllowedDirs = new File[0];
+  private boolean includeDownloadDir;
+  private boolean downloadAllowedEverywhere;
+  private boolean downloadDisabled;
+  private File[] uploadAllowedDirs = new File[0];
+  private boolean uploadAllowedEverywhere;
+
+  NodeClientCoreTransferPolicy(Node node, File downloadsDir) {
+    this.node = node;
+    this.downloadsDir = downloadsDir;
+  }
+
+  boolean isDownloadDisabled() {
+    return downloadDisabled;
+  }
+
+  int registerDownloadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
+    init.nodeConfig()
+        .register(
+            "downloadAllowedDirs",
+            new String[] {"all"},
+            sortOrder,
+            true,
+            true,
+            "NodeClientCore.downloadAllowedDirs",
+            "NodeClientCore.downloadAllowedDirsLong",
+            new StringArrCallback() {
+
+              @Override
+              public String[] get() {
+                synchronized (NodeClientCoreTransferPolicy.this) {
+                  if (downloadAllowedEverywhere) return new String[] {"all"};
+                  String[] dirs =
+                      new String[downloadAllowedDirs.length + (includeDownloadDir ? 1 : 0)];
+                  for (int i = 0; i < downloadAllowedDirs.length; i++)
+                    dirs[i] = downloadAllowedDirs[i].getPath();
+                  if (includeDownloadDir) dirs[downloadAllowedDirs.length] = DOWNLOADS_DIR_NAME;
+                  return dirs;
+                }
+              }
+
+              @Override
+              public void set(String[] val) {
+                setDownloadAllowedDirs(val);
+              }
+            });
+    setDownloadAllowedDirs(init.nodeConfig().getStringArr("downloadAllowedDirs"));
+    return sortOrder + 1;
+  }
+
+  int registerUploadAllowedDirs(NodeClientCoreInit init, int sortOrder) {
+    init.nodeConfig()
+        .register(
+            "uploadAllowedDirs",
+            new String[] {"all"},
+            sortOrder,
+            true,
+            true,
+            "NodeClientCore.uploadAllowedDirs",
+            "NodeClientCore.uploadAllowedDirsLong",
+            new StringArrCallback() {
+
+              @Override
+              public String[] get() {
+                synchronized (NodeClientCoreTransferPolicy.this) {
+                  if (uploadAllowedEverywhere) return new String[] {"all"};
+                  String[] dirs = new String[uploadAllowedDirs.length];
+                  for (int i = 0; i < uploadAllowedDirs.length; i++)
+                    dirs[i] = uploadAllowedDirs[i].getPath();
+                  return dirs;
+                }
+              }
+
+              @Override
+              public void set(String[] val) {
+                setUploadAllowedDirs(val);
+              }
+            });
+    setUploadAllowedDirs(init.nodeConfig().getStringArr("uploadAllowedDirs"));
+    return sortOrder + 1;
+  }
+
+  /**
+   * Configures directories where downloads may be written.
+   *
+   * <p>Recognized entries include {@code "all"} to allow any destination and {@code "downloads"} to
+   * allow the configured downloads directory. Any other string is treated as a filesystem path and
+   * stored as a {@link File}. Passing an empty array disables downloads entirely.
+   */
+  synchronized void setDownloadAllowedDirs(String[] val) {
+    int x = 0;
+    downloadAllowedEverywhere = false;
+    includeDownloadDir = false;
+    downloadDisabled = false;
+    int i;
+    downloadAllowedDirs = new File[val.length];
+    for (i = 0; i < downloadAllowedDirs.length; i++) {
+      String s = val[i];
+      if (s.equals(DOWNLOADS_DIR_NAME)) includeDownloadDir = true;
+      else if (s.equals("all")) downloadAllowedEverywhere = true;
+      else downloadAllowedDirs[x++] = new File(val[i]);
+    }
+    if (x != i) {
+      downloadAllowedDirs = Arrays.copyOf(downloadAllowedDirs, x);
+    }
+    if (i == 0) {
+      downloadDisabled = true;
+    }
+  }
+
+  /**
+   * Configures directories from which uploads may read.
+   *
+   * <p>Recognized entries include {@code "all"} to allow any source. Any other string is treated as
+   * a filesystem path and stored as a {@link File}. The configuration is applied immediately and
+   * affects subsequent permission checks for upload sources.
+   */
+  synchronized void setUploadAllowedDirs(String[] val) {
+    int x = 0;
+    int i;
+    uploadAllowedEverywhere = false;
+    uploadAllowedDirs = new File[val.length];
+    for (i = 0; i < uploadAllowedDirs.length; i++) {
+      String s = val[i];
+      if (s.equals("all")) uploadAllowedEverywhere = true;
+      else uploadAllowedDirs[x++] = new File(val[i]);
+    }
+    if (x != i) {
+      uploadAllowedDirs = Arrays.copyOf(uploadAllowedDirs, x);
+    }
+  }
+
+  /**
+   * Returns whether a file path is permitted as a download target.
+   *
+   * <p>This check enforces the current physical threat level and the configured download allowlist,
+   * including the downloads directory when enabled. If downloads are disabled by configuration, no
+   * target is accepted. The check uses parent-path matching and does not create directories or
+   * touch the filesystem beyond path comparisons.
+   *
+   * @param filename target file path to validate against download allowlist.
+   * @return {@code true} if the path is allowed under current policy.
+   */
+  boolean allowDownloadTo(File filename) {
+    PHYSICAL_THREAT_LEVEL physicalThreatLevel = node.getSecurityLevels().getPhysicalThreatLevel();
+    if (physicalThreatLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM) return false;
+    synchronized (this) {
+      if (downloadAllowedEverywhere) return true;
+      if (includeDownloadDir && FileUtil.isParent(downloadsDir, filename)) return true;
+      for (File dir : downloadAllowedDirs) {
+        if (dir == null) {
+          // Debug mysterious NPE...
+          LOG.error("Null in upload allowed dirs???");
+          continue;
+        }
+        if (FileUtil.isParent(dir, filename)) return true;
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Returns whether a file path is permitted as an upload source.
+   *
+   * <p>This check uses the configured upload allowlist and does not verify file existence. The
+   * result is a snapshot of current configuration and is used to gate upload requests before any
+   * I/O occurs. Paths are matched by parent-directory containment.
+   *
+   * @param filename source file path to validate against upload allowlist.
+   * @return {@code true} if the path is allowed as an upload source.
+   */
+  synchronized boolean allowUploadFrom(File filename) {
+    if (uploadAllowedEverywhere) return true;
+    for (File dir : uploadAllowedDirs) {
+      if (dir == null) {
+        // Debug mysterious NPE...
+        LOG.error("Null in upload allowed dirs???");
+        continue;
+      }
+      if (FileUtil.isParent(dir, filename)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns the current allowlist for download destinations.
+   *
+   * <p>The returned array contains the configured directories used for permission checks. It is a
+   * direct reference to internal state, so callers should not modify the array or its elements.
+   *
+   * @return current allowlist array; entries are internal references, not copies.
+   */
+  synchronized File[] getAllowedDownloadDirs() {
+    return downloadAllowedDirs;
+  }
+
+  /**
+   * Returns the current allowlist for upload sources.
+   *
+   * <p>The returned array contains the configured directories used for permission checks. It is a
+   * direct reference to internal state, so callers should not modify the array or its elements.
+   *
+   * @return current allowlist array; entries are internal references, not copies.
+   */
+  synchronized File[] getAllowedUploadDirs() {
+    return uploadAllowedDirs;
+  }
+}

--- a/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
@@ -1,0 +1,1094 @@
+package network.crypta.node;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import network.crypta.crypt.RandomSource;
+import network.crypta.io.xfer.AbortedException;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.CHKVerifyException;
+import network.crypta.keys.ClientCHK;
+import network.crypta.keys.ClientKey;
+import network.crypta.keys.ClientKeyBlock;
+import network.crypta.keys.ClientSSK;
+import network.crypta.keys.Key;
+import network.crypta.keys.KeyBlock;
+import network.crypta.keys.NodeSSK;
+import network.crypta.keys.SSKBlock;
+import network.crypta.keys.SSKVerifyException;
+import network.crypta.store.KeyCollisionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Executes client fetch and insert operations on behalf of {@link NodeClientCore}.
+ *
+ * <p>This helper encapsulates the request/insert orchestration paths so the core can focus on
+ * wiring services and configuration. It is intentionally stateful, bound to a single core instance.
+ */
+public final class NodeClientCoreTransfers {
+  private static final Logger LOG = LoggerFactory.getLogger(NodeClientCoreTransfers.class);
+  private static final String LOG_BYTES_OPEN = " bytes (";
+  private static final String MSG_CANNOT_LOCK_UID = "Could not lock UID just randomly generated: ";
+  private static final String MSG_BROKEN_PRNG = " - probably indicates broken PRNG";
+  private static final String LOG_DOES_NOT_VERIFY = "Does not verify: ";
+
+  private final NodeClientCore core;
+  private final Node node;
+  private final RandomSource random;
+  private final RequestStarterGroup requestStarters;
+
+  NodeClientCoreTransfers(NodeClientCore core) {
+    this.core = core;
+    this.node = core.getNode();
+    this.random = core.getRandom();
+    this.requestStarters = core.getRequestStarters();
+  }
+
+  /**
+   * Starts an asynchronous fetch for a key.
+   *
+   * <p>If the data is found locally the listener is notified and no network request is started.
+   * Otherwise, a request sender is created and the listener receives completion or failure
+   * callbacks; some successful outcomes may be delivered via the pending-keys mechanism instead of
+   * the listener. The call is non-blocking and returns after scheduling work using a freshly
+   * generated UID. Store access is controlled by {@code localOnly} and {@code ignoreStore}; when
+   * both are {@code false} the datastore is checked first and routing proceeds on miss.
+   *
+   * @param key key to fetch; typically a {@code CHK} or {@link NodeSSK}.
+   * @param offersOnly when true, fetch only from offered-key sources.
+   * @param listener callback notified on completion or failure of the request.
+   * @param canReadClientCache whether this request may read from the client cache.
+   * @param canWriteClientCache whether this request may write into the client cache.
+   * @param realTimeFlag true for latency-optimized routing; false for bulk throughput.
+   * @param localOnly true to check only local store and skip routing.
+   * @param ignoreStore true to bypass datastore and always create a request.
+   */
+  public void asyncGet(
+      final Key key,
+      boolean offersOnly,
+      final RequestCompletionListener listener,
+      boolean canReadClientCache,
+      boolean canWriteClientCache,
+      final boolean realTimeFlag,
+      boolean localOnly,
+      boolean ignoreStore) {
+    final long uid = makeUID();
+    final boolean isSSK = key instanceof NodeSSK;
+    final RequestTag tag =
+        new RequestTag(isSSK, RequestTag.START.ASYNC_GET, null, realTimeFlag, uid, node);
+    if (!node.getTracker().lockUID(uid, isSSK, false, false, true, realTimeFlag, tag)) {
+      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
+      listener.onFailed(
+          new LowLevelGetException(
+              LowLevelGetException.INTERNAL_ERROR,
+              "Could not lock random UID - serious PRNG problem???"));
+      return;
+    }
+    tag.setAccepted();
+    short htl = node.maxHTL();
+    // If another node requested it within the ULPR period at a lower HTL, that may allow
+    // us to cache it in the datastore. Find the lowest HTL fetching the key in that period,
+    // and use that for purposes of deciding whether to cache it in the store.
+    if (offersOnly) {
+      htl = node.getFailureTable().minOfferedHTL(key, htl);
+      if (LOG.isDebugEnabled()) LOG.debug("Using old HTL for GetOfferedKey: {}", htl);
+    }
+    final long startTime = System.currentTimeMillis();
+    startAsyncGet(
+        key,
+        offersOnly,
+        uid,
+        listener,
+        tag,
+        canReadClientCache,
+        canWriteClientCache,
+        htl,
+        realTimeFlag,
+        localOnly,
+        ignoreStore,
+        isSSK,
+        startTime);
+  }
+
+  /**
+   * Start an asynchronous fetch of the key in question, which will complete to the datastore. It
+   * will not decode the data because we don't provide a ClientKey. It will not return anything and
+   * will run asynchronously. Caller is responsible for unlocking the UID.
+   *
+   * @param key The key being fetched.
+   * @param offersOnly If true, only fetch the key from nodes that have offered it, using
+   *     GetOfferedKeys, don't do a normal fetch for it.
+   * @param uid The UID of the request. This should already be locked before calling.
+   * @param requestTag The RequestTag for the request; used for request lifecycle callbacks.
+   * @param listener Will be called by the request sender, if a request is started. However, for
+   *     example, if we fetch it from the store, it will be returned via the tripPendingKeys
+   *     mechanism.
+   * @param canReadClientCache Can this request read the client-cache?
+   * @param canWriteClientCache Can this request write the client-cache?
+   * @param htl The HTL to start the request at. See the caller, this can be modified in the case of
+   *     fetching an offered key.
+   * @param realTimeFlag Is this a real-time request? False = this is a bulk request.
+   * @param localOnly If true, only check the datastore, don't create a request if nothing is found.
+   * @param ignoreStore If true, don't check the datastore, create a request immediately.
+   * @param isSSK Whether the request targets an SSK key type.
+   * @param startTime Start time in milliseconds since epoch for metrics.
+   */
+  @SuppressWarnings("java:S1181")
+  private void startAsyncGet(
+      Key key,
+      boolean offersOnly,
+      long uid,
+      RequestCompletionListener listener,
+      Object requestTag,
+      boolean canReadClientCache,
+      boolean canWriteClientCache,
+      short htl,
+      boolean realTimeFlag,
+      boolean localOnly,
+      boolean ignoreStore,
+      boolean isSSK,
+      long startTime) {
+    RequestTag tag = (RequestTag) requestTag;
+    RequestSenderListener senderListener =
+        new RequestSenderListener() {
+
+          private boolean rejectedOverload;
+
+          @Override
+          public void onCHKTransferBegins() {
+            // Ignore
+          }
+
+          @Override
+          public void onReceivedRejectOverload() {
+            synchronized (this) {
+              if (rejectedOverload) return;
+              rejectedOverload = true;
+            }
+            requestStarters.rejectedOverload(isSSK, false, realTimeFlag);
+          }
+
+          @Override
+          public void onDataFoundLocally() {
+            tag.unlockHandler();
+            listener.onSucceeded();
+          }
+
+          /**
+           * The RequestSender finished.
+           *
+           * @param status The completion status code reported by the sender.
+           * @param fromOfferedKey {@code true} if this completion originated from an offered-key
+           *     fetch path (GetOfferedKeys); {@code false} for a normal fetch.
+           * @param rs The sender that completed and reported the status.
+           */
+          @Override
+          public void onRequestSenderFinished(
+              int status, boolean fromOfferedKey, RequestSender rs) {
+            tag.unlockHandler();
+            boolean rejectedOverloadLocal;
+            synchronized (this) {
+              rejectedOverloadLocal = this.rejectedOverload;
+            }
+            handleAsyncGetFinished(
+                isSSK, listener, startTime, key, realTimeFlag, rs, rejectedOverloadLocal);
+          }
+
+          @Override
+          public void onNotStarted(boolean internalError) {
+            if (internalError)
+              listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
+            else
+              listener.onFailed(
+                  new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND_IN_STORE));
+          }
+        };
+    try {
+      Object o =
+          node.makeRequestSender(
+              key,
+              htl,
+              uid,
+              tag,
+              null,
+              Node.RequestSenderOptions.of(
+                  localOnly,
+                  ignoreStore,
+                  offersOnly,
+                  canReadClientCache,
+                  canWriteClientCache,
+                  realTimeFlag));
+      if (o instanceof KeyBlock) {
+        tag.setServedFromDatastore();
+        senderListener.onDataFoundLocally();
+        return; // Already have it.
+      }
+      if (o == null) {
+        senderListener.onNotStarted(false);
+        tag.unlockHandler();
+        return;
+      }
+      RequestSender rs = (RequestSender) o;
+      rs.addListener(senderListener);
+      if (rs.uid != uid) tag.unlockHandler();
+      // Else it has started a request.
+      if (LOG.isDebugEnabled()) LOG.debug("Started {} for {} for {}", o, uid, key);
+    } catch (RuntimeException | Error e) {
+      LOG.error("Caught error trying to start request: {}", e, e);
+      senderListener.onNotStarted(true);
+    }
+  }
+
+  private void handleAsyncGetFinished(
+      boolean isSSK,
+      RequestCompletionListener listener,
+      long startTime,
+      Key key,
+      boolean realTimeFlag,
+      RequestSender rs,
+      boolean rejectedOverload) {
+    int status = rs.getStatus();
+    if (status == RequestSender.NOT_FINISHED) {
+      LOG.error("Bogus status in onRequestSenderFinished for {}", rs, new Exception("error"));
+      listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
+      return;
+    }
+
+    if (isNonErrorStatus(status)) reportFetchCosts(isSSK, rs, status);
+
+    if (status == RequestSender.TIMED_OUT || status == RequestSender.GENERATED_REJECTED_OVERLOAD) {
+      handleTimeoutOrRejected(isSSK, realTimeFlag, startTime, key, rejectedOverload);
+    } else if (rs.hasForwarded() && isForwardedTerminalStatus(status)) {
+      handleForwardedStatuses(isSSK, realTimeFlag, startTime, key, status);
+    }
+
+    if (status == RequestSender.SUCCESS) {
+      listener.onSucceeded();
+      return;
+    }
+    handleStatusResult(isSSK, listener, rs, status);
+  }
+
+  private boolean isNonErrorStatus(int status) {
+    return status != RequestSender.TIMED_OUT
+        && status != RequestSender.GENERATED_REJECTED_OVERLOAD
+        && status != RequestSender.INTERNAL_ERROR;
+  }
+
+  private void reportFetchCosts(boolean isSSK, RequestSender rs, int status) {
+    if (LOG.isDebugEnabled())
+      LOG.debug(
+          "{} fetch cost {}/{}" + LOG_BYTES_OPEN + "{})",
+          isSSK ? "SSK" : "CHK",
+          rs.getTotalSentBytes(),
+          rs.getTotalReceivedBytes(),
+          status);
+    (isSSK
+            ? node.getNodeStats().localSskFetchBytesSentAverage
+            : node.getNodeStats().localChkFetchBytesSentAverage)
+        .report(rs.getTotalSentBytes());
+    (isSSK
+            ? node.getNodeStats().localSskFetchBytesReceivedAverage
+            : node.getNodeStats().localChkFetchBytesReceivedAverage)
+        .report(rs.getTotalReceivedBytes());
+    if (status == RequestSender.SUCCESS)
+      (isSSK
+              ? node.getNodeStats().successfulSskFetchBytesReceivedAverage
+              : node.getNodeStats().successfulChkFetchBytesReceivedAverage)
+          .report(rs.getTotalReceivedBytes());
+  }
+
+  private boolean isForwardedTerminalStatus(int status) {
+    return status == RequestSender.DATA_NOT_FOUND
+        || status == RequestSender.RECENTLY_FAILED
+        || status == RequestSender.SUCCESS
+        || status == RequestSender.ROUTE_NOT_FOUND
+        || status == RequestSender.VERIFY_FAILURE
+        || status == RequestSender.GET_OFFER_VERIFY_FAILURE;
+  }
+
+  private void handleTimeoutOrRejected(
+      boolean isSSK, boolean realTimeFlag, long startTime, Key key, boolean rejectedOverload) {
+    if (rejectedOverload) return;
+    requestStarters.rejectedOverload(isSSK, false, realTimeFlag);
+    long rtt = System.currentTimeMillis() - startTime;
+    double targetLocation = key.toNormalizedDouble();
+    if (isSSK) node.getNodeStats().reportSSKOutcome(rtt, false, realTimeFlag);
+    else node.getNodeStats().reportCHKOutcome(rtt, false, targetLocation, realTimeFlag);
+  }
+
+  private void handleForwardedStatuses(
+      boolean isSSK, boolean realTimeFlag, long startTime, Key key, int status) {
+    long rtt = System.currentTimeMillis() - startTime;
+    double targetLocation = key.toNormalizedDouble();
+    requestStarters.requestCompleted(isSSK, false, key, realTimeFlag);
+    requestStarters.getThrottle(isSSK, false, realTimeFlag).successfulCompletion(rtt);
+    if (isSSK)
+      node.getNodeStats().reportSSKOutcome(rtt, status == RequestSender.SUCCESS, realTimeFlag);
+    else
+      node.getNodeStats()
+          .reportCHKOutcome(rtt, status == RequestSender.SUCCESS, targetLocation, realTimeFlag);
+    if (status == RequestSender.SUCCESS) {
+      LOG.debug("Successful {} fetch took {}", isSSK ? "SSK" : "CHK", rtt);
+    }
+  }
+
+  private void handleStatusResult(
+      boolean isSSK, RequestCompletionListener listener, RequestSender rs, int status) {
+    switch (status) {
+      case RequestSender.NOT_FINISHED:
+        LOG.error("RS still running in get{}!: {}", isSSK ? "SSK" : "CHK", rs);
+        listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
+        return;
+      case RequestSender.DATA_NOT_FOUND:
+        listener.onFailed(new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND));
+        return;
+      case RequestSender.RECENTLY_FAILED:
+        listener.onFailed(new LowLevelGetException(LowLevelGetException.RECENTLY_FAILED));
+        return;
+      case RequestSender.ROUTE_NOT_FOUND:
+        listener.onFailed(new LowLevelGetException(LowLevelGetException.ROUTE_NOT_FOUND));
+        return;
+      case RequestSender.TRANSFER_FAILED, RequestSender.GET_OFFER_TRANSFER_FAILED:
+        listener.onFailed(new LowLevelGetException(LowLevelGetException.TRANSFER_FAILED));
+        return;
+      case RequestSender.VERIFY_FAILURE, RequestSender.GET_OFFER_VERIFY_FAILURE:
+        listener.onFailed(new LowLevelGetException(LowLevelGetException.VERIFY_FAILED));
+        return;
+      case RequestSender.GENERATED_REJECTED_OVERLOAD, RequestSender.TIMED_OUT:
+        listener.onFailed(new LowLevelGetException(LowLevelGetException.REJECTED_OVERLOAD));
+        return;
+      case RequestSender.INTERNAL_ERROR:
+        listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
+        return;
+      default:
+        LOG.error(
+            "Unknown RequestSender code in get{}: {} on {}", isSSK ? "SSK" : "CHK", status, rs);
+        listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
+    }
+  }
+
+  /**
+   * Synchronously fetches a block for a client key.
+   *
+   * <p>This method blocks until the fetch completes or fails. Depending on {@code localOnly} and
+   * {@code ignoreStore}, it may read from the datastore or issue a routed request through the
+   * network. It returns a verified client block on success and throws a {@link
+   * LowLevelGetException} on any failure. The request uses an internally generated UID and releases
+   * tracking resources before returning.
+   *
+   * @param key client key to fetch; must be {@link ClientCHK} or {@link ClientSSK}.
+   * @param localOnly true to consult only the datastore and stop on miss.
+   * @param ignoreStore true to bypass datastore and route immediately.
+   * @param canWriteClientCache whether the request may write to the client cache.
+   * @param realTimeFlag true for latency-optimized routing; false for bulk routing.
+   * @return verified client block, owned by the caller for use.
+   * @throws LowLevelGetException when not found, verify fails, or internal errors occur.
+   */
+  public ClientKeyBlock realGetKey(
+      ClientKey key,
+      boolean localOnly,
+      boolean ignoreStore,
+      boolean canWriteClientCache,
+      boolean realTimeFlag)
+      throws LowLevelGetException {
+    return switch (key) {
+      case ClientCHK hK ->
+          realGetCHK(hK, localOnly, ignoreStore, canWriteClientCache, realTimeFlag);
+      case ClientSSK sK ->
+          realGetSSK(sK, localOnly, ignoreStore, canWriteClientCache, realTimeFlag);
+      default -> throw new IllegalArgumentException("Not a CHK or SSK: " + key);
+    };
+  }
+
+  /**
+   * Fetches a CHK block, optionally via the network.
+   *
+   * @param key the client CHK to fetch.
+   * @param localOnly when {@code true}, check only the datastore and do not create a network
+   *     request on miss.
+   * @param ignoreStore when {@code true}, skip the datastore and create a network request
+   *     immediately.
+   * @param canWriteClientCache whether the request may write the client cache. Reads from the
+   *     client cache are always allowed for local requests; some callers disable writes to avoid
+   *     cache pollution.
+   * @param realTimeFlag {@code true} for latency-optimized routing; {@code false} for bulk.
+   * @return the verified client block.
+   * @throws LowLevelGetException if the data is not found, recently failed, transfer fails, verify
+   *     fails, or on internal error.
+   */
+  ClientKeyBlock realGetCHK(
+      ClientCHK key,
+      boolean localOnly,
+      boolean ignoreStore,
+      boolean canWriteClientCache,
+      boolean realTimeFlag)
+      throws LowLevelGetException {
+    long startTime = System.currentTimeMillis();
+    long uid = makeUID();
+    RequestTag tag = new RequestTag(false, RequestTag.START.LOCAL, null, realTimeFlag, uid, node);
+    if (!node.getTracker().lockUID(uid, false, false, false, true, realTimeFlag, tag)) {
+      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
+      throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
+    }
+    tag.setAccepted();
+    RequestSender rs;
+    try {
+      Object o =
+          node.makeRequestSender(
+              key.getNodeCHK(),
+              node.maxHTL(),
+              uid,
+              tag,
+              null,
+              Node.RequestSenderOptions.of(
+                  localOnly, ignoreStore, false, true, canWriteClientCache, realTimeFlag));
+      if (o instanceof CHKBlock block)
+        try {
+          tag.setServedFromDatastore();
+          return NodeClientCoreSupport.buildClientChkBlock(block, key);
+        } catch (CHKVerifyException e) {
+          LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
+          throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
+        }
+      if (o == null) throw new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND_IN_STORE);
+      rs = (RequestSender) o;
+      return processChkRequestLoop(rs, key, startTime, realTimeFlag);
+    } finally {
+      tag.unlockHandler();
+    }
+  }
+
+  private ClientKeyBlock processChkRequestLoop(
+      RequestSender rs, ClientCHK key, long startTime, boolean realTimeFlag)
+      throws LowLevelGetException {
+    boolean rejectedOverload = false;
+    short waitStatus = 0;
+    while (true) {
+      waitStatus = rs.waitUntilStatusChange(waitStatus);
+      rejectedOverload =
+          checkAndReportRejectedOverload(rejectedOverload, waitStatus, false, realTimeFlag);
+
+      int status = rs.getStatus();
+      if (status == RequestSender.NOT_FINISHED) continue;
+
+      maybeReportFetchCosts(false, rs, status);
+
+      if (status == RequestSender.TIMED_OUT
+          || status == RequestSender.GENERATED_REJECTED_OVERLOAD
+          || (rs.hasForwarded() && isForwardedTerminalStatus(status))) {
+        maybeHandleTimeoutOrForwarded(
+            false, realTimeFlag, startTime, key.getNodeCHK(), rs, status, rejectedOverload);
+      }
+
+      ClientKeyBlock maybe = tryReturnChkBlock(rs, key, status);
+      if (maybe != null) return maybe;
+      throwForGetStatus(status, rs);
+    }
+  }
+
+  private boolean checkAndReportRejectedOverload(
+      boolean alreadyRejected, short waitStatus, boolean isSSK, boolean realTimeFlag) {
+    if (!alreadyRejected && (waitStatus & RequestSender.WAIT_REJECTED_OVERLOAD) != 0) {
+      requestStarters.rejectedOverload(isSSK, false, realTimeFlag);
+      return true;
+    }
+    return alreadyRejected;
+  }
+
+  private void maybeReportFetchCosts(boolean isSSK, RequestSender rs, int status) {
+    if (isNonErrorStatus(status)) {
+      reportFetchCosts(isSSK, rs, status);
+    }
+  }
+
+  private void maybeHandleTimeoutOrForwarded(
+      boolean isSSK,
+      boolean realTimeFlag,
+      long startTime,
+      Key key,
+      RequestSender rs,
+      int status,
+      boolean rejectedOverload) {
+    if (status == RequestSender.TIMED_OUT || status == RequestSender.GENERATED_REJECTED_OVERLOAD) {
+      handleTimeoutOrRejected(isSSK, realTimeFlag, startTime, key, rejectedOverload);
+    } else if (rs.hasForwarded() && isForwardedTerminalStatus(status)) {
+      handleForwardedStatuses(isSSK, realTimeFlag, startTime, key, status);
+    }
+  }
+
+  private ClientKeyBlock tryReturnChkBlock(RequestSender rs, ClientCHK key, int status)
+      throws LowLevelGetException {
+    if (status == RequestSender.SUCCESS)
+      try {
+        return NodeClientCoreSupport.buildClientChkBlock(
+            rs.getPRB().getBlock(), rs.getHeaders(), key);
+      } catch (CHKVerifyException e) {
+        LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
+        throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
+      } catch (AbortedException e) {
+        LOG.error("Impossible: {}", e, e);
+        throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
+      }
+    return null;
+  }
+
+  private void throwForGetStatus(int status, RequestSender rs) throws LowLevelGetException {
+    switch (status) {
+      case RequestSender.NOT_FINISHED:
+        LOG.error("RS still running in get!: {}", rs);
+        throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
+      case RequestSender.DATA_NOT_FOUND:
+        throw new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND);
+      case RequestSender.RECENTLY_FAILED:
+        throw new LowLevelGetException(LowLevelGetException.RECENTLY_FAILED);
+      case RequestSender.ROUTE_NOT_FOUND:
+        throw new LowLevelGetException(LowLevelGetException.ROUTE_NOT_FOUND);
+      case RequestSender.TRANSFER_FAILED, RequestSender.GET_OFFER_TRANSFER_FAILED:
+        throw new LowLevelGetException(LowLevelGetException.TRANSFER_FAILED);
+      case RequestSender.VERIFY_FAILURE, RequestSender.GET_OFFER_VERIFY_FAILURE:
+        throw new LowLevelGetException(LowLevelGetException.VERIFY_FAILED);
+      case RequestSender.GENERATED_REJECTED_OVERLOAD, RequestSender.TIMED_OUT:
+        throw new LowLevelGetException(LowLevelGetException.REJECTED_OVERLOAD);
+      case RequestSender.INTERNAL_ERROR:
+      default:
+        LOG.error("Unknown RequestSender code in get: {} on {}", status, rs);
+        throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
+    }
+  }
+
+  ClientKeyBlock realGetSSK(
+      ClientSSK key,
+      boolean localOnly,
+      boolean ignoreStore,
+      boolean canWriteClientCache,
+      boolean realTimeFlag)
+      throws LowLevelGetException {
+    long startTime = System.currentTimeMillis();
+    long uid = makeUID();
+    RequestTag tag = new RequestTag(true, RequestTag.START.LOCAL, null, realTimeFlag, uid, node);
+    if (!node.getTracker().lockUID(uid, true, false, false, true, realTimeFlag, tag)) {
+      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
+      throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
+    }
+    tag.setAccepted();
+    RequestSender rs;
+    try {
+      Object o =
+          node.makeRequestSender(
+              key.getNodeKey(true),
+              node.maxHTL(),
+              uid,
+              tag,
+              null,
+              Node.RequestSenderOptions.of(
+                  localOnly, ignoreStore, false, true, canWriteClientCache, realTimeFlag));
+      if (o instanceof SSKBlock block)
+        try {
+          tag.setServedFromDatastore();
+          key.setPublicKey(block.getPubKey());
+          return NodeClientCoreSupport.buildClientSskBlock(block, key);
+        } catch (SSKVerifyException e) {
+          LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
+          throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
+        }
+      if (o == null) throw new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND_IN_STORE);
+      rs = (RequestSender) o;
+      return processSskRequestLoop(rs, key, startTime, realTimeFlag);
+    } finally {
+      tag.unlockHandler();
+    }
+  }
+
+  private ClientKeyBlock processSskRequestLoop(
+      RequestSender rs, ClientSSK key, long startTime, boolean realTimeFlag)
+      throws LowLevelGetException {
+    boolean rejectedOverload = false;
+    short waitStatus = 0;
+    while (true) {
+      waitStatus = rs.waitUntilStatusChange(waitStatus);
+      rejectedOverload =
+          checkAndReportRejectedOverload(rejectedOverload, waitStatus, true, realTimeFlag);
+
+      int status = rs.getStatus();
+      if (status == RequestSender.NOT_FINISHED) continue;
+
+      maybeReportFetchCosts(true, rs, status);
+
+      if (status == RequestSender.TIMED_OUT
+          || status == RequestSender.GENERATED_REJECTED_OVERLOAD
+          || (rs.hasForwarded() && isForwardedTerminalStatus(status))) {
+        maybeHandleTimeoutOrForwarded(
+            true, realTimeFlag, startTime, key.getNodeKey(true), rs, status, rejectedOverload);
+      }
+
+      if (status == RequestSender.SUCCESS) {
+        try {
+          SSKBlock block = rs.getSSKBlock();
+          key.setPublicKey(block.getPubKey());
+          return NodeClientCoreSupport.buildClientSskBlock(block, key);
+        } catch (SSKVerifyException e) {
+          LOG.error(LOG_DOES_NOT_VERIFY + "{}", e, e);
+          throw new LowLevelGetException(LowLevelGetException.DECODE_FAILED);
+        }
+      }
+      if (status == RequestSender.TRANSFER_FAILED
+          || status == RequestSender.GET_OFFER_TRANSFER_FAILED) {
+        LOG.error("Unexpected transfer failure on an SSK for uid {}", (Object) null);
+      }
+      throwForGetStatus(status, rs);
+    }
+  }
+
+  /**
+   * Inserts a block into the network.
+   *
+   * <p>This entry point accepts either CHK or SSK blocks and dispatches to the appropriate insert
+   * path. It performs local bookkeeping, records costs, and may store the block locally according
+   * to caching rules. The call blocks until the insert completes or fails. Failures are mapped to
+   * {@link LowLevelPutException} codes describing routing, overload, or collision outcomes.
+   *
+   * @param block block to insert; must be a {@link CHKBlock} or {@link SSKBlock}.
+   * @param canWriteClientCache whether the insert may update the client cache.
+   * @param forkOnCacheable whether to fork when the block is cacheable.
+   * @param preferInsert whether to prefer insert when multiple strategies apply.
+   * @param ignoreLowBackoff whether to ignore low backoff during routing.
+   * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
+   * @throws LowLevelPutException when routing fails, overload occurs, or an internal error arises.
+   */
+  public void realPut(
+      KeyBlock block,
+      boolean canWriteClientCache,
+      boolean forkOnCacheable,
+      boolean preferInsert,
+      boolean ignoreLowBackoff,
+      boolean realTimeFlag)
+      throws LowLevelPutException {
+    switch (block) {
+      case CHKBlock kBlock1 ->
+          realPutCHK(
+              kBlock1,
+              canWriteClientCache,
+              forkOnCacheable,
+              preferInsert,
+              ignoreLowBackoff,
+              realTimeFlag);
+      case SSKBlock kBlock ->
+          realPutSSK(
+              kBlock,
+              canWriteClientCache,
+              forkOnCacheable,
+              preferInsert,
+              ignoreLowBackoff,
+              realTimeFlag);
+      default -> throw new IllegalArgumentException("Unknown put type " + block.getClass());
+    }
+  }
+
+  /**
+   * Inserts a CHK block into the network and optionally caches it locally.
+   *
+   * <p>This variant constructs a CHK insert sender, waits for completion, reports costs, and stores
+   * the block according to cache policy. It blocks until the insert completes and throws a {@link
+   * LowLevelPutException} on routing failure, overload, or internal errors. The method generates
+   * and locks a request UID internally and releases it before returning.
+   *
+   * @param block CHK block to insert and potentially store locally.
+   * @param canWriteClientCache whether the insert may update the client cache.
+   * @param forkOnCacheable whether to fork when the block is cacheable.
+   * @param preferInsert whether to prefer insert when multiple strategies apply.
+   * @param ignoreLowBackoff whether to ignore low backoff during routing.
+   * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
+   * @throws LowLevelPutException when routing fails, overload, or internal errors arise.
+   */
+  public void realPutCHK(
+      CHKBlock block,
+      boolean canWriteClientCache,
+      boolean forkOnCacheable,
+      boolean preferInsert,
+      boolean ignoreLowBackoff,
+      boolean realTimeFlag)
+      throws LowLevelPutException {
+    byte[] data = block.getData();
+    byte[] headers = block.getHeaders();
+    Node.ChkInsertOptions options =
+        NodeClientCoreSupport.buildChkInsertOptions(
+            headers,
+            data,
+            canWriteClientCache,
+            forkOnCacheable,
+            preferInsert,
+            ignoreLowBackoff,
+            realTimeFlag);
+    CHKInsertSender is;
+    long uid = makeUID();
+    InsertTag tag = new InsertTag(false, InsertTag.START.LOCAL, null, realTimeFlag, uid, node);
+    if (!node.getTracker().lockUID(uid, false, true, false, true, realTimeFlag, tag)) {
+      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
+      throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
+    }
+    tag.setAccepted();
+    try {
+      long startTime = System.currentTimeMillis();
+      is = node.makeInsertSender(block.getKey(), node.maxHTL(), uid, tag, null, options);
+      boolean hasReceivedRejectedOverload = awaitChkCompletion(is, realTimeFlag);
+
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "Completed {} overload={} {}", uid, hasReceivedRejectedOverload, is.getStatusString());
+
+      maybeReportChkCompleted(is, uid, startTime, realTimeFlag, block);
+
+      // Get status explicitly, *after* completed(), so that it will be RECEIVE_FAILED if the
+      // receive failed.
+      int status = is.getStatus();
+      reportChkInsertCosts(status, is);
+      storeChkLocally(is, block, canWriteClientCache);
+
+      logChkInsertResult(status, is, block);
+      if (status != CHKInsertSender.SUCCESS) {
+        throwForChkPutStatus(is);
+      }
+    } finally {
+      tag.unlockHandler();
+    }
+  }
+
+  private void maybeReportChkCompleted(
+      CHKInsertSender is, long uid, long startTime, boolean realTimeFlag, CHKBlock block) {
+    if (is.sentRequest()
+        && (is.uid == uid)
+        && ((is.getStatus() == CHKInsertSender.ROUTE_NOT_FOUND)
+            || (is.getStatus() == CHKInsertSender.SUCCESS))) {
+      long endTime = System.currentTimeMillis();
+      long len = endTime - startTime;
+      requestStarters.getThrottle(false, true, realTimeFlag).successfulCompletion(len);
+      requestStarters.requestCompleted(false, true, block.getKey(), realTimeFlag);
+    }
+  }
+
+  private void reportChkInsertCosts(int status, CHKInsertSender is) {
+    if (status != CHKInsertSender.TIMED_OUT
+        && status != CHKInsertSender.GENERATED_REJECTED_OVERLOAD
+        && status != CHKInsertSender.INTERNAL_ERROR
+        && status != CHKInsertSender.ROUTE_REALLY_NOT_FOUND) {
+      int sent = is.getTotalSentBytes();
+      int received = is.getTotalReceivedBytes();
+      if (LOG.isDebugEnabled())
+        LOG.debug("Local CHK insert cost {}/{}" + LOG_BYTES_OPEN + "{})", sent, received, status);
+      node.getNodeStats().localChkInsertBytesSentAverage.report(sent);
+      node.getNodeStats().localChkInsertBytesReceivedAverage.report(received);
+      if (status == CHKInsertSender.SUCCESS)
+        node.getNodeStats().successfulChkInsertBytesSentAverage.report(sent);
+    }
+  }
+
+  private void storeChkLocally(CHKInsertSender is, CHKBlock block, boolean canWriteClientCache) {
+    boolean deep =
+        node.shouldStoreDeep(block.getKey(), null, is == null ? new PeerNode[0] : is.getRoutedTo());
+    try {
+      node.store(block, deep, canWriteClientCache, false, false);
+    } catch (KeyCollisionException _) {
+      // CHKs don't collide
+    }
+  }
+
+  private void logChkInsertResult(int status, CHKInsertSender is, CHKBlock block) {
+    if (status == CHKInsertSender.SUCCESS) {
+      LOG.info("Succeeded inserting {}", block);
+    } else {
+      String msg = "Failed inserting " + block + " : " + is.getStatusString();
+      if (status == CHKInsertSender.ROUTE_NOT_FOUND)
+        msg +=
+            " - this is normal on small networks; the data will still be propagated, but it can't"
+                + " find the 20+ nodes needed for full success";
+      if (is.getStatus() != CHKInsertSender.ROUTE_NOT_FOUND) LOG.error(msg);
+      else LOG.info(msg);
+    }
+  }
+
+  private boolean awaitChkCompletion(CHKInsertSender is, boolean realTimeFlag) {
+    boolean overloaded = awaitChkInitialStatus(is, realTimeFlag);
+    return awaitChkFinalCompletion(is, realTimeFlag, overloaded);
+  }
+
+  private boolean awaitChkInitialStatus(CHKInsertSender is, boolean realTimeFlag) {
+    boolean hasReceivedRejectedOverload = false;
+    while (true) {
+      if (is.getStatus() == CHKInsertSender.NOT_FINISHED) {
+        is.waitIfNotFinished(SECONDS.toMillis(5));
+      }
+      if (is.getStatus() != CHKInsertSender.NOT_FINISHED) break;
+      if ((!hasReceivedRejectedOverload) && is.receivedRejectedOverload()) {
+        hasReceivedRejectedOverload = true;
+        requestStarters.rejectedOverload(false, true, realTimeFlag);
+      }
+    }
+    return hasReceivedRejectedOverload;
+  }
+
+  private boolean awaitChkFinalCompletion(
+      CHKInsertSender is, boolean realTimeFlag, boolean hasReceivedRejectedOverload) {
+    while (!is.completed()) {
+      is.waitIfNotCompleted(SECONDS.toMillis(10));
+      if (is.anyTransfersFailed() && (!hasReceivedRejectedOverload)) {
+        hasReceivedRejectedOverload = true; // not strictly true but same effect
+        requestStarters.rejectedOverload(false, true, realTimeFlag);
+      }
+    }
+    return hasReceivedRejectedOverload;
+  }
+
+  private void throwForChkPutStatus(CHKInsertSender is) throws LowLevelPutException {
+    switch (is.getStatus()) {
+      case CHKInsertSender.NOT_FINISHED:
+        LOG.error("IS still running in putCHK!: {}", is);
+        throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
+      case CHKInsertSender.GENERATED_REJECTED_OVERLOAD, CHKInsertSender.TIMED_OUT:
+        throw new LowLevelPutException(LowLevelPutException.REJECTED_OVERLOAD);
+      case CHKInsertSender.ROUTE_NOT_FOUND:
+        throw new LowLevelPutException(LowLevelPutException.ROUTE_NOT_FOUND);
+      case CHKInsertSender.ROUTE_REALLY_NOT_FOUND:
+        throw new LowLevelPutException(LowLevelPutException.ROUTE_REALLY_NOT_FOUND);
+      case CHKInsertSender.INTERNAL_ERROR:
+      default:
+        LOG.error("Unknown CHKInsertSender code in putCHK: {} on {}", is.getStatus(), is);
+        throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
+    }
+  }
+
+  /**
+   * Inserts an SSK block.
+   *
+   * <p>This method performs a local collision check using the client cache, then starts an SSK
+   * insert sender and waits for completion. It reports costs, stores the block when appropriate,
+   * and throws {@link LowLevelPutException} for collisions, routing failures, overload, or internal
+   * errors. The call blocks until the insert completes and always releases the request UID.
+   *
+   * @param block SSK block to insert and potentially store locally.
+   * @param canWriteClientCache whether the insert may update the client cache.
+   * @param forkOnCacheable whether to fork when the block is cacheable.
+   * @param preferInsert whether to prefer insert when multiple strategies apply.
+   * @param ignoreLowBackoff whether to ignore low backoff during routing.
+   * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
+   * @throws LowLevelPutException on collision, routing failure, overload, or internal error.
+   */
+  public void realPutSSK(
+      SSKBlock block,
+      boolean canWriteClientCache,
+      boolean forkOnCacheable,
+      boolean preferInsert,
+      boolean ignoreLowBackoff,
+      boolean realTimeFlag)
+      throws LowLevelPutException {
+    SSKInsertSender is;
+    long uid = makeUID();
+    InsertTag tag = new InsertTag(true, InsertTag.START.LOCAL, null, realTimeFlag, uid, node);
+    if (!node.getTracker().lockUID(uid, true, true, false, true, realTimeFlag, tag)) {
+      LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
+      throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
+    }
+    tag.setAccepted();
+    try {
+      long startTime = System.currentTimeMillis();
+      // Be consistent: use the client cache to check for collisions as this is a local insert.
+      SSKBlock altBlock =
+          node.fetch(block.getKey(), false, true, canWriteClientCache, false, false, null);
+      if (altBlock != null && !altBlock.equals(block)) throw new LowLevelPutException(altBlock);
+      is =
+          node.makeInsertSender(
+              block,
+              node.maxHTL(),
+              uid,
+              tag,
+              null,
+              Node.SskInsertOptions.of()
+                  .withFromStore(false)
+                  .withCanWriteClientCache(canWriteClientCache)
+                  .withCanWriteDatastore(false)
+                  .withForkOnCacheable(forkOnCacheable)
+                  .withPreferInsert(preferInsert)
+                  .withIgnoreLowBackoff(ignoreLowBackoff)
+                  .withRealTimeFlag(realTimeFlag));
+      boolean hasReceivedRejectedOverload = awaitSskCompletion(is, realTimeFlag);
+
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "Completed {} overload={} {}", uid, hasReceivedRejectedOverload, is.getStatusString());
+
+      // Finished?
+      maybeReportSskCompleted(is, uid, startTime, realTimeFlag, block, hasReceivedRejectedOverload);
+
+      int status = is.getStatus();
+
+      reportSskInsertCosts(status, is);
+      handleSskCollisionOrStore(is, block, canWriteClientCache);
+
+      logSskInsertResult(status, is, block);
+      if (status != SSKInsertSender.SUCCESS) {
+        throwForSskPutStatus(is);
+      }
+    } finally {
+      tag.unlockHandler();
+    }
+  }
+
+  private boolean awaitSskCompletion(SSKInsertSender is, boolean realTimeFlag) {
+    boolean overloaded = awaitSskInitialStatus(is, realTimeFlag);
+    return awaitSskFinalCompletion(is, overloaded);
+  }
+
+  private boolean awaitSskInitialStatus(SSKInsertSender is, boolean realTimeFlag) {
+    boolean hasReceivedRejectedOverload = false;
+    while (true) {
+      if (is.getStatus() == SSKInsertSender.NOT_FINISHED) {
+        is.waitIfNotFinished(SECONDS.toMillis(5));
+      }
+      if (is.getStatus() != SSKInsertSender.NOT_FINISHED) break;
+      if ((!hasReceivedRejectedOverload) && is.receivedRejectedOverload()) {
+        hasReceivedRejectedOverload = true;
+        requestStarters.rejectedOverload(true, true, realTimeFlag);
+      }
+    }
+    return hasReceivedRejectedOverload;
+  }
+
+  private boolean awaitSskFinalCompletion(SSKInsertSender is, boolean hasReceivedRejectedOverload) {
+    while (is.getStatus() == SSKInsertSender.NOT_FINISHED) {
+      is.waitIfNotFinished(SECONDS.toMillis(10));
+    }
+    return hasReceivedRejectedOverload;
+  }
+
+  private void throwForSskPutStatus(SSKInsertSender is) throws LowLevelPutException {
+    switch (is.getStatus()) {
+      case SSKInsertSender.NOT_FINISHED:
+        LOG.error("IS still running in putCHK!: {}", is);
+        throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
+      case SSKInsertSender.GENERATED_REJECTED_OVERLOAD, SSKInsertSender.TIMED_OUT:
+        throw new LowLevelPutException(LowLevelPutException.REJECTED_OVERLOAD);
+      case SSKInsertSender.ROUTE_NOT_FOUND:
+        throw new LowLevelPutException(LowLevelPutException.ROUTE_NOT_FOUND);
+      case SSKInsertSender.ROUTE_REALLY_NOT_FOUND:
+        throw new LowLevelPutException(LowLevelPutException.ROUTE_REALLY_NOT_FOUND);
+      case SSKInsertSender.INTERNAL_ERROR:
+      default:
+        LOG.error("Unknown CHKInsertSender code in putSSK: {} on {}", is.getStatus(), is);
+        throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
+    }
+  }
+
+  private void reportSskInsertCosts(int status, SSKInsertSender is) {
+    if (status != CHKInsertSender.TIMED_OUT
+        && status != CHKInsertSender.GENERATED_REJECTED_OVERLOAD
+        && status != CHKInsertSender.INTERNAL_ERROR
+        && status != CHKInsertSender.ROUTE_REALLY_NOT_FOUND) {
+      int sent = is.getTotalSentBytes();
+      int received = is.getTotalReceivedBytes();
+      if (LOG.isDebugEnabled())
+        LOG.debug("Local SSK insert cost {}/{}" + LOG_BYTES_OPEN + "{})", sent, received, status);
+      node.getNodeStats().localSskInsertBytesSentAverage.report(sent);
+      node.getNodeStats().localSskInsertBytesReceivedAverage.report(received);
+      if (status == SSKInsertSender.SUCCESS)
+        node.getNodeStats().successfulSskInsertBytesSentAverage.report(sent);
+    }
+  }
+
+  private void maybeReportSskCompleted(
+      SSKInsertSender is,
+      long uid,
+      long startTime,
+      boolean realTimeFlag,
+      SSKBlock block,
+      boolean hasReceivedRejectedOverload) {
+    if (!hasReceivedRejectedOverload
+        && is.sentRequest()
+        && (is.uid == uid)
+        && ((is.getStatus() == SSKInsertSender.ROUTE_NOT_FOUND)
+            || (is.getStatus() == SSKInsertSender.SUCCESS))) {
+      long endTime = System.currentTimeMillis();
+      long rtt = endTime - startTime;
+      requestStarters.requestCompleted(true, true, block.getKey(), realTimeFlag);
+      requestStarters.getThrottle(true, true, realTimeFlag).successfulCompletion(rtt);
+    }
+  }
+
+  private void handleSskCollisionOrStore(
+      SSKInsertSender is, SSKBlock block, boolean canWriteClientCache) throws LowLevelPutException {
+    boolean deep =
+        node.shouldStoreDeep(block.getKey(), null, is == null ? new PeerNode[0] : is.getRoutedTo());
+
+    if (is != null && is.hasCollided()) {
+      SSKBlock collided = is.getBlock();
+      try {
+        node.storeInsert(collided, deep, true, canWriteClientCache, false);
+      } catch (KeyCollisionException e) {
+        LOG.info("collision race? is={}", is, e);
+      }
+      throw new LowLevelPutException(collided);
+    }
+    try {
+      node.storeInsert(block, deep, false, canWriteClientCache, false);
+    } catch (KeyCollisionException e) {
+      NodeSSK key = block.getKey();
+      KeyBlock collided = node.fetch(key, true, canWriteClientCache, false, false, null);
+      if (collided == null) {
+        LOG.error("Collided but no key?!");
+        try {
+          node.store(block, false, canWriteClientCache, false, false);
+        } catch (KeyCollisionException _) {
+          LOG.error("Collided but no key and still collided!");
+          throw new LowLevelPutException(
+              LowLevelPutException.INTERNAL_ERROR,
+              "Collided, can't find block, but still collides!",
+              e);
+        }
+      }
+      throw new LowLevelPutException(collided);
+    }
+  }
+
+  private void logSskInsertResult(int status, SSKInsertSender is, SSKBlock block) {
+    if (status == SSKInsertSender.SUCCESS) {
+      LOG.info("Succeeded inserting {}", block);
+    } else {
+      String msg = "Failed inserting " + block + " : " + is.getStatusString();
+      if (status == CHKInsertSender.ROUTE_NOT_FOUND)
+        msg +=
+            " - this is normal on small networks; the data will still be propagated, but it can't"
+                + " find the 20+ nodes needed for full success";
+      if (is.getStatus() != SSKInsertSender.ROUTE_NOT_FOUND) LOG.error(msg);
+      else LOG.info(msg);
+    }
+  }
+
+  /**
+   * Queues a low-priority reinsert of a key block.
+   *
+   * <p>The block is wrapped in a {@link SimpleSendableInsert} and scheduled on the request starters
+   * at the maximum priority class for reinserts. The operation is asynchronous; it enqueues work
+   * and returns immediately without waiting for completion. Use it to refresh availability for
+   * already known data.
+   *
+   * @param block key block to reinsert and schedule for background routing.
+   */
+  public void queueRandomReinsert(KeyBlock block) {
+    SimpleSendableInsert ssi =
+        new SimpleSendableInsert(core, block, RequestStarter.MAXIMUM_PRIORITY_CLASS);
+    if (LOG.isDebugEnabled()) LOG.debug("Queueing random reinsert for {} : {}", block, ssi);
+    ssi.schedule();
+  }
+
+  /**
+   * Generates a random UID for requests.
+   *
+   * <p>Note: {@code -1} is reserved internally and is never returned. If a peer uses {@code -1} it
+   * is merely scheduled more slowly (round-robin with no-UID messages).
+   */
+  private long makeUID() {
+    while (true) {
+      long uid = random.nextLong();
+      if (uid != -1) return uid;
+    }
+  }
+}

--- a/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
@@ -20,10 +20,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Executes client fetch and insert operations on behalf of {@link NodeClientCore}.
+ * Coordinates client-side fetch and insert operations for a {@link NodeClientCore} instance.
  *
- * <p>This helper encapsulates the request/insert orchestration paths so the core can focus on
- * wiring services and configuration. It is intentionally stateful, bound to a single core instance.
+ * <p>This helper acts as the transfer-focused companion to the core, translating high-level
+ * requests into concrete sender workflows. It allocates and tracks UIDs, consults the datastore and
+ * client cache, and reports routing and transfer costs to node statistics. The instance is
+ * intentionally stateful and bound to a single {@link Node}; it does not reset or share state
+ * between cores. Asynchronous entry points return after scheduling work, while synchronous get/put
+ * methods block until completion and always release tracking resources before returning.
+ *
+ * <p>Thread safety follows the underlying node components; this class adds no extra synchronization
+ * beyond local bookkeeping.
+ *
+ * <ul>
+ *   <li>Schedules asynchronous fetches and forwards completion callbacks.
+ *   <li>Performs blocking CHK/SSK fetches with verification.
+ *   <li>Runs blocking inserts with caching and collision handling.
+ *   <li>Queues background reinserts and records transfer metrics.
+ * </ul>
+ *
+ * @see NodeClientCore
+ * @see RequestSender
+ * @see CHKInsertSender
+ * @see SSKInsertSender
  */
 public final class NodeClientCoreTransfers {
   private static final Logger LOG = LoggerFactory.getLogger(NodeClientCoreTransfers.class);
@@ -45,23 +64,23 @@ public final class NodeClientCoreTransfers {
   }
 
   /**
-   * Starts an asynchronous fetch for a key.
+   * Schedules a non-blocking fetch for the supplied key and arranges completion callbacks.
    *
-   * <p>If the data is found locally the listener is notified and no network request is started.
-   * Otherwise, a request sender is created and the listener receives completion or failure
-   * callbacks; some successful outcomes may be delivered via the pending-keys mechanism instead of
-   * the listener. The call is non-blocking and returns after scheduling work using a freshly
-   * generated UID. Store access is controlled by {@code localOnly} and {@code ignoreStore}; when
-   * both are {@code false} the datastore is checked first and routing proceeds on miss.
+   * <p>This call generates a new request UID, locks it with the tracker, and optionally consults
+   * the datastore before routing. If the data is found locally, the listener is notified and no
+   * network request is started. Otherwise, a {@link RequestSender} is created and the listener is
+   * notified on completion or failure; some successful outcomes may be delivered via the
+   * pending-keys mechanism instead of the listener. The method returns after scheduling work and
+   * does not wait for completion. Each invocation is independent, even for repeated keys.
    *
-   * @param key key to fetch; typically a {@code CHK} or {@link NodeSSK}.
-   * @param offersOnly when true, fetch only from offered-key sources.
-   * @param listener callback notified on completion or failure of the request.
-   * @param canReadClientCache whether this request may read from the client cache.
-   * @param canWriteClientCache whether this request may write into the client cache.
+   * @param key key to fetch; typically a {@link Key} or {@link NodeSSK}.
+   * @param offersOnly true to fetch only from offered-key sources.
+   * @param listener callback notified for success, failure, or local-store hits.
+   * @param canReadClientCache whether the request may read from the client cache.
+   * @param canWriteClientCache whether the request may write into the client cache.
    * @param realTimeFlag true for latency-optimized routing; false for bulk throughput.
-   * @param localOnly true to check only local store and skip routing.
-   * @param ignoreStore true to bypass datastore and always create a request.
+   * @param localOnly true to consult only local storage and skip routing.
+   * @param ignoreStore true to bypass the datastore and always create a request.
    */
   public void asyncGet(
       final Key key,
@@ -369,21 +388,23 @@ public final class NodeClientCoreTransfers {
   }
 
   /**
-   * Synchronously fetches a block for a client key.
+   * Synchronously fetches and verifies a client key block.
    *
-   * <p>This method blocks until the fetch completes or fails. Depending on {@code localOnly} and
-   * {@code ignoreStore}, it may read from the datastore or issue a routed request through the
-   * network. It returns a verified client block on success and throws a {@link
-   * LowLevelGetException} on any failure. The request uses an internally generated UID and releases
-   * tracking resources before returning.
+   * <p>This method blocks until the fetch completes or fails. It routes to the CHK or SSK path
+   * based on the key type and uses {@code localOnly} and {@code ignoreStore} to decide whether to
+   * consult the datastore or issue a network request. The call generates and locks a request UID,
+   * releases tracking resources before returning, and throws a {@link LowLevelGetException} on any
+   * failure. If the key type is unsupported, it throws {@link IllegalArgumentException}.
    *
    * @param key client key to fetch; must be {@link ClientCHK} or {@link ClientSSK}.
    * @param localOnly true to consult only the datastore and stop on miss.
-   * @param ignoreStore true to bypass datastore and route immediately.
-   * @param canWriteClientCache whether the request may write to the client cache.
+   * @param ignoreStore true to bypass the datastore and route immediately.
+   * @param canWriteClientCache whether the request may write into the client cache.
    * @param realTimeFlag true for latency-optimized routing; false for bulk routing.
    * @return verified client block, owned by the caller for use.
-   * @throws LowLevelGetException when not found, verify fails, or internal errors occur.
+   * @throws LowLevelGetException when the fetch fails, verification fails, or internal errors
+   *     occur.
+   * @throws IllegalArgumentException if the key is not a CHK or SSK.
    */
   public ClientKeyBlock realGetKey(
       ClientKey key,
@@ -641,20 +662,22 @@ public final class NodeClientCoreTransfers {
   }
 
   /**
-   * Inserts a block into the network.
+   * Synchronously inserts a CHK or SSK block into the network.
    *
-   * <p>This entry point accepts either CHK or SSK blocks and dispatches to the appropriate insert
-   * path. It performs local bookkeeping, records costs, and may store the block locally according
-   * to caching rules. The call blocks until the insert completes or fails. Failures are mapped to
-   * {@link LowLevelPutException} codes describing routing, overload, or collision outcomes.
+   * <p>This entry point dispatches to the appropriate insert path based on the concrete block type.
+   * It performs local bookkeeping, records transfer costs, and may store the block locally
+   * according to caching rules. The call blocks until the insert completes or fails; failures are
+   * mapped to {@link LowLevelPutException} codes describing routing, overload, or collision
+   * outcomes. Unsupported block types result in {@link IllegalArgumentException}.
    *
    * @param block block to insert; must be a {@link CHKBlock} or {@link SSKBlock}.
    * @param canWriteClientCache whether the insert may update the client cache.
-   * @param forkOnCacheable whether to fork when the block is cacheable.
-   * @param preferInsert whether to prefer insert when multiple strategies apply.
-   * @param ignoreLowBackoff whether to ignore low backoff during routing.
+   * @param forkOnCacheable true to fork inserts when the block is cacheable.
+   * @param preferInsert true to prefer insert strategies when alternatives exist.
+   * @param ignoreLowBackoff true to ignore low backoff during routing decisions.
    * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
-   * @throws LowLevelPutException when routing fails, overload occurs, or an internal error arises.
+   * @throws LowLevelPutException when routing fails, overload occurs, or internal errors arise.
+   * @throws IllegalArgumentException if the block type is unsupported for insert.
    */
   public void realPut(
       KeyBlock block,
@@ -686,20 +709,21 @@ public final class NodeClientCoreTransfers {
   }
 
   /**
-   * Inserts a CHK block into the network and optionally caches it locally.
+   * Synchronously inserts a CHK block and applies local caching rules.
    *
    * <p>This variant constructs a CHK insert sender, waits for completion, reports costs, and stores
    * the block according to cache policy. It blocks until the insert completes and throws a {@link
    * LowLevelPutException} on routing failure, overload, or internal errors. The method generates
-   * and locks a request UID internally and releases it before returning.
+   * and locks a request UID internally and releases it before returning to the caller.
    *
    * @param block CHK block to insert and potentially store locally.
    * @param canWriteClientCache whether the insert may update the client cache.
-   * @param forkOnCacheable whether to fork when the block is cacheable.
-   * @param preferInsert whether to prefer insert when multiple strategies apply.
-   * @param ignoreLowBackoff whether to ignore low backoff during routing.
+   * @param forkOnCacheable true to fork inserts when the block is cacheable.
+   * @param preferInsert true to prefer insert strategies when alternatives exist.
+   * @param ignoreLowBackoff true to ignore low backoff during routing decisions.
    * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
-   * @throws LowLevelPutException when routing fails, overload, or internal errors arise.
+   * @throws LowLevelPutException when routing fails, overload is reported, or internal errors
+   *     arise.
    */
   public void realPutCHK(
       CHKBlock block,
@@ -858,20 +882,21 @@ public final class NodeClientCoreTransfers {
   }
 
   /**
-   * Inserts an SSK block.
+   * Synchronously inserts an SSK block and handles collision checks.
    *
-   * <p>This method performs a local collision check using the client cache, then starts an SSK
-   * insert sender and waits for completion. It reports costs, stores the block when appropriate,
-   * and throws {@link LowLevelPutException} for collisions, routing failures, overload, or internal
-   * errors. The call blocks until the insert completes and always releases the request UID.
+   * <p>This method performs a local collision check using the client cache, starts an SSK insert
+   * sender, and waits for completion. It reports costs, stores the block when appropriate, and
+   * throws {@link LowLevelPutException} for collisions, routing failures, overload, or internal
+   * errors. The call blocks until the insert completes and always releases the request UID before
+   * returning.
    *
    * @param block SSK block to insert and potentially store locally.
    * @param canWriteClientCache whether the insert may update the client cache.
-   * @param forkOnCacheable whether to fork when the block is cacheable.
-   * @param preferInsert whether to prefer insert when multiple strategies apply.
-   * @param ignoreLowBackoff whether to ignore low backoff during routing.
+   * @param forkOnCacheable true to fork inserts when the block is cacheable.
+   * @param preferInsert true to prefer insert strategies when alternatives exist.
+   * @param ignoreLowBackoff true to ignore low backoff during routing decisions.
    * @param realTimeFlag true for latency-optimized inserts; false for bulk routing.
-   * @throws LowLevelPutException on collision, routing failure, overload, or internal error.
+   * @throws LowLevelPutException on collision, routing failure, overload, or internal errors.
    */
   public void realPutSSK(
       SSKBlock block,
@@ -1066,9 +1091,9 @@ public final class NodeClientCoreTransfers {
    * Queues a low-priority reinsert of a key block.
    *
    * <p>The block is wrapped in a {@link SimpleSendableInsert} and scheduled on the request starters
-   * at the maximum priority class for reinserts. The operation is asynchronous; it enqueues work
-   * and returns immediately without waiting for completion. Use it to refresh availability for
-   * already known data.
+   * at the maximum priority class for reinserts. The operation is asynchronous: it enqueues work
+   * and returns immediately without waiting for completion. Use this method to refresh availability
+   * for already known data without blocking the caller.
    *
    * @param block key block to reinsert and schedule for background routing.
    */

--- a/src/main/java/network/crypta/node/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/node/NodeClientPersistence.java
@@ -1,0 +1,177 @@
+package network.crypta.node;
+
+import java.io.File;
+import java.util.Objects;
+import java.util.Random;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientLayerPersister;
+import network.crypta.client.async.DatastoreChecker;
+import network.crypta.client.async.USKManager;
+import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.config.SubConfig;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.crypt.RandomSource;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.RealCompressor;
+import network.crypta.support.io.DiskSpaceCheckingRandomAccessBufferFactory;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.MaybeEncryptedRandomAccessBufferFactory;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.PooledFileRandomAccessBufferFactory;
+import network.crypta.support.io.TempBucketFactory;
+
+/** Encapsulates persistence wiring for {@link NodeClientCore} to keep dependencies localized. */
+public final class NodeClientPersistence {
+  private final ConfigurablePersister persister;
+  private final PersistentRequestRoot persistentRoot = new PersistentRequestRoot();
+  private DiskSpaceCheckingRandomAccessBufferFactory diskChecker;
+  private MaybeEncryptedRandomAccessBufferFactory persistentRafFactory;
+  private final int sortOrderAfter;
+
+  public NodeClientPersistence(
+      Persistable persistable, SubConfig nodeConfig, Node node, int initialSortOrder)
+      throws NodeInitException {
+    int sortOrder = initialSortOrder;
+    persister =
+        new ConfigurablePersister(
+            persistable,
+            nodeConfig,
+            "clientThrottleFile",
+            "client-throttle.dat",
+            sortOrder++,
+            true,
+            false,
+            "NodeClientCore.fileForClientStats",
+            "NodeClientCore.fileForClientStatsLong",
+            node.getTicker(),
+            node.getRunDir());
+    sortOrderAfter = sortOrder;
+  }
+
+  public int getSortOrderAfter() {
+    return sortOrderAfter;
+  }
+
+  public SimpleFieldSet readThrottle() {
+    return persister.read();
+  }
+
+  public void startThrottle() {
+    persister.start();
+  }
+
+  public void initDiskChecker(
+      FilenameGenerator persistentFilenameGenerator,
+      File persistentTempDir,
+      long minDiskFreeLongTerm,
+      TempBucketFactory tempBucketFactory,
+      boolean encryptPersistentTempBuckets) {
+    PooledFileRandomAccessBufferFactory raff =
+        new PooledFileRandomAccessBufferFactory(persistentFilenameGenerator);
+    DiskSpaceCheckingRandomAccessBufferFactory checker =
+        new DiskSpaceCheckingRandomAccessBufferFactory(
+            raff, persistentTempDir, minDiskFreeLongTerm + tempBucketFactory.getMaxRamUsed());
+    diskChecker = checker;
+    persistentRafFactory =
+        new MaybeEncryptedRandomAccessBufferFactory(checker, encryptPersistentTempBuckets);
+  }
+
+  public MaybeEncryptedRandomAccessBufferFactory getPersistentRafFactory() {
+    return Objects.requireNonNull(persistentRafFactory, "Persistent RAF factory not initialized");
+  }
+
+  public boolean hasPersistentRafFactory() {
+    return persistentRafFactory != null;
+  }
+
+  public void setPersistentRafEncryption(boolean enable) {
+    getPersistentRafFactory().setEncryption(enable);
+  }
+
+  public void setPersistentRafMasterSecret(MasterSecret secret) {
+    getPersistentRafFactory().setMasterSecret(secret);
+  }
+
+  public void installDiskChecker(PersistentTempBucketFactory persistentTempBucketFactory) {
+    persistentTempBucketFactory.setDiskSpaceChecker(requireDiskChecker());
+  }
+
+  public void updateMinDiskSpace(long minDiskSpace) {
+    requireDiskChecker().setMinDiskSpace(minDiskSpace);
+  }
+
+  public FCPServer createFcpServer(Node node, NodeClientCore core) {
+    return FCPServer.maybeCreate(node, core, node.getConfig(), persistentRoot);
+  }
+
+  public ClientRequest[] getPersistentRequests() {
+    return persistentRoot.getPersistentRequests();
+  }
+
+  public ClientContext createClientContext(
+      Node node,
+      ClientLayerPersister clientLayerPersister,
+      PriorityAwareExecutor executor,
+      ClientContextResources resources,
+      PersistentTempBucketFactory persistentTempBucketFactory,
+      TempBucketFactory tempBucketFactory,
+      USKManager uskManager,
+      RandomSource random,
+      Random fastWeakRandom,
+      Ticker ticker,
+      MemoryLimitedJobRunner memoryLimitedJobRunner,
+      FilenameGenerator tempFilenameGenerator,
+      FilenameGenerator persistentFilenameGenerator,
+      LockableRandomAccessBufferFactory tempRafFactory,
+      MaybeEncryptedRandomAccessBufferFactory persistentRafFactory,
+      FileRandomAccessBufferFactory fileRafTransient,
+      RealCompressor compressor,
+      DatastoreChecker storeChecker,
+      MasterSecret cryptoSecretTransient,
+      NodeClientCoreInit init,
+      FetchContext defaultFetchContext,
+      InsertContext defaultInsertContext) {
+    DiskSpaceCheckingRandomAccessBufferFactory checker = requireDiskChecker();
+    return new ClientContext(
+        node.getBootId(),
+        clientLayerPersister,
+        executor,
+        resources.getArchiveManager(),
+        persistentTempBucketFactory,
+        tempBucketFactory,
+        persistentTempBucketFactory,
+        resources.getHealingQueue(),
+        uskManager,
+        random,
+        fastWeakRandom,
+        ticker,
+        memoryLimitedJobRunner,
+        tempFilenameGenerator,
+        persistentFilenameGenerator,
+        tempRafFactory,
+        persistentRafFactory,
+        fileRafTransient,
+        checker,
+        compressor,
+        storeChecker,
+        persistentRoot,
+        cryptoSecretTransient,
+        init.getToadlets(),
+        defaultFetchContext,
+        defaultInsertContext,
+        init.getConfig());
+  }
+
+  private DiskSpaceCheckingRandomAccessBufferFactory requireDiskChecker() {
+    return Objects.requireNonNull(diskChecker, "Persistent disk checker not initialized");
+  }
+}

--- a/src/main/java/network/crypta/node/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/node/NodeClientPersistence.java
@@ -364,10 +364,10 @@ public final class NodeClientPersistence {
         storeChecker,
         persistentRoot,
         cryptoSecretTransient,
-        init.getToadlets(),
+        init.toadlets(),
         defaultFetchContext,
         defaultInsertContext,
-        init.getConfig());
+        init.config());
   }
 
   private DiskSpaceCheckingRandomAccessBufferFactory requireDiskChecker() {

--- a/src/main/java/network/crypta/node/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/node/NodeClientPersistence.java
@@ -29,7 +29,34 @@ import network.crypta.support.io.PersistentTempBucketFactory;
 import network.crypta.support.io.PooledFileRandomAccessBufferFactory;
 import network.crypta.support.io.TempBucketFactory;
 
-/** Encapsulates persistence wiring for {@link NodeClientCore} to keep dependencies localized. */
+/**
+ * Centralizes persistence-related wiring for {@link NodeClientCore}.
+ *
+ * <p>This helper isolates the construction of persistence infrastructure that would otherwise
+ * sprawl across the client-core initialization flow. Callers typically construct an instance early
+ * in node startup, configure disk-checking factories once storage directories are known, and then
+ * use it to build the {@link ClientContext} and FCP server wiring. The instance owns a shared
+ * {@link PersistentRequestRoot} so persistent request registration is consistent across the
+ * client-layer components it creates.
+ *
+ * <p>State is initialized in stages: the disk checker and persistent RAF factory are {@code null}
+ * until {@link #initDiskChecker(FilenameGenerator, File, long, TempBucketFactory, boolean)} is
+ * called. Consumers should treat this class as startup-only; it is not designed for concurrent
+ * mutation and expects callers to serialize configuration steps before client activity begins.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Creating and starting a configurable persister for throttle state.
+ *   <li>Building persistent random-access buffer factories with optional encryption.
+ *   <li>Exposing persistent requests and wiring FCP server state.
+ *   <li>Constructing {@link ClientContext} with shared persistent roots.
+ * </ul>
+ *
+ * @see NodeClientCore
+ * @see ClientContext
+ * @see PersistentRequestRoot
+ */
 public final class NodeClientPersistence {
   private final ConfigurablePersister persister;
   private final PersistentRequestRoot persistentRoot = new PersistentRequestRoot();
@@ -37,6 +64,21 @@ public final class NodeClientPersistence {
   private MaybeEncryptedRandomAccessBufferFactory persistentRafFactory;
   private final int sortOrderAfter;
 
+  /**
+   * Creates persistence wiring for client-core startup and configuration.
+   *
+   * <p>The constructor registers a configurable persister under {@code nodeConfig} and selects a
+   * default throttle file path relative to the node run directory. It also tracks the next
+   * configuration sort order so callers can continue registering options in a stable order. This
+   * constructor performs no disk checker setup; callers must invoke {@link #initDiskChecker} before
+   * using persistent factories or building the client context.
+   *
+   * @param persistable provider of throttle state snapshots for persistence.
+   * @param nodeConfig configuration section used to register the throttle file option.
+   * @param node node instance providing ticker and run directory settings.
+   * @param initialSortOrder starting sort order for configuration registration.
+   * @throws NodeInitException if the configured throttle file cannot be created or used.
+   */
   public NodeClientPersistence(
       Persistable persistable, SubConfig nodeConfig, Node node, int initialSortOrder)
       throws NodeInitException {
@@ -57,18 +99,60 @@ public final class NodeClientPersistence {
     sortOrderAfter = sortOrder;
   }
 
+  /**
+   * Returns the next sort order value after persister registration.
+   *
+   * <p>This value lets callers continue registering configuration options without overlapping the
+   * sort order consumed by the persister option in the constructor. The returned value is stable
+   * for the lifetime of the instance.
+   *
+   * @return the sort order value immediately after the persister option.
+   */
   public int getSortOrderAfter() {
     return sortOrderAfter;
   }
 
+  /**
+   * Reads the most recently persisted throttle snapshot.
+   *
+   * <p>This delegates to the underlying {@link ConfigurablePersister} and returns the parsed {@link
+   * SimpleFieldSet} if available. When no persisted file exists or the read fails, the return value
+   * may be {@code null}. The method performs no mutation and is safe to call repeatedly during
+   * startup.
+   *
+   * @return the persisted throttle field set, or {@code null} when unavailable.
+   */
   public SimpleFieldSet readThrottle() {
     return persister.read();
   }
 
+  /**
+   * Starts periodic persistence of throttle state.
+   *
+   * <p>The persister performs an immediate write and schedules future writes on the configured
+   * {@link Ticker}. Repeated calls are ignored by the underlying persister, so callers may safely
+   * invoke this during startup without tracking whether it has already run.
+   */
   public void startThrottle() {
     persister.start();
   }
 
+  /**
+   * Initializes disk-space checking and persistent RAF factories.
+   *
+   * <p>This method wires a {@link DiskSpaceCheckingRandomAccessBufferFactory} backed by a {@link
+   * PooledFileRandomAccessBufferFactory} using the provided filename generator and directory. It
+   * also creates the {@link MaybeEncryptedRandomAccessBufferFactory} used for persistent temporary
+   * buckets. Call this before {@link #getPersistentRafFactory()}, {@link
+   * #installDiskChecker(PersistentTempBucketFactory)}, or {@link #createClientContext} to ensure
+   * those components can access the initialized factories.
+   *
+   * @param persistentFilenameGenerator generator for persistent random-access buffer filenames.
+   * @param persistentTempDir directory used for persistent temporary file storage.
+   * @param minDiskFreeLongTerm minimum free disk space in bytes to preserve.
+   * @param tempBucketFactory transient bucket factory used to account for RAM usage.
+   * @param encryptPersistentTempBuckets whether new persistent temp buckets should be encrypted.
+   */
   public void initDiskChecker(
       FilenameGenerator persistentFilenameGenerator,
       File persistentTempDir,
@@ -85,38 +169,153 @@ public final class NodeClientPersistence {
         new MaybeEncryptedRandomAccessBufferFactory(checker, encryptPersistentTempBuckets);
   }
 
+  /**
+   * Returns the persistent random-access buffer factory.
+   *
+   * <p>The factory is created by {@link #initDiskChecker} and is required for persistent request
+   * workflows. If initialization has not occurred yet, this method throws a {@link
+   * NullPointerException} to surface the missing configuration early.
+   *
+   * @return the initialized persistent RAF factory for future allocations.
+   * @throws NullPointerException if {@link #initDiskChecker} has not been called yet.
+   */
   public MaybeEncryptedRandomAccessBufferFactory getPersistentRafFactory() {
     return Objects.requireNonNull(persistentRafFactory, "Persistent RAF factory not initialized");
   }
 
+  /**
+   * Reports whether the persistent RAF factory has been initialized.
+   *
+   * <p>This is a convenience check for startup flows that may conditionally enable persistence. It
+   * reflects only whether {@link #initDiskChecker} has run; it does not validate any disk
+   * permissions or encryption configuration.
+   *
+   * @return {@code true} when the persistent RAF factory is available.
+   */
   public boolean hasPersistentRafFactory() {
     return persistentRafFactory != null;
   }
 
+  /**
+   * Enables or disables encryption for newly created persistent RAFs.
+   *
+   * <p>The toggle affects buffers allocated after the call and delegates to {@link
+   * MaybeEncryptedRandomAccessBufferFactory}. Existing buffers remain unchanged. This method
+   * requires {@link #initDiskChecker} to have completed.
+   *
+   * @param enable {@code true} to encrypt future allocations, {@code false} for plaintext.
+   * @throws NullPointerException if the persistent RAF factory has not been initialized.
+   */
   public void setPersistentRafEncryption(boolean enable) {
     getPersistentRafFactory().setEncryption(enable);
   }
 
+  /**
+   * Sets the master secret used for encrypting persistent RAF allocations.
+   *
+   * <p>The secret is forwarded to the {@link MaybeEncryptedRandomAccessBufferFactory} used for
+   * persistent temp storage. The value is applied to future allocations only and does not rewrite
+   * already-created buffers. Initialization via {@link #initDiskChecker} is required.
+   *
+   * @param secret master secret used to encrypt newly allocated buffers.
+   * @throws NullPointerException if the persistent RAF factory has not been initialized.
+   */
   public void setPersistentRafMasterSecret(MasterSecret secret) {
     getPersistentRafFactory().setMasterSecret(secret);
   }
 
+  /**
+   * Installs the disk space checker into a persistent bucket factory.
+   *
+   * <p>This delegates to {@link PersistentTempBucketFactory#setDiskSpaceChecker} after verifying
+   * that the internal checker has been initialized. Call {@link #initDiskChecker} first so the
+   * checker reflects the correct directory and reserve limits.
+   *
+   * @param persistentTempBucketFactory factory that should consult disk-space limits.
+   * @throws NullPointerException if the disk checker has not been initialized.
+   */
   public void installDiskChecker(PersistentTempBucketFactory persistentTempBucketFactory) {
     persistentTempBucketFactory.setDiskSpaceChecker(requireDiskChecker());
   }
 
+  /**
+   * Updates the minimum free-space reserve for persistent allocations.
+   *
+   * <p>The reserve is enforced by the underlying {@link DiskSpaceCheckingRandomAccessBufferFactory}
+   * and is expressed in bytes. This method requires the disk checker to be initialized and will
+   * propagate {@link IllegalArgumentException} if a negative reserve is supplied.
+   *
+   * @param minDiskSpace minimum free disk space, in bytes, to preserve.
+   * @throws NullPointerException if the disk checker has not been initialized.
+   * @throws IllegalArgumentException if {@code minDiskSpace} is negative.
+   */
   public void updateMinDiskSpace(long minDiskSpace) {
     requireDiskChecker().setMinDiskSpace(minDiskSpace);
   }
 
+  /**
+   * Creates the FCP server configured for this node and client core.
+   *
+   * <p>The server is constructed via {@link FCPServer#maybeCreate(Node, NodeClientCore,
+   * network.crypta.config.Config, PersistentRequestRoot)} and shares this instance's persistent
+   * request root so durable requests can be managed consistently across reconnects. This method
+   * performs no side effects beyond the delegation.
+   *
+   * @param node node instance supplying configuration and shared services.
+   * @param core client core used by the FCP server for callbacks.
+   * @return the configured FCP server instance from {@code maybeCreate}.
+   */
   public FCPServer createFcpServer(Node node, NodeClientCore core) {
     return FCPServer.maybeCreate(node, core, node.getConfig(), persistentRoot);
   }
 
+  /**
+   * Returns a snapshot of all currently registered persistent requests.
+   *
+   * <p>The snapshot is provided by the shared {@link PersistentRequestRoot} and may include global
+   * and per-client persistent requests. The returned array is a point-in-time view; subsequent
+   * request registrations or removals are not reflected in the array.
+   *
+   * @return an array of persistent client requests; never {@code null}.
+   */
   public ClientRequest[] getPersistentRequests() {
     return persistentRoot.getPersistentRequests();
   }
 
+  /**
+   * Builds a fully wired {@link ClientContext} for client-layer operations.
+   *
+   * <p>This method assembles the context from the supplied schedulers, factories, and defaults,
+   * wiring in the persistent request root and disk checker owned by this instance. Callers should
+   * invoke {@link #initDiskChecker} first; otherwise a {@link NullPointerException} is thrown to
+   * signal the missing persistence wiring. The returned context is a new object and does not mutate
+   * any of the provided collaborators beyond normal constructor usage.
+   *
+   * @param node node instance supplying boot id and configuration references.
+   * @param clientLayerPersister persistence runner used to serialize durable client jobs.
+   * @param executor priority-aware executor for main client-layer scheduling.
+   * @param resources bundle with archive manager and healing queue.
+   * @param persistentTempBucketFactory factory for persistent temp buckets and file tracking.
+   * @param tempBucketFactory factory for transient temp buckets and in-memory limits.
+   * @param uskManager manager for USK coordination and update tracking.
+   * @param random strong random source for cryptographic and protocol needs.
+   * @param fastWeakRandom fast non-cryptographic random source for jitter.
+   * @param ticker scheduler used for time-based client operations.
+   * @param memoryLimitedJobRunner runner constraining memory-intensive background tasks.
+   * @param tempFilenameGenerator generator for transient temp filenames and ids.
+   * @param persistentFilenameGenerator generator for persistent on-disk temp filenames.
+   * @param tempRafFactory factory for transient random-access buffers.
+   * @param persistentRafFactory factory for persistent random-access buffers, possibly encrypted.
+   * @param fileRafTransient factory for transient file-backed random-access buffers.
+   * @param compressor compressor implementation for client-side data pipelines.
+   * @param storeChecker datastore checker for verification and background checks.
+   * @param cryptoSecretTransient transient master secret for this process lifetime.
+   * @param init initialization bundle providing toadlets and config.
+   * @param defaultFetchContext default fetch context template for persistent requests.
+   * @param defaultInsertContext default insert context template for persistent requests.
+   * @return newly constructed client context with wired factories and persistent root.
+   * @throws NullPointerException if the disk checker has not been initialized.
+   */
   public ClientContext createClientContext(
       Node node,
       ClientLayerPersister clientLayerPersister,

--- a/src/main/java/network/crypta/node/RequestStarter.java
+++ b/src/main/java/network/crypta/node/RequestStarter.java
@@ -97,7 +97,7 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
       boolean isSSK,
       boolean realTime) {
     this.core = node;
-    this.stats = core.getNodeStats();
+    this.stats = node.getNode().getNodeStats();
     this.throttle = throttle;
     this.name = name + (realTime ? " (realtime)" : " (bulk)");
     this.averageOutputBytesPerRequest = averageOutputBytesPerRequest;
@@ -112,7 +112,7 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
   }
 
   void start() {
-    core.getExecutor().execute(this, name);
+    core.getNode().getExecutor().execute(this, name);
   }
 
   final String name;
@@ -289,7 +289,8 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
     }
     if (LOG.isDebugEnabled())
       LOG.debug("Start request {} with priority {}", req, req.getPriority());
-    core.getExecutor()
+    core.getNode()
+        .getExecutor()
         .execute(new SenderThread(req, req.key), "RequestStarter$SenderThread for " + req);
     return true;
   }

--- a/src/main/java/network/crypta/node/RequestStarterGroup.java
+++ b/src/main/java/network/crypta/node/RequestStarterGroup.java
@@ -100,7 +100,7 @@ public class RequestStarterGroup {
       ClientContext ctx)
       throws InvalidConfigValueException {
     SubConfig schedulerConfig = config.createSubConfig("node.scheduler");
-    this.stats = core.getNodeStats();
+    this.stats = node.getNodeStats();
 
     throttleWindowBulk =
         new ThrottleWindowManager(2.0, fs == null ? null : fs.subset("ThrottleWindow"), node);

--- a/src/main/java/network/crypta/node/SendableGetRequestSender.java
+++ b/src/main/java/network/crypta/node/SendableGetRequestSender.java
@@ -10,10 +10,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Sends GET requests to the node asynchronously.
  *
- * <p>This implementation submits the request to {@link NodeClientCore#asyncGet(Key, boolean,
- * RequestCompletionListener, boolean, boolean, boolean, boolean, boolean)} and returns immediately.
- * It delivers results via the provided {@link RequestCompletionListener} callbacks which, in turn,
- * notify the originating {@link SendableRequest}.
+ * <p>This implementation submits the request to {@link NodeClientCoreTransfers#asyncGet(Key,
+ * boolean, RequestCompletionListener, boolean, boolean, boolean, boolean, boolean)} and returns
+ * immediately. It delivers results via the provided {@link RequestCompletionListener} callbacks
+ * which, in turn, notify the originating {@link SendableRequest}.
  *
  * <p>Threading: this class does not block the caller; completion occurs on whatever thread the core
  * uses to invoke the listener. Callers should not assume callbacks run on the scheduler thread.
@@ -44,7 +44,7 @@ public class SendableGetRequestSender implements SendableRequestSender {
   /**
    * Submits an asynchronous GET for the provided block.
    *
-   * <p>Validates the request, then calls {@link NodeClientCore#asyncGet(Key, boolean,
+   * <p>Validates the request, then calls {@link NodeClientCoreTransfers#asyncGet(Key, boolean,
    * RequestCompletionListener, boolean, boolean, boolean, boolean, boolean)}. Completion is
    * reported via the supplied listener which delegates to {@code req.onFetchSuccess(context)} or
    * {@code req.onFailure(e, context)}.
@@ -95,26 +95,27 @@ public class SendableGetRequestSender implements SendableRequestSender {
        * and whether the request is local-only; they are forwarded unchanged.
        */
       final Key k = key.getNodeKey();
-      core.asyncGet(
-          k,
-          false,
-          new RequestCompletionListener() {
+      core.getTransfers()
+          .asyncGet(
+              k,
+              false,
+              new RequestCompletionListener() {
 
-            @Override
-            public void onSucceeded() {
-              req.onFetchSuccess(context);
-            }
+                @Override
+                public void onSucceeded() {
+                  req.onFetchSuccess(context);
+                }
 
-            @Override
-            public void onFailed(LowLevelGetException e) {
-              req.onFailure(e, context);
-            }
-          },
-          !req.ignoreStore,
-          req.canWriteClientCache,
-          req.realTimeFlag,
-          req.localRequestOnly,
-          req.ignoreStore);
+                @Override
+                public void onFailed(LowLevelGetException e) {
+                  req.onFailure(e, context);
+                }
+              },
+              !req.ignoreStore,
+              req.canWriteClientCache,
+              req.realTimeFlag,
+              req.localRequestOnly,
+              req.ignoreStore);
     } catch (RuntimeException | Error t) {
       // Convert unexpected throwables into a failure callback to keep the scheduler healthy.
       LOG.error("Unhandled throwable in send: {}", t, t);

--- a/src/main/java/network/crypta/node/SimpleSendableInsert.java
+++ b/src/main/java/network/crypta/node/SimpleSendableInsert.java
@@ -136,10 +136,10 @@ public class SimpleSendableInsert extends SendableInsert {
   /**
    * Handles a successful completion of the single insert attempt.
    *
-   * <p>This callback is invoked by the sender after {@link NodeClientCore#realPut} returns without
-   * throwing. It does not notify any {@link ClientRequester} and performs no state changes; the
-   * finished flag is managed by the sender. The only observable effect is a debug log entry, making
-   * this method safe to call multiple times but ordinarily invoked once per insert.
+   * <p>This callback is invoked by the sender after {@link NodeClientCoreTransfers#realPut} returns
+   * without throwing. It does not notify any {@link ClientRequester} and performs no state changes;
+   * the finished flag is managed by the sender. The only observable effect is a debug log entry,
+   * making this method safe to call multiple times but ordinarily invoked once per insert.
    *
    * @param keyNum token identifying the scheduled item; used for logging only
    * @param key client key associated with the insert; ignored and may be null
@@ -154,7 +154,7 @@ public class SimpleSendableInsert extends SendableInsert {
   /**
    * Handles a failed insert attempt.
    *
-   * <p>This callback is invoked when {@link NodeClientCore#realPut} throws a {@link
+   * <p>This callback is invoked when {@link NodeClientCoreTransfers#realPut} throws a {@link
    * LowLevelPutException}. The method logs the failure at debug level and does not request retries
    * or propagate the exception. Completion state is still finalized by the sender, so this method
    * focuses solely on recording the outcome for diagnostics.
@@ -185,9 +185,9 @@ public class SimpleSendableInsert extends SendableInsert {
   /**
    * Creates a sender that performs the single blocking insert attempt.
    *
-   * <p>The returned {@link SendableRequestSender} issues {@link NodeClientCore#realPut} for the
-   * configured block, records completion by setting {@code finished}, and forwards success or
-   * failure to {@link #onSuccess} or {@link #onFailure}. On success, it also removes the running
+   * <p>The returned {@link SendableRequestSender} issues {@link NodeClientCoreTransfers#realPut}
+   * for the configured block, records completion by setting {@code finished}, and forwards success
+   * or failure to {@link #onSuccess} or {@link #onFailure}. On success, it also removes the running
    * insert from the scheduler. The sender reports blocking behavior and is intended for one-shot
    * use by the scheduler.
    *
@@ -206,13 +206,14 @@ public class SimpleSendableInsert extends SendableInsert {
         try {
           if (LOG.isDebugEnabled()) LOG.debug("Starting request: {}", this);
           // Background inserts run as bulk (realTimeFlag=false).
-          core.realPut(
-              block,
-              req.canWriteClientCache,
-              Node.FORK_ON_CACHEABLE_DEFAULT,
-              Node.PREFER_INSERT_DEFAULT,
-              Node.IGNORE_LOW_BACKOFF_DEFAULT,
-              false);
+          core.getTransfers()
+              .realPut(
+                  block,
+                  req.canWriteClientCache,
+                  Node.FORK_ON_CACHEABLE_DEFAULT,
+                  Node.PREFER_INSERT_DEFAULT,
+                  Node.IGNORE_LOW_BACKOFF_DEFAULT,
+                  false);
           succeeded = true;
         } catch (LowLevelPutException e) {
           onFailure(e, req.token, context);

--- a/src/main/java/network/crypta/node/TextModeClientInterface.java
+++ b/src/main/java/network/crypta/node/TextModeClientInterface.java
@@ -417,7 +417,7 @@ public class TextModeClientInterface implements Runnable {
     sb.append("SHUTDOWN - exit the program\r\n");
     sb.append("ANNOUNCE[:<location>] - announce to the specified location\r\n");
     if (n.isUsingWrapper()) sb.append("RESTART - restart the program\r\n");
-    if (core != null && core.getDirectTMCI() != this) {
+    if (core != null && core.getEndpoints().getDirectTMCI() != this) {
       sb.append("QUIT - close the socket\r\n");
     }
     if (Node.isTestnetEnabled()) {
@@ -694,7 +694,7 @@ public class TextModeClientInterface implements Runnable {
           null,
           null,
           null,
-          core.getLinkFilterExceptionProvider());
+          core.getEndpoints().getToadletContainer());
       outsb.append(outputStream.toString(StandardCharsets.UTF_8));
     } catch (IOException e) {
       outsb.append("Bucket error?: ").append(e.getMessage());
@@ -749,7 +749,7 @@ public class TextModeClientInterface implements Runnable {
 
   private boolean handleQuit(
       String line, String uline, BufferedReader reader, StringBuilder outsb) {
-    if (core.getDirectTMCI() == this) {
+    if (core.getEndpoints().getDirectTMCI() == this) {
       outsb.append("QUIT command not available in console mode.");
       return false;
     }

--- a/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
+++ b/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
@@ -204,7 +204,7 @@ public class TextModeClientInterfaceServer implements Runnable {
               TextModeClientInterfaceConsole.in(),
               TextModeClientInterfaceConsole.out());
       node.getExecutor().execute(directTMCI, "Direct text mode interface");
-      core.setDirectTMCI(directTMCI);
+      core.getEndpoints().setDirectTMCI(directTMCI);
     }
 
     tmciConfig.finishedInitialization();
@@ -222,7 +222,7 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public Boolean get() {
-      return core.getTextModeClientInterface() != null;
+      return core.getEndpoints().getTextModeClientInterface() != null;
     }
 
     @Override
@@ -275,7 +275,7 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public Boolean get() {
-      return core.getDirectTMCI() != null;
+      return core.getEndpoints().getDirectTMCI() != null;
     }
 
     @Override
@@ -301,8 +301,8 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public String get() {
-      if (core.getTextModeClientInterface() != null)
-        return core.getTextModeClientInterface().bindTo;
+      if (core.getEndpoints().getTextModeClientInterface() != null)
+        return core.getEndpoints().getTextModeClientInterface().bindTo;
       else return NetworkInterface.DEFAULT_BIND_TO;
     }
 
@@ -310,7 +310,7 @@ public class TextModeClientInterfaceServer implements Runnable {
     public void set(String val) throws InvalidConfigValueException {
       if (val.equals(get())) return;
       String[] failedAddresses =
-          core.getTextModeClientInterface().networkInterface.setBindTo(val, false);
+          core.getEndpoints().getTextModeClientInterface().networkInterface.setBindTo(val, false);
       if (failedAddresses != null) {
         // This is an advanced option for reasons of reducing clutter,
         // but it is expected to be used by regular users, not devs.
@@ -318,7 +318,7 @@ public class TextModeClientInterfaceServer implements Runnable {
         throw new InvalidConfigValueException(
             "could not change bind to: " + Arrays.toString(failedAddresses));
       }
-      core.getTextModeClientInterface().bindTo = val;
+      core.getEndpoints().getTextModeClientInterface().bindTo = val;
     }
   }
 
@@ -332,8 +332,8 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public String get() {
-      if (core.getTextModeClientInterface() != null) {
-        return core.getTextModeClientInterface().allowedHosts;
+      if (core.getEndpoints().getTextModeClientInterface() != null) {
+        return core.getEndpoints().getTextModeClientInterface().allowedHosts;
       }
       return NetworkInterface.DEFAULT_BIND_TO;
     }
@@ -341,7 +341,7 @@ public class TextModeClientInterfaceServer implements Runnable {
     @Override
     public void set(String val) throws InvalidConfigValueException {
       if (!val.equals(get())) {
-        TextModeClientInterfaceServer server = core.getTextModeClientInterface();
+        TextModeClientInterfaceServer server = core.getEndpoints().getTextModeClientInterface();
         if (server != null) {
           try {
             server.networkInterface.setAllowedHosts(val);
@@ -366,7 +366,8 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public Integer get() {
-      if (core.getTextModeClientInterface() != null) return core.getTextModeClientInterface().port;
+      if (core.getEndpoints().getTextModeClientInterface() != null)
+        return core.getEndpoints().getTextModeClientInterface().port;
       else return 2323;
     }
 
@@ -374,7 +375,7 @@ public class TextModeClientInterfaceServer implements Runnable {
     @Override
     public void set(Integer val) throws InvalidConfigValueException {
       if (get().equals(val)) return;
-      core.getTextModeClientInterface().setPort(val);
+      core.getEndpoints().getTextModeClientInterface().setPort(val);
     }
   }
 

--- a/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
+++ b/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
@@ -233,7 +233,8 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public Boolean get() {
-      return core.getEndpoints().getTextModeClientInterface() != null;
+      ClientEndpoints endpoints = core.getEndpoints();
+      return endpoints != null && endpoints.getTextModeClientInterface() != null;
     }
 
     @Override
@@ -286,7 +287,8 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public Boolean get() {
-      return core.getEndpoints().getDirectTMCI() != null;
+      ClientEndpoints endpoints = core.getEndpoints();
+      return endpoints != null && endpoints.getDirectTMCI() != null;
     }
 
     @Override
@@ -312,9 +314,13 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public String get() {
-      if (core.getEndpoints().getTextModeClientInterface() != null)
-        return core.getEndpoints().getTextModeClientInterface().bindTo;
-      else return NetworkInterface.DEFAULT_BIND_TO;
+      ClientEndpoints endpoints = core.getEndpoints();
+      TextModeClientInterfaceServer server =
+          endpoints == null ? null : endpoints.getTextModeClientInterface();
+      if (server != null) {
+        return server.bindTo;
+      }
+      return NetworkInterface.DEFAULT_BIND_TO;
     }
 
     @Override
@@ -343,8 +349,11 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public String get() {
-      if (core.getEndpoints().getTextModeClientInterface() != null) {
-        return core.getEndpoints().getTextModeClientInterface().allowedHosts;
+      ClientEndpoints endpoints = core.getEndpoints();
+      TextModeClientInterfaceServer server =
+          endpoints == null ? null : endpoints.getTextModeClientInterface();
+      if (server != null) {
+        return server.allowedHosts;
       }
       return NetworkInterface.DEFAULT_BIND_TO;
     }
@@ -377,9 +386,13 @@ public class TextModeClientInterfaceServer implements Runnable {
 
     @Override
     public Integer get() {
-      if (core.getEndpoints().getTextModeClientInterface() != null)
-        return core.getEndpoints().getTextModeClientInterface().port;
-      else return 2323;
+      ClientEndpoints endpoints = core.getEndpoints();
+      TextModeClientInterfaceServer server =
+          endpoints == null ? null : endpoints.getTextModeClientInterface();
+      if (server != null) {
+        return server.port;
+      }
+      return 2323;
     }
 
     // Not implemented: port updates handled elsewhere

--- a/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
+++ b/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
@@ -64,6 +64,19 @@ public class TextModeClientInterfaceServer implements Runnable {
   private static boolean ssl = false;
   final NetworkInterface networkInterface;
 
+  /**
+   * Result returned from {@link #maybeCreate(Node, NodeClientCore, Config)}.
+   *
+   * <p>The returned direct TMCI is created but not started. Callers should register it with {@link
+   * ClientEndpoints#setDirectTMCI(TextModeClientInterface)} and schedule it on the node executor
+   * only after {@link NodeClientCore#getEndpoints()} is fully initialized.
+   *
+   * @param server TMCI server instance, or {@code null} when TMCI is disabled.
+   * @param directTMCI direct text-mode interface instance, or {@code null} when disabled.
+   */
+  public record InitResult(
+      TextModeClientInterfaceServer server, TextModeClientInterface directTMCI) {}
+
   TextModeClientInterfaceServer(
       Node node, NodeClientCore core, int port, String bindTo, String allowedHosts) {
     this.n = node;
@@ -91,21 +104,21 @@ public class TextModeClientInterfaceServer implements Runnable {
   }
 
   /**
-   * Creates a TMCI server according to the provided configuration, or returns {@code null} when the
-   * feature is disabled.
+   * Creates TMCI endpoints according to the provided configuration.
    *
    * <p>This method wires the {@code console} sub-configuration, registers relevant options ({@code
    * enabled}, {@code ssl}, {@code bindTo}, {@code allowedHosts}, {@code port}, and {@code
-   * directEnabled}), and conditionally instantiates the network-backed server. When {@code
-   * directEnabled} is set, a direct in-process text interface is also started using the process
-   * input/output streams; this is independent of the network listener. The returned server is not
-   * started automatically; callers should invoke {@link #start()} when a non-null value is
-   * returned.
+   * directEnabled}), and conditionally instantiates the network-backed server. The returned init
+   * result includes a server instance when TMCI is enabled, or {@code null} when disabled. When
+   * {@code directEnabled} is set, a direct in-process text interface is created using the process
+   * input/output streams; callers are responsible for registering and starting it after the core
+   * endpoints are assigned. The returned server is not started automatically; callers should invoke
+   * {@link #start()} when a non-null value is returned.
    *
    * <pre>{@code
-   * var server = TextModeClientInterfaceServer.maybeCreate(node, core, config);
-   * if (server != null) {
-   *   server.start();
+   * var init = TextModeClientInterfaceServer.maybeCreate(node, core, config);
+   * if (init.server() != null) {
+   *   init.server().start();
    * }
    * }</pre>
    *
@@ -115,12 +128,12 @@ public class TextModeClientInterfaceServer implements Runnable {
    *     must not be {@code null}.
    * @param config the root {@link Config} used to obtain the {@code console} sub-config and read
    *     options that control TMCI behavior; must not be {@code null}.
-   * @return a configured server when TMCI is enabled in the configuration; otherwise {@code null}.
+   * @return a result containing the configured server and optional direct TMCI instance.
    */
-  public static TextModeClientInterfaceServer maybeCreate(
-      Node node, NodeClientCore core, Config config) {
+  public static InitResult maybeCreate(Node node, NodeClientCore core, Config config) {
 
     TextModeClientInterfaceServer server = null;
+    TextModeClientInterface directTMCI = null;
 
     SubConfig tmciConfig = config.createSubConfig("console");
 
@@ -195,7 +208,7 @@ public class TextModeClientInterfaceServer implements Runnable {
     if (direct) {
       HighLevelSimpleClient client =
           core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, false);
-      TextModeClientInterface directTMCI =
+      directTMCI =
           new TextModeClientInterface(
               node,
               core,
@@ -203,13 +216,11 @@ public class TextModeClientInterfaceServer implements Runnable {
               core.getDownloadsDir(),
               TextModeClientInterfaceConsole.in(),
               TextModeClientInterfaceConsole.out());
-      node.getExecutor().execute(directTMCI, "Direct text mode interface");
-      core.getEndpoints().setDirectTMCI(directTMCI);
     }
 
     tmciConfig.finishedInitialization();
 
-    return server; // caller must call start()
+    return new InitResult(server, directTMCI); // caller must call start()
   }
 
   static class TMCIEnabledCallback extends BooleanCallback {

--- a/src/main/java/network/crypta/node/simulator/RealNodeBusyNetworkTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeBusyNetworkTest.java
@@ -245,6 +245,7 @@ public class RealNodeBusyNetworkTest extends RealNodeRoutingTest {
       try {
         randomNode
             .getClientCore()
+            .getTransfers()
             .realPut(chkBlock, false, FORK_ON_CACHEABLE, false, false, REAL_TIME_FLAG);
         LOG.error("Inserted to {}", nodeIndex);
         logBlockPayloadDetails(chkBlock);

--- a/src/main/java/network/crypta/node/simulator/RealNodeRequestInsertTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeRequestInsertTest.java
@@ -284,6 +284,7 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
       insertAttempts++;
       randomNode
           .getClientCore()
+          .getTransfers()
           .realPut(block.getBlock(), false, FORK_ON_CACHEABLE, false, false, REAL_TIME_FLAG);
       LOG.error("Inserted to {}", node1);
     } catch (LowLevelPutException putEx) {
@@ -298,7 +299,10 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
     Node fetchNode = nodes[node2];
     try {
       block =
-          fetchNode.getClientCore().realGetKey(keys.fetchKey, false, false, false, REAL_TIME_FLAG);
+          fetchNode
+              .getClientCore()
+              .getTransfers()
+              .realGetKey(keys.fetchKey, false, false, false, REAL_TIME_FLAG);
     } catch (LowLevelGetException _) {
       block = null;
     }

--- a/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
@@ -335,6 +335,7 @@ public class RealNodeULPRTest extends RealNodeTest {
       try {
         nodes[i % nodes.length]
             .getClientCore()
+            .getTransfers()
             .realGetKey(fetchKey, false, false, false, REAL_TIME_FLAG);
         LOG.error("TEST FAILED: KEY ALREADY PRESENT!!!");
         System.exit(EXIT_KEY_EXISTS);

--- a/src/main/java/network/crypta/node/useralerts/DiskSpaceUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/DiskSpaceUserAlert.java
@@ -6,7 +6,6 @@ import network.crypta.clients.fcp.FeedMessage;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.io.FilenameGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,11 +71,12 @@ public class DiskSpaceUserAlert implements UserAlert {
   Status evaluate() {
     long shortTermLimit = core.getMinDiskFreeShortTerm();
     long longTermLimit = core.getMinDiskFreeLongTerm();
-    File tempDir = core.getTempFilenameGenerator().getDir();
-    if (tempDir.getUsableSpace() < shortTermLimit) return Status.TRANSIENT; // Takes precedence.
-    FilenameGenerator fg = core.getPersistentFilenameGenerator();
-    if (fg != null) {
-      File persistentTempDir = fg.getDir();
+    File tempDir = core.getTempDir();
+    if (tempDir != null && tempDir.getUsableSpace() < shortTermLimit) {
+      return Status.TRANSIENT; // Takes precedence.
+    }
+    File persistentTempDir = core.getPersistentTempDir();
+    if (persistentTempDir != null) {
       long space = persistentTempDir.getUsableSpace();
       if (space < shortTermLimit) return Status.PERSISTENT_COMPLETION;
       if (space < longTermLimit) return Status.PERSISTENT;
@@ -159,12 +159,12 @@ public class DiskSpaceUserAlert implements UserAlert {
     // (e.g., a mount point) would require java.nio.file APIs.
     if (status == Status.PERSISTENT || status == Status.PERSISTENT_COMPLETION) {
       // Be very careful about race conditions!
-      FilenameGenerator fg = core.getPersistentFilenameGenerator();
-      if (fg != null) {
-        return fg.getDir();
+      File persistentTempDir = core.getPersistentTempDir();
+      if (persistentTempDir != null) {
+        return persistentTempDir;
       }
     }
-    return core.getTempFilenameGenerator().getDir();
+    return core.getTempDir();
   }
 
   private synchronized Status getStatus() {

--- a/src/main/java/network/crypta/pluginmanager/PluginManager.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginManager.java
@@ -269,7 +269,8 @@ public class PluginManager {
 
     final Semaphore startingPlugins = new Semaphore(0);
     for (final String name : toStart) {
-      core.getExecutor()
+      core.getNode()
+          .getExecutor()
           .execute(
               () -> {
                 startPluginAuto(name, false);
@@ -277,7 +278,8 @@ public class PluginManager {
               });
     }
 
-    core.getExecutor()
+    core.getNode()
+        .getExecutor()
         .execute(
             () -> {
               startingPlugins.acquireUninterruptibly(toStart.length);
@@ -832,7 +834,8 @@ public class PluginManager {
             pi.getFilename());
       } else {
         Toadlet toadlet = pi.getConfigToadlet();
-        core.getToadletContainer()
+        core.getEndpoints()
+            .getToadletContainer()
             .register(
                 toadlet,
                 "FProxyToadlet.categoryConfig",
@@ -2107,7 +2110,7 @@ public class PluginManager {
   public void unregisterPlugin(PluginInfoWrapper wrapper, FredPlugin plug, boolean reloading) {
     unregisterPluginToadlet(wrapper);
     if (wrapper.isConfigurablePlugin()) {
-      core.getToadletContainer().unregister(wrapper.getConfigToadlet());
+      core.getEndpoints().getToadletContainer().unregister(wrapper.getConfigToadlet());
     }
     if (wrapper.isIPDetectorPlugin())
       node.getIpDetector().unregisterIPDetectorPlugin((FredPluginIPDetector) plug);

--- a/src/main/java/network/crypta/pluginmanager/PluginRespirator.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginRespirator.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.UUID;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.filter.FilterCallback;
+import network.crypta.client.filter.GenericReadFilterCallback;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.FCPPluginConnection;
 import network.crypta.clients.fcp.FCPPluginMessage;
 import network.crypta.clients.http.PageMaker;
@@ -130,7 +132,10 @@ public class PluginRespirator {
    */
   public FilterCallback makeFilterCallback(String path) {
     try {
-      return node.getClientCore().createFilterCallback(URIPreEncoder.encodeURI(path), null);
+      ToadletContainer container = getToadletContainer();
+      LinkFilterExceptionProvider provider =
+          container instanceof LinkFilterExceptionProvider linkProvider ? linkProvider : null;
+      return new GenericReadFilterCallback(URIPreEncoder.encodeURI(path), null, null, provider);
     } catch (URISyntaxException e) {
       throw new AssertionError("Invalid filter callback path: " + path, e);
     }
@@ -259,6 +264,7 @@ public class PluginRespirator {
     // pluginName being null will be handled by createFCPPluginConnectionForIntraNodeFCP().
 
     return node.getClientCore()
+        .getEndpoints()
         .getFCPServer()
         .createFCPPluginConnectionForIntraNodeFCP(pluginName, messageHandler);
   }
@@ -298,7 +304,7 @@ public class PluginRespirator {
    *     discard it.
    */
   public FCPPluginConnection getPluginConnectionByID(UUID connectionID) throws IOException {
-    return node.getClientCore().getFCPServer().getPluginConnectionByID(connectionID);
+    return node.getClientCore().getEndpoints().getFCPServer().getPluginConnectionByID(connectionID);
   }
 
   /**
@@ -316,7 +322,7 @@ public class PluginRespirator {
    * @return the node {@link ToadletContainer}, or {@code null} if HTTP is not available.
    */
   public ToadletContainer getToadletContainer() {
-    return node.getClientCore().getToadletContainer();
+    return node.getClientCore().getEndpoints().getToadletContainer();
   }
 
   /**

--- a/src/test/java/network/crypta/client/HighLevelSimpleClientImplTest.java
+++ b/src/test/java/network/crypta/client/HighLevelSimpleClientImplTest.java
@@ -55,15 +55,17 @@ class HighLevelSimpleClientImplTest {
   @BeforeEach
   void setUp() {
     NodeClientCore core = mock(NodeClientCore.class);
+    network.crypta.node.Node node = mock(network.crypta.node.Node.class);
     bucketFactory = mock(BucketFactory.class);
     PersistentTempBucketFactory persistentTempBucketFactory =
         mock(PersistentTempBucketFactory.class);
     clientContext = mock(ClientContext.class);
     ticker = mock(Ticker.class);
 
+    when(core.getNode()).thenReturn(node);
     when(core.getPersistentTempBucketFactory()).thenReturn(persistentTempBucketFactory);
     when(core.getClientContext()).thenReturn(clientContext);
-    when(core.getTicker()).thenReturn(ticker);
+    when(node.getTicker()).thenReturn(ticker);
 
     // Deterministic RandomSource for key generation tests
     RandomSource random = new DeterministicRandomSource(123456789L);

--- a/src/test/java/network/crypta/client/async/OfferedKeysListTest.java
+++ b/src/test/java/network/crypta/client/async/OfferedKeysListTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import network.crypta.node.KeysFetchingLocally;
 import network.crypta.node.LowLevelGetException;
 import network.crypta.node.LowLevelPutException;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.NodeClientCoreTransfers;
 import network.crypta.node.RequestCompletionListener;
 import network.crypta.node.RequestScheduler;
 import network.crypta.node.SendableRequestItem;
@@ -40,12 +42,15 @@ class OfferedKeysListTest {
   private static final short PRIO = 7;
 
   private NodeClientCore core;
+  private NodeClientCoreTransfers transfers;
   private KeysFetchingLocally fetching;
   private RequestScheduler scheduler;
 
   @BeforeEach
   void setUp() {
     core = mock(NodeClientCore.class);
+    transfers = mock(NodeClientCoreTransfers.class);
+    lenient().when(core.getTransfers()).thenReturn(transfers);
     fetching = mock(KeysFetchingLocally.class);
     scheduler = mock(RequestScheduler.class);
   }
@@ -171,7 +176,7 @@ class OfferedKeysListTest {
               // No-op stub: we drive completion via captured listener after verification.
               return null;
             })
-        .when(core)
+        .when(transfers)
         .asyncGet(
             any(Key.class),
             any(Boolean.class),
@@ -196,7 +201,7 @@ class OfferedKeysListTest {
     ArgumentCaptor<Boolean> rtCap = ArgumentCaptor.forClass(Boolean.class);
     ArgumentCaptor<Boolean> localOnlyCap = ArgumentCaptor.forClass(Boolean.class);
     ArgumentCaptor<Boolean> ignoreStoreCap = ArgumentCaptor.forClass(Boolean.class);
-    verify(core, times(1))
+    verify(transfers, times(1))
         .asyncGet(
             keyCaptor.capture(),
             offersOnlyCap.capture(),

--- a/src/test/java/network/crypta/client/async/SplitFileInserterSenderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterSenderTest.java
@@ -23,6 +23,7 @@ import network.crypta.keys.ClientCHK;
 import network.crypta.keys.ClientCHKBlock;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.NodeClientCoreTransfers;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestScheduler;
 import network.crypta.node.SendableRequestItem;
@@ -340,6 +341,8 @@ class SplitFileInserterSenderTest {
     when(sched.getContext()).thenReturn(ctx);
 
     NodeClientCore core = mock(NodeClientCore.class);
+    NodeClientCoreTransfers transfers = mock(NodeClientCoreTransfers.class);
+    when(core.getTransfers()).thenReturn(transfers);
 
     // Build chosen block with localRequestOnly=false, canWriteClientCache=false,
     // forkOnCacheable=true
@@ -352,7 +355,7 @@ class SplitFileInserterSenderTest {
 
     // Assert
     assertTrue(accepted);
-    verify(core, times(1))
+    verify(transfers, times(1))
         .realPut(
             chkBlock,
             false,

--- a/src/test/java/network/crypta/client/async/USKManagerTest.java
+++ b/src/test/java/network/crypta/client/async/USKManagerTest.java
@@ -326,6 +326,7 @@ class USKManagerTest {
   }
 
   @Mock private network.crypta.node.NodeClientCore core;
+  @Mock private network.crypta.node.Node node;
   @Mock private ClientContext context;
 
   private USKManager manager;
@@ -336,7 +337,8 @@ class USKManagerTest {
     // Provide stub client and direct executor for the manager
     when(core.makeClient(RequestStarter.UPDATE_PRIORITY_CLASS, false, false))
         .thenReturn(new HLClientStub());
-    when(core.getExecutor()).thenReturn(direct);
+    when(core.getNode()).thenReturn(node);
+    when(node.getExecutor()).thenReturn(direct);
     manager = new USKManager(core);
     manager.init(context);
     when(context.getMainExecutor()).thenReturn(direct);

--- a/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
@@ -35,6 +35,7 @@ import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.config.Config;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
+import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.MemoryLimitedJobRunner;
@@ -182,7 +183,9 @@ class ModifyPersistentRequestTest {
 
     when(handler.getRebootRequest(false, handler, "req-7")).thenReturn(rebootRequest);
     when(node.getClientCore()).thenReturn(core);
-    when(core.getFCPServer()).thenReturn(server);
+    ClientEndpoints endpoints = mock(ClientEndpoints.class);
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getFCPServer()).thenReturn(server);
 
     message.run(handler, node);
 
@@ -333,7 +336,9 @@ class ModifyPersistentRequestTest {
 
     ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
     NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getFCPServer()).thenReturn(mock(FCPServer.class));
+    ClientEndpoints endpoints = mock(ClientEndpoints.class);
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getFCPServer()).thenReturn(mock(FCPServer.class));
     Node node = mock(Node.class);
     when(node.getClientCore()).thenReturn(core);
 

--- a/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
+++ b/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.SimpleFieldSet;
@@ -27,6 +28,7 @@ class WatchGlobalTest {
   @Mock private PersistentRequestClient foreverClient;
   @Mock private Node node;
   @Mock private NodeClientCore nodeClientCore;
+  @Mock private ClientEndpoints endpoints;
   @Mock private FCPServer nodeFcpServer;
   @Mock private FCPServer handlerFcpServer;
 
@@ -113,7 +115,8 @@ class WatchGlobalTest {
     verify(handler).getRebootClient();
     verify(handler).getForeverClient();
     verify(node).getClientCore();
-    verify(nodeClientCore).getFCPServer();
+    verify(nodeClientCore).getEndpoints();
+    verify(endpoints).getFCPServer();
     verifyNoMoreInteractions(handler, rebootClient, node, nodeClientCore, nodeFcpServer);
   }
 
@@ -136,7 +139,8 @@ class WatchGlobalTest {
   private void prepareSharedMocks() {
     when(handler.getRebootClient()).thenReturn(rebootClient);
     when(node.getClientCore()).thenReturn(nodeClientCore);
-    when(nodeClientCore.getFCPServer()).thenReturn(nodeFcpServer);
+    when(nodeClientCore.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getFCPServer()).thenReturn(nodeFcpServer);
   }
 
   private SimpleFieldSet fieldSet(boolean enabled, int verbosityMask) {

--- a/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -27,6 +28,7 @@ import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.ContentFilter.FilterStatus;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
+import network.crypta.node.ClientEndpoints;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.Bucket;
@@ -46,7 +48,7 @@ class ContentFilterToadletTest {
 
   private HighLevelSimpleClient client;
   private NodeClientCore core;
-  private ToadletContainer container;
+  private SimpleToadletServer container;
   private ToadletContext ctx;
   private BucketFactory bucketFactory;
 
@@ -54,9 +56,12 @@ class ContentFilterToadletTest {
   void setUp() {
     client = mock(HighLevelSimpleClient.class);
     core = mock(NodeClientCore.class);
-    container = mock(ToadletContainer.class);
+    container = mock(SimpleToadletServer.class);
     ctx = mock(ToadletContext.class);
     bucketFactory = mock(BucketFactory.class);
+    ClientEndpoints endpoints = mock(ClientEndpoints.class);
+    lenient().when(core.getEndpoints()).thenReturn(endpoints);
+    lenient().when(endpoints.getToadletContainer()).thenReturn(container);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/ExternalLinkToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ExternalLinkToadletTest.java
@@ -25,6 +25,7 @@ import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker.RenderParameters;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.HTMLNode;
@@ -61,7 +62,9 @@ class ExternalLinkToadletTest {
 
     when(context.getPageMaker()).thenReturn(pageMaker);
     when(node.getClientCore()).thenReturn(nodeClientCore);
-    when(nodeClientCore.getToadletContainer()).thenReturn(toadletContainer);
+    ClientEndpoints endpoints = mock(ClientEndpoints.class);
+    when(nodeClientCore.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getToadletContainer()).thenReturn(toadletContainer);
 
     doNothing()
         .when(context)

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
@@ -31,6 +31,7 @@ import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeIPDetector;
@@ -78,7 +79,9 @@ class FirstTimeWizardNewToadletTest {
     when(ctx.getPageMaker()).thenReturn(pageMaker);
     when(pageMaker.getPageNode(anyString(), eq(ctx), any(PageMaker.RenderParameters.class)))
         .thenReturn(pageNode);
-    when(core.getToadletContainer()).thenReturn(toadletContainer);
+    ClientEndpoints endpoints = mock(ClientEndpoints.class);
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getToadletContainer()).thenReturn(toadletContainer);
     when(toadletContainer.getFormPassword()).thenReturn("form-pass");
     lenient().when(config.get("node")).thenReturn(nodeSubConfig);
     lenient().when(config.get("fproxy")).thenReturn(fproxySubConfig);

--- a/src/test/java/network/crypta/clients/http/QueueToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletTest.java
@@ -184,7 +184,7 @@ class QueueToadletTest {
     NodeClientCore core = mock(NodeClientCore.class);
     when(core.getNode()).thenReturn(node);
     when(core.getAlerts()).thenReturn(alerts);
-    when(core.getExecutor()).thenReturn(executor);
+    when(node.getExecutor()).thenReturn(executor);
 
     ClientContext context = createClientContext();
     context.init(starters, alerts);

--- a/src/test/java/network/crypta/node/ClientContextResourcesTest.java
+++ b/src/test/java/network/crypta/node/ClientContextResourcesTest.java
@@ -1,0 +1,54 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.async.HealingQueue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientContextResourcesTest {
+  @Mock private ArchiveManager archiveManager;
+  @Mock private HealingQueue healingQueue;
+
+  @Test
+  void getArchiveManager_whenConstructedWithValue_returnsSameInstance() {
+    ClientContextResources resources = new ClientContextResources(archiveManager, healingQueue);
+
+    ArchiveManager result = resources.getArchiveManager();
+
+    assertSame(archiveManager, result);
+  }
+
+  @Test
+  void getHealingQueue_whenConstructedWithValue_returnsSameInstance() {
+    ClientContextResources resources = new ClientContextResources(archiveManager, healingQueue);
+
+    HealingQueue result = resources.getHealingQueue();
+
+    assertSame(healingQueue, result);
+  }
+
+  @Test
+  void getArchiveManager_whenConstructedWithNull_returnsNull() {
+    ClientContextResources resources = new ClientContextResources(null, healingQueue);
+
+    ArchiveManager result = resources.getArchiveManager();
+
+    assertNull(result);
+  }
+
+  @Test
+  void getHealingQueue_whenConstructedWithNull_returnsNull() {
+    ClientContextResources resources = new ClientContextResources(archiveManager, null);
+
+    HealingQueue result = resources.getHealingQueue();
+
+    assertNull(result);
+  }
+}

--- a/src/test/java/network/crypta/node/ClientEndpointsTest.java
+++ b/src/test/java/network/crypta/node/ClientEndpointsTest.java
@@ -170,10 +170,11 @@ class ClientEndpointsTest {
         Mockito.mockStatic(TextModeClientInterfaceServer.class)) {
       tmciMock
           .when(() -> TextModeClientInterfaceServer.maybeCreate(node, core, config))
-          .thenReturn(tmci);
+          .thenReturn(new TextModeClientInterfaceServer.InitResult(tmci, null));
 
-      ClientEndpoints endpoints =
+      ClientEndpoints.InitResult initResult =
           ClientEndpoints.create(node, core, init, persistence, clientContext);
+      ClientEndpoints endpoints = initResult.endpoints();
 
       assertSame(fcpServer, endpoints.getFCPServer());
       assertSame(tmci, endpoints.getTextModeClientInterface());
@@ -199,10 +200,11 @@ class ClientEndpointsTest {
         Mockito.mockStatic(TextModeClientInterfaceServer.class)) {
       tmciMock
           .when(() -> TextModeClientInterfaceServer.maybeCreate(node, core, config))
-          .thenReturn(tmci);
+          .thenReturn(new TextModeClientInterfaceServer.InitResult(tmci, null));
 
-      ClientEndpoints endpoints =
+      ClientEndpoints.InitResult initResult =
           ClientEndpoints.create(node, core, init, persistence, clientContext);
+      ClientEndpoints endpoints = initResult.endpoints();
 
       assertSame(fcpServer, endpoints.getFCPServer());
       assertSame(tmci, endpoints.getTextModeClientInterface());

--- a/src/test/java/network/crypta/node/ClientEndpointsTest.java
+++ b/src/test/java/network/crypta/node/ClientEndpointsTest.java
@@ -1,0 +1,215 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.client.async.ClientContext;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.http.FProxyToadlet;
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.config.Config;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientEndpointsTest {
+
+  @Mock private FCPServer fcpServer;
+  @Mock private TextModeClientInterfaceServer tmci;
+  @Mock private SimpleToadletServer toadletContainer;
+  @Mock private FProxyToadlet fproxy;
+  @Mock private TextModeClientInterface directTmci;
+  @Mock private UserAlertManager userAlertManager;
+  @Mock private Node node;
+  @Mock private NodeClientCore core;
+  @Mock private NodeClientPersistence persistence;
+  @Mock private ClientContext clientContext;
+
+  @Test
+  void constructor_whenProvidedDependencies_returnsSameInstances() {
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+
+    assertSame(fcpServer, endpoints.getFCPServer());
+    assertSame(tmci, endpoints.getTextModeClientInterface());
+    assertSame(toadletContainer, endpoints.getToadletContainer());
+    assertNull(endpoints.getFProxy());
+    assertNull(endpoints.getDirectTMCI());
+  }
+
+  @Test
+  void setFProxy_whenAssigned_updatesGetter() {
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+
+    endpoints.setFProxy(fproxy);
+
+    assertSame(fproxy, endpoints.getFProxy());
+  }
+
+  @Test
+  void setDirectTMCI_whenAssigned_updatesGetter() {
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+
+    endpoints.setDirectTMCI(directTmci);
+
+    assertSame(directTmci, endpoints.getDirectTMCI());
+  }
+
+  @Test
+  void loadPersistentRequestsIfNeeded_whenCalled_loadInvoked() {
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+
+    endpoints.loadPersistentRequestsIfNeeded();
+
+    Mockito.verify(fcpServer).load();
+  }
+
+  @Test
+  void maybeStart_whenTmciPresent_startsFcpAndTmci() {
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+
+    endpoints.maybeStart();
+
+    Mockito.verify(fcpServer).maybeStart();
+    Mockito.verify(tmci).start();
+  }
+
+  @Test
+  void maybeStart_whenTmciNull_startsFcpOnly() {
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, null, toadletContainer);
+
+    endpoints.maybeStart();
+
+    Mockito.verify(fcpServer).maybeStart();
+  }
+
+  @Test
+  void configureBucketFactory_whenCalled_delegatesToToadletContainer() {
+    TempBucketFactory tempBucketFactory = Mockito.mock(TempBucketFactory.class);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+
+    endpoints.configureBucketFactory(tempBucketFactory);
+
+    Mockito.verify(toadletContainer).setBucketFactory(tempBucketFactory);
+  }
+
+  @Test
+  void registerStartupAlerts_whenCalled_registersAlertAndStoresForUnregister() {
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    UserAlert alert = Mockito.mock(UserAlert.class);
+    String title = "Title";
+    String longText = "Long";
+    String shortText = "Short";
+
+    try (MockedStatic<NodeClientCoreSupport> mocked =
+        Mockito.mockStatic(NodeClientCoreSupport.class)) {
+      mocked
+          .when(() -> NodeClientCoreSupport.createStartingUpAlert(title, longText, shortText))
+          .thenReturn(alert);
+
+      endpoints.registerStartupAlerts(userAlertManager, core, title, longText, shortText);
+
+      mocked.verify(() -> NodeClientCoreSupport.createStartingUpAlert(title, longText, shortText));
+      mocked.verify(
+          () -> NodeClientCoreSupport.registerFProxyAlerts(userAlertManager, core, alert));
+    }
+
+    endpoints.unregisterStartupAlert(userAlertManager);
+
+    Mockito.verify(userAlertManager).unregister(alert);
+  }
+
+  @Test
+  void unregisterStartupAlert_whenMissing_doesNothing() {
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+
+    endpoints.unregisterStartupAlert(userAlertManager);
+
+    Mockito.verifyNoInteractions(userAlertManager);
+  }
+
+  @Test
+  void isAdvancedModeEnabled_whenQueried_delegatesToToadletContainer() {
+    Mockito.when(toadletContainer.isAdvancedModeEnabled()).thenReturn(true);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+
+    boolean enabled = endpoints.isAdvancedModeEnabled();
+
+    assertTrue(enabled);
+  }
+
+  @Test
+  void isFProxyJavascriptEnabled_whenQueried_delegatesToToadletContainer() {
+    Mockito.when(toadletContainer.isFProxyJavascriptEnabled()).thenReturn(false);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+
+    boolean enabled = endpoints.isFProxyJavascriptEnabled();
+
+    assertFalse(enabled);
+  }
+
+  @Test
+  void create_whenDatabaseHealthy_loadsFcpAndWiresEndpoints() {
+    Config config = Mockito.mock(Config.class);
+    SimpleToadletServer toadlets = Mockito.mock(SimpleToadletServer.class);
+    NodeClientCoreInit init = new NodeClientCoreInit(config, null, null, toadlets);
+
+    Mockito.when(persistence.createFcpServer(node, core)).thenReturn(fcpServer);
+    Mockito.when(core.killedDatabase()).thenReturn(false);
+
+    try (MockedStatic<TextModeClientInterfaceServer> tmciMock =
+        Mockito.mockStatic(TextModeClientInterfaceServer.class)) {
+      tmciMock
+          .when(() -> TextModeClientInterfaceServer.maybeCreate(node, core, config))
+          .thenReturn(tmci);
+
+      ClientEndpoints endpoints =
+          ClientEndpoints.create(node, core, init, persistence, clientContext);
+
+      assertSame(fcpServer, endpoints.getFCPServer());
+      assertSame(tmci, endpoints.getTextModeClientInterface());
+      assertSame(toadlets, endpoints.getToadletContainer());
+      tmciMock.verify(() -> TextModeClientInterfaceServer.maybeCreate(node, core, config));
+    }
+
+    Mockito.verify(persistence).createFcpServer(node, core);
+    Mockito.verify(clientContext).setDownloadCache(fcpServer);
+    Mockito.verify(fcpServer).load();
+  }
+
+  @Test
+  void create_whenDatabaseKilled_skipsFcpLoad() {
+    Config config = Mockito.mock(Config.class);
+    SimpleToadletServer toadlets = Mockito.mock(SimpleToadletServer.class);
+    NodeClientCoreInit init = new NodeClientCoreInit(config, null, null, toadlets);
+
+    Mockito.when(persistence.createFcpServer(node, core)).thenReturn(fcpServer);
+    Mockito.when(core.killedDatabase()).thenReturn(true);
+
+    try (MockedStatic<TextModeClientInterfaceServer> tmciMock =
+        Mockito.mockStatic(TextModeClientInterfaceServer.class)) {
+      tmciMock
+          .when(() -> TextModeClientInterfaceServer.maybeCreate(node, core, config))
+          .thenReturn(tmci);
+
+      ClientEndpoints endpoints =
+          ClientEndpoints.create(node, core, init, persistence, clientContext);
+
+      assertSame(fcpServer, endpoints.getFCPServer());
+      assertSame(tmci, endpoints.getTextModeClientInterface());
+      assertSame(toadlets, endpoints.getToadletContainer());
+    }
+
+    Mockito.verify(fcpServer, Mockito.never()).load();
+    Mockito.verify(clientContext).setDownloadCache(fcpServer);
+  }
+}

--- a/src/test/java/network/crypta/node/NodeClientCoreInitTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreInitTest.java
@@ -1,0 +1,45 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.config.Config;
+import network.crypta.config.SubConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class NodeClientCoreInitTest {
+  @Mock private Config config;
+  @Mock private SubConfig nodeConfig;
+  @Mock private SubConfig installConfig;
+  @Mock private SimpleToadletServer toadlets;
+
+  @Test
+  void constructor_withNonNullDependencies_storesReferences() {
+    // Arrange
+    NodeClientCoreInit init = new NodeClientCoreInit(config, nodeConfig, installConfig, toadlets);
+
+    // Act + Assert
+    assertSame(config, init.config());
+    assertSame(nodeConfig, init.nodeConfig());
+    assertSame(installConfig, init.installConfig());
+    assertSame(toadlets, init.toadlets());
+  }
+
+  @Test
+  void constructor_withNullDependencies_allowsNullState() {
+    // Arrange
+    NodeClientCoreInit init = new NodeClientCoreInit(null, null, null, null);
+
+    // Act + Assert
+    assertNull(init.config());
+    assertNull(init.nodeConfig());
+    assertNull(init.installConfig());
+    assertNull(init.toadlets());
+  }
+}

--- a/src/test/java/network/crypta/node/NodeClientCoreSupportTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreSupportTest.java
@@ -1,0 +1,531 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.async.SimpleHealingQueue;
+import network.crypta.config.SubConfig;
+import network.crypta.crypt.DummyRandomSource;
+import network.crypta.fs.AppDirs;
+import network.crypta.fs.Resolved;
+import network.crypta.fs.ServiceDirs;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.CHKEncodeException;
+import network.crypta.keys.CHKVerifyException;
+import network.crypta.keys.ClientCHK;
+import network.crypta.keys.ClientCHKBlock;
+import network.crypta.keys.ClientKeyBlock;
+import network.crypta.keys.ClientSSKBlock;
+import network.crypta.keys.InsertableClientSSK;
+import network.crypta.keys.Key;
+import network.crypta.keys.SSKBlock;
+import network.crypta.keys.SSKEncodeException;
+import network.crypta.keys.SSKVerifyException;
+import network.crypta.node.useralerts.DatastoreTooSmallAlert;
+import network.crypta.node.useralerts.DiskSpaceUserAlert;
+import network.crypta.node.useralerts.SimpleUserAlert;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.SimpleReadOnlyArrayBucket;
+import network.crypta.support.compress.Compressor;
+import network.crypta.support.compress.InvalidCompressionCodecException;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class NodeClientCoreSupportTest {
+
+  private static final String SERVICE_MODE_PROPERTY = "cryptad.service.mode";
+  private static final String CFG_KEY = "cfgKey";
+  private static final String DEFAULT_VALUE = "defaultValue";
+  private static final String SHORT_DESC = "shortDesc";
+  private static final String LONG_DESC = "longDesc";
+  private static final String MOVE_ERR = "moveErr";
+  private static final String CHK_SAMPLE = "hello-chk";
+  private static final byte[] SSK_SAMPLE_BYTES = "ssk-data".getBytes(StandardCharsets.UTF_8);
+  private static final String SSK_DOC_NAME = "doc";
+  private static final String START_TITLE = "Start";
+  private static final String START_LONG = "Long";
+  private static final String START_SHORT = "Short";
+
+  @TempDir Path tempDir;
+
+  private String originalServiceMode;
+  private boolean serviceModeTouched;
+
+  @AfterEach
+  void restoreServiceModeProperty() {
+    if (!serviceModeTouched) {
+      return;
+    }
+    if (originalServiceMode == null) {
+      System.clearProperty(SERVICE_MODE_PROPERTY);
+    } else {
+      System.setProperty(SERVICE_MODE_PROPERTY, originalServiceMode);
+    }
+    serviceModeTouched = false;
+    originalServiceMode = null;
+  }
+
+  @Test
+  void resolveDefaultCacheDir_whenServiceModeUser_returnsAppDirsCacheDir() {
+    setServiceModeProperty("user");
+    Resolved resolved = new AppDirs().resolve();
+
+    File cacheDir = NodeClientCoreSupport.resolveDefaultCacheDir();
+
+    assertEquals(resolved.getCacheDir().toFile(), cacheDir);
+  }
+
+  @Test
+  void resolveDefaultDataDir_whenServiceModeUser_returnsAppDirsDataDir() {
+    setServiceModeProperty("user");
+    Resolved resolved = new AppDirs().resolve();
+
+    File dataDir = NodeClientCoreSupport.resolveDefaultDataDir();
+
+    assertEquals(resolved.getDataDir().toFile(), dataDir);
+  }
+
+  @Test
+  void resolveDefaultCacheDir_whenServiceModeService_returnsServiceDirsCacheDir() {
+    setServiceModeProperty("service");
+    Resolved resolved = new ServiceDirs().resolve();
+
+    File cacheDir = NodeClientCoreSupport.resolveDefaultCacheDir();
+
+    assertEquals(resolved.getCacheDir().toFile(), cacheDir);
+  }
+
+  @Test
+  void resolveDefaultDataDir_whenServiceModeService_returnsServiceDirsDataDir() {
+    setServiceModeProperty("service");
+    Resolved resolved = new ServiceDirs().resolve();
+
+    File dataDir = NodeClientCoreSupport.resolveDefaultDataDir();
+
+    assertEquals(resolved.getDataDir().toFile(), dataDir);
+  }
+
+  @Test
+  void setupProgramDirFile_whenMoveErrMsgProvided_returnsResolvedDir() throws Exception {
+    Node node = mock(Node.class);
+    SubConfig installConfig = mock(SubConfig.class);
+    ProgramDirectory programDirectory = new ProgramDirectory();
+    programDirectory.move(tempDir.toString());
+
+    when(node.setupProgramDir(
+            installConfig, CFG_KEY, DEFAULT_VALUE, SHORT_DESC, LONG_DESC, MOVE_ERR))
+        .thenReturn(programDirectory);
+
+    File resolved =
+        NodeClientCoreSupport.setupProgramDirFile(
+            node, installConfig, CFG_KEY, DEFAULT_VALUE, SHORT_DESC, LONG_DESC, MOVE_ERR);
+
+    assertEquals(tempDir.toFile(), resolved);
+    verify(node)
+        .setupProgramDir(installConfig, CFG_KEY, DEFAULT_VALUE, SHORT_DESC, LONG_DESC, MOVE_ERR);
+  }
+
+  @Test
+  void setupProgramDirFile_whenMoveErrMsgOmitted_returnsResolvedDir() throws Exception {
+    Node node = mock(Node.class);
+    SubConfig installConfig = mock(SubConfig.class);
+    ProgramDirectory programDirectory = new ProgramDirectory();
+    programDirectory.move(tempDir.toString());
+
+    when(node.setupProgramDir(installConfig, CFG_KEY, DEFAULT_VALUE, SHORT_DESC, LONG_DESC, null))
+        .thenReturn(programDirectory);
+
+    File resolved =
+        NodeClientCoreSupport.setupProgramDirFile(
+            node, installConfig, CFG_KEY, DEFAULT_VALUE, SHORT_DESC, LONG_DESC);
+
+    assertEquals(tempDir.toFile(), resolved);
+    verify(node)
+        .setupProgramDir(installConfig, CFG_KEY, DEFAULT_VALUE, SHORT_DESC, LONG_DESC, null);
+  }
+
+  @Test
+  void setupProgramDirFile_whenNodeThrows_throwsNodeInitException() throws Exception {
+    Node node = mock(Node.class);
+    SubConfig installConfig = mock(SubConfig.class);
+    NodeInitException exception = new NodeInitException(NodeInitException.EXIT_BAD_DIR, "bad dir");
+
+    when(node.setupProgramDir(installConfig, CFG_KEY, DEFAULT_VALUE, SHORT_DESC, LONG_DESC, null))
+        .thenThrow(exception);
+
+    NodeInitException thrown =
+        assertThrows(
+            NodeInitException.class,
+            () ->
+                NodeClientCoreSupport.setupProgramDirFile(
+                    node, installConfig, CFG_KEY, DEFAULT_VALUE, SHORT_DESC, LONG_DESC));
+
+    assertEquals(exception, thrown);
+  }
+
+  @Test
+  void createClientContextResources_whenCalled_returnsArchiveAndHealingQueue() {
+    Node node = mock(Node.class);
+    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
+
+    ClientContextResources resources =
+        NodeClientCoreSupport.createClientContextResources(
+            node, tempBucketFactory, 5, 10L, 15L, 20, 3);
+
+    assertNotNull(resources);
+    assertInstanceOf(ArchiveManager.class, resources.getArchiveManager());
+    assertInstanceOf(SimpleHealingQueue.class, resources.getHealingQueue());
+  }
+
+  @Test
+  void buildClientChkBlock_whenUsingEncodedBlock_returnsEquivalentBlock() throws Exception {
+    ClientCHKBlock original = encodeSampleChkBlock(CHK_SAMPLE);
+
+    ClientKeyBlock rebuilt =
+        NodeClientCoreSupport.buildClientChkBlock(original.getBlock(), original.getClientKey());
+
+    assertInstanceOf(ClientCHKBlock.class, rebuilt);
+    assertEquals(original, rebuilt);
+  }
+
+  @Test
+  void buildClientChkBlock_whenKeyMismatch_throwsChkVerifyException() throws Exception {
+    ClientCHKBlock original = encodeSampleChkBlock(CHK_SAMPLE);
+    ClientCHKBlock other = encodeSampleChkBlock("other-chk");
+    ClientCHK wrongKey = other.getClientKey();
+
+    assertThrows(
+        CHKVerifyException.class,
+        () -> NodeClientCoreSupport.buildClientChkBlock(original.getBlock(), wrongKey));
+  }
+
+  @Test
+  void buildClientChkBlock_whenUsingRawData_returnsEquivalentBlock() throws Exception {
+    ClientCHKBlock original = encodeSampleChkBlock(CHK_SAMPLE);
+    CHKBlock raw = original.getBlock();
+
+    ClientKeyBlock rebuilt =
+        NodeClientCoreSupport.buildClientChkBlock(
+            raw.getData(), raw.getHeaders(), original.getClientKey());
+
+    assertEquals(original, rebuilt);
+  }
+
+  @Test
+  void buildClientSskBlock_whenBlockMatchesKey_returnsEquivalentBlock() throws Exception {
+    ClientSSKBlock original = encodeSampleSskBlock(42L);
+
+    ClientKeyBlock rebuilt =
+        NodeClientCoreSupport.buildClientSskBlock(
+            (SSKBlock) original.getBlock(), original.getClientKey());
+
+    assertInstanceOf(ClientSSKBlock.class, rebuilt);
+    assertEquals(original, rebuilt);
+  }
+
+  @Test
+  void buildClientSskBlock_whenKeyMismatch_throwsSskVerifyException() throws Exception {
+    ClientSSKBlock original = encodeSampleSskBlock(42L);
+    ClientSSKBlock other = encodeSampleSskBlock(43L);
+
+    assertThrows(
+        SSKVerifyException.class,
+        () ->
+            NodeClientCoreSupport.buildClientSskBlock(
+                (SSKBlock) original.getBlock(), other.getClientKey()));
+  }
+
+  @Test
+  void deleteFile_whenFileExists_removesFile() throws IOException {
+    Path filePath = tempDir.resolve("delete-me.txt");
+    Files.writeString(filePath, "data");
+
+    NodeClientCoreSupport.deleteFile(filePath.toFile());
+
+    assertFalse(Files.exists(filePath));
+  }
+
+  @Test
+  void deleteFile_whenMissing_throwsIOException() {
+    File missing = tempDir.resolve("missing.txt").toFile();
+
+    assertThrows(IOException.class, () -> NodeClientCoreSupport.deleteFile(missing));
+  }
+
+  @Test
+  void checkRecentlyFailed_whenRoutingReportsFailure_returnsWakeup() {
+    Node node = mock(Node.class);
+    PeerManager peers = mock(PeerManager.class);
+    PeerRoutingSelector routingSelector = mock(PeerRoutingSelector.class);
+    Key key = mock(Key.class);
+    short maxHtl = 7;
+    short decremented = 6;
+    long wakeup = 12345L;
+    boolean realTime = true;
+
+    when(node.maxHTL()).thenReturn(maxHtl);
+    when(node.decrementHTL(null, maxHtl)).thenReturn(decremented);
+    when(node.getPeers()).thenReturn(peers);
+    when(peers.routingSelector()).thenReturn(routingSelector);
+    when(key.toNormalizedDouble()).thenReturn(0.25);
+    when(node.enableNewLoadManagement(realTime)).thenReturn(true);
+
+    doAnswer(
+            invocation -> {
+              RecentlyFailedReturn recent = invocation.getArgument(13);
+              recent.fail(wakeup);
+              return null;
+            })
+        .when(routingSelector)
+        .closerPeer(
+            isNull(),
+            anySet(),
+            eq(0.25),
+            eq(true),
+            eq(false),
+            eq(-1),
+            isNull(),
+            eq(2.0),
+            same(key),
+            eq(decremented),
+            eq(0L),
+            eq(true),
+            eq(realTime),
+            any(RecentlyFailedReturn.class),
+            eq(false),
+            anyLong(),
+            eq(true));
+
+    long result = NodeClientCoreSupport.checkRecentlyFailed(node, key, realTime);
+
+    assertEquals(wakeup, result);
+    verify(node).decrementHTL(null, maxHtl);
+    verify(node).enableNewLoadManagement(realTime);
+  }
+
+  @Test
+  void checkRecentlyFailed_whenNoFailure_returnsMinusOne() {
+    Node node = mock(Node.class);
+    PeerManager peers = mock(PeerManager.class);
+    PeerRoutingSelector routingSelector = mock(PeerRoutingSelector.class);
+    Key key = mock(Key.class);
+    short maxHtl = 5;
+    short decremented = 4;
+    boolean realTime = false;
+
+    when(node.maxHTL()).thenReturn(maxHtl);
+    when(node.decrementHTL(null, maxHtl)).thenReturn(decremented);
+    when(node.getPeers()).thenReturn(peers);
+    when(peers.routingSelector()).thenReturn(routingSelector);
+    when(key.toNormalizedDouble()).thenReturn(0.7);
+    when(node.enableNewLoadManagement(realTime)).thenReturn(false);
+
+    when(routingSelector.closerPeer(
+            isNull(),
+            anySet(),
+            eq(0.7),
+            eq(true),
+            eq(false),
+            eq(-1),
+            isNull(),
+            eq(2.0),
+            same(key),
+            eq(decremented),
+            eq(0L),
+            eq(true),
+            eq(realTime),
+            any(RecentlyFailedReturn.class),
+            eq(false),
+            anyLong(),
+            eq(false)))
+        .thenReturn(null);
+
+    long result = NodeClientCoreSupport.checkRecentlyFailed(node, key, realTime);
+
+    assertEquals(-1L, result);
+    verify(node).decrementHTL(null, maxHtl);
+  }
+
+  @Test
+  void createStartingUpAlert_whenCalled_populatesAlertFields() {
+    UserAlert alert =
+        NodeClientCoreSupport.createStartingUpAlert("Title", "Long text", "Short text");
+
+    assertInstanceOf(SimpleUserAlert.class, alert);
+    assertEquals("Title", alert.getTitle());
+    assertEquals("Long text", alert.getText());
+    assertEquals("Short text", alert.getShortText());
+    assertEquals(UserAlert.ERROR, alert.getPriorityClass());
+    assertTrue(alert.userCanDismiss());
+  }
+
+  @Test
+  void registerFProxyAlerts_whenPersistenceKilled_registersAlertsAndIsValid() {
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    File persistentTemp = tempDir.resolve("temp").toFile();
+    File userDir = tempDir.resolve("user").toFile();
+
+    when(core.getNode()).thenReturn(node);
+    when(core.getPersistentTempDir()).thenReturn(persistentTemp);
+    when(core.killedDatabase()).thenReturn(true);
+    when(node.getUserDir()).thenReturn(userDir);
+    when(node.awaitingPassword()).thenReturn(false);
+    when(node.isStopping()).thenReturn(false);
+
+    UserAlert startingUp =
+        NodeClientCoreSupport.createStartingUpAlert(START_TITLE, START_LONG, START_SHORT);
+
+    UserAlert persistenceAlert = capturePersistenceAlert(alerts, core, startingUp);
+
+    assertFalse(persistenceAlert.userCanDismiss());
+    assertEquals(UserAlert.CRITICAL_ERROR, persistenceAlert.getPriorityClass());
+    assertTrue(persistenceAlert.isValid());
+  }
+
+  @Test
+  void registerFProxyAlerts_whenDatabaseNotKilled_persistenceAlertInvalid() {
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+
+    when(core.getNode()).thenReturn(node);
+    when(core.getPersistentTempDir()).thenReturn(tempDir.toFile());
+    when(core.killedDatabase()).thenReturn(false);
+    when(node.getUserDir()).thenReturn(tempDir.toFile());
+
+    UserAlert startingUp =
+        NodeClientCoreSupport.createStartingUpAlert(START_TITLE, START_LONG, START_SHORT);
+
+    UserAlert persistenceAlert = capturePersistenceAlert(alerts, core, startingUp);
+
+    assertFalse(persistenceAlert.isValid());
+  }
+
+  @Test
+  void registerFProxyAlerts_whenAwaitingPassword_persistenceAlertInvalid() {
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+
+    when(core.getNode()).thenReturn(node);
+    when(core.getPersistentTempDir()).thenReturn(tempDir.toFile());
+    when(core.killedDatabase()).thenReturn(true);
+    when(node.getUserDir()).thenReturn(tempDir.toFile());
+    when(node.awaitingPassword()).thenReturn(true);
+
+    UserAlert startingUp =
+        NodeClientCoreSupport.createStartingUpAlert(START_TITLE, START_LONG, START_SHORT);
+
+    UserAlert persistenceAlert = capturePersistenceAlert(alerts, core, startingUp);
+
+    assertFalse(persistenceAlert.isValid());
+  }
+
+  @Test
+  void registerFProxyAlerts_whenStopping_persistenceAlertInvalid() {
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+
+    when(core.getNode()).thenReturn(node);
+    when(core.getPersistentTempDir()).thenReturn(tempDir.toFile());
+    when(core.killedDatabase()).thenReturn(true);
+    when(node.getUserDir()).thenReturn(tempDir.toFile());
+    when(node.awaitingPassword()).thenReturn(false);
+    when(node.isStopping()).thenReturn(true);
+
+    UserAlert startingUp =
+        NodeClientCoreSupport.createStartingUpAlert(START_TITLE, START_LONG, START_SHORT);
+
+    UserAlert persistenceAlert = capturePersistenceAlert(alerts, core, startingUp);
+
+    assertFalse(persistenceAlert.isValid());
+  }
+
+  @Test
+  void registerStorageAlerts_whenCalled_registersDiskAndDatastoreAlerts() {
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+
+    NodeClientCoreSupport.registerStorageAlerts(alerts, core);
+
+    ArgumentCaptor<UserAlert> captor = ArgumentCaptor.forClass(UserAlert.class);
+    verify(alerts, org.mockito.Mockito.times(2)).register(captor.capture());
+    List<UserAlert> registered = captor.getAllValues();
+
+    assertInstanceOf(DiskSpaceUserAlert.class, registered.get(0));
+    assertInstanceOf(DatastoreTooSmallAlert.class, registered.get(1));
+  }
+
+  private void setServiceModeProperty(String value) {
+    if (!serviceModeTouched) {
+      originalServiceMode = System.getProperty(SERVICE_MODE_PROPERTY);
+      serviceModeTouched = true;
+    }
+    if (value == null) {
+      System.clearProperty(SERVICE_MODE_PROPERTY);
+    } else {
+      System.setProperty(SERVICE_MODE_PROPERTY, value);
+    }
+  }
+
+  private UserAlert capturePersistenceAlert(
+      UserAlertManager alerts, NodeClientCore core, UserAlert startingUp) {
+    ArgumentCaptor<UserAlert> captor = ArgumentCaptor.forClass(UserAlert.class);
+    InOrder order = inOrder(alerts);
+
+    NodeClientCoreSupport.registerFProxyAlerts(alerts, core, startingUp);
+
+    order.verify(alerts).register(startingUp);
+    order.verify(alerts).register(captor.capture());
+    return captor.getValue();
+  }
+
+  private ClientCHKBlock encodeSampleChkBlock(String content) throws CHKEncodeException {
+    byte[] data = content.getBytes(StandardCharsets.UTF_8);
+    return ClientCHKBlock.encode(
+        data, false, true, (short) -1, data.length, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+  }
+
+  private ClientSSKBlock encodeSampleSskBlock(long seed)
+      throws SSKEncodeException, IOException, InvalidCompressionCodecException {
+    DummyRandomSource random = new DummyRandomSource(seed);
+    InsertableClientSSK key = InsertableClientSSK.createRandom(random, SSK_DOC_NAME);
+    SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(SSK_SAMPLE_BYTES);
+    return key.encode(
+        bucket, false, true, (short) -1, bucket.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+  }
+}

--- a/src/test/java/network/crypta/node/NodeClientCoreTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTest.java
@@ -62,6 +62,7 @@ class NodeClientCoreTest {
     when(node.getSecurityLevels()).thenReturn(securityLevels);
 
     setField(core, "downloadsDir", tempDir.toFile());
+    setField(core, "transferPolicy", new NodeClientCoreTransferPolicy(node, tempDir.toFile()));
 
     ClientEndpoints endpoints = new ClientEndpoints(Mockito.mock(FCPServer.class), null, toadlets);
     setField(core, "endpoints", endpoints);

--- a/src/test/java/network/crypta/node/NodeClientCoreTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTest.java
@@ -3,9 +3,7 @@ package network.crypta.node;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
@@ -17,8 +15,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import network.crypta.client.async.ClientRequestScheduler;
-import network.crypta.client.filter.FilterCallback;
-import network.crypta.client.filter.GenericReadFilterCallback;
+import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.bookmark.BookmarkManager;
@@ -64,12 +61,10 @@ class NodeClientCoreTest {
     setField(core, "node", node);
     when(node.getSecurityLevels()).thenReturn(securityLevels);
 
-    ProgramDirectory downloads = new ProgramDirectory();
-    // ProgramDirectory.dir is protected s, and we are in the same package — set directly
-    downloads.dir = tempDir.toFile();
-    setField(core, "downloadsDir", downloads);
+    setField(core, "downloadsDir", tempDir.toFile());
 
-    setField(core, "toadletContainer", toadlets);
+    ClientEndpoints endpoints = new ClientEndpoints(Mockito.mock(FCPServer.class), null, toadlets);
+    setField(core, "endpoints", endpoints);
     setField(core, "requestStarters", requestStarters);
 
     // sensible default unless a test overrides
@@ -200,9 +195,9 @@ class NodeClientCoreTest {
     when(toadlets.isAdvancedModeEnabled()).thenReturn(true);
     when(toadlets.isFProxyJavascriptEnabled()).thenReturn(true);
 
-    assertSame(toadlets, core.getLinkFilterExceptionProvider());
-    assertSame(bm, core.getBookmarkManager());
-    assertEquals(0, core.getBookmarkURIs().length);
+    assertSame(toadlets, core.getEndpoints().getToadletContainer());
+    assertSame(bm, core.getEndpoints().getToadletContainer().getBookmarks());
+    assertEquals(0, core.getEndpoints().getToadletContainer().getBookmarkURIs().length);
     assertTrue(core.isAdvancedModeEnabled());
     assertTrue(core.isFProxyJavascriptEnabled());
   }
@@ -210,21 +205,11 @@ class NodeClientCoreTest {
   @Test
   void fproxySetterGetter_and_myName_delegations_work() {
     FProxyToadlet fproxy = Mockito.mock(FProxyToadlet.class);
-    core.setFProxy(fproxy);
-    assertSame(fproxy, core.getFProxy());
+    core.getEndpoints().setFProxy(fproxy);
+    assertSame(fproxy, core.getEndpoints().getFProxy());
 
     when(node.getMyName()).thenReturn("MyNode");
     assertEquals("MyNode", core.getMyName());
-  }
-
-  @Test
-  void createFilterCallback_whenCalled_returnsGenericReadFilterCallback() throws Exception {
-    java.net.URI uri = new java.net.URI("http://example/");
-    network.crypta.client.filter.FoundURICallback cb =
-        Mockito.mock(network.crypta.client.filter.FoundURICallback.class);
-    FilterCallback fc = core.createFilterCallback(uri, cb);
-    assertNotNull(fc);
-    assertInstanceOf(GenericReadFilterCallback.class, fc);
   }
 
   // --- helpers ---

--- a/src/test/java/network/crypta/node/NodeClientCoreTransferPolicyTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTransferPolicyTest.java
@@ -1,0 +1,317 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import network.crypta.config.SubConfig;
+import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.support.api.StringArrCallback;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class NodeClientCoreTransferPolicyTest {
+  private static final String DOWNLOADS_TOKEN = "downloads";
+  private static final String UPLOADS_DIR_NAME = "uploads";
+  private static final String OUTSIDE_FILE_NAME = "outside.bin";
+  private static final String DOWNLOAD_ALLOWED_DIRS_KEY = "downloadAllowedDirs";
+  private static final String UPLOAD_ALLOWED_DIRS_KEY = "uploadAllowedDirs";
+  private static final String DOWNLOAD_ALLOWED_DIRS_SHORT = "NodeClientCore.downloadAllowedDirs";
+  private static final String DOWNLOAD_ALLOWED_DIRS_LONG = "NodeClientCore.downloadAllowedDirsLong";
+  private static final String UPLOAD_ALLOWED_DIRS_SHORT = "NodeClientCore.uploadAllowedDirs";
+  private static final String UPLOAD_ALLOWED_DIRS_LONG = "NodeClientCore.uploadAllowedDirsLong";
+
+  @TempDir Path tempDir;
+
+  @Mock Node node;
+  @Mock SecurityLevels securityLevels;
+  @Mock SubConfig nodeConfig;
+
+  private File downloadsDir;
+  private NodeClientCoreTransferPolicy policy;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    downloadsDir = tempDir.resolve(DOWNLOADS_TOKEN).toFile();
+    Files.createDirectories(downloadsDir.toPath());
+    policy = new NodeClientCoreTransferPolicy(node, downloadsDir);
+  }
+
+  @ParameterizedTest
+  @MethodSource("downloadThreatLevels")
+  void allowDownloadTo_whenAllowedEverywhere_respectsPhysicalThreatLevel(
+      PHYSICAL_THREAT_LEVEL level, boolean expected) {
+    stubPhysicalThreatLevel(level);
+    policy.setDownloadAllowedDirs(new String[] {"all"});
+
+    File target = tempDir.resolve("target.bin").toFile();
+
+    assertEquals(expected, policy.allowDownloadTo(target));
+  }
+
+  private static Stream<Arguments> downloadThreatLevels() {
+    return Stream.of(
+        Arguments.of(PHYSICAL_THREAT_LEVEL.LOW, true),
+        Arguments.of(PHYSICAL_THREAT_LEVEL.NORMAL, true),
+        Arguments.of(PHYSICAL_THREAT_LEVEL.HIGH, true),
+        Arguments.of(PHYSICAL_THREAT_LEVEL.MAXIMUM, false));
+  }
+
+  @Test
+  void setDownloadAllowedDirs_whenEmpty_setsDownloadDisabled() {
+    policy.setDownloadAllowedDirs(new String[] {});
+
+    assertTrue(policy.isDownloadDisabled());
+  }
+
+  @Test
+  void allowDownloadTo_whenNoAllowedDirs_deniesTarget() {
+    stubPhysicalThreatLevel(PHYSICAL_THREAT_LEVEL.NORMAL);
+    policy.setDownloadAllowedDirs(new String[] {});
+
+    File target = tempDir.resolve("target.bin").toFile();
+
+    assertFalse(policy.allowDownloadTo(target));
+  }
+
+  @Test
+  void allowDownloadTo_whenDownloadsDirIncluded_allowsChild() {
+    stubPhysicalThreatLevel(PHYSICAL_THREAT_LEVEL.NORMAL);
+    policy.setDownloadAllowedDirs(new String[] {DOWNLOADS_TOKEN});
+
+    File target = downloadsDir.toPath().resolve("child.bin").toFile();
+
+    assertTrue(policy.allowDownloadTo(target));
+  }
+
+  @Test
+  void allowDownloadTo_whenDownloadsDirIncluded_deniesOutside() {
+    stubPhysicalThreatLevel(PHYSICAL_THREAT_LEVEL.NORMAL);
+    policy.setDownloadAllowedDirs(new String[] {DOWNLOADS_TOKEN});
+
+    File target = tempDir.resolve(OUTSIDE_FILE_NAME).toFile();
+
+    assertFalse(policy.allowDownloadTo(target));
+  }
+
+  @Test
+  void getAllowedDownloadDirs_whenCalled_returnsInternalArrayReference() {
+    File allowedDir = tempDir.resolve("allowed").toFile();
+    policy.setDownloadAllowedDirs(new String[] {allowedDir.getPath()});
+
+    File[] first = policy.getAllowedDownloadDirs();
+    File[] second = policy.getAllowedDownloadDirs();
+
+    assertSame(first, second);
+  }
+
+  @Test
+  void setDownloadAllowedDirs_whenArrayContainsNull_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class, () -> policy.setDownloadAllowedDirs(new String[] {null}));
+  }
+
+  @Test
+  void allowUploadFrom_whenAllowedEverywhere_returnsTrue() {
+    policy.setUploadAllowedDirs(new String[] {"all"});
+
+    File target = tempDir.resolve("upload.bin").toFile();
+
+    assertTrue(policy.allowUploadFrom(target));
+  }
+
+  @Test
+  void allowUploadFrom_whenRestricted_allowsChild() {
+    File allowedDir = tempDir.resolve(UPLOADS_DIR_NAME).toFile();
+    policy.setUploadAllowedDirs(new String[] {allowedDir.getPath()});
+
+    File target = allowedDir.toPath().resolve("child.bin").toFile();
+
+    assertTrue(policy.allowUploadFrom(target));
+  }
+
+  @Test
+  void allowUploadFrom_whenRestricted_deniesOutside() {
+    File allowedDir = tempDir.resolve(UPLOADS_DIR_NAME).toFile();
+    policy.setUploadAllowedDirs(new String[] {allowedDir.getPath()});
+
+    File target = tempDir.resolve(OUTSIDE_FILE_NAME).toFile();
+
+    assertFalse(policy.allowUploadFrom(target));
+  }
+
+  @Test
+  void registerDownloadAllowedDirs_whenCalled_registersCallbackAndReturnsNextSortOrder() {
+    when(nodeConfig.getStringArr(DOWNLOAD_ALLOWED_DIRS_KEY)).thenReturn(new String[] {"all"});
+    NodeClientCoreInit init = new NodeClientCoreInit(null, nodeConfig, null, null);
+
+    int nextSortOrder = policy.registerDownloadAllowedDirs(init, 4);
+
+    verify(nodeConfig)
+        .register(
+            eq(DOWNLOAD_ALLOWED_DIRS_KEY),
+            any(String[].class),
+            eq(4),
+            eq(true),
+            eq(true),
+            eq(DOWNLOAD_ALLOWED_DIRS_SHORT),
+            eq(DOWNLOAD_ALLOWED_DIRS_LONG),
+            any(StringArrCallback.class));
+    assertEquals(5, nextSortOrder);
+  }
+
+  @Test
+  void registerDownloadAllowedDirs_whenCallbackGet_returnsNormalizedValues() {
+    File allowedDir = tempDir.resolve("allowed").toFile();
+    when(nodeConfig.getStringArr(DOWNLOAD_ALLOWED_DIRS_KEY))
+        .thenReturn(new String[] {DOWNLOADS_TOKEN, allowedDir.getPath()});
+    NodeClientCoreInit init = new NodeClientCoreInit(null, nodeConfig, null, null);
+
+    policy.registerDownloadAllowedDirs(init, 0);
+
+    ArgumentCaptor<StringArrCallback> callbackCaptor =
+        ArgumentCaptor.forClass(StringArrCallback.class);
+    verify(nodeConfig)
+        .register(
+            eq(DOWNLOAD_ALLOWED_DIRS_KEY),
+            any(String[].class),
+            eq(0),
+            eq(true),
+            eq(true),
+            eq(DOWNLOAD_ALLOWED_DIRS_SHORT),
+            eq(DOWNLOAD_ALLOWED_DIRS_LONG),
+            callbackCaptor.capture());
+
+    assertArrayEquals(
+        new String[] {allowedDir.getPath(), DOWNLOADS_TOKEN}, callbackCaptor.getValue().get());
+  }
+
+  @Test
+  void registerDownloadAllowedDirs_whenCallbackSet_updatesPolicy() {
+    stubPhysicalThreatLevel(PHYSICAL_THREAT_LEVEL.NORMAL);
+    when(nodeConfig.getStringArr(DOWNLOAD_ALLOWED_DIRS_KEY))
+        .thenReturn(new String[] {DOWNLOADS_TOKEN});
+    NodeClientCoreInit init = new NodeClientCoreInit(null, nodeConfig, null, null);
+
+    policy.registerDownloadAllowedDirs(init, 0);
+
+    ArgumentCaptor<StringArrCallback> callbackCaptor =
+        ArgumentCaptor.forClass(StringArrCallback.class);
+    verify(nodeConfig)
+        .register(
+            eq(DOWNLOAD_ALLOWED_DIRS_KEY),
+            any(String[].class),
+            eq(0),
+            eq(true),
+            eq(true),
+            eq(DOWNLOAD_ALLOWED_DIRS_SHORT),
+            eq(DOWNLOAD_ALLOWED_DIRS_LONG),
+            callbackCaptor.capture());
+
+    assertDoesNotThrow(() -> callbackCaptor.getValue().set(new String[] {"all"}));
+
+    File target = tempDir.resolve(OUTSIDE_FILE_NAME).toFile();
+
+    assertTrue(policy.allowDownloadTo(target));
+  }
+
+  @Test
+  void registerUploadAllowedDirs_whenCalled_registersCallbackAndReturnsNextSortOrder() {
+    when(nodeConfig.getStringArr(UPLOAD_ALLOWED_DIRS_KEY)).thenReturn(new String[] {"all"});
+    NodeClientCoreInit init = new NodeClientCoreInit(null, nodeConfig, null, null);
+
+    int nextSortOrder = policy.registerUploadAllowedDirs(init, 3);
+
+    verify(nodeConfig)
+        .register(
+            eq(UPLOAD_ALLOWED_DIRS_KEY),
+            any(String[].class),
+            eq(3),
+            eq(true),
+            eq(true),
+            eq(UPLOAD_ALLOWED_DIRS_SHORT),
+            eq(UPLOAD_ALLOWED_DIRS_LONG),
+            any(StringArrCallback.class));
+    assertEquals(4, nextSortOrder);
+  }
+
+  @Test
+  void registerUploadAllowedDirs_whenCallbackGet_returnsConfiguredValues() {
+    File allowedDir = tempDir.resolve(UPLOADS_DIR_NAME).toFile();
+    when(nodeConfig.getStringArr(UPLOAD_ALLOWED_DIRS_KEY))
+        .thenReturn(new String[] {allowedDir.getPath()});
+    NodeClientCoreInit init = new NodeClientCoreInit(null, nodeConfig, null, null);
+
+    policy.registerUploadAllowedDirs(init, 0);
+
+    ArgumentCaptor<StringArrCallback> callbackCaptor =
+        ArgumentCaptor.forClass(StringArrCallback.class);
+    verify(nodeConfig)
+        .register(
+            eq(UPLOAD_ALLOWED_DIRS_KEY),
+            any(String[].class),
+            eq(0),
+            eq(true),
+            eq(true),
+            eq(UPLOAD_ALLOWED_DIRS_SHORT),
+            eq(UPLOAD_ALLOWED_DIRS_LONG),
+            callbackCaptor.capture());
+
+    assertArrayEquals(new String[] {allowedDir.getPath()}, callbackCaptor.getValue().get());
+  }
+
+  @Test
+  void registerUploadAllowedDirs_whenCallbackSet_updatesPolicy() {
+    when(nodeConfig.getStringArr(UPLOAD_ALLOWED_DIRS_KEY)).thenReturn(new String[] {});
+    NodeClientCoreInit init = new NodeClientCoreInit(null, nodeConfig, null, null);
+
+    policy.registerUploadAllowedDirs(init, 0);
+
+    ArgumentCaptor<StringArrCallback> callbackCaptor =
+        ArgumentCaptor.forClass(StringArrCallback.class);
+    verify(nodeConfig)
+        .register(
+            eq(UPLOAD_ALLOWED_DIRS_KEY),
+            any(String[].class),
+            eq(0),
+            eq(true),
+            eq(true),
+            eq(UPLOAD_ALLOWED_DIRS_SHORT),
+            eq(UPLOAD_ALLOWED_DIRS_LONG),
+            callbackCaptor.capture());
+
+    assertDoesNotThrow(() -> callbackCaptor.getValue().set(new String[] {"all"}));
+
+    File target = tempDir.resolve(OUTSIDE_FILE_NAME).toFile();
+
+    assertTrue(policy.allowUploadFrom(target));
+  }
+
+  private void stubPhysicalThreatLevel(PHYSICAL_THREAT_LEVEL level) {
+    when(node.getSecurityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getPhysicalThreatLevel()).thenReturn(level);
+  }
+}

--- a/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
@@ -1,0 +1,410 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.crypt.DummyRandomSource;
+import network.crypta.crypt.RandomSource;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.CHKEncodeException;
+import network.crypta.keys.ClientCHK;
+import network.crypta.keys.ClientCHKBlock;
+import network.crypta.keys.ClientKey;
+import network.crypta.keys.ClientKeyBlock;
+import network.crypta.keys.ClientSSK;
+import network.crypta.keys.ClientSSKBlock;
+import network.crypta.keys.InsertableClientSSK;
+import network.crypta.keys.Key;
+import network.crypta.keys.KeyBlock;
+import network.crypta.keys.SSKBlock;
+import network.crypta.keys.SSKEncodeException;
+import network.crypta.support.SimpleReadOnlyArrayBucket;
+import network.crypta.support.compress.Compressor;
+import network.crypta.support.compress.InvalidCompressionCodecException;
+import network.crypta.support.math.TimeDecayingRunningAverage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class NodeClientCoreTransfersTest {
+  private static final String CHK_SAMPLE = "chk-sample";
+  private static final String SSK_DOC_NAME = "test-doc";
+  private static final byte[] SSK_SAMPLE_BYTES = "ssk-sample".getBytes(StandardCharsets.UTF_8);
+
+  @Mock private NodeClientCore core;
+  @Mock private Node node;
+  @Mock private RandomSource random;
+  @Mock private RequestStarterGroup requestStarters;
+  @Mock private RequestTracker tracker;
+  @Mock private RequestCompletionListener completionListener;
+
+  private NodeStats stats;
+  private TimeDecayingRunningAverage chkInsertSentAverage;
+  private TimeDecayingRunningAverage chkInsertReceivedAverage;
+  private TimeDecayingRunningAverage chkInsertSuccessSentAverage;
+  private TimeDecayingRunningAverage sskInsertSentAverage;
+  private TimeDecayingRunningAverage sskInsertReceivedAverage;
+  private TimeDecayingRunningAverage sskInsertSuccessSentAverage;
+
+  private NodeClientCoreTransfers transfers;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    when(core.getNode()).thenReturn(node);
+    when(core.getRandom()).thenReturn(random);
+    when(core.getRequestStarters()).thenReturn(requestStarters);
+    when(node.getTracker()).thenReturn(tracker);
+    when(node.maxHTL()).thenReturn((short) 5);
+    lenient().when(random.nextLong()).thenReturn(123L);
+    lenient()
+        .when(
+            tracker.lockUID(
+                anyLong(),
+                anyBoolean(),
+                anyBoolean(),
+                anyBoolean(),
+                anyBoolean(),
+                anyBoolean(),
+                any()))
+        .thenReturn(true);
+
+    stats = mock(NodeStats.class);
+    chkInsertSentAverage = mock(TimeDecayingRunningAverage.class);
+    chkInsertReceivedAverage = mock(TimeDecayingRunningAverage.class);
+    chkInsertSuccessSentAverage = mock(TimeDecayingRunningAverage.class);
+    sskInsertSentAverage = mock(TimeDecayingRunningAverage.class);
+    sskInsertReceivedAverage = mock(TimeDecayingRunningAverage.class);
+    sskInsertSuccessSentAverage = mock(TimeDecayingRunningAverage.class);
+
+    setField(stats, "localChkFetchBytesSentAverage", mock(TimeDecayingRunningAverage.class));
+    setField(stats, "localChkFetchBytesReceivedAverage", mock(TimeDecayingRunningAverage.class));
+    setField(
+        stats, "successfulChkFetchBytesReceivedAverage", mock(TimeDecayingRunningAverage.class));
+    setField(stats, "localSskFetchBytesSentAverage", mock(TimeDecayingRunningAverage.class));
+    setField(stats, "localSskFetchBytesReceivedAverage", mock(TimeDecayingRunningAverage.class));
+    setField(
+        stats, "successfulSskFetchBytesReceivedAverage", mock(TimeDecayingRunningAverage.class));
+
+    setField(stats, "localChkInsertBytesSentAverage", chkInsertSentAverage);
+    setField(stats, "localChkInsertBytesReceivedAverage", chkInsertReceivedAverage);
+    setField(stats, "successfulChkInsertBytesSentAverage", chkInsertSuccessSentAverage);
+    setField(stats, "localSskInsertBytesSentAverage", sskInsertSentAverage);
+    setField(stats, "localSskInsertBytesReceivedAverage", sskInsertReceivedAverage);
+    setField(stats, "successfulSskInsertBytesSentAverage", sskInsertSuccessSentAverage);
+
+    when(node.getNodeStats()).thenReturn(stats);
+
+    transfers = new NodeClientCoreTransfers(core);
+  }
+
+  @Test
+  void asyncGet_whenUidLockFails_expectListenerFailedInternalError() {
+    Key key = mock(Key.class);
+    when(tracker.lockUID(
+            anyLong(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any()))
+        .thenReturn(false);
+
+    transfers.asyncGet(key, false, completionListener, true, true, false, false, false);
+
+    ArgumentCaptor<LowLevelGetException> captor =
+        ArgumentCaptor.forClass(LowLevelGetException.class);
+    verify(completionListener).onFailed(captor.capture());
+    assertEquals(LowLevelGetException.INTERNAL_ERROR, captor.getValue().code);
+    verify(node, never()).makeRequestSender(any(), anyShort(), anyLong(), any(), any(), any());
+  }
+
+  @Test
+  void asyncGet_whenKeyBlockInStore_expectListenerSucceeded() {
+    Key key = mock(Key.class);
+    when(node.makeRequestSender(any(), anyShort(), anyLong(), any(), any(), any()))
+        .thenReturn(mock(KeyBlock.class));
+
+    transfers.asyncGet(key, false, completionListener, true, true, false, false, false);
+
+    verify(completionListener).onSucceeded();
+    verify(completionListener, never()).onFailed(any());
+  }
+
+  @Test
+  void asyncGet_whenSenderTimesOut_expectRejectedOverloadAndListenerFailed() {
+    Key key = mock(Key.class);
+    when(key.toNormalizedDouble()).thenReturn(0.42);
+    RequestSender sender = mock(RequestSender.class);
+    when(node.makeRequestSender(any(), anyShort(), anyLong(), any(), any(), any()))
+        .thenReturn(sender);
+    when(sender.getStatus()).thenReturn(RequestSender.TIMED_OUT);
+    when(sender.hasForwarded()).thenReturn(false);
+
+    AtomicReference<RequestSenderListener> listenerRef = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              listenerRef.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(sender)
+        .addListener(any());
+
+    transfers.asyncGet(key, false, completionListener, true, true, true, false, false);
+
+    RequestSenderListener senderListener = listenerRef.get();
+    assertNotNull(senderListener);
+    senderListener.onRequestSenderFinished(RequestSender.TIMED_OUT, false, sender);
+
+    ArgumentCaptor<LowLevelGetException> captor =
+        ArgumentCaptor.forClass(LowLevelGetException.class);
+    verify(completionListener).onFailed(captor.capture());
+    assertEquals(LowLevelGetException.REJECTED_OVERLOAD, captor.getValue().code);
+    verify(requestStarters).rejectedOverload(false, false, true);
+    verify(stats).reportCHKOutcome(anyLong(), anyBoolean(), anyDouble(), anyBoolean());
+  }
+
+  @Test
+  void realGetKey_whenNotChkOrSsk_expectIllegalArgumentException() {
+    ClientKey key = mock(ClientKey.class);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> transfers.realGetKey(key, false, false, false, false));
+  }
+
+  @Test
+  void realGetKey_whenChkBlockInStore_expectReturnsClientBlock() throws Exception {
+    ClientCHKBlock original = encodeSampleChkBlock(CHK_SAMPLE);
+    ClientCHK key = original.getClientKey();
+    CHKBlock block = original.getBlock();
+    when(node.makeRequestSender(any(), anyShort(), anyLong(), any(), any(), any()))
+        .thenReturn(block);
+
+    ClientKeyBlock result = transfers.realGetKey(key, true, false, true, false);
+
+    assertEquals(original, result);
+  }
+
+  @Test
+  void realGetKey_whenSskBlockInStore_expectReturnsClientBlock() throws Exception {
+    ClientSSKBlock original = encodeSampleSskBlock(42L);
+    ClientSSK key = original.getClientKey();
+    SSKBlock block = (SSKBlock) original.getBlock();
+    when(node.makeRequestSender(any(), anyShort(), anyLong(), any(), any(), any()))
+        .thenReturn(block);
+
+    ClientKeyBlock result = transfers.realGetKey(key, true, false, false, true);
+
+    assertEquals(original, result);
+    assertNotNull(key.getPubKey());
+  }
+
+  @Test
+  void realPut_whenChkBlock_expectDelegatesToRealPutChk() throws Exception {
+    NodeClientCoreTransfers spy = spy(transfers);
+    CHKBlock block = mock(CHKBlock.class);
+    doNothing().when(spy).realPutCHK(block, true, false, true, false, true);
+
+    spy.realPut(block, true, false, true, false, true);
+
+    verify(spy).realPutCHK(block, true, false, true, false, true);
+    verify(spy, never())
+        .realPutSSK(any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+  }
+
+  @Test
+  void realPut_whenSskBlock_expectDelegatesToRealPutSsk() throws Exception {
+    NodeClientCoreTransfers spy = spy(transfers);
+    SSKBlock block = mock(SSKBlock.class);
+    doNothing().when(spy).realPutSSK(block, true, false, false, false, false);
+
+    spy.realPut(block, true, false, false, false, false);
+
+    verify(spy).realPutSSK(block, true, false, false, false, false);
+    verify(spy, never())
+        .realPutCHK(any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+  }
+
+  @Test
+  void realPut_whenUnknownBlock_expectIllegalArgumentException() {
+    KeyBlock block = mock(KeyBlock.class);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> transfers.realPut(block, true, false, false, false, false));
+  }
+
+  @Test
+  void realPutChk_whenSuccessful_expectStoresAndReports() throws Exception {
+    ClientCHKBlock clientBlock = encodeSampleChkBlock("chk-put");
+    CHKBlock block = clientBlock.getBlock();
+    long uid = 456L;
+    when(random.nextLong()).thenReturn(uid);
+
+    CHKInsertSender sender = mock(CHKInsertSender.class);
+    when(node.makeInsertSender(
+            any(), anyShort(), anyLong(), any(), isNull(), any(Node.ChkInsertOptions.class)))
+        .thenReturn(sender);
+    when(sender.getStatus()).thenReturn(CHKInsertSender.SUCCESS);
+    when(sender.sentRequest()).thenReturn(false);
+    when(sender.getStatusString()).thenReturn("SUCCESS");
+    when(sender.getTotalSentBytes()).thenReturn(123);
+    when(sender.getTotalReceivedBytes()).thenReturn(456);
+    PeerNode[] routedTo = new PeerNode[0];
+    when(sender.getRoutedTo()).thenReturn(routedTo);
+    when(sender.completed()).thenReturn(true);
+    setField(sender, "uid", uid);
+
+    when(node.shouldStoreDeep(block.getKey(), null, routedTo)).thenReturn(true);
+    doNothing().when(node).store(block, true, true, false, false);
+
+    transfers.realPutCHK(block, true, false, false, false, true);
+
+    verify(node).store(block, true, true, false, false);
+    verify(chkInsertSentAverage).report(123L);
+    verify(chkInsertReceivedAverage).report(456L);
+    verify(chkInsertSuccessSentAverage).report(123L);
+  }
+
+  @Test
+  void realPutChk_whenUidLockFails_expectInternalError() throws Exception {
+    ClientCHKBlock clientBlock = encodeSampleChkBlock("chk-fail");
+    CHKBlock block = clientBlock.getBlock();
+    when(tracker.lockUID(
+            anyLong(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any()))
+        .thenReturn(false);
+
+    LowLevelPutException ex =
+        assertThrows(
+            LowLevelPutException.class,
+            () -> transfers.realPutCHK(block, true, false, false, false, false));
+
+    assertEquals(LowLevelPutException.INTERNAL_ERROR, ex.code);
+  }
+
+  @Test
+  void realPutSsk_whenCollisionInCache_expectLowLevelPutExceptionWithCollidedBlock()
+      throws Exception {
+    ClientSSKBlock clientBlock = encodeSampleSskBlock(1L);
+    SSKBlock block = (SSKBlock) clientBlock.getBlock();
+    SSKBlock altBlock = (SSKBlock) encodeSampleSskBlock(2L).getBlock();
+    when(node.fetch(block.getKey(), false, true, true, false, false, null)).thenReturn(altBlock);
+
+    LowLevelPutException ex =
+        assertThrows(
+            LowLevelPutException.class,
+            () -> transfers.realPutSSK(block, true, false, false, false, false));
+
+    assertEquals(LowLevelPutException.COLLISION, ex.code);
+    assertSame(altBlock, ex.getCollidedBlock());
+  }
+
+  @Test
+  void realPutSsk_whenSuccessful_expectStoresAndReports() throws Exception {
+    ClientSSKBlock clientBlock = encodeSampleSskBlock(7L);
+    SSKBlock block = (SSKBlock) clientBlock.getBlock();
+    long uid = 789L;
+    when(random.nextLong()).thenReturn(uid);
+    when(node.fetch(block.getKey(), false, true, true, false, false, null)).thenReturn(null);
+
+    SSKInsertSender sender = mock(SSKInsertSender.class);
+    when(node.makeInsertSender(
+            any(), anyShort(), anyLong(), any(), isNull(), any(Node.SskInsertOptions.class)))
+        .thenReturn(sender);
+    when(sender.getStatus()).thenReturn(SSKInsertSender.SUCCESS);
+    when(sender.sentRequest()).thenReturn(false);
+    when(sender.getStatusString()).thenReturn("SUCCESS");
+    when(sender.getTotalSentBytes()).thenReturn(11);
+    when(sender.getTotalReceivedBytes()).thenReturn(22);
+    PeerNode[] routedTo = new PeerNode[0];
+    when(sender.getRoutedTo()).thenReturn(routedTo);
+    when(sender.hasCollided()).thenReturn(false);
+    setField(sender, "uid", uid);
+
+    when(node.shouldStoreDeep(block.getKey(), null, routedTo)).thenReturn(true);
+    doNothing().when(node).storeInsert(block, true, false, true, false);
+
+    transfers.realPutSSK(block, true, false, false, false, false);
+
+    verify(node).storeInsert(block, true, false, true, false);
+    verify(sskInsertSentAverage).report(11L);
+    verify(sskInsertReceivedAverage).report(22L);
+    verify(sskInsertSuccessSentAverage).report(11L);
+  }
+
+  @Test
+  void queueRandomReinsert_whenCalled_createsAndSchedulesInsert() {
+    KeyBlock block = mock(KeyBlock.class);
+    AtomicReference<List<?>> ctorArgs = new AtomicReference<>();
+
+    try (MockedConstruction<SimpleSendableInsert> mocked =
+        Mockito.mockConstruction(
+            SimpleSendableInsert.class, (_, context) -> ctorArgs.set(context.arguments()))) {
+      transfers.queueRandomReinsert(block);
+
+      assertEquals(1, mocked.constructed().size());
+      List<?> args = ctorArgs.get();
+      assertNotNull(args);
+      assertSame(core, args.get(0));
+      assertSame(block, args.get(1));
+      assertEquals(RequestStarter.MAXIMUM_PRIORITY_CLASS, args.get(2));
+      verify(mocked.constructed().getFirst()).schedule();
+    }
+  }
+
+  private ClientCHKBlock encodeSampleChkBlock(String content) throws CHKEncodeException {
+    byte[] data = content.getBytes(StandardCharsets.UTF_8);
+    return ClientCHKBlock.encode(
+        data, false, true, (short) -1, data.length, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+  }
+
+  private ClientSSKBlock encodeSampleSskBlock(long seed)
+      throws SSKEncodeException, IOException, InvalidCompressionCodecException {
+    DummyRandomSource rng = new DummyRandomSource(seed);
+    InsertableClientSSK key = InsertableClientSSK.createRandom(rng, SSK_DOC_NAME);
+    SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(SSK_SAMPLE_BYTES);
+    return key.encode(
+        bucket, false, true, (short) -1, bucket.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Class<?> type = target.getClass();
+    while (type != null) {
+      try {
+        Field field = type.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+        return;
+      } catch (NoSuchFieldException _) {
+        type = type.getSuperclass();
+      }
+    }
+    throw new IllegalArgumentException("Field not found: " + fieldName);
+  }
+}

--- a/src/test/java/network/crypta/node/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/node/NodeClientPersistenceTest.java
@@ -1,0 +1,517 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Random;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientLayerPersister;
+import network.crypta.client.async.DatastoreChecker;
+import network.crypta.client.async.USKManager;
+import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.PersistentRequestClient;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.config.Config;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.SubConfig;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.crypt.RandomSource;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.RealCompressor;
+import network.crypta.support.io.DiskSpaceChecker;
+import network.crypta.support.io.DiskSpaceCheckingRandomAccessBufferFactory;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.MaybeEncryptedRandomAccessBufferFactory;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class NodeClientPersistenceTest {
+
+  @Test
+  void constructor_whenInitialSortOrderProvided_expectIncrementedSortOrderAfter(
+      @TempDir File tempDir) throws NodeInitException {
+    // Arrange
+    Persistable persistable = mock(Persistable.class);
+    Ticker ticker = mock(Ticker.class);
+    SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
+    Node node = newNode(ticker, tempDir);
+
+    // Act
+    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 7);
+
+    // Assert
+    assertEquals(8, persistence.getSortOrderAfter());
+    assertFalse(persistence.hasPersistentRafFactory());
+  }
+
+  @Test
+  void startThrottle_whenInvoked_expectPersisterQueuedNextRun(@TempDir File tempDir)
+      throws NodeInitException {
+    // Arrange
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("limit", "42");
+    Persistable persistable = mock(Persistable.class);
+    when(persistable.persistThrottlesToFieldSet()).thenReturn(fieldSet);
+    Ticker ticker = mock(Ticker.class);
+    SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
+    Node node = newNode(ticker, tempDir);
+    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 0);
+
+    // Act
+    persistence.startThrottle();
+
+    // Assert
+    verify(ticker).queueTimedJob(any(Runnable.class), eq(Persister.PERIOD));
+  }
+
+  @Test
+  void readThrottle_whenThrottlePersisted_expectValue(@TempDir File tempDir)
+      throws NodeInitException {
+    // Arrange
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("limit", "42");
+    Persistable persistable = mock(Persistable.class);
+    when(persistable.persistThrottlesToFieldSet()).thenReturn(fieldSet);
+    Ticker ticker = mock(Ticker.class);
+    SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
+    Node node = newNode(ticker, tempDir);
+    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 0);
+
+    // Act
+    persistence.startThrottle();
+    SimpleFieldSet result = persistence.readThrottle();
+
+    // Assert
+    assertNotNull(result);
+    assertEquals("42", result.get("limit"));
+  }
+
+  @Test
+  void initDiskChecker_whenCalled_expectPersistentRafFactoryAvailableAndInstalled(
+      @TempDir File tempDir) throws NodeInitException {
+    // Arrange
+    Persistable persistable = mock(Persistable.class);
+    Ticker ticker = mock(Ticker.class);
+    SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
+    Node node = newNode(ticker, tempDir);
+    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 0);
+    FilenameGenerator filenameGenerator = mock(FilenameGenerator.class);
+    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
+    when(tempBucketFactory.getMaxRamUsed()).thenReturn(128L);
+    File persistentTempDir = new File(tempDir, "persistent");
+    assertTrue(persistentTempDir.mkdirs() || persistentTempDir.isDirectory());
+
+    // Act
+    persistence.initDiskChecker(
+        filenameGenerator, persistentTempDir, 1024L, tempBucketFactory, true);
+    PersistentTempBucketFactory persistentTempBucketFactory =
+        mock(PersistentTempBucketFactory.class);
+    persistence.installDiskChecker(persistentTempBucketFactory);
+
+    // Assert
+    assertTrue(persistence.hasPersistentRafFactory());
+    assertNotNull(persistence.getPersistentRafFactory());
+    ArgumentCaptor<DiskSpaceChecker> captor = ArgumentCaptor.forClass(DiskSpaceChecker.class);
+    verify(persistentTempBucketFactory).setDiskSpaceChecker(captor.capture());
+    assertInstanceOf(DiskSpaceCheckingRandomAccessBufferFactory.class, captor.getValue());
+  }
+
+  @Test
+  void getPersistentRafFactory_whenNotInitialized_expectNullPointerException(@TempDir File tempDir)
+      throws NodeInitException {
+    // Arrange
+    NodeClientPersistence persistence = newPersistence(tempDir);
+
+    // Act
+    NullPointerException ex =
+        assertThrows(NullPointerException.class, persistence::getPersistentRafFactory);
+
+    // Assert
+    assertEquals("Persistent RAF factory not initialized", ex.getMessage());
+  }
+
+  @Test
+  void setPersistentRafEncryption_whenNotInitialized_expectNullPointerException(
+      @TempDir File tempDir) throws NodeInitException {
+    // Arrange
+    NodeClientPersistence persistence = newPersistence(tempDir);
+
+    // Act
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class, () -> persistence.setPersistentRafEncryption(true));
+
+    // Assert
+    assertEquals("Persistent RAF factory not initialized", ex.getMessage());
+  }
+
+  @Test
+  void setPersistentRafMasterSecret_whenNotInitialized_expectNullPointerException(
+      @TempDir File tempDir) throws NodeInitException {
+    // Arrange
+    NodeClientPersistence persistence = newPersistence(tempDir);
+
+    // Act
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class, () -> persistence.setPersistentRafMasterSecret(null));
+
+    // Assert
+    assertEquals("Persistent RAF factory not initialized", ex.getMessage());
+  }
+
+  @Test
+  void installDiskChecker_whenNotInitialized_expectNullPointerException(@TempDir File tempDir)
+      throws NodeInitException {
+    // Arrange
+    NodeClientPersistence persistence = newPersistence(tempDir);
+    PersistentTempBucketFactory persistentTempBucketFactory =
+        mock(PersistentTempBucketFactory.class);
+
+    // Act
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class,
+            () -> persistence.installDiskChecker(persistentTempBucketFactory));
+
+    // Assert
+    assertEquals("Persistent disk checker not initialized", ex.getMessage());
+  }
+
+  @Test
+  void updateMinDiskSpace_whenNegative_expectIllegalArgumentException(@TempDir File tempDir)
+      throws NodeInitException {
+    // Arrange
+    NodeClientPersistence persistence = newPersistence(tempDir);
+    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
+    when(tempBucketFactory.getMaxRamUsed()).thenReturn(0L);
+    File persistentTempDir = new File(tempDir, "persistent");
+    assertTrue(persistentTempDir.mkdirs() || persistentTempDir.isDirectory());
+    persistence.initDiskChecker(
+        mock(FilenameGenerator.class), persistentTempDir, 1L, tempBucketFactory, false);
+
+    // Act
+    assertThrows(IllegalArgumentException.class, () -> persistence.updateMinDiskSpace(-1L));
+  }
+
+  @Test
+  void createClientContext_whenDiskCheckerMissing_expectNullPointerException(@TempDir File tempDir)
+      throws NodeInitException {
+    // Arrange
+    NodeClientPersistence persistence = newPersistence(tempDir);
+    Node node = mock(Node.class);
+    ClientLayerPersister clientLayerPersister = mock(ClientLayerPersister.class);
+    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+    ClientContextResources resources =
+        new ClientContextResources(
+            mock(ArchiveManager.class), mock(network.crypta.client.async.HealingQueue.class));
+    PersistentTempBucketFactory persistentTempBucketFactory =
+        mock(PersistentTempBucketFactory.class);
+    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
+    USKManager uskManager = mock(USKManager.class);
+    RandomSource randomSource = mock(RandomSource.class);
+    Random fastWeakRandom = new Random(1234L);
+    Ticker ticker = mock(Ticker.class);
+    MemoryLimitedJobRunner memoryLimitedJobRunner = mock(MemoryLimitedJobRunner.class);
+    FilenameGenerator tempFilenameGenerator = mock(FilenameGenerator.class);
+    FilenameGenerator persistentFilenameGenerator = mock(FilenameGenerator.class);
+    LockableRandomAccessBufferFactory tempRafFactory =
+        mock(LockableRandomAccessBufferFactory.class);
+    MaybeEncryptedRandomAccessBufferFactory persistentRafFactory =
+        mock(MaybeEncryptedRandomAccessBufferFactory.class);
+    FileRandomAccessBufferFactory fileRafTransient = mock(FileRandomAccessBufferFactory.class);
+    RealCompressor compressor = mock(RealCompressor.class);
+    DatastoreChecker storeChecker = mock(DatastoreChecker.class);
+    MasterSecret cryptoSecretTransient = new MasterSecret(new byte[64]);
+    NodeClientCoreInit init =
+        new NodeClientCoreInit(
+            mock(Config.class),
+            mock(SubConfig.class),
+            mock(SubConfig.class),
+            mock(SimpleToadletServer.class));
+    FetchContext defaultFetchContext = mock(FetchContext.class);
+    InsertContext defaultInsertContext = mock(InsertContext.class);
+
+    // Act
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class,
+            () ->
+                persistence.createClientContext(
+                    node,
+                    clientLayerPersister,
+                    executor,
+                    resources,
+                    persistentTempBucketFactory,
+                    tempBucketFactory,
+                    uskManager,
+                    randomSource,
+                    fastWeakRandom,
+                    ticker,
+                    memoryLimitedJobRunner,
+                    tempFilenameGenerator,
+                    persistentFilenameGenerator,
+                    tempRafFactory,
+                    persistentRafFactory,
+                    fileRafTransient,
+                    compressor,
+                    storeChecker,
+                    cryptoSecretTransient,
+                    init,
+                    defaultFetchContext,
+                    defaultInsertContext));
+
+    // Assert
+    assertEquals("Persistent disk checker not initialized", ex.getMessage());
+  }
+
+  @Test
+  void createClientContext_whenInitialized_expectContextWiresDependencies(@TempDir File tempDir)
+      throws NodeInitException {
+    // Arrange
+    Ticker ticker = mock(Ticker.class);
+    PersistentConfig config = mock(PersistentConfig.class);
+    Node node = newNode(ticker, tempDir);
+    when(node.getBootId()).thenReturn(123L);
+    SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
+    NodeClientPersistence persistence =
+        new NodeClientPersistence(mock(Persistable.class), nodeConfig, node, 0);
+    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
+    when(tempBucketFactory.getMaxRamUsed()).thenReturn(0L);
+    File persistentTempDir = new File(tempDir, "persistent");
+    assertTrue(persistentTempDir.mkdirs() || persistentTempDir.isDirectory());
+    persistence.initDiskChecker(
+        mock(FilenameGenerator.class), persistentTempDir, 1L, tempBucketFactory, false);
+
+    ClientLayerPersister clientLayerPersister = mock(ClientLayerPersister.class);
+    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+    ArchiveManager archiveManager = mock(ArchiveManager.class);
+    network.crypta.client.async.HealingQueue healingQueue =
+        mock(network.crypta.client.async.HealingQueue.class);
+    ClientContextResources resources = new ClientContextResources(archiveManager, healingQueue);
+    PersistentTempBucketFactory persistentTempBucketFactory =
+        mock(PersistentTempBucketFactory.class);
+    USKManager uskManager = mock(USKManager.class);
+    RandomSource random = mock(RandomSource.class);
+    Random fastWeakRandom = new Random(1234L);
+    MemoryLimitedJobRunner memoryLimitedJobRunner = mock(MemoryLimitedJobRunner.class);
+    FilenameGenerator tempFilenameGenerator = mock(FilenameGenerator.class);
+    FilenameGenerator persistentFilenameGenerator = mock(FilenameGenerator.class);
+    LockableRandomAccessBufferFactory tempRafFactory =
+        mock(LockableRandomAccessBufferFactory.class);
+    MaybeEncryptedRandomAccessBufferFactory persistentRafFactory =
+        persistence.getPersistentRafFactory();
+    FileRandomAccessBufferFactory fileRafTransient = mock(FileRandomAccessBufferFactory.class);
+    RealCompressor compressor = mock(RealCompressor.class);
+    DatastoreChecker storeChecker = mock(DatastoreChecker.class);
+    MasterSecret cryptoSecretTransient = new MasterSecret(new byte[64]);
+    SimpleToadletServer toadlets = mock(SimpleToadletServer.class);
+    NodeClientCoreInit init =
+        new NodeClientCoreInit(config, mock(SubConfig.class), mock(SubConfig.class), toadlets);
+    FetchContext defaultFetchContext = mock(FetchContext.class);
+    InsertContext defaultInsertContext = mock(InsertContext.class);
+
+    // Act
+    ClientContext context =
+        persistence.createClientContext(
+            node,
+            clientLayerPersister,
+            executor,
+            resources,
+            persistentTempBucketFactory,
+            tempBucketFactory,
+            uskManager,
+            random,
+            fastWeakRandom,
+            ticker,
+            memoryLimitedJobRunner,
+            tempFilenameGenerator,
+            persistentFilenameGenerator,
+            tempRafFactory,
+            persistentRafFactory,
+            fileRafTransient,
+            compressor,
+            storeChecker,
+            cryptoSecretTransient,
+            init,
+            defaultFetchContext,
+            defaultInsertContext);
+
+    // Assert
+    assertAll(
+        () -> assertEquals(123L, context.bootID),
+        () -> assertSame(archiveManager, context.archiveManager),
+        () -> assertSame(persistentTempBucketFactory, context.getPersistentFileTracker()),
+        () -> assertSame(tempBucketFactory, context.tempBucketFactory),
+        () -> assertSame(tempRafFactory, context.tempRAFFactory),
+        () -> assertSame(persistentRafFactory, context.persistentRAFFactory),
+        () -> assertSame(healingQueue, context.healingQueue),
+        () -> assertSame(uskManager, context.uskManager),
+        () -> assertSame(random, context.random),
+        () -> assertSame(fastWeakRandom, context.fastWeakRandom),
+        () -> assertSame(ticker, context.ticker),
+        () -> assertSame(memoryLimitedJobRunner, context.memoryLimitedJobRunner),
+        () -> assertSame(tempFilenameGenerator, context.fg),
+        () -> assertSame(persistentFilenameGenerator, context.persistentFG),
+        () -> assertSame(compressor, context.rc),
+        () -> assertSame(storeChecker, context.checker),
+        () -> assertSame(cryptoSecretTransient, context.cryptoSecretTransient),
+        () -> assertSame(config, context.getConfig()),
+        () -> assertSame(executor, context.getMainExecutor()),
+        () -> assertSame(fileRafTransient, context.getFileRandomAccessBufferFactory(false)),
+        () ->
+            assertInstanceOf(
+                DiskSpaceCheckingRandomAccessBufferFactory.class,
+                context.getFileRandomAccessBufferFactory(true)),
+        () -> assertSame(persistentRafFactory, context.getRandomAccessBufferFactory(true)));
+  }
+
+  @Test
+  void getPersistentRequests_whenRequestResumed_expectIncludesRequest(@TempDir File tempDir)
+      throws NodeInitException {
+    // Arrange
+    Ticker ticker = mock(Ticker.class);
+    PersistentConfig config = mock(PersistentConfig.class);
+    Node node = newNode(ticker, tempDir);
+    when(node.getBootId()).thenReturn(200L);
+    SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
+    NodeClientPersistence persistence =
+        new NodeClientPersistence(mock(Persistable.class), nodeConfig, node, 0);
+    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
+    when(tempBucketFactory.getMaxRamUsed()).thenReturn(0L);
+    File persistentTempDir = new File(tempDir, "persistent");
+    assertTrue(persistentTempDir.mkdirs() || persistentTempDir.isDirectory());
+    persistence.initDiskChecker(
+        mock(FilenameGenerator.class), persistentTempDir, 1L, tempBucketFactory, false);
+
+    ClientContext context =
+        persistence.createClientContext(
+            node,
+            mock(ClientLayerPersister.class),
+            mock(PriorityAwareExecutor.class),
+            new ClientContextResources(
+                mock(ArchiveManager.class), mock(network.crypta.client.async.HealingQueue.class)),
+            mock(PersistentTempBucketFactory.class),
+            tempBucketFactory,
+            mock(USKManager.class),
+            mock(RandomSource.class),
+            new Random(4321L),
+            ticker,
+            mock(MemoryLimitedJobRunner.class),
+            mock(FilenameGenerator.class),
+            mock(FilenameGenerator.class),
+            mock(LockableRandomAccessBufferFactory.class),
+            persistence.getPersistentRafFactory(),
+            mock(FileRandomAccessBufferFactory.class),
+            mock(RealCompressor.class),
+            mock(DatastoreChecker.class),
+            new MasterSecret(new byte[64]),
+            new NodeClientCoreInit(
+                config,
+                mock(SubConfig.class),
+                mock(SubConfig.class),
+                mock(SimpleToadletServer.class)),
+            mock(FetchContext.class),
+            mock(InsertContext.class));
+
+    PersistentRequestRoot root = context.persistentRoot;
+    PersistentRequestClient client = root.registerForeverClient("client", null);
+    ClientRequest request = mock(ClientRequest.class);
+    when(request.hasFinished()).thenReturn(false);
+    when(request.isPersistentForever()).thenReturn(true);
+    client.resume(request);
+
+    // Act
+    ClientRequest[] requests = persistence.getPersistentRequests();
+
+    // Assert
+    assertTrue(Arrays.asList(requests).contains(request));
+  }
+
+  @Test
+  void createFcpServer_whenCalled_expectDelegatesToMaybeCreate(@TempDir File tempDir)
+      throws NodeInitException {
+    // Arrange
+    Persistable persistable = mock(Persistable.class);
+    Ticker ticker = mock(Ticker.class);
+    SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
+    Node node = newNode(ticker, tempDir);
+    PersistentConfig config = mock(PersistentConfig.class);
+    when(node.getConfig()).thenReturn(config);
+    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 0);
+    NodeClientCore core = mock(NodeClientCore.class);
+    FCPServer expected = mock(FCPServer.class);
+
+    // Act
+    try (MockedStatic<FCPServer> fcpServerMock = mockStatic(FCPServer.class)) {
+      fcpServerMock
+          .when(
+              () ->
+                  FCPServer.maybeCreate(
+                      eq(node), eq(core), eq(config), any(PersistentRequestRoot.class)))
+          .thenReturn(expected);
+
+      FCPServer result = persistence.createFcpServer(node, core);
+
+      // Assert
+      assertSame(expected, result);
+      fcpServerMock.verify(
+          () ->
+              FCPServer.maybeCreate(
+                  eq(node), eq(core), eq(config), any(PersistentRequestRoot.class)));
+    }
+  }
+
+  private static SubConfig newNodeConfig(File throttleFile) {
+    SubConfig nodeConfig = mock(SubConfig.class);
+    when(nodeConfig.getString("clientThrottleFile")).thenReturn(throttleFile.getAbsolutePath());
+    return nodeConfig;
+  }
+
+  private static Node newNode(Ticker ticker, File runDir) {
+    Node node = mock(Node.class);
+    when(node.getTicker()).thenReturn(ticker);
+    when(node.getRunDir()).thenReturn(runDir);
+    return node;
+  }
+
+  private static NodeClientPersistence newPersistence(File tempDir) throws NodeInitException {
+    Persistable persistable = mock(Persistable.class);
+    Ticker ticker = mock(Ticker.class);
+    SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
+    Node node = newNode(ticker, tempDir);
+    return new NodeClientPersistence(persistable, nodeConfig, node, 0);
+  }
+}

--- a/src/test/java/network/crypta/node/RequestStarterGroupTest.java
+++ b/src/test/java/network/crypta/node/RequestStarterGroupTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -53,9 +54,9 @@ class RequestStarterGroupTest {
 
   private RequestStarterGroup newGroup() throws InvalidConfigValueException {
     // portNumber only affects thread names; pick a stable value
-    when(core.getNodeStats()).thenReturn(nodeStats);
-    when(core.getStoreChecker())
-        .thenReturn(mock(network.crypta.client.async.DatastoreChecker.class));
+    when(core.getNode()).thenReturn(node);
+    lenient().when(node.getExecutor()).thenReturn(executor);
+    when(node.getNodeStats()).thenReturn(nodeStats);
     return new RequestStarterGroup(node, core, 12345, random, config, null, clientContext);
   }
 
@@ -65,7 +66,6 @@ class RequestStarterGroupTest {
     RequestStarterGroup group = newGroup();
 
     List<String> jobNames = new ArrayList<>();
-    when(core.getExecutor()).thenReturn(executor);
     doAnswer(
             inv -> {
               String name = inv.getArgument(1);

--- a/src/test/java/network/crypta/node/RequestStarterTest.java
+++ b/src/test/java/network/crypta/node/RequestStarterTest.java
@@ -33,7 +33,9 @@ class RequestStarterTest {
   private RequestStarter newStarter(boolean isInsert, boolean realTime) {
     // Minimal wiring required by RequestStarter's constructor; scoped to callers to avoid
     // unnecessary stubbing on tests that don't construct a RequestStarter.
-    when(core.getNodeStats()).thenReturn(nodeStats);
+    Node node = mock(Node.class);
+    when(core.getNode()).thenReturn(node);
+    when(node.getNodeStats()).thenReturn(nodeStats);
     RequestStarter starter =
         new RequestStarter(
             core, throttle, "starter", avgOut, avgIn, isInsert, /* isSSK= */ false, realTime);

--- a/src/test/java/network/crypta/node/SendableGetRequestSenderTest.java
+++ b/src/test/java/network/crypta/node/SendableGetRequestSenderTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -17,6 +18,7 @@ import network.crypta.client.async.ChosenBlock;
 import network.crypta.client.async.ClientContext;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.Key;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -28,8 +30,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class SendableGetRequestSenderTest {
 
   @Mock private NodeClientCore core;
+  @Mock private NodeClientCoreTransfers transfers;
   @Mock private RequestScheduler scheduler;
   @Mock private ClientContext context;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(core.getTransfers()).thenReturn(transfers);
+  }
 
   private SendableGetRequestSender newSender() {
     return new SendableGetRequestSender();
@@ -151,7 +159,7 @@ class SendableGetRequestSenderTest {
               l.onSucceeded();
               return null;
             })
-        .when(core)
+        .when(transfers)
         .asyncGet(
             eq(nodeKey),
             eq(false),
@@ -190,7 +198,7 @@ class SendableGetRequestSenderTest {
               l.onFailed(failure);
               return null;
             })
-        .when(core)
+        .when(transfers)
         .asyncGet(
             eq(nodeKey),
             eq(false),
@@ -273,7 +281,7 @@ class SendableGetRequestSenderTest {
     when(req.isCancelled()).thenReturn(false);
 
     doThrow(new RuntimeException("asyncGet blew up"))
-        .when(core)
+        .when(transfers)
         .asyncGet(
             eq(nodeKey),
             eq(false),

--- a/src/test/java/network/crypta/node/SimpleSendableInsertTest.java
+++ b/src/test/java/network/crypta/node/SimpleSendableInsertTest.java
@@ -82,9 +82,11 @@ class SimpleSendableInsertTest {
     SimpleSendableInsert insert = spy(real);
 
     NodeClientCore core = mock(NodeClientCore.class);
+    NodeClientCoreTransfers transfers = mock(NodeClientCoreTransfers.class);
+    when(core.getTransfers()).thenReturn(transfers);
     // Make realPut succeed (do nothing)
     doNothing()
-        .when(core)
+        .when(transfers)
         .realPut(
             chkBlock,
             true,
@@ -128,7 +130,7 @@ class SimpleSendableInsertTest {
 
     // Assert
     assertTrue(sent);
-    verify(core, times(1))
+    verify(transfers, times(1))
         .realPut(
             chkBlock,
             true,
@@ -152,8 +154,10 @@ class SimpleSendableInsertTest {
     SimpleSendableInsert insert = spy(real);
 
     NodeClientCore core = mock(NodeClientCore.class);
+    NodeClientCoreTransfers transfers = mock(NodeClientCoreTransfers.class);
+    when(core.getTransfers()).thenReturn(transfers);
     doThrow(new LowLevelPutException(LowLevelPutException.REJECTED_OVERLOAD))
-        .when(core)
+        .when(transfers)
         .realPut(
             eq(sskBlock),
             any(Boolean.class),

--- a/src/test/java/network/crypta/node/TextModeClientInterfaceServerTest.java
+++ b/src/test/java/network/crypta/node/TextModeClientInterfaceServerTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -56,7 +55,7 @@ class TextModeClientInterfaceServerTest {
   }
 
   @Test
-  void maybeCreate_whenDirectEnabled_executesAndSetsDirectTMCI() {
+  void maybeCreate_whenDirectEnabled_returnsDirectTMCI() {
     Config cfg = Mockito.mock(Config.class);
     SubConfig sub = Mockito.mock(SubConfig.class);
     Mockito.when(cfg.createSubConfig("console")).thenReturn(sub);
@@ -68,24 +67,18 @@ class TextModeClientInterfaceServerTest {
     Mockito.when(sub.getBoolean("directEnabled")).thenReturn(true);
 
     // Node + core wiring
-    PriorityAwareExecutor exec = new CapturingExecutor();
-    Mockito.when(node.getExecutor()).thenReturn(exec);
     Mockito.when(core.getDownloadsDir()).thenReturn(tempDir);
     Mockito.when(core.makeClient(Mockito.anyShort(), Mockito.eq(true), Mockito.eq(false)))
         .thenReturn(Mockito.mock(network.crypta.client.HighLevelSimpleClient.class));
 
-    TextModeClientInterfaceServer server =
+    TextModeClientInterfaceServer.InitResult init =
         TextModeClientInterfaceServer.maybeCreate(node, core, cfg);
 
     // TMCI is disabled in config, so no server instance is created.
-    assertNull(server);
+    assertNull(init.server());
 
-    // Direct TMCI should be started and registered on the core.
-    ArgumentCaptor<TextModeClientInterface> tmciCaptor =
-        ArgumentCaptor.forClass(TextModeClientInterface.class);
-    Mockito.verify(core).getEndpoints();
-    Mockito.verify(endpoints).setDirectTMCI(tmciCaptor.capture());
-    assertNotNull(tmciCaptor.getValue());
+    // Direct TMCI should be created for later registration/start.
+    assertNotNull(init.directTMCI());
 
     // Sub-config should be finalized.
     Mockito.verify(sub).finishedInitialization();
@@ -229,7 +222,7 @@ class TextModeClientInterfaceServerTest {
     Mockito.verify(serverMock).setPort(12345);
   }
 
-  // Minimal executor used to capture tasks submitted by start() and maybeCreate(direct)
+  // Minimal executor used to capture tasks submitted by start().
   private static final class CapturingExecutor implements PriorityAwareExecutor {
     Runnable lastRunnable;
     String lastJobName;

--- a/src/test/java/network/crypta/node/TextModeClientInterfaceServerTest.java
+++ b/src/test/java/network/crypta/node/TextModeClientInterfaceServerTest.java
@@ -36,6 +36,7 @@ class TextModeClientInterfaceServerTest {
 
   @Mock private Node node;
   @Mock private NodeClientCore core;
+  @Mock private ClientEndpoints endpoints;
 
   @TempDir File tempDir;
 
@@ -51,6 +52,7 @@ class TextModeClientInterfaceServerTest {
     setStaticField(SSL.class, "ssf", null);
     // Reset TMCI SSL flag to a known state.
     setStaticField(TextModeClientInterfaceServer.class, "ssl", false);
+    Mockito.lenient().when(core.getEndpoints()).thenReturn(endpoints);
   }
 
   @Test
@@ -81,7 +83,8 @@ class TextModeClientInterfaceServerTest {
     // Direct TMCI should be started and registered on the core.
     ArgumentCaptor<TextModeClientInterface> tmciCaptor =
         ArgumentCaptor.forClass(TextModeClientInterface.class);
-    Mockito.verify(core).setDirectTMCI(tmciCaptor.capture());
+    Mockito.verify(core).getEndpoints();
+    Mockito.verify(endpoints).setDirectTMCI(tmciCaptor.capture());
     assertNotNull(tmciCaptor.getValue());
 
     // Sub-config should be finalized.
@@ -127,7 +130,7 @@ class TextModeClientInterfaceServerTest {
   @Test
   void TMCIEnabledCallback_getAndSet_behaviour() {
     TextModeClientInterfaceServer serverMock = Mockito.mock(TextModeClientInterfaceServer.class);
-    Mockito.when(core.getTextModeClientInterface()).thenReturn(serverMock);
+    Mockito.when(endpoints.getTextModeClientInterface()).thenReturn(serverMock);
     TextModeClientInterfaceServer.TMCIEnabledCallback cb =
         new TextModeClientInterfaceServer.TMCIEnabledCallback(core);
 
@@ -139,7 +142,7 @@ class TextModeClientInterfaceServerTest {
     assertThrows(InvalidConfigValueException.class, () -> cb.set(false));
 
     // Now with no server
-    Mockito.when(core.getTextModeClientInterface()).thenReturn(null);
+    Mockito.when(endpoints.getTextModeClientInterface()).thenReturn(null);
     assertFalse(cb.get());
     assertDoesNotThrow(() -> cb.set(false));
     assertThrows(InvalidConfigValueException.class, () -> cb.set(true));
@@ -148,7 +151,7 @@ class TextModeClientInterfaceServerTest {
   @Test
   void TMCIDirectEnabledCallback_getAndSet_behaviour() {
     // Direct TMCI present
-    Mockito.when(core.getDirectTMCI()).thenReturn(Mockito.mock(TextModeClientInterface.class));
+    Mockito.when(endpoints.getDirectTMCI()).thenReturn(Mockito.mock(TextModeClientInterface.class));
     TextModeClientInterfaceServer.TMCIDirectEnabledCallback cb =
         new TextModeClientInterfaceServer.TMCIDirectEnabledCallback(core);
 
@@ -156,7 +159,7 @@ class TextModeClientInterfaceServerTest {
     assertDoesNotThrow(() -> cb.set(true));
     assertThrows(InvalidConfigValueException.class, () -> cb.set(false));
 
-    Mockito.when(core.getDirectTMCI()).thenReturn(null);
+    Mockito.when(endpoints.getDirectTMCI()).thenReturn(null);
     assertFalse(cb.get());
     assertDoesNotThrow(() -> cb.set(false));
     assertThrows(InvalidConfigValueException.class, () -> cb.set(true));
@@ -190,7 +193,7 @@ class TextModeClientInterfaceServerTest {
   @Test
   void TMCIBindtoCallback_getDefaultsAndSetNoopWhenEqual() {
     // No server -> get() returns default
-    Mockito.when(core.getTextModeClientInterface()).thenReturn(null);
+    Mockito.when(endpoints.getTextModeClientInterface()).thenReturn(null);
     TextModeClientInterfaceServer.TMCIBindtoCallback cb =
         new TextModeClientInterfaceServer.TMCIBindtoCallback(core);
 
@@ -201,7 +204,7 @@ class TextModeClientInterfaceServerTest {
 
   @Test
   void TMCIAllowedHostsCallback_getDefaultsAndSetWhenDisabled_throws() {
-    Mockito.when(core.getTextModeClientInterface()).thenReturn(null);
+    Mockito.when(endpoints.getTextModeClientInterface()).thenReturn(null);
     TextModeClientInterfaceServer.TMCIAllowedHostsCallback cb =
         new TextModeClientInterfaceServer.TMCIAllowedHostsCallback(core);
 
@@ -214,14 +217,14 @@ class TextModeClientInterfaceServerTest {
   @Test
   void TCMIPortNumberCallback_getDefaultAndSetDelegates() throws InvalidConfigValueException {
     // With no server, get() returns default 2323
-    Mockito.when(core.getTextModeClientInterface()).thenReturn(null);
+    Mockito.when(endpoints.getTextModeClientInterface()).thenReturn(null);
     TextModeClientInterfaceServer.TCMIPortNumberCallback cb =
         new TextModeClientInterfaceServer.TCMIPortNumberCallback(core);
     assertEquals(2323, cb.get());
 
     // With a server present, set() delegates to setPort()
     TextModeClientInterfaceServer serverMock = Mockito.mock(TextModeClientInterfaceServer.class);
-    Mockito.when(core.getTextModeClientInterface()).thenReturn(serverMock);
+    Mockito.when(endpoints.getTextModeClientInterface()).thenReturn(serverMock);
     cb.set(12345);
     Mockito.verify(serverMock).setPort(12345);
   }

--- a/src/test/java/network/crypta/node/TextModeClientInterfaceTest.java
+++ b/src/test/java/network/crypta/node/TextModeClientInterfaceTest.java
@@ -34,10 +34,16 @@ class TextModeClientInterfaceTest {
   @Mock Node node;
   @Mock NodeClientCore core;
   @Mock HighLevelSimpleClient client;
+  @Mock ClientEndpoints endpoints;
 
   @Captor ArgumentCaptor<Boolean> getChkOnlyCaptor;
 
   @TempDir Path tmpDir;
+
+  @org.junit.jupiter.api.BeforeEach
+  void setUp() {
+    when(core.getEndpoints()).thenReturn(endpoints);
+  }
 
   private String runWithInput(String input) throws Exception {
     // Arrange IO
@@ -45,7 +51,7 @@ class TextModeClientInterfaceTest {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
 
     // Minimal stubbing used by header/QUIT path
-    when(core.getDirectTMCI()).thenReturn(null); // enable QUIT on header and command
+    when(endpoints.getDirectTMCI()).thenReturn(null); // enable QUIT on header and command
 
     // Construct SUT
     TextModeClientInterface tmci =
@@ -78,7 +84,7 @@ class TextModeClientInterfaceTest {
   @Test
   void put_singleLine_expectInsertCalledAndUriPrinted() throws Exception {
     // Arrange
-    when(core.getDirectTMCI()).thenReturn(null);
+    when(endpoints.getDirectTMCI()).thenReturn(null);
     when(client.insert(any(), any(Boolean.class), any())).thenReturn(FreenetURI.EMPTY_CHK_URI);
 
     String output = runWithInput("PUT:Hello world!\nQUIT\n");
@@ -96,7 +102,7 @@ class TextModeClientInterfaceTest {
   @Test
   void getchk_multiline_expectInsertCalledWithChkOnlyTrue() throws Exception {
     // Arrange
-    when(core.getDirectTMCI()).thenReturn(null);
+    when(endpoints.getDirectTMCI()).thenReturn(null);
     when(client.insert(any(), any(Boolean.class), any())).thenReturn(FreenetURI.EMPTY_CHK_URI);
 
     String input = "GETCHK:\nLine 1\nLine 2\n.\nQUIT\n";

--- a/src/test/java/network/crypta/node/simulator/RealNodeRequestInsertTestTest.java
+++ b/src/test/java/network/crypta/node/simulator/RealNodeRequestInsertTestTest.java
@@ -17,6 +17,7 @@ import network.crypta.node.LowLevelGetException;
 import network.crypta.node.LowLevelPutException;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.NodeClientCoreTransfers;
 import network.crypta.node.RequestTracker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,6 +31,10 @@ class RealNodeRequestInsertTestTest {
   void insertRequestTest_whenFetchReturnsMatchingData_expectExitZeroOnTarget() throws Exception {
     NodeClientCore insertCore = mock(NodeClientCore.class);
     NodeClientCore fetchCore = mock(NodeClientCore.class);
+    NodeClientCoreTransfers insertTransfers = mock(NodeClientCoreTransfers.class);
+    NodeClientCoreTransfers fetchTransfers = mock(NodeClientCoreTransfers.class);
+    when(insertCore.getTransfers()).thenReturn(insertTransfers);
+    when(fetchCore.getTransfers()).thenReturn(fetchTransfers);
 
     Node insertNode = mock(Node.class);
     Node fetchNode = mock(Node.class);
@@ -41,7 +46,8 @@ class RealNodeRequestInsertTestTest {
 
     RealNodeRequestInsertTest tester = new RealNodeRequestInsertTest(nodes, random, 1);
 
-    when(fetchCore.realGetKey(any(ClientKey.class), eq(false), eq(false), eq(false), eq(false)))
+    when(fetchTransfers.realGetKey(
+            any(ClientKey.class), eq(false), eq(false), eq(false), eq(false)))
         .thenAnswer(
             invocation -> {
               ClientKey key = invocation.getArgument(0);
@@ -55,7 +61,7 @@ class RealNodeRequestInsertTestTest {
     int result = tester.insertRequestTest();
 
     assertEquals(0, result);
-    verify(insertCore)
+    verify(insertTransfers)
         .realPut(
             any(KeyBlock.class),
             eq(false),
@@ -63,14 +69,17 @@ class RealNodeRequestInsertTestTest {
             eq(false),
             eq(false),
             eq(RealNodeRequestInsertTest.REAL_TIME_FLAG));
-    verify(fetchCore).realGetKey(any(ClientKey.class), eq(false), eq(false), eq(false), eq(false));
+    verify(fetchTransfers)
+        .realGetKey(any(ClientKey.class), eq(false), eq(false), eq(false), eq(false));
   }
 
   @Test
   void insertRequestTest_whenInsertThrowsException_expectInsertFailedExitCode() throws Exception {
     NodeClientCore insertCore = mock(NodeClientCore.class);
+    NodeClientCoreTransfers insertTransfers = mock(NodeClientCoreTransfers.class);
+    when(insertCore.getTransfers()).thenReturn(insertTransfers);
     doThrow(new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR))
-        .when(insertCore)
+        .when(insertTransfers)
         .realPut(
             any(KeyBlock.class),
             eq(false),
@@ -99,7 +108,12 @@ class RealNodeRequestInsertTestTest {
 
     NodeClientCore insertCore = mock(NodeClientCore.class);
     NodeClientCore fetchCore = mock(NodeClientCore.class);
-    when(fetchCore.realGetKey(any(ClientKey.class), eq(false), eq(false), eq(false), eq(false)))
+    NodeClientCoreTransfers insertTransfers = mock(NodeClientCoreTransfers.class);
+    NodeClientCoreTransfers fetchTransfers = mock(NodeClientCoreTransfers.class);
+    when(insertCore.getTransfers()).thenReturn(insertTransfers);
+    when(fetchCore.getTransfers()).thenReturn(fetchTransfers);
+    when(fetchTransfers.realGetKey(
+            any(ClientKey.class), eq(false), eq(false), eq(false), eq(false)))
         .thenThrow(new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND));
 
     Node insertNode = mock(Node.class);
@@ -115,7 +129,7 @@ class RealNodeRequestInsertTestTest {
     int result = tester.insertRequestTest();
 
     assertEquals(-1, result);
-    verify(insertCore)
+    verify(insertTransfers)
         .realPut(
             any(KeyBlock.class),
             eq(false),
@@ -129,10 +143,15 @@ class RealNodeRequestInsertTestTest {
   void insertRequestTest_whenFetchReturnsMismatchedData_expectBadDataExitCode() throws Exception {
     NodeClientCore insertCore = mock(NodeClientCore.class);
     NodeClientCore fetchCore = mock(NodeClientCore.class);
+    NodeClientCoreTransfers insertTransfers = mock(NodeClientCoreTransfers.class);
+    NodeClientCoreTransfers fetchTransfers = mock(NodeClientCoreTransfers.class);
+    when(insertCore.getTransfers()).thenReturn(insertTransfers);
+    when(fetchCore.getTransfers()).thenReturn(fetchTransfers);
 
     ClientKeyBlock returnedBlock = mock(ClientKeyBlock.class);
     when(returnedBlock.memoryDecode()).thenReturn("mismatch".getBytes(StandardCharsets.UTF_8));
-    when(fetchCore.realGetKey(any(ClientKey.class), eq(false), eq(false), eq(false), eq(false)))
+    when(fetchTransfers.realGetKey(
+            any(ClientKey.class), eq(false), eq(false), eq(false), eq(false)))
         .thenReturn(returnedBlock);
 
     Node insertNode = mock(Node.class);

--- a/src/test/java/network/crypta/node/useralerts/DiskSpaceUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/DiskSpaceUserAlertTest.java
@@ -18,7 +18,6 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.FilenameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,16 +47,12 @@ class DiskSpaceUserAlertTest {
     lenient().when(core.getMinDiskFreeShortTerm()).thenReturn(shortLimit);
     lenient().when(core.getMinDiskFreeLongTerm()).thenReturn(longLimit);
 
-    FilenameGenerator tempFg = mock(FilenameGenerator.class);
-    lenient().when(tempFg.getDir()).thenReturn(tempDir);
-    lenient().when(core.getTempFilenameGenerator()).thenReturn(tempFg);
+    lenient().when(core.getTempDir()).thenReturn(tempDir);
 
     if (persistentDirOrNull == null) {
-      lenient().when(core.getPersistentFilenameGenerator()).thenReturn(null);
+      lenient().when(core.getPersistentTempDir()).thenReturn(null);
     } else {
-      FilenameGenerator pfg = mock(FilenameGenerator.class);
-      lenient().when(pfg.getDir()).thenReturn(persistentDirOrNull);
-      lenient().when(core.getPersistentFilenameGenerator()).thenReturn(pfg);
+      lenient().when(core.getPersistentTempDir()).thenReturn(persistentDirOrNull);
     }
     return new DiskSpaceUserAlert(core);
   }
@@ -207,8 +202,8 @@ class DiskSpaceUserAlertTest {
     NodeClientCore core = mock(NodeClientCore.class);
     when(core.getMinDiskFreeShortTerm()).thenReturn(100L);
     when(core.getMinDiskFreeLongTerm()).thenReturn(200L);
-    // Cause evaluate() to throw via getTempFilenameGenerator()
-    when(core.getTempFilenameGenerator()).thenThrow(new RuntimeException("boom"));
+    // Cause evaluate() to throw via getTempDir()
+    when(core.getTempDir()).thenThrow(new RuntimeException("boom"));
 
     DiskSpaceUserAlert alert = new DiskSpaceUserAlert(core);
 

--- a/src/test/java/network/crypta/pluginmanager/PluginRespiratorTest.java
+++ b/src/test/java/network/crypta/pluginmanager/PluginRespiratorTest.java
@@ -9,18 +9,19 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.UUID;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.filter.FilterCallback;
+import network.crypta.client.filter.GenericReadFilterCallback;
 import network.crypta.clients.fcp.FCPPluginConnection;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.http.PageMaker;
@@ -28,11 +29,11 @@ import network.crypta.clients.http.SessionManager;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.config.Config;
 import network.crypta.config.SubConfig;
+import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.URIPreEncoder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,6 +67,7 @@ class PluginRespiratorTest {
   @Mock private PluginInfoWrapper pluginInfoWrapper;
   @Mock private FilterCallback filterCallback;
   @Mock private SimpleToadletServer toadletContainer;
+  @Mock private ClientEndpoints endpoints;
   @Mock private PageMaker pageMaker;
   @Mock private FCPServer fcpServer;
   @Mock private FCPPluginConnection pluginConnection;
@@ -81,6 +83,7 @@ class PluginRespiratorTest {
 
     when(pluginInfoWrapper.getPlugin()).thenReturn(plugin);
     when(node.getClientCore()).thenReturn(nodeClientCore);
+    lenient().when(nodeClientCore.getEndpoints()).thenReturn(endpoints);
     when(nodeClientCore.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, false, false))
         .thenReturn(highLevelSimpleClient);
     when(nodeClientCore.getPluginStores()).thenReturn(pluginStores);
@@ -113,16 +116,14 @@ class PluginRespiratorTest {
     // Arrange
     PluginRespirator respirator = new PluginRespirator(node, pluginInfoWrapper);
     String rawPath = "http://example.invalid/a b?q=c d";
-    URI encodedUri = URIPreEncoder.encodeURI(rawPath);
-
-    when(nodeClientCore.createFilterCallback(encodedUri, null)).thenReturn(filterCallback);
+    when(endpoints.getToadletContainer()).thenReturn(toadletContainer);
 
     // Act
     FilterCallback result = respirator.makeFilterCallback(rawPath);
 
     // Assert
-    assertSame(filterCallback, result);
-    verify(nodeClientCore).createFilterCallback(encodedUri, null);
+    assertNotNull(result);
+    assertInstanceOf(GenericReadFilterCallback.class, result);
   }
 
   @Test
@@ -142,7 +143,7 @@ class PluginRespiratorTest {
   @Test
   void getPageMaker_whenToadletContainerNull_returnsNull() {
     // Arrange
-    when(nodeClientCore.getToadletContainer()).thenReturn(null);
+    when(endpoints.getToadletContainer()).thenReturn(null);
     PluginRespirator respirator = new PluginRespirator(node, pluginInfoWrapper);
 
     // Act
@@ -155,7 +156,7 @@ class PluginRespiratorTest {
   @Test
   void getPageMaker_whenToadletContainerPresent_returnsItsPageMaker() {
     // Arrange
-    when(nodeClientCore.getToadletContainer()).thenReturn(toadletContainer);
+    when(endpoints.getToadletContainer()).thenReturn(toadletContainer);
     when(toadletContainer.getPageMaker()).thenReturn(pageMaker);
     PluginRespirator respirator = new PluginRespirator(node, pluginInfoWrapper);
 
@@ -170,7 +171,7 @@ class PluginRespiratorTest {
   @Test
   void getToadletContainer_whenAvailable_returnsContainerFromCore() {
     // Arrange
-    when(nodeClientCore.getToadletContainer()).thenReturn(toadletContainer);
+    when(endpoints.getToadletContainer()).thenReturn(toadletContainer);
     PluginRespirator respirator = new PluginRespirator(node, pluginInfoWrapper);
 
     // Act
@@ -226,7 +227,7 @@ class PluginRespiratorTest {
   @Test
   void connectToOtherPlugin_whenPluginNameNull_delegatesToFcpServerWithNullName() throws Exception {
     // Arrange
-    when(nodeClientCore.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
     when(fcpServer.createFCPPluginConnectionForIntraNodeFCP(null, messageHandler))
         .thenReturn(pluginConnection);
     PluginRespirator respirator = new PluginRespirator(node, pluginInfoWrapper);
@@ -242,7 +243,7 @@ class PluginRespiratorTest {
   @Test
   void connectToOtherPlugin_whenValid_delegatesToFcpServer() throws Exception {
     // Arrange
-    when(nodeClientCore.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
     when(fcpServer.createFCPPluginConnectionForIntraNodeFCP("serverPlugin", messageHandler))
         .thenReturn(pluginConnection);
     PluginRespirator respirator = new PluginRespirator(node, pluginInfoWrapper);
@@ -259,7 +260,7 @@ class PluginRespiratorTest {
   void getPluginConnectionByID_whenFound_delegatesToFcpServer() throws Exception {
     // Arrange
     UUID id = UUID.fromString("01234567-89ab-cdef-0123-456789abcdef");
-    when(nodeClientCore.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
     when(fcpServer.getPluginConnectionByID(id)).thenReturn(pluginConnection);
     PluginRespirator respirator = new PluginRespirator(node, pluginInfoWrapper);
 
@@ -276,7 +277,7 @@ class PluginRespiratorTest {
     // Arrange
     UUID id = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     IOException failure = new IOException("missing");
-    when(nodeClientCore.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
     when(fcpServer.getPluginConnectionByID(id)).thenThrow(failure);
     PluginRespirator respirator = new PluginRespirator(node, pluginInfoWrapper);
 


### PR DESCRIPTION
## Summary
- split NodeClientCore wiring into ClientEndpoints/NodeClientPersistence/NodeClientCoreSupport and supporting records
- document NodeClientCore and client endpoint responsibilities; update call sites accordingly
- expand test coverage for new wiring and persistence behavior

## Testing
- not run (not requested)
