### PR TITLE
refactor(client): split splitfile progress snapshot

### DIFF
--- a/src/main/java/network/crypta/client/async/BaseManifestPutter.java
+++ b/src/main/java/network/crypta/client/async/BaseManifestPutter.java
@@ -22,7 +22,9 @@ import network.crypta.client.Metadata;
 import network.crypta.client.Metadata.DocumentType;
 import network.crypta.client.Metadata.SimpleManifestComposer;
 import network.crypta.client.MetadataUnresolvedException;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.keys.BaseClientKey;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.Key;
@@ -1524,15 +1526,15 @@ public abstract class BaseManifestPutter extends ManifestPutter {
     synchronized (this) {
       e =
           new SplitfileProgressEvent(
-              this.totalBlocks,
-              this.successfulBlocks,
-              this.latestSuccess,
-              this.failedBlocks,
-              this.fatallyFailedBlocks,
-              this.latestFailure,
-              this.minSuccessBlocks,
-              this.minSuccessFetchBlocks,
-              this.blockSetFinalized);
+              new SplitfileProgressCounts(
+                  this.totalBlocks,
+                  this.successfulBlocks,
+                  this.failedBlocks,
+                  this.fatallyFailedBlocks,
+                  this.minSuccessBlocks,
+                  this.minSuccessFetchBlocks,
+                  this.blockSetFinalized),
+              new SplitfileProgressTimestamps(this.latestSuccess, this.latestFailure));
     }
     ctx.getEventProducer().produceEvent(e, context);
   }

--- a/src/main/java/network/crypta/client/async/ClientGetter.java
+++ b/src/main/java/network/crypta/client/async/ClientGetter.java
@@ -31,7 +31,9 @@ import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.client.events.ExpectedMIMEEvent;
 import network.crypta.client.events.SendingToNetworkEvent;
 import network.crypta.client.events.SplitfileCompatibilityModeEvent;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.FilterMIMEType;
 import network.crypta.client.filter.UnsafeContentTypeException;
@@ -958,15 +960,15 @@ public class ClientGetter extends BaseClientGetter
       }
       e =
           new SplitfileProgressEvent(
-              total,
-              this.successfulBlocks,
-              this.latestSuccess,
-              this.failedBlocks,
-              this.fatallyFailedBlocks,
-              this.latestFailure,
-              minSuccess,
-              0,
-              finalized);
+              new SplitfileProgressCounts(
+                  total,
+                  this.successfulBlocks,
+                  this.failedBlocks,
+                  this.fatallyFailedBlocks,
+                  minSuccess,
+                  0,
+                  finalized),
+              new SplitfileProgressTimestamps(this.latestSuccess, this.latestFailure));
     }
     // Already off-thread.
     ctx.getEventProducer().produceEvent(e, context);

--- a/src/main/java/network/crypta/client/async/ClientPutter.java
+++ b/src/main/java/network/crypta/client/async/ClientPutter.java
@@ -10,7 +10,9 @@ import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.Metadata;
 import network.crypta.client.events.SendingToNetworkEvent;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.BaseClientKey;
 import network.crypta.keys.FreenetURI;
@@ -662,15 +664,15 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
     synchronized (this) {
       e =
           new SplitfileProgressEvent(
-              this.totalBlocks,
-              this.successfulBlocks,
-              this.latestSuccess,
-              this.failedBlocks,
-              this.fatallyFailedBlocks,
-              this.latestFailure,
-              this.minSuccessBlocks,
-              this.minSuccessFetchBlocks,
-              this.blockSetFinalized);
+              new SplitfileProgressCounts(
+                  this.totalBlocks,
+                  this.successfulBlocks,
+                  this.failedBlocks,
+                  this.fatallyFailedBlocks,
+                  this.minSuccessBlocks,
+                  this.minSuccessFetchBlocks,
+                  this.blockSetFinalized),
+              new SplitfileProgressTimestamps(this.latestSuccess, this.latestFailure));
     }
     ctx.getEventProducer().produceEvent(e, context);
   }

