### PR TITLE
refactor(filter): bundle filter request data

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientGetWorkerThread.java
+++ b/src/main/java/network/crypta/client/async/ClientGetWorkerThread.java
@@ -12,6 +12,8 @@ import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.ContentFilter.FilterStatus;
+import network.crypta.client.filter.ContentFilterCallbacks;
+import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FoundURICallback;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.client.filter.TagReplacerCallback;
@@ -217,17 +219,12 @@ public class ClientGetWorkerThread extends Thread {
         throw new IOException("Insufficient arguments to worker thread");
       }
       // Send XHTML as HTML because we can't use web-pushing on XHTML.
-      FilterStatus filterStatus =
-          ContentFilter.filter(
-              currentInput,
-              managedOutput,
-              mimeType,
-              uri,
-              schemeHostAndPort,
-              prefetchHook,
-              tagReplacer,
-              charset,
-              linkFilterExceptionProvider);
+      ContentFilterRequest request =
+          new ContentFilterRequest(
+              currentInput, managedOutput, mimeType, charset, schemeHostAndPort, null);
+      ContentFilterCallbacks callbacks =
+          new ContentFilterCallbacks(uri, prefetchHook, tagReplacer, linkFilterExceptionProvider);
+      FilterStatus filterStatus = ContentFilter.filter(request, callbacks);
 
       String detectedMIMEType =
           filterStatus.mimeType.concat(

--- a/src/main/java/network/crypta/client/filter/ContentFilter.java
+++ b/src/main/java/network/crypta/client/filter/ContentFilter.java
@@ -497,6 +497,9 @@ public class ContentFilter {
   /**
    * Filter content from an input stream and write the sanitized result to an output stream.
    *
+   * <p>This legacy overload is retained for source compatibility. Prefer {@link
+   * #filter(ContentFilterRequest, ContentFilterCallbacks)}.
+   *
    * <p>The method chooses a handler based on {@code typeName}, resolves an effective charset when
    * needed, and invokes the handler's read filter. During processing, it may report discovered
    * links through {@code cb} and perform tag substitutions via {@code trc}. When the MIME type is
@@ -522,6 +525,7 @@ public class ContentFilter {
    *     {@link UnsafeContentTypeException} subclasses may be used to classify unsafe types
    * @throws IllegalStateException when input is structurally invalid and the handler cannot recover
    */
+  @SuppressWarnings("java:S107")
   public static FilterStatus filter(
       InputStream input,
       OutputStream output,
@@ -537,6 +541,9 @@ public class ContentFilter {
 
   /**
    * Filter content with an optional provider for link-related exceptions.
+   *
+   * <p>This legacy overload is retained for source compatibility. Prefer {@link
+   * #filter(ContentFilterRequest, ContentFilterCallbacks)}.
    *
    * <p>This overload is identical to {@link #filter(InputStream, OutputStream, String, URI, String,
    * FoundURICallback, TagReplacerCallback, String)} but additionally accepts a provider that
@@ -565,6 +572,7 @@ public class ContentFilter {
    *     {@link UnsafeContentTypeException} subclasses may be used to classify unsafe types
    * @throws IllegalStateException when input is structurally invalid and the handler cannot recover
    */
+  @SuppressWarnings("java:S107")
   public static FilterStatus filter(
       InputStream input,
       OutputStream output,
@@ -576,13 +584,31 @@ public class ContentFilter {
       String maybeCharset,
       LinkFilterExceptionProvider linkFilterExceptionProvider)
       throws IOException {
-    return filter(
-        input,
-        output,
-        typeName,
-        maybeCharset,
-        schemeHostAndPort,
-        new GenericReadFilterCallback(baseURI, cb, trc, linkFilterExceptionProvider));
+    ContentFilterRequest request =
+        new ContentFilterRequest(input, output, typeName, maybeCharset, schemeHostAndPort, null);
+    ContentFilterCallbacks callbacks =
+        new ContentFilterCallbacks(baseURI, cb, trc, linkFilterExceptionProvider);
+    return filter(request, callbacks);
+  }
+
+  /**
+   * Filter content with a structured request and callbacks.
+   *
+   * <p>This overload mirrors {@link #filter(ContentFilterRequest)} but derives the {@link
+   * FilterCallback} from the provided {@link ContentFilterCallbacks}.
+   *
+   * @param request immutable filtering request data
+   * @param callbacks callback bundle for link discovery and tag replacement; may be {@code null}
+   * @return a {@link FilterStatus} carrying the effective charset and MIME type chosen during
+   *     processing
+   * @throws IOException on I/O errors while reading, writing, or decoding the stream; specific
+   *     {@link UnsafeContentTypeException} subclasses may be used to classify unsafe types
+   * @throws IllegalStateException when input is structurally invalid and the handler cannot recover
+   */
+  public static FilterStatus filter(ContentFilterRequest request, ContentFilterCallbacks callbacks)
+      throws IOException {
+    FilterCallback filterCallback = callbacks == null ? null : callbacks.toFilterCallback();
+    return filter(request.withFilterCallback(filterCallback));
   }
 
   /**
@@ -618,33 +644,55 @@ public class ContentFilter {
       String schemeHostAndPort,
       FilterCallback filterCallback)
       throws IOException {
-    if (LOG.isDebugEnabled()) LOG.debug("Filtering data of type{}", typeName);
-    ParsedMime parsed = parseMimeType(typeName);
-    BufferedInputStream buffered = new BufferedInputStream(input);
+    return filter(
+        new ContentFilterRequest(
+            input, output, typeName, maybeCharset, schemeHostAndPort, filterCallback));
+  }
+
+  /**
+   * Core filtering entry point used by higher-level overloads.
+   *
+   * <p>Parses {@link ContentFilterRequest#typeName()}, determines the appropriate handler, resolves
+   * a charset when applicable, and either runs the handler's read filter or copies the bytes
+   * unchanged when marked safe. The callback receives lifecycle notifications and any discovered
+   * links. The output stream is flushed before returning but is not closed.
+   *
+   * @param request immutable request describing the input/output streams and filtering context
+   * @return a {@link FilterStatus} carrying the effective charset and MIME type chosen during
+   *     processing
+   * @throws IOException on I/O errors while reading, writing, or decoding the stream; specific
+   *     {@link UnsafeContentTypeException} subclasses may be used to classify unsafe types
+   * @throws IllegalStateException when input is structurally invalid and the handler cannot recover
+   */
+  public static FilterStatus filter(ContentFilterRequest request) throws IOException {
+    if (LOG.isDebugEnabled()) LOG.debug("Filtering data of type{}", request.typeName());
+    ParsedMime parsed = parseMimeType(request.typeName());
+    BufferedInputStream buffered = new BufferedInputStream(request.input());
+    OutputStream output = request.output();
 
     FilterMIMEType handler = getMIMEType(parsed.type);
-    if (handler == null) throw new UnknownContentTypeException(typeName);
+    if (handler == null) throw new UnknownContentTypeException(request.typeName());
 
     if (handler.readFilter != null) {
       String charset = parsed.charset;
       if (handler.takesACharset && (charset == null || charset.isEmpty())) {
-        charset = readCharsetIfNeeded(buffered, handler, maybeCharset);
+        charset = readCharsetIfNeeded(buffered, handler, request.maybeCharset());
       }
-      return runReadFilter(
-          handler,
-          buffered,
-          output,
-          charset,
-          parsed.otherParams,
-          schemeHostAndPort,
-          filterCallback,
-          typeName);
+      ReadFilterRequest readFilterRequest =
+          new ReadFilterRequest(
+              buffered,
+              output,
+              charset,
+              parsed.otherParams,
+              request.schemeHostAndPort(),
+              request.filterCallback());
+      return runReadFilter(handler, readFilterRequest, request.typeName());
     }
 
     if (handler.safeToRead) {
       FileUtil.copy(buffered, output, -1);
       output.flush();
-      return new FilterStatus(parsed.charset, typeName);
+      return new FilterStatus(parsed.charset, request.typeName());
     }
 
     handler.throwUnsafeContentTypeException();
@@ -794,30 +842,36 @@ public class ContentFilter {
     return detectCharset(charsetBuffer, offset, handler, maybeCharset);
   }
 
+  @SuppressWarnings("resource")
   private static FilterStatus runReadFilter(
-      FilterMIMEType handler,
+      FilterMIMEType handler, ReadFilterRequest request, String typeName) throws IOException {
+    try {
+      handler.readFilter.readFilter(
+          request.input(),
+          request.output(),
+          request.charset(),
+          request.otherMimeTypeParams(),
+          request.schemeHostAndPort(),
+          request.filterCallback());
+    } catch (EOFException e) {
+      LOG.error("EOFException caught: {}", e, e);
+      throw new DataFilterException(l10n("EOFMessage"), l10n("EOFMessage"), l10n("EOFDescription"));
+    } finally {
+      if (request.filterCallback() != null) request.filterCallback().onFinished();
+    }
+    request.output().flush();
+    return new FilterStatus(request.charset(), typeName);
+  }
+
+  private record ParsedMime(String type, String charset, HashMap<String, String> otherParams) {}
+
+  private record ReadFilterRequest(
       InputStream input,
       OutputStream output,
       String charset,
       HashMap<String, String> otherMimeTypeParams,
       String schemeHostAndPort,
-      FilterCallback filterCallback,
-      String typeName)
-      throws IOException {
-    try {
-      handler.readFilter.readFilter(
-          input, output, charset, otherMimeTypeParams, schemeHostAndPort, filterCallback);
-    } catch (EOFException e) {
-      LOG.error("EOFException caught: {}", e, e);
-      throw new DataFilterException(l10n("EOFMessage"), l10n("EOFMessage"), l10n("EOFDescription"));
-    } finally {
-      if (filterCallback != null) filterCallback.onFinished();
-    }
-    output.flush();
-    return new FilterStatus(charset, typeName);
-  }
-
-  private record ParsedMime(String type, String charset, HashMap<String, String> otherParams) {}
+      FilterCallback filterCallback) {}
 
   /**
    * Detect a Byte Order Mark, a sequence of bytes which identifies a document as encoded with a

--- a/src/main/java/network/crypta/client/filter/ContentFilterCallbacks.java
+++ b/src/main/java/network/crypta/client/filter/ContentFilterCallbacks.java
@@ -1,0 +1,32 @@
+package network.crypta.client.filter;
+
+import java.net.URI;
+
+/**
+ * Collects optional callbacks and context used when filtering discovers or rewrites links.
+ *
+ * <p>The encapsulated data is passed to {@link GenericReadFilterCallback} so that the filter
+ * pipeline can report discovered URIs and perform tag substitutions consistently.
+ *
+ * @param baseURI base URI used to resolve relative references during filtering
+ * @param foundUriCallback callback notified for each discovered URI; may be {@code null}
+ * @param tagReplacerCallback callback used to replace or rewrite markup tokens; may be {@code null}
+ * @param linkFilterExceptionProvider provider for constructing link-filter exceptions; may be
+ *     {@code null}
+ */
+public record ContentFilterCallbacks(
+    URI baseURI,
+    FoundURICallback foundUriCallback,
+    TagReplacerCallback tagReplacerCallback,
+    LinkFilterExceptionProvider linkFilterExceptionProvider) {
+
+  /**
+   * Builds a {@link FilterCallback} that wraps the configured link processing callbacks.
+   *
+   * @return a {@link FilterCallback} suitable for {@link
+   *     ContentFilter#filter(ContentFilterRequest)}
+   */
+  public FilterCallback toFilterCallback() {
+    return new GenericReadFilterCallback(this);
+  }
+}

--- a/src/main/java/network/crypta/client/filter/ContentFilterRequest.java
+++ b/src/main/java/network/crypta/client/filter/ContentFilterRequest.java
@@ -1,0 +1,42 @@
+package network.crypta.client.filter;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Immutable request data for {@link ContentFilter#filter(ContentFilterRequest)}.
+ *
+ * <p>This record bundles the streams, MIME metadata, and optional callback used during filtering so
+ * callers can pass a single object through higher-level APIs.
+ *
+ * @param input source stream providing the original bytes; must remain readable for the duration of
+ *     filtering; not closed by the filter
+ * @param output destination stream receiving filtered bytes; the filter flushes but does not close
+ *     it
+ * @param typeName declared MIME type of {@code input}; parameters are allowed and will be parsed
+ * @param maybeCharset hint inherited from a referring document; used when the handler allows
+ *     charset inference and no BOM or explicit declaration is present; may be {@code null}
+ * @param schemeHostAndPort request authority (scheme, host, and port) for same-origin checks and
+ *     rewriting decisions
+ * @param filterCallback callback for link discovery, tag replacement, and completion; may be {@code
+ *     null}
+ */
+public record ContentFilterRequest(
+    InputStream input,
+    OutputStream output,
+    String typeName,
+    String maybeCharset,
+    String schemeHostAndPort,
+    FilterCallback filterCallback) {
+
+  /**
+   * Returns a copy of this request with the provided callback.
+   *
+   * @param callback callback to associate with the request; may be {@code null}
+   * @return a new {@link ContentFilterRequest} with the updated callback
+   */
+  public ContentFilterRequest withFilterCallback(FilterCallback callback) {
+    return new ContentFilterRequest(
+        input, output, typeName, maybeCharset, schemeHostAndPort, callback);
+  }
+}

--- a/src/main/java/network/crypta/client/filter/GenericReadFilterCallback.java
+++ b/src/main/java/network/crypta/client/filter/GenericReadFilterCallback.java
@@ -124,6 +124,20 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
   private static final String ERROR_KEY = "error";
 
   /**
+   * Creates a new callback from a {@link ContentFilterCallbacks} bundle.
+   *
+   * @param callbacks bundle describing the base URI and optional callbacks; must not be {@code
+   *     null}
+   */
+  public GenericReadFilterCallback(ContentFilterCallbacks callbacks) {
+    this(
+        callbacks.baseURI(),
+        callbacks.foundUriCallback(),
+        callbacks.tagReplacerCallback(),
+        callbacks.linkFilterExceptionProvider());
+  }
+
+  /**
    * Creates a new callback bound to a specific base {@link URI}. The base is used to resolve
    * relative references and may be updated later via a valid {@code <base href>} discovered during
    * processing.

--- a/src/main/java/network/crypta/clients/fcp/FilterMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FilterMessage.java
@@ -10,6 +10,8 @@ import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.ContentFilter.FilterStatus;
+import network.crypta.client.filter.ContentFilterCallbacks;
+import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.node.FSParseException;
@@ -349,16 +351,11 @@ public class FilterMessage extends DataCarryingMessage {
     URI fakeUri = resolveFilterUri();
     // ContentFilter currently only supports read filtering; update once write filtering is
     // available.
-    return ContentFilter.filter(
-        input,
-        output,
-        mimeType,
-        fakeUri,
-        null,
-        null,
-        null,
-        null,
-        clientContext.linkFilterExceptionProvider);
+    ContentFilterRequest request =
+        new ContentFilterRequest(input, output, mimeType, null, null, null);
+    ContentFilterCallbacks callbacks =
+        new ContentFilterCallbacks(fakeUri, null, null, clientContext.linkFilterExceptionProvider);
+    return ContentFilter.filter(request, callbacks);
   }
 
   private URI resolveFilterUri() {

--- a/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
@@ -12,6 +12,8 @@ import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.ContentFilter.FilterStatus;
+import network.crypta.client.filter.ContentFilterCallbacks;
+import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.l10n.NodeL10n;
@@ -531,16 +533,11 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
       throws IOException {
     validateOperation(operation);
     URI fakeUri = resolveFilterUri();
-    return ContentFilter.filter(
-        input,
-        output,
-        mimeType,
-        fakeUri,
-        null,
-        null,
-        null,
-        null,
-        core.getEndpoints().getToadletContainer());
+    ContentFilterRequest request =
+        new ContentFilterRequest(input, output, mimeType, null, null, null);
+    ContentFilterCallbacks callbacks =
+        new ContentFilterCallbacks(fakeUri, null, null, core.getEndpoints().getToadletContainer());
+    return ContentFilter.filter(request, callbacks);
   }
 
   private void validateOperation(FilterOperation operation) {

--- a/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
@@ -28,6 +28,8 @@ import network.crypta.client.events.ExpectedMIMEEvent;
 import network.crypta.client.events.SendingToNetworkEvent;
 import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.client.filter.ContentFilter;
+import network.crypta.client.filter.ContentFilterCallbacks;
+import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterMIMEType;
 import network.crypta.client.filter.UnknownContentTypeException;
 import network.crypta.keys.FreenetURI;
@@ -442,17 +444,13 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
     try (Bucket output = context.tempBucketFactory.makeBucket(-1);
         InputStream is = cachedData.getInputStream();
         OutputStream os = output.getOutputStream()) {
-      ContentFilter.filter(
-          is,
-          os,
-          fullMimeType,
-          uri.toURI("/"),
-          fctx.getSchemeHostAndPort(),
-          null,
-          null,
-          fctx.getCharset(),
-          // charset moved behind accessor for S1104
-          context.linkFilterExceptionProvider);
+      ContentFilterRequest request =
+          new ContentFilterRequest(
+              is, os, fullMimeType, fctx.getCharset(), fctx.getSchemeHostAndPort(), null);
+      ContentFilterCallbacks callbacks =
+          new ContentFilterCallbacks(
+              uri.toURI("/"), null, null, context.linkFilterExceptionProvider);
+      ContentFilter.filter(request, callbacks);
       // Since we are not re-using the data bucket, we can happily stay in the
       // FProxyFetchTracker.
       this.onSuccess(new FetchResult(new ClientMetadata(fullMimeType), output), null);

--- a/src/main/java/network/crypta/node/TextModeClientInterface.java
+++ b/src/main/java/network/crypta/node/TextModeClientInterface.java
@@ -44,6 +44,8 @@ import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.DumperSnoopMetadata;
 import network.crypta.client.events.EventDumper;
 import network.crypta.client.filter.ContentFilter;
+import network.crypta.client.filter.ContentFilterCallbacks;
+import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.clients.fcp.AddPeer;
 import network.crypta.crypt.RandomSource;
 import network.crypta.fs.AppEnv;
@@ -685,16 +687,12 @@ public class TextModeClientInterface implements Runnable {
     byte[] inBytes = content.getBytes(StandardCharsets.UTF_8);
     try (InputStream inputStream = new ByteArrayInputStream(inBytes);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-      ContentFilter.filter(
-          inputStream,
-          outputStream,
-          "text/html",
-          new URI(FILTER_BASE_URL),
-          null,
-          null,
-          null,
-          null,
-          core.getEndpoints().getToadletContainer());
+      ContentFilterRequest request =
+          new ContentFilterRequest(inputStream, outputStream, "text/html", null, null, null);
+      ContentFilterCallbacks callbacks =
+          new ContentFilterCallbacks(
+              new URI(FILTER_BASE_URL), null, null, core.getEndpoints().getToadletContainer());
+      ContentFilter.filter(request, callbacks);
       outsb.append(outputStream.toString(StandardCharsets.UTF_8));
     } catch (IOException e) {
       outsb.append("Bucket error?: ").append(e.getMessage());

--- a/src/main/java/network/crypta/pluginmanager/PluginRespirator.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginRespirator.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.UUID;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.filter.ContentFilterCallbacks;
 import network.crypta.client.filter.FilterCallback;
 import network.crypta.client.filter.GenericReadFilterCallback;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
@@ -137,7 +138,8 @@ public class PluginRespirator {
       ToadletContainer container = getToadletContainer();
       LinkFilterExceptionProvider provider =
           container instanceof LinkFilterExceptionProvider linkProvider ? linkProvider : null;
-      return new GenericReadFilterCallback(URIPreEncoder.encodeURI(path), null, null, provider);
+      return new GenericReadFilterCallback(
+          new ContentFilterCallbacks(URIPreEncoder.encodeURI(path), null, null, provider));
     } catch (URISyntaxException e) {
       throw new AssertionError("Invalid filter callback path: " + path, e);
     }

--- a/src/test/java/network/crypta/client/filter/CSSParserTest.java
+++ b/src/test/java/network/crypta/client/filter/CSSParserTest.java
@@ -2024,7 +2024,8 @@ class CSSParserTest {
   private String filter(String css) throws IOException, URISyntaxException {
     StringWriter w = new StringWriter();
     GenericReadFilterCallback cb =
-        new GenericReadFilterCallback(new URI(TEST_BASE_URI), null, null, null);
+        new GenericReadFilterCallback(
+            new ContentFilterCallbacks(new URI(TEST_BASE_URI), null, null, null));
     CSSParser p = new CSSParser(new StringReader(css), w, cb, CHARSET_UTF8, false, false);
     p.parse();
     return w.toString();
@@ -2266,16 +2267,11 @@ class CSSParserTest {
         ArrayBucket outputBucket = new ArrayBucket()) {
       try (InputStream inputStream = inputBucket.getInputStream();
           OutputStream outputStream = outputBucket.getOutputStream()) {
-        filterStatus =
-            ContentFilter.filter(
-                inputStream,
-                outputStream,
-                CONTENT_TYPE_CSS,
-                new URI(TEST_BASE_URI),
-                null,
-                null,
-                null,
-                null);
+        ContentFilterRequest request =
+            new ContentFilterRequest(inputStream, outputStream, CONTENT_TYPE_CSS, null, null, null);
+        ContentFilterCallbacks callbacks =
+            new ContentFilterCallbacks(new URI(TEST_BASE_URI), null, null, null);
+        filterStatus = ContentFilter.filter(request, callbacks);
       }
       filtered = new String(BucketTools.toByteArray(outputBucket), charset);
     }
@@ -2323,16 +2319,11 @@ class CSSParserTest {
         ArrayBucket outputBucket = new ArrayBucket()) {
       try (InputStream inputStream = inputBucket.getInputStream();
           OutputStream outputStream = outputBucket.getOutputStream()) {
-        filterStatus =
-            ContentFilter.filter(
-                inputStream,
-                outputStream,
-                CONTENT_TYPE_CSS,
-                new URI(TEST_BASE_URI),
-                null,
-                null,
-                null,
-                null);
+        ContentFilterRequest request =
+            new ContentFilterRequest(inputStream, outputStream, CONTENT_TYPE_CSS, null, null, null);
+        ContentFilterCallbacks callbacks =
+            new ContentFilterCallbacks(new URI(TEST_BASE_URI), null, null, null);
+        filterStatus = ContentFilter.filter(request, callbacks);
       }
       filtered = new String(BucketTools.toByteArray(outputBucket), charset);
     }
@@ -2380,16 +2371,12 @@ class CSSParserTest {
         ArrayBucket outputBucket = new ArrayBucket()) {
       try (InputStream inputStream = inputBucket.getInputStream();
           OutputStream outputStream = outputBucket.getOutputStream()) {
-        filterStatus =
-            ContentFilter.filter(
-                inputStream,
-                outputStream,
-                CONTENT_TYPE_CSS,
-                new URI(TEST_BASE_URI),
-                null,
-                null,
-                null,
-                charset);
+        ContentFilterRequest request =
+            new ContentFilterRequest(
+                inputStream, outputStream, CONTENT_TYPE_CSS, charset, null, null);
+        ContentFilterCallbacks callbacks =
+            new ContentFilterCallbacks(new URI(TEST_BASE_URI), null, null, null);
+        filterStatus = ContentFilter.filter(request, callbacks);
       }
       filtered = new String(BucketTools.toByteArray(outputBucket), charset);
     }

--- a/src/test/java/network/crypta/client/filter/ContentFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/ContentFilterTest.java
@@ -88,7 +88,10 @@ class ContentFilterTest {
         AutoFreeArrayBucket output = new AutoFreeArrayBucket()) {
       try (OutputStream outputStream = output.getOutputStream();
           InputStream inputStream = input.getInputStream()) {
-        ContentFilter.filter(inputStream, outputStream, typeName, baseURI, null, null, null, null);
+        ContentFilterRequest request =
+            new ContentFilterRequest(inputStream, outputStream, typeName, null, null, null);
+        ContentFilterCallbacks callbacks = new ContentFilterCallbacks(baseURI, null, null, null);
+        ContentFilter.filter(request, callbacks);
       }
       return output.toString();
     }
@@ -374,7 +377,8 @@ class ContentFilterTest {
           AutoFreeArrayBucket out = new AutoFreeArrayBucket()) {
         fo =
             ContentFilter.filter(
-                in.getInputStream(), out.getOutputStream(), TEXT_HTML, null, null, null);
+                new ContentFilterRequest(
+                    in.getInputStream(), out.getOutputStream(), TEXT_HTML, null, null, null));
         fos.write(out.toByteArray());
       }
       failures.add(
@@ -779,7 +783,8 @@ class ContentFilterTest {
 
     // Act
     FilterStatus status =
-        ContentFilter.filter(in, out, typeName, /*maybeCharset*/ null, /*scheme*/ null, null);
+        ContentFilter.filter(
+            new ContentFilterRequest(in, out, typeName, /*maybeCharset*/ null, null, null));
 
     // Assert
     assertArrayEquals(input, out.toByteArray());
@@ -796,7 +801,8 @@ class ContentFilterTest {
         UnknownContentTypeException.class,
         () ->
             ContentFilter.filter(
-                in, out, "application/x-unknown-type", /*maybeCharset*/ null, null, null));
+                new ContentFilterRequest(
+                    in, out, "application/x-unknown-type", /*maybeCharset*/ null, null, null)));
   }
 
   @Test
@@ -805,7 +811,10 @@ class ContentFilterTest {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     assertThrows(
         KnownUnsafeContentTypeException.class,
-        () -> ContentFilter.filter(in, out, "application/pdf", /*maybeCharset*/ null, null, null));
+        () ->
+            ContentFilter.filter(
+                new ContentFilterRequest(
+                    in, out, "application/pdf", /*maybeCharset*/ null, null, null)));
   }
 
   @Test
@@ -848,7 +857,8 @@ class ContentFilterTest {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
 
     // Act
-    FilterStatus status = ContentFilter.filter(in, out, typeName, null, null, null);
+    FilterStatus status =
+        ContentFilter.filter(new ContentFilterRequest(in, out, typeName, null, null, null));
 
     // Assert: data copied and charset detected via extractor
     assertArrayEquals(payload, out.toByteArray());

--- a/src/test/java/network/crypta/client/filter/GenericReadFilterCallbackTest.java
+++ b/src/test/java/network/crypta/client/filter/GenericReadFilterCallbackTest.java
@@ -43,7 +43,8 @@ class GenericReadFilterCallbackTest {
 
   private GenericReadFilterCallback newCallback(String base) throws URISyntaxException {
     return new GenericReadFilterCallback(
-        new URI(base), foundURICallback, tagReplacerCallback, linkFilterExceptionProvider);
+        new ContentFilterCallbacks(
+            new URI(base), foundURICallback, tagReplacerCallback, linkFilterExceptionProvider));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
@@ -219,16 +219,11 @@ class HTMLFilterTest {
     String html = "<!DOCTYPE html><html><body><a href=\"/x\" >Hello</a></body></html>";
     ByteArrayInputStream in = new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8));
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    assertDoesNotThrow(
-        () ->
-            ContentFilter.filter(
-                in,
-                out,
-                "text/html; charset=UTF-8",
-                new java.net.URI("http://example.com/"),
-                "http://example.com",
-                null,
-                null,
-                "UTF-8"));
+    ContentFilterRequest request =
+        new ContentFilterRequest(
+            in, out, "text/html; charset=UTF-8", "UTF-8", "http://example.com", null);
+    ContentFilterCallbacks callbacks =
+        new ContentFilterCallbacks(new java.net.URI("http://example.com/"), null, null, null);
+    assertDoesNotThrow(() -> ContentFilter.filter(request, callbacks));
   }
 }

