### PR TITLE
refactor(client): bundle archive extraction params

### DIFF
--- a/src/main/java/network/crypta/client/ArchiveElementRequest.java
+++ b/src/main/java/network/crypta/client/ArchiveElementRequest.java
@@ -1,0 +1,29 @@
+package network.crypta.client;
+
+import network.crypta.client.async.ClientContext;
+
+/**
+ * Describes a single archive element of interest and its callback.
+ *
+ * <p>The element name may be {@code null} to indicate that no specific entry is requested. The
+ * callback and client context are passed through to the extraction pipeline as provided.
+ */
+final class ArchiveElementRequest {
+  final String element;
+  final ArchiveExtractCallback callback;
+  final ClientContext clientContext;
+
+  /**
+   * Creates a new element request.
+   *
+   * @param element optional element name to prioritize; may be {@code null}
+   * @param callback callback notified when the element is found or missing; may be {@code null}
+   * @param clientContext client execution context for callbacks and background work
+   */
+  ArchiveElementRequest(
+      String element, ArchiveExtractCallback callback, ClientContext clientContext) {
+    this.element = element;
+    this.callback = callback;
+    this.clientContext = clientContext;
+  }
+}

--- a/src/main/java/network/crypta/client/ArchiveExtractionInput.java
+++ b/src/main/java/network/crypta/client/ArchiveExtractionInput.java
@@ -1,0 +1,48 @@
+package network.crypta.client;
+
+import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+
+/**
+ * Bundles the archive source inputs needed to extract a container into the cache.
+ *
+ * <p>This parameter object captures the archive key, format metadata, raw data bucket, and
+ * per-request archive context along with the manager's store context. It performs no validation and
+ * stores references as-is; callers should treat the supplied objects as immutable for the duration
+ * of extraction.
+ */
+final class ArchiveExtractionInput {
+  final FreenetURI key;
+  final ARCHIVE_TYPE archiveType;
+  final COMPRESSOR_TYPE compressorType;
+  final Bucket data;
+  final ArchiveContext archiveContext;
+  final ArchiveStoreContext storeContext;
+
+  /**
+   * Creates a new extraction input bundle.
+   *
+   * @param key key of the archive being extracted
+   * @param archiveType container format used to enumerate entries
+   * @param compressorType optional outer compression type; may be {@code null}
+   * @param data bucket holding the raw archive bytes
+   * @param archiveContext per-request archive context and limits
+   * @param storeContext manager-maintained store context for the archive key
+   */
+  ArchiveExtractionInput(
+      FreenetURI key,
+      ARCHIVE_TYPE archiveType,
+      COMPRESSOR_TYPE compressorType,
+      Bucket data,
+      ArchiveContext archiveContext,
+      ArchiveStoreContext storeContext) {
+    this.key = key;
+    this.archiveType = archiveType;
+    this.compressorType = compressorType;
+    this.data = data;
+    this.archiveContext = archiveContext;
+    this.storeContext = storeContext;
+  }
+}

--- a/src/main/java/network/crypta/client/ArchiveExtractionState.java
+++ b/src/main/java/network/crypta/client/ArchiveExtractionState.java
@@ -1,0 +1,41 @@
+package network.crypta.client;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
+
+/**
+ * Captures per-extraction derived state used across archive processing helpers.
+ *
+ * <p>The state bundles the immutable input and element request parameters together with mutable
+ * flags and derived values computed during extraction. It is created inside {@link
+ * ArchiveManager#extractToCache(ArchiveExtractionInput, ArchiveElementRequest)} and should only be
+ * used within a single extraction flow.
+ */
+final class ArchiveExtractionState {
+  final ArchiveExtractionInput input;
+  final ArchiveElementRequest elementRequest;
+  final MutableBoolean gotElement;
+  final boolean throwAtExit;
+  final long expectedSize;
+
+  /**
+   * Creates a new extraction state bundle.
+   *
+   * @param input source inputs for the archive extraction
+   * @param elementRequest requested element and callback details
+   * @param gotElement mutable flag that tracks when the requested element is delivered
+   * @param throwAtExit whether extraction should trigger a restart after completion
+   * @param expectedSize expected archive size for formats that require it
+   */
+  ArchiveExtractionState(
+      ArchiveExtractionInput input,
+      ArchiveElementRequest elementRequest,
+      MutableBoolean gotElement,
+      boolean throwAtExit,
+      long expectedSize) {
+    this.input = input;
+    this.elementRequest = elementRequest;
+    this.gotElement = gotElement;
+    this.throwAtExit = throwAtExit;
+    this.expectedSize = expectedSize;
+  }
+}

