### PR TITLE
refactor(client): bundle block insert args

### DIFF
--- a/src/main/java/network/crypta/client/async/BlockInsertOptions.java
+++ b/src/main/java/network/crypta/client/async/BlockInsertOptions.java
@@ -1,0 +1,15 @@
+package network.crypta.client.async;
+
+/**
+ * Options controlling persistence and scheduling for block-level inserts.
+ *
+ * <p>This record is a lightweight container that mirrors constructor flags used by single-block
+ * inserters. It performs no validation and stores values verbatim.
+ *
+ * @param persistent whether the insert is persistent across restarts
+ * @param realTimeFlag whether to schedule the insert as real-time
+ * @param freeData whether to free the source bucket on terminal completion
+ * @param extraInserts number of additional successful insert attempts beyond the first
+ */
+public record BlockInsertOptions(
+    boolean persistent, boolean realTimeFlag, boolean freeData, int extraInserts) {}

--- a/src/main/java/network/crypta/client/async/BlockInsertParams.java
+++ b/src/main/java/network/crypta/client/async/BlockInsertParams.java
@@ -1,0 +1,27 @@
+package network.crypta.client.async;
+
+import network.crypta.client.InsertContext;
+
+/**
+ * Bundles the shared constructor arguments for block-level inserters.
+ *
+ * <p>This record groups the parent putter, callback, and immediate notification context required to
+ * set up a block insert. It intentionally performs no validation or normalization; callers and the
+ * receiving inserter remain responsible for enforcing any invariants.
+ *
+ * @param parent parent putter coordinating progress and persistence
+ * @param ctx insert context controlling retries, compression, and scheduling hints
+ * @param callback completion callback invoked for encode/success/failure transitions
+ * @param token numeric correlation token used by callers for logging or indexing
+ * @param tokenObject opaque token returned to callers; may be {@code null}
+ * @param addToParent whether to increment parent must-succeed counters on construction
+ * @param context runtime context used for immediate parent notifications during construction
+ */
+public record BlockInsertParams(
+    BaseClientPutter parent,
+    InsertContext ctx,
+    PutCompletionCallback callback,
+    int token,
+    Object tokenObject,
+    boolean addToParent,
+    ClientContext context) {}

