### PR TITLE
Refactor PeerContext weak references

### DIFF
--- a/src/main/java/network/crypta/io/comm/Message.java
+++ b/src/main/java/network/crypta/io/comm/Message.java
@@ -42,7 +42,7 @@ public class Message {
       "$Id: Message.java,v 1.11 2005/09/15 18:16:04 amphibian Exp $";
 
   private final MessageType spec;
-  private final WeakReference<? extends PeerContext> sourceRef;
+  private final WeakReference<PeerContext> sourceRef;
   private final boolean internal;
   private final HashMap<String, Object> payload = HashMap.newHashMap(8);
   private List<Message> subMessages;

--- a/src/main/java/network/crypta/io/comm/PeerContext.java
+++ b/src/main/java/network/crypta/io/comm/PeerContext.java
@@ -112,7 +112,7 @@ public interface PeerContext {
    * <p>Implementations are encouraged to reuse a single weak reference per instance to avoid
    * allocation overhead.
    */
-  WeakReference<? extends PeerContext> getWeakRef();
+  WeakReference<PeerContext> getWeakRef();
 
   /** Returns a compact, log-friendly description of this peer. */
   String shortToString();

--- a/src/main/java/network/crypta/node/FailureTableEntry.java
+++ b/src/main/java/network/crypta/node/FailureTableEntry.java
@@ -6,6 +6,7 @@ import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.Key;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,7 @@ class FailureTableEntry implements TimedOutNodesList {
   long sentTime;
 
   /** Weak references to peers that have requested this key. */
-  WeakReference<? extends PeerNodeUnlocked>[] requestorNodes;
+  WeakReference<PeerContext>[] requestorNodes;
 
   /** Request times for {@link #requestorNodes} (ms since epoch). */
   long[] requestorTimes;
@@ -63,7 +64,7 @@ class FailureTableEntry implements TimedOutNodesList {
 
   // Membership does not imply DNF/RecentlyFailed; it includes all peers we routed to for this key.
   /** Weak references to peers we routed a request to. */
-  WeakReference<? extends PeerNodeUnlocked>[] requestedNodes;
+  WeakReference<PeerContext>[] requestedNodes;
 
   /**
    * Peer locations when the request was sent. Retained for potential routing heuristics (e.g.,
@@ -98,14 +99,19 @@ class FailureTableEntry implements TimedOutNodesList {
   public static final short[] EMPTY_SHORT_ARRAY = new short[0];
   public static final double[] EMPTY_DOUBLE_ARRAY = new double[0];
 
-  protected static final WeakReference<? extends PeerNodeUnlocked>[] EMPTY_WEAK_REFERENCE =
-      weakArrayOfSize(0);
+  protected static final WeakReference<PeerContext>[] EMPTY_WEAK_REFERENCE = weakArrayOfSize(0);
 
   @SuppressWarnings("unchecked")
-  private static WeakReference<? extends PeerNodeUnlocked>[] weakArrayOfSize(int size) {
-    // Arrays store WeakReference<PeerNodeUnlocked> (or subclasses). This localized cast centralizes
-    // the unchecked conversion and is safe because all assignments respect the element type.
-    return (WeakReference<? extends PeerNodeUnlocked>[]) new WeakReference<?>[size];
+  private static WeakReference<PeerContext>[] weakArrayOfSize(int size) {
+    // Arrays store WeakReference<PeerContext> that should point to PeerNodeUnlocked instances.
+    // This localized cast centralizes the unchecked conversion and is safe for our assignments.
+    return (WeakReference<PeerContext>[]) new WeakReference<?>[size];
+  }
+
+  private static PeerNodeUnlocked asPeerNodeUnlocked(WeakReference<PeerContext> ref) {
+    if (ref == null) return null;
+    PeerContext ctx = ref.get();
+    return (ctx instanceof PeerNodeUnlocked) ? (PeerNodeUnlocked) ctx : null;
   }
 
   FailureTableEntry(Key key) {
@@ -199,7 +205,7 @@ class FailureTableEntry implements TimedOutNodesList {
       int notIncluded,
       int nulls,
       int existingIndex) {
-    WeakReference<? extends PeerNodeUnlocked>[] newRequestorNodes =
+    WeakReference<PeerContext>[] newRequestorNodes =
         weakArrayOfSize(requestorNodes.length + notIncluded - nulls);
     long[] newRequestorTimes = new long[requestorNodes.length + notIncluded - nulls];
     long[] newRequestorBootIDs = new long[requestorNodes.length + notIncluded - nulls];
@@ -208,8 +214,8 @@ class FailureTableEntry implements TimedOutNodesList {
     int toIndex = 0;
     int ret = existingIndex;
     for (int i = 0; i < requestorNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      PeerNodeUnlocked pn = ref == null ? null : ref.get();
+      WeakReference<PeerContext> ref = requestorNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       if (pn != null) {
         if (pn == requestor) ret = toIndex;
         newRequestorNodes[toIndex] = requestorNodes[i];
@@ -247,7 +253,8 @@ class FailureTableEntry implements TimedOutNodesList {
       PeerNodeUnlocked requestor, long now, short origHTL, boolean includedAlready, int nulls) {
     if (nulls == 1 && !includedAlready) {
       for (int i = 0; i < requestorNodes.length; i++) {
-        if (requestorNodes[i] == null || requestorNodes[i].get() == null) {
+        PeerNodeUnlocked existing = asPeerNodeUnlocked(requestorNodes[i]);
+        if (existing == null) {
           requestorNodes[i] = requestor.getWeakRef();
           requestorTimes[i] = now;
           requestorBootIDs[i] = requestor.getBootID();
@@ -265,7 +272,7 @@ class FailureTableEntry implements TimedOutNodesList {
     int nulls = 0;
     int ret = -1;
     for (int i = 0; i < requestorNodes.length; i++) {
-      PeerNodeUnlocked got = requestorNodes[i] == null ? null : requestorNodes[i].get();
+      PeerNodeUnlocked got = asPeerNodeUnlocked(requestorNodes[i]);
       if (got == requestor) {
         includedAlready = true;
         requestorTimes[i] = now;
@@ -318,7 +325,7 @@ class FailureTableEntry implements TimedOutNodesList {
       int notIncluded,
       int nulls,
       int existingIndex) {
-    WeakReference<? extends PeerNodeUnlocked>[] newRequestedNodes =
+    WeakReference<PeerContext>[] newRequestedNodes =
         weakArrayOfSize(requestedNodes.length + notIncluded - nulls);
     double[] newRequestedLocs = new double[requestedNodes.length + notIncluded - nulls];
     long[] newRequestedBootIDs = new long[requestedNodes.length + notIncluded - nulls];
@@ -330,8 +337,8 @@ class FailureTableEntry implements TimedOutNodesList {
     int toIndex = 0;
     int ret = existingIndex;
     for (int i = 0; i < requestedNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
-      PeerNodeUnlocked pn = ref == null ? null : ref.get();
+      WeakReference<PeerContext> ref = requestedNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       if (pn != null) {
         if (pn == requestedFrom) ret = toIndex;
         newRequestedNodes[toIndex] = requestedNodes[i];
@@ -381,7 +388,8 @@ class FailureTableEntry implements TimedOutNodesList {
       PeerNodeUnlocked requestedFrom, long now, boolean includedAlready, int nulls) {
     if (nulls == 1 && !includedAlready) {
       for (int i = 0; i < requestedNodes.length; i++) {
-        if (requestedNodes[i] == null || requestedNodes[i].get() == null) {
+        PeerNodeUnlocked existing = asPeerNodeUnlocked(requestedNodes[i]);
+        if (existing == null) {
           requestedNodes[i] = requestedFrom.getWeakRef();
           requestedLocs[i] = requestedFrom.getLocation();
           requestedBootIDs[i] = requestedFrom.getBootID();
@@ -403,7 +411,7 @@ class FailureTableEntry implements TimedOutNodesList {
     int nulls = 0;
     int ret = -1;
     for (int i = 0; i < requestedNodes.length; i++) {
-      PeerNodeUnlocked got = requestedNodes[i] == null ? null : requestedNodes[i].get();
+      PeerNodeUnlocked got = asPeerNodeUnlocked(requestedNodes[i]);
       if (got == requestedFrom
           && (requestedTimeoutsRF[i] == -1
               || requestedTimeoutsFT[i] == -1
@@ -458,8 +466,8 @@ class FailureTableEntry implements TimedOutNodesList {
 
   private void collectRequestorOfferTargets(HashSet<PeerNodeUnlocked> set) {
     for (int i = 0; i < requestorNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      WeakReference<PeerContext> ref = requestorNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       boolean valid = pn != null && pn.getBootID() == requestorBootIDs[i];
       if (valid && !set.add(pn)) {
         LOG.error("Node is in requestorNodes twice: {}", pn);
@@ -469,8 +477,8 @@ class FailureTableEntry implements TimedOutNodesList {
 
   private void collectRequestedOfferTargets(HashSet<PeerNodeUnlocked> set) {
     for (int i = 0; i < requestedNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
-      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      WeakReference<PeerContext> ref = requestedNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       boolean valid = pn != null && pn.getBootID() == requestedBootIDs[i];
       if (valid) {
         set.add(pn);
@@ -490,8 +498,8 @@ class FailureTableEntry implements TimedOutNodesList {
   public synchronized boolean othersWant() {
     boolean anyValid = false;
     for (int i = 0; i < requestorNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      WeakReference<PeerContext> ref = requestorNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       if (pn == null) {
         requestorNodes[i] = null;
       } else if (pn.getBootID() != requestorBootIDs[i]) {
@@ -523,8 +531,8 @@ class FailureTableEntry implements TimedOutNodesList {
     boolean anyValid = false;
     boolean anyOther = false;
     for (int i = 0; i < requestorNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      WeakReference<PeerContext> ref = requestorNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       if (pn == null) {
         requestorNodes[i] = null;
       } else if (pn.getBootID() != requestorBootIDs[i]) {
@@ -556,8 +564,8 @@ class FailureTableEntry implements TimedOutNodesList {
     boolean anyValid = false;
     boolean ret = false;
     for (int i = 0; i < requestorNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      WeakReference<PeerContext> ref = requestorNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       if (pn == null) {
         requestorNodes[i] = null;
       } else if (pn.getBootID() != requestorBootIDs[i]) {
@@ -588,8 +596,8 @@ class FailureTableEntry implements TimedOutNodesList {
     boolean anyValid = false;
     boolean ret = false;
     for (int i = 0; i < requestedNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
-      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      WeakReference<PeerContext> ref = requestedNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       if (pn == null) {
         requestedNodes[i] = null;
       } else if (pn.getBootID() != requestedBootIDs[i]) {
@@ -641,8 +649,9 @@ class FailureTableEntry implements TimedOutNodesList {
   }
 
   private boolean matchesPeerAndHtl(int index, PeerNode peer, short htl) {
-    WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[index];
-    return ref != null && ref.get() == peer && requestedTimeoutHTLs[index] >= htl;
+    WeakReference<PeerContext> ref = requestedNodes[index];
+    PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
+    return pn == peer && requestedTimeoutHTLs[index] >= htl;
   }
 
   private long computeTimeout(int index, boolean forPerNodeFailureTables) {
@@ -672,8 +681,8 @@ class FailureTableEntry implements TimedOutNodesList {
     boolean empty = true;
     int x = 0;
     for (int i = 0; i < requestorNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      WeakReference<PeerContext> ref = requestorNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       boolean valid =
           pn != null
               && pn.getBootID() == requestorBootIDs[i]
@@ -702,8 +711,8 @@ class FailureTableEntry implements TimedOutNodesList {
     boolean empty = true;
     int x = 0;
     for (int i = 0; i < requestedNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
-      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      WeakReference<PeerContext> ref = requestedNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       boolean valid =
           pn != null
               && pn.getBootID() == requestedBootIDs[i]
@@ -759,8 +768,8 @@ class FailureTableEntry implements TimedOutNodesList {
     long now = System.currentTimeMillis();
     boolean anyValid = false;
     for (int i = 0; i < requestorNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      WeakReference<PeerContext> ref = requestorNodes[i];
+      PeerNodeUnlocked pn = asPeerNodeUnlocked(ref);
       if (pn == null) {
         requestorNodes[i] = null;
       } else if (pn.getBootID() != requestorBootIDs[i]) {

--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -59,6 +59,7 @@ import network.crypta.io.comm.MessageFilter;
 import network.crypta.io.comm.NotConnectedException;
 import network.crypta.io.comm.Peer;
 import network.crypta.io.comm.Peer.LocalAddressException;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.io.comm.PeerParseException;
 import network.crypta.io.comm.ReferenceSignatureVerificationException;
 import network.crypta.io.comm.SocketHandler;
@@ -475,6 +476,12 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
    */
   final WeakReference<PeerNode> myRef;
 
+  /**
+   * A {@link PeerContext}-typed view of {@link #myRef} for APIs that operate on the transport view.
+   * The reference object itself is shared to avoid additional allocations.
+   */
+  private final WeakReference<PeerContext> contextRef;
+
   /** The node is being disconnected, but it may take a while. */
   private boolean disconnecting;
 
@@ -529,6 +536,12 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
     return false;
   }
 
+  @SuppressWarnings("unchecked")
+  private static WeakReference<PeerContext> castPeerContextRef(WeakReference<PeerNode> ref) {
+    // Safe because PeerNode implements PeerContext and the WeakReference only exposes get().
+    return (WeakReference<PeerContext>) (WeakReference<?>) ref;
+  }
+
   /**
    * Creates a PeerNode from a {@link SimpleFieldSet} node reference.
    *
@@ -554,6 +567,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
     boolean noSig = fromLocal || fromAnonymousInitiator();
     // Core finals
     myRef = new WeakReference<>(this);
+    contextRef = castPeerContextRef(myRef);
     this.checkStatusAfterBackoff = new PeerNodeBackoffStatusChecker(myRef);
     this.outgoingMangler = crypto.getPacketMangler();
     this.node = node2;
@@ -4765,8 +4779,8 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
   }
 
   @Override
-  public WeakReference<PeerNode> getWeakRef() {
-    return myRef;
+  public WeakReference<PeerContext> getWeakRef() {
+    return contextRef;
   }
 
   /**

--- a/src/main/java/network/crypta/node/PeerNodeUnlocked.java
+++ b/src/main/java/network/crypta/node/PeerNodeUnlocked.java
@@ -1,6 +1,7 @@
 package network.crypta.node;
 
 import java.lang.ref.WeakReference;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.Key;
 
 /**
@@ -44,15 +45,15 @@ interface PeerNodeUnlocked {
   void offer(Key key);
 
   /**
-   * Returns a weak reference to the backing {@link PeerNode} instance.
+   * Returns a weak reference to the backing peer context.
    *
    * <p>Use a weak reference when storing handles in auxiliary tables to avoid prolonging the
    * lifetime of the underlying peer. The reference may be cleared at any time by the garbage
    * collector.
    *
-   * @return a {@link WeakReference} to the underlying {@link PeerNode}.
+   * @return a {@link WeakReference} to the underlying {@link PeerContext}.
    */
-  WeakReference<PeerNode> getWeakRef();
+  WeakReference<PeerContext> getWeakRef();
 
   /**
    * Returns a concise, human-readable description of the peer intended for logs and metrics.

--- a/src/main/java/network/crypta/node/useralerts/BookmarkFeedUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/BookmarkFeedUserAlert.java
@@ -2,10 +2,10 @@ package network.crypta.node.useralerts;
 
 import java.lang.ref.WeakReference;
 import network.crypta.clients.fcp.BookmarkFeed;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.PeerNode;
 import network.crypta.support.HTMLNode;
 
 /**
@@ -44,7 +44,7 @@ import network.crypta.support.HTMLNode;
  * @see HTMLNode
  */
 public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNodeMessageUserAlert {
-  private final WeakReference<PeerNode> peerRef;
+  private final WeakReference<PeerContext> peerRef;
   private final FreenetURI uri;
   private final int fileNumber;
   private final String name;

--- a/src/main/java/network/crypta/node/useralerts/DownloadFeedUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/DownloadFeedUserAlert.java
@@ -3,10 +3,10 @@ package network.crypta.node.useralerts;
 import java.lang.ref.WeakReference;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.URIFeedMessage;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.PeerNode;
 import network.crypta.support.HTMLNode;
 
 /**
@@ -40,7 +40,7 @@ import network.crypta.support.HTMLNode;
  * @see NodeToNodeMessageUserAlert
  */
 public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNodeMessageUserAlert {
-  private final WeakReference<PeerNode> peerRef;
+  private final WeakReference<PeerContext> peerRef;
   private final FreenetURI uri;
   private final int fileNumber;
   private final String description;

--- a/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
@@ -5,9 +5,9 @@ import java.text.DateFormat;
 import java.util.Date;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.TextFeedMessage;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.PeerNode;
 import network.crypta.support.HTMLNode;
 
 /**
@@ -15,7 +15,7 @@ import network.crypta.support.HTMLNode;
  *
  * <p>This alert encapsulates the text payload and a set of timestamps produced along the delivery
  * path (composed, sent, and received). It also carries lightweight identity information about the
- * source darknet peer and a reference to the originating {@link PeerNode}. The alert exposes
+ * source darknet peer and a reference to the originating {@link PeerContext}. The alert exposes
  * multiple readouts tailored to different front-ends: a localized plain-text title and body, a
  * concise short text for summaries, an {@link HTMLNode} fragment for HTML renderers, and an {@link
  * FCPMessage} view for programmatic consumption via FCP.
@@ -42,7 +42,7 @@ import network.crypta.support.HTMLNode;
  */
 public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessageUserAlert {
   private static final String L10N_PREFIX = "N2NTMUserAlert.";
-  private final WeakReference<PeerNode> peerRef;
+  private final WeakReference<PeerContext> peerRef;
   private final String messageText;
   private final int fileNumber;
   private final long composedTime;

--- a/src/test/java/network/crypta/io/comm/MessageTest.java
+++ b/src/test/java/network/crypta/io/comm/MessageTest.java
@@ -313,7 +313,7 @@ class MessageTest {
 
   // Minimal stub PeerContext for decode paths. Only getWeakRef() is used by Message.
   private static final class TestPeerContext implements PeerContext {
-    private final WeakReference<TestPeerContext> ref = new WeakReference<>(this);
+    private final WeakReference<PeerContext> ref = new WeakReference<>(this);
 
     @Override
     public Peer getPeer() {
@@ -367,7 +367,7 @@ class MessageTest {
     }
 
     @Override
-    public WeakReference<? extends PeerContext> getWeakRef() {
+    public WeakReference<PeerContext> getWeakRef() {
       return ref;
     }
 

--- a/src/test/java/network/crypta/io/xfer/BlockReceiverTest.java
+++ b/src/test/java/network/crypta/io/xfer/BlockReceiverTest.java
@@ -246,7 +246,7 @@ class BlockReceiverTest {
     org.mockito.Mockito.lenient().when(sender.isConnected()).thenReturn(true);
     org.mockito.Mockito.lenient().when(sender.getBootID()).thenReturn(7L);
     org.mockito.Mockito.lenient().when(sender.shortToString()).thenReturn("peer");
-    WeakReference<PeerNode> ref = new WeakReference<>(sender);
+    WeakReference<PeerContext> ref = new WeakReference<>(sender);
     org.mockito.Mockito.lenient().when(sender.getWeakRef()).thenReturn(ref);
 
     // Avoid invoking real bookkeeping on the abstract PeerNode

--- a/src/test/java/network/crypta/io/xfer/BlockTransmitterTest.java
+++ b/src/test/java/network/crypta/io/xfer/BlockTransmitterTest.java
@@ -181,7 +181,7 @@ class BlockTransmitterTest {
     counter.highHtl = false;
 
     when(peer.getBootID()).thenReturn(1L);
-    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<PeerContext>(peer));
     when(peer.shortToString()).thenReturn("peer#manual");
     when(peer.isConnected()).thenReturn(true);
 
@@ -255,7 +255,7 @@ class BlockTransmitterTest {
 
     when(peer.getBootID()).thenReturn(1L);
     when(peer.isConnected()).thenReturn(true);
-    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<PeerContext>(peer));
     when(peer.shortToString()).thenReturn("peer#sendAborted");
 
     // Accumulate pending items so cancelItemsPending() will attempt to unqueue them on abort
@@ -334,7 +334,7 @@ class BlockTransmitterTest {
 
     when(peer.getBootID()).thenReturn(1L);
     when(peer.isConnected()).thenReturn(true);
-    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<PeerContext>(peer));
     when(peer.shortToString()).thenReturn("peer#disc");
 
     // Let the first send succeed, then immediately simulate a disconnect on filters
@@ -386,7 +386,7 @@ class BlockTransmitterTest {
 
     when(peer.getBootID()).thenReturn(1L);
     when(peer.isConnected()).thenReturn(true);
-    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<PeerContext>(peer));
     when(peer.shortToString()).thenReturn("peer#timeout");
 
     // Immediately acknowledge each send, but do NOT send allReceived

--- a/src/test/java/network/crypta/node/FailureTableEntryTest.java
+++ b/src/test/java/network/crypta/node/FailureTableEntryTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.ref.WeakReference;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.Key;
 import network.crypta.keys.NodeCHK;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +51,7 @@ class FailureTableEntryTest {
     when(peer.getLocation()).thenReturn(loc);
     when(peer.isConnected()).thenReturn(true);
     when(peer.shortToString()).thenReturn("peer-" + bootId);
-    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<PeerContext>(peer));
   }
 
   @Test

--- a/src/test/java/network/crypta/node/FailureTableTest.java
+++ b/src/test/java/network/crypta/node/FailureTableTest.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Field;
 import java.util.Random;
 import network.crypta.crypt.EntropySource;
 import network.crypta.crypt.RandomSource;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.Key;
 import network.crypta.keys.KeyBlock;
 import network.crypta.keys.NodeCHK;
@@ -169,7 +170,7 @@ class FailureTableTest {
     PeerNode routedTo = Mockito.mock(PeerNode.class);
     Mockito.when(routedTo.getBootID()).thenReturn(100L);
     Mockito.when(routedTo.getLocation()).thenReturn(0.42);
-    Mockito.when(routedTo.getWeakRef()).thenReturn(new WeakReference<>(routedTo));
+    Mockito.when(routedTo.getWeakRef()).thenReturn(new WeakReference<PeerContext>(routedTo));
     Mockito.when(routedTo.isConnected()).thenReturn(true);
 
     long nowBefore = System.currentTimeMillis();
@@ -198,13 +199,13 @@ class FailureTableTest {
     PeerNode routedTo = Mockito.mock(PeerNode.class);
     Mockito.when(routedTo.getBootID()).thenReturn(200L);
     Mockito.when(routedTo.getLocation()).thenReturn(0.7);
-    Mockito.when(routedTo.getWeakRef()).thenReturn(new WeakReference<>(routedTo));
+    Mockito.when(routedTo.getWeakRef()).thenReturn(new WeakReference<PeerContext>(routedTo));
     Mockito.when(routedTo.isConnected()).thenReturn(true);
 
     PeerNode requestor = Mockito.mock(PeerNode.class);
     Mockito.when(requestor.getBootID()).thenReturn(300L);
     Mockito.when(requestor.getLocation()).thenReturn(0.1);
-    Mockito.when(requestor.getWeakRef()).thenReturn(new WeakReference<>(requestor));
+    Mockito.when(requestor.getWeakRef()).thenReturn(new WeakReference<PeerContext>(requestor));
     Mockito.when(requestor.isConnected()).thenReturn(true);
 
     ft.onFinalFailure(key, routedTo, (short) 5, (short) 7, 1_000L, 1_000L, requestor);
@@ -223,7 +224,7 @@ class FailureTableTest {
     PeerNode requestor = Mockito.mock(PeerNode.class);
     Mockito.when(requestor.getBootID()).thenReturn(111L);
     Mockito.when(requestor.getLocation()).thenReturn(0.33);
-    Mockito.when(requestor.getWeakRef()).thenReturn(new WeakReference<>(requestor));
+    Mockito.when(requestor.getWeakRef()).thenReturn(new WeakReference<PeerContext>(requestor));
     Mockito.when(requestor.isConnected()).thenReturn(true);
 
     // Record a requestor so offer() has a target
@@ -249,7 +250,7 @@ class FailureTableTest {
     PeerNode offeredBy = Mockito.mock(PeerNode.class);
     Mockito.when(offeredBy.getBootID()).thenReturn(55L);
     Mockito.when(offeredBy.getLocation()).thenReturn(0.21);
-    Mockito.when(offeredBy.getWeakRef()).thenReturn(new WeakReference<>(offeredBy));
+    Mockito.when(offeredBy.getWeakRef()).thenReturn(new WeakReference<PeerContext>(offeredBy));
     Mockito.when(offeredBy.isConnected()).thenReturn(true);
 
     // We "asked from" this peer earlier by recording a failure on it.
@@ -277,7 +278,8 @@ class FailureTableTest {
     PeerNode routedElsewhere = Mockito.mock(PeerNode.class);
     Mockito.when(routedElsewhere.getBootID()).thenReturn(777L);
     Mockito.when(routedElsewhere.getLocation()).thenReturn(0.9);
-    Mockito.when(routedElsewhere.getWeakRef()).thenReturn(new WeakReference<>(routedElsewhere));
+    Mockito.when(routedElsewhere.getWeakRef())
+        .thenReturn(new WeakReference<PeerContext>(routedElsewhere));
     Mockito.when(routedElsewhere.isConnected()).thenReturn(true);
 
     // We previously interacted with a different peer.
@@ -286,7 +288,7 @@ class FailureTableTest {
     PeerNode otherPeer = Mockito.mock(PeerNode.class);
     Mockito.when(otherPeer.getBootID()).thenReturn(888L);
     Mockito.when(otherPeer.getLocation()).thenReturn(0.1);
-    Mockito.when(otherPeer.getWeakRef()).thenReturn(new WeakReference<>(otherPeer));
+    Mockito.when(otherPeer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(otherPeer));
     Mockito.when(otherPeer.isConnected()).thenReturn(true);
 
     ft.innerOnOffer(key, otherPeer, new byte[] {9});
@@ -324,7 +326,7 @@ class FailureTableTest {
     try {
       Field f = PeerNode.class.getDeclaredField("myRef");
       f.setAccessible(true);
-      f.set(peer, new WeakReference<>(peer));
+      f.set(peer, new WeakReference<PeerContext>(peer));
     } catch (ReflectiveOperationException e) {
       throw new AssertionError("Failed to set PeerNode.myRef reflectively", e);
     }

--- a/src/test/java/network/crypta/node/NodeDispatcherTest.java
+++ b/src/test/java/network/crypta/node/NodeDispatcherTest.java
@@ -19,6 +19,7 @@ import network.crypta.io.comm.DMT;
 import network.crypta.io.comm.Message;
 import network.crypta.io.comm.NotConnectedException;
 import network.crypta.io.comm.Peer;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.NodeCHK;
 import network.crypta.node.NodeDispatcher.NodeDispatcherCallback;
 import network.crypta.node.updater.NodeUpdateManager;
@@ -113,7 +114,7 @@ class NodeDispatcherTest {
     org.mockito.Mockito.lenient().when(pn.isConnected()).thenReturn(true);
     org.mockito.Mockito.lenient().when(pn.isRoutable()).thenReturn(true);
     org.mockito.Mockito.lenient().when(pn.isRealConnection()).thenReturn(true);
-    java.lang.ref.WeakReference<PeerNode> ref = new java.lang.ref.WeakReference<>(pn);
+    java.lang.ref.WeakReference<PeerContext> ref = new java.lang.ref.WeakReference<>(pn);
     org.mockito.Mockito.lenient().when(pn.getWeakRef()).thenReturn(ref);
     return pn;
   }
@@ -223,7 +224,7 @@ class NodeDispatcherTest {
     org.mockito.Mockito.lenient().when(src.isConnected()).thenReturn(true);
     org.mockito.Mockito.lenient().when(src.isRoutable()).thenReturn(true);
     org.mockito.Mockito.lenient().when(src.isRealConnection()).thenReturn(true);
-    java.lang.ref.WeakReference<PeerNode> ref = new java.lang.ref.WeakReference<>(src);
+    java.lang.ref.WeakReference<PeerContext> ref = new java.lang.ref.WeakReference<>(src);
     org.mockito.Mockito.lenient().when(src.getWeakRef()).thenReturn(ref);
 
     Message m = withSource(DMT.createFNPVisibility((short) 1), src);

--- a/src/test/java/network/crypta/node/NullBasePeerNode.java
+++ b/src/test/java/network/crypta/node/NullBasePeerNode.java
@@ -69,7 +69,7 @@ public class NullBasePeerNode implements BasePeerNode {
   }
 
   @Override
-  public WeakReference<? extends PeerContext> getWeakRef() {
+  public WeakReference<PeerContext> getWeakRef() {
     return new WeakReference<>(this);
   }
 

--- a/src/test/java/network/crypta/node/useralerts/BookmarkFeedUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/BookmarkFeedUserAlertTest.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import network.crypta.clients.fcp.BookmarkFeed;
 import network.crypta.clients.fcp.FCPMessage;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.HTMLNode;
@@ -34,7 +35,7 @@ class BookmarkFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Alice");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
 
     String name = "My Site";
     String description = "Line1\nLine2";
@@ -107,7 +108,7 @@ class BookmarkFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Bob");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
 
     String name = "Site";
     FreenetURI uri = new FreenetURI("KSK@file.txt");
@@ -133,7 +134,7 @@ class BookmarkFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Carol");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
     FreenetURI uri = new FreenetURI("KSK@x.txt");
     BookmarkFeedUserAlert alert =
         new BookmarkFeedUserAlert(peer, "X", "", false, 3, uri, -1L, -1L, -1L);
@@ -152,7 +153,7 @@ class BookmarkFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Dave");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
     FreenetURI uri = new FreenetURI("KSK@offer.txt");
     int fileNumber = 99;
     BookmarkFeedUserAlert alert =
@@ -171,7 +172,7 @@ class BookmarkFeedUserAlertTest {
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Eve");
     // The weak reference resolves to null
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(null));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(null));
     FreenetURI uri = new FreenetURI("KSK@abc.txt");
     BookmarkFeedUserAlert alert =
         new BookmarkFeedUserAlert(peer, "S", null, false, 5, uri, -1L, -1L, -1L);
@@ -188,7 +189,7 @@ class BookmarkFeedUserAlertTest {
     // Arrange: first call returns initial name (constructor), second call returns updated name
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Alice", "Mallory");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
     FreenetURI uri = new FreenetURI("KSK@z.txt");
     BookmarkFeedUserAlert alert =
         new BookmarkFeedUserAlert(peer, "S", null, false, 1, uri, -1L, -1L, -1L);
@@ -209,7 +210,7 @@ class BookmarkFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Frank");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
     FreenetURI uri = new FreenetURI("KSK@data.bin");
     String description = "hello"; // 5 bytes in UTF-8
     String name = "Title";

--- a/src/test/java/network/crypta/node/useralerts/DownloadFeedUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/DownloadFeedUserAlertTest.java
@@ -16,6 +16,7 @@ import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.URIFeedMessage;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.HTMLNode;
@@ -34,7 +35,7 @@ class DownloadFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Alice");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
 
     FreenetURI uri = new FreenetURI("KSK@readme.txt");
     String description = "Line1\nLine2";
@@ -88,7 +89,7 @@ class DownloadFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Bob");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
 
     FreenetURI uri = new FreenetURI("KSK@file.txt");
     DownloadFeedUserAlert alert = new DownloadFeedUserAlert(peer, null, 7, uri, 1L, -1L, -1L);
@@ -111,7 +112,7 @@ class DownloadFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Carol");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
     FreenetURI uri = new FreenetURI("KSK@x.txt");
     DownloadFeedUserAlert alert = new DownloadFeedUserAlert(peer, "", 3, uri, -1L, -1L, -1L);
 
@@ -128,7 +129,7 @@ class DownloadFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Dave");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
     FreenetURI uri = new FreenetURI("KSK@offer.txt");
     int fileNumber = 99;
     DownloadFeedUserAlert alert =
@@ -147,7 +148,7 @@ class DownloadFeedUserAlertTest {
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Eve");
     // The weak reference resolves to null
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(null));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(null));
     FreenetURI uri = new FreenetURI("KSK@abc.txt");
     DownloadFeedUserAlert alert = new DownloadFeedUserAlert(peer, null, 5, uri, -1L, -1L, -1L);
 
@@ -163,7 +164,7 @@ class DownloadFeedUserAlertTest {
     // Arrange: first call returns initial name (constructor), second call returns updated name
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Alice", "Mallory");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
     FreenetURI uri = new FreenetURI("KSK@z.txt");
     DownloadFeedUserAlert alert = new DownloadFeedUserAlert(peer, null, 1, uri, -1L, -1L, -1L);
 
@@ -183,7 +184,7 @@ class DownloadFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Frank");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
     FreenetURI uri = new FreenetURI("KSK@data.bin");
     String description = "hello"; // 5 bytes in UTF-8
     DownloadFeedUserAlert alert =

--- a/src/test/java/network/crypta/node/useralerts/N2NTMUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/N2NTMUserAlertTest.java
@@ -15,6 +15,7 @@ import java.util.TimeZone;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.TextFeedMessage;
 import network.crypta.io.comm.Peer;
+import network.crypta.io.comm.PeerContext;
 import network.crypta.l10n.BaseL10n.LANGUAGE;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
@@ -56,7 +57,7 @@ class N2NTMUserAlertTest {
   void getTitle_whenInitialized_expectLocalizedTitle() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 
@@ -76,7 +77,7 @@ class N2NTMUserAlertTest {
   void getText_and_getShortText_whenInitialized_expectHeaderAndSummary() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 
@@ -98,7 +99,7 @@ class N2NTMUserAlertTest {
   void getHTMLText_whenPeerPresent_expectReplyLinkAndLineBreaks() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 
@@ -122,7 +123,7 @@ class N2NTMUserAlertTest {
   void getHTMLText_whenPeerMissing_expectNoReplyLink() throws Exception {
     // Arrange
     Peer peer = new Peer("example.net:4321", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(null));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(null));
     when(mockPeerNode.getName()).thenReturn("Bob");
     when(mockPeerNode.getPeer()).thenReturn(peer);
     N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "Msg", 5, 0L, 1_000L, 2_000L, 111L);
@@ -141,7 +142,7 @@ class N2NTMUserAlertTest {
   void onDismiss_whenPeerPresent_expectDeleteCalled() throws Exception {
     // Arrange
     Peer peer = new Peer("node.local:5555", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Carol");
     when(mockPeerNode.getPeer()).thenReturn(peer);
     N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "X", 77, 0L, 1_000L, 2_000L, 1L);
@@ -157,7 +158,7 @@ class N2NTMUserAlertTest {
   void onDismiss_whenPeerMissing_expectDeleteNotCalled() throws Exception {
     // Arrange
     Peer peer = new Peer("node.local:5555", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(null));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(null));
     when(mockPeerNode.getName()).thenReturn("Carol");
     when(mockPeerNode.getPeer()).thenReturn(peer);
     N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "X", 88, 0L, 1_000L, 2_000L, 1L);
@@ -173,7 +174,7 @@ class N2NTMUserAlertTest {
   void getFCPMessage_whenConstructed_expectFieldSetContainsSourceAndTimes() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 
@@ -204,7 +205,7 @@ class N2NTMUserAlertTest {
   void getFCPMessage_whenMessageNull_expectZeroLengthMessageTextBucket() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
     N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, null, 7, 0L, 1_000L, 2_000L, 123L);
@@ -220,7 +221,7 @@ class N2NTMUserAlertTest {
   void isValid_whenPeerUpdates_expectTitleReflectsNewNameAndPeer() throws Exception {
     // Arrange
     Peer peer1 = new Peer("old.example:100", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("OldName");
     when(mockPeerNode.getPeer()).thenReturn(peer1);
     N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "Msg", 3, 0L, 1_000L, 2_000L, 55L);
@@ -250,7 +251,7 @@ class N2NTMUserAlertTest {
   void constructor_withoutMsgId_expectMsgIdNegativeOne() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 


### PR DESCRIPTION
## Summary
- replace wildcard WeakReference usage with `WeakReference<PeerContext>` in comm APIs
- cache a typed weak reference in PeerNode and adapt FailureTableEntry casting helpers
- update user alerts and tests to match the new signature

## Testing
- ./gradlew test