### PR TITLE
refactor(client): replace FetchContext ctor

### DIFF
--- a/src/main/java/network/crypta/client/FetchContext.java
+++ b/src/main/java/network/crypta/client/FetchContext.java
@@ -224,114 +224,60 @@ public class FetchContext implements Serializable {
   private final String schemeHostAndPort;
 
   /**
-   * Construct a new fetch context with explicit limits and behavior flags.
+   * Construct a new fetch context from the supplied options bundle.
    *
-   * <p>Every numeric limit must be non‑negative unless documented to accept {@code -1} for
+   * <p>Every numeric limit must be non-negative unless documented to accept {@code -1} for
    * "unlimited". Values are validated and an {@link IllegalArgumentException} is thrown when a
-   * constraint is violated. The supplied {@code producer} is used for client events emitted during
-   * the request.
+   * constraint is violated.
    *
-   * @param curMaxLength Maximum size of the returned payload in bytes; must be non‑negative.
-   * @param curMaxTempLength Maximum size of intermediary data (metadata, containers) in bytes; must
-   *     be non‑negative.
-   * @param maxMetadataSize Maximum allowed metadata size in bytes; must be non‑negative.
-   * @param maxRecursionLevel Maximum recursion depth for redirects and container lookups; {@code 1}
-   *     means only a single block is fetched.
-   * @param maxArchiveRestarts Maximum number of archive restarts permitted; must be non‑negative.
-   * @param maxArchiveLevels Maximum number of manifest lookups within containers; must be
-   *     non‑negative.
-   * @param dontEnterImplicitArchives When {@code true}, do not descend into implicit archives on
-   *     the path.
-   * @param maxSplitfileBlockRetries Maximum retries for splitfile blocks; {@code -1} for unlimited,
-   *     otherwise non‑negative.
-   * @param maxNonSplitfileRetries Maximum retries for non‑splitfile blocks; {@code -1} for
-   *     unlimited, otherwise non‑negative.
-   * @param maxUSKRetries Maximum retries for USK requests; {@code -1} for unlimited, otherwise
-   *     non‑negative.
-   * @param allowSplitfiles Whether splitfiles are allowed to be downloaded.
-   * @param followRedirects Whether simple redirects may be followed by the fetcher.
-   * @param localRequestOnly Whether the request must be satisfied from local stores only.
-   * @param filterData Whether the content filter should be applied to fetched data.
-   * @param maxDataBlocksPerSegment Maximum allowed data blocks per splitfile segment; must be
-   *     within codec bounds.
-   * @param maxCheckBlocksPerSegment Maximum allowed check blocks per splitfile segment; must be
-   *     within codec bounds.
-   * @param producer Event producer to receive client events; must not be {@code null}.
-   * @param ignoreTooManyPathComponents Whether to ignore excess path components during resolution.
-   * @param canWriteClientCache Whether the client cache may be written by this request.
-   * @param charset Optional charset to assume for filtration when needed; {@code null} to use
-   *     defaults.
-   * @param overrideMIME Optional MIME type to force for the content filter; {@code null} to clear.
-   * @param schemeHostAndPort Optional forced URI prefix in the form {@code scheme://host:port}.
+   * @param options configuration bundle describing limits, retry policy, and behavior.
    */
-  public FetchContext(
-      long curMaxLength,
-      long curMaxTempLength,
-      int maxMetadataSize,
-      int maxRecursionLevel,
-      int maxArchiveRestarts,
-      int maxArchiveLevels,
-      boolean dontEnterImplicitArchives,
-      int maxSplitfileBlockRetries,
-      int maxNonSplitfileRetries,
-      int maxUSKRetries,
-      boolean allowSplitfiles,
-      boolean followRedirects,
-      boolean localRequestOnly,
-      boolean filterData,
-      int maxDataBlocksPerSegment,
-      int maxCheckBlocksPerSegment,
-      ClientEventProducer producer,
-      boolean ignoreTooManyPathComponents,
-      boolean canWriteClientCache,
-      String charset,
-      String overrideMIME,
-      String schemeHostAndPort) {
+  public FetchContext(FetchContextOptions options) {
     this.blocks = null;
-    this.maxOutputLength = curMaxLength;
+    this.maxOutputLength = options.maxOutputLength();
     if (maxOutputLength < 0) throw new IllegalArgumentException("Bad max output length");
-    this.maxTempLength = curMaxTempLength;
+    this.maxTempLength = options.maxTempLength();
     if (maxTempLength < 0) throw new IllegalArgumentException("Bad max temp length");
-    this.maxMetadataSize = maxMetadataSize;
+    this.maxMetadataSize = options.maxMetadataSize();
     if (maxMetadataSize < 0) throw new IllegalArgumentException("Bad max metadata size");
-    this.maxRecursionLevel = maxRecursionLevel;
+    this.maxRecursionLevel = options.maxRecursionLevel();
     if (maxRecursionLevel < 0) throw new IllegalArgumentException("Bad max recursion level");
-    this.maxArchiveRestarts = maxArchiveRestarts;
+    this.maxArchiveRestarts = options.maxArchiveRestarts();
     if (maxArchiveRestarts < 0) throw new IllegalArgumentException("Bad max archive restarts");
-    this.maxArchiveLevels = maxArchiveLevels;
+    this.maxArchiveLevels = options.maxArchiveLevels();
     if (maxArchiveLevels < 0) throw new IllegalArgumentException("Bad max archive levels");
-    this.dontEnterImplicitArchives = dontEnterImplicitArchives;
-    this.maxSplitfileBlockRetries = maxSplitfileBlockRetries;
+    this.dontEnterImplicitArchives = options.dontEnterImplicitArchives();
+    this.maxSplitfileBlockRetries = options.maxSplitfileBlockRetries();
     if (maxSplitfileBlockRetries < -1)
       throw new IllegalArgumentException("Bad max splitfile block retries");
-    this.maxNonSplitfileRetries = maxNonSplitfileRetries;
+    this.maxNonSplitfileRetries = options.maxNonSplitfileRetries();
     if (maxNonSplitfileRetries < -1)
       throw new IllegalArgumentException("Bad non-splitfile retries");
-    this.maxUSKRetries = maxUSKRetries;
+    this.maxUSKRetries = options.maxUSKRetries();
     if (maxUSKRetries < -1) throw new IllegalArgumentException("Bad max USK retries");
-    this.allowSplitfiles = allowSplitfiles;
-    this.followRedirects = followRedirects;
-    this.localRequestOnly = localRequestOnly;
-    this.eventProducer = producer;
-    this.maxDataBlocksPerSegment = maxDataBlocksPerSegment;
+    this.allowSplitfiles = options.allowSplitfiles();
+    this.followRedirects = options.followRedirects();
+    this.localRequestOnly = options.localRequestOnly();
+    this.eventProducer = options.eventProducer();
+    this.maxDataBlocksPerSegment = options.maxDataBlocksPerSegment();
     if (maxDataBlocksPerSegment < 0
         || maxDataBlocksPerSegment > FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT)
       throw new IllegalArgumentException("Bad max blocks per segment");
-    this.maxCheckBlocksPerSegment = maxCheckBlocksPerSegment;
+    this.maxCheckBlocksPerSegment = options.maxCheckBlocksPerSegment();
     if (maxCheckBlocksPerSegment < 0
         || maxCheckBlocksPerSegment > FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT)
       throw new IllegalArgumentException("Bad max blocks per segment");
-    this.filterData = filterData;
-    this.ignoreTooManyPathComponents = ignoreTooManyPathComponents;
-    this.canWriteClientCache = canWriteClientCache;
-    this.charset = charset;
-    this.overrideMIME = overrideMIME;
+    this.filterData = options.filterData();
+    this.ignoreTooManyPathComponents = options.ignoreTooManyPathComponents();
+    this.canWriteClientCache = options.canWriteClientCache();
+    this.charset = options.charset();
+    this.overrideMIME = options.overrideMIME();
     this.cooldownRetries = RequestScheduler.COOLDOWN_RETRIES;
     this.cooldownTime = RequestScheduler.COOLDOWN_PERIOD;
     // Default behavior: do not ignore USK DATEHINTs.
     this.ignoreUSKDatehints = false;
     hasOwnEventProducer = true;
-    this.schemeHostAndPort = schemeHostAndPort;
+    this.schemeHostAndPort = options.schemeHostAndPort();
   }
 
   /**

--- a/src/main/java/network/crypta/client/FetchContextOptions.java
+++ b/src/main/java/network/crypta/client/FetchContextOptions.java
@@ -1,0 +1,324 @@
+package network.crypta.client;
+
+import network.crypta.client.events.ClientEventProducer;
+
+/**
+ * Immutable bundle of parameters used to construct a {@link FetchContext}.
+ *
+ * <p>Use {@link Builder} to populate the full set of values. {@link FetchContext} performs
+ * validation so this class can remain a lightweight carrier of configuration.
+ */
+public final class FetchContextOptions {
+  private final long maxOutputLength;
+  private final long maxTempLength;
+  private final int maxMetadataSize;
+  private final int maxRecursionLevel;
+  private final int maxArchiveRestarts;
+  private final int maxArchiveLevels;
+  private final boolean dontEnterImplicitArchives;
+  private final int maxSplitfileBlockRetries;
+  private final int maxNonSplitfileRetries;
+  private final int maxUSKRetries;
+  private final boolean allowSplitfiles;
+  private final boolean followRedirects;
+  private final boolean localRequestOnly;
+  private final boolean filterData;
+  private final int maxDataBlocksPerSegment;
+  private final int maxCheckBlocksPerSegment;
+  private final ClientEventProducer eventProducer;
+  private final boolean ignoreTooManyPathComponents;
+  private final boolean canWriteClientCache;
+  private final String charset;
+  private final String overrideMIME;
+  private final String schemeHostAndPort;
+
+  private FetchContextOptions(Builder builder) {
+    this.maxOutputLength = builder.maxOutputLength;
+    this.maxTempLength = builder.maxTempLength;
+    this.maxMetadataSize = builder.maxMetadataSize;
+    this.maxRecursionLevel = builder.maxRecursionLevel;
+    this.maxArchiveRestarts = builder.maxArchiveRestarts;
+    this.maxArchiveLevels = builder.maxArchiveLevels;
+    this.dontEnterImplicitArchives = builder.dontEnterImplicitArchives;
+    this.maxSplitfileBlockRetries = builder.maxSplitfileBlockRetries;
+    this.maxNonSplitfileRetries = builder.maxNonSplitfileRetries;
+    this.maxUSKRetries = builder.maxUSKRetries;
+    this.allowSplitfiles = builder.allowSplitfiles;
+    this.followRedirects = builder.followRedirects;
+    this.localRequestOnly = builder.localRequestOnly;
+    this.filterData = builder.filterData;
+    this.maxDataBlocksPerSegment = builder.maxDataBlocksPerSegment;
+    this.maxCheckBlocksPerSegment = builder.maxCheckBlocksPerSegment;
+    this.eventProducer = builder.eventProducer;
+    this.ignoreTooManyPathComponents = builder.ignoreTooManyPathComponents;
+    this.canWriteClientCache = builder.canWriteClientCache;
+    this.charset = builder.charset;
+    this.overrideMIME = builder.overrideMIME;
+    this.schemeHostAndPort = builder.schemeHostAndPort;
+  }
+
+  public long maxOutputLength() {
+    return maxOutputLength;
+  }
+
+  public long maxTempLength() {
+    return maxTempLength;
+  }
+
+  public int maxMetadataSize() {
+    return maxMetadataSize;
+  }
+
+  public int maxRecursionLevel() {
+    return maxRecursionLevel;
+  }
+
+  public int maxArchiveRestarts() {
+    return maxArchiveRestarts;
+  }
+
+  public int maxArchiveLevels() {
+    return maxArchiveLevels;
+  }
+
+  public boolean dontEnterImplicitArchives() {
+    return dontEnterImplicitArchives;
+  }
+
+  public int maxSplitfileBlockRetries() {
+    return maxSplitfileBlockRetries;
+  }
+
+  public int maxNonSplitfileRetries() {
+    return maxNonSplitfileRetries;
+  }
+
+  public int maxUSKRetries() {
+    return maxUSKRetries;
+  }
+
+  public boolean allowSplitfiles() {
+    return allowSplitfiles;
+  }
+
+  public boolean followRedirects() {
+    return followRedirects;
+  }
+
+  public boolean localRequestOnly() {
+    return localRequestOnly;
+  }
+
+  public boolean filterData() {
+    return filterData;
+  }
+
+  public int maxDataBlocksPerSegment() {
+    return maxDataBlocksPerSegment;
+  }
+
+  public int maxCheckBlocksPerSegment() {
+    return maxCheckBlocksPerSegment;
+  }
+
+  public ClientEventProducer eventProducer() {
+    return eventProducer;
+  }
+
+  public boolean ignoreTooManyPathComponents() {
+    return ignoreTooManyPathComponents;
+  }
+
+  public boolean canWriteClientCache() {
+    return canWriteClientCache;
+  }
+
+  public String charset() {
+    return charset;
+  }
+
+  public String overrideMIME() {
+    return overrideMIME;
+  }
+
+  public String schemeHostAndPort() {
+    return schemeHostAndPort;
+  }
+
+  /**
+   * Returns a new builder for {@link FetchContextOptions}.
+   *
+   * @return builder instance for configuring fetch context parameters.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for {@link FetchContextOptions}.
+   *
+   * <p>The builder is mutable and not thread-safe. Callers should set each option group and then
+   * call {@link #build()} to obtain an immutable snapshot.
+   */
+  public static final class Builder {
+    private long maxOutputLength;
+    private long maxTempLength;
+    private int maxMetadataSize;
+    private int maxRecursionLevel;
+    private int maxArchiveRestarts;
+    private int maxArchiveLevels;
+    private boolean dontEnterImplicitArchives;
+    private int maxSplitfileBlockRetries;
+    private int maxNonSplitfileRetries;
+    private int maxUSKRetries;
+    private boolean allowSplitfiles;
+    private boolean followRedirects;
+    private boolean localRequestOnly;
+    private boolean filterData;
+    private int maxDataBlocksPerSegment;
+    private int maxCheckBlocksPerSegment;
+    private ClientEventProducer eventProducer;
+    private boolean ignoreTooManyPathComponents;
+    private boolean canWriteClientCache;
+    private String charset;
+    private String overrideMIME;
+    private String schemeHostAndPort;
+
+    /**
+     * Sets size limits for the fetch operation.
+     *
+     * @param maxOutputLength maximum size of the returned payload in bytes; must be non-negative.
+     * @param maxTempLength maximum size of intermediary data (metadata, containers) in bytes; must
+     *     be non-negative.
+     * @param maxMetadataSize maximum allowed metadata size in bytes; must be non-negative.
+     * @return this builder for chaining.
+     */
+    public Builder limits(long maxOutputLength, long maxTempLength, int maxMetadataSize) {
+      this.maxOutputLength = maxOutputLength;
+      this.maxTempLength = maxTempLength;
+      this.maxMetadataSize = maxMetadataSize;
+      return this;
+    }
+
+    /**
+     * Sets recursion and archive traversal limits.
+     *
+     * @param maxRecursionLevel maximum recursion depth for redirects and container lookups; {@code
+     *     1} means only a single block is fetched.
+     * @param maxArchiveRestarts maximum number of archive restarts permitted; must be non-negative.
+     * @param maxArchiveLevels maximum number of manifest lookups within containers; must be
+     *     non-negative.
+     * @param dontEnterImplicitArchives when {@code true}, do not descend into implicit archives on
+     *     the path.
+     * @return this builder for chaining.
+     */
+    public Builder archiveLimits(
+        int maxRecursionLevel,
+        int maxArchiveRestarts,
+        int maxArchiveLevels,
+        boolean dontEnterImplicitArchives) {
+      this.maxRecursionLevel = maxRecursionLevel;
+      this.maxArchiveRestarts = maxArchiveRestarts;
+      this.maxArchiveLevels = maxArchiveLevels;
+      this.dontEnterImplicitArchives = dontEnterImplicitArchives;
+      return this;
+    }
+
+    /**
+     * Sets retry limits for the request.
+     *
+     * @param maxSplitfileBlockRetries maximum retries for splitfile blocks; {@code -1} for
+     *     unlimited, otherwise non-negative.
+     * @param maxNonSplitfileRetries maximum retries for non-splitfile blocks; {@code -1} for
+     *     unlimited, otherwise non-negative.
+     * @param maxUSKRetries maximum retries for USK requests; {@code -1} for unlimited, otherwise
+     *     non-negative.
+     * @return this builder for chaining.
+     */
+    public Builder retryLimits(
+        int maxSplitfileBlockRetries, int maxNonSplitfileRetries, int maxUSKRetries) {
+      this.maxSplitfileBlockRetries = maxSplitfileBlockRetries;
+      this.maxNonSplitfileRetries = maxNonSplitfileRetries;
+      this.maxUSKRetries = maxUSKRetries;
+      return this;
+    }
+
+    /**
+     * Sets splitfile limits for block segmentation.
+     *
+     * @param allowSplitfiles whether splitfiles are allowed to be downloaded.
+     * @param maxDataBlocksPerSegment maximum allowed data blocks per splitfile segment; must be
+     *     within codec bounds.
+     * @param maxCheckBlocksPerSegment maximum allowed check blocks per splitfile segment; must be
+     *     within codec bounds.
+     * @return this builder for chaining.
+     */
+    public Builder splitfileLimits(
+        boolean allowSplitfiles, int maxDataBlocksPerSegment, int maxCheckBlocksPerSegment) {
+      this.allowSplitfiles = allowSplitfiles;
+      this.maxDataBlocksPerSegment = maxDataBlocksPerSegment;
+      this.maxCheckBlocksPerSegment = maxCheckBlocksPerSegment;
+      return this;
+    }
+
+    /**
+     * Sets redirect, locality, and filtering behavior.
+     *
+     * @param followRedirects whether simple redirects may be followed by the fetcher.
+     * @param localRequestOnly whether the request must be satisfied from local stores only.
+     * @param filterData whether the content filter should be applied to fetched data.
+     * @return this builder for chaining.
+     */
+    public Builder behavior(boolean followRedirects, boolean localRequestOnly, boolean filterData) {
+      this.followRedirects = followRedirects;
+      this.localRequestOnly = localRequestOnly;
+      this.filterData = filterData;
+      return this;
+    }
+
+    /**
+     * Sets event and cache-related options.
+     *
+     * @param eventProducer event producer to receive client events; may be {@code null}.
+     * @param ignoreTooManyPathComponents whether to ignore excess path components during
+     *     resolution.
+     * @param canWriteClientCache whether the client cache may be written by this request.
+     * @return this builder for chaining.
+     */
+    public Builder clientOptions(
+        ClientEventProducer eventProducer,
+        boolean ignoreTooManyPathComponents,
+        boolean canWriteClientCache) {
+      this.eventProducer = eventProducer;
+      this.ignoreTooManyPathComponents = ignoreTooManyPathComponents;
+      this.canWriteClientCache = canWriteClientCache;
+      return this;
+    }
+
+    /**
+     * Sets filter override hints for the request.
+     *
+     * @param charset optional charset to assume for filtration when needed; {@code null} to use
+     *     defaults.
+     * @param overrideMIME optional MIME type to force for the content filter; {@code null} to
+     *     clear.
+     * @param schemeHostAndPort optional forced URI prefix in the form {@code scheme://host:port}.
+     * @return this builder for chaining.
+     */
+    public Builder filterOverrides(String charset, String overrideMIME, String schemeHostAndPort) {
+      this.charset = charset;
+      this.overrideMIME = overrideMIME;
+      this.schemeHostAndPort = schemeHostAndPort;
+      return this;
+    }
+
+    /**
+     * Builds an immutable {@link FetchContextOptions} snapshot from the builder values.
+     *
+     * @return new options instance capturing the current builder state.
+     */
+    public FetchContextOptions build() {
+      return new FetchContextOptions(this);
+    }
+  }
+}

--- a/src/main/java/network/crypta/client/FetchContextOptions.java
+++ b/src/main/java/network/crypta/client/FetchContextOptions.java
@@ -1,6 +1,7 @@
 package network.crypta.client;
 
 import network.crypta.client.events.ClientEventProducer;
+import network.crypta.client.events.SimpleEventProducer;
 
 /**
  * Immutable bundle of parameters used to construct a {@link FetchContext}.
@@ -177,7 +178,7 @@ public final class FetchContextOptions {
     private boolean filterData;
     private int maxDataBlocksPerSegment;
     private int maxCheckBlocksPerSegment;
-    private ClientEventProducer eventProducer;
+    private ClientEventProducer eventProducer = new SimpleEventProducer();
     private boolean ignoreTooManyPathComponents;
     private boolean canWriteClientCache;
     private String charset;
@@ -279,7 +280,9 @@ public final class FetchContextOptions {
     /**
      * Sets event and cache-related options.
      *
-     * @param eventProducer event producer to receive client events; may be {@code null}.
+     * <p>If this method is not called, the builder will use a new {@link SimpleEventProducer}.
+     *
+     * @param eventProducer event producer to receive client events; must not be {@code null}.
      * @param ignoreTooManyPathComponents whether to ignore excess path components during
      *     resolution.
      * @param canWriteClientCache whether the client cache may be written by this request.
@@ -289,6 +292,9 @@ public final class FetchContextOptions {
         ClientEventProducer eventProducer,
         boolean ignoreTooManyPathComponents,
         boolean canWriteClientCache) {
+      if (eventProducer == null) {
+        throw new IllegalArgumentException("eventProducer must not be null");
+      }
       this.eventProducer = eventProducer;
       this.ignoreTooManyPathComponents = ignoreTooManyPathComponents;
       this.canWriteClientCache = canWriteClientCache;

--- a/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
+++ b/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
@@ -658,29 +658,24 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
       maxLength = overrideMaxSize;
       maxTempLength = overrideMaxSize;
     }
-    return new FetchContext(
-        maxLength,
-        maxTempLength,
-        curMaxMetadataLength,
-        MAX_RECURSION,
-        MAX_ARCHIVE_RESTARTS,
-        MAX_ARCHIVE_LEVELS,
-        DONT_ENTER_IMPLICIT_ARCHIVES,
-        SPLITFILE_BLOCK_RETRIES,
-        NON_SPLITFILE_RETRIES,
-        USK_RETRIES,
-        FETCH_SPLITFILES,
-        FOLLOW_REDIRECTS,
-        LOCAL_REQUESTS_ONLY,
-        FILTER_DATA,
-        MAX_SPLITFILE_BLOCKS_PER_SEGMENT,
-        MAX_SPLITFILE_CHECK_BLOCKS_PER_SEGMENT,
-        eventProducer,
-        false,
-        CAN_WRITE_CLIENT_CACHE,
-        null,
-        null,
-        schemeHostAndPort);
+    FetchContextOptions options =
+        FetchContextOptions.builder()
+            .limits(maxLength, maxTempLength, curMaxMetadataLength)
+            .archiveLimits(
+                MAX_RECURSION,
+                MAX_ARCHIVE_RESTARTS,
+                MAX_ARCHIVE_LEVELS,
+                DONT_ENTER_IMPLICIT_ARCHIVES)
+            .retryLimits(SPLITFILE_BLOCK_RETRIES, NON_SPLITFILE_RETRIES, USK_RETRIES)
+            .splitfileLimits(
+                FETCH_SPLITFILES,
+                MAX_SPLITFILE_BLOCKS_PER_SEGMENT,
+                MAX_SPLITFILE_CHECK_BLOCKS_PER_SEGMENT)
+            .behavior(FOLLOW_REDIRECTS, LOCAL_REQUESTS_ONLY, FILTER_DATA)
+            .clientOptions(eventProducer, false, CAN_WRITE_CLIENT_CACHE)
+            .filterOverrides(null, null, schemeHostAndPort)
+            .build();
+    return new FetchContext(options);
   }
 
   /**
@@ -704,29 +699,24 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
       long maxTempLength,
       BucketFactory bucketFactory,
       SimpleEventProducer eventProducer) {
-    return new FetchContext(
-        maxLength,
-        maxTempLength,
-        1024 * 1024,
-        MAX_RECURSION,
-        MAX_ARCHIVE_RESTARTS,
-        MAX_ARCHIVE_LEVELS,
-        DONT_ENTER_IMPLICIT_ARCHIVES,
-        SPLITFILE_BLOCK_RETRIES,
-        NON_SPLITFILE_RETRIES,
-        USK_RETRIES,
-        FETCH_SPLITFILES,
-        FOLLOW_REDIRECTS,
-        LOCAL_REQUESTS_ONLY,
-        FILTER_DATA,
-        MAX_SPLITFILE_BLOCKS_PER_SEGMENT,
-        MAX_SPLITFILE_CHECK_BLOCKS_PER_SEGMENT,
-        eventProducer,
-        false,
-        CAN_WRITE_CLIENT_CACHE,
-        null,
-        null,
-        null);
+    FetchContextOptions options =
+        FetchContextOptions.builder()
+            .limits(maxLength, maxTempLength, 1024 * 1024)
+            .archiveLimits(
+                MAX_RECURSION,
+                MAX_ARCHIVE_RESTARTS,
+                MAX_ARCHIVE_LEVELS,
+                DONT_ENTER_IMPLICIT_ARCHIVES)
+            .retryLimits(SPLITFILE_BLOCK_RETRIES, NON_SPLITFILE_RETRIES, USK_RETRIES)
+            .splitfileLimits(
+                FETCH_SPLITFILES,
+                MAX_SPLITFILE_BLOCKS_PER_SEGMENT,
+                MAX_SPLITFILE_CHECK_BLOCKS_PER_SEGMENT)
+            .behavior(FOLLOW_REDIRECTS, LOCAL_REQUESTS_ONLY, FILTER_DATA)
+            .clientOptions(eventProducer, false, CAN_WRITE_CLIENT_CACHE)
+            .filterOverrides(null, null, null)
+            .build();
+    return new FetchContext(options);
   }
 
   @Override

--- a/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
+++ b/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
@@ -658,29 +658,24 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
       maxLength = overrideMaxSize;
       maxTempLength = overrideMaxSize;
     }
-    return new FetchContext(
-        maxLength,
-        maxTempLength,
-        curMaxMetadataLength,
-        MAX_RECURSION,
-        MAX_ARCHIVE_RESTARTS,
-        MAX_ARCHIVE_LEVELS,
-        DONT_ENTER_IMPLICIT_ARCHIVES,
-        SPLITFILE_BLOCK_RETRIES,
-        NON_SPLITFILE_RETRIES,
-        USK_RETRIES,
-        FETCH_SPLITFILES,
-        FOLLOW_REDIRECTS,
-        LOCAL_REQUESTS_ONLY,
-        FILTER_DATA,
-        MAX_SPLITFILE_BLOCKS_PER_SEGMENT,
-        MAX_SPLITFILE_CHECK_BLOCKS_PER_SEGMENT,
-        eventProducer,
-        false,
-        CAN_WRITE_CLIENT_CACHE,
-        null,
-        null,
-        schemeHostAndPort);
+    FetchContextOptions options =
+        FetchContextOptions.builder()
+            .limits(maxLength, maxTempLength, curMaxMetadataLength)
+            .archiveLimits(
+                MAX_RECURSION,
+                MAX_ARCHIVE_RESTARTS,
+                MAX_ARCHIVE_LEVELS,
+                DONT_ENTER_IMPLICIT_ARCHIVES)
+            .retryLimits(SPLITFILE_BLOCK_RETRIES, NON_SPLITFILE_RETRIES, USK_RETRIES)
+            .splitfileLimits(
+                FETCH_SPLITFILES,
+                MAX_SPLITFILE_BLOCKS_PER_SEGMENT,
+                MAX_SPLITFILE_CHECK_BLOCKS_PER_SEGMENT)
+            .behavior(FOLLOW_REDIRECTS, LOCAL_REQUESTS_ONLY, FILTER_DATA)
+            .clientOptions(eventProducer, false, CAN_WRITE_CLIENT_CACHE)
+            .filterOverrides(null, null, schemeHostAndPort)
+            .build();
+    return new FetchContext(options);
   }
 
   /**
@@ -698,29 +693,24 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
    */
   public static FetchContext makeDefaultFetchContext(
       long maxLength, long maxTempLength, SimpleEventProducer eventProducer) {
-    return new FetchContext(
-        maxLength,
-        maxTempLength,
-        1024 * 1024,
-        MAX_RECURSION,
-        MAX_ARCHIVE_RESTARTS,
-        MAX_ARCHIVE_LEVELS,
-        DONT_ENTER_IMPLICIT_ARCHIVES,
-        SPLITFILE_BLOCK_RETRIES,
-        NON_SPLITFILE_RETRIES,
-        USK_RETRIES,
-        FETCH_SPLITFILES,
-        FOLLOW_REDIRECTS,
-        LOCAL_REQUESTS_ONLY,
-        FILTER_DATA,
-        MAX_SPLITFILE_BLOCKS_PER_SEGMENT,
-        MAX_SPLITFILE_CHECK_BLOCKS_PER_SEGMENT,
-        eventProducer,
-        false,
-        CAN_WRITE_CLIENT_CACHE,
-        null,
-        null,
-        null);
+    FetchContextOptions options =
+        FetchContextOptions.builder()
+            .limits(maxLength, maxTempLength, 1024 * 1024)
+            .archiveLimits(
+                MAX_RECURSION,
+                MAX_ARCHIVE_RESTARTS,
+                MAX_ARCHIVE_LEVELS,
+                DONT_ENTER_IMPLICIT_ARCHIVES)
+            .retryLimits(SPLITFILE_BLOCK_RETRIES, NON_SPLITFILE_RETRIES, USK_RETRIES)
+            .splitfileLimits(
+                FETCH_SPLITFILES,
+                MAX_SPLITFILE_BLOCKS_PER_SEGMENT,
+                MAX_SPLITFILE_CHECK_BLOCKS_PER_SEGMENT)
+            .behavior(FOLLOW_REDIRECTS, LOCAL_REQUESTS_ONLY, FILTER_DATA)
+            .clientOptions(eventProducer, false, CAN_WRITE_CLIENT_CACHE)
+            .filterOverrides(null, null, null)
+            .build();
+    return new FetchContext(options);
   }
 
   @Override

--- a/src/test/java/network/crypta/client/FetchContextTest.java
+++ b/src/test/java/network/crypta/client/FetchContextTest.java
@@ -104,28 +104,7 @@ class FetchContextTest {
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                -1L,
-                VALID_MAX_TEMP,
-                VALID_MAX_METADATA,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                VALID_SPLIT_BLOCK_RETRIES,
-                VALID_NON_SPLIT_RETRIES,
-                VALID_USK_RETRIES,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                VALID_MAX_DATABLOCKS,
-                VALID_MAX_CHECKBLOCKS,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder().limits(-1L, VALID_MAX_TEMP, VALID_MAX_METADATA).build()));
   }
 
   @Test
