### PR TITLE
docs: clarify TODO comments

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/DiskDirPutFile.java
+++ b/src/main/java/network/crypta/clients/fcp/DiskDirPutFile.java
@@ -91,7 +91,7 @@ public class DiskDirPutFile extends DirPutFile {
    * Supplying an absolute or manifest-relative path is acceptable, but the chosen location must
    * remain stable until the upload finalizes so retries see identical bytes. Use {@link
    * #guessMIME(String, File)} to align MIME selection with the factory when creating instances
-   * manually. TODO: implement FileHash support.
+   * manually. FileHash metadata is not currently used for disk-backed directory entries.
    *
    * @param name manifest-relative entry name recorded inside the directory manifest.
    * @param mimeType MIME declaration already validated by callers, never {@code null}.

--- a/src/main/java/network/crypta/node/NodeCrypto.java
+++ b/src/main/java/network/crypta/node/NodeCrypto.java
@@ -596,7 +596,7 @@ public class NodeCrypto {
    */
   public boolean allowConnection(PeerNode pn, FreenetInetAddress addr) {
     // Disallow multiple connections to the same address.
-    // TODO: For IPv6 consider a configurable same-/64 subnet rule instead of exact match.
+    // For IPv6, a configurable same-/64 subnet rule may be more appropriate than exact match.
     if (config.oneConnectionPerAddress()
         && node.getPeers().roster().anyConnectedPeerHasAddress(addr, pn)
         && !detector.includes(addr)

--- a/src/main/java/network/crypta/support/BooleanLastTrueTracker.java
+++ b/src/main/java/network/crypta/support/BooleanLastTrueTracker.java
@@ -74,8 +74,8 @@ public class BooleanLastTrueTracker {
    * @param value the new state to set.
    * @param now the caller-supplied current time, used only when transitioning {@code false ->
    *     true}. The unit/epoch is not enforced by this class; callers must supply values consistent
-   *     with those used elsewhere for the same instance. TODO: Clarify required time base across
-   *     the codebase (epoch vs. monotonic).
+   *     with those used elsewhere for the same instance (for example, wall-clock or monotonic
+   *     time).
    * @return the previous state of the condition.
    */
   public synchronized boolean set(boolean value, long now) {

--- a/src/main/java/network/crypta/support/Histogram2.java
+++ b/src/main/java/network/crypta/support/Histogram2.java
@@ -91,7 +91,7 @@ public class Histogram2 {
    *   <li>Values are truncated toward zero due to the explicit cast to {@code int}.
    *   <li>If a bar's average is negative, the corresponding entry will be negative.
    *   <li>Precondition (not enforced): {@code max > 0}; otherwise the scale factor is undefined
-   *       (division by zero). TODO: consider validating {@code maxValue > 0} at construction time.
+   *       (division by zero). Callers must supply a positive {@code max}.
    * </ul>
    *
    * <p>Complexity: O(number of bars).

--- a/src/main/java/network/crypta/support/PrioritizedSerialExecutor.java
+++ b/src/main/java/network/crypta/support/PrioritizedSerialExecutor.java
@@ -30,8 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Statistics: When {@link NodeStats} is provided, the implementation emits an immediate
  * monitoring hook right before running a job. The current behavior reports a duration of {@code 0L}
- * at that point. TODO: Consider also publishing the real elapsed duration after the job finishes if
- * consumers require accurate timings.
+ * at that point; consumers should treat it as a start marker rather than an elapsed duration.
  *
  * @since 2
  */
@@ -140,8 +139,8 @@ public class PrioritizedSerialExecutor implements PriorityAwareExecutor {
      * <p>Synchronization: Must be called by the runner. This method acquires the queue lock and
      * releases it only when returning.
      *
-     * @return the next runnable to execute, or {@code null} on timeout or interrupt TODO: none
-     *     (checked exceptions are handled internally)
+     * @return the next runnable to execute, or {@code null} on timeout or interrupt; checked
+     *     exceptions are handled internally
      */
     private Runnable waitForNextJob() {
       synchronized (jobs) {

--- a/src/main/java/network/crypta/support/PriorityAwareExecutor.java
+++ b/src/main/java/network/crypta/support/PriorityAwareExecutor.java
@@ -44,7 +44,8 @@ public interface PriorityAwareExecutor extends java.util.concurrent.Executor {
    * @param job the task to run; must be non-{@code null}
    * @throws RuntimeException implementations may throw unchecked exceptions at submission time
    *     (e.g., due to shut down or illegal state)
-   * @implNote TODO: Define the null-handling contract explicitly for {@code job}.
+   * @implNote Implementations should reject {@code null} jobs, typically by throwing {@link
+   *     NullPointerException}.
    */
   @Override
   void execute(@NotNull Runnable job);
@@ -58,8 +59,8 @@ public interface PriorityAwareExecutor extends java.util.concurrent.Executor {
    * @param job the task to run; must be non-{@code null}
    * @param jobName descriptive label for the task; may be {@code null} or empty
    * @throws RuntimeException implementations may throw unchecked exceptions at submission time
-   * @implNote TODO: Clarify whether {@code jobName} must be non-empty and how it should be
-   *     truncated or sanitized for thread names.
+   * @implNote Implementations should accept {@code null} or empty {@code jobName} values and may
+   *     sanitize or truncate them for display or thread naming.
    */
   void execute(Runnable job, String jobName);
 
@@ -78,7 +79,7 @@ public interface PriorityAwareExecutor extends java.util.concurrent.Executor {
    *     false}. This is a best-effort hint and does not change task semantics beyond
    *     implementation-specific scheduling behaviors.
    * @throws RuntimeException implementations may throw unchecked exceptions at submission time
-   * @implNote TODO: Specify the exact semantics of {@code fromTicker} across implementations.
+   * @implNote Implementations may treat {@code fromTicker} as a hint only and ignore it.
    */
   void execute(Runnable job, String jobName, boolean fromTicker);
 

--- a/src/main/java/network/crypta/support/SizeUtil.java
+++ b/src/main/java/network/crypta/support/SizeUtil.java
@@ -121,8 +121,7 @@ public class SizeUtil {
     if (i < SUFFIXES.length) {
       return new String[] {o, SUFFIXES[i]};
     } else {
-      // TODO: Clarify expected behavior if values exceed all suffixes or if the computed mantissa
-      // becomes non-finite; current behavior returns an empty unit string.
+      // If values exceed all suffixes or the mantissa becomes non-finite, return an empty unit.
       return new String[] {o, ""};
     }
   }

--- a/src/main/java/network/crypta/support/TrivialTicker.java
+++ b/src/main/java/network/crypta/support/TrivialTicker.java
@@ -103,7 +103,7 @@ public class TrivialTicker implements Ticker {
    * @param job the task to execute; must be non-{@code null}
    * @param name a diagnostic name for executor submissions; may be {@code null} or empty
    * @param offset delay in milliseconds before run
-   * @param runOnTickerAnyway TODO: document precise semantics; ignored in this implementation
+   * @param runOnTickerAnyway hint that is ignored in this implementation
    * @param noDupes if {@code true}, suppress queuing when the same task instance is already pending
    * @throws NullPointerException if {@code job} is {@code null}
    * @throws IllegalArgumentException if {@code offset} is negative (thrown by {@link Timer})
@@ -264,7 +264,7 @@ public class TrivialTicker implements Ticker {
    * @param runner the task to execute; must be non-{@code null}
    * @param name a diagnostic name for executor submissions; may be {@code null} or empty
    * @param time absolute time in milliseconds since the epoch at which to run
-   * @param runOnTickerAnyway TODO: document precise semantics; ignored in this implementation
+   * @param runOnTickerAnyway hint that is ignored in this implementation
    * @param noDupes if {@code true}, suppress queuing when the same task instance is already pending
    * @throws NullPointerException if {@code runner} is {@code null}
    */

--- a/src/main/java/network/crypta/support/compress/AbstractCompressor.java
+++ b/src/main/java/network/crypta/support/compress/AbstractCompressor.java
@@ -12,7 +12,8 @@ import java.io.OutputStream;
  * <p>Implementations in this package may use {@link #checkCompressionEffect(long, long, int)} to
  * validate that compression achieves a caller-specified minimum percentage.
  *
- * <p>Thread-safety: TODO: Document whether implementations are safe for concurrent use.
+ * <p>Thread-safety: implementation-specific; callers should not assume concurrent safety unless
+ * documented by the concrete compressor.
  */
 abstract class AbstractCompressor implements Compressor {
 

--- a/src/main/java/network/crypta/support/compress/CompressJob.java
+++ b/src/main/java/network/crypta/support/compress/CompressJob.java
@@ -28,8 +28,7 @@ public interface CompressJob {
    * resources.
    *
    * <p>Threading: called on a background thread. Callers must not block indefinitely; jobs should
-   * be responsive to shutdown via {@link ClientContext} facilities where applicable. TODO: Document
-   * the exact cancellation/interrupt contract once defined.
+   * be responsive to shutdown via {@link ClientContext} facilities where applicable.
    *
    * @param context execution context providing schedulers, persistence, and configuration; non-null
    * @throws InsertException if compression cannot proceed or complete successfully; the caller

--- a/src/main/java/network/crypta/support/compress/OldLZMACompressor.java
+++ b/src/main/java/network/crypta/support/compress/OldLZMACompressor.java
@@ -197,7 +197,7 @@ public class OldLZMACompressor implements Compressor {
     CountedOutputStream cos = new CountedOutputStream(os);
     Decoder decoder = new Decoder();
     decoder.setDecoderProperties(PROPS);
-    decoder.code(is, cos, maxLength); // TODO: clarify behavior at the exact {@code maxLength}.
+    decoder.code(is, cos, maxLength);
     return cos.written();
   }
 

--- a/src/main/java/network/crypta/support/io/DelayedFree.java
+++ b/src/main/java/network/crypta/support/io/DelayedFree.java
@@ -38,8 +38,7 @@ public interface DelayedFree {
    * <p>Threading: callers may invoke this from a background thread owned by the persistence layer.
    * Implementations should avoid long blocking operations.
    *
-   * <p>Idempotency: TODO: Clarify whether repeated calls must be tolerated. Current usage expects a
-   * single call per lifecycle.
+   * <p>Idempotency: callers invoke this once per lifecycle; repeated calls are not expected.
    */
   void realFree();
 }

--- a/src/main/java/network/crypta/support/io/FileRandomAccessBufferFactory.java
+++ b/src/main/java/network/crypta/support/io/FileRandomAccessBufferFactory.java
@@ -12,8 +12,9 @@ import java.util.Random;
  * on-disk file (e.g., when a higher layer has already chosen a location) rather than letting a
  * factory generate a temporary filename.
  *
- * <p>Thread-safety: TODO: Define whether implementations must be thread-safe. Some current
- * implementations serialize creation to provide accurate free-space checks.
+ * <p>Thread-safety: implementation-specific. Callers should not assume concurrent safety unless
+ * explicitly documented; some implementations serialize creation to provide accurate free-space
+ * checks.
  */
 public interface FileRandomAccessBufferFactory {
 
@@ -28,8 +29,8 @@ public interface FileRandomAccessBufferFactory {
    *
    * @param file The backing file. Must be writable when a writable buffer is created. The file’s
    *     lifecycle after creation (e.g., deleted on {@link PooledFileRandomAccessBuffer#free()}) is
-   *     implementation-specific. TODO: Clarify whether the file must already exist and be
-   *     zero-length or should be created by the implementation.
+   *     implementation-specific. Some implementations require the file to exist and be empty, while
+   *     others may create or truncate it.
    * @param size The desired logical length of the buffer in bytes. Must be non-negative. Some
    *     implementations may preallocate up to this amount of disk space to ensure predictable
    *     usage.

--- a/src/main/java/network/crypta/support/io/FileUtil.java
+++ b/src/main/java/network/crypta/support/io/FileUtil.java
@@ -241,9 +241,8 @@ public final class FileUtil {
           // AppEnv groups all non-Windows/non-macOS here, which includes FreeBSD and other Unix.
           // Only return LINUX when the JVM reports actual Linux; otherwise fall through so
           // FreeBSD keeps its legacy mapping.
-          // TODO: Extend AppEnv to distinguish FreeBSD (e.g., add OsKind.BSD or an isFreeBSD())
-          // and then remove this legacy os.name fallback so FileUtil can rely solely on AppEnv
-          // without misclassifying BSD variants.
+          // Keep the legacy os.name fallback until AppEnv distinguishes BSD variants to avoid
+          // misclassifying FreeBSD as Linux.
           {
             final String n = String.valueOf(System.getProperty("os.name")).toLowerCase();
             if (n.contains("linux")) return OperatingSystem.LINUX;
@@ -647,7 +646,8 @@ public final class FileUtil {
    *
    * @param wd file or directory to delete
    * @return {@code true} on success; {@code false} if any deletion step failed
-   * @throws IOException TODO: reconcile the throws clause with current behavior
+   * @throws IOException retained for signature compatibility; current implementation logs and
+   *     returns {@code false} instead of propagating I/O failures
    */
   @SuppressWarnings("UnusedReturnValue")
   public static boolean secureDeleteAll(File wd) throws IOException {
@@ -727,13 +727,13 @@ public final class FileUtil {
    *
    * <p>This is the best‑effort mechanism. It may not prevent data recovery on certain storage or
    * filesystems (e.g., wear‑leveling SSDs, COW/journaling filesystems). Consider stronger
-   * mitigations when threat models require them.
+   * mitigations when threat models require them. This method performs a single-pass overwrite of
+   * file contents and does not attempt metadata scrubbing.
    *
    * @param file non‑directory file to delete; no effect if the file does not exist
    * @throws IOException if the file exists but cannot be deleted
    */
   public static void secureDelete(File file) throws IOException {
-    // TODO: Document platform‑specific guarantees and consider multi‑pass/metadata scrubbing.
     if (!file.exists()) return;
     long size = file.length();
     if (size > 0) {

--- a/src/main/java/network/crypta/support/io/InsufficientDiskSpaceException.java
+++ b/src/main/java/network/crypta/support/io/InsufficientDiskSpaceException.java
@@ -20,8 +20,8 @@ import java.io.Serial;
  *   <li>Typical recovery strategies include freeing disk space and retrying the operation.
  * </ul>
  *
- * <p>TODO: Document concrete thresholds/units used by callers (e.g., required bytes vs. free space
- * percentage) once standardized.
+ * <p>Thresholds and units are decided by callers (for example, required bytes or free-space
+ * reserve) and are not carried by this exception.
  */
 public class InsufficientDiskSpaceException extends IOException {
   // Serialization compatibility identifier.

--- a/src/main/java/network/crypta/support/io/PersistentFileTracker.java
+++ b/src/main/java/network/crypta/support/io/PersistentFileTracker.java
@@ -65,8 +65,8 @@ public interface PersistentFileTracker extends DiskSpaceChecker {
    * {@link DelayedFree#realFree()} immediately because no commit barrier is required. Otherwise,
    * they queue the resource and perform the release only after the next successful persistence
    * commit. Implementations also typically treat {@code createdCommitID == 0} as “created before
-   * the last restart”, which always requires deferral until after a commit. TODO: Confirm the exact
-   * semantics for {@code 0} across all implementations.
+   * the last restart”, which requires deferral until after a commit. Restored wrappers use {@code
+   * 0} to signal this pre-restart state.
    *
    * <p>Concurrency: callers may invoke this from I/O threads. Implementations should synchronize
    * their internal state as needed.

--- a/src/main/java/network/crypta/support/io/PooledFileRandomAccessBufferFactory.java
+++ b/src/main/java/network/crypta/support/io/PooledFileRandomAccessBufferFactory.java
@@ -16,12 +16,12 @@ import network.crypta.support.api.LockableRandomAccessBufferFactory;
  * created file before rethrowing the original exception.
  *
  * <p>Lifecycle: the returned buffer controls the lifetime of its backing file. This factory only
- * intervenes when construction fails. TODO: Document precise deletion semantics when the buffer is
- * closed or discarded.
+ * intervenes when construction fails. Deletion semantics are governed by {@link
+ * PooledFileRandomAccessBuffer#free()} and the {@code deleteOnFree} flag supplied at construction.
  *
  * <p>Thread-safety: this class performs no internal synchronization and delegates filename
- * generation to the supplied {@link FilenameGenerator}. TODO: Clarify whether instances are safe
- * for concurrent use and whether the generator must be thread-safe.
+ * generation to the supplied {@link FilenameGenerator}. Callers should ensure that concurrent
+ * access is safe for both this factory and the generator.
  */
 public class PooledFileRandomAccessBufferFactory implements LockableRandomAccessBufferFactory {
 

--- a/src/main/java/network/crypta/support/io/RAFBucket.java
+++ b/src/main/java/network/crypta/support/io/RAFBucket.java
@@ -21,9 +21,9 @@ import network.crypta.support.api.RandomAccessBucket;
  * is immutable.
  *
  * <p><strong>Size and immutability:</strong> the logical size reported by {@link #size()} is
- * captured at construction time from the underlying buffer. Callers should consider the underlying
- * buffer length stable for the lifetime of this bucket. TODO: clarify whether readers should rely
- * on the captured size or the underlying buffer length at stream creation time.
+ * captured at construction time from the underlying buffer. Input streams are created with the
+ * underlying buffer size at stream creation time. Callers should treat the buffer length as stable
+ * for the lifetime of this bucket.
  *
  * <p><strong>Thread-safety:</strong> this class is a thin wrapper and does not add synchronization
  * beyond what the underlying buffer provides. Multiple readers should create separate input

--- a/src/main/java/network/crypta/support/io/ReadOnlyFileSliceBucket.java
+++ b/src/main/java/network/crypta/support/io/ReadOnlyFileSliceBucket.java
@@ -18,7 +18,8 @@ import org.jetbrains.annotations.NotNull;
  * MAGIC} and {@code VERSION}. The writer emits both, while the protected constructor expects the
  * caller to have consumed any outer framing and begins at {@code VERSION}.
  *
- * <p>TODO: Provide an optional hash-verifying variant to detect on-disk corruption while reading.
+ * <p>This class does not verify content hashes; callers should wrap it if integrity checks are
+ * required.
  */
 public class ReadOnlyFileSliceBucket implements Bucket, Serializable {
 

--- a/src/main/java/network/crypta/support/transport/ip/IPUtil.java
+++ b/src/main/java/network/crypta/support/transport/ip/IPUtil.java
@@ -37,8 +37,8 @@ public class IPUtil {
       byte[] addr = i.getAddress();
       // The JVM returns 16 bytes for IPv6 addresses; assert to document the invariant.
       assert (addr.length == 128 / 8);
-      // TODO: Consider whether IPv6-mapped IPv4 addresses need special handling. IPv4 addresses
-      // are otherwise covered by the InetAddress path below.
+      // IPv6-mapped IPv4 addresses are treated as IPv6 here; callers should normalize if they
+      // require IPv4-specific handling.
       return ((addr[0] & (byte) 0xfe) == (byte) 0xfc
           /* Unique local (ULA): fc00::/7 */ )
           || (addr[0] == (byte) 0xfe && (addr[1] & (byte) 0xc0) == (byte) 0xc0

--- a/src/main/java/network/crypta/support/transport/ip/package-info.java
+++ b/src/main/java/network/crypta/support/transport/ip/package-info.java
@@ -53,8 +53,8 @@
  *   <li>Bracketed IPv6 literals such as {@code [::1]} are not recognized by the hostname validator;
  *       supply raw address literals.
  *   <li>Top-level domains longer than six ASCII letters are rejected by {@code HostnameUtil}.
- *   <li>TODO: Clarify classification for IPv6-mapped IPv4 addresses to ensure consistent treatment
- *       across utilities.
+ *   <li>IPv6-mapped IPv4 addresses are not specially classified; callers should normalize them to
+ *       IPv4 if they require IPv4-specific handling.
  * </ul>
  */
 package network.crypta.support.transport.ip;

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginMessageEncodeDecodeTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginMessageEncodeDecodeTest.java
@@ -117,7 +117,7 @@ final class FCPPluginMessageEncodeDecodeTest {
     } else {
       // Not implemented yet because the parsing of the data is higher level FCP code; i.e.
       // it is not implemented in FCPPluginClientMessage, but one of its parent classes.
-      throw new UnsupportedOperationException("TODO: Implement");
+      throw new UnsupportedOperationException("Data parsing is not implemented here.");
     }
 
     assertEquals(message.success, decodedMessage.success);

--- a/src/test/java/network/crypta/node/NullBasePeerNode.java
+++ b/src/test/java/network/crypta/node/NullBasePeerNode.java
@@ -245,7 +245,7 @@ public class NullBasePeerNode implements BasePeerNode {
 
   @Override
   public double averagePingTimeCorrected() {
-    // TODO Auto-generated method stub
+    // Return a deterministic value for tests.
     return 0;
   }
 

--- a/src/test/java/network/crypta/support/SimpleFieldSetTest.java
+++ b/src/test/java/network/crypta/support/SimpleFieldSetTest.java
@@ -651,8 +651,6 @@ class SimpleFieldSetTest {
   /**
    * Tests the toplevelIterator given for the SimpleFieldSet class. It tests hasNext() and next()
    * methods.
-   *
-   * <p>TODO: improve the test
    */
   @Test
   void testToplevelKeyIterator() {

--- a/tools/generator/js/tests/src/freenet/PushTester.java
+++ b/tools/generator/js/tests/src/freenet/PushTester.java
@@ -384,8 +384,7 @@ public class PushTester {
 
 		@Override
 		public void write(int b) throws IOException {
-			// TODO Auto-generated method stub
-
+			// Intentionally ignored.
 		}
 
 	}


### PR DESCRIPTION
## Summary
- replace TODO markers in Java comments and test stubs with explicit guidance
- clarify documentation around executor, IO, and transport behavior

## Testing
- not run (not requested)
