### PR TITLE
test(fcp): cover ProbeRequest responses

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
@@ -7,53 +7,80 @@ import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Probe;
 import network.crypta.node.probe.Type;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * FCP Message which is received from a client and requests a network probe of a specific type.
+ * Represents an inbound FCP request that initiates a network probe and delivers results back to the
+ * client.
+ *
+ * <p>This message is created from a parsed {@link SimpleFieldSet} and validates the probe type and
+ * optional hop budget before execution. Callers typically obtain it through the FCP dispatch layer
+ * and then invoke {@link #run(FCPConnectionHandler, Node)} to start the probe asynchronously. The
+ * request retains the identifier, type, and hop budget as immutable state; it is not intended to be
+ * reused across unrelated client sessions. A {@code null} identifier is supported and results in
+ * response messages that omit the {@code Identifier} field.
+ *
+ * <p>Execution requires full-access credentials. When authorized, {@link #run(FCPConnectionHandler,
+ * Node)} constructs a {@link Listener} that adapts probe callbacks into concrete {@link FCPMessage}
+ * responses, and delegates to {@link Node#startProbe(byte, long, Type, Listener)}. The method does
+ * not block for completion; responses arrive asynchronously via the handler.
  *
  * <ul>
- *   <li>Identifier: Optional; identifier to match probe request with results.
- *   <li>type: Mandatory; denotes the desired response type. Valid values are:
- *       <ul>
- *         <li>BANDWIDTH - returns outgoing bandwidth limit in KiB per second.
- *         <li>BUILD - returns Freenet build / main version.
- *         <li>IDENTIFIER - returns identifier and integer 7-day uptime percentage.
- *         <li>LINK_LENGTHS - returns link lengths between the endpoint and its connected peers.
- *         <li>LOCATION - returns the endpoint's location.
- *         <li>REJECT_STATS - returns CHK and SSK reject percentage for bulk inserts and bulk
- *             requests.
- *         <li>STORE_SIZE - returns store size in GiB.
- *         <li>UPTIME_48H - returns 48-hour uptime percentage.
- *         <li>UPTIME_7D - returns 7-day uptime percentage.
- *       </ul>
- *   <li>hopsToLive: Optional; approximately how many hops the probe will take before possibly
- *       returning a result. Valid values are [1, Probe.MAX_HTL]. If omitted Probe.MAX_HTL is used.
+ *   <li><strong>Responsibilities:</strong> validate fields, enforce access, and bridge callbacks.
+ *   <li><strong>Notable behaviors:</strong> defaults {@code HopsToLive} to {@link Probe#MAX_HTL}
+ *       and rejects negative values.
+ *   <li><strong>Thread-safety:</strong> immutable after construction; no internal synchronization.
  * </ul>
+ *
+ * @see Probe
+ * @see Type
+ * @see Listener
+ * @see FCPConnectionHandler
  */
 public class ProbeRequest extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ProbeRequest.class);
 
+  /**
+   * Wire-level message name used for serialization and protocol dispatch.
+   *
+   * <p>The value is a stable, human-readable token that must stay consistent with the FCP protocol
+   * identifier clients send on the wire. Keeping it constant preserves interoperability and ensures
+   * the {@link FCPMessage} factory can resolve this request type reliably.
+   */
   public static final String NAME = "ProbeRequest";
 
-  private final String identifier;
-  private final Type type;
-  private final byte htl;
+  private final String requestIdentifier;
+  private final Type probeType;
+  private final byte hopsToLive;
 
+  /**
+   * Parses a probe request from the provided field set and validates required fields.
+   *
+   * <p>The constructor reads the optional {@code Identifier}, the mandatory {@code Type}, and an
+   * optional {@code HopsToLive} value. When the hop budget is missing, it defaults to {@link
+   * Probe#MAX_HTL}; negative values are rejected. Any parsing or validation failure results in a
+   * {@link MessageInvalidException} with {@link ProtocolErrorMessage#INVALID_MESSAGE}, which the
+   * caller should translate into an FCP protocol error response.
+   *
+   * <pre>{@code
+   * SimpleFieldSet fields = ...;
+   * ProbeRequest request = new ProbeRequest(fields);
+   * }</pre>
+   *
+   * @param fs parsed field set containing Identifier, Type, and optional HopsToLive.
+   * @throws MessageInvalidException if the type is invalid or hopsToLive cannot be parsed.
+   */
   public ProbeRequest(SimpleFieldSet fs) throws MessageInvalidException {
     /* If not defined in the field set Identifier will be null. As adding a null value to the field set does
      * not actually add something under the key, it will also be omitted in the response messages.
      */
-    this.identifier = fs.get(IDENTIFIER);
+    this.requestIdentifier = fs.get(IDENTIFIER);
 
     try {
-      this.type = Type.valueOf(fs.get(TYPE));
+      this.probeType = Type.valueOf(fs.get(TYPE));
 
       // If HTL is not specified default to MAX_HTL.
-      this.htl = fs.get(HTL) == null ? Probe.MAX_HTL : fs.getByte(HTL);
+      this.hopsToLive = fs.get(HTL) == null ? Probe.MAX_HTL : fs.getByte(HTL);
 
-      if (this.htl < 0) {
+      if (this.hopsToLive < 0) {
         throw new MessageInvalidException(
             ProtocolErrorMessage.INVALID_MESSAGE, "hopsToLive cannot be negative.", null, false);
       }
@@ -74,73 +101,111 @@ public class ProbeRequest extends FCPMessage {
     }
   }
 
+  /**
+   * Returns an empty field set for outbound serialization of this request.
+   *
+   * <p>Probe requests are primarily consumed inbound, and this implementation does not serialize
+   * the parsed fields back onto the wire. Each invocation allocates a new {@link SimpleFieldSet}
+   * marked short-lived, leaving the caller free to mutate it if required by higher-level framing.
+   * The returned instance intentionally omits the identifier, type, and hop budget captured at
+   * construction time.
+   *
+   * @return new empty, mutable field set owned by the caller.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Returns the protocol name token that identifies this request on the wire.
+   *
+   * <p>The name is constant and matches the identifier expected by FCP clients. It is used when
+   * serializing outbound messages and when routing inbound messages to this implementation. The
+   * method is side-effect free and performs no allocation beyond returning the constant string.
+   *
+   * @return stable protocol name token, never null, matching {@link #NAME}.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Starts the probe execution and forwards results to the provided handler.
+   *
+   * <p>The handler must have full access; otherwise a {@link MessageInvalidException} with {@link
+   * ProtocolErrorMessage#ACCESS_DENIED} is thrown and no probe is started. When authorized, this
+   * method builds a {@link Listener} that maps each callback to the corresponding {@link
+   * FCPResponse} message and then delegates to {@link Node#startProbe(byte, long, Type, Listener)}
+   * using the stored hop budget and a fresh random UID from the node. The call is non-blocking and
+   * returns immediately while responses are emitted asynchronously via {@link
+   * FCPConnectionHandler#send(FCPMessage)}.
+   *
+   * @param handler connection handler used to authorize and send probe responses.
+   * @param node node instance that executes the probe and supplies randomness.
+   * @throws MessageInvalidException if the caller lacks full access for probe execution.
+   */
   @Override
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, "Probe requires full access.", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "Probe requires full access.",
+          requestIdentifier,
+          false);
     }
 
     Listener listener =
         new Listener() {
           @Override
           public void onError(Error error, Byte code, boolean local) {
-            handler.send(new ProbeError(identifier, error, code, local));
+            handler.send(new ProbeError(requestIdentifier, error, code, local));
           }
 
           @Override
           public void onRefused() {
-            handler.send(new ProbeRefused(identifier));
+            handler.send(new ProbeRefused(requestIdentifier));
           }
 
           @Override
           public void onOutputBandwidth(float outputBandwidth) {
-            handler.send(new ProbeBandwidth(identifier, outputBandwidth));
+            handler.send(new ProbeBandwidth(requestIdentifier, outputBandwidth));
           }
 
           @Override
           public void onBuild(int build) {
-            handler.send(new ProbeBuild(identifier, build));
+            handler.send(new ProbeBuild(requestIdentifier, build));
           }
 
           @Override
           public void onIdentifier(long probeIdentifier, byte percentageUptime) {
-            handler.send(new ProbeIdentifier(identifier, probeIdentifier, percentageUptime));
+            handler.send(new ProbeIdentifier(requestIdentifier, probeIdentifier, percentageUptime));
           }
 
           @Override
           public void onLinkLengths(float[] linkLengths) {
-            handler.send(new ProbeLinkLengths(identifier, linkLengths));
+            handler.send(new ProbeLinkLengths(requestIdentifier, linkLengths));
           }
 
           @Override
           public void onLocation(float location) {
-            handler.send(new ProbeLocation(identifier, location));
+            handler.send(new ProbeLocation(requestIdentifier, location));
           }
 
           @Override
           public void onStoreSize(float storeSize) {
-            handler.send(new ProbeStoreSize(identifier, storeSize));
+            handler.send(new ProbeStoreSize(requestIdentifier, storeSize));
           }
 
           @Override
           public void onUptime(float uptimePercent) {
-            handler.send(new ProbeUptime(identifier, uptimePercent));
+            handler.send(new ProbeUptime(requestIdentifier, uptimePercent));
           }
 
           @Override
           public void onRejectStats(byte[] stats) {
-            handler.send(new ProbeRejectStats(identifier, stats));
+            handler.send(new ProbeRejectStats(requestIdentifier, stats));
           }
 
           @Override
@@ -148,9 +213,9 @@ public class ProbeRequest extends FCPMessage {
               byte bandwidthClassForCapacityUsage, float capacityUsage) {
             handler.send(
                 new ProbeOverallBulkOutputCapacityUsage(
-                    identifier, bandwidthClassForCapacityUsage, capacityUsage));
+                    requestIdentifier, bandwidthClassForCapacityUsage, capacityUsage));
           }
         };
