### PR TITLE
refactor(client): introduce ClientContext bundles

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientContext.java
+++ b/src/main/java/network/crypta/client/async/ClientContext.java
@@ -161,7 +161,7 @@ public class ClientContext {
 
   /**
    * Used for memory intensive jobs such as in-RAM FEC decodes. Some of these jobs may do disk I/O,
-   * and we don't guarantee to serialise them. The new splitfile code does FEC decode entirely in
+   * and we don't guarantee to serialize them. The new splitfile code does FEC decode entirely in
    * memory, which saves a lot of seeks and improves robustness.
    */
   public final MemoryLimitedJobRunner memoryLimitedJobRunner;
@@ -196,101 +196,48 @@ public class ClientContext {
    *
    * @param bootID Monotonic identifier for this process instance; remains constant until restart
    *     and can be used to disambiguate ephemeral artifacts.
-   * @param jobRunner Runner that serializes persistence-affecting jobs to keep on-disk state
-   *     consistent and allow targeted flushing when required.
-   * @param mainExecutor Main executor for client-layer work that benefits from priority-aware task
-   *     scheduling without blocking persistence operations.
-   * @param archiveManager Manager coordinating archive-related tasks invoked by client operations;
-   *     may be a no-op depending on configuration.
-   * @param ptbf Factory for temporary buckets backed by persistent storage across restarts; used by
-   *     persistent requests.
-   * @param tbf Factory for purely transient temporary buckets; used by short-lived operations.
-   * @param tracker Persistent file tracker that records files created by client requests so they
-   *     can be recovered or cleaned safely.
-   * @param hq Background healing queue for deferred repairs or follow-up work emitted by requests.
-   * @param uskManager Manager for USK coordination and updates required by some client workflows.
-   * @param strongRandom Cryptographically strong random source suitable for keys and protocol
-   *     randomness.
-   * @param fastWeakRandom Non-cryptographic random for jitter/backoff and UI-level randomness; do
-   *     not use for secrets.
-   * @param ticker Lightweight scheduler for timed jobs and delayed execution used by the client.
-   * @param memoryLimitedJobRunner Runner for memory-intensive tasks (e.g., FEC) with resource
-   *     limiting to avoid exhausting available memory.
-   * @param fg Filename generator for transient paths created by client operations.
-   * @param persistentFG Filename generator for persistent on-disk artifacts that must survive
-   *     restarts.
-   * @param rafFactory Factory producing random-access buffers for transient data paths.
-   * @param persistentRAFFactory Factory producing random-access buffers for persistent data paths.
-   * @param fileRAFTransient Random-access file factory for transient files.
-   * @param fileRAFPersistent Random-access file factory for persistent files.
-   * @param rc Compressor implementation used by client code paths when compression is applied.
-   * @param checker Datastore checker utility available to client-layer operations.
-   * @param persistentRoot Persistent request root coordinating durable request state.
-   * @param cryptoSecretTransient Transient master secret used for cryptographic operations this
-   *     run.
-   * @param linkFilterExceptionProvider Provider surfacing link filter exceptions for client code.
-   * @param defaultPersistentFetchContext Template fetch context used when creating persistent fetch
-   *     operations.
-   * @param defaultPersistentInsertContext Template insert context used when creating persistent
-   *     inserts.
-   * @param config Effective configuration backing client-layer decisions and defaults.
+   * @param runtime Runtime executors, schedulers, and randomness sources used by the client layer.
+   * @param storageFactories Storage factories and filename generators for transient and persistent
+   *     artifacts.
+   * @param rafFactories Random-access buffer factories for transient and persistent buffers.
+   * @param services Shared service collaborators such as archive/healing resources and managers.
+   * @param defaults Default fetch/insert contexts and configuration backing client operations.
    */
   public ClientContext(
       long bootID,
-      ClientLayerPersister jobRunner,
-      PriorityAwareExecutor mainExecutor,
-      ArchiveManager archiveManager,
-      PersistentTempBucketFactory ptbf,
-      TempBucketFactory tbf,
-      PersistentFileTracker tracker,
-      HealingQueue hq,
-      USKManager uskManager,
-      RandomSource strongRandom,
-      Random fastWeakRandom,
-      Ticker ticker,
-      MemoryLimitedJobRunner memoryLimitedJobRunner,
-      FilenameGenerator fg,
-      FilenameGenerator persistentFG,
-      LockableRandomAccessBufferFactory rafFactory,
-      LockableRandomAccessBufferFactory persistentRAFFactory,
-      FileRandomAccessBufferFactory fileRAFTransient,
-      FileRandomAccessBufferFactory fileRAFPersistent,
-      RealCompressor rc,
-      DatastoreChecker checker,
-      PersistentRequestRoot persistentRoot,
-      MasterSecret cryptoSecretTransient,
-      LinkFilterExceptionProvider linkFilterExceptionProvider,
-      FetchContext defaultPersistentFetchContext,
-      InsertContext defaultPersistentInsertContext,
-      Config config) {
+      ClientContextRuntime runtime,
+      ClientContextStorageFactories storageFactories,
+      ClientContextRafFactories rafFactories,
+      ClientContextServices services,
+      ClientContextDefaults defaults) {
     this.bootID = bootID;
-    this.jobRunner = jobRunner;
-    this.mainExecutorInternal = mainExecutor;
-    this.random = strongRandom;
-    this.archiveManager = archiveManager;
-    this.persistentBucketFactory = ptbf;
-    this.persistentFileTracker = tracker;
-    this.tempBucketFactory = tbf;
-    this.healingQueue = hq;
-    this.uskManager = uskManager;
-    this.fastWeakRandom = fastWeakRandom;
-    this.ticker = ticker;
-    this.fg = fg;
-    this.persistentFG = persistentFG;
-    this.persistentRAFFactory = persistentRAFFactory;
-    this.fileRAFPersistent = fileRAFPersistent;
-    this.fileRAFTransient = fileRAFTransient;
-    this.rc = rc;
-    this.checker = checker;
-    this.linkFilterExceptionProvider = linkFilterExceptionProvider;
-    this.memoryLimitedJobRunner = memoryLimitedJobRunner;
-    this.tempRAFFactory = rafFactory;
-    this.persistentRoot = persistentRoot;
+    this.jobRunner = runtime.jobRunner();
+    this.mainExecutorInternal = runtime.mainExecutor();
+    this.random = runtime.strongRandom();
+    this.archiveManager = services.resources().archiveManager();
+    this.persistentBucketFactory = storageFactories.persistentBucketFactory();
+    this.persistentFileTracker = storageFactories.persistentFileTracker();
+    this.tempBucketFactory = storageFactories.tempBucketFactory();
+    this.healingQueue = services.resources().healingQueue();
+    this.uskManager = services.uskManager();
+    this.fastWeakRandom = runtime.fastWeakRandom();
+    this.ticker = runtime.ticker();
+    this.fg = storageFactories.filenameGenerator();
+    this.persistentFG = storageFactories.persistentFilenameGenerator();
+    this.persistentRAFFactory = rafFactories.persistentRAFFactory();
+    this.fileRAFPersistent = storageFactories.fileRAFPersistent();
+    this.fileRAFTransient = storageFactories.fileRAFTransient();
+    this.rc = services.compressor();
+    this.checker = services.checker();
+    this.linkFilterExceptionProvider = services.linkFilterExceptionProvider();
+    this.memoryLimitedJobRunner = runtime.memoryLimitedJobRunner();
+    this.tempRAFFactory = rafFactories.tempRAFFactory();
+    this.persistentRoot = services.persistentRoot();
     this.dummyJobRunner = new DummyJobRunner(mainExecutorInternal, this);
-    this.defaultPersistentFetchContext = defaultPersistentFetchContext;
-    this.defaultPersistentInsertContext = defaultPersistentInsertContext;
-    this.cryptoSecretTransient = cryptoSecretTransient;
-    this.config = config;
+    this.defaultPersistentFetchContext = defaults.defaultPersistentFetchContext();
+    this.defaultPersistentInsertContext = defaults.defaultPersistentInsertContext();
+    this.cryptoSecretTransient = runtime.cryptoSecretTransient();
+    this.config = defaults.config();
   }
 
   /**
@@ -419,8 +366,8 @@ public class ClientContext {
    * @param getter The getter to start; must be configured and not already running.
    * @throws FetchException If the request is transient and fails to start due to validation or
    *     immediate setup conditions.
-   * @throws PersistenceDisabledException If persistence would be required but is disabled or
-   *     unavailable at this time.
+   * @throws PersistenceDisabledException If persistence was required but is disabled or unavailable
+   *     at this time.
    */
   public void start(final ClientGetter getter) throws FetchException, PersistenceDisabledException {
     if (getter.persistent()) {
@@ -451,8 +398,8 @@ public class ClientContext {
    * @param inserter The manifest putter to start; must not have been started before.
    * @throws InsertException If the insert is transient and fails to start due to validation or
    *     immediate setup conditions.
-   * @throws PersistenceDisabledException If persistence would be required but is currently disabled
-   *     or locked.
+   * @throws PersistenceDisabledException If persistence was required but is currently disabled or
+   *     locked.
    */
   public void start(final BaseManifestPutter inserter)
       throws InsertException, PersistenceDisabledException {

--- a/src/main/java/network/crypta/client/async/ClientContextDefaults.java
+++ b/src/main/java/network/crypta/client/async/ClientContextDefaults.java
@@ -1,0 +1,17 @@
+package network.crypta.client.async;
+
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
+import network.crypta.config.Config;
+
+/**
+ * Encapsulates default contexts and configuration used by {@link ClientContext}.
+ *
+ * @param defaultPersistentFetchContext template fetch context for persistent requests
+ * @param defaultPersistentInsertContext template insert context for persistent requests
+ * @param config configuration backing client-layer defaults
+ */
+public record ClientContextDefaults(
+    FetchContext defaultPersistentFetchContext,
+    InsertContext defaultPersistentInsertContext,
+    Config config) {}

--- a/src/main/java/network/crypta/client/async/ClientContextRafFactories.java
+++ b/src/main/java/network/crypta/client/async/ClientContextRafFactories.java
@@ -1,0 +1,13 @@
+package network.crypta.client.async;
+
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+
+/**
+ * Holds random-access buffer factories used for transient and persistent client operations.
+ *
+ * @param tempRAFFactory factory for transient random-access buffers
+ * @param persistentRAFFactory factory for persistent random-access buffers
+ */
+public record ClientContextRafFactories(
+    LockableRandomAccessBufferFactory tempRAFFactory,
+    LockableRandomAccessBufferFactory persistentRAFFactory) {}

--- a/src/main/java/network/crypta/client/async/ClientContextRuntime.java
+++ b/src/main/java/network/crypta/client/async/ClientContextRuntime.java
@@ -1,0 +1,32 @@
+package network.crypta.client.async;
+
+import java.util.Random;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.crypt.RandomSource;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+
+/**
+ * Bundles runtime services and random/crypto state needed to execute client operations.
+ *
+ * <p>This record groups the executors, schedulers, and randomness sources that power client-layer
+ * tasks. It keeps high-frequency dependencies together so {@link ClientContext} construction can
+ * stay focused and call sites can reuse a shared parameter object.
+ *
+ * @param jobRunner persistence-aware job runner used for durable work queues
+ * @param mainExecutor priority-aware executor for client-layer scheduling
+ * @param memoryLimitedJobRunner runner for memory-intensive tasks such as in-RAM FEC work
+ * @param ticker time source and scheduler for timed jobs
+ * @param strongRandom cryptographically strong random source for protocol-level randomness
+ * @param fastWeakRandom non-cryptographic random source for jitter and lightweight decisions
+ * @param cryptoSecretTransient transient master secret used for runtime crypto operations
+ */
+public record ClientContextRuntime(
+    ClientLayerPersister jobRunner,
+    PriorityAwareExecutor mainExecutor,
+    MemoryLimitedJobRunner memoryLimitedJobRunner,
+    Ticker ticker,
+    RandomSource strongRandom,
+    Random fastWeakRandom,
+    MasterSecret cryptoSecretTransient) {}

--- a/src/main/java/network/crypta/client/async/ClientContextServices.java
+++ b/src/main/java/network/crypta/client/async/ClientContextServices.java
@@ -1,0 +1,27 @@
+package network.crypta.client.async;
+
+import network.crypta.client.filter.LinkFilterExceptionProvider;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.node.ClientContextResources;
+import network.crypta.support.compress.RealCompressor;
+
+/**
+ * Collects shared services wired into {@link ClientContext} beyond storage and executors.
+ *
+ * <p>This record keeps related service collaborators together, including archive/healing resources
+ * and managers that are consulted by client operations.
+ *
+ * @param resources archive manager and healing queue bundle
+ * @param uskManager manager for USK coordination and updates
+ * @param compressor compressor implementation used in client pipelines
+ * @param checker datastore checker used for verification work
+ * @param persistentRoot persistent request root for durable request coordination
+ * @param linkFilterExceptionProvider provider for link filter exceptions
+ */
+public record ClientContextServices(
+    ClientContextResources resources,
+    USKManager uskManager,
+    RealCompressor compressor,
+    DatastoreChecker checker,
+    PersistentRequestRoot persistentRoot,
+    LinkFilterExceptionProvider linkFilterExceptionProvider) {}

--- a/src/main/java/network/crypta/client/async/ClientContextStorageFactories.java
+++ b/src/main/java/network/crypta/client/async/ClientContextStorageFactories.java
@@ -1,0 +1,31 @@
+package network.crypta.client.async;
+
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
+
+/**
+ * Groups storage-related factories and filename generators used by {@link ClientContext}.
+ *
+ * <p>The factories in this record create temporary buckets and file-backed buffers for both
+ * transient and persistent operations. The filename generators are used to derive unique names for
+ * files created by client requests.
+ *
+ * @param persistentBucketFactory factory for persistent temporary buckets
+ * @param tempBucketFactory factory for transient temporary buckets
+ * @param persistentFileTracker tracker for persistent files created by client requests
+ * @param filenameGenerator generator for transient filenames
+ * @param persistentFilenameGenerator generator for persistent filenames
+ * @param fileRAFTransient file factory for transient random-access buffers
+ * @param fileRAFPersistent file factory for persistent random-access buffers
+ */
+public record ClientContextStorageFactories(
+    PersistentTempBucketFactory persistentBucketFactory,
+    TempBucketFactory tempBucketFactory,
+    PersistentFileTracker persistentFileTracker,
+    FilenameGenerator filenameGenerator,
+    FilenameGenerator persistentFilenameGenerator,
+    FileRandomAccessBufferFactory fileRAFTransient,
+    FileRandomAccessBufferFactory fileRAFPersistent) {}

--- a/src/main/java/network/crypta/node/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/node/NodeClientPersistence.java
@@ -6,6 +6,11 @@ import java.util.Random;
 import network.crypta.client.FetchContext;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.USKManager;
@@ -340,34 +345,33 @@ public final class NodeClientPersistence {
       FetchContext defaultFetchContext,
       InsertContext defaultInsertContext) {
     DiskSpaceCheckingRandomAccessBufferFactory checker = requireDiskChecker();
+    ClientContextRuntime runtime =
+        new ClientContextRuntime(
+            clientLayerPersister,
+            executor,
+            memoryLimitedJobRunner,
+            ticker,
+            random,
+            fastWeakRandom,
+            cryptoSecretTransient);
+    ClientContextStorageFactories storageFactories =
+        new ClientContextStorageFactories(
+            persistentTempBucketFactory,
+            tempBucketFactory,
+            persistentTempBucketFactory,
+            tempFilenameGenerator,
+            persistentFilenameGenerator,
+            fileRafTransient,
+            checker);
+    ClientContextRafFactories rafFactories =
+        new ClientContextRafFactories(tempRafFactory, persistentRafFactory);
+    ClientContextServices services =
+        new ClientContextServices(
+            resources, uskManager, compressor, storeChecker, persistentRoot, init.toadlets());
+    ClientContextDefaults defaults =
+        new ClientContextDefaults(defaultFetchContext, defaultInsertContext, init.config());
     return new ClientContext(
-        node.getBootId(),
-        clientLayerPersister,
-        executor,
-        resources.getArchiveManager(),
-        persistentTempBucketFactory,
-        tempBucketFactory,
-        persistentTempBucketFactory,
-        resources.getHealingQueue(),
-        uskManager,
-        random,
-        fastWeakRandom,
-        ticker,
-        memoryLimitedJobRunner,
-        tempFilenameGenerator,
-        persistentFilenameGenerator,
-        tempRafFactory,
-        persistentRafFactory,
-        fileRafTransient,
-        checker,
-        compressor,
-        storeChecker,
-        persistentRoot,
-        cryptoSecretTransient,
-        init.toadlets(),
-        defaultFetchContext,
-        defaultInsertContext,
-        init.config());
+        node.getBootId(), runtime, storageFactories, rafFactories, services, defaults);
   }
 
   private DiskSpaceCheckingRandomAccessBufferFactory requireDiskChecker() {

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -28,6 +28,7 @@ import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Config;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.DummyJobRunner;
@@ -124,39 +125,38 @@ class ClientContextTest {
     ctx =
         new ClientContext(
             BOOT_ID,
-            new ClientLayerPersister(
+            new ClientContextRuntime(
+                new ClientLayerPersister(
+                    mainExecutor,
+                    ticker,
+                    null,
+                    null,
+                    persistentTempBucketFactory,
+                    tempBucketFactory,
+                    null),
                 mainExecutor,
+                memoryLimitedJobRunner,
                 ticker,
-                null,
-                null,
+                strongRandom,
+                fastWeakRandom,
+                cryptoSecretTransient),
+            new ClientContextStorageFactories(
                 persistentTempBucketFactory,
                 tempBucketFactory,
-                null),
-            mainExecutor,
-            archiveManager,
-            persistentTempBucketFactory,
-            tempBucketFactory,
-            persistentFileTracker,
-            healingQueue,
-            uskManager,
-            strongRandom,
-            fastWeakRandom,
-            ticker,
-            memoryLimitedJobRunner,
-            fg,
-            persistentFG,
-            tempRAF,
-            persistentRAF,
-            fileRAFTransient,
-            fileRAFPersistent,
-            realCompressor,
-            datastoreChecker,
-            persistentRoot,
-            cryptoSecretTransient,
-            linkFilterExceptionProvider,
-            defaultFetchCtx,
-            defaultInsertCtx,
-            config);
+                persistentFileTracker,
+                fg,
+                persistentFG,
+                fileRAFTransient,
+                fileRAFPersistent),
+            new ClientContextRafFactories(tempRAF, persistentRAF),
+            new ClientContextServices(
+                new ClientContextResources(archiveManager, healingQueue),
+                uskManager,
+                realCompressor,
+                datastoreChecker,
+                persistentRoot,
+                linkFilterExceptionProvider),
+            new ClientContextDefaults(defaultFetchCtx, defaultInsertCtx, config));
 
     // Replace the real jobRunner created above with a controllable fake for start() tests
     setField(ctx, "dummyJobRunner", new DummyJobRunner(mainExecutor, ctx));

--- a/src/test/java/network/crypta/client/async/ClientGetterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientGetterTest.java
@@ -40,6 +40,7 @@ import network.crypta.config.Config;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.FreenetURI;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.RequestClient;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
@@ -220,32 +221,34 @@ class ClientGetterTest {
       USKManager uskManager) {
     return new ClientContext(
         1L,
-        jobRunner,
-        new DirectExecutor(),
-        Mockito.mock(ArchiveManager.class),
-        Mockito.mock(PersistentTempBucketFactory.class),
-        Mockito.mock(TempBucketFactory.class),
-        Mockito.mock(PersistentFileTracker.class),
-        Mockito.mock(HealingQueue.class),
-        uskManager,
-        Mockito.mock(RandomSource.class),
-        new Random(123),
-        new DirectTicker(),
-        Mockito.mock(MemoryLimitedJobRunner.class),
-        Mockito.mock(FilenameGenerator.class),
-        Mockito.mock(FilenameGenerator.class),
-        Mockito.mock(LockableRandomAccessBufferFactory.class),
-        Mockito.mock(LockableRandomAccessBufferFactory.class),
-        Mockito.mock(FileRandomAccessBufferFactory.class),
-        Mockito.mock(FileRandomAccessBufferFactory.class),
-        Mockito.mock(RealCompressor.class),
-        Mockito.mock(DatastoreChecker.class),
-        Mockito.mock(PersistentRequestRoot.class),
-        Mockito.mock(MasterSecret.class),
-        linkFilterExceptionProvider,
-        defaultPF,
-        defaultPI,
-        Mockito.mock(Config.class));
+        new ClientContextRuntime(
+            jobRunner,
+            new DirectExecutor(),
+            Mockito.mock(MemoryLimitedJobRunner.class),
+            new DirectTicker(),
+            Mockito.mock(RandomSource.class),
+            new Random(123),
+            Mockito.mock(MasterSecret.class)),
+        new ClientContextStorageFactories(
+            Mockito.mock(PersistentTempBucketFactory.class),
+            Mockito.mock(TempBucketFactory.class),
+            Mockito.mock(PersistentFileTracker.class),
+            Mockito.mock(FilenameGenerator.class),
+            Mockito.mock(FilenameGenerator.class),
+            Mockito.mock(FileRandomAccessBufferFactory.class),
+            Mockito.mock(FileRandomAccessBufferFactory.class)),
+        new ClientContextRafFactories(
+            Mockito.mock(LockableRandomAccessBufferFactory.class),
+            Mockito.mock(LockableRandomAccessBufferFactory.class)),
+        new ClientContextServices(
+            new ClientContextResources(
+                Mockito.mock(ArchiveManager.class), Mockito.mock(HealingQueue.class)),
+            uskManager,
+            Mockito.mock(RealCompressor.class),
+            Mockito.mock(DatastoreChecker.class),
+            Mockito.mock(PersistentRequestRoot.class),
+            linkFilterExceptionProvider),
+        new ClientContextDefaults(defaultPF, defaultPI, Mockito.mock(Config.class)));
   }
 
   private static FetchContext newFetchContext(boolean filter) {

--- a/src/test/java/network/crypta/client/async/ClientRequestSchedulerTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSchedulerTest.java
@@ -26,6 +26,7 @@ import java.util.Random;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.Key;
 import network.crypta.node.BaseSendableGet;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.LowLevelGetException;
 import network.crypta.node.LowLevelPutException;
 import network.crypta.node.Node;
@@ -67,32 +68,13 @@ class ClientRequestSchedulerTest {
     context =
         new ClientContext(
             1L,
-            jobRunner,
-            mainExecutor,
-            /* archiveManager */ null,
-            /* ptbf */ null,
-            /* tbf */ null,
-            /* tracker */ null,
-            /* healingQueue */ null,
-            /* uskManager */ null,
-            /* strongRandom */ random,
-            /* fastWeakRandom */ new Random(0L),
-            /* ticker */ ticker,
-            /* memoryLimitedJobRunner */ null,
-            /* fg */ null,
-            /* persistentFG */ null,
-            /* rafFactory */ null,
-            /* persistentRAFFactory */ null,
-            /* fileRAFTransient */ null,
-            /* fileRAFPersistent */ null,
-            /* rc */ null,
-            /* checker */ datastoreChecker,
-            /* persistentRoot */ null,
-            /* cryptoSecretTransient */ null,
-            /* linkFilterExceptionProvider */ null,
-            /* defaultPersistentFetchContext */ null,
-            /* defaultPersistentInsertContext */ null,
-            /* config */ null);
+            new ClientContextRuntime(
+                jobRunner, mainExecutor, null, ticker, random, new Random(0L), null),
+            new ClientContextStorageFactories(null, null, null, null, null, null, null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), null, null, datastoreChecker, null, null),
+            new ClientContextDefaults(null, null, null));
 
     when(core.getStoreChecker()).thenReturn(datastoreChecker);
   }

--- a/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
@@ -38,6 +38,7 @@ import network.crypta.crypt.RandomSource;
 import network.crypta.keys.Key;
 import network.crypta.keys.NodeCHK;
 import network.crypta.node.BaseSendableGet;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.SendableGet;
@@ -299,32 +300,13 @@ class ClientRequestSelectorTest {
     ClientLayerPersister runner = mock(ClientLayerPersister.class);
     return new ClientContext(
         1L,
-        runner,
-        mainExecutor,
-        /* archiveManager */ null,
-        /* ptbf */ null,
-        /* tbf */ null,
-        /* tracker */ null,
-        /* healingQueue */ null,
-        /* uskManager */ null,
-        /* strongRandom */ new DummyRandomSource(42),
-        /* fastWeakRandom */ new Random(0L),
-        /* ticker */ t,
-        /* memoryLimitedJobRunner */ null,
-        /* fg */ null,
-        /* persistentFG */ null,
-        /* rafFactory */ null,
-        /* persistentRAFFactory */ null,
-        /* fileRAFTransient */ null,
-        /* fileRAFPersistent */ null,
-        /* rc */ null,
-        /* checker */ null,
-        /* persistentRoot */ null,
-        /* cryptoSecretTransient */ null,
-        /* linkFilterExceptionProvider */ null,
-        /* defaultPersistentFetchContext */ null,
-        /* defaultPersistentInsertContext */ null,
-        /* config */ null);
+        new ClientContextRuntime(
+            runner, mainExecutor, null, t, new DummyRandomSource(42), new Random(0L), null),
+        new ClientContextStorageFactories(null, null, null, null, null, null, null),
+        new ClientContextRafFactories(null, null),
+        new ClientContextServices(
+            new ClientContextResources(null, null), null, null, null, null, null),
+        new ClientContextDefaults(null, null, null));
   }
 
   private static byte[] randomNodeChkBytes() {

--- a/src/test/java/network/crypta/client/async/DatastoreCheckerTest.java
+++ b/src/test/java/network/crypta/client/async/DatastoreCheckerTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import network.crypta.keys.Key;
 import network.crypta.keys.KeyBlock;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.Node;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarter;
@@ -351,33 +352,19 @@ class DatastoreCheckerTest {
     ClientContext context =
         new ClientContext(
             1L,
-            jobRunner,
-            mainExec,
-            null, // ArchiveManager
-            null, // PersistentTempBucketFactory
-            null, // TempBucketFactory
-            null, // PersistentFileTracker
-            null, // HealingQueue
-            null, // USKManager
-            null, // RandomSource strongRandom
-            new SecureRandom(), // fastWeakRandom (secure for Sonar rule)
-            null, // Ticker
-            null, // MemoryLimitedJobRunner
-            null, // FilenameGenerator fg
-            null, // FilenameGenerator persistentFG
-            null, // LockableRandomAccessBufferFactory rafFactory
-            null, // LockableRandomAccessBufferFactory persistentRAFFactory
-            null, // FileRandomAccessBufferFactory fileRAFTransient
-            null, // FileRandomAccessBufferFactory fileRAFPersistent
-            null, // RealCompressor rc
-            null, // DatastoreChecker checker
-            null, // PersistentRequestRoot
-            null, // MasterSecret cryptoSecretTransient
-            null, // LinkFilterExceptionProvider
-            null, // defaultPersistentFetchContext
-            null, // defaultPersistentInsertContext
-            null // Config
-            );
+            new ClientContextRuntime(
+                jobRunner,
+                mainExec,
+                null,
+                null,
+                null,
+                new SecureRandom(), // fastWeakRandom (secure for Sonar rule)
+                null),
+            new ClientContextStorageFactories(null, null, null, null, null, null, null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), null, null, null, null, null),
+            new ClientContextDefaults(null, null, null));
 
     DatastoreChecker checker = new DatastoreChecker(node, true, executor, THREAD_NAME);
     checker.setContext(context);

--- a/src/test/java/network/crypta/client/async/InsertCompressorTest.java
+++ b/src/test/java/network/crypta/client/async/InsertCompressorTest.java
@@ -26,6 +26,7 @@ import network.crypta.crypt.HashResult;
 import network.crypta.crypt.HashType;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.FreenetURI;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
@@ -141,51 +142,32 @@ class InsertCompressorTest {
     // Provide minimal but valid defaults for required ctor parameters; most are unused in tests
     return new ClientContext(
         /*bootID*/ 1L,
-        /*jobRunner*/ jobRunner,
-        /*mainExecutor*/ mainExec,
-        /*archiveManager*/ null,
-        /*ptbf*/ null,
-        /*tbf*/ null,
-        /*tracker*/ null,
-        /*hq*/ null,
-        /*uskManager*/ null,
-        /*strongRandom*/ null,
-        /*fastWeakRandom*/ new Random(0),
-        /*ticker*/ null,
-        /*memoryLimitedJobRunner*/ null,
-        /*fg*/ null,
-        /*persistentFG*/ null,
-        /*rafFactory*/ null,
-        /*persistentRAFFactory*/ null,
-        /*fileRAFTransient*/ null,
-        /*fileRAFPersistent*/ null,
-        /*rc*/ rc,
-        /*checker*/ null,
-        /*persistentRoot*/ null,
-        /*cryptoSecretTransient*/ null,
-        /*linkFilterExceptionProvider*/ null,
-        /*defaultPersistentFetchContext*/
-        new network.crypta.client.FetchContext(
-            FetchContextOptions.builder()
-                .limits(0L, 0L, 0)
-                .archiveLimits(1, 0, 0, false)
-                .retryLimits(0, 0, 0)
-                .splitfileLimits(false, 0, 0)
-                .behavior(false, false, false)
-                .clientOptions(new SimpleEventProducer(), true, false)
-                .filterOverrides(null, null, null)
-                .build()),
-        /*defaultPersistentInsertContext*/
-        new InsertContext(
-            InsertContextOptions.builder()
-                .retryLimits(0, 0)
-                .splitfileSegmentLimits(128, 128)
-                .clientOptions(new SimpleEventProducer(), false, false, false)
-                .compressorDescriptor(Compressor.DEFAULT_COMPRESSORDESCRIPTOR)
-                .redundancy(0, 0)
-                .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
-                .build()),
-        /*config*/ config);
+        new ClientContextRuntime(jobRunner, mainExec, null, null, null, new Random(0), null),
+        new ClientContextStorageFactories(null, null, null, null, null, null, null),
+        new ClientContextRafFactories(null, null),
+        new ClientContextServices(
+            new ClientContextResources(null, null), null, rc, null, null, null),
+        new ClientContextDefaults(
+            new network.crypta.client.FetchContext(
+                FetchContextOptions.builder()
+                    .limits(0L, 0L, 0)
+                    .archiveLimits(1, 0, 0, false)
+                    .retryLimits(0, 0, 0)
+                    .splitfileLimits(false, 0, 0)
+                    .behavior(false, false, false)
+                    .clientOptions(new SimpleEventProducer(), true, false)
+                    .filterOverrides(null, null, null)
+                    .build()),
+            new InsertContext(
+                InsertContextOptions.builder()
+                    .retryLimits(0, 0)
+                    .splitfileSegmentLimits(128, 128)
+                    .clientOptions(new SimpleEventProducer(), false, false, false)
+                    .compressorDescriptor(Compressor.DEFAULT_COMPRESSORDESCRIPTOR)
+                    .redundancy(0, 0)
+                    .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+                    .build()),
+            config));
   }
 
   private static InsertContext makeInsertCtx(String compressorDescriptor) {

--- a/src/test/java/network/crypta/client/async/PersistentJobRunnerImplTest.java
+++ b/src/test/java/network/crypta/client/async/PersistentJobRunnerImplTest.java
@@ -2,6 +2,7 @@ package network.crypta.client.async;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.CheatingTicker;
 import network.crypta.support.PooledExecutor;
 import network.crypta.support.PriorityAwareExecutor;
@@ -16,8 +17,13 @@ class PersistentJobRunnerImplTest {
     jobRunner = new JobRunner(exec, ticker, 1000);
     context =
         new ClientContext(
-            0, null, exec, null, null, null, null, null, null, null, null, ticker, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null, null);
+            0,
+            new ClientContextRuntime(null, exec, null, ticker, null, null, null),
+            new ClientContextStorageFactories(null, null, null, null, null, null, null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), null, null, null, null, null),
+            new ClientContextDefaults(null, null, null));
     jobRunner.start(context);
     jobRunner.onStarted(false);
     exec.waitForIdle();

--- a/src/test/java/network/crypta/client/async/SimpleHealingQueueTest.java
+++ b/src/test/java/network/crypta/client/async/SimpleHealingQueueTest.java
@@ -18,6 +18,7 @@ import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.crypt.DummyRandomSource;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.Key;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -55,32 +56,19 @@ class SimpleHealingQueueTest {
     clientCtx =
         new ClientContext(
             /*bootID*/ 1L,
-            /*jobRunner*/ null,
-            /*mainExecutor*/ directExec,
-            /*archiveManager*/ null,
-            /*ptbf*/ null,
-            /*tbf*/ null,
-            /*tracker*/ null,
-            /*healingQueue*/ null,
-            /*uskManager*/ null,
-            /*strongRandom*/ new DummyRandomSource(123L),
-            /*fastWeakRandom*/ new Random(42L),
-            /*ticker*/ new NoopTicker(directExec),
-            /*memoryLimitedJobRunner*/ mlr,
-            /*fg*/ null,
-            /*persistentFG*/ null,
-            /*rafFactory*/ null,
-            /*persistentRAFFactory*/ null,
-            /*fileRAFTransient*/ null,
-            /*fileRAFPersistent*/ null,
-            /*rc*/ null,
-            /*checker*/ null,
-            /*persistentRoot*/ null,
-            /*cryptoSecretTransient*/ null,
-            /*linkFilterExceptionProvider*/ null,
-            /*defaultPersistentFetchContext*/ null,
-            /*defaultPersistentInsertContext*/ insertCtx,
-            /*config*/ null);
+            new ClientContextRuntime(
+                null,
+                directExec,
+                mlr,
+                new NoopTicker(directExec),
+                new DummyRandomSource(123L),
+                new Random(42L),
+                null),
+            new ClientContextStorageFactories(null, null, null, null, null, null, null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), null, null, null, null, null),
+            new ClientContextDefaults(null, insertCtx, null));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/SingleBlockInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SingleBlockInserterTest.java
@@ -26,6 +26,7 @@ import network.crypta.crypt.RandomSource;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.ClientKeyBlock;
 import network.crypta.keys.FreenetURI;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.KeysFetchingLocally;
 import network.crypta.node.LowLevelPutException;
 import network.crypta.support.MemoryLimitedJobRunner;
@@ -108,33 +109,20 @@ class SingleBlockInserterTest {
     MemoryLimitedJobRunner mlr = new MemoryLimitedJobRunner(1, 1, directExec, 1);
     return new ClientContext(
         /*bootID*/ 1L,
-        /*jobRunner*/ null,
-        /*mainExecutor*/ directExec,
-        /*archiveManager*/ null,
-        /*ptbf*/ null,
-        /*tbf*/ null,
-        /*tracker*/ null,
-        /*healingQueue*/ null,
-        /*uskManager*/ null,
-        /*strongRandom*/ new DummyRandomSource(123L),
-        /*fastWeakRandom*/ new Random(42L),
-        /*ticker*/ new NoopTicker(directExec),
-        /*memoryLimitedJobRunner*/ mlr,
-        /*fg*/ null,
-        /*persistentFG*/ null,
-        /*rafFactory*/ null,
-        /*persistentRAFFactory*/ null,
-        /*fileRAFTransient*/ null,
-        /*fileRAFPersistent*/ null,
-        /*rc*/ null,
-        /*checker*/ null,
-        /*persistentRoot*/ null,
-        /*cryptoSecretTransient*/ null,
-        /*linkFilterExceptionProvider*/ null,
-        /*defaultPersistentFetchContext*/ null,
-        /*defaultPersistentInsertContext*/ new InsertContext(
-            defaultInsertCtx, new SimpleEventProducer()),
-        /*config*/ null);
+        new ClientContextRuntime(
+            null,
+            directExec,
+            mlr,
+            new NoopTicker(directExec),
+            new DummyRandomSource(123L),
+            new Random(42L),
+            null),
+        new ClientContextStorageFactories(null, null, null, null, null, null, null),
+        new ClientContextRafFactories(null, null),
+        new ClientContextServices(
+            new ClientContextResources(null, null), null, null, null, null, null),
+        new ClientContextDefaults(
+            null, new InsertContext(defaultInsertCtx, new SimpleEventProducer()), null));
   }
 
   // --- Tests ---