@@ -134,28 +113,7 @@ class FetchContextTest {
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                VALID_MAX_OUTPUT,
-                -2L,
-                VALID_MAX_METADATA,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                VALID_SPLIT_BLOCK_RETRIES,
-                VALID_NON_SPLIT_RETRIES,
-                VALID_USK_RETRIES,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                VALID_MAX_DATABLOCKS,
-                VALID_MAX_CHECKBLOCKS,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder().limits(VALID_MAX_OUTPUT, -2L, VALID_MAX_METADATA).build()));
   }
 
   @Test
@@ -164,28 +122,7 @@ class FetchContextTest {
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                VALID_MAX_OUTPUT,
-                VALID_MAX_TEMP,
-                -1,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                VALID_SPLIT_BLOCK_RETRIES,
-                VALID_NON_SPLIT_RETRIES,
-                VALID_USK_RETRIES,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                VALID_MAX_DATABLOCKS,
-                VALID_MAX_CHECKBLOCKS,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder().limits(VALID_MAX_OUTPUT, VALID_MAX_TEMP, -1).build()));
   }
 
   @Test
@@ -194,28 +131,9 @@ class FetchContextTest {
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                VALID_MAX_OUTPUT,
-                VALID_MAX_TEMP,
-                VALID_MAX_METADATA,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                -2,
-                VALID_NON_SPLIT_RETRIES,
-                VALID_USK_RETRIES,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                VALID_MAX_DATABLOCKS,
-                VALID_MAX_CHECKBLOCKS,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder()
+                    .retryLimits(-2, VALID_NON_SPLIT_RETRIES, VALID_USK_RETRIES)
+                    .build()));
   }
 
   @Test