--- a/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
@@ -223,7 +223,7 @@ class HTMLFilterTest {
         new ContentFilterRequest(
             in, out, "text/html; charset=UTF-8", "UTF-8", "http://example.com", null);
     ContentFilterCallbacks callbacks =
-        new ContentFilterCallbacks(new java.net.URI("http://example.com/"), null, null, null);
+        new ContentFilterCallbacks(java.net.URI.create("http://example.com/"), null, null, null);
     assertDoesNotThrow(() -> ContentFilter.filter(request, callbacks));
   }
 }

--- a/src/test/java/network/crypta/client/filter/M3UFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/M3UFilterTest.java
@@ -52,7 +52,8 @@ class M3UFilterTest {
             StandardCharsets.UTF_8.name(),
             Map.of(),
             SCHEME_HOST_PORT,
-            new GenericReadFilterCallback(new URI(BASE_URI), null, null, null));
+            new GenericReadFilterCallback(
+                new ContentFilterCallbacks(new URI(BASE_URI), null, null, null)));
 
         String result = normalizeEol(processed.toString());
         assertEquals(

--- a/src/test/java/network/crypta/client/filter/TagVerifierTest.java
+++ b/src/test/java/network/crypta/client/filter/TagVerifierTest.java
@@ -35,7 +35,8 @@ class TagVerifierTest {
             null,
             null,
             "utf-8",
-            new GenericReadFilterCallback(new URI(ALT_BASE_URI), null, null, null),
+            new GenericReadFilterCallback(
+                new ContentFilterCallbacks(new URI(ALT_BASE_URI), null, null, null)),
             false);
   }
 

