### PR TITLE
refactor(fec): add MatrixMulParams for matMul

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,6 @@ some Kotlin components.
 ## Development Guidelines
 
 - Primary language: Kotlin/Java
-    - New files should be always in Kotlin
     - Kotlin source location: place all Kotlin sources under `src/*/kotlin/` (e.g., `src/main/kotlin`, `src/test/kotlin`). Do not add Kotlin files under `src/*/java/`.
     - Prefer top-level functions over wrapping in objects/classes when appropriate (idiomatic Kotlin)
 - Code style:

--- a/src/main/java/com/onionnetworks/fec/FECMath.java
+++ b/src/main/java/com/onionnetworks/fec/FECMath.java
@@ -80,7 +80,7 @@ public class FECMath {
   /**
    * To speed up computations, we have tables for logarithm, exponent and inverse of a number. If
    * gfBits <= 8, we use a table for multiplication as well (it takes 64K, no big deal even on a
-   * PDA, especially because it can be pre-initialized a put into a ROM!), otherwhise we use a table
+   * PDA, especially because it can be pre-initialized a put into a ROM!), otherwise we use a table
    * of logarithms.
    */
 
@@ -493,7 +493,7 @@ public class FECMath {
    * @param m number of columns in {@code b} and {@code c}
    */
   public final void matMul(char[] a, char[] b, char[] c, int n, int k, int m) {
-    matMul(a, 0, b, 0, c, 0, n, k, m);
+    matMul(new MatrixMulParams(a, 0, b, 0, c, 0, n, k, m));
   }
 
   /*
@@ -503,18 +503,18 @@ public class FECMath {
    * Matrix multiplication with explicit starting offsets for each operand. This overload supports
    * slicing into larger buffers without copying submatrices.
    *
-   * @param a backing array for the left matrix; data begins at {@code aStart}
-   * @param aStart offset into {@code a} where the {@code n x k} block starts
-   * @param b backing array for the right matrix; data begins at {@code bStart}
-   * @param bStart offset into {@code b} where the {@code k x m} block starts
-   * @param c destination array that receives the {@code n x m} product block
-   * @param cStart offset into {@code c} where results are written
-   * @param n number of rows in the left matrix and output
-   * @param k shared inner dimension of the matrices
-   * @param m number of columns in the right matrix and output
+   * @param params grouped matrix slice and dimension settings
    */
-  public final void matMul(
-      char[] a, int aStart, char[] b, int bStart, char[] c, int cStart, int n, int k, int m) {
+  public final void matMul(MatrixMulParams params) {
+    char[] a = params.a();
+    char[] b = params.b();
+    char[] c = params.c();
+    int aStart = params.aStart();
+    int bStart = params.bStart();
+    int cStart = params.cStart();
+    int n = params.n();
+    int k = params.k();
+    int m = params.m();
 
     for (int row = 0; row < n; row++) {
       for (int col = 0; col < m; col++) {
@@ -782,7 +782,7 @@ public class FECMath {
      */
     // much faster than invertMatrix
     invertVandermonde(tmpMatrix, k);
-    matMul(tmpMatrix, k * k, tmpMatrix, 0, encMatrix, k * k, n - k, k, k);
+    matMul(new MatrixMulParams(tmpMatrix, k * k, tmpMatrix, 0, encMatrix, k * k, n - k, k, k));
 
     /*
      * the upper matrix is I so do not bother with a slow multiply

--- a/src/main/java/com/onionnetworks/fec/MatrixMulParams.java
+++ b/src/main/java/com/onionnetworks/fec/MatrixMulParams.java
@@ -1,0 +1,88 @@
+package com.onionnetworks.fec;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Parameter carrier for finite-field matrix multiplication slices.
+ *
+ * @param a backing array for the left matrix
+ * @param aStart offset into {@code a} where the {@code n x k} block starts
+ * @param b backing array for the right matrix
+ * @param bStart offset into {@code b} where the {@code k x m} block starts
+ * @param c destination array for the {@code n x m} product
+ * @param cStart offset into {@code c} where results are written
+ * @param n number of rows in the left matrix and output
+ * @param k shared inner dimension of the matrices
+ * @param m number of columns in the right matrix and output
+ */
+public record MatrixMulParams(
+    char[] a, int aStart, char[] b, int bStart, char[] c, int cStart, int n, int k, int m) {
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj
+        instanceof
+        MatrixMulParams(
+            char[] otherA,
+            int otherAStart,
+            char[] otherB,
+            int otherBStart,
+            char[] otherC,
+            int otherCStart,
+            int otherN,
+            int otherK,
+            int otherM))) {
+      return false;
+    }
+    return java.util.Arrays.equals(a, otherA)
+        && aStart == otherAStart
+        && java.util.Arrays.equals(b, otherB)
+        && bStart == otherBStart
+        && java.util.Arrays.equals(c, otherC)
+        && cStart == otherCStart
+        && n == otherN
+        && k == otherK
+        && m == otherM;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = java.util.Arrays.hashCode(a);
+    result = 31 * result + Integer.hashCode(aStart);
+    result = 31 * result + java.util.Arrays.hashCode(b);
+    result = 31 * result + Integer.hashCode(bStart);
+    result = 31 * result + java.util.Arrays.hashCode(c);
+    result = 31 * result + Integer.hashCode(cStart);
+    result = 31 * result + Integer.hashCode(n);
+    result = 31 * result + Integer.hashCode(k);
+    result = 31 * result + Integer.hashCode(m);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "MatrixMulParams{"
+        + "a="
+        + java.util.Arrays.toString(a)
+        + ", aStart="
+        + aStart
+        + ", b="
+        + java.util.Arrays.toString(b)
+        + ", bStart="
+        + bStart
+        + ", c="
+        + java.util.Arrays.toString(c)
+        + ", cStart="
+        + cStart
+        + ", n="
+        + n
+        + ", k="
+        + k
+        + ", m="
+        + m
+        + '}';
+  }
+}


### PR DESCRIPTION
## Summary
- add `MatrixMulParams` record for matrix slice inputs
- refactor `FECMath#matMul` to take the parameter record
- update `AGENTS.md` by removing the kotlin-only new file rule

## Testing
- `./gradlew spotlessApply`

## Breaking change
- `FECMath#matMul(char[], int, char[], int, char[], int, int, int, int)` removed; callers must use `MatrixMulParams`