### PR TITLE
refactor(client): bundle manifest putter params

### DIFF
--- a/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
+++ b/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
@@ -11,6 +11,7 @@ import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.DefaultManifestPutter;
+import network.crypta.client.async.ManifestPutterParams;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.TooManyFilesInsertException;
 import network.crypta.client.events.ClientEventListener;
@@ -607,15 +608,16 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
     try {
       putter =
           new DefaultManifestPutter(
-              pw,
-              BaseManifestPutter.bucketsByNameToManifestEntries(bucketsByName),
-              priorityClass,
-              insertURI,
-              defaultName,
-              getInsertContext(true),
-              false,
-              forceCryptoKey,
-              core.getClientContext());
+              new ManifestPutterParams(
+                  pw,
+                  BaseManifestPutter.bucketsByNameToManifestEntries(bucketsByName),
+                  priorityClass,
+                  insertURI,
+                  defaultName,
+                  getInsertContext(true),
+                  forceCryptoKey,
+                  core.getClientContext()),
+              false);
     } catch (TooManyFilesInsertException _) {
       throw new InsertException(InsertExceptionMode.TOO_MANY_FILES);
     }

--- a/src/main/java/network/crypta/client/async/DefaultManifestPutter.java
+++ b/src/main/java/network/crypta/client/async/DefaultManifestPutter.java
@@ -4,9 +4,7 @@ import java.io.Serial;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import network.crypta.client.InsertContext;
 import network.crypta.client.Metadata;
-import network.crypta.keys.FreenetURI;
 import network.crypta.support.ContainerSizeEstimator;
 import network.crypta.support.ContainerSizeEstimator.ContainerSize;
 import network.crypta.support.api.ManifestElement;
@@ -166,57 +164,34 @@ public class DefaultManifestPutter extends BaseManifestPutter {
    * parameters (e.g., randomized splitfile keys for SSK targets). No network I/O occurs until
    * {@code start(...)} is invoked on the enclosing put workflow.
    *
-   * @param clientCallback callback receiver for progress and completion events; must remain valid
-   *     for the duration of the insert. Null is not permitted.
-   * @param manifestElements hierarchical map of entry names to {@link
-   *     network.crypta.support.api.ManifestElement} or nested {@code Map}s; values are copied.
-   *     Entry names must be simple names relative to their directory level.
-   * @param prioClass priority class controlling scheduler behavior; higher priority may preempt
-   *     lower tiers. Valid values are implementation‑defined.
-   * @param target target {@link network.crypta.keys.FreenetURI} for the root container; SSK targets
-   *     enable randomized splitfile keys downstream.
-   * @param defaultName default document name within each directory. Provide a simple file name
-   *     without path separators; if missing in a given directory, no default is set there.
-   * @param ctx insert context with tuning parameters and compatibility mode; used to configure data
-   *     chunking and retries. Must be non‑null.
+   * @param params shared manifest putter parameters, including callback, manifest map, priorities
+   *     and context. The manifest map is defensively copied before packing.
    * @param persistent whether the job participates in persistence across restarts; when {@code
    *     true}, the putter coordinates with persistent job runners.
-   * @param forceCryptoKey optional override for content encryption; when {@code null}, defaults are
-   *     derived from the target and context.
-   * @param context environment and runtime services for the client; used for job scheduling and
-   *     resuming. Must be non‑null.
    * @throws TooManyFilesInsertException if the input contains an excessive number of files within a
    *     single directory such that reasonable packing cannot proceed.
    */
-  public DefaultManifestPutter(
-      ClientPutCallback clientCallback,
-      Map<String, Object> manifestElements,
-      short prioClass,
-      FreenetURI target,
-      String defaultName,
-      InsertContext ctx,
-      boolean persistent,
-      byte[] forceCryptoKey,
-      ClientContext context)
+  public DefaultManifestPutter(ManifestPutterParams params, boolean persistent)
       throws TooManyFilesInsertException {
     // If the top level key is an SSK, all CHK blocks and particularly splitfiles below it should
     // have
-    // randomised keys. This substantially improves security by making it impossible to identify
+    // randomized keys. This substantially improves security by making it impossible to identify
     // blocks
     // even if you know the content. In the user interface, we will offer the option of inserting as
     // a
     // random SSK to take advantage of this.
     super(
         new InitParams()
-            .withCb(clientCallback)
-            .withManifestElements(new HashMap<>(manifestElements))
-            .withPrioClass(prioClass)
-            .withTarget(target)
-            .withDefaultName(defaultName)
-            .withCtx(ctx)
-            .withRandomiseCryptoKeys(ClientPutter.randomiseSplitfileKeys(target, ctx))
-            .withForceCryptoKey(forceCryptoKey)
-            .withContext(context));
+            .withCb(params.clientCallback())
+            .withManifestElements(new HashMap<>(params.manifestElements()))
+            .withPrioClass(params.prioClass())
+            .withTarget(params.target())
+            .withDefaultName(params.defaultName())
+            .withCtx(params.ctx())
+            .withRandomiseCryptoKeys(
+                ClientPutter.randomiseSplitfileKeys(params.target(), params.ctx()))
+            .withForceCryptoKey(params.forceCryptoKey())
+            .withContext(params.context()));
     if (LOG.isDebugEnabled()) LOG.debug("DefaultManifestPutter persistent={}", persistent);
   }
 
