### PR TITLE
refactor(client): bundle splitfile fetch persistence params

### DIFF
--- a/src/main/java/network/crypta/client/async/SplitFileFetchOriginalDetails.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetchOriginalDetails.java
@@ -1,0 +1,84 @@
+package network.crypta.client.async;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.keys.FreenetURI;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Bundles the original request details persisted for splitfile fetch recovery.
+ *
+ * <p>This record groups the current key, original key, client detail bytes, and the final-fetch
+ * flag so persistence helpers can pass a single parameter object instead of long argument lists.
+ * The client detail bytes are stored by reference; callers should not mutate the array after
+ * construction if they rely on stable serialization output.
+ *
+ * <ul>
+ *   <li>Captures the current and original request keys used for persistence.
+ *   <li>Stores client detail bytes verbatim for later replay.
+ *   <li>Includes whether the fetch is considered final.
+ * </ul>
+ *
+ * @param thisKey key of the fetch currently being persisted
+ * @param origKey original request key that seeded the fetch
+ * @param clientDetails client detail bytes written verbatim to storage
+ * @param isFinalFetch true when the request is a final-fetch operation
+ */
+public record SplitFileFetchOriginalDetails(
+    FreenetURI thisKey, FreenetURI origKey, byte[] clientDetails, boolean isFinalFetch) {
+  /**
+   * Compares this instance to another by value, including the client detail bytes.
+   *
+   * @param o object to compare against; may be {@code null}.
+   * @return {@code true} when all components are equal, including array contents.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o
+        instanceof
+        SplitFileFetchOriginalDetails(
+            FreenetURI otherThisKey,
+            FreenetURI otherOrigKey,
+            byte[] otherClientDetails,
+            boolean otherIsFinalFetch))) {
+      return false;
+    }
+    return isFinalFetch == otherIsFinalFetch
+        && Objects.equals(thisKey, otherThisKey)
+        && Objects.equals(origKey, otherOrigKey)
+        && Arrays.equals(clientDetails, otherClientDetails);
+  }
+
+  /**
+   * Computes a hash code that incorporates the client detail bytes.
+   *
+   * @return a hash code derived from all components.
+   */
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(thisKey, origKey, isFinalFetch);
+    result = 31 * result + Arrays.hashCode(clientDetails);
+    return result;
+  }
+
+  /**
+   * Returns a diagnostic string that includes array contents.
+   *
+   * @return a non-null string describing this instance.
+   */
+  @Override
+  public @NotNull String toString() {
+    return "SplitFileFetchOriginalDetails[thisKey="
+        + thisKey
+        + ", origKey="
+        + origKey
+        + ", clientDetails="
+        + Arrays.toString(clientDetails)
+        + ", isFinalFetch="
+        + isFinalFetch
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/client/async/SplitFileFetchRetryPolicy.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetchRetryPolicy.java
@@ -1,0 +1,21 @@
+package network.crypta.client.async;
+
+/**
+ * Captures retry and cooldown policy values persisted for splitfile fetch recovery.
+ *
+ * <p>This record groups retry-related settings so persistence helpers can pass a single parameter
+ * object when encoding or decoding the on-disk layout. Values are stored as-is; callers are
+ * responsible for applying any validation rules or special semantics such as {@code -1} meaning
+ * unlimited retries.
+ *
+ * <ul>
+ *   <li>Limits non-fatal retries with {@code maxRetries}.
+ *   <li>Defines how often cooldowns occur via {@code cooldownTries}.
+ *   <li>Controls cooldown duration with {@code cooldownLength}.
+ * </ul>
+ *
+ * @param maxRetries maximum retry count persisted for future resume logic
+ * @param cooldownTries number of retry attempts before cooldown applies
+ * @param cooldownLength cooldown duration in milliseconds for retry scheduling
+ */
+public record SplitFileFetchRetryPolicy(int maxRetries, int cooldownTries, long cooldownLength) {}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
@@ -394,19 +394,18 @@ public class SplitFileFetcherStorage {
     SplitFileFetcherStoragePersistence.PreparedMetadata prepared = null;
     byte[] encodedBasicSettings;
     if (persistent) {
+      SplitFileFetchOriginalDetails originalDetails =
+          new SplitFileFetchOriginalDetails(p.thisKey, p.origKey, p.clientDetails, p.isFinalFetch);
+      SplitFileFetchRetryPolicy retryPolicy =
+          new SplitFileFetchRetryPolicy(maxRetries, cooldownTries, cooldownLength);
       prepared =
           SplitFileFetcherStoragePersistence.preparePersistent(
               p.metadata,
               p.tempBucketFactory,
-              p.thisKey,
-              p.origKey,
-              p.clientDetails,
-              p.isFinalFetch,
+              originalDetails,
               offsetOriginalMetadata,
               checksumChecker,
-              maxRetries,
-              cooldownTries,
-              cooldownLength);
+              retryPolicy);
       offsetOriginalDetails = prepared.offsetOriginalDetails();
       this.offsetBasicSettings = prepared.offsetBasicSettings();
       // Now offsets are final, we can encode the basic settings which embed them.

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStoragePersistence.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStoragePersistence.java
@@ -15,7 +15,6 @@ import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashType;
 import network.crypta.crypt.MultiHashOutputStream;
-import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.LockableRandomAccessBuffer;
@@ -154,22 +153,26 @@ final class SplitFileFetcherStoragePersistence {
    * staged bucket and the computed offsets; the bucket remains open until it is copied.
    *
    * <pre>{@code
-   * PreparedMetadata prepared = SplitFileFetcherStoragePersistence.preparePersistent(
-   *     metadata, tempBucketFactory, thisKey, origKey, clientDetails, isFinalFetch,
-   *     offsetOriginalMetadata, checksumChecker, maxRetries, cooldownTries, cooldownLength);
+   * SplitFileFetchOriginalDetails details =
+   *     new SplitFileFetchOriginalDetails(thisKey, origKey, clientDetails, isFinalFetch);
+   * SplitFileFetchRetryPolicy retryPolicy =
+   *     new SplitFileFetchRetryPolicy(maxRetries, cooldownTries, cooldownLength);
+   * PreparedMetadata prepared =
+   *     SplitFileFetcherStoragePersistence.preparePersistent(
+   *         metadata,
+   *         tempBucketFactory,
+   *         details,
+   *         offsetOriginalMetadata,
+   *         checksumChecker,
+   *         retryPolicy);
    * }</pre>
    *
    * @param metadata resolved metadata to serialize into the persistent layout
    * @param tempBucketFactory factory used to allocate the temporary metadata bucket
-   * @param thisKey key of the fetch currently being persisted
-   * @param origKey original request key that seeded the fetch
-   * @param clientDetails non-null client detail bytes written verbatim to storage
-   * @param isFinalFetch true when the request is a final-fetch operation
+   * @param originalDetails original fetch request details persisted alongside metadata
    * @param offsetOriginalMetadata base byte offset for metadata placement in storage
    * @param checksumChecker checksum provider used for metadata and details framing
-   * @param maxRetries maximum retry count persisted for future resume logic
-   * @param cooldownTries number of retry attempts before cooldown applies
-   * @param cooldownLength cooldown duration in milliseconds for retry scheduling
+   * @param retryPolicy retry and cooldown settings persisted for future resume logic
    * @return prepared metadata with staged bytes and computed offset positions
    * @throws FetchException if metadata is unresolved or encoding fails internally
    * @throws IOException if bucket I/O or checksum output cannot complete
@@ -177,15 +180,10 @@ final class SplitFileFetcherStoragePersistence {
   static PreparedMetadata preparePersistent(
       Metadata metadata,
       BucketFactory tempBucketFactory,
-      FreenetURI thisKey,
-      FreenetURI origKey,
-      byte[] clientDetails,
-      boolean isFinalFetch,
+      SplitFileFetchOriginalDetails originalDetails,
       long offsetOriginalMetadata,
       ChecksumChecker checksumChecker,
-      int maxRetries,
-      int cooldownTries,
-      long cooldownLength)
+      SplitFileFetchRetryPolicy retryPolicy)
       throws FetchException, IOException {
     Bucket metadataTemp = tempBucketFactory.makeBucket(-1);
     try (OutputStream os = metadataTemp.getOutputStream();
@@ -204,15 +202,7 @@ final class SplitFileFetcherStoragePersistence {
     long computedOffsetOriginalDetails = offsetOriginalMetadata + metadataLength;
 
     byte[] encodedURI =
-        encodeAndChecksumOriginalDetails(
-            thisKey,
-            origKey,
-            clientDetails,
-            isFinalFetch,
-            checksumChecker,
-            maxRetries,
-            cooldownTries,
-            cooldownLength);
+        encodeAndChecksumOriginalDetails(originalDetails, checksumChecker, retryPolicy);
     long computedOffsetBasicSettings = computedOffsetOriginalDetails + encodedURI.length;
 
     return new PreparedMetadata(
@@ -299,37 +289,27 @@ final class SplitFileFetcherStoragePersistence {
    * persistence layout. The returned byte array contains the encoded payload followed by the
    * checksum bytes produced by {@link ChecksumChecker#appendChecksum(byte[])}.
    *
-   * @param thisKey key of the fetch currently being persisted
-   * @param origKey original request key that seeded the fetch
-   * @param clientDetails non-null client detail bytes written verbatim to storage
-   * @param isFinalFetch true when the request is a final-fetch operation
+   * @param originalDetails original fetch request details persisted alongside metadata
    * @param checksumChecker checksum provider used to append checksum bytes
-   * @param maxRetries maximum retry count persisted for future resume logic
-   * @param cooldownTries number of retry attempts before cooldown applies
-   * @param cooldownLength cooldown duration in milliseconds for retry scheduling
+   * @param retryPolicy retry and cooldown settings persisted for future resume logic
    * @return encoded payload followed by checksum bytes for persistence
    * @throws IOException if an unexpected stream write fails
    */
   private static byte[] encodeAndChecksumOriginalDetails(
-      FreenetURI thisKey,
-      FreenetURI origKey,
-      byte[] clientDetails,
-      boolean isFinalFetch,
+      SplitFileFetchOriginalDetails originalDetails,
       ChecksumChecker checksumChecker,
-      int maxRetries,
-      int cooldownTries,
-      long cooldownLength)
+      SplitFileFetchRetryPolicy retryPolicy)
       throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(baos);
-    dos.writeUTF(thisKey.toASCIIString());
-    dos.writeUTF(origKey.toASCIIString());
-    dos.writeBoolean(isFinalFetch);
-    dos.writeInt(clientDetails.length);
-    dos.write(clientDetails);
-    dos.writeInt(maxRetries);
-    dos.writeInt(cooldownTries);
-    dos.writeLong(cooldownLength);
+    dos.writeUTF(originalDetails.thisKey().toASCIIString());
+    dos.writeUTF(originalDetails.origKey().toASCIIString());
+    dos.writeBoolean(originalDetails.isFinalFetch());
+    dos.writeInt(originalDetails.clientDetails().length);
+    dos.write(originalDetails.clientDetails());
+    dos.writeInt(retryPolicy.maxRetries());
+    dos.writeInt(retryPolicy.cooldownTries());
+    dos.writeLong(retryPolicy.cooldownLength());
     return checksumChecker.appendChecksum(baos.toByteArray());
   }
 

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStoragePersistenceTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStoragePersistenceTest.java
@@ -162,19 +162,13 @@ class SplitFileFetcherStoragePersistenceTest {
     FreenetURI origKey = new FreenetURI(WANNA_USK_1);
     byte[] clientDetails = "client-details".getBytes(StandardCharsets.UTF_8);
 
+    SplitFileFetchOriginalDetails originalDetails =
+        new SplitFileFetchOriginalDetails(thisKey, origKey, clientDetails, isFinalFetch);
+    SplitFileFetchRetryPolicy retryPolicy =
+        new SplitFileFetchRetryPolicy(maxRetries, cooldownTries, cooldownLength);
     SplitFileFetcherStoragePersistence.PreparedMetadata prepared =
         SplitFileFetcherStoragePersistence.preparePersistent(
-            metadata,
-            bucketFactory,
-            thisKey,
-            origKey,
-            clientDetails,
-            isFinalFetch,
-            offset,
-            checksumChecker,
-            maxRetries,
-            cooldownTries,
-            cooldownLength);
+            metadata, bucketFactory, originalDetails, offset, checksumChecker, retryPolicy);
 
     byte[] metadataBytes = serializeMetadata(metadata);
     byte[] bucketBytes = BucketTools.toByteArray(prepared.metadataTemp());
@@ -216,22 +210,16 @@ class SplitFileFetcherStoragePersistenceTest {
         new MetadataUnresolvedException(new Metadata[0], "unresolved");
     doThrow(unresolved).when(metadata).writeTo(any(DataOutputStream.class));
 
+    SplitFileFetchOriginalDetails originalDetails =
+        new SplitFileFetchOriginalDetails(
+            new FreenetURI(WANNA_CHK_1), new FreenetURI(WANNA_USK_1), new byte[] {9}, false);
+    SplitFileFetchRetryPolicy retryPolicy = new SplitFileFetchRetryPolicy(1, 1, 5L);
     FetchException thrown =
         assertThrows(
             FetchException.class,
             () ->
                 SplitFileFetcherStoragePersistence.preparePersistent(
-                    metadata,
-                    bucketFactory,
-                    new FreenetURI(WANNA_CHK_1),
-                    new FreenetURI(WANNA_USK_1),
-                    new byte[] {9},
-                    false,
-                    12L,
-                    checksumChecker,
-                    1,
-                    1,
-                    5L));
+                    metadata, bucketFactory, originalDetails, 12L, checksumChecker, retryPolicy));
 
     assertEquals(FetchExceptionMode.INTERNAL_ERROR, thrown.getMode());
     assertSame(unresolved, thrown.getCause());
@@ -248,19 +236,16 @@ class SplitFileFetcherStoragePersistenceTest {
             null,
             new FreenetURI(WANNA_CHK_1),
             new ClientMetadata("text/plain"));
-    SplitFileFetcherStoragePersistence.PreparedMetadata prepared =
-        SplitFileFetcherStoragePersistence.preparePersistent(
-            metadata,
-            bucketFactory,
+    SplitFileFetchOriginalDetails originalDetails =
+        new SplitFileFetchOriginalDetails(
             new FreenetURI(WANNA_CHK_1),
             new FreenetURI(WANNA_USK_1),
             "client-details".getBytes(StandardCharsets.UTF_8),
-            true,
-            32L,
-            checksumChecker,
-            2,
-            1,
-            99L);
+            true);
+    SplitFileFetchRetryPolicy retryPolicy = new SplitFileFetchRetryPolicy(2, 1, 99L);
+    SplitFileFetcherStoragePersistence.PreparedMetadata prepared =
+        SplitFileFetcherStoragePersistence.preparePersistent(
+            metadata, bucketFactory, originalDetails, 32L, checksumChecker, retryPolicy);
 
     byte[] metadataBytes = BucketTools.toByteArray(prepared.metadataTemp());
     byte[] basicPayload = "basic-settings".getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
## Summary
- introduce shared parameter records for splitfile fetch persistence (original details + retry policy)
- update persistence helpers and callers to use the bundled params
- adjust persistence tests to construct the new records

## Testing
- ./gradlew --parallel test