### PR TITLE
refactor(filter): split MIME type metadata

### DIFF
--- a/src/main/java/network/crypta/client/filter/ContentFilter.java
+++ b/src/main/java/network/crypta/client/filter/ContentFilter.java
@@ -82,147 +82,72 @@ public class ContentFilter {
     // Plain text
     register(
         new FilterMIMEType(
-            "text/plain",
-            "txt",
-            new String[0],
-            new String[] {"text", "pot"},
-            true,
-            true,
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            l10n("textPlainReadAdvice"),
-            true,
-            "US-ASCII",
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "text/plain", "txt", new String[0], new String[] {"text", "pot"}),
+            new FilterMIMETypeSafety(true, true, null, l10n("textPlainReadAdvice")),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(true, "US-ASCII", null, false)));
 
     // Images
     // GIF - has a filter
     register(
         new FilterMIMEType(
-            "image/gif",
-            "gif",
-            new String[0],
-            new String[0],
-            true,
-            false,
-            new GIFFilter(),
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            l10n("imageGifReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames("image/gif", "gif", new String[0], new String[0]),
+            new FilterMIMETypeSafety(true, false, new GIFFilter(), l10n("imageGifReadAdvice")),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     // JPEG - has a filter
     register(
         new FilterMIMEType(
-            "image/jpeg",
-            "jpeg",
-            new String[0],
-            new String[] {"jpg"},
-            true,
-            false,
-            new JPEGFilter(true, true),
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            l10n("imageJpegReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames("image/jpeg", "jpeg", new String[0], new String[] {"jpg"}),
+            new FilterMIMETypeSafety(
+                true, false, new JPEGFilter(true, true), l10n("imageJpegReadAdvice")),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     // PNG - has a filter
     register(
         new FilterMIMEType(
-            "image/png",
-            "png",
-            new String[] {"image/x-png"},
-            new String[0],
-            true,
-            false,
-            new PNGFilter(true, true, true),
-            false,
-            false,
-            false,
-            false,
-            true,
-            false,
-            l10n("imagePngReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "image/png", "png", new String[] {"image/x-png"}, new String[0]),
+            new FilterMIMETypeSafety(
+                true, false, new PNGFilter(true, true, true), l10n("imagePngReadAdvice")),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, true, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     // BMP - has a filter
     // Reference: http://filext.com/file-extension/BMP
     register(
         new FilterMIMEType(
-            "image/bmp",
-            "bmp",
-            new String[] {
-              "image/x-bmp",
-              "image/x-bitmap",
-              "image/x-xbitmap",
-              "image/x-win-bitmap",
-              "image/x-windows-bmp",
-              "image/ms-bmp",
-              "image/x-ms-bmp",
-              "application/bmp",
-              "application/x-bmp",
-              "application/x-win-bitmap"
-            },
-            new String[0],
-            true,
-            false,
-            new BMPFilter(),
-            false,
-            false,
-            false,
-            false,
-            true,
-            false,
-            l10n("imageBMPReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "image/bmp",
+                "bmp",
+                new String[] {
+                  "image/x-bmp",
+                  "image/x-bitmap",
+                  "image/x-xbitmap",
+                  "image/x-win-bitmap",
+                  "image/x-windows-bmp",
+                  "image/ms-bmp",
+                  "image/x-ms-bmp",
+                  "application/bmp",
+                  "application/x-bmp",
+                  "application/x-win-bitmap"
+                },
+                new String[0]),
+            new FilterMIMETypeSafety(true, false, new BMPFilter(), l10n("imageBMPReadAdvice")),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, true, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     // WEBP - has a filter
     register(
         new FilterMIMEType(
-            "image/webp",
-            "webp",
-            new String[] {"image/webp"},
-            new String[0],
-            true,
-            false,
-            new WebPFilter(),
-            false,
-            false,
-            false,
-            false,
-            true,
-            false,
-            l10n("imageWebPReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "image/webp", "webp", new String[] {"image/webp"}, new String[0]),
+            new FilterMIMETypeSafety(true, false, new WebPFilter(), l10n("imageWebPReadAdvice")),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, true, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     // Audio
     /* Ogg - has a filter
@@ -233,24 +158,14 @@ public class ContentFilter {
      */
     register(
         new FilterMIMEType(
-            "application/ogg",
-            "ogx",
-            new String[] {"video/ogg", "audio/ogg"},
-            new String[] {"ogg", "oga", "ogv"},
-            true,
-            false,
-            new OggFilter(),
-            true,
-            true,
-            false,
-            true,
-            false,
-            false,
-            l10n("containerOggReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "application/ogg",
+                "ogx",
+                new String[] {"video/ogg", "audio/ogg"},
+                new String[] {"ogg", "oga", "ogv"}),
+            new FilterMIMETypeSafety(true, false, new OggFilter(), l10n("containerOggReadAdvice")),
+            new FilterMIMETypeDangerousFlags(true, true, false, true, false, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     /* FLAC - has a filter
      * Lossless audio format. This data is sometimes encapsulated inside
@@ -260,51 +175,28 @@ public class ContentFilter {
      */
     register(
         new FilterMIMEType(
-            "audio/flac",
-            "flac",
-            new String[] {"application/x-flac"},
-            new String[0],
-            true,
-            true,
-            new FlacFilter(),
-            true,
-            true,
-            false,
-            true,
-            false,
-            false,
-            l10n("audioFLACReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "audio/flac", "flac", new String[] {"application/x-flac"}, new String[0]),
+            new FilterMIMETypeSafety(true, true, new FlacFilter(), l10n("audioFLACReadAdvice")),
+            new FilterMIMETypeDangerousFlags(true, true, false, true, false, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     // M3U - strict filter
     register(
         new FilterMIMEType(
-            "audio/mpegurl",
-            "m3u",
-            new String[] {
-              "application/vnd.apple.mpegurl",
-              "application/mpegurl",
-              "application/x-mpegurl",
-              "audio/x-mpegurl"
-            },
-            new String[] {"m3u8"},
-            false,
-            false,
-            new M3UFilter(),
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            l10n("audioM3UReadAdvice"),
-            false,
-            "utf-8",
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "audio/mpegurl",
+                "m3u",
+                new String[] {
+                  "application/vnd.apple.mpegurl",
+                  "application/mpegurl",
+                  "application/x-mpegurl",
+                  "audio/x-mpegurl"
+                },
+                new String[] {"m3u8"}),
+            new FilterMIMETypeSafety(false, false, new M3UFilter(), l10n("audioM3UReadAdvice")),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(false, "utf-8", null, false)));
 
     /* MP3
      *
@@ -312,55 +204,35 @@ public class ContentFilter {
      */
     register(
         new FilterMIMEType(
-            "audio/mpeg",
-            "mp3",
-            new String[] {
-              "audio/mp3",
-              "audio/x-mp3",
-              "audio/x-mpeg",
-              "audio/mpeg3",
-              "audio/x-mpeg3",
-              "audio/mpg",
-              "audio/x-mpg",
-              "audio/mpegaudio"
-            },
-            new String[0],
-            true,
-            false,
-            new MP3Filter(),
-            true,
-            true,
-            false,
-            true,
-            false,
-            false,
-            l10n("audioMP3ReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "audio/mpeg",
+                "mp3",
+                new String[] {
+                  "audio/mp3",
+                  "audio/x-mp3",
+                  "audio/x-mpeg",
+                  "audio/mpeg3",
+                  "audio/x-mpeg3",
+                  "audio/mpg",
+                  "audio/x-mpg",
+                  "audio/mpegaudio"
+                },
+                new String[0]),
+            new FilterMIMETypeSafety(true, false, new MP3Filter(), l10n("audioMP3ReadAdvice")),
+            new FilterMIMETypeDangerousFlags(true, true, false, true, false, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     // WAV - has a filter
     register(
         new FilterMIMEType(
-            "audio/vnd.wave",
-            "wav",
-            new String[] {"audio/x-wav", "audio/wav", "audio/wave"},
-            new String[0],
-            true,
-            true,
-            new WAVFilter(),
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            l10n("audioWAVReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "audio/vnd.wave",
+                "wav",
+                new String[] {"audio/x-wav", "audio/wav", "audio/wave"},
+                new String[0]),
+            new FilterMIMETypeSafety(true, true, new WAVFilter(), l10n("audioWAVReadAdvice")),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     // ICO needs filtering.
     // Format is not the same as BMP iirc.
@@ -372,68 +244,33 @@ public class ContentFilter {
     // PDF - very dangerous - ideally we would have a filter as this is a very common format.
     register(
         new FilterMIMEType(
-            "application/pdf",
-            "pdf",
-            new String[] {"application/x-pdf"},
-            new String[0],
-            false,
-            false,
-            null,
-            true,
-            true,
-            true,
-            false,
-            true,
-            true,
-            l10n("applicationPdfReadAdvice"),
-            false,
-            null,
-            null,
-            false));
+            new FilterMIMETypeNames(
+                "application/pdf", "pdf", new String[] {"application/x-pdf"}, new String[0]),
+            new FilterMIMETypeSafety(false, false, null, l10n("applicationPdfReadAdvice")),
+            new FilterMIMETypeDangerousFlags(true, true, true, false, true, true),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false)));
 
     // HTML - dangerous if not filtered
     register(
         new FilterMIMEType(
-            HTML_MIME_TYPES[0],
-            "html",
-            Arrays.copyOfRange(HTML_MIME_TYPES, 1, HTML_MIME_TYPES.length),
-            new String[] {"htm"},
-            false,
-            false /* maybe? */,
-            new HTMLFilter(),
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            l10n("textHtmlReadAdvice"),
-            true,
-            "iso-8859-1",
-            new HTMLFilter(),
-            false));
+            new FilterMIMETypeNames(
+                HTML_MIME_TYPES[0],
+                "html",
+                Arrays.copyOfRange(HTML_MIME_TYPES, 1, HTML_MIME_TYPES.length),
+                new String[] {"htm"}),
+            new FilterMIMETypeSafety(
+                false, false /* maybe? */, new HTMLFilter(), l10n("textHtmlReadAdvice")),
+            new FilterMIMETypeDangerousFlags(true, true, true, true, true, true),
+            new FilterMIMETypeCharsetPolicy(true, "iso-8859-1", new HTMLFilter(), false)));
 
     // CSS - dangerous if not filtered, not sure about the filter
     register(
         new FilterMIMEType(
-            "text/css",
-            "css",
-            new String[0],
-            new String[0],
-            false,
-            false /* unknown */,
-            new CSSReadFilter(),
-            true,
-            true,
-            true,
-            true,
-            true,
-            false,
-            l10n("textCssReadAdvice"),
-            true,
-            "utf-8",
-            new CSSReadFilter(),
-            true));
+            new FilterMIMETypeNames("text/css", "css", new String[0], new String[0]),
+            new FilterMIMETypeSafety(
+                false, false /* unknown */, new CSSReadFilter(), l10n("textCssReadAdvice")),
+            new FilterMIMETypeDangerousFlags(true, true, true, true, true, false),
+            new FilterMIMETypeCharsetPolicy(true, "utf-8", new CSSReadFilter(), true)));
   }
 
   private static String l10n(String key) {

--- a/src/main/java/network/crypta/client/filter/FilterMIMEType.java
+++ b/src/main/java/network/crypta/client/filter/FilterMIMEType.java
@@ -201,42 +201,28 @@ public class FilterMIMEType {
   public final boolean useMaybeCharset;
 
   FilterMIMEType(
-      String type,
-      String ext,
-      String[] extraTypes,
-      String[] extraExts,
-      boolean safeToRead,
-      boolean safeToWrite,
-      ContentDataFilter readFilter,
-      boolean dangerousLinks,
-      boolean dangerousInlines,
-      boolean dangerousScripting,
-      boolean dangerousReadMetadata,
-      boolean dangerousWriteMetadata,
-      boolean dangerousToWriteEvenWithFilter,
-      String readDescription,
-      boolean takesACharset,
-      String defaultCharset,
-      CharsetExtractor charsetExtractor,
-      boolean useMaybeCharset) {
-    this.primaryMimeType = type;
-    this.primaryExtension = ext;
-    this.alternateMimeTypes = extraTypes;
-    this.alternateExtensions = extraExts;
-    this.safeToRead = safeToRead;
-    this.safeToWrite = safeToWrite;
-    this.readFilter = readFilter;
-    this.dangerousLinks = dangerousLinks;
-    this.dangerousInlines = dangerousInlines;
-    this.dangerousScripting = dangerousScripting;
-    this.dangerousReadMetadata = dangerousReadMetadata;
-    this.dangerousWriteMetadata = dangerousWriteMetadata;
-    this.dangerousToWriteEvenWithFilter = dangerousToWriteEvenWithFilter;
-    this.readDescription = readDescription;
-    this.takesACharset = takesACharset;
-    this.defaultCharset = defaultCharset;
-    this.charsetExtractor = charsetExtractor;
-    this.useMaybeCharset = useMaybeCharset;
+      FilterMIMETypeNames names,
+      FilterMIMETypeSafety safety,
+      FilterMIMETypeDangerousFlags dangerousFlags,
+      FilterMIMETypeCharsetPolicy charsetPolicy) {
+    this.primaryMimeType = names.primaryMimeType();
+    this.primaryExtension = names.primaryExtension();
+    this.alternateMimeTypes = names.alternateMimeTypes();
+    this.alternateExtensions = names.alternateExtensions();
+    this.safeToRead = safety.safeToRead();
+    this.safeToWrite = safety.safeToWrite();
+    this.readFilter = safety.readFilter();
+    this.dangerousLinks = dangerousFlags.dangerousLinks();
+    this.dangerousInlines = dangerousFlags.dangerousInlines();
+    this.dangerousScripting = dangerousFlags.dangerousScripting();
+    this.dangerousReadMetadata = dangerousFlags.dangerousReadMetadata();
+    this.dangerousWriteMetadata = dangerousFlags.dangerousWriteMetadata();
+    this.dangerousToWriteEvenWithFilter = dangerousFlags.dangerousToWriteEvenWithFilter();
+    this.readDescription = safety.readDescription();
+    this.takesACharset = charsetPolicy.takesACharset();
+    this.defaultCharset = charsetPolicy.defaultCharset();
+    this.charsetExtractor = charsetPolicy.charsetExtractor();
+    this.useMaybeCharset = charsetPolicy.useMaybeCharset();
   }
 
   /**

--- a/src/main/java/network/crypta/client/filter/FilterMIMETypeCharsetPolicy.java
+++ b/src/main/java/network/crypta/client/filter/FilterMIMETypeCharsetPolicy.java
@@ -1,0 +1,18 @@
+package network.crypta.client.filter;
+
+/**
+ * Charset handling rules for a MIME type.
+ *
+ * <p>This record captures whether a charset parameter is accepted, what default to assume when none
+ * is declared, and the optional extractor used for in-band detection.
+ *
+ * @param takesACharset whether the MIME type accepts a charset parameter
+ * @param defaultCharset fallback charset when no explicit declaration is present
+ * @param charsetExtractor optional extractor used to infer a charset from a byte prefix
+ * @param useMaybeCharset whether to fall back to a referring document's charset hint
+ */
+public record FilterMIMETypeCharsetPolicy(
+    boolean takesACharset,
+    String defaultCharset,
+    CharsetExtractor charsetExtractor,
+    boolean useMaybeCharset) {}

--- a/src/main/java/network/crypta/client/filter/FilterMIMETypeDangerousFlags.java
+++ b/src/main/java/network/crypta/client/filter/FilterMIMETypeDangerousFlags.java
@@ -1,0 +1,22 @@
+package network.crypta.client.filter;
+
+/**
+ * Flags describing content risks associated with a MIME type.
+ *
+ * <p>Each flag indicates whether a particular content aspect is considered dangerous even after
+ * filtering, allowing higher-level callers to enforce additional policy.
+ *
+ * @param dangerousLinks whether embedded links are considered risky
+ * @param dangerousInlines whether inline external references are considered risky
+ * @param dangerousScripting whether scripts or active content are considered risky
+ * @param dangerousReadMetadata whether metadata is risky to read
+ * @param dangerousWriteMetadata whether metadata is risky to write
+ * @param dangerousToWriteEvenWithFilter whether writing remains unsafe even after filtering
+ */
+public record FilterMIMETypeDangerousFlags(
+    boolean dangerousLinks,
+    boolean dangerousInlines,
+    boolean dangerousScripting,
+    boolean dangerousReadMetadata,
+    boolean dangerousWriteMetadata,
+    boolean dangerousToWriteEvenWithFilter) {}

--- a/src/main/java/network/crypta/client/filter/FilterMIMETypeNames.java
+++ b/src/main/java/network/crypta/client/filter/FilterMIMETypeNames.java
@@ -1,0 +1,70 @@
+package network.crypta.client.filter;
+
+import java.util.Arrays;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Identifies a MIME type and its common filename extensions.
+ *
+ * <p>This record bundles the canonical type string with any alternate type aliases and filename
+ * extensions so callers can pass a single immutable object when registering handlers.
+ *
+ * @param primaryMimeType canonical MIME type name (for example, {@code "text/html"})
+ * @param primaryExtension primary filename extension without the leading dot (for example, {@code
+ *     "html"})
+ * @param alternateMimeTypes additional MIME type aliases accepted for this handler
+ * @param alternateExtensions additional filename extensions associated with the type
+ */
+public record FilterMIMETypeNames(
+    String primaryMimeType,
+    String primaryExtension,
+    String[] alternateMimeTypes,
+    String[] alternateExtensions) {
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj
+        instanceof
+        FilterMIMETypeNames(
+            String otherPrimaryMimeType,
+            String otherPrimaryExtension,
+            String[] otherAlternateMimeTypes,
+            String[] otherAlternateExtensions))) {
+      return false;
+    }
+    return Objects.equals(primaryMimeType, otherPrimaryMimeType)
+        && Objects.equals(primaryExtension, otherPrimaryExtension)
+        && Arrays.equals(alternateMimeTypes, otherAlternateMimeTypes)
+        && Arrays.equals(alternateExtensions, otherAlternateExtensions);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(primaryMimeType, primaryExtension);
+    result = 31 * result + Arrays.hashCode(alternateMimeTypes);
+    result = 31 * result + Arrays.hashCode(alternateExtensions);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "FilterMIMETypeNames["
+        + "primaryMimeType="
+        + primaryMimeType
+        + ", primaryExtension="
+        + primaryExtension
+        + ", alternateMimeTypes="
+        + formatArray(alternateMimeTypes)
+        + ", alternateExtensions="
+        + formatArray(alternateExtensions)
+        + "]";
+  }
+
+  private static String formatArray(String[] values) {
+    return values == null ? "null" : Arrays.toString(values);
+  }
+}

--- a/src/main/java/network/crypta/client/filter/FilterMIMETypeSafety.java
+++ b/src/main/java/network/crypta/client/filter/FilterMIMETypeSafety.java
@@ -1,0 +1,18 @@
+package network.crypta.client.filter;
+
+/**
+ * Describes baseline safety characteristics for a MIME type.
+ *
+ * <p>This record captures whether a type is safe to read or write directly and the optional
+ * sanitizing filter and description used for user-facing diagnostics.
+ *
+ * @param safeToRead whether bytes may be delivered without a filter
+ * @param safeToWrite whether bytes may be persisted or emitted without additional handling
+ * @param readFilter optional stream filter that sanitizes untrusted input
+ * @param readDescription human-readable description of read-side handling
+ */
+public record FilterMIMETypeSafety(
+    boolean safeToRead,
+    boolean safeToWrite,
+    ContentDataFilter readFilter,
+    String readDescription) {}

--- a/src/test/java/network/crypta/client/filter/ContentFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/ContentFilterTest.java
@@ -831,24 +831,14 @@ class ContentFilterTest {
     RecordingEchoFilter echo = new RecordingEchoFilter();
     FilterMIMEType mt =
         new FilterMIMEType(
-            "application/x-unit-test",
-            "ut",
-            new String[0],
-            new String[0],
-            /*safeToRead*/ false,
-            /*safeToWrite*/ false,
-            echo,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            "desc",
-            /*takesACharset*/ true,
-            /*defaultCharset*/ WINDOWS_1252,
-            extractor,
-            /*useMaybeCharset*/ false);
+            new FilterMIMETypeNames("application/x-unit-test", "ut", new String[0], new String[0]),
+            new FilterMIMETypeSafety(/*safeToRead*/ false, /*safeToWrite*/ false, echo, "desc"),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(
+                /*takesACharset*/ true, /*defaultCharset*/
+                WINDOWS_1252,
+                extractor,
+                /*useMaybeCharset*/ false));
     ContentFilter.register(mt);
 
     String typeName = "application/x-unit-test; foo=bar; boundary=abc";
@@ -882,24 +872,10 @@ class ContentFilterTest {
     byte[] utf8 = new byte[] {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, 'x'};
     FilterMIMEType dummy =
         new FilterMIMEType(
-            "text/x-dummy",
-            "dum",
-            new String[0],
-            new String[0],
-            true,
-            true,
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            "desc",
-            true,
-            null,
-            null,
-            false);
+            new FilterMIMETypeNames("text/x-dummy", "dum", new String[0], new String[0]),
+            new FilterMIMETypeSafety(true, true, null, "desc"),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(true, null, null, false));
     assertEquals("UTF-8", ContentFilter.detectCharset(utf8, utf8.length, dummy, null));
 
     // UTF-16LE BOM
@@ -921,24 +897,10 @@ class ContentFilterTest {
     byte[] bad = new byte[] {0, 0, (byte) 0xFF, (byte) 0xFE, 'x'};
     FilterMIMEType dummy =
         new FilterMIMEType(
-            "text/x-dummy",
-            "dum",
-            new String[0],
-            new String[0],
-            true,
-            true,
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            "desc",
-            true,
-            null,
-            null,
-            false);
+            new FilterMIMETypeNames("text/x-dummy", "dum", new String[0], new String[0]),
+            new FilterMIMETypeSafety(true, true, null, "desc"),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(true, null, null, false));
     assertThrows(
         UnsupportedCharsetInFilterException.class,
         () -> ContentFilter.detectCharset(bad, bad.length, dummy, null));

--- a/src/test/java/network/crypta/client/filter/FilterMIMETypeTest.java
+++ b/src/test/java/network/crypta/client/filter/FilterMIMETypeTest.java
@@ -51,24 +51,16 @@ class FilterMIMETypeTest {
     // Act
     FilterMIMEType mt =
         new FilterMIMEType(
-            type,
-            ext,
-            extraTypes,
-            extraExts,
-            safeToRead,
-            safeToWrite,
-            null,
-            dangerousLinks,
-            dangerousInlines,
-            dangerousScripting,
-            dangerousReadMetadata,
-            dangerousWriteMetadata,
-            dangerousToWriteEvenWithFilter,
-            readDescription,
-            takesACharset,
-            defaultCharset,
-            null,
-            useMaybeCharset);
+            new FilterMIMETypeNames(type, ext, extraTypes, extraExts),
+            new FilterMIMETypeSafety(safeToRead, safeToWrite, null, readDescription),
+            new FilterMIMETypeDangerousFlags(
+                dangerousLinks,
+                dangerousInlines,
+                dangerousScripting,
+                dangerousReadMetadata,
+                dangerousWriteMetadata,
+                dangerousToWriteEvenWithFilter),
+            new FilterMIMETypeCharsetPolicy(takesACharset, defaultCharset, null, useMaybeCharset));
 
     // Assert
     assertEquals(type, mt.primaryMimeType);
@@ -97,8 +89,10 @@ class FilterMIMETypeTest {
     String mime = "text/html<svg>"; // include characters that require HTML escaping
     FilterMIMEType mt =
         new FilterMIMEType(
-            mime, "html", null, null, false, false, null, false, false, true, false, false, false,
-            "desc", true, "UTF-8", null, false);
+            new FilterMIMETypeNames(mime, "html", null, null),
+            new FilterMIMETypeSafety(false, false, null, "desc"),
+            new FilterMIMETypeDangerousFlags(false, false, true, false, false, false),
+            new FilterMIMETypeCharsetPolicy(true, "UTF-8", null, false));
 
     // Act + Assert
     KnownUnsafeContentTypeException ex =
@@ -131,24 +125,10 @@ class FilterMIMETypeTest {
     // Arrange: all flags false
     FilterMIMEType mt =
         new FilterMIMEType(
-            "application/x-none",
-            "bin",
-            null,
-            null,
-            false,
-            false,
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            "",
-            false,
-            null,
-            null,
-            false);
+            new FilterMIMETypeNames("application/x-none", "bin", null, null),
+            new FilterMIMETypeSafety(false, false, null, ""),
+            new FilterMIMETypeDangerousFlags(false, false, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false));
 
     // Act
     KnownUnsafeContentTypeException ex =
@@ -165,24 +145,10 @@ class FilterMIMETypeTest {
     // Arrange: scripting true, others false (reflects current implementation logic)
     FilterMIMEType mt =
         new FilterMIMEType(
-            "application/x-scr",
-            "scr",
-            null,
-            null,
-            false,
-            false,
-            null,
-            false,
-            false,
-            true,
-            false,
-            false,
-            false,
-            "",
-            false,
-            null,
-            null,
-            false);
+            new FilterMIMETypeNames("application/x-scr", "scr", null, null),
+            new FilterMIMETypeSafety(false, false, null, ""),
+            new FilterMIMETypeDangerousFlags(false, false, true, false, false, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false));
 
     KnownUnsafeContentTypeException ex =
         assertThrows(KnownUnsafeContentTypeException.class, mt::throwUnsafeContentTypeException);
@@ -203,24 +169,10 @@ class FilterMIMETypeTest {
     // Arrange: inlines + links true
     FilterMIMEType mt =
         new FilterMIMEType(
-            "application/x-img",
-            "img",
-            null,
-            null,
-            false,
-            false,
-            null,
-            true,
-            true,
-            false,
-            false,
-            false,
-            false,
-            "",
-            false,
-            null,
-            null,
-            false);
+            new FilterMIMETypeNames("application/x-img", "img", null, null),
+            new FilterMIMETypeSafety(false, false, null, ""),
+            new FilterMIMETypeDangerousFlags(true, true, false, false, false, false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false));
 
     KnownUnsafeContentTypeException ex =
         assertThrows(KnownUnsafeContentTypeException.class, mt::throwUnsafeContentTypeException);
@@ -241,24 +193,13 @@ class FilterMIMETypeTest {
     // Arrange: metadata flags true but scripting false
     FilterMIMEType mt =
         new FilterMIMEType(
-            "application/x-meta",
-            "mta",
-            null,
-            null,
-            false,
-            false,
-            null,
-            false,
-            false,
-            false,
-            true, // dangerousReadMetadata
-            true, // dangerousWriteMetadata
-            false,
-            "",
-            false,
-            null,
-            null,
-            false);
+            new FilterMIMETypeNames("application/x-meta", "mta", null, null),
+            new FilterMIMETypeSafety(false, false, null, ""),
+            new FilterMIMETypeDangerousFlags(
+                false, false, false, true, // dangerousReadMetadata
+                true, // dangerousWriteMetadata
+                false),
+            new FilterMIMETypeCharsetPolicy(false, null, null, false));
 
     KnownUnsafeContentTypeException ex =
         assertThrows(KnownUnsafeContentTypeException.class, mt::throwUnsafeContentTypeException);


### PR DESCRIPTION
## Summary
- extract MIME type metadata into dedicated records (names, safety, charset policy, dangerous flags)
- update `FilterMIMEType` constructor and content filter registrations
- adjust related tests for new constructor shape

## Testing
- not run (spotlessApply only)