@@ -229,7 +204,7 @@ public class DefaultManifestPutter extends BaseManifestPutter {
    * externals; leftovers are grouped into overflow archives to keep containers within limits.
    *
    * @param manifestElements hierarchical map of file names to elements or nested maps; must contain
-   *     only supported types as validated by {@link #verifyManifest(HashMap)}.
+   *     only supported types as validated by {@link #verifyManifest(Map)}.
    * @param defaultName default document name to apply within directories where a matching entry
    *     exists.
    * @throws TooManyFilesInsertException if a directory contains so many entries that a reasonable

--- a/src/main/java/network/crypta/client/async/ManifestPutterParams.java
+++ b/src/main/java/network/crypta/client/async/ManifestPutterParams.java
@@ -1,0 +1,142 @@
+package network.crypta.client.async;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.client.InsertContext;
+import network.crypta.keys.FreenetURI;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Bundles the shared construction arguments for manifest putters.
+ *
+ * <p>This record collects the common inputs required to construct manifest putters such as {@link
+ * DefaultManifestPutter} and {@link PlainManifestPutter}. Typical call sites assemble the manifest
+ * tree, select a priority class and target {@link FreenetURI}, then pass this bundle to a putter
+ * constructor alongside any mode-specific flags (for example, persistence). It is intentionally
+ * lightweight: it performs no validation, transformation, or defensive copying, so callers and the
+ * receiving putter determine how and when values are checked or copied.
+ *
+ * <p>Because the record carries references, its thread-safety depends on the referenced objects.
+ * The record instance itself is immutable, but mutable inputs such as the manifest map or the
+ * crypto key byte array can be modified by external code. If shared across threads, callers should
+ * provide appropriately safe, stable inputs. Equality and hashing compare array contents for the
+ * crypto key to avoid reference-only comparisons.
+ *
+ * <ul>
+ *   <li>Groups parameters that are repeated across manifest putter constructors.
+ *   <li>Preserves existing semantics by avoiding validation or copying.
+ *   <li>Supports content-based equality for the optional crypto key.
+ * </ul>
+ *
+ * @param clientCallback callback receiver for progress and completion events; must remain valid for
+ *     the putter lifetime and may be {@code null} if callers allow it.
+ * @param manifestElements manifest tree of entry names to elements or sub-maps; contents are
+ *     interpreted by the target putter without additional normalization here.
+ * @param prioClass scheduler priority class for the request; valid values depend on scheduler
+ *     configuration and must match the caller’s intent.
+ * @param target target URI for the root manifest; typically an SSK or CHK-like {@link FreenetURI}.
+ * @param defaultName default document name for directory levels; may be {@code null} when no
+ *     default document should be inferred.
+ * @param ctx insert context providing retry, chunking, and compatibility settings; must align with
+ *     the caller’s overall insertion policy.
+ * @param forceCryptoKey optional explicit splitfile key material; {@code null} means the putter may
+ *     derive or randomize keys as needed.
+ * @param context client context providing randomness and scheduling services; expected to be
+ *     non-{@code null} during putter execution.
+ */
+public record ManifestPutterParams(
+    ClientPutCallback clientCallback,
+    Map<String, Object> manifestElements,
+    short prioClass,
+    FreenetURI target,
+    String defaultName,
+    InsertContext ctx,
+    byte[] forceCryptoKey,
+    ClientContext context) {
+  /**
+   * Compares this parameter bundle to another for structural equality.
+   *
+   * <p>All reference fields are compared using their {@link Object#equals(Object)} implementations,
+   * while the {@code forceCryptoKey} array is compared by content. The method does not treat any
+   * field as optional beyond normal {@code null} handling, and it does not attempt to validate or
+   * normalize values. As a result, two bundles created from distinct but equal maps or URIs will be
+   * considered equal, while identity-different arrays with the same bytes will also be equal.
+   *
+   * @param o candidate object to compare with this bundle; may be {@code null}.
+   * @return {@code true} when all fields are equal by the rules above, otherwise {@code false}.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o
+        instanceof
+        ManifestPutterParams(
+            ClientPutCallback otherClientCallback,
+            Map<String, Object> otherManifestElements,
+            short otherPrioClass,
+            FreenetURI otherTarget,
+            String otherDefaultName,
+            InsertContext otherCtx,
+            byte[] otherForceCryptoKey,
+            ClientContext otherContext))) return false;
+    return prioClass == otherPrioClass
+        && Objects.equals(clientCallback, otherClientCallback)
+        && Objects.equals(manifestElements, otherManifestElements)
+        && Objects.equals(target, otherTarget)
+        && Objects.equals(defaultName, otherDefaultName)
+        && Objects.equals(ctx, otherCtx)
+        && Arrays.equals(forceCryptoKey, otherForceCryptoKey)
+        && Objects.equals(context, otherContext);
+  }
+
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash uses {@link Objects#hash(Object...)} for reference fields and {@link
+   * Arrays#hashCode(byte[])} for the crypto key array to preserve content-based semantics. This is
+   * suitable for use in hash-based collections as long as callers do not mutate referenced objects
+   * that participate in equality.
+   *
+   * @return hash code derived from all record components, including the array contents.
+   */
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            clientCallback, manifestElements, prioClass, target, defaultName, ctx, context);
+    result = 31 * result + Arrays.hashCode(forceCryptoKey);
+    return result;
+  }
+
+  /**
+   * Returns a human-readable representation of the bundle for diagnostics.
+   *
+   * <p>The string includes all record components in declaration order and renders the crypto key
+   * using {@link Arrays#toString(byte[])} for byte-content visibility. It is intended for logging
+   * and debugging and should not be parsed or used for security-sensitive output.
+   *
+   * @return descriptive string including component values and the crypto key contents.
+   */
+  @Override
+  public @NotNull String toString() {
+    return "ManifestPutterParams{"
+        + "clientCallback="
+        + clientCallback
+        + ", manifestElements="
+        + manifestElements
+        + ", prioClass="
+        + prioClass
+        + ", target="
+        + target
+        + ", defaultName="
+        + defaultName
+        + ", ctx="
+        + ctx
+        + ", forceCryptoKey="
+        + Arrays.toString(forceCryptoKey)
+        + ", context="
+        + context
+        + '}';
+  }
+}

--- a/src/main/java/network/crypta/client/async/PlainManifestPutter.java
+++ b/src/main/java/network/crypta/client/async/PlainManifestPutter.java
@@ -65,29 +65,37 @@ public class PlainManifestPutter extends BaseManifestPutter {
    * Map<String, Object> root = new HashMap<>();
    * root.put("dir", sub);
    * root.put("readme.txt", elementReadme);
-   * var putter = new PlainManifestPutter(cb, root, prio, target, "index.html", ctx, key, context);
+   * var params = new ManifestPutterParams(cb, root, prio, target, "index.html", ctx, key, context);
+   * var putter = new PlainManifestPutter(params);
    * }</pre>
    *
-   * @param clientCallback callback receiving progress and completion events; must be non-null and
-   *     remain valid for the lifetime of the putter.
-   * @param manifestElements directory tree where keys are entry names and values are either {@code
-   *     Map<String, Object>} for subdirectories or {@code ManifestElement} for files; map
-   *     implementations may be immutable or mutable and are normalized internally.
-   * @param prioClass scheduler priority class for the request; higher values may receive greater
-   *     priority under the active scheduling policy.
-   * @param target desired target URI for the top-level manifest; the final URI may include metadata
-   *     as determined by the insert process.
-   * @param defaultName default document name considered within each directory level; compared by
-   *     exact name equality against child file entries.
-   * @param ctx insert context providing sizes, retry limits, and feature toggles; must match the
-   *     caller’s expectations for compatibility.
-   * @param forceCryptoKey optional explicit key material for splitfiles; when {@code null} and the
-   *     {@code target}/{@code ctx} imply randomization, a key may be generated internally.
-   * @param context client context providing randomness sources and scheduler access; must remain
-   *     accessible for the duration of the insert.
+   * @param params shared manifest putter parameters including callback, manifest map, and context
+   *     required by the base putter.
    * @throws TooManyFilesInsertException if the manifest contains more items than supported or
    *     exceeds structural limits during handler creation.
    */
+  public PlainManifestPutter(ManifestPutterParams params) throws TooManyFilesInsertException {
+    super(
+        new InitParams()
+            .withCb(params.clientCallback())
+            .withManifestElements(params.manifestElements())
+            .withPrioClass(params.prioClass())
+            .withTarget(params.target())
+            .withDefaultName(params.defaultName())
+            .withCtx(params.ctx())
+            .withRandomiseCryptoKeys(
+                ClientPutter.randomiseSplitfileKeys(params.target(), params.ctx()))
+            .withForceCryptoKey(params.forceCryptoKey())
+            .withContext(params.context()));
+  }
+
+  /**
+   * Legacy constructor retained for callers that do not yet use {@link ManifestPutterParams}.
+   *
+   * @deprecated Use {@link #PlainManifestPutter(ManifestPutterParams)} instead.
+   */
+  @Deprecated
+  @SuppressWarnings("java:S107")
   public PlainManifestPutter(
       ClientPutCallback clientCallback,
       Map<String, Object> manifestElements,
@@ -98,17 +106,16 @@ public class PlainManifestPutter extends BaseManifestPutter {
       byte[] forceCryptoKey,
       ClientContext context)
       throws TooManyFilesInsertException {
-    super(
-        new InitParams()
-            .withCb(clientCallback)
-            .withManifestElements(manifestElements)
-            .withPrioClass(prioClass)
-            .withTarget(target)
-            .withDefaultName(defaultName)
-            .withCtx(ctx)
-            .withRandomiseCryptoKeys(ClientPutter.randomiseSplitfileKeys(target, ctx))
-            .withForceCryptoKey(forceCryptoKey)
-            .withContext(context));
+    this(
+        new ManifestPutterParams(
+            clientCallback,
+            manifestElements,
+            prioClass,
+            target,
+            defaultName,
+            ctx,
+            forceCryptoKey,
+            context));
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -20,6 +20,7 @@ import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.ContainerInserter;
 import network.crypta.client.async.DefaultManifestPutter;
 import network.crypta.client.async.ManifestPutter;
+import network.crypta.client.async.ManifestPutterParams;
 import network.crypta.client.async.TooManyFilesInsertException;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
@@ -421,15 +422,16 @@ public class ClientPutDir extends ClientPutBase {
   private void makePutter(ClientContext context) throws TooManyFilesInsertException {
     putter =
         new DefaultManifestPutter(
-            this,
-            manifestElements,
-            priorityClass,
-            uri,
-            defaultName,
-            ctx,
-            persistence == Persistence.FOREVER,
-            overrideSplitfileCryptoKey,
-            context);
+            new ManifestPutterParams(
+                this,
+                manifestElements,
+                priorityClass,
+                uri,
+                defaultName,
+                ctx,
+                overrideSplitfileCryptoKey,
+                context),
+            persistence == Persistence.FOREVER);
   }
 
   /**

--- a/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
@@ -73,15 +73,16 @@ class DefaultManifestPutterTest {
         IllegalArgumentException.class,
         () ->
             new DefaultManifestPutter(
-                cb,
-                root,
-                /*prioClass*/ (short) 0,
-                FreenetURI.EMPTY_CHK_URI,
-                /*defaultName*/ "index.html",
-                ctx,
-                /*persistent*/ false,
-                /*forceCryptoKey*/ null,
-                /*context*/ mock(ClientContext.class)));
+                new ManifestPutterParams(
+                    cb,
+                    root,
+                    /*prioClass*/ (short) 0,
+                    FreenetURI.EMPTY_CHK_URI,
+                    /*defaultName*/ "index.html",
+                    ctx,
+                    /*forceCryptoKey*/ null,
+                    /*context*/ mock(ClientContext.class)),
+                /*persistent*/ false));
   }
 
   // A subclass that lets us spy on the builders created during packing
