### PR TITLE
refactor(client): add getter request records

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientGetter.java
+++ b/src/main/java/network/crypta/client/async/ClientGetter.java
@@ -171,6 +171,42 @@ public class ClientGetter extends BaseClientGetter
 
   private transient boolean resumedFetcher;
 
+  // Constructors.
+
+  /**
+   * Create a getter from a request and optional settings.
+   *
+   * <p>This constructor centralizes request initialization while keeping the request parameters and
+   * optional behavior flags in reusable parameter objects. It performs no validation and preserves
+   * the legacy behavior of the expanded constructor.
+   *
+   * @param request base request parameters including callback, URI, context, and priority
+   * @param options optional settings such as return buckets and binary blob recording
+   */
+  public ClientGetter(ClientGetterRequest request, ClientGetterOptions options) {
+    super(request.priorityClass(), request.client().getRequestClient());
+    this.clientCallback = request.client();
+    this.returnBucket = options.returnBucket();
+    this.uri = request.uri();
+    this.ctx = request.ctx();
+    this.finished = false;
+    this.actx = new ArchiveContext(ctx.getMaxTempLength(), ctx.getMaxArchiveLevels());
+    this.binaryBlobWriter = options.binaryBlobWriter();
+    this.dontFinalizeBlobWriter = options.dontFinalizeBlobWriter();
+    this.initialMetadata = options.initialMetadata();
+    archiveRestarts = 0;
+    this.forceCompatibleExtension = options.forceCompatibleExtension();
+  }
+
+  /**
+   * Create a getter with default options.
+   *
+   * @param request base request parameters including callback, URI, context, and priority
+   */
+  public ClientGetter(ClientGetterRequest request) {
+    this(request, ClientGetterOptions.defaults());
+  }
+
   // Shorter constructors for convenience and backwards compatibility.
 
   /**
@@ -187,7 +223,7 @@ public class ClientGetter extends BaseClientGetter
    */
   public ClientGetter(
       ClientGetCallback client, FreenetURI uri, FetchContext ctx, short priorityClass) {
-    this(client, uri, ctx, priorityClass, null, null, null);
+    this(new ClientGetterRequest(client, uri, ctx, priorityClass), ClientGetterOptions.defaults());
   }
 
   /**
@@ -208,7 +244,9 @@ public class ClientGetter extends BaseClientGetter
       FetchContext ctx,
       short priorityClass,
       Bucket returnBucket) {
-    this(client, uri, ctx, priorityClass, returnBucket, null, null);
+    this(
+        new ClientGetterRequest(client, uri, ctx, priorityClass),
+        ClientGetterOptions.withReturnBucket(returnBucket));
   }
 
   /**
@@ -234,7 +272,9 @@ public class ClientGetter extends BaseClientGetter
       short priorityClass,
       Bucket returnBucket,
       BinaryBlobWriter binaryBlobWriter) {
-    this(client, uri, ctx, priorityClass, returnBucket, binaryBlobWriter, null);
+    this(
+        new ClientGetterRequest(client, uri, ctx, priorityClass),
+        ClientGetterOptions.withBinaryBlobWriter(returnBucket, binaryBlobWriter));
   }
 
   /**
@@ -262,15 +302,8 @@ public class ClientGetter extends BaseClientGetter
       BinaryBlobWriter binaryBlobWriter,
       Bucket initialMetadata) {
     this(
-        client,
-        uri,
-        ctx,
-        priorityClass,
-        returnBucket,
-        binaryBlobWriter,
-        false,
-        initialMetadata,
-        null);
+        new ClientGetterRequest(client, uri, ctx, priorityClass),
+        ClientGetterOptions.withInitialMetadata(returnBucket, binaryBlobWriter, initialMetadata));
   }
 
   /**
@@ -291,6 +324,7 @@ public class ClientGetter extends BaseClientGetter
    * @param forceCompatibleExtension If set, and filtering is enabled, the MIME type we filter with
    *     must be compatible with this extension
    */