--- a/src/main/java/network/crypta/client/events/SplitfileProgressCounts.java
+++ b/src/main/java/network/crypta/client/events/SplitfileProgressCounts.java
@@ -1,0 +1,38 @@
+package network.crypta.client.events;
+
+/**
+ * Collects the numeric progress counters for a splitfile operation snapshot.
+ *
+ * <p>This record carries the integer counters that summarize progress at a single point in time for
+ * splitfile fetches and inserts. It is intended to be paired with a timestamp snapshot and passed
+ * to the surrounding splitfile progress event as a compact, immutable bundle. The values are
+ * read-only and thread-safe after construction because records are immutable and contain only
+ * primitives.
+ *
+ * <p>The counters express totals, successes, and failures as absolute block counts, plus a success
+ * threshold that indicates when the overall operation can be considered complete. The {@code
+ * finalizedTotal} flag distinguishes provisional totals from final ones, which helps callers avoid
+ * presenting misleading percentages while discovery is still in progress.
+ *
+ * <ul>
+ *   <li>Represents a point-in-time snapshot rather than live, mutable counters.
+ *   <li>Uses block counts only; no time-based or size-based units are embedded.
+ *   <li>Separates total discovery from completion thresholds via {@code minSuccessfulBlocks}.
+ * </ul>
+ *
+ * @param totalBlocks total known blocks in the splitfile at this snapshot, non-negative count
+ * @param succeedBlocks blocks completed successfully at this instant, non-negative count
+ * @param failedBlocks retryable failures recorded so far, non-negative count
+ * @param fatallyFailedBlocks permanent failures that will not retry, non-negative count
+ * @param minSuccessfulBlocks minimum success threshold required for completion, non-negative count
+ * @param minSuccessFetchBlocks minimum fetchable blocks needed to proceed, non-negative count
+ * @param finalizedTotal whether {@code totalBlocks} is final and no longer growing
+ */
+public record SplitfileProgressCounts(
+    int totalBlocks,
+    int succeedBlocks,
+    int failedBlocks,
+    int fatallyFailedBlocks,
+    int minSuccessfulBlocks,
+    int minSuccessFetchBlocks,
+    boolean finalizedTotal) {}