-    node.startProbe(htl, node.getRandom().nextLong(), type, listener);
+    node.startProbe(hopsToLive, node.getRandom().nextLong(), probeType, listener);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
@@ -1,0 +1,383 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.FSParseException;
+import network.crypta.node.Node;
+import network.crypta.node.probe.Error;
+import network.crypta.node.probe.Listener;
+import network.crypta.node.probe.Probe;
+import network.crypta.node.probe.Type;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ProbeRequestTest {
+
+  private static final long REQUEST_UID = 4242L;
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void constructor_whenTypeUnrecognized_expectMessageInvalidException() {
+    SimpleFieldSet fieldSet = fieldSet("probe-1", "NO_SUCH_TYPE", "5");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ProbeRequest(fieldSet));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertTrue(exception.getMessage().contains("Unrecognized parse probe type"));
+    assertTrue(exception.getMessage().contains("NO_SUCH_TYPE"));
+  }
+
+  @Test
+  void constructor_whenHtlNegative_expectMessageInvalidException() {
+    SimpleFieldSet fieldSet = fieldSet("probe-1", Type.BUILD, (byte) -1);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ProbeRequest(fieldSet));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals("hopsToLive cannot be negative.", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenHtlNotNumber_expectMessageInvalidException() {
+    SimpleFieldSet fieldSet = fieldSet("probe-1", Type.BUILD.name(), "not-a-number");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ProbeRequest(fieldSet));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertTrue(exception.getMessage().contains("Unable to parse hopsToLive"));
+    assertTrue(exception.getMessage().contains("not-a-number"));
+  }
+
+  @Test
+  void getFieldSet_whenCalled_returnsIndependentEmptyFieldSet() throws MessageInvalidException {
+    SimpleFieldSet input = fieldSet("probe-1", Type.BUILD, (byte) 5);
+    ProbeRequest request = new ProbeRequest(input);
+
+    SimpleFieldSet result = request.getFieldSet();
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    assertNotSame(input, result);
+  }
+
+  @Test
+  void getName_whenCalled_returnsProbeRequestConstant() throws MessageInvalidException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 5));
+
+    assertEquals(ProbeRequest.NAME, request.getName());
+  }
+
+  @Test
+  void run_whenHandlerWithoutFullAccess_expectAccessDeniedException()
+      throws MessageInvalidException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 5));
+    when(handler.hasFullAccess()).thenReturn(false);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> request.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
+    assertEquals("probe-1", exception.ident);
+    assertEquals("Probe requires full access.", exception.getMessage());
+    verify(node, never()).startProbe(anyByte(), anyLong(), any(Type.class), any(Listener.class));
+  }
+
+  @Test
+  void run_whenHtlMissing_usesProbeMaxHtl() throws MessageInvalidException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, null));
+    when(handler.hasFullAccess()).thenReturn(true);
+    RandomSource random = mock(RandomSource.class);
+    when(random.nextLong()).thenReturn(REQUEST_UID);
+    when(node.getRandom()).thenReturn(random);
+    ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+
+    request.run(handler, node);
+
+    verify(node)
+        .startProbe(eq(Probe.MAX_HTL), eq(REQUEST_UID), eq(Type.BUILD), listenerCaptor.capture());
+    assertNotNull(listenerCaptor.getValue());
+  }
+
+  @Test
+  void run_whenHtlProvided_usesProvidedValue() throws MessageInvalidException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 12));
+    when(handler.hasFullAccess()).thenReturn(true);
+    RandomSource random = mock(RandomSource.class);
+    when(random.nextLong()).thenReturn(REQUEST_UID);
+    when(node.getRandom()).thenReturn(random);
+    ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+
+    request.run(handler, node);
+
+    verify(node)
+        .startProbe(eq((byte) 12), eq(REQUEST_UID), eq(Type.BUILD), listenerCaptor.capture());
+    assertNotNull(listenerCaptor.getValue());
+  }
+
+  @Test
+  void run_whenProbeErrors_sendsProbeError() throws MessageInvalidException, FSParseException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BANDWIDTH, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+    Byte code = (byte) 7;
+
+    listener.onError(Error.TIMEOUT, code, true);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeError.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    assertEquals(Error.TIMEOUT.name(), fields.get(FCPMessage.TYPE));
+    assertEquals(code.byteValue(), fields.getByte(FCPMessage.CODE));
+    assertTrue(fields.getBoolean(FCPMessage.LOCAL));
+  }
+
+  @Test
+  void run_whenProbeRefused_sendsProbeRefused() throws MessageInvalidException {
+    ProbeRequest request = new ProbeRequest(fieldSet(null, Type.BANDWIDTH, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+
+    listener.onRefused();
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeRefused.class, sent);
+    assertNull(sent.getFieldSet().get(FCPMessage.IDENTIFIER));
+  }
+
+  @Test
+  void run_whenProbeOutputsBandwidth_sendsProbeBandwidth()
+      throws MessageInvalidException, FSParseException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BANDWIDTH, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+
+    listener.onOutputBandwidth(12.5f);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeBandwidth.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    assertEquals(12.5d, fields.getDouble(FCPMessage.OUTPUT_BANDWIDTH), 0.0001d);
+  }
+
+  @Test
+  void run_whenProbeBuildReported_sendsProbeBuild()
+      throws MessageInvalidException, FSParseException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+
+    listener.onBuild(123456);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeBuild.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    assertEquals(123456, fields.getInt(FCPMessage.BUILD));
+  }
+
+  @Test
+  void run_whenProbeIdentifierReported_sendsProbeIdentifier()
+      throws MessageInvalidException, FSParseException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.IDENTIFIER, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+
+    listener.onIdentifier(99L, (byte) 42);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeIdentifier.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    assertEquals(99L, fields.getLong(FCPMessage.PROBE_IDENTIFIER));
+    assertEquals(42L, fields.getLong(FCPMessage.UPTIME_PERCENT));
+  }
+
+  @Test
+  void run_whenProbeLinkLengthsReported_sendsProbeLinkLengths() throws MessageInvalidException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.LINK_LENGTHS, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+    float[] lengths = new float[] {1.25f, 2.5f, 3.75f};
+
+    listener.onLinkLengths(lengths);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeLinkLengths.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    String[] encoded = fields.getAll(FCPMessage.LINK_LENGTHS);
+    assertNotNull(encoded);
+    float[] parsed = new float[encoded.length];
+    for (int i = 0; i < encoded.length; i++) {
+      parsed[i] = Float.parseFloat(encoded[i]);
+    }
+    assertArrayEquals(lengths, parsed, 0.0001f);
+  }
+
+  @Test
+  void run_whenProbeLocationReported_sendsProbeLocation()
+      throws MessageInvalidException, FSParseException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.LOCATION, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+
+    listener.onLocation(0.75f);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeLocation.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    assertEquals(0.75d, fields.getDouble(FCPMessage.LOCATION), 0.0001d);
+  }
+
+  @Test
+  void run_whenProbeStoreSizeReported_sendsProbeStoreSize()
+      throws MessageInvalidException, FSParseException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.STORE_SIZE, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+
+    listener.onStoreSize(512.5f);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeStoreSize.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    assertEquals(512.5d, fields.getDouble(FCPMessage.STORE_SIZE), 0.0001d);
+  }
+
+  @Test
+  void run_whenProbeUptimeReported_sendsProbeUptime()
+      throws MessageInvalidException, FSParseException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.UPTIME_7D, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+
+    listener.onUptime(99.5f);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeUptime.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    assertEquals(99.5d, fields.getDouble(FCPMessage.UPTIME_PERCENT), 0.0001d);
+  }
+
+  @Test
+  void run_whenProbeRejectStatsReported_sendsProbeRejectStats()
+      throws MessageInvalidException, FSParseException {
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.REJECT_STATS, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+    byte[] stats = new byte[] {1, 2, 3, 4};
+
+    listener.onRejectStats(stats);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeRejectStats.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    assertEquals(1, fields.getInt(FCPMessage.BULK_CHK_REQUEST_REJECTS));
+    assertEquals(2, fields.getInt(FCPMessage.BULK_SSK_REQUEST_REJECTS));
+    assertEquals(3, fields.getInt(FCPMessage.BULK_CHK_INSERT_REJECTS));
+    assertEquals(4, fields.getInt(FCPMessage.BULK_SSK_INSERT_REJECTS));
+  }
+
+  @Test
+  void run_whenProbeOverallBulkCapacityReported_sendsProbeOverallBulkOutputCapacityUsage()
+      throws MessageInvalidException, FSParseException {
+    ProbeRequest request =
+        new ProbeRequest(fieldSet("probe-1", Type.OVERALL_BULK_OUTPUT_CAPACITY_USAGE, (byte) 5));
+    Listener listener = runAndCaptureListener(request);
+
+    listener.onOverallBulkOutputCapacity((byte) 3, 0.67f);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(ProbeOverallBulkOutputCapacityUsage.class, sent);
+    SimpleFieldSet fields = sent.getFieldSet();
+    assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
+    assertEquals((byte) 3, fields.getByte(FCPMessage.OUTPUT_BANDWIDTH_CLASS));
+    assertEquals(0.67d, fields.getDouble(FCPMessage.OVERALL_BULK_OUTPUT_CAPACITY_USAGE), 0.0001d);
+  }
+
+  private Listener runAndCaptureListener(ProbeRequest request) throws MessageInvalidException {
+    when(handler.hasFullAccess()).thenReturn(true);
+    RandomSource random = mock(RandomSource.class);
+    when(random.nextLong()).thenReturn(REQUEST_UID);
+    when(node.getRandom()).thenReturn(random);
+    AtomicReference<Listener> listenerRef = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              listenerRef.set(invocation.getArgument(3));
+              return null;
+            })
+        .when(node)
+        .startProbe(anyByte(), anyLong(), any(Type.class), any(Listener.class));
+
+    request.run(handler, node);
+
+    return listenerRef.get();
+  }
+
+  private static SimpleFieldSet fieldSet(String identifier, Type type, Byte htl) {
+    return fieldSet(
+        identifier, type == null ? null : type.name(), htl == null ? null : Byte.toString(htl));
+  }
+
+  private static SimpleFieldSet fieldSet(String identifier, String typeValue, String htlValue) {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    if (identifier != null) {
+      fieldSet.putSingle(FCPMessage.IDENTIFIER, identifier);
+    }
+    if (typeValue != null) {
+      fieldSet.putSingle(FCPMessage.TYPE, typeValue);
+    }
+    if (htlValue != null) {
+      fieldSet.putSingle(FCPMessage.HTL, htlValue);
+    }
+    return fieldSet;
+  }
+}


### PR DESCRIPTION
## Summary
- add deterministic unit tests for `ProbeRequest` validation and probe callback mapping
- expand `ProbeRequest` Javadoc to satisfy doclint with long-form API docs

## Testing
- ./gradlew test
- javadoc -quiet -Xdoclint:all -classpath "build/classes/java/main:build/resources/main" -sourcepath . -d /tmp/doclint-out "src/main/java/network/crypta/clients/fcp/ProbeRequest.java"