--- a/src/main/java/network/crypta/client/async/BlockInsertPayload.java
+++ b/src/main/java/network/crypta/client/async/BlockInsertPayload.java
@@ -1,0 +1,102 @@
+package network.crypta.client.async;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Immutable bundle describing the data and encoding parameters for a single block insert.
+ *
+ * <p>This record groups the bucket payload with the key and encoding metadata required by
+ * block-level inserters such as {@link SingleBlockInserter} and {@link USKInserter}. It performs no
+ * validation or defensive copying; callers are responsible for supplying valid values and for
+ * ensuring the referenced bucket remains readable for the duration of the insert.
+ *
+ * <p>The {@code cryptoKey} array is stored by reference and compared by content for equality. Avoid
+ * mutating it after construction if you rely on stable equality or hash semantics.
+ *
+ * @param data source bucket containing the bytes to insert; must remain readable during encoding
+ * @param uri target URI that determines the key type (e.g., CHK/SSK/USK)
+ * @param compressionCodec compression codec identifier; {@code -1} lets the encoder decide
+ * @param isMetadata whether the content should be encoded as metadata
+ * @param sourceLength uncompressed source length in bytes, or {@code -1} if unknown
+ * @param cryptoAlgorithm identifier for optional per-block cryptography; {@code 0} for none
+ * @param cryptoKey raw key material for {@code cryptoAlgorithm}; may be {@code null} when unused
+ */
+public record BlockInsertPayload(
+    Bucket data,
+    FreenetURI uri,
+    short compressionCodec,
+    boolean isMetadata,
+    int sourceLength,
+    byte cryptoAlgorithm,
+    byte[] cryptoKey) {
+
+  /**
+   * Compares this payload to another for structural equality, including array contents.
+   *
+   * @param o candidate object to compare with this payload; may be {@code null}
+   * @return {@code true} when all fields match by value; otherwise {@code false}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o
+        instanceof
+        BlockInsertPayload(
+            Bucket otherData,
+            FreenetURI otherUri,
+            short otherCompressionCodec,
+            boolean otherIsMetadata,
+            int otherSourceLength,
+            byte otherCryptoAlgorithm,
+            byte[] otherCryptoKey))) return false;
+    return compressionCodec == otherCompressionCodec
+        && isMetadata == otherIsMetadata
+        && sourceLength == otherSourceLength
+        && cryptoAlgorithm == otherCryptoAlgorithm
+        && Objects.equals(data, otherData)
+        && Objects.equals(uri, otherUri)
+        && Arrays.equals(cryptoKey, otherCryptoKey);
+  }
+
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * @return hash code derived from all components, including crypto key contents
+   */
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(data, uri, compressionCodec, isMetadata, sourceLength, cryptoAlgorithm);
+    result = 31 * result + Arrays.hashCode(cryptoKey);
+    return result;
+  }
+
+  /**
+   * Returns a descriptive string including the crypto key contents.
+   *
+   * @return a non-null string representation of this payload
+   */
+  @Override
+  public @NotNull String toString() {
+    return "BlockInsertPayload["
+        + "data="
+        + data
+        + ", uri="
+        + uri
+        + ", compressionCodec="
+        + compressionCodec
+        + ", isMetadata="
+        + isMetadata
+        + ", sourceLength="
+        + sourceLength
+        + ", cryptoAlgorithm="
+        + cryptoAlgorithm
+        + ", cryptoKey="
+        + Arrays.toString(cryptoKey)
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/client/async/SimpleHealingQueue.java
+++ b/src/main/java/network/crypta/client/async/SimpleHealingQueue.java
@@ -135,25 +135,17 @@ public class SimpleHealingQueue extends BaseClientPutter
       try {
         sbi =
             new SingleBlockInserter(
-                this,
-                data,
-                (short) -1,
-                FreenetURI.EMPTY_CHK_URI,
-                ctx,
-                realTimeFlag,
-                this,
-                false,
-                CHKBlock.DATA_LENGTH,
-                ctr,
-                false,
-                false,
-                data,
-                context,
-                false,
-                true,
-                0,
-                cryptoAlgorithm,
-                cryptoKey);
+                new BlockInsertPayload(
+                    data,
+                    FreenetURI.EMPTY_CHK_URI,
+                    (short) -1,
+                    false,
+                    CHKBlock.DATA_LENGTH,
+                    cryptoAlgorithm,
+                    cryptoKey),
+                new BlockInsertParams(this, ctx, this, ctr, data, false, context),
+                new BlockInsertOptions(false, realTimeFlag, true, 0),
+                false);
       } catch (Exception e) {
         LOG.error("Caught trying to insert healing block", e);
         return false;

--- a/src/main/java/network/crypta/client/async/SingleBlockInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleBlockInserter.java
@@ -185,74 +185,42 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
    * register it with the scheduler or {@link #tryEncode(ClientContext)} to trigger an early encode
    * when the context enables it.
    *
-   * @param parent The owning putter; must be active and used for progress aggregation.
-   * @param data The source {@link Bucket} containing the bytes to encode and insert; never null.
-   * @param compressionCodec Compression codec id; {@code -1} delegates to context/implementation.
-   * @param uri Base URI whose key type determines CHK/SSK/KSK behavior and encoding rules.
-   * @param ctx Insert policy and limits (retries, RNF heuristics, compressor descriptor, etc.).
-   * @param realTimeFlag Whether to schedule this insert as real-time in the underlying framework.
-   * @param cb Callback notified on encode and when the request finally succeeds or fails.
-   * @param isMetadata Whether the data should be encoded as metadata rather than ordinary content.
-   * @param sourceLength Length of the original, uncompressed data (bytes), or {@code -1} if
-   *     unknown.
-   * @param token Integer token used by callers to correlate this block (e.g., splitfile indices).
-   * @param addToParent When true, increments the parent's must-succeed counter and notifies
-   *     clients.
+   * @param payload block data and encoding parameters for this insert
+   * @param params shared inserter parameters including parent, callbacks, and insert context
+   * @param options persistence and scheduling options for this block insert
    * @param dontSendEncoded Suppress the early on-encode callback even if a key is available.
-   * @param tokenObject Opaque token exposed via {@link #getToken()} to identify this request.
-   * @param context Runtime context used immediately for parent notifications on construction.
-   * @param persistent Whether this request is persistent across restarts in the client framework.
-   * @param freeData Whether to free {@code data} when the request reaches a terminal state.
-   * @param extraInserts Number of additional successful inserts to perform after the first success.
-   * @param cryptoAlgorithm Identifier for optional per-block cryptography; {@code 0} for none.
-   * @param cryptoKey Raw key bytes used with {@code cryptoAlgorithm}; {@code null} when not used.
    */
   public SingleBlockInserter(
-      BaseClientPutter parent,
-      Bucket data,
-      short compressionCodec,
-      FreenetURI uri,
-      InsertContext ctx,
-      boolean realTimeFlag,
-      PutCompletionCallback cb,
-      boolean isMetadata,
-      int sourceLength,
-      int token,
-      boolean addToParent,
-      boolean dontSendEncoded,
-      Object tokenObject,
-      ClientContext context,
-      boolean persistent,
-      boolean freeData,
-      int extraInserts,
-      byte cryptoAlgorithm,
-      byte[] cryptoKey) {
-    super(persistent, realTimeFlag);
+      BlockInsertPayload payload,
+      BlockInsertParams params,
+      BlockInsertOptions options,
+      boolean dontSendEncoded) {
+    super(options.persistent(), options.realTimeFlag());
     this.consecutiveRNFs = 0;
-    this.tokenObject = tokenObject;
-    this.token = token;
-    this.parent = parent;
+    this.tokenObject = params.tokenObject();
+    this.token = params.token();
+    this.parent = params.parent();
     this.dontSendEncoded = dontSendEncoded;
     this.retries = 0;
     this.finished = false;
-    this.ctx = ctx;
-    this.freeData = freeData;
+    this.ctx = params.ctx();
+    this.freeData = options.freeData();
     errors = new FailureCodeTracker(true);
-    this.cb = cb;
-    this.uri = uri;
-    this.compressionCodec = compressionCodec;
-    this.sourceData = data;
+    this.cb = params.callback();
+    this.uri = payload.uri();
+    this.compressionCodec = payload.compressionCodec();
+    this.sourceData = payload.data();
     if (sourceData == null) throw new NullPointerException();
-    this.isMetadata = isMetadata;
-    this.sourceLength = sourceLength;
+    this.isMetadata = payload.isMetadata();
+    this.sourceLength = payload.sourceLength();
     isSSK = uri.getKeyType().equalsIgnoreCase("SSK");
-    if (addToParent) {
-      parent.addMustSucceedBlocks(1);
-      parent.notifyClients(context);
+    if (params.addToParent()) {
+      params.parent().addMustSucceedBlocks(1);
+      params.parent().notifyClients(params.context());
     }
-    this.extraInserts = extraInserts;
-    this.cryptoAlgorithm = cryptoAlgorithm;
-    this.cryptoKey = cryptoKey;
+    this.extraInserts = options.extraInserts();
+    this.cryptoAlgorithm = payload.cryptoAlgorithm();
+    this.cryptoKey = payload.cryptoKey();
   }
 
   /**
@@ -271,14 +239,15 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     try {
       return innerEncode(
           random,
-          uri,
-          sourceData,
-          isMetadata,
-          compressionCodec,
-          sourceLength,
-          ctx.getCompressorDescriptor(),
-          cryptoAlgorithm,
-          cryptoKey);
+          new BlockInsertPayload(
+              sourceData,
+              uri,
+              compressionCodec,
+              isMetadata,
+              sourceLength,
+              cryptoAlgorithm,
+              cryptoKey),
+          ctx.getCompressorDescriptor());
     } catch (KeyEncodeException | InvalidCompressionCodecException e) {
       throw new InsertException(InsertExceptionMode.INTERNAL_ERROR, e, null);
     } catch (MalformedURLException e) {
@@ -298,15 +267,8 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
    * implementation may choose whether to compress. Callers must provide a non-null {@code random}.
    *
    * @param random Randomness provider required by the encoders; must not be {@code null}.
-   * @param uri Target URI whose key type selects the encoding path (CHK/SSK/KSK).
-   * @param sourceData Bucket containing the bytes to encode; implementations may read it multiple
-   *     times.
-   * @param isMetadata Whether the content should be marked as metadata in the encoded block.
-   * @param compressionCodec Compression codec id; {@code -1} lets the encoder decide.
-   * @param sourceLength Uncompressed source length in bytes, when known; {@code -1} if unknown.
+   * @param payload Block payload and encoding parameters; must not be {@code null}.
    * @param compressorDescriptor Human-readable compressor descriptor used by encoders and logs.
-   * @param cryptoAlgorithm Optional algorithm id for per-block cryptography; {@code 0} for none.
-   * @param cryptoKey Raw key material for {@code cryptoAlgorithm}; may be {@code null} when unused.
    * @return Encoded block ready for scheduling and transmission.
    * @throws InsertException If the URI type is unknown or otherwise invalid for insertion.
    * @throws CHKEncodeException If CHK encoding fails due to content or configuration issues.
@@ -315,40 +277,32 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
    * @throws InvalidCompressionCodecException If the codec id is not recognized by encoders.
    */
   protected static ClientKeyBlock innerEncode(
-      RandomSource random,
-      FreenetURI uri,
-      Bucket sourceData,
-      boolean isMetadata,
-      short compressionCodec,
-      int sourceLength,
-      String compressorDescriptor,
-      byte cryptoAlgorithm,
-      byte[] cryptoKey)
+      RandomSource random, BlockInsertPayload payload, String compressorDescriptor)
       throws InsertException,
           CHKEncodeException,
           IOException,
           SSKEncodeException,
           InvalidCompressionCodecException {
     Objects.requireNonNull(random, "random");
-    String uriType = uri.getKeyType();
+    String uriType = payload.uri().getKeyType();
     if (uriType.equals("CHK")) {
       return ClientCHKBlock.encode(
-          sourceData,
-          isMetadata,
-          compressionCodec == -1,
-          compressionCodec,
-          sourceLength,
+          payload.data(),
+          payload.isMetadata(),
+          payload.compressionCodec() == -1,
+          payload.compressionCodec(),
+          payload.sourceLength(),
           compressorDescriptor,
-          cryptoKey,
-          cryptoAlgorithm);
+          payload.cryptoKey(),
+          payload.cryptoAlgorithm());
     } else if (uriType.equals("SSK") || uriType.equals("KSK")) {
-      InsertableClientSSK ik = InsertableClientSSK.create(uri);
+      InsertableClientSSK ik = InsertableClientSSK.create(payload.uri());
       return ik.encode(
-          sourceData,
-          isMetadata,
-          compressionCodec == -1,
-          compressionCodec,
-          sourceLength,
+          payload.data(),
+          payload.isMetadata(),
+          payload.compressionCodec() == -1,
+          payload.compressionCodec(),
+          payload.sourceLength(),
           compressorDescriptor);
     } else {
       throw new InsertException(
@@ -743,14 +697,15 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     try {
       return innerEncode(
           context.random,
-          block.uri,
-          block.copyBucket,
-          block.isMetadata,
-          block.compressionCodec,
-          block.sourceLength,
-          compressorDescriptor,
-          block.cryptoAlgorithm,
-          block.cryptoKey);
+          new BlockInsertPayload(
+              block.copyBucket,
+              block.uri,
+              block.compressionCodec,
+              block.isMetadata,
+              block.sourceLength,
+              block.cryptoAlgorithm,
+              block.cryptoKey),
+          compressorDescriptor);
     } catch (CHKEncodeException
         | SSKEncodeException
         | InsertException
@@ -950,14 +905,9 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
       }
       return new BlockItem(
           key,
-          data,
-          isMetadata,
-          compressionCodec,
-          sourceLength,
-          u,
-          persistent,
-          cryptoAlgorithm,
-          cryptoKey);
+          new BlockInsertPayload(
+              data, u, compressionCodec, isMetadata, sourceLength, cryptoAlgorithm, cryptoKey),
+          persistent);
     } catch (IOException e) {
       throw new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null);
     }
@@ -1005,25 +955,16 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     private final byte cryptoAlgorithm;
     private final byte[] cryptoKey;
 
-    BlockItem(
-        BlockItemKey key,
-        Bucket bucket,
-        boolean meta,
-        short codec,
-        int srclen,
-        FreenetURI u,
-        boolean persistent,
-        byte cryptoAlgorithm,
-        byte[] cryptoKey) {
+    BlockItem(BlockItemKey key, BlockInsertPayload payload, boolean persistent) {
       this.key = key;
-      this.copyBucket = bucket;
-      this.uri = u;
-      this.isMetadata = meta;
-      this.compressionCodec = codec;
-      this.sourceLength = srclen;
+      this.copyBucket = payload.data();
+      this.uri = payload.uri();
+      this.isMetadata = payload.isMetadata();
+      this.compressionCodec = payload.compressionCodec();
+      this.sourceLength = payload.sourceLength();
       this.persistent = persistent;
-      this.cryptoAlgorithm = cryptoAlgorithm;
-      this.cryptoKey = cryptoKey;
+      this.cryptoAlgorithm = payload.cryptoAlgorithm();
+      this.cryptoKey = payload.cryptoKey();
     }
 
     @Override

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -532,27 +532,23 @@ class SingleFileInserter implements ClientPutState, Serializable {
       throws InsertException {
     SingleBlockInserter dataPutter =
         new SingleBlockInserter(
-            parent,
-            data,
-            codecNumber,
-            FreenetURI.EMPTY_CHK_URI,
-            ctx,
-            realTimeFlag,
-            cb,
-            metadata,
-            (int) origSize,
-            -1,
-            true,
-            true,
-            token,
-            context,
-            persistent,
-            shouldFreeData,
-            forSplitfile
-                ? ctx.getExtraInsertsSplitfileHeaderBlock()
-                : ctx.getExtraInsertsSingleBlock(),
-            cryptoAlgorithm,
-            forceCryptoKey);
+            new BlockInsertPayload(
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                codecNumber,
+                metadata,
+                (int) origSize,
+                cryptoAlgorithm,
+                forceCryptoKey),
+            new BlockInsertParams(parent, ctx, cb, -1, token, true, context),
+            new BlockInsertOptions(
+                persistent,
+                realTimeFlag,
+                shouldFreeData,
+                forSplitfile
+                    ? ctx.getExtraInsertsSplitfileHeaderBlock()
+                    : ctx.getExtraInsertsSingleBlock()),
+            true);
     if (LOG.isTraceEnabled()) LOG.trace("Inserting with metadata: {} for {}", dataPutter, this);
     Metadata meta = makeMetadata(archiveType, dataPutter.getURI(context), hashes);
     cb.onMetadata(meta, this, context);
@@ -578,27 +574,23 @@ class SingleFileInserter implements ClientPutState, Serializable {
         new MultiPutCompletionCallback(cb, parent, token, persistent, false, ctx.isEarlyEncode());
     SingleBlockInserter dataPutter =
         new SingleBlockInserter(
-            parent,
-            data,
-            codecNumber,
-            FreenetURI.EMPTY_CHK_URI,
-            ctx,
-            realTimeFlag,
-            mcb,
-            metadata,
-            (int) origSize,
-            -1,
-            true,
-            false,
-            token,
-            context,
-            persistent,
-            shouldFreeData,
-            forSplitfile
-                ? ctx.getExtraInsertsSplitfileHeaderBlock()
-                : ctx.getExtraInsertsSingleBlock(),
-            cryptoAlgorithm,
-            forceCryptoKey);
+            new BlockInsertPayload(
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                codecNumber,
+                metadata,
+                (int) origSize,
+                cryptoAlgorithm,
+                forceCryptoKey),
+            new BlockInsertParams(parent, ctx, mcb, -1, token, true, context),
+            new BlockInsertOptions(
+                persistent,
+                realTimeFlag,
+                shouldFreeData,
+                forSplitfile
+                    ? ctx.getExtraInsertsSplitfileHeaderBlock()
+                    : ctx.getExtraInsertsSingleBlock()),
+            false);
     if (LOG.isTraceEnabled()) LOG.trace("Inserting data: {} for {}", dataPutter, this);
     Metadata meta = makeMetadata(archiveType, dataPutter.getURI(context), hashes);
     RandomAccessBucket metadataBucket;
@@ -926,53 +918,45 @@ class SingleFileInserter implements ClientPutState, Serializable {
     if (uri.getKeyType().equals("USK")) {
       try {
         return new USKInserter(
-            parent,
-            data,
-            compressionCodec,
-            uri,
-            ctx,
-            cb,
-            isMetadata,
-            sourceLength,
-            -1,
-            true,
-            this.token,
-            context,
-            freeData,
-            persistent,
-            realTimeFlag,
-            forSplitfile
-                ? ctx.getExtraInsertsSplitfileHeaderBlock()
-                : ctx.getExtraInsertsSingleBlock(),
-            cryptoAlgorithm,
-            forceCryptoKey);
+            new BlockInsertPayload(
+                data,
+                uri,
+                compressionCodec,
+                isMetadata,
+                sourceLength,
+                cryptoAlgorithm,
+                forceCryptoKey),
+            new BlockInsertParams(parent, ctx, cb, -1, this.token, true, context),
+            new BlockInsertOptions(
+                persistent,
+                realTimeFlag,
+                freeData,
+                forSplitfile
+                    ? ctx.getExtraInsertsSplitfileHeaderBlock()
+                    : ctx.getExtraInsertsSingleBlock()));
       } catch (MalformedURLException e) {
         throw new InsertException(InsertExceptionMode.INVALID_URI, e, null);
       }
     } else {
       SingleBlockInserter sbi =
           new SingleBlockInserter(
-              parent,
-              data,
-              compressionCodec,
-              uri,
-              ctx,
-              realTimeFlag,
-              cb,
-              isMetadata,
-              sourceLength,
-              -1,
-              true,
-              false,
-              this.token,
-              context,
-              persistent,
-              freeData,
-              forSplitfile
-                  ? ctx.getExtraInsertsSplitfileHeaderBlock()
-                  : ctx.getExtraInsertsSingleBlock(),
-              cryptoAlgorithm,
-              forceCryptoKey);
+              new BlockInsertPayload(
+                  data,
+                  uri,
+                  compressionCodec,
+                  isMetadata,
+                  sourceLength,
+                  cryptoAlgorithm,
+                  forceCryptoKey),
+              new BlockInsertParams(parent, ctx, cb, -1, this.token, true, context),
+              new BlockInsertOptions(
+                  persistent,
+                  realTimeFlag,
+                  freeData,
+                  forSplitfile
+                      ? ctx.getExtraInsertsSplitfileHeaderBlock()
+                      : ctx.getExtraInsertsSingleBlock()),
+              false);
       // pass uri to SBI
       block.nullURI();
       return sbi;

--- a/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/src/main/java/network/crypta/client/async/USKInserter.java
@@ -273,25 +273,11 @@ public class USKInserter
             BucketTools.makeImmutableBucket(context.getBucketFactory(persistent), hintData);
         SingleBlockInserter sb =
             new SingleBlockInserter(
-                parent,
-                bucket,
-                (short) -1,
-                uri,
-                ctx,
-                realTimeFlag,
-                m,
-                false,
-                sourceLength,
-                token,
-                true,
-                true /* we don't use it */,
-                null,
-                context,
-                persistent,
-                true,
-                extraInserts,
-                cryptoAlgorithm,
-                forceCryptoKey);
+                new BlockInsertPayload(
+                    bucket, uri, (short) -1, false, sourceLength, cryptoAlgorithm, forceCryptoKey),
+                new BlockInsertParams(parent, ctx, m, token, null, true, context),
+                new BlockInsertOptions(persistent, realTimeFlag, true, extraInserts),
+                true /* we don't use it */);
         LOG.info("Inserting {} with {} for insert of {}", uri, sb, pubUSK);
         m.add(sb);
         sb.schedule(context);
@@ -327,25 +313,17 @@ public class USKInserter
       if (LOG.isDebugEnabled()) LOG.debug("scheduling insert for {} {}", pubUSK.getURI(), edition);
       sbi =
           new SingleBlockInserter(
-              parent,
-              data,
-              compressionCodec,
-              privUSK.getInsertableSSK(edition).getInsertURI(),
-              ctx,
-              realTimeFlag,
-              this,
-              isMetadata,
-              sourceLength,
-              token,
-              false,
-              true /* we don't use it */,
-              tokenObject,
-              context,
-              persistent,
-              false,
-              extraInserts,
-              cryptoAlgorithm,
-              forceCryptoKey);
+              new BlockInsertPayload(
+                  data,
+                  privUSK.getInsertableSSK(edition).getInsertURI(),
+                  compressionCodec,
+                  isMetadata,
+                  sourceLength,
+                  cryptoAlgorithm,
+                  forceCryptoKey),
+              new BlockInsertParams(parent, ctx, this, token, tokenObject, false, context),
+              new BlockInsertOptions(persistent, realTimeFlag, false, extraInserts),
+              true /* we don't use it */);
     }
     try {
       sbi.schedule(context);
@@ -456,78 +434,43 @@ public class USKInserter
   }
 
   /**
-   * Creates a new inserter for the given USK and payload.
+   * Creates a new inserter for the given USK payload.
    *
    * <p>The constructor captures all parameters needed to discover the target edition and perform an
    * SSK block insert. No I/O or scheduling occurs until {@link #schedule(ClientContext)} is called.
    * Callers may choose to have the payload freed automatically upon terminal completion.
    *
-   * @param parent parent putter coordinating progress, priority, and client identity; non-null
-   * @param data source bucket providing the bytes to insert; may be freed on completion when
-   *     enabled
-   * @param compressionCodec compression codec identifier to apply to {@code data} prior to insert
-   * @param uri base USK URI that will be used to derive concrete per-edition insert URIs
-   * @param ctx insert context controlling behavior such as priorities, retries, and date hints
-   * @param cb completion callback receiving success, failure, and encode notifications
-   * @param isMetadata whether {@code data} represents metadata rather than primary content
-   * @param sourceLength original content length in bytes, when known; used for progress reporting
-   * @param token numeric token associated with this insert for correlation and logging
-   * @param addToParent if {@code true}, increments parent accounting and notifies clients
-   *     immediately
-   * @param tokenObject opaque token to return in callbacks; may be {@code null}
-   * @param context client context used for immediate parent notifications performed by the
-   *     constructor
-   * @param freeData if {@code true}, frees {@code data} on terminal completion (success/failure)
-   * @param persistent whether this inserter is persistent and can be resumed after restart
-   * @param realTimeFlag real-time scheduling hint that may influence downstream prioritization
-   * @param extraInserts additional insert attempts or related tuning delegated to lower layers
-   * @param cryptoAlgorithm crypto algorithm identifier for the underlying SSK insert
-   * @param forceCryptoKey optional crypto key override; {@code null} to auto-select
-   * @throws MalformedURLException if {@code uri} does not form a valid insertable USK
+   * @param payload block data and encoding parameters for the USK insert
+   * @param params shared inserter parameters including parent, callbacks, and insert context
+   * @param options persistence and scheduling options for this insert
+   * @throws MalformedURLException if {@code payload.uri()} does not form a valid insertable USK
    */
   public USKInserter(
-      BaseClientPutter parent,
-      Bucket data,
-      short compressionCodec,
-      FreenetURI uri,
-      InsertContext ctx,
-      PutCompletionCallback cb,
-      boolean isMetadata,
-      int sourceLength,
-      int token,
-      boolean addToParent,
-      Object tokenObject,
-      ClientContext context,
-      boolean freeData,
-      boolean persistent,
-      boolean realTimeFlag,
-      int extraInserts,
-      byte cryptoAlgorithm,
-      byte[] forceCryptoKey)
+      BlockInsertPayload payload, BlockInsertParams params, BlockInsertOptions options)
       throws MalformedURLException {
     this.hashCode = super.hashCode();
-    this.tokenObject = tokenObject;
-    this.persistent = persistent;
-    this.parent = parent;
-    this.data = data;
-    this.compressionCodec = compressionCodec;
-    this.ctx = ctx;
-    this.cb = cb;
-    this.isMetadata = isMetadata;
-    this.sourceLength = sourceLength;
-    this.token = token;
-    if (addToParent) {
-      parent.addMustSucceedBlocks(1);
-      parent.notifyClients(context);
+    this.tokenObject = params.tokenObject();
+    this.persistent = options.persistent();
+    this.parent = params.parent();
+    this.data = payload.data();
+    this.compressionCodec = payload.compressionCodec();
+    this.ctx = params.ctx();
+    this.cb = params.callback();
+    this.isMetadata = payload.isMetadata();
+    this.sourceLength = payload.sourceLength();
+    this.token = params.token();
+    if (params.addToParent()) {
+      params.parent().addMustSucceedBlocks(1);
+      params.parent().notifyClients(params.context());
     }
-    privUSK = InsertableUSK.createInsertable(uri, persistent);
+    privUSK = InsertableUSK.createInsertable(payload.uri(), options.persistent());
     pubUSK = privUSK.getUSK();
     edition = pubUSK.suggestedEdition;
-    this.freeData = freeData;
-    this.extraInserts = extraInserts;
-    this.cryptoAlgorithm = cryptoAlgorithm;
-    this.forceCryptoKey = forceCryptoKey;
-    this.realTimeFlag = realTimeFlag;
+    this.freeData = options.freeData();
+    this.extraInserts = options.extraInserts();
+    this.cryptoAlgorithm = payload.cryptoAlgorithm();
+    this.forceCryptoKey = payload.cryptoKey();
+    this.realTimeFlag = options.realTimeFlag();
   }
 
   /**
@@ -622,7 +565,7 @@ public class USKInserter
   }
 
   /**
-   * Indicates that the fetcher was cancelled unexpectedly.
+   * Indicates that the fetcher was canceled unexpectedly.
    *
    * <p>Treats this as an error and cancels the overall operation, reporting a cancellation failure
    * to the completion callback.

--- a/src/main/java/network/crypta/node/simulator/LongTermManySingleBlocksTest.java
+++ b/src/main/java/network/crypta/node/simulator/LongTermManySingleBlocksTest.java
@@ -131,6 +131,8 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
       BatchInsert bi = new BatchInsert(block);
       synchronized (this) {
         inserts.add(bi);
+        runningInserts++;
+        LOGGER.info("Starting insert: running {}", runningInserts);
       }
       bi.start();
     }
@@ -154,10 +156,6 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
 
       @Override
       public void run() {
-        synchronized (InsertBatch.this) {
-          runningInserts++;
-          LOGGER.info("Starting insert: running {}", runningInserts);
-        }
         long t1 = 0;
         long t2 = 0;
         FreenetURI thisURI = null;

--- a/src/test/java/network/crypta/client/async/SimpleHealingQueueTest.java
+++ b/src/test/java/network/crypta/client/async/SimpleHealingQueueTest.java
@@ -151,25 +151,17 @@ class SimpleHealingQueueTest {
 
     SingleBlockInserter sbi =
         new SingleBlockInserter(
-            queue,
-            data,
-            (short) -1,
-            FreenetURI.EMPTY_CHK_URI,
-            insertCtx,
-            /*realTime*/ false,
-            queue,
-            /*isMetadata*/ false,
-            /*sourceLength*/ 0,
-            /*token*/ 123,
-            /*addToParent*/ false,
-            /*dontSendEncoded*/ true,
-            /*tokenObject*/ data,
-            clientCtx,
-            /*persistent*/ false,
-            /*freeData*/ false,
-            /*extraInserts*/ 0,
-            /*cryptoAlgorithm*/ Key.ALGO_AES_CTR_256_SHA256,
-            /*cryptoKey*/ null);
+            new BlockInsertPayload(
+                data,
+                FreenetURI.EMPTY_CHK_URI,
+                (short) -1,
+                /*isMetadata*/ false,
+                /*sourceLength*/ 0,
+                /*cryptoAlgorithm*/ Key.ALGO_AES_CTR_256_SHA256,
+                /*cryptoKey*/ null),
+            new BlockInsertParams(queue, insertCtx, queue, 123, data, false, clientCtx),
+            new BlockInsertOptions(false, false, false, 0),
+            /*dontSendEncoded*/ true);
 
     // Put into the running map as SimpleHealingQueue does when healing is accepted
     queue.runningInserters.put(data, sbi);

