### PR TITLE
refactor(fcp): bundle persistent put params

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -618,29 +618,35 @@ public class ClientPut extends ClientPutBase {
   @Override
   protected FCPMessage persistentTagMessage() {
     if (putter == null) LOG.warn("putter == null");
-    return new PersistentPut(
-        identifier,
-        publicURI,
-        uri,
-        verbosity,
-        priorityClass,
-        uploadFrom,
-        targetURI,
-        persistence,
-        origFilename,
-        clientMetadata.getMIMEType(),
-        client.isGlobalQueue,
-        getDataSize(),
-        clientToken,
-        started,
-        ctx.getMaxInsertRetries(),
-        targetFilename,
-        binaryBlob,
-        this.ctx.getCompatibilityMode(),
-        this.ctx.isDontCompress(),
-        this.ctx.getCompressorDescriptor(),
-        isRealTime(),
-        putter != null ? putter.getSplitfileCryptoKey() : null);
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            publicURI,
+            identifier,
+            verbosity,
+            priorityClass,
+            persistence,
+            isRealTime(),
+            clientToken,
+            client.isGlobalQueue);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            uri,
+            started,
+            ctx.getMaxInsertRetries(),
+            this.ctx.getCompatibilityMode(),
+            this.ctx.isDontCompress(),
+            this.ctx.getCompressorDescriptor(),
+            putter != null ? putter.getSplitfileCryptoKey() : null);
+    ClientPutUpload upload =
+        new ClientPutUpload(
+            uploadFrom,
+            origFilename,
+            clientMetadata.getMIMEType(),
+            null,
+            targetURI,
+            targetFilename,
+            binaryBlob);
+    return new PersistentPut(requestParams, upload, metadata, getDataSize());
   }
 
   private boolean isRealTime() {

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -526,25 +526,26 @@ public class ClientPutDir extends ClientPutBase {
     if (putter == null) LOG.warn("putter == null");
     HashMap<String, Object> manifestSnapshot =
         manifestElements != null ? new HashMap<>(manifestElements) : null;
-    return new PersistentPutDir(
-        identifier,
-        publicURI,
-        uri,
-        verbosity,
-        priorityClass,
-        persistence,
-        global,
-        defaultName,
-        manifestSnapshot,
-        clientToken,
-        started,
-        ctx.getMaxInsertRetries(),
-        ctx.isDontCompress(),
-        ctx.getCompressorDescriptor(),
-        wasDiskPut,
-        isRealTime(),
-        putter != null ? putter.getSplitfileCryptoKey() : null,
-        this.ctx.getCompatibilityMode());
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            publicURI,
+            identifier,
+            verbosity,
+            priorityClass,
+            persistence,
+            isRealTime(),
+            clientToken,
+            global);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            uri,
+            started,
+            ctx.getMaxInsertRetries(),
+            this.ctx.getCompatibilityMode(),
+            ctx.isDontCompress(),
+            ctx.getCompressorDescriptor(),
+            putter != null ? putter.getSplitfileCryptoKey() : null);
+    return new PersistentPutDir(requestParams, metadata, defaultName, manifestSnapshot, wasDiskPut);
   }
 
   private boolean isRealTime() {

--- a/src/main/java/network/crypta/clients/fcp/PersistentPut.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentPut.java
@@ -22,7 +22,7 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <ul>
  *   <li>Report the state of an insert back to an FCP client.
- *   <li>Preserve the identifiers and upload source used during request creation.
+ *   <li>Preserve the identifiers and upload the source used during request creation.
  *   <li>Emit metadata such as MIME type, compression codecs, and crypto keys alongside persistence
  *       settings.
  * </ul>
@@ -68,74 +68,38 @@ public class PersistentPut extends FCPMessage {
    * serializes the message. The splitfile crypto key and compatibility mode are stored verbatim so
    * downstream components can honor the client's encryption and codec expectations.
    *
-   * @param identifier unique request token echoed back to clients when listing
-   * @param publicURI public insert URI associated with the persistent request
-   * @param privateURI optional private insert URI used for future control
-   * @param verbosity numeric verbosity flag requested by the originating client
-   * @param priorityClass scheduler priority assigned to the insert operation
-   * @param uploadFrom source indicating how the payload is supplied to FCP
-   * @param targetURI optional destination URI when the insert is redirected
-   * @param persistence desired persistence policy for the underlying request
-   * @param origFilename local file backing the upload when present on disk
-   * @param mimeType declared MIME type to include in metadata, if available
-   * @param global whether the request was marked global across client sessions
+   * @param requestParams core request identifiers, scheduling flags, and persistence settings
+   * @param upload upload metadata describing the payload source and MIME hints
+   * @param metadata shared persistent insert metadata such as retry and compression flags
    * @param size content length in bytes, or {@code -1} when unspecified
-   * @param clientToken opaque client-provided token preserved in responses
-   * @param started whether the insert has already begun processing
-   * @param maxRetries maximum retry attempts configured for this insert
-   * @param targetFilename preferred filename for on-disk storage when provided
-   * @param binaryBlob whether the payload should bypass metadata processing
-   * @param compatMode insert compatibility mode requested by the client
-   * @param dontCompress indicates compression avoidance despite default behavior
-   * @param compressorDescriptor explicit codec pipeline description, if supplied
-   * @param realTime whether the request should be treated with real-time bias
-   * @param splitfileCryptoKey encryption key for splitfile segments, if known
    */
   public PersistentPut(
-      String identifier,
-      FreenetURI publicURI,
-      FreenetURI privateURI,
-      int verbosity,
-      short priorityClass,
-      UploadFrom uploadFrom,
-      FreenetURI targetURI,
-      Persistence persistence,
-      File origFilename,
-      String mimeType,
-      boolean global,
-      long size,
-      String clientToken,
-      boolean started,
-      int maxRetries,
-      String targetFilename,
-      boolean binaryBlob,
-      InsertContext.CompatibilityMode compatMode,
-      boolean dontCompress,
-      String compressorDescriptor,
-      boolean realTime,
-      byte[] splitfileCryptoKey) {
-    this.requestIdentifier = identifier;
-    this.uri = publicURI;
-    this.privateURI = privateURI;
-    this.verbosity = verbosity;
-    this.priorityClass = priorityClass;
-    this.uploadFrom = uploadFrom;
-    this.targetURI = targetURI;
-    this.persistence = persistence;
-    this.origFilename = origFilename;
-    this.mimeType = mimeType;
-    this.global = global;
+      ClientRequestParams requestParams,
+      ClientPutUpload upload,
+      PersistentPutRequestMetadata metadata,
+      long size) {
+    this.requestIdentifier = requestParams.identifier();
+    this.uri = requestParams.uri();
+    this.privateURI = metadata.privateURI();
+    this.verbosity = requestParams.verbosity();
+    this.priorityClass = requestParams.priorityClass();
+    this.uploadFrom = upload.uploadFromType();
+    this.targetURI = upload.redirectTarget();
+    this.persistence = requestParams.persistence();
+    this.origFilename = upload.origFilename();
+    this.mimeType = upload.contentType();
+    this.global = requestParams.global();
     this.size = size;
-    this.token = clientToken;
-    this.started = started;
-    this.maxRetries = maxRetries;
-    this.targetFilename = targetFilename;
-    this.binaryBlob = binaryBlob;
-    this.compatMode = compatMode;
-    this.dontCompress = dontCompress;
-    this.compressorDescriptor = compressorDescriptor;
-    this.realTime = realTime;
-    this.splitfileCryptoKey = splitfileCryptoKey;
+    this.token = requestParams.clientToken();
+    this.started = metadata.started();
+    this.maxRetries = metadata.maxRetries();
+    this.targetFilename = upload.targetFilename();
+    this.binaryBlob = upload.binaryBlob();
+    this.compatMode = metadata.compatMode();
+    this.dontCompress = metadata.dontCompress();
+    this.compressorDescriptor = metadata.compressorDescriptor();
+    this.realTime = requestParams.realTime();
+    this.splitfileCryptoKey = metadata.splitfileCryptoKey();
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/PersistentPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentPutDir.java
@@ -29,13 +29,13 @@ import org.slf4j.LoggerFactory;
  * that the server sends back to clients. The instance is immutable after construction; all data is
  * pre-flattened into a {@link SimpleFieldSet} so callers can transmit the message repeatedly
  * without re-walking the manifest tree. Use this class when the node needs to mirror a client's
- * persistent directory insertion, for example during reconnects or resumptions where the node must
- * restate the pending request.
+ * persistent directory insertion, for example, during reconnections or resumptions where the node
+ * must restate the pending request.
  *
  * <p>Concurrency: the object contains only final fields and is thread-safe for read-only access.
  * Large manifests are supported by avoiding eager string copies where possible; however, the
- * resulting field set can still be sizeable, so callers should reuse instances rather than building
- * them per send. The class does not perform I/O beyond inspecting the supplied buckets.
+ * resulting field set can still be sizable, so callers should reuse instances rather than building
+ * them per sending. The class does not perform I/O beyond inspecting the supplied buckets.
  *
  * <ul>
  *   <li><strong>Responsibilities:</strong> normalize manifest elements, emit stable message fields,
@@ -78,80 +78,39 @@ public class PersistentPutDir extends FCPMessage {
    * set so repeated invocations of {@link #getFieldSet()} are cheap. Callers should pass the URIs
    * exactly as issued by the node; no additional validation or escaping is performed here.
    *
-   * @param clientIdentifier unique identifier that ties the message to the originating client
-   *     session; may be any non-null token the client previously registered.
-   * @param publicURI public {@link FreenetURI} that names the target insert; used when announcing
-   *     the put to peers and to reconstruct state after restarts.
-   * @param privateURI optional private {@link FreenetURI} that enables resume or cancellation for
-   *     the same request; may be {@code null} when none was issued.
-   * @param verbosity server verbosity level requested by the client; higher values surface more
-   *     progress updates and diagnostics through FCP callbacks.
-   * @param priorityClass priority band for queueing; lower numbers generally represent faster
-   *     scheduling according to node policy.
-   * @param persistence persistence scope chosen by the client; defines whether the request survives
-   *     restarts or disconnects and maps directly to {@link Persistence} values.
-   * @param global whether the request is globally scoped across the node; {@code true} keeps it
-   *     active even if the originating client disconnects.
-   * @param defaultName default filename applied to manifest entries lacking an explicit name; also
-   *     used by UI layers when constructing links.
+   * @param requestParams core request identifiers, scheduling flags, and persistence settings
+   * @param metadata shared persistent insert metadata such as retries and compression flags
+   * @param defaultName the default filename applied to manifest entries lacking an explicit name;
+   *     also used by UI layers when constructing links.
    * @param manifestElements flattened or hierarchical manifest elements supplied by the client; any
    *     redirect entries must include a target URI while file entries must carry data buckets.
-   * @param token optional opaque token returned in progress callbacks; callers can use it to
-   *     correlate asynchronous updates without inspecting request identifiers.
-   * @param started whether the node should treat the request as already started, typically used
-   *     during resume flows to avoid requeuing work that was previously underway.
-   * @param maxRetries maximum retry attempts the node should perform for transient failures; zero
-   *     disables retries while positive values cap retry loops.
-   * @param dontCompress flag indicating the client disabled compression for the insert; honored as
-   *     a hint when constructing splitfiles.
-   * @param compressorDescriptor optional compressor descriptor string when compression is allowed;
-   *     may be {@code null} to use node defaults.
    * @param wasDiskPut whether the original request streamed from disk; affects how the node
    *     represents the upload source within the field set.
-   * @param realTime whether the insert participates in real-time scheduling, prioritizing latency
-   *     over throughput while consuming more bandwidth headroom.
-   * @param splitfileCryptoKey optional raw splitfile encryption key bytes; when provided, they are
-   *     hex-encoded into the outgoing message for client consumption.
-   * @param cmode compatibility mode derived from {@link InsertContext}; governs how manifests are
-   *     serialized for different protocol expectations.
    */
   public PersistentPutDir(
-      String clientIdentifier,
-      FreenetURI publicURI,
-      FreenetURI privateURI,
-      int verbosity,
-      short priorityClass,
-      Persistence persistence,
-      boolean global,
+      ClientRequestParams requestParams,
+      PersistentPutRequestMetadata metadata,
       String defaultName,
       Map<String, Object> manifestElements,
-      String token,
-      boolean started,
-      int maxRetries,
-      boolean dontCompress,
-      String compressorDescriptor,
-      boolean wasDiskPut,
-      boolean realTime,
-      byte[] splitfileCryptoKey,
-      InsertContext.CompatibilityMode cmode) {
-    this.clientIdentifier = clientIdentifier;
-    this.uri = publicURI;
-    this.privateURI = privateURI;
-    this.verbosity = verbosity;
-    this.priorityClass = priorityClass;
-    this.persistence = persistence;
-    this.global = global;
+      boolean wasDiskPut) {
+    this.clientIdentifier = requestParams.identifier();
+    this.uri = requestParams.uri();
+    this.privateURI = metadata.privateURI();
+    this.verbosity = requestParams.verbosity();
+    this.priorityClass = requestParams.priorityClass();
+    this.persistence = requestParams.persistence();
+    this.global = requestParams.global();
     this.defaultName = defaultName;
     this.manifestElements = manifestElements;
-    this.token = token;
-    this.started = started;
-    this.maxRetries = maxRetries;
+    this.token = requestParams.clientToken();
+    this.started = metadata.started();
+    this.maxRetries = metadata.maxRetries();
     this.wasDiskPut = wasDiskPut;
-    this.dontCompress = dontCompress;
-    this.compressorDescriptor = compressorDescriptor;
-    this.realTime = realTime;
-    this.splitfileCryptoKey = splitfileCryptoKey;
-    this.compatMode = cmode;
+    this.dontCompress = metadata.dontCompress();
+    this.compressorDescriptor = metadata.compressorDescriptor();
+    this.realTime = requestParams.realTime();
+    this.splitfileCryptoKey = metadata.splitfileCryptoKey();
+    this.compatMode = metadata.compatMode();
     cached = generateFieldSet();
   }
 
@@ -264,7 +223,7 @@ public class PersistentPutDir extends FCPMessage {
    * <p>The returned {@link SimpleFieldSet} is built once during construction and reused; callers
    * must not mutate it. The structure contains a flattened manifest, upload sources, and all
    * optional control flags so it can be sent directly over FCP. Because the field set is cached, it
-   * is safe to reuse this instance across reconnects or retransmissions without re-walking the
+   * is safe to reuse this instance across reconnections or retransmissions without re-walking the
    * manifest. The object is read-only after construction, making it suitable for sharing across
    * threads that only need to serialize the data.
    *

--- a/src/main/java/network/crypta/clients/fcp/PersistentPutRequestMetadata.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentPutRequestMetadata.java
@@ -1,0 +1,80 @@
+package network.crypta.clients.fcp;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.client.InsertContext;
+import network.crypta.keys.FreenetURI;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Shared metadata describing persistent put requests.
+ *
+ * <p>This record groups the optional private URI alongside retry and compression settings that are
+ * reused by both single-file and directory persistent put messages.
+ *
+ * @param privateURI optional private insert URI for resume or cancellation
+ * @param started whether the request has already begun processing
+ * @param maxRetries maximum retry attempts configured for the insert
+ * @param compatMode insert compatibility mode requested by the client
+ * @param dontCompress whether compression should be avoided for this insert
+ * @param compressorDescriptor optional codec pipeline description
+ * @param splitfileCryptoKey encryption key for splitfile segments, if known
+ */
+public record PersistentPutRequestMetadata(
+    FreenetURI privateURI,
+    boolean started,
+    int maxRetries,
+    InsertContext.CompatibilityMode compatMode,
+    boolean dontCompress,
+    String compressorDescriptor,
+    byte[] splitfileCryptoKey) {
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o
+        instanceof
+        PersistentPutRequestMetadata(
+            FreenetURI otherPrivateUri,
+            boolean otherStarted,
+            int otherMaxRetries,
+            InsertContext.CompatibilityMode otherCompatMode,
+            boolean otherDontCompress,
+            String otherCompressorDescriptor,
+            byte[] otherSplitfileCryptoKey))) return false;
+    return started == otherStarted
+        && maxRetries == otherMaxRetries
+        && dontCompress == otherDontCompress
+        && Objects.equals(privateURI, otherPrivateUri)
+        && compatMode == otherCompatMode
+        && Objects.equals(compressorDescriptor, otherCompressorDescriptor)
+        && Arrays.equals(splitfileCryptoKey, otherSplitfileCryptoKey);
+  }
+
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            privateURI, started, maxRetries, compatMode, dontCompress, compressorDescriptor);
+    result = 31 * result + Arrays.hashCode(splitfileCryptoKey);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "PersistentPutRequestMetadata[privateURI="
+        + privateURI
+        + ", started="
+        + started
+        + ", maxRetries="
+        + maxRetries
+        + ", compatMode="
+        + compatMode
+        + ", dontCompress="
+        + dontCompress
+        + ", compressorDescriptor="
+        + compressorDescriptor
+        + ", splitfileCryptoKey="
+        + (splitfileCryptoKey == null ? "null" : Arrays.toString(splitfileCryptoKey))
+        + ']';
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/PersistentPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentPutDirTest.java
@@ -204,73 +204,78 @@ class PersistentPutDirTest {
 
   private SimpleFieldSet buildFullFieldSet(
       Map<String, Object> manifest, FreenetURI publicUri, FreenetURI privateUri, byte[] cryptoKey) {
-    PersistentPutDir message =
-        new PersistentPutDir(
-            "id-123",
-            publicUri,
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            publicUri, "id-123", 2, (short) 3, Persistence.FOREVER, true, "client-token", true);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
             privateUri,
-            2,
-            (short) 3,
-            Persistence.FOREVER,
-            true,
-            "index.html",
-            new LinkedHashMap<>(manifest),
-            "client-token",
             true,
             5,
+            InsertContext.CompatibilityMode.COMPAT_1468,
             true,
             "gzip",
-            true,
-            true,
-            cryptoKey,
-            InsertContext.CompatibilityMode.COMPAT_1468);
+            cryptoKey);
+    PersistentPutDir message =
+        new PersistentPutDir(
+            requestParams, metadata, "index.html", new LinkedHashMap<>(manifest), true);
     return message.getFieldSet();
   }
 
   private SimpleFieldSet buildOptionalFieldSet(Map<String, Object> manifest) {
-    PersistentPutDir message =
-        new PersistentPutDir(
-            "id-opt",
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
             new FreenetURI("CHK", "pub"),
-            null,
+            "id-opt",
             0,
             (short) 1,
             Persistence.CONNECTION,
             false,
-            DEFAULT_NAME,
-            new LinkedHashMap<>(manifest),
             null,
-            false,
-            0,
-            false,
-            null,
-            false,
-            false,
-            null,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+            false);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            null, false, 0, InsertContext.CompatibilityMode.COMPAT_CURRENT, false, null, null);
+    PersistentPutDir message =
+        new PersistentPutDir(
+            requestParams, metadata, DEFAULT_NAME, new LinkedHashMap<>(manifest), false);
     return message.getFieldSet();
   }
 
   private PersistentPutDir buildWrappedMessage(Map<String, Object> manifest) {
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            new FreenetURI("CHK", "pub2"),
+            "id-wrap",
+            1,
+            (short) 1,
+            Persistence.REBOOT,
+            false,
+            null,
+            false);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            null, false, 1, InsertContext.CompatibilityMode.COMPAT_1250, false, null, null);
     return new PersistentPutDir(
-        "id-wrap",
-        new FreenetURI("CHK", "pub2"),
-        null,
-        1,
-        (short) 1,
-        Persistence.REBOOT,
-        false,
-        "wrapped",
-        new LinkedHashMap<>(manifest),
-        null,
-        false,
-        1,
-        false,
-        null,
-        false,
-        false,
-        null,
-        InsertContext.CompatibilityMode.COMPAT_1250);
+        requestParams, metadata, "wrapped", new LinkedHashMap<>(manifest), false);
+  }
+
+  private PersistentPutDir buildRunMessage(Map<String, Object> manifest) {
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            new FreenetURI("CHK", "pub3"),
+            "ident",
+            1,
+            (short) 1,
+            Persistence.CONNECTION,
+            false,
+            null,
+            true);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            null, false, 0, InsertContext.CompatibilityMode.COMPAT_CURRENT, false, null, null);
+    return new PersistentPutDir(
+        requestParams, metadata, DEFAULT_NAME, new LinkedHashMap<>(manifest), false);
   }
 
   @Test