--- a/src/test/java/network/crypta/client/async/SplitFileInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterTest.java
@@ -23,6 +23,7 @@ import network.crypta.client.Metadata;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.crypt.HashResult;
 import network.crypta.crypt.RandomSource;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.RequestClient;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -180,32 +181,25 @@ class SplitFileInserterTest {
     ClientContext ctx =
         new ClientContext(
             1L,
-            runner,
-            immediateExecutor,
-            archiveManager,
-            ptbf,
-            tbf,
-            tracker,
-            hq,
-            uskManager,
-            strongRandom,
-            fastWeakRandom,
-            ticker,
-            memLimited,
-            fg,
-            persistentFG,
-            rafFactory,
-            persistentRAFFactory,
-            fileRAFTransient,
-            fileRAFPersistent,
-            rc,
-            dsChecker,
-            persistentRoot,
-            masterSecret,
-            linkFilterProvider,
-            fetchCtx,
-            insertCtx,
-            config);
+            new ClientContextRuntime(
+                runner,
+                immediateExecutor,
+                memLimited,
+                ticker,
+                strongRandom,
+                fastWeakRandom,
+                masterSecret),
+            new ClientContextStorageFactories(
+                ptbf, tbf, tracker, fg, persistentFG, fileRAFTransient, fileRAFPersistent),
+            new ClientContextRafFactories(rafFactory, persistentRAFFactory),
+            new ClientContextServices(
+                new ClientContextResources(archiveManager, hq),
+                uskManager,
+                rc,
+                dsChecker,
+                persistentRoot,
+                linkFilterProvider),
+            new ClientContextDefaults(fetchCtx, insertCtx, config));
 
     // Spy to stub scheduler access used by SplitFileInserter's constructor.
     ClientContext spyCtx = Mockito.spy(ctx);