--- a/src/test/java/network/crypta/client/async/SingleBlockInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SingleBlockInserterTest.java
@@ -130,26 +130,17 @@ class SingleBlockInserterTest {
   @Test
   void constructor_whenAddToParentTrue_notifiesParent() {
     ClientContext ctx = newMinimalClientContext(insertCtx);
-    new SingleBlockInserter(
-        parent,
+    newInserter(
+        ctx,
         bucket,
-        (short) -1,
         FreenetURI.EMPTY_CHK_URI,
-        insertCtx,
-        /*realTime*/ false,
-        cb,
         /*isMetadata*/ false,
         /*sourceLength*/ 0,
         /*token*/ 7,
         /*addToParent*/ true,
         /*dontSendEncoded*/ true,
         /*tokenObject*/ new Object(),
-        ctx,
-        /*persistent*/ false,
-        /*freeData*/ false,
-        /*extraInserts*/ 0,
-        /*cryptoAlgorithm*/ (byte) 0,
-        /*cryptoKey*/ null);
+        /*freeData*/ false);
 
     verify(parent, times(1)).addMustSucceedBlocks(1);
     verify(parent, times(1)).notifyClients(ctx);
@@ -159,26 +150,17 @@ class SingleBlockInserterTest {
   void encode_whenDontSendEncodedFalse_callsCallbackAndSetsKey() throws Exception {
     ClientContext ctx = newMinimalClientContext(insertCtx);
     SingleBlockInserter sbi =
-        new SingleBlockInserter(
-            parent,
+        newInserter(
+            ctx,
             bucket,
-            (short) -1,
             FreenetURI.EMPTY_CHK_URI,
-            insertCtx,
-            false,
-            cb,
-            false,
-            0,
-            1,
-            false,
+            /*isMetadata*/ false,
+            /*sourceLength*/ 0,
+            /*token*/ 1,
+            /*addToParent*/ false,
             /*dontSendEncoded*/ false,
             new Object(),
-            ctx,
-            false,
-            /*freeData*/ false,
-            0,
-            (byte) 0,
-            null);
+            /*freeData*/ false);
 
     // Spy to stub innerEncode, returning a block with a known key
     SingleBlockInserter spy = Mockito.spy(sbi);
@@ -198,26 +180,17 @@ class SingleBlockInserterTest {
   void encode_whenDontSendEncodedTrue_doesNotCallCallback() throws Exception {
     ClientContext ctx = newMinimalClientContext(insertCtx);
     SingleBlockInserter sbi =
-        new SingleBlockInserter(
-            parent,
+        newInserter(
+            ctx,
             bucket,
-            (short) -1,
             FreenetURI.EMPTY_CHK_URI,
-            insertCtx,
-            false,
-            cb,
-            false,
-            0,
-            1,
-            false,
+            /*isMetadata*/ false,
+            /*sourceLength*/ 0,
+            /*token*/ 1,
+            /*addToParent*/ false,
             /*dontSendEncoded*/ true,
             new Object(),
-            ctx,
-            false,
-            /*freeData*/ false,
-            0,
-            (byte) 0,
-            null);
+            /*freeData*/ false);
 
     SingleBlockInserter spy = Mockito.spy(sbi);
     ClientKeyBlock block = mock(ClientKeyBlock.class);
@@ -235,26 +208,17 @@ class SingleBlockInserterTest {
     ClientContext ctx = newMinimalClientContext(insertCtx);
     // freeData=true so source bucket is freed on failure
     SingleBlockInserter inserter =
-        new SingleBlockInserter(
-            parent,
-            bucket,
-            (short) -1,
-            FreenetURI.EMPTY_CHK_URI,
-            insertCtx,
-            false,
-            cb,
-            false,
-            0,
-            1,
-            false,
-            true,
-            new Object(),
+        newInserter(
             ctx,
-            false,
-            /*freeData*/ true,
-            0,
-            (byte) 0,
-            null);
+            bucket,
+            FreenetURI.EMPTY_CHK_URI,
+            /*isMetadata*/ false,
+            /*sourceLength*/ 0,
+            /*token*/ 1,
+            /*addToParent*/ false,
+            /*dontSendEncoded*/ true,
+            new Object(),
+            /*freeData*/ true);
 
     inserter.onFailure(new LowLevelPutException(LowLevelPutException.COLLISION), null, ctx);
 
@@ -271,26 +235,17 @@ class SingleBlockInserterTest {
     // freeData=true so bucket is freed on success path
     try (ArrayBucket realBucket = new ArrayBucket()) {
       SingleBlockInserter inserter =
-          new SingleBlockInserter(
-              parent,
-              realBucket,
-              (short) -1,
-              FreenetURI.EMPTY_CHK_URI,
-              insertCtx,
-              false,
-              cb,
-              false,
-              0,
-              1,
-              false,
-              true,
-              new Object(),
+          newInserter(
               ctx,
-              false,
-              /*freeData*/ true,
-              0,
-              (byte) 0,
-              null);
+              realBucket,
+              FreenetURI.EMPTY_CHK_URI,
+              /*isMetadata*/ false,
+              /*sourceLength*/ 0,
+              /*token*/ 1,
+              /*addToParent*/ false,
+              /*dontSendEncoded*/ true,
+              new Object(),
+              /*freeData*/ true);
 
       inserter.onFailure(new LowLevelPutException(LowLevelPutException.ROUTE_NOT_FOUND), null, ctx);
       inserter.onFailure(new LowLevelPutException(LowLevelPutException.ROUTE_NOT_FOUND), null, ctx);
@@ -314,26 +269,17 @@ class SingleBlockInserterTest {
     when(ctx.getChkInsertScheduler(false)).thenReturn(mockScheduler);
 
     SingleBlockInserter inserter =
-        new SingleBlockInserter(
-            parent,
-            bucket,
-            (short) -1,
-            FreenetURI.EMPTY_CHK_URI,
-            insertCtx,
-            false,
-            cb,
-            false,
-            0,
-            1,
-            false,
-            true,
-            new Object(),
+        newInserter(
             ctx,
-            false,
-            false,
-            0,
-            (byte) 0,
-            null);
+            bucket,
+            FreenetURI.EMPTY_CHK_URI,
+            /*isMetadata*/ false,
+            /*sourceLength*/ 0,
+            /*token*/ 1,
+            /*addToParent*/ false,
+            /*dontSendEncoded*/ true,
+            new Object(),
+            /*freeData*/ false);
 
     long wake = inserter.getWakeupTime(ctx, /*now*/ 0L);
     assertEquals(Long.MAX_VALUE, wake);
@@ -349,26 +295,17 @@ class SingleBlockInserterTest {
     when(ctx.getChkInsertScheduler(false)).thenReturn(mockScheduler);
 
     SingleBlockInserter inserter =
-        new SingleBlockInserter(
-            parent,
-            bucket,
-            (short) -1,
-            FreenetURI.EMPTY_CHK_URI,
-            insertCtx,
-            false,
-            cb,
-            false,
-            0,
-            1,
-            false,
-            true,
-            new Object(),
+        newInserter(
             ctx,
-            false,
-            false,
-            0,
-            (byte) 0,
-            null);
+            bucket,
+            FreenetURI.EMPTY_CHK_URI,
+            /*isMetadata*/ false,
+            /*sourceLength*/ 0,
+            /*token*/ 1,
+            /*addToParent*/ false,
+            /*dontSendEncoded*/ true,
+            new Object(),
+            /*freeData*/ false);
 
     long wake = inserter.getWakeupTime(ctx, /*now*/ 0L);
     assertEquals(0L, wake);
@@ -378,26 +315,17 @@ class SingleBlockInserterTest {
   void cancel_marksFinished_andNotifies_andFrees() {
     ClientContext ctx = newMinimalClientContext(insertCtx);
     SingleBlockInserter inserter =
-        new SingleBlockInserter(
-            parent,
-            bucket,
-            (short) -1,
-            FreenetURI.EMPTY_CHK_URI,
-            insertCtx,
-            false,
-            cb,
-            false,
-            0,
-            1,
-            false,
-            true,
-            new Object(),
+        newInserter(
             ctx,
-            false,
-            /*freeData*/ true,
-            0,
-            (byte) 0,
-            null);
+            bucket,
+            FreenetURI.EMPTY_CHK_URI,
+            /*isMetadata*/ false,
+            /*sourceLength*/ 0,
+            /*token*/ 1,
+            /*addToParent*/ false,
+            /*dontSendEncoded*/ true,
+            new Object(),
+            /*freeData*/ true);
 
     inserter.cancel(ctx);
 
@@ -412,26 +340,17 @@ class SingleBlockInserterTest {
   void innerOnResume_callsBucketResume_andCallbackResume_andSchedules() throws Exception {
     ClientContext ctx = newMinimalClientContext(insertCtx);
     SingleBlockInserter sbi =
-        new SingleBlockInserter(
-            parent,
-            bucket,
-            (short) -1,
-            FreenetURI.EMPTY_CHK_URI,
-            insertCtx,
-            false,
-            cb,
-            false,
-            0,
-            1,
-            false,
-            true,
-            new Object(),
+        newInserter(
             ctx,
-            false,
-            false,
-            0,
-            (byte) 0,
-            null);
+            bucket,
+            FreenetURI.EMPTY_CHK_URI,
+            /*isMetadata*/ false,
+            /*sourceLength*/ 0,
+            /*token*/ 1,
+            /*addToParent*/ false,
+            /*dontSendEncoded*/ true,
+            new Object(),
+            /*freeData*/ false);
     SingleBlockInserter spy = Mockito.spy(sbi);
     doNothing().when(spy).schedule(ctx);
 
@@ -446,26 +365,17 @@ class SingleBlockInserterTest {
   void flags_and_isSSK_reflectContextAndUri() {
     ClientContext ctx = newMinimalClientContext(insertCtx);
     SingleBlockInserter chkInserter =
-        new SingleBlockInserter(
-            parent,
-            bucket,
-            (short) -1,
-            FreenetURI.EMPTY_CHK_URI,
-            insertCtx,
-            false,
-            cb,
-            true,
-            0,
-            1,
-            false,
-            true,
-            new Object(),
+        newInserter(
             ctx,
-            false,
-            false,
-            0,
-            (byte) 0,
-            null);
+            bucket,
+            FreenetURI.EMPTY_CHK_URI,
+            /*isMetadata*/ true,
+            /*sourceLength*/ 0,
+            /*token*/ 1,
+            /*addToParent*/ false,
+            /*dontSendEncoded*/ true,
+            new Object(),
+            /*freeData*/ false);
 
     assertFalse(chkInserter.isSSK());
     assertTrue(chkInserter.canWriteClientCache());
@@ -474,26 +384,17 @@ class SingleBlockInserterTest {
 
     // SSK variant: the constructor only inspects uri.getKeyType()
     SingleBlockInserter sskInserter =
-        new SingleBlockInserter(
-            parent,
-            bucket,
-            (short) -1,
-            new FreenetURI("SSK", "doc"),
-            insertCtx,
-            false,
-            cb,
-            false,
-            0,
-            1,
-            false,
-            true,
-            new Object(),
+        newInserter(
             ctx,
-            false,
-            false,
-            0,
-            (byte) 0,
-            null);
+            bucket,
+            new FreenetURI("SSK", "doc"),
+            /*isMetadata*/ false,
+            /*sourceLength*/ 0,
+            /*token*/ 1,
+            /*addToParent*/ false,
+            /*dontSendEncoded*/ true,
+            new Object(),
+            /*freeData*/ false);
     assertTrue(sskInserter.isSSK());
   }
 
@@ -507,14 +408,15 @@ class SingleBlockInserterTest {
           () ->
               SingleBlockInserter.innerEncode(
                   new DummyRandomSource(1L),
-                  usk,
-                  src,
-                  /*isMetadata*/ false,
-                  (short) -1,
-                  /*sourceLength*/ 0,
-                  /*compressorDescriptor*/ null,
-                  /*cryptoAlgorithm*/ (byte) 0,
-                  /*cryptoKey*/ null),
+                  new BlockInsertPayload(
+                      src,
+                      usk,
+                      (short) -1,
+                      /*isMetadata*/ false,
+                      /*sourceLength*/ 0,
+                      /*cryptoAlgorithm*/ (byte) 0,
+                      /*cryptoKey*/ null),
+                  /*compressorDescriptor*/ null),
           "Unknown key types must throw InsertException(INVALID_URI)");
     }
   }
@@ -555,5 +457,23 @@ class SingleBlockInserterTest {
         Runnable runner, String name, long time, boolean runOnTickerAnyway, boolean noDupes) {
       exec.execute(runner);
     }
+  }
+
+  private SingleBlockInserter newInserter(
+      ClientContext ctx,
+      Bucket data,
+      FreenetURI uri,
+      boolean isMetadata,
+      int sourceLength,
+      int token,
+      boolean addToParent,
+      boolean dontSendEncoded,
+      Object tokenObject,
+      boolean freeData) {
+    return new SingleBlockInserter(
+        new BlockInsertPayload(data, uri, (short) -1, isMetadata, sourceLength, (byte) 0, null),
+        new BlockInsertParams(parent, insertCtx, cb, token, tokenObject, addToParent, ctx),
+        new BlockInsertOptions(false, false, freeData, 0),
+        dontSendEncoded);
   }
 }

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -264,24 +264,16 @@ class USKInserterTest {
     Mockito.lenient().when(rc.realTimeFlag()).thenReturn(cfg.realTimeFlag);
 
     return new USKInserter(
-        parent,
-        data,
-        compressionCodec,
-        uskUri,
-        insertCtx,
-        cb,
-        cfg.isMetadata,
-        (int) data.size(),
-        123,
-        cfg.addToParent,
-        "token",
-        context,
-        cfg.freeData,
-        cfg.persistent,
-        cfg.realTimeFlag,
-        0,
-        Key.ALGO_AES_PCFB_256_SHA256,
-        null);
+        new BlockInsertPayload(
+            data,
+            uskUri,
+            compressionCodec,
+            cfg.isMetadata,
+            (int) data.size(),
+            Key.ALGO_AES_PCFB_256_SHA256,
+            null),
+        new BlockInsertParams(parent, insertCtx, cb, 123, "token", cfg.addToParent, context),
+        new BlockInsertOptions(cfg.persistent, cfg.realTimeFlag, cfg.freeData, 0));
   }
 
   @Test
@@ -532,24 +524,10 @@ class USKInserterTest {
 
     USKInserter inserter =
         new USKInserter(
-            parent,
-            data,
-            (short) 0,
-            insertUri,
-            ic,
-            cb,
-            false,
-            1,
-            7,
-            false,
-            "tok",
-            context,
-            false,
-            false,
-            false,
-            0,
-            Key.ALGO_AES_PCFB_256_SHA256,
-            null);
+            new BlockInsertPayload(
+                data, insertUri, (short) 0, false, 1, Key.ALGO_AES_PCFB_256_SHA256, null),
+            new BlockInsertParams(parent, ic, cb, 7, "tok", false, context),
+            new BlockInsertOptions(false, false, false, 0));
 
     // Assert
     assertSame("tok", inserter.getToken());


### PR DESCRIPTION
## Summary
- add BlockInsertPayload/Params/Options records to bundle SingleBlockInserter/USKInserter inputs
- update client inserter call sites and related tests to use the bundled constructors
- adjust insert-start logging order in LongTermManySingleBlocksTest

## Testing
- ./gradlew spotlessApply