### PR TITLE
refactor(client): add InsertContextOptions

### DIFF
--- a/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
+++ b/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
@@ -716,18 +716,19 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
   @Override
   public InsertContext getInsertContext(boolean forceNonPersistent) {
     return new InsertContext(
-        INSERT_RETRIES,
-        CONSECUTIVE_RNFS_ASSUME_SUCCESS,
-        SPLITFILE_BLOCKS_PER_SEGMENT,
-        SPLITFILE_CHECK_BLOCKS_PER_SEGMENT,
-        eventProducer,
-        CAN_WRITE_CLIENT_CACHE_INSERTS,
-        Node.FORK_ON_CACHEABLE_DEFAULT,
-        false,
-        Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-        EXTRA_INSERTS_SINGLE_BLOCK,
-        EXTRA_INSERTS_SPLITFILE_HEADER,
-        InsertContext.CompatibilityMode.COMPAT_DEFAULT);
+        InsertContextOptions.builder()
+            .retryLimits(INSERT_RETRIES, CONSECUTIVE_RNFS_ASSUME_SUCCESS)
+            .splitfileSegmentLimits(
+                SPLITFILE_BLOCKS_PER_SEGMENT, SPLITFILE_CHECK_BLOCKS_PER_SEGMENT)
+            .clientOptions(
+                eventProducer,
+                CAN_WRITE_CLIENT_CACHE_INSERTS,
+                Node.FORK_ON_CACHEABLE_DEFAULT,
+                false)
+            .compressorDescriptor(Compressor.DEFAULT_COMPRESSORDESCRIPTOR)
+            .redundancy(EXTRA_INSERTS_SINGLE_BLOCK, EXTRA_INSERTS_SPLITFILE_HEADER)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_DEFAULT)
+            .build());
   }
 
   /**
@@ -750,18 +751,19 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
           "makeDefaultInsertContext invoked (bucketFactory passed={})", bucketFactory != null);
     }
     return new InsertContext(
-        INSERT_RETRIES,
-        CONSECUTIVE_RNFS_ASSUME_SUCCESS,
-        SPLITFILE_BLOCKS_PER_SEGMENT,
-        SPLITFILE_CHECK_BLOCKS_PER_SEGMENT,
-        eventProducer,
-        CAN_WRITE_CLIENT_CACHE_INSERTS,
-        Node.FORK_ON_CACHEABLE_DEFAULT,
-        false,
-        Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-        EXTRA_INSERTS_SINGLE_BLOCK,
-        EXTRA_INSERTS_SPLITFILE_HEADER,
-        InsertContext.CompatibilityMode.COMPAT_DEFAULT);
+        InsertContextOptions.builder()
+            .retryLimits(INSERT_RETRIES, CONSECUTIVE_RNFS_ASSUME_SUCCESS)
+            .splitfileSegmentLimits(
+                SPLITFILE_BLOCKS_PER_SEGMENT, SPLITFILE_CHECK_BLOCKS_PER_SEGMENT)
+            .clientOptions(
+                eventProducer,
+                CAN_WRITE_CLIENT_CACHE_INSERTS,
+                Node.FORK_ON_CACHEABLE_DEFAULT,
+                false)
+            .compressorDescriptor(Compressor.DEFAULT_COMPRESSORDESCRIPTOR)
+            .redundancy(EXTRA_INSERTS_SINGLE_BLOCK, EXTRA_INSERTS_SPLITFILE_HEADER)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_DEFAULT)
+            .build());
   }
 
   /**

--- a/src/main/java/network/crypta/client/InsertContext.java
+++ b/src/main/java/network/crypta/client/InsertContext.java
@@ -17,7 +17,7 @@ import network.crypta.support.compress.Compressor;
  * inserts.
  *
  * <p>An {@code InsertContext} captures all tunable parameters that influence how data is prepared
- * for insertion into the network: compression behaviour, splitfile sizing, redundancy, cache
+ * for insertion into the network: compression behavior, splitfile sizing, redundancy, cache
  * policies, and compatibility rules for on-disk and on-wire formats. Higher-level clients typically
  * obtain a baseline instance from a helper or {@code ClientContext} and then adjust a small subset
  * of fields via the provided setters before starting an insert. The same context may be reused
@@ -80,7 +80,7 @@ public class InsertContext implements Serializable {
 
   /**
    * Can this insert write to the client-cache? We don't store all requests in the client cache, in
-   * particular big stuff usually isn't written to it, to maximise its effectiveness. Plus, local
+   * particular big stuff usually isn't written to it, to maximize its effectiveness. Plus, local
    * inserts are not written to the client-cache by default for privacy reasons.
    */
   private boolean canWriteClientCache;