@@ -280,26 +285,7 @@ class PersistentPutDirTest {
     Map<String, Object> manifest = new LinkedHashMap<>();
     manifest.put(FILE_TXT_NAME, element);
 
-    PersistentPutDir message =
-        new PersistentPutDir(
-            "ident",
-            new FreenetURI("CHK", "pub3"),
-            null,
-            1,
-            (short) 1,
-            Persistence.CONNECTION,
-            true,
-            DEFAULT_NAME,
-            new LinkedHashMap<>(manifest),
-            null,
-            false,
-            0,
-            false,
-            null,
-            false,
-            false,
-            null,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    PersistentPutDir message = buildRunMessage(manifest);
 
     MessageInvalidException ex =
         assertThrows(MessageInvalidException.class, () -> message.run(connectionHandler, node));
@@ -319,24 +305,20 @@ class PersistentPutDirTest {
   }
 
   private void createPersistentPutDirWith(Map<String, Object> manifest) {
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            new FreenetURI("CHK", "pub4"),
+            "id-bad",
+            0,
+            (short) 1,
+            Persistence.CONNECTION,
+            false,
+            null,
+            false);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            null, false, 0, InsertContext.CompatibilityMode.COMPAT_CURRENT, false, null, null);
     new PersistentPutDir(
-        "id-bad",
-        new FreenetURI("CHK", "pub4"),
-        null,
-        0,
-        (short) 1,
-        Persistence.CONNECTION,
-        false,
-        DEFAULT_NAME,
-        new LinkedHashMap<>(manifest),
-        null,
-        false,
-        0,
-        false,
-        null,
-        false,
-        false,
-        null,
-        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+        requestParams, metadata, DEFAULT_NAME, new LinkedHashMap<>(manifest), false);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/PersistentPutTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentPutTest.java
@@ -34,30 +34,22 @@ class PersistentPutTest {
     File originalFile = tempDir.resolve("upload.bin").toFile();
     byte[] cryptoKey = new byte[] {0x01, 0x02, 0x0A, (byte) 0xFF};
 
-    PersistentPut put =
-        new PersistentPut(
-            "id-123",
-            publicUri,
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            publicUri, "id-123", 2, (short) 5, Persistence.FOREVER, true, "token-abc", true);
+    ClientPutUpload upload =
+        new ClientPutUpload(
+            UploadFrom.DIRECT, originalFile, "text/plain", null, targetUri, "target.dat", true);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
             privateUri,
-            2,
-            (short) 5,
-            UploadFrom.DIRECT,
-            targetUri,
-            Persistence.FOREVER,
-            originalFile,
-            "text/plain",
-            true,
-            1024L,
-            "token-abc",
             true,
             3,
-            "target.dat",
-            true,
             InsertContext.CompatibilityMode.COMPAT_1468,
             true,
             "lzma",
-            true,
             cryptoKey);
+    PersistentPut put = new PersistentPut(requestParams, upload, metadata, 1024L);
 
     SimpleFieldSet fs = put.getFieldSet();
 
@@ -119,30 +111,22 @@ class PersistentPutTest {
 
   @Test
   void getName_alwaysReturnsConstant() {
-    PersistentPut put =
-        new PersistentPut(
-            "id-name",
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
             new FreenetURI("KSK", "name"),
-            null,
+            "id-name",
             1,
             (short) 1,
-            UploadFrom.DIRECT,
-            null,
             Persistence.REBOOT,
-            null,
-            null,
-            false,
-            -1,
-            null,
-            false,
-            0,
-            null,
-            false,
-            InsertContext.CompatibilityMode.COMPAT_CURRENT,
             false,
             null,
-            false,
-            null);
+            false);
+    ClientPutUpload upload =
+        new ClientPutUpload(UploadFrom.DIRECT, null, null, null, null, null, false);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            null, false, 0, InsertContext.CompatibilityMode.COMPAT_CURRENT, false, null, null);
+    PersistentPut put = new PersistentPut(requestParams, upload, metadata, -1);
 
     assertEquals("PersistentPut", put.getName());
   }
@@ -175,28 +159,13 @@ class PersistentPutTest {
       Persistence persistence,
       boolean global,
       UploadFrom uploadFrom) {
-    return new PersistentPut(
-        identifier,
-        publicUri,
-        null,
-        0,
-        (short) 0,
-        uploadFrom,
-        null,
-        persistence,
-        null,
-        null,
-        global,
-        -1,
-        null,
-        false,
-        0,
-        null,
-        false,
-        InsertContext.CompatibilityMode.COMPAT_UNKNOWN,
-        false,
-        null,
-        false,
-        null);
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            publicUri, identifier, 0, (short) 0, persistence, false, null, global);
+    ClientPutUpload upload = new ClientPutUpload(uploadFrom, null, null, null, null, null, false);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            null, false, 0, InsertContext.CompatibilityMode.COMPAT_UNKNOWN, false, null, null);
+    return new PersistentPut(requestParams, upload, metadata, -1);
   }
 }


### PR DESCRIPTION
## Summary
- replace long persistent put parameter lists with shared request/upload/metadata records
- add PersistentPutRequestMetadata with array-aware equality/hash/toString
- update persistent put tests to build the new parameter objects

## Testing
- ./gradlew test