--- a/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
@@ -13,13 +13,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.ContentFilter.FilterStatus;
+import network.crypta.client.filter.ContentFilterCallbacks;
+import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.node.Node;
@@ -210,19 +211,13 @@ class FilterMessageTest {
           .when(
               () ->
                   ContentFilter.filter(
-                      Mockito.any(InputStream.class),
-                      Mockito.any(OutputStream.class),
-                      Mockito.eq("text/plain"),
-                      Mockito.any(URI.class),
-                      Mockito.isNull(),
-                      Mockito.isNull(),
-                      Mockito.isNull(),
-                      Mockito.isNull(),
-                      Mockito.isNull()))
+                      Mockito.any(ContentFilterRequest.class),
+                      Mockito.any(ContentFilterCallbacks.class)))
           .thenAnswer(
               invocation -> {
-                InputStream input = invocation.getArgument(0);
-                OutputStream output = invocation.getArgument(1);
+                ContentFilterRequest request = invocation.getArgument(0);
+                InputStream input = request.input();
+                OutputStream output = request.output();
                 output.write(input.readAllBytes());
                 return status;
               });
@@ -279,15 +274,8 @@ class FilterMessageTest {
           .when(
               () ->
                   ContentFilter.filter(
-                      Mockito.any(InputStream.class),
-                      Mockito.any(OutputStream.class),
-                      Mockito.eq("text/plain"),
-                      Mockito.any(URI.class),
-                      Mockito.isNull(),
-                      Mockito.isNull(),
-                      Mockito.isNull(),
-                      Mockito.isNull(),
-                      Mockito.isNull()))
+                      Mockito.any(ContentFilterRequest.class),
+                      Mockito.any(ContentFilterCallbacks.class)))
           .thenThrow(unsafe);
 
       message.run(handler, Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS));

