### PR TITLE
refactor(fcp): split ClientGet helpers and update failure callback

### DIFF
--- a/src/main/java/network/crypta/client/FetchWaiter.java
+++ b/src/main/java/network/crypta/client/FetchWaiter.java
@@ -16,11 +16,11 @@ import network.crypta.node.RequestClient;
  * #waitForCompletion()} to obtain the outcome.
  *
  * <p>The instance holds the first terminal outcome it receives: either {@link
- * #onSuccess(FetchResult, ClientGetter)} or {@link #onFailure(FetchException, ClientGetter)}.
- * Subsequent terminal signals are ignored to preserve the single-result invariant. Callers waiting
- * in {@link #waitForCompletion()} block until the outcome is available or the current thread is
- * interrupted. If interrupted, the method preserves the interrupt status and reports cancellation
- * via a {@link FetchException} with mode {@code CANCELLED}.
+ * #onSuccess(FetchResult, ClientGetter)} or {@link #onFailure(FetchException)}. Subsequent terminal
+ * signals are ignored to preserve the single-result invariant. Callers waiting in {@link
+ * #waitForCompletion()} block until the outcome is available or the current thread is interrupted.
+ * If interrupted, the method preserves the interrupt status and reports cancellation via a {@link
+ * FetchException} with mode {@code CANCELLED}.
  *
  * <p>Thread-safety: all state access is synchronized on {@code this}. Multiple threads may wait for
  * completion concurrently; exactly one terminal outcome is observed. The class performs no I/O and
@@ -85,10 +85,9 @@ public class FetchWaiter implements ClientGetCallback {
    * is stored as-is and later rethrown by {@link #waitForCompletion()}.
    *
    * @param e Non-null {@link FetchException} describing why the fetch failed or was canceled.
-   * @param state The originating {@link ClientGetter} for correlation; not stored by this class.
    */
   @Override
-  public synchronized void onFailure(FetchException e, ClientGetter state) {
+  public synchronized void onFailure(FetchException e) {
     if (finished) return;
     this.error = e;
     finished = true;
@@ -99,10 +98,10 @@ public class FetchWaiter implements ClientGetCallback {
    * Blocks until a terminal outcome is available and returns the result or throws the failure.
    *
    * <p>This method waits until either {@link #onSuccess(FetchResult, ClientGetter)} or {@link
-   * #onFailure(FetchException, ClientGetter)} has been invoked. If the current thread is
-   * interrupted while waiting, the interrupt flag is restored and a {@link FetchException} with
-   * mode {@code CANCELLED} is thrown to signal cancellation to the caller. The method is safe to
-   * call from multiple threads; once completed, all callers observe the same terminal outcome.
+   * #onFailure(FetchException)} has been invoked. If the current thread is interrupted while
+   * waiting, the interrupt flag is restored and a {@link FetchException} with mode {@code
+   * CANCELLED} is thrown to signal cancellation to the caller. The method is safe to call from
+   * multiple threads; once completed, all callers observe the same terminal outcome.
    *
    * <pre>{@code
    * // Example: simple synchronous fetch pattern

--- a/src/main/java/network/crypta/client/NullClientCallback.java
+++ b/src/main/java/network/crypta/client/NullClientCallback.java
@@ -61,20 +61,17 @@ public class NullClientCallback implements ClientGetCallback, ClientPutCallback 
   /**
    * Handles a fetch failure without performing application-level recovery.
    *
-   * <p>This implementation logs the supplied {@link FetchException} together with the associated
-   * {@link ClientGetter} at trace level when tracing is enabled and otherwise does nothing. It does
-   * not attempt retries, modify the {@code state}, or rethrow the exception. The method is safe to
-   * use in scenarios where failures should be recorded for diagnostics but silently ignored at the
-   * caller boundary.
+   * <p>This implementation logs the supplied {@link FetchException} at trace level when tracing is
+   * enabled and otherwise does nothing. It does not attempt retries or rethrow the exception. The
+   * method is safe to use in scenarios where failures should be recorded for diagnostics but
+   * silently ignored at the caller boundary.
    *
    * @param e the failure description produced by the fetch logic; passed through to logging and
    *     never modified by this implementation.
-   * @param state the originating getter that reported the failure; used only for logging and may be
-   *     {@code null} when no concrete state object is available.
    */
   @Override
-  public void onFailure(FetchException e, ClientGetter state) {
-    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onFailure e={}, state={}", e, state, e);
+  public void onFailure(FetchException e) {
+    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onFailure e={}", e, e);
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/ClientContext.java
+++ b/src/main/java/network/crypta/client/async/ClientContext.java
@@ -431,7 +431,7 @@ public class ClientContext {
                   getter.start(context);
                 } catch (FetchException e) {
                   if (getter.clientCallback != null) {
-                    getter.clientCallback.onFailure(e, getter);
+                    getter.clientCallback.onFailure(e);
                   }
                 }
                 return true;

--- a/src/main/java/network/crypta/client/async/ClientGetCallback.java
+++ b/src/main/java/network/crypta/client/async/ClientGetCallback.java
@@ -57,8 +57,6 @@ public interface ClientGetCallback extends ClientBaseCallback {
    *
    * @param e The {@link FetchException} describing why the fetch did not complete successfully; it
    *     may include causes and structured error codes for diagnostics and policy decisions.
-   * @param state The original {@link ClientGetter} that initiated the fetch; useful for correlating
-   *     application state, logging, and potential retry logic.
    */
-  void onFailure(FetchException e, ClientGetter state);
+  void onFailure(FetchException e);
 }

--- a/src/main/java/network/crypta/client/async/ClientGetter.java
+++ b/src/main/java/network/crypta/client/async/ClientGetter.java
@@ -800,7 +800,7 @@ public class ClientGetter extends BaseClientGetter
 
     e = normalizeFetchException(e);
     if (LOG.isDebugEnabled()) LOG.debug("onFailure({}, {}) on {} for {}", e, state, this, uri, e);
-    if (!alreadyFinished) clientCallback.onFailure(e, ClientGetter.this);
+    if (!alreadyFinished) clientCallback.onFailure(e);
   }
 
   private FetchException adjustTooBigForFilter(FetchException e) {

--- a/src/main/java/network/crypta/client/async/USKManager.java
+++ b/src/main/java/network/crypta/client/async/USKManager.java
@@ -441,7 +441,7 @@ public class USKManager {
               }
 
               @Override
-              public void onFailure(FetchException e, ClientGetter state) {
+              public void onFailure(FetchException e) {
                 if (e.isDataFound()) cb.success(origURI, token);
                 else if (e.isDNF()) cb.dnf(origURI, token, e);
                 else cb.failed(origURI, token, e);
@@ -634,7 +634,7 @@ public class USKManager {
       final USK key, final long edition, final ClientContext ctx) {
     return new ClientGetCallback() {
       @Override
-      public void onFailure(FetchException e, ClientGetter state) {
+      public void onFailure(FetchException e) {
         if (e.newURI != null) {
           if (LOG.isDebugEnabled()) LOG.debug("Prefetch succeeded with redirect for {}", key);
           updateKnownGood(key, edition, ctx);

--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -146,19 +146,50 @@ public class ClientGet extends ClientRequest {
       "Unable to read fetch settings, will use default settings";
 
   /**
-   * Return-handling strategies that drive how response bytes are surfaced to the FCP caller.
+   * Defines how fetched bytes are delivered to the remote FCP caller.
    *
-   * <p>The enum combines with serialized {@link #code} values so persistent queues can restore the
-   * original delivery semantics quickly during restarts.
+   * <p>This enum is serialized into compact short codes so persistent requests can be restored
+   * exactly across restarts and reconnections. It also drives which message types are emitted (such
+   * as {@link AllDataMessage} versus metadata-only status updates) and whether the request
+   * allocates disk buckets up front. Callers choose a value based on the desired delivery
+   * semantics, expected payload size, and whether they need immediate access to the content or only
+   * completion status.
+   *
+   * <p>Because the value is persisted, any changes must remain backward compatible with the stored
+   * codes.
    */
   public enum ReturnType {
-    /** Returns the downloaded data immediately as an {@link AllDataMessage} bucket. */
+    /**
+     * Returns the downloaded data immediately as an {@link AllDataMessage} bucket.
+     *
+     * <p>This mode is appropriate for direct client reads where the connection is expected to
+     * remain open until completion. The payload is surfaced as a bucket that the connection handler
+     * streams to the caller, and callers should treat the bucket contents as read-only.
+     */
     DIRECT((short) 0),
-    /** Suppresses data transfer entirely and reports only success or failure metadata. */
+    /**
+     * Suppresses data transfer entirely and reports only success or failure metadata.
+     *
+     * <p>This mode is useful for probes or availability checks where only status, sizes, or MIME
+     * hints are needed. The request still performs validation and updates progress caches, but it
+     * does not emit the payload itself.
+     */
     NONE((short) 1),
-    /** Streams the fully downloaded payload into a caller-provided file on disk. */
+    /**
+     * Streams the fully downloaded payload into a caller-provided file on disk.
+     *
+     * <p>Disk output is gated by DDA and node policy checks, and the target path is validated
+     * before the fetch starts. Callers should ensure the destination is writable and stable across
+     * restarts because the request may resume or restart.
+     */
     DISK((short) 2),
-    /** Provides the payload over the chunked transfer protocol extension. */
+    /**
+     * Provides the payload over the chunked transfer protocol extension.
+     *
+     * <p>This mode streams bytes in chunks rather than a single terminal message, enabling large
+     * downloads over long-lived connections. Progress and completion events are still emitted so
+     * clients can reconcile final status with partial chunk delivery.
+     */
     CHUNKED((short) 3);
 
     final short code;
@@ -170,12 +201,14 @@ public class ClientGet extends ClientRequest {
     /**
      * Maps a serialized return-type code back to the corresponding enum constant.
      *
-     * <p>Persistence files and FCP messages use compact shorts to save bandwidth, so this helper
-     * restores the strongly typed enum and fails fast when unexpected values surface.
+     * <p>Persistence files and FCP messages store a short code to minimize storage and bandwidth.
+     * This helper converts that compact value into the strongly typed enum used by the rest of the
+     * request pipeline. Unknown codes indicate corrupt persistence data or an incompatible sender
+     * and are rejected immediately to avoid ambiguous delivery behavior.
      *
-     * @param x numeric tag emitted by persistent storage or remote clients.
-     * @return matching {@link ReturnType} describing how the caller expects data to be delivered.
-     * @throws IllegalArgumentException if the code is not recognized.
+     * @param x numeric tag emitted by persistent storage or remote clients to decode.
+     * @return matching {@link ReturnType} describing the expected delivery semantics.
+     * @throws IllegalArgumentException if the provided code does not map to a known constant.
      */
     public static ReturnType getByCode(short x) {
       return switch (x) {
@@ -193,36 +226,37 @@ public class ClientGet extends ClientRequest {
   /**
    * Builds a persistent GET request for callers that enqueue work outside live FCP sessions.
    *
-   * <p>The constructor clones the node's default {@link FetchContext}, wires up event listeners,
+   * <p>This constructor clones the node's default {@link FetchContext}, wires up event listeners,
    * normalizes retry limits, and resolves the return path before handing everything to a dedicated
    * {@link ClientGetter}. It is typically used by built-in services that want their requests to be
    * restartable across reboots and obey the global queue semantics rather than the per-connection
-   * queue. The supplied flags tightly control datastore reachability, filtering, cache writes, and
-   * the maximum size of the temporary buckets allocated on behalf of this request.
+   * queue. The supplied flags control datastore reachability, filtering, cache writes, and the
+   * maximum size of the temporary buckets allocated for the request. The resulting instance is
+   * ready to register and start once constructed.
    *
-   * @param globalClient Persistent client facade owning the global queue slot.
+   * @param globalClient persistent client facade owning the global queue slot.
    * @param uri FreenetURI describing the content key and optional metadata.
-   * @param dsOnly True to confine fetching to the local datastore only.
-   * @param ignoreDS Bypasses the datastore entirely when evaluating availability hints.
-   * @param filterData Applies on-the-fly MIME filtering before writing or returning data.
-   * @param maxSplitfileRetries Maximum block retries for splitfile reconstruction attempts.
-   * @param maxNonSplitfileRetries Retry ceiling for simple non-splitfile requests before failing.
-   * @param maxOutputLength Upper bound in bytes for payload and temporary storage usage.
-   * @param returnType Delivery strategy describing whether bytes stream, persist, or skip.
-   * @param persistRebootOnly True to persist only across reboots instead of fully forever.
-   * @param identifier Application supplied identifier echoed through FCP status events.
-   * @param verbosity Bitmask controlling which progress events get forwarded back.
-   * @param prioClass Priority class guiding scheduler fairness and bandwidth allocation.
-   * @param returnFilename Destination filesystem path used solely when disk output requested.
-   * @param charset Legacy charset hint ignored here but preserved for compatibility logging.
-   * @param writeToClientCache Allows writing the payload into the client HTTP cache.
-   * @param realTimeFlag True when the request participates in the realtime scheduler lane.
-   * @param binaryBlob Enables BinaryBlob writer semantics instead of classic bucket delivery.
-   * @param core Node client core providing factories, permission checks, and trackers.
-   * @throws IdentifierCollisionException Identifier already present on the owning persistent
+   * @param dsOnly true to confine fetching to the local datastore only.
+   * @param ignoreDS bypasses the datastore entirely when evaluating availability hints.
+   * @param filterData applies MIME filtering before writing or returning data.
+   * @param maxSplitfileRetries maximum block retries for splitfile reconstruction attempts.
+   * @param maxNonSplitfileRetries retry ceiling for non-splitfile requests before failing.
+   * @param maxOutputLength upper bound in bytes for payload and temporary storage usage.
+   * @param returnType delivery strategy describing whether bytes stream, persist, or skip.
+   * @param persistRebootOnly true to persist only across reboots instead of forever.
+   * @param identifier application-supplied identifier echoed through FCP status events.
+   * @param verbosity bitmask controlling which progress events get forwarded back.
+   * @param prioClass priority class guiding scheduler fairness and bandwidth allocation.
+   * @param returnFilename destination filesystem path used solely when disk output requested.
+   * @param charset legacy charset hint ignored but retained for compatibility logging.
+   * @param writeToClientCache allows writing the payload into the client HTTP cache.
+   * @param realTimeFlag true when the request participates in the realtime scheduler lane.
+   * @param binaryBlob enables BinaryBlob writer semantics instead of classic bucket delivery.
+   * @param core node client core providing factories, permission checks, and trackers.
+   * @throws IdentifierCollisionException identifier already present on the owning persistent
    *     client.
-   * @throws NotAllowedException Download target rejected by DDA or security policy.
-   * @throws IOException Filesystem errors while preparing disk buckets or output locations.
+   * @throws NotAllowedException download target rejected by DDA or security policy.
+   * @throws IOException filesystem errors while preparing disk buckets or output locations.
    */
   public ClientGet(
       PersistentRequestClient globalClient,
@@ -286,18 +320,18 @@ public class ClientGet extends ClientRequest {
   /**
    * Creates a {@code ClientGet} sourced from an incoming {@link ClientGetMessage} on an FCP link.
    *
-   * <p>This path mirrors the original client parameters as closely as possible: it validates DDA
-   * permissions, copies all caller-defined {@link FetchContext} overrides, seeds allowed MIME
-   * lists, and prepares any disk buckets before instantiating the {@link ClientGetter}. Identifiers
-   * can be scoped either to the connection or to the global queue, so both handler-level and
-   * persistent collision checks are performed before the request becomes visible to other
-   * components.
+   * <p>This path mirrors the caller's parameters as closely as possible: it validates DDA
+   * permissions, copies {@link FetchContext} overrides, seeds allowed MIME lists, and prepares any
+   * disk buckets before instantiating the {@link ClientGetter}. Identifiers can be scoped either to
+   * the connection or to the global queue, so both handler-level and persistent collision checks
+   * are performed before the request becomes visible to other components. The resulting request is
+   * ready to register and start immediately.
    *
-   * @param handler Connection handler responsible for per-client identifiers and DDA checks.
-   * @param message Parsed ClientGetMessage containing all caller preferences and flags.
-   * @param core Node client core granting fetch contexts, caches, and permission evaluators.
-   * @throws IdentifierCollisionException Identifier already active on this handler or its client.
-   * @throws MessageInvalidException Message failed validation or violated configured DDA policies.
+   * @param handler connection handler responsible for per-client identifiers and DDA checks.
+   * @param message parsed message containing caller preferences, flags, and return settings.
+   * @param core node client core granting fetch contexts, caches, and permission evaluators.
+   * @throws IdentifierCollisionException identifier already active on this handler or its client.
+   * @throws MessageInvalidException message failed validation or violated configured DDA policies.
    */
   public ClientGet(FCPConnectionHandler handler, ClientGetMessage message, NodeClientCore core)
       throws IdentifierCollisionException, MessageInvalidException {
@@ -354,25 +388,21 @@ public class ClientGet extends ClientRequest {
   private ReturnSetup configureReturnHandlingForGlobalRequest(
       ReturnType type, File returnFilename, boolean filterData, NodeClientCore core)
       throws NotAllowedException, IOException {
-    return switch (type) {
-      case DISK -> {
-        File file = Objects.requireNonNull(returnFilename, "returnFilename");
-        ensureDownloadAllowed(core, file);
-        yield createDiskReturnSetup(file, filterData);
-      }
-      case NONE -> new ReturnSetup(null, null, null);
-      default -> new ReturnSetup(null, null, null);
-    };
+    if (type == ReturnType.DISK) {
+      File file = Objects.requireNonNull(returnFilename, "returnFilename");
+      ensureDownloadAllowed(core, file);
+      return createDiskReturnSetup(file, filterData);
+    }
+    return new ReturnSetup(null, null, null);
   }
 
   private ReturnSetup configureReturnHandlingForMessage(
       ClientGetMessage message, NodeClientCore core, FCPConnectionHandler handler)
       throws MessageInvalidException {
-    return switch (message.returnType) {
-      case DISK -> buildDiskSetupForMessage(message, core, handler);
-      case NONE -> new ReturnSetup(null, null, null);
-      default -> new ReturnSetup(null, null, null);
-    };
+    if (message.returnType == ReturnType.DISK) {
+      return buildDiskSetupForMessage(message, core, handler);
+    }
+    return new ReturnSetup(null, null, null);
   }
 
   private ReturnSetup buildDiskSetupForMessage(
@@ -494,11 +524,12 @@ public class ClientGet extends ClientRequest {
   /**
    * Serialization-only constructor used when reconstructing requests from persistent storage.
    *
-   * <p>All fields are intentionally left {@code null} (or primitive defaults) so that
+   * <p>All fields are intentionally left {@code null} (or primitive defaults) so that the
    * deserialization helpers can populate them explicitly via {@link #innerResume(ClientContext)}
    * and related restoration methods. Production code should never invoke this constructor directly;
    * always use one of the fully parameterized alternatives that configure a {@link FetchContext}
-   * and getter.
+   * and {@link ClientGetter}. This constructor exists solely to satisfy the Java serialization
+   * framework and keep field initialization centralized in the resume path.
    */
   protected ClientGet() {
     // For serialization.
@@ -533,14 +564,16 @@ public class ClientGet extends ClientRequest {
   /**
    * Starts the asynchronous fetch if it has not yet reached a terminal state.
    *
-   * <p>The method synchronizes briefly to avoid racing with completion logic, kicks off the
+   * <p>This method synchronizes briefly to avoid racing with completion logic, kicks off the
    * underlying {@link ClientGetter}, and emits a persistent tag when the request is tracked beyond
-   * the connection scope. It also updates {@link RequestStatusCache} listeners so GUIs immediately
-   * reflect the {@code started} flag even if the fetch fails before any progress callbacks are
-   * produced. Exceptions raised by the getter are translated into {@link FetchException}s which are
-   * handled by {@link #onFailure(FetchException, ClientGetter)} to guarantee consistent cleanup.
+   * the connection scope. It updates {@link RequestStatusCache} listeners so UIs can reflect the
+   * {@code started} flag even if the fetch fails before any progress callbacks are produced. The
+   * call is idempotent with respect to terminal state: if the request is already finished, it
+   * returns immediately without side effects. Exceptions raised by the getter are translated into
+   * {@link FetchException} instances and routed through {@link #onFailure(FetchException)} to
+   * ensure consistent cleanup.
    *
-   * @param context Client context providing schedulers and bucket factories for execution.
+   * @param context client context providing schedulers and bucket factories for execution.
    */
   @Override
   public void start(ClientContext context) {
@@ -566,12 +599,12 @@ public class ClientGet extends ClientRequest {
       synchronized (this) {
         started = true;
       } // before the failure handler
-      onFailure(e, null);
+      onFailure(e);
     } catch (Exception t) {
       synchronized (this) {
         started = true;
       }
-      onFailure(new FetchException(FetchExceptionMode.INTERNAL_ERROR, t), null);
+      onFailure(new FetchException(FetchExceptionMode.INTERNAL_ERROR, t));
     }
   }
 
@@ -584,11 +617,13 @@ public class ClientGet extends ClientRequest {
   /**
    * Handles disconnections from the node core scheduler or client transport.
    *
-   * <p>If the request was scoped to the connection persistence model, the loss of transport means
-   * the request can never complete for that client, so it is cancelled immediately. Global queue
-   * requests simply continue running and rely on later reconnection to deliver pending messages.
+   * <p>If the request uses connection-scoped persistence, the loss of transport means the request
+   * can no longer deliver results to that client, so it is canceled immediately. Global queue
+   * requests continue running and rely on later reconnection to deliver any pending messages. This
+   * method does not attempt to resume or restart; it only decides whether the request remains
+   * active based on the persistence model. The call is safe to invoke multiple times.
    *
-   * @param context Client context owning the request; unused but kept for contract parity.
+   * @param context client context owning the request; unused but retained for parity.
    */
   @Override
   public void onLostConnection(ClientContext context) {
@@ -601,13 +636,13 @@ public class ClientGet extends ClientRequest {
    *
    * <p>The method snapshots final MIME type, payload length, completion timestamp, and the bucket
    * or blob handle returned by {@link ClientGetter}. Depending on {@link ReturnType}, it either
-   * retains the bucket for {@link AllDataMessage} delivery or leaves the bytes on disk. Afterward
-   * it emits {@link DataFoundMessage}, {@link AllDataMessage}, marks statistics caches, and informs
-   * the owning {@link FCPConnectionHandler} or {@link PersistentRequestClient}. Any secondary calls
-   * are ignored defensively to avoid double frees.
+   * retains the bucket for {@link AllDataMessage} delivery or leaves the bytes on disk. It then
+   * emits {@link DataFoundMessage} and {@link AllDataMessage} as appropriate, updates status
+   * caches, and informs the owning {@link FCPConnectionHandler} or {@link PersistentRequestClient}.
+   * Any secondary calls are ignored defensively to prevent double frees or duplicate notifications.
    *
-   * @param result Result wrapper exposing MIME metadata and bucket accessors.
-   * @param state ClientGetter instance used for blob access during binary-blob transfers.
+   * @param result result wrapper exposing MIME metadata and bucket accessors.
+   * @param state client getter instance used for blob access during BinaryBlob transfers.
    */
   public void onSuccess(FetchResult result, ClientGetter state) {
     LOG.debug("Succeeded: {}", identifier);
@@ -645,12 +680,12 @@ public class ClientGet extends ClientRequest {
    * match the recorded {@code foundDataLength}, captures the supplied completion timestamp, and
    * stores the provided bucket when {@link ReturnType#DIRECT} applies. Any mismatch results in a
    * {@link ResumeFailedException}, forcing the caller to restart the download rather than trusting
-   * potentially corrupted state.
+   * potentially corrupted state. This method is intended for controlled migration flows only.
    *
-   * @param context Client context performing the migration and validation checks.
-   * @param completionTime Epoch milliseconds representing the recorded completion instant.
-   * @param data Bucket already holding the downloaded payload for direct returns.
-   * @throws ResumeFailedException Validation failed because existing output looked inconsistent.
+   * @param context client context performing the migration and validation checks.
+   * @param completionTime epoch milliseconds representing the recorded completion instant.
+   * @param data bucket already holding the downloaded payload for direct returns.
+   * @throws ResumeFailedException validation failed because existing output looked inconsistent.
    */
   @SuppressWarnings("unused")
   public void setSuccessForMigration(ClientContext context, long completionTime, Bucket data)
@@ -760,12 +795,13 @@ public class ClientGet extends ClientRequest {
    * requested) the {@link AllDataMessage}. It also ships compatibility metadata, hashes, MIME
    * hints, and expected lengths so late subscribers observe the same state as live listeners. When
    * the caller only wants data, the method enforces {@link ReturnType#DIRECT} and otherwise emits a
-   * {@link ProtocolErrorMessage}.
+   * {@link ProtocolErrorMessage}. The method is idempotent and only reflects the cached request
+   * state at the time of invocation.
    *
-   * @param handler Output handler representing the destination connection to replay into.
-   * @param listRequestIdentifier Optional secondary identifier for multi-request list operations.
-   * @param includeData True to include {@link AllDataMessage} bodies when available.
-   * @param onlyData True to request data frames exclusively, skipping metadata messages.
+   * @param handler output handler representing the destination connection to replay into.
+   * @param listRequestIdentifier optional secondary identifier for multi-request list operations.
+   * @param includeData true to include {@link AllDataMessage} bodies when available.
+   * @param onlyData true to request data frames exclusively, skipping metadata messages.
    */
   @Override
   public void sendPendingMessages(
@@ -860,11 +896,11 @@ public class ClientGet extends ClientRequest {
    * {@link GetFailedMessage}, records completion timestamps, and marks the request as finished so
    * restart logic can take over. It then emits {@link DataFoundMessage} or {@link GetFailedMessage}
    * equivalents, intentionally leaving buckets intact so restart attempts can reuse cached blocks.
+   * Secondary invocations after completion are ignored to preserve idempotency.
    *
-   * @param e Detailed {@link FetchException} describing the failure classification.
-   * @param state Optional getter supplying buckets to retain across restarts; may be {@code null}.
+   * @param e detailed {@link FetchException} describing the failure classification.
    */
-  public void onFailure(FetchException e, ClientGetter state) {
+  public void onFailure(FetchException e) {
     if (finished) return;
     synchronized (this) {
       if (e.getExpectedSize() != 0) this.foundDataLength = e.getExpectedSize();
@@ -884,18 +920,19 @@ public class ClientGet extends ClientRequest {
   }
 
   /**
-   * Cleans up when the owning queue removes the request, either manually or due to shutdown.
+   * Cleans up when the owning queue removes the request, either manually or due to shut down.
    *
    * <p>If the fetch was still running it fabricates a cancellation {@link FetchException} so the
    * client receives a {@link GetFailedMessage} with an explicit code. Afterward it notifies the
    * connection or persistent client that the entry disappeared, frees associated buckets, and calls
-   * the superclass hook so shared accounting (such as tag persistence) also runs.
+   * the superclass hook so shared accounting (such as tag persistence) also runs. This method is
+   * safe to invoke once per removal event.
    *
-   * @param context Client context invoking the removal.
+   * @param context client context invoking the removal for lifecycle bookkeeping.
    */
   @Override
   public void requestWasRemoved(ClientContext context) {
-    // if request is still running, send a GetFailed with code=cancelled
+    // if request is still running, send a GetFailed with code=canceled
     if (!finished) {
       synchronized (this) {
         succeeded = false;
@@ -965,11 +1002,29 @@ public class ClientGet extends ClientRequest {
     }
   }
 
+  /**
+   * Exposes the underlying {@link ClientRequester} for base-class scheduling operations.
+   *
+   * <p>The base {@link ClientRequest} infrastructure uses this accessor to determine which
+   * requester instance owns the in-flight operation for persistence, cancellation, and stats
+   * tracking. The returned object is the request's active {@link ClientGetter} and should be
+   * treated as read-only by callers outside the request lifecycle.
+   *
+   * @return client requester instance used to run this request.
+   */
   @Override
   protected ClientRequester getClientRequest() {
     return getter;
   }
 
+  /**
+   * Releases in-memory buckets owned by the request once completion is finalized.
+   *
+   * <p>This method intentionally does not remove data written to disk, because disk-backed requests
+   * are expected to leave the payload in place for the caller. It clears and frees any
+   * direct-return buckets and the initial metadata bucket if present. The method is safe to call
+   * multiple times; subsequent invocations become no-ops.
+   */
   @Override
   protected void freeData() {
     // We don't remove the data if written to a file.
@@ -988,9 +1043,11 @@ public class ClientGet extends ClientRequest {
    * Reports whether the request has completed successfully and retained its payload metadata.
    *
    * <p>The value remains {@code true} even after {@link #freeData()} releases buckets so that
-   * clients can distinguish between cleanly finished requests and those cancelled during restart.
+   * clients can distinguish between cleanly finished requests and those canceled during restart. It
+   * is set when {@link #onSuccess(FetchResult, ClientGetter)} records the terminal state and never
+   * reset unless a restart is initiated.
    *
-   * @return {@code true} once {@link #onSuccess(FetchResult, ClientGetter)} recorded final state.
+   * @return {@code true} once final success has been recorded for this request.
    */
   @Override
   public boolean hasSucceeded() {
@@ -1002,7 +1059,8 @@ public class ClientGet extends ClientRequest {
    *
    * <p>Direct mode keeps the downloaded bucket resident so reconnecting clients can still replay an
    * {@link AllDataMessage}. Disk-bound and chunked requests, by contrast, cannot ship the payload
-   * back through the queue once the transfer has completed.
+   * back through the queue once the transfer has completed. This flag is informational and does not
+   * initiate any I/O.
    *
    * @return {@code true} when AllData messages should be emitted upon completion.
    */
@@ -1014,7 +1072,8 @@ public class ClientGet extends ClientRequest {
    * Indicates whether the payload should be written directly to the caller's disk path.
    *
    * <p>{@link ReturnType#DISK} requests rely on {@link #targetFile} for their lifecycle checks,
-   * including restart validation to ensure partially written files are safe to reuse.
+   * including restart validation to ensure partially written files are safe to reuse. This flag
+   * mirrors the configured return type and does not check whether the file already exists.
    *
    * @return {@code true} when this request writes into a caller-specified file.
    */
@@ -1025,7 +1084,12 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the current URI the request is fetching, including redirects applied after restarts.
    *
-   * @return Mutable {@link FreenetURI} instance representing the active key being chased.
+   * <p>The URI may change over time if redirects are followed during retries or restarts. The
+   * returned instance is the live reference used by this request, so callers should treat it as
+   * read-only and avoid mutating it. This accessor is side-effect free and can be called at any
+   * time, but it does not synchronize with concurrent updates beyond the request's own locking.
+   *
+   * @return current {@link FreenetURI} reference describing the active fetch target.
    */
   public FreenetURI getURI() {
     return uri;
@@ -1035,9 +1099,11 @@ public class ClientGet extends ClientRequest {
    * Returns the best-known payload size in bytes, either from splitter hints or the final download.
    *
    * <p>The value is persisted between restarts and updated whenever {@link FetchException}
-   * discloses an expected size, allowing clients to show progress even before real data arrives.
+   * discloses an expected size, allowing clients to show progress even before real data arrives. A
+   * value of {@code -1} means the size is still unknown. This accessor does not trigger any network
+   * activity and simply returns the latest cached estimate.
    *
-   * @return Byte length recorded for the fetched data, or {@code -1} if still unknown.
+   * @return recorded payload length in bytes, or {@code -1} when unknown.
    */
   public long getDataSize() {
     if (foundDataLength > 0) return foundDataLength;
@@ -1047,9 +1113,10 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the MIME type detected so far for the payload.
    *
-   * <p>Splitter hints, {@link ExpectedMIMEEvent}s, and final {@link FetchResult} metadata all
-   * update this string, which is persisted to help clients decide whether to stream or store
-   * results.
+   * <p>Splitter hints, {@code ExpectedMIMEEvent} notifications, and the final {@link FetchResult}
+   * metadata all update this string, which is persisted to help clients decide whether to stream or
+   * store results. The value can be {@code null} if no MIME information has been reported yet. This
+   * accessor returns the latest cached value without forcing any additional validation.
    *
    * @return MIME type reported for the payload, or {@code null} if undetermined.
    */
@@ -1061,7 +1128,12 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the on-disk destination file if the request was configured for disk output.
    *
-   * @return Absolute file path reserved for disk downloads, or {@code null} otherwise.
+   * <p>The file reference is established during request construction and remains stable across
+   * restarts. It may not exist until the download succeeds, and callers should not assume it is
+   * created or populated. When the return type is not {@link ReturnType#DISK}, this method returns
+   * {@code null}.
+   *
+   * @return destination file for disk downloads, or {@code null} otherwise.
    */
   public File getDestFilename() {
     return targetFile;
@@ -1070,11 +1142,12 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the fraction of splitfile blocks downloaded successfully.
    *
-   * <p>The metric reflects the most recent {@link SplitfileProgressEvent} cached via {@link
-   * #progressPending}, making it useful for dashboards that prefer percentages over raw block
-   * counts. When no progress has been recorded it returns {@code -1} to signal "unknown".
+   * <p>The metric reflects the most recent {@code SplitfileProgressEvent} cached via {@link
+   * #progressPending}, making it useful for dashboards that prefer percentages to raw block counts.
+   * When no progress has been recorded it returns {@code -1} to signal an unknown fraction. The
+   * value is a snapshot and may lag behind the underlying fetcher in highly concurrent flows.
    *
-   * @return Value between {@code 0.0} and {@code 1.0}, or {@code -1} when unavailable.
+   * @return value between {@code 0.0} and {@code 1.0}, or {@code -1} when unavailable.
    */
   @Override
   public double getSuccessFraction() {
@@ -1086,7 +1159,11 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the total number of blocks expected for the splitfile once finalized.
    *
-   * @return Total block count from the latest progress event, or {@code 1} when unknown.
+   * <p>The count is derived from the latest progress snapshot and is intended for UI display or
+   * coarse scheduling decisions. If no progress snapshot exists yet, this method returns {@code 1}
+   * as a neutral nonzero denominator to avoid division by zero in callers.
+   *
+   * @return total block count from the latest progress event, or {@code 1} when unknown.
    */
   @Override
   public double getTotalBlocks() {
@@ -1098,7 +1175,11 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the minimum number of blocks that must be fetched before decode succeeds.
    *
-   * @return Minimum required blocks based on splitter metadata, or {@code 1} if unspecified.
+   * <p>The value comes from the most recent splitfile progress snapshot and may be lower than the
+   * total block count when redundancy is available. If the request has not reported progress yet,
+   * this method returns {@code 1} to represent an unknown, nonzero minimum.
+   *
+   * @return minimum required blocks based on progress, or {@code 1} if unspecified.
    */
   @Override
   public double getMinBlocks() {
@@ -1110,7 +1191,11 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the number of blocks that have failed but might be retried successfully later.
    *
-   * @return Count of non-fatal failed blocks, defaulting to {@code 0} when unknown.
+   * <p>This value is taken from the most recent progress message and represents blocks that have
+   * failed during reconstruction. It may reset or change as retries occur. If no progress has been
+   * recorded, the method returns {@code 0} to indicate an unknown or empty failure count.
+   *
+   * @return count of non-fatal failed blocks, defaulting to {@code 0} when unknown.
    */
   @Override
   public double getFailedBlocks() {
@@ -1122,7 +1207,11 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the number of blocks that failed permanently and will never be retried.
    *
-   * @return Fatal failure block count, defaulting to {@code 0} when no data exists yet.
+   * <p>Fatal failures represent blocks that cannot be recovered with additional retries or
+   * redundancy. The value is taken from the last progress snapshot and may remain {@code 0} for
+   * successful or in-progress requests. If no progress has been recorded, {@code 0} is returned.
+   *
+   * @return fatal failure block count, defaulting to {@code 0} when no data exists yet.
    */
   @Override
   public double getFatalyFailedBlocks() {
@@ -1134,7 +1223,12 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns how many blocks have been successfully fetched so far.
    *
-   * @return Number of fetched blocks, defaulting to {@code 0} when progress is unavailable.
+   * <p>The count reflects the most recent progress snapshot and is useful for rough throughput or
+   * completion estimates. It does not represent the number of blocks already delivered to the
+   * client, only those retrieved by the fetcher. If no progress has been recorded, {@code 0} is
+   * returned.
+   *
+   * @return number of fetched blocks, defaulting to {@code 0} when progress is unavailable.
    */
   @Override
   public double getFetchedBlocks() {
@@ -1146,10 +1240,12 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the compatibility modes detected while traversing splitfile metadata.
    *
-   * <p>The values help reinsertion logic or UI surfaces decide whether a retrieved file can be
-   * reinserted using legacy encodings.
+   * <p>The values are accumulated as splitfile metadata is parsed and are persisted across
+   * restarts. They help reinsertion logic or UI surfaces decide whether a retrieved file can be
+   * reinserted using legacy encodings. The returned array is owned by the compatibility analyzer,
+   * so callers should treat it as read-only.
    *
-   * @return Array of compatibility modes; may be empty but never {@code null}.
+   * @return array of compatibility modes; may be empty but never {@code null}.
    */
   public InsertContext.CompatibilityMode[] getCompatibilityMode() {
     return compatMode.getModes();
@@ -1158,6 +1254,11 @@ public class ClientGet extends ClientRequest {
   /**
    * Indicates whether reinsertion should skip compression because the source data was
    * precompressed.
+   *
+   * <p>This flag is derived from splitfile metadata analysis and is persisted across restarts. It
+   * is intended for downstream insert flows that want to preserve original byte structure rather
+   * than applying a second compression pass. The value is informational and does not affect the
+   * fetch itself.
    *
    * @return {@code true} when compression should not be applied to subsequent insert contexts.
    */
@@ -1168,7 +1269,11 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the crypto key inferred while parsing splitfile metadata, if one was embedded.
    *
-   * @return Copy of the crypto key bytes, or {@code null} when no override was observed.
+   * <p>The key is extracted from compatibility hints and is useful for reinsertion workflows that
+   * need to preserve the original encryption parameters. It may be {@code null} if no override was
+   * present. Callers should treat the returned bytes as immutable.
+   *
+   * @return copy of the crypto key bytes, or {@code null} when no override was observed.
    */
   public byte[] getOverriddenSplitfileCryptoKey() {
     return compatMode.getCryptoKey();
@@ -1177,8 +1282,13 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns a textual explanation for the most recent failure, if any.
    *
+   * <p>The summary is derived from the cached {@link GetFailedMessage} and may include additional
+   * diagnostic text when requested. It returns {@code null} when no failure has been recorded,
+   * which typically means the request is still running or has completed successfully. The returned
+   * text is suitable for UI display and is not guaranteed to be stable across versions.
+   *
    * @param longDescription {@code true} to include any extended diagnostic text when available.
-   * @return Human-readable failure summary, or {@code null} when the request has not failed.
+   * @return human-readable failure summary, or {@code null} when no failure exists.
    */
   @Override
   public String getFailureReason(boolean longDescription) {
@@ -1197,8 +1307,12 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the {@link FetchExceptionMode} associated with the last failure.
    *
-   * @return {@link FetchExceptionMode} describing the failure classification, or {@code null} if
-   *     the request has not failed.
+   * <p>This classification is recorded when a failure is handled and remains available for status
+   * reporting until the request is restarted. It can be {@code null} if the request has not failed
+   * or if no failure has been recorded yet. Callers should treat the value as a snapshot rather
+   * than a live view of the underlying fetcher.
+   *
+   * @return failure classification mode, or {@code null} when no failure exists.
    */
   public FetchExceptionMode getFailureReasonCode() {
     if (getFailedMessage == null) return null;
@@ -1207,6 +1321,11 @@ public class ClientGet extends ClientRequest {
 
   /**
    * Indicates whether the splitter has reported a finalized total block count.
+   *
+   * <p>This is primarily a progress-reporting flag. A value of {@code true} means the total block
+   * count is stable and suitable for percent-based UI calculations. Completed successful requests
+   * are treated as finalized even if no explicit progress snapshot is present. The value may be
+   * {@code false} early in a fetch when metadata is incomplete.
    *
    * @return {@code true} once progress reporting marked the total as finalized or upon success.
    */
@@ -1223,9 +1342,11 @@ public class ClientGet extends ClientRequest {
    * Returns a {@link Bucket} representing the downloaded payload according to the return type.
    *
    * <p>Direct requests hand back the in-memory bucket, disk requests wrap the destination file, and
-   * other return types yield {@code null}. Callers should treat the returned bucket as read-only.
+   * other return types yield {@code null}. Callers should treat the returned bucket as read-only
+   * and should not assume it is non-null unless the return type requires it. The returned instance
+   * reflects the most recent stored payload and does not trigger additional disk or network work.
    *
-   * @return Bucket containing the payload, or {@code null} when no bucket form exists.
+   * @return bucket containing the payload, or {@code null} when no bucket form exists.
    */
   public Bucket getBucket() {
     return makeBucket(true);
@@ -1247,7 +1368,9 @@ public class ClientGet extends ClientRequest {
    * Indicates whether the request can be restarted after a failure.
    *
    * <p>The getter must support restart semantics, the request must have finished, and it must not
-   * have succeeded already. Success cases require manual deletion before another attempt.
+   * have succeeded already. Success cases require manual deletion or explicit reset before another
+   * attempt. This method performs the minimal checks needed to decide if {@link
+   * #restart(ClientContext, boolean)} is likely to proceed without immediate failure.
    *
    * @return {@code true} when {@link #restart(ClientContext, boolean)} may be invoked.
    */
@@ -1267,11 +1390,13 @@ public class ClientGet extends ClientRequest {
   /**
    * Attempts to restart the request after a failure or redirect.
    *
-   * <p>It clears cached errors, resets compatibility tracking, optionally disables filtering, and
-   * hands the restart request to the underlying {@link ClientGetter}. Cache observers are updated
-   * so that frontends show the new redirect or restarted state immediately.
+   * <p>The method clears cached errors, resets compatibility tracking, optionally disables
+   * filtering, and hands the restart request to the underlying {@link ClientGetter}. Cache
+   * observers are updated so that frontends show the new redirect or restarted state immediately.
+   * If the underlying getter fails to restart, the failure is routed through {@link
+   * #onFailure(FetchException)} and the method returns {@code false}.
    *
-   * @param context Client context providing schedulers and persistent storage for restart logic.
+   * @param context client context providing schedulers and persistent storage for restart logic.
    * @param disableFilterData {@code true} to temporarily disable filtering for the next attempt.
    * @return {@code true} when the restart was initiated successfully.
    */
@@ -1287,7 +1412,7 @@ public class ClientGet extends ClientRequest {
       notifyCacheStartedFlag();
       return true;
     } catch (FetchException e) {
-      onFailure(e, null);
+      onFailure(e);
       return false;
     }
   }
@@ -1340,6 +1465,11 @@ public class ClientGet extends ClientRequest {
   /**
    * Indicates whether the last failure provided a permanent redirect URI.
    *
+   * <p>This flag is derived from the most recent {@link GetFailedMessage} and is used by restart
+   * logic to decide whether a redirect should be applied automatically. The value is only
+   * meaningful after a failure has been recorded; otherwise it will return {@code false}. The
+   * method is synchronized to read the cached failure state consistently.
+   *
    * @return {@code true} when {@link GetFailedMessage#redirectURI} is non-null.
    */
   public synchronized boolean hasPermRedirect() {
@@ -1348,6 +1478,10 @@ public class ClientGet extends ClientRequest {
 
   /**
    * Returns whether filterData is currently enabled on the {@link FetchContext}.
+   *
+   * <p>The flag controls whether content filtering is applied before delivery. It can be toggled
+   * during restart flows to temporarily disable filtering for a retry. This method simply reads the
+   * current {@link FetchContext} setting and does not alter any state.
    *
    * @return {@code true} when payloads should be filtered before delivery.
    */
@@ -1444,14 +1578,15 @@ public class ClientGet extends ClientRequest {
   /**
    * Serializes the request state for persistence so that it can be resumed later.
    *
-   * <p>Only FOREVER-persistence requests write detail entries. The method records URIs, return
-   * types, binary-blob preferences, fetch contexts, metadata buckets, and—when finished—either the
-   * success bucket or the failure descriptor. It also streams recent progress snapshots so restarts
-   * can resume without re-downloading already verified blocks.
+   * <p>Only {@link Persistence#FOREVER} requests write detail entries. The method records URIs,
+   * return types, binary-blob preferences, fetch contexts, metadata buckets, and—when finished—
+   * either the success bucket or the failure descriptor. It also streams recent progress snapshots
+   * so restarts can resume without re-downloading already verified blocks. Callers should provide a
+   * stream that is already framed by the persistence layer.
    *
-   * @param dos Destination stream receiving the serialized form with embedded checksums.
-   * @param checker Checksum helper that wraps streams to guard against corruption.
-   * @throws IOException If any of the serialization steps fail or a bucket cannot be stored.
+   * @param dos destination stream receiving the serialized form with embedded checksums.
+   * @param checker checksum helper that wraps streams to guard against corruption.
+   * @throws IOException if serialization fails or a bucket cannot be stored.
    */
   @Override
   public void getClientDetail(DataOutputStream dos, ChecksumChecker checker) throws IOException {
@@ -1517,14 +1652,20 @@ public class ClientGet extends ClientRequest {
   /**
    * Recreates a {@link ClientGet} from serialized persistent storage.
    *
-   * @param dis Input stream positioned at the serialized client detail block.
-   * @param reqID Identifier tuple describing the owner and reference type.
-   * @param context Client context supplying factories used during restoration.
-   * @param checker Checksum helper verifying integrity of embedded buckets.
-   * @return Fully reconstructed {@link ClientRequest} instance ready for resumption.
-   * @throws StorageFormatException Serialized data failed validation or used unknown versions.
-   * @throws IOException Stream IO failed while reading buckets or metadata.
-   * @throws ResumeFailedException Request could not be reconstructed and must restart from scratch.
+   * <p>This factory method is used during startup to restore previously persisted requests. It
+   * validates the serialized header, rebuilds the {@link FetchContext}, restores progress state,
+   * and reconstructs the underlying {@link ClientGetter} where possible. If the stored data is
+   * incomplete or inconsistent, it throws a {@link ResumeFailedException} to signal that the
+   * request should restart rather than trust corrupted state.
+   *
+   * @param dis input stream positioned at the serialized client detail block.
+   * @param reqID identifier tuple describing the owner and reference type.
+   * @param context client context supplying factories used during restoration.
+   * @param checker checksum helper verifying integrity of embedded buckets.
+   * @return fully reconstructed {@link ClientRequest} instance ready for resumption.
+   * @throws StorageFormatException serialized data failed validation or used unknown versions.
+   * @throws IOException stream IO failed while reading buckets or metadata.
+   * @throws ResumeFailedException request could not be reconstructed and must restart.
    */
   public static ClientRequest restartFrom(
       DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
@@ -1719,6 +1860,18 @@ public class ClientGet extends ClientRequest {
     ClientGetGetterFactory.writeExpectedHashes(dos, expectedHashes);
   }
 
+  /**
+   * Rehydrates transient state after a persistent resume has restored core fields.
+   *
+   * <p>This hook is invoked by the base resume flow once serialization has recreated the request
+   * and the {@link ClientGetter}. It forwards the resume signal to any retained buckets and then
+   * repopulates size and MIME hints from the getter if they were not stored explicitly. The method
+   * does not trigger network activity; it only rebinds state so subsequent status queries are
+   * consistent.
+   *
+   * @param context client context used for bucket resume callbacks and defaults.
+   * @throws ResumeFailedException if bucket resume logic reports unrecoverable failure.
+   */
   @Override
   protected void innerResume(ClientContext context) throws ResumeFailedException {
     if (returnBucketDirect != null) returnBucketDirect.onResume(context);
@@ -1734,8 +1887,12 @@ public class ClientGet extends ClientRequest {
   }
 
   /**
-   * Indicates whether every component of the request—especially the {@link ClientGetter}—has been
-   * restored successfully after a persistence resume.
+   * Indicates whether every component of the request has been restored successfully after resume.
+   *
+   * <p>This is a lightweight health check used by persistence logic to decide whether the request
+   * can continue without restarting. It delegates to {@link ClientGetter#resumedFetcher()} and also
+   * ensures the getter itself is present. A {@code false} return indicates that the request should
+   * be restarted or rebuilt.
    *
    * @return {@code true} when {@link ClientGetter#resumedFetcher()} confirms a valid resume.
    */
@@ -1744,11 +1901,30 @@ public class ClientGet extends ClientRequest {
     return getter != null && getter.resumedFetcher();
   }
 
+  /**
+   * Compares this request to another object for equality using the base implementation.
+   *
+   * <p>Equality is defined by {@link ClientRequest} and typically reflects request identity rather
+   * than mutable progress state. This override exists to preserve the base semantics while keeping
+   * the contract explicit in this subtype. The comparison is side-effect free.
+   *
+   * @param obj object to compare against, possibly {@code null}.
+   * @return {@code true} when the base implementation considers the objects equal.
+   */
   @Override
   public boolean equals(Object obj) {
     return super.equals(obj);
   }
 
+  /**
+   * Computes the hash code for this request using the base implementation.
+   *
+   * <p>The hash code is stable for the identity fields used by {@link ClientRequest} and does not
+   * incorporate mutable progress state. This makes the value suitable for hash-based collections
+   * that store requests by identity. The computation has no side effects.
+   *
+   * @return hash code derived from {@link ClientRequest} identity fields.
+   */
   @Override
   public int hashCode() {
     return super.hashCode();

--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -5,7 +5,6 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
-import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.util.Date;
 import java.util.HashSet;
@@ -15,37 +14,17 @@ import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchResult;
 import network.crypta.client.InsertContext;
-import network.crypta.client.async.BinaryBlob;
-import network.crypta.client.async.BinaryBlobWriter;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetCallback;
 import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.CompatibilityAnalyser;
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentClientCallback;
-import network.crypta.client.async.PersistentJob;
-import network.crypta.client.events.ClientEvent;
-import network.crypta.client.events.ClientEventListener;
-import network.crypta.client.events.EnterFiniteCooldownEvent;
-import network.crypta.client.events.ExpectedFileSizeEvent;
-import network.crypta.client.events.ExpectedHashesEvent;
-import network.crypta.client.events.ExpectedMIMEEvent;
-import network.crypta.client.events.SendingToNetworkEvent;
-import network.crypta.client.events.SplitfileCompatibilityModeEvent;
-import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.ChecksumFailedException;
-import network.crypta.crypt.HashResult;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.api.Bucket;
-import network.crypta.support.io.ArrayBucketFactory;
 import network.crypta.support.io.BucketTools;
-import network.crypta.support.io.FileBucket;
-import network.crypta.support.io.NativeThread;
-import network.crypta.support.io.NullBucket;
 import network.crypta.support.io.ResumeFailedException;
 import network.crypta.support.io.StorageFormatException;
 import org.slf4j.Logger;
@@ -56,17 +35,17 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The request owns its {@link FetchContext}, {@link ClientGetter}, progress caches, and
  * persistence metadata so it can migrate cleanly between the connection queue, the global queue,
- * and durable storage across node restarts. It translates raw {@link ClientEvent}s into the
- * higher-level FCP messages required by remote clients, tracks retry policy, and resolves whatever
- * output strategy the caller selected (direct bucket, disk file, chunked stream, or acknowledgement
- * only). The class is therefore the boundary between long-lived persistent jobs and transient FCP
+ * and durable storage across node restarts. It translates raw client events into the higher-level
+ * FCP messages required by remote clients, tracks retry policy, and resolves whatever output
+ * strategy the caller selected (direct bucket, disk file, chunked stream, or acknowledgement only).
+ * The class is therefore the boundary between long-lived persistent jobs and transient FCP
  * sessions.
  *
  * <p>The implementation is largely thread-safe through fine-grained {@code synchronized} sections.
  * State transitions such as success, failure, or cancellation update cached progress snapshots and
- * immediately propagate notifications to any registered {@link ClientEventListener}. During
- * restarts, it rehydrates buckets, metadata, and compatibility hints from the serialized form
- * before delegating back to {@link ClientGetter}.
+ * immediately propagate notifications to any registered event listeners. During restarts, it
+ * rehydrates buckets, metadata, and compatibility hints from the serialized form before delegating
+ * back to {@link ClientGetter}.
  *
  * <ul>
  *   <li>Queueing and persistence: registers against either the connection-scoped or global queue.
@@ -76,10 +55,9 @@ import org.slf4j.LoggerFactory;
  *
  * @see ClientRequest
  * @see ClientGetter
- * @see ClientGetCallback
+ * @see network.crypta.client.async.ClientGetCallback
  */
-public class ClientGet extends ClientRequest
-    implements ClientGetCallback, ClientEventListener, PersistentClientCallback {
+public class ClientGet extends ClientRequest {
   private static final Logger LOG = LoggerFactory.getLogger(ClientGet.class);
 
   @Serial private static final long serialVersionUID = 1L;
@@ -114,13 +92,13 @@ public class ClientGet extends ClientRequest
   private final Bucket initialMetadata;
 
   // Verbosity bitmasks
-  private static final int VERBOSITY_SPLITFILE_PROGRESS = 1;
-  private static final int VERBOSITY_SENT_TO_NETWORK = 2;
-  private static final int VERBOSITY_COMPATIBILITY_MODE = 4;
-  private static final int VERBOSITY_EXPECTED_HASHES = 8;
-  private static final int VERBOSITY_EXPECTED_TYPE = 32;
-  private static final int VERBOSITY_EXPECTED_SIZE = 64;
-  private static final int VERBOSITY_ENTER_FINITE_COOLDOWN = 128;
+  static final int VERBOSITY_SPLITFILE_PROGRESS = 1;
+  static final int VERBOSITY_SENT_TO_NETWORK = 2;
+  static final int VERBOSITY_COMPATIBILITY_MODE = 4;
+  static final int VERBOSITY_EXPECTED_HASHES = 8;
+  static final int VERBOSITY_EXPECTED_TYPE = 32;
+  static final int VERBOSITY_EXPECTED_SIZE = 64;
+  static final int VERBOSITY_ENTER_FINITE_COOLDOWN = 128;
 
   // Stuff waiting for reconnection
   /** Did the request succeed? Valid if finished. */
@@ -212,8 +190,6 @@ public class ClientGet extends ClientRequest
 
   private record ReturnSetup(Bucket bucket, File targetFile, String extension) {}
 
-  private record EventProgress(FCPMessage message, int verbosityMask) {}
-
   /**
    * Builds a persistent GET request for callers that enqueue work outside live FCP sessions.
    *
@@ -283,7 +259,7 @@ public class ClientGet extends ClientRequest
 
     ensureGlobalIdentifierAvailable(globalClient, identifier);
     fctx = core.getClientContext().getDefaultPersistentFetchContext();
-    fctx.getEventProducer().addEventListener(this);
+    fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
     fctx.setLocalRequestOnly(dsOnly);
     fctx.setIgnoreStore(ignoreDS);
     fctx.setMaxNonSplitfileRetries(maxNonSplitfileRetries);
@@ -341,7 +317,7 @@ public class ClientGet extends ClientRequest
     // Create a Fetcher directly in order to get more fine-grained control,
     // since the client may override a few context elements.
     fctx = core.getClientContext().getDefaultPersistentFetchContext();
-    fctx.getEventProducer().addEventListener(this);
+    fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
     // ignoreDS
     fctx.setLocalRequestOnly(message.dsOnly);
     fctx.setIgnoreStore(message.ignoreDS);
@@ -384,7 +360,7 @@ public class ClientGet extends ClientRequest
         ensureDownloadAllowed(core, file);
         yield createDiskReturnSetup(file, filterData);
       }
-      case NONE -> new ReturnSetup(new NullBucket(), null, null);
+      case NONE -> new ReturnSetup(null, null, null);
       default -> new ReturnSetup(null, null, null);
     };
   }
@@ -394,7 +370,7 @@ public class ClientGet extends ClientRequest
       throws MessageInvalidException {
     return switch (message.returnType) {
       case DISK -> buildDiskSetupForMessage(message, core, handler);
-      case NONE -> new ReturnSetup(new NullBucket(), null, null);
+      case NONE -> new ReturnSetup(null, null, null);
       default -> new ReturnSetup(null, null, null);
     };
   }
@@ -437,7 +413,7 @@ public class ClientGet extends ClientRequest
   }
 
   private ReturnSetup createDiskReturnSetup(File file, boolean filterData) {
-    Bucket bucket = new FileBucket(file, false, true, false, false);
+    Bucket bucket = ClientGetGetterFactory.diskReturnBucket(file);
     return new ReturnSetup(bucket, file, filterData ? deriveExtension(file) : null);
   }
 
@@ -501,24 +477,18 @@ public class ClientGet extends ClientRequest
   }
 
   private ClientGetter makeGetter(NodeClientCore core, Bucket ret) throws IOException {
-    if (binaryBlob && ret == null) {
-      //noinspection resource
-      ret =
-          core.getClientContext()
-              .getBucketFactory(persistence == Persistence.FOREVER)
-              .makeBucket(fctx.getMaxOutputLength());
-    }
-
-    return new ClientGetter(
+    return ClientGetGetterFactory.createGetter(
         this,
         uri,
         fctx,
         priorityClass,
-        binaryBlob ? new NullBucket() : ret,
-        binaryBlob ? new BinaryBlobWriter(ret) : null,
-        false,
+        ret,
         initialMetadata,
-        extensionCheck);
+        extensionCheck,
+        returnType == ReturnType.NONE,
+        binaryBlob,
+        persistence == Persistence.FOREVER,
+        core);
   }
 
   /**
@@ -639,7 +609,6 @@ public class ClientGet extends ClientRequest
    * @param result Result wrapper exposing MIME metadata and bucket accessors.
    * @param state ClientGetter instance used for blob access during binary-blob transfers.
    */
-  @Override
   public void onSuccess(FetchResult result, ClientGetter state) {
     LOG.debug("Succeeded: {}", identifier);
     Bucket data = binaryBlob ? state.getBlobBucket() : result.asBucket();
@@ -650,7 +619,7 @@ public class ClientGet extends ClientRequest
       }
       started = true;
       if (!binaryBlob) this.foundDataMimeType = result.getMimeType();
-      else this.foundDataMimeType = BinaryBlob.MIME_TYPE;
+      else this.foundDataMimeType = ClientGetGetterFactory.binaryBlobMimeType();
 
       // completionTime is set here rather than in finish() for two reasons:
       // 1. It must be set inside the lock.
@@ -773,7 +742,7 @@ public class ClientGet extends ClientRequest
     }
   }
 
-  private void queueProgressMessageInner(FCPMessage msg, int verbosityMask) {
+  void queueProgressMessageInner(FCPMessage msg, int verbosityMask) {
     if (persistence == Persistence.CONNECTION) {
       if (origHandler != null) {
         origHandler.send(msg);
@@ -817,7 +786,7 @@ public class ClientGet extends ClientRequest
                 new SendingToNetworkMessage(identifier, global), listRequestIdentifier));
       if (finished) trySendDataFoundOrGetFailed(handler, listRequestIdentifier);
     } else if (returnType != ReturnType.DIRECT) {
-      ProtocolErrorMessage msg =
+      FCPMessage msg =
           new ProtocolErrorMessage(
               ProtocolErrorMessage.WRONG_RETURN_TYPE, false, "No AllData", identifier, global);
       handler.handler.send(msg);
@@ -895,7 +864,6 @@ public class ClientGet extends ClientRequest
    * @param e Detailed {@link FetchException} describing the failure classification.
    * @param state Optional getter supplying buckets to retain across restarts; may be {@code null}.
    */
-  @Override
   public void onFailure(FetchException e, ClientGetter state) {
     if (finished) return;
     synchronized (this) {
@@ -948,144 +916,39 @@ public class ClientGet extends ClientRequest
     super.requestWasRemoved(context);
   }
 
-  /**
-   * Consumes {@link ClientEvent}s streamed by the {@link ClientGetter} and forwards the relevant
-   * ones to the remote client according to verbosity flags.
-   *
-   * <p>Compatibility mode updates may need to be handled within the persistence job runner to avoid
-   * blocking IO threads, while other events are translated into {@link SimpleProgressMessage},
-   * {@link ExpectedHashes}, or size/type notifications. Verbosity masks ensure clients only see the
-   * signals they subscribed to, keeping reconnections lightweight. Unknown events are logged to aid
-   * diagnosis without breaking the stream.
-   *
-   * @param ce Event describing progress, compatibility hints, or splitter metadata.
-   * @param context Client context whose job runner may execute deferred compatibility processing.
-   */
-  @Override
-  public void receive(ClientEvent ce, ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("Receiving {} on {}", ce, this);
-    if (ce instanceof SplitfileCompatibilityModeEvent compatibilityModeEvent) {
-      handleCompatibilityMode(compatibilityModeEvent, context);
-      return;
-    }
-    EventProgress eventProgress = createEventProgress(ce);
-    if (eventProgress == null) {
-      return;
-    }
-    if ((verbosity & eventProgress.verbosityMask()) == 0) {
-      return;
-    }
-    queueProgressMessageInner(eventProgress.message(), eventProgress.verbosityMask());
+  synchronized void markSentToNetwork() {
+    sentToNetwork = true;
   }
 
-  private EventProgress createEventProgress(ClientEvent event) {
-    if (event instanceof SplitfileProgressEvent progressEvent) {
-      return handleSplitfileProgress(progressEvent);
-    }
-    if (event instanceof SendingToNetworkEvent) {
-      synchronized (this) {
-        sentToNetwork = true;
-      }
-      return new EventProgress(
-          new SendingToNetworkMessage(identifier, global), VERBOSITY_SENT_TO_NETWORK);
-    }
-    if (event instanceof ExpectedHashesEvent hashesEvent) {
-      return handleExpectedHashes(hashesEvent);
-    }
-    if (event instanceof ExpectedMIMEEvent mimeEvent) {
-      return handleExpectedMime(mimeEvent);
-    }
-    if (event instanceof ExpectedFileSizeEvent sizeEvent) {
-      return handleExpectedSize(sizeEvent);
-    }
-    if (event instanceof EnterFiniteCooldownEvent cooldownEvent) {
-      return new EventProgress(
-          new EnterFiniteCooldown(identifier, global, cooldownEvent.wakeupTime),
-          VERBOSITY_ENTER_FINITE_COOLDOWN);
-    }
-    LOG.error("Unknown event {}", event);
-    return null;
+  synchronized void recordSplitfileProgress(SimpleProgressMessage message) {
+    progressPending = message;
   }
 
-  private EventProgress handleSplitfileProgress(SplitfileProgressEvent event) {
-    SimpleProgressMessage message;
-    synchronized (this) {
-      message = progressPending = new SimpleProgressMessage(identifier, global, event);
+  synchronized boolean trySetExpectedHashes(ExpectedHashes message) {
+    if (expectedHashes != null) {
+      LOG.warn("Got a new ExpectedHashes");
+      return false;
     }
-    if (client != null) {
-      RequestStatusCache cache = client.getRequestStatusCache();
-      if (cache != null) {
-        cache.updateStatus(identifier, progressPending.getEvent());
-      }
-    }
-    return new EventProgress(message, VERBOSITY_SPLITFILE_PROGRESS);
+    expectedHashes = message;
+    return true;
   }
 
-  private EventProgress handleExpectedHashes(ExpectedHashesEvent event) {
-    synchronized (this) {
-      if (expectedHashes != null) {
-        LOG.warn("Got a new ExpectedHashes");
-        return null;
-      }
-      expectedHashes = new ExpectedHashes(event, identifier, global);
-      return new EventProgress(expectedHashes, VERBOSITY_EXPECTED_HASHES);
-    }
+  synchronized void recordExpectedMimeType(String mimeType) {
+    foundDataMimeType = mimeType;
   }
 
-  private EventProgress handleExpectedMime(ExpectedMIMEEvent event) {
-    synchronized (this) {
-      foundDataMimeType = event.expectedMIMEType;
-    }
-    if (client != null) {
-      RequestStatusCache cache = client.getRequestStatusCache();
-      if (cache != null) {
-        cache.updateExpectedMIME(identifier, foundDataMimeType);
-      }
-    }
-    return new EventProgress(
-        new ExpectedMIME(identifier, global, event.expectedMIMEType), VERBOSITY_EXPECTED_TYPE);
+  synchronized void recordExpectedDataLength(long length) {
+    foundDataLength = length;
   }
 
-  private EventProgress handleExpectedSize(ExpectedFileSizeEvent event) {
-    synchronized (this) {
-      foundDataLength = event.expectedSize;
-    }
-    if (client != null) {
-      RequestStatusCache cache = client.getRequestStatusCache();
-      if (cache != null) {
-        cache.updateExpectedDataLength(identifier, foundDataLength);
-      }
-    }
-    return new EventProgress(
-        new ExpectedDataLength(identifier, global, event.expectedSize), VERBOSITY_EXPECTED_SIZE);
-  }
-
-  private void handleCompatibilityMode(
-      final SplitfileCompatibilityModeEvent ce, ClientContext context) {
-    if (persistence == Persistence.FOREVER && context.jobRunner.hasLoaded()) {
-      try {
-        context.jobRunner.queue(
-            (PersistentJob)
-                context1 -> {
-                  innerHandleCompatibilityMode(ce);
-                  return false;
-                },
-            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-      } catch (PersistenceDisabledException _) {
-        // Not much we can do
-      }
-    } else {
-      innerHandleCompatibilityMode(ce);
-    }
-  }
-
-  private void innerHandleCompatibilityMode(SplitfileCompatibilityModeEvent ce) {
+  void mergeCompatibilityMode(
+      InsertContext.CompatibilityMode minCompatibilityMode,
+      InsertContext.CompatibilityMode maxCompatibilityMode,
+      byte[] splitfileCryptoKey,
+      boolean dontCompress,
+      boolean bottomLayer) {
     compatMode.merge(
-        ce.minCompatibilityMode,
-        ce.maxCompatibilityMode,
-        ce.splitfileCryptoKey,
-        ce.dontCompress,
-        ce.bottomLayer);
+        minCompatibilityMode, maxCompatibilityMode, splitfileCryptoKey, dontCompress, bottomLayer);
     if (client != null) {
       RequestStatusCache cache = client.getRequestStatusCache();
       if (cache != null) {
@@ -1096,9 +959,10 @@ public class ClientGet extends ClientRequest
             compatMode.dontCompress());
       }
     }
-    if ((verbosity & VERBOSITY_COMPATIBILITY_MODE) != 0)
+    if ((verbosity & VERBOSITY_COMPATIBILITY_MODE) != 0) {
       queueProgressMessageInner(
           new CompatibilityMode(identifier, global, compatMode), VERBOSITY_COMPATIBILITY_MODE);
+    }
   }
 
   @Override
@@ -1374,7 +1238,7 @@ public class ClientGet extends ClientRequest
           yield returnBucketDirect;
         }
       }
-      case DISK -> new FileBucket(targetFile, readOnly, false, false, false);
+      case DISK -> ClientGetGetterFactory.diskBucket(targetFile, readOnly);
       default -> null;
     };
   }
@@ -1602,8 +1466,7 @@ public class ClientGet extends ClientRequest
       dos.writeUTF(targetFile.toString());
     }
     dos.writeBoolean(binaryBlob);
-    try (DataOutputStream ctxStream =
-        new DataOutputStream(checker.checksumWriterWithLength(dos, new ArrayBucketFactory()))) {
+    try (DataOutputStream ctxStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
       fctx.writeTo(ctxStream);
     }
     if (extensionCheck != null) {
@@ -1615,7 +1478,7 @@ public class ClientGet extends ClientRequest
     if (initialMetadata != null) {
       dos.writeBoolean(true);
       try (DataOutputStream metadataStream =
-          new DataOutputStream(checker.checksumWriterWithLength(dos, new ArrayBucketFactory()))) {
+          ClientGetGetterFactory.checksummedWriter(dos, checker)) {
         initialMetadata.storeTo(metadataStream);
       }
     } else {
@@ -1628,15 +1491,13 @@ public class ClientGet extends ClientRequest
         if (succeeded) {
           if (returnType == ReturnType.DIRECT) {
             try (DataOutputStream bucketStream =
-                new DataOutputStream(
-                    checker.checksumWriterWithLength(dos, new ArrayBucketFactory()))) {
+                ClientGetGetterFactory.checksummedWriter(dos, checker)) {
               returnBucketDirect.storeTo(bucketStream);
             }
           }
         } else {
           try (DataOutputStream failureStream =
-              new DataOutputStream(
-                  checker.checksumWriterWithLength(dos, new ArrayBucketFactory()))) {
+              ClientGetGetterFactory.checksummedWriter(dos, checker)) {
             getFailedMessage.writeTo(failureStream);
           }
         }
@@ -1646,8 +1507,7 @@ public class ClientGet extends ClientRequest
     // Not finished, or was recently not finished.
     // Don't hold lock while calling getter.
     // If it's just finished we get a race and restart. That's okay.
-    try (DataOutputStream progressStream =
-        new DataOutputStream(checker.checksumWriterWithLength(dos, new ArrayBucketFactory()))) {
+    try (DataOutputStream progressStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
       if (getter.writeTrivialProgress(progressStream)) {
         writeTransientProgressFields(progressStream);
       }
@@ -1682,7 +1542,7 @@ public class ClientGet extends ClientRequest
     targetFile = returnType == ReturnType.DISK ? new File(dis.readUTF()) : null;
     binaryBlob = dis.readBoolean();
     this.fctx = readFetchContext(dis, context, checker);
-    fctx.getEventProducer().addEventListener(this);
+    fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
     extensionCheck = dis.readBoolean() ? dis.readUTF() : null;
     initialMetadata = readInitialMetadata(dis, context, checker);
     ClientGetter restoredGetter = restoreState(dis, reqID, context, checker);
@@ -1710,7 +1570,7 @@ public class ClientGet extends ClientRequest
   private FreenetURI parseUri(String serializedUri) throws StorageFormatException {
     try {
       return new FreenetURI(serializedUri);
-    } catch (MalformedURLException _) {
+    } catch (Exception _) {
       throw new StorageFormatException("Bad URI");
     }
   }
@@ -1844,12 +1704,7 @@ public class ClientGet extends ClientRequest
     if (dis.readBoolean()) foundDataMimeType = dis.readUTF();
     else foundDataMimeType = null;
     compatMode = new CompatibilityAnalyser(dis);
-    HashResult[] hashes = HashResult.readHashes(dis);
-    if (hashes == null || hashes.length == 0) {
-      expectedHashes = null;
-    } else {
-      expectedHashes = new ExpectedHashes(hashes, identifier, global);
-    }
+    expectedHashes = ClientGetGetterFactory.readExpectedHashes(dis, identifier, global);
   }
 
   private synchronized void writeTransientProgressFields(DataOutputStream dos) throws IOException {
@@ -1861,7 +1716,7 @@ public class ClientGet extends ClientRequest
       dos.writeBoolean(false);
     }
     compatMode.writeTo(dos);
-    HashResult.write(expectedHashes == null ? null : expectedHashes.hashes, dos);
+    ClientGetGetterFactory.writeExpectedHashes(dos, expectedHashes);
   }
 
   @Override
@@ -1891,10 +1746,7 @@ public class ClientGet extends ClientRequest
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    return obj instanceof ClientGet && super.equals(obj);
+    return super.equals(obj);
   }
 
   @Override

--- a/src/main/java/network/crypta/clients/fcp/ClientGetEventHandling.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetEventHandling.java
@@ -135,7 +135,7 @@ final class ClientGetEventHandling implements ClientEventListener {
       try {
         context.jobRunner.queue(
             (PersistentJob)
-                context1 -> {
+                _ -> {
                   request.mergeCompatibilityMode(
                       event.minCompatibilityMode,
                       event.maxCompatibilityMode,

--- a/src/main/java/network/crypta/clients/fcp/ClientGetEventHandling.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetEventHandling.java
@@ -1,0 +1,160 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.events.ClientEvent;
+import network.crypta.client.events.ClientEventListener;
+import network.crypta.client.events.EnterFiniteCooldownEvent;
+import network.crypta.client.events.ExpectedFileSizeEvent;
+import network.crypta.client.events.ExpectedHashesEvent;
+import network.crypta.client.events.ExpectedMIMEEvent;
+import network.crypta.client.events.SendingToNetworkEvent;
+import network.crypta.client.events.SplitfileCompatibilityModeEvent;
+import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.support.io.NativeThread;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Translates {@link ClientEvent} updates emitted by {@link network.crypta.client.FetchContext} into
+ * FCP-level progress messages, while keeping the coupling-heavy event taxonomy out of {@link
+ * ClientGet}.
+ *
+ * <p>The helper exists primarily to satisfy Sonar rule {@code java:S6539} ("Monster Class") by
+ * separating the event-to-message translation responsibility from the core request lifecycle and
+ * persistence logic owned by {@link ClientGet}.
+ */
+final class ClientGetEventHandling implements ClientEventListener {
+  private static final Logger LOG = LoggerFactory.getLogger(ClientGetEventHandling.class);
+
+  private final ClientGet request;
+
+  private record EventProgress(FCPMessage message, int verbosityMask) {}
+
+  ClientGetEventHandling(ClientGet request) {
+    this.request = Objects.requireNonNull(request, "request");
+  }
+
+  @Override
+  public void receive(ClientEvent event, ClientContext context) {
+    if (LOG.isDebugEnabled()) LOG.debug("Receiving {} on {}", event, request);
+    if (event instanceof SplitfileCompatibilityModeEvent compatibilityModeEvent) {
+      handleCompatibilityMode(compatibilityModeEvent, context);
+      return;
+    }
+    EventProgress eventProgress = createEventProgress(event);
+    if (eventProgress == null) {
+      return;
+    }
+    if ((request.verbosity & eventProgress.verbosityMask()) == 0) {
+      return;
+    }
+    request.queueProgressMessageInner(eventProgress.message(), eventProgress.verbosityMask());
+  }
+
+  private EventProgress createEventProgress(ClientEvent event) {
+    if (event instanceof SplitfileProgressEvent progressEvent) {
+      return handleSplitfileProgress(progressEvent);
+    }
+    if (event instanceof SendingToNetworkEvent) {
+      request.markSentToNetwork();
+      return new EventProgress(
+          new SendingToNetworkMessage(request.identifier, request.global),
+          ClientGet.VERBOSITY_SENT_TO_NETWORK);
+    }
+    if (event instanceof ExpectedHashesEvent hashesEvent) {
+      return handleExpectedHashes(hashesEvent);
+    }
+    if (event instanceof ExpectedMIMEEvent mimeEvent) {
+      return handleExpectedMime(mimeEvent);
+    }
+    if (event instanceof ExpectedFileSizeEvent sizeEvent) {
+      return handleExpectedSize(sizeEvent);
+    }
+    if (event instanceof EnterFiniteCooldownEvent cooldownEvent) {
+      return new EventProgress(
+          new EnterFiniteCooldown(request.identifier, request.global, cooldownEvent.wakeupTime),
+          ClientGet.VERBOSITY_ENTER_FINITE_COOLDOWN);
+    }
+    LOG.error("Unknown event {}", event);
+    return null;
+  }
+
+  private EventProgress handleSplitfileProgress(SplitfileProgressEvent event) {
+    SimpleProgressMessage message =
+        new SimpleProgressMessage(request.identifier, request.global, event);
+    request.recordSplitfileProgress(message);
+    if (request.client != null) {
+      RequestStatusCache cache = request.client.getRequestStatusCache();
+      if (cache != null) {
+        cache.updateStatus(request.identifier, event);
+      }
+    }
+    return new EventProgress(message, ClientGet.VERBOSITY_SPLITFILE_PROGRESS);
+  }
+
+  private EventProgress handleExpectedHashes(ExpectedHashesEvent event) {
+    ExpectedHashes hashes = new ExpectedHashes(event, request.identifier, request.global);
+    if (!request.trySetExpectedHashes(hashes)) {
+      return null;
+    }
+    return new EventProgress(hashes, ClientGet.VERBOSITY_EXPECTED_HASHES);
+  }
+
+  private EventProgress handleExpectedMime(ExpectedMIMEEvent event) {
+    request.recordExpectedMimeType(event.expectedMIMEType);
+    if (request.client != null) {
+      RequestStatusCache cache = request.client.getRequestStatusCache();
+      if (cache != null) {
+        cache.updateExpectedMIME(request.identifier, event.expectedMIMEType);
+      }
+    }
+    return new EventProgress(
+        new ExpectedMIME(request.identifier, request.global, event.expectedMIMEType),
+        ClientGet.VERBOSITY_EXPECTED_TYPE);
+  }
+
+  private EventProgress handleExpectedSize(ExpectedFileSizeEvent event) {
+    request.recordExpectedDataLength(event.expectedSize);
+    if (request.client != null) {
+      RequestStatusCache cache = request.client.getRequestStatusCache();
+      if (cache != null) {
+        cache.updateExpectedDataLength(request.identifier, event.expectedSize);
+      }
+    }
+    return new EventProgress(
+        new ExpectedDataLength(request.identifier, request.global, event.expectedSize),
+        ClientGet.VERBOSITY_EXPECTED_SIZE);
+  }
+
+  private void handleCompatibilityMode(
+      SplitfileCompatibilityModeEvent event, ClientContext context) {
+    if (request.persistence == ClientRequest.Persistence.FOREVER && context.jobRunner.hasLoaded()) {
+      try {
+        context.jobRunner.queue(
+            (PersistentJob)
+                context1 -> {
+                  request.mergeCompatibilityMode(
+                      event.minCompatibilityMode,
+                      event.maxCompatibilityMode,
+                      event.splitfileCryptoKey,
+                      event.dontCompress,
+                      event.bottomLayer);
+                  return false;
+                },
+            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+      } catch (PersistenceDisabledException _) {
+        // Not much we can do.
+      }
+    } else {
+      request.mergeCompatibilityMode(
+          event.minCompatibilityMode,
+          event.maxCompatibilityMode,
+          event.splitfileCryptoKey,
+          event.dontCompress,
+          event.bottomLayer);
+    }
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -109,8 +109,8 @@ final class ClientGetGetterFactory {
     }
 
     @Override
-    public void onFailure(FetchException e, ClientGetter state) {
-      request.onFailure(e, state);
+    public void onFailure(FetchException e) {
+      request.onFailure(e);
     }
 
     @Override

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -1,0 +1,157 @@
+package network.crypta.clients.fcp;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchResult;
+import network.crypta.client.async.BinaryBlob;
+import network.crypta.client.async.BinaryBlobWriter;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetCallback;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.PersistentClientCallback;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.HashResult;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucketFactory;
+import network.crypta.support.io.FileBucket;
+import network.crypta.support.io.NullBucket;
+import network.crypta.support.io.ResumeFailedException;
+
+/**
+ * Creates {@link ClientGetter} instances for {@link ClientGet}, including optional BinaryBlob
+ * support.
+ *
+ * <p>The factory keeps the {@link BinaryBlob} and {@link BinaryBlobWriter} dependencies out of
+ * {@link ClientGet} so the request class can focus on lifecycle and persistence responsibilities
+ * without exceeding Sonar coupling limits (rule {@code java:S6539}).
+ */
+final class ClientGetGetterFactory {
+  private ClientGetGetterFactory() {}
+
+  static String binaryBlobMimeType() {
+    return BinaryBlob.MIME_TYPE;
+  }
+
+  private static final class CallbackAdapter
+      implements ClientGetCallback, PersistentClientCallback, Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final ClientGet request;
+
+    private CallbackAdapter(ClientGet request) {
+      this.request = request;
+    }
+
+    @Override
+    public void onSuccess(FetchResult result, ClientGetter state) {
+      request.onSuccess(result, state);
+    }
+
+    @Override
+    public void onFailure(FetchException e, ClientGetter state) {
+      request.onFailure(e, state);
+    }
+
+    @Override
+    public void onResume(ClientContext context) throws ResumeFailedException {
+      request.onResume(context);
+    }
+
+    @Override
+    public RequestClient getRequestClient() {
+      return request.getRequestClient();
+    }
+
+    @Override
+    public void getClientDetail(DataOutputStream dos, ChecksumChecker checker) throws IOException {
+      request.getClientDetail(dos, checker);
+    }
+  }
+
+  static DataOutputStream checksummedWriter(DataOutputStream target, ChecksumChecker checker)
+      throws IOException {
+    return new DataOutputStream(checker.checksumWriterWithLength(target, new ArrayBucketFactory()));
+  }
+
+  static Bucket diskReturnBucket(File file) {
+    return new FileBucket(file, false, true, false, false);
+  }
+
+  static Bucket diskBucket(File file, boolean readOnly) {
+    return new FileBucket(file, readOnly, false, false, false);
+  }
+
+  static ExpectedHashes readExpectedHashes(DataInputStream dis, String identifier, boolean global)
+      throws IOException {
+    HashResult[] hashes = HashResult.readHashes(dis);
+    if (hashes == null || hashes.length == 0) {
+      return null;
+    }
+    return new ExpectedHashes(hashes, identifier, global);
+  }
+
+  static void writeExpectedHashes(DataOutputStream dos, ExpectedHashes expectedHashes)
+      throws IOException {
+    HashResult.write(expectedHashes == null ? null : expectedHashes.hashes, dos);
+  }
+
+  static ClientGetter createGetter(
+      ClientGet request,
+      FreenetURI uri,
+      FetchContext fetchContext,
+      short priorityClass,
+      Bucket returnBucket,
+      Bucket initialMetadata,
+      String extensionCheck,
+      boolean discardData,
+      boolean binaryBlob,
+      boolean persistenceForever,
+      NodeClientCore core)
+      throws IOException {
+    ClientGetCallback callback = new CallbackAdapter(request);
+    Bucket blobBucket = returnBucket;
+    if (binaryBlob) {
+      if (blobBucket == null) {
+        Objects.requireNonNull(core, "core");
+        //noinspection resource
+        blobBucket =
+            core.getClientContext()
+                .getBucketFactory(persistenceForever)
+                .makeBucket(fetchContext.getMaxOutputLength());
+      }
+      return new ClientGetter(
+          callback,
+          uri,
+          fetchContext,
+          priorityClass,
+          new NullBucket(),
+          new BinaryBlobWriter(blobBucket),
+          false,
+          initialMetadata,
+          extensionCheck);
+    }
+    if (discardData) {
+      returnBucket = new NullBucket();
+    }
+    return new ClientGetter(
+        callback,
+        uri,
+        fetchContext,
+        priorityClass,
+        returnBucket,
+        null,
+        false,
+        initialMetadata,
+        extensionCheck);
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -28,26 +28,77 @@ import network.crypta.support.io.NullBucket;
 import network.crypta.support.io.ResumeFailedException;
 
 /**
- * Creates {@link ClientGetter} instances for {@link ClientGet}, including optional BinaryBlob
+ * Creates {@link ClientGetter} instances for {@link ClientGet} requests, including Binary Blob
  * support.
  *
- * <p>The factory keeps the {@link BinaryBlob} and {@link BinaryBlobWriter} dependencies out of
- * {@link ClientGet} so the request class can focus on lifecycle and persistence responsibilities
- * without exceeding Sonar coupling limits (rule {@code java:S6539}).
+ * <p>This utility centralizes the wiring required to build a {@link ClientGetter} with the correct
+ * callback adapter, bucket choices, and optional {@link BinaryBlobWriter} so the request class can
+ * focus on persistence and lifecycle duties. Callers typically invoke it during request creation or
+ * resume paths to obtain a fully configured fetcher while keeping Binary Blob concerns out of
+ * {@link ClientGet} and under the Sonar coupling limit (rule {@code java:S6539}).
+ *
+ * <p>There is no mutable-shared state beyond a reusable {@link NullBucket} instance, so the class
+ * is effectively stateless. Thread-safety is therefore determined by the collaborators passed in,
+ * not by this factory. The method contracts favor explicit inputs (for example, whether to discard
+ * data or enable Binary Blob recording) and will fail fast when required dependencies such as
+ * {@link NodeClientCore} are missing.
+ *
+ * <ul>
+ *   <li>Wires request callbacks via an adapter that implements persistence interfaces.
+ *   <li>Selects output buckets and Binary Blob writers based on caller intent.
+ *   <li>Creates disk-backed buckets and hash envelopes for persistence helpers.
+ * </ul>
+ *
+ * @see ClientGetter
+ * @see ClientGet
+ * @see BinaryBlobWriter
  */
 final class ClientGetGetterFactory {
+  /**
+   * Reusable {@link NullBucket} to discard output without allocating per call.
+   *
+   * <p>The instance holds no external resources and has no state changes, so it is safe to share
+   * across factory invocations. It is returned where a caller asks to discard data or when Binary
+   * Blob fetching should ignore the ordinary return bucket.
+   */
+  @SuppressWarnings("java:S2095")
+  private static final Bucket NULL_BUCKET = new NullBucket();
+
+  /** Prevents instantiation because this class is a static factory. */
   private ClientGetGetterFactory() {}
 
+  /**
+   * Returns the MIME type for Binary Blob responses.
+   *
+   * <p>This is a simple pass-through to {@link BinaryBlob#MIME_TYPE} so callers can label Binary
+   * Blob fetch results consistently without referencing the Binary Blob class directly.
+   *
+   * @return the canonical Binary Blob MIME type string used by fetch responses.
+   */
   static String binaryBlobMimeType() {
     return BinaryBlob.MIME_TYPE;
   }
 
+  /**
+   * Adapter that forwards fetch callbacks back to the owning {@link ClientGet}.
+   *
+   * <p>The adapter implements both {@link ClientGetCallback} and {@link PersistentClientCallback}
+   * so persistent requests can resume and serialize details through a single delegate. The only
+   * state retained is the request instance provided at construction time.
+   */
   private static final class CallbackAdapter
       implements ClientGetCallback, PersistentClientCallback, Serializable {
+    /** Serialization identifier for the adapter; no evolving state is persisted. */
     @Serial private static final long serialVersionUID = 1L;
 
+    /** Request to receive all callback signals from the fetcher. */
     private final ClientGet request;
 
+    /**
+     * Creates an adapter that forwards callbacks to the supplied request.
+     *
+     * @param request owning request that implements the callback logic; must not be {@code null}.
+     */
     private CallbackAdapter(ClientGet request) {
       this.request = request;
     }
@@ -78,19 +129,65 @@ final class ClientGetGetterFactory {
     }
   }
 
+  /**
+   * Wraps a {@link DataOutputStream} with length-prefixing and checksum enforcement.
+   *
+   * <p>The returned stream writes a length-prefixed payload and appends a checksum on close, using
+   * a temporary {@link ArrayBucketFactory} to buffer the data. Callers must close the returned
+   * stream to flush the checksum. The underlying target stream is provided by the caller and may be
+   * closed when the wrapper is closed.
+   *
+   * @param target output stream that receives the length-prefixed, checksummed payload.
+   * @param checker checksum implementation to use for writing and verification.
+   * @return a data output stream that emits a length prefix and checksum when closed.
+   * @throws IOException if the checksum writer cannot be created or initialized.
+   */
   static DataOutputStream checksummedWriter(DataOutputStream target, ChecksumChecker checker)
       throws IOException {
     return new DataOutputStream(checker.checksumWriterWithLength(target, new ArrayBucketFactory()));
   }
 
+  /**
+   * Creates a disk-backed bucket intended to receive final download output.
+   *
+   * <p>The bucket is configured so the file must not pre-exist on first write, helping prevent
+   * accidental overwrites. The bucket is writable by default and does not register for
+   * delete-on-exit or delete-on-free behavior.
+   *
+   * @param file destination file backing the bucket; may be relative or absolute.
+   * @return a new writable {@link FileBucket} configured for return data.
+   */
   static Bucket diskReturnBucket(File file) {
     return new FileBucket(file, false, true, false, false);
   }
 
+  /**
+   * Creates a disk-backed bucket for staging data with optional read-only behavior.
+   *
+   * <p>The bucket does not enforce create-only semantics, allowing it to map to an existing file
+   * for resume scenarios. Callers control the read-only flag explicitly.
+   *
+   * @param file file backing the bucket; may point to existing or new storage.
+   * @param readOnly whether the bucket should reject further writes immediately.
+   * @return a {@link FileBucket} backed by {@code file} with the specified read-only setting.
+   */
   static Bucket diskBucket(File file, boolean readOnly) {
     return new FileBucket(file, readOnly, false, false, false);
   }
 
+  /**
+   * Reads expected hashes from a stream and wraps them in an {@link ExpectedHashes} message.
+   *
+   * <p>An empty or missing hash list is represented as {@code null} to preserve historical wire
+   * semantics. The caller supplies the identifier and global flag that are attached to the message
+   * when hashes are present.
+   *
+   * @param dis input stream positioned at the hash bitmask and values.
+   * @param identifier request identifier to attach to the message when hashes exist.
+   * @param global whether the identifier uses the global namespace for the client.
+   * @return a populated {@link ExpectedHashes} or {@code null} when no hashes are present.
+   * @throws IOException if the underlying stream cannot be read.
+   */
   static ExpectedHashes readExpectedHashes(DataInputStream dis, String identifier, boolean global)
       throws IOException {
     HashResult[] hashes = HashResult.readHashes(dis);
@@ -100,11 +197,49 @@ final class ClientGetGetterFactory {
     return new ExpectedHashes(hashes, identifier, global);
   }
 
+  /**
+   * Writes expected hashes to the stream in the canonical hash encoding.
+   *
+   * <p>When {@code expectedHashes} is {@code null}, the method writes an empty hash set marker.
+   * Otherwise, the hash list is written in the order defined by {@link HashResult#write}.
+   *
+   * @param dos output stream that receives the hash bitmask and values.
+   * @param expectedHashes expected hash message to encode; may be {@code null}.
+   * @throws IOException if the stream cannot be written to.
+   */
   static void writeExpectedHashes(DataOutputStream dos, ExpectedHashes expectedHashes)
       throws IOException {
     HashResult.write(expectedHashes == null ? null : expectedHashes.hashes, dos);
   }
 
+  /**
+   * Creates a configured {@link ClientGetter} for a {@link ClientGet} request.
+   *
+   * <p>The factory wires a {@link CallbackAdapter}, chooses the correct return bucket strategy, and
+   * optionally sets up a {@link BinaryBlobWriter} when Binary Blob recording is requested. If
+   * {@code binaryBlob} is enabled and {@code returnBucket} is {@code null}, the method uses {@code
+   * core} to allocate a bucket sized to {@link FetchContext#getMaxOutputLength()}. When {@code
+   * discardData} is true and Binary Blob is disabled, the returned fetcher writes into a shared
+   * {@link NullBucket} instead of the provided bucket.
+   *
+   * @param request owning request to receive callbacks and resume signals; must not be {@code
+   *     null}.
+   * @param uri target {@link FreenetURI} to fetch; must not be {@code null}.
+   * @param fetchContext fetch configuration that defines size limits and filters; must not be
+   *     {@code null}.
+   * @param priorityClass scheduler priority class for the request.
+   * @param returnBucket bucket for final data, or {@code null} to let the getter allocate one.
+   * @param initialMetadata optional metadata bucket to seed the fetcher, may be {@code null}.
+   * @param extensionCheck optional extension used by MIME filtering; may be {@code null}.
+   * @param discardData whether to discard payload bytes entirely when Binary Blob is disabled.
+   * @param binaryBlob whether to record a Binary Blob stream instead of regular output data.
+   * @param persistenceForever whether the request is persisted across restarts for bucket choice.
+   * @param core node core used to allocate buckets when needed; required if {@code binaryBlob} is
+   *     true and {@code returnBucket} is {@code null}.
+   * @return a fully constructed {@link ClientGetter} ready to start.
+   * @throws IOException if bucket allocation fails or underlying stream setup fails.
+   * @throws NullPointerException if {@code core} is required but not provided.
+   */
   static ClientGetter createGetter(
       ClientGet request,
       FreenetURI uri,
@@ -123,7 +258,6 @@ final class ClientGetGetterFactory {
     if (binaryBlob) {
       if (blobBucket == null) {
         Objects.requireNonNull(core, "core");
-        //noinspection resource
         blobBucket =
             core.getClientContext()
                 .getBucketFactory(persistenceForever)
@@ -134,14 +268,14 @@ final class ClientGetGetterFactory {
           uri,
           fetchContext,
           priorityClass,
-          new NullBucket(),
+          NULL_BUCKET,
           new BinaryBlobWriter(blobBucket),
           false,
           initialMetadata,
           extensionCheck);
     }
     if (discardData) {
-      returnBucket = new NullBucket();
+      returnBucket = NULL_BUCKET;
     }
     return new ClientGetter(
         callback,

--- a/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
@@ -426,8 +426,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
       if (type == null || ((!type.safeToRead) && type.readFilter == null)) {
         UnknownContentTypeException e = new UnknownContentTypeException(strippedMimeType);
         onFailure(
-            new FetchException(e.getFetchErrorCode(), cachedData.size(), e, strippedMimeType),
-            null);
+            new FetchException(e.getFetchErrorCode(), cachedData.size(), e, strippedMimeType));
         return true;
       }
       if (type.safeToRead) {
@@ -567,7 +566,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   }
 
   @Override
-  public void onFailure(FetchException e, ClientGetter state) {
+  public void onFailure(FetchException e) {
     synchronized (this) {
       this.failed = e;
       this.finished = true;

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -306,12 +306,12 @@ public class NodeUpdateManager {
       } catch (PersistenceDisabledException _) {
         // Impossible
       } catch (FetchException e) {
-        onFailure(e, null);
+        onFailure(e);
       }
     }
 
     @Override
-    public void onFailure(FetchException e, ClientGetter state) {
+    public void onFailure(FetchException e) {
       LOG.warn("Failed to fetch {}", filename, e);
     }
 

--- a/src/main/java/network/crypta/node/updater/NodeUpdater.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdater.java
@@ -677,7 +677,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
   }
 
   @Override
-  public void onFailure(FetchException e, ClientGetter state) {
+  public void onFailure(FetchException e) {
     // Debug gating derives from LOG.isDebugEnabled() where needed
     if (!isRunning) return;
     FetchExceptionMode errorCode = e.getMode();
@@ -687,7 +687,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
       LOG.warn("Unable to delete temp blob {} on failure", tempBlobFile, ex);
     }
 
-    if (LOG.isDebugEnabled()) LOG.debug("onFailure({},{})", e, state);
+    if (LOG.isDebugEnabled()) LOG.debug("onFailure({},{})", e, cg);
     synchronized (this) {
       this.cg = null;
       isFetching = false;

--- a/src/main/java/network/crypta/node/updater/RevocationChecker.java
+++ b/src/main/java/network/crypta/node/updater/RevocationChecker.java
@@ -458,12 +458,12 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
    *
    * @param e the failure information, including the {@link FetchExceptionMode} and user‑friendly
    *     detail message; never {@code null}.
-   * @param state the associated request state supplied by the client framework; not used for logic
-   *     beyond diagnostics.
    */
   @Override
-  public void onFailure(FetchException e, ClientGetter state) {
-    onFailure(e, state, state.getBlobBucket());
+  public void onFailure(FetchException e) {
+    ClientGetter getter = revocationGetter;
+    Bucket blob = getter == null ? null : getter.getBlobBucket();
+    onFailure(e, getter, blob);
   }
 
   void onFailure(FetchException e, ClientGetter state, Bucket blob) {

--- a/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
+++ b/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
@@ -1438,7 +1438,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
       updateManager.getNode().getClientCore().getClientContext().start(cg);
     } catch (FetchException e1) {
       LOG.error("Failed to decode UOM blob", e1);
-      myCallback.onFailure(e1, cg);
+      myCallback.onFailure(e1);
     } catch (PersistenceDisabledException _) {
       // Impossible
     }
@@ -1498,7 +1498,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
       final ArrayBucket cleanedBlob) {
     return new ClientGetCallback() {
       @Override
-      public void onFailure(FetchException e, ClientGetter state) {
+      public void onFailure(FetchException e) {
         if (e.mode == FetchExceptionMode.CANCELLED) {
           LOG.error(
               "Cancelled fetch from store/blob of revocation certificate from {} to {} - please"
@@ -1511,7 +1511,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
                   + " bad data)",
               source,
               e);
-          updateManager.getRevocationChecker().onFailure(e, state, cleanedBlob);
+          updateManager.getRevocationChecker().onFailure(e, null, cleanedBlob);
           if (!fromDisk) temp.free();
           insertRevocationBlob(updateManager.getRevocationChecker().getBlobBucket());
         } else {
@@ -2040,7 +2040,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
     try {
       updateManager.getNode().getClientCore().getClientContext().start(cg);
     } catch (FetchException e1) {
-      myCallback.onFailure(e1, cg);
+      myCallback.onFailure(e1);
     } catch (PersistenceDisabledException _) {
       // Impossible
     }
@@ -2076,7 +2076,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
     return new ClientGetCallback() {
 
       @Override
-      public void onFailure(FetchException e, ClientGetter state) {
+      public void onFailure(FetchException e) {
         handleMainJarFetchFailure(e, temp, version, toString, cleanedBlob);
       }
 

--- a/src/main/kotlin/network/crypta/node/updater/CoreUpdater.kt
+++ b/src/main/kotlin/network/crypta/node/updater/CoreUpdater.kt
@@ -614,7 +614,7 @@ class CoreUpdater(
     }
 
     /** Records failure information and forwards the exception to the logger. */
-    override fun onFailure(e: FetchException, state: ClientGetter) {
+    override fun onFailure(e: FetchException) {
       complete = true
       successFile = null
       failed = true

--- a/src/test/java/network/crypta/client/FetchWaiterTest.java
+++ b/src/test/java/network/crypta/client/FetchWaiterTest.java
@@ -47,7 +47,7 @@ class FetchWaiterTest {
     FetchWaiter waiter = new FetchWaiter(requestClient);
     FetchException failure = new FetchException(FetchExceptionMode.INTERNAL_ERROR);
 
-    waiter.onFailure(failure, null);
+    waiter.onFailure(failure);
     FetchException thrown =
         assertThrows(
             FetchException.class,
@@ -111,7 +111,7 @@ class FetchWaiterTest {
     t.start();
 
     awaitWaiting(t, Duration.ofSeconds(2));
-    waiter.onFailure(failure, null);
+    waiter.onFailure(failure);
 
     assertTrue(done.await(2, TimeUnit.SECONDS), "Worker thread should complete after onFailure");
     assertSame(failure, thrownRef.get(), "Worker should observe the same exception instance");

--- a/src/test/java/network/crypta/client/NullClientCallbackTest.java
+++ b/src/test/java/network/crypta/client/NullClientCallbackTest.java
@@ -110,7 +110,7 @@ class NullClientCallbackTest {
     FetchException exception = new FetchException(FetchExceptionMode.INTERNAL_ERROR);
 
     // Act & Assert
-    assertDoesNotThrow(() -> callback.onFailure(exception, clientGetter));
+    assertDoesNotThrow(() -> callback.onFailure(exception));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -395,7 +395,7 @@ class ClientContextTest {
 
     ctx.start(getter);
     jobRunner.runLast(ctx);
-    verify(cb, times(1)).onFailure(any(network.crypta.client.FetchException.class), any());
+    verify(cb, times(1)).onFailure(any(network.crypta.client.FetchException.class));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/ClientGetterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientGetterTest.java
@@ -377,7 +377,7 @@ class ClientGetterTest {
 
     // Assert
     ArgumentCaptor<FetchException> exc = ArgumentCaptor.forClass(FetchException.class);
-    verify(callback, times(1)).onFailure(exc.capture(), eq(getter));
+    verify(callback, times(1)).onFailure(exc.capture());
     assertEquals(FetchExceptionMode.MIME_INCOMPATIBLE_WITH_EXTENSION, exc.getValue().mode);
     verify(callback, never()).onSuccess(any(FetchResult.class), any(ClientGetter.class));
   }
@@ -406,7 +406,7 @@ class ClientGetterTest {
 
     // Assert
     ArgumentCaptor<FetchException> exc = ArgumentCaptor.forClass(FetchException.class);
-    verify(callback, times(1)).onFailure(exc.capture(), eq(getter));
+    verify(callback, times(1)).onFailure(exc.capture());
     assertEquals(FetchExceptionMode.BUCKET_ERROR, exc.getValue().mode);
   }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
@@ -1,0 +1,422 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Date;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.client.events.ClientEvent;
+import network.crypta.client.events.EnterFiniteCooldownEvent;
+import network.crypta.client.events.ExpectedFileSizeEvent;
+import network.crypta.client.events.ExpectedHashesEvent;
+import network.crypta.client.events.ExpectedMIMEEvent;
+import network.crypta.client.events.SendingToNetworkEvent;
+import network.crypta.client.events.SplitfileCompatibilityModeEvent;
+import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.crypt.HashResult;
+import network.crypta.crypt.HashType;
+import network.crypta.support.io.NativeThread;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetEventHandlingTest {
+  private static final String CLIENT_FIELD = "client";
+  private static final String EXPECTED_MIME = "text/plain";
+  private static final String IDENTIFIER = "id";
+  private static final String ALT_IDENTIFIER = "other-id";
+
+  @Test
+  void constructor_whenRequestNull_expectNullPointerException() {
+    // Arrange
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> new ClientGetEventHandling(null));
+  }
+
+  @Test
+  void receive_whenSplitfileProgressEvent_expectRecordUpdateAndQueue() {
+    // Arrange
+    ClientGet request =
+        newRequestWith(
+            IDENTIFIER,
+            ClientGet.VERBOSITY_SPLITFILE_PROGRESS,
+            false,
+            ClientRequest.Persistence.CONNECTION);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    RequestStatusCache cache = Mockito.mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    setField(request, ClientRequest.class, CLIENT_FIELD, client);
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    SplitfileProgressEvent event = newProgressEvent();
+
+    // Act
+    handler.receive(event, Mockito.mock(ClientContext.class));
+
+    // Assert
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(request).recordSplitfileProgress(any(SimpleProgressMessage.class));
+    verify(cache).updateStatus(IDENTIFIER, event);
+    verify(request)
+        .queueProgressMessageInner(
+            messageCaptor.capture(), eq(ClientGet.VERBOSITY_SPLITFILE_PROGRESS));
+    assertInstanceOf(SimpleProgressMessage.class, messageCaptor.getValue());
+  }
+
+  @Test
+  void receive_whenSplitfileProgressEventAndVerbosityDisabled_expectNoQueueButRecord() {
+    // Arrange
+    ClientGet request = newRequestWith(IDENTIFIER, 0, false, ClientRequest.Persistence.CONNECTION);
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    SplitfileProgressEvent event = newProgressEvent();
+
+    // Act
+    handler.receive(event, Mockito.mock(ClientContext.class));
+
+    // Assert
+    verify(request).recordSplitfileProgress(any(SimpleProgressMessage.class));
+    verify(request, never()).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+  }
+
+  @Test
+  void receive_whenSendingToNetworkEvent_expectMarkAndQueue() {
+    // Arrange
+    ClientGet request =
+        newRequestWith(
+            IDENTIFIER,
+            ClientGet.VERBOSITY_SENT_TO_NETWORK,
+            false,
+            ClientRequest.Persistence.CONNECTION);
+    doNothing().when(request).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+
+    // Act
+    handler.receive(new SendingToNetworkEvent(), Mockito.mock(ClientContext.class));
+
+    // Assert
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(request).markSentToNetwork();
+    verify(request)
+        .queueProgressMessageInner(
+            messageCaptor.capture(), eq(ClientGet.VERBOSITY_SENT_TO_NETWORK));
+    assertInstanceOf(SendingToNetworkMessage.class, messageCaptor.getValue());
+  }
+
+  @Test
+  void receive_whenExpectedHashesEventAndTrySetFails_expectNoQueue() {
+    // Arrange
+    ClientGet request =
+        newRequestWith(
+            IDENTIFIER,
+            ClientGet.VERBOSITY_EXPECTED_HASHES,
+            false,
+            ClientRequest.Persistence.CONNECTION);
+    Mockito.doReturn(false).when(request).trySetExpectedHashes(any(ExpectedHashes.class));
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    ExpectedHashesEvent event = new ExpectedHashesEvent(new HashResult[] {newSha256Hash()});
+
+    // Act
+    handler.receive(event, Mockito.mock(ClientContext.class));
+
+    // Assert
+    verify(request).trySetExpectedHashes(any(ExpectedHashes.class));
+    verify(request, never()).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+  }
+
+  @Test
+  void receive_whenExpectedHashesEventAndTrySetSucceeds_expectQueue() {
+    // Arrange
+    ClientGet request =
+        newRequestWith(
+            IDENTIFIER,
+            ClientGet.VERBOSITY_EXPECTED_HASHES,
+            false,
+            ClientRequest.Persistence.CONNECTION);
+    doNothing().when(request).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    ExpectedHashesEvent event = new ExpectedHashesEvent(new HashResult[] {newSha256Hash()});
+
+    // Act
+    handler.receive(event, Mockito.mock(ClientContext.class));
+
+    // Assert
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(request)
+        .queueProgressMessageInner(
+            messageCaptor.capture(), eq(ClientGet.VERBOSITY_EXPECTED_HASHES));
+    assertInstanceOf(ExpectedHashes.class, messageCaptor.getValue());
+  }
+
+  @Test
+  void receive_whenExpectedMimeEvent_expectRecordCacheAndQueue() {
+    // Arrange
+    ClientGet request =
+        newRequestWith(
+            IDENTIFIER,
+            ClientGet.VERBOSITY_EXPECTED_TYPE,
+            false,
+            ClientRequest.Persistence.CONNECTION);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    RequestStatusCache cache = Mockito.mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    setField(request, ClientRequest.class, CLIENT_FIELD, client);
+    doNothing().when(request).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    ExpectedMIMEEvent event = new ExpectedMIMEEvent(EXPECTED_MIME);
+
+    // Act
+    handler.receive(event, Mockito.mock(ClientContext.class));
+
+    // Assert
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(request).recordExpectedMimeType(EXPECTED_MIME);
+    verify(cache).updateExpectedMIME(IDENTIFIER, EXPECTED_MIME);
+    verify(request)
+        .queueProgressMessageInner(messageCaptor.capture(), eq(ClientGet.VERBOSITY_EXPECTED_TYPE));
+    assertInstanceOf(ExpectedMIME.class, messageCaptor.getValue());
+  }
+
+  @Test
+  void receive_whenExpectedFileSizeEvent_expectRecordCacheAndQueue() {
+    // Arrange
+    ClientGet request =
+        newRequestWith(
+            IDENTIFIER,
+            ClientGet.VERBOSITY_EXPECTED_SIZE,
+            false,
+            ClientRequest.Persistence.CONNECTION);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    RequestStatusCache cache = Mockito.mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    setField(request, ClientRequest.class, CLIENT_FIELD, client);
+    doNothing().when(request).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    ExpectedFileSizeEvent event = new ExpectedFileSizeEvent(42L);
+
+    // Act
+    handler.receive(event, Mockito.mock(ClientContext.class));
+
+    // Assert
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(request).recordExpectedDataLength(42L);
+    verify(cache).updateExpectedDataLength(IDENTIFIER, 42L);
+    verify(request)
+        .queueProgressMessageInner(messageCaptor.capture(), eq(ClientGet.VERBOSITY_EXPECTED_SIZE));
+    assertInstanceOf(ExpectedDataLength.class, messageCaptor.getValue());
+  }
+
+  @Test
+  void receive_whenEnterFiniteCooldownEvent_expectQueue() {
+    // Arrange
+    ClientGet request =
+        newRequestWith(
+            ALT_IDENTIFIER,
+            ClientGet.VERBOSITY_ENTER_FINITE_COOLDOWN,
+            true,
+            ClientRequest.Persistence.CONNECTION);
+    doNothing().when(request).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    EnterFiniteCooldownEvent event = new EnterFiniteCooldownEvent(1_000L);
+
+    // Act
+    handler.receive(event, Mockito.mock(ClientContext.class));
+
+    // Assert
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(request)
+        .queueProgressMessageInner(
+            messageCaptor.capture(), eq(ClientGet.VERBOSITY_ENTER_FINITE_COOLDOWN));
+    assertInstanceOf(EnterFiniteCooldown.class, messageCaptor.getValue());
+  }
+
+  @Test
+  void receive_whenCompatibilityModeEventAndPersistenceForeverLoaded_expectQueuedJobInvokesMerge()
+      throws PersistenceDisabledException {
+    // Arrange
+    ClientGet request = newRequestWith(IDENTIFIER, 0, false, ClientRequest.Persistence.FOREVER);
+    doNothing()
+        .when(request)
+        .mergeCompatibilityMode(
+            any(CompatibilityMode.class),
+            any(CompatibilityMode.class),
+            any(),
+            anyBoolean(),
+            anyBoolean());
+    PersistentJobRunner jobRunner = Mockito.mock(PersistentJobRunner.class);
+    when(jobRunner.hasLoaded()).thenReturn(true);
+    doNothing().when(jobRunner).queue(any(PersistentJob.class), anyInt());
+    ClientContext context = newContextWithJobRunner(jobRunner);
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    SplitfileCompatibilityModeEvent event =
+        new SplitfileCompatibilityModeEvent(
+            CompatibilityMode.COMPAT_1250,
+            CompatibilityMode.COMPAT_1468,
+            new byte[] {1, 2, 3},
+            true,
+            false);
+
+    // Act
+    handler.receive(event, context);
+
+    // Assert
+    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
+    ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
+    verify(jobRunner)
+        .queue(jobCaptor.capture(), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
+    jobCaptor.getValue().run(Mockito.mock(ClientContext.class));
+    verify(request)
+        .mergeCompatibilityMode(
+            eq(CompatibilityMode.COMPAT_1250),
+            eq(CompatibilityMode.COMPAT_1468),
+            keyCaptor.capture(),
+            eq(true),
+            eq(false));
+    assertArrayEquals(new byte[] {1, 2, 3}, keyCaptor.getValue());
+  }
+
+  @Test
+  void receive_whenCompatibilityModeEventAndNotForever_expectDirectMerge()
+      throws PersistenceDisabledException {
+    // Arrange
+    ClientGet request = newRequestWith(IDENTIFIER, 0, false, ClientRequest.Persistence.CONNECTION);
+    doNothing()
+        .when(request)
+        .mergeCompatibilityMode(
+            any(CompatibilityMode.class),
+            any(CompatibilityMode.class),
+            any(),
+            anyBoolean(),
+            anyBoolean());
+    PersistentJobRunner jobRunner = Mockito.mock(PersistentJobRunner.class);
+    ClientContext context = newContextWithJobRunner(jobRunner);
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    SplitfileCompatibilityModeEvent event =
+        new SplitfileCompatibilityModeEvent(
+            CompatibilityMode.COMPAT_1250,
+            CompatibilityMode.COMPAT_1468,
+            new byte[] {4, 5, 6},
+            false,
+            true);
+
+    // Act
+    handler.receive(event, context);
+
+    // Assert
+    ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
+    verify(request)
+        .mergeCompatibilityMode(
+            eq(CompatibilityMode.COMPAT_1250),
+            eq(CompatibilityMode.COMPAT_1468),
+            keyCaptor.capture(),
+            eq(false),
+            eq(true));
+    assertArrayEquals(new byte[] {4, 5, 6}, keyCaptor.getValue());
+    verify(jobRunner, never()).queue(any(PersistentJob.class), anyInt());
+  }
+
+  @Test
+  void receive_whenCompatibilityModeQueueThrows_expectNoThrow() throws Exception {
+    // Arrange
+    ClientGet request = newRequestWith(IDENTIFIER, 0, false, ClientRequest.Persistence.FOREVER);
+    PersistentJobRunner jobRunner = Mockito.mock(PersistentJobRunner.class);
+    when(jobRunner.hasLoaded()).thenReturn(true);
+    doThrow(new PersistenceDisabledException())
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+    ClientContext context = newContextWithJobRunner(jobRunner);
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    SplitfileCompatibilityModeEvent event =
+        new SplitfileCompatibilityModeEvent(
+            CompatibilityMode.COMPAT_1250,
+            CompatibilityMode.COMPAT_1468,
+            new byte[] {7, 8, 9},
+            true,
+            true);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> handler.receive(event, context));
+  }
+
+  @Test
+  void receive_whenUnknownEvent_expectNoQueue() {
+    // Arrange
+    ClientGet request = newRequestWith(IDENTIFIER, 0, false, ClientRequest.Persistence.CONNECTION);
+    ClientGetEventHandling handler = new ClientGetEventHandling(request);
+    ClientEvent unknownEvent =
+        new ClientEvent() {
+          @Override
+          public int getCode() {
+            return 999;
+          }
+
+          @Override
+          public String getDescription() {
+            return "unknown";
+          }
+        };
+
+    // Act
+    handler.receive(unknownEvent, Mockito.mock(ClientContext.class));
+
+    // Assert
+    verify(request, never()).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+  }
+
+  private static SplitfileProgressEvent newProgressEvent() {
+    return new SplitfileProgressEvent(10, 2, new Date(0L), 1, 0, new Date(0L), 10, 10, true);
+  }
+
+  private static HashResult newSha256Hash() {
+    return new HashResult(HashType.SHA256, new byte[HashType.SHA256.hashLength]);
+  }
+
+  private static ClientGet newRequestWith(
+      String identifier, int verbosity, boolean global, ClientRequest.Persistence persistence) {
+    ClientGet request =
+        Mockito.mock(
+            ClientGet.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    setField(request, ClientRequest.class, "identifier", identifier);
+    setField(request, ClientRequest.class, "verbosity", verbosity);
+    setField(request, ClientRequest.class, "global", global);
+    setField(request, ClientRequest.class, "persistence", persistence);
+    return request;
+  }
+
+  private static ClientContext newContextWithJobRunner(PersistentJobRunner jobRunner) {
+    ClientContext context =
+        Mockito.mock(
+            ClientContext.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    setField(context, ClientContext.class, "jobRunner", jobRunner);
+    return context;
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void setField(Object target, Class<?> owner, String fieldName, Object value) {
+    try {
+      Field field = owner.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new AssertionError("Failed to set field: " + fieldName, e);
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
@@ -1,0 +1,453 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchResult;
+import network.crypta.client.async.BinaryBlob;
+import network.crypta.client.async.BinaryBlobWriter;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetCallback;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.PersistentClientCallback;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.HashResult;
+import network.crypta.crypt.HashType;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.FileBucket;
+import network.crypta.support.io.NullBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientGetGetterFactoryTest {
+  @TempDir File tempDir;
+
+  @Test
+  void binaryBlobMimeType_whenCalled_returnsBinaryBlobMimeType() {
+    String mimeType = ClientGetGetterFactory.binaryBlobMimeType();
+
+    assertEquals(BinaryBlob.MIME_TYPE, mimeType);
+  }
+
+  @Test
+  void checksummedWriter_whenCalled_usesChecksumWriterWithLength() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream target = new DataOutputStream(output);
+    RecordingChecksumChecker checker = new RecordingChecksumChecker();
+
+    DataOutputStream writer = ClientGetGetterFactory.checksummedWriter(target, checker);
+    writer.writeInt(1234);
+    writer.close();
+
+    assertNotNull(writer);
+    assertEquals(8, checker.lastSkipPrefix);
+    assertSame(target, checker.lastTarget);
+  }
+
+  @Test
+  void diskReturnBucket_whenCreated_configuresFileBucketFlags() {
+    File file = new File(tempDir, "return.bin");
+
+    try (Bucket bucket = ClientGetGetterFactory.diskReturnBucket(file)) {
+      assertInstanceOf(FileBucket.class, bucket);
+      FileBucket fileBucket = (FileBucket) bucket;
+      assertEquals(file.getAbsoluteFile(), fileBucket.getFile());
+      assertFalse(fileBucket.isReadOnly());
+      assertTrue(readBooleanField(fileBucket, "createFileOnlyFlag"));
+      assertFalse(readBooleanField(fileBucket, "deleteOnExitFlag"));
+      assertFalse(readBooleanField(fileBucket, "deleteOnFreeFlag"));
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true", "false"})
+  void diskBucket_whenCreated_appliesReadOnlyFlag(boolean readOnly) {
+    File file = new File(tempDir, "bucket.bin");
+
+    try (Bucket bucket = ClientGetGetterFactory.diskBucket(file, readOnly)) {
+      assertInstanceOf(FileBucket.class, bucket);
+      FileBucket fileBucket = (FileBucket) bucket;
+      assertEquals(file.getAbsoluteFile(), fileBucket.getFile());
+      assertEquals(readOnly, fileBucket.isReadOnly());
+      assertFalse(readBooleanField(fileBucket, "createFileOnlyFlag"));
+    }
+  }
+
+  @Test
+  void readExpectedHashes_whenNoHashes_returnsNull() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(output);
+    dos.writeInt(0);
+    dos.flush();
+
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(output.toByteArray()));
+    ExpectedHashes result = ClientGetGetterFactory.readExpectedHashes(dis, "identifier", true);
+
+    assertNull(result);
+  }
+
+  @Test
+  void readExpectedHashes_whenHashesPresent_returnsExpectedHashes() throws IOException {
+    HashResult[] hashes = new HashResult[] {hashFor(HashType.SHA256, (byte) 7)};
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(output);
+    HashResult.write(hashes, dos);
+    dos.flush();
+
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(output.toByteArray()));
+    ExpectedHashes result = ClientGetGetterFactory.readExpectedHashes(dis, "id", false);
+
+    assertNotNull(result);
+    assertEquals("id", result.messageIdentifier);
+    assertFalse(result.global);
+    assertNotNull(result.hashes);
+    assertEquals(1, result.hashes.length);
+    assertEquals(hashes[0], result.hashes[0]);
+  }
+
+  @Test
+  void writeExpectedHashes_whenNull_writesEmptyHashes() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(output);
+
+    ClientGetGetterFactory.writeExpectedHashes(dos, null);
+
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(output.toByteArray()));
+    ExpectedHashes result = ClientGetGetterFactory.readExpectedHashes(dis, "ignored", false);
+    assertNull(result);
+  }
+
+  @Test
+  void writeExpectedHashes_whenPresent_roundTripsThroughRead() throws IOException {
+    HashResult[] hashes = new HashResult[] {hashFor(HashType.SHA1, (byte) 3)};
+    ExpectedHashes expected = new ExpectedHashes(hashes, "abc", true);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(output);
+
+    ClientGetGetterFactory.writeExpectedHashes(dos, expected);
+
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(output.toByteArray()));
+    ExpectedHashes result = ClientGetGetterFactory.readExpectedHashes(dis, "abc", true);
+
+    assertNotNull(result);
+    assertEquals("abc", result.messageIdentifier);
+    assertTrue(result.global);
+    assertNotNull(result.hashes);
+    assertEquals(hashes[0], result.hashes[0]);
+  }
+
+  @Test
+  void createGetter_whenBinaryBlobTrueAndReturnBucketProvided_usesBucketWriter() throws Exception {
+    ClientGet request = mockRequestWithClient();
+    FetchContext fetchContext = mock(FetchContext.class);
+    Bucket returnBucket = mock(Bucket.class);
+
+    ClientGetter getter =
+        ClientGetGetterFactory.createGetter(
+            request,
+            mock(FreenetURI.class),
+            fetchContext,
+            (short) 1,
+            returnBucket,
+            null,
+            null,
+            false,
+            true,
+            false,
+            null);
+
+    Bucket storedReturnBucket = (Bucket) readField(getter, "returnBucket");
+    BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
+
+    assertInstanceOf(NullBucket.class, storedReturnBucket);
+    assertNotNull(writer);
+    assertSame(returnBucket, readField(writer, "out"));
+  }
+
+  @Test
+  void createGetter_whenBinaryBlobTrueAndReturnBucketNull_requiresCore() {
+    ClientGet request = mock(ClientGet.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            ClientGetGetterFactory.createGetter(
+                request,
+                mock(FreenetURI.class),
+                fetchContext,
+                (short) 1,
+                null,
+                null,
+                null,
+                false,
+                true,
+                false,
+                null));
+  }
+
+  @Test
+  void createGetter_whenBinaryBlobTrueAndReturnBucketNull_allocatesBucket() throws Exception {
+    ClientGet request = mockRequestWithClient();
+    FetchContext fetchContext = mock(FetchContext.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    ClientContext clientContext = mock(ClientContext.class);
+    BucketFactory bucketFactory = mock(BucketFactory.class);
+    RandomAccessBucket createdBucket = mock(RandomAccessBucket.class);
+
+    when(fetchContext.getMaxOutputLength()).thenReturn(128L);
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(clientContext.getBucketFactory(true)).thenReturn(bucketFactory);
+    when(bucketFactory.makeBucket(128L)).thenReturn(createdBucket);
+
+    ClientGetter getter =
+        ClientGetGetterFactory.createGetter(
+            request,
+            mock(FreenetURI.class),
+            fetchContext,
+            (short) 1,
+            null,
+            null,
+            null,
+            false,
+            true,
+            true,
+            core);
+
+    BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
+    assertNotNull(writer);
+    assertSame(createdBucket, readField(writer, "out"));
+  }
+
+  @Test
+  void createGetter_whenDiscardDataTrue_usesNullBucket() throws Exception {
+    ClientGet request = mockRequestWithClient();
+    FetchContext fetchContext = mock(FetchContext.class);
+    Bucket returnBucket = mock(Bucket.class);
+
+    ClientGetter getter =
+        ClientGetGetterFactory.createGetter(
+            request,
+            mock(FreenetURI.class),
+            fetchContext,
+            (short) 1,
+            returnBucket,
+            null,
+            null,
+            true,
+            false,
+            false,
+            null);
+
+    Bucket storedReturnBucket = (Bucket) readField(getter, "returnBucket");
+
+    assertInstanceOf(NullBucket.class, storedReturnBucket);
+  }
+
+  @Test
+  void createGetter_whenDiscardDataFalse_preservesReturnBucket() throws Exception {
+    ClientGet request = mockRequestWithClient();
+    FetchContext fetchContext = mock(FetchContext.class);
+    Bucket returnBucket = mock(Bucket.class);
+
+    ClientGetter getter =
+        ClientGetGetterFactory.createGetter(
+            request,
+            mock(FreenetURI.class),
+            fetchContext,
+            (short) 1,
+            returnBucket,
+            null,
+            null,
+            false,
+            false,
+            false,
+            null);
+
+    Bucket storedReturnBucket = (Bucket) readField(getter, "returnBucket");
+    BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
+
+    assertSame(returnBucket, storedReturnBucket);
+    assertNull(writer);
+  }
+
+  @Test
+  void createGetter_whenBinaryBlobFalse_callbackDelegatesToRequest() throws Exception {
+    ClientGet request = mock(ClientGet.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RequestClient requestClient = mock(RequestClient.class);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    DataOutputStream dos = new DataOutputStream(new ByteArrayOutputStream());
+    ClientContext context = mock(ClientContext.class);
+    FetchResult fetchResult = mock(FetchResult.class);
+    FetchException fetchException = mock(FetchException.class);
+
+    when(request.getRequestClient()).thenReturn(requestClient);
+    doNothing().when(request).getClientDetail(dos, checker);
+
+    ClientGetter getter =
+        ClientGetGetterFactory.createGetter(
+            request,
+            mock(FreenetURI.class),
+            fetchContext,
+            (short) 1,
+            null,
+            null,
+            null,
+            false,
+            false,
+            false,
+            null);
+
+    ClientGetCallback callback = getter.getClientCallback();
+
+    assertInstanceOf(PersistentClientCallback.class, callback);
+
+    callback.onSuccess(fetchResult, getter);
+    callback.onFailure(fetchException, getter);
+    callback.onResume(context);
+    RequestClient resolvedClient = callback.getRequestClient();
+    ((PersistentClientCallback) callback).getClientDetail(dos, checker);
+
+    assertSame(requestClient, resolvedClient);
+    verify(request).onSuccess(fetchResult, getter);
+    verify(request).onFailure(fetchException, getter);
+    verify(request).onResume(context);
+    verify(request).getClientDetail(dos, checker);
+  }
+
+  @Test
+  void createGetter_whenBinaryBlobTrueAndBucketProvided_doesNotTouchCore() throws IOException {
+    ClientGet request = mockRequestWithClient();
+    FetchContext fetchContext = mock(FetchContext.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    Bucket returnBucket = mock(Bucket.class);
+
+    ClientGetGetterFactory.createGetter(
+        request,
+        mock(FreenetURI.class),
+        fetchContext,
+        (short) 1,
+        returnBucket,
+        null,
+        null,
+        false,
+        true,
+        false,
+        core);
+
+    verifyNoInteractions(core);
+  }
+
+  private static HashResult hashFor(HashType type, byte seed) {
+    byte[] bytes = new byte[type.hashLength];
+    for (int i = 0; i < bytes.length; i++) {
+      bytes[i] = (byte) (seed + i);
+    }
+    return new HashResult(type, bytes);
+  }
+
+  private static ClientGet mockRequestWithClient() {
+    ClientGet request = mock(ClientGet.class);
+    RequestClient requestClient = mock(RequestClient.class);
+    when(request.getRequestClient()).thenReturn(requestClient);
+    return request;
+  }
+
+  private static Object readField(Object target, String name) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private static boolean readBooleanField(Object target, String name) {
+    try {
+      Field field = target.getClass().getDeclaredField(name);
+      field.setAccessible(true);
+      return field.getBoolean(target);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static final class RecordingChecksumChecker extends ChecksumChecker {
+    private int lastSkipPrefix = -1;
+    private OutputStream lastTarget;
+
+    @Override
+    public int checksumLength() {
+      return 0;
+    }
+
+    @Override
+    public OutputStream checksumWriter(OutputStream os, int skipPrefix) {
+      lastSkipPrefix = skipPrefix;
+      lastTarget = os;
+      return os;
+    }
+
+    @Override
+    public byte[] appendChecksum(byte[] data) {
+      return data;
+    }
+
+    @Override
+    public boolean checkChecksum(byte[] data, int offset, int length, byte[] checksum) {
+      return true;
+    }
+
+    @Override
+    public byte[] generateChecksum(byte[] bufToChecksum, int offset, int length) {
+      return new byte[0];
+    }
+
+    @Override
+    public int getChecksumTypeID() {
+      return 0;
+    }
+
+    @Override
+    public void copyAndStripChecksum(InputStream is, OutputStream os, long length) {
+      throw new UnsupportedOperationException("Not used in tests");
+    }
+
+    @Override
+    public void readAndChecksum(DataInput is, byte[] buf, int offset, int length) {
+      throw new UnsupportedOperationException("Not used in tests");
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
@@ -338,14 +338,14 @@ class ClientGetGetterFactoryTest {
     assertInstanceOf(PersistentClientCallback.class, callback);
 
     callback.onSuccess(fetchResult, getter);
-    callback.onFailure(fetchException, getter);
+    callback.onFailure(fetchException);
     callback.onResume(context);
     RequestClient resolvedClient = callback.getRequestClient();
     ((PersistentClientCallback) callback).getClientDetail(dos, checker);
 
     assertSame(requestClient, resolvedClient);
     verify(request).onSuccess(fetchResult, getter);
-    verify(request).onFailure(fetchException, getter);
+    verify(request).onFailure(fetchException);
     verify(request).onResume(context);
     verify(request).getClientDetail(dos, checker);
   }

--- a/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
@@ -109,7 +109,7 @@ class FProxyFetchInProgressTest {
   void notFinishedOrFatallyFinished_whenFatalFailure_returnsTrue() {
     FProxyFetchInProgress progress = newProgress(newFetchContext());
 
-    progress.onFailure(new FetchException(FetchExceptionMode.TOO_BIG), null);
+    progress.onFailure(new FetchException(FetchExceptionMode.TOO_BIG));
 
     assertTrue(progress.notFinishedOrFatallyFinished());
   }
@@ -118,7 +118,7 @@ class FProxyFetchInProgressTest {
   void notFinishedOrFatallyFinished_whenNonFatalFailureEventuallyReturnsFalse() throws Exception {
     FProxyFetchInProgress progress = newProgress(newFetchContext());
 
-    progress.onFailure(new FetchException(FetchExceptionMode.DATA_NOT_FOUND), null);
+    progress.onFailure(new FetchException(FetchExceptionMode.DATA_NOT_FOUND));
     assertTrue(progress.notFinishedOrFatallyFinished());
 
     setField(progress, "timeFailed", System.currentTimeMillis() - 1500);


### PR DESCRIPTION
## Summary
- split ClientGet event and getter construction into dedicated helper classes to reduce coupling
- update ClientGetCallback failure signature and propagate changes across callers
- add focused unit tests for the new helpers and factory behaviors

## Testing
- not run (not requested)