--- a/src/main/java/network/crypta/client/ArchiveHandlerImpl.java
+++ b/src/main/java/network/crypta/client/ArchiveHandlerImpl.java
@@ -19,9 +19,7 @@ import org.slf4j.LoggerFactory;
  * small piece of state indicating whether the next lookup should skip the cache ({@code
  * forceRefetchArchive}). This class does not perform any network I/O and does not parse container
  * formats by itself; it merely looks up previously extracted items and delegates extraction to
- * {@link ArchiveManager#extractToCache(FreenetURI, ARCHIVE_TYPE,
- * network.crypta.support.compress.Compressor.COMPRESSOR_TYPE, Bucket, ArchiveContext,
- * ArchiveStoreContext, String, ArchiveExtractCallback, ClientContext)}.
+ * {@link ArchiveManager#extractToCache(ArchiveExtractionInput, ArchiveElementRequest)}.
  *
  * <p>Typical usage is:
  *
@@ -159,9 +157,8 @@ class ArchiveHandlerImpl implements ArchiveHandler, Serializable {
    * lookups to proceed. The method constructs an {@link ArchiveStoreContext} for the key via {@link
    * ArchiveManager#makeContext(FreenetURI, ARCHIVE_TYPE,
    * network.crypta.support.compress.Compressor.COMPRESSOR_TYPE, boolean)} and delegates the heavy
-   * lifting to {@link ArchiveManager#extractToCache(FreenetURI, ARCHIVE_TYPE,
-   * network.crypta.support.compress.Compressor.COMPRESSOR_TYPE, Bucket, ArchiveContext,
-   * ArchiveStoreContext, String, ArchiveExtractCallback, ClientContext)}.
+   * lifting to {@link ArchiveManager#extractToCache(ArchiveExtractionInput,
+   * ArchiveElementRequest)}.
    *
    * @param bucket The raw bytes of the outer archive to unpack; must provide readable content for
    *     the duration of the call.
