### PR TITLE
style(test): use '_' for ignored exceptions

### DIFF
--- a/src/test/java/com/onionnetworks/util/AsyncPersistentPropsTest.java
+++ b/src/test/java/com/onionnetworks/util/AsyncPersistentPropsTest.java
@@ -27,7 +27,7 @@ class AsyncPersistentPropsTest {
     if (props != null) {
       try {
         props.close();
-      } catch (IOException ignored) {
+      } catch (IOException _) {
         // Ignore to allow cleanup when the writer thread already failed.
       }
     }

--- a/src/test/java/com/onionnetworks/util/InvokingDispatchTest.java
+++ b/src/test/java/com/onionnetworks/util/InvokingDispatchTest.java
@@ -66,12 +66,12 @@ class InvokingDispatchTest {
                         if (!awaited) {
                           timedOutAwaitingFinish.set(true);
                         }
-                      } catch (InterruptedException e) {
+                      } catch (InterruptedException _) {
                         Thread.currentThread().interrupt();
                       }
                     });
                 returned.set(true);
-              } catch (InterruptedException e) {
+              } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
               }
             },

--- a/src/test/java/network/crypta/client/HighLevelSimpleClientImplTest.java
+++ b/src/test/java/network/crypta/client/HighLevelSimpleClientImplTest.java
@@ -442,7 +442,7 @@ class HighLevelSimpleClientImplTest {
       Field f;
       try {
         f = getter.getClass().getDeclaredField("ctx");
-      } catch (NoSuchFieldException nsf) {
+      } catch (NoSuchFieldException _) {
         f = getter.getClass().getSuperclass().getDeclaredField("ctx");
       }
       f.setAccessible(true);

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -442,7 +442,7 @@ class ClientContextTest {
       Field f = target.getClass().getDeclaredField(fieldName);
       f.setAccessible(true);
       f.set(target, value);
-    } catch (NoSuchFieldException e) {
+    } catch (NoSuchFieldException _) {
       // Try superclass (useful for mocks)
       try {
         Field f = target.getClass().getSuperclass().getDeclaredField(fieldName);

--- a/src/test/java/network/crypta/client/async/ClientLayerPersisterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientLayerPersisterTest.java
@@ -328,7 +328,7 @@ class ClientLayerPersisterTest {
       InMemoryBucket copy = new InMemoryBucket();
       try (OutputStream os = copy.getOutputStream()) {
         os.write(baos.toByteArray(), 0, baos.size());
-      } catch (IOException ignored) {
+      } catch (IOException _) {
         // Best-effort in test helper: if copying fails, return an empty-shadow bucket.
       }
       return copy;

--- a/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
@@ -219,7 +219,7 @@ class ClientRequestSelectorTest {
         checkFailed();
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           // Ignore.
         }
       }
@@ -236,7 +236,7 @@ class ClientRequestSelectorTest {
         checkFailed();
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           // Ignore.
         }
       }

--- a/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
@@ -333,7 +333,7 @@ class DefaultManifestPutterTest {
         Field f = cls.getDeclaredField(fieldName);
         f.setAccessible(true);
         return f.get(target);
-      } catch (NoSuchFieldException ignored) {
+      } catch (NoSuchFieldException _) {
         cls = cls.getSuperclass();
       }
     }

--- a/src/test/java/network/crypta/client/async/PersistentJobRunnerImplTest.java
+++ b/src/test/java/network/crypta/client/async/PersistentJobRunnerImplTest.java
@@ -74,7 +74,7 @@ class PersistentJobRunnerImplTest {
         while (!wake) {
           try {
             wait();
-          } catch (InterruptedException e) {
+          } catch (InterruptedException _) {
             // Ignore.
           }
         }
@@ -97,7 +97,7 @@ class PersistentJobRunnerImplTest {
       while (!started) {
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           // Ignore.
         }
       }
@@ -163,7 +163,7 @@ class PersistentJobRunnerImplTest {
       while (!finished) {
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           // Ignore.
         }
       }
@@ -173,7 +173,7 @@ class PersistentJobRunnerImplTest {
       while (!started) {
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           // Ignore.
         }
       }

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherGetTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherGetTest.java
@@ -295,7 +295,7 @@ class SplitFileFetcherGetTest {
       Field f = target.getClass().getDeclaredField(fieldName);
       f.setAccessible(true);
       f.set(target, value);
-    } catch (NoSuchFieldException e) {
+    } catch (NoSuchFieldException _) {
       // Try superclass for protected fields
       try {
         Field f = target.getClass().getSuperclass().getDeclaredField(fieldName);

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherKeyListenerTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherKeyListenerTest.java
@@ -485,7 +485,7 @@ class SplitFileFetcherKeyListenerTest {
     while (t != null) {
       try {
         return t.getDeclaredField("segments");
-      } catch (NoSuchFieldException ignored) {
+      } catch (NoSuchFieldException _) {
         t = t.getSuperclass();
       }
     }

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
@@ -958,7 +958,7 @@ class SplitFileFetcherStorageTest {
       Object chooser = f.get(segment);
       java.lang.reflect.Method m = chooser.getClass().getMethod("clearCooldown");
       m.invoke(chooser);
-    } catch (ReflectiveOperationException ignored) {
+    } catch (ReflectiveOperationException _) {
       // Best effort: if reflection fails, tests remain as before.
     }
   }
@@ -1550,7 +1550,7 @@ class SplitFileFetcherStorageTest {
       while (!(succeeded || failed)) {
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           Thread.currentThread().interrupt();
           Assertions.fail("Interrupted while waiting for finished");
         }
@@ -1561,7 +1561,7 @@ class SplitFileFetcherStorageTest {
       while (!(succeeded || failed)) {
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           Thread.currentThread().interrupt();
           Assertions.fail("Interrupted while waiting for failure");
         }
@@ -1574,7 +1574,7 @@ class SplitFileFetcherStorageTest {
         while (!closed) {
           try {
             wait();
-          } catch (InterruptedException e) {
+          } catch (InterruptedException _) {
             Thread.currentThread().interrupt();
             Assertions.fail("Interrupted while waiting for free");
           }

--- a/src/test/java/network/crypta/client/filter/ContentFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/ContentFilterTest.java
@@ -363,7 +363,7 @@ class ContentFilterTest {
       failures.add(
           new RuntimeException(
               "Filter accepted dangerous UTF8 text with BOM as UTF16! (HTMLFilter)"));
-    } catch (DataFilterException e) {
+    } catch (DataFilterException _) {
       // Assert (expected rejection)
       // no logging needed in tests
     }
@@ -382,7 +382,7 @@ class ContentFilterTest {
               "Filter accepted dangerous UTF8 text with BOM as UTF16! (ContentFilter) - Detected "
                   + "charset: "
                   + (fo == null ? "<null>" : fo.charset)));
-    } catch (DataFilterException e) {
+    } catch (DataFilterException _) {
       // Assert (expected rejection)
       // no logging needed in tests
     }
@@ -394,7 +394,7 @@ class ContentFilterTest {
         () -> {
           try (FileOutputStream fos = new FileOutputStream("unfiltered")) {
             fos.write(total);
-          } catch (IOException ignored) {
+          } catch (IOException _) {
             // best-effort debug write; ignore secondary I/O errors
           }
           RuntimeException first = failures.getFirst();

--- a/src/test/java/network/crypta/client/filter/M3UFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/M3UFilterTest.java
@@ -59,9 +59,9 @@ class M3UFilterTest {
             bucketToString(expectedBucket),
             result,
             original + " should be filtered as " + expected + " but was filtered as\n" + result);
-      } catch (DataFilterException dfe) {
+      } catch (DataFilterException _) {
         fail("Filtering " + original + " failed");
-      } catch (URISyntaxException use) {
+      } catch (URISyntaxException _) {
         fail("Creating URI from BASE_URI " + BASE_URI + " failed");
       } catch (IOException ioe) {
         fail("I/O failure while filtering " + original + ": " + ioe.getMessage());

--- a/src/test/java/network/crypta/client/filter/PNGFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/PNGFilterTest.java
@@ -86,7 +86,7 @@ class PNGFilterTest {
                       ib.getInputStream(), out.getOutputStream(), "", null, null, null),
               filename + " should not be valid");
         }
-      } catch (IOException e) {
+      } catch (IOException _) {
         // Resource missing in test data; skip silently
       }
     }
@@ -383,7 +383,7 @@ class PNGFilterTest {
     try (FileBucket bucket = new FileBucket(pngFile, true, false, false, false);
         FileOutputStream outputStream = new FileOutputStream(filteredPngFile)) {
       filter.readFilter(bucket.getInputStream(), outputStream, "", null, null, null);
-    } catch (DataFilterException e) {
+    } catch (DataFilterException _) {
       return emptyList();
     }
     return PngUtil.getChunks(filteredPngFile);

--- a/src/test/java/network/crypta/client/filter/TheoraBitstreamFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/TheoraBitstreamFilterTest.java
@@ -55,7 +55,7 @@ class TheoraBitstreamFilterTest {
           }
 
           page = OggPage.readPage(input);
-        } catch (EOFException e) {
+        } catch (EOFException _) {
           break;
         }
       }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
@@ -250,7 +250,7 @@ class ClientGetTest {
     while (current != null) {
       try {
         return current.getDeclaredField(fieldName);
-      } catch (NoSuchFieldException ignore) {
+      } catch (NoSuchFieldException _) {
         current = current.getSuperclass();
       }
     }

--- a/src/test/java/network/crypta/clients/http/FProxyFetchTrackerTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchTrackerTest.java
@@ -244,7 +244,7 @@ class FProxyFetchTrackerTest {
     while (current != null) {
       try {
         return current.getDeclaredField(name);
-      } catch (NoSuchFieldException ignored) {
+      } catch (NoSuchFieldException _) {
         current = current.getSuperclass();
       }
     }

--- a/src/test/java/network/crypta/config/ConfigTest.java
+++ b/src/test/java/network/crypta/config/ConfigTest.java
@@ -51,7 +51,7 @@ class ConfigTest {
     /* test if it prevents multiple registrations */
     try {
       conf.register(sc);
-    } catch (IllegalArgumentException ie) {
+    } catch (IllegalArgumentException _) {
       return;
     }
     fail();

--- a/src/test/java/network/crypta/config/WrapperConfigTest.java
+++ b/src/test/java/network/crypta/config/WrapperConfigTest.java
@@ -62,7 +62,7 @@ class WrapperConfigTest {
       Files.deleteIfExists(wrapperDir.resolve("wrapper.conf"));
       Files.deleteIfExists(wrapperDir.resolve("wrapper.conf.new"));
       Files.deleteIfExists(wrapperDir.resolve("wrapper.conf.old"));
-    } catch (IOException ignore) {
+    } catch (IOException _) {
       // ignore cleanup errors
     }
   }

--- a/src/test/java/network/crypta/crypt/AEADStreamsTest.java
+++ b/src/test/java/network/crypta/crypt/AEADStreamsTest.java
@@ -83,7 +83,7 @@ class AEADStreamsTest {
       BucketTools.copyFrom(decoded, cis, -1);
       cis.close();
       fail("Checksum error should have been seen");
-    } catch (AEADVerificationFailedException e) {
+    } catch (AEADVerificationFailedException _) {
       // Expected.
     }
     assertEquals(decoded.size(), input.size());
@@ -166,7 +166,7 @@ class AEADStreamsTest {
     try {
       cis.close();
       fail("Hash should be bogus due to garbage data at end");
-    } catch (AEADVerificationFailedException e) {
+    } catch (AEADVerificationFailedException _) {
       // Expected.
     }
   }

--- a/src/test/java/network/crypta/crypt/BlockCiphersTest.java
+++ b/src/test/java/network/crypta/crypt/BlockCiphersTest.java
@@ -126,7 +126,7 @@ class BlockCiphersTest {
       try {
         cipher.processBlock(in, 0, out, 0);
         throw new AssertionError("Expected an exception for too-short input");
-      } catch (ArrayIndexOutOfBoundsException | IllegalArgumentException expected) {
+      } catch (ArrayIndexOutOfBoundsException | IllegalArgumentException _) {
         // acceptable for various JCE providers
       }
     } else {

--- a/src/test/java/network/crypta/crypt/JceLoaderTest.java
+++ b/src/test/java/network/crypta/crypt/JceLoaderTest.java
@@ -183,7 +183,7 @@ class JceLoaderTest {
           ecdhOk = true;
           ecdsaOk = true;
         }
-      } catch (Exception ignored) {
+      } catch (Exception _) {
         // keep flags false
       }
       System.out.println("BC_ECDH_ALG_OK=" + ecdhOk);

--- a/src/test/java/network/crypta/crypt/SSLTest.java
+++ b/src/test/java/network/crypta/crypt/SSLTest.java
@@ -60,7 +60,7 @@ class SSLTest {
     // If already disabled this is a no-op.
     try {
       sslConfig.set(OPT_ENABLE, false);
-    } catch (InvalidConfigValueException | NodeNeedRestartException ignored) {
+    } catch (InvalidConfigValueException | NodeNeedRestartException _) {
       // Ignore: we only need SSL disabled; failures here would surface in assertions anyway.
     }
   }
@@ -70,7 +70,7 @@ class SSLTest {
     // Return SSL to a disabled state so tests are independent.
     try {
       sslConfig.set(OPT_ENABLE, false);
-    } catch (InvalidConfigValueException | NodeNeedRestartException ignored) {
+    } catch (InvalidConfigValueException | NodeNeedRestartException _) {
       // Ignore on cleanup
     }
   }

--- a/src/test/java/network/crypta/io/NetworkInterfaceTest.java
+++ b/src/test/java/network/crypta/io/NetworkInterfaceTest.java
@@ -288,7 +288,7 @@ class NetworkInterfaceTest {
         Socket s = queue.poll(wait, TimeUnit.MILLISECONDS);
         if (s == null) throw new SocketTimeoutException("timeout");
         return s;
-      } catch (InterruptedException ie) {
+      } catch (InterruptedException _) {
         Thread.currentThread().interrupt();
         throw new SocketException("interrupted");
       }

--- a/src/test/java/network/crypta/io/comm/IOStatisticCollectorTest.java
+++ b/src/test/java/network/crypta/io/comm/IOStatisticCollectorTest.java
@@ -146,7 +146,7 @@ class IOStatisticCollectorTest {
                 for (int i = 0; i < incrementsPerThread; i++) {
                   collector.reportSentBytes(remote, bytesPerIncrement);
                 }
-              } catch (InterruptedException e) {
+              } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
               } finally {
                 done.countDown();
@@ -181,7 +181,7 @@ class IOStatisticCollectorTest {
                 for (int i = 0; i < incrementsPerThread; i++) {
                   collector.reportReceivedBytes(remote, bytesPerIncrement);
                 }
-              } catch (InterruptedException e) {
+              } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
               } finally {
                 done.countDown();

--- a/src/test/java/network/crypta/io/comm/MessageTypeTest.java
+++ b/src/test/java/network/crypta/io/comm/MessageTypeTest.java
@@ -23,7 +23,7 @@ class MessageTypeTest {
     for (MessageType mt : toCleanup) {
       try {
         mt.unregister();
-      } catch (Throwable ignored) {
+      } catch (Throwable _) {
         // best-effort cleanup
       }
     }

--- a/src/test/java/network/crypta/io/xfer/BulkTransmitterTest.java
+++ b/src/test/java/network/crypta/io/xfer/BulkTransmitterTest.java
@@ -95,7 +95,7 @@ class BulkTransmitterTest {
     for (int b = 0; b < BLOCKS; b++) {
       try {
         rab.pwrite((long) b * BLOCK_SIZE, pattern, 0, BLOCK_SIZE);
-      } catch (Exception ignored) {
+      } catch (Exception _) {
         // ByteArrayRandomAccessBuffer bounds are correct for our input; no exception expected.
       }
     }

--- a/src/test/java/network/crypta/node/DNSRequesterTest.java
+++ b/src/test/java/network/crypta/node/DNSRequesterTest.java
@@ -82,7 +82,7 @@ class DNSRequesterTest {
                 waiting.countDown();
                 try {
                   requester.wait(5000);
-                } catch (InterruptedException ignored) {
+                } catch (InterruptedException _) {
                   Thread.currentThread().interrupt();
                 }
               }

--- a/src/test/java/network/crypta/node/OpennetPeerNodeTest.java
+++ b/src/test/java/network/crypta/node/OpennetPeerNodeTest.java
@@ -433,7 +433,7 @@ class OpennetPeerNodeTest {
     while (t != null) {
       try {
         return t.getDeclaredField(name);
-      } catch (NoSuchFieldException ignore) {
+      } catch (NoSuchFieldException _) {
         t = t.getSuperclass();
       }
     }

--- a/src/test/java/network/crypta/node/RequestStarterTest.java
+++ b/src/test/java/network/crypta/node/RequestStarterTest.java
@@ -130,7 +130,7 @@ class RequestStarterTest {
                 enteredWait.countDown();
                 try {
                   starter.wait(5000L); // Will be interrupted by notifyAll()
-                } catch (InterruptedException ignored) {
+                } catch (InterruptedException _) {
                   // not expected in this test
                 }
               }

--- a/src/test/java/network/crypta/node/SemiOrderedShutdownHookTest.java
+++ b/src/test/java/network/crypta/node/SemiOrderedShutdownHookTest.java
@@ -102,7 +102,7 @@ class SemiOrderedShutdownHookTest {
               events.add("earlySlow-start");
               try {
                 allowEarlySlowToFinish.await();
-              } catch (InterruptedException ignored) {
+              } catch (InterruptedException _) {
                 // ignored for test: we want deterministic completion ordering
               }
               events.add("earlySlow-done");

--- a/src/test/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnosticsTest.java
+++ b/src/test/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnosticsTest.java
@@ -39,7 +39,7 @@ class DefaultThreadDiagnosticsTest {
     if (bean.isThreadCpuTimeSupported() && !bean.isThreadCpuTimeEnabled()) {
       try {
         bean.setThreadCpuTimeEnabled(true);
-      } catch (UnsupportedOperationException ignored) {
+      } catch (UnsupportedOperationException _) {
         // If the platform forbids enabling, tests still run asserting non-negative deltas where
         // possible.
       }

--- a/src/test/java/network/crypta/node/useralerts/DatastoreTooSmallAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/DatastoreTooSmallAlertTest.java
@@ -65,7 +65,7 @@ class DatastoreTooSmallAlertTest {
     int initVal;
     try {
       initVal = Integer.parseInt(initial);
-    } catch (NumberFormatException e) {
+    } catch (NumberFormatException _) {
       initVal = 0;
     }
     nodeConfig.register(

--- a/src/test/java/network/crypta/node/useralerts/UpdatedVersionAvailableUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/UpdatedVersionAvailableUserAlertTest.java
@@ -204,7 +204,7 @@ class UpdatedVersionAvailableUserAlertTest {
                 p -> {
                   try {
                     Files.deleteIfExists(p);
-                  } catch (IOException ignore) {
+                  } catch (IOException _) {
                     // best-effort cleanup
                   }
                 });

--- a/src/test/java/network/crypta/store/caching/SleepingFreenetStore.java
+++ b/src/test/java/network/crypta/store/caching/SleepingFreenetStore.java
@@ -24,7 +24,7 @@ public class SleepingFreenetStore<T extends StorableBlock> extends ProxyFreenetS
       throws IOException, KeyCollisionException {
     try {
       Thread.sleep(delay);
-    } catch (InterruptedException e) {
+    } catch (InterruptedException _) {
       // Ignore.
     }
     super.put(block, data, header, overwrite, oldBlock);

--- a/src/test/java/network/crypta/support/PooledExecutorTest.java
+++ b/src/test/java/network/crypta/support/PooledExecutorTest.java
@@ -101,14 +101,14 @@ class PooledExecutorTest {
     try {
       exec.execute(badLow, "badLow");
       fail("expected IllegalArgumentException for low priority");
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalArgumentException _) {
       // ok
     }
 
     try {
       exec.execute(badHigh, "badHigh");
       fail("expected IllegalArgumentException for high priority");
-    } catch (IllegalArgumentException expected) {
+    } catch (IllegalArgumentException _) {
       // ok
     }
   }
@@ -300,7 +300,7 @@ class PooledExecutorTest {
     while (!done && System.nanoTime() < deadline) {
       try {
         done = latch.await(5, TimeUnit.MILLISECONDS);
-      } catch (InterruptedException ignored) {
+      } catch (InterruptedException _) {
         // retry until deadline
       }
     }

--- a/src/test/java/network/crypta/support/PrioritizedSerialExecutorTest.java
+++ b/src/test/java/network/crypta/support/PrioritizedSerialExecutorTest.java
@@ -158,7 +158,7 @@ class PrioritizedSerialExecutorTest {
       try {
         onThreadFlags.put(exec.onThread());
         completingJob.put(name);
-      } catch (InterruptedException e) {
+      } catch (InterruptedException _) {
         Thread.currentThread().interrupt();
       }
     }
@@ -201,7 +201,7 @@ class PrioritizedSerialExecutorTest {
         boolean ok = release.await(1, TimeUnit.SECONDS);
         awaitFlags.put(ok);
         completingJob.put(name);
-      } catch (InterruptedException e) {
+      } catch (InterruptedException _) {
         Thread.currentThread().interrupt();
       }
     }
@@ -357,7 +357,7 @@ class PrioritizedSerialExecutorTest {
           try {
             boolean ok = release.await(1, TimeUnit.SECONDS);
             jobAwaited.set(ok);
-          } catch (InterruptedException ie) {
+          } catch (InterruptedException _) {
             // Preserve interrupt status so the test runner can react if needed.
             Thread.currentThread().interrupt();
           }

--- a/src/test/java/network/crypta/support/PrioritizedTickerTest.java
+++ b/src/test/java/network/crypta/support/PrioritizedTickerTest.java
@@ -114,7 +114,7 @@ class PrioritizedTickerTest {
       while (!proceed) {
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           // Ignore.
         }
       }

--- a/src/test/java/network/crypta/support/SerialExecutorTest.java
+++ b/src/test/java/network/crypta/support/SerialExecutorTest.java
@@ -93,7 +93,7 @@ class SerialExecutorTest {
               // Timed out: allow test to proceed; runner will block on next poll
               return;
             }
-          } catch (InterruptedException ignored) {
+          } catch (InterruptedException _) {
             Thread.currentThread().interrupt();
           }
           seq.compareAndSet(0, 1);

--- a/src/test/java/network/crypta/support/TrivialTickerTest.java
+++ b/src/test/java/network/crypta/support/TrivialTickerTest.java
@@ -48,7 +48,7 @@ class TrivialTickerTest {
     if (ticker != null) {
       try {
         ticker.shutdown();
-      } catch (RuntimeException | Error ignored) {
+      } catch (RuntimeException | Error _) {
         // Some tests call shutdown explicitly; ignore repeated shutdown side effects.
       }
     }

--- a/src/test/java/network/crypta/support/WaitableExecutor.java
+++ b/src/test/java/network/crypta/support/WaitableExecutor.java
@@ -51,7 +51,7 @@ public class WaitableExecutor implements PriorityAwareExecutor {
     while (count > 0) {
       try {
         wait();
-      } catch (InterruptedException e) {
+      } catch (InterruptedException _) {
         // Ignore.
       }
     }

--- a/src/test/java/network/crypta/support/io/BarrierRandomAccessBuffer.java
+++ b/src/test/java/network/crypta/support/io/BarrierRandomAccessBuffer.java
@@ -26,7 +26,7 @@ public class BarrierRandomAccessBuffer implements LockableRandomAccessBuffer {
       while (waiting == 0) {
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           // Ignore.
         }
       }
@@ -109,7 +109,7 @@ public class BarrierRandomAccessBuffer implements LockableRandomAccessBuffer {
       while (!proceed) {
         try {
           wait();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
           // Ignore.
         }
       }

--- a/src/test/java/network/crypta/support/io/PrependLengthOutputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/PrependLengthOutputStreamTest.java
@@ -40,7 +40,7 @@ class PrependLengthOutputStreamTest {
       // Safe double-close to assert idempotency across tests
       try {
         underTest.close();
-      } catch (Throwable ignore) {
+      } catch (Throwable _) {
         // Some tests intentionally provoke errors during close; ignore here
       }
     }

--- a/src/test/java/network/crypta/support/io/RAFBucketTest.java
+++ b/src/test/java/network/crypta/support/io/RAFBucketTest.java
@@ -61,7 +61,7 @@ class RAFBucketTest {
           PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
       Path p = Files.createTempDirectory(prefix, attr);
       return p.toFile();
-    } catch (UnsupportedOperationException e) {
+    } catch (UnsupportedOperationException _) {
       // Non-POSIX (e.g., Windows). Create under user.home instead of public tmp.
       File base = new File(System.getProperty("user.home"));
       File dir = new File(base, prefix + System.nanoTime());

--- a/src/test/java/network/crypta/support/io/RAFInputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/RAFInputStreamTest.java
@@ -259,7 +259,7 @@ class RAFInputStreamTest {
           for (int i = 0; i < n; i++) {
             collected.add(buf[i]);
           }
-        } catch (EOFException eof) {
+        } catch (EOFException _) {
           break; // expected at the end
         }
       }

--- a/src/test/java/network/crypta/support/io/TempBucketFactoryTempRandomAccessBufferTest.java
+++ b/src/test/java/network/crypta/support/io/TempBucketFactoryTempRandomAccessBufferTest.java
@@ -80,7 +80,7 @@ class TempBucketFactoryTempRandomAccessBufferTest {
       for (File f : files) {
         try {
           Files.deleteIfExists(f.toPath());
-        } catch (IOException ignore) {
+        } catch (IOException _) {
           // ignore: best-effort cleanup in tests
         }
       }

--- a/src/test/java/network/crypta/support/math/TrivialRunningAverageTest.java
+++ b/src/test/java/network/crypta/support/math/TrivialRunningAverageTest.java
@@ -258,7 +258,7 @@ class TrivialRunningAverageTest {
                 for (int i = 1; i <= itemsPerThread; i++) {
                   avg.report(base + i);
                 }
-              } catch (InterruptedException e) {
+              } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
                 fail("Interrupted during test execution");
               } finally {

--- a/src/test/java/network/crypta/test/PngUtil.java
+++ b/src/test/java/network/crypta/test/PngUtil.java
@@ -80,7 +80,7 @@ public class PngUtil {
           dataInputStream.readFully(data);
           int crc = dataInputStream.readInt();
           chunks.add(new Chunk(new String(type, StandardCharsets.UTF_8), data, crc));
-        } catch (EOFException e) {
+        } catch (EOFException _) {
           break;
         }
       }


### PR DESCRIPTION
## Summary
- replace ignored exception variable names with `_` across tests to make unused parameters explicit

## Testing
- not run (spotlessApply only)