### PR TITLE
refactor(fcp): bundle request status snapshots

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -257,34 +257,36 @@ final class ClientGetGetterFactory {
     boolean overriddenDataType =
         fetchContext.getOverrideMIME() != null || fetchContext.getCharset() != null;
 
-    return new DownloadRequestStatus(
-        identifier,
-        persistence,
-        started,
-        finished,
-        succeeded,
-        total,
-        min,
-        fetched,
-        latestSuccess,
-        fatal,
-        failed,
-        latestFailure,
-        totalFinalized,
-        priorityClass,
-        failureCode,
-        foundDataMimeType,
-        foundDataLength,
-        target,
-        compatModes,
-        splitfileKey,
-        uri,
-        failureReasonShort,
-        failureReasonLong,
-        overriddenDataType,
-        shadow,
-        filterData,
-        dontCompress);
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            identifier,
+            persistence,
+            started,
+            finished,
+            succeeded,
+            total,
+            min,
+            fetched,
+            latestSuccess,
+            fatal,
+            failed,
+            latestFailure,
+            totalFinalized,
+            priorityClass);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(
+            foundDataLength,
+            foundDataMimeType,
+            failureCode,
+            failureReasonShort,
+            failureReasonLong,
+            shadow,
+            filterData);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(
+            outcome, target, compatModes, splitfileKey, uri, overriddenDataType, dontCompress);
+
+    return new DownloadRequestStatus(statusSnapshot, details);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -968,30 +968,27 @@ public class ClientPut extends ClientPutBase {
       totalFinalized = msg.isTotalFinalized();
     }
 
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            identifier,
+            persistence,
+            started,
+            finished,
+            succeeded,
+            total,
+            min,
+            fetched,
+            latestSuccess,
+            fatal,
+            failed,
+            latestFailure,
+            totalFinalized,
+            priorityClass);
+    UploadRequestStatusDetails details =
+        new UploadRequestStatusDetails(
+            finalURI, uri, failureCode, failureReasonShort, failureReasonLong);
     return new UploadFileRequestStatus(
-        identifier,
-        persistence,
-        started,
-        finished,
-        succeeded,
-        total,
-        min,
-        fetched,
-        latestSuccess,
-        fatal,
-        failed,
-        latestFailure,
-        totalFinalized,
-        priorityClass,
-        finalURI,
-        uri,
-        failureCode,
-        failureReasonShort,
-        failureReasonLong,
-        getDataSize(),
-        mimeType,
-        fnam,
-        isCompressing());
+        statusSnapshot, details, getDataSize(), mimeType, fnam, isCompressing());
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -748,28 +748,25 @@ public class ClientPutDir extends ClientPutBase {
       totalFinalized = msg.isTotalFinalized();
     }
 
-    return new UploadDirRequestStatus(
-        identifier,
-        persistence,
-        started,
-        finished,
-        succeeded,
-        total,
-        min,
-        fetched,
-        latestSuccess,
-        fatal,
-        failed,
-        latestFailure,
-        totalFinalized,
-        priorityClass,
-        finalURI,
-        uri,
-        failureCode,
-        failureReasonShort,
-        null,
-        totalSize,
-        numberOfFiles);
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            identifier,
+            persistence,
+            started,
+            finished,
+            succeeded,
+            total,
+            min,
+            fetched,
+            latestSuccess,
+            fatal,
+            failed,
+            latestFailure,
+            totalFinalized,
+            priorityClass);
+    UploadRequestStatusDetails details =
+        new UploadRequestStatusDetails(finalURI, uri, failureCode, failureReasonShort, null);
+    return new UploadDirRequestStatus(statusSnapshot, details, totalSize, numberOfFiles);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/DownloadOutcomeInfo.java
+++ b/src/main/java/network/crypta/clients/fcp/DownloadOutcomeInfo.java
@@ -1,0 +1,27 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Captures outcome details for a completed or in-flight download.
+ *
+ * <p>This bundle mirrors the fields that are updated when a download reaches a terminal state or
+ * when cached status entries are reconstructed.
+ *
+ * @param dataSize size of the retrieved data in bytes.
+ * @param mimeType MIME type hint for the payload.
+ * @param failureCode failure classification, if any.
+ * @param failureReasonShort concise failure reason for summaries.
+ * @param failureReasonLong verbose failure reason for logs.
+ * @param dataShadow shadow bucket holding the retrieved data, if available.
+ * @param filterData whether the data was filtered.
+ */
+public record DownloadOutcomeInfo(
+    long dataSize,
+    String mimeType,
+    FetchExceptionMode failureCode,
+    String failureReasonShort,
+    String failureReasonLong,
+    Bucket dataShadow,
+    boolean filterData) {}

--- a/src/main/java/network/crypta/clients/fcp/DownloadRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/DownloadRequestStatus.java
@@ -1,12 +1,10 @@
 package network.crypta.clients.fcp;
 
 import java.io.File;
