### PR TITLE
refactor(fcp): modularize ClientGet return planning

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -5,7 +5,6 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
-import java.nio.file.Files;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Objects;
@@ -221,21 +220,13 @@ public class ClientGet extends ClientRequest {
     }
   }
 
-  private record ReturnSetup(Bucket bucket, File targetFile, String extension) {}
-
   /**
-   * Builds a persistent GET request for callers that enqueue work outside live FCP sessions.
+   * Bundles configuration for persistent global GET requests to keep constructors concise.
    *
-   * <p>This constructor clones the node's default {@link FetchContext}, wires up event listeners,
-   * normalizes retry limits, and resolves the return path before handing everything to a dedicated
-   * {@link ClientGetter}. It is typically used by built-in services that want their requests to be
-   * restartable across reboots and obey the global queue semantics rather than the per-connection
-   * queue. The supplied flags control datastore reachability, filtering, cache writes, and the
-   * maximum size of the temporary buckets allocated for the request. The resulting instance is
-   * ready to register and start once constructed.
+   * <p>Instances capture all per-request tuning parameters that are otherwise passed positionally.
+   * The record is intentionally immutable so callers can safely reuse it across retries or
+   * validation steps without worrying about concurrent mutation.
    *
-   * @param globalClient persistent client facade owning the global queue slot.
-   * @param uri FreenetURI describing the content key and optional metadata.
    * @param dsOnly true to confine fetching to the local datastore only.
    * @param ignoreDS bypasses the datastore entirely when evaluating availability hints.
    * @param filterData applies MIME filtering before writing or returning data.
@@ -252,15 +243,8 @@ public class ClientGet extends ClientRequest {
    * @param writeToClientCache allows writing the payload into the client HTTP cache.
    * @param realTimeFlag true when the request participates in the realtime scheduler lane.
    * @param binaryBlob enables BinaryBlob writer semantics instead of classic bucket delivery.
-   * @param core node client core providing factories, permission checks, and trackers.
-   * @throws IdentifierCollisionException identifier already present on the owning persistent
-   *     client.
-   * @throws NotAllowedException download target rejected by DDA or security policy.
-   * @throws IOException filesystem errors while preparing disk buckets or output locations.
    */
