### PR TITLE
refactor(client): bundle putter params

### DIFF
--- a/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
+++ b/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
@@ -10,6 +10,8 @@ import network.crypta.client.async.ClientGetCallback;
 import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
+import network.crypta.client.async.ClientPutterOptions;
+import network.crypta.client.async.ClientPutterRequest;
 import network.crypta.client.async.DefaultManifestPutter;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.TooManyFilesInsertException;
@@ -473,17 +475,15 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
     PutWaiter pw = new PutWaiter(this);
     ClientPutter put =
         new ClientPutter(
-            pw,
-            insert.getData(),
-            insert.desiredURI,
-            insert.clientMetadata,
-            ctx,
-            priority,
-            isMetadata,
-            filenameHint,
-            false,
-            forceCryptoKey,
-            -1);
+            new ClientPutterRequest(
+                pw,
+                insert.getData(),
+                insert.desiredURI,
+                insert.clientMetadata,
+                ctx,
+                priority,
+                isMetadata),
+            new ClientPutterOptions(filenameHint, false, forceCryptoKey, -1));
     try {
       core.getClientContext().start(put);
     } catch (PersistenceDisabledException _) {
@@ -514,17 +514,15 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
       throws InsertException {
     ClientPutter put =
         new ClientPutter(
-            cb,
-            insert.getData(),
-            insert.desiredURI,
-            insert.clientMetadata,
-            ctx,
-            priority,
-            isMetadata,
-            filenameHint,
-            false,
-            null,
-            -1);
+            new ClientPutterRequest(
+                cb,
+                insert.getData(),
+                insert.desiredURI,
+                insert.clientMetadata,
+                ctx,
+                priority,
+                isMetadata),
+            new ClientPutterOptions(filenameHint, false, null, -1));
     try {
       core.getClientContext().start(put);
     } catch (PersistenceDisabledException _) {

--- a/src/main/java/network/crypta/client/async/ClientPutter.java
+++ b/src/main/java/network/crypta/client/async/ClientPutter.java
@@ -156,54 +156,26 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
    * network.crypta.support.io.NoFreeBucket}. When {@code targetFilename} is provided, a one-file
    * manifest is created so clients can retrieve the file as {@code <final-key>/<targetFilename>}.
    *
-   * @param callback callback receiving lifecycle events, success/failure, and generated outputs;
-   *     must remain valid for the lifetime of the insert, never {@code null}.
-   * @param data data source to publish; readable for the duration of the insert and freed on
-   *     completion unless wrapped in a non-freeing bucket implementation.
-   * @param targetURI desired destination URI; may be CHK/SSK/KSK/USK depending on configuration;
-   *     must be an insert-capable form and passes {@link FreenetURI#checkInsertURI()}.
-   * @param cm client-visible metadata such as MIME type and optional attributes; may be cloned if
-   *     persistence is enabled to shield against caller mutation during the insert.
-   * @param ctx insert configuration controlling splitfile strategy, priority, and compatibility
-   *     mode; used throughout to drive scheduling and encoding decisions.
-   * @param priorityClass priority hint for scheduling; higher values may be deprioritized under
-   *     load depending on scheduler policy; preserved across restarts.
-   * @param isMetadata when {@code true}, treats the content as metadata-only to be stored
-   *     accordingly; callers should set based on their retrieval expectations.
-   * @param targetFilename optional manifest filename to expose the single file under; when set,
-   *     clients can fetch {@code <final-URI>/<targetFilename>} directly.
-   * @param binaryBlob enable the binary-blob inserter path used by some protocols; otherwise the
-   *     standard single-file inserter path is chosen.
-   * @param overrideSplitfileCrypto optional 32-byte key to override random generation; when
-   *     provided, length must be exactly 32 bytes; {@code null} enables randomization.
-   * @param metadataThreshold when greater than zero, returns compact final metadata instead of a
-   *     URI when the encoded metadata length is below this threshold; units are bytes.
+   * @param request bundled request parameters including callback, data, target URI, and insert
+   *     context; values are stored without validation to preserve legacy behavior.
+   * @param options optional settings for filename hints, binary-blob behavior, splitfile crypto
+   *     overrides, and metadata thresholding; use {@link ClientPutterOptions#defaults()} for
+   *     standard behavior.
    */
-  public ClientPutter(
-      ClientPutCallback callback,
-      RandomAccessBucket data,
-      FreenetURI targetURI,
-      ClientMetadata cm,
-      InsertContext ctx,
-      short priorityClass,
-      boolean isMetadata,
-      String targetFilename,
-      boolean binaryBlob,
-      byte[] overrideSplitfileCrypto,
-      long metadataThreshold) {
-    super(priorityClass, callback.getRequestClient());
-    this.cm = cm;
-    this.isMetadata = isMetadata;
-    this.callback = callback;
-    this.data = data;
-    this.targetURI = targetURI;
-    this.ctx = ctx;
+  public ClientPutter(ClientPutterRequest request, ClientPutterOptions options) {
+    super(request.priorityClass(), request.callback().getRequestClient());
+    this.cm = request.clientMetadata();
+    this.isMetadata = request.isMetadata();
+    this.callback = request.callback();
+    this.data = request.data();
+    this.targetURI = request.targetURI();
+    this.ctx = request.insertContext();
     this.finished = false;
     this.cancelled = false;
-    this.targetFilename = targetFilename;
-    this.binaryBlob = binaryBlob;
-    this.overrideSplitfileCrypto = overrideSplitfileCrypto;
-    this.metadataThreshold = metadataThreshold;
+    this.targetFilename = options.targetFilename();
+    this.binaryBlob = options.binaryBlob();
+    this.overrideSplitfileCrypto = options.overrideSplitfileCrypto();
+    this.metadataThreshold = options.metadataThreshold();
   }
 
   /**
@@ -228,7 +200,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
    *
    * <p>When {@code restart} is {@code true}, internal counters are reset and the insert is
    * re-scheduled if the previous attempt has finished. The method returns {@code false} when a
-   * start is rejected by guards (e.g., already starting, currently running, or cancelled). If an
+   * start is rejected by guards (e.g., already starting, currently running, or canceled). If an
    * {@link InsertException} occurs during preparation, the callback is notified and the method
    * returns {@code true} only when scheduling has successfully begun.
    *
@@ -237,7 +209,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
    * @param context execution context with schedulers and utilities required by the insert; must be
    *     non-null and remain valid while the insert is active.
    * @return {@code true} if the insert was accepted and scheduled; {@code false} if a guard
-   *     prevented starting or the operation was cancelled before scheduling.
+   *     prevented starting or the operation was canceled before scheduling.
    * @throws InsertException if validation, bucket access, or other preconditions fail during
    *     preparation; the callback is notified with the same exception instance.
    */
@@ -251,7 +223,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
         throw new InsertException(InsertExceptionMode.BUCKET_ERROR, "No data to insert", null);
 
       if (!prepareAndBuildState(restart, context, cryptoAlgorithm, randomiseKeys)) {
-        // If the insert was actually cancelled, report cancellation; otherwise this was a guard
+        // If the insert was actually canceled, report cancellation; otherwise this was a guard
         // rejection (e.g., already starting/running) and should not notify failure.
         synchronized (this) {
           if (cancelled) {
@@ -423,7 +395,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
   public static boolean randomiseSplitfileKeys(FreenetURI targetURI, InsertContext ctx) {
     // If the top level key is an SSK, all CHK blocks and particularly splitfiles below it should
     // have
-    // randomised keys. This substantially improves security by making it impossible to identify
+    // randomized keys. This substantially improves security by making it impossible to identify
     // blocks
     // even if you know the content. In the user interface, we will offer the option of inserting as
     // a
@@ -537,7 +509,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
 
   /**
    * Cancels the insert if it has not already finished. This triggers a failure callback with a
-   * {@link InsertExceptionMode#CANCELLED} reason unless the request was already cancelled.
+   * {@link InsertExceptionMode#CANCELLED} reason unless the request was already canceled.
    */
   @Override
   public void cancel(ClientContext context) {
@@ -554,7 +526,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
   }
 
   /**
-   * Indicates whether the insert has completed or was cancelled. The return value becomes stable
+   * Indicates whether the insert has completed or was canceled. The return value becomes stable
    * after completion; callers may poll to drive UI state while waiting for callbacks.
    */
   @Override
@@ -752,7 +724,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
    * @param context execution context with schedulers and utilities required by the insert; must be
    *     non-null and valid for rescheduling.
    * @return {@code true} if the restart was accepted and scheduled; {@code false} if guards
-   *     rejected the attempt or the request was cancelled.
+   *     rejected the attempt or the request was canceled.
    * @throws InsertException if validation or preparation fails during restart; the callback is
    *     notified with the thrown exception.
    */
@@ -764,7 +736,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
   public void onTransition(
       ClientGetState oldState, ClientGetState newState, ClientContext context) {
     // Ignore, at the moment
-    // This exists here because e.g. USKInserter does requests as well as inserts.
+    // This exists here because e.g. USKInserter does request as well as inserts.
   }
 
   @Override

--- a/src/main/java/network/crypta/client/async/ClientPutterOptions.java
+++ b/src/main/java/network/crypta/client/async/ClientPutterOptions.java
@@ -1,0 +1,30 @@
+package network.crypta.client.async;
+
+/**
+ * Optional settings for constructing a {@link ClientPutter}.
+ *
+ * <p>This record bundles optional filename hints, binary-blob behavior, splitfile crypto overrides,
+ * and metadata thresholding. All fields are optional and are stored without validation so the
+ * putter preserves the behavior of legacy constructors.
+ *
+ * @param targetFilename optional manifest filename for single-file inserts; may be {@code null}.
+ * @param binaryBlob when {@code true}, use the binary-blob insertion path.
+ * @param overrideSplitfileCrypto optional 32-byte key overriding random splitfile key generation.
+ * @param metadataThreshold when greater than zero, return compact metadata instead of a URI when
+ *     the encoded metadata length is below this threshold; units are bytes.
+ */
+public record ClientPutterOptions(
+    String targetFilename,
+    boolean binaryBlob,
+    byte[] overrideSplitfileCrypto,
+    long metadataThreshold) {
+
+  /**
+   * Returns default options with all optional settings disabled.
+   *
+   * @return a {@link ClientPutterOptions} instance with defaults applied.
+   */
+  public static ClientPutterOptions defaults() {
+    return new ClientPutterOptions(null, false, null, -1);
+  }
+}

--- a/src/main/java/network/crypta/client/async/ClientPutterOptions.java
+++ b/src/main/java/network/crypta/client/async/ClientPutterOptions.java
@@ -1,17 +1,34 @@
 package network.crypta.client.async;
 
+import java.util.Arrays;
+import org.jetbrains.annotations.NotNull;
+
 /**
- * Optional settings for constructing a {@link ClientPutter}.
+ * Immutable bundle of optional settings for constructing a {@link ClientPutter}.
  *
- * <p>This record bundles optional filename hints, binary-blob behavior, splitfile crypto overrides,
- * and metadata thresholding. All fields are optional and are stored without validation so the
- * putter preserves the behavior of legacy constructors.
+ * <p>This record carries opt-in configuration that is read by client putter creation logic but does
+ * not itself perform validation or normalization. Callers typically construct an instance with the
+ * desired values and pass it to the relevant {@link ClientPutter} entry point, or they start from
+ * {@link #defaults()} and replace individual components. Each component is stored exactly as
+ * provided, which preserves legacy constructor behavior and keeps this type free of side effects.
  *
- * @param targetFilename optional manifest filename for single-file inserts; may be {@code null}.
- * @param binaryBlob when {@code true}, use the binary-blob insertion path.
- * @param overrideSplitfileCrypto optional 32-byte key overriding random splitfile key generation.
- * @param metadataThreshold when greater than zero, return compact metadata instead of a URI when
- *     the encoded metadata length is below this threshold; units are bytes.
+ * <p>The record is effectively immutable in terms of its component references, but callers should
+ * treat the {@code overrideSplitfileCrypto} array as shared mutable state: its contents are not
+ * copied, so later mutations will be observed by equality checks and by any consumer that reads the
+ * array. For stable behavior across threads, keep the array content fixed after construction or
+ * pass a defensively copied buffer.
+ *
+ * <ul>
+ *   <li>Optional manifest filename hint for single-file inserts.
+ *   <li>Binary-blob insertion toggle for alternate storage behavior.
+ *   <li>Splitfile crypto override key stored verbatim without validation.
+ *   <li>Metadata size threshold for compact metadata responses.
+ * </ul>
+ *
+ * @param targetFilename optional manifest filename for single-file inserts; may be null.
+ * @param binaryBlob whether to use the binary-blob insertion path.
+ * @param overrideSplitfileCrypto optional 32-byte key to override random splitfile key generation.
+ * @param metadataThreshold byte threshold for compact metadata; non-positive disables optimization.
  */
 public record ClientPutterOptions(
     String targetFilename,
@@ -20,11 +37,96 @@ public record ClientPutterOptions(
     long metadataThreshold) {
 
   /**
-   * Returns default options with all optional settings disabled.
+   * Creates default options with all optional settings disabled.
    *
-   * @return a {@link ClientPutterOptions} instance with defaults applied.
+   * <p>The returned instance sets {@code targetFilename} and {@code overrideSplitfileCrypto} to
+   * {@code null}, {@code binaryBlob} to {@code false}, and {@code metadataThreshold} to {@code -1}
+   * to indicate that no compact-metadata threshold is active. This method is idempotent and always
+   * allocates a new record instance, so callers may hold onto it or create fresh defaults without
+   * affecting other call sites.
+   *
+   * <pre>{@code
+   * ClientPutterOptions options = ClientPutterOptions.defaults();
+   * }</pre>
+   *
+   * @return a new options record containing the standard default component values.
    */
   public static ClientPutterOptions defaults() {
     return new ClientPutterOptions(null, false, null, -1);
+  }
+
+  /**
+   * Determines equality by comparing each component, including array content.
+   *
+   * <p>This implementation mirrors record value semantics but treats {@code
+   * overrideSplitfileCrypto} specially by comparing the array contents with {@link
+   * Arrays#equals(byte[], byte[])}. If the array is mutated after construction, equality results
+   * may change over time; callers should treat the array as immutable for stable behavior. The
+   * comparison is null-safe for all components.
+   *
+   * @param other the other instance to compare against, or {@code null}.
+   * @return {@code true} when every component matches, including array contents.
+   */
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other
+        instanceof
+        ClientPutterOptions(
+            String otherTargetFilename,
+            boolean otherBinaryBlob,
+            byte[] otherOverrideSplitfileCrypto,
+            long otherMetadataThreshold))) {
+      return false;
+    }
+    return binaryBlob == otherBinaryBlob
+        && metadataThreshold == otherMetadataThreshold
+        && java.util.Objects.equals(targetFilename, otherTargetFilename)
+        && Arrays.equals(overrideSplitfileCrypto, otherOverrideSplitfileCrypto);
+  }
+
+  /**
+   * Computes a hash code consistent with the equality semantics for arrays.
+   *
+   * <p>The hash combines the non-array components with the content hash of {@code
+   * overrideSplitfileCrypto} via {@link Arrays#hashCode(byte[])}. This keeps the hash code aligned
+   * with {@link #equals(Object)} even when the array is non-null. If the array contents are mutated
+   * after construction, the hash code will also change, so avoid mutating once used in hashed
+   * collections.
+   *
+   * @return a hash code derived from all components and the array contents.
+   */
+  @Override
+  public int hashCode() {
+    int result = java.util.Objects.hash(targetFilename, binaryBlob, metadataThreshold);
+    result = 31 * result + Arrays.hashCode(overrideSplitfileCrypto);
+    return result;
+  }
+
+  /**
+   * Formats the options using component names and array contents.
+   *
+   * <p>The output mirrors the standard record style but expands {@code overrideSplitfileCrypto}
+   * using {@link Arrays#toString(byte[])} so callers can see the array contents without additional
+   * tooling. When the array is {@code null}, the rendered value is {@code "null"}. This method does
+   * not redact or validate values and is intended for debugging or logging where the raw components
+   * are acceptable.
+   *
+   * @return a non-null string representation of the current component values.
+   */
+  @Override
+  public @NotNull String toString() {
+    return "ClientPutterOptions["
+        + "targetFilename="
+        + targetFilename
+        + ", binaryBlob="
+        + binaryBlob
+        + ", overrideSplitfileCrypto="
+        + Arrays.toString(overrideSplitfileCrypto)
+        + ", metadataThreshold="
+        + metadataThreshold
+        + "]";
   }
 }

--- a/src/main/java/network/crypta/client/async/ClientPutterRequest.java
+++ b/src/main/java/network/crypta/client/async/ClientPutterRequest.java
@@ -1,0 +1,30 @@
+package network.crypta.client.async;
+
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertContext;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.RandomAccessBucket;
+
+/**
+ * Base request parameters for constructing a {@link ClientPutter}.
+ *
+ * <p>This record groups the callback, data source, target URI, metadata, insert context, and
+ * priority for a single-file insert request. Values are stored as provided and no validation is
+ * performed so the caller retains full control over request setup.
+ *
+ * @param callback callback receiving lifecycle events and final outputs.
+ * @param data payload bucket to insert; must remain readable for the insert lifetime.
+ * @param targetURI destination URI for the insert; must be insert-capable.
+ * @param clientMetadata client-visible metadata such as MIME type; may be {@code null}.
+ * @param insertContext insert configuration controlling splitfile strategy and scheduling.
+ * @param priorityClass scheduling priority class; smaller values represent higher priority.
+ * @param isMetadata whether the payload represents metadata rather than user content.
+ */
+public record ClientPutterRequest(
+    ClientPutCallback callback,
+    RandomAccessBucket data,
+    FreenetURI targetURI,
+    ClientMetadata clientMetadata,
+    InsertContext insertContext,
+    short priorityClass,
+    boolean isMetadata) {}

--- a/src/main/java/network/crypta/client/async/ClientPutterRequest.java
+++ b/src/main/java/network/crypta/client/async/ClientPutterRequest.java
@@ -6,19 +6,34 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.RandomAccessBucket;
 
 /**
- * Base request parameters for constructing a {@link ClientPutter}.
+ * Immutable bundle of inputs for a single-file {@link ClientPutter} request.
  *
- * <p>This record groups the callback, data source, target URI, metadata, insert context, and
- * priority for a single-file insert request. Values are stored as provided and no validation is
- * performed so the caller retains full control over request setup.
+ * <p>This record captures the callback, payload source, destination URI, metadata, and scheduling
+ * configuration needed to construct a putter. Callers typically create one instance per insert,
+ * populate it with the desired references, and hand it to the relevant {@link ClientPutter} entry
+ * point. The record performs no validation and stores references verbatim, which preserves legacy
+ * behavior and gives the caller full control over how inputs are prepared and validated.
  *
- * @param callback callback receiving lifecycle events and final outputs.
- * @param data payload bucket to insert; must remain readable for the insert lifetime.
- * @param targetURI destination URI for the insert; must be insert-capable.
- * @param clientMetadata client-visible metadata such as MIME type; may be {@code null}.
+ * <p>The record itself is shallowly immutable, but the referenced objects may be mutable; avoid
+ * mutating those references after construction if you need consistent behavior. In particular, the
+ * payload bucket must remain readable for the duration of the insert, and the URI/metadata should
+ * not change unexpectedly.
+ *
+ * <ul>
+ *   <li>Collects all required inputs for a single-file insert.
+ *   <li>Defers validation and normalization to the caller.
+ *   <li>Provides a stable, reusable container for scheduling parameters.
+ * </ul>
+ *
+ * @param callback callback receiving progress and completion events; may be {@code null}.
+ * @param data payload bucket to insert; must remain readable for insert lifetime.
+ * @param targetURI destination URI for the insert; should be insert-capable.
+ * @param clientMetadata optional client-visible metadata such as MIME type; may be {@code null}.
  * @param insertContext insert configuration controlling splitfile strategy and scheduling.
  * @param priorityClass scheduling priority class; smaller values represent higher priority.
  * @param isMetadata whether the payload represents metadata rather than user content.
+ * @see ClientPutter
+ * @see ClientPutterOptions
  */
 public record ClientPutterRequest(
     ClientPutCallback callback,

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -25,6 +25,8 @@ import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.client.async.BinaryBlob;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientPutter;
+import network.crypta.client.async.ClientPutterOptions;
+import network.crypta.client.async.ClientPutterRequest;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.crypt.SHA256;
@@ -247,17 +249,12 @@ public class ClientPut extends ClientPutBase {
 
     putter =
         new ClientPutter(
-            this,
-            data,
-            this.uri,
-            cm,
-            ctx,
-            priorityClass,
-            isMetadata,
-            this.uri.getDocName() == null ? targetFilename : null,
-            binaryBlob,
-            overrideSplitfileKey,
-            -1);
+            new ClientPutterRequest(this, data, this.uri, cm, ctx, priorityClass, isMetadata),
+            new ClientPutterOptions(
+                this.uri.getDocName() == null ? targetFilename : null,
+                binaryBlob,
+                overrideSplitfileKey,
+                -1));
   }
 
   /**
@@ -338,17 +335,13 @@ public class ClientPut extends ClientPutBase {
     if (LOG.isDebugEnabled()) LOG.debug(DATA_UPLOAD_LOG_TEMPLATE, data, uploadFrom);
     putter =
         new ClientPutter(
-            this,
-            data,
-            this.uri,
-            cm,
-            ctx,
-            priorityClass,
-            preparedData.isMetadata(),
-            this.uri.getDocName() == null ? targetFilename : null,
-            binaryBlob,
-            message.overrideSplitfileCryptoKey,
-            message.metadataThreshold);
+            new ClientPutterRequest(
+                this, data, this.uri, cm, ctx, priorityClass, preparedData.isMetadata()),
+            new ClientPutterOptions(
+                this.uri.getDocName() == null ? targetFilename : null,
+                binaryBlob,
+                message.overrideSplitfileCryptoKey,
+                message.metadataThreshold));
   }
 
   private static String ensureConnectionIdentifierAvailable(

--- a/src/main/java/network/crypta/node/NodeARKInserter.java
+++ b/src/main/java/network/crypta/node/NodeARKInserter.java
@@ -12,6 +12,8 @@ import network.crypta.client.async.BaseClientPutter;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
+import network.crypta.client.async.ClientPutterOptions;
+import network.crypta.client.async.ClientPutterRequest;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.io.comm.Peer;
 import network.crypta.io.comm.PeerParseException;
@@ -189,18 +191,16 @@ public class NodeARKInserter implements ClientPutCallback, RequestClient {
         node.services().clientCore().makeClient((short) 0, true, false).getInsertContext(true);
     inserter =
         new ClientPutter(
-            this,
-            b,
-            uri,
-            null, // Modern ARKs fit in ~1 KiB so use pure SSKs (no MIME type) to improve
-            // fetchability
-            ctx,
-            RequestStarter.INTERACTIVE_PRIORITY_CLASS,
-            false,
-            null,
-            false,
-            null,
-            -1);
+            new ClientPutterRequest(
+                this,
+                b,
+                uri,
+                null, // Modern ARKs fit in ~1 KiB so use pure SSKs (no MIME type) to improve
+                // fetchability
+                ctx,
+                RequestStarter.INTERACTIVE_PRIORITY_CLASS,
+                false),
+            ClientPutterOptions.defaults());
 
     try {
 

--- a/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
+++ b/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
@@ -39,6 +39,8 @@ import network.crypta.client.async.ClientGetCallback;
 import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
+import network.crypta.client.async.ClientPutterOptions;
+import network.crypta.client.async.ClientPutterRequest;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.SimpleBlockSet;
 import network.crypta.crypt.SHA256;
@@ -1612,17 +1614,9 @@ public class UpdateOverMandatoryManager implements RequestClient {
             .getInsertContext(true);
     ClientPutter putter =
         new ClientPutter(
-            callback,
-            bucket,
-            FreenetURI.EMPTY_CHK_URI,
-            null,
-            ctx,
-            priority,
-            false,
-            null,
-            true,
-            null,
-            -1);
+            new ClientPutterRequest(
+                callback, bucket, FreenetURI.EMPTY_CHK_URI, null, ctx, priority, false),
+            new ClientPutterOptions(null, true, null, -1));
     try {
       updateManager.getNode().services().clientCore().getClientContext().start(putter);
     } catch (InsertException e1) {

--- a/src/test/java/network/crypta/client/async/ClientPutterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientPutterTest.java
@@ -72,17 +72,19 @@ class ClientPutterTest {
   void start_whenDataNull_expectClientFailureAndFinished() throws Exception {
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            /*data*/ null,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata("text/plain"),
-            insertContextCurrent,
-            /*priorityClass*/ (short) 0,
-            /*isMetadata*/ false,
-            /*targetFilename*/ null,
-            /*binaryBlob*/ false,
-            /*overrideSplitfileCrypto*/ null,
-            /*metadataThreshold*/ 0L);
+            new ClientPutterRequest(
+                clientCallback,
+                /*data*/ null,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata("text/plain"),
+                insertContextCurrent,
+                /*priorityClass*/ (short) 0,
+                /*isMetadata*/ false),
+            new ClientPutterOptions(
+                /*targetFilename*/ null,
+                /*binaryBlob*/ false,
+                /*overrideSplitfileCrypto*/ null,
+                /*metadataThreshold*/ 0L));
 
     boolean result = putter.start(false, mock(ClientContext.class));
 
@@ -101,17 +103,15 @@ class ClientPutterTest {
     byte[] badOverride = new byte[16];
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            data,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            null,
-            false,
-            badOverride,
-            0L);
+            new ClientPutterRequest(
+                clientCallback,
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions(null, false, badOverride, 0L));
 
     boolean result = putter.start(false, mock(ClientContext.class));
 
@@ -147,17 +147,15 @@ class ClientPutterTest {
     RandomAccessBucket data = mock(RandomAccessBucket.class);
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            data,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            null,
-            false,
-            null,
-            0L);
+            new ClientPutterRequest(
+                clientCallback,
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions(null, false, null, 0L));
 
     // Simulate a re-entry while a start is already in progress
     Field startedStartingField = ClientPutter.class.getDeclaredField("startedStarting");
@@ -174,17 +172,15 @@ class ClientPutterTest {
       throws NoSuchFieldException, IllegalAccessException {
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            data,
-            new FreenetURI("SSK", "doc"),
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            null,
-            false,
-            override,
-            0L);
+            new ClientPutterRequest(
+                clientCallback,
+                data,
+                new FreenetURI("SSK", "doc"),
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions(null, false, override, 0L));
 
     // Set the protected 'cancelled' flag to true via reflection to simulate pre-cancel state.
     Field cancelledField = ClientRequester.class.getDeclaredField("cancelled");
@@ -221,17 +217,15 @@ class ClientPutterTest {
     RandomAccessBucket data = mock(RandomAccessBucket.class);
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            data,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            "file.txt",
-            false,
-            null,
-            0L);
+            new ClientPutterRequest(
+                clientCallback,
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions("file.txt", false, null, 0L));
 
     FreenetURI base = new FreenetURI("CHK", null, new byte[32], new byte[32], null);
     BaseClientKey key = mock(BaseClientKey.class);
@@ -256,17 +250,15 @@ class ClientPutterTest {
     RandomAccessBucket data = mock(RandomAccessBucket.class);
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            data,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            null,
-            false,
-            null,
-            0L);
+            new ClientPutterRequest(
+                clientCallback,
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions(null, false, null, 0L));
 
     Bucket bucket1 = mock(Bucket.class);
     Bucket bucket2 = mock(Bucket.class);
@@ -285,17 +277,15 @@ class ClientPutterTest {
     RandomAccessBucket data = mock(RandomAccessBucket.class);
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            data,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            null,
-            false,
-            null,
-            0L);
+            new ClientPutterRequest(
+                clientCallback,
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions(null, false, null, 0L));
 
     ClientPutState state = mock(ClientPutState.class);
     // Set currentState via onTransition(null, state, ...)
@@ -316,17 +306,15 @@ class ClientPutterTest {
     RandomAccessBucket data = mock(RandomAccessBucket.class);
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            data,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            null,
-            false,
-            null,
-            0L);
+            new ClientPutterRequest(
+                clientCallback,
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions(null, false, null, 0L));
 
     // Initially: no current state, data present
     assertTrue(putter.canRestart());
@@ -347,17 +335,15 @@ class ClientPutterTest {
     RandomAccessBucket data = mock(RandomAccessBucket.class);
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            data,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            null,
-            false,
-            null,
-            0L);
+            new ClientPutterRequest(
+                clientCallback,
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions(null, false, null, 0L));
 
     assertEquals(0, putter.getMinSuccessFetchBlocks());
     putter.addBlock();
@@ -371,17 +357,15 @@ class ClientPutterTest {
     RandomAccessBucket data = mock(RandomAccessBucket.class);
     ClientPutter putter =
         new ClientPutter(
-            clientCallback,
-            data,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            null,
-            false,
-            null,
-            0L);
+            new ClientPutterRequest(
+                clientCallback,
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions(null, false, null, 0L));
 
     ClientPutState state = mock(ClientPutState.class);
     putter.onSuccess(state, mock(ClientContext.class));
@@ -422,17 +406,15 @@ class ClientPutterTest {
   private byte[] getDetail(ClientPutCallback multiCb, RandomAccessBucket data) throws IOException {
     ClientPutter putter =
         new ClientPutter(
-            multiCb,
-            data,
-            FreenetURI.EMPTY_CHK_URI,
-            new ClientMetadata(),
-            insertContextCurrent,
-            (short) 0,
-            false,
-            null,
-            false,
-            null,
-            0L);
+            new ClientPutterRequest(
+                multiCb,
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                new ClientMetadata(),
+                insertContextCurrent,
+                (short) 0,
+                false),
+            new ClientPutterOptions(null, false, null, 0L));
 
     // Use a minimal ChecksumChecker stub; methods unused in this path
     ChecksumChecker checker =


### PR DESCRIPTION
## Summary
- introduce ClientPutterRequest and ClientPutterOptions records
- update ClientPutter construction call sites to use bundled parameters
- adjust ClientPutter tests to use the new request/options records

## Testing
- not run (not requested)