--- a/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
@@ -26,6 +26,8 @@ import java.nio.charset.StandardCharsets;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.ContentFilter.FilterStatus;
+import network.crypta.client.filter.ContentFilterCallbacks;
+import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.node.ClientEndpoints;
@@ -117,10 +119,11 @@ class ContentFilterToadletTest {
             .when(
                 () ->
                     ContentFilter.filter(
-                        any(), any(), anyString(), any(), any(), any(), any(), any(), any()))
+                        any(ContentFilterRequest.class), any(ContentFilterCallbacks.class)))
             .thenAnswer(
                 invocation -> {
-                  OutputStream output = invocation.getArgument(1);
+                  ContentFilterRequest request = invocation.getArgument(0);
+                  OutputStream output = request.output();
                   output.write(filtered);
                   try {
                     return newFilterStatus("utf-8", "text/plain");
@@ -161,10 +164,11 @@ class ContentFilterToadletTest {
             .when(
                 () ->
                     ContentFilter.filter(
-                        any(), any(), anyString(), any(), any(), any(), any(), any(), any()))
+                        any(ContentFilterRequest.class), any(ContentFilterCallbacks.class)))
             .thenAnswer(
                 invocation -> {
-                  OutputStream output = invocation.getArgument(1);
+                  ContentFilterRequest request = invocation.getArgument(0);
+                  OutputStream output = request.output();
                   output.write(filtered);
                   try {
                     return newFilterStatus(null, "application/octet-stream");
@@ -234,7 +238,7 @@ class ContentFilterToadletTest {
             .when(
                 () ->
                     ContentFilter.filter(
-                        any(), any(), anyString(), any(), any(), any(), any(), any(), any()))
+                        any(ContentFilterRequest.class), any(ContentFilterCallbacks.class)))
             .thenThrow(
                 new UnsafeContentTypeException() {
                   @Serial private static final long serialVersionUID = 1L;


### PR DESCRIPTION
## Summary
- introduce ContentFilterRequest and ContentFilterCallbacks to bundle filter inputs and callbacks
- add request-based ContentFilter overloads and delegate legacy overloads
- update call sites and tests to use the new request/callback bundles

## Testing
- not run (formatting only: `./gradlew spotlessApply`)