-import java.util.Date;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
-import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
@@ -25,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * insert compatibility modes so that retry logic can make informed decisions about compression and
  * storage layout.
  *
- * <p>Thread-safety is deliberately coarse grained: most mutators are {@code synchronized} to
+ * <p>Thread-safety is deliberately coarsely grained: most mutators are {@code synchronized} to
  * simplify reasoning over state transitions, while getters expose the most recent consistent view
  * without additional locking. Callers should prefer cloning via {@link #copy()} when they need to
  * hold a reference beyond a single read, because inner arrays (such as split-file keys) are copied
@@ -66,92 +64,50 @@ public class DownloadRequestStatus extends RequestStatus {
 
   private boolean detectedDontCompress;
 
-  synchronized void setFinished(
-      boolean success,
-      long dataSize,
-      String mimeType,
-      FetchExceptionMode failureCode,
-      String failureReasonLong,
-      String failureReasonShort,
-      Bucket dataShadow,
-      boolean filtered) {
+  synchronized void setFinished(boolean success, DownloadOutcomeInfo outcome) {
     setFinished(success);
-    if (mimeType == null
-        && (failureCode == FetchExceptionMode.CONTENT_VALIDATION_UNKNOWN_MIME
-            || failureCode == FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME)) {
-      logMimeTypeMismatch(failureCode, getIdentifier(), uri);
+    if (outcome.mimeType() == null
+        && (outcome.failureCode() == FetchExceptionMode.CONTENT_VALIDATION_UNKNOWN_MIME
+            || outcome.failureCode() == FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME)) {
+      logMimeTypeMismatch(outcome.failureCode(), getIdentifier(), uri);
     }
-    this.dataSize = dataSize;
-    this.mimeType = mimeType;
-    this.failureCode = failureCode;
-    this.failureReasonLong = failureReasonLong;
-    this.failureReasonShort = failureReasonShort;
-    this.dataShadow = dataShadow;
-    this.filterData = filtered;
+    this.dataSize = outcome.dataSize();
+    this.mimeType = outcome.mimeType();
+    this.failureCode = outcome.failureCode();
+    this.failureReasonLong = outcome.failureReasonLong();
+    this.failureReasonShort = outcome.failureReasonShort();
+    this.dataShadow = outcome.dataShadow();
+    this.filterData = outcome.filterData();
   }
 
+  /**
+   * Creates a new download status entry from preassembled snapshots.
+   *
+   * @param statusSnapshot base request counters and timestamps.
+   * @param details download-specific metadata and completion details.
+   */
   DownloadRequestStatus(
-      String identifier,
-      Persistence persistence,
-      boolean started,
-      boolean finished,
-      boolean success,
-      int total,
-      int min,
-      int fetched,
-      Date latestSuccess,
-      int fatal,
-      int failed,
-      Date latestFailure,
-      boolean totalFinalized,
-      short prio,
-      // all above these passed to parent
-      FetchExceptionMode failureCode,
-      String mime,
-      long size,
-      File dest,
-      CompatibilityMode[] compat,
-      byte[] splitfileKey,
-      FreenetURI uri,
-      String failureReasonShort,
-      String failureReasonLong,
-      boolean overriddenDataType,
-      Bucket dataShadow,
-      boolean filterData,
-      boolean dontCompress) {
-    super(
-        identifier,
-        persistence,
-        started,
-        finished,
-        success,
-        total,
-        min,
-        fetched,
-        latestSuccess,
-        fatal,
-        failed,
-        latestFailure,
-        totalFinalized,
-        prio);
-    if (mime == null
-        && (failureCode == FetchExceptionMode.CONTENT_VALIDATION_UNKNOWN_MIME
-            || failureCode == FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME)) {
-      logMimeTypeMismatch(failureCode, identifier, uri);
+      RequestStatusSnapshot statusSnapshot, DownloadRequestStatusDetails details) {
+    super(statusSnapshot);
+    DownloadOutcomeInfo outcome = details.outcome();
+    if (outcome.mimeType() == null
+        && (outcome.failureCode() == FetchExceptionMode.CONTENT_VALIDATION_UNKNOWN_MIME
+            || outcome.failureCode() == FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME)) {
+      logMimeTypeMismatch(outcome.failureCode(), statusSnapshot.identifier(), details.uri());
     }
-    this.overriddenDataType = overriddenDataType;
-    this.failureCode = failureCode;
-    this.mimeType = mime;
-    this.dataSize = size;
-    this.destFilename = dest;
-    this.detectedCompatModes = compat;
-    this.detectedSplitfileKey = splitfileKey;
-    this.uri = uri;
-    this.failureReasonShort = failureReasonShort;
-    this.failureReasonLong = failureReasonLong;
-    this.dataShadow = dataShadow;
-    this.filterData = filterData;
-    this.detectedDontCompress = dontCompress;
+    this.overriddenDataType = details.overriddenDataType();
+    this.failureCode = outcome.failureCode();
+    this.mimeType = outcome.mimeType();
+    this.dataSize = outcome.dataSize();
+    this.destFilename = details.destFilename();
+    this.detectedCompatModes = details.compatModes();
+    this.detectedSplitfileKey = details.splitfileKey();
+    this.uri = details.uri();
+    this.failureReasonShort = outcome.failureReasonShort();
+    this.failureReasonLong = outcome.failureReasonLong();
+    this.dataShadow = outcome.dataShadow();
+    this.filterData = outcome.filterData();
+    this.detectedDontCompress = details.dontCompress();
   }
 
   private DownloadRequestStatus(DownloadRequestStatus source) {
@@ -269,7 +225,7 @@ public class DownloadRequestStatus extends RequestStatus {
   }
 
   /**
-   * Supplies the URI that is currently associated with the request, including redirects.
+   * Supplies the URI currently associated with the request, including redirects.
    *
    * <p>The value initially reflects the URI provided by the caller, but the worker may swap in a
    * redirection target once detected via {@link #redirect(FreenetURI)}. Consumers should therefore
@@ -353,8 +309,8 @@ public class DownloadRequestStatus extends RequestStatus {
    * Provides the filename clients should display when offering a save dialog or progress entry.
    *
    * <p>The destination filename takes precedence when explicitly provided. Otherwise, the method
-   * derives a name from {@link FreenetURI#getPreferredFilename()} provided the URI supplies meta
-   * strings or a document name. {@code null} is returned when no reasonable candidate exists.
+   * derives a name from {@link FreenetURI#getPreferredFilename()} provided the URI supplies
+   * meta-strings or a document name. {@code null} is returned when no reasonable candidate exists.
    *
    * @return a display-ready filename suggestion, or {@code null} when unavailable.
    */

--- a/src/main/java/network/crypta/clients/fcp/DownloadRequestStatusDetails.java
+++ b/src/main/java/network/crypta/clients/fcp/DownloadRequestStatusDetails.java
@@ -1,0 +1,86 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.keys.FreenetURI;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Parameter bundle containing download-specific status metadata.
+ *
+ * <p>This record complements {@link RequestStatusSnapshot} by packaging fields that are unique to
+ * {@link DownloadRequestStatus}.
+ *
+ * @param outcome completion details such as MIME type and failure descriptions.
+ * @param destFilename destination file requested by the client, if any.
+ * @param compatModes compatibility modes observed for splitfiles.
+ * @param splitfileKey splitfile crypto key override, if provided.
+ * @param uri request URI, including any redirects.
+ * @param overriddenDataType whether the client overrode MIME settings.
+ * @param dontCompress whether reinsertion should skip compression.
+ */
+public record DownloadRequestStatusDetails(
+    DownloadOutcomeInfo outcome,
+    File destFilename,
+    CompatibilityMode[] compatModes,
+    byte[] splitfileKey,
+    FreenetURI uri,
+    boolean overriddenDataType,
+    boolean dontCompress) {
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other
+        instanceof
+        DownloadRequestStatusDetails(
+            DownloadOutcomeInfo otherOutcome,
+            File otherDestFilename,
+            CompatibilityMode[] otherCompatModes,
+            byte[] otherSplitfileKey,
+            FreenetURI otherUri,
+            boolean otherOverriddenDataType,
+            boolean otherDontCompress))) {
+      return false;
+    }
+    return overriddenDataType == otherOverriddenDataType
+        && dontCompress == otherDontCompress
+        && Objects.equals(outcome, otherOutcome)
+        && Objects.equals(destFilename, otherDestFilename)
+        && Arrays.equals(compatModes, otherCompatModes)
+        && Arrays.equals(splitfileKey, otherSplitfileKey)
+        && Objects.equals(uri, otherUri);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(outcome, destFilename, uri, overriddenDataType, dontCompress);
+    result = 31 * result + Arrays.hashCode(compatModes);
+    result = 31 * result + Arrays.hashCode(splitfileKey);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "DownloadRequestStatusDetails["
+        + "outcome="
+        + outcome
+        + ", destFilename="
+        + destFilename
+        + ", compatModes="
+        + Arrays.toString(compatModes == null ? null : compatModes.clone())
+        + ", splitfileKey="
+        + Arrays.toString(splitfileKey == null ? null : splitfileKey.clone())
+        + ", uri="
+        + uri
+        + ", overriddenDataType="
+        + overriddenDataType
+        + ", dontCompress="
+        + dontCompress
+        + ']';
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
@@ -262,16 +262,16 @@ public class PersistentRequestClient {
     }
     Bucket shadow = download.getBucket();
     if (shadow != null) shadow = shadow.createShadow();
-    statusCache.finishedDownload(
-        download.getIdentifier(),
-        download.hasSucceeded(),
-        download.getDataSize(),
-        download.getMIMEType(),
-        failureCode,
-        longFailMessage,
-        shortFailMessage,
-        shadow,
-        download.filterData());
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(
+            download.getDataSize(),
+            download.getMIMEType(),
+            failureCode,
+            shortFailMessage,
+            longFailMessage,
+            shadow,
+            download.filterData());
+    statusCache.finishedDownload(download.getIdentifier(), download.hasSucceeded(), outcome);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/RequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestStatus.java
@@ -142,6 +142,32 @@ public abstract class RequestStatus {
   }
 
   /**
+   * Creates a status instance using a preassembled snapshot of request counters.
+   *
+   * <p>The snapshot fields are copied verbatim, and mutable timestamps are cloned in the same way
+   * as the primary constructor.
+   *
+   * @param snapshot bundle containing the base request status fields.
+   */
+  RequestStatus(RequestStatusSnapshot snapshot) {
+    this(
+        snapshot.identifier(),
+        snapshot.persistence(),
+        snapshot.started(),
+        snapshot.finished(),
+        snapshot.success(),
+        snapshot.total(),
+        snapshot.min(),
+        snapshot.fetched(),
+        snapshot.latestSuccess(),
+        snapshot.fatal(),
+        snapshot.failed(),
+        snapshot.latestFailure(),
+        snapshot.totalFinalized(),
+        snapshot.priority());
+  }
+
+  /**
    * Builds a defensive copy of another status instance so subclasses can expose snapshots.
    *
    * <p>The constructor copies every scalar, clones mutable timestamps, and intentionally omits any

--- a/src/main/java/network/crypta/clients/fcp/RequestStatusCache.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestStatusCache.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import network.crypta.client.ClientMetadata;
-import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.async.CacheFetchResult;
@@ -74,26 +73,10 @@ public class RequestStatusCache {
   }
 
   synchronized void finishedDownload(
-      String identifier,
-      boolean success,
-      long dataSize,
-      String mimeType,
-      FetchExceptionMode failureCode,
-      String failureReasonLong,
-      String failureReasonShort,
-      Bucket dataShadow,
-      boolean filtered) {
+      String identifier, boolean success, DownloadOutcomeInfo outcome) {
     DownloadRequestStatus status = (DownloadRequestStatus) requestsByIdentifier.get(identifier);
     if (status == null) return; // Can happen during cancel etc.
-    status.setFinished(
-        success,
-        dataSize,
-        mimeType,
-        failureCode,
-        failureReasonLong,
-        failureReasonShort,
-        dataShadow,
-        filtered);
+    status.setFinished(success, outcome);
   }
 
   synchronized void gotFinalURI(String identifier, FreenetURI finalURI) {

--- a/src/main/java/network/crypta/clients/fcp/RequestStatusSnapshot.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestStatusSnapshot.java
@@ -1,0 +1,42 @@
+package network.crypta.clients.fcp;
+
+import java.util.Date;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+
+/**
+ * Parameter bundle describing the core {@link RequestStatus} fields.
+ *
+ * <p>This snapshot mirrors the inputs required by the {@link RequestStatus} constructor so callers
+ * can pass a single value across status implementations. Timestamps are captured as-is and are
+ * still defensively cloned by {@link RequestStatus} when applied.
+ *
+ * @param identifier stable request identifier.
+ * @param persistence persistence policy of the request.
+ * @param started whether the request has begun.
+ * @param finished whether the request is finished.
+ * @param success whether the request completed successfully.
+ * @param total total number of blocks known so far.
+ * @param min minimum required block count.
+ * @param fetched number of blocks fetched so far.
+ * @param latestSuccess timestamp of the most recent success.
+ * @param fatal number of fatal block failures.
+ * @param failed number of transient block failures.
+ * @param latestFailure timestamp of the most recent failure.
+ * @param totalFinalized whether the total block count is final.
+ * @param priority scheduler priority class.
+ */
+public record RequestStatusSnapshot(
+    String identifier,
+    Persistence persistence,
+    boolean started,
+    boolean finished,
+    boolean success,
+    int total,
+    int min,
+    int fetched,
+    Date latestSuccess,
+    int fatal,
+    int failed,
+    Date latestFailure,
+    boolean totalFinalized,
+    short priority) {}

--- a/src/main/java/network/crypta/clients/fcp/UploadDirRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadDirRequestStatus.java
@@ -1,10 +1,5 @@
 package network.crypta.clients.fcp;
 
-import java.util.Date;
-import network.crypta.client.InsertException.InsertExceptionMode;
-import network.crypta.clients.fcp.ClientRequest.Persistence;
-import network.crypta.keys.FreenetURI;
-
 /**
  * Captures the evolving status of a site or directory upload handled through the FCP layer.
  *
@@ -47,91 +42,19 @@ public class UploadDirRequestStatus extends UploadRequestStatus {
    * cache.put(status.getIdentifier(), status);
    * }</pre>
    *
-   * @param identifier unique string used to correlate request updates across the FCP layer; must
-   *     remain stable for the lifetime of the upload.
-   * @param persistence persistence mode describing whether the upload survives disconnections or
-   *     restarts; see {@link ClientRequest.Persistence} for the allowed values.
-   * @param started {@code true} when the underlying splitter already began transferring data;
-   *     otherwise {@code false} so new listeners know the request is dormant.
-   * @param finished flag indicating whether the upload is already in a terminal state at the moment
-   *     this status object is created.
-   * @param success outcome marker that is meaningful only when {@code finished} is {@code true}; it
-   *     reports whether the insert succeeded without fatal errors.
-   * @param total number of blocks currently known for the insert, typically the splitfile total or
-   *     an estimated upper bound.
-   * @param min minimum block count needed before the request can be considered complete even if the
-   *     total grows later.
-   * @param fetched number of blocks that have been successfully inserted so far; used for progress
-   *     ratios and ETA calculations.
-   * @param latestSuccess timestamp of the most recent successful block or finalization event; may
-   *     be {@code null} if nothing has succeeded yet.
-   * @param fatal number of blocks that permanently failed and will not be retried any further.
-   * @param failed number of retryable blocks that have failed so far but could still succeed on the
-   *     next attempt.
-   * @param latestFailure timestamp of the most recent failure notification; {@code null} when no
-   *     failures have occurred.
-   * @param totalFinalized {@code true} when {@code total} is final and additional blocks will not
-   *     be discovered by the splitter.
-   * @param prio scheduler priority controlling how the request competes for bandwidth relative to
-   *     other uploads.
-   * @param finalURI published {@link FreenetURI} when the upload already committed; may be {@code
-   *     null} until completion.
-   * @param targetURI desired {@link FreenetURI} originally requested by the client; usually
-   *     non-null even before the final URI exists.
-   * @param failureCode machine-readable failure classification explaining why the last attempt
-   *     failed; can be {@code null} when no error occurred.
-   * @param failureReasonShort concise failure description suitable for tables or notifications;
-   *     {@code null} when no failure is known.
-   * @param failureReasonLong long-form failure explanation for logs, REST responses, or verbose
-   *     status pages.
+   * @param statusSnapshot base request counters and timestamps.
+   * @param details upload-specific URI and failure metadata.
    * @param size aggregate payload size of the directory in bytes; callers may pass zero to indicate
    *     an empty manifest or unknown size.
    * @param files total number of files scheduled for insertion at this time; may be zero for
    *     metadata-only structures.
    */
   public UploadDirRequestStatus(
-      String identifier,
-      Persistence persistence,
-      boolean started,
-      boolean finished,
-      boolean success,
-      int total,
-      int min,
-      int fetched,
-      Date latestSuccess,
-      int fatal,
-      int failed,
-      Date latestFailure,
-      boolean totalFinalized,
-      short prio,
-      FreenetURI finalURI,
-      FreenetURI targetURI,
-      InsertExceptionMode failureCode,
-      String failureReasonShort,
-      String failureReasonLong,
-      // all of the above are passed to parent
+      RequestStatusSnapshot statusSnapshot,
+      UploadRequestStatusDetails details,
       long size,
       int files) {
-    super(
-        identifier,
-        persistence,
-        started,
-        finished,
-        success,
-        total,
-        min,
-        fetched,
-        latestSuccess,
-        fatal,
-        failed,
-        latestFailure,
-        totalFinalized,
-        prio,
-        finalURI,
-        targetURI,
-        failureCode,
-        failureReasonShort,
-        failureReasonLong);
+    super(statusSnapshot, details);
     this.totalDataSize = size;
     this.totalFiles = files;
   }

--- a/src/main/java/network/crypta/clients/fcp/UploadFileRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadFileRequestStatus.java
@@ -1,11 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.io.File;
-import java.util.Date;
-import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
-import network.crypta.clients.fcp.ClientRequest.Persistence;
-import network.crypta.keys.FreenetURI;
 
 /**
  * Captures the evolving status of a single file upload handled through the FCP client API.
@@ -42,51 +38,24 @@ public class UploadFileRequestStatus extends UploadRequestStatus {
 
   private COMPRESS_STATE compressing;
 
+  /**
+   * Creates a file upload status entry from bundled snapshots.
+   *
+   * @param statusSnapshot base request counters and timestamps.
+   * @param details upload-specific URI and failure metadata.
+   * @param dataSize size of the payload in bytes.
+   * @param mimeType MIME type hint for the upload.
+   * @param origFilename original filename, if known.
+   * @param compressing current compression state.
+   */
   UploadFileRequestStatus(
-      String identifier,
-      Persistence persistence,
-      boolean started,
-      boolean finished,
-      boolean success,
-      int total,
-      int min,
-      int fetched,
-      Date latestSuccess,
-      int fatal,
-      int failed,
-      Date latestFailure,
-      boolean totalFinalized,
-      short prio,
-      FreenetURI finalURI,
-      FreenetURI targetURI,
-      InsertExceptionMode failureCode,
-      String failureReasonShort,
-      String failureReasonLong,
-      // all of the above are passed to parent
+      RequestStatusSnapshot statusSnapshot,
+      UploadRequestStatusDetails details,
       long dataSize,
       String mimeType,
       File origFilename,
       COMPRESS_STATE compressing) {
-    super(
-        identifier,
-        persistence,
-        started,
-        finished,
-        success,
-        total,
-        min,
-        fetched,
-        latestSuccess,
-        fatal,
-        failed,
-        latestFailure,
-        totalFinalized,
-        prio,
-        finalURI,
-        targetURI,
-        failureCode,
-        failureReasonShort,
-        failureReasonLong);
+    super(statusSnapshot, details);
     this.dataSize = dataSize;
     this.mimeType = mimeType;
     this.origFilename = origFilename;

--- a/src/main/java/network/crypta/clients/fcp/UploadRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadRequestStatus.java
@@ -1,8 +1,6 @@
 package network.crypta.clients.fcp;
 
-import java.util.Date;
 import network.crypta.client.InsertException.InsertExceptionMode;
-import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 
 /**
@@ -43,47 +41,19 @@ public abstract class UploadRequestStatus extends RequestStatus {
   private String failureReasonShort;
   private String failureReasonLong;
 
-  UploadRequestStatus(
-      String identifier,
-      Persistence persistence,
-      boolean started,
-      boolean finished,
-      boolean success,
-      int total,
-      int min,
-      int fetched,
-      Date latestSuccess,
-      int fatal,
-      int failed,
-      Date latestFailure,
-      boolean totalFinalized,
-      short prio,
-      // all of the above are passed to parent
-      FreenetURI finalURI,
-      FreenetURI targetURI,
-      InsertExceptionMode failureCode,
-      String failureReasonShort,
-      String failureReasonLong) {
-    super(
-        identifier,
-        persistence,
-        started,
-        finished,
-        success,
-        total,
-        min,
-        fetched,
-        latestSuccess,
-        fatal,
-        failed,
-        latestFailure,
-        totalFinalized,
-        prio);
-    this.finalURI = finalURI;
-    this.targetURI = targetURI;
-    this.failureCode = failureCode;
-    this.failureReasonShort = failureReasonShort;
-    this.failureReasonLong = failureReasonLong;
+  /**
+   * Creates an upload status entry from bundled request snapshots.
+   *
+   * @param statusSnapshot base request counters and timestamps.
+   * @param details upload-specific URI and failure metadata.
+   */
+  UploadRequestStatus(RequestStatusSnapshot statusSnapshot, UploadRequestStatusDetails details) {
+    super(statusSnapshot);
+    this.finalURI = details.finalURI();
+    this.targetURI = details.targetURI();
+    this.failureCode = details.failureCode();
+    this.failureReasonShort = details.failureReasonShort();
+    this.failureReasonLong = details.failureReasonLong();
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/UploadRequestStatusDetails.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadRequestStatusDetails.java
@@ -1,0 +1,22 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Parameter bundle describing upload-specific status metadata.
+ *
+ * <p>This record captures the URI and failure fields shared across upload status implementations.
+ *
+ * @param finalURI published URI if the upload has completed.
+ * @param targetURI intended URI supplied by the client.
+ * @param failureCode failure classification reported by the insert.
+ * @param failureReasonShort concise failure reason.
+ * @param failureReasonLong verbose failure reason.
+ */
+public record UploadRequestStatusDetails(
+    FreenetURI finalURI,
+    FreenetURI targetURI,
+    InsertExceptionMode failureCode,
+    String failureReasonShort,
+    String failureReasonLong) {}

--- a/src/test/java/network/crypta/clients/fcp/DownloadRequestStatusTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DownloadRequestStatusTest.java
@@ -111,13 +111,14 @@ class DownloadRequestStatusTest {
 
     status.setFinished(
         true,
-        2048L,
-        "image/png",
-        FetchExceptionMode.CONTENT_HASH_FAILED,
-        "new long",
-        "new short",
-        completedBucket,
-        true);
+        new DownloadOutcomeInfo(
+            2048L,
+            "image/png",
+            FetchExceptionMode.CONTENT_HASH_FAILED,
+            "new short",
+            "new long",
+            completedBucket,
+            true));
 
     assertTrue(status.hasFinished());
     assertTrue(status.hasSucceeded());
@@ -205,33 +206,40 @@ class DownloadRequestStatusTest {
 
   private static DownloadRequestStatus buildStatus(
       File destination, FreenetURI uri, boolean dontCompress, Bucket dataShadow) {
-    return new DownloadRequestStatus(
-        IDENTIFIER,
-        Persistence.CONNECTION,
-        true,
-        false,
-        false,
-        10,
-        5,
-        3,
-        new Date(0L),
-        0,
-        0,
-        null,
-        true,
-        PRIORITY,
-        FetchExceptionMode.DATA_NOT_FOUND,
-        "text/plain",
-        1024L,
-        destination,
-        COMPAT_SAMPLE.clone(),
-        SPLITFILE_KEY.clone(),
-        uri,
-        "Short reason",
-        "Detailed long reason",
-        false,
-        dataShadow,
-        false,
-        dontCompress);
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            IDENTIFIER,
+            Persistence.CONNECTION,
+            true,
+            false,
+            false,
+            10,
+            5,
+            3,
+            new Date(0L),
+            0,
+            0,
+            null,
+            true,
+            PRIORITY);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(
+            1024L,
+            "text/plain",
+            FetchExceptionMode.DATA_NOT_FOUND,
+            "Short reason",
+            "Detailed long reason",
+            dataShadow,
+            false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(
+            outcome,
+            destination,
+            COMPAT_SAMPLE.clone(),
+            SPLITFILE_KEY.clone(),
+            uri,
+            false,
+            dontCompress);
+    return new DownloadRequestStatus(statusSnapshot, details);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -152,8 +152,8 @@ class FCPServerTest {
     FCPServer server = newServer(false, false);
     PersistentRequestClient rebootClient = server.getGlobalRebootClient();
     FreenetURI uri = mock(FreenetURI.class);
-    DownloadRequestStatus status =
-        new DownloadRequestStatus(
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
             "id-1",
             Persistence.REBOOT,
             false,
@@ -167,20 +167,12 @@ class FCPServerTest {
             0,
             null,
             false,
-            (short) 0,
-            null,
-            "text/plain",
-            10,
-            null,
-            null,
-            null,
-            uri,
-            null,
-            null,
-            false,
-            mock(Bucket.class),
-            false,
-            false);
+            (short) 0);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(10, "text/plain", null, null, null, mock(Bucket.class), false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
+    DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
     rebootClient.getRequestStatusCache().addDownload(status);
 
     // Act
@@ -199,8 +191,8 @@ class FCPServerTest {
     FreenetURI uri = mock(FreenetURI.class);
     Bucket bucket = mock(Bucket.class);
     when(bucket.size()).thenReturn(5L);
-    DownloadRequestStatus status =
-        new DownloadRequestStatus(
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
             "cached",
             Persistence.FOREVER,
             false,
@@ -214,20 +206,12 @@ class FCPServerTest {
             0,
             null,
             true,
-            (short) 0,
-            null,
-            "image/png",
-            5,
-            null,
-            null,
-            null,
-            uri,
-            null,
-            null,
-            false,
-            bucket,
-            false,
-            false);
+            (short) 0);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(5, "image/png", null, null, null, bucket, false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
+    DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
     foreverClient.getRequestStatusCache().addDownload(status);
 
     // Act

--- a/src/test/java/network/crypta/clients/fcp/RequestStatusCacheTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RequestStatusCacheTest.java
@@ -66,27 +66,12 @@ class RequestStatusCacheTest {
     cache.addDownload(status);
 
     Bucket bucket = mock(Bucket.class);
-    cache.finishedDownload(
-        "download-1",
-        true,
-        42L,
-        "text/plain",
-        FetchExceptionMode.BUCKET_ERROR,
-        "long",
-        "short",
-        bucket,
-        false);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(
+            42L, "text/plain", FetchExceptionMode.BUCKET_ERROR, "short", "long", bucket, false);
+    cache.finishedDownload("download-1", true, outcome);
 
-    verify(status)
-        .setFinished(
-            true,
-            42L,
-            "text/plain",
-            FetchExceptionMode.BUCKET_ERROR,
-            "long",
-            "short",
-            bucket,
-            false);
+    verify(status).setFinished(true, outcome);
   }
 
   @Test
@@ -112,8 +97,8 @@ class RequestStatusCacheTest {
     FreenetURI originalUri = mock(FreenetURI.class);
     FreenetURI redirectUri = mock(FreenetURI.class);
 
-    DownloadRequestStatus status =
-        new DownloadRequestStatus(
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
             "dl",
             Persistence.CONNECTION,
             false,
@@ -127,20 +112,12 @@ class RequestStatusCacheTest {
             0,
             null,
             false,
-            (short) 1,
-            null,
-            "text/plain",
-            1L,
-            null,
-            null,
-            null,
-            originalUri,
-            null,
-            null,
-            false,
-            null,
-            false,
-            false);
+            (short) 1);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(1L, "text/plain", null, null, null, null, false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(outcome, null, null, null, originalUri, false, false);
+    DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
 
     cache.addDownload(status);
 
@@ -160,8 +137,8 @@ class RequestStatusCacheTest {
     FreenetURI uri = mock(FreenetURI.class);
     Bucket bucket = new FixedBucket(8);
 
-    DownloadRequestStatus status =
-        new DownloadRequestStatus(
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
             "shadow",
             Persistence.CONNECTION,
             true,
@@ -175,20 +152,12 @@ class RequestStatusCacheTest {
             0,
             null,
             false,
-            (short) 1,
-            null,
-            "image/png",
-            8L,
-            null,
-            null,
-            null,
-            uri,
-            null,
-            null,
-            false,
-            bucket,
-            false,
-            false);
+            (short) 1);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(8L, "image/png", null, null, null, bucket, false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
+    DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
 
     cache.addDownload(status);
 
@@ -207,8 +176,8 @@ class RequestStatusCacheTest {
     FreenetURI uri = mock(FreenetURI.class);
     Bucket bucket = new FixedBucket(2);
 
-    DownloadRequestStatus status =
-        new DownloadRequestStatus(
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
             "shadow-filter",
             Persistence.CONNECTION,
             true,
@@ -222,20 +191,12 @@ class RequestStatusCacheTest {
             0,
             null,
             false,
-            (short) 1,
-            null,
-            "text/plain",
-            2L,
-            null,
-            null,
-            null,
-            uri,
-            null,
-            null,
-            false,
-            bucket,
-            true,
-            false);
+            (short) 1);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(2L, "text/plain", null, null, null, bucket, true);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
+    DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
 
     cache.addDownload(status);
 
@@ -247,8 +208,8 @@ class RequestStatusCacheTest {
     RequestStatusCache cache = new RequestStatusCache();
 
     FreenetURI uri = mock(FreenetURI.class);
-    DownloadRequestStatus status =
-        new DownloadRequestStatus(
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
             "remove-dl",
             Persistence.CONNECTION,
             true,
@@ -262,20 +223,12 @@ class RequestStatusCacheTest {
             0,
             null,
             false,
-            (short) 1,
-            null,
-            "text/plain",
-            1L,
-            null,
-            null,
-            null,
-            uri,
-            null,
-            null,
-            false,
-            new FixedBucket(1),
-            false,
-            false);
+            (short) 1);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(1L, "text/plain", null, null, null, new FixedBucket(1), false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
+    DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
 
     cache.addDownload(status);
 

--- a/src/test/java/network/crypta/clients/fcp/UploadDirRequestStatusTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UploadDirRequestStatusTest.java
@@ -93,27 +93,25 @@ class UploadDirRequestStatusTest {
       String failureReasonLong,
       long totalSize,
       int files) {
-    return new UploadDirRequestStatus(
-        "identifier",
-        Persistence.REBOOT,
-        true,
-        false,
-        false,
-        20,
-        10,
-        5,
-        SUCCESS_DATE,
-        1,
-        2,
-        FAILURE_DATE,
-        true,
-        (short) 5,
-        finalUri,
-        targetUri,
-        failureCode,
-        failureReasonShort,
-        failureReasonLong,
-        totalSize,
-        files);
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            "identifier",
+            Persistence.REBOOT,
+            true,
+            false,
+            false,
+            20,
+            10,
+            5,
+            SUCCESS_DATE,
+            1,
+            2,
+            FAILURE_DATE,
+            true,
+            (short) 5);
+    UploadRequestStatusDetails details =
+        new UploadRequestStatusDetails(
+            finalUri, targetUri, failureCode, failureReasonShort, failureReasonLong);
+    return new UploadDirRequestStatus(statusSnapshot, details, totalSize, files);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/UploadFileRequestStatusTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UploadFileRequestStatusTest.java
@@ -118,29 +118,26 @@ class UploadFileRequestStatusTest {
       long dataSize,
       String mimeType,
       COMPRESS_STATE compressState) {
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            "identifier",
+            Persistence.CONNECTION,
+            true,
+            false,
+            false,
+            10,
+            5,
+            3,
+            SUCCESS_DATE,
+            1,
+            2,
+            FAILURE_DATE,
+            true,
+            (short) 3);
+    UploadRequestStatusDetails details =
+        new UploadRequestStatusDetails(
+            finalUri, targetUri, InsertExceptionMode.INTERNAL_ERROR, "short", "long");
     return new UploadFileRequestStatus(
-        "identifier",
-        Persistence.CONNECTION,
-        true,
-        false,
-        false,
-        10,
-        5,
-        3,
-        SUCCESS_DATE,
-        1,
-        2,
-        FAILURE_DATE,
-        true,
-        (short) 3,
-        finalUri,
-        targetUri,
-        InsertExceptionMode.INTERNAL_ERROR,
-        "short",
-        "long",
-        dataSize,
-        mimeType,
-        origFile,
-        compressState);
+        statusSnapshot, details, dataSize, mimeType, origFile, compressState);
   }
 }


### PR DESCRIPTION
## Summary
- introduce request status snapshot/detail records for download/upload metadata
- route FCP status construction and cache updates through the new bundles
- update FCP status tests to build snapshots and outcomes

## Testing
- Not run (not requested)