### PR TITLE
refactor(client): wrap USK found edition payload

### DIFF
--- a/src/main/java/network/crypta/client/async/SingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SingleFileFetcher.java
@@ -2183,21 +2183,16 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
     }
 
     @Override
-    public void onFoundEdition(
-        long l,
-        USK newUSK,
-        ClientContext context,
-        boolean metadata,
-        short codec,
-        byte[] data,
-        boolean newKnownGood,
-        boolean newSlotToo) {
-      if (l < usk.suggestedEdition && datastoreOnly) {
-        l = usk.suggestedEdition;
+    public void onFoundEdition(USKFoundEdition foundEdition) {
+      long edition = foundEdition.edition();
+      USK newUSK = foundEdition.key();
+      ClientContext context = foundEdition.context();
+      if (edition < usk.suggestedEdition && datastoreOnly) {
+        edition = usk.suggestedEdition;
       }
-      ClientSSK key = usk.getSSK(l);
+      ClientSSK key = usk.getSSK(edition);
       try {
-        if (l == usk.suggestedEdition || (l == 0 && usk.suggestedEdition == 1)) {
+        if (edition == usk.suggestedEdition || (edition == 0 && usk.suggestedEdition == 1)) {
           InitParams p = new InitParams();
           p.parent = parent;
           p.cb = cb;
@@ -2240,7 +2235,9 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
       FetchException e = null;
       if (datastoreOnly) {
         try {
-          onFoundEdition(usk.suggestedEdition, usk, context, false, (short) -1, null, false, false);
+          onFoundEdition(
+              new USKFoundEdition(
+                  usk.suggestedEdition, usk, context, false, (short) -1, null, false, false));
           return;
         } catch (Exception t) {
           e = new FetchException(FetchExceptionMode.INTERNAL_ERROR, t);

--- a/src/main/java/network/crypta/client/async/USKCallback.java
+++ b/src/main/java/network/crypta/client/async/USKCallback.java
@@ -1,7 +1,5 @@
 package network.crypta.client.async;
 
-import network.crypta.keys.USK;
-
 /**
  * Callback interface notified about updates to a USK subscription.
  *
@@ -11,12 +9,12 @@ import network.crypta.keys.USK;
  * maintains background fetchers, and receive callbacks on internal worker threads whenever the
  * observed state changes. The same implementation may be shared across multiple subscriptions.
  *
- * <p>Typical usage is to subscribe, react to {@link #onFoundEdition(long, USK, ClientContext,
- * boolean, short, byte[], boolean, boolean)} events, and decide whether to request further work or
- * update downstream state. Implementations should keep callbacks short and avoid blocking: heavy
- * processing should be dispatched to application executors to prevent head-of-line blocking of
- * internal polling. Callers can influence background polling by returning priority values from the
- * {@link #getPollingPriorityNormal()} and {@link #getPollingPriorityProgress()} methods.
+ * <p>Typical usage is to subscribe, react to {@link #onFoundEdition(USKFoundEdition)} events, and
+ * decide whether to request further work or update downstream state. Implementations should keep
+ * callbacks short and avoid blocking: heavy processing should be dispatched to application
+ * executors to prevent head-of-line blocking of internal polling. Callers can influence background
+ * polling by returning priority values from the {@link #getPollingPriorityNormal()} and {@link
+ * #getPollingPriorityProgress()} methods.
  *
  * <ul>
  *   <li>State model: callbacks may be invoked repeatedly as the latest known edition advances.
@@ -42,26 +40,9 @@ public interface USKCallback {
    * the first indicates that the highest edition known to fetch successfully has increased; the
    * second indicates that the highest examined SSK slot has advanced as well.
    *
-   * @param l The discovered logical edition number. Higher values represent newer editions.
-   * @param key A copy of the key with the discovered edition set for this notification.
-   * @param context Execution context with client-layer services and schedulers for follow-up work.
-   * @param metadata True when the bytes correspond to metadata for the edition rather than content.
-   * @param codec Short identifier of the content codec associated with the returned byte payload.
-   * @param data Raw byte payload for the discovered edition or its metadata, as provided by
-   *     fetcher.
-   * @param newKnownGood True when the highest known-good, successfully fetched edition has
-   *     advanced.
-   * @param newSlotToo True when the highest known SSK slot has also advanced alongside known-good.
+   * @param foundEdition The payload describing the discovered edition and its metadata.
    */
-  void onFoundEdition(
-      long l,
-      USK key,
-      ClientContext context,
-      boolean metadata,
-      short codec,
-      byte[] data,
-      boolean newKnownGood,
-      boolean newSlotToo);
+  void onFoundEdition(USKFoundEdition foundEdition);
 
   /**
    * Returns the steady-state priority used for background polling.

--- a/src/main/java/network/crypta/client/async/USKFetcher.java
+++ b/src/main/java/network/crypta/client/async/USKFetcher.java
@@ -770,14 +770,15 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
         if (ed == -1) c.onFailure(context);
         else
           c.onFoundEdition(
-              ed,
-              origUSK.copy(ed),
-              context,
-              lastWasMetadata,
-              lastCompressionCodec,
-              data,
-              false,
-              false);
+              new USKFoundEdition(
+                  ed,
+                  origUSK.copy(ed),
+                  context,
+                  lastWasMetadata,
+                  lastCompressionCodec,
+                  data,
+                  false,
+                  false));
       } catch (Exception e) {
         LOG.error(
             "An exception occured while dealing with a callback:{}\n{}", c, e.getMessage(), e);
@@ -1687,35 +1688,25 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
    * other cases, the method updates the manager and continues the discovery loop as appropriate for
    * the configured mode.
    *
-   * @param ed the edition that was discovered or confirmed; non-negative
-   * @param key the USK associated with the edition; must not be {@code null}
-   * @param context execution context used to schedule any follow-up actions; must not be {@code
-   *     null}
-   * @param metadata whether the payload represents metadata rather than content; used when decoding
-   * @param codec the compression codec identifier, if any, reported by the fetch pipeline
-   * @param data optional byte content of the edition when decoding was requested and succeeded; may
-   *     be {@code null}
-   * @param newKnownGood whether this edition is a new known-good for the USK
-   * @param newSlotToo whether a corresponding new slot has been discovered in the index
+   * @param foundEdition The payload describing the discovered edition and its metadata.
    */
   @Override
-  public void onFoundEdition(
-      long ed,
-      USK key,
-      final ClientContext context,
-      boolean metadata,
-      short codec,
-      byte[] data,
-      boolean newKnownGood,
-      boolean newSlotToo) {
-    if (newKnownGood && !newSlotToo) return; // Only interested in slots
+  public void onFoundEdition(USKFoundEdition foundEdition) {
+    if (foundEdition.newKnownGood() && !foundEdition.newSlotToo())
+      return; // Only interested in slots
     // Because this is frequently run off-thread, it is actually possible that the looked up edition
     // is not the same as the edition we are being notified of.
-    FoundPlan plan = prepareFoundPlan(ed, data, context);
+    FoundPlan plan =
+        prepareFoundPlan(foundEdition.edition(), foundEdition.data(), foundEdition.context());
     if (plan == null) return;
-    finishCancelBefore(plan.killAttempts, context);
-    if (plan.registerNow) registerAttempts(context);
-    applyFoundDecodedData(plan.decode, metadata, codec, data, context);
+    finishCancelBefore(plan.killAttempts, foundEdition.context());
+    if (plan.registerNow) registerAttempts(foundEdition.context());
+    applyFoundDecodedData(
+        plan.decode,
+        foundEdition.metadata(),
+        foundEdition.codec(),
+        foundEdition.data(),
+        foundEdition.context());
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/USKFetcherCallback.java
+++ b/src/main/java/network/crypta/client/async/USKFetcherCallback.java
@@ -1,7 +1,5 @@
 package network.crypta.client.async;
 
-import network.crypta.keys.USK;
-
 /**
  * Callback interface used by the asynchronous USK fetch machinery.
  *
@@ -64,34 +62,11 @@ public interface USKFetcherCallback extends USKCallback {
    *
    * <pre>{@code
    * // Example: record the resolved edition then hand off for processing
-   * callback.onFoundEdition(edition, usk, ctx, false, codec, bytes, true, false);
+   * callback.onFoundEdition(new USKFoundEdition(edition, usk, ctx, false, codec, bytes, true, false));
    * }</pre>
    *
-   * @param l the resolved edition number for the USK; non-negative and monotonically increasing
-   *     across successful updates for the same key within the network
-   * @param key the USK identifying the namespace and site; the reference is owned by the caller and
-   *     should not be mutated by the callback implementation
-   * @param context the client execution context that initiated the fetch; provides access to
-   *     environment services useful for post-processing and logging
-   * @param metadata whether the {@code data} buffer represents metadata rather than primary
-   *     content; consumers should branch appropriately when this flag is {@code true}
-   * @param codec a short identifier for the data’s encoding or transport codec; value ranges and
-   *     semantics are defined by the surrounding client protocol version
-   * @param data the raw bytes of the fetched object or its metadata; the array may be reused by the
-   *     caller and should not be retained or modified by the callee without copying
-   * @param newKnownGood whether this edition advanced the known-good marker for the key within the
-   *     local client; {@code true} implies subsequent fetches may use this as a baseline
-   * @param newSlotToo whether a new slot was also discovered alongside the edition; used by the
-   *     caller to convey additional progress that might influence scheduling heuristics
+   * @param foundEdition The payload describing the discovered edition and its metadata.
    */
   @Override
-  void onFoundEdition(
-      long l,
-      USK key,
-      ClientContext context,
-      boolean metadata,
-      short codec,
-      byte[] data,
-      boolean newKnownGood,
-      boolean newSlotToo);
+  void onFoundEdition(USKFoundEdition foundEdition);
 }

--- a/src/main/java/network/crypta/client/async/USKFetcherTag.java
+++ b/src/main/java/network/crypta/client/async/USKFetcherTag.java
@@ -364,28 +364,11 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
    * the callback on the appropriate executor depending on persistence. The provided data may be
    * {@code null} when only metadata is available.
    *
-   * @param l The edition number that was found; expected to be non‑negative.
-   * @param key The concrete {@link USK} (possibly copied/adjusted) that produced the result.
-   * @param context Client context to execute the callback or to enqueue a persistent job.
-   * @param metadata {@code true} when only metadata was retrieved; {@code false} when content data
-   *     is available.
-   * @param codec Codec identifier used for the data, if any; interpretation is upstream‑defined.
-   * @param data Byte array containing fetched data; may be {@code null} when {@code metadata} is
-   *     {@code true}.
-   * @param newKnownGood {@code true} if this edition improved the best known good value.
-   * @param newSlotToo {@code true} if a new slot was also confirmed during this fetch.
+   * @param foundEdition The payload describing the discovered edition and its metadata.
    */
   @Override
-  public void onFoundEdition(
-      final long l,
-      final USK key,
-      ClientContext context,
-      final boolean metadata,
-      final short codec,
-      final byte[] data,
-      final boolean newKnownGood,
-      final boolean newSlotToo) {
-    if (LOG.isDebugEnabled()) LOG.debug("Found edition {} on {}", l, this);
+  public void onFoundEdition(final USKFoundEdition foundEdition) {
+    if (LOG.isDebugEnabled()) LOG.debug("Found edition {} on {}", foundEdition.edition(), this);
     synchronized (this) {
       if (fetcher == null) {
         LOG.warn(
@@ -399,6 +382,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
       finished = true;
       fetcher = null;
     }
+    ClientContext context = foundEdition.context();
     if (persistent) {
       try {
         context.jobRunner.queue(
@@ -406,8 +390,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
                 context1 -> {
                   if (callback instanceof USKFetcherTagCallback tagCallback)
                     tagCallback.setTag(USKFetcherTag.this, context1);
-                  callback.onFoundEdition(
-                      l, key, context1, metadata, codec, data, newKnownGood, newSlotToo);
+                  callback.onFoundEdition(foundEdition.withContext(context1));
                   return false;
                 },
             NativeThread.PriorityLevel.HIGH_PRIORITY.value);
@@ -417,7 +400,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
     } else {
       if (callback instanceof USKFetcherTagCallback tagCallback)
         tagCallback.setTag(USKFetcherTag.this, context);
-      callback.onFoundEdition(l, key, context, metadata, codec, data, newKnownGood, newSlotToo);
+      callback.onFoundEdition(foundEdition);
     }
   }
 

--- a/src/main/java/network/crypta/client/async/USKFoundEdition.java
+++ b/src/main/java/network/crypta/client/async/USKFoundEdition.java
@@ -1,0 +1,102 @@
+package network.crypta.client.async;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.keys.USK;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Immutable notification payload describing a discovered USK edition.
+ *
+ * <p>This value object bundles the edition metadata, payload, and progress flags emitted by USK
+ * fetchers and subscriptions. It is shared across callbacks to avoid long parameter lists and to
+ * keep related data coherent during async handoff.
+ *
+ * @param edition The discovered logical edition number.
+ * @param key A copy of the key with the discovered edition set for this notification.
+ * @param context Execution context with client-layer services and schedulers for follow-up work.
+ * @param metadata True when the bytes correspond to metadata for the edition rather than content.
+ * @param codec Short identifier of the content codec associated with the returned byte payload.
+ * @param data Raw byte payload for the discovered edition or its metadata, as provided by fetcher.
+ * @param newKnownGood True when the highest known-good, successfully fetched edition has advanced.
+ * @param newSlotToo True when the highest known SSK slot has also advanced alongside known-good.
+ */
+public record USKFoundEdition(
+    long edition,
+    USK key,
+    ClientContext context,
+    boolean metadata,
+    short codec,
+    byte[] data,
+    boolean newKnownGood,
+    boolean newSlotToo) {
+
+  /**
+   * Returns a copy of this payload with a different execution context.
+   *
+   * <p>This is useful when dispatching the same event through an alternate context, such as a
+   * persistent job runner, without mutating the original record.
+   *
+   * @param context The execution context to carry.
+   * @return A copy of this event with the supplied context.
+   */
+  public USKFoundEdition withContext(ClientContext context) {
+    return new USKFoundEdition(
+        edition, key, context, metadata, codec, data, newKnownGood, newSlotToo);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj
+        instanceof
+        USKFoundEdition(
+            long otherEdition,
+            USK otherKey,
+            ClientContext otherContext,
+            boolean otherMetadata,
+            short otherCodec,
+            byte[] otherData,
+            boolean otherNewKnownGood,
+            boolean otherNewSlotToo))) {
+      return false;
+    }
+    return edition == otherEdition
+        && metadata == otherMetadata
+        && codec == otherCodec
+        && newKnownGood == otherNewKnownGood
+        && newSlotToo == otherNewSlotToo
+        && Objects.equals(key, otherKey)
+        && Objects.equals(context, otherContext)
+        && Arrays.equals(data, otherData);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(edition, key, context, metadata, codec, newKnownGood, newSlotToo);
+    result = 31 * result + Arrays.hashCode(data);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "USKFoundEdition["
+        + "edition="
+        + edition
+        + ", key="
+        + key
+        + ", context="
+        + context
+        + ", metadata="
+        + metadata
+        + ", codec="
+        + codec
+        + ", data="
+        + Arrays.toString(data)
+        + ", newKnownGood="
+        + newKnownGood
+        + ", newSlotToo="
+        + newSlotToo
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/src/main/java/network/crypta/client/async/USKInserter.java
@@ -197,28 +197,18 @@ public class USKInserter
    * present by comparing data and codec. If the payload is already inserted at the reported
    * edition, completes successfully. Otherwise, schedules an insert attempt at the next edition.
    *
-   * @param l the discovered latest edition number (non-negative)
-   * @param key the USK associated with the discovery callback; same logical USK as this inserter
-   * @param context the client context used to schedule subsequent work
-   * @param lastContentWasMetadata whether the discovered edition contains metadata content
-   * @param codec the compression codec detected on the discovered edition
-   * @param hisData the discovered edition bytes when available; may be {@code null}
-   * @param newKnownGood true if this discovery advanced the known-good edition state
-   * @param newSlotToo true if the next slot is now known to exist or be reserved
+   * @param foundEdition The payload describing the discovered edition and its metadata.
    */
   @Override
-  public void onFoundEdition(
-      long l,
-      USK key,
-      ClientContext context,
-      boolean lastContentWasMetadata,
-      short codec,
-      byte[] hisData,
-      boolean newKnownGood,
-      boolean newSlotToo) {
+  public void onFoundEdition(USKFoundEdition foundEdition) {
+    long editionFound = foundEdition.edition();
+    ClientContext context = foundEdition.context();
+    boolean lastContentWasMetadata = foundEdition.metadata();
+    short codec = foundEdition.codec();
+    byte[] hisData = foundEdition.data();
     boolean alreadyInserted = false;
     synchronized (this) {
-      edition = Math.max(l, edition);
+      edition = Math.max(editionFound, edition);
       consecutiveCollisions = 0;
       if ((lastContentWasMetadata == isMetadata)
           && hisData != null
@@ -243,7 +233,7 @@ public class USKInserter
       // Success!
       parent.completedBlock(true, context);
       cb.onEncode(pubUSK.copy(edition), this, context);
-      insertSucceeded(context, l);
+      insertSucceeded(context, editionFound);
       if (freeData) {
         data.free();
       }

--- a/src/main/java/network/crypta/client/async/USKManager.java
+++ b/src/main/java/network/crypta/client/async/USKManager.java
@@ -718,14 +718,15 @@ public class USKManager {
             .execute(
                 () ->
                     callback.onFoundEdition(
-                        number,
-                        usk, // non-persistent
-                        context,
-                        false,
-                        (short) -1,
-                        null,
-                        true,
-                        newSlotToo),
+                        new USKFoundEdition(
+                            number,
+                            usk, // non-persistent
+                            context,
+                            false,
+                            (short) -1,
+                            null,
+                            true,
+                            newSlotToo)),
                 "USKManager callback executor for " + callback);
     }
   }
@@ -760,14 +761,15 @@ public class USKManager {
             .execute(
                 () ->
                     callback.onFoundEdition(
-                        number,
-                        usk, // non-persistent
-                        context,
-                        false,
-                        (short) -1,
-                        null,
-                        false,
-                        false),
+                        new USKFoundEdition(
+                            number,
+                            usk, // non-persistent
+                            context,
+                            false,
+                            (short) -1,
+                            null,
+                            false,
+                            false)),
                 "USKManager callback executor for " + callback);
     }
   }
@@ -842,9 +844,12 @@ public class USKManager {
 
     if (goodEd > ed)
       cb.onFoundEdition(
-          goodEd, origUSK.copy(curEd), context, false, (short) -1, null, true, curEd > ed);
+          new USKFoundEdition(
+              goodEd, origUSK.copy(curEd), context, false, (short) -1, null, true, curEd > ed));
     else if (curEd > ed)
-      cb.onFoundEdition(curEd, origUSK.copy(curEd), context, false, (short) -1, null, false, false);
+      cb.onFoundEdition(
+          new USKFoundEdition(
+              curEd, origUSK.copy(curEd), context, false, (short) -1, null, false, false));
 
     final USKFetcher fetcher = plan.toSchedule;
     if (fetcher != null) {

--- a/src/main/java/network/crypta/client/async/USKRetriever.java
+++ b/src/main/java/network/crypta/client/async/USKRetriever.java
@@ -43,10 +43,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Typical usage is to construct the retriever with a {@link FetchContext}, a priority and a
  * {@link RequestClient}, subscribe it through a {@code USKManager}, and wait for {@linkplain
- * #onFoundEdition(long, USK, ClientContext, boolean, short, byte[], boolean, boolean) edition
- * notifications}. When an edition equal to or newer than the requested one is seen, the retriever
- * schedules a {@code SingleFileFetcher} to download the data, decompresses it when needed, and
- * reports a {@link FetchResult} to the provided {@link USKRetrieverCallback}.
+ * #onFoundEdition(USKFoundEdition) edition notifications}. When an edition equal to or newer than
+ * the requested one is seen, the retriever schedules a {@code SingleFileFetcher} to download the
+ * data, decompresses it when needed, and reports a {@link FetchResult} to the provided {@link
+ * USKRetrieverCallback}.
  *
  * <ul>
  *   <li>Thread safety: instances are not documented as thread‑safe. Callbacks are invoked on
@@ -126,30 +126,26 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
   }
 
   @Override
-  public void onFoundEdition(
-      long l,
-      USK key,
-      ClientContext context,
-      boolean metadata,
-      short codec,
-      byte[] data,
-      boolean newKnownGood,
-      boolean newSlotToo) {
-    if (l < 0) {
-      LOG.error("Found negative edition: {} for {} !!!", l, key);
+  public void onFoundEdition(USKFoundEdition foundEdition) {
+    long edition = foundEdition.edition();
+    USK key = foundEdition.key();
+    ClientContext context = foundEdition.context();
+    if (edition < 0) {
+      LOG.error("Found negative edition: {} for {} !!!", edition, key);
       return;
     }
-    if (l < origUSK.suggestedEdition) {
-      LOG.info("Found edition {} < requested {} for {}", l, origUSK.suggestedEdition, origUSK);
+    if (edition < origUSK.suggestedEdition) {
+      LOG.info(
+          "Found edition {} < requested {} for {}", edition, origUSK.suggestedEdition, origUSK);
       return;
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Found edition {} for {} - fetching...", l, this);
+    if (LOG.isDebugEnabled()) LOG.debug("Found edition {} for {} - fetching...", edition, this);
     // Create a SingleFileFetcher for the key (as an SSK).
     // Put the edition number into its context object.
     // Put ourselves as callback.
     // Fetch it. If it fails, ignore it, if it succeeds, return the data with the edition # to the
     // client.
-    FreenetURI uri = key.getSSK(l).getURI();
+    FreenetURI uri = key.getSSK(edition).getURI();
     try {
       SingleFileFetcher getter =
           (SingleFileFetcher)
@@ -161,7 +157,7 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
                   new ArchiveContext(ctx.getMaxTempLength(), ctx.getMaxArchiveLevels()),
                   new SingleFileFetcher.CreationPolicy(
                       ctx.getMaxNonSplitfileRetries(), 0, true, true, false, false),
-                  new SingleFileFetcher.CreationRuntime(context, realTimeFlag, l));
+                  new SingleFileFetcher.CreationRuntime(context, realTimeFlag, edition));
       getter.schedule(context);
     } catch (MalformedURLException e) {
       LOG.error("Impossible: {}", e, e);

--- a/src/main/java/network/crypta/client/async/USKSparseProxyCallback.java
+++ b/src/main/java/network/crypta/client/async/USKSparseProxyCallback.java
@@ -83,32 +83,15 @@ public class USKSparseProxyCallback implements USKProgressCallback {
    * boundary has been signalled; otherwise the information is retained and may be forwarded later
    * from {@link #onSendingToNetwork(ClientContext)} or {@link #onRoundFinished(ClientContext)}.
    *
-   * @param l The logical edition discovered by the fetcher; higher values denote newer editions and
-   *     should be non-negative where available.
-   * @param key A copy of the USK associated with this discovery; typically carries {@code l} as its
-   *     edition component.
-   * @param context Execution context for the request; non-null and scoped to the current
-   *     subscription lifecycle.
-   * @param metadata True when {@code data} represents metadata for the edition rather than full
-   *     content; consumers may use this to defer expensive processing.
-   * @param codec Short identifier of the content codec for {@code data}; a negative value indicates
-   *     that no codec applies to the current payload.
-   * @param data Raw bytes for the discovered edition or its metadata; may be {@code null} when only
-   *     structural advancement is being reported.
-   * @param newKnownGood True when the highest successfully fetched (known-good) edition increased
-   *     as a result of this discovery.
-   * @param newSlotToo True when the highest examined SSK slot also advanced alongside known-good.
+   * @param foundEdition The payload describing the discovered edition and its metadata.
    */
   @Override
-  public void onFoundEdition(
-      long l,
-      USK key,
-      ClientContext context,
-      boolean metadata,
-      short codec,
-      byte[] data,
-      boolean newKnownGood,
-      boolean newSlotToo) {
+  public void onFoundEdition(USKFoundEdition foundEdition) {
+    long l = foundEdition.edition();
+    boolean metadata = foundEdition.metadata();
+    short codec = foundEdition.codec();
+    byte[] data = foundEdition.data();
+    boolean newKnownGood = foundEdition.newKnownGood();
     synchronized (this) {
       if (l < lastEdition) {
         if (!roundFinished) return;
@@ -124,7 +107,7 @@ public class USKSparseProxyCallback implements USKProgressCallback {
       }
       if (!roundFinished) return;
     }
-    target.onFoundEdition(l, key, context, metadata, codec, data, newKnownGood, newSlotToo);
+    target.onFoundEdition(foundEdition);
   }
 
   /**
@@ -201,6 +184,7 @@ public class USKSparseProxyCallback implements USKProgressCallback {
       wasKnownGood = false;
     }
     // At this point, either we returned above or ed is guaranteed != -1
-    target.onFoundEdition(ed, key, context, meta, codec, data, wasKnownGood, wasKnownGood);
+    target.onFoundEdition(
+        new USKFoundEdition(ed, key, context, meta, codec, data, wasKnownGood, wasKnownGood));
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
@@ -2,6 +2,7 @@ package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.USKCallback;
+import network.crypta.client.async.USKFoundEdition;
 import network.crypta.client.async.USKProgressCallback;
 import network.crypta.keys.USK;
 import network.crypta.node.NodeClientCore;
@@ -97,31 +98,23 @@ public class SubscribeUSK implements USKProgressCallback {
    * closed, in which case it unsubscribes to conserve resources. Data bytes are not sent here; only
    * edition and freshness metadata travel across the connection.
    *
-   * @param l edition number that was found; typically monotonically increasing over time.
-   * @param key USK key associated with the subscription; matches the key provided at construction.
-   * @param context client context for the ongoing fetch; may provide shared state across callbacks.
-   * @param wasMetadata {@code true} when the retrieved payload consists solely of metadata blocks.
-   * @param codec codec hint used during retrieval; supplied by the node to describe the data type.
-   * @param data raw payload bytes; may be empty if only metadata was requested or delivered.
-   * @param newKnownGood {@code true} when this edition improved the known-good marker for the key.
-   * @param newSlotToo {@code true} when a newer slot (latest edition) was discovered alongside it.
+   * @param foundEdition The payload describing the discovered edition and its metadata.
    */
   @Override
-  public void onFoundEdition(
-      long l,
-      USK key,
-      ClientContext context,
-      boolean wasMetadata,
-      short codec,
-      byte[] data,
-      boolean newKnownGood,
-      boolean newSlotToo) {
+  public void onFoundEdition(USKFoundEdition foundEdition) {
+    USK key = foundEdition.key();
     if (handler.isClosed()) {
       core.getUskManager().unsubscribe(key, toUnsub);
       return;
     }
     // if(newKnownGood && !newSlotToo) return;
-    FCPMessage msg = new SubscribedUSKUpdate(clientIdentifier, l, key, newKnownGood, newSlotToo);
+    FCPMessage msg =
+        new SubscribedUSKUpdate(
+            clientIdentifier,
+            foundEdition.edition(),
+            key,
+            foundEdition.newKnownGood(),
+            foundEdition.newSlotToo());
     handler.send(msg);
   }
 

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -10,8 +10,8 @@ import java.net.MalformedURLException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.USKCallback;
+import network.crypta.client.async.USKFoundEdition;
 import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
@@ -195,17 +195,9 @@ public class BookmarkManager implements RequestClient {
   private class USKUpdatedCallback implements USKCallback {
 
     @Override
-    public void onFoundEdition(
-        long edition,
-        USK key,
-        ClientContext context,
-        boolean wasMetadata,
-        short codec,
-        byte[] data,
-        boolean newKnownGood,
-        boolean newSlotToo) {
-      if (!newKnownGood) {
-        FreenetURI uri = key.copy(edition).getURI();
+    public void onFoundEdition(USKFoundEdition foundEdition) {
+      if (!foundEdition.newKnownGood()) {
+        FreenetURI uri = foundEdition.key().copy(foundEdition.edition()).getURI();
         node.makeClient(PRIORITY_PROGRESS, false, false)
             .prefetch(
                 uri,
@@ -215,6 +207,8 @@ public class BookmarkManager implements RequestClient {
                 PRIORITY_PROGRESS);
         return;
       }
+      long edition = foundEdition.edition();
+      USK key = foundEdition.key();
       List<BookmarkItem> items = MAIN_CATEGORY.getAllItems();
       boolean matched = false;
       boolean updated = false;

--- a/src/main/java/network/crypta/node/updater/NodeUpdater.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdater.java
@@ -23,6 +23,7 @@ import network.crypta.client.async.ClientGetCallback;
 import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.USKCallback;
+import network.crypta.client.async.USKFoundEdition;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
 import network.crypta.node.Node;
@@ -183,22 +184,14 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
   }
 
   @Override
-  public void onFoundEdition(
-      long l,
-      USK key,
-      ClientContext context,
-      boolean wasMetadata,
-      short codec,
-      byte[] data,
-      boolean newKnownGood,
-      boolean newSlotToo) {
-    if (newKnownGood && !newSlotToo) return;
+  public void onFoundEdition(USKFoundEdition foundEdition) {
+    if (foundEdition.newKnownGood() && !foundEdition.newSlotToo()) return;
     // Debug gating derives from LOG.isDebugEnabled() where needed
-    if (LOG.isDebugEnabled()) LOG.debug("Found edition {}", l);
+    if (LOG.isDebugEnabled()) LOG.debug("Found edition {}", foundEdition.edition());
     int found;
     synchronized (this) {
       if (!isRunning) return;
-      found = (int) key.suggestedEdition;
+      found = (int) foundEdition.key().suggestedEdition;
 
       realAvailableVersion = found;
       if (found > maxDeployVersion) {
@@ -206,7 +199,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
           LOG.warn(
               "Ignoring {} update edition {}: version too new (min {} max {})",
               artifactName(),
-              l,
+              foundEdition.edition(),
               minDeployVersion,
               maxDeployVersion);
         found = maxDeployVersion;

--- a/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
+++ b/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
@@ -9,8 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
@@ -449,51 +447,29 @@ class USKFetcherTagTest {
     byte[] data = new byte[] {1, 2, 3};
 
     // Act
-    tag.onFoundEdition(edition, usk.copy(edition), mockContext, false, codec, data, true, true);
+    tag.onFoundEdition(
+        new USKFoundEdition(
+            edition, usk.copy(edition), mockContext, false, codec, data, true, true));
 
     // Assert
     verify(cb, times(1)).setTag(tag, mockContext);
     // Capture and assert arguments instead of eq(...)
-    ArgumentCaptor<Long> lCap = ArgumentCaptor.forClass(Long.class);
-    ArgumentCaptor<USK> uCap = ArgumentCaptor.forClass(USK.class);
-    ArgumentCaptor<ClientContext> cCap = ArgumentCaptor.forClass(ClientContext.class);
-    ArgumentCaptor<Boolean> mCap = ArgumentCaptor.forClass(Boolean.class);
-    ArgumentCaptor<Short> codecCap = ArgumentCaptor.forClass(Short.class);
-    ArgumentCaptor<byte[]> dataCap = ArgumentCaptor.forClass(byte[].class);
-    ArgumentCaptor<Boolean> kCap = ArgumentCaptor.forClass(Boolean.class);
-    ArgumentCaptor<Boolean> sCap = ArgumentCaptor.forClass(Boolean.class);
-    verify(cb, times(1))
-        .onFoundEdition(
-            lCap.capture(),
-            uCap.capture(),
-            cCap.capture(),
-            mCap.capture(),
-            codecCap.capture(),
-            dataCap.capture(),
-            kCap.capture(),
-            sCap.capture());
-    assertEquals(edition, lCap.getValue());
-    assertEquals(mockContext, cCap.getValue());
-    assertFalse(mCap.getValue());
-    assertEquals(codec, codecCap.getValue());
-    assertArrayEquals(data, dataCap.getValue());
-    assertTrue(kCap.getValue());
-    assertTrue(sCap.getValue());
+    ArgumentCaptor<USKFoundEdition> foundEdition = ArgumentCaptor.forClass(USKFoundEdition.class);
+    verify(cb, times(1)).onFoundEdition(foundEdition.capture());
+    assertEquals(edition, foundEdition.getValue().edition());
+    assertEquals(mockContext, foundEdition.getValue().context());
+    assertFalse(foundEdition.getValue().metadata());
+    assertEquals(codec, foundEdition.getValue().codec());
+    assertArrayEquals(data, foundEdition.getValue().data());
+    assertTrue(foundEdition.getValue().newKnownGood());
+    assertTrue(foundEdition.getValue().newSlotToo());
     assertTrue(tag.isFinished());
 
     // Calling again should be ignored because finished
     tag.onFoundEdition(
-        edition + 1, usk.copy(edition + 1), mockContext, false, codec, data, true, true);
-    verify(cb, times(1))
-        .onFoundEdition(
-            anyLong(),
-            any(USK.class),
-            any(ClientContext.class),
-            anyBoolean(),
-            anyShort(),
-            any(),
-            anyBoolean(),
-            anyBoolean());
+        new USKFoundEdition(
+            edition + 1, usk.copy(edition + 1), mockContext, false, codec, data, true, true));
+    verify(cb, times(1)).onFoundEdition(any(USKFoundEdition.class));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/USKFetcherTest.java
+++ b/src/test/java/network/crypta/client/async/USKFetcherTest.java
@@ -160,15 +160,7 @@ class USKFetcherTest {
           }
 
           @Override
-          public void onFoundEdition(
-              long ed,
-              USK key,
-              ClientContext context,
-              boolean metadata,
-              short codec,
-              byte[] data,
-              boolean newKnownGood,
-              boolean newSlotToo) {
+          public void onFoundEdition(USKFoundEdition foundEdition) {
             // Intentionally empty for this test: the callback exists only to
             // exercise subscriber add/remove mechanics. No behavior under test
             // depends on receiving or handling edition notifications here.

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -356,7 +356,8 @@ class USKInserterTest {
 
     // Act: Found matching edition with identical data
     long foundEdition = 7L;
-    inserter.onFoundEdition(foundEdition, publicUSK, context, false, (short) 3, bytes, true, true);
+    inserter.onFoundEdition(
+        new USKFoundEdition(foundEdition, publicUSK, context, false, (short) 3, bytes, true, true));
 
     // Assert: parent and callback methods invoked; success path without date hints
     verify(parent, times(1)).completedBlock(true, context);

--- a/src/test/java/network/crypta/client/async/USKManagerTest.java
+++ b/src/test/java/network/crypta/client/async/USKManagerTest.java
@@ -386,22 +386,14 @@ class USKManagerTest {
     final AtomicInteger calls = new AtomicInteger();
 
     @Override
-    public void onFoundEdition(
-        long l,
-        USK key,
-        ClientContext context,
-        boolean metadata,
-        short codec,
-        byte[] data,
-        boolean newKnownGood,
-        boolean newSlotToo) {
-      this.l = l;
-      this.key = key;
-      this.metadata = metadata;
-      this.codec = codec;
-      this.data = data;
-      this.newKnownGood = newKnownGood;
-      this.newSlotToo = newSlotToo;
+    public void onFoundEdition(USKFoundEdition foundEdition) {
+      this.l = foundEdition.edition();
+      this.key = foundEdition.key();
+      this.metadata = foundEdition.metadata();
+      this.codec = foundEdition.codec();
+      this.data = foundEdition.data();
+      this.newKnownGood = foundEdition.newKnownGood();
+      this.newSlotToo = foundEdition.newSlotToo();
       calls.incrementAndGet();
     }
 
@@ -485,15 +477,7 @@ class USKManagerTest {
   // Simple USKFetcherCallback for tag creation tests
   private static final class DummyFetcherCallback implements USKFetcherCallback {
     @Override
-    public void onFoundEdition(
-        long l,
-        USK key,
-        ClientContext context,
-        boolean metadata,
-        short codec,
-        byte[] data,
-        boolean newKnownGood,
-        boolean newSlotToo) {
+    public void onFoundEdition(USKFoundEdition foundEdition) {
       // Intentionally no-op: test stub does not assert fetcher callback payloads.
       // These tests only verify tag creation/mapping, not callback behavior.
     }

--- a/src/test/java/network/crypta/client/async/USKRetrieverTest.java
+++ b/src/test/java/network/crypta/client/async/USKRetrieverTest.java
@@ -489,11 +489,15 @@ class USKRetrieverTest {
 
     // Negative edition: early return
     assertDoesNotThrow(
-        () -> retriever.onFoundEdition(-1L, usk, ctx, false, (short) -1, null, false, false));
+        () ->
+            retriever.onFoundEdition(
+                new USKFoundEdition(-1L, usk, ctx, false, (short) -1, null, false, false)));
 
     // Lower than requested (origUSK.suggestedEdition == 100): early return
     assertDoesNotThrow(
-        () -> retriever.onFoundEdition(50L, usk, ctx, false, (short) -1, null, false, false));
+        () ->
+            retriever.onFoundEdition(
+                new USKFoundEdition(50L, usk, ctx, false, (short) -1, null, false, false)));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
+++ b/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
@@ -2,7 +2,6 @@ package network.crypta.client.async;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -231,32 +230,23 @@ class USKSparseProxyCallbackTest {
     // Act: two updates before the round finishes; should not pass through yet
     byte[] data12 = new byte[] {1, 2};
     byte[] data345 = new byte[] {3, 4, 5};
-    proxy.onFoundEdition(1L, usk, context, true, (short) 7, data12, false, false);
-    proxy.onFoundEdition(2L, usk, context, false, (short) 9, data345, true, true);
+    proxy.onFoundEdition(foundEdition(1L, usk, context, true, (short) 7, data12, false, false));
+    proxy.onFoundEdition(foundEdition(2L, usk, context, false, (short) 9, data345, true, true));
 
     // Assert: no call yet
-    verify(target, never())
-        .onFoundEdition(
-            any(Long.class),
-            eq(usk),
-            eq(context),
-            any(Boolean.class),
-            any(Short.class),
-            any(),
-            any(Boolean.class),
-            any(Boolean.class));
+    verify(target, never()).onFoundEdition(any(USKFoundEdition.class));
 
     // Act: finish the round; should flush a single latest notification (edition 2)
     proxy.onRoundFinished(context);
 
     // Assert: exactly once with latest values and knownGood propagated
     verify(target, times(1))
-        .onFoundEdition(2L, usk, context, false, (short) 9, data345, true, true);
+        .onFoundEdition(foundEdition(2L, usk, context, false, (short) 9, data345, true, true));
 
     // Act: finishing again without new updates should not duplicate
     proxy.onRoundFinished(context);
     verify(target, times(1))
-        .onFoundEdition(2L, usk, context, false, (short) 9, data345, true, true);
+        .onFoundEdition(foundEdition(2L, usk, context, false, (short) 9, data345, true, true));
   }
 
   @Test
@@ -267,17 +257,17 @@ class USKSparseProxyCallbackTest {
 
     // Act: update then flush via sending-to-network
     byte[] data8 = new byte[] {8};
-    proxy.onFoundEdition(5L, usk, context, false, (short) 1, data8, false, false);
+    proxy.onFoundEdition(foundEdition(5L, usk, context, false, (short) 1, data8, false, false));
     proxy.onSendingToNetwork(context);
 
     // Assert: flushed once with wasKnownGood=false → both flags false
     verify(target, times(1))
-        .onFoundEdition(5L, usk, context, false, (short) 1, data8, false, false);
+        .onFoundEdition(foundEdition(5L, usk, context, false, (short) 1, data8, false, false));
 
     // Act: call again without new updates — should not duplicate
     proxy.onSendingToNetwork(context);
     verify(target, times(1))
-        .onFoundEdition(5L, usk, context, false, (short) 1, data8, false, false);
+        .onFoundEdition(foundEdition(5L, usk, context, false, (short) 1, data8, false, false));
   }
 
   @Test
@@ -288,29 +278,11 @@ class USKSparseProxyCallbackTest {
 
     // Case 1: with no prior editions seen, guard returns early and nothing is forwarded
     proxy.onRoundFinished(context);
-    verify(target, never())
-        .onFoundEdition(
-            any(Long.class),
-            eq(usk),
-            eq(context),
-            any(Boolean.class),
-            any(Short.class),
-            any(),
-            any(Boolean.class),
-            any(Boolean.class));
+    verify(target, never()).onFoundEdition(any(USKFoundEdition.class));
 
     // Case 2: calling again without any prior edition still results in no call
     proxy.onRoundFinished(context);
-    verify(target, never())
-        .onFoundEdition(
-            any(Long.class),
-            eq(usk),
-            eq(context),
-            any(Boolean.class),
-            any(Short.class),
-            any(),
-            any(Boolean.class),
-            any(Boolean.class));
+    verify(target, never()).onFoundEdition(any(USKFoundEdition.class));
   }
 
   @Test
@@ -320,17 +292,18 @@ class USKSparseProxyCallbackTest {
     // Arrange
     USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
     byte[] data1 = new byte[] {1};
-    proxy.onFoundEdition(5L, usk, context, false, (short) 0, data1, false, false);
+    proxy.onFoundEdition(foundEdition(5L, usk, context, false, (short) 0, data1, false, false));
     proxy.onRoundFinished(context); // finish the round so subsequent older edition may pass through
 
     // Act: older edition but newKnownGood=true should call through immediately
     byte[] data9 = new byte[] {9};
-    proxy.onFoundEdition(4L, usk, context, true, (short) 2, data9, true, false);
+    proxy.onFoundEdition(foundEdition(4L, usk, context, true, (short) 2, data9, true, false));
 
     // Assert: called with the older edition's parameters
     verify(target, times(1))
-        .onFoundEdition(5L, usk, context, false, (short) 0, data1, false, false);
-    verify(target, times(1)).onFoundEdition(4L, usk, context, true, (short) 2, data9, true, false);
+        .onFoundEdition(foundEdition(5L, usk, context, false, (short) 0, data1, false, false));
+    verify(target, times(1))
+        .onFoundEdition(foundEdition(4L, usk, context, true, (short) 2, data9, true, false));
   }
 
   @Test
@@ -341,12 +314,13 @@ class USKSparseProxyCallbackTest {
 
     // Act: first store the edition (knownGood=false), then mark same edition as knownGood
     byte[] data23 = new byte[] {2, 3};
-    proxy.onFoundEdition(7L, usk, context, true, (short) 11, data23, false, false);
-    proxy.onFoundEdition(7L, usk, context, true, (short) 11, data23, true, false);
+    proxy.onFoundEdition(foundEdition(7L, usk, context, true, (short) 11, data23, false, false));
+    proxy.onFoundEdition(foundEdition(7L, usk, context, true, (short) 11, data23, true, false));
     proxy.onRoundFinished(context);
 
     // Assert: the flush uses wasKnownGood=true for both flags
-    verify(target, times(1)).onFoundEdition(7L, usk, context, true, (short) 11, data23, true, true);
+    verify(target, times(1))
+        .onFoundEdition(foundEdition(7L, usk, context, true, (short) 11, data23, true, true));
   }
 
   @Test
@@ -359,5 +333,18 @@ class USKSparseProxyCallbackTest {
 
     assertEquals(12, proxy.getPollingPriorityNormal());
     assertEquals(34, proxy.getPollingPriorityProgress());
+  }
+
+  private USKFoundEdition foundEdition(
+      long edition,
+      USK key,
+      ClientContext context,
+      boolean metadata,
+      short codec,
+      byte[] data,
+      boolean newKnownGood,
+      boolean newSlotToo) {
+    return new USKFoundEdition(
+        edition, key, context, metadata, codec, data, newKnownGood, newSlotToo);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.USKFoundEdition;
 import network.crypta.client.async.USKManager;
 import network.crypta.client.async.USKSparseProxyCallback;
 import network.crypta.keys.USK;
@@ -90,7 +91,8 @@ class SubscribeUSKTest {
     when(handler.isClosed()).thenReturn(true);
 
     subscription.onFoundEdition(
-        7L, message.key, clientContext, false, (short) 1, new byte[0], true, false);
+        new USKFoundEdition(
+            7L, message.key, clientContext, false, (short) 1, new byte[0], true, false));
 
     verify(uskManager).unsubscribe(message.key, subscription);
     verify(handler, never()).send(any());
@@ -105,7 +107,7 @@ class SubscribeUSKTest {
     when(handler.isClosed()).thenReturn(false);
 
     subscription.onFoundEdition(
-        12L, message.key, clientContext, false, (short) 1, null, true, false);
+        new USKFoundEdition(12L, message.key, clientContext, false, (short) 1, null, true, false));
 
     ArgumentCaptor<SubscribedUSKUpdate> captor = ArgumentCaptor.forClass(SubscribedUSKUpdate.class);
     verify(handler).send(captor.capture());


### PR DESCRIPTION
## Summary
- introduce `USKFoundEdition` record to bundle callback payload data
- update USK fetchers, callbacks, and managers to use the new payload object
- adjust related tests and downstream consumers (FCP/bookmarks/updater)

## Testing
- not run (not requested)