+  @SuppressWarnings("java:S107")
   public ClientGetter(
       ClientGetCallback client,
       FreenetURI uri,
@@ -301,18 +335,14 @@ public class ClientGetter extends BaseClientGetter
       boolean dontFinalizeBlobWriter,
       Bucket initialMetadata,
       String forceCompatibleExtension) {
-    super(priorityClass, client.getRequestClient());
-    this.clientCallback = client;
-    this.returnBucket = returnBucket;
-    this.uri = uri;
-    this.ctx = ctx;
-    this.finished = false;
-    this.actx = new ArchiveContext(ctx.getMaxTempLength(), ctx.getMaxArchiveLevels());
-    this.binaryBlobWriter = binaryBlobWriter;
-    this.dontFinalizeBlobWriter = dontFinalizeBlobWriter;
-    this.initialMetadata = initialMetadata;
-    archiveRestarts = 0;
-    this.forceCompatibleExtension = forceCompatibleExtension;
+    this(
+        new ClientGetterRequest(client, uri, ctx, priorityClass),
+        new ClientGetterOptions(
+            returnBucket,
+            binaryBlobWriter,
+            dontFinalizeBlobWriter,
+            initialMetadata,
+            forceCompatibleExtension));
   }
 
   /** Required because we implement {@link Serializable}. */

--- a/src/main/java/network/crypta/client/async/ClientGetterOptions.java
+++ b/src/main/java/network/crypta/client/async/ClientGetterOptions.java
@@ -1,0 +1,69 @@
+package network.crypta.client.async;
+
+import network.crypta.support.api.Bucket;
+
+/**
+ * Optional settings for constructing a {@link ClientGetter}.
+ *
+ * <p>This record bundles optional bucket destinations, binary blob recording behavior, initial
+ * metadata, and MIME extension constraints. All fields are optional and are stored without
+ * validation so the getter preserves the original behavior of the legacy constructor.
+ *
+ * @param returnBucket optional destination bucket for the final data; {@code null} means allocate a
+ *     temporary bucket.
+ * @param binaryBlobWriter optional writer that records accessed keys into a binary blob.
+ * @param dontFinalizeBlobWriter whether the caller finalizes the blob writer lifecycle.
+ * @param initialMetadata optional metadata bucket to seed the request.
+ * @param forceCompatibleExtension optional extension used by MIME filtering; may be {@code null}.
+ */
+public record ClientGetterOptions(
+    Bucket returnBucket,
+    BinaryBlobWriter binaryBlobWriter,
+    boolean dontFinalizeBlobWriter,
+    Bucket initialMetadata,
+    String forceCompatibleExtension) {
+
+  /**
+   * Returns default options with all optional settings disabled.
+   *
+   * @return a {@link ClientGetterOptions} instance with all fields set to their defaults.
+   */
+  public static ClientGetterOptions defaults() {
+    return new ClientGetterOptions(null, null, false, null, null);
+  }
+
+  /**
+   * Returns options that only specify a return bucket.
+   *
+   * @param returnBucket destination bucket for the final data; may be {@code null}.
+   * @return a {@link ClientGetterOptions} instance with the return bucket configured.
+   */
+  public static ClientGetterOptions withReturnBucket(Bucket returnBucket) {
+    return new ClientGetterOptions(returnBucket, null, false, null, null);
+  }
+
+  /**
+   * Returns options that specify a return bucket and binary blob writer.
+   *
+   * @param returnBucket destination bucket for the final data; may be {@code null}.
+   * @param binaryBlobWriter writer that records accessed keys; may be {@code null}.
+   * @return a {@link ClientGetterOptions} instance with binary blob recording configured.
+   */
+  public static ClientGetterOptions withBinaryBlobWriter(
+      Bucket returnBucket, BinaryBlobWriter binaryBlobWriter) {
+    return new ClientGetterOptions(returnBucket, binaryBlobWriter, false, null, null);
+  }
+
+  /**
+   * Returns options that specify a return bucket, binary blob writer, and initial metadata.
+   *
+   * @param returnBucket destination bucket for the final data; may be {@code null}.
+   * @param binaryBlobWriter writer that records accessed keys; may be {@code null}.
+   * @param initialMetadata metadata bucket used to seed the request; may be {@code null}.
+   * @return a {@link ClientGetterOptions} instance with initial metadata configured.
+   */
+  public static ClientGetterOptions withInitialMetadata(
+      Bucket returnBucket, BinaryBlobWriter binaryBlobWriter, Bucket initialMetadata) {
+    return new ClientGetterOptions(returnBucket, binaryBlobWriter, false, initialMetadata, null);
+  }
+}