@@ -188,8 +185,10 @@ class ArchiveHandlerImpl implements ArchiveHandler, Serializable {
       throws ArchiveFailureException, ArchiveRestartException {
     forceRefetchArchive = false; // now we don't need to force refetch anymore
     ArchiveStoreContext ctx = manager.makeContext(key, archiveType, compressorType, false);
-    manager.extractToCache(
-        key, archiveType, compressorType, bucket, actx, ctx, element, callback, context);
+    ArchiveExtractionInput input =
+        new ArchiveExtractionInput(key, archiveType, compressorType, bucket, actx, ctx);
+    ArchiveElementRequest elementRequest = new ArchiveElementRequest(element, callback, context);
+    manager.extractToCache(input, elementRequest);
   }
 
   /**

--- a/src/main/java/network/crypta/client/ArchiveManager.java
+++ b/src/main/java/network/crypta/client/ArchiveManager.java
@@ -327,28 +327,20 @@ public class ArchiveManager {
   /**
    * Extract data to cache. Call synchronized on ctx.
    *
-   * @param key The key the data was fetched from.
-   * @param archiveType The archive type. Must be Metadata.ARCHIVE_ZIP | Metadata.ARCHIVE_TAR.
-   * @param data The actual data fetched.
-   * @param archiveContext The context for the whole fetch process.
-   * @param ctx The ArchiveStoreContext for this key.
-   * @param element A particular element that the caller is especially interested in, or null.
-   * @param callback A callback to be called if we find that element, or if we don't.
+   * @param input source inputs describing the archive bytes and associated contexts
+   * @param elementRequest requested element and callback details; element may be {@code null}
    * @throws ArchiveFailureException If we could not extract the data, or it was too big, etc.
    * @throws ArchiveRestartException If the request needs to be restarted because the archive
    *     changed.
    */
-  void extractToCache(
-      FreenetURI key,
-      ARCHIVE_TYPE archiveType,
-      COMPRESSOR_TYPE ctype,
-      final Bucket data,
-      ArchiveContext archiveContext,
-      ArchiveStoreContext ctx,
-      String element,
-      ArchiveExtractCallback callback,
-      ClientContext context)
+  void extractToCache(ArchiveExtractionInput input, ArchiveElementRequest elementRequest)
       throws ArchiveFailureException, ArchiveRestartException {
+
+    FreenetURI key = input.key;
+    Bucket data = input.data;
+    ArchiveContext archiveContext = input.archiveContext;
+    ArchiveStoreContext ctx = input.storeContext;
+    String element = elementRequest.element;
 
     MutableBoolean gotElement = element != null ? new MutableBoolean() : null;
 
@@ -386,19 +378,9 @@ public class ArchiveManager {
       LOG.debug("Container size (possibly compressed): {} for {}", archiveSize, data);
 
     try {
-      ExceptionWrapper wrapper =
-          processByCompressor(
-              archiveType,
-              ctype,
-              data,
-              ctx,
-              key,
-              element,
-              callback,
-              gotElement,
-              throwAtExit,
-              context,
-              expectedSize);
+      ArchiveExtractionState state =
+          new ArchiveExtractionState(input, elementRequest, gotElement, throwAtExit, expectedSize);
+      ExceptionWrapper wrapper = processByCompressor(state);
       checkWrapperException(wrapper);
     } catch (IOException ioe) {
       throw new ArchiveFailureException("An IOE occured: " + ioe.getMessage(), ioe);
@@ -412,207 +394,119 @@ public class ArchiveManager {
       throw new ArchiveFailureException("An exception occured decompressing: " + e.getMessage(), e);
   }
 
-  private ExceptionWrapper processByCompressor(
-      ARCHIVE_TYPE archiveType,
-      COMPRESSOR_TYPE ctype,
-      Bucket data,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
-      boolean throwAtExit,
-      ClientContext context,
-      long expectedSize)
+  private ExceptionWrapper processByCompressor(ArchiveExtractionState state)
       throws IOException, ArchiveFailureException, ArchiveRestartException {
+    ArchiveExtractionInput input = state.input;
+    ARCHIVE_TYPE archiveType = input.archiveType;
+    COMPRESSOR_TYPE ctype = input.compressorType;
     if ((ctype == null) || (ARCHIVE_TYPE.ZIP == archiveType)) {
-      return handleNoCompressionOrZip(
-          archiveType, ctx, key, data, element, callback, gotElement, throwAtExit, context);
+      return handleNoCompressionOrZip(state);
     }
     if (ctype == COMPRESSOR_TYPE.BZIP2) {
-      return handleBzip2(
-          archiveType, ctx, key, data, element, callback, gotElement, throwAtExit, context);
+      return handleBzip2(state);
     }
     if (ctype == COMPRESSOR_TYPE.GZIP) {
-      return handleGzip(
-          archiveType, ctx, key, data, element, callback, gotElement, throwAtExit, context);
+      return handleGzip(state);
     }
     if (ctype == COMPRESSOR_TYPE.LZMA_NEW) {
-      return handleLzmaNew(
-          archiveType,
-          ctx,
-          key,
-          data,
-          element,
-          callback,
-          gotElement,
-          throwAtExit,
-          context,
-          expectedSize);
+      return handleLzmaNew(state);
     }
     if (ctype == COMPRESSOR_TYPE.LZMA) {
-      return handleLzma(
-          archiveType, ctx, key, data, element, callback, gotElement, throwAtExit, context);
+      return handleLzma(state);
     }
     return null;
   }
 
-  private ExceptionWrapper handleNoCompressionOrZip(
-      ARCHIVE_TYPE archiveType,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      Bucket data,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
-      boolean throwAtExit,
-      ClientContext context)
+  private ExceptionWrapper handleNoCompressionOrZip(ArchiveExtractionState state)
       throws IOException, ArchiveFailureException, ArchiveRestartException {
     if (LOG.isDebugEnabled()) LOG.debug("No compression");
-    try (InputStream is = data.getInputStream()) {
-      handleArchiveWithStream(
-          archiveType, ctx, key, is, element, callback, gotElement, throwAtExit, context);
+    try (InputStream is = state.input.data.getInputStream()) {
+      handleArchiveWithStream(state, is);
     }
     return null;
   }
 
-  private ExceptionWrapper handleBzip2(
-      ARCHIVE_TYPE archiveType,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      Bucket data,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
-      boolean throwAtExit,
-      ClientContext context)
+  private ExceptionWrapper handleBzip2(ArchiveExtractionState state)
       throws IOException, ArchiveFailureException, ArchiveRestartException {
     if (LOG.isDebugEnabled()) LOG.debug("dealing with BZIP2");
-    try (InputStream baseIs = data.getInputStream();
+    try (InputStream baseIs = state.input.data.getInputStream();
         InputStream is = new BZip2CompressorInputStream(baseIs)) {
-      handleArchiveWithStream(
-          archiveType, ctx, key, is, element, callback, gotElement, throwAtExit, context);
+      handleArchiveWithStream(state, is);
     }
     return null;
   }
 
-  private ExceptionWrapper handleGzip(
-      ARCHIVE_TYPE archiveType,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      Bucket data,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
-      boolean throwAtExit,
-      ClientContext context)
+  private ExceptionWrapper handleGzip(ArchiveExtractionState state)
       throws IOException, ArchiveFailureException, ArchiveRestartException {
     if (LOG.isDebugEnabled()) LOG.debug("dealing with GZIP");
-    try (InputStream baseIs = data.getInputStream();
+    try (InputStream baseIs = state.input.data.getInputStream();
         InputStream is = new GZIPInputStream(baseIs)) {
-      handleArchiveWithStream(
-          archiveType, ctx, key, is, element, callback, gotElement, throwAtExit, context);
+      handleArchiveWithStream(state, is);
     }
     return null;
   }
 
-  private ExceptionWrapper handleLzmaNew(
-      ARCHIVE_TYPE archiveType,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      Bucket data,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
-      boolean throwAtExit,
-      ClientContext context,
-      long expectedSize)
+  private ExceptionWrapper handleLzmaNew(ArchiveExtractionState state)
       throws IOException, ArchiveFailureException, ArchiveRestartException {
     ExceptionWrapper wrapper = new ExceptionWrapper();
     try (PipedInputStream pis = new PipedInputStream()) {
       // Connect the pipe before handing the reader to the archive handler to avoid races where
       // the reader attempts to consume before the writer is attached ("Pipe not connected").
       final PipedOutputStream pos = new PipedOutputStream(pis);
+      ArchiveExtractionInput input = state.input;
+      ClientContext context = state.elementRequest.clientContext;
       context
           .getMainExecutor()
           .execute(
               () -> {
-                try (InputStream is = data.getInputStream();
+                try (InputStream is = input.data.getInputStream();
                     OutputStream os = new BufferedOutputStream(pos)) {
-                  Compressor.COMPRESSOR_TYPE.LZMA_NEW.decompress(is, os, data.size(), expectedSize);
+                  Compressor.COMPRESSOR_TYPE.LZMA_NEW.decompress(
+                      is, os, input.data.size(), state.expectedSize);
                 } catch (IOException e) {
                   LOG.error("Failed to decompress archive: {}", e, e);
                   wrapper.set(e);
                 }
               });
-      handleArchiveWithStream(
-          archiveType, ctx, key, pis, element, callback, gotElement, throwAtExit, context);
+      handleArchiveWithStream(state, pis);
     }
     return wrapper;
   }
 
-  private ExceptionWrapper handleLzma(
-      ARCHIVE_TYPE archiveType,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      Bucket data,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
-      boolean throwAtExit,
-      ClientContext context)
+  private ExceptionWrapper handleLzma(ArchiveExtractionState state)
       throws IOException, ArchiveFailureException, ArchiveRestartException {
     if (LOG.isDebugEnabled()) LOG.debug("dealing with LZMA");
-    try (InputStream baseIs = data.getInputStream();
+    try (InputStream baseIs = state.input.data.getInputStream();
         InputStream is = new LzmaInputStream(baseIs)) {
-      handleArchiveWithStream(
-          archiveType, ctx, key, is, element, callback, gotElement, throwAtExit, context);
+      handleArchiveWithStream(state, is);
     }
     return null;
   }
 
-  private void handleArchiveWithStream(
-      ARCHIVE_TYPE archiveType,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      InputStream is,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
-      boolean throwAtExit,
-      ClientContext context)
+  private void handleArchiveWithStream(ArchiveExtractionState state, InputStream is)
       throws ArchiveFailureException, ArchiveRestartException {
-    switch (archiveType) {
-      case ZIP ->
-          handleZIPArchive(ctx, key, is, element, callback, gotElement, throwAtExit, context);
+    switch (state.input.archiveType) {
+      case ZIP -> handleZIPArchive(state, is);
       case TAR ->
           // COMPRESS-449 workaround, see https://freenet.mantishub.io/view.php?id=6921
-          handleTARArchive(
-              ctx,
-              key,
-              new SkipShieldingInputStream(is),
-              element,
-              callback,
-              gotElement,
-              throwAtExit,
-              context);
+          handleTARArchive(state, new SkipShieldingInputStream(is));
       default ->
           throw new ArchiveFailureException(
-              "Unknown or unsupported archive algorithm " + archiveType);
+              "Unknown or unsupported archive algorithm " + state.input.archiveType);
     }
   }
 
-  private void handleTARArchive(
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      InputStream data,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
-      boolean throwAtExit,
-      ClientContext context)
+  private void handleTARArchive(ArchiveExtractionState state, InputStream data)
       throws ArchiveFailureException, ArchiveRestartException {
     if (LOG.isDebugEnabled()) LOG.debug("Handling a TAR Archive");
+    ArchiveExtractionInput input = state.input;
+    ArchiveElementRequest elementRequest = state.elementRequest;
+    FreenetURI key = input.key;
+    String element = elementRequest.element;
+    ArchiveExtractCallback callback = elementRequest.callback;
+    MutableBoolean gotElement = state.gotElement;
+    boolean throwAtExit = state.throwAtExit;
+    ClientContext context = elementRequest.clientContext;
     try (TarArchiveInputStream tarIS = new TarArchiveInputStream(data)) {
       byte[] buf = new byte[32768];
       HashSet<String> names = new HashSet<>();
@@ -628,26 +522,14 @@ public class ArchiveManager {
             LOG.error("Duplicate key {} in archive {}", name, key);
           } else {
             long size = entry.getSize();
-            gotMetadata |=
-                processArchiveEntry(
-                    name,
-                    size,
-                    tarIS,
-                    ctx,
-                    key,
-                    element,
-                    callback,
-                    gotElement,
-                    names,
-                    buf,
-                    context);
+            gotMetadata |= processArchiveEntry(name, size, tarIS, state, names, buf);
           }
         }
       }
 
       // If no metadata, generate some
       if (!gotMetadata) {
-        generateMetadata(ctx, key, names, gotElement, element, callback, context);
+        generateMetadata(state, names);
         trimStoredData();
       }
       if (throwAtExit) throw new ArchiveRestartException("Archive changed on re-fetch");
@@ -659,30 +541,26 @@ public class ArchiveManager {
     }
   }
 
-  private void handleZIPArchive(
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      InputStream data,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
-      boolean throwAtExit,
-      ClientContext context)
+  private void handleZIPArchive(ArchiveExtractionState state, InputStream data)
       throws ArchiveFailureException, ArchiveRestartException {
     if (LOG.isDebugEnabled()) LOG.debug("Handling a ZIP Archive");
+    ArchiveElementRequest elementRequest = state.elementRequest;
+    ArchiveExtractCallback callback = elementRequest.callback;
+    String element = elementRequest.element;
+    MutableBoolean gotElement = state.gotElement;
+    boolean throwAtExit = state.throwAtExit;
+    ClientContext context = elementRequest.clientContext;
     try (ZipArchiveInputStream zis = new ZipArchiveInputStream(data)) {
       byte[] buf = new byte[32768];
       HashSet<String> names = new HashSet<>();
       boolean gotMetadata = false;
       for (ArchiveEntry entry = zis.getNextEntry(); entry != null; entry = zis.getNextEntry()) {
-        gotMetadata |=
-            handleZipEntry(
-                entry, ctx, key, zis, element, callback, gotElement, names, buf, context);
+        gotMetadata |= handleZipEntry(entry, state, zis, names, buf);
       }
 
       // If no metadata, generate some
       if (!gotMetadata) {
-        generateMetadata(ctx, key, names, gotElement, element, callback, context);
+        generateMetadata(state, names);
         trimStoredData();
       }
       if (throwAtExit) throw new ArchiveRestartException("Archive changed on re-fetch");
@@ -696,16 +574,13 @@ public class ArchiveManager {
 
   private boolean handleZipEntry(
       ArchiveEntry entry,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
+      ArchiveExtractionState state,
       InputStream zis,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
       Set<String> names,
-      byte[] buf,
-      ClientContext context)
+      byte[] buf)
       throws IOException {
+    ArchiveExtractionInput input = state.input;
+    FreenetURI key = input.key;
     if (entry.isDirectory()) {
       return false;
     }
@@ -718,8 +593,7 @@ public class ArchiveManager {
       return false;
     } else {
       long size = getSize(entry);
-      return processArchiveEntry(
-          name, size, zis, ctx, key, element, callback, gotElement, names, buf, context);
+      return processArchiveEntry(name, size, zis, state, names, buf);
     }
   }
 
@@ -742,19 +616,19 @@ public class ArchiveManager {
       String name,
       long size,
       InputStream in,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      String element,
-      ArchiveExtractCallback callback,
-      MutableBoolean gotElement,
+      ArchiveExtractionState state,
       Set<String> names,
-      byte[] buf,
-      ClientContext context)
+      byte[] buf)
       throws IOException {
+    ArchiveElementRequest elementRequest = state.elementRequest;
+    String element = elementRequest.element;
+    ArchiveExtractCallback callback = elementRequest.callback;
+    MutableBoolean gotElement = state.gotElement;
+    ClientContext context = elementRequest.clientContext;
     boolean isMetadata = METADATA_NAME.equals(name);
     if (size > maxArchivedFileSize && !name.equals(element)) {
       addErrorElement(
-          ctx, key, name, ERR_FILE_TOO_BIG + size + ERR_LIMIT_SUFFIX + maxArchivedFileSize);
+          state, name, ERR_FILE_TOO_BIG + size + ERR_LIMIT_SUFFIX + maxArchivedFileSize);
       return isMetadata;
     }
 
@@ -768,8 +642,7 @@ public class ArchiveManager {
         realLen += readBytes;
         if (realLen > maxArchivedFileSize) {
           addErrorElement(
-              ctx,
-              key,
+              state,
               name,
               ERR_FILE_TOO_BIG + maxArchivedFileSize + ERR_LIMIT_SUFFIX + maxArchivedFileSize);
           shouldFree = true;
@@ -783,7 +656,7 @@ public class ArchiveManager {
     }
     long finalSize = (size > 0) ? size : realLen;
     if (finalSize <= maxArchivedFileSize) {
-      addStoreElement(ctx, key, name, output, gotElement, element, callback, context);
+      addStoreElement(state, name, output);
       names.add(name);
       trimStoredData();
     } else {
@@ -791,7 +664,7 @@ public class ArchiveManager {
       callback.gotBucket(output, context);
       gotElement.setTrue();
       addErrorElement(
-          ctx, key, name, ERR_FILE_TOO_BIG + finalSize + ERR_LIMIT_SUFFIX + maxArchivedFileSize);
+          state, name, ERR_FILE_TOO_BIG + finalSize + ERR_LIMIT_SUFFIX + maxArchivedFileSize);
     }
     return isMetadata;
   }
@@ -809,24 +682,11 @@ public class ArchiveManager {
    * {@link #METADATA_NAME} entry, enabling clients to inspect archive contents without scanning the
    * raw container.
    *
-   * @param ctx archive store context used to register the generated metadata in the local cache
-   * @param key archive key from which the container was fetched; used for cache indexing
+   * @param state extraction state carrying the cache context and callback wiring
    * @param names set of member names already discovered while scanning the archive
-   * @param gotElement flag that is updated when the requested element is satisfied via callback
-   * @param element2 optional element name the caller is particularly interested in; when equal to
-   *     {@link #METADATA_NAME} the {@code callback} is invoked with the generated bucket
-   * @param callback callback notified when the requested element is produced by this method
-   * @param context client context passed through to the callback
    * @throws ArchiveFailureException if metadata construction or bucket serialization fails
    */
-  private void generateMetadata(
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      Set<String> names,
-      MutableBoolean gotElement,
-      String element2,
-      ArchiveExtractCallback callback,
-      ClientContext context)
+  private void generateMetadata(ArchiveExtractionState state, Set<String> names)
       throws ArchiveFailureException {
     /* What we have to do is to:
      * - Construct a filesystem tree of the names.
@@ -847,11 +707,11 @@ public class ArchiveManager {
     while (true) {
       try {
         bucket = metadata.toBucket(tempBucketFactory);
-        addStoreElement(ctx, key, METADATA_NAME, bucket, gotElement, element2, callback, context);
+        addStoreElement(state, METADATA_NAME, bucket);
         return;
       } catch (MetadataUnresolvedException e) {
         try {
-          x = resolve(e, x, tempBucketFactory, ctx, key, gotElement, element2, callback, context);
+          x = resolve(e, x, state);
         } catch (IOException e1) {
           throw new ArchiveFailureException("Failed to create metadata: " + e1, e1);
         }
@@ -861,30 +721,13 @@ public class ArchiveManager {
     }
   }
 
-  private int resolve(
-      MetadataUnresolvedException e,
-      int x,
-      BucketFactory bf,
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      MutableBoolean gotElement,
-      String element2,
-      ArchiveExtractCallback callback,
-      ClientContext context)
+  private int resolve(MetadataUnresolvedException e, int x, ArchiveExtractionState state)
       throws IOException {
     for (Metadata m : e.mustResolve) {
       try {
-        addStoreElement(
-            ctx,
-            key,
-            ".metadata-" + (x++),
-            m.toBucket(bf),
-            gotElement,
-            element2,
-            callback,
-            context);
+        addStoreElement(state, ".metadata-" + (x++), m.toBucket(tempBucketFactory));
       } catch (MetadataUnresolvedException _) {
-        x = resolve(e, x, bf, ctx, key, gotElement, element2, callback, context);
+        x = resolve(e, x, state);
       }
     }
     return x;
@@ -953,13 +796,15 @@ public class ArchiveManager {
    * Add an error element to the cache. This happens when a single file in the archive is invalid
    * (usually because it is too large).
    *
-   * @param ctx The ArchiveStoreContext which must be notified about this element's creation.
-   * @param key The key from which the archive was fetched.
+   * @param state extraction state carrying the cache context
    * @param name The name of the file within the archive.
    * @param error The error message to be included on the eventual exception thrown, if anyone tries
    *     to extract the data for this element.
    */
-  private void addErrorElement(ArchiveStoreContext ctx, FreenetURI key, String name, String error) {
+  private void addErrorElement(ArchiveExtractionState state, String name, String error) {
+    ArchiveExtractionInput input = state.input;
+    ArchiveStoreContext ctx = input.storeContext;
+    FreenetURI key = input.key;
     ErrorArchiveStoreItem element = new ErrorArchiveStoreItem(ctx, key, name, error, true);
     element.addToContext();
     if (LOG.isDebugEnabled()) LOG.debug("Adding error element: {} for {} {}", element, key, name);
@@ -979,22 +824,19 @@ public class ArchiveManager {
   /**
    * Add a store element.
    *
-   * @param callbackName If set, the name of the file for which we must call the callback if this
-   *     file happens to match.
-   * @param gotElement Flag indicating whether we've already found the file for the callback. If so
-   *     we must not call it again.
-   * @param callback Callback to be called if we do find it. We must getReaderBucket() before adding
-   *     the data to the LRU, otherwise it may be deleted before it reaches the client.
+   * @param state extraction state carrying the cache context and callback wiring
+   * @param name archive entry name to store
+   * @param temp bucket holding the extracted data
    */
-  private void addStoreElement(
-      ArchiveStoreContext ctx,
-      FreenetURI key,
-      String name,
-      Bucket temp,
-      MutableBoolean gotElement,
-      String callbackName,
-      ArchiveExtractCallback callback,
-      ClientContext context) {
+  private void addStoreElement(ArchiveExtractionState state, String name, Bucket temp) {
+    ArchiveExtractionInput input = state.input;
+    ArchiveElementRequest elementRequest = state.elementRequest;
+    ArchiveStoreContext ctx = input.storeContext;
+    FreenetURI key = input.key;
+    MutableBoolean gotElement = state.gotElement;
+    String callbackName = elementRequest.element;
+    ArchiveExtractCallback callback = elementRequest.callback;
+    ClientContext context = elementRequest.clientContext;
     RealArchiveStoreItem element = new RealArchiveStoreItem(ctx, key, name, temp);
     element.addToContext();
     if (LOG.isDebugEnabled())

--- a/src/test/java/network/crypta/client/ArchiveHandlerImplTest.java
+++ b/src/test/java/network/crypta/client/ArchiveHandlerImplTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -116,17 +117,22 @@ class ArchiveHandlerImplTest {
     handler.extractToCache(bucket, archiveContext, "element.txt", callback, manager, clientContext);
 
     verify(manager).makeContext(key, archiveType, compressorType, false);
-    verify(manager)
-        .extractToCache(
-            key,
-            archiveType,
-            compressorType,
-            bucket,
-            archiveContext,
-            storeContext,
-            "element.txt",
-            callback,
-            clientContext);
+    ArgumentCaptor<ArchiveExtractionInput> inputCaptor =
+        ArgumentCaptor.forClass(ArchiveExtractionInput.class);
+    ArgumentCaptor<ArchiveElementRequest> elementCaptor =
+        ArgumentCaptor.forClass(ArchiveElementRequest.class);
+    verify(manager).extractToCache(inputCaptor.capture(), elementCaptor.capture());
+    ArchiveExtractionInput input = inputCaptor.getValue();
+    ArchiveElementRequest elementRequest = elementCaptor.getValue();
+    assertEquals(key, input.key);
+    assertEquals(archiveType, input.archiveType);
+    assertEquals(compressorType, input.compressorType);
+    assertSame(bucket, input.data);
+    assertSame(archiveContext, input.archiveContext);
+    assertSame(storeContext, input.storeContext);
+    assertEquals("element.txt", elementRequest.element);
+    assertSame(callback, elementRequest.callback);
+    assertSame(clientContext, elementRequest.clientContext);
 
     // Now forceRefetch should be cleared; a subsequent get should consult the manager
     when(manager.getCached(key, AFTER_TXT)).thenReturn(null);

--- a/src/test/java/network/crypta/client/ArchiveManagerTest.java
+++ b/src/test/java/network/crypta/client/ArchiveManagerTest.java
@@ -149,7 +149,7 @@ class ArchiveManagerTest {
     try (Bucket data = new SimpleReadOnlyArrayBucket(createZip(entries))) {
       // Act
       mgr.extractToCache(
-          key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx, "a.txt", callback, clientContext);
+          extractionInput(key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx), elementRequest("a.txt"));
 
       // Assert: callback got the requested entry
       ArgumentCaptor<Bucket> bucketCaptor = ArgumentCaptor.forClass(Bucket.class);
@@ -189,7 +189,8 @@ class ArchiveManagerTest {
     try (Bucket data = new SimpleReadOnlyArrayBucket(createZip(entries))) {
       // Act
       mgr.extractToCache(
-          key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx, "missing.txt", callback, clientContext);
+          extractionInput(key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx),
+          elementRequest("missing.txt"));
 
       // Assert: callback says it's missing
       verify(callback, times(1)).notInArchive(clientContext);
@@ -214,7 +215,8 @@ class ArchiveManagerTest {
     try (Bucket data = new SimpleReadOnlyArrayBucket(createZip(entries))) {
       // Act (request a non-existent element to avoid null gotElement)
       mgr.extractToCache(
-          key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx, "__unused__", callback, clientContext);
+          extractionInput(key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx),
+          elementRequest("__unused__"));
 
       // Assert: too big entry is represented as an error item; cache lookup yields null bucket
       assertNull(mgr.getCached(key, "big.bin"));
@@ -237,7 +239,7 @@ class ArchiveManagerTest {
     try (Bucket data = new SimpleReadOnlyArrayBucket(createStoredZip(entries))) {
       // Act: request the big element explicitly
       mgr.extractToCache(
-          key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx, "big.bin", callback, clientContext);
+          extractionInput(key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx), elementRequest("big.bin"));
 
       // Assert: current implementation reports not-in-archive for too-big entries (no callback
       // data)
@@ -261,15 +263,8 @@ class ArchiveManagerTest {
     try (Bucket data = new SimpleReadOnlyArrayBucket(gzip(createTar(entries)))) {
       // Act
       mgr.extractToCache(
-          key,
-          ARCHIVE_TYPE.TAR,
-          COMPRESSOR_TYPE.GZIP,
-          data,
-          actx,
-          ctx,
-          "dir/a.txt",
-          callback,
-          clientContext);
+          extractionInput(key, ARCHIVE_TYPE.TAR, COMPRESSOR_TYPE.GZIP, data, actx, ctx),
+          elementRequest("dir/a.txt"));
 
       // Assert: the element is cached and callback invoked
       Bucket cached = mgr.getCached(key, "dir/a.txt");
@@ -305,15 +300,8 @@ class ArchiveManagerTest {
           ArchiveRestartException.class,
           () ->
               mgr.extractToCache(
-                  key,
-                  ARCHIVE_TYPE.ZIP,
-                  null,
-                  data,
-                  actx,
-                  ctx,
-                  "__unused__",
-                  callback,
-                  clientContext));
+                  extractionInput(key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx),
+                  elementRequest("__unused__")));
 
       // But entries should be cached regardless
       Bucket cached = mgr.getCached(key, "a.txt");
@@ -341,7 +329,8 @@ class ArchiveManagerTest {
     try (Bucket data = new SimpleReadOnlyArrayBucket(createZip(entries))) {
       // Act: extract; the manager will add entries in iteration order (.metadata, a then b)
       mgr.extractToCache(
-          key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx, "__unused__", callback, clientContext);
+          extractionInput(key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx),
+          elementRequest("__unused__"));
 
       // Assert: only the most recent (b.txt) remains due to maxCachedElements=1
       assertNull(mgr.getCached(key, ".metadata"));
@@ -367,15 +356,8 @@ class ArchiveManagerTest {
     try (Bucket data = new SimpleReadOnlyArrayBucket(createZip(entries))) {
       // Act
       mgr.extractToCache(
-          key,
-          ARCHIVE_TYPE.ZIP,
-          null,
-          data,
-          actx,
-          ctx,
-          expectedStoredName,
-          callback,
-          clientContext);
+          extractionInput(key, ARCHIVE_TYPE.ZIP, null, data, actx, ctx),
+          elementRequest(expectedStoredName));
 
       // Assert
       Bucket cached = mgr.getCached(key, expectedStoredName);
@@ -389,6 +371,21 @@ class ArchiveManagerTest {
   }
 
   // ----------------- Helpers -----------------
+
+  private ArchiveExtractionInput extractionInput(
+      FreenetURI key,
+      ARCHIVE_TYPE archiveType,
+      COMPRESSOR_TYPE compressorType,
+      Bucket data,
+      ArchiveContext archiveContext,
+      ArchiveStoreContext storeContext) {
+    return new ArchiveExtractionInput(
+        key, archiveType, compressorType, data, archiveContext, storeContext);
+  }
+
+  private ArchiveElementRequest elementRequest(String element) {
+    return new ArchiveElementRequest(element, callback, clientContext);
+  }
 
   private static byte[] createZip(Map<String, byte[]> entries) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
## Summary
- introduce archive extraction parameter bundles and state helpers
- refactor ArchiveManager/ArchiveHandlerImpl to use the new bundles
- update archive extraction tests to match the new signatures

## Testing
- ./gradlew test
- ./gradlew spotlessApply