@@ -224,28 +142,9 @@ class FetchContextTest {
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                VALID_MAX_OUTPUT,
-                VALID_MAX_TEMP,
-                VALID_MAX_METADATA,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                VALID_SPLIT_BLOCK_RETRIES,
-                -5,
-                VALID_USK_RETRIES,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                VALID_MAX_DATABLOCKS,
-                VALID_MAX_CHECKBLOCKS,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder()
+                    .retryLimits(VALID_SPLIT_BLOCK_RETRIES, -5, VALID_USK_RETRIES)
+                    .build()));
   }
 
   @Test
@@ -254,28 +153,9 @@ class FetchContextTest {
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                VALID_MAX_OUTPUT,
-                VALID_MAX_TEMP,
-                VALID_MAX_METADATA,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                VALID_SPLIT_BLOCK_RETRIES,
-                VALID_NON_SPLIT_RETRIES,
-                -2,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                VALID_MAX_DATABLOCKS,
-                VALID_MAX_CHECKBLOCKS,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder()
+                    .retryLimits(VALID_SPLIT_BLOCK_RETRIES, VALID_NON_SPLIT_RETRIES, -2)
+                    .build()));
   }
 
   @Test
@@ -285,55 +165,20 @@ class FetchContextTest {
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                VALID_MAX_OUTPUT,
-                VALID_MAX_TEMP,
-                VALID_MAX_METADATA,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                VALID_SPLIT_BLOCK_RETRIES,
-                VALID_NON_SPLIT_RETRIES,
-                VALID_USK_RETRIES,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                -1,
-                VALID_MAX_CHECKBLOCKS,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder()
+                    .splitfileLimits(VALID_ALLOW_SPLIT, -1, VALID_MAX_CHECKBLOCKS)
+                    .build()));
     // Greater than allowed
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                VALID_MAX_OUTPUT,
-                VALID_MAX_TEMP,
-                VALID_MAX_METADATA,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                VALID_SPLIT_BLOCK_RETRIES,
-                VALID_NON_SPLIT_RETRIES,
-                VALID_USK_RETRIES,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT + 1,
-                VALID_MAX_CHECKBLOCKS,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder()
+                    .splitfileLimits(
+                        VALID_ALLOW_SPLIT,
+                        FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT + 1,
+                        VALID_MAX_CHECKBLOCKS)
+                    .build()));
   }
 
   @Test