@@ -101,7 +102,9 @@ class DefaultManifestPutterTest {
         byte[] forceKey,
         ClientContext context)
         throws TooManyFilesInsertException {
-      super(cb, manifest, prio, target, defaultName, ctx, persistent, forceKey, context);
+      super(
+          new ManifestPutterParams(cb, manifest, prio, target, defaultName, ctx, forceKey, context),
+          persistent);
     }
 
     @Override

--- a/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
@@ -73,14 +73,15 @@ class PlainManifestPutterTest {
     // Act
     PlainManifestPutter putter =
         new PlainManifestPutter(
-            cb,
-            root,
-            /*prioClass*/ (short) 0,
-            FreenetURI.EMPTY_CHK_URI,
-            /*defaultName*/ "index.html",
-            ctx,
-            forceKey,
-            /*context*/ mock(ClientContext.class));
+            new ManifestPutterParams(
+                cb,
+                root,
+                /*prioClass*/ (short) 0,
+                FreenetURI.EMPTY_CHK_URI,
+                /*defaultName*/ "index.html",
+                ctx,
+                forceKey,
+                /*context*/ mock(ClientContext.class)));
 
     // Assert
     assertEquals(2, putter.countFiles(), "counts only external data elements");
@@ -115,14 +116,15 @@ class PlainManifestPutterTest {
         ClientContext context)
         throws TooManyFilesInsertException {
       super(
-          cb,
-          manifest,
-          /*prioClass*/ (short) 0,
-          FreenetURI.EMPTY_CHK_URI,
-          /*defaultName*/ "index.html",
-          ctx,
-          forceKey,
-          context);
+          new ManifestPutterParams(
+              cb,
+              manifest,
+              /*prioClass*/ (short) 0,
+              FreenetURI.EMPTY_CHK_URI,
+              /*defaultName*/ "index.html",
+              ctx,
+              forceKey,
+              context));
     }
 
     void setInjectedBuilder(FreeFormBuilder b) {
@@ -265,14 +267,15 @@ class PlainManifestPutterTest {
 
     PlainManifestPutter putter =
         new PlainManifestPutter(
-            cb,
-            new HashMap<>(),
-            /*prioClass*/ (short) 0,
-            FreenetURI.EMPTY_CHK_URI,
-            /*defaultName*/ "index.html",
-            ctx,
-            forceKey,
-            mock(ClientContext.class));
+            new ManifestPutterParams(
+                cb,
+                new HashMap<>(),
+                /*prioClass*/ (short) 0,
+                FreenetURI.EMPTY_CHK_URI,
+                /*defaultName*/ "index.html",
+                ctx,
+                forceKey,
+                mock(ClientContext.class)));
 
     // We expect notifyClients() to call getJobRunner(true).queueNormalOrDrop(...)
     ClientContext context = mock(ClientContext.class);


### PR DESCRIPTION
## Summary
- add ManifestPutterParams to bundle shared manifest putter inputs
- update Default/Plain manifest putter call sites to use the parameter bundle
- keep legacy PlainManifestPutter constructor as a deprecated shim

## Testing
- ./gradlew spotlessApply