--- a/src/main/java/network/crypta/client/async/ClientGetterRequest.java
+++ b/src/main/java/network/crypta/client/async/ClientGetterRequest.java
@@ -1,0 +1,19 @@
+package network.crypta.client.async;
+
+import network.crypta.client.FetchContext;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Base request parameters for constructing a {@link ClientGetter}.
+ *
+ * <p>This record groups the callback, target URI, fetch context, and scheduling priority required
+ * to enqueue a client fetch request. It performs no validation and stores the supplied references
+ * verbatim so callers retain full control over request setup and lifecycle.
+ *
+ * @param client callback that receives completion and failure notifications.
+ * @param uri target {@link FreenetURI} to fetch.
+ * @param ctx fetch configuration including limits and filtering flags.
+ * @param priorityClass scheduling priority; smaller values represent higher priority.
+ */
+public record ClientGetterRequest(
+    ClientGetCallback client, FreenetURI uri, FetchContext ctx, short priorityClass) {}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -15,6 +15,8 @@ import network.crypta.client.async.BinaryBlobWriter;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientGetCallback;
 import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.ClientGetterOptions;
+import network.crypta.client.async.ClientGetterRequest;
 import network.crypta.client.async.PersistentClientCallback;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
@@ -264,28 +266,19 @@ final class ClientGetGetterFactory {
                 .makeBucket(fetchContext.getMaxOutputLength());
       }
       return new ClientGetter(
-          callback,
-          uri,
-          fetchContext,
-          priorityClass,
-          NULL_BUCKET,
-          new BinaryBlobWriter(blobBucket),
-          false,
-          initialMetadata,
-          extensionCheck);
+          new ClientGetterRequest(callback, uri, fetchContext, priorityClass),
+          new ClientGetterOptions(
+              NULL_BUCKET,
+              new BinaryBlobWriter(blobBucket),
+              false,
+              initialMetadata,
+              extensionCheck));
     }
     if (discardData) {
       returnBucket = NULL_BUCKET;
     }
     return new ClientGetter(
-        callback,
-        uri,
-        fetchContext,
-        priorityClass,
-        returnBucket,
-        null,
-        false,
-        initialMetadata,
-        extensionCheck);
+        new ClientGetterRequest(callback, uri, fetchContext, priorityClass),
+        new ClientGetterOptions(returnBucket, null, false, initialMetadata, extensionCheck));
   }
 }

