### PR TITLE
refactor(fcp): bundle feed params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ tmp*
 
 # Local migration helpers
 tools/migrate_logger_slf4j.py
+/.opencode/

--- a/src/main/java/network/crypta/clients/fcp/BookmarkFeed.java
+++ b/src/main/java/network/crypta/clients/fcp/BookmarkFeed.java
@@ -60,24 +60,8 @@ public class BookmarkFeed extends N2NFeedMessage {
    * with a {@link NullBucket} placeholder to keep payload structure stable. All supplied strings
    * are treated as display text, so callers should pre-sanitize any user-provided content.
    *
-   * @param header single-line headline shown most prominently in feed readers; may be {@code null}
-   *     when the short text already summarizes the recommendation.
-   * @param shortText concise secondary summary that elaborates on {@code header}; {@code null}
-   *     values omit the field from the serialized header.
-   * @param text long-form body of the recommendation encoded in UTF-8 and stored as payload bytes;
-   *     must be non-{@code null}, and callers keep ownership of the original string.
-   * @param priorityClass numeric priority hint (higher values are sent sooner) mirrored into the
-   *     {@link SimpleFieldSet}; typical ranges align with other feed messages.
-   * @param updatedTime timestamp in milliseconds representing the producer's notion of freshness;
-   *     readers can use it to deduplicate edits.
-   * @param sourceNodeName human-readable identifier of the peer that originated the bookmark; may
-   *     be {@code null} or empty when anonymity is preferred.
-   * @param composed epoch milliseconds when the peer composed the message; pass {@code -1} if
-   *     unknown so the field is omitted from the serialized header.
-   * @param sent epoch milliseconds describing when the peer transmitted the entry; negative values
-   *     indicate the timestamp is not available.
-   * @param received milliseconds since epoch recording when this node ingested the message;
-   *     negative values omit the field, mirroring the other timestamps' conventions.
+   * @param params bundled feed metadata describing the header, body text, priority, update time,
+   *     source node name, and timing information for this entry.
    * @param bookmarkTitle short label for the bookmark being recommended; appears as {@code "Name"}
    *     in the outgoing field set and should not contain newlines.
    * @param bookmarkUri parsed Freenet URI pointing to the recommended resource; the constructor
@@ -88,29 +72,12 @@ public class BookmarkFeed extends N2NFeedMessage {
    *     merely informational content.
    */
   public BookmarkFeed(
-      String header,
-      String shortText,
-      String text,
-      short priorityClass,
-      long updatedTime,
-      String sourceNodeName,
-      long composed,
-      long sent,
-      long received,
+      N2NFeedMessageParams params,
       String bookmarkTitle,
       FreenetURI bookmarkUri,
       String description,
       boolean hasAnActivelink) {
-    super(
-        header,
-        shortText,
-        text,
-        priorityClass,
-        updatedTime,
-        sourceNodeName,
-        composed,
-        sent,
-        received);
+    super(params);
     this.bookmarkTitle = bookmarkTitle;
     this.bookmarkUri = bookmarkUri;
     this.hasAnActivelink = hasAnActivelink;

--- a/src/main/java/network/crypta/clients/fcp/N2NFeedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/N2NFeedMessage.java
@@ -65,55 +65,24 @@ public abstract class N2NFeedMessage extends FeedMessage {
   /**
    * Create a new node‑to‑node feed message with timing metadata and textual content.
    *
-   * <p>The textual arguments mirror those of {@link FeedMessage}: a short {@code header}, a
-   * secondary {@code shortText}, and a full {@code text} body that is stored as a binary payload.
-   * The {@code priorityClass} and {@code updatedTime} parameters are passed through to the
-   * superclass unchanged, while {@code sourceNodeName} and the three timestamp values are retained
-   * to describe the origin and life‑cycle of the message as it flows between nodes.
+   * <p>The supplied {@link N2NFeedMessageParams} bundles the base feed text fields, priority and
+   * update timestamps, and the node timing metadata. The values are forwarded unchanged to the
+   * superclass and stored for later serialization.
    *
-   * @param header short one‑line summary describing the message; callers should avoid embedding
-   *     newline characters because the value is placed directly into the textual FCP header and may
-   *     be {@code null} when no separate title is required.
-   * @param shortText secondary summary that gives additional context beyond {@code header}; like
-   *     the header it is expected to be a single logical line of text and may be {@code null} if
-   *     there is no distinct short description.
-   * @param text full body of the feed entry that will be sent as payload bytes; this string is
-   *     converted to UTF‑8 and may contain arbitrary characters, including newlines, but must not
-   *     be {@code null} when constructing an instance.
-   * @param priorityClass numeric priority hint used by the surrounding FCP infrastructure to order
-   *     outgoing messages; higher values typically indicate entries that should be delivered before
-   *     lower‑priority ones on the same connection.
-   * @param updatedTime timestamp representing the last update time of the feed entry from the
-   *     perspective of the sender or alerting subsystem; the concrete semantics are defined by the
-   *     code that constructs the message and are not interpreted further here.
-   * @param sourceNodeName human‑readable name of the node that originated the message; this value
-   *     is exported in the {@code "SourceNodeName"} header field and may be {@code null} or empty
-   *     when no friendly identifier is available for the peer.
-   * @param composed time at which the sender composed the message content, expressed in
-   *     milliseconds since the Unix epoch; use {@code -1} when the composition time is unknown or
-   *     not tracked by the upstream component.
-   * @param sent time at which the sender transmitted the message towards this node, also in epoch
-   *     milliseconds; use {@code -1} if the transport does not expose a precise send time or if it
-   *     is otherwise unavailable.
-   * @param received time at which this node received the message from the network, in epoch
-   *     milliseconds; a value of {@code -1} indicates that the receipt time could not be recorded
-   *     or is intentionally left unspecified.
+   * @param params bundled feed metadata describing the text fields, priority, update time, source
+   *     node name, and lifecycle timestamps for this message.
    */
-  protected N2NFeedMessage(
-      String header,
-      String shortText,
-      String text,
-      short priorityClass,
-      long updatedTime,
-      String sourceNodeName,
-      long composed,
-      long sent,
-      long received) {
-    super(header, shortText, text, priorityClass, updatedTime);
-    this.sourceNodeName = sourceNodeName;
-    this.composed = composed;
-    this.sent = sent;
-    this.received = received;
+  protected N2NFeedMessage(N2NFeedMessageParams params) {
+    super(
+        params.header(),
+        params.shortText(),
+        params.text(),
+        params.priorityClass(),
+        params.updatedTime());
+    this.sourceNodeName = params.sourceNodeName();
+    this.composed = params.composed();
+    this.sent = params.sent();
+    this.received = params.received();
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/N2NFeedMessageParams.java
+++ b/src/main/java/network/crypta/clients/fcp/N2NFeedMessageParams.java
@@ -1,0 +1,37 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Parameter bundle describing the shared metadata for node-to-node feed messages.
+ *
+ * <p>Instances capture the core feed text fields alongside the originating node name and the
+ * timestamps that describe when the message was composed, sent, and received. The values are passed
+ * through to {@link FeedMessage} and {@link N2NFeedMessage} without modification, preserving the
+ * existing wire format and validation behavior.
+ *
+ * @param header short one-line title shown prominently to users; may be {@code null} if no distinct
+ *     header is needed.
+ * @param shortText secondary summary line; may be {@code null} when no short description is used.
+ * @param text full feed body text that will be encoded as UTF-8 bytes; must be non-{@code null}.
+ * @param priorityClass numeric priority hint used by the FCP infrastructure to order outgoing
+ *     messages.
+ * @param updatedTime timestamp in milliseconds since the epoch indicating when the entry was last
+ *     updated.
+ * @param sourceNodeName human-readable name of the node that originated the message; may be {@code
+ *     null} or empty.
+ * @param composed epoch milliseconds when the sender composed the message; use {@code -1} if
+ *     unknown.
+ * @param sent epoch milliseconds when the sender transmitted the message; use {@code -1} if
+ *     unknown.
+ * @param received epoch milliseconds when this node received the message; use {@code -1} if
+ *     unknown.
+ */
+public record N2NFeedMessageParams(
+    String header,
+    String shortText,
+    String text,
+    short priorityClass,
+    long updatedTime,
+    String sourceNodeName,
+    long composed,
+    long sent,
+    long received) {}

--- a/src/main/java/network/crypta/clients/fcp/TextFeedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TextFeedMessage.java
@@ -54,49 +54,14 @@ public class TextFeedMessage extends N2NFeedMessage {
    * <p>The resulting instance is ready to be serialized and sent to an FCP client. No further
    * mutation of bucket contents is expected once construction completes.
    *
-   * @param header short human‑readable title for the feed entry; may be {@code null} when no
-   *     dedicated header line is required by the caller.
-   * @param shortText secondary summary line providing compact context beyond {@code header}; may be
-   *     {@code null} if the feed entry does not use a short description.
-   * @param text full body text for the main feed payload; converted to UTF‑8 bytes and stored in a
-   *     {@code "Text"} bucket, and therefore must not be {@code null}.
-   * @param priorityClass numeric priority hint used by the surrounding FCP infrastructure when
-   *     ordering outgoing messages; higher values generally indicate more urgent notifications.
-   * @param updatedTime timestamp in milliseconds since the Unix epoch indicating when the feed
-   *     entry was last updated from the perspective of the producer.
-   * @param sourceNodeName descriptive name of the remote node that originated this message; written
-   *     to the {@code "SourceNodeName"} header field and may be {@code null} or empty.
-   * @param composed time at which the sender composed the message body, expressed in epoch
-   *     milliseconds; use {@code -1} when the composition time is unknown or not tracked.
-   * @param sent time at which the message was transmitted towards this node, in epoch milliseconds;
-   *     use {@code -1} when a precise send time is unavailable or intentionally omitted.
-   * @param received time at which this node received the message, in epoch milliseconds; use {@code
-   *     -1} when the receipt time could not be recorded or is not meaningful.
+   * @param params bundled feed metadata describing the header, body text, priority, update time,
+   *     source node name, and timing information for this entry.
    * @param messageText optional additional textual payload carried in the {@code "MessageText"}
    *     bucket; when {@code null}, an empty {@link NullBucket} is used instead of an {@link
    *     ArrayBucket}.
    */
-  public TextFeedMessage(
-      String header,
-      String shortText,
-      String text,
-      short priorityClass,
-      long updatedTime,
-      String sourceNodeName,
-      long composed,
-      long sent,
-      long received,
-      String messageText) {
-    super(
-        header,
-        shortText,
-        text,
-        priorityClass,
-        updatedTime,
-        sourceNodeName,
-        composed,
-        sent,
-        received);
+  public TextFeedMessage(N2NFeedMessageParams params, String messageText) {
+    super(params);
     final Bucket messageTextBucket;
     if (messageText != null) {
       messageTextBucket = new ArrayBucket(messageText.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/network/crypta/clients/fcp/URIFeedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/URIFeedMessage.java
@@ -62,54 +62,16 @@ public class URIFeedMessage extends N2NFeedMessage {
    * "TimeComposed"}, {@code "TimeSent"}, or {@code "TimeReceived"} field so callers can signal
    * unknown times without inventing placeholder values.
    *
-   * @param header short, user-visible title shown most prominently; may be {@code null} and should
-   *     not contain embedded newlines because it is copied into the textual FCP header.
-   * @param shortText secondary summary providing additional context; may be {@code null} and is
-   *     likewise expected to be a single logical line of text without newlines.
-   * @param text full body of the feed entry to be delivered as the primary payload; must be
-   *     non-{@code null} and may contain arbitrary characters, including Unicode and line breaks.
-   * @param priorityClass numeric priority hint used by the FCP infrastructure when ordering
-   *     outgoing messages; higher values typically indicate more urgent notifications.
-   * @param updatedTime timestamp in milliseconds since the Unix epoch representing when the entry
-   *     was last updated from the server's perspective; the value is forwarded unchanged.
-   * @param sourceNodeName human-readable name of the peer that announced the URI; may be {@code
-   *     null} or empty when no friendly identifier is available, and is exported as the {@code
-   *     "SourceNodeName"} header field.
-   * @param composed time at which the remote peer composed the announcement, expressed in epoch
-   *     milliseconds; use {@code -1} to indicate that this information is not known.
-   * @param sent time when the remote peer sent the announcement towards this node, in epoch
-   *     milliseconds; {@code -1} again indicates an unknown or unavailable value.
-   * @param received time when this node received the announcement from the network, in epoch
-   *     milliseconds; {@code -1} suppresses the corresponding header field in {@link
-   *     #getFieldSet()}.
+   * @param params bundled feed metadata describing the header, body text, priority, update time,
+   *     source node name, and timing information for this entry.
    * @param uri target {@link FreenetURI} that identifies the advertised content; must not be {@code
    *     null} and is neither normalized nor modified by this constructor.
    * @param description optional textual description associated with the URI; when non-{@code null}
    *     it is encoded as UTF-8 bytes into a {@link Bucket} named {@code "Description"}, otherwise a
    *     {@link NullBucket} is used to represent the absence of description data.
    */
-  public URIFeedMessage(
-      String header,
-      String shortText,
-      String text,
-      short priorityClass,
-      long updatedTime,
-      String sourceNodeName,
-      long composed,
-      long sent,
-      long received,
-      FreenetURI uri,
-      String description) {
-    super(
-        header,
-        shortText,
-        text,
-        priorityClass,
-        updatedTime,
-        sourceNodeName,
-        composed,
-        sent,
-        received);
+  public URIFeedMessage(N2NFeedMessageParams params, FreenetURI uri, String description) {
+    super(params);
     this.uri = Objects.requireNonNull(uri, "uri");
     final Bucket descriptionBucket;
     if (description != null) {

--- a/src/main/java/network/crypta/node/useralerts/BookmarkFeedUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/BookmarkFeedUserAlert.java
@@ -2,6 +2,7 @@ package network.crypta.node.useralerts;
 
 import java.lang.ref.WeakReference;
 import network.crypta.clients.fcp.BookmarkFeed;
+import network.crypta.clients.fcp.N2NFeedMessageParams;
 import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
@@ -242,20 +243,18 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
    */
   @Override
   public BookmarkFeed getFCPMessage() {
-    return new BookmarkFeed(
-        getTitle(),
-        getShortText(),
-        getText(),
-        getPriorityClass(),
-        getUpdatedTime(),
-        sourceNodeName,
-        composed,
-        sent,
-        received,
-        name,
-        uri,
-        description,
-        hasAnActivelink);
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
+            getTitle(),
+            getShortText(),
+            getText(),
+            getPriorityClass(),
+            getUpdatedTime(),
+            sourceNodeName,
+            composed,
+            sent,
+            received);
+    return new BookmarkFeed(params, name, uri, description, hasAnActivelink);
   }
 
   /**

--- a/src/main/java/network/crypta/node/useralerts/DownloadFeedUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/DownloadFeedUserAlert.java
@@ -2,6 +2,7 @@ package network.crypta.node.useralerts;
 
 import java.lang.ref.WeakReference;
 import network.crypta.clients.fcp.FCPMessage;
+import network.crypta.clients.fcp.N2NFeedMessageParams;
 import network.crypta.clients.fcp.URIFeedMessage;
 import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
@@ -218,18 +219,18 @@ public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNo
    */
   @Override
   public FCPMessage getFCPMessage() {
-    return new URIFeedMessage(
-        getTitle(),
-        getShortText(),
-        getText(),
-        getPriorityClass(),
-        getUpdatedTime(),
-        sourceNodeName,
-        composed,
-        sent,
-        received,
-        uri,
-        description);
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
+            getTitle(),
+            getShortText(),
+            getText(),
+            getPriorityClass(),
+            getUpdatedTime(),
+            sourceNodeName,
+            composed,
+            sent,
+            received);
+    return new URIFeedMessage(params, uri, description);
   }
 
   /**

--- a/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
@@ -4,6 +4,7 @@ import java.lang.ref.WeakReference;
 import java.text.DateFormat;
 import java.util.Date;
 import network.crypta.clients.fcp.FCPMessage;
+import network.crypta.clients.fcp.N2NFeedMessageParams;
 import network.crypta.clients.fcp.TextFeedMessage;
 import network.crypta.io.comm.PeerContext;
 import network.crypta.l10n.NodeL10n;
@@ -256,17 +257,18 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
    */
   @Override
   public FCPMessage getFCPMessage() {
-    return new TextFeedMessage(
-        getTitle(),
-        getShortText(),
-        getText(),
-        getPriorityClass(),
-        getUpdatedTime(),
-        sourceNodeName,
-        composedTime,
-        sentTime,
-        receivedTime,
-        messageText);
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
+            getTitle(),
+            getShortText(),
+            getText(),
+            getPriorityClass(),
+            getUpdatedTime(),
+            sourceNodeName,
+            composedTime,
+            sentTime,
+            receivedTime);
+    return new TextFeedMessage(params, messageText);
   }
 
   /**

--- a/src/test/java/network/crypta/clients/fcp/BookmarkFeedTest.java
+++ b/src/test/java/network/crypta/clients/fcp/BookmarkFeedTest.java
@@ -32,20 +32,7 @@ class BookmarkFeedTest {
   void getFieldSet_whenBookmarkHasMetadata_exportsNameUriAndFlags() throws Exception {
     FreenetURI uri = sampleUri();
     BookmarkFeed feed =
-        new BookmarkFeed(
-            HEADER,
-            SHORT_TEXT,
-            BODY_TEXT,
-            PRIORITY_CLASS,
-            UPDATED_TIME,
-            SOURCE_NODE_NAME,
-            COMPOSED,
-            SENT,
-            RECEIVED,
-            BOOKMARK_NAME,
-            uri,
-            "A bookmark description",
-            true);
+        new BookmarkFeed(baseParams(), BOOKMARK_NAME, uri, "A bookmark description", true);
 
     SimpleFieldSet fieldSet = feed.getFieldSet();
 
@@ -93,7 +80,11 @@ class BookmarkFeedTest {
   }
 
   private static BookmarkFeed createFeedWithDescription(String description) {
-    return new BookmarkFeed(
+    return new BookmarkFeed(baseParams(), BOOKMARK_NAME, sampleUri(), description, false);
+  }
+
+  private static N2NFeedMessageParams baseParams() {
+    return new N2NFeedMessageParams(
         HEADER,
         SHORT_TEXT,
         BODY_TEXT,
@@ -102,11 +93,7 @@ class BookmarkFeedTest {
         SOURCE_NODE_NAME,
         COMPOSED,
         SENT,
-        RECEIVED,
-        BOOKMARK_NAME,
-        sampleUri(),
-        description,
-        false);
+        RECEIVED);
   }
 
   private static FreenetURI sampleUri() {

--- a/src/test/java/network/crypta/clients/fcp/TextFeedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/TextFeedMessageTest.java
@@ -32,8 +32,8 @@ class TextFeedMessageTest {
     long received = 300L;
     String messageText = "Additional message text";
 
-    TextFeedMessage message =
-        new TextFeedMessage(
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
             header,
             shortText,
             text,
@@ -42,8 +42,8 @@ class TextFeedMessageTest {
             sourceNodeName,
             composed,
             sent,
-            received,
-            messageText);
+            received);
+    TextFeedMessage message = new TextFeedMessage(params, messageText);
 
     // Act
     SimpleFieldSet fieldSet = message.getFieldSet();
@@ -86,18 +86,10 @@ class TextFeedMessageTest {
     String sourceNodeName = "UnknownNode";
     String messageText = "Message payload";
 
-    TextFeedMessage message =
-        new TextFeedMessage(
-            header,
-            shortText,
-            text,
-            priorityClass,
-            updatedTime,
-            sourceNodeName,
-            -1L,
-            -1L,
-            -1L,
-            messageText);
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
+            header, shortText, text, priorityClass, updatedTime, sourceNodeName, -1L, -1L, -1L);
+    TextFeedMessage message = new TextFeedMessage(params, messageText);
 
     // Act
     SimpleFieldSet fieldSet = message.getFieldSet();
@@ -119,9 +111,10 @@ class TextFeedMessageTest {
     short priorityClass = 3;
     long updatedTime = 1234L;
 
-    TextFeedMessage message =
-        new TextFeedMessage(
-            "Header", "Short", text, priorityClass, updatedTime, "SomeNode", 10L, 20L, 30L, null);
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
+            "Header", "Short", text, priorityClass, updatedTime, "SomeNode", 10L, 20L, 30L);
+    TextFeedMessage message = new TextFeedMessage(params, null);
 
     // Act
     SimpleFieldSet fieldSet = message.getFieldSet();
@@ -141,9 +134,9 @@ class TextFeedMessageTest {
   @Test
   void getName_whenCalled_expectTextFeedConstantReturned() {
     // Arrange
-    TextFeedMessage message =
-        new TextFeedMessage(
-            "Header", "Short", "Body", (short) 1, 0L, "Node", -1L, -1L, -1L, "message");
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams("Header", "Short", "Body", (short) 1, 0L, "Node", -1L, -1L, -1L);
+    TextFeedMessage message = new TextFeedMessage(params, "message");
 
     // Act & Assert
     assertEquals(TextFeedMessage.NAME, message.getName());

--- a/src/test/java/network/crypta/clients/fcp/URIFeedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/URIFeedMessageTest.java
@@ -37,8 +37,8 @@ class URIFeedMessageTest {
     long received = 300L;
     String description = "Description with UTF-8 ✓";
 
-    URIFeedMessage message =
-        new URIFeedMessage(
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
             header,
             shortText,
             text,
@@ -47,9 +47,8 @@ class URIFeedMessageTest {
             sourceNodeName,
             composed,
             sent,
-            received,
-            uriMock,
-            description);
+            received);
+    URIFeedMessage message = new URIFeedMessage(params, uriMock, description);
 
     int textBytes = text.getBytes(StandardCharsets.UTF_8).length;
     int descriptionBytes = description.getBytes(StandardCharsets.UTF_8).length;
@@ -84,19 +83,10 @@ class URIFeedMessageTest {
     short priorityClass = 3;
     long updatedTime = 1234L;
 
-    URIFeedMessage message =
-        new URIFeedMessage(
-            "Header",
-            "Short",
-            text,
-            priorityClass,
-            updatedTime,
-            "SomeNode",
-            10L,
-            20L,
-            30L,
-            uriMock,
-            null);
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
+            "Header", "Short", text, priorityClass, updatedTime, "SomeNode", 10L, 20L, 30L);
+    URIFeedMessage message = new URIFeedMessage(params, uriMock, null);
 
     int textBytes = text.getBytes(StandardCharsets.UTF_8).length;
 
@@ -125,19 +115,10 @@ class URIFeedMessageTest {
     short priorityClass = 2;
     long updatedTime = 99L;
 
-    URIFeedMessage message =
-        new URIFeedMessage(
-            "Header",
-            "Short",
-            text,
-            priorityClass,
-            updatedTime,
-            "Node",
-            1L,
-            2L,
-            3L,
-            uriMock,
-            description);
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
+            "Header", "Short", text, priorityClass, updatedTime, "Node", 1L, 2L, 3L);
+    URIFeedMessage message = new URIFeedMessage(params, uriMock, description);
 
     int textBytes = text.getBytes(StandardCharsets.UTF_8).length;
 
@@ -171,8 +152,8 @@ class URIFeedMessageTest {
     String uriString = "KSK@some-doc";
     org.mockito.Mockito.when(uriMock.toString()).thenReturn(uriString);
 
-    URIFeedMessage message =
-        new URIFeedMessage(
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
             header,
             shortText,
             text,
@@ -181,9 +162,8 @@ class URIFeedMessageTest {
             sourceNodeName,
             composed,
             sent,
-            received,
-            uriMock,
-            description);
+            received);
+    URIFeedMessage message = new URIFeedMessage(params, uriMock, description);
 
     // Act
     SimpleFieldSet fieldSet = message.getFieldSet();
@@ -226,19 +206,10 @@ class URIFeedMessageTest {
 
     org.mockito.Mockito.when(uriMock.toString()).thenReturn(uriString);
 
-    URIFeedMessage message =
-        new URIFeedMessage(
-            "Header",
-            "Short",
-            text,
-            priorityClass,
-            updatedTime,
-            sourceNodeName,
-            -1L,
-            -1L,
-            -1L,
-            uriMock,
-            description);
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams(
+            "Header", "Short", text, priorityClass, updatedTime, sourceNodeName, -1L, -1L, -1L);
+    URIFeedMessage message = new URIFeedMessage(params, uriMock, description);
 
     // Act
     SimpleFieldSet fieldSet = message.getFieldSet();
@@ -256,19 +227,9 @@ class URIFeedMessageTest {
   @Test
   void getName_whenCalled_expectUriFeedConstantReturned() {
     // Arrange
-    URIFeedMessage message =
-        new URIFeedMessage(
-            "Header",
-            "Short",
-            "Text",
-            (short) 1,
-            0L,
-            "Node",
-            -1L,
-            -1L,
-            -1L,
-            uriMock,
-            "Description");
+    N2NFeedMessageParams params =
+        new N2NFeedMessageParams("Header", "Short", "Text", (short) 1, 0L, "Node", -1L, -1L, -1L);
+    URIFeedMessage message = new URIFeedMessage(params, uriMock, "Description");
 
     // Act & Assert
     assertEquals(URIFeedMessage.NAME, message.getName());


### PR DESCRIPTION
## Summary
- add `N2NFeedMessageParams` to share node-to-node feed metadata
- update feed message constructors and user alerts to pass the shared params
- adjust FCP feed tests to use the params bundle
- ignore local `.opencode/` directory

## Testing
- `./gradlew spotlessApply`