-  public ClientGet(
-      PersistentRequestClient globalClient,
-      FreenetURI uri,
+  public record GlobalRequestConfig(
       boolean dsOnly,
       boolean ignoreDS,
       boolean filterData,
@@ -276,41 +260,70 @@ public class ClientGet extends ClientRequest {
       String charset,
       boolean writeToClientCache,
       boolean realTimeFlag,
-      boolean binaryBlob,
+      boolean binaryBlob) {}
+
+  /**
+   * Builds a persistent GET request for callers that enqueue work outside live FCP sessions.
+   *
+   * <p>This constructor clones the node's default {@link FetchContext}, wires up event listeners,
+   * normalizes retry limits, and resolves the return path before handing everything to a dedicated
+   * {@link ClientGetter}. It is typically used by built-in services that want their requests to be
+   * restartable across reboots and obey the global queue semantics rather than the per-connection
+   * queue. The supplied {@link GlobalRequestConfig} controls datastore reachability, filtering,
+   * cache writes, and the maximum size of the temporary buckets allocated for the request. The
+   * resulting instance is ready to register and start once constructed.
+   *
+   * @param globalClient persistent client facade owning the global queue slot.
+   * @param uri FreenetURI describing the content key and optional metadata.
+   * @param requestConfig configuration bundle describing retry limits and return handling.
+   * @param core node client core providing factories, permission checks, and trackers.
+   * @throws IdentifierCollisionException identifier already present on the owning persistent
+   *     client.
+   * @throws NotAllowedException download target rejected by DDA or security policy.
+   * @throws IOException filesystem errors while preparing disk buckets or output locations.
+   */
+  public ClientGet(
+      PersistentRequestClient globalClient,
+      FreenetURI uri,
+      GlobalRequestConfig requestConfig,
       NodeClientCore core)
       throws IdentifierCollisionException, NotAllowedException, IOException {
     super(
         uri,
-        identifier,
-        verbosity,
+        requestConfig.identifier(),
+        requestConfig.verbosity(),
         null,
         globalClient,
-        prioClass,
-        (persistRebootOnly ? Persistence.REBOOT : Persistence.FOREVER),
-        realTimeFlag,
+        requestConfig.prioClass(),
+        (requestConfig.persistRebootOnly() ? Persistence.REBOOT : Persistence.FOREVER),
+        requestConfig.realTimeFlag(),
         null,
         true);
 
-    ensureGlobalIdentifierAvailable(globalClient, identifier);
+    ensureGlobalIdentifierAvailable(globalClient, requestConfig.identifier());
     fctx = core.getClientContext().getDefaultPersistentFetchContext();
     fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
-    fctx.setLocalRequestOnly(dsOnly);
-    fctx.setIgnoreStore(ignoreDS);
-    fctx.setMaxNonSplitfileRetries(maxNonSplitfileRetries);
-    fctx.setMaxSplitfileBlockRetries(maxSplitfileRetries);
-    fctx.setFilterData(filterData);
-    fctx.setMaxOutputLength(maxOutputLength);
-    fctx.setMaxTempLength(maxOutputLength);
-    fctx.setCanWriteClientCache(writeToClientCache);
+    fctx.setLocalRequestOnly(requestConfig.dsOnly());
+    fctx.setIgnoreStore(requestConfig.ignoreDS());
+    fctx.setMaxNonSplitfileRetries(requestConfig.maxNonSplitfileRetries());
+    fctx.setMaxSplitfileBlockRetries(requestConfig.maxSplitfileRetries());
+    fctx.setFilterData(requestConfig.filterData());
+    fctx.setMaxOutputLength(requestConfig.maxOutputLength());
+    fctx.setMaxTempLength(requestConfig.maxOutputLength());
+    fctx.setCanWriteClientCache(requestConfig.writeToClientCache());
     compatMode = new CompatibilityAnalyser();
     // USK date hints are configured explicitly for FCP messages.
-    this.returnType = returnType;
-    this.binaryBlob = binaryBlob;
-    if (charset != null && LOG.isDebugEnabled()) {
-      LOG.debug("Charset parameter is ignored for ClientGet global queue requests: {}", charset);
+    this.returnType = requestConfig.returnType();
+    this.binaryBlob = requestConfig.binaryBlob();
+    if (requestConfig.charset() != null && LOG.isDebugEnabled()) {
+      LOG.debug(
+          "Charset parameter is ignored for ClientGet global queue requests: {}",
+          requestConfig.charset());
     }
-    ReturnSetup setup =
-        configureReturnHandlingForGlobalRequest(returnType, returnFilename, filterData, core);
+    ClientGetReturnPlanner returnPlanner = new ClientGetReturnPlanner(identifier, global, fctx);
+    ClientGetReturnPlanner.ReturnSetup setup =
+        returnPlanner.forGlobalRequest(
+            returnType, requestConfig.returnFilename(), requestConfig.filterData(), core);
     this.targetFile = setup.targetFile();
     this.extensionCheck = setup.extension();
     this.initialMetadata = null;
@@ -374,7 +387,8 @@ public class ClientGet extends ClientRequest {
 
     this.returnType = message.returnType;
     this.binaryBlob = message.binaryBlob;
-    ReturnSetup setup = configureReturnHandlingForMessage(message, core, handler);
+    ClientGetReturnPlanner returnPlanner = new ClientGetReturnPlanner(identifier, global, fctx);
+    ClientGetReturnPlanner.ReturnSetup setup = returnPlanner.forMessage(message, core, handler);
     this.targetFile = setup.targetFile();
     this.extensionCheck = setup.extension();
     initialMetadata = message.getInitialMetadata();
@@ -382,98 +396,6 @@ public class ClientGet extends ClientRequest {
       getter = makeGetter(core, setup.bucket());
     } catch (IOException e) {
       throw bucketCreationFailure(e);
-    }
-  }
-
-  private ReturnSetup configureReturnHandlingForGlobalRequest(
-      ReturnType type, File returnFilename, boolean filterData, NodeClientCore core)
-      throws NotAllowedException, IOException {
-    if (type == ReturnType.DISK) {
-      File file = Objects.requireNonNull(returnFilename, "returnFilename");
-      ensureDownloadAllowed(core, file);
-      return createDiskReturnSetup(file, filterData);
-    }
-    return new ReturnSetup(null, null, null);
-  }
-
-  private ReturnSetup configureReturnHandlingForMessage(
-      ClientGetMessage message, NodeClientCore core, FCPConnectionHandler handler)
-      throws MessageInvalidException {
-    if (message.returnType == ReturnType.DISK) {
-      return buildDiskSetupForMessage(message, core, handler);
-    }
-    return new ReturnSetup(null, null, null);
-  }
-
-  private ReturnSetup buildDiskSetupForMessage(
-      ClientGetMessage message, NodeClientCore core, FCPConnectionHandler handler)
-      throws MessageInvalidException {
-    File diskFile = message.diskFile;
-    if (!core.allowDownloadTo(diskFile)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED,
-          "Not allowed to download to " + diskFile,
-          identifier,
-          global);
-    }
-    if (!handler.ddaAccessController().allowDDAFrom(diskFile, true)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED,
-          "Not allowed to download to "
-              + diskFile
-              + ". You might need to do a "
-              + TestDdaRequestMessage.NAME
-              + " first.",
-          identifier,
-          global);
-    }
-    try {
-      handleExistingTargetFile(diskFile);
-    } catch (IOException e) {
-      MessageInvalidException mie =
-          new MessageInvalidException(
-              ProtocolErrorMessage.INTERNAL_ERROR,
-              "Target filename exists already: " + diskFile,
-              identifier,
-              global);
-      mie.initCause(e);
-      throw mie;
-    }
-    return createDiskReturnSetup(diskFile, fctx.getFilterData());
-  }
-
-  private ReturnSetup createDiskReturnSetup(File file, boolean filterData) {
-    Bucket bucket = ClientGetGetterFactory.diskReturnBucket(file);
-    return new ReturnSetup(bucket, file, filterData ? deriveExtension(file) : null);
-  }
-
-  private static String deriveExtension(File file) {
-    String name = file.getName();
-    int idx = name.lastIndexOf('.');
-    if (idx == -1 || idx == name.length() - 1) {
-      return null;
-    }
-    return name.substring(idx + 1);
-  }
-
-  private void ensureDownloadAllowed(NodeClientCore core, File file)
-      throws NotAllowedException, IOException {
-    if (!core.allowDownloadTo(file)) {
-      throw new NotAllowedException();
-    }
-    handleExistingTargetFile(file);
-  }
-
-  private void handleExistingTargetFile(File file) throws IOException {
-    if (!file.exists()) {
-      return;
-    }
-    if (file.length() == 0) {
-      Files.delete(file.toPath());
-      LOG.error("Target file already exists but is zero length, deleting...");
-    }
-    if (file.exists()) {
-      throw new IOException("Target filename exists already: " + file);
     }
   }
 

--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -12,8 +12,6 @@ import network.crypta.client.FetchResult;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientGetter;
-import network.crypta.client.async.ClientGetterOptions;
-import network.crypta.client.async.ClientGetterRequest;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.CompatibilityAnalyser;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
@@ -432,14 +430,7 @@ public class ClientGet extends ClientRequest {
   }
 
   private ClientGetter makeGetter(NodeClientCore core, Bucket ret) throws IOException {
-    ClientGetterRequest getterRequest =
-        ClientGetGetterFactory.createGetterRequest(this, uri, fctx, priorityClass);
-    ClientGetterOptions options =
-        new ClientGetterOptions(ret, null, false, initialMetadata, extensionCheck);
-    ClientGetGetterFlags flags =
-        new ClientGetGetterFlags(
-            returnType == ReturnType.NONE, binaryBlob, persistence == Persistence.FOREVER);
-    return ClientGetGetterFactory.createGetter(getterRequest, options, flags, core);
+    return ClientGetGetterFactory.createGetterForRequest(this, ret, core);
   }
 
   /**
@@ -1018,6 +1009,51 @@ public class ClientGet extends ClientRequest {
    */
   public FreenetURI getURI() {
     return uri;
+  }
+
+  /**
+   * Exposes the fetch context for package-local helpers.
+   *
+   * @return live {@link FetchContext} backing this request.
+   */
+  FetchContext fetchContextForGetter() {
+    return fctx;
+  }
+
+  /**
+   * Exposes the metadata bucket associated with this request.
+   *
+   * @return initial metadata bucket, or {@code null} when unset.
+   */
+  Bucket initialMetadataBucket() {
+    return initialMetadata;
+  }
+
+  /**
+   * Returns the optional filename extension hint used for validation.
+   *
+   * @return extension hint or {@code null} when none is set.
+   */
+  String extensionCheckForGetter() {
+    return extensionCheck;
+  }
+
+  /**
+   * Returns the configured delivery strategy for the request.
+   *
+   * @return configured {@link ReturnType} for result delivery.
+   */
+  ReturnType returnTypeForGetter() {
+    return returnType;
+  }
+
+  /**
+   * Indicates whether Binary Blob recording is enabled for this request.
+   *
+   * @return {@code true} when Binary Blob output is expected.
+   */
+  boolean binaryBlobRequested() {
+    return binaryBlob;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -5,9 +5,6 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Objects;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
@@ -19,11 +16,9 @@ import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.CompatibilityAnalyser;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.crypt.ChecksumChecker;
-import network.crypta.crypt.ChecksumFailedException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.api.Bucket;
-import network.crypta.support.io.BucketTools;
 import network.crypta.support.io.ResumeFailedException;
 import network.crypta.support.io.StorageFormatException;
 import org.slf4j.Logger;
@@ -138,11 +133,6 @@ public class ClientGet extends ClientRequest {
   private ExpectedHashes expectedHashes;
 
   // Legacy threshold callback removed.
-
-  private static final String COMPLETED_DOWNLOAD_RESTORE_FAILURE =
-      "Failed to restore completed download-to-temp-space request, restarting instead";
-  private static final String FETCH_SETTINGS_FALLBACK_MESSAGE =
-      "Unable to read fetch settings, will use default settings";
 
   /**
    * Defines how fetched bytes are delivered to the remote FCP caller.
@@ -320,14 +310,20 @@ public class ClientGet extends ClientRequest {
           "Charset parameter is ignored for ClientGet global queue requests: {}",
           requestConfig.charset());
     }
-    ClientGetReturnPlanner returnPlanner = new ClientGetReturnPlanner(identifier, global, fctx);
-    ClientGetReturnPlanner.ReturnSetup setup =
-        returnPlanner.forGlobalRequest(
-            returnType, requestConfig.returnFilename(), requestConfig.filterData(), core);
-    this.targetFile = setup.targetFile();
-    this.extensionCheck = setup.extension();
+    Object[] setup =
+        ClientGetGetterFactory.planReturnForGlobal(
+            identifier,
+            global,
+            fctx,
+            returnType,
+            requestConfig.returnFilename(),
+            requestConfig.filterData(),
+            core);
+    Bucket returnBucket = (Bucket) setup[0];
+    this.targetFile = (File) setup[1];
+    this.extensionCheck = (String) setup[2];
     this.initialMetadata = null;
-    getter = makeGetter(core, setup.bucket());
+    getter = makeGetter(core, returnBucket);
   }
 
   /**
@@ -378,22 +374,19 @@ public class ClientGet extends ClientRequest {
     fctx.setIgnoreUSKDatehints(message.ignoreUSKDatehints);
     compatMode = new CompatibilityAnalyser();
 
-    if (message.allowedMIMETypes != null) {
-      fctx.setAllowedMIMETypes(new HashSet<>());
-      for (String mime : message.allowedMIMETypes) {
-        fctx.getAllowedMIMETypes().add(mime);
-      }
-    }
+    ClientGetGetterFactory.applyAllowedMimeTypes(fctx, message.allowedMIMETypes);
 
     this.returnType = message.returnType;
     this.binaryBlob = message.binaryBlob;
-    ClientGetReturnPlanner returnPlanner = new ClientGetReturnPlanner(identifier, global, fctx);
-    ClientGetReturnPlanner.ReturnSetup setup = returnPlanner.forMessage(message, core, handler);
-    this.targetFile = setup.targetFile();
-    this.extensionCheck = setup.extension();
+    Object[] setup =
+        ClientGetGetterFactory.planReturnForMessage(
+            identifier, global, fctx, message, core, handler);
+    Bucket returnBucket = (Bucket) setup[0];
+    this.targetFile = (File) setup[1];
+    this.extensionCheck = (String) setup[2];
     initialMetadata = message.getInitialMetadata();
     try {
-      getter = makeGetter(core, setup.bucket());
+      getter = makeGetter(core, returnBucket);
     } catch (IOException e) {
       throw bucketCreationFailure(e);
     }
@@ -473,8 +466,10 @@ public class ClientGet extends ClientRequest {
   void register(boolean noTags) throws IdentifierCollisionException {
     assert client == null || (this.persistence == client.persistence);
     if (persistence != Persistence.CONNECTION) {
-      PersistentRequestClient persistentClient =
-          Objects.requireNonNull(client, "Persistent client must be available to register");
+      if (client == null) {
+        throw new NullPointerException("Persistent client must be available to register");
+      }
+      PersistentRequestClient persistentClient = client;
       persistentClient.register(this);
       if (!noTags) {
         FCPMessage msg = persistentTagMessage();
@@ -612,7 +607,9 @@ public class ClientGet extends ClientRequest {
   @SuppressWarnings("unused")
   public void setSuccessForMigration(ClientContext context, long completionTime, Bucket data)
       throws ResumeFailedException {
-    Objects.requireNonNull(context, "context");
+    if (context == null) {
+      throw new NullPointerException("context");
+    }
     synchronized (this) {
       succeeded = true;
       started = true;
@@ -1413,84 +1410,23 @@ public class ClientGet extends ClientRequest {
 
   @Override
   synchronized RequestStatus getStatus() {
-    boolean totalFinalized = false;
-    int total = 0;
-    int min = 0;
-    int fetched = 0;
-    int fatal = 0;
-    int failed = 0;
-    // See ClientRequester.getLatestSuccess() for why this defaults to current time.
-    Date latestSuccess = new Date();
-    Date latestFailure = null;
-
-    if (progressPending != null) {
-      totalFinalized = progressPending.isTotalFinalized();
-      // The progress API reports doubles to preserve partial block counts from the splitter.
-      total = (int) progressPending.getTotalBlocks();
-      min = (int) progressPending.getMinBlocks();
-      fetched = (int) progressPending.getFetchedBlocks();
-      latestSuccess = progressPending.getLatestSuccess();
-      fatal = (int) progressPending.getFatalyFailedBlocks();
-      failed = (int) progressPending.getFailedBlocks();
-      latestFailure = progressPending.getLatestFailure();
-    }
-    if (finished && succeeded) totalFinalized = true;
-    FetchExceptionMode failureCode = null;
-    String failureReasonShort = null;
-    String failureReasonLong = null;
-    if (getFailedMessage != null) {
-      failureCode = getFailedMessage.failureMode;
-      failureReasonShort = getFailedMessage.getShortFailedMessage();
-      failureReasonLong = getFailedMessage.getLongFailedMessage();
-    }
-    String mimeType = foundDataMimeType;
-    long dataSize = foundDataLength;
-    File target = getDestFilename();
-    if (target != null) target = new File(target.getPath());
-
-    Bucket shadow = (finished && succeeded) ? getBucket() : null;
-    if (shadow != null) {
-      if (dataSize != shadow.size()) {
-        LOG.error(
-            "Size of downloaded data has changed: {} -> {} on {}", dataSize, shadow.size(), shadow);
-        shadow = null;
-      } else {
-        shadow = shadow.createShadow();
-      }
-    }
-
-    boolean filterData;
-    boolean overriddenDataType;
-    filterData = fctx.getFilterData();
-    overriddenDataType = fctx.getOverrideMIME() != null || fctx.getCharset() != null;
-
-    return new DownloadRequestStatus(
+    return ClientGetGetterFactory.buildStatus(
         identifier,
         persistence,
         started,
         finished,
         succeeded,
-        total,
-        min,
-        fetched,
-        latestSuccess,
-        fatal,
-        failed,
-        latestFailure,
-        totalFinalized,
+        progressPending,
+        getFailedMessage,
+        foundDataMimeType,
+        foundDataLength,
+        getDestFilename(),
+        getBucket(),
+        fctx,
         priorityClass,
-        failureCode,
-        mimeType,
-        dataSize,
-        target,
         getCompatibilityMode(),
         getOverriddenSplitfileCryptoKey(),
         getURI(),
-        failureReasonShort,
-        failureReasonLong,
-        overriddenDataType,
-        shadow,
-        filterData,
         getDontCompress());
   }
 
@@ -1604,10 +1540,10 @@ public class ClientGet extends ClientRequest {
     returnType = parseReturnType(dis.readShort());
     targetFile = returnType == ReturnType.DISK ? new File(dis.readUTF()) : null;
     binaryBlob = dis.readBoolean();
-    this.fctx = readFetchContext(dis, context, checker);
+    this.fctx = ClientGetGetterFactory.readFetchContextOrDefault(dis, context, checker);
     fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
     extensionCheck = dis.readBoolean() ? dis.readUTF() : null;
-    initialMetadata = readInitialMetadata(dis, context, checker);
+    initialMetadata = ClientGetGetterFactory.readInitialMetadata(dis, context, checker);
     ClientGetter restoredGetter = restoreState(dis, reqID, context, checker);
     if (compatMode == null) {
       compatMode = new CompatibilityAnalyser();
@@ -1646,37 +1582,6 @@ public class ClientGet extends ClientRequest {
     }
   }
 
-  private FetchContext readFetchContext(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker) {
-    try (DataInputStream inner = createChecksummedInput(dis, context, checker)) {
-      return new FetchContext(inner);
-    } catch (StorageFormatException | IOException e) {
-      LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE, e);
-    } catch (ChecksumFailedException _) {
-      LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE);
-    }
-    return context.getDefaultPersistentFetchContext();
-  }
-
-  private Bucket readInitialMetadata(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker)
-      throws IOException, StorageFormatException, ResumeFailedException {
-    if (!dis.readBoolean()) {
-      return null;
-    }
-    try (DataInputStream metadataStream = createChecksummedInput(dis, context, checker)) {
-      return BucketTools.restoreFrom(
-          metadataStream,
-          context.persistentFG,
-          context.getPersistentFileTracker(),
-          context.getPersistentMasterSecret());
-    } catch (ChecksumFailedException e) {
-      StorageFormatException sfe = new StorageFormatException("Unable to restore initial metadata");
-      sfe.initCause(e);
-      throw sfe;
-    }
-  }
-
   private ClientGetter restoreState(
       DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
       throws IOException, StorageFormatException, ResumeFailedException {
@@ -1685,7 +1590,7 @@ public class ClientGet extends ClientRequest {
       return null;
     }
     ClientGetter inProgressGetter = makeGetter(makeBucket(false));
-    restoreInProgressState(dis, context, checker, inProgressGetter);
+    ClientGetGetterFactory.restoreInProgressState(dis, context, checker, inProgressGetter, this);
     return inProgressGetter;
   }
 
@@ -1695,74 +1600,32 @@ public class ClientGet extends ClientRequest {
     succeeded = dis.readBoolean();
     readTransientProgressFields(dis);
     if (succeeded) {
-      restoreCompletedBucket(dis, context, checker);
-    } else {
-      restoreFailureMessage(dis, reqID, context, checker);
-    }
-  }
-
-  private void restoreCompletedBucket(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker)
-      throws ResumeFailedException {
-    if (returnType != ReturnType.DIRECT) {
-      return;
-    }
-    try (DataInputStream inner = createChecksummedInput(dis, context, checker)) {
-      returnBucketDirect =
-          BucketTools.restoreFrom(
-              inner,
-              context.persistentFG,
-              context.getPersistentFileTracker(),
-              context.getPersistentMasterSecret());
-    } catch (IOException | ChecksumFailedException | StorageFormatException e) {
-      LOG.error(COMPLETED_DOWNLOAD_RESTORE_FAILURE, e);
-      returnBucketDirect = null;
-      succeeded = false;
-      finished = false;
-    }
-  }
-
-  private void restoreFailureMessage(
-      DataInputStream dis,
-      RequestIdentifier reqID,
-      ClientContext context,
-      ChecksumChecker checker) {
-    try (DataInputStream inner = createChecksummedInput(dis, context, checker)) {
-      getFailedMessage = new GetFailedMessage(inner, reqID, foundDataLength, foundDataMimeType);
-      started = true;
-    } catch (IOException | ChecksumFailedException | StorageFormatException e) {
-      LOG.error("Unable to restore reason for failure, restarting request", e);
-      finished = false;
-      getFailedMessage = null;
-    }
-  }
-
-  private void restoreInProgressState(
-      DataInputStream dis,
-      ClientContext context,
-      ChecksumChecker checker,
-      ClientGetter inProgressGetter)
-      throws StorageFormatException {
-    try (DataInputStream inner = createChecksummedInput(dis, context, checker)) {
-      if (inProgressGetter.resumeFromTrivialProgress(inner, context)) {
-        readTransientProgressFields(inner);
+      if (returnType == ReturnType.DIRECT) {
+        Bucket restoredBucket =
+            ClientGetGetterFactory.restoreCompletedDirectBucketOrNull(dis, context, checker);
+        if (restoredBucket != null) {
+          returnBucketDirect = restoredBucket;
+        } else {
+          returnBucketDirect = null;
+          succeeded = false;
+          finished = false;
+        }
       }
-    } catch (IOException e) {
-      LOG.error("Unable to restore splitfile, restarting: {}", e.toString());
-    } catch (ChecksumFailedException _) {
-      LOG.error("Unable to restore splitfile, restarting (checksum failed)");
+    } else {
+      GetFailedMessage restoredMessage =
+          ClientGetGetterFactory.restoreFailureMessageOrNull(
+              dis, reqID, foundDataLength, foundDataMimeType, context, checker);
+      if (restoredMessage != null) {
+        getFailedMessage = restoredMessage;
+        started = true;
+      } else {
+        finished = false;
+        getFailedMessage = null;
+      }
     }
   }
 
-  private DataInputStream createChecksummedInput(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker)
-      throws IOException, ChecksumFailedException {
-    return new DataInputStream(
-        checker.checksumReaderWithLength(dis, context.tempBucketFactory, 65536));
-  }
-
-  private void readTransientProgressFields(DataInputStream dis)
-      throws IOException, StorageFormatException {
+  void readTransientProgressFields(DataInputStream dis) throws IOException, StorageFormatException {
     foundDataLength = dis.readLong();
     if (dis.readBoolean()) foundDataMimeType = dis.readUTF();
     else foundDataMimeType = null;

--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -12,6 +12,8 @@ import network.crypta.client.FetchResult;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.ClientGetterOptions;
+import network.crypta.client.async.ClientGetterRequest;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.CompatibilityAnalyser;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
@@ -310,7 +312,7 @@ public class ClientGet extends ClientRequest {
           "Charset parameter is ignored for ClientGet global queue requests: {}",
           requestConfig.charset());
     }
-    Object[] setup =
+    ClientGetReturnPlanner.ReturnSetup setup =
         ClientGetGetterFactory.planReturnForGlobal(
             identifier,
             global,
@@ -319,9 +321,9 @@ public class ClientGet extends ClientRequest {
             requestConfig.returnFilename(),
             requestConfig.filterData(),
             core);
-    Bucket returnBucket = (Bucket) setup[0];
-    this.targetFile = (File) setup[1];
-    this.extensionCheck = (String) setup[2];
+    Bucket returnBucket = setup.bucket();
+    this.targetFile = setup.targetFile();
+    this.extensionCheck = setup.extension();
     this.initialMetadata = null;
     getter = makeGetter(core, returnBucket);
   }
@@ -378,12 +380,12 @@ public class ClientGet extends ClientRequest {
 
     this.returnType = message.returnType;
     this.binaryBlob = message.binaryBlob;
-    Object[] setup =
+    ClientGetReturnPlanner.ReturnSetup setup =
         ClientGetGetterFactory.planReturnForMessage(
             identifier, global, fctx, message, core, handler);
-    Bucket returnBucket = (Bucket) setup[0];
-    this.targetFile = (File) setup[1];
-    this.extensionCheck = (String) setup[2];
+    Bucket returnBucket = setup.bucket();
+    this.targetFile = setup.targetFile();
+    this.extensionCheck = setup.extension();
     initialMetadata = message.getInitialMetadata();
     try {
       getter = makeGetter(core, returnBucket);
@@ -422,18 +424,14 @@ public class ClientGet extends ClientRequest {
   }
 
   private ClientGetter makeGetter(NodeClientCore core, Bucket ret) throws IOException {
-    return ClientGetGetterFactory.createGetter(
-        this,
-        uri,
-        fctx,
-        priorityClass,
-        ret,
-        initialMetadata,
-        extensionCheck,
-        returnType == ReturnType.NONE,
-        binaryBlob,
-        persistence == Persistence.FOREVER,
-        core);
+    ClientGetterRequest getterRequest =
+        ClientGetGetterFactory.createGetterRequest(this, uri, fctx, priorityClass);
+    ClientGetterOptions options =
+        new ClientGetterOptions(ret, null, false, initialMetadata, extensionCheck);
+    ClientGetGetterFlags flags =
+        new ClientGetGetterFlags(
+            returnType == ReturnType.NONE, binaryBlob, persistence == Persistence.FOREVER);
+    return ClientGetGetterFactory.createGetter(getterRequest, options, flags, core);
   }
 
   /**
@@ -1411,23 +1409,24 @@ public class ClientGet extends ClientRequest {
   @Override
   synchronized RequestStatus getStatus() {
     return ClientGetGetterFactory.buildStatus(
-        identifier,
-        persistence,
-        started,
-        finished,
-        succeeded,
-        progressPending,
-        getFailedMessage,
-        foundDataMimeType,
-        foundDataLength,
-        getDestFilename(),
-        getBucket(),
-        fctx,
-        priorityClass,
-        getCompatibilityMode(),
-        getOverriddenSplitfileCryptoKey(),
-        getURI(),
-        getDontCompress());
+        new ClientGetStatusSnapshot(
+            identifier,
+            persistence,
+            started,
+            finished,
+            succeeded,
+            progressPending,
+            getFailedMessage,
+            foundDataMimeType,
+            foundDataLength,
+            getDestFilename(),
+            getBucket(),
+            fctx,
+            priorityClass,
+            getCompatibilityMode(),
+            getOverriddenSplitfileCryptoKey(),
+            getURI(),
+            getDontCompress()));
   }
 
   private static final long CLIENT_DETAIL_MAGIC = 0x67145b675d2e22f4L;

--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -101,35 +101,35 @@ public class ClientGet extends ClientRequest {
   private boolean succeeded;
 
   /**
-   * Length of the found data. Will be updated from ClientGetter in onResume() but we persist it
+   * Length of the found data. Will be updated from ClientGetter in onResume(), but we persist it
    * anyway.
    */
   private long foundDataLength = -1;
 
   /**
-   * MIME type of the found data. Will be updated from ClientGetter in onResume() but we persist it
+   * MIME type of the found data. Will be updated from ClientGetter in onResume(), but we persist it
    * anyway.
    */
   private String foundDataMimeType;
 
-  /** Details of request failure. */
+  /** Details of the request failure. */
   private GetFailedMessage getFailedMessage;
 
-  /** Last progress message. Not persistent, ClientGetter will update on onResume(). */
+  /** Last progress message. Not persistently, ClientGetter will update on onResume(). */
   private transient SimpleProgressMessage progressPending;
 
   /** Have we received a SendingToNetworkEvent? */
   private boolean sentToNetwork;
 
   /**
-   * Current compatibility mode. This is updated over time as the request progresses, and can be
-   * used e.g. to reinsert the file. This is NOT transient, as the ClientGetter does not retain this
+   * Current compatibility mode. This is updated over time as the request progresses and can be used
+   * e.g., to reinsert the file. This is NOT transient, as the ClientGetter does not retain this
    * information.
    */
   private CompatibilityAnalyser compatMode;
 
   /**
-   * Expected hashes of the final data. Will be updated from ClientGetter in onResume() but we
+   * Expected hashes of the final data. Will be updated from ClientGetter in onResume(), but we
    * persist it anyway.
    */
   private ExpectedHashes expectedHashes;
@@ -216,14 +216,22 @@ public class ClientGet extends ClientRequest {
    * Bundles configuration for persistent global GET requests to keep constructors concise.
    *
    * <p>Instances capture all per-request tuning parameters that are otherwise passed positionally.
-   * The record is intentionally immutable so callers can safely reuse it across retries or
-   * validation steps without worrying about concurrent mutation.
+   * The record is intentionally immutable, so callers can safely reuse it across retries or
+   * validation steps without worrying about concurrent mutation. Callers typically populate it from
+   * parsed FCP messages or persisted metadata before invoking the global-queue constructor, and the
+   * values are meant to be safe for logging or storage because they avoid holding live buckets.
+   *
+   * <ul>
+   *   <li>Queue scope: persistence flags, identifiers, and real-time scheduling hints.
+   *   <li>Data handling: maximum output sizes, return type, and disk destination path.
+   *   <li>Behavior flags: datastore reachability, filtering, and cache-write preferences.
+   * </ul>
    *
    * @param dsOnly true to confine fetching to the local datastore only.
    * @param ignoreDS bypasses the datastore entirely when evaluating availability hints.
    * @param filterData applies MIME filtering before writing or returning data.
    * @param maxSplitfileRetries maximum block retries for splitfile reconstruction attempts.
-   * @param maxNonSplitfileRetries retry ceiling for non-splitfile requests before failing.
+   * @param maxNonSplitfileRetries retry the ceiling for non-splitfile requests before failing.
    * @param maxOutputLength upper bound in bytes for payload and temporary storage usage.
    * @param returnType delivery strategy describing whether bytes stream, persist, or skip.
    * @param persistRebootOnly true to persist only across reboots instead of forever.
@@ -359,7 +367,7 @@ public class ClientGet extends ClientRequest {
     if (message.persistence == Persistence.CONNECTION) {
       ensureConnectionIdentifierAvailable(handler, message.identifier);
     }
-    // Create a Fetcher directly in order to get more fine-grained control,
+    // Create a Fetcher directly to get more fine-grained control,
     // since the client may override a few context elements.
     fctx = core.getClientContext().getDefaultPersistentFetchContext();
     fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
@@ -456,7 +464,7 @@ public class ClientGet extends ClientRequest {
   }
 
   /**
-   * Must be called just after construction, but within a transaction.
+   * Must be called just after construction but within a transaction.
    *
    * @throws IdentifierCollisionException If the identifier is already in use.
    */
@@ -799,7 +807,7 @@ public class ClientGet extends ClientRequest {
   private boolean isRealTime() {
     if (lowLevelClient == null) {
       // This can happen but only due to data corruption - old databases on which various bugs have
-      // resulted in it getting deleted, and also possibly failed deletions.
+      // resulted in it getting deleted and also possibly failed deletions.
       LOG.warn("lowLevelClient == null");
       return false;
     }
@@ -839,7 +847,7 @@ public class ClientGet extends ClientRequest {
   /**
    * Cleans up when the owning queue removes the request, either manually or due to shut down.
    *
-   * <p>If the fetch was still running it fabricates a cancellation {@link FetchException} so the
+   * <p>If the fetch was still running, it fabricates a cancellation {@link FetchException} so the
    * client receives a {@link GetFailedMessage} with an explicit code. Afterward it notifies the
    * connection or persistent client that the entry disappeared, frees associated buckets, and calls
    * the superclass hook so shared accounting (such as tag persistence) also runs. This method is
@@ -849,7 +857,7 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   public void requestWasRemoved(ClientContext context) {
-    // if request is still running, send a GetFailed with code=canceled
+    // if the request is still running, send a GetFailed with code=canceled
     if (!finished) {
       synchronized (this) {
         succeeded = false;
@@ -859,7 +867,7 @@ public class ClientGet extends ClientRequest {
       }
       trySendDataFoundOrGetFailed(null, null);
     }
-    // notify client that request was removed
+    // notify client that the request was removed
     FCPMessage msg = new PersistentRequestRemovedMessage(getIdentifier(), global);
     if (persistence != Persistence.CONNECTION) {
       client.queueClientRequestMessage(msg, 0);
@@ -940,7 +948,7 @@ public class ClientGet extends ClientRequest {
    * <p>This method intentionally does not remove data written to disk, because disk-backed requests
    * are expected to leave the payload in place for the caller. It clears and frees any
    * direct-return buckets and the initial metadata bucket if present. The method is safe to call
-   * multiple times; subsequent invocations become no-ops.
+   * multiple times; later invocations become no-ops.
    */
   @Override
   protected void freeData() {
@@ -1173,11 +1181,11 @@ public class ClientGet extends ClientRequest {
    * precompressed.
    *
    * <p>This flag is derived from splitfile metadata analysis and is persisted across restarts. It
-   * is intended for downstream insert flows that want to preserve original byte structure rather
-   * than applying a second compression pass. The value is informational and does not affect the
-   * fetch itself.
+   * is intended for downstream insert flows that want to preserve the original byte structure
+   * rather than applying a second compression pass. The value is informational and does not affect
+   * the fetch itself.
    *
-   * @return {@code true} when compression should not be applied to subsequent insert contexts.
+   * @return {@code true} when compression should not be applied to later insert contexts.
    */
   public boolean getDontCompress() {
     return compatMode.dontCompress();
@@ -1285,7 +1293,7 @@ public class ClientGet extends ClientRequest {
    * Indicates whether the request can be restarted after a failure.
    *
    * <p>The getter must support restart semantics, the request must have finished, and it must not
-   * have succeeded already. Success cases require manual deletion or explicit reset before another
+   * have succeeded yet. Success cases require manual deletion or explicit reset before another
    * attempt. This method performs the minimal checks needed to decide if {@link
    * #restart(ClientContext, boolean)} is likely to proceed without immediate failure.
    *
@@ -1384,8 +1392,10 @@ public class ClientGet extends ClientRequest {
    *
    * <p>This flag is derived from the most recent {@link GetFailedMessage} and is used by restart
    * logic to decide whether a redirect should be applied automatically. The value is only
-   * meaningful after a failure has been recorded; otherwise it will return {@code false}. The
-   * method is synchronized to read the cached failure state consistently.
+   * meaningful after a failure has been recorded; otherwise it will return {@code false}. A {@code
+   * false} result means no redirect hint was captured for the last failure and no further redirect
+   * inference is attempted here. The method is synchronized to read the cached failure state
+   * consistently.
    *
    * @return {@code true} when {@link GetFailedMessage#redirectURI} is non-null.
    */
@@ -1398,7 +1408,9 @@ public class ClientGet extends ClientRequest {
    *
    * <p>The flag controls whether content filtering is applied before delivery. It can be toggled
    * during restart flows to temporarily disable filtering for a retry. This method simply reads the
-   * current {@link FetchContext} setting and does not alter any state.
+   * current {@link FetchContext} setting and does not alter any state. Because restarts can change
+   * the flag between attempts, callers should treat the value as a point-in-time snapshot rather
+   * than a promise about future retries.
    *
    * @return {@code true} when payloads should be filtered before delivery.
    */
@@ -1439,7 +1451,7 @@ public class ClientGet extends ClientRequest {
    * return types, binary-blob preferences, fetch contexts, metadata buckets, and—when finished—
    * either the success bucket or the failure descriptor. It also streams recent progress snapshots
    * so restarts can resume without re-downloading already verified blocks. Callers should provide a
-   * stream that is already framed by the persistence layer.
+   * stream already framed by the persistence layer.
    *
    * @param dos destination stream receiving the serialized form with embedded checksums.
    * @param checker checksum helper that wraps streams to guard against corruption.
@@ -1497,8 +1509,8 @@ public class ClientGet extends ClientRequest {
       }
     }
     // Not finished, or was recently not finished.
-    // Don't hold lock while calling getter.
-    // If it's just finished we get a race and restart. That's okay.
+    // Don't hold the lock while calling getter.
+    // If it's just finished, we get a race and restart. That's okay.
     try (DataOutputStream progressStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
       if (getter.writeTrivialProgress(progressStream)) {
         writeTransientProgressFields(progressStream);
@@ -1518,7 +1530,7 @@ public class ClientGet extends ClientRequest {
    * @param dis input stream positioned at the serialized client detail block.
    * @param reqID identifier tuple describing the owner and reference type.
    * @param context client context supplying factories used during restoration.
-   * @param checker checksum helper verifying integrity of embedded buckets.
+   * @param checker checksum helper verifying the integrity of embedded buckets.
    * @return fully reconstructed {@link ClientRequest} instance ready for resumption.
    * @throws StorageFormatException serialized data failed validation or used unknown versions.
    * @throws IOException stream IO failed while reading buckets or metadata.
@@ -1650,7 +1662,7 @@ public class ClientGet extends ClientRequest {
    * <p>This hook is invoked by the base resume flow once serialization has recreated the request
    * and the {@link ClientGetter}. It forwards the resume signal to any retained buckets and then
    * repopulates size and MIME hints from the getter if they were not stored explicitly. The method
-   * does not trigger network activity; it only rebinds state so subsequent status queries are
+   * does not trigger network activity; it only rebinds state so later status queries are
    * consistent.
    *
    * @param context client context used for bucket resume callbacks and defaults.
@@ -1690,7 +1702,7 @@ public class ClientGet extends ClientRequest {
    *
    * <p>Equality is defined by {@link ClientRequest} and typically reflects request identity rather
    * than mutable progress state. This override exists to preserve the base semantics while keeping
-   * the contract explicit in this subtype. The comparison is side-effect free.
+   * the contract explicit in this subtype. The comparison is side-effect-free.
    *
    * @param obj object to compare against, possibly {@code null}.
    * @return {@code true} when the base implementation considers the objects equal.

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -519,6 +519,39 @@ final class ClientGetGetterFactory {
   }
 
   /**
+   * Builds a {@link ClientGetter} for the supplied request settings.
+   *
+   * <p>This convenience wrapper keeps the request class free from option and flag types while still
+   * delegating to {@link #createGetter} for the actual fetcher creation.
+   *
+   * @param request owning request that receives fetch callbacks.
+   * @param returnBucket bucket holding returned data when not discarded.
+   * @param core node core used to allocate buckets when required.
+   * @return a configured {@link ClientGetter} ready to run.
+   * @throws IOException if bucket allocation fails.
+   */
+  static ClientGetter createGetterForRequest(
+      ClientGet request, Bucket returnBucket, NodeClientCore core) throws IOException {
+    ClientGetterRequest getterRequest =
+        createGetterRequest(
+            request, request.getURI(), request.fetchContextForGetter(), request.getPriority());
+    ClientGetterOptions options =
+        new ClientGetterOptions(
+            returnBucket,
+            null,
+            false,
+            request.initialMetadataBucket(),
+            request.extensionCheckForGetter());
+    ClientGet.ReturnType returnType = request.returnTypeForGetter();
+    ClientGetGetterFlags flags =
+        new ClientGetGetterFlags(
+            returnType == ClientGet.ReturnType.NONE,
+            request.binaryBlobRequested(),
+            request.persistence == ClientRequest.Persistence.FOREVER);
+    return createGetter(getterRequest, options, flags, core);
+  }
+
+  /**
    * Creates a configured {@link ClientGetter} for a {@link ClientGet} request.
    *
    * <p>The factory chooses the correct return bucket strategy and optionally sets up a {@link

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -6,10 +6,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Date;
+import java.util.HashSet;
 import java.util.Objects;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchResult;
+import network.crypta.client.InsertContext;
 import network.crypta.client.async.BinaryBlob;
 import network.crypta.client.async.BinaryBlobWriter;
 import network.crypta.client.async.ClientContext;
@@ -18,6 +22,7 @@ import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientGetterOptions;
 import network.crypta.client.async.ClientGetterRequest;
 import network.crypta.client.async.PersistentClientCallback;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
 import network.crypta.keys.FreenetURI;
@@ -28,6 +33,9 @@ import network.crypta.support.io.ArrayBucketFactory;
 import network.crypta.support.io.FileBucket;
 import network.crypta.support.io.NullBucket;
 import network.crypta.support.io.ResumeFailedException;
+import network.crypta.support.io.StorageFormatException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Creates {@link ClientGetter} instances for {@link ClientGet} requests, including Binary Blob
@@ -56,6 +64,8 @@ import network.crypta.support.io.ResumeFailedException;
  * @see BinaryBlobWriter
  */
 final class ClientGetGetterFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(ClientGet.class);
+
   /**
    * Reusable {@link NullBucket} to discard output without allocating per call.
    *
@@ -147,6 +157,297 @@ final class ClientGetGetterFactory {
   static DataOutputStream checksummedWriter(DataOutputStream target, ChecksumChecker checker)
       throws IOException {
     return new DataOutputStream(checker.checksumWriterWithLength(target, new ArrayBucketFactory()));
+  }
+
+  /**
+   * Applies allowed MIME types to a fetch context.
+   *
+   * <p>The method initializes the allowed MIME type set when configured in the request message.
+   * Passing {@code null} leaves the fetch context unchanged.
+   *
+   * @param fetchContext fetch context to update with allowed MIME types.
+   * @param allowedMimeTypes optional list of allowed MIME type strings.
+   */
+  static void applyAllowedMimeTypes(FetchContext fetchContext, String[] allowedMimeTypes) {
+    if (allowedMimeTypes == null) {
+      return;
+    }
+    fetchContext.setAllowedMIMETypes(new HashSet<>());
+    for (String mime : allowedMimeTypes) {
+      fetchContext.getAllowedMIMETypes().add(mime);
+    }
+  }
+
+  /**
+   * Builds a {@link RequestStatus} snapshot for a download request.
+   *
+   * <p>The helper mirrors the status construction from {@link ClientGet} while keeping additional
+   * dependencies out of the request class.
+   *
+   * @param identifier request identifier to report.
+   * @param persistence persistence mode for the request.
+   * @param started whether the request has started.
+   * @param finished whether the request has finished.
+   * @param succeeded whether the request has succeeded.
+   * @param progressPending last recorded progress snapshot, if any.
+   * @param failedMessage cached failure message, if any.
+   * @param foundDataMimeType MIME type discovered for the data.
+   * @param foundDataLength data length recorded for the request.
+   * @param destinationFile destination file for disk requests.
+   * @param dataBucket bucket containing result data.
+   * @param fetchContext fetch context providing filter and MIME overrides.
+   * @param priorityClass scheduler priority class.
+   * @param compatModes compatibility modes observed for the request.
+   * @param splitfileKey splitfile crypto key override, if any.
+   * @param uri request URI to report.
+   * @param dontCompress whether reinsertion should skip compression.
+   * @return a populated {@link DownloadRequestStatus} instance.
+   */
+  static RequestStatus buildStatus(
+      String identifier,
+      Persistence persistence,
+      boolean started,
+      boolean finished,
+      boolean succeeded,
+      SimpleProgressMessage progressPending,
+      GetFailedMessage failedMessage,
+      String foundDataMimeType,
+      long foundDataLength,
+      File destinationFile,
+      Bucket dataBucket,
+      FetchContext fetchContext,
+      short priorityClass,
+      InsertContext.CompatibilityMode[] compatModes,
+      byte[] splitfileKey,
+      FreenetURI uri,
+      boolean dontCompress) {
+    boolean totalFinalized = false;
+    int total = 0;
+    int min = 0;
+    int fetched = 0;
+    int fatal = 0;
+    int failed = 0;
+    // See ClientRequester.getLatestSuccess() for why this defaults to current time.
+    Date latestSuccess = new Date();
+    Date latestFailure = null;
+
+    if (progressPending != null) {
+      totalFinalized = progressPending.isTotalFinalized();
+      // The progress API reports doubles to preserve partial block counts from the splitter.
+      total = (int) progressPending.getTotalBlocks();
+      min = (int) progressPending.getMinBlocks();
+      fetched = (int) progressPending.getFetchedBlocks();
+      latestSuccess = progressPending.getLatestSuccess();
+      fatal = (int) progressPending.getFatalyFailedBlocks();
+      failed = (int) progressPending.getFailedBlocks();
+      latestFailure = progressPending.getLatestFailure();
+    }
+    if (finished && succeeded) totalFinalized = true;
+    FetchExceptionMode failureCode = null;
+    String failureReasonShort = null;
+    String failureReasonLong = null;
+    if (failedMessage != null) {
+      failureCode = failedMessage.failureMode;
+      failureReasonShort = failedMessage.getShortFailedMessage();
+      failureReasonLong = failedMessage.getLongFailedMessage();
+    }
+    String mimeType = foundDataMimeType;
+    long dataSize = foundDataLength;
+    File target = destinationFile;
+    if (target != null) target = new File(target.getPath());
+
+    Bucket shadow = (finished && succeeded) ? dataBucket : null;
+    if (shadow != null) {
+      if (dataSize != shadow.size()) {
+        LOG.error(
+            "Size of downloaded data has changed: {} -> {} on {}", dataSize, shadow.size(), shadow);
+        shadow = null;
+      } else {
+        shadow = shadow.createShadow();
+      }
+    }
+
+    boolean filterData = fetchContext.getFilterData();
+    boolean overriddenDataType =
+        fetchContext.getOverrideMIME() != null || fetchContext.getCharset() != null;
+
+    return new DownloadRequestStatus(
+        identifier,
+        persistence,
+        started,
+        finished,
+        succeeded,
+        total,
+        min,
+        fetched,
+        latestSuccess,
+        fatal,
+        failed,
+        latestFailure,
+        totalFinalized,
+        priorityClass,
+        failureCode,
+        mimeType,
+        dataSize,
+        target,
+        compatModes,
+        splitfileKey,
+        uri,
+        failureReasonShort,
+        failureReasonLong,
+        overriddenDataType,
+        shadow,
+        filterData,
+        dontCompress);
+  }
+
+  /**
+   * Plans return handling for a global request.
+   *
+   * <p>The returned array contains the return bucket, target file, and extension hint in that
+   * order.
+   *
+   * @param identifier request identifier used for policy checks.
+   * @param global whether the request uses the global identifier namespace.
+   * @param fetchContext fetch context for return planning.
+   * @param returnType configured return type.
+   * @param returnFilename target file for disk returns.
+   * @param filterData whether to derive an extension hint when filtering.
+   * @param core node core used for policy checks.
+   * @return array containing {@link Bucket}, {@link File}, and extension {@link String}.
+   * @throws NotAllowedException if the node policy rejects the requested target path.
+   * @throws IOException if an existing target file cannot be removed or is unsafe to overwrite.
+   */
+  static Object[] planReturnForGlobal(
+      String identifier,
+      boolean global,
+      FetchContext fetchContext,
+      ClientGet.ReturnType returnType,
+      File returnFilename,
+      boolean filterData,
+      NodeClientCore core)
+      throws NotAllowedException, IOException {
+    ClientGetReturnPlanner returnPlanner =
+        new ClientGetReturnPlanner(identifier, global, fetchContext);
+    ClientGetReturnPlanner.ReturnSetup setup =
+        returnPlanner.forGlobalRequest(returnType, returnFilename, filterData, core);
+    return new Object[] {setup.bucket(), setup.targetFile(), setup.extension()};
+  }
+
+  /**
+   * Plans return handling for a client message.
+   *
+   * <p>The returned array contains the return bucket, target file, and extension hint in that
+   * order.
+   *
+   * @param identifier request identifier used for policy checks.
+   * @param global whether the request uses the global identifier namespace.
+   * @param fetchContext fetch context for return planning.
+   * @param message message containing return settings.
+   * @param core node core used for policy checks.
+   * @param handler connection handler providing DDA validation.
+   * @return array containing {@link Bucket}, {@link File}, and extension {@link String}.
+   * @throws MessageInvalidException if policy checks fail or the target file is unsafe to use.
+   */
+  static Object[] planReturnForMessage(
+      String identifier,
+      boolean global,
+      FetchContext fetchContext,
+      ClientGetMessage message,
+      NodeClientCore core,
+      FCPConnectionHandler handler)
+      throws MessageInvalidException {
+    ClientGetReturnPlanner returnPlanner =
+        new ClientGetReturnPlanner(identifier, global, fetchContext);
+    ClientGetReturnPlanner.ReturnSetup setup = returnPlanner.forMessage(message, core, handler);
+    return new Object[] {setup.bucket(), setup.targetFile(), setup.extension()};
+  }
+
+  /**
+   * Restores a {@link FetchContext} or defaults when recovery fails.
+   *
+   * @param dis input stream positioned at the fetch context data.
+   * @param context client context providing default fetch settings.
+   * @param checker checksum helper used to verify the serialized block.
+   * @return restored {@link FetchContext} or the default when recovery fails.
+   */
+  static FetchContext readFetchContextOrDefault(
+      DataInputStream dis, ClientContext context, ChecksumChecker checker) {
+    return ClientGetPersistenceIO.readFetchContextOrDefault(dis, context, checker);
+  }
+
+  /**
+   * Restores an initial metadata bucket for the request, if present.
+   *
+   * @param dis input stream positioned at the metadata bucket marker.
+   * @param context client context owning persistent bucket services.
+   * @param checker checksum helper used to verify the bucket metadata.
+   * @return restored bucket or {@code null} when no metadata marker was set.
+   * @throws IOException if the underlying stream cannot be read.
+   * @throws StorageFormatException if metadata integrity checks fail.
+   * @throws ResumeFailedException if bucket restoration fails.
+   */
+  static Bucket readInitialMetadata(
+      DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      throws IOException, StorageFormatException, ResumeFailedException {
+    return ClientGetPersistenceIO.readInitialMetadata(dis, context, checker);
+  }
+
+  /**
+   * Restores a completed direct bucket from persistent storage.
+   *
+   * @param dis input stream positioned at the bucket payload.
+   * @param context client context owning persistent bucket services.
+   * @param checker checksum helper used to verify the bucket metadata.
+   * @return restored bucket, or {@code null} when restoration failed.
+   * @throws ResumeFailedException if bucket restoration fails.
+   */
+  static Bucket restoreCompletedDirectBucketOrNull(
+      DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      throws ResumeFailedException {
+    return ClientGetPersistenceIO.restoreCompletedDirectBucketOrNull(dis, context, checker);
+  }
+
+  /**
+   * Restores the failure message for a finished request.
+   *
+   * @param dis input stream positioned at the failure message payload.
+   * @param reqID request identifier used to populate the failure message.
+   * @param foundDataLength recorded data length for the request.
+   * @param foundDataMimeType recorded MIME type for the request.
+   * @param context client context providing checksum helpers.
+   * @param checker checksum helper used to verify the payload.
+   * @return restored {@link GetFailedMessage} or {@code null} when recovery fails.
+   */
+  static GetFailedMessage restoreFailureMessageOrNull(
+      DataInputStream dis,
+      RequestIdentifier reqID,
+      long foundDataLength,
+      String foundDataMimeType,
+      ClientContext context,
+      ChecksumChecker checker) {
+    return ClientGetPersistenceIO.restoreFailureMessageOrNull(
+        dis, reqID, foundDataLength, foundDataMimeType, context, checker);
+  }
+
+  /**
+   * Restores in-progress getter state along with transient progress fields.
+   *
+   * @param dis input stream positioned at the progress data block.
+   * @param context client context used to resume the getter.
+   * @param checker checksum helper used to validate the block.
+   * @param inProgressGetter getter instance to resume.
+   * @param request request instance for restoring transient fields.
+   * @throws StorageFormatException if the serialized state is invalid.
+   */
+  static void restoreInProgressState(
+      DataInputStream dis,
+      ClientContext context,
+      ChecksumChecker checker,
+      ClientGetter inProgressGetter,
+      ClientGet request)
+      throws StorageFormatException {
+    ClientGetPersistenceIO.restoreInProgressState(dis, context, checker, inProgressGetter, request);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -44,8 +44,8 @@ import org.slf4j.LoggerFactory;
  * <p>This utility centralizes the wiring required to build a {@link ClientGetter} with the correct
  * callback adapter, bucket choices, and optional {@link BinaryBlobWriter} so the request class can
  * focus on persistence and lifecycle duties. Callers typically invoke it during request creation or
- * resume paths to obtain a fully configured fetcher while keeping Binary Blob concerns out of
- * {@link ClientGet} and under the Sonar coupling limit (rule {@code java:S6539}).
+ * resume paths to get a fully configured fetcher while keeping Binary Blob concerns out of {@link
+ * ClientGet} and under the Sonar coupling limit (rule {@code java:S6539}).
  *
  * <p>There is no mutable-shared state beyond a reusable {@link NullBucket} instance, so the class
  * is effectively stateless. Thread-safety is therefore determined by the collaborators passed in,
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
  * @see BinaryBlobWriter
  */
 final class ClientGetGetterFactory {
-  private static final Logger LOG = LoggerFactory.getLogger(ClientGet.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ClientGetGetterFactory.class);
 
   /**
    * Reusable {@link NullBucket} to discard output without allocating per call.
@@ -184,52 +184,37 @@ final class ClientGetGetterFactory {
    * <p>The helper mirrors the status construction from {@link ClientGet} while keeping additional
    * dependencies out of the request class.
    *
-   * @param identifier request identifier to report.
-   * @param persistence persistence mode for the request.
-   * @param started whether the request has started.
-   * @param finished whether the request has finished.
-   * @param succeeded whether the request has succeeded.
-   * @param progressPending last recorded progress snapshot, if any.
-   * @param failedMessage cached failure message, if any.
-   * @param foundDataMimeType MIME type discovered for the data.
-   * @param foundDataLength data length recorded for the request.
-   * @param destinationFile destination file for disk requests.
-   * @param dataBucket bucket containing result data.
-   * @param fetchContext fetch context providing filter and MIME overrides.
-   * @param priorityClass scheduler priority class.
-   * @param compatModes compatibility modes observed for the request.
-   * @param splitfileKey splitfile crypto key override, if any.
-   * @param uri request URI to report.
-   * @param dontCompress whether reinsertion should skip compression.
+   * @param snapshot captured request state used to populate the status.
    * @return a populated {@link DownloadRequestStatus} instance.
    */
-  static RequestStatus buildStatus(
-      String identifier,
-      Persistence persistence,
-      boolean started,
-      boolean finished,
-      boolean succeeded,
-      SimpleProgressMessage progressPending,
-      GetFailedMessage failedMessage,
-      String foundDataMimeType,
-      long foundDataLength,
-      File destinationFile,
-      Bucket dataBucket,
-      FetchContext fetchContext,
-      short priorityClass,
-      InsertContext.CompatibilityMode[] compatModes,
-      byte[] splitfileKey,
-      FreenetURI uri,
-      boolean dontCompress) {
+  @SuppressWarnings("resource")
+  static RequestStatus buildStatus(ClientGetStatusSnapshot snapshot) {
     boolean totalFinalized = false;
     int total = 0;
     int min = 0;
     int fetched = 0;
     int fatal = 0;
     int failed = 0;
-    // See ClientRequester.getLatestSuccess() for why this defaults to current time.
+    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
     Date latestSuccess = new Date();
     Date latestFailure = null;
+    String identifier = snapshot.identifier();
+    Persistence persistence = snapshot.persistence();
+    boolean started = snapshot.started();
+    boolean finished = snapshot.finished();
+    boolean succeeded = snapshot.succeeded();
+    SimpleProgressMessage progressPending = snapshot.progressPending();
+    GetFailedMessage failedMessage = snapshot.failedMessage();
+    String foundDataMimeType = snapshot.foundDataMimeType();
+    long foundDataLength = snapshot.foundDataLength();
+    File destinationFile = snapshot.destinationFile();
+    Bucket dataBucket = snapshot.dataBucket();
+    FetchContext fetchContext = snapshot.fetchContext();
+    short priorityClass = snapshot.priorityClass();
+    InsertContext.CompatibilityMode[] compatModes = snapshot.compatModes();
+    byte[] splitfileKey = snapshot.splitfileKey();
+    FreenetURI uri = snapshot.uri();
+    boolean dontCompress = snapshot.dontCompress();
 
     if (progressPending != null) {
       totalFinalized = progressPending.isTotalFinalized();
@@ -251,16 +236,17 @@ final class ClientGetGetterFactory {
       failureReasonShort = failedMessage.getShortFailedMessage();
       failureReasonLong = failedMessage.getLongFailedMessage();
     }
-    String mimeType = foundDataMimeType;
-    long dataSize = foundDataLength;
     File target = destinationFile;
     if (target != null) target = new File(target.getPath());
 
     Bucket shadow = (finished && succeeded) ? dataBucket : null;
     if (shadow != null) {
-      if (dataSize != shadow.size()) {
+      if (foundDataLength != shadow.size()) {
         LOG.error(
-            "Size of downloaded data has changed: {} -> {} on {}", dataSize, shadow.size(), shadow);
+            "Size of downloaded data has changed: {} -> {} on {}",
+            foundDataLength,
+            shadow.size(),
+            shadow);
         shadow = null;
       } else {
         shadow = shadow.createShadow();
@@ -287,8 +273,8 @@ final class ClientGetGetterFactory {
         totalFinalized,
         priorityClass,
         failureCode,
-        mimeType,
-        dataSize,
+        foundDataMimeType,
+        foundDataLength,
         target,
         compatModes,
         splitfileKey,
@@ -304,7 +290,7 @@ final class ClientGetGetterFactory {
   /**
    * Plans return handling for a global request.
    *
-   * <p>The returned array contains the return bucket, target file, and extension hint in that
+   * <p>The returned setup contains the return bucket, target file, and extension hint in that
    * order.
    *
    * @param identifier request identifier used for policy checks.
@@ -314,11 +300,11 @@ final class ClientGetGetterFactory {
    * @param returnFilename target file for disk returns.
    * @param filterData whether to derive an extension hint when filtering.
    * @param core node core used for policy checks.
-   * @return array containing {@link Bucket}, {@link File}, and extension {@link String}.
+   * @return setup containing {@link Bucket}, {@link File}, and extension {@link String}.
    * @throws NotAllowedException if the node policy rejects the requested target path.
    * @throws IOException if an existing target file cannot be removed or is unsafe to overwrite.
    */
-  static Object[] planReturnForGlobal(
+  static ClientGetReturnPlanner.ReturnSetup planReturnForGlobal(
       String identifier,
       boolean global,
       FetchContext fetchContext,
@@ -329,15 +315,13 @@ final class ClientGetGetterFactory {
       throws NotAllowedException, IOException {
     ClientGetReturnPlanner returnPlanner =
         new ClientGetReturnPlanner(identifier, global, fetchContext);
-    ClientGetReturnPlanner.ReturnSetup setup =
-        returnPlanner.forGlobalRequest(returnType, returnFilename, filterData, core);
-    return new Object[] {setup.bucket(), setup.targetFile(), setup.extension()};
+    return returnPlanner.forGlobalRequest(returnType, returnFilename, filterData, core);
   }
 
   /**
    * Plans return handling for a client message.
    *
-   * <p>The returned array contains the return bucket, target file, and extension hint in that
+   * <p>The returned setup contains the return bucket, target file, and extension hint in that
    * order.
    *
    * @param identifier request identifier used for policy checks.
@@ -346,10 +330,10 @@ final class ClientGetGetterFactory {
    * @param message message containing return settings.
    * @param core node core used for policy checks.
    * @param handler connection handler providing DDA validation.
-   * @return array containing {@link Bucket}, {@link File}, and extension {@link String}.
+   * @return setup containing {@link Bucket}, {@link File}, and extension {@link String}.
    * @throws MessageInvalidException if policy checks fail or the target file is unsafe to use.
    */
-  static Object[] planReturnForMessage(
+  static ClientGetReturnPlanner.ReturnSetup planReturnForMessage(
       String identifier,
       boolean global,
       FetchContext fetchContext,
@@ -359,8 +343,7 @@ final class ClientGetGetterFactory {
       throws MessageInvalidException {
     ClientGetReturnPlanner returnPlanner =
         new ClientGetReturnPlanner(identifier, global, fetchContext);
-    ClientGetReturnPlanner.ReturnSetup setup = returnPlanner.forMessage(message, core, handler);
-    return new Object[] {setup.bucket(), setup.targetFile(), setup.extension()};
+    return returnPlanner.forMessage(message, core, handler);
   }
 
   /**
@@ -451,7 +434,7 @@ final class ClientGetGetterFactory {
   }
 
   /**
-   * Creates a disk-backed bucket intended to receive final download output.
+   * Creates a disk-backed bucket intended to receive the final download output.
    *
    * <p>The bucket is configured so the file must not pre-exist on first write, helping prevent
    * accidental overwrites. The bucket is writable by default and does not register for
@@ -516,14 +499,10 @@ final class ClientGetGetterFactory {
   }
 
   /**
-   * Creates a configured {@link ClientGetter} for a {@link ClientGet} request.
+   * Builds the {@link ClientGetterRequest} used to start a {@link ClientGet} fetch.
    *
-   * <p>The factory wires a {@link CallbackAdapter}, chooses the correct return bucket strategy, and
-   * optionally sets up a {@link BinaryBlobWriter} when Binary Blob recording is requested. If
-   * {@code binaryBlob} is enabled and {@code returnBucket} is {@code null}, the method uses {@code
-   * core} to allocate a bucket sized to {@link FetchContext#getMaxOutputLength()}. When {@code
-   * discardData} is true and Binary Blob is disabled, the returned fetcher writes into a shared
-   * {@link NullBucket} instead of the provided bucket.
+   * <p>The request wires a {@link CallbackAdapter} so persistence operations and result delivery
+   * are delegated to the owning {@link ClientGet} instance.
    *
    * @param request owning request to receive callbacks and resume signals; must not be {@code
    *     null}.
@@ -531,43 +510,53 @@ final class ClientGetGetterFactory {
    * @param fetchContext fetch configuration that defines size limits and filters; must not be
    *     {@code null}.
    * @param priorityClass scheduler priority class for the request.
-   * @param returnBucket bucket for final data, or {@code null} to let the getter allocate one.
-   * @param initialMetadata optional metadata bucket to seed the fetcher, may be {@code null}.
-   * @param extensionCheck optional extension used by MIME filtering; may be {@code null}.
-   * @param discardData whether to discard payload bytes entirely when Binary Blob is disabled.
-   * @param binaryBlob whether to record a Binary Blob stream instead of regular output data.
-   * @param persistenceForever whether the request is persisted across restarts for bucket choice.
-   * @param core node core used to allocate buckets when needed; required if {@code binaryBlob} is
-   *     true and {@code returnBucket} is {@code null}.
+   * @return a {@link ClientGetterRequest} configured for the provided request context.
+   */
+  static ClientGetterRequest createGetterRequest(
+      ClientGet request, FreenetURI uri, FetchContext fetchContext, short priorityClass) {
+    ClientGetCallback callback = new CallbackAdapter(request);
+    return new ClientGetterRequest(callback, uri, fetchContext, priorityClass);
+  }
+
+  /**
+   * Creates a configured {@link ClientGetter} for a {@link ClientGet} request.
+   *
+   * <p>The factory chooses the correct return bucket strategy and optionally sets up a {@link
+   * BinaryBlobWriter} when Binary Blob recording is requested. If Binary Blob recording is enabled
+   * and the options do not specify a return bucket, the method uses {@code core} to allocate a
+   * bucket sized to {@link FetchContext#getMaxOutputLength()}. When {@link
+   * ClientGetGetterFlags#discardData()} is true and Binary Blob is disabled, the returned fetcher
+   * writes into a shared {@link NullBucket} instead of the provided bucket.
+   *
+   * @param request request parameters including the callback, URI, and fetch context.
+   * @param options return bucket, metadata, and extension options for the fetcher.
+   * @param flags behavior flags for Binary Blob recording and discard handling.
+   * @param core node core used to allocate buckets when needed; required if Binary Blob recording
+   *     is enabled and no return bucket is supplied.
    * @return a fully constructed {@link ClientGetter} ready to start.
    * @throws IOException if bucket allocation fails or underlying stream setup fails.
    * @throws NullPointerException if {@code core} is required but not provided.
    */
   static ClientGetter createGetter(
-      ClientGet request,
-      FreenetURI uri,
-      FetchContext fetchContext,
-      short priorityClass,
-      Bucket returnBucket,
-      Bucket initialMetadata,
-      String extensionCheck,
-      boolean discardData,
-      boolean binaryBlob,
-      boolean persistenceForever,
+      ClientGetterRequest request,
+      ClientGetterOptions options,
+      ClientGetGetterFlags flags,
       NodeClientCore core)
       throws IOException {
-    ClientGetCallback callback = new CallbackAdapter(request);
+    Bucket returnBucket = options.returnBucket();
+    Bucket initialMetadata = options.initialMetadata();
+    String extensionCheck = options.forceCompatibleExtension();
     Bucket blobBucket = returnBucket;
-    if (binaryBlob) {
+    if (flags.binaryBlob()) {
       if (blobBucket == null) {
         Objects.requireNonNull(core, "core");
         blobBucket =
             core.getClientContext()
-                .getBucketFactory(persistenceForever)
-                .makeBucket(fetchContext.getMaxOutputLength());
+                .getBucketFactory(flags.persistenceForever())
+                .makeBucket(request.ctx().getMaxOutputLength());
       }
       return new ClientGetter(
-          new ClientGetterRequest(callback, uri, fetchContext, priorityClass),
+          request,
           new ClientGetterOptions(
               NULL_BUCKET,
               new BinaryBlobWriter(blobBucket),
@@ -575,11 +564,11 @@ final class ClientGetGetterFactory {
               initialMetadata,
               extensionCheck));
     }
-    if (discardData) {
+    if (flags.discardData()) {
       returnBucket = NULL_BUCKET;
     }
     return new ClientGetter(
-        new ClientGetterRequest(callback, uri, fetchContext, priorityClass),
+        request,
         new ClientGetterOptions(returnBucket, null, false, initialMetadata, extensionCheck));
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFlags.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFlags.java
@@ -1,0 +1,16 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Flags describing how {@link ClientGetGetterFactory} should configure a getter.
+ *
+ * <p>The flags capture whether a request should discard data, record a Binary Blob stream, and
+ * allocate persistent buckets. They are kept together to reduce parameter counts while preserving
+ * the existing getter wiring behavior.
+ *
+ * @param discardData whether payload bytes should be discarded when Binary Blob recording is
+ *     disabled.
+ * @param binaryBlob whether to record a Binary Blob stream instead of regular output data.
+ * @param persistenceForever whether the request persists across restarts for bucket selection.
+ */
+public record ClientGetGetterFlags(
+    boolean discardData, boolean binaryBlob, boolean persistenceForever) {}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 final class ClientGetPersistenceIO {
   private static final Logger LOG = LoggerFactory.getLogger(ClientGetPersistenceIO.class);
 
+  private static final long CHECKSUMMED_BLOCK_MAX_LENGTH = 65536L;
   private static final String COMPLETED_DOWNLOAD_RESTORE_FAILURE =
       "Failed to restore completed download-to-temp-space request, restarting instead";
   private static final String FETCH_SETTINGS_FALLBACK_MESSAGE =
@@ -36,15 +37,26 @@ final class ClientGetPersistenceIO {
    * @param dis input stream positioned at the checksummed payload.
    * @param context client context providing a temporary bucket factory.
    * @param checker checksum helper used to verify the payload.
+   * @param maxLength maximum length accepted for the checksummed payload.
    * @return a {@link DataInputStream} that validates checksums on close.
    * @throws IOException if the reader cannot be created.
-   * @throws ChecksumFailedException if checksum verification fails.
+   * @throws StorageFormatException if checksum verification fails.
    */
-  static DataInputStream checksummedReader(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker)
-      throws IOException, ChecksumFailedException {
-    return new DataInputStream(
-        checker.checksumReaderWithLength(dis, context.tempBucketFactory, 65536));
+  static DataInputStream openChecksummed(
+      DataInputStream dis, ClientContext context, ChecksumChecker checker, long maxLength)
+      throws IOException, StorageFormatException {
+    try {
+      return new DataInputStream(
+          checker.checksumReaderWithLength(dis, context.tempBucketFactory, maxLength));
+    } catch (ChecksumFailedException e) {
+      StorageFormatException storageFormatException = new StorageFormatException("Checksum failed");
+      storageFormatException.initCause(e);
+      throw storageFormatException;
+    }
+  }
+
+  private static boolean isChecksumFailure(StorageFormatException exception) {
+    return exception.getCause() instanceof ChecksumFailedException;
   }
 
   /**
@@ -57,14 +69,43 @@ final class ClientGetPersistenceIO {
    */
   static FetchContext readFetchContextOrDefault(
       DataInputStream dis, ClientContext context, ChecksumChecker checker) {
-    try (DataInputStream inner = checksummedReader(dis, context, checker)) {
+    try (DataInputStream inner =
+        openChecksummed(dis, context, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
       return new FetchContext(inner);
-    } catch (StorageFormatException | IOException e) {
+    } catch (IOException e) {
       LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE, e);
-    } catch (ChecksumFailedException _) {
-      LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE);
+    } catch (StorageFormatException e) {
+      if (isChecksumFailure(e)) {
+        LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE);
+      } else {
+        LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE, e);
+      }
     }
     return context.getDefaultPersistentFetchContext();
+  }
+
+  /**
+   * Restores a bucket from a checksummed payload.
+   *
+   * @param dis input stream positioned at the bucket payload.
+   * @param context client context owning persistent bucket services.
+   * @param checker checksum helper used to verify the bucket metadata.
+   * @return restored bucket from the checksummed payload.
+   * @throws IOException if the underlying stream cannot be read.
+   * @throws StorageFormatException if checksum validation fails.
+   * @throws ResumeFailedException if bucket restoration fails.
+   */
+  static Bucket restoreBucketFromChecksummedBlock(
+      DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      throws IOException, StorageFormatException, ResumeFailedException {
+    try (DataInputStream inner =
+        openChecksummed(dis, context, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
+      return BucketTools.restoreFrom(
+          inner,
+          context.persistentFG,
+          context.getPersistentFileTracker(),
+          context.getPersistentMasterSecret());
+    }
   }
 
   /**
@@ -84,16 +125,17 @@ final class ClientGetPersistenceIO {
     if (!dis.readBoolean()) {
       return null;
     }
-    try (DataInputStream metadataStream = checksummedReader(dis, context, checker)) {
-      return BucketTools.restoreFrom(
-          metadataStream,
-          context.persistentFG,
-          context.getPersistentFileTracker(),
-          context.getPersistentMasterSecret());
-    } catch (ChecksumFailedException e) {
-      StorageFormatException sfe = new StorageFormatException("Unable to restore initial metadata");
-      sfe.initCause(e);
-      throw sfe;
+    try {
+      return restoreBucketFromChecksummedBlock(dis, context, checker);
+    } catch (StorageFormatException e) {
+      if (isChecksumFailure(e)) {
+        StorageFormatException storageFormatException =
+            new StorageFormatException("Unable to restore initial metadata");
+        Throwable cause = e.getCause() == null ? e : e.getCause();
+        storageFormatException.initCause(cause);
+        throw storageFormatException;
+      }
+      throw e;
     }
   }
 
@@ -109,13 +151,9 @@ final class ClientGetPersistenceIO {
   static Bucket restoreCompletedDirectBucketOrNull(
       DataInputStream dis, ClientContext context, ChecksumChecker checker)
       throws ResumeFailedException {
-    try (DataInputStream inner = checksummedReader(dis, context, checker)) {
-      return BucketTools.restoreFrom(
-          inner,
-          context.persistentFG,
-          context.getPersistentFileTracker(),
-          context.getPersistentMasterSecret());
-    } catch (IOException | ChecksumFailedException | StorageFormatException e) {
+    try {
+      return restoreBucketFromChecksummedBlock(dis, context, checker);
+    } catch (IOException | StorageFormatException e) {
       LOG.error(COMPLETED_DOWNLOAD_RESTORE_FAILURE, e);
       return null;
     }
@@ -139,9 +177,10 @@ final class ClientGetPersistenceIO {
       String foundDataMimeType,
       ClientContext context,
       ChecksumChecker checker) {
-    try (DataInputStream inner = checksummedReader(dis, context, checker)) {
+    try (DataInputStream inner =
+        openChecksummed(dis, context, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
       return new GetFailedMessage(inner, reqID, foundDataLength, foundDataMimeType);
-    } catch (IOException | ChecksumFailedException | StorageFormatException e) {
+    } catch (IOException | StorageFormatException e) {
       LOG.error("Unable to restore reason for failure, restarting request", e);
       return null;
     }
@@ -164,14 +203,19 @@ final class ClientGetPersistenceIO {
       ClientGetter inProgressGetter,
       ClientGet request)
       throws StorageFormatException {
-    try (DataInputStream inner = checksummedReader(dis, context, checker)) {
+    try (DataInputStream inner =
+        openChecksummed(dis, context, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
       if (inProgressGetter.resumeFromTrivialProgress(inner, context)) {
         request.readTransientProgressFields(inner);
       }
     } catch (IOException e) {
       LOG.error("Unable to restore splitfile, restarting: {}", e.toString());
-    } catch (ChecksumFailedException _) {
-      LOG.error("Unable to restore splitfile, restarting (checksum failed)");
+    } catch (StorageFormatException e) {
+      if (isChecksumFailure(e)) {
+        LOG.error("Unable to restore splitfile, restarting (checksum failed)");
+      } else {
+        throw e;
+      }
     }
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
@@ -1,0 +1,177 @@
+package network.crypta.clients.fcp;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import network.crypta.client.FetchContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.ChecksumFailedException;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.BucketTools;
+import network.crypta.support.io.ResumeFailedException;
+import network.crypta.support.io.StorageFormatException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles persistent I/O for {@link ClientGet} instances.
+ *
+ * <p>The helper encapsulates checksummed input streams, bucket restoration, and failure recovery so
+ * {@link ClientGet} can delegate persistence logic without increasing coupling.
+ */
+final class ClientGetPersistenceIO {
+  private static final Logger LOG = LoggerFactory.getLogger(ClientGetPersistenceIO.class);
+
+  private static final String COMPLETED_DOWNLOAD_RESTORE_FAILURE =
+      "Failed to restore completed download-to-temp-space request, restarting instead";
+  private static final String FETCH_SETTINGS_FALLBACK_MESSAGE =
+      "Unable to read fetch settings, will use default settings";
+
+  private ClientGetPersistenceIO() {}
+
+  /**
+   * Creates a checksummed reader that wraps the supplied stream.
+   *
+   * @param dis input stream positioned at the checksummed payload.
+   * @param context client context providing a temporary bucket factory.
+   * @param checker checksum helper used to verify the payload.
+   * @return a {@link DataInputStream} that validates checksums on close.
+   * @throws IOException if the reader cannot be created.
+   * @throws ChecksumFailedException if checksum verification fails.
+   */
+  static DataInputStream checksummedReader(
+      DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      throws IOException, ChecksumFailedException {
+    return new DataInputStream(
+        checker.checksumReaderWithLength(dis, context.tempBucketFactory, 65536));
+  }
+
+  /**
+   * Restores the {@link FetchContext}, or returns defaults when recovery fails.
+   *
+   * @param dis input stream positioned at the fetch context data.
+   * @param context client context providing default fetch settings.
+   * @param checker checksum helper used to verify the serialized block.
+   * @return restored {@link FetchContext} or the default when recovery fails.
+   */
+  static FetchContext readFetchContextOrDefault(
+      DataInputStream dis, ClientContext context, ChecksumChecker checker) {
+    try (DataInputStream inner = checksummedReader(dis, context, checker)) {
+      return new FetchContext(inner);
+    } catch (StorageFormatException | IOException e) {
+      LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE, e);
+    } catch (ChecksumFailedException _) {
+      LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE);
+    }
+    return context.getDefaultPersistentFetchContext();
+  }
+
+  /**
+   * Restores an initial metadata bucket for the request, if present.
+   *
+   * @param dis input stream positioned at the metadata bucket marker.
+   * @param context client context owning persistent bucket services.
+   * @param checker checksum helper used to verify the bucket metadata.
+   * @return restored bucket or {@code null} when no metadata marker was set.
+   * @throws IOException if the underlying stream cannot be read.
+   * @throws StorageFormatException if metadata integrity checks fail.
+   * @throws ResumeFailedException if bucket restoration fails.
+   */
+  static Bucket readInitialMetadata(
+      DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      throws IOException, StorageFormatException, ResumeFailedException {
+    if (!dis.readBoolean()) {
+      return null;
+    }
+    try (DataInputStream metadataStream = checksummedReader(dis, context, checker)) {
+      return BucketTools.restoreFrom(
+          metadataStream,
+          context.persistentFG,
+          context.getPersistentFileTracker(),
+          context.getPersistentMasterSecret());
+    } catch (ChecksumFailedException e) {
+      StorageFormatException sfe = new StorageFormatException("Unable to restore initial metadata");
+      sfe.initCause(e);
+      throw sfe;
+    }
+  }
+
+  /**
+   * Restores a completed direct bucket from persistent storage.
+   *
+   * @param dis input stream positioned at the bucket payload.
+   * @param context client context owning persistent bucket services.
+   * @param checker checksum helper used to verify the bucket metadata.
+   * @return restored bucket, or {@code null} when restoration failed.
+   * @throws ResumeFailedException if bucket restoration fails.
+   */
+  static Bucket restoreCompletedDirectBucketOrNull(
+      DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      throws ResumeFailedException {
+    try (DataInputStream inner = checksummedReader(dis, context, checker)) {
+      return BucketTools.restoreFrom(
+          inner,
+          context.persistentFG,
+          context.getPersistentFileTracker(),
+          context.getPersistentMasterSecret());
+    } catch (IOException | ChecksumFailedException | StorageFormatException e) {
+      LOG.error(COMPLETED_DOWNLOAD_RESTORE_FAILURE, e);
+      return null;
+    }
+  }
+
+  /**
+   * Restores the failure message for a finished request.
+   *
+   * @param dis input stream positioned at the failure message payload.
+   * @param reqID request identifier used to populate the failure message.
+   * @param foundDataLength recorded data length for the request.
+   * @param foundDataMimeType recorded MIME type for the request.
+   * @param context client context providing checksum helpers.
+   * @param checker checksum helper used to verify the payload.
+   * @return restored {@link GetFailedMessage} or {@code null} when recovery fails.
+   */
+  static GetFailedMessage restoreFailureMessageOrNull(
+      DataInputStream dis,
+      RequestIdentifier reqID,
+      long foundDataLength,
+      String foundDataMimeType,
+      ClientContext context,
+      ChecksumChecker checker) {
+    try (DataInputStream inner = checksummedReader(dis, context, checker)) {
+      return new GetFailedMessage(inner, reqID, foundDataLength, foundDataMimeType);
+    } catch (IOException | ChecksumFailedException | StorageFormatException e) {
+      LOG.error("Unable to restore reason for failure, restarting request", e);
+      return null;
+    }
+  }
+
+  /**
+   * Restores in-progress getter state along with transient progress fields.
+   *
+   * @param dis input stream positioned at the progress data block.
+   * @param context client context used to resume the getter.
+   * @param checker checksum helper used to validate the block.
+   * @param inProgressGetter getter instance to resume.
+   * @param request request instance for restoring transient fields.
+   * @throws StorageFormatException if the serialized state is invalid.
+   */
+  static void restoreInProgressState(
+      DataInputStream dis,
+      ClientContext context,
+      ChecksumChecker checker,
+      ClientGetter inProgressGetter,
+      ClientGet request)
+      throws StorageFormatException {
+    try (DataInputStream inner = checksummedReader(dis, context, checker)) {
+      if (inProgressGetter.resumeFromTrivialProgress(inner, context)) {
+        request.readTransientProgressFields(inner);
+      }
+    } catch (IOException e) {
+      LOG.error("Unable to restore splitfile, restarting: {}", e.toString());
+    } catch (ChecksumFailedException _) {
+      LOG.error("Unable to restore splitfile, restarting (checksum failed)");
+    }
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetReturnPlanner.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetReturnPlanner.java
@@ -1,0 +1,261 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Objects;
+import network.crypta.client.FetchContext;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.api.Bucket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Builds disk and bucket return handling for {@link ClientGet} requests.
+ *
+ * <p>This helper isolates DDA checks, existing file handling, and extension validation so the core
+ * request flow can focus on scheduling and status coordination. It is intentionally stateful to
+ * carry the request identifier and {@link FetchContext} needed for error reporting and per-request
+ * validation.
+ *
+ * <p>Typical usage is to construct one planner per request and call either {@link
+ * #forGlobalRequest(ClientGet.ReturnType, File, boolean, NodeClientCore)} for global requests or
+ * {@link #forMessage(ClientGetMessage, NodeClientCore, FCPConnectionHandler)} for FCP message
+ * handling. The planner enforces policy checks (node download permissions and DDA access),
+ * validates that disk targets are safe to use, and prepares a {@link Bucket} plus optional file
+ * extension hint for filtered data. It does not perform I/O beyond basic file existence checks and
+ * deletion of zero-length stale files.
+ *
+ * <p>The class is not thread-safe and is designed for single-request, single-threaded use. All
+ * state is immutable after construction; methods derive a {@link ReturnSetup} based on inputs and
+ * may throw exceptions to signal invalid requests or unsafe targets.
+ *
+ * <ul>
+ *   <li>Validates node policy and DDA access for disk destinations.
+ *   <li>Normalizes existing file handling to avoid overwriting data.
+ *   <li>Derives extension hints when filtered output is requested.
+ * </ul>
+ */
+final class ClientGetReturnPlanner {
+  /** Logger for exceptional disk target situations that require operator visibility. */
+  private static final Logger LOG = LoggerFactory.getLogger(ClientGetReturnPlanner.class);
+
+  /** Identifier for the owning request, echoed in error responses and logs. */
+  private final String identifier;
+
+  /** Whether errors should be marked as global to the connection. */
+  private final boolean global;
+
+  /** Fetch settings supplying filter decisions for disk return setups. */
+  private final FetchContext fetchContext;
+
+  /**
+   * Creates a planner for a single request using the supplied identifier and fetch settings.
+   *
+   * <p>The planner retains the identifier and global flag for subsequent error reporting and uses
+   * the fetch context to decide whether to derive file extensions for filtered data. Instances are
+   * lightweight and intended to be short-lived for the lifetime of a single {@link ClientGet}
+   * request.
+   *
+   * @param identifier request identifier to associate with protocol errors; must be non-null.
+   * @param global whether generated errors should be flagged as connection-global.
+   * @param fetchContext fetch settings used for filter decisions; must be non-null.
+   * @throws NullPointerException if {@code identifier} or {@code fetchContext} is null.
+   */
+  ClientGetReturnPlanner(String identifier, boolean global, FetchContext fetchContext) {
+    this.identifier = Objects.requireNonNull(identifier, "identifier");
+    this.global = global;
+    this.fetchContext = Objects.requireNonNull(fetchContext, "fetchContext");
+  }
+
+  /**
+   * Builds return handling for a global request with explicit disk parameters.
+   *
+   * <p>The method validates node policy for disk downloads, checks whether the target file is safe
+   * to use, and prepares a disk-backed bucket when the return type is {@link
+   * ClientGet.ReturnType#DISK}. For non-disk return types, the returned setup is empty with all
+   * fields set to {@code null}. The caller is expected to pass a valid {@link NodeClientCore}
+   * instance and, for disk requests, a concrete target file.
+   *
+   * @param type return strategy describing whether disk output is required.
+   * @param returnFilename target file to write to when {@code type} is disk.
+   * @param filterData whether to derive an extension hint for filtered output.
+   * @param core node core that enforces download policy checks.
+   * @return a prepared {@link ReturnSetup} describing bucket, target, and extension hint.
+   * @throws NotAllowedException if the node policy rejects the requested target path.
+   * @throws IOException if an existing target file cannot be removed or is unsafe to overwrite.
+   * @throws NullPointerException if {@code returnFilename} is null when disk output is requested.
+   */
+  ReturnSetup forGlobalRequest(
+      ClientGet.ReturnType type, File returnFilename, boolean filterData, NodeClientCore core)
+      throws NotAllowedException, IOException {
+    if (type == ClientGet.ReturnType.DISK) {
+      File file = Objects.requireNonNull(returnFilename, "returnFilename");
+      ensureDownloadAllowed(core, file);
+      return createDiskReturnSetup(file, filterData);
+    }
+    return new ReturnSetup(null, null, null);
+  }
+
+  /**
+   * Builds return handling from an already-parsed {@link ClientGetMessage}.
+   *
+   * <p>The method performs node policy checks and DDA validation before returning a disk setup for
+   * {@link ClientGet.ReturnType#DISK} messages. Any invalid condition results in a {@link
+   * MessageInvalidException} carrying an appropriate protocol error code and identifier. For
+   * non-disk return types, the returned setup is empty with all fields set to {@code null}.
+   *
+   * @param message parsed request message containing return type and disk filename.
+   * @param core node core used to validate download policy for disk targets.
+   * @param handler connection handler providing DDA access control decisions.
+   * @return a prepared {@link ReturnSetup} describing bucket, target, and extension hint.
+   * @throws MessageInvalidException if policy checks fail or the target file is unsafe to use.
+   * @throws NullPointerException if {@code message}, {@code core}, or {@code handler} is null.
+   */
+  ReturnSetup forMessage(
+      ClientGetMessage message, NodeClientCore core, FCPConnectionHandler handler)
+      throws MessageInvalidException {
+    if (message.returnType == ClientGet.ReturnType.DISK) {
+      return buildDiskSetupForMessage(message, core, handler);
+    }
+    return new ReturnSetup(null, null, null);
+  }
+
+  /**
+   * Validates and prepares disk return handling for an FCP message.
+   *
+   * <p>This method enforces node download policy, DDA access permission, and target file safety
+   * before constructing the {@link ReturnSetup}. It maps failures to {@link
+   * MessageInvalidException} instances with protocol-appropriate error codes to allow callers to
+   * respond to the remote peer deterministically.
+   *
+   * @param message parsed message providing the disk target and return settings.
+   * @param core node core that enforces download policy for the target.
+   * @param handler connection handler that provides DDA access validation.
+   * @return prepared disk return setup with bucket, target file, and optional extension.
+   * @throws MessageInvalidException if any policy or disk checks fail.
+   */
+  private ReturnSetup buildDiskSetupForMessage(
+      ClientGetMessage message, NodeClientCore core, FCPConnectionHandler handler)
+      throws MessageInvalidException {
+    File diskFile = message.diskFile;
+    if (!core.allowDownloadTo(diskFile)) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "Not allowed to download to " + diskFile,
+          identifier,
+          global);
+    }
+    if (!handler.ddaAccessController().allowDDAFrom(diskFile, true)) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED,
+          "Not allowed to download to "
+              + diskFile
+              + ". You might need to do a "
+              + TestDdaRequestMessage.NAME
+              + " first.",
+          identifier,
+          global);
+    }
+    try {
+      handleExistingTargetFile(diskFile);
+    } catch (IOException e) {
+      MessageInvalidException mie =
+          new MessageInvalidException(
+              ProtocolErrorMessage.INTERNAL_ERROR,
+              "Target filename exists already: " + diskFile,
+              identifier,
+              global);
+      mie.initCause(e);
+      throw mie;
+    }
+    return createDiskReturnSetup(diskFile, fetchContext.getFilterData());
+  }
+
+  /**
+   * Creates a disk-backed return setup for the supplied file target.
+   *
+   * <p>The returned setup contains a {@link Bucket} that writes to the target file and optionally
+   * includes an extension hint when filtering is enabled. The method does not verify the file
+   * itself; callers must ensure it is safe to use before invoking this helper.
+   *
+   * @param file disk target file to back the return bucket.
+   * @param filterData whether to derive a file extension hint for filtered data.
+   * @return a {@link ReturnSetup} holding the disk bucket, target file, and optional extension.
+   */
+  private ReturnSetup createDiskReturnSetup(File file, boolean filterData) {
+    Bucket bucket = ClientGetGetterFactory.diskReturnBucket(file);
+    return new ReturnSetup(bucket, file, filterData ? deriveExtension(file) : null);
+  }
+
+  /**
+   * Derives an extension hint from the target filename.
+   *
+   * <p>The extension is the substring after the final {@code "."} in the filename. If the file has
+   * no dot or ends with a dot, the method returns {@code null} to indicate no usable extension.
+   *
+   * @param file file whose name should be inspected for an extension.
+   * @return the extension substring without the dot, or {@code null} if none is present.
+   */
+  private static String deriveExtension(File file) {
+    String name = file.getName();
+    int idx = name.lastIndexOf('.');
+    if (idx == -1 || idx == name.length() - 1) {
+      return null;
+    }
+    return name.substring(idx + 1);
+  }
+
+  /**
+   * Verifies that the node allows disk downloads and that the target file is safe to use.
+   *
+   * <p>The method delegates policy validation to {@link NodeClientCore#allowDownloadTo(File)} and
+   * then ensures the destination does not already exist, except for the special case where a
+   * zero-length file is deleted as a stale placeholder. It does not create directories or touch the
+   * filesystem beyond existence checks and optional deletion of a zero-length file.
+   *
+   * @param core node core used to verify download policy for the target path.
+   * @param file destination file for disk output.
+   * @throws NotAllowedException if the node policy rejects the target file location.
+   * @throws IOException if the target file exists and cannot be safely removed.
+   */
+  private void ensureDownloadAllowed(NodeClientCore core, File file)
+      throws NotAllowedException, IOException {
+    if (!core.allowDownloadTo(file)) {
+      throw new NotAllowedException();
+    }
+    handleExistingTargetFile(file);
+  }
+
+  /**
+   * Ensures the target file does not already exist or is safely removed when empty.
+   *
+   * <p>If the file does not exist, the method returns immediately. If it exists and is zero length,
+   * it is deleted and a warning is logged. If it still exists afterward, the method throws an
+   * {@link IOException} to prevent accidental overwrites.
+   *
+   * @param file file path to inspect and potentially delete.
+   * @throws IOException if the file exists after zero-length cleanup attempts.
+   */
+  private void handleExistingTargetFile(File file) throws IOException {
+    if (!file.exists()) {
+      return;
+    }
+    if (file.length() == 0) {
+      Files.delete(file.toPath());
+      LOG.error("Target file already exists but is zero length, deleting...");
+    }
+    if (file.exists()) {
+      throw new IOException("Target filename exists already: " + file);
+    }
+  }
+
+  /**
+   * Captures prepared return handling information for the request.
+   *
+   * @param bucket bucket to stream or persist, or {@code null} when unused
+   * @param targetFile disk destination when {@link ClientGet.ReturnType#DISK} is selected
+   * @param extension optional extension hint for filtered payload validation
+   */
+  record ReturnSetup(Bucket bucket, File targetFile, String extension) {}
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshot.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshot.java
@@ -1,0 +1,164 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.util.Arrays;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Parameter bundle describing a {@link ClientGet} request status snapshot.
+ *
+ * <p>This record mirrors the inputs required to construct a {@link DownloadRequestStatus} from the
+ * current state of a {@link ClientGet} request. It is intentionally immutable and performs no
+ * validation, so callers can reuse it across status refreshes without altering behavior.
+ *
+ * @param identifier request identifier to report.
+ * @param persistence persistence mode for the request.
+ * @param started whether the request has started.
+ * @param finished whether the request has finished.
+ * @param succeeded whether the request has succeeded.
+ * @param progressPending last recorded progress snapshot, if any.
+ * @param failedMessage cached failure message, if any.
+ * @param foundDataMimeType MIME type discovered for the data.
+ * @param foundDataLength data length recorded for the request.
+ * @param destinationFile destination file for disk requests.
+ * @param dataBucket bucket containing result data.
+ * @param fetchContext fetch context providing filter and MIME overrides.
+ * @param priorityClass scheduler priority class.
+ * @param compatModes compatibility modes observed for the request.
+ * @param splitfileKey splitfile crypto key override, if any.
+ * @param uri request URI to report.
+ * @param dontCompress whether reinsertion should skip compression.
+ */
+public record ClientGetStatusSnapshot(
+    String identifier,
+    ClientRequest.Persistence persistence,
+    boolean started,
+    boolean finished,
+    boolean succeeded,
+    SimpleProgressMessage progressPending,
+    GetFailedMessage failedMessage,
+    String foundDataMimeType,
+    long foundDataLength,
+    File destinationFile,
+    Bucket dataBucket,
+    FetchContext fetchContext,
+    short priorityClass,
+    CompatibilityMode[] compatModes,
+    byte[] splitfileKey,
+    FreenetURI uri,
+    boolean dontCompress) {
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other
+        instanceof
+        ClientGetStatusSnapshot(
+            String otherIdentifier,
+            ClientRequest.Persistence otherPersistence,
+            boolean otherStarted,
+            boolean otherFinished,
+            boolean otherSucceeded,
+            SimpleProgressMessage otherProgressPending,
+            GetFailedMessage otherFailedMessage,
+            String otherFoundDataMimeType,
+            long otherFoundDataLength,
+            File otherDestinationFile,
+            Bucket otherDataBucket,
+            FetchContext otherFetchContext,
+            short otherPriorityClass,
+            CompatibilityMode[] otherCompatModes,
+            byte[] otherSplitfileKey,
+            FreenetURI otherUri,
+            boolean otherDontCompress))) {
+      return false;
+    }
+    return started == otherStarted
+        && finished == otherFinished
+        && succeeded == otherSucceeded
+        && foundDataLength == otherFoundDataLength
+        && priorityClass == otherPriorityClass
+        && dontCompress == otherDontCompress
+        && java.util.Objects.equals(identifier, otherIdentifier)
+        && persistence == otherPersistence
+        && java.util.Objects.equals(progressPending, otherProgressPending)
+        && java.util.Objects.equals(failedMessage, otherFailedMessage)
+        && java.util.Objects.equals(foundDataMimeType, otherFoundDataMimeType)
+        && java.util.Objects.equals(destinationFile, otherDestinationFile)
+        && java.util.Objects.equals(dataBucket, otherDataBucket)
+        && java.util.Objects.equals(fetchContext, otherFetchContext)
+        && Arrays.equals(compatModes, otherCompatModes)
+        && Arrays.equals(splitfileKey, otherSplitfileKey)
+        && java.util.Objects.equals(uri, otherUri);
+  }
+
+  @Override
+  public int hashCode() {
+    int result =
+        java.util.Objects.hash(
+            identifier,
+            persistence,
+            started,
+            finished,
+            succeeded,
+            progressPending,
+            failedMessage,
+            foundDataMimeType,
+            foundDataLength,
+            destinationFile,
+            dataBucket,
+            fetchContext,
+            priorityClass,
+            uri,
+            dontCompress);
+    result = 31 * result + Arrays.hashCode(compatModes);
+    result = 31 * result + Arrays.hashCode(splitfileKey);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "ClientGetStatusSnapshot["
+        + "identifier="
+        + identifier
+        + ", persistence="
+        + persistence
+        + ", started="
+        + started
+        + ", finished="
+        + finished
+        + ", succeeded="
+        + succeeded
+        + ", progressPending="
+        + progressPending
+        + ", failedMessage="
+        + failedMessage
+        + ", foundDataMimeType="
+        + foundDataMimeType
+        + ", foundDataLength="
+        + foundDataLength
+        + ", destinationFile="
+        + destinationFile
+        + ", dataBucket="
+        + dataBucket
+        + ", fetchContext="
+        + fetchContext
+        + ", priorityClass="
+        + priorityClass
+        + ", compatModes="
+        + Arrays.toString(compatModes)
+        + ", splitfileKey="
+        + Arrays.toString(splitfileKey)
+        + ", uri="
+        + uri
+        + ", dontCompress="
+        + dontCompress
+        + ']';
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -1243,10 +1243,8 @@ public class FCPServer implements Runnable, DownloadCache {
       boolean realTimeFlag)
       throws IdentifierCollisionException, NotAllowedException, IOException {
     FetchContext defaultFetchContext = core.getClientContext().getDefaultPersistentFetchContext();
-    final ClientGet cg =
-        new ClientGet(
-            persistRebootOnly ? globalRebootClient : globalForeverClient,
-            fetchURI,
+    ClientGet.GlobalRequestConfig requestConfig =
+        new ClientGet.GlobalRequestConfig(
             defaultFetchContext.getLocalRequestOnly(),
             defaultFetchContext.getIgnoreStore(),
             filterData,
@@ -1262,7 +1260,12 @@ public class FCPServer implements Runnable, DownloadCache {
             null,
             false,
             realTimeFlag,
-            false,
+            false);
+    final ClientGet cg =
+        new ClientGet(
+            persistRebootOnly ? globalRebootClient : globalForeverClient,
+            fetchURI,
+            requestConfig,
             core);
     cg.register(false);
     cg.start(core.getClientContext());

--- a/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
@@ -32,6 +32,8 @@ import network.crypta.client.async.BinaryBlobWriter;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientGetCallback;
 import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.ClientGetterOptions;
+import network.crypta.client.async.ClientGetterRequest;
 import network.crypta.client.async.PersistentClientCallback;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
@@ -177,7 +179,7 @@ class ClientGetGetterFactoryTest {
     Bucket returnBucket = mock(Bucket.class);
 
     ClientGetter getter =
-        ClientGetGetterFactory.createGetter(
+        createGetter(
             request,
             mock(FreenetURI.class),
             fetchContext,
@@ -206,7 +208,7 @@ class ClientGetGetterFactoryTest {
     assertThrows(
         NullPointerException.class,
         () ->
-            ClientGetGetterFactory.createGetter(
+            createGetter(
                 request,
                 mock(FreenetURI.class),
                 fetchContext,
@@ -235,7 +237,7 @@ class ClientGetGetterFactoryTest {
     when(bucketFactory.makeBucket(128L)).thenReturn(createdBucket);
 
     ClientGetter getter =
-        ClientGetGetterFactory.createGetter(
+        createGetter(
             request,
             mock(FreenetURI.class),
             fetchContext,
@@ -260,7 +262,7 @@ class ClientGetGetterFactoryTest {
     Bucket returnBucket = mock(Bucket.class);
 
     ClientGetter getter =
-        ClientGetGetterFactory.createGetter(
+        createGetter(
             request,
             mock(FreenetURI.class),
             fetchContext,
@@ -285,7 +287,7 @@ class ClientGetGetterFactoryTest {
     Bucket returnBucket = mock(Bucket.class);
 
     ClientGetter getter =
-        ClientGetGetterFactory.createGetter(
+        createGetter(
             request,
             mock(FreenetURI.class),
             fetchContext,
@@ -320,7 +322,7 @@ class ClientGetGetterFactoryTest {
     doNothing().when(request).getClientDetail(dos, checker);
 
     ClientGetter getter =
-        ClientGetGetterFactory.createGetter(
+        createGetter(
             request,
             mock(FreenetURI.class),
             fetchContext,
@@ -357,7 +359,7 @@ class ClientGetGetterFactoryTest {
     NodeClientCore core = mock(NodeClientCore.class);
     Bucket returnBucket = mock(Bucket.class);
 
-    ClientGetGetterFactory.createGetter(
+    createGetter(
         request,
         mock(FreenetURI.class),
         fetchContext,
@@ -371,6 +373,28 @@ class ClientGetGetterFactoryTest {
         core);
 
     verifyNoInteractions(core);
+  }
+
+  private static ClientGetter createGetter(
+      ClientGet request,
+      FreenetURI uri,
+      FetchContext fetchContext,
+      short priorityClass,
+      Bucket returnBucket,
+      Bucket initialMetadata,
+      String extensionCheck,
+      boolean discardData,
+      boolean binaryBlob,
+      boolean persistenceForever,
+      NodeClientCore core)
+      throws IOException {
+    ClientGetterRequest getterRequest =
+        ClientGetGetterFactory.createGetterRequest(request, uri, fetchContext, priorityClass);
+    ClientGetterOptions options =
+        new ClientGetterOptions(returnBucket, null, false, initialMetadata, extensionCheck);
+    ClientGetGetterFlags flags =
+        new ClientGetGetterFlags(discardData, binaryBlob, persistenceForever);
+    return ClientGetGetterFactory.createGetter(getterRequest, options, flags, core);
   }
 
   private static HashResult hashFor(HashType type, byte seed) {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
@@ -69,8 +69,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ClientGetPersistenceIOTest {
 
   @Test
-  void checksummedReader_whenChecksumReturnsStream_readsPayload()
-      throws IOException, ChecksumFailedException {
+  void openChecksummed_whenChecksumReturnsStream_readsPayload()
+      throws IOException, ChecksumFailedException, StorageFormatException {
     ClientContext context = newClientContext();
     ChecksumChecker checker = mock(ChecksumChecker.class);
     ByteArrayOutputStream payloadBuffer = new ByteArrayOutputStream();
@@ -82,7 +82,8 @@ class ClientGetPersistenceIOTest {
     when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
         .thenReturn(new ByteArrayInputStream(payloadBuffer.toByteArray()));
 
-    DataInputStream result = ClientGetPersistenceIO.checksummedReader(input, context, checker);
+    DataInputStream result =
+        ClientGetPersistenceIO.openChecksummed(input, context, checker, 65536L);
 
     assertEquals(42, result.readInt());
     verify(checker).checksumReaderWithLength(input, context.tempBucketFactory, 65536);

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
@@ -1,0 +1,457 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.security.SecureRandom;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
+import network.crypta.client.FetchException;
+import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.ClientLayerPersister;
+import network.crypta.client.async.DatastoreChecker;
+import network.crypta.client.async.HealingQueue;
+import network.crypta.client.async.USKManager;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
+import network.crypta.config.Config;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.ChecksumFailedException;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.ClientContextResources;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.RealCompressor;
+import network.crypta.support.io.BucketTools;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.ResumeFailedException;
+import network.crypta.support.io.StorageFormatException;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientGetPersistenceIOTest {
+
+  @Test
+  void checksummedReader_whenChecksumReturnsStream_readsPayload()
+      throws IOException, ChecksumFailedException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ByteArrayOutputStream payloadBuffer = new ByteArrayOutputStream();
+    try (DataOutputStream payloadOut = new DataOutputStream(payloadBuffer)) {
+      payloadOut.writeInt(42);
+    }
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenReturn(new ByteArrayInputStream(payloadBuffer.toByteArray()));
+
+    DataInputStream result = ClientGetPersistenceIO.checksummedReader(input, context, checker);
+
+    assertEquals(42, result.readInt());
+    verify(checker).checksumReaderWithLength(input, context.tempBucketFactory, 65536);
+  }
+
+  @Test
+  void readFetchContextOrDefault_whenValidData_returnsRestoredContext()
+      throws IOException, ChecksumFailedException {
+    ClientContext context = newClientContext();
+    FetchContext expected = buildFetchContext();
+    byte[] payload = serializeFetchContext(expected);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenReturn(new ByteArrayInputStream(payload));
+
+    FetchContext restored =
+        ClientGetPersistenceIO.readFetchContextOrDefault(input, context, checker);
+
+    assertArrayEquals(payload, serializeFetchContext(restored));
+  }
+
+  @Test
+  void readFetchContextOrDefault_whenChecksumFails_returnsDefault()
+      throws IOException, ChecksumFailedException {
+    ClientContext context = newClientContext();
+    FetchContext fallback = context.getDefaultPersistentFetchContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenThrow(new ChecksumFailedException());
+
+    FetchContext restored =
+        ClientGetPersistenceIO.readFetchContextOrDefault(input, context, checker);
+
+    assertArrayEquals(serializeFetchContext(fallback), serializeFetchContext(restored));
+  }
+
+  @Test
+  void readInitialMetadata_whenMarkerFalse_returnsNull()
+      throws IOException, StorageFormatException, ResumeFailedException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ByteArrayOutputStream data = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(data)) {
+      out.writeBoolean(false);
+    }
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(data.toByteArray()));
+
+    Bucket result = ClientGetPersistenceIO.readInitialMetadata(input, context, checker);
+
+    assertNull(result);
+    verifyNoInteractions(checker);
+  }
+
+  @Test
+  void readInitialMetadata_whenChecksumFails_throwsStorageFormatException()
+      throws IOException, ChecksumFailedException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ByteArrayOutputStream data = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(data)) {
+      out.writeBoolean(true);
+    }
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(data.toByteArray()));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenThrow(new ChecksumFailedException());
+
+    StorageFormatException error =
+        assertThrows(
+            StorageFormatException.class,
+            () -> ClientGetPersistenceIO.readInitialMetadata(input, context, checker));
+
+    assertEquals(ChecksumFailedException.class, error.getCause().getClass());
+  }
+
+  @Test
+  void restoreCompletedDirectBucketOrNull_whenRestoreSucceeds_returnsBucket()
+      throws ResumeFailedException, IOException, ChecksumFailedException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    Bucket expectedBucket = mock(Bucket.class);
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenReturn(new ByteArrayInputStream(new byte[0]));
+
+    try (MockedStatic<BucketTools> bucketTools = mockStatic(BucketTools.class)) {
+      bucketTools
+          .when(
+              () ->
+                  BucketTools.restoreFrom(
+                      any(DataInputStream.class),
+                      eq(context.persistentFG),
+                      eq(context.getPersistentFileTracker()),
+                      eq(context.getPersistentMasterSecret())))
+          .thenReturn(expectedBucket);
+
+      Bucket restored =
+          ClientGetPersistenceIO.restoreCompletedDirectBucketOrNull(input, context, checker);
+
+      assertEquals(expectedBucket, restored);
+    }
+  }
+
+  @Test
+  void restoreCompletedDirectBucketOrNull_whenChecksumFails_returnsNull()
+      throws ResumeFailedException, IOException, ChecksumFailedException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenThrow(new ChecksumFailedException());
+
+    Bucket restored =
+        ClientGetPersistenceIO.restoreCompletedDirectBucketOrNull(input, context, checker);
+
+    assertNull(restored);
+  }
+
+  @Test
+  void restoreFailureMessageOrNull_whenValidMessage_returnsMessage()
+      throws IOException, ChecksumFailedException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    RequestIdentifier reqID =
+        new RequestIdentifier(true, null, "req-1", RequestIdentifier.RequestType.GET);
+    long expectedLength = 123L;
+    String expectedType = "text/plain";
+    byte[] payload =
+        serializeFailureMessage(
+            FetchException.FetchExceptionMode.DATA_NOT_FOUND, "missing", false, null);
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenReturn(new ByteArrayInputStream(payload));
+
+    GetFailedMessage restored =
+        ClientGetPersistenceIO.restoreFailureMessageOrNull(
+            input, reqID, expectedLength, expectedType, context, checker);
+
+    assertNotNull(restored);
+    assertEquals(FetchException.FetchExceptionMode.DATA_NOT_FOUND, restored.failureMode);
+    assertEquals(reqID.identifier, restored.requestIdentifier);
+    assertEquals(reqID.globalQueue, restored.global);
+    assertEquals(expectedLength, restored.expectedDataLength);
+    assertEquals(expectedType, restored.expectedMimeType);
+  }
+
+  @Test
+  void restoreFailureMessageOrNull_whenRedirectProvided_readsRedirect()
+      throws IOException, ChecksumFailedException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    RequestIdentifier reqID =
+        new RequestIdentifier(true, null, "req-redirect", RequestIdentifier.RequestType.GET);
+    String redirectUri =
+        "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
+    byte[] payload =
+        serializeFailureMessage(
+            FetchException.FetchExceptionMode.INTERNAL_ERROR, "boom", true, redirectUri);
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenReturn(new ByteArrayInputStream(payload));
+
+    GetFailedMessage restored =
+        ClientGetPersistenceIO.restoreFailureMessageOrNull(
+            input, reqID, -1L, null, context, checker);
+
+    assertNotNull(restored);
+    assertEquals("boom", restored.extraDescription);
+    assertTrue(restored.finalizedExpected);
+    assertNotNull(restored.redirectURI);
+    assertEquals(redirectUri, restored.redirectURI.toString());
+  }
+
+  @Test
+  void restoreFailureMessageOrNull_whenInvalidPayload_returnsNull()
+      throws IOException, ChecksumFailedException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    RequestIdentifier reqID =
+        new RequestIdentifier(false, "client", "req-2", RequestIdentifier.RequestType.GET);
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+    byte[] payload = serializeInvalidFailureMessage();
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenReturn(new ByteArrayInputStream(payload));
+
+    GetFailedMessage restored =
+        ClientGetPersistenceIO.restoreFailureMessageOrNull(
+            input, reqID, -1L, null, context, checker);
+
+    assertNull(restored);
+  }
+
+  @Test
+  void restoreInProgressState_whenResumeReturnsTrue_readsTransientFields()
+      throws IOException, ChecksumFailedException, StorageFormatException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ClientGetter getter = mock(ClientGetter.class);
+    ClientGet request = mock(ClientGet.class);
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenReturn(new ByteArrayInputStream(new byte[0]));
+    when(getter.resumeFromTrivialProgress(any(DataInputStream.class), eq(context)))
+        .thenReturn(true);
+
+    ClientGetPersistenceIO.restoreInProgressState(input, context, checker, getter, request);
+
+    verify(getter).resumeFromTrivialProgress(any(DataInputStream.class), eq(context));
+    verify(request).readTransientProgressFields(any(DataInputStream.class));
+  }
+
+  @Test
+  void restoreInProgressState_whenChecksumFails_skipsResume()
+      throws IOException, ChecksumFailedException, StorageFormatException {
+    ClientContext context = newClientContext();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ClientGetter getter = mock(ClientGetter.class);
+    ClientGet request = mock(ClientGet.class);
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+
+    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
+        .thenThrow(new ChecksumFailedException());
+
+    ClientGetPersistenceIO.restoreInProgressState(input, context, checker, getter, request);
+
+    verifyNoInteractions(getter, request);
+  }
+
+  private static ClientContext newClientContext() {
+    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
+    PriorityAwareExecutor mainExecutor = mock(PriorityAwareExecutor.class);
+    MemoryLimitedJobRunner memoryLimitedJobRunner = mock(MemoryLimitedJobRunner.class);
+    Ticker ticker = mock(Ticker.class);
+    RandomSource strongRandom = mock(RandomSource.class);
+    SecureRandom fastWeakRandom = new SecureRandom();
+    MasterSecret transientSecret = mock(MasterSecret.class);
+    MasterSecret persistentSecret = mock(MasterSecret.class);
+    PersistentTempBucketFactory persistentBucketFactory = mock(PersistentTempBucketFactory.class);
+    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
+    PersistentFileTracker persistentFileTracker = mock(PersistentFileTracker.class);
+    FilenameGenerator fg = mock(FilenameGenerator.class);
+    FilenameGenerator persistentFG = mock(FilenameGenerator.class);
+    FileRandomAccessBufferFactory fileRAFTransient = mock(FileRandomAccessBufferFactory.class);
+    FileRandomAccessBufferFactory fileRAFPersistent = mock(FileRandomAccessBufferFactory.class);
+    LockableRandomAccessBufferFactory tempRAF = mock(LockableRandomAccessBufferFactory.class);
+    LockableRandomAccessBufferFactory persistentRAF = mock(LockableRandomAccessBufferFactory.class);
+    ArchiveManager archiveManager = mock(ArchiveManager.class);
+    HealingQueue healingQueue = mock(HealingQueue.class);
+    USKManager uskManager = mock(USKManager.class);
+    RealCompressor compressor = mock(RealCompressor.class);
+    DatastoreChecker datastoreChecker = mock(DatastoreChecker.class);
+    PersistentRequestRoot persistentRoot = mock(PersistentRequestRoot.class);
+    LinkFilterExceptionProvider linkFilterExceptionProvider =
+        mock(LinkFilterExceptionProvider.class);
+
+    FetchContext defaultFetchContext = buildFetchContext();
+    InsertContext defaultInsertContext = buildInsertContext();
+
+    ClientContext context =
+        new ClientContext(
+            1L,
+            new ClientContextRuntime(
+                jobRunner,
+                mainExecutor,
+                memoryLimitedJobRunner,
+                ticker,
+                strongRandom,
+                fastWeakRandom,
+                transientSecret),
+            new ClientContextStorageFactories(
+                persistentBucketFactory,
+                tempBucketFactory,
+                persistentFileTracker,
+                fg,
+                persistentFG,
+                fileRAFTransient,
+                fileRAFPersistent),
+            new ClientContextRafFactories(tempRAF, persistentRAF),
+            new ClientContextServices(
+                new ClientContextResources(archiveManager, healingQueue),
+                uskManager,
+                compressor,
+                datastoreChecker,
+                persistentRoot,
+                linkFilterExceptionProvider),
+            new ClientContextDefaults(defaultFetchContext, defaultInsertContext, new Config()));
+
+    context.setPersistentMasterSecret(persistentSecret);
+    return context;
+  }
+
+  private static FetchContext buildFetchContext() {
+    return new FetchContext(
+        FetchContextOptions.builder()
+            .limits(1024L, 2048L, 4096)
+            .archiveLimits(2, 3, 1, false)
+            .retryLimits(1, 1, 0)
+            .splitfileLimits(true, 16, 16)
+            .behavior(true, false, true)
+            .clientOptions(new SimpleEventProducer(), false, true)
+            .filterOverrides(null, null, null)
+            .build());
+  }
+
+  private static InsertContext buildInsertContext() {
+    return new InsertContext(
+        InsertContextOptions.builder()
+            .retryLimits(1, 0)
+            .splitfileSegmentLimits(16, 16)
+            .clientOptions(new SimpleEventProducer(), true, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
+            .build());
+  }
+
+  private static byte[] serializeFetchContext(FetchContext context) throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      context.writeTo(out);
+    }
+    return buffer.toByteArray();
+  }
+
+  private static byte[] serializeFailureMessage(
+      FetchException.FetchExceptionMode mode,
+      String description,
+      boolean finalizedExpected,
+      String redirectUri)
+      throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeInt(GetFailedMessage.VERSION);
+      out.writeInt(mode.code);
+      writePossiblyNull(out, description);
+      out.writeBoolean(finalizedExpected);
+      writePossiblyNull(out, redirectUri);
+    }
+    return buffer.toByteArray();
+  }
+
+  private static byte[] serializeInvalidFailureMessage() throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeInt(GetFailedMessage.VERSION + 1);
+      out.writeInt(FetchException.FetchExceptionMode.DATA_NOT_FOUND.code);
+      writePossiblyNull(out, "bad");
+      out.writeBoolean(false);
+      writePossiblyNull(out, null);
+    }
+    return buffer.toByteArray();
+  }
+
+  private static void writePossiblyNull(DataOutputStream out, String value) throws IOException {
+    if (value == null) {
+      out.writeBoolean(false);
+    } else {
+      out.writeBoolean(true);
+      out.writeUTF(value);
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetReturnPlannerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetReturnPlannerTest.java
@@ -1,0 +1,216 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.client.FetchContext;
+import network.crypta.clients.fcp.ClientGet.ReturnType;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.io.FileBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientGetReturnPlannerTest {
+  private static final String VALID_URI =
+      "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,"
+          + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
+  private static final String PAYLOAD_BIN = "payload.bin";
+  private static final String REQUEST_ID = "id";
+
+  @Mock private FetchContext fetchContext;
+  @Mock private NodeClientCore core;
+  @Mock private FCPConnectionHandler handler;
+  @Mock private DdaAccessController ddaAccessController;
+
+  @TempDir Path tempDir;
+
+  @Test
+  void constructor_whenIdentifierNull_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class, () -> new ClientGetReturnPlanner(null, false, fetchContext));
+  }
+
+  @Test
+  void constructor_whenFetchContextNull_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class, () -> new ClientGetReturnPlanner(REQUEST_ID, false, null));
+  }
+
+  @Test
+  void forGlobalRequest_whenReturnTypeNotDisk_returnsEmptySetup() throws Exception {
+    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+
+    ClientGetReturnPlanner.ReturnSetup setup =
+        planner.forGlobalRequest(ReturnType.DIRECT, null, false, core);
+
+    assertAll(
+        () -> assertNull(setup.bucket()),
+        () -> assertNull(setup.targetFile()),
+        () -> assertNull(setup.extension()));
+    verifyNoInteractions(core);
+  }
+
+  @Test
+  void forGlobalRequest_whenDiskNotAllowed_throwsNotAllowedException() {
+    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    File target = tempDir.resolve(PAYLOAD_BIN).toFile();
+    when(core.allowDownloadTo(target)).thenReturn(false);
+
+    assertThrows(
+        NotAllowedException.class,
+        () -> planner.forGlobalRequest(ReturnType.DISK, target, false, core));
+
+    verify(core).allowDownloadTo(target);
+  }
+
+  @Test
+  void forGlobalRequest_whenDiskAndZeroLengthFile_deletesAndReturnsSetup() throws Exception {
+    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    File target = tempDir.resolve(PAYLOAD_BIN).toFile();
+    assertTrue(target.createNewFile());
+    when(core.allowDownloadTo(target)).thenReturn(true);
+
+    ClientGetReturnPlanner.ReturnSetup setup =
+        planner.forGlobalRequest(ReturnType.DISK, target, true, core);
+
+    assertAll(
+        () -> assertInstanceOf(FileBucket.class, setup.bucket()),
+        () -> assertEquals(target, setup.targetFile()),
+        () -> assertEquals("bin", setup.extension()),
+        () -> assertFalse(target.exists()));
+  }
+
+  @Test
+  void forGlobalRequest_whenDiskAndExistingNonZeroFile_throwsIOException() throws Exception {
+    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    Path targetPath = tempDir.resolve(PAYLOAD_BIN);
+    Files.writeString(targetPath, "data");
+    File target = targetPath.toFile();
+    when(core.allowDownloadTo(target)).thenReturn(true);
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> planner.forGlobalRequest(ReturnType.DISK, target, false, core));
+
+    assertTrue(thrown.getMessage().contains("Target filename exists already"));
+    assertTrue(target.exists());
+  }
+
+  @Test
+  void forMessage_whenReturnTypeNotDisk_returnsEmptySetup() throws Exception {
+    ClientGetMessage message = buildMessage(ReturnType.NONE, null);
+    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+
+    ClientGetReturnPlanner.ReturnSetup setup = planner.forMessage(message, core, handler);
+
+    assertAll(
+        () -> assertNull(setup.bucket()),
+        () -> assertNull(setup.targetFile()),
+        () -> assertNull(setup.extension()));
+    verifyNoInteractions(core, handler);
+  }
+
+  @Test
+  void forMessage_whenDownloadNotAllowed_throwsMessageInvalidException() throws Exception {
+    Path targetPath = tempDir.resolve(PAYLOAD_BIN);
+    ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
+    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, true, fetchContext);
+    when(core.allowDownloadTo(targetPath.toFile())).thenReturn(false);
+
+    MessageInvalidException thrown =
+        assertThrows(
+            MessageInvalidException.class, () -> planner.forMessage(message, core, handler));
+
+    assertAll(
+        () -> assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode),
+        () -> assertEquals(REQUEST_ID, thrown.ident),
+        () -> assertTrue(thrown.global));
+  }
+
+  @Test
+  void forMessage_whenDdaDenied_throwsMessageInvalidException() throws Exception {
+    Path targetPath = tempDir.resolve(PAYLOAD_BIN);
+    ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
+    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    when(core.allowDownloadTo(targetPath.toFile())).thenReturn(true);
+    when(handler.ddaAccessController()).thenReturn(ddaAccessController);
+    when(ddaAccessController.allowDDAFrom(targetPath.toFile(), true)).thenReturn(false);
+
+    MessageInvalidException thrown =
+        assertThrows(
+            MessageInvalidException.class, () -> planner.forMessage(message, core, handler));
+
+    assertEquals(ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED, thrown.protocolCode);
+  }
+
+  @Test
+  void forMessage_whenExistingNonZeroFile_throwsMessageInvalidExceptionWithCause()
+      throws Exception {
+    Path targetPath = tempDir.resolve(PAYLOAD_BIN);
+    ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
+    Files.writeString(targetPath, "data");
+    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    when(core.allowDownloadTo(targetPath.toFile())).thenReturn(true);
+    when(handler.ddaAccessController()).thenReturn(ddaAccessController);
+    when(ddaAccessController.allowDDAFrom(targetPath.toFile(), true)).thenReturn(true);
+
+    MessageInvalidException thrown =
+        assertThrows(
+            MessageInvalidException.class, () -> planner.forMessage(message, core, handler));
+
+    assertAll(
+        () -> assertEquals(ProtocolErrorMessage.INTERNAL_ERROR, thrown.protocolCode),
+        () -> assertNotNull(thrown.getCause()),
+        () -> assertInstanceOf(IOException.class, thrown.getCause()));
+  }
+
+  @Test
+  void forMessage_whenAllowedAndFilterDataTrue_returnsSetupWithExtension() throws Exception {
+    Path targetPath = tempDir.resolve("payload.txt");
+    ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
+    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    when(core.allowDownloadTo(targetPath.toFile())).thenReturn(true);
+    when(handler.ddaAccessController()).thenReturn(ddaAccessController);
+    when(ddaAccessController.allowDDAFrom(targetPath.toFile(), true)).thenReturn(true);
+    when(fetchContext.getFilterData()).thenReturn(true);
+
+    ClientGetReturnPlanner.ReturnSetup setup = planner.forMessage(message, core, handler);
+
+    assertAll(
+        () -> assertInstanceOf(FileBucket.class, setup.bucket()),
+        () -> assertEquals(targetPath.toFile(), setup.targetFile()),
+        () -> assertEquals("txt", setup.extension()));
+  }
+
+  private ClientGetMessage buildMessage(ReturnType type, File diskFile)
+      throws MessageInvalidException {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("Identifier", REQUEST_ID);
+    fieldSet.putSingle("URI", VALID_URI);
+    fieldSet.putSingle("ReturnType", type.name());
+    if (type == ReturnType.DISK) {
+      fieldSet.putSingle("Filename", diskFile.getPath());
+    }
+    return new ClientGetMessage(fieldSet);
+  }
+}

--- a/src/test/java/network/crypta/support/io/PersistentTempBucketFactoryTest.java
+++ b/src/test/java/network/crypta/support/io/PersistentTempBucketFactoryTest.java
@@ -120,7 +120,9 @@ class PersistentTempBucketFactoryTest {
         assertInstanceOf(PersistentTempFileBucket.class, wrapper.getUnderlying());
     assertTrue(underlying.getFile().exists(), "Backing file should exist");
     assertEquals(
-        tempDir.toFile(), underlying.getFile().getParentFile(), "File should live in temp dir");
+        tempDir.toRealPath(),
+        underlying.getFile().getParentFile().toPath().toRealPath(),
+        "File should live in temp dir");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- extract ClientGet return planning/persistence/status helpers into dedicated utilities
- bundle getter configuration flags and snapshot data for cleaner ClientGet wiring
- add tests covering return planning and persistence restoration