--- a/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
+++ b/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
@@ -39,6 +39,7 @@ import network.crypta.keys.Key;
 import network.crypta.keys.KeyBlock;
 import network.crypta.keys.NodeSSK;
 import network.crypta.keys.USK;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -162,32 +163,34 @@ class USKFetcherTagTest {
       TempBucketFactory tbf) {
     return new ClientContext(
         1L,
-        jobRunner,
-        new DirectExecutor(),
-        Mockito.mock(ArchiveManager.class),
-        ptbf,
-        tbf,
-        Mockito.mock(PersistentFileTracker.class),
-        Mockito.mock(HealingQueue.class),
-        uskManager,
-        Mockito.mock(RandomSource.class),
-        new java.util.Random(123),
-        new DirectTicker(),
-        Mockito.mock(MemoryLimitedJobRunner.class),
-        Mockito.mock(FilenameGenerator.class),
-        Mockito.mock(FilenameGenerator.class),
-        Mockito.mock(LockableRandomAccessBufferFactory.class),
-        Mockito.mock(LockableRandomAccessBufferFactory.class),
-        Mockito.mock(FileRandomAccessBufferFactory.class),
-        Mockito.mock(FileRandomAccessBufferFactory.class),
-        Mockito.mock(RealCompressor.class),
-        Mockito.mock(DatastoreChecker.class),
-        Mockito.mock(PersistentRequestRoot.class),
-        Mockito.mock(MasterSecret.class),
-        linkFilterExceptionProvider,
-        defaultPF,
-        defaultPI,
-        Mockito.mock(Config.class));
+        new ClientContextRuntime(
+            jobRunner,
+            new DirectExecutor(),
+            Mockito.mock(MemoryLimitedJobRunner.class),
+            new DirectTicker(),
+            Mockito.mock(RandomSource.class),
+            new java.util.Random(123),
+            Mockito.mock(MasterSecret.class)),
+        new ClientContextStorageFactories(
+            ptbf,
+            tbf,
+            Mockito.mock(PersistentFileTracker.class),
+            Mockito.mock(FilenameGenerator.class),
+            Mockito.mock(FilenameGenerator.class),
+            Mockito.mock(FileRandomAccessBufferFactory.class),
+            Mockito.mock(FileRandomAccessBufferFactory.class)),
+        new ClientContextRafFactories(
+            Mockito.mock(LockableRandomAccessBufferFactory.class),
+            Mockito.mock(LockableRandomAccessBufferFactory.class)),
+        new ClientContextServices(
+            new ClientContextResources(
+                Mockito.mock(ArchiveManager.class), Mockito.mock(HealingQueue.class)),
+            uskManager,
+            Mockito.mock(RealCompressor.class),
+            Mockito.mock(DatastoreChecker.class),
+            Mockito.mock(PersistentRequestRoot.class),
+            linkFilterExceptionProvider),
+        new ClientContextDefaults(defaultPF, defaultPI, Mockito.mock(Config.class)));
   }
 
   // ---------------- Test fixture ----------------

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -27,6 +27,7 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
 import network.crypta.keys.Key;
 import network.crypta.keys.USK;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.api.Bucket;
 import org.junit.jupiter.api.BeforeEach;