--- a/src/main/java/network/crypta/client/events/SplitfileProgressEvent.java
+++ b/src/main/java/network/crypta/client/events/SplitfileProgressEvent.java
@@ -99,44 +99,28 @@ public class SplitfileProgressEvent implements ClientEvent {
   /**
    * Creates a new snapshot of splitfile progress.
    *
-   * <p>All counts are non-negative. Date parameters may be {@code null} when no corresponding event
-   * has occurred. {@code latestSuccess} and {@code latestFailure} are defensively copied to
-   * preserve immutability of the event instance.
+   * <p>All counts are non-negative. Timestamp values may be {@code null} when no corresponding
+   * event has occurred. Timestamps are defensively copied to preserve immutability of the event
+   * instance.
    *
-   * @param totalBlocks the total number of blocks known at creation time; may grow until {@code
-   *     finalizedTotal} becomes {@code true}
-   * @param succeedBlocks the number of blocks completed successfully; monotonically non-decreasing
-   * @param latestSuccess timestamp of the most recent successful block, or {@code null} if none
-   * @param failedBlocks the number of non-fatal failures that may be retried by the client
-   * @param fatallyFailedBlocks the number of permanent failures that will not be retried
-   * @param latestFailure timestamp of the most recent failure, or {@code null} if none
-   * @param minSuccessfulBlocks the success threshold that determines when the overall operation can
-   *     finish successfully
-   * @param minSuccessFetchBlocks the minimum number of blocks that must be fetchable to proceed;
-   *     used for fetch-side progress modeling
-   * @param finalizedTotal whether {@code totalBlocks} represents a finalized, non-growing count
+   * @param counts numeric progress counters for the splitfile operation
+   * @param timestamps latest success and failure timestamps, or {@code null} values when unknown
    */
   public SplitfileProgressEvent(
-      int totalBlocks,
-      int succeedBlocks,
-      Date latestSuccess,
-      int failedBlocks,
-      int fatallyFailedBlocks,
-      Date latestFailure,
-      int minSuccessfulBlocks,
-      int minSuccessFetchBlocks,
-      boolean finalizedTotal) {
-    this.totalBlocks = totalBlocks;
-    this.succeedBlocks = succeedBlocks;
-    // Defensive copy because Date is mutable.
-    this.latestSuccess = latestSuccess != null ? new Date(latestSuccess.getTime()) : null;
-    this.failedBlocks = failedBlocks;
-    this.fatallyFailedBlocks = fatallyFailedBlocks;
-    // Defensive copy because Date is mutable.
-    this.latestFailure = latestFailure != null ? new Date(latestFailure.getTime()) : null;
-    this.minSuccessfulBlocks = minSuccessfulBlocks;
-    this.finalizedTotal = finalizedTotal;
-    this.minSuccessFetchBlocks = minSuccessFetchBlocks;
+      SplitfileProgressCounts counts, SplitfileProgressTimestamps timestamps) {
+    this.totalBlocks = counts.totalBlocks();
+    this.succeedBlocks = counts.succeedBlocks();
+    Date latestSuccessTimestamp = timestamps.latestSuccess();
+    this.latestSuccess =
+        latestSuccessTimestamp != null ? new Date(latestSuccessTimestamp.getTime()) : null;
+    this.failedBlocks = counts.failedBlocks();
+    this.fatallyFailedBlocks = counts.fatallyFailedBlocks();
+    Date latestFailureTimestamp = timestamps.latestFailure();
+    this.latestFailure =
+        latestFailureTimestamp != null ? new Date(latestFailureTimestamp.getTime()) : null;
+    this.minSuccessfulBlocks = counts.minSuccessfulBlocks();
+    this.finalizedTotal = counts.finalizedTotal();
+    this.minSuccessFetchBlocks = counts.minSuccessFetchBlocks();
     if (LOG.isDebugEnabled())
       LOG.debug(
           "Created SplitfileProgressEvent: total={} succeed={} failed={} fatally={} min success={}"

--- a/src/main/java/network/crypta/client/events/SplitfileProgressTimestamps.java
+++ b/src/main/java/network/crypta/client/events/SplitfileProgressTimestamps.java
@@ -1,0 +1,44 @@
+package network.crypta.client.events;
+
+import java.util.Date;
+
+/**
+ * Captures the latest success and failure timestamps for a splitfile operation snapshot.
+ *
+ * <p>This record holds the most recent success and failure {@link Date} values associated with a
+ * splitfile fetch or insert. It is typically created alongside the splitfile progress counters and
+ * passed to the corresponding progress event so consumers can display timing hints without
+ * maintaining direct references to mutable timestamps. The record is immutable and therefore safe
+ * to share across threads as a read-only snapshot.
+ *
+ * <p>The canonical constructor defensively copies the incoming {@link Date} instances. Callers may
+ * pass {@code null} for either timestamp to indicate that no success or failure has occurred yet. A
+ * {@code null} value remains {@code null} in the stored snapshot, while non-null dates are copied
+ * to prevent external mutation after construction.
+ *
+ * <ul>
+ *   <li>Represents timestamps only; it does not contain counters or totals.
+ *   <li>Uses {@link Date} values in milliseconds since the epoch.
+ *   <li>Provides a stable, read-only view of the latest known activity.
+ * </ul>
+ *
+ * @param latestSuccess time of the most recent successful block, or {@code null} if none yet
+ * @param latestFailure time of the most recent failure, or {@code null} if none yet
+ */
+public record SplitfileProgressTimestamps(Date latestSuccess, Date latestFailure) {
+  /**
+   * Creates a snapshot of the latest success and failure timestamps.
+   *
+   * <p>This constructor copies the supplied {@link Date} instances to preserve immutability. It
+   * performs no validation beyond null handling and is idempotent with respect to already-copied
+   * values. Passing {@code null} for either argument leaves that component unset in the snapshot,
+   * which callers can interpret as “no event yet.”
+   *
+   * @param latestSuccess time of the most recent successful block, or {@code null} if absent
+   * @param latestFailure time of the most recent failure, or {@code null} if absent
+   */
+  public SplitfileProgressTimestamps {
+    latestSuccess = latestSuccess != null ? new Date(latestSuccess.getTime()) : null;
+    latestFailure = latestFailure != null ? new Date(latestFailure.getTime()) : null;
+  }
+}

--- a/src/test/java/network/crypta/client/events/SplitfileProgressEventTest.java
+++ b/src/test/java/network/crypta/client/events/SplitfileProgressEventTest.java
@@ -18,7 +18,10 @@ class SplitfileProgressEventTest {
 
   @Test
   void api_whenQueried_expectImplementsClientEventAndStableCode() {
-    SplitfileProgressEvent event = new SplitfileProgressEvent(10, 3, null, 1, 0, null, 5, 2, false);
+    SplitfileProgressEvent event =
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(10, 3, 1, 0, 5, 2, false),
+            new SplitfileProgressTimestamps(null, null));
 
     assertInstanceOf(ClientEvent.class, event, "Event must implement ClientEvent");
     assertEquals(SplitfileProgressEvent.CODE, event.getCode(), "getCode must return CODE");
@@ -31,7 +34,9 @@ class SplitfileProgressEventTest {
     Date failure = new Date(2_000_000L);
 
     SplitfileProgressEvent event =
-        new SplitfileProgressEvent(1, 0, success, 0, 0, failure, 1, 0, false);
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(1, 0, 0, 0, 1, 0, false),
+            new SplitfileProgressTimestamps(success, failure));
 
     // Mutate the original inputs after construction
     success.setTime(9_999_999L);
@@ -45,7 +50,10 @@ class SplitfileProgressEventTest {
 
   @Test
   void constructor_whenNullDatesProvided_storesNulls() {
-    SplitfileProgressEvent event = new SplitfileProgressEvent(0, 0, null, 0, 0, null, 1, 0, false);
+    SplitfileProgressEvent event =
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(0, 0, 0, 0, 1, 0, false),
+            new SplitfileProgressTimestamps(null, null));
 
     assertNull(event.latestSuccess, "Null latestSuccess input must store null");
     assertNull(event.latestFailure, "Null latestFailure input must store null");
@@ -77,13 +85,15 @@ class SplitfileProgressEventTest {
   void getDescription_whenNormalValues_formatsPercentAndFields() {
     SplitfileProgressEvent event =
         new SplitfileProgressEvent(
-            100, // total
-            25, // succeed
-            null, 2, // failed
-            1, // fatally failed
-            null, 50, // minSuccessfulBlocks
-            5, // minSuccessFetchBlocks
-            false);
+            new SplitfileProgressCounts(
+                100, // total
+                25, // succeed
+                2, // failed
+                1, // fatally failed
+                50, // minSuccessfulBlocks
+                5, // minSuccessFetchBlocks
+                false),
+            new SplitfileProgressTimestamps(null, null));
 
     String desc = event.getDescription();
 
@@ -95,7 +105,10 @@ class SplitfileProgressEventTest {
   @Test
   @DisplayName("getDescription_whenFinalizedTrue_appendsFinalizedLabel")
   void getDescription_whenFinalizedTrue_appendsFinalizedLabel() {
-    SplitfileProgressEvent event = new SplitfileProgressEvent(10, 5, null, 0, 0, null, 10, 0, true);
+    SplitfileProgressEvent event =
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(10, 5, 0, 0, 10, 0, true),
+            new SplitfileProgressTimestamps(null, null));
 
     String desc = event.getDescription();
 
@@ -108,7 +121,10 @@ class SplitfileProgressEventTest {
       "getDescription_whenMinSuccessfulZeroAndSucceedZero_normalizesDenominatorAndShowsZeroPercent")
   void
       getDescription_whenMinSuccessfulZeroAndSucceedZero_normalizesDenominatorAndShowsZeroPercent() {
-    SplitfileProgressEvent event = new SplitfileProgressEvent(0, 0, null, 0, 0, null, 0, 0, false);
+    SplitfileProgressEvent event =
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(0, 0, 0, 0, 0, 0, false),
+            new SplitfileProgressTimestamps(null, null));
 
     String desc = event.getDescription();
 
@@ -124,7 +140,10 @@ class SplitfileProgressEventTest {
       "getDescription_whenMinSuccessfulZeroAndSucceedPositive_omitsPercentAndKeepsDenominatorZero")
   void
       getDescription_whenMinSuccessfulZeroAndSucceedPositive_omitsPercentAndKeepsDenominatorZero() {
-    SplitfileProgressEvent event = new SplitfileProgressEvent(0, 3, null, 0, 0, null, 0, 0, false);
+    SplitfileProgressEvent event =
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(0, 3, 0, 0, 0, 0, false),
+            new SplitfileProgressTimestamps(null, null));
 
     String desc = event.getDescription();
 
@@ -147,7 +166,9 @@ class SplitfileProgressEventTest {
   void getDescription_whenVariousRatios_formatsIntegerPercent(
       int succeed, int minSuccessful, int expectedPercent) {
     SplitfileProgressEvent event =
-        new SplitfileProgressEvent(0, succeed, null, 0, 0, null, minSuccessful, 0, false);
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(0, succeed, 0, 0, minSuccessful, 0, false),
+            new SplitfileProgressTimestamps(null, null));
 
     String desc = event.getDescription();
 

--- a/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
@@ -28,7 +28,9 @@ import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.client.events.ExpectedMIMEEvent;
 import network.crypta.client.events.SendingToNetworkEvent;
 import network.crypta.client.events.SplitfileCompatibilityModeEvent;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.crypt.HashResult;
 import network.crypta.crypt.HashType;
 import network.crypta.support.io.NativeThread;
@@ -382,7 +384,9 @@ class ClientGetEventHandlingTest {
   }
 
   private static SplitfileProgressEvent newProgressEvent() {
-    return new SplitfileProgressEvent(10, 2, new Date(0L), 1, 0, new Date(0L), 10, 10, true);
+    return new SplitfileProgressEvent(
+        new SplitfileProgressCounts(10, 2, 1, 0, 10, 10, true),
+        new SplitfileProgressTimestamps(new Date(0L), new Date(0L)));
   }
 
   private static HashResult newSha256Hash() {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
@@ -18,7 +18,9 @@ import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.async.CompatibilityAnalyser;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
@@ -73,7 +75,9 @@ class ClientGetTest {
   void progressAccessors_whenProgressPresent_returnEventValues() {
     ClientGet clientGet = newClientGet();
     SplitfileProgressEvent event =
-        new SplitfileProgressEvent(10, 7, new Date(1_000L), 2, 1, new Date(2_000L), 8, 5, true);
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(10, 7, 2, 1, 8, 5, true),
+            new SplitfileProgressTimestamps(new Date(1_000L), new Date(2_000L)));
     SimpleProgressMessage progress = new SimpleProgressMessage("req", false, event);
     setField(clientGet, "progressPending", progress);
 

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
@@ -20,7 +20,9 @@ import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ContainerInserter;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.ManifestElement;
@@ -100,7 +102,9 @@ class ClientPutDirTest {
     setField(ClientPutDir.class, putDir, "totalSize", 2048L);
     setField(ClientPutDir.class, putDir, "numberOfFiles", 7);
     SplitfileProgressEvent event =
-        new SplitfileProgressEvent(50, 10, new Date(1000), 4, 2, new Date(2000), 20, 5, true);
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(50, 10, 4, 2, 20, 5, true),
+            new SplitfileProgressTimestamps(new Date(1000), new Date(2000)));
     setField(
         ClientPutBase.class,
         putDir,

--- a/src/test/java/network/crypta/clients/fcp/SimpleProgressMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SimpleProgressMessageTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +23,9 @@ class SimpleProgressMessageTest {
   @Test
   void getFieldSet_whenMinSuccessFetchZero_excludesOptionalField() {
     SplitfileProgressEvent event =
-        new SplitfileProgressEvent(10, 4, SUCCESS_TIME, 2, 1, FAILURE_TIME, 6, 0, true);
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(10, 4, 2, 1, 6, 0, true),
+            new SplitfileProgressTimestamps(SUCCESS_TIME, FAILURE_TIME));
     SimpleProgressMessage message = new SimpleProgressMessage(IDENTIFIER, true, event);
 
     SimpleFieldSet fieldSet = message.getFieldSet();
@@ -40,7 +44,10 @@ class SimpleProgressMessageTest {
 
   @Test
   void getFieldSet_whenMinSuccessFetchPresent_includesOptionalField() {
-    SplitfileProgressEvent event = new SplitfileProgressEvent(8, 2, null, 1, 0, null, 5, 3, false);
+    SplitfileProgressEvent event =
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(8, 2, 1, 0, 5, 3, false),
+            new SplitfileProgressTimestamps(null, null));
     SimpleProgressMessage message = new SimpleProgressMessage("other", false, event);
 
     SimpleFieldSet fieldSet = message.getFieldSet();
@@ -52,7 +59,10 @@ class SimpleProgressMessageTest {
 
   @Test
   void run_whenInvoked_throwsMessageInvalidException() {
-    SplitfileProgressEvent event = new SplitfileProgressEvent(1, 0, null, 0, 0, null, 1, 0, false);
+    SplitfileProgressEvent event =
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(1, 0, 0, 0, 1, 0, false),
+            new SplitfileProgressTimestamps(null, null));
     SimpleProgressMessage message = new SimpleProgressMessage(IDENTIFIER, true, event);
 
     MessageInvalidException thrown =
@@ -68,7 +78,9 @@ class SimpleProgressMessageTest {
   @Test
   void getFraction_whenPartialProgress_returnsRatio() {
     SplitfileProgressEvent event =
-        new SplitfileProgressEvent(20, 5, SUCCESS_TIME, 0, 0, null, 10, 0, false);
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(20, 5, 0, 0, 10, 0, false),
+            new SplitfileProgressTimestamps(SUCCESS_TIME, null));
     SimpleProgressMessage message = new SimpleProgressMessage(IDENTIFIER, false, event);
 
     assertEquals(0.25d, message.getFraction(), 1e-9);
@@ -77,7 +89,9 @@ class SimpleProgressMessageTest {
   @Test
   void getLatestSuccess_whenModified_doesNotAffectStoredValue() {
     SplitfileProgressEvent event =
-        new SplitfileProgressEvent(5, 3, SUCCESS_TIME, 0, 0, null, 4, 0, false);
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(5, 3, 0, 0, 4, 0, false),
+            new SplitfileProgressTimestamps(SUCCESS_TIME, null));
     SimpleProgressMessage message = new SimpleProgressMessage(IDENTIFIER, false, event);
 
     Date returned = message.getLatestSuccess();
@@ -90,7 +104,9 @@ class SimpleProgressMessageTest {
   @Test
   void getLatestFailure_whenModified_doesNotAffectStoredValue() {
     SplitfileProgressEvent event =
-        new SplitfileProgressEvent(5, 3, SUCCESS_TIME, 0, 1, FAILURE_TIME, 4, 0, false);
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(5, 3, 0, 1, 4, 0, false),
+            new SplitfileProgressTimestamps(SUCCESS_TIME, FAILURE_TIME));
     SimpleProgressMessage message = new SimpleProgressMessage(IDENTIFIER, false, event);
 
     Date returned = message.getLatestFailure();
@@ -103,7 +119,9 @@ class SimpleProgressMessageTest {
   @Test
   void getters_whenCalled_returnUnderlyingCounts() {
     SplitfileProgressEvent event =
-        new SplitfileProgressEvent(12, 9, SUCCESS_TIME, 2, 1, FAILURE_TIME, 10, 4, true);
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(12, 9, 2, 1, 10, 4, true),
+            new SplitfileProgressTimestamps(SUCCESS_TIME, FAILURE_TIME));
     SimpleProgressMessage message = new SimpleProgressMessage(IDENTIFIER, true, event);
 
     assertEquals(0.75d, message.getFraction(), 1e-9);

--- a/src/test/java/network/crypta/pluginmanager/PluginDownLoaderFreenetTest.java
+++ b/src/test/java/network/crypta/pluginmanager/PluginDownLoaderFreenetTest.java
@@ -37,7 +37,9 @@ import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientGetter;
 import network.crypta.client.events.ClientEventListener;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
@@ -240,7 +242,9 @@ class PluginDownLoaderFreenetTest {
 
       reset(progress);
       SplitfileProgressEvent split =
-          new SplitfileProgressEvent(100, 40, null, 3, 1, null, 80, 0, /* finalizedTotal= */ true);
+          new SplitfileProgressEvent(
+              new SplitfileProgressCounts(100, 40, 3, 1, 80, 0, true),
+              new SplitfileProgressTimestamps(null, null));
       hookHolder[0].receive(split, mock(ClientContext.class));
 
       verify(progress).setDownloadProgress(80, 40, 100, 3, 1, true);
@@ -295,7 +299,9 @@ class PluginDownLoaderFreenetTest {
 
       reset(progress);
       SplitfileProgressEvent split =
-          new SplitfileProgressEvent(100, 40, null, 3, 1, null, 80, 0, /* finalizedTotal= */ false);
+          new SplitfileProgressEvent(
+              new SplitfileProgressCounts(100, 40, 3, 1, 80, 0, false),
+              new SplitfileProgressTimestamps(null, null));
       hookHolder[0].receive(split, mock(ClientContext.class));
 
       verify(progress, never())


### PR DESCRIPTION
## Summary
- extract splitfile progress counters into `SplitfileProgressCounts`
- capture latest success/failure timestamps in `SplitfileProgressTimestamps`
- update progress event construction and related tests

## Testing
- not run (only `./gradlew spotlessApply`)