@@ -284,7 +284,7 @@ public class InsertContext implements Serializable {
 
   /**
    * If true, try to find the final URI as quickly as possible, and insert the upper layers as soon
-   * as we can, rather than waiting for the lower layers. The default behaviour is safer, because an
+   * as we can, rather than waiting for the lower layers. The default behavior is safer, because an
    * attacker can usually only identify the datastream once he has the top block, or once you have
    * announced the key.
    */
@@ -353,65 +353,31 @@ public class InsertContext implements Serializable {
   }
 
   /**
-   * Creates a new insert context with the supplied tuning parameters.
+   * Creates a new insert context using the supplied options.
    *
-   * <p>Callers typically obtain baseline values from higher-level helpers and override only those
-   * fields that must differ for a particular request. No validation is performed here; the caller
-   * is responsible for supplying values that are meaningful for the surrounding system.
+   * <p>Callers typically build an {@link InsertContextOptions} instance by selecting a baseline
+   * configuration and then overriding only the fields that must differ for a particular request. No
+   * validation is performed here; the caller is responsible for supplying values that are
+   * meaningful for the surrounding system.
    *
-   * @param maxRetries maximum number of retries for each data block; negative values indicate
-   *     retrying indefinitely until either success or a fatal error occurs.
-   * @param rnfsToSuccess number of route-not-found outcomes that are tolerated and still counted as
-   *     overall success on very small networks.
-   * @param splitfileSegmentDataBlocks maximum number of data blocks per splitfile segment; affects
-   *     how large files are partitioned.
-   * @param splitfileSegmentCheckBlocks maximum number of check (parity) blocks per segment; may be
-   *     reduced when fewer data blocks are present.
-   * @param eventProducer producer that receives client-visible events such as progress updates; may
-   *     be shared between multiple contexts.
-   * @param canWriteClientCache whether this insert may write opaque data into the client cache;
-   *     large or privacy-sensitive inserts may disable this.
-   * @param forkOnCacheable whether the insert is permitted to fork into extra work when results are
-   *     cacheable, improving redundancy at the cost of additional traffic.
-   * @param localRequestOnly whether the insert should be restricted to local requests only instead
-   *     of being announced to the wider network.
-   * @param compressorDescriptor descriptor string listing compressors to try; a {@code null} value
-   *     falls back to implementation defaults.
-   * @param extraInsertsSingleBlock number of additional insert attempts for single-block inserts in
-   *     order to increase redundancy.
-   * @param extraInsertsSplitfileHeaderBlock number of extra insert attempts for splitfile header
-   *     blocks, which are critical for reconstructing the file.
-   * @param compatibilityMode initial compatibility mode used to shape metadata and block layout;
-   *     normalized via {@link CompatibilityMode#intern()}.
+   * @param options bundle of parameters that control insert behavior; must not be {@code null}.
    */
-  public InsertContext(
-      int maxRetries,
-      int rnfsToSuccess,
-      int splitfileSegmentDataBlocks,
-      int splitfileSegmentCheckBlocks,
-      ClientEventProducer eventProducer,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      boolean localRequestOnly,
-      String compressorDescriptor,
-      int extraInsertsSingleBlock,
-      int extraInsertsSplitfileHeaderBlock,
-      CompatibilityMode compatibilityMode) {
+  public InsertContext(InsertContextOptions options) {
     dontCompress = false;
     splitfileAlgo = SplitfileAlgorithm.ONION_STANDARD;
     splitfileAlgorithm = splitfileAlgo.code;
-    this.consecutiveRNFsCountAsSuccess = rnfsToSuccess;
-    this.maxInsertRetries = maxRetries;
-    this.eventProducer = eventProducer;
-    this.splitfileSegmentDataBlocks = splitfileSegmentDataBlocks;
-    this.splitfileSegmentCheckBlocks = splitfileSegmentCheckBlocks;
-    this.canWriteClientCache = canWriteClientCache;
-    this.forkOnCacheable = forkOnCacheable;
-    this.compressorDescriptor = compressorDescriptor;
-    this.extraInsertsSingleBlock = extraInsertsSingleBlock;
-    this.extraInsertsSplitfileHeaderBlock = extraInsertsSplitfileHeaderBlock;
-    this.realCompatMode = compatibilityMode.intern();
-    this.localRequestOnly = localRequestOnly;
+    this.consecutiveRNFsCountAsSuccess = options.consecutiveRNFsCountAsSuccess();
+    this.maxInsertRetries = options.maxInsertRetries();
+    this.eventProducer = options.eventProducer();
+    this.splitfileSegmentDataBlocks = options.splitfileSegmentDataBlocks();
+    this.splitfileSegmentCheckBlocks = options.splitfileSegmentCheckBlocks();
+    this.canWriteClientCache = options.canWriteClientCache();
+    this.forkOnCacheable = options.forkOnCacheable();
+    this.compressorDescriptor = options.compressorDescriptor();
+    this.extraInsertsSingleBlock = options.extraInsertsSingleBlock();
+    this.extraInsertsSplitfileHeaderBlock = options.extraInsertsSplitfileHeaderBlock();
+    this.realCompatMode = options.compatibilityMode().intern();
+    this.localRequestOnly = options.localRequestOnly();
     this.ignoreUSKDatehints = false;
   }
 
@@ -449,7 +415,7 @@ public class InsertContext implements Serializable {
    * #eventProducer} reference is copied as-is; if a new event stream is desired, use {@link
    * #InsertContext(InsertContext, SimpleEventProducer)} instead.
    *
-   * @param other source context whose configuration and behaviour should be duplicated.
+   * @param other source context whose configuration and behavior should be duplicated.
    */
   public InsertContext(InsertContext other) {
     this.dontCompress = other.dontCompress;
@@ -696,7 +662,7 @@ public class InsertContext implements Serializable {
   /**
    * Indicates whether inserts may fork additional work when results are cacheable.
    *
-   * @return {@code true} if fork-on-cacheable behaviour is enabled; otherwise {@code false}.
+   * @return {@code true} if fork-on-cacheable behavior is enabled; otherwise {@code false}.
    */
   public boolean isForkOnCacheable() {
     return forkOnCacheable;
@@ -706,7 +672,7 @@ public class InsertContext implements Serializable {
    * Sets whether inserts may fork additional work when results are cacheable.
    *
    * @param forkOnCacheable {@code true} to allow additional work for cacheable inserts; {@code
-   *     false} to disable this behaviour.
+   *     false} to disable this behavior.
    */
   public void setForkOnCacheable(boolean forkOnCacheable) {
     this.forkOnCacheable = forkOnCacheable;
@@ -774,7 +740,7 @@ public class InsertContext implements Serializable {
   /**
    * Indicates whether USK date hints are ignored for this insert.
    *
-   * @return {@code true} if USK date hints are ignored; {@code false} if they are honoured.
+   * @return {@code true} if USK date hints are ignored; {@code false} if they are honored.
    */
   public boolean isIgnoreUSKDatehints() {
     return ignoreUSKDatehints;
@@ -783,7 +749,7 @@ public class InsertContext implements Serializable {
   /**
    * Sets whether USK date hints should be ignored for this insert.
    *
-   * @param ignoreUSKDatehints {@code true} to ignore USK date hints; {@code false} to honour them
+   * @param ignoreUSKDatehints {@code true} to ignore USK date hints; {@code false} to honor them
    *     when polling for the maximum edition.
    */
   public void setIgnoreUSKDatehints(boolean ignoreUSKDatehints) {
@@ -813,8 +779,8 @@ public class InsertContext implements Serializable {
   /**
    * Indicates whether the insert should attempt to finalize the URI as early as possible.
    *
-   * @return {@code true} if early encode is enabled; {@code false} if the safer default behaviour
-   *     is used.
+   * @return {@code true} if early encode is enabled; {@code false} if the safer default behavior is
+   *     used.
    */
   public boolean isEarlyEncode() {
     return earlyEncode;
@@ -824,7 +790,7 @@ public class InsertContext implements Serializable {
    * Sets whether the insert should attempt to finalize the URI as early as possible.
    *
    * @param earlyEncode {@code true} to enable early URI determination; {@code false} to use the
-   *     safer default behaviour.
+   *     safer default behavior.
    */
   public void setEarlyEncode(boolean earlyEncode) {
     this.earlyEncode = earlyEncode;

--- a/src/main/java/network/crypta/client/InsertContextOptions.java
+++ b/src/main/java/network/crypta/client/InsertContextOptions.java
@@ -1,0 +1,213 @@
+package network.crypta.client;
+
+import network.crypta.client.events.ClientEventProducer;
+import network.crypta.client.events.SimpleEventProducer;
+
+/**
+ * Immutable bundle of parameters used to construct an {@link InsertContext}.
+ *
+ * <p>Use {@link Builder} to populate the full set of values. {@link InsertContext} performs no
+ * validation, so callers are responsible for supplying values that are meaningful for their
+ * environment.
+ */
+public final class InsertContextOptions {
+  private final int maxInsertRetries;
+  private final int consecutiveRNFsCountAsSuccess;
+  private final int splitfileSegmentDataBlocks;
+  private final int splitfileSegmentCheckBlocks;
+  private final ClientEventProducer eventProducer;
+  private final boolean canWriteClientCache;
+  private final boolean forkOnCacheable;
+  private final boolean localRequestOnly;
+  private final String compressorDescriptor;
+  private final int extraInsertsSingleBlock;
+  private final int extraInsertsSplitfileHeaderBlock;
+  private final InsertContext.CompatibilityMode compatibilityMode;
+
+  private InsertContextOptions(Builder builder) {
+    this.maxInsertRetries = builder.maxInsertRetries;
+    this.consecutiveRNFsCountAsSuccess = builder.consecutiveRNFsCountAsSuccess;
+    this.splitfileSegmentDataBlocks = builder.splitfileSegmentDataBlocks;
+    this.splitfileSegmentCheckBlocks = builder.splitfileSegmentCheckBlocks;
+    this.eventProducer = builder.eventProducer;
+    this.canWriteClientCache = builder.canWriteClientCache;
+    this.forkOnCacheable = builder.forkOnCacheable;
+    this.localRequestOnly = builder.localRequestOnly;
+    this.compressorDescriptor = builder.compressorDescriptor;
+    this.extraInsertsSingleBlock = builder.extraInsertsSingleBlock;
+    this.extraInsertsSplitfileHeaderBlock = builder.extraInsertsSplitfileHeaderBlock;
+    this.compatibilityMode = builder.compatibilityMode;
+  }
+
+  public int maxInsertRetries() {
+    return maxInsertRetries;
+  }
+
+  public int consecutiveRNFsCountAsSuccess() {
+    return consecutiveRNFsCountAsSuccess;
+  }
+
+  public int splitfileSegmentDataBlocks() {
+    return splitfileSegmentDataBlocks;
+  }
+
+  public int splitfileSegmentCheckBlocks() {
+    return splitfileSegmentCheckBlocks;
+  }
+
+  public ClientEventProducer eventProducer() {
+    return eventProducer;
+  }
+
+  public boolean canWriteClientCache() {
+    return canWriteClientCache;
+  }
+
+  public boolean forkOnCacheable() {
+    return forkOnCacheable;
+  }
+
+  public boolean localRequestOnly() {
+    return localRequestOnly;
+  }
+
+  public String compressorDescriptor() {
+    return compressorDescriptor;
+  }
+
+  public int extraInsertsSingleBlock() {
+    return extraInsertsSingleBlock;
+  }
+
+  public int extraInsertsSplitfileHeaderBlock() {
+    return extraInsertsSplitfileHeaderBlock;
+  }
+
+  public InsertContext.CompatibilityMode compatibilityMode() {
+    return compatibilityMode;
+  }
+
+  /**
+   * Returns a new builder for {@link InsertContextOptions}.
+   *
+   * @return builder instance for configuring insert context parameters.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for {@link InsertContextOptions}.
+   *
+   * <p>The builder is mutable and not thread-safe. Callers should set each option group and then
+   * call {@link #build()} to obtain an immutable snapshot.
+   */
+  public static final class Builder {
+    private int maxInsertRetries;
+    private int consecutiveRNFsCountAsSuccess;
+    private int splitfileSegmentDataBlocks;
+    private int splitfileSegmentCheckBlocks;
+    private ClientEventProducer eventProducer = new SimpleEventProducer();
+    private boolean canWriteClientCache;
+    private boolean forkOnCacheable;
+    private boolean localRequestOnly;
+    private String compressorDescriptor;
+    private int extraInsertsSingleBlock;
+    private int extraInsertsSplitfileHeaderBlock;
+    private InsertContext.CompatibilityMode compatibilityMode =
+        InsertContext.CompatibilityMode.COMPAT_DEFAULT;
+
+    /**
+     * Sets retry limits for the insert.
+     *
+     * @param maxInsertRetries maximum retries per block; {@code -1} for unlimited retries.
+     * @param consecutiveRNFsCountAsSuccess number of route-not-found results that still count as
+     *     success on very small networks.
+     * @return this builder for chaining.
+     */
+    public Builder retryLimits(int maxInsertRetries, int consecutiveRNFsCountAsSuccess) {
+      this.maxInsertRetries = maxInsertRetries;
+      this.consecutiveRNFsCountAsSuccess = consecutiveRNFsCountAsSuccess;
+      return this;
+    }
+
+    /**
+     * Sets splitfile segment sizing limits.
+     *
+     * @param splitfileSegmentDataBlocks maximum data blocks per segment.
+     * @param splitfileSegmentCheckBlocks maximum check blocks per segment.
+     * @return this builder for chaining.
+     */
+    public Builder splitfileSegmentLimits(
+        int splitfileSegmentDataBlocks, int splitfileSegmentCheckBlocks) {
+      this.splitfileSegmentDataBlocks = splitfileSegmentDataBlocks;
+      this.splitfileSegmentCheckBlocks = splitfileSegmentCheckBlocks;
+      return this;
+    }
+
+    /**
+     * Sets client-facing behavior flags and the event producer.
+     *
+     * @param eventProducer producer used to publish insert events; may be {@code null}.
+     * @param canWriteClientCache whether inserted data may be written to the client cache.
+     * @param forkOnCacheable whether inserts may fork when results are cacheable.
+     * @param localRequestOnly whether inserts must remain local to the node.
+     * @return this builder for chaining.
+     */
+    public Builder clientOptions(
+        ClientEventProducer eventProducer,
+        boolean canWriteClientCache,
+        boolean forkOnCacheable,
+        boolean localRequestOnly) {
+      this.eventProducer = eventProducer;
+      this.canWriteClientCache = canWriteClientCache;
+      this.forkOnCacheable = forkOnCacheable;
+      this.localRequestOnly = localRequestOnly;
+      return this;
+    }
+
+    /**
+     * Sets the compressor descriptor string.
+     *
+     * @param compressorDescriptor descriptor string naming compressors to try.
+     * @return this builder for chaining.
+     */
+    public Builder compressorDescriptor(String compressorDescriptor) {
+      this.compressorDescriptor = compressorDescriptor;
+      return this;
+    }
+
+    /**
+     * Sets redundancy parameters for extra insert attempts.
+     *
+     * @param extraInsertsSingleBlock extra inserts for single-block payloads.
+     * @param extraInsertsSplitfileHeaderBlock extra inserts for splitfile header blocks.
+     * @return this builder for chaining.
+     */
+    public Builder redundancy(int extraInsertsSingleBlock, int extraInsertsSplitfileHeaderBlock) {
+      this.extraInsertsSingleBlock = extraInsertsSingleBlock;
+      this.extraInsertsSplitfileHeaderBlock = extraInsertsSplitfileHeaderBlock;
+      return this;
+    }
+
+    /**
+     * Sets the compatibility mode for the insert.
+     *
+     * @param compatibilityMode compatibility mode used to shape metadata and block layout.
+     * @return this builder for chaining.
+     */
+    public Builder compatibility(InsertContext.CompatibilityMode compatibilityMode) {
+      this.compatibilityMode = compatibilityMode;
+      return this;
+    }
+
+    /**
+     * Builds a new immutable {@link InsertContextOptions} instance.
+     *
+     * @return configured {@link InsertContextOptions} snapshot.
+     */
+    public InsertContextOptions build() {
+      return new InsertContextOptions(this);
+    }
+  }
+}

--- a/src/main/java/network/crypta/node/NodeClientCoreSupport.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreSupport.java
@@ -9,6 +9,7 @@ import network.crypta.client.FECCodec;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.async.HealingDecisionSupplier;
 import network.crypta.client.async.SimpleHealingQueue;
 import network.crypta.client.events.SimpleEventProducer;
@@ -194,18 +195,15 @@ public final class NodeClientCoreSupport {
     SimpleHealingQueue healingQueue =
         new SimpleHealingQueue(
             new InsertContext(
-                0,
-                2,
-                0,
-                0,
-                new SimpleEventProducer(),
-                false,
-                Node.FORK_ON_CACHEABLE_DEFAULT,
-                false,
-                Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-                0,
-                0,
-                InsertContext.CompatibilityMode.COMPAT_DEFAULT),
+                InsertContextOptions.builder()
+                    .retryLimits(0, 2)
+                    .splitfileSegmentLimits(0, 0)
+                    .clientOptions(
+                        new SimpleEventProducer(), false, Node.FORK_ON_CACHEABLE_DEFAULT, false)
+                    .compressorDescriptor(Compressor.DEFAULT_COMPRESSORDESCRIPTOR)
+                    .redundancy(0, 0)
+                    .compatibility(InsertContext.CompatibilityMode.COMPAT_DEFAULT)
+                    .build()),
             RequestStarter.PREFETCH_PRIORITY_CLASS,
             maxRunningHealingInserts,
             new HealingDecisionSupplier(node::getLocation, node::isOpennetEnabled));

--- a/src/test/java/network/crypta/client/InsertContextTest.java
+++ b/src/test/java/network/crypta/client/InsertContextTest.java
@@ -49,19 +49,14 @@ class InsertContextTest {
 
   private static InsertContext newContextWithDefaults(CompatibilityMode mode) {
     return new InsertContext(
-        3, // maxRetries
-        2, // rnfsToSuccess
-        128, // splitfileSegmentDataBlocks
-        96, // splitfileSegmentCheckBlocks
-        new SimpleEventProducer(), // eventProducer
-        true, // canWriteClientCache
-        true, // forkOnCacheable
-        false, // localRequestOnly
-        "GZIP", // compressorDescriptor
-        1, // extraInsertsSingleBlock
-        2, // extraInsertsSplitfileHeaderBlock
-        mode // compatibilityMode
-        );
+        InsertContextOptions.builder()
+            .retryLimits(3, 2)
+            .splitfileSegmentLimits(128, 96)
+            .clientOptions(new SimpleEventProducer(), true, true, false)
+            .compressorDescriptor("GZIP")
+            .redundancy(1, 2)
+            .compatibility(mode)
+            .build());
   }
 
   @Test
@@ -82,18 +77,14 @@ class InsertContextTest {
     // Act
     InsertContext ctx =
         new InsertContext(
-            maxRetries,
-            rnfsToSuccess,
-            dataBlocks,
-            checkBlocks,
-            mockProducer,
-            canWriteClientCache,
-            forkOnCacheable,
-            localRequestOnly,
-            descriptor,
-            extraSingle,
-            extraHeader,
-            mode);
+            InsertContextOptions.builder()
+                .retryLimits(maxRetries, rnfsToSuccess)
+                .splitfileSegmentLimits(dataBlocks, checkBlocks)
+                .clientOptions(mockProducer, canWriteClientCache, forkOnCacheable, localRequestOnly)
+                .compressorDescriptor(descriptor)
+                .redundancy(extraSingle, extraHeader)
+                .compatibility(mode)
+                .build());
 
     // Assert
     assertFalse(ctx.isDontCompress());

--- a/src/test/java/network/crypta/client/async/BinaryBlobInserterTest.java
+++ b/src/test/java/network/crypta/client/async/BinaryBlobInserterTest.java
@@ -13,6 +13,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.events.SimpleEventProducer;
@@ -74,18 +75,14 @@ class BinaryBlobInserterTest {
 
   private static InsertContext newInsertCtx(int maxRetries, int rnfsToSuccess) {
     return new InsertContext(
-        maxRetries,
-        rnfsToSuccess,
-        128,
-        128,
-        new SimpleEventProducer(),
-        true,
-        false,
-        false,
-        null,
-        0,
-        0,
-        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(maxRetries, rnfsToSuccess)
+            .splitfileSegmentLimits(128, 128)
+            .clientOptions(new SimpleEventProducer(), true, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -20,6 +20,7 @@ import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
@@ -109,18 +110,14 @@ class ClientContextTest {
 
     defaultInsertCtx =
         new InsertContext(
-            1, // maxRetries
-            0, // rnfsToSuccess
-            16, // data blocks per segment
-            16, // check blocks per segment
-            new SimpleEventProducer(),
-            true, // canWriteClientCache
-            false, // forkOnCacheable
-            false, // localRequestOnly
-            null, // compressorDescriptor
-            0, // extra inserts single block
-            0, // extra inserts for splitfile header
-            CompatibilityMode.COMPAT_CURRENT);
+            InsertContextOptions.builder()
+                .retryLimits(1, 0)
+                .splitfileSegmentLimits(16, 16)
+                .clientOptions(new SimpleEventProducer(), true, false, false)
+                .compressorDescriptor(null)
+                .redundancy(0, 0)
+                .compatibility(CompatibilityMode.COMPAT_CURRENT)
+                .build());
 
     Config config = new Config();
 

--- a/src/test/java/network/crypta/client/async/ClientGetterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientGetterTest.java
@@ -32,6 +32,7 @@ import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchResult;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.PersistentRequestRoot;
@@ -263,18 +264,14 @@ class ClientGetterTest {
 
   private static InsertContext newInsertContext() {
     return new InsertContext(
-        0,
-        0,
-        0,
-        0,
-        new SimpleEventProducer(),
-        true,
-        false,
-        false,
-        null,
-        0,
-        0,
-        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(0, 0)
+            .splitfileSegmentLimits(0, 0)
+            .clientOptions(new SimpleEventProducer(), true, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   @Mock private ClientGetCallback callback;

--- a/src/test/java/network/crypta/client/async/ClientPutterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientPutterTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Field;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.events.SimpleEventProducer;
@@ -49,18 +50,14 @@ class ClientPutterTest {
 
   private static InsertContext newInsertContext(CompatibilityMode mode) {
     return new InsertContext(
-        /*maxRetries*/ 1,
-        /*rnfsToSuccess*/ 0,
-        /*segmentData*/ 128,
-        /*segmentCheck*/ 128,
-        new SimpleEventProducer(),
-        /*canWriteClientCache*/ false,
-        /*forkOnCacheable*/ false,
-        /*localRequestOnly*/ false,
-        /*compressorDescriptor*/ null,
-        /*extraInsertsSingleBlock*/ 0,
-        /*extraInsertsSplitfileHeaderBlock*/ 0,
-        mode);
+        InsertContextOptions.builder()
+            .retryLimits(1, 0)
+            .splitfileSegmentLimits(128, 128)
+            .clientOptions(new SimpleEventProducer(), false, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(mode)
+            .build());
   }
 
   @BeforeEach

--- a/src/test/java/network/crypta/client/async/ContainerInserterTest.java
+++ b/src/test/java/network/crypta/client/async/ContainerInserterTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.Metadata;
 import network.crypta.client.Metadata.DocumentType;
@@ -279,18 +280,14 @@ class ContainerInserterTest {
 
   private static InsertContext newInsertContext() {
     return new InsertContext(
-        0,
-        0,
-        0,
-        0,
-        new SimpleEventProducer(),
-        true,
-        false,
-        false,
-        null,
-        0,
-        0,
-        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(0, 0)
+            .splitfileSegmentLimits(0, 0)
+            .clientOptions(new SimpleEventProducer(), true, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   @Mock private PutCompletionCallback callback;

--- a/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.Metadata;
 import network.crypta.client.Metadata.DocumentType;
 import network.crypta.client.NullClientCallback;
@@ -38,18 +39,14 @@ class DefaultManifestPutterTest {
 
   private static InsertContext newInsertContextCurrent() {
     return new InsertContext(
-        /*maxRetries*/ 1,
-        /*rnfsToSuccess*/ 0,
-        /*segmentData*/ 128,
-        /*segmentCheck*/ 128,
-        new SimpleEventProducer(),
-        /*canWriteClientCache*/ false,
-        /*forkOnCacheable*/ false,
-        /*localRequestOnly*/ false,
-        /*compressorDescriptor*/ null,
-        /*extraInsertsSingleBlock*/ 0,
-        /*extraInsertsSplitfileHeaderBlock*/ 0,
-        network.crypta.client.InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(1, 0)
+            .splitfileSegmentLimits(128, 128)
+            .clientOptions(new SimpleEventProducer(), false, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(network.crypta.client.InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   // Helper to create a bucket with a specific size

--- a/src/test/java/network/crypta/client/async/InsertCompressorTest.java
+++ b/src/test/java/network/crypta/client/async/InsertCompressorTest.java
@@ -16,6 +16,7 @@ import java.util.Random;
 import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertBlock;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.events.SimpleEventProducer;
@@ -176,35 +177,27 @@ class InsertCompressorTest {
                 .build()),
         /*defaultPersistentInsertContext*/
         new InsertContext(
-            0,
-            0,
-            128,
-            128,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT),
+            InsertContextOptions.builder()
+                .retryLimits(0, 0)
+                .splitfileSegmentLimits(128, 128)
+                .clientOptions(new SimpleEventProducer(), false, false, false)
+                .compressorDescriptor(Compressor.DEFAULT_COMPRESSORDESCRIPTOR)
+                .redundancy(0, 0)
+                .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+                .build()),
         /*config*/ config);
   }
 
   private static InsertContext makeInsertCtx(String compressorDescriptor) {
     return new InsertContext(
-        0,
-        0,
-        128,
-        128,
-        new SimpleEventProducer(),
-        false,
-        false,
-        false,
-        compressorDescriptor,
-        0,
-        0,
-        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(0, 0)
+            .splitfileSegmentLimits(128, 128)
+            .clientOptions(new SimpleEventProducer(), false, false, false)
+            .compressorDescriptor(compressorDescriptor)
+            .redundancy(0, 0)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   private static RandomAccessBucket makeData(byte[] bytes) throws IOException {

--- a/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import java.io.OutputStream;
 import java.util.HashMap;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.NullClientCallback;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.keys.FreenetURI;
@@ -35,18 +36,14 @@ class PlainManifestPutterTest {
 
   private static InsertContext newInsertContextCurrent() {
     return new InsertContext(
-        /*maxRetries*/ 1,
-        /*rnfsToSuccess*/ 0,
-        /*segmentData*/ 128,
-        /*segmentCheck*/ 128,
-        new SimpleEventProducer(),
-        /*canWriteClientCache*/ false,
-        /*forkOnCacheable*/ false,
-        /*localRequestOnly*/ false,
-        /*compressorDescriptor*/ null,
-        /*extraInsertsSingleBlock*/ 0,
-        /*extraInsertsSplitfileHeaderBlock*/ 0,
-        network.crypta.client.InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(1, 0)
+            .splitfileSegmentLimits(128, 128)
+            .clientOptions(new SimpleEventProducer(), false, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(network.crypta.client.InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   // Helper to create a bucket with a specific size

--- a/src/test/java/network/crypta/client/async/SimpleHealingQueueTest.java
+++ b/src/test/java/network/crypta/client/async/SimpleHealingQueueTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.Random;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.crypt.DummyRandomSource;
@@ -38,18 +39,14 @@ class SimpleHealingQueueTest {
   void setUp() {
     insertCtx =
         new InsertContext(
-            /*maxRetries*/ 0,
-            /*rnfsToSuccess*/ 1,
-            /*splitfileSegmentDataBlocks*/ 1,
-            /*splitfileSegmentCheckBlocks*/ 1,
-            /*eventProducer*/ new SimpleEventProducer(),
-            /*canWriteClientCache*/ false,
-            /*forkOnCacheable*/ false,
-            /*localRequestOnly*/ false,
-            /*compressorDescriptor*/ null,
-            /*extraInsertsSingleBlock*/ 0,
-            /*extraInsertsSplitfileHeaderBlock*/ 0,
-            /*compat*/ CompatibilityMode.COMPAT_CURRENT);
+            InsertContextOptions.builder()
+                .retryLimits(0, 1)
+                .splitfileSegmentLimits(1, 1)
+                .clientOptions(new SimpleEventProducer(), false, false, false)
+                .compressorDescriptor(null)
+                .redundancy(0, 0)
+                .compatibility(CompatibilityMode.COMPAT_CURRENT)
+                .build());
     insertCtx.setGetCHKOnly(true); // make SingleBlockInserter.schedule() complete synchronously
 
     // Minimal, deterministic ClientContext

--- a/src/test/java/network/crypta/client/async/SingleBlockInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SingleBlockInserterTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.Random;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.crypt.DummyRandomSource;
@@ -54,18 +55,14 @@ class SingleBlockInserterTest {
   void setUp() {
     insertCtx =
         new InsertContext(
-            /*maxRetries*/ 5,
-            /*rnfsToSuccess*/ 2,
-            /*splitfileSegmentDataBlocks*/ 1,
-            /*splitfileSegmentCheckBlocks*/ 1,
-            /*eventProducer*/ new SimpleEventProducer(),
-            /*canWriteClientCache*/ true,
-            /*forkOnCacheable*/ true,
-            /*localRequestOnly*/ false,
-            /*compressorDescriptor*/ null,
-            /*extraInsertsSingleBlock*/ 0,
-            /*extraInsertsSplitfileHeaderBlock*/ 0,
-            /*compat*/ CompatibilityMode.COMPAT_CURRENT);
+            InsertContextOptions.builder()
+                .retryLimits(5, 2)
+                .splitfileSegmentLimits(1, 1)
+                .clientOptions(new SimpleEventProducer(), true, true, false)
+                .compressorDescriptor(null)
+                .redundancy(0, 0)
+                .compatibility(CompatibilityMode.COMPAT_CURRENT)
+                .build());
     bucket = mock(Bucket.class);
 
     // Reasonable parent defaults used by callbacks (lenient to avoid strict stubbing violations)

--- a/src/test/java/network/crypta/client/async/SingleFileInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SingleFileInserterTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import java.io.OutputStream;
 import network.crypta.client.InsertBlock;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.events.ClientEventProducer;
 import network.crypta.client.events.SimpleEventProducer;
@@ -80,18 +81,14 @@ class SingleFileInserterTest {
     inlineExecutor = new InlineExecutor();
     insertCtx =
         new InsertContext(
-            0,
-            0,
-            128,
-            128,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+            InsertContextOptions.builder()
+                .retryLimits(0, 0)
+                .splitfileSegmentLimits(128, 128)
+                .clientOptions(new SimpleEventProducer(), false, false, false)
+                .compressorDescriptor(Compressor.DEFAULT_COMPRESSORDESCRIPTOR)
+                .redundancy(0, 0)
+                .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+                .build());
   }
 
   // Helper for constructing a SingleFileInserter instance used by the
@@ -286,18 +283,14 @@ class SingleFileInserterTest {
     ClientEventProducer producer = mock(ClientEventProducer.class);
     insertCtx =
         new InsertContext(
-            0,
-            0,
-            128,
-            128,
-            producer,
-            false,
-            false,
-            false,
-            Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+            InsertContextOptions.builder()
+                .retryLimits(0, 0)
+                .splitfileSegmentLimits(128, 128)
+                .clientOptions(producer, false, false, false)
+                .compressorDescriptor(Compressor.DEFAULT_COMPRESSORDESCRIPTOR)
+                .redundancy(0, 0)
+                .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+                .build());
 
     SingleFileInserter sfi = buildSfiForStartCompression(parentAndCb, sameCb, insertCtx);
 

--- a/src/test/java/network/crypta/client/async/SplitFileInserterSenderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterSenderTest.java
@@ -16,8 +16,10 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.SplitFileInserterSegmentStorage.BlockInsert;
+import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.ClientCHK;
 import network.crypta.keys.ClientCHKBlock;
@@ -49,18 +51,14 @@ class SplitFileInserterSenderTest {
   void setup() throws Exception {
     insertCtx =
         new InsertContext(
-            /*maxRetries*/ 1,
-            /*rnfsToSuccess*/ 0,
-            /*splitfileSegmentDataBlocks*/ 128,
-            /*splitfileSegmentCheckBlocks*/ 128,
-            /*eventProducer*/ new network.crypta.client.events.SimpleEventProducer(),
-            /*canWriteClientCache*/ true,
-            /*forkOnCacheable*/ true,
-            /*localRequestOnly*/ false,
-            /*compressorDescriptor*/ null,
-            /*extraInsertsSingleBlock*/ 0,
-            /*extraInsertsSplitfileHeaderBlock*/ 0,
-            /*compatibilityMode*/ InsertContext.CompatibilityMode.COMPAT_CURRENT);
+            InsertContextOptions.builder()
+                .retryLimits(1, 0)
+                .splitfileSegmentLimits(128, 128)
+                .clientOptions(new SimpleEventProducer(), true, true, false)
+                .compressorDescriptor(null)
+                .redundancy(0, 0)
+                .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+                .build());
     // Default flags; individual tests may override
     insertCtx.setCanWriteClientCache(true);
     insertCtx.setLocalRequestOnly(false);

--- a/src/test/java/network/crypta/client/async/SplitFileInserterStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterStorageTest.java
@@ -16,9 +16,11 @@ import java.util.Random;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FECCodec;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.Metadata.SplitfileAlgorithm;
+import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.CHKBlock;
 import network.crypta.node.KeysFetchingLocally;
@@ -72,18 +74,15 @@ class SplitFileInserterStorageTest {
     // Keep values small and deterministic. Blocks per segment defaults are in
     // HighLevelSimpleClientImpl.
     return new InsertContext(
-        /* maxRetries= */ 3,
-        /* rnfsToSuccess= */ 0,
-        /* splitfileSegmentDataBlocks= */ FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT,
-        /* splitfileSegmentCheckBlocks= */ FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT,
-        /* eventProducer= */ new network.crypta.client.events.SimpleEventProducer(),
-        /* canWriteClientCache= */ false,
-        /* forkOnCacheable= */ false,
-        /* localRequestOnly= */ false,
-        /* compressorDescriptor= */ null,
-        /* extraInsertsSingleBlock= */ 0,
-        /* extraInsertsSplitfileHeaderBlock= */ 0,
-        cmode);
+        InsertContextOptions.builder()
+            .retryLimits(3, 0)
+            .splitfileSegmentLimits(
+                FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT, FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT)
+            .clientOptions(new SimpleEventProducer(), false, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(cmode)
+            .build());
   }
 
   private SplitFileInserterStorage newStorage(

--- a/src/test/java/network/crypta/client/async/SplitFileInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterTest.java
@@ -16,9 +16,11 @@ import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.Metadata;
+import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.crypt.HashResult;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.RequestClient;
@@ -165,18 +167,14 @@ class SplitFileInserterTest {
     var fetchCtx = Mockito.mock(network.crypta.client.FetchContext.class);
     var insertCtx =
         new InsertContext(
-            0,
-            0,
-            128,
-            128,
-            new network.crypta.client.events.SimpleEventProducer(),
-            true,
-            false,
-            false,
-            null,
-            0,
-            0,
-            CompatibilityMode.COMPAT_CURRENT);
+            InsertContextOptions.builder()
+                .retryLimits(0, 0)
+                .splitfileSegmentLimits(128, 128)
+                .clientOptions(new SimpleEventProducer(), true, false, false)
+                .compressorDescriptor(null)
+                .redundancy(0, 0)
+                .compatibility(CompatibilityMode.COMPAT_CURRENT)
+                .build());
     var config = Mockito.mock(network.crypta.config.Config.class);
 
     ClientContext ctx =
@@ -220,18 +218,14 @@ class SplitFileInserterTest {
 
   private InsertContext newInsertContext() {
     return new InsertContext(
-        0,
-        0,
-        128,
-        128,
-        new network.crypta.client.events.SimpleEventProducer(),
-        true,
-        false,
-        false,
-        null,
-        0,
-        0,
-        CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(0, 0)
+            .splitfileSegmentLimits(128, 128)
+            .clientOptions(new SimpleEventProducer(), true, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   private SplitFileInserter newInserter(

--- a/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
+++ b/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
@@ -24,6 +24,7 @@ import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.PersistentRequestRoot;
@@ -141,18 +142,14 @@ class USKFetcherTagTest {
 
   private static InsertContext newInsertContext() {
     return new InsertContext(
-        0, // maxRetries
-        0, // rnfsToSuccess
-        0, // splitfileSegmentDataBlocks
-        0, // splitfileSegmentCheckBlocks
-        new SimpleEventProducer(),
-        true, // canWriteClientCache
-        false, // forkOnCacheable
-        false, // localRequestOnly
-        null, // compressorDescriptor
-        0, // extraInsertsSingleBlock
-        0, // extraInsertsSplitfileHeaderBlock
-        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(0, 0)
+            .splitfileSegmentLimits(0, 0)
+            .clientOptions(new SimpleEventProducer(), true, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   private static ClientContext minimalContext(

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -18,6 +18,7 @@ import java.security.SecureRandom;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.events.SimpleEventProducer;
@@ -169,24 +170,24 @@ class USKInserterTest {
                     .clientOptions(new SimpleEventProducer(), false, false)
                     .filterOverrides(null, null, null)
                     .build()),
-            new InsertContext(
-                0,
-                0,
-                0,
-                0,
-                new SimpleEventProducer(),
-                false,
-                false,
-                false,
-                null,
-                0,
-                0,
-                InsertContext.CompatibilityMode.COMPAT_CURRENT),
+            newInsertContext(),
             null // Config
             );
   }
 
   // Helpers in tests create per-test SSKs to build consistent public/insertable USK URIs.
+
+  private static InsertContext newInsertContext() {
+    return new InsertContext(
+        InsertContextOptions.builder()
+            .retryLimits(0, 0)
+            .splitfileSegmentLimits(0, 0)
+            .clientOptions(new SimpleEventProducer(), false, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
+  }
 
   private static Bucket makeBucket(byte[] data) {
     // Minimal bucket backed by provided bytes; supports read and free().
@@ -312,20 +313,7 @@ class USKInserterTest {
     byte[] bytes = "data".getBytes(StandardCharsets.UTF_8);
     Bucket bucket = makeBucket(bytes);
 
-    InsertContext ic =
-        new InsertContext(
-            0,
-            0,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            null,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    InsertContext ic = newInsertContext();
     ic.setIgnoreUSKDatehints(false);
 
     when(uskManager.getFetcherForInsertDontSchedule(
@@ -378,20 +366,7 @@ class USKInserterTest {
                 ssk.getURI().getExtra(),
                 edition));
 
-    InsertContext ic =
-        new InsertContext(
-            0,
-            0,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            null,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    InsertContext ic = newInsertContext();
     ic.setIgnoreUSKDatehints(true); // skip USK date hints path for determinism
 
     USKInserter inserter =
@@ -430,20 +405,7 @@ class USKInserterTest {
             ssk.getInsertURI().getExtra(),
             edition);
 
-    InsertContext ic =
-        new InsertContext(
-            0,
-            0,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            null,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    InsertContext ic = newInsertContext();
     ic.setIgnoreUSKDatehints(true); // deterministic: avoid date hints branch
 
     USKInserter inserter =
@@ -494,20 +456,7 @@ class USKInserterTest {
             ssk.getInsertURI().getExtra(),
             edition);
 
-    InsertContext ic =
-        new InsertContext(
-            0,
-            0,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            null,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    InsertContext ic = newInsertContext();
 
     USKInserter inserter =
         newInserter(
@@ -552,20 +501,7 @@ class USKInserterTest {
             ssk.getInsertURI().getCryptoKey(),
             ssk.getInsertURI().getExtra(),
             edition);
-    InsertContext ic =
-        new InsertContext(
-            0,
-            0,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            null,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    InsertContext ic = newInsertContext();
     USKInserter inserter;
     try {
       inserter =
@@ -601,20 +537,7 @@ class USKInserterTest {
             ssk.getInsertURI().getCryptoKey(),
             ssk.getInsertURI().getExtra(),
             edition);
-    InsertContext ic =
-        new InsertContext(
-            0,
-            0,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            null,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    InsertContext ic = newInsertContext();
     Bucket data = makeBucket("t".getBytes(StandardCharsets.UTF_8));
     doReturn((short) 42).when(parent).getPriorityClass();
 
@@ -661,20 +584,7 @@ class USKInserterTest {
             ssk2.getInsertURI().getCryptoKey(),
             ssk2.getInsertURI().getExtra(),
             edition2);
-    InsertContext ic =
-        new InsertContext(
-            0,
-            0,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            null,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    InsertContext ic = newInsertContext();
 
     USKInserter inserter =
         newInserter(
@@ -719,20 +629,7 @@ class USKInserterTest {
             ssk3.getInsertURI().getCryptoKey(),
             ssk3.getInsertURI().getExtra(),
             edition3);
-    InsertContext ic =
-        new InsertContext(
-            0,
-            0,
-            0,
-            0,
-            new SimpleEventProducer(),
-            false,
-            false,
-            false,
-            null,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    InsertContext ic = newInsertContext();
 
     USKInserter inserter =
         newInserter(

--- a/src/test/java/network/crypta/client/async/USKRetrieverTest.java
+++ b/src/test/java/network/crypta/client/async/USKRetrieverTest.java
@@ -27,6 +27,7 @@ import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchResult;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.PersistentRequestRoot;
@@ -146,18 +147,14 @@ class USKRetrieverTest {
 
   private static InsertContext newInsertContext() {
     return new InsertContext(
-        0, // maxRetries
-        0, // rnfsToSuccess
-        0, // splitfileSegmentDataBlocks
-        0, // splitfileSegmentCheckBlocks
-        new SimpleEventProducer(),
-        true, // canWriteClientCache
-        false, // forkOnCacheable
-        false, // localRequestOnly
-        null, // compressorDescriptor
-        0, // extraInsertsSingleBlock
-        0, // extraInsertsSplitfileHeaderBlock
-        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(0, 0)
+            .splitfileSegmentLimits(0, 0)
+            .clientOptions(new SimpleEventProducer(), true, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   private static ClientContext minimalContext(

--- a/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
+++ b/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
@@ -14,6 +14,7 @@ import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.PersistentRequestRoot;
@@ -144,18 +145,14 @@ class USKSparseProxyCallbackTest {
 
   private static InsertContext newInsertContext() {
     return new InsertContext(
-        0, // maxRetries
-        0, // rnfsToSuccess
-        0, // splitfileSegmentDataBlocks
-        0, // splitfileSegmentCheckBlocks
-        new SimpleEventProducer(),
-        true, // canWriteClientCache
-        false, // forkOnCacheable
-        false, // localRequestOnly
-        null, // compressorDescriptor
-        0, // extraInsertsSingleBlock
-        0, // extraInsertsSplitfileHeaderBlock
-        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        InsertContextOptions.builder()
+            .retryLimits(0, 0)
+            .splitfileSegmentLimits(0, 0)
+            .clientOptions(new SimpleEventProducer(), true, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
   }
 
   private static ClientContext minimalContext(

--- a/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Field;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.async.ClientContext;
@@ -48,18 +49,14 @@ class ClientPutTest {
     clientPut = new ClientPut();
     insertContext =
         new InsertContext(
-            1,
-            0,
-            1,
-            1,
-            new SimpleEventProducer(),
-            true,
-            false,
-            false,
-            null,
-            0,
-            0,
-            CompatibilityMode.COMPAT_CURRENT);
+            InsertContextOptions.builder()
+                .retryLimits(1, 0)
+                .splitfileSegmentLimits(1, 1)
+                .clientOptions(new SimpleEventProducer(), true, false, false)
+                .compressorDescriptor(null)
+                .redundancy(0, 0)
+                .compatibility(CompatibilityMode.COMPAT_CURRENT)
+                .build());
     setField(ClientPutBase.class, clientPut, "ctx", insertContext);
     setField(ClientPut.class, clientPut, "clientMetadata", new ClientMetadata("text/plain"));
     setField(ClientRequest.class, clientPut, "identifier", "test-id");

--- a/src/test/java/network/crypta/node/NodeARKInserterTest.java
+++ b/src/test/java/network/crypta/node/NodeARKInserterTest.java
@@ -15,11 +15,13 @@ import static org.mockito.Mockito.when;
 
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.async.BaseClientPutter;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientPutter;
+import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.io.comm.Peer;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
@@ -94,18 +96,14 @@ class NodeARKInserterTest {
     // Default: provide an InsertContext so ClientPutter constructor receives a non-null ctx
     InsertContext ctx =
         new InsertContext(
-            1,
-            1,
-            1,
-            1,
-            new network.crypta.client.events.SimpleEventProducer(),
-            true,
-            false,
-            false,
-            null,
-            0,
-            0,
-            InsertContext.CompatibilityMode.COMPAT_DEFAULT);
+            InsertContextOptions.builder()
+                .retryLimits(1, 1)
+                .splitfileSegmentLimits(1, 1)
+                .clientOptions(new SimpleEventProducer(), true, false, false)
+                .compressorDescriptor(null)
+                .redundancy(0, 0)
+                .compatibility(InsertContext.CompatibilityMode.COMPAT_DEFAULT)
+                .build());
     org.mockito.Mockito.lenient().when(core.makeClient((short) 0, true, false)).thenReturn(hlsc);
     org.mockito.Mockito.lenient().when(hlsc.getInsertContext(true)).thenReturn(ctx);
 


### PR DESCRIPTION
## Summary
- add InsertContextOptions builder with sensible defaults
- update InsertContext construction call sites to use options
- remove the long-parameter InsertContext constructor

## Testing
- `./gradlew --parallel test`