@@ -134,45 +135,33 @@ class USKInserterTest {
     context =
         new ClientContext(
             1L,
-            Mockito.mock(ClientLayerPersister.class),
-            new InlineExecutor(),
-            null, // ArchiveManager
-            null, // PersistentTempBucketFactory
-            null, // TempBucketFactory
-            null, // PersistentFileTracker
-            null, // HealingQueue
-            uskManager,
-            new DummyRandomSource(),
-            new SecureRandom(),
-            null, // Ticker
-            null, // MemoryLimitedJobRunner
-            null, // FilenameGenerator fg
-            null, // FilenameGenerator persistentFG
-            null, // LockableRandomAccessBufferFactory rafFactory
-            null, // LockableRandomAccessBufferFactory persistentRAFFactory
-            null, // FileRandomAccessBufferFactory transient
-            null, // FileRandomAccessBufferFactory persistent
-            null, // RealCompressor
-            null, // DatastoreChecker
-            null, // PersistentRequestRoot
-            null, // MasterSecret transient
-            null, // LinkFilterExceptionProvider
-            // Default persistent contexts used only when building fetchers internally; not
-            // exercised
-            // in these tests.
-            new FetchContext(
-                FetchContextOptions.builder()
-                    .limits(0, 0, 0)
-                    .archiveLimits(1, 0, 0, true)
-                    .retryLimits(0, 0, 0)
-                    .splitfileLimits(false, 0, 0)
-                    .behavior(false, false, false)
-                    .clientOptions(new SimpleEventProducer(), false, false)
-                    .filterOverrides(null, null, null)
-                    .build()),
-            newInsertContext(),
-            null // Config
-            );
+            new ClientContextRuntime(
+                Mockito.mock(ClientLayerPersister.class),
+                new InlineExecutor(),
+                null,
+                null,
+                new DummyRandomSource(),
+                new SecureRandom(),
+                null),
+            new ClientContextStorageFactories(null, null, null, null, null, null, null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), uskManager, null, null, null, null),
+            new ClientContextDefaults(
+                // Default persistent contexts used only when building fetchers internally; not
+                // exercised in these tests.
+                new FetchContext(
+                    FetchContextOptions.builder()
+                        .limits(0, 0, 0)
+                        .archiveLimits(1, 0, 0, true)
+                        .retryLimits(0, 0, 0)
+                        .splitfileLimits(false, 0, 0)
+                        .behavior(false, false, false)
+                        .clientOptions(new SimpleEventProducer(), false, false)
+                        .filterOverrides(null, null, null)
+                        .build()),
+                newInsertContext(),
+                null));
   }
 
   // Helpers in tests create per-test SSKs to build consistent public/insertable USK URIs.