--- a/src/test/java/network/crypta/client/async/ClientGetterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientGetterTest.java
@@ -302,7 +302,8 @@ class ClientGetterTest {
             });
 
     return new ClientGetter(
-        callback, uri, fctx, (short) 1, returnBucket, null, false, null, forceCompatibleExt);
+        new ClientGetterRequest(callback, uri, fctx, (short) 1),
+        new ClientGetterOptions(returnBucket, null, false, null, forceCompatibleExt));
   }
 
   private ClientContext newContext(FetchContext fctx, InsertContext ictx) {
@@ -382,7 +383,7 @@ class ClientGetterTest {
 
     StreamGenerator generator = Mockito.mock(StreamGenerator.class);
     doAnswer(
-            inv -> {
+            _ -> {
               throw new IOException("boom");
             })
         .when(generator)

--- a/src/test/java/network/crypta/node/NodeAndClientLayerBlobTest.java
+++ b/src/test/java/network/crypta/node/NodeAndClientLayerBlobTest.java
@@ -18,6 +18,8 @@ import network.crypta.client.async.BinaryBlob;
 import network.crypta.client.async.BinaryBlobFormatException;
 import network.crypta.client.async.BinaryBlobWriter;
 import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.ClientGetterOptions;
+import network.crypta.client.async.ClientGetterRequest;
 import network.crypta.client.async.SimpleBlockSet;
 import network.crypta.crypt.DummyRandomSource;
 import network.crypta.keys.FreenetURI;
@@ -47,7 +49,7 @@ class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
     DummyRandomSource random = new DummyRandomSource(25312);
     final PriorityAwareExecutor executor = new PooledExecutor();
     FileUtil.removeAll(dir);
-    dir.mkdir();
+    assertTrue(dir.mkdirs() || dir.isDirectory());
     NodeStarter.globalTestInit(dir, false, Level.ERROR, "", true, random);
     TestNodeParameters params = new TestNodeParameters();
     params.setRandom(new DummyRandomSource(253121));
@@ -63,7 +65,7 @@ class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
     ictx.setLocalRequestOnly(true);
     InsertBlock block = generateBlock(random, false);
     FreenetURI uri = client.insert(block, "", (short) 0, ictx);
-    assertEquals(uri.getKeyType(), "SSK");
+    assertEquals("SSK", uri.getKeyType());
     FetchContext ctx = client.getFetchContext(FILE_SIZE * 2);
     ctx.setLocalRequestOnly(true);
     FetchWaiter fw = new FetchWaiter(rc);
@@ -75,7 +77,10 @@ class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
     Bucket blobBucket =
         node.services().clientCore().getTempBucketFactory().makeBucket(FILE_SIZE * 3);
     BinaryBlobWriter bbw = new BinaryBlobWriter(blobBucket);
-    ClientGetter getter = new ClientGetter(fw, uri, ctx, (short) 0, null, bbw, false, null, null);
+    ClientGetter getter =
+        new ClientGetter(
+            new ClientGetterRequest(fw, uri, ctx, (short) 0),
+            ClientGetterOptions.withBinaryBlobWriter(null, bbw));
     getter.start(node.services().clientCore().getClientContext());
     fw.waitForCompletion();
     assertTrue(blobBucket.size() > 0);
@@ -85,7 +90,8 @@ class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
     params.setRamStore(true);
     params.setStoreSize(FILE_SIZE * 3);
     params.setBaseDirectory(new File(dir, "fetchNode"));
-    params.getBaseDirectory().mkdir();
+    File fetchNodeDir = params.getBaseDirectory();
+    assertTrue(fetchNodeDir.mkdirs() || fetchNodeDir.isDirectory());
     params.setExecutor(executor);
     Node node2 = NodeStarter.createTestNode(params);
     node2.start(false);
@@ -97,7 +103,7 @@ class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
     BinaryBlob.readBinaryBlob(dis, blocks, true);
     ctx2 = new FetchContext(ctx2, FetchContext.IDENTICAL_MASK, true, blocks);
     fw = new FetchWaiter(rc);
-    getter = client2.fetch(uri, FILE_SIZE * 2, fw, ctx2, (short) 0);
+    client2.fetch(uri, FILE_SIZE * 2, fw, ctx2, (short) 0);
     result = fw.waitForCompletion();
     assertTrue(BucketTools.equalBuckets(result.asBucket(), block.getData()));
   }


### PR DESCRIPTION
## Summary
- introduce `ClientGetterRequest` and `ClientGetterOptions` records to centralize constructor parameters
- update `ClientGetter` constructors and call sites to use the new records
- adjust related tests and minor assertions

## Testing
- not run (spotlessApply only)
