### PR TITLE
refactor(client): drop unused fetch context arg

### DIFF
--- a/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
+++ b/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
@@ -687,23 +687,17 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
    * Builds a {@link FetchContext} with defaults suitable for most interactive reads.
    *
    * <p>The returned context carries sensible retry counts and enables splitfile support and
-   * redirect following. The maximum output and temporary sizes are taken from the parameters. The
-   * supplied {@link BucketFactory} is used for any intermediate storage that the fetcher needs.
+   * redirect following. The maximum output and temporary sizes are taken from the parameters.
    *
    * @param maxLength maximum allowed size of the fetched payload in bytes; negative disables the
    *     limit.
    * @param maxTempLength maximum temporary storage in bytes for intermediate structures; negative
    *     disables the limit.
-   * @param bucketFactory factory used for intermediate buckets; must not be {@code null} when the
-   *     fetcher needs temporary storage.
    * @param eventProducer producer used to publish client events to listeners; may be shared.
    * @return a new {@link FetchContext} instance initialized with this class's defaults.
    */
   public static FetchContext makeDefaultFetchContext(
-      long maxLength,
-      long maxTempLength,
-      BucketFactory bucketFactory,
-      SimpleEventProducer eventProducer) {
+      long maxLength, long maxTempLength, SimpleEventProducer eventProducer) {
     return new FetchContext(
         maxLength,
         maxTempLength,

--- a/src/test/java/network/crypta/client/FetchContextTest.java
+++ b/src/test/java/network/crypta/client/FetchContextTest.java
@@ -22,7 +22,6 @@ import network.crypta.client.events.ClientEventProducer;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.FoundURICallback;
 import network.crypta.node.RequestScheduler;
-import network.crypta.support.io.ArrayBucketFactory;
 import network.crypta.support.io.StorageFormatException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,7 +62,7 @@ class FetchContextTest {
       throws IOException, StorageFormatException {
     FetchContext context =
         HighLevelSimpleClientImpl.makeDefaultFetchContext(
-            Long.MAX_VALUE, Long.MAX_VALUE, new ArrayBucketFactory(), new SimpleEventProducer());
+            Long.MAX_VALUE, Long.MAX_VALUE, new SimpleEventProducer());
     byte[] bytes;
     try (var baos = new ByteArrayOutputStream();
         var dos = new DataOutputStream(baos)) {

--- a/src/test/java/network/crypta/client/HighLevelSimpleClientImplTest.java
+++ b/src/test/java/network/crypta/client/HighLevelSimpleClientImplTest.java
@@ -144,9 +144,8 @@ class HighLevelSimpleClientImplTest {
   @Test
   void makeDefaultFetchContext_returnsContextWithProvidedProducerAndLimits() {
     SimpleEventProducer ep = new SimpleEventProducer();
-    BucketFactory bf = mock(BucketFactory.class);
 
-    FetchContext ctx = HighLevelSimpleClientImpl.makeDefaultFetchContext(777L, 888L, bf, ep);
+    FetchContext ctx = HighLevelSimpleClientImpl.makeDefaultFetchContext(777L, 888L, ep);
 
     assertEquals(777L, ctx.getMaxOutputLength());
     assertEquals(888L, ctx.getMaxTempLength());
@@ -231,8 +230,7 @@ class HighLevelSimpleClientImplTest {
     ClientGetCallback cb = mock(ClientGetCallback.class);
     when(cb.getRequestClient()).thenReturn(client);
     FetchContext fctx =
-        HighLevelSimpleClientImpl.makeDefaultFetchContext(
-            10L, 20L, bucketFactory, new SimpleEventProducer());
+        HighLevelSimpleClientImpl.makeDefaultFetchContext(10L, 20L, new SimpleEventProducer());
 
     // Act
     client.fetch(uri, 4096L, cb, fctx, (short) 5);
@@ -259,8 +257,7 @@ class HighLevelSimpleClientImplTest {
   void fetch_asyncWithNullUri_throwsNPE() {
     ClientGetCallback cb = mock(ClientGetCallback.class);
     FetchContext fctx =
-        HighLevelSimpleClientImpl.makeDefaultFetchContext(
-            1L, 1L, bucketFactory, new SimpleEventProducer());
+        HighLevelSimpleClientImpl.makeDefaultFetchContext(1L, 1L, new SimpleEventProducer());
     assertThrows(NullPointerException.class, () -> client.fetch(null, cb, fctx, (short) 1));
   }
 
@@ -371,8 +368,7 @@ class HighLevelSimpleClientImplTest {
     ClientGetCallback cb = mock(ClientGetCallback.class);
     when(cb.getRequestClient()).thenReturn(client);
     FetchContext fctx =
-        HighLevelSimpleClientImpl.makeDefaultFetchContext(
-            100L, 200L, bucketFactory, new SimpleEventProducer());
+        HighLevelSimpleClientImpl.makeDefaultFetchContext(100L, 200L, new SimpleEventProducer());
 
     // Act
     ClientGetter getter = client.fetchFromMetadata(initial, cb, fctx, (short) 3);

--- a/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
@@ -391,8 +391,7 @@ class ClientRequestSelectorTest {
 
     // FetchContext options
     network.crypta.client.FetchContext fctx =
-        HighLevelSimpleClientImpl.makeDefaultFetchContext(
-            1024, 1024, null, new SimpleEventProducer());
+        HighLevelSimpleClientImpl.makeDefaultFetchContext(1024, 1024, new SimpleEventProducer());
     fctx.setLocalRequestOnly(true);
     fctx.setIgnoreStore(true);
     fctx.setCanWriteClientCache(true);

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
@@ -1223,7 +1223,7 @@ class SplitFileFetcherStorageTest {
 
     public FetchContext makeFetchContext() {
       return HighLevelSimpleClientImpl.makeDefaultFetchContext(
-          Long.MAX_VALUE, Long.MAX_VALUE, bf, new SimpleEventProducer());
+          Long.MAX_VALUE, Long.MAX_VALUE, new SimpleEventProducer());
     }
 
     public void verifyOutput(SplitFileFetcherStorage storage) throws IOException {

--- a/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
@@ -18,7 +18,6 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
-import network.crypta.support.io.ArrayBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -139,7 +138,7 @@ class FProxyFetchInProgressTest {
 
   private static FetchContext newFetchContext() {
     return HighLevelSimpleClientImpl.makeDefaultFetchContext(
-        2048L, 4096L, new ArrayBucketFactory(), new SimpleEventProducer());
+        2048L, 4096L, new SimpleEventProducer());
   }
 
   private static void setField(Object target, String name, Object value) throws Exception {


### PR DESCRIPTION
## Summary
- remove the unused bucketFactory parameter from makeDefaultFetchContext
- update tests to use the simplified signature
- clean up unused imports

## Testing
- ./gradlew test --tests '*FetchContextTest'
- ./gradlew --parallel test