--- a/src/test/java/network/crypta/client/async/USKProxyCompletionCallbackTest.java
+++ b/src/test/java/network/crypta/client/async/USKProxyCompletionCallbackTest.java
@@ -21,6 +21,7 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.keys.Key;
 import network.crypta.keys.NodeSSK;
 import network.crypta.keys.USK;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.compress.Compressor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,33 +45,12 @@ class USKProxyCompletionCallbackTest {
     context =
         new ClientContext(
             0L, // bootID
-            null, // ClientLayerPersister jobRunner
-            null, // PriorityAwareExecutor mainExecutor
-            null, // ArchiveManager archiveManager
-            null, // PersistentTempBucketFactory ptbf
-            null, // TempBucketFactory tbf
-            null, // PersistentFileTracker tracker
-            null, // HealingQueue hq
-            uskManager, // USKManager
-            null, // RandomSource strongRandom
-            null, // Random fastWeakRandom
-            null, // Ticker ticker
-            null, // MemoryLimitedJobRunner
-            null, // FilenameGenerator fg
-            null, // FilenameGenerator persistentFG
-            null, // LockableRandomAccessBufferFactory rafFactory
-            null, // LockableRandomAccessBufferFactory persistentRAFFactory
-            null, // FileRandomAccessBufferFactory fileRAFTransient
-            null, // FileRandomAccessBufferFactory fileRAFPersistent
-            null, // RealCompressor rc
-            null, // DatastoreChecker checker
-            null, // PersistentRequestRoot persistentRoot
-            null, // MasterSecret cryptoSecretTransient
-            null, // LinkFilterExceptionProvider
-            null, // FetchContext defaultPersistentFetchContext
-            null, // InsertContext defaultPersistentInsertContext
-            null // Config config
-            );
+            new ClientContextRuntime(null, null, null, null, null, null, null),
+            new ClientContextStorageFactories(null, null, null, null, null, null, null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), uskManager, null, null, null, null),
+            new ClientContextDefaults(null, null, null));
   }
 
   private static byte[] bytes32(byte value) {

--- a/src/test/java/network/crypta/client/async/USKRetrieverTest.java
+++ b/src/test/java/network/crypta/client/async/USKRetrieverTest.java
@@ -39,6 +39,7 @@ import network.crypta.keys.Key;
 import network.crypta.keys.KeyBlock;
 import network.crypta.keys.NodeSSK;
 import network.crypta.keys.USK;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.RequestClient;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
@@ -167,32 +168,34 @@ class USKRetrieverTest {
       TempBucketFactory tbf) {
     return new ClientContext(
         1L,
-        jobRunner,
-        new DirectExecutor(),
-        Mockito.mock(ArchiveManager.class),
-        ptbf,
-        tbf,
-        Mockito.mock(PersistentFileTracker.class),
-        Mockito.mock(HealingQueue.class),
-        uskManager,
-        Mockito.mock(RandomSource.class),
-        new java.util.Random(123),
-        new DirectTicker(),
-        Mockito.mock(MemoryLimitedJobRunner.class),
-        Mockito.mock(FilenameGenerator.class),
-        Mockito.mock(FilenameGenerator.class),
-        Mockito.mock(LockableRandomAccessBufferFactory.class),
-        Mockito.mock(LockableRandomAccessBufferFactory.class),
-        Mockito.mock(FileRandomAccessBufferFactory.class),
-        Mockito.mock(FileRandomAccessBufferFactory.class),
-        Mockito.mock(RealCompressor.class),
-        Mockito.mock(DatastoreChecker.class),
-        Mockito.mock(PersistentRequestRoot.class),
-        Mockito.mock(MasterSecret.class),
-        linkFilterExceptionProvider,
-        defaultPF,
-        defaultPI,
-        Mockito.mock(Config.class));
+        new ClientContextRuntime(
+            jobRunner,
+            new DirectExecutor(),
+            Mockito.mock(MemoryLimitedJobRunner.class),
+            new DirectTicker(),
+            Mockito.mock(RandomSource.class),
+            new java.util.Random(123),
+            Mockito.mock(MasterSecret.class)),
+        new ClientContextStorageFactories(
+            ptbf,
+            tbf,
+            Mockito.mock(PersistentFileTracker.class),
+            Mockito.mock(FilenameGenerator.class),
+            Mockito.mock(FilenameGenerator.class),
+            Mockito.mock(FileRandomAccessBufferFactory.class),
+            Mockito.mock(FileRandomAccessBufferFactory.class)),
+        new ClientContextRafFactories(
+            Mockito.mock(LockableRandomAccessBufferFactory.class),
+            Mockito.mock(LockableRandomAccessBufferFactory.class)),
+        new ClientContextServices(
+            new ClientContextResources(
+                Mockito.mock(ArchiveManager.class), Mockito.mock(HealingQueue.class)),
+            uskManager,
+            Mockito.mock(RealCompressor.class),
+            Mockito.mock(DatastoreChecker.class),
+            Mockito.mock(PersistentRequestRoot.class),
+            linkFilterExceptionProvider),
+        new ClientContextDefaults(defaultPF, defaultPI, Mockito.mock(Config.class)));
   }
 
   private static RequestClient transientClient() {

--- a/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
+++ b/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
@@ -26,6 +26,7 @@ import network.crypta.keys.Key;
 import network.crypta.keys.KeyBlock;
 import network.crypta.keys.NodeSSK;
 import network.crypta.keys.USK;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -165,32 +166,34 @@ class USKSparseProxyCallbackTest {
       TempBucketFactory tbf) {
     return new ClientContext(
         1L,
-        jobRunner,
-        new DirectExecutor(),
-        Mockito.mock(ArchiveManager.class),
-        ptbf,
-        tbf,
-        Mockito.mock(PersistentFileTracker.class),
-        Mockito.mock(HealingQueue.class),
-        uskManager,
-        Mockito.mock(RandomSource.class),
-        new Random(123),
-        new DirectTicker(),
-        Mockito.mock(MemoryLimitedJobRunner.class),
-        Mockito.mock(FilenameGenerator.class),
-        Mockito.mock(FilenameGenerator.class),
-        Mockito.mock(LockableRandomAccessBufferFactory.class),
-        Mockito.mock(LockableRandomAccessBufferFactory.class),
-        Mockito.mock(FileRandomAccessBufferFactory.class),
-        Mockito.mock(FileRandomAccessBufferFactory.class),
-        Mockito.mock(RealCompressor.class),
-        Mockito.mock(DatastoreChecker.class),
-        Mockito.mock(PersistentRequestRoot.class),
-        Mockito.mock(MasterSecret.class),
-        linkFilterExceptionProvider,
-        defaultPF,
-        defaultPI,
-        Mockito.mock(Config.class));
+        new ClientContextRuntime(
+            jobRunner,
+            new DirectExecutor(),
+            Mockito.mock(MemoryLimitedJobRunner.class),
+            new DirectTicker(),
+            Mockito.mock(RandomSource.class),
+            new Random(123),
+            Mockito.mock(MasterSecret.class)),
+        new ClientContextStorageFactories(
+            ptbf,
+            tbf,
+            Mockito.mock(PersistentFileTracker.class),
+            Mockito.mock(FilenameGenerator.class),
+            Mockito.mock(FilenameGenerator.class),
+            Mockito.mock(FileRandomAccessBufferFactory.class),
+            Mockito.mock(FileRandomAccessBufferFactory.class)),
+        new ClientContextRafFactories(
+            Mockito.mock(LockableRandomAccessBufferFactory.class),
+            Mockito.mock(LockableRandomAccessBufferFactory.class)),
+        new ClientContextServices(
+            new ClientContextResources(
+                Mockito.mock(ArchiveManager.class), Mockito.mock(HealingQueue.class)),
+            uskManager,
+            Mockito.mock(RealCompressor.class),
+            Mockito.mock(DatastoreChecker.class),
+            Mockito.mock(PersistentRequestRoot.class),
+            linkFilterExceptionProvider),
+        new ClientContextDefaults(defaultPF, defaultPI, Mockito.mock(Config.class)));
   }
 
   // ---------------- Mocks and test fixture ----------------

