### PR TITLE
fix(fcp): avoid Identifier field clash

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
@@ -41,7 +41,7 @@ public class ModifyPeerNote extends FCPMessage {
   static final String NAME = "ModifyPeerNote";
 
   final SimpleFieldSet fs;
-  final String identifier;
+  final String requestIdentifier;
 
   /**
    * Creates a new {@code ModifyPeerNote} message wrapper from an incoming field set.
@@ -57,7 +57,7 @@ public class ModifyPeerNote extends FCPMessage {
    */
   public ModifyPeerNote(SimpleFieldSet fs) {
     this.fs = fs;
-    identifier = fs.get("Identifier");
+    requestIdentifier = fs.get("Identifier");
     fs.removeValue("Identifier");
   }
 
@@ -119,7 +119,7 @@ public class ModifyPeerNote extends FCPMessage {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,
           "ModifyPeerNote requires full access",
-          identifier,
+          requestIdentifier,
           false);
     }
     String nodeIdentifier = fs.get("NodeIdentifier");
@@ -127,12 +127,12 @@ public class ModifyPeerNote extends FCPMessage {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "Error: NodeIdentifier field missing",
-          identifier,
+          requestIdentifier,
           false);
     }
     PeerNode pn = node.getPeerNode(nodeIdentifier);
     if (pn == null) {
-      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
+      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
       handler.send(msg);
       return;
     }
@@ -140,7 +140,7 @@ public class ModifyPeerNote extends FCPMessage {
       throw new MessageInvalidException(
           ProtocolErrorMessage.DARKNET_ONLY,
           "ModifyPeerNote only available for darknet peers",
-          identifier,
+          requestIdentifier,
           false);
     }
     int peerNoteType;
@@ -150,13 +150,16 @@ public class ModifyPeerNote extends FCPMessage {
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_FIELD,
           "Error parsing PeerNoteType field: " + e.getMessage(),
-          identifier,
+          requestIdentifier,
           false);
     }
     String encodedNoteText = fs.get("NoteText");
     if (encodedNoteText == null) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "Error: NoteText field missing", identifier, false);
+          ProtocolErrorMessage.MISSING_FIELD,
+          "Error: NoteText field missing",
+          requestIdentifier,
+          false);
     }
     String noteText;
     // **FIXME** this should be generalized for multiple peer notes per peer, after PeerNode is
