### PR TITLE
refactor(fcp): bundle insert request params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ tmp*
 # Local migration helpers
 tools/migrate_logger_slf4j.py
 /.opencode/
+.rooignore

--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -287,16 +287,17 @@ public class ClientGet extends ClientRequest {
       NodeClientCore core)
       throws IdentifierCollisionException, NotAllowedException, IOException {
     super(
-        uri,
-        requestConfig.identifier(),
-        requestConfig.verbosity(),
+        new ClientRequestParams(
+            uri,
+            requestConfig.identifier(),
+            requestConfig.verbosity(),
+            requestConfig.prioClass(),
+            (requestConfig.persistRebootOnly() ? Persistence.REBOOT : Persistence.FOREVER),
+            requestConfig.realTimeFlag(),
+            null,
+            true),
         null,
-        globalClient,
-        requestConfig.prioClass(),
-        (requestConfig.persistRebootOnly() ? Persistence.REBOOT : Persistence.FOREVER),
-        requestConfig.realTimeFlag(),
-        null,
-        true);
+        globalClient);
 
     ensureGlobalIdentifierAvailable(globalClient, requestConfig.identifier());
     fctx = core.getClientContext().getDefaultPersistentFetchContext();
@@ -353,15 +354,16 @@ public class ClientGet extends ClientRequest {
   public ClientGet(FCPConnectionHandler handler, ClientGetMessage message, NodeClientCore core)
       throws IdentifierCollisionException, MessageInvalidException {
     super(
-        message.uri,
-        message.identifier,
-        message.verbosity,
-        handler,
-        message.priorityClass,
-        message.persistence,
-        message.realTimeFlag,
-        message.clientToken,
-        message.global);
+        new ClientRequestParams(
+            message.uri,
+            message.identifier,
+            message.verbosity,
+            message.priorityClass,
+            message.persistence,
+            message.realTimeFlag,
+            message.clientToken,
+            message.global),
+        handler);
     if (message.persistence == Persistence.CONNECTION) {
       ensureConnectionIdentifierAvailable(handler, message.identifier);
     }

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -139,31 +139,17 @@ public class ClientPut extends ClientPutBase {
           NotAllowedException,
           MetadataUnresolvedException,
           IOException {
-    super(
-        checkEmptySSK(request.uri(), upload.targetFilename(), core.getClientContext()),
-        ensurePersistentIdentifierAvailable(request.client(), request.identifier()),
-        request.verbosity(),
-        request.charset(),
-        null,
-        request.client(),
-        request.priorityClass(),
-        request.persistence(),
-        null,
-        request.global(),
-        options.getCHKOnly(),
-        options.dontCompress(),
-        options.maxRetries(),
-        options.earlyEncode(),
-        options.canWriteClientCache(),
-        options.forkOnCacheable(),
-        false,
-        options.extraInsertsSingleBlock(),
-        options.extraInsertsSplitfileHeaderBlock(),
-        options.realTimeFlag(),
-        null,
-        options.compatibilityMode(),
-        false /*XXX ignoreUSKDatehints*/,
-        core);
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            checkEmptySSK(request.uri(), upload.targetFilename(), core.getClientContext()),
+            ensurePersistentIdentifierAvailable(request.client(), request.identifier()),
+            request.verbosity(),
+            request.priorityClass(),
+            request.persistence(),
+            options.realTimeFlag(),
+            null,
+            request.global());
+    super(requestParams, request.charset(), options, null, request.client(), core);
     UploadFrom uploadFromType = upload.uploadFromType();
     File uploadOrigFilename = upload.origFilename();
     String contentType = upload.contentType();
@@ -231,30 +217,33 @@ public class ClientPut extends ClientPutBase {
    */
   public ClientPut(FCPConnectionHandler handler, ClientPutMessage message, FCPServer server)
       throws IdentifierCollisionException, MessageInvalidException, IOException {
-    super(
-        checkEmptySSK(message.uri, message.targetFilename, server.getCore().getClientContext()),
-        ensureConnectionIdentifierAvailable(handler, message),
-        message.verbosity,
-        null,
-        handler,
-        message.priorityClass,
-        message.persistence,
-        message.clientToken,
-        message.global,
-        message.getCHKOnly,
-        message.dontCompress,
-        message.localRequestOnly,
-        message.maxRetries,
-        message.earlyEncode,
-        message.canWriteClientCache,
-        message.forkOnCacheable,
-        message.compressorDescriptor,
-        message.extraInsertsSingleBlock,
-        message.extraInsertsSplitfileHeaderBlock,
-        message.realTimeFlag,
-        message.compatibilityMode,
-        message.ignoreUSKDatehints,
-        server);
+    FcpInsertOptions options =
+        new FcpInsertOptions(
+            message.getCHKOnly,
+            message.dontCompress,
+            message.localRequestOnly,
+            message.maxRetries,
+            message.earlyEncode,
+            message.canWriteClientCache,
+            message.forkOnCacheable,
+            message.compressorDescriptor,
+            message.extraInsertsSingleBlock,
+            message.extraInsertsSplitfileHeaderBlock,
+            message.realTimeFlag,
+            message.compatibilityMode,
+            message.ignoreUSKDatehints,
+            message.overrideSplitfileCryptoKey);
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            checkEmptySSK(message.uri, message.targetFilename, server.getCore().getClientContext()),
+            ensureConnectionIdentifierAvailable(handler, message),
+            message.verbosity,
+            message.priorityClass,
+            message.persistence,
+            options.realTimeFlag(),
+            message.clientToken,
+            message.global);
+    super(requestParams, null, options, handler, server);
     binaryBlob = message.binaryBlob;
 
     DiskUploadContext diskContext =

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -16,7 +16,6 @@ import java.util.Date;
 import java.util.Objects;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.Metadata;
@@ -117,128 +116,79 @@ public class ClientPut extends ClientPutBase {
    * Use it whenever an external client wants the node to own persistence, resume points, and retry
    * state for an upload that might span restarts. Callers remain responsible for supplying buckets
    * that stay readable for the lifetime of the insert. Compression configuration is honored exactly
-   * as supplied so callers can trade throughput for determinism.
+   * as supplied, so callers can trade throughput for determinism.
    *
-   * @param globalClient Persistent queue owner used to detect identifier reuse collisions.
-   * @param uri Destination {@link FreenetURI} that will anchor the inserted content object.
-   * @param identifier Client-supplied identifier for queue deduplication and status updates.
-   * @param verbosity Verbosity bitmask controlling server-side progress and error callbacks.
-   * @param charset Optional charset hint announcing textual encoding for default metadata.
-   * @param priorityClass Scheduler priority communicated to the node's insert throttling logic.
-   * @param persistence Persistence mode (connection, forever) defining lifetime expectations and
-   *     restarts.
-   * @param clientToken Opaque token echoed back in async events to disambiguate clients.
-   * @param getCHKOnly When true, compute CHK but skip actually committing data to store.
-   * @param dontCompress Forces literal storage without compression, honoring caller-specific data
-   *     semantics.
-   * @param maxRetries Maximum automatic retries granted before failing the insert permanently.
-   * @param uploadFromType Describes source of bytes (disk, direct, redirect, memory bucket).
-   * @param origFilename Local disk path candidate; used for MIME guessing and DDA checks.
-   * @param contentType Explicit MIME type string overriding automatic guesses when supplied.
-   * @param data Random-access bucket carrying payload; may be null for redirects.
-   * @param redirectTarget Target URI for redirect inserts when {@code uploadFromType} requests
-   *     metadata.
-   * @param targetFilename Preferred remote filename advertised to downloaders lacking metadata
-   *     hints.
-   * @param earlyEncode Whether to start encoding blocks before full file arrival to pipeline.
-   * @param canWriteClientCache Allows storing data in the client's cache for resume efficiency.
-   * @param forkOnCacheable Creates forked insert contexts when cache writes are expected to
-   *     succeed.
-   * @param extraInsertsSingleBlock Additional low-level inserts for redundancy on single-block
-   *     payloads.
-   * @param extraInsertsSplitfileHeaderBlock Redundancy count for splitfile headers, improving
-   *     manifest durability.
-   * @param realTimeFlag True to favor low-latency routing; false to conserve resources.
-   * @param compatMode Compatibility hints guiding encoding parameters for legacy node
-   *     interoperability.
-   * @param overrideSplitfileKey Optional caller-provided crypto key overriding generated splitfile
-   *     secrets.
-   * @param binaryBlob Marks insert as opaque blob without metadata or URI derivation.
+   * @param request Persistent request metadata including URI, identifier, and queue settings.
+   * @param options Insert tuning options such as retries, compression, and redundancy.
+   * @param upload Upload payload metadata describing source and content hints.
    * @param core Owning {@link NodeClientCore} providing policies, factories, and scheduler hooks.
    * @throws IdentifierCollisionException Thrown when the chosen identifier already exists within
-   *     persistence scope.
-   * @throws NotAllowedException Raised when configured upload source violates server-side safety
+   *     the persistence scope.
+   * @throws NotAllowedException Raised when a configured upload source violates server-side safety
    *     policies.
    * @throws MetadataUnresolvedException Bubble-up if redirect metadata cannot serialize into a
    *     bucket factory.
    * @throws IOException Propagated for filesystem or bucket reads when preparing payload streams.
    */
   public ClientPut(
-      PersistentRequestClient globalClient,
-      FreenetURI uri,
-      String identifier,
-      int verbosity,
-      String charset,
-      short priorityClass,
-      Persistence persistence,
-      String clientToken,
-      boolean getCHKOnly,
-      boolean dontCompress,
-      int maxRetries,
-      UploadFrom uploadFromType,
-      File origFilename,
-      String contentType,
-      RandomAccessBucket data,
-      FreenetURI redirectTarget,
-      String targetFilename,
-      boolean earlyEncode,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      int extraInsertsSingleBlock,
-      int extraInsertsSplitfileHeaderBlock,
-      boolean realTimeFlag,
-      InsertContext.CompatibilityMode compatMode,
-      byte[] overrideSplitfileKey,
-      boolean binaryBlob,
+      FcpInsertRequest request,
+      FcpInsertOptions options,
+      ClientPutUpload upload,
       NodeClientCore core)
       throws IdentifierCollisionException,
           NotAllowedException,
           MetadataUnresolvedException,
           IOException {
     super(
-        checkEmptySSK(uri, targetFilename, core.getClientContext()),
-        ensurePersistentIdentifierAvailable(globalClient, identifier),
-        verbosity,
-        charset,
+        checkEmptySSK(request.uri(), upload.targetFilename(), core.getClientContext()),
+        ensurePersistentIdentifierAvailable(request.client(), request.identifier()),
+        request.verbosity(),
+        request.charset(),
         null,
-        globalClient,
-        priorityClass,
-        persistence,
+        request.client(),
+        request.priorityClass(),
+        request.persistence(),
         null,
-        true,
-        getCHKOnly,
-        dontCompress,
-        maxRetries,
-        earlyEncode,
-        canWriteClientCache,
-        forkOnCacheable,
+        request.global(),
+        options.getCHKOnly(),
+        options.dontCompress(),
+        options.maxRetries(),
+        options.earlyEncode(),
+        options.canWriteClientCache(),
+        options.forkOnCacheable(),
         false,
-        extraInsertsSingleBlock,
-        extraInsertsSplitfileHeaderBlock,
-        realTimeFlag,
+        options.extraInsertsSingleBlock(),
+        options.extraInsertsSplitfileHeaderBlock(),
+        options.realTimeFlag(),
         null,
-        compatMode,
+        options.compatibilityMode(),
         false /*XXX ignoreUSKDatehints*/,
         core);
+    UploadFrom uploadFromType = upload.uploadFromType();
+    File uploadOrigFilename = upload.origFilename();
+    String contentType = upload.contentType();
+    String uploadTargetFilename = upload.targetFilename();
+    RandomAccessBucket tempData = upload.data();
+
     if (uploadFromType == UploadFrom.DISK) {
-      if (!core.allowUploadFrom(origFilename)) throw new NotAllowedException();
-      if (!(origFilename.exists() && origFilename.canRead())) throw new FileNotFoundException();
+      if (!core.allowUploadFrom(uploadOrigFilename)) throw new NotAllowedException();
+      if (!(uploadOrigFilename.exists() && uploadOrigFilename.canRead()))
+        throw new FileNotFoundException();
     }
 
-    this.binaryBlob = binaryBlob;
-    if (binaryBlob) contentType = null;
-    this.targetFilename = targetFilename;
+    this.binaryBlob = upload.binaryBlob();
+    if (this.binaryBlob) contentType = null;
+    this.targetFilename = uploadTargetFilename;
     this.uploadFrom = uploadFromType;
-    this.origFilename = origFilename;
+    this.origFilename = uploadOrigFilename;
     // Now go through the fields one at a time
     String mimeType = contentType;
-    this.clientToken = clientToken;
-    RandomAccessBucket tempData = data;
+    this.clientToken = request.clientToken();
     ClientMetadata cm = new ClientMetadata(mimeType);
     boolean isMetadata = false;
     if (LOG.isDebugEnabled()) LOG.debug(DATA_UPLOAD_LOG_TEMPLATE, tempData, uploadFrom);
     if (uploadFrom == UploadFrom.REDIRECT) {
-      this.targetURI = redirectTarget;
+      this.targetURI = upload.redirectTarget();
       Metadata m = new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, targetURI, cm);
       tempData = m.toBucket(core.getClientContext().getBucketFactory(isPersistentForever()));
       isMetadata = true;
@@ -251,9 +201,9 @@ public class ClientPut extends ClientPutBase {
         new ClientPutter(
             new ClientPutterRequest(this, data, this.uri, cm, ctx, priorityClass, isMetadata),
             new ClientPutterOptions(
-                this.uri.getDocName() == null ? targetFilename : null,
-                binaryBlob,
-                overrideSplitfileKey,
+                this.uri.getDocName() == null ? uploadTargetFilename : null,
+                this.binaryBlob,
+                options.overrideSplitfileCryptoKey(),
                 -1));
   }
 
@@ -262,8 +212,8 @@ public class ClientPut extends ClientPutBase {
    *
    * <p>This constructor is used for transient or connection-scoped inserts issued over the socket
    * protocol. It verifies disk upload permissions, optional salted hashes, and MIME hints supplied
-   * by the client before crafting in-memory buckets or redirect metadata. Because the handler may
-   * multiplex many inserts, identifier validation is performed against the connection’s map to
+   * by the client before crafting in-memory buckets or redirecting metadata. Because the handler
+   * may multiplex many inserts, identifier validation is performed against the connection’s map to
    * avoid collisions that would otherwise corrupt status routing. All costly bucket conversions
    * happen before {@link ClientPutter} starts so any validation errors surface immediately to the
    * client.
@@ -275,8 +225,8 @@ public class ClientPut extends ClientPutBase {
    * @param server Owning server providing {@link NodeClientCore} accessors and capability checks.
    * @throws IdentifierCollisionException If another request on the connection already uses the
    *     identifier.
-   * @throws MessageInvalidException When client supplied fields (hashes, MIME, permissions) prove
-   *     invalid.
+   * @throws MessageInvalidException Throw when client supplied fields (hashes, MIME, permissions)
+   *     prove invalid.
    * @throws IOException If message-provided buckets cannot be read to compute salted hashes.
    */
   public ClientPut(FCPConnectionHandler handler, ClientPutMessage message, FCPServer server)
@@ -596,7 +546,7 @@ public class ClientPut extends ClientPutBase {
    *
    * @param in Source stream managed by Java serialization infrastructure.
    * @throws IOException If the serialized form is truncated or unreadable.
-   * @throws ClassNotFoundException If referenced classes in the stream cannot be resolved.
+   * @throws ClassNotFoundException If referenced, classes in the stream cannot be resolved.
    */
   @Serial
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -619,8 +569,8 @@ public class ClientPut extends ClientPutBase {
    * <p>The method is idempotent: if the request already finished or the putter previously started,
    * it simply refreshes the persistent tag. Otherwise, it schedules the insert, updates
    * bookkeeping, and emits persistent-queue tags if necessary so external monitors observe the
-   * in-flight status. Callers should invoke this once after construction or resume to reattach UI
-   * state.
+   * in-flight status. Callers should invoke this once after construction or resume to reattach the
+   * UI state.
    *
    * @param context Client execution context providing schedulers, bucket factories, and thread
    *     pools.
@@ -707,7 +657,7 @@ public class ClientPut extends ClientPutBase {
   private boolean isRealTime() {
     if (lowLevelClient == null) {
       // This can happen but only due to data corruption - old databases on which various bugs have
-      // resulted in it getting deleted, and also possibly failed deletions.
+      // resulted in it getting deleted and also possibly failed deletions.
       LOG.warn("lowLevelClient == null");
       return false;
     }
@@ -723,7 +673,7 @@ public class ClientPut extends ClientPutBase {
    * immutable history. It is safe to poll frequently; the backing field is volatile through {@link
    * ClientPutBase} synchronization.
    *
-   * @return True once the insert commits and the node has acknowledged durable storage.
+   * @return True, once the insert commits and the node has acknowledged durable storage.
    */
   @Override
   public boolean hasSucceeded() {
@@ -839,8 +789,8 @@ public class ClientPut extends ClientPutBase {
    * Replays the insert after a failure, optionally skipping filter-data regeneration when
    * configured.
    *
-   * <p>Before scheduling the new attempt, the method resets local state, updates status caches, and
-   * notifies observers that the request left the finished state. Failures during {@link
+   * <p>Before scheduling the new attempt, the method resets the local state, updates status caches,
+   * and notifies observers that the request left the finished state. Failures during {@link
    * ClientPutter} startup are handed to {@link ClientPutBase#onFailure(InsertException,
    * network.crypta.client.async.BaseClientPutter)} so retry logic remains consistent with the
    * normal start path.
@@ -916,8 +866,8 @@ public class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Enumerates the user-visible compression lifecycle so status polling can expose intuitive
-   * progress wording.
+   * Lists the user-visible compression lifecycle so status polling can expose intuitive progress
+   * wording.
    *
    * <p>The values summarize scheduler queues, CPU-bound work, and downstream insertion so clients
    * quickly understand whether throughput bottlenecks stem from contention or routing.
@@ -925,16 +875,16 @@ public class ClientPut extends ClientPutBase {
   public enum COMPRESS_STATE {
     /**
      * Waiting for a slot on the compression scheduler while previous inserts finish; users should
-     * expect zero CPU usage but the request remains queued for work.
+     * expect zero CPU usage, but the request remains queued for work.
      */
     WAITING,
     /**
-     * Actively compressing the payload or metadata; byte throughput is CPU-bound and restarts will
+     * Actively compressing the payload or metadata; byte throughput is CPU-bound, and restarts will
      * resume from the last fully written block rather than discarding work.
      */
     COMPRESSING,
     /**
-     * Compression finished and the request now streams blocks into the network or datastore,
+     * Compression finished, and the request now streams blocks into the network or datastore,
      * meaning failures are likely due to routing rather than preprocessing.
      */
     WORKING
@@ -1013,7 +963,7 @@ public class ClientPut extends ClientPutBase {
     int fetched = 0;
     int fatal = 0;
     int failed = 0;
-    // See ClientRequester.getLatestSuccess() for why this defaults to current time.
+    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
     Date latestSuccess = new Date();
     Date latestFailure = null;
     boolean totalFinalized = false;
@@ -1059,7 +1009,7 @@ public class ClientPut extends ClientPutBase {
    * Reattaches transient resources (notably {@link RandomAccessBucket} instances) after the request
    * is brought back from persistent storage.
    *
-   * <p>Delegates to each bucket so they can reopen files, memory maps, or network handles. Failure
+   * <p>Delegates to each bucket, so they can reopen files, memory maps, or network handles. Failure
    * to resume throws {@link ResumeFailedException}, which bubbles to queue management for user
    * visibility.
    *

--- a/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Coordinates the lifecycle of FCP insert requests that persist across reconnects and restarts.
+ * Coordinates the lifecycle of FCP insert requests that persist across reconnections and restarts.
  *
  * <p>The class centralizes common state tracking for {@link ClientPut} and {@link ClientPutDir},
  * wiring FCP-facing identifiers, scheduling metadata, persistence constraints, and node callbacks
@@ -116,8 +116,8 @@ public abstract class ClientPutBase extends ClientRequest
   private Bucket generatedMetadata;
 
   /**
-   * Name of the FCP field carrying the SHA-256 hash of source data when clients request that value
-   * instead of a final URI.
+   * The name of the FCP field carrying the SHA-256 hash of source data when clients request that
+   * value instead of a final URI.
    */
   public static final String FILE_HASH = "FileHash";
 
@@ -126,9 +126,9 @@ public abstract class ClientPutBase extends ClientRequest
   private static final Map<Integer, UploadFrom> uploadFromByCode = new HashMap<>();
 
   /**
-   * Enumerates where the bytes for a put operation originate, which drives validation and bucket
+   * Lists where the bytes for a put operation originate, which drives validation and bucket
    * ownership rules during persistence and resume scenarios. The value is serialized with
-   * persistent requests so future versions can continue applying consistent invariants.
+   * persistent requests, so future versions can continue applying consistent invariants.
    */
   public enum UploadFrom { // Codes must be constant at least for migration
     /**
@@ -143,7 +143,7 @@ public abstract class ClientPutBase extends ClientRequest
     DISK(1),
     /**
      * The put represents a redirect and leverages an existing URI rather than raw data, so
-     * insert-time validation is minimal and no bucket ownership is required.
+     * insert-time validation is minimal, and no bucket ownership is required.
      */
     REDIRECT(2);
 
@@ -159,14 +159,14 @@ public abstract class ClientPutBase extends ClientRequest
 
     /**
      * Resolves a serialized upload source code back into the enum constant used to stage buckets
-     * and stubs after a restart. The helper keeps a static map so the conversion is O(1) even when
-     * invoked frequently. Callers typically load the integer from disk and feed it here before
-     * reconstructing bucket ownership policy.
+     * and stubs after a restart. The helper keeps a static map, so the conversion is O(1) even when
+     * invoked frequently. Callers typically load the integer from the disk and feed it here before
+     * reconstructing the bucket ownership policy.
      *
      * @param x integer code stored with persistent state or received via FCP, expected to be one of
      *     the constants defined in this enum
      * @return matching enum instance; never {@code null} for valid codes because results are cached
-     * @throws IllegalArgumentException when the caller supplies an unknown code, signalling corrupt
+     * @throws IllegalArgumentException when the caller supplies an unknown code, signaling corrupt
      *     or out-of-date persistence data that the caller must handle separately
      */
     public static UploadFrom getByCode(int x) {
@@ -185,82 +185,36 @@ public abstract class ClientPutBase extends ClientRequest
    * control returns because scheduling metadata, verbosity flags, and caches have all been
    * populated consistently.
    *
-   * @param uri canonical insert URI requested by the client; must not be {@code null}
-   * @param identifier unique identifier echoed back on all FCP messages for this insert
-   * @param verbosity bitmask describing which progress categories should be emitted
+   * @param requestParams request metadata including URI, identifiers, and scheduling flags
    * @param charset optional declared source charset; unsupported values trigger warnings only
+   * @param options insert tuning options covering retries, compression, and caching behavior
    * @param handler owning connection handler responsible for queuing outbound replies
-   * @param priorityClass scheduler priority class; must be within the node-supported range
-   * @param persistence requested persistence mode determining how long the request survives
-   * @param clientToken opaque token mirrored back during {@code ListPersistentRequests}
-   * @param global whether the request participates in the shared global queue instead of per-client
-   * @param getCHKOnly true when the caller only needs a CHK hash instead of storing data
-   * @param dontCompress true to forcefully disable on-the-fly compression stages
-   * @param localRequestOnly true to avoid advertising blocks beyond the local node
-   * @param maxRetries maximum block retries before surfacing failure to clients
-   * @param earlyEncode whether the inserter should pre-encode splitfiles before contacting peers
-   * @param canWriteClientCache true if the insert may touch the persistent client-side cache
-   * @param forkOnCacheable instructs the inserter to spawn redundancy when payloads are cacheable
-   * @param compressorDescriptor comma-separated list of compressor identifiers to attempt
-   * @param extraInsertsSingleBlock redundancy factor for standalone blocks outside splitfiles
-   * @param extraInsertsSplitfileHeader redundancy factor for splitfile header blocks
-   * @param realTimeFlag true to schedule the job in the latency-sensitive queue
-   * @param compatibilityMode compatibility profile that dictates metadata layouts and crypto tweaks
-   * @param ignoreUSKDatehints true to skip USK DATEHINT emission and consumption
    * @param server server providing node context, bucket factories, and persistent insert defaults
-   * @throws MalformedURLException if {@code uri} cannot be normalized into an insertable form
+   * @throws MalformedURLException if the URI cannot be normalized into an insertable form
    */
   protected ClientPutBase(
-      FreenetURI uri,
-      String identifier,
-      int verbosity,
+      ClientRequestParams requestParams,
       String charset,
+      FcpInsertOptions options,
       FCPConnectionHandler handler,
-      short priorityClass,
-      Persistence persistence,
-      String clientToken,
-      boolean global,
-      boolean getCHKOnly,
-      boolean dontCompress,
-      boolean localRequestOnly,
-      int maxRetries,
-      boolean earlyEncode,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      String compressorDescriptor,
-      int extraInsertsSingleBlock,
-      int extraInsertsSplitfileHeader,
-      boolean realTimeFlag,
-      InsertContext.CompatibilityMode compatibilityMode,
-      boolean ignoreUSKDatehints,
       FCPServer server)
       throws MalformedURLException {
-    super(
-        new ClientRequestParams(
-            uri,
-            identifier,
-            verbosity,
-            priorityClass,
-            persistence,
-            realTimeFlag,
-            clientToken,
-            global),
-        handler);
+    super(requestParams, handler);
     warnIfUnsupportedCharset(charset);
     ctx = server.getCore().getClientContext().getDefaultPersistentInsertContext();
-    ctx.setGetCHKOnly(getCHKOnly);
-    ctx.setDontCompress(dontCompress);
+    ctx.setGetCHKOnly(options.getCHKOnly());
+    ctx.setDontCompress(options.dontCompress());
     ctx.getEventProducer().addEventListener(this);
-    ctx.setMaxInsertRetries(maxRetries);
-    ctx.setCanWriteClientCache(canWriteClientCache);
-    ctx.setCompressorDescriptor(compressorDescriptor);
-    ctx.setForkOnCacheable(forkOnCacheable);
-    ctx.setExtraInsertsSingleBlock(extraInsertsSingleBlock);
-    ctx.setExtraInsertsSplitfileHeaderBlock(extraInsertsSplitfileHeader);
-    ctx.setCompatibilityMode(compatibilityMode);
-    ctx.setLocalRequestOnly(localRequestOnly);
-    ctx.setEarlyEncode(earlyEncode);
-    ctx.setIgnoreUSKDatehints(ignoreUSKDatehints);
+    ctx.setMaxInsertRetries(options.maxRetries());
+    ctx.setCanWriteClientCache(options.canWriteClientCache());
+    ctx.setCompressorDescriptor(options.compressorDescriptor());
+    ctx.setForkOnCacheable(options.forkOnCacheable());
+    ctx.setExtraInsertsSingleBlock(options.extraInsertsSingleBlock());
+    ctx.setExtraInsertsSplitfileHeaderBlock(options.extraInsertsSplitfileHeaderBlock());
+    ctx.setCompatibilityMode(options.compatibilityMode());
+    ctx.setLocalRequestOnly(options.localRequestOnly());
+    ctx.setEarlyEncode(options.earlyEncode());
+    ctx.setIgnoreUSKDatehints(options.ignoreUSKDatehints());
     publicURI = this.uri.deriveRequestURIFromInsertURI();
   }
 
@@ -307,85 +261,38 @@ public abstract class ClientPutBase extends ClientRequest
    * or resuming jobs to bypass socket handlers entirely while preserving the same configuration
    * surface.
    *
-   * @param uri canonical insert URI previously persisted for this request
-   * @param identifier client-supplied correlation identifier used across restarts
-   * @param verbosity bitmask of progress categories to forward to the persistent queue
+   * @param requestParams request metadata including URI, identifiers, and scheduling flags
    * @param charset optional charset hint that influences metadata generation when meaningful
+   * @param options insert tuning options that should persist across restarts
    * @param handler connection handler for immediate responses during the resume handshake
    * @param client persistent request owner used to enqueue outbound messages after resumption
-   * @param priorityClass scheduler priority class remembered from the original request
-   * @param persistence persistence tier expected for the resumed job; usually {@code FOREVER}
-   * @param clientToken opaque identifier mirrored to external monitoring dashboards
-   * @param global whether the resumed request rejoins the global queue or remains client-local
-   * @param getCHKOnly true to compute a CHK and drop payload storage like the connection variant
-   * @param dontCompress true when the resumed job must avoid compression for deterministic output
-   * @param maxRetries retry count retained from the previous incarnation for fairness
-   * @param earlyEncode whether pre-encoding should resume immediately, matching stored state
-   * @param canWriteClientCache true when cached blocks may be written again post-resume
-   * @param forkOnCacheable indicates whether cacheable content may spawn redundancy jobs
-   * @param localRequestOnly true when inserts must remain within the local node for privacy
-   * @param extraInsertsSingleBlock redundancy factor for single-block inserts that persists
-   * @param extraInsertsSplitfileHeader redundancy factor for splitfile headers that persists
-   * @param realTimeFlag true to push the resumed job into the real-time scheduler lanes
-   * @param compressorDescriptor list of compressor names that continue to apply
-   * @param compatMode compatibility mode pinned earlier to guarantee deterministic hashes
-   * @param ignoreUSKDatehints true when the job must avoid writing or reading USK hints
-   * @param core node core used to obtain shared factories and contexts for resumed jobs
-   * @throws MalformedURLException if {@code uri} cannot be normalized into a supported insert type
+   * @param core node core used to get shared factories and contexts for resumed jobs
+   * @throws MalformedURLException if the URI cannot be normalized into a supported insert type
    */
   protected ClientPutBase(
-      FreenetURI uri,
-      String identifier,
-      int verbosity,
+      ClientRequestParams requestParams,
       String charset,
+      FcpInsertOptions options,
       FCPConnectionHandler handler,
       PersistentRequestClient client,
-      short priorityClass,
-      Persistence persistence,
-      String clientToken,
-      boolean global,
-      boolean getCHKOnly,
-      boolean dontCompress,
-      int maxRetries,
-      boolean earlyEncode,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      boolean localRequestOnly,
-      int extraInsertsSingleBlock,
-      int extraInsertsSplitfileHeader,
-      boolean realTimeFlag,
-      String compressorDescriptor,
-      InsertContext.CompatibilityMode compatMode,
-      boolean ignoreUSKDatehints,
       NodeClientCore core)
       throws MalformedURLException {
-    super(
-        new ClientRequestParams(
-            uri,
-            identifier,
-            verbosity,
-            priorityClass,
-            persistence,
-            realTimeFlag,
-            clientToken,
-            global),
-        handler,
-        client);
+    super(requestParams, handler, client);
     warnIfUnsupportedCharset(charset);
     ctx = core.getClientContext().getDefaultPersistentInsertContext();
-    ctx.setGetCHKOnly(getCHKOnly);
-    ctx.setDontCompress(dontCompress);
+    ctx.setGetCHKOnly(options.getCHKOnly());
+    ctx.setDontCompress(options.dontCompress());
     ctx.getEventProducer().addEventListener(this);
-    ctx.setMaxInsertRetries(maxRetries);
-    ctx.setCanWriteClientCache(canWriteClientCache);
-    ctx.setCompressorDescriptor(compressorDescriptor);
-    ctx.setForkOnCacheable(forkOnCacheable);
-    ctx.setExtraInsertsSingleBlock(extraInsertsSingleBlock);
-    ctx.setExtraInsertsSplitfileHeaderBlock(extraInsertsSplitfileHeader);
-    ctx.setLocalRequestOnly(localRequestOnly);
-    ctx.setCompatibilityMode(compatMode);
-    ctx.setIgnoreUSKDatehints(ignoreUSKDatehints);
-    ctx.setEarlyEncode(earlyEncode);
+    ctx.setMaxInsertRetries(options.maxRetries());
+    ctx.setCanWriteClientCache(options.canWriteClientCache());
+    ctx.setCompressorDescriptor(options.compressorDescriptor());
+    ctx.setForkOnCacheable(options.forkOnCacheable());
+    ctx.setExtraInsertsSingleBlock(options.extraInsertsSingleBlock());
+    ctx.setExtraInsertsSplitfileHeaderBlock(options.extraInsertsSplitfileHeaderBlock());
+    ctx.setLocalRequestOnly(options.localRequestOnly());
+    ctx.setCompatibilityMode(options.compatibilityMode());
+    ctx.setIgnoreUSKDatehints(options.ignoreUSKDatehints());
+    ctx.setEarlyEncode(options.earlyEncode());
     publicURI = this.uri.deriveRequestURIFromInsertURI();
   }
 
@@ -423,7 +330,7 @@ public abstract class ClientPutBase extends ClientRequest
   public void onSuccess(BaseClientPutter state) {
     synchronized (this) {
       // Including these helps with certain bugs...
-      started = true; // Keep started flag set for resume compatibility.
+      started = true; // Keep the started flag set for resume compatibility.
       succeeded = true;
       finished = true;
       completionTime = System.currentTimeMillis();
@@ -442,8 +349,8 @@ public abstract class ClientPutBase extends ClientRequest
    * Records a fatal insert failure, captures the {@link InsertException}, and notifies clients
    * through a {@code PutFailed} message.
    *
-   * <p>The method treats the first invocation as authoritative and ignores subsequent calls once
-   * {@link #finished} becomes {@code true}. Connection-scoped requests relinquish buffered data,
+   * <p>The method treats the first invocation as authoritative and ignores later calls once {@link
+   * #finished} becomes {@code true}. Connection-scoped requests relinquish buffered data,
    * persistent requests keep the failure payload so that reconnecting clients can inspect detailed
    * codes, and registered {@link PersistentRequestClient}s are notified immediately.
    *
@@ -454,7 +361,7 @@ public abstract class ClientPutBase extends ClientRequest
   public void onFailure(InsertException e, BaseClientPutter state) {
     if (finished) return;
     synchronized (this) {
-      started = true; // Keep started flag set for resume compatibility.
+      started = true; // Keep the started flag set for resume compatibility.
       finished = true;
       completionTime = System.currentTimeMillis();
       putFailedMessage = new PutFailedMessage(e, identifier, global);
@@ -518,9 +425,9 @@ public abstract class ClientPutBase extends ClientRequest
    * Captures metadata generated instead of a URI and either forwards or frees the supplied bucket
    * depending on whether another metadata payload is already stored.
    *
-   * <p>Only the first metadata bucket is retained so disconnecting clients cannot accidentally leak
-   * resources. Duplicate deliveries are logged and freed immediately. Non-duplicate metadata is
-   * queued for FCP delivery and persisted if the request survives restarts.
+   * <p>Only the first metadata bucket is retained, so disconnecting clients cannot accidentally
+   * leak resources. Duplicate deliveries are logged and freed immediately. Non-duplicate metadata
+   * is queued for FCP delivery and persisted if the request survives restarts.
    *
    * @param metadata metadata bucket; ownership transfers to this method on success
    * @param state inserter reporting metadata generation; used for logging context only
@@ -558,7 +465,7 @@ public abstract class ClientPutBase extends ClientRequest
    */
   @Override
   public void requestWasRemoved(ClientContext context) {
-    // if request is still running, send a PutFailed with code=cancelled
+    // if the request is still running, send a PutFailed with code=canceled
     if (!finished) {
       synchronized (this) {
         finished = true;
@@ -567,7 +474,7 @@ public abstract class ClientPutBase extends ClientRequest
       }
       trySendFinalMessage(null, null);
     }
-    // notify client that request was removed
+    // notify client that the request was removed
     FCPMessage msg = new PersistentRequestRemovedMessage(getIdentifier(), global);
     if (persistence == Persistence.CONNECTION) origHandler.send(msg);
     else client.queueClientRequestMessage(msg, 0);
@@ -656,7 +563,7 @@ public abstract class ClientPutBase extends ClientRequest
   }
 
   /**
-   * Invoked whenever the inserter finishes a compression phase so subclasses can flush UI state,
+   * Invoked whenever the inserter finishes a compression phase, so subclasses can flush UI state,
    * release temporary buffers, or update accounting that depends on compression ratios. The method
    * is called on the same thread that receives events and should therefore avoid blocking. Typical
    * implementations toggle a “compressing” flag or decrement a counter used by progress dialogs.
@@ -784,7 +691,7 @@ public abstract class ClientPutBase extends ClientRequest
    * client reconnects. Implementations should return inexpensive, side-effect-free objects because
    * the value is regenerated each time {@link #sendPendingMessages(FCPConnectionOutputHandler,
    * String, boolean, boolean)} runs, and they must embed enough metadata for clients to recognize
-   * which request the subsequent payload refers to.
+   * which request the later payload refers to.
    *
    * @return tag message describing the specific request type and identifiers
    */
@@ -866,9 +773,9 @@ public abstract class ClientPutBase extends ClientRequest
   }
 
   /**
-   * Returns the minimum number of fetched blocks needed to reconstruct the payload according to the
-   * most recent progress update. This helps UI code communicate resilience to failures because it
-   * represents the erasure-coded threshold that must be met. A return value of {@code -1} means
+   * Returns the minimum number of fetched blocks needed to reconstruct the payload, according to
+   * the most recent progress update. This helps UI code communicate resilience to failures because
+   * it represents the erasure-coded threshold that must be met. A return value of {@code -1} means
    * progress has not been reported yet or the job has just restarted.
    *
    * @return minimum required block count or {@code -1} when unknown
@@ -916,8 +823,8 @@ public abstract class ClientPutBase extends ClientRequest
   }
 
   /**
-   * Returns the number of blocks that have been fetched (or inserted) successfully according to the
-   * latest progress report. The value is monotonically non-decreasing for a given snapshot and
+   * Returns the number of blocks that have been fetched (or inserted) successfully, according to
+   * the latest progress report. The value is monotonically non-decreasing for a given snapshot and
    * gives clients a sense of throughput over time. A return value of {@code -1} mirrors the “no
    * progress yet” condition used by the other metrics.
    *
@@ -994,8 +901,8 @@ public abstract class ClientPutBase extends ClientRequest
    * Resets volatile fields so that a persistent request can be restarted cleanly without reusing
    * stale progress, failure state, or bookkeeping flags. This method does not alter persisted
    * metadata or tokens and is safe to call multiple times. Callers typically invoke it immediately
-   * before enqueuing a restarted request to guarantee that subsequent callbacks behave as if the
-   * job were freshly created.
+   * before enqueuing a restarted request to guarantee that later callbacks behave as if the job
+   * were freshly created.
    */
   public synchronized void setVarsRestart() {
     finished = false;

--- a/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
@@ -236,15 +236,16 @@ public abstract class ClientPutBase extends ClientRequest
       FCPServer server)
       throws MalformedURLException {
     super(
-        uri,
-        identifier,
-        verbosity,
-        handler,
-        priorityClass,
-        persistence,
-        realTimeFlag,
-        clientToken,
-        global);
+        new ClientRequestParams(
+            uri,
+            identifier,
+            verbosity,
+            priorityClass,
+            persistence,
+            realTimeFlag,
+            clientToken,
+            global),
+        handler);
     warnIfUnsupportedCharset(charset);
     ctx = server.getCore().getClientContext().getDefaultPersistentInsertContext();
     ctx.setGetCHKOnly(getCHKOnly);
@@ -359,16 +360,17 @@ public abstract class ClientPutBase extends ClientRequest
       NodeClientCore core)
       throws MalformedURLException {
     super(
-        uri,
-        identifier,
-        verbosity,
+        new ClientRequestParams(
+            uri,
+            identifier,
+            verbosity,
+            priorityClass,
+            persistence,
+            realTimeFlag,
+            clientToken,
+            global),
         handler,
-        client,
-        priorityClass,
-        persistence,
-        realTimeFlag,
-        clientToken,
-        global);
+        client);
     warnIfUnsupportedCharset(charset);
     ctx = core.getClientContext().getDefaultPersistentInsertContext();
     ctx.setGetCHKOnly(getCHKOnly);

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -11,7 +11,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.Metadata;
@@ -181,92 +180,77 @@ public class ClientPutDir extends ClientPutBase {
    * NodeClientCore}.
    *
    * <pre>{@code
-   * var request = new ClientPutDir(client, uri, "upload", 1, priority,
-   *     Persistence.CONNECTION, token, false, false, 3, new File("site"),
-   *     "index.html", false, false, false, false, true, false, 0, 0,
-   *     false, null, core);
+   * var request =
+   *     new ClientPutDir(
+   *         new FcpInsertRequest(
+   *             client, uri, "upload", 1, null, priority, Persistence.CONNECTION, token, false),
+   *         new FcpInsertOptions(
+   *             false,
+   *             false,
+   *             3,
+   *             false,
+   *             true,
+   *             false,
+   *             0,
+   *             0,
+   *             false,
+   *             InsertContext.CompatibilityMode.COMPAT_DEFAULT,
+   *             null),
+   *         new File("site"),
+   *         "index.html",
+   *         false,
+   *         false,
+   *         core);
    * request.start(core.getClientContext());
    * }</pre>
    *
-   * @param client persistent client coordinating request lifecycle and status notifications.
-   * @param uri destination URI that will anchor this directory insert request.
-   * @param identifier user-visible identifier echoed on status and completion messages.
-   * @param verbosity verbosity level applied to subsequent FCP progress messages.
-   * @param priorityClass priority bucket controlling scheduler weight and fairness.
-   * @param persistence persistence window determining whether the request survives restarts.
-   * @param clientToken opaque token echoed back so callers can correlate local state.
-   * @param getCHKOnly true to compute the resulting URI without storing persistent data.
-   * @param dontCompress true to spill raw blocks instead of applying automatic compression.
-   * @param maxRetries cap on automatic retries before the request is marked permanently failed.
+   * @param request persistent insert request metadata for the directory insert.
+   * @param options insert tuning options such as retries and compression choices.
    * @param dir root directory that will be enumerated and uploaded recursively.
    * @param defaultName default manifest document served when consumers fetch the directory.
    * @param allowUnreadableFiles true to skip unreadable entries instead of aborting immediately.
    * @param includeHiddenFiles true to include filesystem entries marked hidden by the OS.
-   * @param global true to expose the request across global queues, false for connection-only.
-   * @param earlyEncode true to pre-encode blocks before scheduling network transmission.
-   * @param canWriteClientCache true if client-side block caching is permitted for this insert.
-   * @param forkOnCacheable true to fork child requests when blocks become cacheable mid-insert.
-   * @param extraInsertsSingleBlock number of redundant inserts for single-block containers.
-   * @param extraInsertsSplitfileHeaderBlock number of redundant inserts for splitfile headers.
-   * @param realTimeFlag true to prefer real-time scheduling semantics and reduced latency.
-   * @param overrideSplitfileCryptoKey caller-supplied key material overriding generated keys.
    * @param core node client core providing context services and cryptographic settings.
    * @throws FileNotFoundException if unreadable files are encountered while not permitted.
    * @throws MalformedURLException if the URI cannot be parsed, normalized, or validated.
    * @throws TooManyFilesInsertException if the directory exceeds the configured file limit.
    */
   public ClientPutDir(
-      PersistentRequestClient client,
-      FreenetURI uri,
-      String identifier,
-      int verbosity,
-      short priorityClass,
-      Persistence persistence,
-      String clientToken,
-      boolean getCHKOnly,
-      boolean dontCompress,
-      int maxRetries,
+      FcpInsertRequest request,
+      FcpInsertOptions options,
       File dir,
       String defaultName,
       boolean allowUnreadableFiles,
       boolean includeHiddenFiles,
-      boolean global,
-      boolean earlyEncode,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      int extraInsertsSingleBlock,
-      int extraInsertsSplitfileHeaderBlock,
-      boolean realTimeFlag,
-      byte[] overrideSplitfileCryptoKey,
       NodeClientCore core)
       throws FileNotFoundException, MalformedURLException, TooManyFilesInsertException {
     super(
-        checkEmptySSK(uri, "site", core.getClientContext()),
-        identifier,
-        verbosity,
+        checkEmptySSK(request.uri(), "site", core.getClientContext()),
+        request.identifier(),
+        request.verbosity(),
+        request.charset(),
         null,
-        null,
-        client,
-        priorityClass,
-        persistence,
-        clientToken,
-        global,
-        getCHKOnly,
-        dontCompress,
-        maxRetries,
-        earlyEncode,
-        canWriteClientCache,
-        forkOnCacheable,
+        request.client(),
+        request.priorityClass(),
+        request.persistence(),
+        request.clientToken(),
+        request.global(),
+        options.getCHKOnly(),
+        options.dontCompress(),
+        options.maxRetries(),
+        options.earlyEncode(),
+        options.canWriteClientCache(),
+        options.forkOnCacheable(),
         false,
-        extraInsertsSingleBlock,
-        extraInsertsSplitfileHeaderBlock,
-        realTimeFlag,
+        options.extraInsertsSingleBlock(),
+        options.extraInsertsSplitfileHeaderBlock(),
+        options.realTimeFlag(),
         null,
-        InsertContext.CompatibilityMode.COMPAT_DEFAULT,
+        options.compatibilityMode(),
         false /*XXX ignoreUSKDatehints*/,
         core);
     wasDiskPut = true;
-    this.overrideSplitfileCryptoKey = overrideSplitfileCryptoKey;
+    this.overrideSplitfileCryptoKey = options.overrideSplitfileCryptoKey();
     // debug level captured via LOG.isDebugEnabled()
     this.manifestElements = makeDiskDirManifest(dir, "", allowUnreadableFiles, includeHiddenFiles);
     this.defaultName = defaultName;

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -103,7 +103,7 @@ public class ClientPutDir extends ClientPutBase {
    * request.start(core.getClientContext());
    * }</pre>
    *
-   * @param handler connection handler responsible for routing progress replies to the caller.
+   * @param handler the connection handler responsible for routing progress replies to the caller.
    * @param message parsed message supplying URI, identifiers, persistence mode, and limits.
    * @param manifestElements manifest tree contributed by the caller, keyed by child names.
    * @param wasDiskPut true if the manifest originated from a disk enumeration on the node.
@@ -118,33 +118,36 @@ public class ClientPutDir extends ClientPutBase {
       boolean wasDiskPut,
       FCPServer server)
       throws MalformedURLException, TooManyFilesInsertException {
-    super(
-        checkEmptySSK(
-            message.uri,
-            message.targetFilename != null ? message.targetFilename : "site",
-            server.getCore().getClientContext()),
-        message.identifier,
-        message.verbosity,
-        null,
-        handler,
-        message.priorityClass,
-        message.persistence,
-        message.clientToken,
-        message.global,
-        message.getCHKOnly,
-        message.dontCompress,
-        message.localRequestOnly,
-        message.maxRetries,
-        message.earlyEncode,
-        message.canWriteClientCache,
-        message.forkOnCacheable,
-        message.compressorDescriptor,
-        message.extraInsertsSingleBlock,
-        message.extraInsertsSplitfileHeaderBlock,
-        message.realTimeFlag,
-        message.compatibilityMode,
-        message.ignoreUSKDatehints,
-        server);
+    FcpInsertOptions options =
+        new FcpInsertOptions(
+            message.getCHKOnly,
+            message.dontCompress,
+            message.localRequestOnly,
+            message.maxRetries,
+            message.earlyEncode,
+            message.canWriteClientCache,
+            message.forkOnCacheable,
+            message.compressorDescriptor,
+            message.extraInsertsSingleBlock,
+            message.extraInsertsSplitfileHeaderBlock,
+            message.realTimeFlag,
+            message.compatibilityMode,
+            message.ignoreUSKDatehints,
+            message.overrideSplitfileCryptoKey);
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            checkEmptySSK(
+                message.uri,
+                message.targetFilename != null ? message.targetFilename : "site",
+                server.getCore().getClientContext()),
+            message.identifier,
+            message.verbosity,
+            message.priorityClass,
+            message.persistence,
+            options.realTimeFlag(),
+            message.clientToken,
+            message.global);
+    super(requestParams, null, options, handler, server);
     // debug level captured via LOG.isDebugEnabled()
     this.wasDiskPut = wasDiskPut;
     this.overrideSplitfileCryptoKey = message.overrideSplitfileCryptoKey;
@@ -174,7 +177,7 @@ public class ClientPutDir extends ClientPutBase {
    * the directory, optionally skipping hidden files, builds {@link ManifestElement} instances
    * backed by {@link FileBucket}s, and configures retry, compression, and persistence knobs before
    * the request is registered with a {@link PersistentRequestClient}. The constructor immediately
-   * counts files and bytes so progress meters have deterministic totals, and it captures the
+   * counts files and bytes, so progress meters have deterministic totals, and it captures the
    * optional override splitfile key for callers who precompute keys. After construction, invoke
    * {@link #start(ClientContext)} to stream blocks while leveraging the provided {@link
    * NodeClientCore}.
@@ -187,14 +190,17 @@ public class ClientPutDir extends ClientPutBase {
    *         new FcpInsertOptions(
    *             false,
    *             false,
+   *             false,
    *             3,
    *             false,
    *             true,
    *             false,
+   *             null,
    *             0,
    *             0,
    *             false,
    *             InsertContext.CompatibilityMode.COMPAT_DEFAULT,
+   *             false,
    *             null),
    *         new File("site"),
    *         "index.html",
@@ -224,31 +230,17 @@ public class ClientPutDir extends ClientPutBase {
       boolean includeHiddenFiles,
       NodeClientCore core)
       throws FileNotFoundException, MalformedURLException, TooManyFilesInsertException {
-    super(
-        checkEmptySSK(request.uri(), "site", core.getClientContext()),
-        request.identifier(),
-        request.verbosity(),
-        request.charset(),
-        null,
-        request.client(),
-        request.priorityClass(),
-        request.persistence(),
-        request.clientToken(),
-        request.global(),
-        options.getCHKOnly(),
-        options.dontCompress(),
-        options.maxRetries(),
-        options.earlyEncode(),
-        options.canWriteClientCache(),
-        options.forkOnCacheable(),
-        false,
-        options.extraInsertsSingleBlock(),
-        options.extraInsertsSplitfileHeaderBlock(),
-        options.realTimeFlag(),
-        null,
-        options.compatibilityMode(),
-        false /*XXX ignoreUSKDatehints*/,
-        core);
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            checkEmptySSK(request.uri(), "site", core.getClientContext()),
+            request.identifier(),
+            request.verbosity(),
+            request.priorityClass(),
+            request.persistence(),
+            options.realTimeFlag(),
+            request.clientToken(),
+            request.global());
+    super(requestParams, request.charset(), options, null, request.client(), core);
     wasDiskPut = true;
     this.overrideSplitfileCryptoKey = options.overrideSplitfileCryptoKey();
     // debug level captured via LOG.isDebugEnabled()
@@ -462,8 +454,8 @@ public class ClientPutDir extends ClientPutBase {
    * <p>This hook is invoked once the request either finishes or transitions into a persisted state
    * where the manifest can be lazily rebuilt later. It recursively traverses the manifest map,
    * frees {@link ManifestElement} buckets, and nulls the root reference to allow garbage
-   * collection. The logic is conservative about synchronization so callers may invoke it regardless
-   * of the current persistence mode without risking double-free behavior.
+   * collection. The logic is conservative about synchronization, so callers may invoke it
+   * regardless of the current persistence mode without risking double-free behavior.
    */
   @Override
   protected void freeData() {
@@ -477,7 +469,7 @@ public class ClientPutDir extends ClientPutBase {
     }
     if (LOG.isDebugEnabled())
       LOG.debug("freeData() more on {} persistence type = {}", this, persistence);
-    // We have to commit everything, so activating everything here doesn't cost us much memory...?
+    // We have to commit everything, so activating everything here costs us little memory...?
     freeData(manifestElements);
     manifestElements = null;
   }
@@ -505,9 +497,9 @@ public class ClientPutDir extends ClientPutBase {
    *
    * <p>The manifest putter encapsulates all block scheduling and retry logic. Returning it here
    * lets the superclass manage cross-cutting behaviors such as throttling, serialization, and
-   * statistics updates in a uniform manner. Callers should treat the returned instance as
-   * transient; once {@link #freeData()} runs or the request completes, the putter may be {@code
-   * null} and should not be reused.
+   * statistics updates uniformly. Callers should treat the returned instance as transient; once
+   * {@link #freeData()} runs or the request completes, the putter may be {@code null} and should
+   * not be reused.
    *
    * @return currently active requester coordinating splitfile inserts, or {@code null} when torn
    *     down.
@@ -558,7 +550,7 @@ public class ClientPutDir extends ClientPutBase {
   private boolean isRealTime() {
     if (lowLevelClient == null) {
       // This can happen but only due to data corruption - old databases on which various bugs have
-      // resulted in it getting deleted, and also possibly failed deletions.
+      // resulted in it getting deleted and also possibly failed deletions.
       LOG.warn("lowLevelClient == null");
       return false;
     }
@@ -740,7 +732,7 @@ public class ClientPutDir extends ClientPutBase {
     int fetched = 0;
     int fatal = 0;
     int failed = 0;
-    // See ClientRequester.getLatestSuccess() for why this defaults to current time.
+    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
     Date latestSuccess = new Date();
     Date latestFailure = null;
     boolean totalFinalized = false;

--- a/src/main/java/network/crypta/clients/fcp/ClientPutUpload.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutUpload.java
@@ -1,0 +1,30 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.RandomAccessBucket;
+
+/**
+ * Describes the payload source and metadata hints for a single-file put request.
+ *
+ * <p>The upload specification keeps the original filename, optional content type, bucket handle,
+ * redirect target, and output filename together so callers can pass them as a single unit when
+ * constructing {@link ClientPut} instances.
+ *
+ * @param uploadFromType source of the upload bytes (direct, disk, or redirect)
+ * @param origFilename original filesystem filename when uploading from disk; may be {@code null}
+ * @param contentType MIME type override for the upload; may be {@code null}
+ * @param data bucket containing upload data or {@code null} for redirects
+ * @param redirectTarget target URI for redirect uploads; may be {@code null}
+ * @param targetFilename filename hint to store in metadata; may be {@code null}
+ * @param binaryBlob whether the insert is an opaque binary blob with no metadata
+ */
+public record ClientPutUpload(
+    UploadFrom uploadFromType,
+    File origFilename,
+    String contentType,
+    RandomAccessBucket data,
+    FreenetURI redirectTarget,
+    String targetFilename,
+    boolean binaryBlob) {}

--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -26,22 +26,22 @@ import org.slf4j.LoggerFactory;
 /**
  * Represents a single high-level request that the node carries out on behalf of an FCP client.
  *
- * <p>Instances of this class encapsulate the lifecycle, persistence configuration and bookkeeping
+ * <p>Instances of this class encapsulate the lifecycle, persistence configuration, and bookkeeping
  * for operations such as {@code ClientGet}, {@code ClientPut} and multi-key fetches. A {@code
  * ClientRequest} is created by the FCP layer when a client issues a request, then scheduled and
- * tracked by the node until it completes, fails or is explicitly cancelled. Subclasses implement
+ * tracked by the node until it completes, fails, or is explicitly canceled. Subclasses implement
  * the protocol-specific behavior while this base class coordinates common state and interaction
  * with the core node.
  *
- * <p>Requests may be connection-bound, reboot-persistent or fully persistent on disk. Each instance
- * keeps a stable identifier, priority class, client token and statistics that are used for progress
- * reporting and scheduling. Implementations are typically confined to the owning {@link
- * ClientContext} and must be safe to invoke from the node's worker threads.
+ * <p>Requests may be connection-bound, reboot-persistent, or fully persistent on disk. Each
+ * instance keeps a stable identifier, priority class, client token, and statistics that are used
+ * for progress reporting and scheduling. Implementations are typically confined to the owning
+ * {@link ClientContext} and must be safe to invoke from the node's worker threads.
  *
  * <ul>
  *   <li>Tracks client-visible metadata such as identifiers, tokens and verbosity.
- *   <li>Coordinates persistence, resumption and cancellation across reconnects and restarts.
- *   <li>Provides hooks for status reporting, restart and orderly shutdown.
+ *   <li>Coordinates persistence, resumption, and cancellation across reconnections and restarts.
+ *   <li>Provides hooks for status reporting, restart, and orderly shutdown.
  * </ul>
  *
  * @see RequestIdentifier
@@ -135,51 +135,35 @@ public abstract class ClientRequest implements Serializable {
    *
    * <p>This constructor is used when a {@link PersistentRequestClient} has already been resolved,
    * typically while resuming a request. It configures core metadata such as the requested {@link
-   * FreenetURI}, client-visible identifier, verbosity, priority class and persistence mode, and
+   * FreenetURI}, client-visible identifier, verbosity, priority class, and persistence mode, and
    * wires the request to the appropriate global or per-client queue.
    *
-   * @param uri2 target URI being fetched or inserted on behalf of the client
-   * @param identifier2 unique identifier string supplied by the FCP client for correlation
-   * @param verbosity2 requested verbosity level for progress and status messages
+   * @param params request metadata including identifiers, priority and persistence settings
    * @param handler connection handler owning the request while persistence is {@code CONNECTION}
    * @param client persistent request client instance that represents the owning FCP client
-   * @param priorityClass2 initial priority class used by the scheduler to order work
-   * @param persistenceType2 persistence mode controlling lifetime across disconnects and restarts
-   * @param realTime whether the request is scheduled as real-time instead of background bulk
-   * @param clientToken2 optional opaque token echoed back to the client in notifications
-   * @param global whether the request belongs to the shared global queue rather than a client
    */
   protected ClientRequest(
-      FreenetURI uri2,
-      String identifier2,
-      int verbosity2,
-      FCPConnectionHandler handler,
-      PersistentRequestClient client,
-      short priorityClass2,
-      Persistence persistenceType2,
-      boolean realTime,
-      String clientToken2,
-      boolean global) {
+      ClientRequestParams params, FCPConnectionHandler handler, PersistentRequestClient client) {
     int hash = super.hashCode();
     if (hash == 0) hash = 1;
     hashCode = hash;
-    this.uri = uri2;
-    this.identifier = identifier2;
-    if (global) {
+    this.uri = params.uri();
+    this.identifier = params.identifier();
+    if (params.global()) {
       this.verbosity = Integer.MAX_VALUE;
       this.clientName = null;
     } else {
-      this.verbosity = verbosity2;
+      this.verbosity = params.verbosity();
       this.clientName = client.name;
     }
     this.finished = false;
-    this.priorityClass = priorityClass2;
-    this.persistence = persistenceType2;
-    this.clientToken = clientToken2;
-    this.global = global;
+    this.priorityClass = params.priorityClass();
+    this.persistence = params.persistence();
+    this.clientToken = params.clientToken();
+    this.global = params.global();
     if (persistence == Persistence.CONNECTION) {
       this.origHandler = handler;
-      lowLevelClient = origHandler.connectionRequestClient(realTime);
+      lowLevelClient = origHandler.connectionRequestClient(params.realTime());
       this.client = null;
     } else {
       origHandler = null;
@@ -190,11 +174,11 @@ public abstract class ClientRequest implements Serializable {
       if (client.persistence != persistence) {
         throw new IllegalStateException("Persistent client has mismatched persistence");
       }
-      lowLevelClient = client.lowLevelClient(realTime);
+      lowLevelClient = client.lowLevelClient(params.realTime());
     }
     assert lowLevelClient != null;
     this.startupTime = System.currentTimeMillis();
-    this.realTime = realTime;
+    this.realTime = params.realTime();
   }
 
   /**
@@ -202,62 +186,46 @@ public abstract class ClientRequest implements Serializable {
    *
    * <p>This constructor is typically used when a request is first created from an FCP command. It
    * determines the appropriate persistent client (global or per-connection), configures the
-   * request's persistence mode, priority and verbosity and allocates a low-level {@link
+   * request's persistence mode, priority, and verbosity, and allocates a low-level {@link
    * RequestClient} suitable for either real-time or bulk scheduling.
    *
-   * @param uri2 target URI being fetched or inserted on behalf of the client
-   * @param identifier2 unique identifier string supplied by the FCP client for correlation
-   * @param verbosity2 requested verbosity level for progress and status messages
+   * @param params request metadata including identifiers, priority and persistence settings
    * @param handler connection handler from which persistent client information is derived
-   * @param priorityClass2 initial priority class used by the scheduler to order work
-   * @param persistenceType2 persistence mode controlling lifetime across disconnects and restarts
-   * @param realTime whether the request is scheduled as real-time instead of background bulk
-   * @param clientToken2 optional opaque token echoed back to the client in notifications
-   * @param global whether the request belongs to the shared global queue rather than a client
    */
-  protected ClientRequest(
-      FreenetURI uri2,
-      String identifier2,
-      int verbosity2,
-      FCPConnectionHandler handler,
-      short priorityClass2,
-      Persistence persistenceType2,
-      final boolean realTime,
-      String clientToken2,
-      boolean global) {
+  protected ClientRequest(ClientRequestParams params, FCPConnectionHandler handler) {
     int hash = super.hashCode();
     if (hash == 0) hash = 1;
     hashCode = hash;
-    this.uri = uri2;
-    this.identifier = identifier2;
+    this.uri = params.uri();
+    this.identifier = params.identifier();
     this.finished = false;
-    this.priorityClass = priorityClass2;
-    this.persistence = persistenceType2;
-    this.clientToken = clientToken2;
-    this.global = global;
+    this.priorityClass = params.priorityClass();
+    this.persistence = params.persistence();
+    this.clientToken = params.clientToken();
+    this.global = params.global();
     if (persistence == Persistence.CONNECTION) {
       this.origHandler = handler;
       client = null;
-      lowLevelClient = new RequestClientBuilder().realTime(realTime).build();
+      lowLevelClient = new RequestClientBuilder().realTime(params.realTime()).build();
       this.clientName = null;
-      this.verbosity = verbosity2;
+      this.verbosity = params.verbosity();
     } else {
       origHandler = null;
-      client = resolvePersistentClient(handler, persistenceType2, global);
-      if (global) {
+      client = resolvePersistentClient(handler, params.persistence(), params.global());
+      if (params.global()) {
         this.verbosity = Integer.MAX_VALUE;
         clientName = null;
       } else {
-        this.verbosity = verbosity2;
+        this.verbosity = params.verbosity();
         this.clientName = client.name;
       }
-      lowLevelClient = client.lowLevelClient(realTime);
+      lowLevelClient = client.lowLevelClient(params.realTime());
       if (lowLevelClient == null)
         throw new NullPointerException(
             "No lowLevelClient from client: "
                 + client
                 + " global = "
-                + global
+                + params.global()
                 + " persistence = "
                 + persistence);
     }
@@ -269,7 +237,7 @@ public abstract class ClientRequest implements Serializable {
               + persistence);
     assert client == null || (client.persistence == persistence);
     this.startupTime = System.currentTimeMillis();
-    this.realTime = realTime;
+    this.realTime = params.realTime();
   }
 
   private PersistentRequestClient resolvePersistentClient(
@@ -308,8 +276,8 @@ public abstract class ClientRequest implements Serializable {
    *
    * <p>The node calls this method when the underlying FCP connection terminates unexpectedly or is
    * closed by the client. Implementations typically record the condition, adjust any queued
-   * responses and decide whether the request should continue running as a persistent background job
-   * or be cancelled outright. This callback is invoked on a node worker thread and should return
+   * responses, and decide whether the request should continue running as a persistent background
+   * job or be canceled outright. This callback is invoked on a node worker thread and should return
    * quickly.
    *
    * @param context client context providing access to schedulers, queues and persistent roots
@@ -320,7 +288,7 @@ public abstract class ClientRequest implements Serializable {
    * Sends any queued protocol messages for this request to a reconnecting client.
    *
    * <p>This is used when the client lists persistent requests or re-establishes an FCP session and
-   * wants to receive outstanding messages such as progress updates, completion notifications or
+   * wants to receive outstanding messages such as progress updates, completion notifications, or
    * failure details. Implementations should respect {@code includeData} to avoid resending large
    * payloads unnecessarily and may honor {@code onlyData} when a client is interested only in bulk
    * data transfers.
@@ -342,7 +310,7 @@ public abstract class ClientRequest implements Serializable {
    * Describes how long a client request remains associated with the node.
    *
    * <p>The persistence mode determines whether a request is tied to the lifetime of a single FCP
-   * connection, survives reconnects within the same node process or is durably stored on disk
+   * connection, survives reconnections within the same node process, or is durably stored on disk
    * across restarts. The chosen value influences queue selection, resumption behavior and whether
    * {@link PersistentRequestClient} instances are created.
    */
@@ -350,7 +318,7 @@ public abstract class ClientRequest implements Serializable {
     /** Default: persists until connection loss. */
     CONNECTION,
     /**
-     * Reports to client by name; persists over connection loss. Not saved to disk, so dies on
+     * Reports to a client by name; persists over connection loss. Not saved to disk, so dies on
      * reboot.
      */
     REBOOT,
@@ -441,7 +409,7 @@ public abstract class ClientRequest implements Serializable {
    *
    * <p>This flag is set once the core node has either successfully completed the operation or
    * determined that it has irrecoverably failed. The request object may still remain registered,
-   * for example until the client acknowledges the completion message.
+   * for example, until the client acknowledges the completion message.
    *
    * @return {@code true} once the request has finished and will not perform further work
    */
@@ -513,8 +481,8 @@ public abstract class ClientRequest implements Serializable {
    * segment of a split file or key-based chunk. Implementations should return a value between
    * {@code 0.0} and {@code 1.0} when the total block count is known.
    *
-   * @return completion fraction in the range {@code 0.0} to {@code 1.0}, or an implementation
-   *     specific sentinel
+   * @return completion fraction in the range {@code 0.0} to {@code 1.0}, or an
+   *     implementation-specific sentinel
    */
   @SuppressWarnings("unused")
   public abstract double getSuccessFraction();
@@ -556,7 +524,7 @@ public abstract class ClientRequest implements Serializable {
    * Returns how many blocks have permanently failed during the current run.
    *
    * <p>Blocks counted here are not expected to succeed on their own without a restart.
-   * Implementations decide when to classify a failure as permanent, for example after exhausting
+   * Implementations decide when to classify a failure as permanent, for example, after exhausting
    * retry attempts.
    *
    * @return number of blocks that failed irrecoverably under the current request run
@@ -602,10 +570,10 @@ public abstract class ClientRequest implements Serializable {
    * Starts the request if it has not already been started.
    *
    * <p>Implementations are responsible for creating the underlying {@link ClientRequester},
-   * scheduling it on the appropriate queues and updating any status caches. This method may be
+   * scheduling it on the appropriate queues, and updating any status caches. This method may be
    * called again after a restart request but should avoid duplicating work when already running.
    *
-   * @param context client context providing access to schedulers, factories and persistent roots
+   * @param context client context providing access to schedulers, factories, and persistent roots
    */
   public abstract void start(ClientContext context);
 
@@ -649,9 +617,10 @@ public abstract class ClientRequest implements Serializable {
   /**
    * Restarts the request synchronously using the supplied client context.
    *
-   * <p>The implementation may reuse persistent on-disk state where available or start from scratch
-   * otherwise. Callers are responsible for checking {@link #canRestart()} beforehand. Depending on
-   * the request type this operation can be expensive and may block briefly while scheduling work.
+   * <p>The implementation may reuse a persistent on-disk state where available or start from
+   * scratch otherwise. Callers are responsible for checking {@link #canRestart()} beforehand.
+   * Depending on the request type, this operation can be expensive and may block briefly while
+   * scheduling work.
    *
    * @param context client context used to create new requesters and schedule work
    * @param disableFilterData whether associated filter data should be disabled for the restart
@@ -822,7 +791,7 @@ public abstract class ClientRequest implements Serializable {
    * <p>This may be {@code null} for connection-persistent requests that are not attached to a named
    * persistent client.
    *
-   * @return owning persistent client, or {@code null} for connection-bound requests
+   * @return owning a persistent client, or {@code null} for connection-bound requests
    */
   public PersistentRequestClient getClient() {
     return client;
@@ -863,7 +832,7 @@ public abstract class ClientRequest implements Serializable {
     // uri will be handled by subclasses.
     // This can change.
     dos.writeShort(priorityClass);
-    // This can change and is variable size.
+    // This can change and is a variable size.
     if (clientToken == null) dos.writeBoolean(false);
     else {
       dos.writeBoolean(true);
@@ -878,7 +847,7 @@ public abstract class ClientRequest implements Serializable {
    * encoding written by {@link #getClientDetail(DataOutputStream, ChecksumChecker)}.
    *
    * <p>This constructor is used when resuming requests from disk. It validates the magic number,
-   * version and {@link RequestIdentifier}, then restores scheduling parameters and recreates the
+   * version and {@link RequestIdentifier}, then restores scheduling parameters, and recreates the
    * {@link PersistentRequestClient} and {@link RequestClient} references needed for further
    * processing.
    *
@@ -946,7 +915,7 @@ public abstract class ClientRequest implements Serializable {
    * ClientRequester} tree to avoid recursion.
    *
    * @param context client context providing access to node-wide services required to resume
-   * @throws ResumeFailedException if required resources cannot be reacquired during resumption
+   * @throws ResumeFailedException if required, resources cannot be reacquired during resumption
    */
   protected abstract void innerResume(ClientContext context) throws ResumeFailedException;
 
@@ -1015,7 +984,7 @@ public abstract class ClientRequest implements Serializable {
   public abstract boolean fullyResumed();
 
   /**
-   * Called just before the node performs its final write during shutdown.
+   * Called just before the node performs its final writing during shutdown.
    *
    * <p>Subclasses can override this hook to flush any outstanding state to disk or perform
    * bookkeeping that cannot be recovered automatically after restart. The default implementation

--- a/src/main/java/network/crypta/clients/fcp/ClientRequestParams.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequestParams.java
@@ -1,0 +1,30 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Immutable request metadata shared across FCP client request constructors.
+ *
+ * <p>This record groups the core scheduling and identification fields that are common to all {@link
+ * ClientRequest} variants. It keeps constructors concise while preserving the exact semantics of
+ * the original parameter list.
+ *
+ * @param uri target URI being fetched or inserted on behalf of the client
+ * @param identifier unique identifier string supplied by the FCP client for correlation
+ * @param verbosity requested verbosity level for progress and status messages
+ * @param priorityClass initial priority class used by the scheduler to order work
+ * @param persistence persistence mode controlling lifetime across disconnects and restarts
+ * @param realTime whether the request is scheduled as real-time instead of background bulk
+ * @param clientToken optional opaque token echoed back to the client in notifications
+ * @param global whether the request belongs to the shared global queue rather than a client
+ */
+public record ClientRequestParams(
+    FreenetURI uri,
+    String identifier,
+    int verbosity,
+    short priorityClass,
+    Persistence persistence,
+    boolean realTime,
+    String clientToken,
+    boolean global) {}

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertOptions.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertOptions.java
@@ -14,27 +14,33 @@ import org.jetbrains.annotations.NotNull;
  *
  * @param getCHKOnly whether to compute the CHK without persisting blocks
  * @param dontCompress whether compression should be disabled for the insert
+ * @param localRequestOnly whether the insert should remain on the local node only
  * @param maxRetries maximum retries before failing the insert
  * @param earlyEncode whether encoding should begin before all data is received
  * @param canWriteClientCache whether client cache writes are permitted
  * @param forkOnCacheable whether to fork insert contexts when blocks become cacheable
+ * @param compressorDescriptor optional compressor descriptor string; may be {@code null}
  * @param extraInsertsSingleBlock redundancy factor for single-block inserts
  * @param extraInsertsSplitfileHeaderBlock redundancy factor for splitfile header blocks
  * @param realTimeFlag whether to schedule the insert in real-time queues
  * @param compatibilityMode compatibility mode guiding splitfile encoding parameters
+ * @param ignoreUSKDatehints whether USK datehints should be ignored during insert
  * @param overrideSplitfileCryptoKey optional splitfile crypto key override; may be {@code null}
  */
 public record FcpInsertOptions(
     boolean getCHKOnly,
     boolean dontCompress,
+    boolean localRequestOnly,
     int maxRetries,
     boolean earlyEncode,
     boolean canWriteClientCache,
     boolean forkOnCacheable,
+    String compressorDescriptor,
     int extraInsertsSingleBlock,
     int extraInsertsSplitfileHeaderBlock,
     boolean realTimeFlag,
     InsertContext.CompatibilityMode compatibilityMode,
+    boolean ignoreUSKDatehints,
     byte[] overrideSplitfileCryptoKey) {
   @Override
   public boolean equals(Object o) {
@@ -44,25 +50,31 @@ public record FcpInsertOptions(
         FcpInsertOptions(
             boolean otherGetCHKOnly,
             boolean otherDontCompress,
+            boolean otherLocalRequestOnly,
             int otherMaxRetries,
             boolean otherEarlyEncode,
             boolean otherCanWriteClientCache,
             boolean otherForkOnCacheable,
+            String otherCompressorDescriptor,
             int otherExtraInsertsSingleBlock,
             int otherExtraInsertsSplitfileHeaderBlock,
             boolean otherRealTimeFlag,
             InsertContext.CompatibilityMode otherCompatibilityMode,
+            boolean otherIgnoreUSKDatehints,
             byte[] otherOverrideSplitfileCryptoKey))) return false;
     return getCHKOnly == otherGetCHKOnly
         && dontCompress == otherDontCompress
+        && localRequestOnly == otherLocalRequestOnly
         && maxRetries == otherMaxRetries
         && earlyEncode == otherEarlyEncode
         && canWriteClientCache == otherCanWriteClientCache
         && forkOnCacheable == otherForkOnCacheable
+        && Objects.equals(compressorDescriptor, otherCompressorDescriptor)
         && extraInsertsSingleBlock == otherExtraInsertsSingleBlock
         && extraInsertsSplitfileHeaderBlock == otherExtraInsertsSplitfileHeaderBlock
         && realTimeFlag == otherRealTimeFlag
         && compatibilityMode == otherCompatibilityMode
+        && ignoreUSKDatehints == otherIgnoreUSKDatehints
         && Arrays.equals(overrideSplitfileCryptoKey, otherOverrideSplitfileCryptoKey);
   }
 
@@ -72,14 +84,17 @@ public record FcpInsertOptions(
         Objects.hash(
             getCHKOnly,
             dontCompress,
+            localRequestOnly,
             maxRetries,
             earlyEncode,
             canWriteClientCache,
             forkOnCacheable,
+            compressorDescriptor,
             extraInsertsSingleBlock,
             extraInsertsSplitfileHeaderBlock,
             realTimeFlag,
-            compatibilityMode);
+            compatibilityMode,
+            ignoreUSKDatehints);
     result = 31 * result + Arrays.hashCode(overrideSplitfileCryptoKey);
     return result;
   }
@@ -90,6 +105,8 @@ public record FcpInsertOptions(
         + getCHKOnly
         + ", dontCompress="
         + dontCompress
+        + ", localRequestOnly="
+        + localRequestOnly
         + ", maxRetries="
         + maxRetries
         + ", earlyEncode="
@@ -98,6 +115,8 @@ public record FcpInsertOptions(
         + canWriteClientCache
         + ", forkOnCacheable="
         + forkOnCacheable
+        + ", compressorDescriptor="
+        + compressorDescriptor
         + ", extraInsertsSingleBlock="
         + extraInsertsSingleBlock
         + ", extraInsertsSplitfileHeaderBlock="
@@ -106,6 +125,8 @@ public record FcpInsertOptions(
         + realTimeFlag
         + ", compatibilityMode="
         + compatibilityMode
+        + ", ignoreUSKDatehints="
+        + ignoreUSKDatehints
         + ", overrideSplitfileCryptoKey="
         + (overrideSplitfileCryptoKey == null
             ? "null"

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertOptions.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertOptions.java
@@ -1,0 +1,115 @@
+package network.crypta.clients.fcp;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.client.InsertContext;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Captures insert-specific tuning knobs supplied by FCP callers.
+ *
+ * <p>The options encapsulate retry limits, compression preferences, cache behaviors, redundancy
+ * factors, real-time scheduling, and compatibility mode hints. They are shared between file and
+ * directory put requests to ensure consistent configuration across insert flows.
+ *
+ * @param getCHKOnly whether to compute the CHK without persisting blocks
+ * @param dontCompress whether compression should be disabled for the insert
+ * @param maxRetries maximum retries before failing the insert
+ * @param earlyEncode whether encoding should begin before all data is received
+ * @param canWriteClientCache whether client cache writes are permitted
+ * @param forkOnCacheable whether to fork insert contexts when blocks become cacheable
+ * @param extraInsertsSingleBlock redundancy factor for single-block inserts
+ * @param extraInsertsSplitfileHeaderBlock redundancy factor for splitfile header blocks
+ * @param realTimeFlag whether to schedule the insert in real-time queues
+ * @param compatibilityMode compatibility mode guiding splitfile encoding parameters
+ * @param overrideSplitfileCryptoKey optional splitfile crypto key override; may be {@code null}
+ */
+public record FcpInsertOptions(
+    boolean getCHKOnly,
+    boolean dontCompress,
+    int maxRetries,
+    boolean earlyEncode,
+    boolean canWriteClientCache,
+    boolean forkOnCacheable,
+    int extraInsertsSingleBlock,
+    int extraInsertsSplitfileHeaderBlock,
+    boolean realTimeFlag,
+    InsertContext.CompatibilityMode compatibilityMode,
+    byte[] overrideSplitfileCryptoKey) {
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o
+        instanceof
+        FcpInsertOptions(
+            boolean otherGetCHKOnly,
+            boolean otherDontCompress,
+            int otherMaxRetries,
+            boolean otherEarlyEncode,
+            boolean otherCanWriteClientCache,
+            boolean otherForkOnCacheable,
+            int otherExtraInsertsSingleBlock,
+            int otherExtraInsertsSplitfileHeaderBlock,
+            boolean otherRealTimeFlag,
+            InsertContext.CompatibilityMode otherCompatibilityMode,
+            byte[] otherOverrideSplitfileCryptoKey))) return false;
+    return getCHKOnly == otherGetCHKOnly
+        && dontCompress == otherDontCompress
+        && maxRetries == otherMaxRetries
+        && earlyEncode == otherEarlyEncode
+        && canWriteClientCache == otherCanWriteClientCache
+        && forkOnCacheable == otherForkOnCacheable
+        && extraInsertsSingleBlock == otherExtraInsertsSingleBlock
+        && extraInsertsSplitfileHeaderBlock == otherExtraInsertsSplitfileHeaderBlock
+        && realTimeFlag == otherRealTimeFlag
+        && compatibilityMode == otherCompatibilityMode
+        && Arrays.equals(overrideSplitfileCryptoKey, otherOverrideSplitfileCryptoKey);
+  }
+
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            getCHKOnly,
+            dontCompress,
+            maxRetries,
+            earlyEncode,
+            canWriteClientCache,
+            forkOnCacheable,
+            extraInsertsSingleBlock,
+            extraInsertsSplitfileHeaderBlock,
+            realTimeFlag,
+            compatibilityMode);
+    result = 31 * result + Arrays.hashCode(overrideSplitfileCryptoKey);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "FcpInsertOptions[getCHKOnly="
+        + getCHKOnly
+        + ", dontCompress="
+        + dontCompress
+        + ", maxRetries="
+        + maxRetries
+        + ", earlyEncode="
+        + earlyEncode
+        + ", canWriteClientCache="
+        + canWriteClientCache
+        + ", forkOnCacheable="
+        + forkOnCacheable
+        + ", extraInsertsSingleBlock="
+        + extraInsertsSingleBlock
+        + ", extraInsertsSplitfileHeaderBlock="
+        + extraInsertsSplitfileHeaderBlock
+        + ", realTimeFlag="
+        + realTimeFlag
+        + ", compatibilityMode="
+        + compatibilityMode
+        + ", overrideSplitfileCryptoKey="
+        + (overrideSplitfileCryptoKey == null
+            ? "null"
+            : Arrays.toString(overrideSplitfileCryptoKey))
+        + ']';
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertRequest.java
@@ -1,0 +1,32 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Groups persistent insert request identity and queue metadata for FCP-based inserts.
+ *
+ * <p>The record captures the URI, identifier, verbosity, priority, and persistence settings needed
+ * to wire a {@link ClientPutBase}-derived request into the persistent queue while also retaining
+ * optional charset and client token hints for metadata construction and status reporting.
+ *
+ * @param client persistent request owner used for queue bookkeeping
+ * @param uri target insert URI requested by the client
+ * @param identifier client-supplied identifier echoed back in status updates
+ * @param verbosity verbosity bitmask for progress messages
+ * @param charset optional charset hint for metadata generation; may be {@code null}
+ * @param priorityClass scheduler priority to apply to the insert
+ * @param persistence persistence mode for the insert lifecycle
+ * @param clientToken optional client token echoed back to external observers; may be {@code null}
+ * @param global whether the request participates in the global queue
+ */
+public record FcpInsertRequest(
+    PersistentRequestClient client,
+    FreenetURI uri,
+    String identifier,
+    int verbosity,
+    String charset,
+    short priorityClass,
+    Persistence persistence,
+    String clientToken,
+    boolean global) {}

--- a/src/main/java/network/crypta/clients/http/ProgressCellContext.java
+++ b/src/main/java/network/crypta/clients/http/ProgressCellContext.java
@@ -1,0 +1,20 @@
+package network.crypta.clients.http;
+
+import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
+
+/**
+ * Bundles rendering flags needed for queue progress cells.
+ *
+ * <p>The context captures the request state that is orthogonal to the numeric progress counters,
+ * such as whether the queue is in advanced mode, whether the request has started, the current
+ * compression state, and whether the request represents an upload. Combined with a {@link
+ * network.crypta.client.events.SplitfileProgressCounts} snapshot, this provides all information
+ * needed to render progress cells consistently across queue and plugin UIs.
+ *
+ * @param advancedMode {@code true} to render detailed block counts
+ * @param started {@code true} once the transfer has started
+ * @param compressing current compression state for the request
+ * @param upload {@code true} when rendering an upload progress cell
+ */
+public record ProgressCellContext(
+    boolean advancedMode, boolean started, COMPRESS_STATE compressing, boolean upload) {}

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -38,6 +38,7 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.TooManyFilesInsertException;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.FilterMIMEType;
 import network.crypta.client.filter.KnownUnsafeContentTypeException;
@@ -90,15 +91,15 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This toadlet serves queue HTML pages, processes form submissions for starting, stopping,
  * deleting, or restarting requests, and emits user alerts when completed transfers need attention.
- * It coordinates with the {@link network.crypta.clients.fcp.FCPServer} to obtain live request
- * state, persists completed identifiers so notifications survive restarts, and delegates
- * file-browsing workflows to the dedicated local toadlets. Instances are bound either to the
- * download or upload queue and reuse shared rendering helpers that build tables, progress cells,
- * and bulk action forms.
+ * It coordinates with the {@link network.crypta.clients.fcp.FCPServer} to get live request state,
+ * persists completed identifiers so notifications survive restarts, and delegates file-browsing
+ * workflows to the dedicated local toadlets. Instances are bound either to the download or upload
+ * queue and reuse shared rendering helpers that build tables, progress cells, and bulk action
+ * forms.
  *
  * <p>The class is stateful and not thread-safe; it caches completed identifiers and keeps
- * per-request bookkeeping to avoid double-signalling events. All request-handling entry points are
- * invoked by the HTTP server on the same thread that processes the incoming toadlet request;
+ * per-request bookkeeping to avoid double-signaling events. The HTTP server invokes all
+ * request-handling entry points on the same thread that processes the incoming toadlet request;
  * longer-running operations are kept minimal to avoid blocking the request pipeline. Callers should
  * therefore avoid expensive per-request work and rely on the existing asynchronous FCP callbacks to
  * feed fresh status.
@@ -121,10 +122,10 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
    *
    * <p>Each value corresponds to a specific data point drawn from a {@link
    * network.crypta.clients.fcp.RequestStatus} and controls how headers, sort keys, and cells are
-   * emitted during rendering. The enum is shared by advanced and simple queue views so both modes
+   * emitted during rendering. The enum is shared by advanced and simple queue views, so both modes
    * can map the same underlying request state to different presentation layouts. Column selection
    * is intentionally conservative: it favors stable identifiers, sizes, and statuses that users can
-   * correlate with FCP logs over transient internal counters. Ordering is managed outside the enum
+   * correlate with FCP logs over transient internal counters. Ordering is managed outside the enum,
    * so callers can adapt to user-selected sorting without mutating the enum itself.
    */
   public enum QueueColumn {
@@ -179,9 +180,9 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
      */
     TOTAL_SIZE,
     /**
-     * Progress indicator displayed as counts or percentage depending on request type. Shows fetched
-     * versus total blocks, compression steps, and finalized markers so users can track long-running
-     * transfers.
+     * Progress indicator displayed as counts or percentage depending on the request type. Shows
+     * fetched versus total blocks, compression steps, and finalized markers so users can track
+     * long-running transfers.
      */
     PROGRESS,
     /**
@@ -257,6 +258,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private static final String ERROR_ACCESS_DENIED_FILE_KEY = "errorAccessDeniedFile";
   private static final String ERROR_NO_FILE_OR_CANNOT_READ = "errorNoFileOrCannotRead";
   private static final String COMPRESS_LABEL = ", compress=";
+  private static final String CMODE_LABEL = ", cmode=";
   private static final String OVERRIDE_SPLITFILE_KEY_LABEL = ", overrideSplitfileKey=";
   private static final char[] HEX_ARRAY = "0123456789abcdef".toCharArray();
 
@@ -495,7 +497,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       try {
         throw new RedirectException(LocalDirectoryToadlet.basePath() + PATH_DOWNLOADS);
       } catch (URISyntaxException _) {
-        // Shouldn't happen, path is defined as such.
+        // Shouldn't happen, a path is defined as such.
       }
       return true;
     }
@@ -980,7 +982,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             + ", identifier='"
             + identifier
             + '\''
-            + ", cmode="
+            + CMODE_LABEL
             + cmode
             + OVERRIDE_SPLITFILE_KEY_LABEL
             + Arrays.toString(overrideSplitfileKey)
@@ -1019,7 +1021,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return "InsertOptions{"
             + COMPRESS_LABEL
             + compress
-            + ", cmode="
+            + CMODE_LABEL
             + cmode
             + OVERRIDE_SPLITFILE_KEY_LABEL
             + Arrays.toString(overrideSplitfileKey)
@@ -1134,7 +1136,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             + uri
             + COMPRESS_LABEL
             + compress
-            + ", cmode="
+            + CMODE_LABEL
             + cmode
             + OVERRIDE_SPLITFILE_KEY_LABEL
             + Arrays.toString(overrideSplitfileKey)
@@ -2079,7 +2081,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
    *
    * <p>The method enforces public-gateway restrictions, determines the requested intent (full HTML
    * view, count-only view, or key list export), and either renders synchronously or schedules
-   * background work to assemble results. When an intent requires background computation, the method
+   * background work to assemble results. When intent requires background computation, the method
    * waits for the job result and writes the response in the same HTTP request cycle. Errors related
    * to persistence or disabled FCP are mapped to user-friendly pages instead of propagating raw
    * exceptions.
@@ -2169,8 +2171,8 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
                     }
                   }
                 }
-                // Do not use maximal priority: There may be exceptional cases which have higher
-                // priority than the UI, to get rid of excessive garbage for example.
+                // Do not use maximal priority: There may be exceptional cases that have higher
+                // priority than the UI, to get rid of excessive garbage, for example.
               },
               NativeThread.PriorityLevel.HIGH_PRIORITY.value);
     } catch (PersistenceDisabledException _) {
@@ -3606,61 +3608,44 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
    *
    * <p>The cell mirrors the appearance used on the queue page, including early status messages for
    * compression, unknown totals, and finalized uploads. The method is deterministic and does not
-   * mutate request state; it only formats progress based on the provided counters. Callers can
-   * reuse the returned node within larger tables, and should pass consistent counters so the
-   * percent calculations remain stable between refreshes.
+   * mutate the request state; it only formats progress based on the provided counters. Callers can
+   * reuse the returned node within larger tables and should pass consistent counters so the percent
+   * calculations remain stable between refreshes.
    *
-   * @param advancedMode {@code true} for detailed block counts, {@code false} for simplified view.
-   * @param started {@code true} once transfer starts; affects placeholder messaging.
-   * @param compressing current compression state; use {@code NONE} when inactive.
-   * @param fetched blocks transferred successfully so far; negative if unknown.
-   * @param failed blocks failed but still eligible for retry.
-   * @param fatallyFailed blocks failed permanently and will not retry.
-   * @param min minimum blocks required before completion is possible.
-   * @param total total expected blocks; non-positive when unavailable.
-   * @param finalized {@code true} once terminal state reached; suppresses updates.
-   * @param upload {@code true} for upload progress, {@code false} for downloads.
+   * @param context rendering context for the request state flags.
+   * @param counts progress counters for the request.
    * @return HTML node representing the progress cell, ready to attach.
    */
   public static HTMLNode createProgressCell(
-      boolean advancedMode,
-      boolean started,
-      COMPRESS_STATE compressing,
-      int fetched,
-      int failed,
-      int fatallyFailed,
-      int min,
-      int total,
-      boolean finalized,
-      boolean upload) {
+      ProgressCellContext context, SplitfileProgressCounts counts) {
     HTMLNode progressCell = new HTMLNode("td", ATTR_CLASS, "request-progress");
-    if (handleEarlyProgressMessages(advancedMode, started, compressing, progressCell)) {
+    if (handleEarlyProgressMessages(context, progressCell)) {
       return progressCell;
     }
 
-    int adjustedTotal = adjustTotal(advancedMode, min, total);
+    int adjustedTotal =
+        adjustTotal(context.advancedMode(), counts.minSuccessfulBlocks(), counts.totalBlocks());
 
-    if ((fetched < 0) || (adjustedTotal <= 0)) {
+    if ((counts.succeedBlocks() < 0) || (adjustedTotal <= 0)) {
       progressCell.addChild("span", ATTR_CLASS, "progress_fraction_unknown", l10n(UNKNOWN));
     } else {
-      ProgressBlockCounts progressCounts =
-          new ProgressBlockCounts(fetched, failed, fatallyFailed, min, adjustedTotal);
-      addProgressBar(progressCell, progressCounts, finalized, upload);
+      addProgressBar(
+          progressCell, counts, adjustedTotal, counts.finalizedTotal(), context.upload());
     }
     return progressCell;
   }
 
   private static boolean handleEarlyProgressMessages(
-      boolean advancedMode, boolean started, COMPRESS_STATE compressing, HTMLNode progressCell) {
-    if (!started) {
+      ProgressCellContext context, HTMLNode progressCell) {
+    if (!context.started()) {
       progressCell.addChild("#", l10n("starting"));
       return true;
     }
-    if (compressing == COMPRESS_STATE.WAITING && advancedMode) {
+    if (context.compressing() == COMPRESS_STATE.WAITING && context.advancedMode()) {
       progressCell.addChild("#", l10n("awaitingCompression"));
       return true;
     }
-    if (compressing != COMPRESS_STATE.WORKING) {
+    if (context.compressing() != COMPRESS_STATE.WORKING) {
       progressCell.addChild("#", l10n("compressing"));
       return true;
     }
@@ -3671,39 +3656,39 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     return (!advancedMode || total < min) ? min : total;
   }
 
-  private record ProgressBlockCounts(
-      int fetched, int failed, int fatallyFailed, int min, int total) {}
-
   private static void addProgressBar(
       HTMLNode progressCell,
-      ProgressBlockCounts progressCounts,
+      SplitfileProgressCounts progressCounts,
+      int adjustedTotal,
       boolean finalized,
       boolean upload) {
-    int fetchedPercent = (int) (progressCounts.fetched() / (double) progressCounts.total() * 100);
-    int failedPercent = (int) (progressCounts.failed() / (double) progressCounts.total() * 100);
+    int fetchedPercent = (int) (progressCounts.succeedBlocks() / (double) adjustedTotal * 100);
+    int failedPercent = (int) (progressCounts.failedBlocks() / (double) adjustedTotal * 100);
     int fatallyFailedPercent =
-        (int) (progressCounts.fatallyFailed() / (double) progressCounts.total() * 100);
-    int minPercent = (int) (progressCounts.min() / (double) progressCounts.total() * 100);
+        (int) (progressCounts.fatallyFailedBlocks() / (double) adjustedTotal * 100);
+    int minPercent = (int) (progressCounts.minSuccessfulBlocks() / (double) adjustedTotal * 100);
     HTMLNode progressBar = progressCell.addChild("div", ATTR_CLASS, "progressbar");
     progressBar.addChild(
         "div",
         new String[] {ATTR_CLASS, ATTR_STYLE},
         new String[] {"progressbar-done", CSS_WIDTH_PREFIX + fetchedPercent + "%;"});
 
-    if (progressCounts.failed() > 0) {
+    if (progressCounts.failedBlocks() > 0) {
       progressBar.addChild(
           "div",
           new String[] {ATTR_CLASS, ATTR_STYLE},
           new String[] {"progressbar-failed", CSS_WIDTH_PREFIX + failedPercent + "%;"});
     }
-    if (progressCounts.fatallyFailed() > 0) {
+    if (progressCounts.fatallyFailedBlocks() > 0) {
       progressBar.addChild(
           "div",
           new String[] {ATTR_CLASS, ATTR_STYLE},
           new String[] {"progressbar-failed2", CSS_WIDTH_PREFIX + fatallyFailedPercent + "%;"});
     }
-    if ((progressCounts.fetched() + progressCounts.failed() + progressCounts.fatallyFailed())
-        < progressCounts.min()) {
+    if ((progressCounts.succeedBlocks()
+            + progressCounts.failedBlocks()
+            + progressCounts.fatallyFailedBlocks())
+        < progressCounts.minSuccessfulBlocks()) {
       progressBar.addChild(
           "div",
           new String[] {ATTR_CLASS, ATTR_STYLE},
@@ -3713,9 +3698,18 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     }
 
     String prefix =
-        '(' + Integer.toString(progressCounts.fetched()) + "/ " + progressCounts.min() + "): ";
+        '('
+            + Integer.toString(progressCounts.succeedBlocks())
+            + "/ "
+            + progressCounts.minSuccessfulBlocks()
+            + "): ";
     addProgressTitle(
-        progressBar, progressCounts.fetched(), progressCounts.min(), finalized, upload, prefix);
+        progressBar,
+        progressCounts.succeedBlocks(),
+        progressCounts.minSuccessfulBlocks(),
+        finalized,
+        upload,
+        prefix);
   }
 
   private static void addProgressTitle(
@@ -3996,7 +3990,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
               TAG_INPUT,
               new String[] {ATTR_TYPE, ATTR_VALUE, ATTR_NAME, "id"},
               new String[] {"radio", "disk", TARGET, BULK_DOWNLOAD_SELECT_OPTION_DISK}
-              // Nicer spacing for radio button
+              // Nicer spacing for the radio button
               )
           .addChild(
               TAG_LABEL,
@@ -4076,10 +4070,10 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private HTMLNode createLastActivityCell(long now, Date lastActivity) {
     HTMLNode lastActivityCell = new HTMLNode("td", ATTR_CLASS, "request-last-activity");
     if (lastActivity == null) {
-      // During normal operation, lastActivity will never be null even if there was no
+      // During normal operation, the lastActivity will never be null even if there was no
       // activity yet. It will default to the Date when the request was added. (See
       // ClientRequester.getLatestSuccess() for the usability motivation behind that.)
-      // lastActivity can however be null if the user had been using a pre-release of
+      // lastActivity can, however, be null if the user had been using a pre-release of
       // purge-db4o which did not store the lastActivity Date to the database yet.
       // Thus, we initialize to "unknown" instead of "never" to stress that there was possibly
       // activity, but we cannot know because the Date was not stored yet.
@@ -4348,30 +4342,25 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
   private HTMLNode createProgressCellForRequest(
       ToadletContext ctx, RequestStatus clientRequest, boolean isUploadQueue) {
-    if (clientRequest instanceof UploadFileRequestStatus uploadStatus) {
-      return createProgressCell(
-          ctx.isAdvancedModeEnabled(),
-          clientRequest.isStarted(),
-          uploadStatus.isCompressing(),
-          clientRequest.getFetchedBlocks(),
-          clientRequest.getFailedBlocks(),
-          clientRequest.getFatalyFailedBlocks(),
-          clientRequest.getMinBlocks(),
-          clientRequest.getTotalBlocks(),
-          true,
-          isUploadQueue);
-    }
-    return createProgressCell(
-        ctx.isAdvancedModeEnabled(),
-        clientRequest.isStarted(),
-        COMPRESS_STATE.WORKING,
-        clientRequest.getFetchedBlocks(),
-        clientRequest.getFailedBlocks(),
-        clientRequest.getFatalyFailedBlocks(),
-        clientRequest.getMinBlocks(),
-        clientRequest.getTotalBlocks(),
-        clientRequest.isTotalFinalized(),
-        isUploadQueue);
+    COMPRESS_STATE compressing =
+        clientRequest instanceof UploadFileRequestStatus uploadStatus
+            ? uploadStatus.isCompressing()
+            : COMPRESS_STATE.WORKING;
+    boolean finalizedTotal =
+        clientRequest instanceof UploadFileRequestStatus || clientRequest.isTotalFinalized();
+    ProgressCellContext progressContext =
+        new ProgressCellContext(
+            ctx.isAdvancedModeEnabled(), clientRequest.isStarted(), compressing, isUploadQueue);
+    SplitfileProgressCounts progressCounts =
+        new SplitfileProgressCounts(
+            clientRequest.getTotalBlocks(),
+            clientRequest.getFetchedBlocks(),
+            clientRequest.getFailedBlocks(),
+            clientRequest.getFatalyFailedBlocks(),
+            clientRequest.getMinBlocks(),
+            clientRequest.getMinBlocks(),
+            finalizedTotal);
+    return createProgressCell(progressContext, progressCounts);
   }
 
   private static String toHex(byte[] data) {
@@ -4496,7 +4485,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   /**
    * Reports whether the queue toadlet is enabled for the current request context.
    *
-   * <p>The queue UI is available when the node is not operating in public-gateway mode, or when the
+   * <p>The queue UI is available when the node is not operating in public-gateway mode or when the
    * caller has full access permissions in the provided context. The check is intentionally
    * conservative and does not attempt to infer permissions from other request attributes. Callers
    * should pass the same context used for rendering to keep enablement decisions consistent.

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -46,10 +46,13 @@ import network.crypta.clients.fcp.ClientPut;
 import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
 import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
 import network.crypta.clients.fcp.ClientPutDir;
+import network.crypta.clients.fcp.ClientPutUpload;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.DownloadRequestStatus;
 import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpInsertOptions;
+import network.crypta.clients.fcp.FcpInsertRequest;
 import network.crypta.clients.fcp.IdentifierCollisionException;
 import network.crypta.clients.fcp.NotAllowedException;
 import network.crypta.clients.fcp.RequestCompletionCallback;
@@ -1353,32 +1356,36 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             IdentifierCollisionException,
             IOException {
       return new ClientPut(
-          fcp.getGlobalForeverClient(),
-          params.insertURI(),
-          params.identifier(),
-          Integer.MAX_VALUE,
-          null,
-          RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-          Persistence.FOREVER,
-          null,
-          false,
-          !params.compress(),
-          -1,
-          UploadFrom.DIRECT,
-          null,
-          params.file().getContentType(),
-          copiedBucket,
-          null,
-          params.filenameForKey(),
-          false,
-          false,
-          Node.FORK_ON_CACHEABLE_DEFAULT,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-          false,
-          params.cmode(),
-          params.overrideSplitfileKey(),
-          false,
+          new FcpInsertRequest(
+              fcp.getGlobalForeverClient(),
+              params.insertURI(),
+              params.identifier(),
+              Integer.MAX_VALUE,
+              null,
+              RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
+              Persistence.FOREVER,
+              null,
+              true),
+          new FcpInsertOptions(
+              false,
+              !params.compress(),
+              -1,
+              false,
+              false,
+              Node.FORK_ON_CACHEABLE_DEFAULT,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+              false,
+              params.cmode(),
+              params.overrideSplitfileKey()),
+          new ClientPutUpload(
+              UploadFrom.DIRECT,
+              null,
+              params.file().getContentType(),
+              copiedBucket,
+              null,
+              params.filenameForKey(),
+              false),
           fcp.getCore());
     }
 
@@ -1551,32 +1558,36 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             IdentifierCollisionException,
             IOException {
       return new ClientPut(
-          fcp.getGlobalForeverClient(),
-          params.uri(),
-          params.id(),
-          Integer.MAX_VALUE,
-          null,
-          RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-          Persistence.FOREVER,
-          null,
-          false,
-          !params.compress(),
-          -1,
-          UploadFrom.DISK,
-          params.file(),
-          params.contentType(),
-          bucket,
-          null,
-          params.target(),
-          false,
-          false,
-          Node.FORK_ON_CACHEABLE_DEFAULT,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-          false,
-          params.cmode(),
-          params.overrideSplitfileKey(),
-          false,
+          new FcpInsertRequest(
+              fcp.getGlobalForeverClient(),
+              params.uri(),
+              params.id(),
+              Integer.MAX_VALUE,
+              null,
+              RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
+              Persistence.FOREVER,
+              null,
+              true),
+          new FcpInsertOptions(
+              false,
+              !params.compress(),
+              -1,
+              false,
+              false,
+              Node.FORK_ON_CACHEABLE_DEFAULT,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+              false,
+              params.cmode(),
+              params.overrideSplitfileKey()),
+          new ClientPutUpload(
+              UploadFrom.DISK,
+              params.file(),
+              params.contentType(),
+              bucket,
+              null,
+              params.target(),
+              false),
           fcp.getCore());
     }
 
@@ -1701,28 +1712,32 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     private ClientPutDir createLocalDirPut(LocalDirInsertParams params)
         throws IOException, TooManyFilesInsertException {
       return new ClientPutDir(
-          fcp.getGlobalForeverClient(),
-          params.uri(),
-          params.identifier(),
-          Integer.MAX_VALUE,
-          RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-          Persistence.FOREVER,
-          null,
-          false,
-          !params.compress(),
-          -1,
+          new FcpInsertRequest(
+              fcp.getGlobalForeverClient(),
+              params.uri(),
+              params.identifier(),
+              Integer.MAX_VALUE,
+              null,
+              RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
+              Persistence.FOREVER,
+              null,
+              true),
+          new FcpInsertOptions(
+              false,
+              !params.compress(),
+              -1,
+              false,
+              false,
+              Node.FORK_ON_CACHEABLE_DEFAULT,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+              HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+              false,
+              CompatibilityMode.COMPAT_DEFAULT,
+              params.overrideSplitfileKey()),
           params.file(),
           null,
           false,
           false,
-          true,
-          false,
-          false,
-          Node.FORK_ON_CACHEABLE_DEFAULT,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-          HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-          false,
-          params.overrideSplitfileKey(),
           fcp.getCore());
     }
 

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -1095,6 +1095,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         String identifier,
         FreenetURI uri,
         boolean compress,
+        CompatibilityMode cmode,
         byte[] overrideSplitfileKey) {
       @Override
       public boolean equals(Object o) {
@@ -1105,8 +1106,10 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
                     var otherIdentifier,
                     var otherUri,
                     var otherCompress,
+                    var otherCmode,
                     var otherOverrideSplitfileKey)
             && compress == otherCompress
+            && cmode == otherCmode
             && Objects.equals(file, otherFile)
             && Objects.equals(identifier, otherIdentifier)
             && Objects.equals(uri, otherUri)
@@ -1115,7 +1118,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
       @Override
       public int hashCode() {
-        int result = Objects.hash(file, identifier, uri, compress);
+        int result = Objects.hash(file, identifier, uri, compress, cmode);
         return 31 * result + Arrays.hashCode(overrideSplitfileKey);
       }
 
@@ -1131,6 +1134,8 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             + uri
             + COMPRESS_LABEL
             + compress
+            + ", cmode="
+            + cmode
             + OVERRIDE_SPLITFILE_KEY_LABEL
             + Arrays.toString(overrideSplitfileKey)
             + '}';
@@ -1369,14 +1374,17 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
           new FcpInsertOptions(
               false,
               !params.compress(),
+              false,
               -1,
               false,
               false,
               Node.FORK_ON_CACHEABLE_DEFAULT,
+              null,
               HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
               HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
               false,
               params.cmode(),
+              false,
               params.overrideSplitfileKey()),
           new ClientPutUpload(
               UploadFrom.DIRECT,
@@ -1571,14 +1579,17 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
           new FcpInsertOptions(
               false,
               !params.compress(),
+              false,
               -1,
               false,
               false,
               Node.FORK_ON_CACHEABLE_DEFAULT,
+              null,
               HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
               HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
               false,
               params.cmode(),
+              false,
               params.overrideSplitfileKey()),
           new ClientPutUpload(
               UploadFrom.DISK,
@@ -1620,6 +1631,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       String identifier = file.getName() + FRED_SUFFIX + System.currentTimeMillis();
       String key = request.getPartAsStringFailsafe("key", MAX_KEY_LENGTH);
       boolean compress = request.isPartSet(COMPRESS_FIELD);
+      CompatibilityMode cmode = parseCompatibilityMode(request);
       byte[] overrideSplitfileKey =
           normalizeOverrideSplitfileKey(parseOverrideSplitfileKey(request));
       FreenetURI furi;
@@ -1633,7 +1645,8 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       } else {
         furi = new FreenetURI("CHK@");
       }
-      return new LocalDirInsertParams(file, identifier, furi, compress, overrideSplitfileKey);
+      return new LocalDirInsertParams(
+          file, identifier, furi, compress, cmode, overrideSplitfileKey);
     }
 
     private boolean queueLocalDirInsert(
@@ -1725,14 +1738,17 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
           new FcpInsertOptions(
               false,
               !params.compress(),
+              false,
               -1,
               false,
               false,
               Node.FORK_ON_CACHEABLE_DEFAULT,
+              null,
               HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
               HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
               false,
               CompatibilityMode.COMPAT_DEFAULT,
+              false,
               params.overrideSplitfileKey()),
           params.file(),
           null,

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -1749,7 +1749,7 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
               HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
               HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
               false,
-              CompatibilityMode.COMPAT_DEFAULT,
+              params.cmode(),
               false,
               params.overrideSplitfileKey()),
           params.file(),

--- a/src/main/java/network/crypta/pluginmanager/PluginManager.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginManager.java
@@ -28,8 +28,10 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.clients.fcp.ClientPut;
 import network.crypta.clients.http.PageMaker.THEME;
+import network.crypta.clients.http.ProgressCellContext;
 import network.crypta.clients.http.QueueToadlet;
 import network.crypta.clients.http.Toadlet;
 import network.crypta.config.InvalidConfigValueException;
@@ -120,7 +122,7 @@ public class PluginManager {
    * <p>This method does not start plugins. Call {@link #start()} after construction to schedule
    * plugin startup work.
    *
-   * @param node owning node instance whose services and configuration are used by plugins
+   * @param node owning a node instance whose services and configuration are used by plugins
    * @param lastVersion node build number used to apply upgrade-time compatibility adjustments
    * @return the newly created plugin manager instance for {@code node}
    */
@@ -564,8 +566,8 @@ public class PluginManager {
    * Starts a plugin from a Freenet URI specification.
    *
    * <p>The provided string is expected to be a key that the Freenet-based downloader can resolve.
-   * Depending on downloader policy, the manager may keep cached copies in the plugin directory and
-   * may schedule retries when the plugin cannot be fetched immediately.
+   * Depending on the downloader policy, the manager may keep cached copies in the plugin directory
+   * and may schedule retries when the plugin cannot be fetched immediately.
    *
    * @param filename freenet key string that identifies the plugin content
    * @param store whether to persist configuration after the load attempt completes
@@ -694,7 +696,7 @@ public class PluginManager {
         msg = e.getMessage();
         stacktrace = null;
       } else {
-        // If it's something wierd, we need to know what it is.
+        // If it's weird, we need to know what it is.
         msg = e.getClass() + ": " + e.getMessage();
         stacktrace = e.getStackTrace();
       }
@@ -871,7 +873,7 @@ public class PluginManager {
    * set to avoid reporting them as still loading.
    *
    * @param filename plugin name to match against starting plugins
-   * @param exceptFor progress instance that should not be canceled, or {@code null} to cancel all
+   * @param exceptFor progress instance that should not be canceled or {@code null} to cancel all
    */
   public void cancelRunningLoads(String filename, PluginProgress exceptFor) {
     LOG.info("Cancelling loads for plugin {}", filename);
@@ -946,7 +948,7 @@ public class PluginManager {
    */
   public void removeCachedCopy(String pluginSpecification) {
     if (pluginSpecification == null) {
-      // Will be null if the file for a given plugin can't be found, e.g. if it has already been
+      // Will be null if the file for a given plugin can't be found, e.g., if it has already been
       // removed. Ignore it since the file isn't there anyway
       LOG.warn("Can't remove null from cache. Ignoring");
       return;
@@ -959,7 +961,7 @@ public class PluginManager {
       lastSlash = pluginSpecification.lastIndexOf('\\');
     File pluginDirectory = node.getPluginDir();
     if (lastSlash == -1) {
-      /* it's an official plugin or filename without path */
+      /* it's an official plugin or filename without a path */
       if (pluginSpecification.toLowerCase().endsWith(".jar")) pluginFilename = pluginSpecification;
       else pluginFilename = pluginSpecification + ".jar";
     } else pluginFilename = pluginSpecification.substring(lastSlash + 1);
@@ -985,7 +987,7 @@ public class PluginManager {
    * Unregisters a plugin's HTTP handler mapping from the {@code /plugins/} namespace.
    *
    * <p>This method removes the plugin's class-name mapping from the internal handler registry. It
-   * is invoked as part of plugin unload, and can also be called defensively during cleanup.
+   * is invoked as part of a plugin unloaded and can also be called defensively during cleanup.
    *
    * @param pi wrapper for the plugin whose handler entry should be removed
    */
@@ -1029,7 +1031,7 @@ public class PluginManager {
    * Legacy method kept for compatibility.
    *
    * <p>This method removes the aliases from the internal registry and asks the wrapper to forget
-   * each alias so it will not be restored on subsequent operations.
+   * each alias so it will not be restored on later operations.
    *
    * @param pi wrapper for the plugin whose alias mappings should be removed
    */
@@ -1056,8 +1058,8 @@ public class PluginManager {
   /**
    * Returns a human-readable summary of currently loaded plugins.
    *
-   * <p>The returned string is primarily intended for diagnostics and may change format. Each line
-   * corresponds to a single {@link PluginInfoWrapper#toString()} value for a loaded plugin.
+   * <p>The returned string is primarily intended for diagnostics and may change the format. Each
+   * line corresponds to a single {@link PluginInfoWrapper#toString()} value for a loaded plugin.
    *
    * @return multi-line summary of loaded plugins, or an empty string when none are loaded
    */
@@ -1072,7 +1074,7 @@ public class PluginManager {
   /**
    * Returns the current set of loaded plugins.
    *
-   * <p>The returned set is a snapshot and may not reflect subsequent load/unload activity.
+   * <p>The returned set is a snapshot and may not reflect later load/unload activity.
    *
    * @return sorted snapshot set of currently loaded plugin wrappers
    */
@@ -1122,7 +1124,7 @@ public class PluginManager {
   }
 
   /**
-   * Look for PluginInfo for a Plugin with given classname or filename.
+   * Look for PluginInfo for a Plugin with a given classname or filename.
    *
    * @param plugname plugin class name or plugin filename to search for
    * @return the matching plugin info wrapper, or {@code null} if not found
@@ -1174,7 +1176,7 @@ public class PluginManager {
   }
 
   /**
-   * look for a Plugin with given classname
+   * look for a Plugin with a given classname
    *
    * @param plugname plugin class name or plugin filename to search for
    * @return {@code true} if the plugin is currently loaded, otherwise {@code false}
@@ -1271,7 +1273,7 @@ public class PluginManager {
    * PluginInfoWrapper#getThreadName()} and, if found, calls {@link
    * PluginInfoWrapper#stopPlugin(PluginManager, long, boolean)} on that wrapper.
    *
-   * @param name expected thread name of the plugin to stop
+   * @param name expected the thread name of the plugin to stop
    * @param maxWaitTime maximum time to wait in milliseconds for plugin shutdown
    * @param reloading whether this stop is part of a reload operation
    */
@@ -1361,8 +1363,8 @@ public class PluginManager {
   }
 
   /**
-   * Returns a list of the names of all available official plugins. Right now this list is hardcoded
-   * but in future we could retrieve this list from emu or from freenet itself.
+   * Returns a list of the names of all available official plugins. Right now this list is
+   * hardcoded, but in the future we could retrieve this list from emu or from freenet itself.
    *
    * @return A list of all available plugin names
    */
@@ -1423,9 +1425,9 @@ public class PluginManager {
   }
 
   /**
-   * Tries to load a plugin from the given name. If the name only contains the name of a plugin it
+   * Tries to load a plugin from the given name. If the name only contains the name of a plugin, it
    * is loaded from the plugin directory, if found, otherwise it's loaded from the project server.
-   * If the name contains a complete url and the short file already exists in the plugin directory
+   * If the name contains a complete url and the short file already exists in the plugin directory,
    * it's loaded from the plugin directory, otherwise it's retrieved from the remote server.
    *
    * @param pdl downloader that resolves and fetches the plugin content, if needed
@@ -1451,7 +1453,7 @@ public class PluginManager {
         getTargetFileForPluginDownload(
             pluginDirectory, filename, !pdl.isCachingProhibited() && !alwaysDownload);
 
-    /* check if file needs to be downloaded. */
+    /* check if a file needs to be downloaded. */
     if (LOG.isDebugEnabled())
       LOG.debug(
           "plugin file {} exists: {} downloader {} name {}",
@@ -1629,7 +1631,7 @@ public class PluginManager {
       }
       return pluginMainClassName;
     } catch (IOException ioe1) {
-      throw new PluginNotFoundException("error procesesing jar file", ioe1);
+      throw new PluginNotFoundException("error processing jar file", ioe1);
     }
   }
 
@@ -1745,7 +1747,7 @@ public class PluginManager {
 
   /**
    * This returns all existing instances of cached JAR files that start with the given filename
-   * followed by a dash (“-”), sorted numerically by the appendix, largest (i.e. newest) first.
+   * followed by a dash (“-”), sorted numerically by the appendix, largest (i.e., newest) first.
    *
    * @param pluginDirectory The plugin cache directory
    * @param filename The name of the JAR file
@@ -1825,7 +1827,7 @@ public class PluginManager {
      * Represents the coarse-grained phase of a plugin load operation.
      *
      * <p>This enum is intentionally small and UI-friendly: it describes whether a plugin is still
-     * being fetched/verified or whether it has transitioned into in-process startup.
+     * being fetched/verified or whether it has transitioned into an in-process startup.
      */
     public enum ProgressState {
       /** The plugin content is being fetched, cached, and verified. */
@@ -1912,7 +1914,7 @@ public class PluginManager {
 
     /**
      * If this object is one of the constants {@link ProgressState#DOWNLOADING} or {@link
-     * ProgressState#STARTING}, the name of those constants will be returned, otherwise a textual
+     * ProgressState#STARTING}, the name of those constants will be returned; otherwise a textual
      * representation of the plugin progress is returned.
      *
      * @return The name of a constant, or the plugin progress
@@ -1932,25 +1934,26 @@ public class PluginManager {
      * Returns a localized HTML node describing the current progress.
      *
      * <p>The returned node is intended for embedding into existing UI tables. For downloading
-     * progress it delegates to {@link QueueToadlet#createProgressCell(boolean, boolean,
-     * ClientPut.COMPRESS_STATE, int, int, int, int, int, boolean, boolean)}; otherwise it returns a
-     * localized label for the current {@link ProgressState}.
+     * progress it delegates to {@link QueueToadlet#createProgressCell(ProgressCellContext,
+     * network.crypta.client.events.SplitfileProgressCounts)}; otherwise it returns a localized
+     * label for the current {@link ProgressState}.
      *
      * @return a {@link HTMLNode} describing the current load state for UI display
      */
     public HTMLNode toLocalisedHTML() {
       if (pluginProgress == ProgressState.DOWNLOADING && total > 0) {
-        return QueueToadlet.createProgressCell(
-            false,
-            true,
-            ClientPut.COMPRESS_STATE.WORKING,
-            current,
-            failed,
-            fatallyFailed,
-            minSuccessful,
-            total,
-            finalisedTotal,
-            false);
+        SplitfileProgressCounts progressCounts =
+            new SplitfileProgressCounts(
+                total,
+                current,
+                failed,
+                fatallyFailed,
+                minSuccessful,
+                minSuccessful,
+                finalisedTotal);
+        ProgressCellContext progressContext =
+            new ProgressCellContext(false, true, ClientPut.COMPRESS_STATE.WORKING, false);
+        return QueueToadlet.createProgressCell(progressContext, progressCounts);
       } else if (pluginProgress == ProgressState.DOWNLOADING)
         return new HTMLNode(
             "td", NodeL10n.getBase().getString("PproxyToadlet.startingPluginStatus.downloading"));
@@ -1964,7 +1967,7 @@ public class PluginManager {
      * Updates download progress counters for this plugin.
      *
      * <p>The supplied values are treated as raw counters whose exact unit is defined by the loader
-     * (for example bytes versus blocks). This method does not perform validation; callers should
+     * (for example, bytes versus blocks). This method does not perform validation; callers should
      * provide consistent values across calls.
      *
      * @param minSuccess minimum successful units required to treat the download as complete
@@ -2103,7 +2106,7 @@ public class PluginManager {
   }
 
   /**
-   * Unregisters a plugin from node subsystems during unload.
+   * Unregisters a plugin from node subsystems during unloading.
    *
    * <p>This removes plugin-provided toadlets, configuration pages, and auxiliary integrations (IP
    * detector and port forwarding hooks). When not reloading, it also stops the plugin updater for
@@ -2111,7 +2114,7 @@ public class PluginManager {
    *
    * @param wrapper wrapper describing the plugin capabilities and registered components
    * @param plug plugin instance being unloaded; used for type-specific unregister calls
-   * @param reloading whether this unload is part of a plugin reload operation
+   * @param reloading whether this unloading is part of a plugin reload operation
    */
   public void unregisterPlugin(PluginInfoWrapper wrapper, FredPlugin plug, boolean reloading) {
     unregisterPluginToadlet(wrapper);
@@ -2132,7 +2135,7 @@ public class PluginManager {
   /**
    * Returns whether the plugin system is enabled for this node.
    *
-   * <p>This value is read from configuration at construction time and does not change until the
+   * <p>This value is read from the configuration at construction time and does not change until the
    * node restarts.
    *
    * @return {@code true} if the plugin manager will load plugins, otherwise {@code false}

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestClientTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestClientTest.java
@@ -168,7 +168,11 @@ class PersistentRequestClientTest {
     int requestRemovedCalls;
 
     TestClientRequest(PersistentRequestClient client, String identifier, boolean finished) {
-      super(null, identifier, 0, null, client, (short) 1, client.persistence, false, null, false);
+      super(
+          new ClientRequestParams(
+              null, identifier, 0, (short) 1, client.persistence, false, null, false),
+          null,
+          client);
       this.finished = finished;
     }
 

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
@@ -146,7 +146,11 @@ class PersistentRequestRootTest {
         boolean global,
         boolean finished,
         boolean succeeded) {
-      super(null, identifier, 0, null, client, (short) 0, Persistence.FOREVER, false, null, global);
+      super(
+          new ClientRequestParams(
+              null, identifier, 0, (short) 0, Persistence.FOREVER, false, null, global),
+          null,
+          client);
       this.finished = finished;
       this.succeeded = succeeded;
     }


### PR DESCRIPTION
## Summary
- bundle FCP request metadata into `ClientRequestParams`, `FcpInsertOptions`, and `FcpInsertRequest`
- centralize upload metadata in `ClientPutUpload` and reuse it across insert flows
- streamline queue progress rendering via `ProgressCellContext` and `SplitfileProgressCounts`

## Testing
- ./gradlew test --tests "*QueueToadlet*"