--- a/src/test/java/network/crypta/clients/fcp/ListPersistentRequestsMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPersistentRequestsMessageTest.java
@@ -18,6 +18,11 @@ import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.HealingQueue;
@@ -27,6 +32,7 @@ import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.config.Config;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.MemoryLimitedJobRunner;
@@ -283,32 +289,34 @@ class ListPersistentRequestsMessageTest {
 
     return new ClientContext(
         1L,
-        jobRunner,
-        executor,
-        mock(ArchiveManager.class),
-        mock(PersistentTempBucketFactory.class),
-        mock(TempBucketFactory.class),
-        mock(PersistentFileTracker.class),
-        mock(HealingQueue.class),
-        mock(USKManager.class),
-        mock(RandomSource.class),
-        new Random(0),
-        ticker,
-        mock(MemoryLimitedJobRunner.class),
-        mock(FilenameGenerator.class),
-        mock(FilenameGenerator.class),
-        mock(LockableRandomAccessBufferFactory.class),
-        mock(LockableRandomAccessBufferFactory.class),
-        mock(FileRandomAccessBufferFactory.class),
-        mock(FileRandomAccessBufferFactory.class),
-        mock(RealCompressor.class),
-        mock(DatastoreChecker.class),
-        mock(PersistentRequestRoot.class),
-        mock(MasterSecret.class),
-        mock(LinkFilterExceptionProvider.class),
-        mock(FetchContext.class),
-        mock(InsertContext.class),
-        mock(Config.class));
+        new ClientContextRuntime(
+            jobRunner,
+            executor,
+            mock(MemoryLimitedJobRunner.class),
+            ticker,
+            mock(RandomSource.class),
+            new Random(0),
+            mock(MasterSecret.class)),
+        new ClientContextStorageFactories(
+            mock(PersistentTempBucketFactory.class),
+            mock(TempBucketFactory.class),
+            mock(PersistentFileTracker.class),
+            mock(FilenameGenerator.class),
+            mock(FilenameGenerator.class),
+            mock(FileRandomAccessBufferFactory.class),
+            mock(FileRandomAccessBufferFactory.class)),
+        new ClientContextRafFactories(
+            mock(LockableRandomAccessBufferFactory.class),
+            mock(LockableRandomAccessBufferFactory.class)),
+        new ClientContextServices(
+            new ClientContextResources(mock(ArchiveManager.class), mock(HealingQueue.class)),
+            mock(USKManager.class),
+            mock(RealCompressor.class),
+            mock(DatastoreChecker.class),
+            mock(PersistentRequestRoot.class),
+            mock(LinkFilterExceptionProvider.class)),
+        new ClientContextDefaults(
+            mock(FetchContext.class), mock(InsertContext.class), mock(Config.class)));
   }
 
   private static class TrackingListJob extends ListPersistentRequestsMessage.ListJob {

--- a/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
@@ -25,6 +25,11 @@ import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.HealingQueue;
@@ -35,6 +40,7 @@ import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.config.Config;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
@@ -386,31 +392,33 @@ class ModifyPersistentRequestTest {
 
     return new ClientContext(
         1L,
-        jobRunner,
-        executor,
-        mock(ArchiveManager.class),
-        mock(PersistentTempBucketFactory.class),
-        mock(TempBucketFactory.class),
-        mock(PersistentFileTracker.class),
-        mock(HealingQueue.class),
-        mock(USKManager.class),
-        mock(RandomSource.class),
-        new Random(0),
-        ticker,
-        mock(MemoryLimitedJobRunner.class),
-        mock(FilenameGenerator.class),
-        mock(FilenameGenerator.class),
-        mock(LockableRandomAccessBufferFactory.class),
-        mock(LockableRandomAccessBufferFactory.class),
-        mock(FileRandomAccessBufferFactory.class),
-        mock(FileRandomAccessBufferFactory.class),
-        mock(RealCompressor.class),
-        mock(DatastoreChecker.class),
-        mock(PersistentRequestRoot.class),
-        mock(MasterSecret.class),
-        mock(LinkFilterExceptionProvider.class),
-        mock(FetchContext.class),
-        mock(InsertContext.class),
-        mock(Config.class));
+        new ClientContextRuntime(
+            jobRunner,
+            executor,
+            mock(MemoryLimitedJobRunner.class),
+            ticker,
+            mock(RandomSource.class),
+            new Random(0),
+            mock(MasterSecret.class)),
+        new ClientContextStorageFactories(
+            mock(PersistentTempBucketFactory.class),
+            mock(TempBucketFactory.class),
+            mock(PersistentFileTracker.class),
+            mock(FilenameGenerator.class),
+            mock(FilenameGenerator.class),
+            mock(FileRandomAccessBufferFactory.class),
+            mock(FileRandomAccessBufferFactory.class)),
+        new ClientContextRafFactories(
+            mock(LockableRandomAccessBufferFactory.class),
+            mock(LockableRandomAccessBufferFactory.class)),
+        new ClientContextServices(
+            new ClientContextResources(mock(ArchiveManager.class), mock(HealingQueue.class)),
+            mock(USKManager.class),
+            mock(RealCompressor.class),
+            mock(DatastoreChecker.class),
+            mock(PersistentRequestRoot.class),
+            mock(LinkFilterExceptionProvider.class)),
+        new ClientContextDefaults(
+            mock(FetchContext.class), mock(InsertContext.class), mock(Config.class)));
   }
 }

