### PR TITLE
refactor(client): bundle single-file insert params

### DIFF
--- a/src/main/java/network/crypta/client/async/BaseManifestPutter.java
+++ b/src/main/java/network/crypta/client/async/BaseManifestPutter.java
@@ -113,21 +113,10 @@ public abstract class BaseManifestPutter extends ManifestPutter {
         HashMap<String, Object> data,
         FreenetURI insertURI) {
       super(bmp, parent, name, null, containerPutHandlers);
-      this.origSFI =
-          new ContainerInserter(
-              this,
-              this,
-              data,
-              insertURI,
-              ctx,
-              new ContainerInserter.Options(
-                  false,
-                  false,
-                  null,
-                  ARCHIVE_TYPE.TAR,
-                  forceCryptoKey,
-                  cryptoAlgorithm,
-                  realTimeFlag));
+      InsertExecutionOptions execOptions =
+          new InsertExecutionOptions(
+              false, false, ARCHIVE_TYPE.TAR, forceCryptoKey, cryptoAlgorithm, realTimeFlag);
+      this.origSFI = new ContainerInserter(this, this, data, insertURI, ctx, execOptions, null);
     }
 
     @Override
@@ -192,21 +181,10 @@ public abstract class BaseManifestPutter extends ManifestPutter {
         FreenetURI insertURI,
         HashSet<PutHandler> runningMap) {
       super(bmp, parent, name, null, runningMap);
-      this.origSFI =
-          new ContainerInserter(
-              this,
-              this,
-              data,
-              insertURI,
-              ctx,
-              new ContainerInserter.Options(
-                  false,
-                  false,
-                  null,
-                  ARCHIVE_TYPE.TAR,
-                  forceCryptoKey,
-                  cryptoAlgorithm,
-                  realTimeFlag));
+      InsertExecutionOptions execOptions =
+          new InsertExecutionOptions(
+              false, false, ARCHIVE_TYPE.TAR, forceCryptoKey, cryptoAlgorithm, realTimeFlag);
+      this.origSFI = new ContainerInserter(this, this, data, insertURI, ctx, execOptions, null);
     }
 
     @Override
@@ -262,28 +240,27 @@ public abstract class BaseManifestPutter extends ManifestPutter {
         ClientMetadata cm2) {
       super(bmp, parent, name, cm2, runningPutHandlers);
       InsertBlock block = new InsertBlock(data, cm, FreenetURI.EMPTY_CHK_URI);
-      this.origSFI =
-          new SingleFileInserter(
-              this,
-              this,
-              block,
-              false,
-              ctx,
-              realTimeFlag,
-              false,
-              true,
-              null,
-              null,
-              false,
-              null,
-              false,
-              persistent(),
-              0,
-              0,
-              null,
-              cryptoAlgorithm,
-              forceCryptoKey,
-              -1);
+      InsertExecutionOptions execOptions =
+          new InsertExecutionOptions(
+              false, true, null, forceCryptoKey, cryptoAlgorithm, realTimeFlag);
+      SingleFileInserterParams params =
+          new SingleFileInserterParams()
+              .withParent(this)
+              .withCallback(this)
+              .withBlock(block)
+              .withMetadata(false)
+              .withCtx(ctx)
+              .withExecutionOptions(execOptions)
+              .withToken(null)
+              .withFreeData(false)
+              .withTargetFilename(null)
+              .withForSplitfile(false)
+              .withPersistent(persistent())
+              .withOrigDataLength(0)
+              .withOrigCompressedDataLength(0)
+              .withOrigHashes(null)
+              .withMetadataThreshold(-1);
+      this.origSFI = new SingleFileInserter(params);
     }
 
     @Override