@@ -343,55 +188,20 @@ class FetchContextTest {
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                VALID_MAX_OUTPUT,
-                VALID_MAX_TEMP,
-                VALID_MAX_METADATA,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                VALID_SPLIT_BLOCK_RETRIES,
-                VALID_NON_SPLIT_RETRIES,
-                VALID_USK_RETRIES,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                VALID_MAX_DATABLOCKS,
-                -1,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder()
+                    .splitfileLimits(VALID_ALLOW_SPLIT, VALID_MAX_DATABLOCKS, -1)
+                    .build()));
     // Greater than allowed
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new FetchContext(
-                VALID_MAX_OUTPUT,
-                VALID_MAX_TEMP,
-                VALID_MAX_METADATA,
-                VALID_MAX_RECURSION,
-                VALID_MAX_ARCHIVE_RESTARTS,
-                VALID_MAX_ARCHIVE_LEVELS,
-                VALID_DONT_ENTER_IMPLICIT,
-                VALID_SPLIT_BLOCK_RETRIES,
-                VALID_NON_SPLIT_RETRIES,
-                VALID_USK_RETRIES,
-                VALID_ALLOW_SPLIT,
-                VALID_FOLLOW_REDIRECTS,
-                VALID_LOCAL_ONLY,
-                VALID_FILTER_DATA,
-                VALID_MAX_DATABLOCKS,
-                FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT + 1,
-                producerMock,
-                VALID_IGNORE_TOO_MANY,
-                VALID_CAN_WRITE_CLIENT_CACHE,
-                VALID_CHARSET,
-                VALID_OVERRIDE_MIME,
-                VALID_SCHEME));
+                validOptionsBuilder()
+                    .splitfileLimits(
+                        VALID_ALLOW_SPLIT,
+                        VALID_MAX_DATABLOCKS,
+                        FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT + 1)
+                    .build()));
   }
 
   @Test