--- a/src/test/java/network/crypta/clients/http/QueueToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletTest.java
@@ -25,6 +25,11 @@ import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.HealingQueue;
@@ -40,6 +45,7 @@ import network.crypta.config.Config;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.FreenetURI;
+import network.crypta.node.ClientContextResources;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.ProgramDirectory;
@@ -257,32 +263,25 @@ class QueueToadletTest {
 
     return new ClientContext(
         1L,
-        jobRunner,
-        executor,
-        archiveManager,
-        ptbf,
-        tbf,
-        tracker,
-        hq,
-        uskManager,
-        strongRandom,
-        new Random(123),
-        ticker,
-        memoryLimitedJobRunner,
-        fg,
-        fg,
-        rafFactory,
-        persistentRAFFactory,
-        fileRAFTransient,
-        fileRAFPersistent,
-        rc,
-        checker,
-        persistentRoot,
-        masterSecret,
-        linkFilterExceptionProvider,
-        fetchContext,
-        insertContext,
-        config);
+        new ClientContextRuntime(
+            jobRunner,
+            executor,
+            memoryLimitedJobRunner,
+            ticker,
+            strongRandom,
+            new Random(123),
+            masterSecret),
+        new ClientContextStorageFactories(
+            ptbf, tbf, tracker, fg, fg, fileRAFTransient, fileRAFPersistent),
+        new ClientContextRafFactories(rafFactory, persistentRAFFactory),
+        new ClientContextServices(
+            new ClientContextResources(archiveManager, hq),
+            uskManager,
+            rc,
+            checker,
+            persistentRoot,
+            linkFilterExceptionProvider),
+        new ClientContextDefaults(fetchContext, insertContext, config));
   }
 
   private FreenetURI sampleUri() {

--- a/src/test/java/network/crypta/crypt/EncryptedRandomAccessBucketTest.java
+++ b/src/test/java/network/crypta/crypt/EncryptedRandomAccessBucketTest.java
@@ -25,6 +25,12 @@ import java.security.Security;
 import java.util.Arrays;
 import java.util.Random;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import network.crypta.support.api.RandomAccessBucket;
@@ -370,8 +376,13 @@ class EncryptedRandomAccessBucketTest extends BucketTestBase {
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
     ClientContext context =
         new ClientContext(
-            0, null, null, null, null, null, null, null, null, null, r, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null, null);
+            0,
+            new ClientContextRuntime(null, null, null, null, null, r, null),
+            new ClientContextStorageFactories(null, null, null, null, null, null, null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), null, null, null, null, null),
+            new ClientContextDefaults(null, null, null));
     context.setPersistentMasterSecret(secret);
     EncryptedRandomAccessBucket restored =
         (EncryptedRandomAccessBucket)
@@ -410,8 +421,13 @@ class EncryptedRandomAccessBucketTest extends BucketTestBase {
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
     ClientContext context =
         new ClientContext(
-            0, null, null, null, null, null, null, null, null, null, r, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null, null);
+            0,
+            new ClientContextRuntime(null, null, null, null, null, r, null),
+            new ClientContextStorageFactories(null, null, null, null, null, null, null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), null, null, null, null, null),
+            new ClientContextDefaults(null, null, null));
     context.setPersistentMasterSecret(secret);
     ObjectInputStream ois = new ObjectInputStream(dis);
     EncryptedRandomAccessBucket restored = (EncryptedRandomAccessBucket) ois.readObject();
@@ -454,8 +470,13 @@ class EncryptedRandomAccessBucketTest extends BucketTestBase {
       EncryptedRandomAccessBucket restored = (EncryptedRandomAccessBucket) ois.readObject();
       ClientContext context =
           new ClientContext(
-              0, null, null, null, null, null, null, null, null, null, r, null, null, null, null,
-              null, null, null, null, null, null, null, null, null, null, null, null);
+              0,
+              new ClientContextRuntime(null, null, null, null, null, r, null),
+              new ClientContextStorageFactories(null, null, null, null, null, null, null),
+              new ClientContextRafFactories(null, null),
+              new ClientContextServices(
+                  new ClientContextResources(null, null), null, null, null, null, null),
+              new ClientContextDefaults(null, null, null));
       context.setPersistentMasterSecret(secret);
       restored.onResume(context);
       assertEquals(buf.length, restored.size());

--- a/src/test/java/network/crypta/support/RandomGrabArrayTest.java
+++ b/src/test/java/network/crypta/support/RandomGrabArrayTest.java
@@ -15,7 +15,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.client.async.ClientRequestSelector;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.RemoveRandom.RemoveRandomReturn;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,33 +40,12 @@ class RandomGrabArrayTest {
     var ticker = new network.crypta.support.CheatingTicker(exec);
     return new ClientContext(
         0L,
-        null, // ClientLayerPersister
-        exec,
-        null, // ArchiveManager
-        null, // PersistentTempBucketFactory
-        null, // TempBucketFactory
-        null, // PersistentFileTracker
-        null, // HealingQueue
-        null, // USKManager
-        null, // RandomSource strongRandom
-        new Random(seed), // fastWeakRandom
-        ticker, // Ticker
-        null, // MemoryLimitedJobRunner
-        null, // FilenameGenerator
-        null, // FilenameGenerator persistent
-        null, // LockableRandomAccessBufferFactory temp
-        null, // LockableRandomAccessBufferFactory persistent
-        null, // FileRandomAccessBufferFactory transient
-        null, // FileRandomAccessBufferFactory persistent
-        null, // RealCompressor
-        null, // DatastoreChecker
-        null, // PersistentRequestRoot
-        null, // MasterSecret
-        null, // LinkFilterExceptionProvider
-        null, // FetchContext
-        null, // InsertContext
-        null // Config
-        );
+        new ClientContextRuntime(null, exec, null, ticker, null, new Random(seed), null),
+        new ClientContextStorageFactories(null, null, null, null, null, null, null),
+        new ClientContextRafFactories(null, null),
+        new ClientContextServices(
+            new ClientContextResources(null, null), null, null, null, null, null),
+        new ClientContextDefaults(null, null, null));
   }
 
   private static class TestItem implements RandomGrabArrayItem {

--- a/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBucketTest.java
+++ b/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBucketTest.java
@@ -31,7 +31,13 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Random;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.crypt.MasterSecret;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import network.crypta.support.api.RandomAccessBucket;
@@ -128,32 +134,38 @@ class DelayedFreeRandomAccessBucketTest {
     ClientContext ctx =
         new ClientContext(
             1L,
-            mock(network.crypta.client.async.ClientLayerPersister.class),
-            mock(PriorityAwareExecutor.class),
-            mock(network.crypta.client.ArchiveManager.class),
-            newFactory, // persistentBucketFactory
-            mock(TempBucketFactory.class),
-            mock(PersistentFileTracker.class),
-            mock(network.crypta.client.async.HealingQueue.class),
-            mock(network.crypta.client.async.USKManager.class),
-            mock(network.crypta.crypt.RandomSource.class),
-            fastWeak,
-            mock(network.crypta.support.Ticker.class),
-            mock(network.crypta.support.MemoryLimitedJobRunner.class),
-            mock(FilenameGenerator.class),
-            mock(FilenameGenerator.class),
-            mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
-            mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
-            mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
-            mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
-            mock(network.crypta.support.compress.RealCompressor.class),
-            mock(network.crypta.client.async.DatastoreChecker.class),
-            mock(network.crypta.clients.fcp.PersistentRequestRoot.class),
-            mock(MasterSecret.class),
-            mock(network.crypta.client.filter.LinkFilterExceptionProvider.class),
-            mock(network.crypta.client.FetchContext.class),
-            mock(network.crypta.client.InsertContext.class),
-            mock(network.crypta.config.Config.class));
+            new ClientContextRuntime(
+                mock(network.crypta.client.async.ClientLayerPersister.class),
+                mock(PriorityAwareExecutor.class),
+                mock(network.crypta.support.MemoryLimitedJobRunner.class),
+                mock(network.crypta.support.Ticker.class),
+                mock(network.crypta.crypt.RandomSource.class),
+                fastWeak,
+                mock(MasterSecret.class)),
+            new ClientContextStorageFactories(
+                newFactory,
+                mock(TempBucketFactory.class),
+                mock(PersistentFileTracker.class),
+                mock(FilenameGenerator.class),
+                mock(FilenameGenerator.class),
+                mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
+                mock(network.crypta.support.io.FileRandomAccessBufferFactory.class)),
+            new ClientContextRafFactories(
+                mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
+                mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class)),
+            new ClientContextServices(
+                new ClientContextResources(
+                    mock(network.crypta.client.ArchiveManager.class),
+                    mock(network.crypta.client.async.HealingQueue.class)),
+                mock(network.crypta.client.async.USKManager.class),
+                mock(network.crypta.support.compress.RealCompressor.class),
+                mock(network.crypta.client.async.DatastoreChecker.class),
+                mock(network.crypta.clients.fcp.PersistentRequestRoot.class),
+                mock(network.crypta.client.filter.LinkFilterExceptionProvider.class)),
+            new ClientContextDefaults(
+                mock(network.crypta.client.FetchContext.class),
+                mock(network.crypta.client.InsertContext.class),
+                mock(network.crypta.config.Config.class)));
 
     // Act: resume then free
     bucket.onResume(ctx);

