### PR TITLE
refactor(launcher): clarify ThemeSwitcher flow

### DIFF
--- a/src/main/kotlin/network/crypta/launcher/ThemeSwitcher.kt
+++ b/src/main/kotlin/network/crypta/launcher/ThemeSwitcher.kt
@@ -7,20 +7,48 @@ import com.formdev.flatlaf.themes.FlatMacDarkLaf
 import com.formdev.flatlaf.themes.FlatMacLightLaf
 import com.jthemedetecor.OsThemeDetector
 import java.util.function.Consumer
+import javax.swing.LookAndFeel
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.plaf.FontUIResource
 import network.crypta.fs.AppEnv
 
 /**
- * Installs FlatLaf matching the current OS theme and switches live on changes. Uses
- * jSystemThemeDetector (OsThemeDetector) for cross‑platform OS theme detection.
+ * Applies a FlatLaf look-and-feel that tracks the operating system theme and keeps Swing components
+ * synchronized as the OS preference changes.
+ *
+ * This singleton is designed for early application startup: call [install] before any Swing
+ * components are created so the initial look-and-feel is consistent and does not flash from a
+ * default theme. It selects a platform-appropriate FlatLaf variant, configures window decorations
+ * for Linux/Flatpak, and wires an [OsThemeDetector] listener so later OS theme changes update the
+ * UI. The implementation keeps the minimal mutable state needed to unregister the listener in
+ * [shutdown], and it is safe to call from any thread because internal dispatch uses the EDT.
+ *
+ * Notable behaviors:
+ * <ul>
+ * <li>Initial theme application is synchronous to avoid UI creation races.</li>
+ * <li>Live switches refresh the UI on the EDT.</li>
+ * <li>macOS applies a default logical font to avoid JDK-8355079.</li>
+ * </ul>
+ *
+ * @see FlatpakAwareOsThemeDetector
+ * @see FlatLaf
+ * @see AppEnv
  */
 object ThemeSwitcher {
   @Volatile private var detector: OsThemeDetector? = null
   @Volatile private var listener: Consumer<Boolean>? = null
 
-  /** Initialize OS theme detection and apply the matching FlatLaf before UI creation. */
+  /**
+   * Initialize OS theme detection and apply the matching FlatLaf before UI creation.
+   *
+   * Call this once during application startup, before any Swing component is constructed, so the
+   * initial theme is applied synchronously on the EDT and remains stable. The method configures
+   * platform-specific details (macOS appearance hint and Linux client decorations), creates a
+   * detector via [FlatpakAwareOsThemeDetector], applies the current theme immediately, and then
+   * registers a listener for subsequent OS theme changes. Repeated calls replace the stored
+   * detector reference, but the intent is a single early call to avoid redundant listeners.
+   */
   fun install() {
     // macOS: ensure the system appearance is reported to Java/Swing
     try {
@@ -49,7 +77,14 @@ object ThemeSwitcher {
     det.registerListener(consumer)
   }
 
-  /** Stop OS theme change reporting (call on shutdown to avoid leaks). */
+  /**
+   * Stop OS theme change reporting and release any registered listener.
+   *
+   * This is intended for application shutdown to avoid leaks or spurious callbacks after the UI is
+   * torn down. If [install] was never called, this method is a no-op. It clears the cached detector
+   * and listener references after attempting to unregister them, and it does not touch the current
+   * look-and-feel state.
+   */
   fun shutdown() {
     val det = detector
     val c = listener
@@ -60,42 +95,19 @@ object ThemeSwitcher {
 
   private fun applyFor(useDark: Boolean, synchronous: Boolean = false) {
     val mac = AppEnv().isMac()
-    val laf =
-      if (mac) {
-        if (useDark) FlatMacDarkLaf() else FlatMacLightLaf()
-      } else {
-        if (useDark) FlatDarkLaf() else FlatLightLaf()
-      }
+    val laf = createLaf(useDark, mac)
+    applyLaf(laf, mac, synchronous)
+  }
 
-    val apply: () -> Unit = {
-      try {
-        if (mac) {
-          // Work around JDK-8355079: set a sane default logical font on macOS
-          UIManager.put("defaultFont", FontUIResource("SansSerif", java.awt.Font.PLAIN, 13))
-        }
-        // Use FlatLaf client decorations on Linux/Flatpak to avoid light server-side title bars
-        val inFlatpak = System.getenv("FLATPAK_ID")?.isNotEmpty() == true
-        val useNativeDeco = AppEnv().isMac().not() && !inFlatpak
-        FlatLaf.setUseNativeWindowDecorations(useNativeDeco)
-        // Apply LAF explicitly via UIManager to catch errors, then let FlatLaf do extra setup
-        try {
-          UIManager.setLookAndFeel(laf)
-        } catch (t: Throwable) {
-          logDebug("UIManager.setLookAndFeel() failed", t)
-        }
-        // Also set swing.defaultlaf so the EDT initialization cannot override us to GTK
-        try {
-          System.setProperty("swing.defaultlaf", laf.javaClass.name)
-        } catch (t: Throwable) {
-          logDebug("Failed to set swing.defaultlaf system property", t)
-        }
-        FlatLaf.setup(laf)
-        // For live switches after startup, refresh UI
-        if (!synchronous) FlatLaf.updateUI()
-      } catch (e: Exception) {
-        logWarn("Failed to apply FlatLaf theme", e)
-      }
+  private fun createLaf(useDark: Boolean, mac: Boolean): LookAndFeel =
+    if (mac) {
+      if (useDark) FlatMacDarkLaf() else FlatMacLightLaf()
+    } else {
+      if (useDark) FlatDarkLaf() else FlatLightLaf()
     }
+
+  private fun applyLaf(laf: LookAndFeel, mac: Boolean, synchronous: Boolean) {
+    val apply: () -> Unit = { applyLafInternal(laf, mac, synchronous) }
 
     if (synchronous) {
       if (SwingUtilities.isEventDispatchThread()) {
@@ -110,6 +122,48 @@ object ThemeSwitcher {
       }
     } else {
       SwingUtilities.invokeLater(apply)
+    }
+  }
+
+  private fun applyLafInternal(laf: LookAndFeel, mac: Boolean, synchronous: Boolean) {
+    try {
+      if (mac) {
+        // Work around JDK-8355079: set a sane default logical font on macOS
+        UIManager.put("defaultFont", FontUIResource("SansSerif", java.awt.Font.PLAIN, 13))
+      }
+      configureWindowDecorations()
+      applyLookAndFeel(laf)
+      setDefaultLafProperty(laf)
+      FlatLaf.setup(laf)
+      // For live switches after startup, refresh UI
+      if (!synchronous) FlatLaf.updateUI()
+    } catch (e: Exception) {
+      logWarn("Failed to apply FlatLaf theme", e)
+    }
+  }
+
+  private fun configureWindowDecorations() {
+    // Use FlatLaf client decorations on Linux/Flatpak to avoid light server-side title bars
+    val inFlatpak = System.getenv("FLATPAK_ID")?.isNotEmpty() == true
+    val useNativeDeco = AppEnv().isMac().not() && !inFlatpak
+    FlatLaf.setUseNativeWindowDecorations(useNativeDeco)
+  }
+
+  private fun applyLookAndFeel(laf: LookAndFeel) {
+    // Apply LAF explicitly via UIManager to catch errors, then let FlatLaf do extra set up
+    try {
+      UIManager.setLookAndFeel(laf)
+    } catch (t: Throwable) {
+      logDebug("UIManager.setLookAndFeel() failed", t)
+    }
+  }
+
+  private fun setDefaultLafProperty(laf: LookAndFeel) {
+    // Also set swing.defaultlaf so the EDT initialization cannot override us to GTK
+    try {
+      System.setProperty("swing.defaultlaf", laf.javaClass.name)
+    } catch (t: Throwable) {
+      logDebug("Failed to set swing.defaultlaf system property", t)
     }
   }
 }

--- a/src/test/kotlin/network/crypta/launcher/ThemeSwitcherTest.kt
+++ b/src/test/kotlin/network/crypta/launcher/ThemeSwitcherTest.kt
@@ -1,0 +1,294 @@
+package network.crypta.launcher
+
+import com.formdev.flatlaf.FlatDarkLaf
+import com.formdev.flatlaf.FlatLaf
+import com.formdev.flatlaf.FlatLightLaf
+import com.formdev.flatlaf.themes.FlatMacLightLaf
+import com.jthemedetecor.OsThemeDetector
+import com.jthemedetecor.PortalThemeDetector
+import java.util.function.Consumer
+import javax.swing.JDialog
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+import javax.swing.UIManager
+import javax.swing.plaf.FontUIResource
+import network.crypta.fs.AppEnv
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.MockedConstruction
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+@SuppressWarnings("java:S100")
+@Suppress("kotlin:S100")
+internal class ThemeSwitcherTest {
+  companion object {
+    private const val APPLE_APPEARANCE_KEY = "apple.awt.application.appearance"
+    private const val SWING_DEFAULT_LAF_KEY = "swing.defaultlaf"
+  }
+
+  @AfterEach
+  fun tearDown() {
+    ThemeSwitcher.shutdown()
+  }
+
+  @Test
+  fun install_whenNonMacDark_thenRegistersListenerAndSwitchesOnChange() {
+    val priorApple = System.getProperty(APPLE_APPEARANCE_KEY)
+    val priorDefaultLaf = System.getProperty(SWING_DEFAULT_LAF_KEY)
+
+    val detector = Mockito.mock(OsThemeDetector::class.java)
+    Mockito.`when`(detector.isDark).thenReturn(true)
+
+    val osDetectorMock = Mockito.mockStatic(OsThemeDetector::class.java)
+    val appEnvConstruction =
+      Mockito.mockConstruction(AppEnv::class.java) { mock, _ ->
+        Mockito.`when`(mock.isMac()).thenReturn(false)
+        Mockito.`when`(mock.isLinux()).thenReturn(false)
+      }
+    val swingMock = Mockito.mockStatic(SwingUtilities::class.java)
+    val flatLafMock = Mockito.mockStatic(FlatLaf::class.java)
+    val uiManagerMock = Mockito.mockStatic(UIManager::class.java)
+
+    osDetectorMock.`when`<OsThemeDetector> { OsThemeDetector.getDetector() }.thenReturn(detector)
+    swingMock.`when`<Boolean> { SwingUtilities.isEventDispatchThread() }.thenReturn(false)
+    swingMock
+      .`when`<Unit> { SwingUtilities.invokeAndWait(Mockito.any(Runnable::class.java)) }
+      .thenAnswer { invocation ->
+        val runnable = invocation.arguments[0] as Runnable
+        runnable.run()
+        null
+      }
+    swingMock
+      .`when`<Unit> { SwingUtilities.invokeLater(Mockito.any(Runnable::class.java)) }
+      .thenAnswer { invocation ->
+        val runnable = invocation.arguments[0] as Runnable
+        runnable.run()
+        null
+      }
+    uiManagerMock
+      .`when`<Unit> { UIManager.setLookAndFeel(Mockito.any(javax.swing.LookAndFeel::class.java)) }
+      .thenAnswer { null }
+    uiManagerMock
+      .`when`<Any> { UIManager.put(Mockito.anyString(), Mockito.any(Any::class.java)) }
+      .thenAnswer { null }
+
+    try {
+      // Arrange
+      @Suppress("UNCHECKED_CAST")
+      val listenerCaptor: ArgumentCaptor<Consumer<Boolean>> =
+        ArgumentCaptor.forClass(Consumer::class.java) as ArgumentCaptor<Consumer<Boolean>>
+
+      // Act
+      ThemeSwitcher.install()
+
+      // Assert
+      Mockito.verify(detector).registerListener(listenerCaptor.capture())
+      val listener = listenerCaptor.value
+      assertNotNull(listener)
+
+      val lookAndFeelCaptor = ArgumentCaptor.forClass(javax.swing.LookAndFeel::class.java)
+
+      // Act
+      listener.accept(false)
+
+      // Assert
+      uiManagerMock.verify(
+        { UIManager.setLookAndFeel(lookAndFeelCaptor.capture()) },
+        Mockito.times(2),
+      )
+      assertTrue(lookAndFeelCaptor.allValues.first() is FlatDarkLaf)
+      assertTrue(lookAndFeelCaptor.allValues.last() is FlatLightLaf)
+
+      val expectedNativeDeco = System.getenv("FLATPAK_ID").isNullOrEmpty()
+      flatLafMock.verify(
+        { FlatLaf.setUseNativeWindowDecorations(expectedNativeDeco) },
+        Mockito.times(2),
+      )
+      flatLafMock.verify(
+        { FlatLaf.setup(Mockito.any(javax.swing.LookAndFeel::class.java)) },
+        Mockito.times(2),
+      )
+      flatLafMock.verify({ FlatLaf.updateUI() }, Mockito.times(1))
+      uiManagerMock.verify(
+        { UIManager.put(Mockito.anyString(), Mockito.any(Any::class.java)) },
+        Mockito.never(),
+      )
+    } finally {
+      osDetectorMock.close()
+      appEnvConstruction.close()
+      swingMock.close()
+      flatLafMock.close()
+      uiManagerMock.close()
+      if (priorApple == null) {
+        System.clearProperty(APPLE_APPEARANCE_KEY)
+      } else {
+        System.setProperty(APPLE_APPEARANCE_KEY, priorApple)
+      }
+      if (priorDefaultLaf == null) {
+        System.clearProperty(SWING_DEFAULT_LAF_KEY)
+      } else {
+        System.setProperty(SWING_DEFAULT_LAF_KEY, priorDefaultLaf)
+      }
+    }
+  }
+
+  @Test
+  fun install_whenMacLight_thenSetsDefaultFontAndDisablesNativeDecorations() {
+    val priorApple = System.getProperty(APPLE_APPEARANCE_KEY)
+    val priorDefaultLaf = System.getProperty(SWING_DEFAULT_LAF_KEY)
+
+    val detector = Mockito.mock(OsThemeDetector::class.java)
+    Mockito.`when`(detector.isDark).thenReturn(false)
+
+    val osDetectorMock = Mockito.mockStatic(OsThemeDetector::class.java)
+    val appEnvConstruction =
+      Mockito.mockConstruction(AppEnv::class.java) { mock, _ ->
+        Mockito.`when`(mock.isMac()).thenReturn(true)
+        Mockito.`when`(mock.isLinux()).thenReturn(false)
+      }
+    val swingMock = Mockito.mockStatic(SwingUtilities::class.java)
+    val flatLafMock = Mockito.mockStatic(FlatLaf::class.java)
+    val uiManagerMock = Mockito.mockStatic(UIManager::class.java)
+
+    osDetectorMock.`when`<OsThemeDetector> { OsThemeDetector.getDetector() }.thenReturn(detector)
+    swingMock.`when`<Boolean> { SwingUtilities.isEventDispatchThread() }.thenReturn(true)
+    swingMock
+      .`when`<Unit> { SwingUtilities.invokeLater(Mockito.any(Runnable::class.java)) }
+      .thenAnswer { invocation ->
+        val runnable = invocation.arguments[0] as Runnable
+        runnable.run()
+        null
+      }
+    uiManagerMock
+      .`when`<Unit> { UIManager.setLookAndFeel(Mockito.any(javax.swing.LookAndFeel::class.java)) }
+      .thenAnswer { null }
+    uiManagerMock
+      .`when`<Any> { UIManager.put(Mockito.anyString(), Mockito.any(Any::class.java)) }
+      .thenAnswer { null }
+
+    try {
+      // Act
+      ThemeSwitcher.install()
+
+      // Assert
+      uiManagerMock.verify {
+        UIManager.put(Mockito.eq("defaultFont"), Mockito.any(FontUIResource::class.java))
+      }
+      flatLafMock.verify { FlatLaf.setUseNativeWindowDecorations(false) }
+      val lookAndFeelCaptor = ArgumentCaptor.forClass(javax.swing.LookAndFeel::class.java)
+      uiManagerMock.verify { UIManager.setLookAndFeel(lookAndFeelCaptor.capture()) }
+      assertTrue(lookAndFeelCaptor.value is FlatMacLightLaf)
+      assertEquals(FlatMacLightLaf::class.java.name, System.getProperty(SWING_DEFAULT_LAF_KEY))
+      flatLafMock.verify({ FlatLaf.updateUI() }, Mockito.never())
+    } finally {
+      osDetectorMock.close()
+      appEnvConstruction.close()
+      swingMock.close()
+      flatLafMock.close()
+      uiManagerMock.close()
+      if (priorApple == null) {
+        System.clearProperty(APPLE_APPEARANCE_KEY)
+      } else {
+        System.setProperty(APPLE_APPEARANCE_KEY, priorApple)
+      }
+      if (priorDefaultLaf == null) {
+        System.clearProperty(SWING_DEFAULT_LAF_KEY)
+      } else {
+        System.setProperty(SWING_DEFAULT_LAF_KEY, priorDefaultLaf)
+      }
+    }
+  }
+
+  @Test
+  fun install_whenLinux_thenEnablesClientDecorationsAndShutdownUnregistersListener() {
+    val priorApple = System.getProperty(APPLE_APPEARANCE_KEY)
+    val priorDefaultLaf = System.getProperty(SWING_DEFAULT_LAF_KEY)
+
+    val appEnvConstruction: MockedConstruction<AppEnv> =
+      Mockito.mockConstruction(AppEnv::class.java) { mock, _ ->
+        Mockito.`when`(mock.isMac()).thenReturn(false)
+        Mockito.`when`(mock.isLinux()).thenReturn(true)
+      }
+    val portalConstruction: MockedConstruction<PortalThemeDetector> =
+      Mockito.mockConstruction(PortalThemeDetector::class.java) { mock, _ ->
+        Mockito.`when`(mock.isDark).thenReturn(false)
+      }
+    val swingMock: MockedStatic<SwingUtilities> = Mockito.mockStatic(SwingUtilities::class.java)
+    val flatLafMock: MockedStatic<FlatLaf> = Mockito.mockStatic(FlatLaf::class.java)
+    val uiManagerMock: MockedStatic<UIManager> = Mockito.mockStatic(UIManager::class.java)
+    val jFrameMock: MockedStatic<JFrame> = Mockito.mockStatic(JFrame::class.java)
+    val jDialogMock: MockedStatic<JDialog> = Mockito.mockStatic(JDialog::class.java)
+
+    swingMock.`when`<Boolean> { SwingUtilities.isEventDispatchThread() }.thenReturn(false)
+    swingMock
+      .`when`<Unit> { SwingUtilities.invokeAndWait(Mockito.any(Runnable::class.java)) }
+      .thenAnswer { invocation ->
+        val runnable = invocation.arguments[0] as Runnable
+        runnable.run()
+        null
+      }
+    swingMock
+      .`when`<Unit> { SwingUtilities.invokeLater(Mockito.any(Runnable::class.java)) }
+      .thenAnswer { invocation ->
+        val runnable = invocation.arguments[0] as Runnable
+        runnable.run()
+        null
+      }
+    uiManagerMock
+      .`when`<Unit> { UIManager.setLookAndFeel(Mockito.any(javax.swing.LookAndFeel::class.java)) }
+      .thenAnswer { null }
+    uiManagerMock
+      .`when`<Any> { UIManager.put(Mockito.anyString(), Mockito.any(Any::class.java)) }
+      .thenAnswer { null }
+    jFrameMock.`when`<Unit> { JFrame.setDefaultLookAndFeelDecorated(true) }.thenAnswer { null }
+    jDialogMock.`when`<Unit> { JDialog.setDefaultLookAndFeelDecorated(true) }.thenAnswer { null }
+
+    try {
+      // Act
+      ThemeSwitcher.install()
+
+      // Assert
+      jFrameMock.verify { JFrame.setDefaultLookAndFeelDecorated(true) }
+      jDialogMock.verify { JDialog.setDefaultLookAndFeelDecorated(true) }
+
+      assertTrue(portalConstruction.constructed().isNotEmpty())
+      val detector = portalConstruction.constructed().first()
+      val listenerField = ThemeSwitcher::class.java.getDeclaredField("listener")
+      listenerField.isAccessible = true
+      @Suppress("UNCHECKED_CAST", "kotlin:S6518")
+      val listener = requireNotNull(listenerField.get(null) as Consumer<Boolean>?)
+      Mockito.verify(detector).registerListener(listener)
+
+      ThemeSwitcher.shutdown()
+
+      Mockito.verify(detector).removeListener(listener)
+      flatLafMock.verify { FlatLaf.setup(Mockito.any(javax.swing.LookAndFeel::class.java)) }
+    } finally {
+      appEnvConstruction.close()
+      portalConstruction.close()
+      swingMock.close()
+      flatLafMock.close()
+      uiManagerMock.close()
+      jFrameMock.close()
+      jDialogMock.close()
+      if (priorApple == null) {
+        System.clearProperty(APPLE_APPEARANCE_KEY)
+      } else {
+        System.setProperty(APPLE_APPEARANCE_KEY, priorApple)
+      }
+      if (priorDefaultLaf == null) {
+        System.clearProperty(SWING_DEFAULT_LAF_KEY)
+      } else {
+        System.setProperty(SWING_DEFAULT_LAF_KEY, priorDefaultLaf)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Split ThemeSwitcher apply flow into helpers for clarity.
- Expand KDoc on startup/shutdown behavior.
- Add ThemeSwitcher tests for macOS/Linux and live switching.

## Testing
- ./gradlew test --tests 'network.crypta.launcher.ThemeSwitcherTest'
- ./gradlew test