@@ -693,29 +503,22 @@ class FetchContextTest {
     assertNotEquals(a, b);
   }
 
+  private FetchContextOptions.Builder validOptionsBuilder() {
+    return FetchContextOptions.builder()
+        .limits(VALID_MAX_OUTPUT, VALID_MAX_TEMP, VALID_MAX_METADATA)
+        .archiveLimits(
+            VALID_MAX_RECURSION,
+            VALID_MAX_ARCHIVE_RESTARTS,
+            VALID_MAX_ARCHIVE_LEVELS,
+            VALID_DONT_ENTER_IMPLICIT)
+        .retryLimits(VALID_SPLIT_BLOCK_RETRIES, VALID_NON_SPLIT_RETRIES, VALID_USK_RETRIES)
+        .splitfileLimits(VALID_ALLOW_SPLIT, VALID_MAX_DATABLOCKS, VALID_MAX_CHECKBLOCKS)
+        .behavior(VALID_FOLLOW_REDIRECTS, VALID_LOCAL_ONLY, VALID_FILTER_DATA)
+        .clientOptions(producerMock, VALID_IGNORE_TOO_MANY, VALID_CAN_WRITE_CLIENT_CACHE)
+        .filterOverrides(VALID_CHARSET, VALID_OVERRIDE_MIME, VALID_SCHEME);
+  }
+
   private FetchContext createValidContext() {
-    return new FetchContext(
-        VALID_MAX_OUTPUT,
-        VALID_MAX_TEMP,
-        VALID_MAX_METADATA,
-        VALID_MAX_RECURSION,
-        VALID_MAX_ARCHIVE_RESTARTS,
-        VALID_MAX_ARCHIVE_LEVELS,
-        VALID_DONT_ENTER_IMPLICIT,
-        VALID_SPLIT_BLOCK_RETRIES,
-        VALID_NON_SPLIT_RETRIES,
-        VALID_USK_RETRIES,
-        VALID_ALLOW_SPLIT,
-        VALID_FOLLOW_REDIRECTS,
-        VALID_LOCAL_ONLY,
-        VALID_FILTER_DATA,
-        VALID_MAX_DATABLOCKS,
-        VALID_MAX_CHECKBLOCKS,
-        producerMock,
-        VALID_IGNORE_TOO_MANY,
-        VALID_CAN_WRITE_CLIENT_CACHE,
-        VALID_CHARSET,
-        VALID_OVERRIDE_MIME,
-        VALID_SCHEME);
+    return new FetchContext(validOptionsBuilder().build());
   }
 }

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Field;
 import java.util.Random;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.InsertException;
