### PR TITLE
refactor(fcp): bundle insert request parameters

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -16,7 +16,6 @@ import java.util.Date;
 import java.util.Objects;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.Metadata;
@@ -117,128 +116,79 @@ public class ClientPut extends ClientPutBase {
    * Use it whenever an external client wants the node to own persistence, resume points, and retry
    * state for an upload that might span restarts. Callers remain responsible for supplying buckets
    * that stay readable for the lifetime of the insert. Compression configuration is honored exactly
-   * as supplied so callers can trade throughput for determinism.
+   * as supplied, so callers can trade throughput for determinism.
    *
-   * @param globalClient Persistent queue owner used to detect identifier reuse collisions.
-   * @param uri Destination {@link FreenetURI} that will anchor the inserted content object.
-   * @param identifier Client-supplied identifier for queue deduplication and status updates.
-   * @param verbosity Verbosity bitmask controlling server-side progress and error callbacks.
-   * @param charset Optional charset hint announcing textual encoding for default metadata.
-   * @param priorityClass Scheduler priority communicated to the node's insert throttling logic.
-   * @param persistence Persistence mode (connection, forever) defining lifetime expectations and
-   *     restarts.
-   * @param clientToken Opaque token echoed back in async events to disambiguate clients.
-   * @param getCHKOnly When true, compute CHK but skip actually committing data to store.
-   * @param dontCompress Forces literal storage without compression, honoring caller-specific data
-   *     semantics.
-   * @param maxRetries Maximum automatic retries granted before failing the insert permanently.
-   * @param uploadFromType Describes source of bytes (disk, direct, redirect, memory bucket).
-   * @param origFilename Local disk path candidate; used for MIME guessing and DDA checks.
-   * @param contentType Explicit MIME type string overriding automatic guesses when supplied.
-   * @param data Random-access bucket carrying payload; may be null for redirects.
-   * @param redirectTarget Target URI for redirect inserts when {@code uploadFromType} requests
-   *     metadata.
-   * @param targetFilename Preferred remote filename advertised to downloaders lacking metadata
-   *     hints.
-   * @param earlyEncode Whether to start encoding blocks before full file arrival to pipeline.
-   * @param canWriteClientCache Allows storing data in the client's cache for resume efficiency.
-   * @param forkOnCacheable Creates forked insert contexts when cache writes are expected to
-   *     succeed.
-   * @param extraInsertsSingleBlock Additional low-level inserts for redundancy on single-block
-   *     payloads.
-   * @param extraInsertsSplitfileHeaderBlock Redundancy count for splitfile headers, improving
-   *     manifest durability.
-   * @param realTimeFlag True to favor low-latency routing; false to conserve resources.
-   * @param compatMode Compatibility hints guiding encoding parameters for legacy node
-   *     interoperability.
-   * @param overrideSplitfileKey Optional caller-provided crypto key overriding generated splitfile
-   *     secrets.
-   * @param binaryBlob Marks insert as opaque blob without metadata or URI derivation.
+   * @param request Persistent request metadata including URI, identifier, and queue settings.
+   * @param options Insert tuning options such as retries, compression, and redundancy.
+   * @param upload Upload payload metadata describing source and content hints.
    * @param core Owning {@link NodeClientCore} providing policies, factories, and scheduler hooks.
    * @throws IdentifierCollisionException Thrown when the chosen identifier already exists within
-   *     persistence scope.
-   * @throws NotAllowedException Raised when configured upload source violates server-side safety
+   *     the persistence scope.
+   * @throws NotAllowedException Raised when a configured upload source violates server-side safety
    *     policies.
    * @throws MetadataUnresolvedException Bubble-up if redirect metadata cannot serialize into a
    *     bucket factory.
    * @throws IOException Propagated for filesystem or bucket reads when preparing payload streams.
    */
   public ClientPut(
-      PersistentRequestClient globalClient,
-      FreenetURI uri,
-      String identifier,
-      int verbosity,
-      String charset,
-      short priorityClass,
-      Persistence persistence,
-      String clientToken,
-      boolean getCHKOnly,
-      boolean dontCompress,
-      int maxRetries,
-      UploadFrom uploadFromType,
-      File origFilename,
-      String contentType,
-      RandomAccessBucket data,
-      FreenetURI redirectTarget,
-      String targetFilename,
-      boolean earlyEncode,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      int extraInsertsSingleBlock,
-      int extraInsertsSplitfileHeaderBlock,
-      boolean realTimeFlag,
-      InsertContext.CompatibilityMode compatMode,
-      byte[] overrideSplitfileKey,
-      boolean binaryBlob,
+      FcpInsertRequest request,
+      FcpInsertOptions options,
+      ClientPutUpload upload,
       NodeClientCore core)
       throws IdentifierCollisionException,
           NotAllowedException,
           MetadataUnresolvedException,
           IOException {
     super(
-        checkEmptySSK(uri, targetFilename, core.getClientContext()),
-        ensurePersistentIdentifierAvailable(globalClient, identifier),
-        verbosity,
-        charset,
+        checkEmptySSK(request.uri(), upload.targetFilename(), core.getClientContext()),
+        ensurePersistentIdentifierAvailable(request.client(), request.identifier()),
+        request.verbosity(),
+        request.charset(),
         null,
-        globalClient,
-        priorityClass,
-        persistence,
+        request.client(),
+        request.priorityClass(),
+        request.persistence(),
         null,
-        true,
-        getCHKOnly,
-        dontCompress,
-        maxRetries,
-        earlyEncode,
-        canWriteClientCache,
-        forkOnCacheable,
+        request.global(),
+        options.getCHKOnly(),
+        options.dontCompress(),
+        options.maxRetries(),
+        options.earlyEncode(),
+        options.canWriteClientCache(),
+        options.forkOnCacheable(),
         false,
-        extraInsertsSingleBlock,
-        extraInsertsSplitfileHeaderBlock,
-        realTimeFlag,
+        options.extraInsertsSingleBlock(),
+        options.extraInsertsSplitfileHeaderBlock(),
+        options.realTimeFlag(),
         null,
-        compatMode,
+        options.compatibilityMode(),
         false /*XXX ignoreUSKDatehints*/,
         core);
+    UploadFrom uploadFromType = upload.uploadFromType();
+    File uploadOrigFilename = upload.origFilename();
+    String contentType = upload.contentType();
+    String uploadTargetFilename = upload.targetFilename();
+    RandomAccessBucket tempData = upload.data();
+
     if (uploadFromType == UploadFrom.DISK) {
-      if (!core.allowUploadFrom(origFilename)) throw new NotAllowedException();
-      if (!(origFilename.exists() && origFilename.canRead())) throw new FileNotFoundException();
+      if (!core.allowUploadFrom(uploadOrigFilename)) throw new NotAllowedException();
+      if (!(uploadOrigFilename.exists() && uploadOrigFilename.canRead()))
+        throw new FileNotFoundException();
     }
 
-    this.binaryBlob = binaryBlob;
-    if (binaryBlob) contentType = null;
-    this.targetFilename = targetFilename;
+    this.binaryBlob = upload.binaryBlob();
+    if (this.binaryBlob) contentType = null;
+    this.targetFilename = uploadTargetFilename;
     this.uploadFrom = uploadFromType;
-    this.origFilename = origFilename;
+    this.origFilename = uploadOrigFilename;
     // Now go through the fields one at a time
     String mimeType = contentType;
-    this.clientToken = clientToken;
-    RandomAccessBucket tempData = data;
+    this.clientToken = request.clientToken();
     ClientMetadata cm = new ClientMetadata(mimeType);
     boolean isMetadata = false;
     if (LOG.isDebugEnabled()) LOG.debug(DATA_UPLOAD_LOG_TEMPLATE, tempData, uploadFrom);
     if (uploadFrom == UploadFrom.REDIRECT) {
-      this.targetURI = redirectTarget;
+      this.targetURI = upload.redirectTarget();
       Metadata m = new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, targetURI, cm);
       tempData = m.toBucket(core.getClientContext().getBucketFactory(isPersistentForever()));
       isMetadata = true;
@@ -251,9 +201,9 @@ public class ClientPut extends ClientPutBase {
         new ClientPutter(
             new ClientPutterRequest(this, data, this.uri, cm, ctx, priorityClass, isMetadata),
             new ClientPutterOptions(
-                this.uri.getDocName() == null ? targetFilename : null,
-                binaryBlob,
-                overrideSplitfileKey,
+                this.uri.getDocName() == null ? uploadTargetFilename : null,
+                this.binaryBlob,
+                options.overrideSplitfileCryptoKey(),
                 -1));
   }
 
@@ -262,8 +212,8 @@ public class ClientPut extends ClientPutBase {
    *
    * <p>This constructor is used for transient or connection-scoped inserts issued over the socket
    * protocol. It verifies disk upload permissions, optional salted hashes, and MIME hints supplied
-   * by the client before crafting in-memory buckets or redirect metadata. Because the handler may
-   * multiplex many inserts, identifier validation is performed against the connection’s map to
+   * by the client before crafting in-memory buckets or redirecting metadata. Because the handler
+   * may multiplex many inserts, identifier validation is performed against the connection’s map to
    * avoid collisions that would otherwise corrupt status routing. All costly bucket conversions
    * happen before {@link ClientPutter} starts so any validation errors surface immediately to the
    * client.
@@ -275,8 +225,8 @@ public class ClientPut extends ClientPutBase {
    * @param server Owning server providing {@link NodeClientCore} accessors and capability checks.
    * @throws IdentifierCollisionException If another request on the connection already uses the
    *     identifier.
-   * @throws MessageInvalidException When client supplied fields (hashes, MIME, permissions) prove
-   *     invalid.
+   * @throws MessageInvalidException Throw when client supplied fields (hashes, MIME, permissions)
+   *     prove invalid.
    * @throws IOException If message-provided buckets cannot be read to compute salted hashes.
    */
   public ClientPut(FCPConnectionHandler handler, ClientPutMessage message, FCPServer server)
@@ -596,7 +546,7 @@ public class ClientPut extends ClientPutBase {
    *
    * @param in Source stream managed by Java serialization infrastructure.
    * @throws IOException If the serialized form is truncated or unreadable.
-   * @throws ClassNotFoundException If referenced classes in the stream cannot be resolved.
+   * @throws ClassNotFoundException If referenced, classes in the stream cannot be resolved.
    */
   @Serial
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -619,8 +569,8 @@ public class ClientPut extends ClientPutBase {
    * <p>The method is idempotent: if the request already finished or the putter previously started,
    * it simply refreshes the persistent tag. Otherwise, it schedules the insert, updates
    * bookkeeping, and emits persistent-queue tags if necessary so external monitors observe the
-   * in-flight status. Callers should invoke this once after construction or resume to reattach UI
-   * state.
+   * in-flight status. Callers should invoke this once after construction or resume to reattach the
+   * UI state.
    *
    * @param context Client execution context providing schedulers, bucket factories, and thread
    *     pools.
@@ -707,7 +657,7 @@ public class ClientPut extends ClientPutBase {
   private boolean isRealTime() {
     if (lowLevelClient == null) {
       // This can happen but only due to data corruption - old databases on which various bugs have
-      // resulted in it getting deleted, and also possibly failed deletions.
+      // resulted in it getting deleted and also possibly failed deletions.
       LOG.warn("lowLevelClient == null");
       return false;
     }
@@ -723,7 +673,7 @@ public class ClientPut extends ClientPutBase {
    * immutable history. It is safe to poll frequently; the backing field is volatile through {@link
    * ClientPutBase} synchronization.
    *
-   * @return True once the insert commits and the node has acknowledged durable storage.
+   * @return True, once the insert commits and the node has acknowledged durable storage.
    */
   @Override
   public boolean hasSucceeded() {
@@ -839,8 +789,8 @@ public class ClientPut extends ClientPutBase {
    * Replays the insert after a failure, optionally skipping filter-data regeneration when
    * configured.
    *
-   * <p>Before scheduling the new attempt, the method resets local state, updates status caches, and
-   * notifies observers that the request left the finished state. Failures during {@link
+   * <p>Before scheduling the new attempt, the method resets the local state, updates status caches,
+   * and notifies observers that the request left the finished state. Failures during {@link
    * ClientPutter} startup are handed to {@link ClientPutBase#onFailure(InsertException,
    * network.crypta.client.async.BaseClientPutter)} so retry logic remains consistent with the
    * normal start path.
@@ -916,8 +866,8 @@ public class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Enumerates the user-visible compression lifecycle so status polling can expose intuitive
-   * progress wording.
+   * Lists the user-visible compression lifecycle so status polling can expose intuitive progress
+   * wording.
    *
    * <p>The values summarize scheduler queues, CPU-bound work, and downstream insertion so clients
    * quickly understand whether throughput bottlenecks stem from contention or routing.
@@ -925,16 +875,16 @@ public class ClientPut extends ClientPutBase {
   public enum COMPRESS_STATE {
     /**
      * Waiting for a slot on the compression scheduler while previous inserts finish; users should
-     * expect zero CPU usage but the request remains queued for work.
+     * expect zero CPU usage, but the request remains queued for work.
      */
     WAITING,
     /**
-     * Actively compressing the payload or metadata; byte throughput is CPU-bound and restarts will
+     * Actively compressing the payload or metadata; byte throughput is CPU-bound, and restarts will
      * resume from the last fully written block rather than discarding work.
      */
     COMPRESSING,
     /**
-     * Compression finished and the request now streams blocks into the network or datastore,
+     * Compression finished, and the request now streams blocks into the network or datastore,
      * meaning failures are likely due to routing rather than preprocessing.
      */
     WORKING
@@ -1013,7 +963,7 @@ public class ClientPut extends ClientPutBase {
     int fetched = 0;
     int fatal = 0;
     int failed = 0;
-    // See ClientRequester.getLatestSuccess() for why this defaults to current time.
+    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
     Date latestSuccess = new Date();
     Date latestFailure = null;
     boolean totalFinalized = false;
@@ -1059,7 +1009,7 @@ public class ClientPut extends ClientPutBase {
    * Reattaches transient resources (notably {@link RandomAccessBucket} instances) after the request
    * is brought back from persistent storage.
    *
-   * <p>Delegates to each bucket so they can reopen files, memory maps, or network handles. Failure
+   * <p>Delegates to each bucket, so they can reopen files, memory maps, or network handles. Failure
    * to resume throws {@link ResumeFailedException}, which bubbles to queue management for user
    * visibility.
    *

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -11,7 +11,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.Metadata;
@@ -181,92 +180,77 @@ public class ClientPutDir extends ClientPutBase {
    * NodeClientCore}.
    *
    * <pre>{@code
-   * var request = new ClientPutDir(client, uri, "upload", 1, priority,
-   *     Persistence.CONNECTION, token, false, false, 3, new File("site"),
-   *     "index.html", false, false, false, false, true, false, 0, 0,
-   *     false, null, core);
+   * var request =
+   *     new ClientPutDir(
+   *         new FcpInsertRequest(
+   *             client, uri, "upload", 1, null, priority, Persistence.CONNECTION, token, false),
+   *         new FcpInsertOptions(
+   *             false,
+   *             false,
+   *             3,
+   *             false,
+   *             true,
+   *             false,
+   *             0,
+   *             0,
+   *             false,
+   *             InsertContext.CompatibilityMode.COMPAT_DEFAULT,
+   *             null),
+   *         new File("site"),
+   *         "index.html",
+   *         false,
+   *         false,
+   *         core);
    * request.start(core.getClientContext());
    * }</pre>
    *
-   * @param client persistent client coordinating request lifecycle and status notifications.
-   * @param uri destination URI that will anchor this directory insert request.
-   * @param identifier user-visible identifier echoed on status and completion messages.
-   * @param verbosity verbosity level applied to subsequent FCP progress messages.
-   * @param priorityClass priority bucket controlling scheduler weight and fairness.
-   * @param persistence persistence window determining whether the request survives restarts.
-   * @param clientToken opaque token echoed back so callers can correlate local state.
-   * @param getCHKOnly true to compute the resulting URI without storing persistent data.
-   * @param dontCompress true to spill raw blocks instead of applying automatic compression.
-   * @param maxRetries cap on automatic retries before the request is marked permanently failed.
+   * @param request persistent insert request metadata for the directory insert.
+   * @param options insert tuning options such as retries and compression choices.
    * @param dir root directory that will be enumerated and uploaded recursively.
    * @param defaultName default manifest document served when consumers fetch the directory.
    * @param allowUnreadableFiles true to skip unreadable entries instead of aborting immediately.
    * @param includeHiddenFiles true to include filesystem entries marked hidden by the OS.
-   * @param global true to expose the request across global queues, false for connection-only.
-   * @param earlyEncode true to pre-encode blocks before scheduling network transmission.
-   * @param canWriteClientCache true if client-side block caching is permitted for this insert.
-   * @param forkOnCacheable true to fork child requests when blocks become cacheable mid-insert.
-   * @param extraInsertsSingleBlock number of redundant inserts for single-block containers.
-   * @param extraInsertsSplitfileHeaderBlock number of redundant inserts for splitfile headers.
-   * @param realTimeFlag true to prefer real-time scheduling semantics and reduced latency.
-   * @param overrideSplitfileCryptoKey caller-supplied key material overriding generated keys.
    * @param core node client core providing context services and cryptographic settings.
    * @throws FileNotFoundException if unreadable files are encountered while not permitted.
    * @throws MalformedURLException if the URI cannot be parsed, normalized, or validated.
    * @throws TooManyFilesInsertException if the directory exceeds the configured file limit.
    */
   public ClientPutDir(
-      PersistentRequestClient client,
-      FreenetURI uri,
-      String identifier,
-      int verbosity,
-      short priorityClass,
-      Persistence persistence,
-      String clientToken,
-      boolean getCHKOnly,
-      boolean dontCompress,
-      int maxRetries,
+      FcpInsertRequest request,
+      FcpInsertOptions options,
       File dir,
       String defaultName,
       boolean allowUnreadableFiles,
       boolean includeHiddenFiles,
-      boolean global,
-      boolean earlyEncode,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      int extraInsertsSingleBlock,
-      int extraInsertsSplitfileHeaderBlock,
-      boolean realTimeFlag,
-      byte[] overrideSplitfileCryptoKey,
       NodeClientCore core)
       throws FileNotFoundException, MalformedURLException, TooManyFilesInsertException {
     super(
-        checkEmptySSK(uri, "site", core.getClientContext()),
-        identifier,
-        verbosity,
+        checkEmptySSK(request.uri(), "site", core.getClientContext()),
+        request.identifier(),
+        request.verbosity(),
+        request.charset(),
         null,
-        null,
-        client,
-        priorityClass,
-        persistence,
-        clientToken,
-        global,
-        getCHKOnly,
-        dontCompress,
-        maxRetries,
-        earlyEncode,
-        canWriteClientCache,
-        forkOnCacheable,
+        request.client(),
+        request.priorityClass(),
+        request.persistence(),
+        request.clientToken(),
+        request.global(),
+        options.getCHKOnly(),
+        options.dontCompress(),
+        options.maxRetries(),
+        options.earlyEncode(),
+        options.canWriteClientCache(),
+        options.forkOnCacheable(),
         false,
-        extraInsertsSingleBlock,
-        extraInsertsSplitfileHeaderBlock,
-        realTimeFlag,
+        options.extraInsertsSingleBlock(),
+        options.extraInsertsSplitfileHeaderBlock(),
+        options.realTimeFlag(),
         null,
-        InsertContext.CompatibilityMode.COMPAT_DEFAULT,
+        options.compatibilityMode(),
         false /*XXX ignoreUSKDatehints*/,
         core);
     wasDiskPut = true;
-    this.overrideSplitfileCryptoKey = overrideSplitfileCryptoKey;
+    this.overrideSplitfileCryptoKey = options.overrideSplitfileCryptoKey();
     // debug level captured via LOG.isDebugEnabled()
     this.manifestElements = makeDiskDirManifest(dir, "", allowUnreadableFiles, includeHiddenFiles);
     this.defaultName = defaultName;

--- a/src/main/java/network/crypta/clients/fcp/ClientPutUpload.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutUpload.java
@@ -1,0 +1,30 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.RandomAccessBucket;
+
+/**
+ * Describes the payload source and metadata hints for a single-file put request.
+ *
+ * <p>The upload specification keeps the original filename, optional content type, bucket handle,
+ * redirect target, and output filename together so callers can pass them as a single unit when
+ * constructing {@link ClientPut} instances.
+ *
+ * @param uploadFromType source of the upload bytes (direct, disk, or redirect)
+ * @param origFilename original filesystem filename when uploading from disk; may be {@code null}
+ * @param contentType MIME type override for the upload; may be {@code null}
+ * @param data bucket containing upload data or {@code null} for redirects
+ * @param redirectTarget target URI for redirect uploads; may be {@code null}
+ * @param targetFilename filename hint to store in metadata; may be {@code null}
+ * @param binaryBlob whether the insert is an opaque binary blob with no metadata
+ */
+public record ClientPutUpload(
+    UploadFrom uploadFromType,
+    File origFilename,
+    String contentType,
+    RandomAccessBucket data,
+    FreenetURI redirectTarget,
+    String targetFilename,
+    boolean binaryBlob) {}

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertOptions.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertOptions.java
@@ -1,0 +1,115 @@
+package network.crypta.clients.fcp;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.client.InsertContext;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Captures insert-specific tuning knobs supplied by FCP callers.
+ *
+ * <p>The options encapsulate retry limits, compression preferences, cache behaviors, redundancy
+ * factors, real-time scheduling, and compatibility mode hints. They are shared between file and
+ * directory put requests to ensure consistent configuration across insert flows.
+ *
+ * @param getCHKOnly whether to compute the CHK without persisting blocks
+ * @param dontCompress whether compression should be disabled for the insert
+ * @param maxRetries maximum retries before failing the insert
+ * @param earlyEncode whether encoding should begin before all data is received
+ * @param canWriteClientCache whether client cache writes are permitted
+ * @param forkOnCacheable whether to fork insert contexts when blocks become cacheable
+ * @param extraInsertsSingleBlock redundancy factor for single-block inserts
+ * @param extraInsertsSplitfileHeaderBlock redundancy factor for splitfile header blocks
+ * @param realTimeFlag whether to schedule the insert in real-time queues
+ * @param compatibilityMode compatibility mode guiding splitfile encoding parameters
+ * @param overrideSplitfileCryptoKey optional splitfile crypto key override; may be {@code null}
+ */
+public record FcpInsertOptions(
+    boolean getCHKOnly,
+    boolean dontCompress,
+    int maxRetries,
+    boolean earlyEncode,
+    boolean canWriteClientCache,
+    boolean forkOnCacheable,
+    int extraInsertsSingleBlock,
+    int extraInsertsSplitfileHeaderBlock,
+    boolean realTimeFlag,
+    InsertContext.CompatibilityMode compatibilityMode,
+    byte[] overrideSplitfileCryptoKey) {
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o
+        instanceof
+        FcpInsertOptions(
+            boolean otherGetCHKOnly,
+            boolean otherDontCompress,
+            int otherMaxRetries,
+            boolean otherEarlyEncode,
+            boolean otherCanWriteClientCache,
+            boolean otherForkOnCacheable,
+            int otherExtraInsertsSingleBlock,
+            int otherExtraInsertsSplitfileHeaderBlock,
+            boolean otherRealTimeFlag,
+            InsertContext.CompatibilityMode otherCompatibilityMode,
+            byte[] otherOverrideSplitfileCryptoKey))) return false;
+    return getCHKOnly == otherGetCHKOnly
+        && dontCompress == otherDontCompress
+        && maxRetries == otherMaxRetries
+        && earlyEncode == otherEarlyEncode
+        && canWriteClientCache == otherCanWriteClientCache
+        && forkOnCacheable == otherForkOnCacheable
+        && extraInsertsSingleBlock == otherExtraInsertsSingleBlock
+        && extraInsertsSplitfileHeaderBlock == otherExtraInsertsSplitfileHeaderBlock
+        && realTimeFlag == otherRealTimeFlag
+        && compatibilityMode == otherCompatibilityMode
+        && Arrays.equals(overrideSplitfileCryptoKey, otherOverrideSplitfileCryptoKey);
+  }
+
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            getCHKOnly,
+            dontCompress,
+            maxRetries,
+            earlyEncode,
+            canWriteClientCache,
+            forkOnCacheable,
+            extraInsertsSingleBlock,
+            extraInsertsSplitfileHeaderBlock,
+            realTimeFlag,
+            compatibilityMode);
+    result = 31 * result + Arrays.hashCode(overrideSplitfileCryptoKey);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "FcpInsertOptions[getCHKOnly="
+        + getCHKOnly
+        + ", dontCompress="
+        + dontCompress
+        + ", maxRetries="
+        + maxRetries
+        + ", earlyEncode="
+        + earlyEncode
+        + ", canWriteClientCache="
+        + canWriteClientCache
+        + ", forkOnCacheable="
+        + forkOnCacheable
+        + ", extraInsertsSingleBlock="
+        + extraInsertsSingleBlock
+        + ", extraInsertsSplitfileHeaderBlock="
+        + extraInsertsSplitfileHeaderBlock
+        + ", realTimeFlag="
+        + realTimeFlag
+        + ", compatibilityMode="
+        + compatibilityMode
+        + ", overrideSplitfileCryptoKey="
+        + (overrideSplitfileCryptoKey == null
+            ? "null"
+            : Arrays.toString(overrideSplitfileCryptoKey))
+        + ']';
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertRequest.java
@@ -1,0 +1,32 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Groups persistent insert request identity and queue metadata for FCP-based inserts.
+ *
+ * <p>The record captures the URI, identifier, verbosity, priority, and persistence settings needed
+ * to wire a {@link ClientPutBase}-derived request into the persistent queue while also retaining
+ * optional charset and client token hints for metadata construction and status reporting.
+ *
+ * @param client persistent request owner used for queue bookkeeping
+ * @param uri target insert URI requested by the client
+ * @param identifier client-supplied identifier echoed back in status updates
+ * @param verbosity verbosity bitmask for progress messages
+ * @param charset optional charset hint for metadata generation; may be {@code null}
+ * @param priorityClass scheduler priority to apply to the insert
+ * @param persistence persistence mode for the insert lifecycle
+ * @param clientToken optional client token echoed back to external observers; may be {@code null}
+ * @param global whether the request participates in the global queue
+ */
+public record FcpInsertRequest(
+    PersistentRequestClient client,
+    FreenetURI uri,
+    String identifier,
+    int verbosity,
+    String charset,
+    short priorityClass,
+    Persistence persistence,
+    String clientToken,
+    boolean global) {}

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -46,10 +46,13 @@ import network.crypta.clients.fcp.ClientPut;
 import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
 import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
 import network.crypta.clients.fcp.ClientPutDir;
+import network.crypta.clients.fcp.ClientPutUpload;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.DownloadRequestStatus;
 import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpInsertOptions;
+import network.crypta.clients.fcp.FcpInsertRequest;
 import network.crypta.clients.fcp.IdentifierCollisionException;
 import network.crypta.clients.fcp.NotAllowedException;
 import network.crypta.clients.fcp.RequestCompletionCallback;
@@ -1353,32 +1356,36 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             IdentifierCollisionException,
             IOException {
       return new ClientPut(
-          fcp.getGlobalForeverClient(),
-          params.insertURI(),
-          params.identifier(),
-          Integer.MAX_VALUE,
-          null,
-          RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-          Persistence.FOREVER,
-          null,
-          false,
-          !params.compress(),
-          -1,
-          UploadFrom.DIRECT,
-          null,
-          params.file().getContentType(),
-          copiedBucket,
-          null,
-          params.filenameForKey(),
-          false,
-          false,
-          Node.FORK_ON_CACHEABLE_DEFAULT,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-          false,
-          params.cmode(),
-          params.overrideSplitfileKey(),
-          false,
+          new FcpInsertRequest(
+              fcp.getGlobalForeverClient(),
+              params.insertURI(),
+              params.identifier(),
+              Integer.MAX_VALUE,
+              null,
+              RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
+              Persistence.FOREVER,
+              null,
+              true),
+          new FcpInsertOptions(
+              false,
+              !params.compress(),
+              -1,
+              false,
+              false,
+              Node.FORK_ON_CACHEABLE_DEFAULT,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+              false,
+              params.cmode(),
+              params.overrideSplitfileKey()),
+          new ClientPutUpload(
+              UploadFrom.DIRECT,
+              null,
+              params.file().getContentType(),
+              copiedBucket,
+              null,
+              params.filenameForKey(),
+              false),
           fcp.getCore());
     }
 
@@ -1551,32 +1558,36 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             IdentifierCollisionException,
             IOException {
       return new ClientPut(
-          fcp.getGlobalForeverClient(),
-          params.uri(),
-          params.id(),
-          Integer.MAX_VALUE,
-          null,
-          RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-          Persistence.FOREVER,
-          null,
-          false,
-          !params.compress(),
-          -1,
-          UploadFrom.DISK,
-          params.file(),
-          params.contentType(),
-          bucket,
-          null,
-          params.target(),
-          false,
-          false,
-          Node.FORK_ON_CACHEABLE_DEFAULT,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-          false,
-          params.cmode(),
-          params.overrideSplitfileKey(),
-          false,
+          new FcpInsertRequest(
+              fcp.getGlobalForeverClient(),
+              params.uri(),
+              params.id(),
+              Integer.MAX_VALUE,
+              null,
+              RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
+              Persistence.FOREVER,
+              null,
+              true),
+          new FcpInsertOptions(
+              false,
+              !params.compress(),
+              -1,
+              false,
+              false,
+              Node.FORK_ON_CACHEABLE_DEFAULT,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+              false,
+              params.cmode(),
+              params.overrideSplitfileKey()),
+          new ClientPutUpload(
+              UploadFrom.DISK,
+              params.file(),
+              params.contentType(),
+              bucket,
+              null,
+              params.target(),
+              false),
           fcp.getCore());
     }
 
@@ -1701,28 +1712,32 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     private ClientPutDir createLocalDirPut(LocalDirInsertParams params)
         throws IOException, TooManyFilesInsertException {
       return new ClientPutDir(
-          fcp.getGlobalForeverClient(),
-          params.uri(),
-          params.identifier(),
-          Integer.MAX_VALUE,
-          RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-          Persistence.FOREVER,
-          null,
-          false,
-          !params.compress(),
-          -1,
+          new FcpInsertRequest(
+              fcp.getGlobalForeverClient(),
+              params.uri(),
+              params.identifier(),
+              Integer.MAX_VALUE,
+              null,
+              RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
+              Persistence.FOREVER,
+              null,
+              true),
+          new FcpInsertOptions(
+              false,
+              !params.compress(),
+              -1,
+              false,
+              false,
+              Node.FORK_ON_CACHEABLE_DEFAULT,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+              false,
+              CompatibilityMode.COMPAT_DEFAULT,
+              params.overrideSplitfileKey()),
           params.file(),
           null,
           false,
           false,
-          true,
-          false,
-          false,
-          Node.FORK_ON_CACHEABLE_DEFAULT,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-          false,
-          params.overrideSplitfileKey(),
           fcp.getCore());
     }
 


### PR DESCRIPTION
## Summary
- bundle FCP insert request metadata into `FcpInsertRequest` and `FcpInsertOptions`
- introduce `ClientPutUpload` to carry file upload payload hints
- update `ClientPut`, `ClientPutDir`, and queue inserts to use the new grouped objects