### PR TITLE
refactor(client): bundle segment chooser params

### DIFF
--- a/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentBlockChooser.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentBlockChooser.java
@@ -37,7 +37,7 @@ public class SplitFileFetcherSegmentBlockChooser extends CooldownBlockChooser {
    *
    * <p>The {@code blocks} argument defines the number of candidate block indices tracked by this
    * chooser. Cooldown behavior and retry limits are inherited from {@link CooldownBlockChooser}.
-   * When {@code ignoreLastBlock} is non‑negative, that zero‑based index is excluded from
+   * When {@code params.ignoreLastBlock()} is non‑negative, that zero‑based index is excluded from
    * eligibility checks performed by {@link #checkValid(int)}.
    *
    * @param blocks total number of blocks managed by this chooser; valid indices are {@code [0,
@@ -50,12 +50,7 @@ public class SplitFileFetcherSegmentBlockChooser extends CooldownBlockChooser {
    *     cooldownTries}th attempt schedules a temporary cooldown window for a block.
    * @param cooldownTime cooldown duration in milliseconds added to {@link
    *     System#currentTimeMillis()} to compute per‑block wake‑up times.
-   * @param segment backing segment storage that provides key material and overall segment context;
-   *     must not be {@code null}.
-   * @param keysFetching coordinator tracking keys being fetched locally so duplicate work can be
-   *     avoided; used to filter out in‑flight duplicates.
-   * @param ignoreLastBlock zero‑based block index to exclude from selection, or {@code -1} to
-   *     disable the exclusion and consider all indices.
+   * @param params segment-specific chooser parameters such as key storage and in-flight tracking.
    */
   public SplitFileFetcherSegmentBlockChooser(
       int blocks,
@@ -63,13 +58,11 @@ public class SplitFileFetcherSegmentBlockChooser extends CooldownBlockChooser {
       int maxRetries,
       int cooldownTries,
       long cooldownTime,
-      SplitFileFetcherSegmentStorage segment,
-      KeysFetchingLocally keysFetching,
-      int ignoreLastBlock) {
+      SplitFileFetcherSegmentBlockChooserParams params) {
     super(blocks, random, maxRetries, cooldownTries, cooldownTime);
-    this.segment = segment;
-    this.keysFetching = keysFetching;
-    this.ignoreLastBlock = ignoreLastBlock;
+    this.segment = params.segment();
+    this.keysFetching = params.keysFetching();
+    this.ignoreLastBlock = params.ignoreLastBlock();
   }
 
   private final SplitFileFetcherSegmentStorage segment;
@@ -100,7 +93,7 @@ public class SplitFileFetcherSegmentBlockChooser extends CooldownBlockChooser {
           keys.getNodeKey(chosen, null, false), segment.parent.fetcher.getSendableGet());
     } catch (final IOException e) {
       segment.parent.jobRunner.queueNormalOrDrop(
-          context -> {
+          _ -> {
             segment.parent.failOnDiskError(e);
             return true;
           });

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentBlockChooserParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentBlockChooserParams.java
@@ -1,0 +1,21 @@
+package network.crypta.client.async;
+
+import network.crypta.node.KeysFetchingLocally;
+
+/**
+ * Bundles the segment-specific inputs for {@link SplitFileFetcherSegmentBlockChooser}.
+ *
+ * <p>This parameter object keeps the chooser constructor focused on the shared cooldown and retry
+ * settings while grouping the segment context that determines fetch eligibility.
+ *
+ * @param segment backing segment storage that provides key material and segment context; must not
+ *     be {@code null}.
+ * @param keysFetching coordinator tracking keys currently fetched locally to avoid duplicate
+ *     fetches.
+ * @param ignoreLastBlock zero-based block index to exclude from selection, or {@code -1} to disable
+ *     the exclusion and consider all indices.
+ */
+public record SplitFileFetcherSegmentBlockChooserParams(
+    SplitFileFetcherSegmentStorage segment,
+    KeysFetchingLocally keysFetching,
+    int ignoreLastBlock) {}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentStorage.java
@@ -68,7 +68,7 @@ public class SplitFileFetcherSegmentStorage {
   private static final Logger LOG = LoggerFactory.getLogger(SplitFileFetcherSegmentStorage.class);
 
   // Set this to false to turn off checking the CHKs on blocks decoded (and encoded) via FEC.
-  // Generally it is a good idea to have consistent behaviour regardless of what order we fetched
+  // Generally it is a good idea to have consistent behavior regardless of what order we fetched
   // the blocks in, whether binary blobs are enabled etc ... and this has caught nasty bugs in
   // the past, although now we have hashes at file level ...
   private static final boolean FORCE_CHECK_FEC_KEYS = true;
@@ -145,7 +145,7 @@ public class SplitFileFetcherSegmentStorage {
   private boolean finished;
 
   /**
-   * True if the segment has been cancelled, has failed due to an internal error, etc. In which case
+   * True if the segment has been canceled, has failed due to an internal error, etc. In which case
    * it is not interested in further blocks. Not true if it has run out of retries, in which case
    * (for cross-segment) we may still be interested in blocks.
    */
@@ -225,9 +225,8 @@ public class SplitFileFetcherSegmentStorage {
             parent.maxRetries,
             parent.cooldownTries,
             parent.cooldownLength,
-            this,
-            p.keysFetching,
-            ignoreLastBlock ? p.dataBlocks - 1 : -1);
+            new SplitFileFetcherSegmentBlockChooserParams(
+                this, p.keysFetching, ignoreLastBlock ? p.dataBlocks - 1 : -1));
     int minFetched = blocksForDecode();
     if (this.crossSegmentCheckBlocks != 0)
       crossSegmentsByBlock = new SplitFileFetcherCrossSegmentStorage[minFetched];
@@ -299,9 +298,8 @@ public class SplitFileFetcherSegmentStorage {
             parent.maxRetries,
             parent.cooldownTries,
             parent.cooldownLength,
-            this,
-            p.keysFetching,
-            ignoreLastBlock ? dataBlocks - 1 : -1);
+            new SplitFileFetcherSegmentBlockChooserParams(
+                this, p.keysFetching, ignoreLastBlock ? dataBlocks - 1 : -1));
     int minFetched = blocksForDecode();
     if (crossSegmentCheckBlocks != 0)
       crossSegmentsByBlock = new SplitFileFetcherCrossSegmentStorage[minFetched];
@@ -476,7 +474,7 @@ public class SplitFileFetcherSegmentStorage {
 
   /**
    * Attempt FEC decoding. Check blocks before decoding in case there is disk corruption. Check the
-   * new decoded blocks afterward to ensure reproducible behaviour.
+   * new decoded blocks afterward to ensure reproducible behavior.
    */
   private void innerDecode() throws IOException {
     if (LOG.isDebugEnabled()) LOG.debug("Trying to decode {} for {}", this, parent);
@@ -1226,7 +1224,7 @@ public class SplitFileFetcherSegmentStorage {
   }
 
   /**
-   * Returns whether the segment has reached a terminal state: succeeded, cancelled, or given up
+   * Returns whether the segment has reached a terminal state: succeeded, canceled, or given up
    * after exhausting retries.
    *
    * @return {@code true} when no further work will be performed.
@@ -1580,7 +1578,7 @@ public class SplitFileFetcherSegmentStorage {
 
   /**
    * Marks this segment as finished without completing decode, typically because the higher-level
-   * operation was cancelled. If decode is in progress, the final callback is deferred until the
+   * operation was canceled. If decode is in progress, the final callback is deferred until the
    * decoder reports back; otherwise the parent is notified immediately.
    */
   public void cancel() {

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherSegmentBlockChooserTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherSegmentBlockChooserTest.java
@@ -71,9 +71,8 @@ class SplitFileFetcherSegmentBlockChooserTest {
             3, /*cooldownTries*/
             0,
             /*cooldownTime*/ 0L,
-            seg,
-            keysFetching, /*ignoreLastBlock*/
-            0);
+            new SplitFileFetcherSegmentBlockChooserParams(
+                seg, keysFetching, /*ignoreLastBlock*/ 0));
 
     // Act
     int chosen = chooser.chooseKey();
@@ -104,7 +103,12 @@ class SplitFileFetcherSegmentBlockChooserTest {
 
     SplitFileFetcherSegmentBlockChooser chooser =
         new SplitFileFetcherSegmentBlockChooser(
-            1, new Random(7L), /*maxRetries*/ 3, /*cooldownTries*/ 0, 0L, seg, keysFetching, -1);
+            1,
+            new Random(7L),
+            /*maxRetries*/ 3,
+            /*cooldownTries*/ 0,
+            0L,
+            new SplitFileFetcherSegmentBlockChooserParams(seg, keysFetching, -1));
 
     // Act
     int chosen = chooser.chooseKey();
@@ -134,7 +138,12 @@ class SplitFileFetcherSegmentBlockChooserTest {
 
     SplitFileFetcherSegmentBlockChooser chooser =
         new SplitFileFetcherSegmentBlockChooser(
-            1, new Random(99L), /*maxRetries*/ 3, /*cooldownTries*/ 0, 0L, seg, keysFetching, -1);
+            1,
+            new Random(99L),
+            /*maxRetries*/ 3,
+            /*cooldownTries*/ 0,
+            0L,
+            new SplitFileFetcherSegmentBlockChooserParams(seg, keysFetching, -1));
 
     // Act
     int chosen = chooser.chooseKey();
@@ -156,7 +165,12 @@ class SplitFileFetcherSegmentBlockChooserTest {
 
     SplitFileFetcherSegmentBlockChooser chooser =
         new SplitFileFetcherSegmentBlockChooser(
-            1, new Random(1L), /*maxRetries*/ 3, /*cooldownTries*/ 0, 0L, seg, keysFetching, -1);
+            1,
+            new Random(1L),
+            /*maxRetries*/ 3,
+            /*cooldownTries*/ 0,
+            0L,
+            new SplitFileFetcherSegmentBlockChooserParams(seg, keysFetching, -1));
 
     // Act
     int chosen = chooser.chooseKey();


### PR DESCRIPTION
## Summary
- introduce `SplitFileFetcherSegmentBlockChooserParams` to group segment-specific inputs
- update segment storage and chooser tests to use the new record

## Testing
- not run (formatting only: `./gradlew spotlessApply`)