@@ -172,10 +175,10 @@ public class ModifyPeerNote extends FCPMessage {
     if (peerNoteType == Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT) {
       dpn.setPrivateDarknetCommentNote(noteText);
     } else {
-      FCPMessage msg = new UnknownPeerNoteTypeMessage(peerNoteType, identifier);
+      FCPMessage msg = new UnknownPeerNoteTypeMessage(peerNoteType, requestIdentifier);
       handler.send(msg);
       return;
     }
-    handler.send(new PeerNote(nodeIdentifier, noteText, peerNoteType, identifier));
+    handler.send(new PeerNote(nodeIdentifier, noteText, peerNoteType, requestIdentifier));
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
@@ -42,7 +42,7 @@ public class ModifyPersistentRequest extends FCPMessage {
 
   static final String NAME = "ModifyPersistentRequest";
 
-  final String identifier;
+  final String requestIdentifier;
   final boolean global;
   // negative means don't change
   final short priorityClass;
@@ -50,9 +50,9 @@ public class ModifyPersistentRequest extends FCPMessage {
 
   ModifyPersistentRequest(SimpleFieldSet fs) throws MessageInvalidException {
     this.global = fs.getBoolean("Global", false);
-    this.identifier = fs.get("Identifier");
+    this.requestIdentifier = fs.get("Identifier");
     this.clientToken = fs.get("ClientToken");
-    if (identifier == null)
+    if (requestIdentifier == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "Missing field: Identifier", null, global);
     String prio = fs.get("PriorityClass");
@@ -68,13 +68,13 @@ public class ModifyPersistentRequest extends FCPMessage {
                   + RequestStarter.PAUSED_PRIORITY_CLASS
                   + " to "
                   + RequestStarter.MAXIMUM_PRIORITY_CLASS,
-              identifier,
+              requestIdentifier,
               global);
       } catch (NumberFormatException e) {
         throw new MessageInvalidException(
             ProtocolErrorMessage.ERROR_PARSING_NUMBER,
             "Could not parse PriorityClass: " + e.getMessage(),
-            identifier,
+            requestIdentifier,
             global);
       }
     } else priorityClass = -1;
@@ -101,7 +101,7 @@ public class ModifyPersistentRequest extends FCPMessage {
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", requestIdentifier);
     fs.put("Global", global);
     fs.put("PriorityClass", priorityClass);
     if (clientToken != null) fs.putSingle("ClientToken", clientToken);
@@ -154,7 +154,7 @@ public class ModifyPersistentRequest extends FCPMessage {
   @Override
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
 
-    ClientRequest req = handler.getRebootRequest(global, handler, identifier);
+    ClientRequest req = handler.getRebootRequest(global, handler, requestIdentifier);
     if (req == null) {
       try {
         node.getClientCore()
@@ -163,7 +163,8 @@ public class ModifyPersistentRequest extends FCPMessage {
             .queue(
                 (PersistentJob)
                     context -> {
-                      ClientRequest req1 = handler.getForeverRequest(global, handler, identifier);
+                      ClientRequest req1 =
+                          handler.getForeverRequest(global, handler, requestIdentifier);
                       if (req1 == null) {
                         LOG.error("Huh ? the request is null!");
                         ProtocolErrorMessage msg =
@@ -171,7 +172,7 @@ public class ModifyPersistentRequest extends FCPMessage {
                                 ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
                                 false,
                                 null,
-                                identifier,
+                                requestIdentifier,
                                 global);
                         handler.send(msg);
                         return false;
@@ -184,7 +185,7 @@ public class ModifyPersistentRequest extends FCPMessage {
       } catch (PersistenceDisabledException _) {
         ProtocolErrorMessage msg =
             new ProtocolErrorMessage(
-                ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, identifier, global);
+                ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, requestIdentifier, global);
         handler.send(msg);
       }
     } else {

--- a/src/main/java/network/crypta/clients/fcp/PutFetchableMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PutFetchableMessage.java
@@ -28,12 +28,12 @@ import network.crypta.support.SimpleFieldSet;
 public class PutFetchableMessage extends FCPMessage {
 
   PutFetchableMessage(String ident, boolean global, FreenetURI uri) {
-    this.identifier = ident;
+    this.requestIdentifier = ident;
     this.global = global;
     this.uri = uri;
   }
 
-  final String identifier;
+  final String requestIdentifier;
   final boolean global;
   final FreenetURI uri;
 
@@ -53,7 +53,7 @@ public class PutFetchableMessage extends FCPMessage {
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", requestIdentifier);
     fs.put("Global", global);
     if (uri != null) fs.putSingle("URI", uri.toString(false, false));
     return fs;
@@ -93,7 +93,7 @@ public class PutFetchableMessage extends FCPMessage {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PutFetchable goes from server to client not the other way around",
-        identifier,
+        requestIdentifier,
         global);
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKUpdate.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKUpdate.java
@@ -27,7 +27,7 @@ import network.crypta.support.SimpleFieldSet;
  */
 public class SubscribedUSKUpdate extends FCPMessage {
 
-  final String identifier;
+  final String requestIdentifier;
   final long edition;
   final USK key;
   final boolean newKnownGood;
@@ -53,7 +53,7 @@ public class SubscribedUSKUpdate extends FCPMessage {
    */
   public SubscribedUSKUpdate(
       String identifier, long l, USK key, boolean newKnownGood, boolean newSlotToo) {
-    this.identifier = identifier;
+    this.requestIdentifier = identifier;
     this.edition = l;
     this.key = key;
     this.newKnownGood = newKnownGood;
@@ -74,7 +74,7 @@ public class SubscribedUSKUpdate extends FCPMessage {
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", requestIdentifier);
     fs.put("Edition", edition);
     fs.putSingle("URI", key.getURI().toString());
     fs.put("NewKnownGood", newKnownGood);
@@ -113,7 +113,7 @@ public class SubscribedUSKUpdate extends FCPMessage {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "SubscribedUSKUpdate goes from server to client not the other way around",
-        identifier,
+        requestIdentifier,
         false);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
@@ -115,7 +115,7 @@ class ModifyPersistentRequestTest {
 
     ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
 
-    assertEquals("req-3", message.identifier);
+    assertEquals("req-3", message.requestIdentifier);
     assertTrue(message.global);
     assertEquals(-1, message.priorityClass);
     assertNull(message.clientToken);

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
@@ -111,7 +111,7 @@ class SubscribeUSKTest {
     verify(handler).send(captor.capture());
 
     SubscribedUSKUpdate update = captor.getValue();
-    assertEquals("id-open", update.identifier);
+    assertEquals("id-open", update.requestIdentifier);
     assertEquals(12L, update.edition);
     assertSame(message.key, update.key);
     assertTrue(update.newKnownGood);


### PR DESCRIPTION
## Summary
- rename FCP message identifier fields to `requestIdentifier` to avoid confusing clashes with `FCPMessage.IDENTIFIER`
- update related tests to assert the renamed field

## Testing
- ./gradlew test