@@ -378,28 +355,26 @@ public abstract class BaseManifestPutter extends ManifestPutter {
     private MetaPutHandler(BaseManifestPutter smp, PutHandler parent, InsertBlock insertBlock) {
       super(smp, parent, null, null, null);
       // Treat as splitfile for purposes of determining number of reinserts.
-      this.origSFI =
-          new SingleFileInserter(
-              this,
-              this,
-              insertBlock,
-              true,
-              ctx,
-              realTimeFlag,
-              false,
-              false,
-              null,
-              null,
-              true,
-              null,
-              true,
-              persistent(),
-              0,
-              0,
-              null,
-              cryptoAlgorithm,
-              null,
-              -1);
+      InsertExecutionOptions execOptions =
+          new InsertExecutionOptions(false, false, null, null, cryptoAlgorithm, realTimeFlag);
+      SingleFileInserterParams params =
+          new SingleFileInserterParams()
+              .withParent(this)
+              .withCallback(this)
+              .withBlock(insertBlock)
+              .withMetadata(true)
+              .withCtx(ctx)
+              .withExecutionOptions(execOptions)
+              .withToken(null)
+              .withFreeData(true)
+              .withTargetFilename(null)
+              .withForSplitfile(true)
+              .withPersistent(persistent())
+              .withOrigDataLength(0)
+              .withOrigCompressedDataLength(0)
+              .withOrigHashes(null)
+              .withMetadataThreshold(-1);
+      this.origSFI = new SingleFileInserter(params);
       if (LOG.isDebugEnabled()) LOG.debug("Inserting root metadata: {}", origSFI);
     }
 
@@ -412,28 +387,26 @@ public abstract class BaseManifestPutter extends ManifestPutter {
       metadata = toResolve;
       // Treat as splitfile for purposes of determining number of reinserts.
       InsertBlock ib = new InsertBlock(b, null, FreenetURI.EMPTY_CHK_URI);
-      this.origSFI =
-          new SingleFileInserter(
-              this,
-              this,
-              ib,
-              true,
-              ctx,
-              realTimeFlag,
-              false,
-              false,
-              toResolve,
-              null,
-              true,
-              null,
-              true,
-              persistent(),
-              0,
-              0,
-              null,
-              cryptoAlgorithm,
-              null,
-              -1);
+      InsertExecutionOptions execOptions =
+          new InsertExecutionOptions(false, false, null, null, cryptoAlgorithm, realTimeFlag);
+      SingleFileInserterParams params =
+          new SingleFileInserterParams()
+              .withParent(this)
+              .withCallback(this)
+              .withBlock(ib)
+              .withMetadata(true)
+              .withCtx(ctx)
+              .withExecutionOptions(execOptions)
+              .withToken(toResolve)
+              .withFreeData(true)
+              .withTargetFilename(null)
+              .withForSplitfile(true)
+              .withPersistent(persistent())
+              .withOrigDataLength(0)
+              .withOrigCompressedDataLength(0)
+              .withOrigHashes(null)
+              .withMetadataThreshold(-1);
+      this.origSFI = new SingleFileInserter(params);
       if (LOG.isDebugEnabled())
         LOG.debug("Inserting subsidiary metadata: {} for {}", origSFI, toResolve);
     }

--- a/src/main/java/network/crypta/client/async/ClientPutter.java
+++ b/src/main/java/network/crypta/client/async/ClientPutter.java
@@ -341,28 +341,26 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
     if (!binaryBlob) {
       ClientMetadata meta = cm;
       if (meta != null) meta = persistent() ? ClientMetadata.copyOf(meta) : meta;
-      currentState =
-          new SingleFileInserter(
-              this,
-              this,
-              new InsertBlock(data, meta, targetURI),
-              isMetadata,
-              ctx,
-              realTimeFlag,
-              false,
-              false,
-              null,
-              null,
-              false,
-              targetFilename,
-              false,
-              persistent(),
-              0,
-              0,
-              null,
-              cryptoAlgorithm,
-              cryptoKey,
-              metadataThreshold);
+      InsertExecutionOptions execOptions =
+          new InsertExecutionOptions(false, false, null, cryptoKey, cryptoAlgorithm, realTimeFlag);
+      SingleFileInserterParams params =
+          new SingleFileInserterParams()
+              .withParent(this)
+              .withCallback(this)
+              .withBlock(new InsertBlock(data, meta, targetURI))
+              .withMetadata(isMetadata)
+              .withCtx(ctx)
+              .withExecutionOptions(execOptions)
+              .withToken(null)
+              .withFreeData(false)
+              .withTargetFilename(targetFilename)
+              .withForSplitfile(false)
+              .withPersistent(persistent())
+              .withOrigDataLength(0)
+              .withOrigCompressedDataLength(0)
+              .withOrigHashes(null)
+              .withMetadataThreshold(metadataThreshold);
+      currentState = new SingleFileInserter(params);
     } else {
       currentState =
           new BinaryBlobInserter(data, this, getClient(), false, priorityClass, ctx, context);

--- a/src/main/java/network/crypta/client/async/ContainerInserter.java
+++ b/src/main/java/network/crypta/client/async/ContainerInserter.java
@@ -66,92 +66,6 @@ public class ContainerInserter implements ClientPutState, Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
 
-  /**
-   * Options used to configure a {@link ContainerInserter}. Reduces constructor parameter count and
-   * captures flags that influence archive creation and insertion behavior.
-   *
-   * <p>Instances of this class are serializable. The {@link #token} is marked {@code transient}
-   * because it is an application-supplied correlation object that may not be serializable and is
-   * not required to restore insertion state.
-   */
-  public static final class Options implements Serializable {
-    @Serial private static final long serialVersionUID = 1L;
-
-    /**
-     * When {@code true}, disables content compression. For {@link ARCHIVE_TYPE#ZIP} this is forced
-     * to {@code true} regardless of the requested value so entries are stored uncompressed.
-     */
-    public final boolean dontCompress;
-
-    /**
-     * When {@code true}, perform the metadata preparation flow only and report results without
-     * starting the actual network insertion. Useful for dry-run or inspection scenarios.
-     */
-    public final boolean reportMetadataOnly;
-
-    /**
-     * Application correlation token passed through callbacks. It is never serialized; callers own
-     * its lifecycle and may supply any object (including {@code null}).
-     */
-    public final transient Object token;
-
-    /** Archive type to create for the container (e.g., TAR or ZIP). */
-    public final ARCHIVE_TYPE archiveType;
-
-    /**
-     * Optional explicit encryption key material. When non-{@code null}, it overrides derived keys
-     * in downstream inserters. Ownership is not transferred and the array is not defensively
-     * copied.
-     */
-    public final byte[] forceCryptoKey;
-
-    /**
-     * Crypto algorithm identifier consumed by downstream inserters. Acceptable values depend on the
-     * network configuration; unknown values will cause insertion to fail early.
-     */
-    public final byte cryptoAlgorithm;
-
-    /**
-     * Enables real-time insertion behavior when {@code true}. This can reduce latency at the cost
-     * of increased resource use depending on the insertion context.
-     */
-    public final boolean realTimeFlag;
-
-    /**
-     * Constructs an {@link Options} bundle describing how the container and downstream insertion
-     * should behave.
-     *
-     * @param dontCompress set to {@code true} to disable compression of the container contents; ZIP
-     *     containers are stored uncompressed regardless of this flag
-     * @param reportMetadataOnly set to {@code true} to prepare metadata and report it without
-     *     starting the network insertion; used for dry-run and diagnostics
-     * @param token arbitrary application token forwarded to callbacks; never serialized and may be
-     *     {@code null}
-     * @param archiveType the archive format to build for the container; typically TAR or ZIP
-     * @param forceCryptoKey optional explicit encryption key material; when non-{@code null},
-     *     overrides derived keys in downstream components
-     * @param cryptoAlgorithm algorithm identifier understood by downstream inserters; invalid
-     *     values will cause the insertion to fail
-     * @param realTimeFlag when {@code true}, requests lower-latency, real-time insertion behavior
-     */
-    public Options(
-        boolean dontCompress,
-        boolean reportMetadataOnly,
-        Object token,
-        ARCHIVE_TYPE archiveType,
-        byte[] forceCryptoKey,
-        byte cryptoAlgorithm,
-        boolean realTimeFlag) {
-      this.dontCompress = dontCompress;
-      this.reportMetadataOnly = reportMetadataOnly;
-      this.token = token;
-      this.archiveType = archiveType;
-      this.forceCryptoKey = forceCryptoKey;
-      this.cryptoAlgorithm = cryptoAlgorithm;
-      this.realTimeFlag = realTimeFlag;
-    }
-  }
-
   private record ContainerElement(Bucket data, String targetInArchive) {}
 
   /** Items to include in the container archive; populated during metadata resolution. */
@@ -222,7 +136,9 @@ public class ContainerInserter implements ClientPutState, Serializable {
    * @param targetURI2 target URI; callers should provide a cloned, persistent instance suitable for
    *     serialization
    * @param ctx2 insert context supplying bucket factories and operational settings
-   * @param options additional options configuring compression, report-only mode, crypto, and token
+   * @param options execution options configuring compression, report-only mode, archive type, and
+   *     crypto settings
+   * @param token application correlation token echoed through callbacks; may be {@code null}
    */
   public ContainerInserter(
       BaseClientPutter parent2,
@@ -230,22 +146,23 @@ public class ContainerInserter implements ClientPutState, Serializable {
       Map<String, Object> metadata2,
       FreenetURI targetURI2,
       InsertContext ctx2,
-      Options options) {
+      InsertExecutionOptions options,
+      Object token) {
     parent = parent2;
     cb = cb2;
     hashCode = super.hashCode();
     persistent = parent.persistent();
     origMetadata = Metadata.forceMap(metadata2);
-    archiveType = options.archiveType;
+    archiveType = options.archiveType();
     targetURI = targetURI2;
-    token = options.token;
+    this.token = token;
     ctx = ctx2;
-    dontCompress = options.dontCompress;
-    reportMetadataOnly = options.reportMetadataOnly;
+    dontCompress = options.dontCompress();
+    reportMetadataOnly = options.reportMetadataOnly();
     containerItems = new ArrayList<>();
-    this.forceCryptoKey = options.forceCryptoKey;
-    this.cryptoAlgorithm = options.cryptoAlgorithm;
-    this.realTimeFlag = options.realTimeFlag;
+    this.forceCryptoKey = options.forceCryptoKey();
+    this.cryptoAlgorithm = options.cryptoAlgorithm();
+    this.realTimeFlag = options.realTimeFlag();
   }
 
   /**
@@ -349,27 +266,27 @@ public class ContainerInserter implements ClientPutState, Serializable {
     }
 
     // Treat it as a splitfile for purposes of determining reinsert count.
-    return new SingleFileInserter(
-        parent,
-        cb,
-        block,
-        false,
-        ctx,
-        realTimeFlag,
-        dc,
-        reportMetadataOnly,
-        token,
-        archiveType,
-        true,
-        null,
-        true,
-        persistent,
-        0,
-        0,
-        null,
-        cryptoAlgorithm,
-        forceCryptoKey,
-        -1);
+    InsertExecutionOptions execOptions =
+        new InsertExecutionOptions(
+            dc, reportMetadataOnly, archiveType, forceCryptoKey, cryptoAlgorithm, realTimeFlag);
+    SingleFileInserterParams params =
+        new SingleFileInserterParams()
+            .withParent(parent)
+            .withCallback(cb)
+            .withBlock(block)
+            .withMetadata(false)
+            .withCtx(ctx)
+            .withExecutionOptions(execOptions)
+            .withToken(token)
+            .withFreeData(true)
+            .withTargetFilename(null)
+            .withForSplitfile(true)
+            .withPersistent(persistent)
+            .withOrigDataLength(0)
+            .withOrigCompressedDataLength(0)
+            .withOrigHashes(null)
+            .withMetadataThreshold(-1);
+    return new SingleFileInserter(params);
   }
 
   private void makeMetadata(ClientContext context) {

--- a/src/main/java/network/crypta/client/async/InsertExecutionOptions.java
+++ b/src/main/java/network/crypta/client/async/InsertExecutionOptions.java
@@ -1,0 +1,96 @@
+package network.crypta.client.async;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Shared execution options for insert operations.
+ *
+ * <p>This record groups configuration flags that affect compression behavior, metadata-only
+ * operation, archive handling, crypto settings, and scheduling hints. It is intentionally a simple
+ * data carrier: values are stored as provided and no validation or defensive copying is performed.
+ *
+ * <p>The {@code forceCryptoKey} array is stored by reference and compared by content for equality.
+ * Callers should avoid mutating it after construction if they rely on stable equality or hash
+ * semantics.
+ *
+ * @param dontCompress whether compression is disabled for the insert
+ * @param reportMetadataOnly whether to stop after preparing metadata and report it directly
+ * @param archiveType optional archive type used when building metadata for redirects or manifests
+ * @param forceCryptoKey optional explicit crypto key material; {@code null} to derive or randomize
+ * @param cryptoAlgorithm crypto algorithm identifier understood by downstream inserters
+ * @param realTimeFlag whether to request real-time scheduling behavior
+ */
+public record InsertExecutionOptions(
+    boolean dontCompress,
+    boolean reportMetadataOnly,
+    ARCHIVE_TYPE archiveType,
+    byte[] forceCryptoKey,
+    byte cryptoAlgorithm,
+    boolean realTimeFlag) {
+
+  /**
+   * Compares two option bundles by value, including array contents.
+   *
+   * @param o object to compare against; may be {@code null}
+   * @return {@code true} when all components match by value
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o
+        instanceof
+        InsertExecutionOptions(
+            boolean otherDontCompress,
+            boolean otherReportMetadataOnly,
+            ARCHIVE_TYPE otherArchiveType,
+            byte[] otherForceCryptoKey,
+            byte otherCryptoAlgorithm,
+            boolean otherRealTimeFlag))) return false;
+    return dontCompress == otherDontCompress
+        && reportMetadataOnly == otherReportMetadataOnly
+        && cryptoAlgorithm == otherCryptoAlgorithm
+        && realTimeFlag == otherRealTimeFlag
+        && archiveType == otherArchiveType
+        && Arrays.equals(forceCryptoKey, otherForceCryptoKey);
+  }
+
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * @return hash code derived from all components, including array contents
+   */
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(dontCompress, reportMetadataOnly, archiveType, cryptoAlgorithm, realTimeFlag);
+    result = 31 * result + Arrays.hashCode(forceCryptoKey);
+    return result;
+  }
+
+  /**
+   * Returns a descriptive string without exposing crypto key material.
+   *
+   * @return non-null string representation of this options bundle
+   */
+  @Override
+  public @NotNull String toString() {
+    String keyState = (forceCryptoKey == null) ? "null" : "<redacted>";
+    return "InsertExecutionOptions["
+        + "dontCompress="
+        + dontCompress
+        + ", reportMetadataOnly="
+        + reportMetadataOnly
+        + ", archiveType="
+        + archiveType
+        + ", forceCryptoKey="
+        + keyState
+        + ", cryptoAlgorithm="
+        + cryptoAlgorithm
+        + ", realTimeFlag="
+        + realTimeFlag
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -147,83 +147,31 @@ class SingleFileInserter implements ClientPutState, Serializable {
    * underlying strategy (single block vs. splitfile). For large content, it may also construct and
    * insert metadata such as a redirect or archive manifest.
    *
-   * @param parent owning putter that receives state transitions and aggregates results; never
-   *     {@code null}.
-   * @param cb callback that observes progress and completion events; must be serializable for
-   *     durable requests.
-   * @param block input data and client metadata to insert; desired URI determines key type and
-   *     sizing.
-   * @param metadata whether this inserter represents metadata rather than primary data; affects
-   *     hashing and redirect behavior.
-   * @param ctx insertion configuration including compatibility mode, compression policy, and event
-   *     producer.
-   * @param realTimeFlag hint that the request prefers reduced latency to throughput; may affect
-   *     scheduling.
-   * @param dontCompress when {@code true}, disables compression regardless of heuristics.
-   * @param reportMetadataOnly when {@code true}, do not insert metadata; return it directly
-   *     instead.
-   * @param token application correlation token echoed on callbacks; may be {@code null}.
-   * @param archiveType optional archive type indicating an archive manifest should be produced
-   *     (when applicable); may be {@code null}.
-   * @param freeData when {@code true}, frees underlying data as soon as possible to reduce resource
-   *     usage.
-   * @param targetFilename optional preferred filename for redirect/manifest entries; may be {@code
-   *     null}.
-   * @param forSplitfile whether this insertion is above a splitfile, affecting duplicate extra
-   *     insert policy.
-   * @param persistent whether the request is durable across restarts; influences bucket selection
-   *     and resume behavior.
-   * @param origDataLength original uncompressed length for reporting; {@code 0} when unknown.
-   * @param origCompressedDataLength original compressed length for reporting; {@code 0} when
-   *     unknown.
-   * @param origHashes optional precomputed hashes to reuse; {@code null} to compute if needed.
-   * @param cryptoAlgorithm CHK cryptographic algorithm identifier to use when generating keys.
-   * @param forceCryptoKey optional explicit CHK key material; {@code null} to use a random key.
-   * @param metadataThreshold when positive, return metadata bytes directly if serialized metadata
-   *     is shorter than this many bytes.
+   * @param params parameter bundle describing the insert inputs and execution options
    */
-  SingleFileInserter(
-      BaseClientPutter parent,
-      PutCompletionCallback cb,
-      InsertBlock block,
-      boolean metadata,
-      InsertContext ctx,
-      boolean realTimeFlag,
-      boolean dontCompress,
-      boolean reportMetadataOnly,
-      Object token,
-      ARCHIVE_TYPE archiveType,
-      boolean freeData,
-      String targetFilename,
-      boolean forSplitfile,
-      boolean persistent,
-      long origDataLength,
-      long origCompressedDataLength,
-      HashResult[] origHashes,
-      byte cryptoAlgorithm,
-      byte[] forceCryptoKey,
-      long metadataThreshold) {
+  SingleFileInserter(SingleFileInserterParams params) {
     hashCode = super.hashCode();
-    this.reportMetadataOnly = reportMetadataOnly;
-    this.token = token;
-    this.parent = parent;
-    this.block = block;
-    this.ctx = ctx;
-    this.realTimeFlag = realTimeFlag;
-    this.metadata = metadata;
-    this.cb = cb;
-    this.archiveType = archiveType;
-    this.freeData = freeData;
-    this.targetFilename = targetFilename;
-    this.persistent = persistent;
-    this.forSplitfile = forSplitfile;
-    this.origCompressedDataLength = origCompressedDataLength;
-    this.origDataLength = origDataLength;
-    this.origHashes = origHashes;
-    this.forceCryptoKey = forceCryptoKey;
-    this.cryptoAlgorithm = cryptoAlgorithm;
-    this.metadataThreshold = metadataThreshold;
-    this.dontCompress = dontCompress;
+    InsertExecutionOptions execOptions = params.executionOptions;
+    this.reportMetadataOnly = execOptions.reportMetadataOnly();
+    this.token = params.token;
+    this.parent = params.parent;
+    this.block = params.block;
+    this.ctx = params.ctx;
+    this.realTimeFlag = execOptions.realTimeFlag();
+    this.metadata = params.metadata;
+    this.cb = params.callback;
+    this.archiveType = execOptions.archiveType();
+    this.freeData = params.freeData;
+    this.targetFilename = params.targetFilename;
+    this.persistent = params.persistent;
+    this.forSplitfile = params.forSplitfile;
+    this.origCompressedDataLength = params.origCompressedDataLength;
+    this.origDataLength = params.origDataLength;
+    this.origHashes = params.origHashes;
+    this.forceCryptoKey = execOptions.forceCryptoKey();
+    this.cryptoAlgorithm = execOptions.cryptoAlgorithm();
+    this.metadataThreshold = params.metadataThreshold;
+    this.dontCompress = execOptions.dontCompress();
     if (LOG.isDebugEnabled())
       LOG.debug("Created {} persistent={} freeData={}", this, persistent, freeData);
   }
@@ -471,14 +419,15 @@ class SingleFileInserter implements ClientPutState, Serializable {
     if (persistent && (data instanceof NotPersistentBucket)) data = fixNotPersistent(data, context);
     ClientPutState bi =
         createInserter(
-            parent,
-            data,
-            codecNumber,
-            ctx,
-            cb,
-            metadata,
-            (int) origSize,
-            context,
+            new BlockInsertPayload(
+                data,
+                block.desiredURI,
+                codecNumber,
+                metadata,
+                (int) origSize,
+                cryptoAlgorithm,
+                forceCryptoKey),
+            new BlockInsertParams(parent, ctx, cb, -1, token, true, context),
             shouldFreeData,
             forSplitfile);
     if (LOG.isTraceEnabled()) LOG.trace("Inserting without metadata: {} for {}", bi, this);
@@ -572,6 +521,8 @@ class SingleFileInserter implements ClientPutState, Serializable {
       throws InsertException {
     MultiPutCompletionCallback mcb =
         new MultiPutCompletionCallback(cb, parent, token, persistent, false, ctx.isEarlyEncode());
+    BlockInsertParams insertParams =
+        new BlockInsertParams(parent, ctx, mcb, -1, token, true, context);
     SingleBlockInserter dataPutter =
         new SingleBlockInserter(
             new BlockInsertPayload(
@@ -582,7 +533,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
                 (int) origSize,
                 cryptoAlgorithm,
                 forceCryptoKey),
-            new BlockInsertParams(parent, ctx, mcb, -1, token, true, context),
+            insertParams,
             new BlockInsertOptions(
                 persistent,
                 realTimeFlag,
@@ -607,14 +558,15 @@ class SingleFileInserter implements ClientPutState, Serializable {
     }
     ClientPutState metaPutter =
         createInserter(
-            parent,
-            metadataBucket,
-            (short) -1,
-            ctx,
-            mcb,
-            true,
-            (int) origSize,
-            context,
+            new BlockInsertPayload(
+                metadataBucket,
+                block.desiredURI,
+                (short) -1,
+                true,
+                (int) origSize,
+                cryptoAlgorithm,
+                forceCryptoKey),
+            insertParams,
             true,
             false);
     if (LOG.isTraceEnabled()) LOG.trace("Inserting metadata: {} for {}", metaPutter, this);
@@ -847,24 +799,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
 
   private Metadata makeMetadata(ARCHIVE_TYPE archiveType, FreenetURI uri, HashResult[] hashes) {
     Metadata meta;
-    boolean allowTopBlocks = origDataLength != 0;
-    int req = 0;
-    int total = 0;
-    long data = 0;
-    long compressed = 0;
-    boolean topDontCompress = false;
-    CompatibilityMode topCompatibilityMode = CompatibilityMode.COMPAT_UNKNOWN;
-    if (allowTopBlocks) {
-      req = parent.getMinSuccessFetchBlocks();
-      total = parent.totalBlocks;
-      topDontCompress = (ctx.isDontCompress() || this.dontCompress);
-      topCompatibilityMode = ctx.getCompatibilityMode();
-      data = origDataLength;
-      compressed = origCompressedDataLength;
-    }
-    MetadataTopLayerInfo topLayer =
-        new MetadataTopLayerInfo(
-            data, compressed, req, total, topDontCompress, topCompatibilityMode, hashes, null);
+    MetadataTopLayerInfo topLayer = buildTopLayerInfo(hashes);
     if (archiveType != null) {
       meta =
           new Metadata(
@@ -886,6 +821,26 @@ class SingleFileInserter implements ClientPutState, Serializable {
     return meta;
   }
 
+  private MetadataTopLayerInfo buildTopLayerInfo(HashResult[] hashes) {
+    boolean allowTopBlocks = origDataLength != 0;
+    int req = 0;
+    int total = 0;
+    long data = 0;
+    long compressed = 0;
+    boolean topDontCompress = false;
+    CompatibilityMode topCompatibilityMode = CompatibilityMode.COMPAT_UNKNOWN;
+    if (allowTopBlocks) {
+      req = parent.getMinSuccessFetchBlocks();
+      total = parent.totalBlocks;
+      topDontCompress = (ctx.isDontCompress() || this.dontCompress);
+      topCompatibilityMode = ctx.getCompatibilityMode();
+      data = origDataLength;
+      compressed = origCompressedDataLength;
+    }
+    return new MetadataTopLayerInfo(
+        data, compressed, req, total, topDontCompress, topCompatibilityMode, hashes, null);
+  }
+
   /**
    * Create an inserter, either for a USK or a single block.
    *
@@ -897,19 +852,10 @@ class SingleFileInserter implements ClientPutState, Serializable {
    *     multiple inserts of the same block.
    */
   private ClientPutState createInserter(
-      BaseClientPutter parent,
-      Bucket data,
-      short compressionCodec,
-      InsertContext ctx,
-      PutCompletionCallback cb,
-      boolean isMetadata,
-      int sourceLength,
-      ClientContext context,
-      boolean freeData,
-      boolean forSplitfile)
+      BlockInsertPayload payload, BlockInsertParams params, boolean freeData, boolean forSplitfile)
       throws InsertException {
 
-    FreenetURI uri = block.desiredURI;
+    FreenetURI uri = payload.uri();
     if (uri == null) {
       throw new InsertException(InsertExceptionMode.INVALID_URI, "Null key type", null);
     }
@@ -918,44 +864,30 @@ class SingleFileInserter implements ClientPutState, Serializable {
     if (uri.getKeyType().equals("USK")) {
       try {
         return new USKInserter(
-            new BlockInsertPayload(
-                data,
-                uri,
-                compressionCodec,
-                isMetadata,
-                sourceLength,
-                cryptoAlgorithm,
-                forceCryptoKey),
-            new BlockInsertParams(parent, ctx, cb, -1, this.token, true, context),
+            payload,
+            params,
             new BlockInsertOptions(
                 persistent,
                 realTimeFlag,
                 freeData,
                 forSplitfile
-                    ? ctx.getExtraInsertsSplitfileHeaderBlock()
-                    : ctx.getExtraInsertsSingleBlock()));
+                    ? params.ctx().getExtraInsertsSplitfileHeaderBlock()
+                    : params.ctx().getExtraInsertsSingleBlock()));
       } catch (MalformedURLException e) {
         throw new InsertException(InsertExceptionMode.INVALID_URI, e, null);
       }
     } else {
       SingleBlockInserter sbi =
           new SingleBlockInserter(
-              new BlockInsertPayload(
-                  data,
-                  uri,
-                  compressionCodec,
-                  isMetadata,
-                  sourceLength,
-                  cryptoAlgorithm,
-                  forceCryptoKey),
-              new BlockInsertParams(parent, ctx, cb, -1, this.token, true, context),
+              payload,
+              params,
               new BlockInsertOptions(
                   persistent,
                   realTimeFlag,
                   freeData,
                   forSplitfile
-                      ? ctx.getExtraInsertsSplitfileHeaderBlock()
-                      : ctx.getExtraInsertsSingleBlock()),
+                      ? params.ctx().getExtraInsertsSplitfileHeaderBlock()
+                      : params.ctx().getExtraInsertsSingleBlock()),
               false);
       // pass uri to SBI
       block.nullURI();
@@ -972,7 +904,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
    * it constructs and schedules a dedicated metadata inserter.
    *
    * <p>Lifecycle: the handler tolerates out-of-order completion (metadata first or data first),
-   * idempotently ignores duplicate notifications, and ensures both branches are cancelled on
+   * idempotently ignores duplicate notifications, and ensures both branches are canceled on
    * failure. On resume, it rewires missing callbacks for deserialized children and restarts work as
    * permitted by policy.
    */
@@ -1329,28 +1261,27 @@ class SingleFileInserter implements ClientPutState, Serializable {
         ClientContext context) {
       InsertBlock newBlock = new InsertBlock(metadataBucket, m, block.desiredURI);
       synchronized (this) {
-        metadataPutter =
-            new SingleFileInserter(
-                parent,
-                this,
-                newBlock,
-                true,
-                ctx,
-                realTimeFlag,
-                false,
-                false,
-                token,
-                archiveType,
-                true,
-                metaPutterTargetFilename,
-                true,
-                persistent,
-                origDataLength,
-                origCompressedDataLength,
-                origHashes,
-                cryptoAlgorithm,
-                forceCryptoKey,
-                metadataThreshold);
+        InsertExecutionOptions execOptions =
+            new InsertExecutionOptions(
+                false, false, archiveType, forceCryptoKey, cryptoAlgorithm, realTimeFlag);
+        SingleFileInserterParams params =
+            new SingleFileInserterParams()
+                .withParent(parent)
+                .withCallback(this)
+                .withBlock(newBlock)
+                .withMetadata(true)
+                .withCtx(ctx)
+                .withExecutionOptions(execOptions)
+                .withToken(token)
+                .withFreeData(true)
+                .withTargetFilename(metaPutterTargetFilename)
+                .withForSplitfile(true)
+                .withPersistent(persistent)
+                .withOrigDataLength(origDataLength)
+                .withOrigCompressedDataLength(origCompressedDataLength)
+                .withOrigHashes(origHashes)
+                .withMetadataThreshold(metadataThreshold);
+        metadataPutter = new SingleFileInserter(params);
         if (origHashes != null) {
           SingleFileInserter.this.origHashes = null;
         }

--- a/src/main/java/network/crypta/client/async/SingleFileInserterParams.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserterParams.java
@@ -1,0 +1,377 @@
+package network.crypta.client.async;
+
+import network.crypta.client.InsertBlock;
+import network.crypta.client.InsertContext;
+import network.crypta.crypt.HashResult;
+
+/**
+ * Mutable parameter bundle for constructing {@link SingleFileInserter} instances.
+ *
+ * <p>This type centralizes the inputs that would otherwise be passed as a long constructor argument
+ * list, keeping call sites readable while preserving the original semantics. Callers typically
+ * allocate a new instance, configure it fluently with the {@code with*} methods, and pass it
+ * directly to {@link SingleFileInserter}. The bundle performs no validation, normalization, or
+ * defensive copying; it exists purely as a structured carrier of values that the inserter will
+ * interpret later.
+ *
+ * <p>Because the fields are mutable and package-visible, instances are not thread-safe and should
+ * be treated as short-lived setup objects. After construction, callers should avoid reusing or
+ * mutating the same instance across threads or across unrelated insert operations. Any mutable
+ * references (such as {@code origHashes}) are stored by reference, so callers retain ownership of
+ * their contents and must keep them stable until the inserter no longer needs them.
+ *
+ * <ul>
+ *   <li>Encapsulates inserter inputs without adding validation or behavior.
+ *   <li>Supports a fluent setup style via package-local {@code with*} methods.
+ *   <li>Intended for one-shot configuration, not long-term storage.
+ * </ul>
+ *
+ * @see SingleFileInserter
+ */
+public final class SingleFileInserterParams {
+  /**
+   * Parent putter that owns the insert lifecycle and receives state transitions.
+   *
+   * <p>Set this before construction to ensure callbacks and counters are wired correctly. This
+   * reference is stored as-is and may be {@code null} only in test or specialized flows that
+   * tolerate a missing parent.
+   */
+  BaseClientPutter parent;
+
+  /**
+   * Callback invoked for state changes, completion, and failure notifications.
+   *
+   * <p>The callback must remain valid for the duration of the insert. It may be {@code null} only
+   * when the caller intentionally suppresses notifications, such as in tightly scoped tests.
+   */
+  PutCompletionCallback callback;
+
+  /**
+   * Input block containing data, optional client metadata, and the desired URI.
+   *
+   * <p>The inserter reads from this block and may null out its data after scheduling when the
+   * request is persistent. The block reference is stored without copying.
+   */
+  InsertBlock block;
+
+  /**
+   * Flag indicating whether this inserter is processing metadata rather than primary content.
+   *
+   * <p>This influences hashing behavior and redirect/manifest handling. The value is stored
+   * verbatim and interpreted by {@link SingleFileInserter} during preprocessing.
+   */
+  boolean metadata;
+
+  /**
+   * Insert context that supplies compatibility settings, retry policies, and factories.
+   *
+   * <p>The context is read at scheduling time and is expected to remain stable for the lifetime of
+   * the insert. It is stored by reference without validation.
+   */
+  InsertContext ctx;
+
+  /**
+   * Execution options controlling compression, crypto settings, and scheduling hints.
+   *
+   * <p>These options are reused across inserter types and are stored as provided. Callers should
+   * not mutate shared instances once passed to the inserter.
+   */
+  InsertExecutionOptions executionOptions;
+
+  /**
+   * Application-supplied correlation token forwarded to callbacks.
+   *
+   * <p>This token may be {@code null}. It is stored by reference and typically used for logging or
+   * request correlation by higher layers.
+   */
+  Object token;
+
+  /**
+   * Whether the underlying data bucket should be freed as soon as possible.
+   *
+   * <p>This flag allows memory- or disk-backed buckets to be released early once the inserter no
+   * longer needs the payload. It does not affect the logical success or failure of the insert.
+   */
+  boolean freeData;
+
+  /**
+   * Optional filename to use when emitting a redirect/manifest wrapper.
+   *
+   * <p>When non-{@code null}, the inserter wraps generated metadata under this name. The string is
+   * stored as provided and is not validated here.
+   */
+  String targetFilename;
+
+  /**
+   * Indicates whether this insert is above a splitfile layer.
+   *
+   * <p>This flag affects extra-insert policies for block scheduling. It is stored verbatim and
+   * evaluated by the inserter when constructing downstream components.
+   */
+  boolean forSplitfile;
+
+  /**
+   * Whether the insert should survive process restarts and resume later.
+   *
+   * <p>Persistent inserts use different bucket factories and may serialize state. The flag is
+   * passed through to downstream inserters without validation.
+   */
+  boolean persistent;
+
+  /**
+   * Original uncompressed length of the payload in bytes, or {@code 0} when unknown.
+   *
+   * <p>This value is used for metadata reporting and progress displays. It is not validated for
+   * consistency with the data bucket size.
+   */
+  long origDataLength;
+
+  /**
+   * Original compressed length of the payload in bytes, or {@code 0} when unknown.
+   *
+   * <p>This is used for reporting and metadata emission when available. The value is stored as
+   * provided without range checks.
+   */
+  long origCompressedDataLength;
+
+  /**
+   * Optional precomputed hashes for the original data.
+   *
+   * <p>The array is stored by reference and may be {@code null}. Callers must keep the contents
+   * stable until the inserter finishes consuming them.
+   */
+  HashResult[] origHashes;
+
+  /**
+   * Threshold in bytes for returning inline metadata instead of a URI, or non-positive to disable.
+   *
+   * <p>The inserter compares this to the serialized metadata size to decide whether to return raw
+   * metadata bytes. The value is stored as provided.
+   */
+  long metadataThreshold;
+
+  /**
+   * Creates an empty parameter bundle with all fields left at their default values.
+   *
+   * <p>This constructor performs no initialization beyond the Java defaults. Callers are expected
+   * to populate every required field using the fluent {@code with*} methods before handing the
+   * instance to {@link SingleFileInserter}. Leaving fields unset will defer validation to the
+   * inserter and may result in failures during scheduling or preprocessing. This constructor is
+   * intentionally lightweight and side-effect free.
+   */
+  public SingleFileInserterParams() {
+    // Intentionally empty: callers configure fields via the fluent setters.
+  }
+
+  /**
+   * Sets the parent putter that coordinates this insert.
+   *
+   * <p>This should be a non-null instance that can accept progress notifications. The value is
+   * stored by reference with no validation. Returns {@code this} to allow fluent setup.
+   *
+   * @param parent parent putter responsible for lifecycle coordination; may be {@code null} in
+   *     controlled test scenarios
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withParent(BaseClientPutter parent) {
+    this.parent = parent;
+    return this;
+  }
+
+  /**
+   * Sets the completion callback to receive state transitions and terminal events.
+   *
+   * <p>The callback should remain valid for the duration of the insert. The reference is stored
+   * verbatim, and {@code null} is only appropriate when callers intentionally suppress callbacks.
+   *
+   * @param callback callback to receive insert lifecycle notifications; may be {@code null} when
+   *     callers do not require notifications
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withCallback(PutCompletionCallback callback) {
+    this.callback = callback;
+    return this;
+  }
+
+  /**
+   * Sets the input {@link InsertBlock} containing data and target URI information.
+   *
+   * <p>The block is stored by reference and may be mutated by the inserter during scheduling for
+   * persistence reasons. Callers should not reuse the block after passing it along.
+   *
+   * @param block insert block with data, optional metadata, and desired URI; may be {@code null}
+   *     only when tests intentionally bypass scheduling
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withBlock(InsertBlock block) {
+    this.block = block;
+    return this;
+  }
+
+  /**
+   * Sets whether this inserter is treating the payload as metadata.
+   *
+   * <p>Metadata inserts can alter hashing and redirect behavior. This flag is stored as given and
+   * interpreted by {@link SingleFileInserter} later.
+   *
+   * @param metadata {@code true} to treat the payload as metadata; {@code false} for primary data
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withMetadata(boolean metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+
+  /**
+   * Sets the {@link InsertContext} that provides compatibility and operational settings.
+   *
+   * <p>The context reference is stored without validation or copying. It should remain usable for
+   * the duration of the insert.
+   *
+   * @param ctx insert context supplying policies and factories; may be {@code null} only in tests
+   *     that never schedule the inserter
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withCtx(InsertContext ctx) {
+    this.ctx = ctx;
+    return this;
+  }
+
+  /**
+   * Sets the execution options that control compression, crypto, and scheduling hints.
+   *
+   * <p>The options object is stored by reference and should not be mutated after being set. This
+   * method performs no validation.
+   *
+   * @param executionOptions options describing compression, crypto, and scheduling behavior; may be
+   *     {@code null} only if the inserter tolerates missing options
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withExecutionOptions(InsertExecutionOptions executionOptions) {
+    this.executionOptions = executionOptions;
+    return this;
+  }
+
+  /**
+   * Sets the application correlation token forwarded to callbacks.
+   *
+   * <p>The token is stored by reference and may be {@code null}. Callers typically use it for
+   * request tracking or logging.
+   *
+   * @param token opaque application token to echo on callbacks; may be {@code null}
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withToken(Object token) {
+    this.token = token;
+    return this;
+  }
+
+  /**
+   * Sets whether the inserter should free the data bucket as early as possible.
+   *
+   * <p>This flag influences resource release timing but does not affect insert correctness.
+   *
+   * @param freeData {@code true} to free data as soon as possible; {@code false} to retain longer
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withFreeData(boolean freeData) {
+    this.freeData = freeData;
+    return this;
+  }
+
+  /**
+   * Sets an optional filename to use when wrapping metadata in a redirect manifest.
+   *
+   * <p>When non-{@code null}, the inserter emits a redirect manifest keyed by this name. No
+   * validation is performed here.
+   *
+   * @param targetFilename optional filename for metadata wrapping; may be {@code null}
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withTargetFilename(String targetFilename) {
+    this.targetFilename = targetFilename;
+    return this;
+  }
+
+  /**
+   * Sets whether the insertion is above a splitfile layer.
+   *
+   * <p>This affects extra-insert policies in downstream inserters. The value is stored verbatim.
+   *
+   * @param forSplitfile {@code true} when the insert is above a splitfile; {@code false} otherwise
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withForSplitfile(boolean forSplitfile) {
+    this.forSplitfile = forSplitfile;
+    return this;
+  }
+
+  /**
+   * Sets whether the insert should be durable across restarts.
+   *
+   * <p>Persistent inserts use durable buckets and may be serialized for resume. No validation is
+   * performed by this method.
+   *
+   * @param persistent {@code true} for durable inserts; {@code false} for transient inserts
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withPersistent(boolean persistent) {
+    this.persistent = persistent;
+    return this;
+  }
+
+  /**
+   * Sets the original uncompressed data length for reporting and metadata emission.
+   *
+   * <p>Use {@code 0} when the length is unknown. The value is stored as provided without checks.
+   *
+   * @param origDataLength original uncompressed length in bytes; {@code 0} when unknown
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withOrigDataLength(long origDataLength) {
+    this.origDataLength = origDataLength;
+    return this;
+  }
+
+  /**
+   * Sets the original compressed data length for reporting and metadata emission.
+   *
+   * <p>Use {@code 0} when unknown. The value is stored as provided and may be inconsistent with the
+   * actual compressed size, which is not validated here.
+   *
+   * @param origCompressedDataLength original compressed length in bytes; {@code 0} when unknown
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withOrigCompressedDataLength(long origCompressedDataLength) {
+    this.origCompressedDataLength = origCompressedDataLength;
+    return this;
+  }
+
+  /**
+   * Sets the precomputed hash array for the original data.
+   *
+   * <p>The array is stored by reference and may be {@code null}. Callers should not mutate its
+   * contents after passing it in if they rely on stable hashing output.
+   *
+   * @param origHashes optional precomputed hashes for the original data; may be {@code null}
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withOrigHashes(HashResult[] origHashes) {
+    this.origHashes = origHashes;
+    return this;
+  }
+
+  /**
+   * Sets the metadata size threshold for returning inline bytes.
+   *
+   * <p>Values greater than zero cause the inserter to return raw metadata bytes when the serialized
+   * metadata fits under this threshold. Non-positive values disable the optimization.
+   *
+   * @param metadataThreshold byte threshold for inline metadata; non-positive disables inlining
+   * @return this bundle instance for chained configuration
+   */
+  SingleFileInserterParams withMetadataThreshold(long metadataThreshold) {
+    this.metadataThreshold = metadataThreshold;
+    return this;
+  }
+}

--- a/src/test/java/network/crypta/client/async/ContainerInserterTest.java
+++ b/src/test/java/network/crypta/client/async/ContainerInserterTest.java
@@ -307,8 +307,8 @@ class ContainerInserterTest {
             manifest,
             new FreenetURI("CHK", null, (byte[]) null, null, null),
             newInsertContext(),
-            new ContainerInserter.Options(
-                true, false, null, ARCHIVE_TYPE.ZIP, null, (byte) 0, false));
+            new InsertExecutionOptions(true, false, ARCHIVE_TYPE.ZIP, null, (byte) 0, false),
+            null);
 
     // Act
     inserter.cancel(clientContext);
@@ -333,8 +333,8 @@ class ContainerInserterTest {
             new HashMap<>(),
             new FreenetURI("CHK", null, (byte[]) null, null, null),
             newInsertContext(),
-            new ContainerInserter.Options(
-                true, false, token, ARCHIVE_TYPE.ZIP, null, (byte) 0, false));
+            new InsertExecutionOptions(true, false, ARCHIVE_TYPE.ZIP, null, (byte) 0, false),
+            token);
 
     assertEquals(parent, inserter.getParent());
     assertEquals(token, inserter.getToken());
@@ -407,8 +407,8 @@ class ContainerInserterTest {
             manifest,
             new FreenetURI("CHK", null, (byte[]) null, null, null),
             newInsertContext(),
-            new ContainerInserter.Options(
-                true, false, null, ARCHIVE_TYPE.TAR, null, (byte) 0, false));
+            new InsertExecutionOptions(true, false, ARCHIVE_TYPE.TAR, null, (byte) 0, false),
+            null);
 
     // Act
     inserter.onResume(clientContext);
@@ -526,8 +526,8 @@ class ContainerInserterTest {
             manifest,
             new FreenetURI("CHK", null, (byte[]) null, null, null),
             newInsertContext(),
-            new ContainerInserter.Options(
-                false, false, null, ARCHIVE_TYPE.ZIP, null, (byte) 0, false));
+            new InsertExecutionOptions(false, false, ARCHIVE_TYPE.ZIP, null, (byte) 0, false),
+            null);
 
     // Act: schedule and stop after inspection
     try {
@@ -628,8 +628,8 @@ class ContainerInserterTest {
             manifest,
             new FreenetURI("CHK", null, (byte[]) null, null, null),
             newInsertContext(),
-            new ContainerInserter.Options(
-                false, false, null, ARCHIVE_TYPE.TAR, null, (byte) 0, false));
+            new InsertExecutionOptions(false, false, ARCHIVE_TYPE.TAR, null, (byte) 0, false),
+            null);
 
     try {
       inserter.schedule(clientContext);
@@ -660,8 +660,8 @@ class ContainerInserterTest {
             manifest,
             new FreenetURI("CHK", null, (byte[]) null, null, null),
             newInsertContext(),
-            new ContainerInserter.Options(
-                false, false, null, ARCHIVE_TYPE.ZIP, null, (byte) 0, false));
+            new InsertExecutionOptions(false, false, ARCHIVE_TYPE.ZIP, null, (byte) 0, false),
+            null);
 
     // Act
     inserter.schedule(clientContext);

--- a/src/test/java/network/crypta/client/async/InsertCompressorTest.java
+++ b/src/test/java/network/crypta/client/async/InsertCompressorTest.java
@@ -99,26 +99,23 @@ class InsertCompressorTest {
     TestInserter(
         InsertBlock block, InsertContext ctx, boolean persistent, PutCompletionCallback cb) {
       super(
-          /*parent*/ null,
-          /*cb*/ cb,
-          /*block*/ block,
-          /*metadata*/ false,
-          /*ctx*/ ctx,
-          /*realTimeFlag*/ false,
-          /*dontCompress*/ false,
-          /*reportMetadataOnly*/ false,
-          /*token*/ new Object(),
-          /*archiveType*/ null,
-          /*freeData*/ false,
-          /*targetFilename*/ null,
-          /*forSplitfile*/ false,
-          /*persistent*/ persistent,
-          /*origDataLength*/ 0L,
-          /*origCompressedDataLength*/ 0L,
-          /*origHashes*/ null,
-          /*cryptoAlgorithm*/ (byte) 0,
-          /*forceCryptoKey*/ null,
-          /*metadataThreshold*/ 0L);
+          new SingleFileInserterParams()
+              .withParent(null)
+              .withCallback(cb)
+              .withBlock(block)
+              .withMetadata(false)
+              .withCtx(ctx)
+              .withExecutionOptions(
+                  new InsertExecutionOptions(false, false, null, null, (byte) 0, false))
+              .withToken(new Object())
+              .withFreeData(false)
+              .withTargetFilename(null)
+              .withForSplitfile(false)
+              .withPersistent(persistent)
+              .withOrigDataLength(0L)
+              .withOrigCompressedDataLength(0L)
+              .withOrigHashes(null)
+              .withMetadataThreshold(0L));
       this.testCb = cb;
     }
 

--- a/src/test/java/network/crypta/client/async/SingleFileInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SingleFileInserterTest.java
@@ -96,27 +96,26 @@ class SingleFileInserterTest {
   private static SingleFileInserter buildSfiForStartCompression(
       BaseClientPutter parentAndCb, PutCompletionCallback cb, InsertContext ctx) {
     InsertBlock block = new InsertBlock(new ArrayBucket(), null, FreenetURI.EMPTY_CHK_URI);
-    return new SingleFileInserter(
-        parentAndCb,
-        cb,
-        block,
-        false,
-        ctx,
-        false,
-        false,
-        false,
-        new Object(),
-        null,
-        false,
-        null,
-        false,
-        false,
-        0L,
-        0L,
-        null,
-        (byte) 0,
-        null,
-        0L);
+    InsertExecutionOptions execOptions =
+        new InsertExecutionOptions(false, false, null, null, (byte) 0, false);
+    SingleFileInserterParams params =
+        new SingleFileInserterParams()
+            .withParent(parentAndCb)
+            .withCallback(cb)
+            .withBlock(block)
+            .withMetadata(false)
+            .withCtx(ctx)
+            .withExecutionOptions(execOptions)
+            .withToken(new Object())
+            .withFreeData(false)
+            .withTargetFilename(null)
+            .withForSplitfile(false)
+            .withPersistent(false)
+            .withOrigDataLength(0L)
+            .withOrigCompressedDataLength(0L)
+            .withOrigHashes(null)
+            .withMetadataThreshold(0L);
+    return new SingleFileInserter(params);
   }
 
   private static RandomAccessBucket makeData(byte[] bytes) throws Exception {
@@ -140,28 +139,26 @@ class SingleFileInserterTest {
     RandomAccessBucket data = makeData("hello".getBytes());
     InsertBlock block =
         new InsertBlock(data, null, new FreenetURI("ABC", null, (byte[]) null, null, null));
-    SingleFileInserter sfi =
-        new SingleFileInserter(
-            /*parent*/ mock(BaseClientPutter.class),
-            /*cb*/ cb,
-            /*block*/ block,
-            /*metadata*/ false,
-            /*ctx*/ insertCtx,
-            /*realTimeFlag*/ false,
-            /*dontCompress*/ false,
-            /*reportMetadataOnly*/ false,
-            /*token*/ new Object(),
-            /*archiveType*/ null,
-            /*freeData*/ false,
-            /*targetFilename*/ null,
-            /*forSplitfile*/ false,
-            /*persistent*/ false,
-            /*origDataLength*/ 0L,
-            /*origCompressedDataLength*/ 0L,
-            /*origHashes*/ null,
-            /*cryptoAlgorithm*/ (byte) 0,
-            /*forceCryptoKey*/ null,
-            /*metadataThreshold*/ 0L);
+    InsertExecutionOptions execOptions =
+        new InsertExecutionOptions(false, false, null, null, (byte) 0, false);
+    SingleFileInserterParams params =
+        new SingleFileInserterParams()
+            .withParent(mock(BaseClientPutter.class))
+            .withCallback(cb)
+            .withBlock(block)
+            .withMetadata(false)
+            .withCtx(insertCtx)
+            .withExecutionOptions(execOptions)
+            .withToken(new Object())
+            .withFreeData(false)
+            .withTargetFilename(null)
+            .withForSplitfile(false)
+            .withPersistent(false)
+            .withOrigDataLength(0L)
+            .withOrigCompressedDataLength(0L)
+            .withOrigHashes(null)
+            .withMetadataThreshold(0L);
+    SingleFileInserter sfi = new SingleFileInserter(params);
 
     ClientContext context = mockContextWithInlineExecution(inlineExecutor);
     CompressionOutput output = new CompressionOutput(block.getData(), null, null);
@@ -192,26 +189,23 @@ class SingleFileInserterTest {
 
     SingleFileInserter sfi =
         new SingleFileInserter(
-            /*parent*/ mock(BaseClientPutter.class),
-            /*cb*/ cb,
-            /*block*/ block,
-            /*metadata*/ false,
-            /*ctx*/ insertCtx,
-            /*realTimeFlag*/ false,
-            /*dontCompress*/ false,
-            /*reportMetadataOnly*/ false,
-            /*token*/ new Object(),
-            /*archiveType*/ null,
-            /*freeData*/ false,
-            /*targetFilename*/ null,
-            /*forSplitfile*/ false,
-            /*persistent*/ false,
-            /*origDataLength*/ 0L,
-            /*origCompressedDataLength*/ 0L,
-            /*origHashes*/ null,
-            /*cryptoAlgorithm*/ (byte) 0,
-            /*forceCryptoKey*/ null,
-            /*metadataThreshold*/ 0L);
+            new SingleFileInserterParams()
+                .withParent(mock(BaseClientPutter.class))
+                .withCallback(cb)
+                .withBlock(block)
+                .withMetadata(false)
+                .withCtx(insertCtx)
+                .withExecutionOptions(
+                    new InsertExecutionOptions(false, false, null, null, (byte) 0, false))
+                .withToken(new Object())
+                .withFreeData(false)
+                .withTargetFilename(null)
+                .withForSplitfile(false)
+                .withPersistent(false)
+                .withOrigDataLength(0L)
+                .withOrigCompressedDataLength(0L)
+                .withOrigHashes(null)
+                .withMetadataThreshold(0L));
 
     ClientContext context = mockContextWithInlineExecution(inlineExecutor);
     CompressionOutput output = new CompressionOutput(block.getData(), null, null);
@@ -235,26 +229,23 @@ class SingleFileInserterTest {
     InsertBlock block = new InsertBlock(data, null, FreenetURI.EMPTY_CHK_URI);
     SingleFileInserter sfi =
         new SingleFileInserter(
-            /*parent*/ mock(BaseClientPutter.class),
-            /*cb*/ cb,
-            /*block*/ block,
-            /*metadata*/ false,
-            /*ctx*/ insertCtx,
-            /*realTimeFlag*/ false,
-            /*dontCompress*/ false,
-            /*reportMetadataOnly*/ false,
-            /*token*/ new Object(),
-            /*archiveType*/ null,
-            /*freeData*/ true,
-            /*targetFilename*/ null,
-            /*forSplitfile*/ false,
-            /*persistent*/ false,
-            /*origDataLength*/ 0L,
-            /*origCompressedDataLength*/ 0L,
-            /*origHashes*/ null,
-            /*cryptoAlgorithm*/ (byte) 0,
-            /*forceCryptoKey*/ null,
-            /*metadataThreshold*/ 0L);
+            new SingleFileInserterParams()
+                .withParent(mock(BaseClientPutter.class))
+                .withCallback(cb)
+                .withBlock(block)
+                .withMetadata(false)
+                .withCtx(insertCtx)
+                .withExecutionOptions(
+                    new InsertExecutionOptions(false, false, null, null, (byte) 0, false))
+                .withToken(new Object())
+                .withFreeData(true)
+                .withTargetFilename(null)
+                .withForSplitfile(false)
+                .withPersistent(false)
+                .withOrigDataLength(0L)
+                .withOrigCompressedDataLength(0L)
+                .withOrigHashes(null)
+                .withMetadataThreshold(0L));
 
     ClientContext context = mockContextWithInlineExecution(inlineExecutor);
 
@@ -316,26 +307,23 @@ class SingleFileInserterTest {
 
     SingleFileInserter sfi =
         new SingleFileInserter(
-            /*parent*/ mock(BaseClientPutter.class),
-            /*cb*/ cb,
-            /*block*/ block,
-            /*metadata*/ false,
-            /*ctx*/ insertCtx,
-            /*realTimeFlag*/ false,
-            /*dontCompress*/ false,
-            /*reportMetadataOnly*/ false,
-            /*token*/ new Object(),
-            /*archiveType*/ null,
-            /*freeData*/ false,
-            /*targetFilename*/ null,
-            /*forSplitfile*/ false,
-            /*persistent*/ false,
-            /*origDataLength*/ 0L,
-            /*origCompressedDataLength*/ 0L,
-            /*origHashes*/ null,
-            /*cryptoAlgorithm*/ (byte) 0,
-            /*forceCryptoKey*/ null,
-            /*metadataThreshold*/ 0L);
+            new SingleFileInserterParams()
+                .withParent(mock(BaseClientPutter.class))
+                .withCallback(cb)
+                .withBlock(block)
+                .withMetadata(false)
+                .withCtx(insertCtx)
+                .withExecutionOptions(
+                    new InsertExecutionOptions(false, false, null, null, (byte) 0, false))
+                .withToken(new Object())
+                .withFreeData(false)
+                .withTargetFilename(null)
+                .withForSplitfile(false)
+                .withPersistent(false)
+                .withOrigDataLength(0L)
+                .withOrigCompressedDataLength(0L)
+                .withOrigHashes(null)
+                .withMetadataThreshold(0L));
 
     ClientContext context = mock(ClientContext.class);
     Mockito.lenient().when(context.getMainExecutor()).thenReturn(inlineExecutor);


### PR DESCRIPTION
## Summary
- introduce `SingleFileInserterParams` and shared `InsertExecutionOptions` to reduce constructor parameter sprawl
- update inserter construction call sites, tests, and helper wiring for new parameter bundles
- add detailed Javadoc and redact crypto keys in `toString()`

## Testing
- `./gradlew spotlessApply`
- `./gradlew compileJava`
- `./gradlew test`
