### PR TITLE
Refactor FCP config section selection

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ConfigData.java
+++ b/src/main/java/network/crypta/clients/fcp/ConfigData.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import java.util.EnumSet;
 import network.crypta.config.Config;
 import network.crypta.config.PersistentConfig;
 import network.crypta.node.Node;
@@ -20,7 +21,7 @@ import network.crypta.support.SimpleFieldSet;
  * one section is requested, preventing unnecessary work when the message would otherwise be empty.
  *
  * <ul>
- *   <li>Intended consumers are FCP clients that need a snapshot of configuration state.
+ *   <li>Intended consumers are FCP clients that need a snapshot of the configuration state.
  *   <li>Messages are constructed on the server and never accepted from clients.
  *   <li>The produced field set omits empty subsections so payloads stay compact.
  * </ul>
@@ -32,66 +33,40 @@ import network.crypta.support.SimpleFieldSet;
 public class ConfigData extends FCPMessage {
   static final String NAME = "ConfigData";
 
+  /** Flags describing which configuration subsections to export. */
+  public enum Section {
+    CURRENT,
+    DEFAULTS,
+    SORT_ORDER,
+    EXPERT_FLAG,
+    FORCE_WRITE_FLAG,
+    SHORT_DESCRIPTION,
+    LONG_DESCRIPTION,
+    DATA_TYPES
+  }
+
   final Node node;
-  final boolean withCurrent;
-  final boolean withDefaults;
-  final boolean withSortOrder;
-  final boolean withExpertFlag;
-  final boolean withForceWriteFlag;
-  final boolean withShortDescription;
-  final boolean withLongDescription;
-  final boolean withDataTypes;
+  private final EnumSet<Section> sections;
   final String requestIdentifier;
 
   /**
    * Creates a configuration snapshot request with a precisely scoped payload budget.
    *
-   * <p>The supplied boolean switches determine which sections are exported, allowing callers to
-   * tailor the trade-off between completeness and serialization cost. All flags default to {@code
-   * false}, so a caller must explicitly opt in to each exported view. The identifier is optional
-   * but recommended for clients that expect multiple outstanding responses.
+   * <p>The supplied section set determines which subsections are exported, allowing callers to
+   * tailor the trade-off between completeness and serialization cost. Use {@link EnumSet#noneOf} to
+   * request only an identifier, or {@link EnumSet#allOf} to include every available section. The
+   * identifier is optional but recommended for clients that expect multiple outstanding responses.
    *
    * @param node node instance providing the backing {@link PersistentConfig}; must be non-null and
    *     ready for read-only queries.
-   * @param withCurrent exports {@link Config.RequestType#CURRENT_SETTINGS} when {@code true}; set
-   *     to {@code false} to omit effective values entirely.
-   * @param withDefaults exports {@link Config.RequestType#DEFAULT_SETTINGS} when {@code true}; best
-   *     used when clients offer reset-to-default UX controls.
-   * @param withSortOrder includes {@link Config.RequestType#SORT_ORDER} entries to help UIs order
-   *     options consistently; unused interfaces can set this to {@code false}.
-   * @param withExpertFlag includes {@link Config.RequestType#EXPERT_FLAG} metadata to annotate
-   *     advanced options in downstream tooling when {@code true}.
-   * @param withForceWriteFlag exports {@link Config.RequestType#FORCE_WRITE_FLAG} information so
-   *     clients know which settings require explicit confirmation.
-   * @param withShortDescription exports {@link Config.RequestType#SHORT_DESCRIPTION} strings for
-   *     concise UI labels; disable to reduce payload size in automated workflows.
-   * @param withLongDescription exports {@link Config.RequestType#LONG_DESCRIPTION} prose for
-   *     help-text rich interfaces that surface detailed guidance.
-   * @param withDataTypes includes {@link Config.RequestType#DATA_TYPE} tokens describing how values
-   *     should be parsed or rendered on the client.
+   * @param sections subset of {@link Section} values describing which configuration views to
+   *     include.
    * @param identifier identifier echoed into the payload via {@link FCPMessage#IDENTIFIER}; may be
    *     {@code null} when the caller does not need correlation.
    */
-  public ConfigData(
-      Node node,
-      boolean withCurrent,
-      boolean withDefaults,
-      boolean withSortOrder,
-      boolean withExpertFlag,
-      boolean withForceWriteFlag,
-      boolean withShortDescription,
-      boolean withLongDescription,
-      boolean withDataTypes,
-      String identifier) {
+  public ConfigData(Node node, EnumSet<Section> sections, String identifier) {
     this.node = node;
-    this.withCurrent = withCurrent;
-    this.withDefaults = withDefaults;
-    this.withSortOrder = withSortOrder;
-    this.withExpertFlag = withExpertFlag;
-    this.withForceWriteFlag = withForceWriteFlag;
-    this.withShortDescription = withShortDescription;
-    this.withLongDescription = withLongDescription;
-    this.withDataTypes = withDataTypes;
+    this.sections = EnumSet.copyOf(sections);
     this.requestIdentifier = identifier;
   }
 
@@ -102,11 +77,13 @@ public class ConfigData extends FCPMessage {
    * <p>The exporter requests each enabled subsection from {@link PersistentConfig} exactly once and
    * attaches it under a stable key (for example {@code current}, {@code default}, or {@code
    * shortDescription}). Empty subsections are suppressed to avoid emitting redundant braces. When
-   * no sections are enabled the returned field set is empty unless an identifier is present.
+   * no sections are enabled, the returned field set is empty unless an identifier is present.
    *
    * <pre>{@code
-   * ConfigData data = new ConfigData(node, true, false, false, false,
-   *     false, true, false, false, "cfg-1");
+   * ConfigData data = new ConfigData(
+   *     node,
+   *     EnumSet.of(Section.CURRENT, Section.SHORT_DESCRIPTION),
+   *     "cfg-1");
    * SimpleFieldSet payload = data.getFieldSet();
    * }</pre>
    *
@@ -117,46 +94,78 @@ public class ConfigData extends FCPMessage {
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     PersistentConfig config = needsConfigLookup() ? node.getConfig() : null;
-    addSection(fs, config, withCurrent, Config.RequestType.CURRENT_SETTINGS, true, "current");
-    addSection(fs, config, withDefaults, Config.RequestType.DEFAULT_SETTINGS, false, "default");
-    addSection(fs, config, withSortOrder, Config.RequestType.SORT_ORDER, false, "sortOrder");
-    addSection(fs, config, withExpertFlag, Config.RequestType.EXPERT_FLAG, false, "expertFlag");
     addSection(
         fs,
         config,
-        withForceWriteFlag,
+        sections.contains(Section.CURRENT),
+        Config.RequestType.CURRENT_SETTINGS,
+        true,
+        "current");
+    addSection(
+        fs,
+        config,
+        sections.contains(Section.DEFAULTS),
+        Config.RequestType.DEFAULT_SETTINGS,
+        false,
+        "default");
+    addSection(
+        fs,
+        config,
+        sections.contains(Section.SORT_ORDER),
+        Config.RequestType.SORT_ORDER,
+        false,
+        "sortOrder");
+    addSection(
+        fs,
+        config,
+        sections.contains(Section.EXPERT_FLAG),
+        Config.RequestType.EXPERT_FLAG,
+        false,
+        "expertFlag");
+    addSection(
+        fs,
+        config,
+        sections.contains(Section.FORCE_WRITE_FLAG),
         Config.RequestType.FORCE_WRITE_FLAG,
         false,
         "forceWriteFlag");
     addSection(
         fs,
         config,
-        withShortDescription,
+        sections.contains(Section.SHORT_DESCRIPTION),
         Config.RequestType.SHORT_DESCRIPTION,
         false,
         "shortDescription");
     addSection(
         fs,
         config,
-        withLongDescription,
+        sections.contains(Section.LONG_DESCRIPTION),
         Config.RequestType.LONG_DESCRIPTION,
         false,
         "longDescription");
-    addSection(fs, config, withDataTypes, Config.RequestType.DATA_TYPE, false, "dataType");
+    addSection(
+        fs,
+        config,
+        sections.contains(Section.DATA_TYPES),
+        Config.RequestType.DATA_TYPE,
+        false,
+        "dataType");
     if (requestIdentifier != null) fs.putSingle("Identifier", requestIdentifier);
     return fs;
   }
 
+  /**
+   * Returns a snapshot of the enabled configuration sections.
+   *
+   * @return a new {@link EnumSet} containing the enabled {@link Section} values.
+   */
+  public EnumSet<Section> getSections() {
+    return EnumSet.copyOf(sections);
+  }
+
   /** Returns {@code true} if any section flag is enabled and a configuration lookup is required. */
   private boolean needsConfigLookup() {
-    return withCurrent
-        || withDefaults
-        || withSortOrder
-        || withExpertFlag
-        || withForceWriteFlag
-        || withShortDescription
-        || withLongDescription
-        || withDataTypes;
+    return !sections.isEmpty();
   }
 
   /** Adds a subsection when the flag is enabled and the exported data is non-empty. */

--- a/src/main/java/network/crypta/clients/fcp/GetConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/GetConfig.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import java.util.EnumSet;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
@@ -10,7 +11,7 @@ import network.crypta.support.SimpleFieldSet;
  * immutable thereafter; each boolean flag records whether the client wants current values,
  * defaults, ordering hints, expert visibility, force-write allowances, and both short and long
  * textual descriptions. The request is executed by the FCP server thread that owns the connection
- * and never touches mutable node state directly, making it safe to reuse across concurrent
+ * and never touches the mutable node state directly, making it safe to reuse across concurrent
  * connections as long as each instance is used once.
  *
  * <p>Typical usage constructs {@code GetConfig} immediately after parsing inbound fields and calls
@@ -46,8 +47,8 @@ public class GetConfig extends FCPMessage {
    * <p>The constructor copies all optional inclusion flags from the provided field set, falling
    * back to {@code false} when a flag is absent, and captures the caller-specified identifier for
    * correlation in the response. After extracting the identifier it removes it from the mutable
-   * {@link SimpleFieldSet} to avoid leaking the token into subsequent processing. The resulting
-   * instance is ready to be executed once and does not modify the provided field set again.
+   * {@link SimpleFieldSet} to avoid leaking the token into later processing. The resulting instance
+   * is ready to be executed once and does not modify the provided field set again.
    *
    * @param fs incoming fields that describe which configuration details the caller wants; must not
    *     be {@code null} and is consumed for flag and identifier extraction.
@@ -68,7 +69,7 @@ public class GetConfig extends FCPMessage {
   /**
    * Returns an empty field set because this message is built solely from incoming data.
    *
-   * <p>The FCP framework invokes this method when it needs to serialise a request. For {@code
+   * <p>The FCP framework invokes this method when it needs to serialize a request. For {@code
    * GetConfig} instances created from client input, the outbound representation is blank and acts
    * only as a signal to trigger the configuration transfer using the previously cached flags.
    * Callers should treat the returned field set as immutable and discard it after sending.
@@ -122,17 +123,35 @@ public class GetConfig extends FCPMessage {
           requestIdentifier,
           false);
     }
-    handler.send(
-        new ConfigData(
-            node,
-            withCurrent,
-            withDefaults,
-            withSortOrder,
-            withExpertFlag,
-            withForceWriteFlag,
-            withShortDescription,
-            withLongDescription,
-            withDataTypes,
-            requestIdentifier));
+    handler.send(new ConfigData(node, buildSections(), requestIdentifier));
+  }
+
+  private EnumSet<ConfigData.Section> buildSections() {
+    EnumSet<ConfigData.Section> sections = EnumSet.noneOf(ConfigData.Section.class);
+    if (withCurrent) {
+      sections.add(ConfigData.Section.CURRENT);
+    }
+    if (withDefaults) {
+      sections.add(ConfigData.Section.DEFAULTS);
+    }
+    if (withSortOrder) {
+      sections.add(ConfigData.Section.SORT_ORDER);
+    }
+    if (withExpertFlag) {
+      sections.add(ConfigData.Section.EXPERT_FLAG);
+    }
+    if (withForceWriteFlag) {
+      sections.add(ConfigData.Section.FORCE_WRITE_FLAG);
+    }
+    if (withShortDescription) {
+      sections.add(ConfigData.Section.SHORT_DESCRIPTION);
+    }
+    if (withLongDescription) {
+      sections.add(ConfigData.Section.LONG_DESCRIPTION);
+    }
+    if (withDataTypes) {
+      sections.add(ConfigData.Section.DATA_TYPES);
+    }
+    return sections;
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ModifyConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyConfig.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import java.util.EnumSet;
 import network.crypta.config.Config;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
@@ -64,8 +65,8 @@ public class ModifyConfig extends FCPMessage {
    *
    * <p>This message type is purely request-oriented: clients send option overrides and expect a
    * {@link ConfigData} reply rather than a chained payload. Returning a fresh, empty structure
-   * maintains symmetry with other message classes while signalling to callers that no additional
-   * fields need to be serialized. The field set remains mutable so downstream code can augment it
+   * maintains symmetry with other message classes while signaling to callers that no additional
+   * fields need to be serialized. The field set remains mutable, so downstream code can augment it
    * if protocol extensions are introduced.
    *
    * @return new {@link SimpleFieldSet} instance with {@code true} indicating case-insensitive key
@@ -111,7 +112,7 @@ public class ModifyConfig extends FCPMessage {
    *     must not be {@code null} and should support full access for this message.
    * @param node target node whose configuration is adjusted; expected to be initialized and ready
    *     for persistence operations.
-   * @throws MessageInvalidException if the connection lacks full access or the message is not
+   * @throws MessageInvalidException if the connection lacks full access, or the message is not
    *     permitted in the current context.
    */
   @Override
@@ -132,16 +133,14 @@ public class ModifyConfig extends FCPMessage {
       }
     }
     node.services().clientCore().storeConfig();
-    handler.send(
-        new ConfigData(
-            node, true, false, false, false, false, false, false, false, requestIdentifier));
+    handler.send(new ConfigData(node, EnumSet.of(ConfigData.Section.CURRENT), requestIdentifier));
   }
 
   /**
    * Updates a single option when the incoming field set provides a new value.
    *
    * <p>Only different values are applied; unchanged entries are skipped to avoid unnecessary work
-   * and log noise. Invalid values are reported via the logger but do not interrupt processing so
+   * and log noise. Invalid values are reported via the logger but do not interrupt processing, so
    * the remaining options can still be evaluated.
    */
   private void updateOption(String prefix, Option<?> option) {

--- a/src/test/java/network/crypta/clients/fcp/ConfigDataTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ConfigDataTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.EnumSet;
 import java.util.Map;
 import network.crypta.config.Config.RequestType;
 import network.crypta.config.PersistentConfig;
@@ -52,7 +53,7 @@ class ConfigDataTest {
     when(config.exportFieldSet(RequestType.DATA_TYPE, false)).thenReturn(dataTypes);
 
     ConfigData configData =
-        new ConfigData(node, true, true, true, true, true, true, true, true, "request-42");
+        new ConfigData(node, EnumSet.allOf(ConfigData.Section.class), "request-42");
 
     SimpleFieldSet result = configData.getFieldSet();
 
@@ -71,8 +72,7 @@ class ConfigDataTest {
 
   @Test
   void getFieldSet_whenNoFlagsEnabled_expectEmptyResultAndNoConfigAccess() {
-    ConfigData configData =
-        new ConfigData(node, false, false, false, false, false, false, false, false, null);
+    ConfigData configData = new ConfigData(node, EnumSet.noneOf(ConfigData.Section.class), null);
 
     SimpleFieldSet result = configData.getFieldSet();
 
@@ -89,7 +89,7 @@ class ConfigDataTest {
         .thenReturn(new SimpleFieldSet(true));
 
     ConfigData configData =
-        new ConfigData(node, false, false, false, false, false, true, false, false, "id");
+        new ConfigData(node, EnumSet.of(ConfigData.Section.SHORT_DESCRIPTION), "id");
 
     SimpleFieldSet result = configData.getFieldSet();
 
@@ -100,16 +100,14 @@ class ConfigDataTest {
 
   @Test
   void getName_whenCalled_returnsStaticName() {
-    ConfigData configData =
-        new ConfigData(node, false, false, false, false, false, false, false, false, null);
+    ConfigData configData = new ConfigData(node, EnumSet.noneOf(ConfigData.Section.class), null);
 
     assertEquals("ConfigData", configData.getName());
   }
 
   @Test
   void run_whenInvoked_throwsMessageInvalidException() {
-    ConfigData configData =
-        new ConfigData(node, false, false, false, false, false, false, false, false, null);
+    ConfigData configData = new ConfigData(node, EnumSet.noneOf(ConfigData.Section.class), null);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> configData.run(connectionHandler, node));

--- a/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.EnumSet;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
@@ -108,14 +109,15 @@ class GetConfigTest {
     ConfigData sent = captor.getValue();
 
     assertEquals(node, sent.node);
-    assertTrue(sent.withCurrent);
-    assertTrue(sent.withDefaults);
-    assertFalse(sent.withSortOrder);
-    assertTrue(sent.withExpertFlag);
-    assertFalse(sent.withForceWriteFlag);
-    assertTrue(sent.withShortDescription);
-    assertFalse(sent.withLongDescription);
-    assertTrue(sent.withDataTypes);
+    EnumSet<ConfigData.Section> sections = sent.getSections();
+    assertTrue(sections.contains(ConfigData.Section.CURRENT));
+    assertTrue(sections.contains(ConfigData.Section.DEFAULTS));
+    assertFalse(sections.contains(ConfigData.Section.SORT_ORDER));
+    assertTrue(sections.contains(ConfigData.Section.EXPERT_FLAG));
+    assertFalse(sections.contains(ConfigData.Section.FORCE_WRITE_FLAG));
+    assertTrue(sections.contains(ConfigData.Section.SHORT_DESCRIPTION));
+    assertFalse(sections.contains(ConfigData.Section.LONG_DESCRIPTION));
+    assertTrue(sections.contains(ConfigData.Section.DATA_TYPES));
     assertEquals("cfg-7", sent.requestIdentifier);
   }
 }


### PR DESCRIPTION
## Summary
- replace ConfigData boolean flags with enum-based section selection
- centralize GetConfig/ModifyConfig section construction for replies
- update FCP config tests for section snapshots