### PR TITLE
refactor(client): consolidate chosen block params

### DIFF
--- a/src/main/java/network/crypta/client/async/ChosenBlockImpl.java
+++ b/src/main/java/network/crypta/client/async/ChosenBlockImpl.java
@@ -1,7 +1,6 @@
 package network.crypta.client.async;
 
 import network.crypta.keys.ClientKey;
-import network.crypta.keys.Key;
 import network.crypta.node.LowLevelGetException;
 import network.crypta.node.LowLevelPutException;
 import network.crypta.node.RequestScheduler;
@@ -71,20 +70,10 @@ public class ChosenBlockImpl extends ChosenBlock {
    *     success or failure.
    * @param token the scheduling token for the sub-request within the larger operation; not {@code
    *     null}.
-   * @param key the low-level key to fetch/insert; may be {@code null} for request types that do not
-   *     operate on a raw key.
-   * @param ckey the client-layer key associated with this operation; may be {@code null} when not
-   *     applicable.
-   * @param localRequestOnly when {@code true}, perform work using only local resources; do not
-   *     contact peers.
-   * @param ignoreStore when {@code true}, bypass normal on-disk store lookups for reads where
-   *     supported.
-   * @param canWriteClientCache when {@code true}, allow writing client-level caches when the result
-   *     is cacheable.
-   * @param forkOnCacheable when {@code true}, permit sender/scheduler to fork on cacheable results
-   *     to improve throughput.
-   * @param realTimeFlag when {@code true}, mark work as real-time to prefer lower-latency
-   *     strategies where possible.
+   * @param keys the resolved node and client keys for the chosen token; must not be {@code null},
+   *     though individual values may be {@code null} depending on request type.
+   * @param options execution flags controlling local-only behavior, store reads, cache writes, and
+   *     real-time hints; not {@code null}.
    * @param sched the {@link RequestScheduler} coordinating this block; not {@code null}.
    * @param persistent {@code true} for persistent requests queued on the persistent runner;
    *     otherwise use the transient runner.
@@ -92,21 +81,11 @@ public class ChosenBlockImpl extends ChosenBlock {
   public ChosenBlockImpl(
       SendableRequest req,
       SendableRequestItem token,
-      Key key,
-      ClientKey ckey,
-      boolean localRequestOnly,
-      boolean ignoreStore,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      boolean realTimeFlag,
+      KeyAndClientKey keys,
+      Options options,
       RequestScheduler sched,
       boolean persistent) {
-    super(
-        token,
-        key,
-        ckey,
-        new Options(
-            localRequestOnly, ignoreStore, canWriteClientCache, forkOnCacheable, realTimeFlag));
+    super(token, keys.key(), keys.ckey(), options);
     this.request = req;
     this.sched = sched;
     this.persistent = persistent;
@@ -239,7 +218,7 @@ public class ChosenBlockImpl extends ChosenBlock {
     context
         .getJobRunner(persistent)
         .queueNormalOrDrop(
-            context1 -> {
+            _ -> {
               try {
                 sched.succeeded((SendableGet) request, false);
               } finally {

--- a/src/main/java/network/crypta/client/async/ClientRequestSelector.java
+++ b/src/main/java/network/crypta/client/async/ClientRequestSelector.java
@@ -301,20 +301,8 @@ public class ClientRequestSelector implements KeysFetchingLocally {
     }
 
     KeyAndClientKey keys = resolveKeys(req, token);
-    RequestFlags flags = resolveRequestFlags(req);
-    ChosenBlock ret =
-        new ChosenBlockImpl(
-            req,
-            token,
-            keys.key,
-            keys.ckey,
-            flags.localRequestOnly,
-            flags.ignoreStore,
-            flags.canWriteClientCache,
-            flags.forkOnCacheable,
-            flags.realTimeFlag,
-            sched,
-            req.persistent());
+    ChosenBlock.Options options = resolveRequestOptions(req);
+    ChosenBlock ret = new ChosenBlockImpl(req, token, keys, options, sched, req.persistent());
     if (LOG.isDebugEnabled()) LOG.debug("Created {}" + FOR + "{}", ret, req);
     return ret;
   }
@@ -344,47 +332,27 @@ public class ClientRequestSelector implements KeysFetchingLocally {
     return new KeyAndClientKey(key, ckey);
   }
 
-  private RequestFlags resolveRequestFlags(SendableRequest req) {
+  private ChosenBlock.Options resolveRequestOptions(SendableRequest req) {
     return switch (req) {
       case SendableGet sg -> {
-        RequestFlags f = new RequestFlags();
         FetchContext ctx = sg.getContext();
-        f.localRequestOnly = ctx.getLocalRequestOnly();
-        f.ignoreStore = ctx.getIgnoreStore();
-        f.canWriteClientCache = ctx.getCanWriteClientCache();
-        f.realTimeFlag = sg.realTimeFlag();
-        f.forkOnCacheable = false;
-        yield f;
+        yield new ChosenBlock.Options(
+            ctx.getLocalRequestOnly(),
+            ctx.getIgnoreStore(),
+            ctx.getCanWriteClientCache(),
+            false,
+            sg.realTimeFlag());
       }
-      case SendableInsert insert -> {
-        RequestFlags f = new RequestFlags();
-        f.localRequestOnly = insert.localRequestOnly();
-        f.ignoreStore = false;
-        f.canWriteClientCache = insert.canWriteClientCache();
-        f.forkOnCacheable = insert.forkOnCacheable();
-        f.realTimeFlag = req.realTimeFlag();
-        yield f;
-      }
-      default -> {
-        RequestFlags f = new RequestFlags();
-        f.localRequestOnly = false;
-        f.ignoreStore = false;
-        f.canWriteClientCache = false;
-        f.forkOnCacheable = Node.FORK_ON_CACHEABLE_DEFAULT;
-        f.realTimeFlag = false;
-        yield f;
-      }
+      case SendableInsert insert ->
+          new ChosenBlock.Options(
+              insert.localRequestOnly(),
+              false,
+              insert.canWriteClientCache(),
+              insert.forkOnCacheable(),
+              req.realTimeFlag());
+      default ->
+          new ChosenBlock.Options(false, false, false, Node.FORK_ON_CACHEABLE_DEFAULT, false);
     };
-  }
-
-  private record KeyAndClientKey(Key key, ClientKey ckey) {}
-
-  private static final class RequestFlags {
-    boolean localRequestOnly;
-    boolean ignoreStore;
-    boolean canWriteClientCache;
-    boolean forkOnCacheable;
-    boolean realTimeFlag;
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/KeyAndClientKey.java
+++ b/src/main/java/network/crypta/client/async/KeyAndClientKey.java
@@ -1,0 +1,15 @@
+package network.crypta.client.async;
+
+import network.crypta.keys.ClientKey;
+import network.crypta.keys.Key;
+
+/**
+ * Bundles a resolved node {@link Key} and its optional {@link ClientKey} counterpart.
+ *
+ * <p>Either component may be {@code null} depending on the request type (for example, insert
+ * requests do not necessarily operate on a pre-existing node key).
+ *
+ * @param key the resolved node-level key; may be {@code null}.
+ * @param ckey the client-layer key associated with the operation; may be {@code null}.
+ */
+public record KeyAndClientKey(Key key, ClientKey ckey) {}

--- a/src/test/java/network/crypta/client/async/ChosenBlockImplTest.java
+++ b/src/test/java/network/crypta/client/async/ChosenBlockImplTest.java
@@ -46,9 +46,7 @@ class ChosenBlockImplTest {
     // Arrange
     SendableRequest req = org.mockito.Mockito.mock(SendableRequest.class);
     when(req.isCancelled()).thenReturn(true);
-    ChosenBlockImpl block =
-        new ChosenBlockImpl(
-            req, token, nodeKey, clientKey, false, false, false, false, false, sched, false);
+    ChosenBlockImpl block = newBlock(req, false, false, false, false, false, false);
 
     // Act + Assert
     Assertions.assertTrue(block.isCancelled());
@@ -58,12 +56,8 @@ class ChosenBlockImplTest {
   void isPersistent_whenConstructed_reflectsFlag() {
     SendableRequest req = org.mockito.Mockito.mock(SendableRequest.class);
 
-    ChosenBlockImpl ptrue =
-        new ChosenBlockImpl(
-            req, token, nodeKey, clientKey, false, false, false, false, false, sched, true);
-    ChosenBlockImpl pfalse =
-        new ChosenBlockImpl(
-            req, token, nodeKey, clientKey, false, false, false, false, false, sched, false);
+    ChosenBlockImpl ptrue = newBlock(req, false, false, false, false, false, true);
+    ChosenBlockImpl pfalse = newBlock(req, false, false, false, false, false, false);
 
     Assertions.assertTrue(ptrue.isPersistent());
     Assertions.assertFalse(pfalse.isPersistent());
@@ -73,9 +67,7 @@ class ChosenBlockImplTest {
   void getPriority_whenCalled_delegatesToRequest() {
     SendableRequest req = org.mockito.Mockito.mock(SendableRequest.class);
     when(req.getPriorityClass()).thenReturn((short) 42);
-    ChosenBlockImpl block =
-        new ChosenBlockImpl(
-            req, token, nodeKey, clientKey, false, false, false, false, true, sched, true);
+    ChosenBlockImpl block = newBlock(req, false, false, false, false, true, true);
 
     assertEquals(42, block.getPriority());
   }
@@ -85,9 +77,7 @@ class ChosenBlockImplTest {
     SendableRequest req = org.mockito.Mockito.mock(SendableRequest.class);
     SendableRequestSender sender = org.mockito.Mockito.mock(SendableRequestSender.class);
     when(req.getSender(clientContext)).thenReturn(sender);
-    ChosenBlockImpl block =
-        new ChosenBlockImpl(
-            req, token, nodeKey, clientKey, false, true, false, false, false, sched, false);
+    ChosenBlockImpl block = newBlock(req, false, true, false, false, false, false);
 
     SendableRequestSender got = block.getSender(clientContext);
     assertSame(sender, got);
@@ -101,9 +91,7 @@ class ChosenBlockImplTest {
     when(token.getKey()).thenReturn(tokenKey);
     when(clientContext.getJobRunner(true)).thenReturn(persistentRunner);
 
-    ChosenBlockImpl block =
-        new ChosenBlockImpl(
-            insert, token, nodeKey, clientKey, false, false, false, false, false, sched, true);
+    ChosenBlockImpl block = newBlock(insert, false, false, false, false, false, true);
 
     LowLevelPutException ex = new LowLevelPutException(LowLevelPutException.REJECTED_OVERLOAD);
 
@@ -130,9 +118,7 @@ class ChosenBlockImplTest {
     when(token.getKey()).thenReturn(tokenKey);
     when(clientContext.getJobRunner(true)).thenReturn(persistentRunner);
 
-    ChosenBlockImpl block =
-        new ChosenBlockImpl(
-            insert, token, nodeKey, clientKey, false, false, false, false, true, sched, true);
+    ChosenBlockImpl block = newBlock(insert, false, false, false, false, true, true);
 
     ArgumentCaptor<PersistentJob> captor = ArgumentCaptor.forClass(PersistentJob.class);
 
@@ -156,9 +142,7 @@ class ChosenBlockImplTest {
     SendableGet get = org.mockito.Mockito.mock(SendableGet.class);
     when(clientContext.getJobRunner(false)).thenReturn(transientRunner);
 
-    ChosenBlockImpl block =
-        new ChosenBlockImpl(
-            get, token, nodeKey, clientKey, true, false, false, false, false, sched, false);
+    ChosenBlockImpl block = newBlock(get, true, false, false, false, false, false);
 
     LowLevelGetException ex = new LowLevelGetException(LowLevelGetException.ROUTE_NOT_FOUND);
 
@@ -184,9 +168,7 @@ class ChosenBlockImplTest {
     SendableGet get = org.mockito.Mockito.mock(SendableGet.class);
     when(clientContext.getJobRunner(false)).thenReturn(transientRunner);
 
-    ChosenBlockImpl block =
-        new ChosenBlockImpl(
-            get, token, nodeKey, clientKey, false, true, false, false, false, sched, false);
+    ChosenBlockImpl block = newBlock(get, false, true, false, false, false, false);
 
     ArgumentCaptor<PersistentJob> captor = ArgumentCaptor.forClass(PersistentJob.class);
 
@@ -210,9 +192,7 @@ class ChosenBlockImplTest {
     SendableGet get = org.mockito.Mockito.mock(SendableGet.class);
     when(clientContext.getJobRunner(false)).thenReturn(transientRunner);
 
-    ChosenBlockImpl block =
-        new ChosenBlockImpl(
-            get, token, nodeKey, clientKey, false, false, false, false, false, sched, false);
+    ChosenBlockImpl block = newBlock(get, false, false, false, false, false, false);
 
     LowLevelGetException ex = new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR, "boom");
 
@@ -240,9 +220,7 @@ class ChosenBlockImplTest {
     when(token.getKey()).thenReturn(tokenKey);
     when(clientContext.getJobRunner(true)).thenReturn(persistentRunner);
 
-    ChosenBlockImpl block =
-        new ChosenBlockImpl(
-            insert, token, nodeKey, clientKey, false, false, false, false, false, sched, true);
+    ChosenBlockImpl block = newBlock(insert, false, false, false, false, false, true);
 
     LowLevelPutException ex = new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
 
@@ -258,5 +236,23 @@ class ChosenBlockImplTest {
     assertThrows(RuntimeException.class, () -> job.run(clientContext));
     verify(sched, times(1)).removeRunningInsert(same(insert), same(tokenKey));
     verify(sched, never()).wakeStarter();
+  }
+
+  private ChosenBlockImpl newBlock(
+      SendableRequest req,
+      boolean localRequestOnly,
+      boolean ignoreStore,
+      boolean canWriteClientCache,
+      boolean forkOnCacheable,
+      boolean realTimeFlag,
+      boolean persistent) {
+    return new ChosenBlockImpl(
+        req,
+        token,
+        new KeyAndClientKey(nodeKey, clientKey),
+        new ChosenBlock.Options(
+            localRequestOnly, ignoreStore, canWriteClientCache, forkOnCacheable, realTimeFlag),
+        sched,
+        persistent);
   }
 }

--- a/src/test/java/network/crypta/client/async/SplitFileInserterSenderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterSenderTest.java
@@ -301,7 +301,12 @@ class SplitFileInserterSenderTest {
     // Build chosen block with localRequestOnly=true
     ChosenBlockImpl chosen =
         new ChosenBlockImpl(
-            sender, token, null, null, true, false, true, false, false, sched, true);
+            sender,
+            token,
+            new KeyAndClientKey(null, null),
+            new ChosenBlock.Options(true, false, true, false, false),
+            sched,
+            true);
 
     // Act
     boolean accepted = chosen.send(core, sched);
@@ -346,7 +351,12 @@ class SplitFileInserterSenderTest {
     // forkOnCacheable=true
     ChosenBlockImpl chosen =
         new ChosenBlockImpl(
-            sender, token, null, null, false, false, false, true, false, sched, true);
+            sender,
+            token,
+            new KeyAndClientKey(null, null),
+            new ChosenBlock.Options(false, false, false, true, false),
+            sched,
+            true);
 
     // Act
     boolean accepted = chosen.send(core, sched);
@@ -394,7 +404,12 @@ class SplitFileInserterSenderTest {
 
     ChosenBlockImpl chosen =
         new ChosenBlockImpl(
-            sender, token, null, null, true, false, true, false, false, sched, true);
+            sender,
+            token,
+            new KeyAndClientKey(null, null),
+            new ChosenBlock.Options(true, false, true, false, false),
+            sched,
+            true);
 
     // Act
     boolean accepted = chosen.send(core, sched);
@@ -428,7 +443,12 @@ class SplitFileInserterSenderTest {
 
     ChosenBlockImpl chosen =
         new ChosenBlockImpl(
-            sender, token, null, null, false, false, false, false, false, sched, true);
+            sender,
+            token,
+            new KeyAndClientKey(null, null),
+            new ChosenBlock.Options(false, false, false, false, false),
+            sched,
+            true);
 
     // Act
     boolean accepted = chosen.send(core, sched);
@@ -462,7 +482,12 @@ class SplitFileInserterSenderTest {
 
     ChosenBlockImpl chosen =
         new ChosenBlockImpl(
-            sender, token, null, null, false, false, false, false, false, sched, true);
+            sender,
+            token,
+            new KeyAndClientKey(null, null),
+            new ChosenBlock.Options(false, false, false, false, false),
+            sched,
+            true);
 
     // Act
     boolean accepted = chosen.send(core, sched);
@@ -495,7 +520,12 @@ class SplitFileInserterSenderTest {
 
     ChosenBlockImpl chosen =
         new ChosenBlockImpl(
-            sender, token, null, null, false, false, false, false, false, sched, true);
+            sender,
+            token,
+            new KeyAndClientKey(null, null),
+            new ChosenBlock.Options(false, false, false, false, false),
+            sched,
+            true);
 
     // Act
     boolean accepted = chosen.send(core, sched);

--- a/src/test/java/network/crypta/node/SimpleSendableInsertTest.java
+++ b/src/test/java/network/crypta/node/SimpleSendableInsertTest.java
@@ -20,9 +20,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import network.crypta.client.async.ChosenBlock;
 import network.crypta.client.async.ChosenBlockImpl;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequestScheduler;
+import network.crypta.client.async.KeyAndClientKey;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.KeyBlock;
 import network.crypta.keys.SSKBlock;
@@ -114,13 +116,13 @@ class SimpleSendableInsertTest {
         new ChosenBlockImpl(
             insert,
             token,
-            null,
-            null,
-            false,
-            false,
-            true, // canWriteClientCache propagated into realPut
-            Node.FORK_ON_CACHEABLE_DEFAULT,
-            false,
+            new KeyAndClientKey(null, null),
+            new ChosenBlock.Options(
+                false,
+                false,
+                true, // canWriteClientCache propagated into realPut
+                Node.FORK_ON_CACHEABLE_DEFAULT,
+                false),
             requestScheduler,
             false);
 
@@ -184,13 +186,8 @@ class SimpleSendableInsertTest {
         new ChosenBlockImpl(
             insert,
             token,
-            null,
-            null,
-            false,
-            false,
-            false,
-            Node.FORK_ON_CACHEABLE_DEFAULT,
-            false,
+            new KeyAndClientKey(null, null),
+            new ChosenBlock.Options(false, false, false, Node.FORK_ON_CACHEABLE_DEFAULT, false),
             requestScheduler,
             false);
 


### PR DESCRIPTION
## Summary
- replace long ChosenBlockImpl parameter list with KeyAndClientKey + ChosenBlock.Options
- reuse options creation in ClientRequestSelector and update tests accordingly

## Testing
- ./gradlew test