### PR TITLE
refactor(fcp): use registry for plugin messages

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -13,7 +13,6 @@ import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.TooManyFilesInsertException;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestClientBuilder;
-import network.crypta.pluginmanager.PluginNotFoundException;
 import network.crypta.support.HexUtil;
 import network.crypta.support.io.NativeThread;
 import org.slf4j.Logger;
@@ -72,6 +71,10 @@ public class FCPConnectionHandler implements Closeable {
   final HashMap<String, ClientRequest> requestsByIdentifier;
 
   private final PluginConnectionRegistry pluginConnectionRegistry = new PluginConnectionRegistry();
+
+  PluginConnectionRegistry pluginConnectionRegistry() {
+    return pluginConnectionRegistry;
+  }
 
   private static final class CloseSnapshot {
     final ClientRequest[] requests;
@@ -285,7 +288,7 @@ public class FCPConnectionHandler implements Closeable {
           .jobRunner
           .queue(
               (PersistentJob)
-                  context -> {
+                  _ -> {
                     if ((rebootClient != null) && !rebootClient.hasPersistentRequests()) {
                       server.unregisterClient(rebootClient);
                     }
@@ -856,18 +859,6 @@ public class FCPConnectionHandler implements Closeable {
    */
   public PersistentRequestClient getRebootClient() {
     return rebootClient;
-  }
-
-  /**
-   * @return The {@link FCPPluginConnection} for the given serverPluginName. Atomically creates and
-   *     stores it if there does not exist one yet. This ensures that for each FCPConnectionHandler,
-   *     there can be only one {@link FCPPluginConnection} for a given serverPluginName.
-   * @throws PluginNotFoundException If the specified plugin is not loaded or does not provide an
-   *     FCP server.
-   */
-  FCPPluginConnection getFCPPluginConnection(String serverPluginName)
-      throws PluginNotFoundException {
-    return pluginConnectionRegistry.get(serverPluginName, server, this);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginClientMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginClientMessage.java
@@ -214,12 +214,9 @@ public class FCPPluginClientMessage extends DataCarryingMessage {
 
     final FCPPluginConnection serverConnection;
     try {
-      serverConnection = handler.getFCPPluginConnection(pluginname);
+      serverConnection =
+          handler.pluginConnectionRegistry().get(pluginname, handler.getServer(), handler);
     } catch (PluginNotFoundException _) {
-      throw pluginUnavailable();
-    }
-
-    if (serverConnection == null) {
       throw pluginUnavailable();
     }
 

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginConnectionImpl.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginConnectionImpl.java
@@ -197,7 +197,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
 
   /**
    * Shall be used to ensure thread-safety of {@link #synchronousSends}. <br>
-   * (Please read its JavaDoc before continuing to read this JavaDoc: It explains the mechanism of
+   * (Please read its Javadoc before continuing to read this Javadoc: It explains the mechanism of
    * synchronous sends, and it is assumed that you understand it in what follows here.)<br>
    * <br>
    * It is a {@link ReadWriteLock} because synchronous sends shall by design be used infrequently,
@@ -420,8 +420,8 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
   }
 
   /**
-   * ATTENTION: Only for internal use in {@link FCPConnectionHandler#getFCPPluginConnection(
-   * String)}.<br>
+   * ATTENTION: Only for internal use by {@link PluginConnectionRegistry} when resolving plugin
+   * connections for a {@link FCPConnectionHandler}.<br>
    * Server / client code should instead always send messages, for example via {@link
    * #send(SendDirection, FCPPluginMessage)}, to check whether the connection is alive. This is to
    * ensure that the implementation of this class could safely be changed to allow the server to be
@@ -628,14 +628,14 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     // sendSynchronous() is waiting for.
     // So it is our job to pass the reply to a possibly existing sendSynchronous() thread.
     // We do this through the Map FCPPluginConnectionImpl.synchronousSends, which is guarded by
-    // FCPPluginConnectionImpl.synchronousSendsLock. Also see the JavaDoc of the Map for an
+    // FCPPluginConnectionImpl.synchronousSendsLock. Also see the Javadoc of the Map for an
     // overview of this mechanism.
 
     if (!message.isReplyMessage()) {
       return false;
     }
 
-    // Since the JavaDoc of sendSynchronous() tells people to use it not very often due to
+    // Since the Javadoc of sendSynchronous() tells people to use it not very often due to
     // the impact upon thread count, we assume that the percentage of messages which pass
     // through here for which there is an actual sendSynchronous() thread waiting is small.
     // Thus, a ReadWriteLock is used, and we here only take the ReadLock, which can be taken
@@ -905,16 +905,16 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
       final SynchronousSend synchronousSend = new SynchronousSend(completionSignal);
 
       // An assert() instead of a throwing is fine:
-      // - The constructor of FCPPluginMessage which we tell the user to use in the JavaDoc
+      // - The constructor of FCPPluginMessage which we tell the user to use in the Javadoc
       //   does generate a random identifier, so collisions will only happen if the user
-      //   ignores the JavaDoc or changes the constructor.
+      //   ignores the Javadoc or changes the constructor.
       // - If the assertion is not true, then the following put() will replace the old
       //   SynchronousSend, so its Condition will never get signaled, and its
       //   thread waiting in sendSynchronous() will timeout safely. It IS possible that this
       //   thread will then get a reply which does not belong to it. But the wrong reply will
       //   only affect the caller, the FCPPluginConnectionImpl will keep working fine,
       //   especially no threads will become stalled forever. As the caller is at fault for
-      //   the issue, it is fine if he breaks his own stuff :) The JavaDoc also documents this
+      //   the issue, it is fine if he breaks his own stuff :) The Javadoc also documents this
 
       if (synchronousSends.containsKey(message.identifier)) {
         throw new IllegalStateException("FCPPluginMessage.identifier should be unique");

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginClientMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginClientMessageTest.java
@@ -155,7 +155,11 @@ class FCPPluginClientMessageTest {
 
     try (FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class)) {
       FCPPluginConnection connection = Mockito.mock(FCPPluginConnection.class);
-      Mockito.when(handler.getFCPPluginConnection(PLUGIN_NAME)).thenReturn(connection);
+      FCPServer server = Mockito.mock(FCPServer.class);
+      PluginConnectionRegistry registry = Mockito.mock(PluginConnectionRegistry.class);
+      Mockito.when(handler.getServer()).thenReturn(server);
+      Mockito.when(handler.pluginConnectionRegistry()).thenReturn(registry);
+      Mockito.when(registry.get(PLUGIN_NAME, server, handler)).thenReturn(connection);
       Node node = Mockito.mock(Node.class);
 
       message.run(handler, node);
@@ -177,7 +181,11 @@ class FCPPluginClientMessageTest {
     FCPPluginClientMessage message = createMessage(null);
     try (FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class)) {
       FCPPluginConnection connection = Mockito.mock(FCPPluginConnection.class);
-      Mockito.when(handler.getFCPPluginConnection(PLUGIN_NAME)).thenReturn(connection);
+      FCPServer server = Mockito.mock(FCPServer.class);
+      PluginConnectionRegistry registry = Mockito.mock(PluginConnectionRegistry.class);
+      Mockito.when(handler.getServer()).thenReturn(server);
+      Mockito.when(handler.pluginConnectionRegistry()).thenReturn(registry);
+      Mockito.when(registry.get(PLUGIN_NAME, server, handler)).thenReturn(connection);
       Mockito.doThrow(new IOException("boom"))
           .when(connection)
           .send(Mockito.eq(SendDirection.TO_SERVER), Mockito.any());
@@ -195,24 +203,12 @@ class FCPPluginClientMessageTest {
   void run_whenHandlerThrowsPluginNotFound_throwsMessageInvalid() throws Exception {
     FCPPluginClientMessage message = createMessage(null);
     try (FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class)) {
-      Mockito.when(handler.getFCPPluginConnection(PLUGIN_NAME))
+      FCPServer server = Mockito.mock(FCPServer.class);
+      PluginConnectionRegistry registry = Mockito.mock(PluginConnectionRegistry.class);
+      Mockito.when(handler.getServer()).thenReturn(server);
+      Mockito.when(handler.pluginConnectionRegistry()).thenReturn(registry);
+      Mockito.when(registry.get(PLUGIN_NAME, server, handler))
           .thenThrow(new PluginNotFoundException());
-
-      Node node = Mockito.mock(Node.class);
-
-      MessageInvalidException ex =
-          assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
-
-      assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, ex.protocolCode);
-      assertEquals(IDENTIFIER, ex.ident);
-    }
-  }
-
-  @Test
-  void run_whenPluginConnectionMissing_throwsMessageInvalid() throws Exception {
-    FCPPluginClientMessage message = createMessage(null);
-    try (FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class)) {
-      Mockito.when(handler.getFCPPluginConnection(PLUGIN_NAME)).thenReturn(null);
 
       Node node = Mockito.mock(Node.class);
 


### PR DESCRIPTION
## Summary
- Remove `FCPConnectionHandler#getFCPPluginConnection(...)` in favor of a package-scoped `pluginConnectionRegistry()` accessor.
- Resolve server plugin connections directly via `PluginConnectionRegistry#get(...)` in `FCPPluginClientMessage` and treat `PluginNotFoundException` as the unavailable signal.
- Update unit tests to stub the registry lookup and drop the now-impossible `null` connection case.
- Minor Javadoc wording fixes in `FCPPluginConnectionImpl`.

## Testing
- `./gradlew spotlessApply`
- `./gradlew test --tests '*FCPPluginClientMessageTest'`