@@ -96,28 +97,15 @@ class ClientContextTest {
     // Minimal default contexts used by accessors under test
     defaultFetchCtx =
         new FetchContext(
-            1024L,
-            2048L,
-            4096,
-            2,
-            3,
-            1,
-            false,
-            1,
-            1,
-            0,
-            true,
-            true,
-            false,
-            true,
-            16,
-            16,
-            new SimpleEventProducer(),
-            false,
-            true,
-            null,
-            null,
-            null);
+            FetchContextOptions.builder()
+                .limits(1024L, 2048L, 4096)
+                .archiveLimits(2, 3, 1, false)
+                .retryLimits(1, 1, 0)
+                .splitfileLimits(true, 16, 16)
+                .behavior(true, false, true)
+                .clientOptions(new SimpleEventProducer(), false, true)
+                .filterOverrides(null, null, null)
+                .build());
 
     defaultInsertCtx =
         new InsertContext(

--- a/src/test/java/network/crypta/client/async/ClientGetterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientGetterTest.java
@@ -27,6 +27,7 @@ import java.util.Random;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchResult;
@@ -249,28 +250,15 @@ class ClientGetterTest {
   private static FetchContext newFetchContext(boolean filter) {
     // Use reasonable small limits; values are not critical for these tests.
     return new FetchContext(
-        16 * 1024,
-        16 * 1024,
-        4096,
-        4,
-        0,
-        2,
-        false,
-        1,
-        1,
-        0,
-        true,
-        true,
-        false,
-        filter,
-        0,
-        0,
-        new SimpleEventProducer(),
-        true,
-        true,
-        null,
-        null,
-        null);
+        FetchContextOptions.builder()
+            .limits(16 * 1024, 16 * 1024, 4096)
+            .archiveLimits(4, 0, 2, false)
+            .retryLimits(1, 1, 0)
+            .splitfileLimits(true, 0, 0)
+            .behavior(true, false, filter)
+            .clientOptions(new SimpleEventProducer(), true, true)
+            .filterOverrides(null, null, null)
+            .build());
   }
 
   private static InsertContext newInsertContext() {

--- a/src/test/java/network/crypta/client/async/InsertCompressorTest.java
+++ b/src/test/java/network/crypta/client/async/InsertCompressorTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Random;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertBlock;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException;
@@ -164,28 +165,15 @@ class InsertCompressorTest {
         /*linkFilterExceptionProvider*/ null,
         /*defaultPersistentFetchContext*/
         new network.crypta.client.FetchContext(
-            0L,
-            0L,
-            0,
-            1,
-            0,
-            0,
-            false,
-            0,
-            0,
-            0,
-            false,
-            false,
-            false,
-            false,
-            0,
-            0,
-            new SimpleEventProducer(),
-            true,
-            false,
-            null,
-            null,
-            null),
+            FetchContextOptions.builder()
+                .limits(0L, 0L, 0)
+                .archiveLimits(1, 0, 0, false)
+                .retryLimits(0, 0, 0)
+                .splitfileLimits(false, 0, 0)
+                .behavior(false, false, false)
+                .clientOptions(new SimpleEventProducer(), true, false)
+                .filterOverrides(null, null, null)
+                .build()),
         /*defaultPersistentInsertContext*/
         new InsertContext(
             0,

--- a/src/test/java/network/crypta/client/async/SingleFileFetcherTest.java
+++ b/src/test/java/network/crypta/client/async/SingleFileFetcherTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchResult;
@@ -59,28 +60,15 @@ class SingleFileFetcherTest {
   private FetchContext newCtx(long maxOut, boolean ignoreTooMany) {
     // Use simple, valid values for all required constructor parameters.
     return new FetchContext(
-        maxOut, /* maxOutputLength */
-        Long.MAX_VALUE, /* maxTempLength */
-        1024 * 1024, /* maxMetadataSize */
-        8, /* maxRecursionLevel */
-        4, /* maxArchiveRestarts */
-        8, /* maxArchiveLevels */
-        false, /* dontEnterImplicitArchives */
-        0, /* maxSplitfileBlockRetries */
-        0, /* maxNonSplitfileRetries */
-        0, /* maxUSKRetries */
-        true, /* allowSplitfiles */
-        true, /* followRedirects */
-        false, /* localRequestOnly */
-        false, /* filterData */
-        0, /* maxDataBlocksPerSegment */
-        0, /* maxCheckBlocksPerSegment */
-        new SimpleEventProducer(),
-        ignoreTooMany, /* ignoreTooManyPathComponents */
-        true, /* canWriteClientCache */
-        null, /* charset */
-        null, /* overrideMIME */
-        null /* schemeHostAndPort */);
+        FetchContextOptions.builder()
+            .limits(maxOut, Long.MAX_VALUE, 1024 * 1024)
+            .archiveLimits(8, 4, 8, false)
+            .retryLimits(0, 0, 0)
+            .splitfileLimits(true, 0, 0)
+            .behavior(true, false, false)
+            .clientOptions(new SimpleEventProducer(), ignoreTooMany, true)
+            .filterOverrides(null, null, null)
+            .build());
   }
 
   @BeforeEach

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherGetTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherGetTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.Key;
@@ -70,28 +71,15 @@ class SplitFileFetcherGetTest {
     // Build a basic FetchContext and then a masked copy that carries a BlockSet
     FetchContext base =
         new FetchContext(
-            1024L,
-            1024L,
-            1024,
-            1,
-            0,
-            0,
-            true,
-            1,
-            1,
-            1,
-            false,
-            false,
-            false,
-            false,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            true,
-            null,
-            null,
-            null);
+            FetchContextOptions.builder()
+                .limits(1024L, 1024L, 1024)
+                .archiveLimits(1, 0, 0, true)
+                .retryLimits(1, 1, 1)
+                .splitfileLimits(false, 0, 0)
+                .behavior(false, false, false)
+                .clientOptions(new SimpleEventProducer(), false, true)
+                .filterOverrides(null, null, null)
+                .build());
     blockSet = new SimpleBlockSet();
     blockFetchContext =
         new FetchContext(base, FetchContext.SPLITFILE_DEFAULT_BLOCK_MASK, false, blockSet);

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherTest.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.InsertContext.CompatibilityMode;
@@ -486,28 +487,15 @@ class SplitFileFetcherTest {
     // Prepare a FetchContext instance with localRequestOnly=true
     FetchContext fc =
         new FetchContext(
-            1L,
-            1L,
-            1,
-            1,
-            0,
-            0,
-            true,
-            0,
-            0,
-            0,
-            true,
-            true,
-            true,
-            false,
-            0,
-            0,
-            new network.crypta.client.events.SimpleEventProducer(),
-            true,
-            true,
-            null,
-            null,
-            null);
+            FetchContextOptions.builder()
+                .limits(1L, 1L, 1)
+                .archiveLimits(1, 0, 0, true)
+                .retryLimits(0, 0, 0)
+                .splitfileLimits(true, 0, 0)
+                .behavior(true, true, false)
+                .clientOptions(new network.crypta.client.events.SimpleEventProducer(), true, true)
+                .filterOverrides(null, null, null)
+                .build());
     // Set parent.ctx reflectively so resume ctor copies it into blockFetchContext
     setParentCtx(parent, fc);
 

--- a/src/test/java/network/crypta/client/async/USKDateHintFetchesTest.java
+++ b/src/test/java/network/crypta/client/async/USKDateHintFetchesTest.java
@@ -18,6 +18,7 @@ import java.net.MalformedURLException;
 import java.util.HashSet;
 import java.util.Random;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.keys.ClientSSK;
 import network.crypta.keys.FreenetURI;
@@ -240,28 +241,15 @@ class USKDateHintFetchesTest {
 
   private static FetchContext createFetchContext() {
     return new FetchContext(
-        1024,
-        1024,
-        1024,
-        1,
-        0,
-        0,
-        false,
-        0,
-        0,
-        0,
-        true,
-        true,
-        false,
-        false,
-        1,
-        1,
-        new SimpleEventProducer(),
-        false,
-        true,
-        null,
-        null,
-        null);
+        FetchContextOptions.builder()
+            .limits(1024, 1024, 1024)
+            .archiveLimits(1, 0, 0, false)
+            .retryLimits(0, 0, 0)
+            .splitfileLimits(true, 1, 1)
+            .behavior(true, false, false)
+            .clientOptions(new SimpleEventProducer(), false, true)
+            .filterOverrides(null, null, null)
+            .build());
   }
 
   private static USK createUsk() throws MalformedURLException {

--- a/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
+++ b/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 import java.util.Arrays;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertContext;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
@@ -127,29 +128,15 @@ class USKFetcherTagTest {
   private static FetchContext newFetchContext() {
     // Small, deterministic limits; context is forwarded only.
     return new FetchContext(
-        16L * 1024, // maxOutputLength
-        16L * 1024, // maxTempLength
-        4096, // maxMetadataSize
-        4, // maxRecursionLevel
-        0, // maxArchiveRestarts
-        2, // maxArchiveLevels
-        false, // dontEnterImplicitArchives
-        1, // maxSplitfileBlockRetries
-        1, // maxNonSplitfileRetries
-        1, // maxUSKRetries
-        true, // allowSplitfiles
-        true, // followRedirects
-        false, // localRequestOnly
-        false, // filterData
-        0, // maxDataBlocksPerSegment
-        0, // maxCheckBlocksPerSegment
-        new SimpleEventProducer(),
-        true, // ignoreTooManyPathComponents
-        true, // canWriteClientCache
-        null, // charset
-        null, // overrideMIME
-        null // schemeHostAndPort
-        );
+        FetchContextOptions.builder()
+            .limits(16L * 1024, 16L * 1024, 4096)
+            .archiveLimits(4, 0, 2, false)
+            .retryLimits(1, 1, 1)
+            .splitfileLimits(true, 0, 0)
+            .behavior(true, false, false)
+            .clientOptions(new SimpleEventProducer(), true, true)
+            .filterOverrides(null, null, null)
+            .build());
   }
 
   private static InsertContext newInsertContext() {

--- a/src/test/java/network/crypta/client/async/USKFetcherTest.java
+++ b/src/test/java/network/crypta/client/async/USKFetcherTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import java.math.BigInteger;
 import java.util.Random;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.crypt.DSAPublicKey;
 import network.crypta.crypt.Global;
@@ -62,28 +63,15 @@ class USKFetcherTest {
     // Minimal real FetchContext (used/cloned by USKFetcher)
     fetchContext =
         new FetchContext(
-            64 * 1024,
-            64 * 1024,
-            1024,
-            1,
-            0,
-            0,
-            true,
-            0,
-            0,
-            3,
-            true,
-            false,
-            false,
-            false,
-            0,
-            0,
-            new SimpleEventProducer(),
-            true,
-            false,
-            null,
-            null,
-            null);
+            FetchContextOptions.builder()
+                .limits(64 * 1024, 64 * 1024, 1024)
+                .archiveLimits(1, 0, 0, true)
+                .retryLimits(0, 0, 3)
+                .splitfileLimits(true, 0, 0)
+                .behavior(false, false, false)
+                .clientOptions(new SimpleEventProducer(), true, false)
+                .filterOverrides(null, null, null)
+                .build());
 
     // Common requester stubs
     when(requester.realTimeFlag()).thenReturn(false);

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -16,6 +16,7 @@ import java.io.Serial;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
@@ -159,28 +160,15 @@ class USKInserterTest {
             // exercised
             // in these tests.
             new FetchContext(
-                0,
-                0,
-                0,
-                1,
-                0,
-                0,
-                true,
-                0,
-                0,
-                0,
-                false,
-                false,
-                false,
-                false,
-                0,
-                0,
-                new SimpleEventProducer(),
-                false,
-                false,
-                null,
-                null,
-                null),
+                FetchContextOptions.builder()
+                    .limits(0, 0, 0)
+                    .archiveLimits(1, 0, 0, true)
+                    .retryLimits(0, 0, 0)
+                    .splitfileLimits(false, 0, 0)
+                    .behavior(false, false, false)
+                    .clientOptions(new SimpleEventProducer(), false, false)
+                    .filterOverrides(null, null, null)
+                    .build()),
             new InsertContext(
                 0,
                 0,

--- a/src/test/java/network/crypta/client/async/USKManagerTest.java
+++ b/src/test/java/network/crypta/client/async/USKManagerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.net.MalformedURLException;
 import java.util.concurrent.atomic.AtomicInteger;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.events.SimpleEventProducer;
@@ -216,29 +217,15 @@ class USKManagerTest {
     public FetchContext getFetchContext() {
       // Minimal, deterministic context (values patterned after existing tests)
       return new FetchContext(
-          Long.MAX_VALUE, // maxOutputLength
-          Long.MAX_VALUE, // maxTempLength
-          1024 * 1024, // maxMetadataSize
-          1, // maxRecursionLevel
-          1, // maxArchiveRestarts
-          1, // maxArchiveLevels
-          false, // dontEnterImplicitArchives
-          0, // maxSplitfileBlockRetries
-          0, // maxNonSplitfileRetries
-          0, // maxUSKRetries
-          true, // allowSplitfiles
-          true, // followRedirects
-          false, // localRequestOnly
-          false, // filterData
-          1, // maxDataBlocksPerSegment
-          1, // maxCheckBlocksPerSegment
-          new SimpleEventProducer(), // eventProducer
-          false, // ignoreTooManyPathComponents
-          true, // canWriteClientCache
-          null, // charset
-          null, // overrideMIME
-          null // schemeHostAndPort
-          );
+          FetchContextOptions.builder()
+              .limits(Long.MAX_VALUE, Long.MAX_VALUE, 1024 * 1024)
+              .archiveLimits(1, 1, 1, false)
+              .retryLimits(0, 0, 0)
+              .splitfileLimits(true, 1, 1)
+              .behavior(true, false, false)
+              .clientOptions(new SimpleEventProducer(), false, true)
+              .filterOverrides(null, null, null)
+              .build());
     }
 
     @Override

--- a/src/test/java/network/crypta/client/async/USKRetrieverTest.java
+++ b/src/test/java/network/crypta/client/async/USKRetrieverTest.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchResult;
@@ -132,29 +133,15 @@ class USKRetrieverTest {
   private static FetchContext newFetchContext() {
     // Small, deterministic limits; FetchContext is used here only for max{Temp,Output}Length.
     return new FetchContext(
-        16L * 1024, // maxOutputLength
-        16L * 1024, // maxTempLength
-        4096, // maxMetadataSize
-        4, // maxRecursionLevel
-        0, // maxArchiveRestarts
-        2, // maxArchiveLevels
-        false, // dontEnterImplicitArchives
-        1, // maxSplitfileBlockRetries
-        1, // maxNonSplitfileRetries
-        1, // maxUSKRetries
-        true, // allowSplitfiles
-        true, // followRedirects
-        false, // localRequestOnly
-        false, // filterData
-        0, // maxDataBlocksPerSegment
-        0, // maxCheckBlocksPerSegment
-        new SimpleEventProducer(),
-        true, // ignoreTooManyPathComponents
-        true, // canWriteClientCache
-        null, // charset
-        null, // overrideMIME
-        null // schemeHostAndPort
-        );
+        FetchContextOptions.builder()
+            .limits(16L * 1024, 16L * 1024, 4096)
+            .archiveLimits(4, 0, 2, false)
+            .retryLimits(1, 1, 1)
+            .splitfileLimits(true, 0, 0)
+            .behavior(true, false, false)
+            .clientOptions(new SimpleEventProducer(), true, true)
+            .filterOverrides(null, null, null)
+            .build());
   }
 
   private static InsertContext newInsertContext() {

--- a/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
+++ b/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
@@ -12,6 +12,7 @@ import java.net.MalformedURLException;
 import java.util.Random;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertContext;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
@@ -130,28 +131,15 @@ class USKSparseProxyCallbackTest {
   private static FetchContext newFetchContext() {
     // Copied pattern from existing tests to match constructor signature
     return new FetchContext(
-        64 * 1024,
-        64 * 1024,
-        1024,
-        1,
-        0,
-        0,
-        true,
-        0,
-        0,
-        3,
-        true,
-        false,
-        false,
-        false,
-        0,
-        0,
-        new SimpleEventProducer(),
-        true,
-        false,
-        null,
-        null,
-        null);
+        FetchContextOptions.builder()
+            .limits(64 * 1024, 64 * 1024, 1024)
+            .archiveLimits(1, 0, 0, true)
+            .retryLimits(0, 0, 3)
+            .splitfileLimits(true, 0, 0)
+            .behavior(false, false, false)
+            .clientOptions(new SimpleEventProducer(), true, false)
+            .filterOverrides(null, null, null)
+            .build());
   }
 
   private static InsertContext newInsertContext() {

--- a/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
+++ b/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.events.SimpleEventProducer;
@@ -109,28 +110,15 @@ class NodeUpdateManagerTest {
   private static @NotNull FetchContext getFetchContext() {
     SimpleEventProducer ep = new SimpleEventProducer();
     return new FetchContext(
-        Long.MAX_VALUE,
-        Long.MAX_VALUE,
-        1024 * 1024,
-        1,
-        1,
-        1,
-        false,
-        0,
-        0,
-        0,
-        true,
-        true,
-        false,
-        false,
-        1,
-        1,
-        ep,
-        false,
-        true,
-        null,
-        null,
-        null);
+        FetchContextOptions.builder()
+            .limits(Long.MAX_VALUE, Long.MAX_VALUE, 1024 * 1024)
+            .archiveLimits(1, 1, 1, false)
+            .retryLimits(0, 0, 0)
+            .splitfileLimits(true, 1, 1)
+            .behavior(true, false, false)
+            .clientOptions(ep, false, true)
+            .filterOverrides(null, null, null)
+            .build());
   }
 
   @Test

--- a/src/test/java/network/crypta/node/updater/PluginJarUpdaterTest.java
+++ b/src/test/java/network/crypta/node/updater/PluginJarUpdaterTest.java
@@ -20,6 +20,7 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.async.ClientContext;
@@ -123,28 +124,15 @@ class PluginJarUpdaterTest {
   private static FetchContext makeFetchContext() {
     SimpleEventProducer ep = new SimpleEventProducer();
     return new FetchContext(
-        Long.MAX_VALUE,
-        Long.MAX_VALUE,
-        1024 * 1024,
-        1,
-        1,
-        1,
-        false,
-        0,
-        0,
-        0,
-        true,
-        true,
-        false,
-        false,
-        1,
-        1,
-        ep,
-        false,
-        true,
-        null,
-        null,
-        null);
+        FetchContextOptions.builder()
+            .limits(Long.MAX_VALUE, Long.MAX_VALUE, 1024 * 1024)
+            .archiveLimits(1, 1, 1, false)
+            .retryLimits(0, 0, 0)
+            .splitfileLimits(true, 1, 1)
+            .behavior(true, false, false)
+            .clientOptions(ep, false, true)
+            .filterOverrides(null, null, null)
+            .build());
   }
 
   @Test

--- a/src/test/java/network/crypta/node/updater/RevocationCheckerTest.java
+++ b/src/test/java/network/crypta/node/updater/RevocationCheckerTest.java
@@ -18,6 +18,7 @@ import java.io.FileOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchResult;
@@ -90,28 +91,15 @@ class RevocationCheckerTest {
   private static @NotNull FetchContext getFetchContext() {
     SimpleEventProducer ep = new SimpleEventProducer();
     return new FetchContext(
-        Long.MAX_VALUE,
-        Long.MAX_VALUE,
-        1024 * 1024,
-        1,
-        1,
-        1,
-        false,
-        0,
-        0,
-        0,
-        true,
-        true,
-        false,
-        false,
-        1,
-        1,
-        ep,
-        false,
-        true,
-        null,
-        null,
-        null);
+        FetchContextOptions.builder()
+            .limits(Long.MAX_VALUE, Long.MAX_VALUE, 1024 * 1024)
+            .archiveLimits(1, 1, 1, false)
+            .retryLimits(0, 0, 0)
+            .splitfileLimits(true, 1, 1)
+            .behavior(true, false, false)
+            .clientOptions(ep, false, true)
+            .filterOverrides(null, null, null)
+            .build());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add `FetchContextOptions` builder to bundle fetch parameters
- update `FetchContext` to consume the options bundle
- migrate default context creation and tests to the new builder

## Breaking change
- removed the long-parameter `FetchContext` constructor; use `FetchContextOptions`

## Testing
- `./gradlew --parallel test`
- `./gradlew spotlessApply`