--- a/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBufferTest.java
+++ b/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBufferTest.java
@@ -25,7 +25,13 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Random;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.crypt.MasterSecret;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import network.crypta.support.api.LockableRandomAccessBuffer.RAFLock;
@@ -81,32 +87,38 @@ class DelayedFreeRandomAccessBufferTest {
     ClientContext ctx =
         new ClientContext(
             1L,
-            mock(network.crypta.client.async.ClientLayerPersister.class),
-            mock(PriorityAwareExecutor.class),
-            mock(network.crypta.client.ArchiveManager.class),
-            newFactory,
-            mock(TempBucketFactory.class),
-            mock(PersistentFileTracker.class),
-            mock(network.crypta.client.async.HealingQueue.class),
-            mock(network.crypta.client.async.USKManager.class),
-            mock(network.crypta.crypt.RandomSource.class),
-            fastWeak,
-            mock(network.crypta.support.Ticker.class),
-            mock(network.crypta.support.MemoryLimitedJobRunner.class),
-            mock(FilenameGenerator.class),
-            mock(FilenameGenerator.class),
-            mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
-            mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
-            mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
-            mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
-            mock(network.crypta.support.compress.RealCompressor.class),
-            mock(network.crypta.client.async.DatastoreChecker.class),
-            mock(network.crypta.clients.fcp.PersistentRequestRoot.class),
-            mock(MasterSecret.class),
-            mock(network.crypta.client.filter.LinkFilterExceptionProvider.class),
-            mock(network.crypta.client.FetchContext.class),
-            mock(network.crypta.client.InsertContext.class),
-            mock(network.crypta.config.Config.class));
+            new ClientContextRuntime(
+                mock(network.crypta.client.async.ClientLayerPersister.class),
+                mock(PriorityAwareExecutor.class),
+                mock(network.crypta.support.MemoryLimitedJobRunner.class),
+                mock(network.crypta.support.Ticker.class),
+                mock(network.crypta.crypt.RandomSource.class),
+                fastWeak,
+                mock(MasterSecret.class)),
+            new ClientContextStorageFactories(
+                newFactory,
+                mock(TempBucketFactory.class),
+                mock(PersistentFileTracker.class),
+                mock(FilenameGenerator.class),
+                mock(FilenameGenerator.class),
+                mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
+                mock(network.crypta.support.io.FileRandomAccessBufferFactory.class)),
+            new ClientContextRafFactories(
+                mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
+                mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class)),
+            new ClientContextServices(
+                new ClientContextResources(
+                    mock(network.crypta.client.ArchiveManager.class),
+                    mock(network.crypta.client.async.HealingQueue.class)),
+                mock(network.crypta.client.async.USKManager.class),
+                mock(network.crypta.support.compress.RealCompressor.class),
+                mock(network.crypta.client.async.DatastoreChecker.class),
+                mock(network.crypta.clients.fcp.PersistentRequestRoot.class),
+                mock(network.crypta.client.filter.LinkFilterExceptionProvider.class)),
+            new ClientContextDefaults(
+                mock(network.crypta.client.FetchContext.class),
+                mock(network.crypta.client.InsertContext.class),
+                mock(network.crypta.config.Config.class)));
 
     buf.onResume(ctx);
     buf.free();

--- a/src/test/java/network/crypta/support/io/PersistentTempFileBucketTest.java
+++ b/src/test/java/network/crypta/support/io/PersistentTempFileBucketTest.java
@@ -25,6 +25,12 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.security.SecureRandom;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.api.RandomAccessBucket;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -255,32 +261,19 @@ class PersistentTempFileBucketTest {
       context =
           new ClientContext(
               0L,
-              null,
-              null,
-              null,
-              ptbfSpy,
-              null,
-              ptbfSpy,
-              null,
-              null,
-              null,
-              seededSecureRandom(1),
-              null,
-              null,
-              new FilenameGenerator(seededSecureRandom(2), false, tempDir.toFile(), "trans-"),
-              generator,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null);
+              new ClientContextRuntime(null, null, null, null, null, seededSecureRandom(1), null),
+              new ClientContextStorageFactories(
+                  ptbfSpy,
+                  null,
+                  ptbfSpy,
+                  new FilenameGenerator(seededSecureRandom(2), false, tempDir.toFile(), "trans-"),
+                  generator,
+                  null,
+                  null),
+              new ClientContextRafFactories(null, null),
+              new ClientContextServices(
+                  new ClientContextResources(null, null), null, null, null, null, null),
+              new ClientContextDefaults(null, null, null));
 
       // Act
       bucket.innerResume(context);

--- a/src/test/java/network/crypta/support/io/TempFileBucketTest.java
+++ b/src/test/java/network/crypta/support/io/TempFileBucketTest.java
@@ -21,6 +21,12 @@ import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.Random;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
+import network.crypta.node.ClientContextResources;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.RandomAccessBucket;
 import org.junit.jupiter.api.AfterEach;
@@ -200,32 +206,19 @@ class TempFileBucketTest extends BucketTestBase {
     ClientContext context =
         new ClientContext(
             0L,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            seededSecureRandom(1),
-            null,
-            null,
-            new FilenameGenerator(seededSecureRandom(2), false, tempDir.toFile(), "trans-"),
-            gen,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null);
+            new ClientContextRuntime(null, null, null, null, null, seededSecureRandom(1), null),
+            new ClientContextStorageFactories(
+                null,
+                null,
+                null,
+                new FilenameGenerator(seededSecureRandom(2), false, tempDir.toFile(), "trans-"),
+                gen,
+                null,
+                null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), null, null, null, null, null),
+            new ClientContextDefaults(null, null, null));
 
     try (TempFileBucket bucket = new TempFileBucket()) {
       bucket.filenameID = id; // package-private field, same package
@@ -258,32 +251,19 @@ class TempFileBucketTest extends BucketTestBase {
       ClientContext context =
           new ClientContext(
               0L,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              seededSecureRandom(10),
-              null,
-              null,
-              new FilenameGenerator(seededSecureRandom(11), false, tempDir.toFile(), "trans-"),
-              spyGen,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null);
+              new ClientContextRuntime(null, null, null, null, null, seededSecureRandom(10), null),
+              new ClientContextStorageFactories(
+                  null,
+                  null,
+                  null,
+                  new FilenameGenerator(seededSecureRandom(11), false, tempDir.toFile(), "trans-"),
+                  spyGen,
+                  null,
+                  null),
+              new ClientContextRafFactories(null, null),
+              new ClientContextServices(
+                  new ClientContextResources(null, null), null, null, null, null, null),
+              new ClientContextDefaults(null, null, null));
 
       // Act
       bucket.innerResume(context);
@@ -304,32 +284,19 @@ class TempFileBucketTest extends BucketTestBase {
       ClientContext context =
           new ClientContext(
               0L,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              seededSecureRandom(12),
-              null,
-              null,
-              new FilenameGenerator(seededSecureRandom(13), false, tempDir.toFile(), "trans-"),
-              generatorMock,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null);
+              new ClientContextRuntime(null, null, null, null, null, seededSecureRandom(12), null),
+              new ClientContextStorageFactories(
+                  null,
+                  null,
+                  null,
+                  new FilenameGenerator(seededSecureRandom(13), false, tempDir.toFile(), "trans-"),
+                  generatorMock,
+                  null,
+                  null),
+              new ClientContextRafFactories(null, null),
+              new ClientContextServices(
+                  new ClientContextResources(null, null), null, null, null, null, null),
+              new ClientContextDefaults(null, null, null));
 
       // Act / Assert
       assertThrows(ResumeFailedException.class, () -> bucket.innerResume(context));


### PR DESCRIPTION
## Summary
- Replace the long ClientContext constructor with shared parameter records
- Wire NodeClientPersistence and tests to build the new bundles
- Remove legacy constructor and consolidate context construction

## Testing
- ./gradlew spotlessApply
- ./gradlew --parallel test