### PR TITLE
refactor(http): add fetch criteria record

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyFetchCriteria.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchCriteria.java
@@ -1,0 +1,13 @@
+package network.crypta.clients.http;
+
+import network.crypta.client.FetchContext;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Immutable criteria used to locate or create an in-progress FProxy fetch.
+ *
+ * <p>The criteria pairs a target {@link FreenetURI} with a maximum size constraint and an optional
+ * {@link FetchContext} that must be equivalent for reuse. Callers can supply a {@code null} {@code
+ * fetchContext} when they intend to match any context.
+ */
+public record FProxyFetchCriteria(FreenetURI key, long maxSize, FetchContext fetchContext) {}

--- a/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * <p>This holder coordinates the shared state between the asynchronous {@link ClientGetter} running
  * inside the client layer and the lightweight waiter objects used by the HTTP toadlet. It owns the
  * request lifecycle, forwards network and splitfile events to listeners, and exposes progress
- * snapshots that are rendered into FProxy status pages. Typical callers obtain a waiter via {@link
+ * snapshots that are rendered into FProxy status pages. Typical callers get a waiter via {@link
  * #getWaiter()}, start the fetch with {@link #start(ClientContext)}, and poll {@link
  * #innerGetResult(boolean)} from the waiter thread until either data or an error arrives.
  *
@@ -58,8 +58,8 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>Responsibilities: manage a single URI fetch, collect progress, and dispatch listener
  *       events.
- *   <li>Concurrency: all externally visible state is guarded by the instance monitor; callbacks may
- *       arrive from worker threads.
+ *   <li>Concurrency: the instance monitor guards all externally visible state; callbacks may arrive
+ *       from worker threads.
  *   <li>Lifecycle: constructed with immutable fetch parameters, started once, and then either
  *       finishes, fails, or is canceled by the tracker.
  * </ul>
@@ -113,7 +113,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   private final ClientGetter getter;
 
   /**
-   * Any request which is waiting for a progress screen or data. We may want to wake requests
+   * Any request that is waiting for a progress screen or data. We may want to wake requests
    * separately in the future.
    */
   private final ArrayList<FProxyFetchWaiter> waiters;
@@ -174,7 +174,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   final FProxyFetchTracker tracker;
 
   /**
-   * Show even non-fatal failures for 5 seconds. Necessary for javascript to work, because it
+   * Show even non-fatal failures for 5 seconds. Necessary for JavaScript to work, because it
    * fetches the page and then reloads it if it isn't a progress update.
    */
   private long timeFailed;
@@ -201,32 +201,28 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
    * does not start network activity; callers must invoke {@link #start(ClientContext)} after adding
    * any waiters or listeners.
    *
-   * @param tracker owning tracker that manages cancellation and lifecycle for this fetch
-   * @param key target Freenet URI, including edition information for USKs when present
-   * @param maxSize2 maximum response size in bytes allowed by the caller for output
+   * @param tracker the owning tracker that manages cancellation and lifecycle for this fetch
+   * @param criteria immutable request criteria containing URI, size limit, and fetch context
    * @param identifier monotonically increasing identifier used for UI correlation and logs
    * @param context initial client context providing caches and factories for the fetch
-   * @param fctx base fetch context copied and adjusted for this request's output limits
    * @param rc request client identity used for network scheduling and throttling
    * @param refilter policy describing how cached filtered data should be reused or refreshed
    */
   public FProxyFetchInProgress(
       FProxyFetchTracker tracker,
-      FreenetURI key,
-      long maxSize2,
+      FProxyFetchCriteria criteria,
       long identifier,
       ClientContext context,
-      FetchContext fctx,
       RequestClient rc,
       REFILTER_POLICY refilter) {
     this.identifier = identifier;
     this.initialContext = context;
     this.refilterPolicy = refilter;
     this.tracker = tracker;
-    this.uri = key;
-    this.maxSize = maxSize2;
+    this.uri = criteria.key();
+    this.maxSize = criteria.maxSize();
     this.timeStarted = System.currentTimeMillis();
-    this.fctx = fctx;
+    this.fctx = criteria.fetchContext();
     this.rc = rc;
     FetchContext alteredFctx = new FetchContext(fctx, FetchContext.IDENTICAL_MASK);
     alteredFctx.setMaxOutputLength(maxSize);
@@ -318,10 +314,9 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
    * Begins the fetch by consulting caches and, if necessary, scheduling network retrieval.
    *
    * <p>The method is idempotent for a given instance: it will only trigger the underlying {@link
-   * ClientGetter} once, and subsequent calls simply reflect the first result. Cache hits may
-   * immediately complete the fetch and notify listeners. Checked exceptions indicate startup
-   * failures such as malformed URIs or context misconfiguration and leave the instance marked as
-   * failed.
+   * ClientGetter} once, and later calls simply reflect the first result. Cache hits may immediately
+   * complete the fetch and notify listeners. Checked exceptions indicate startup failures such as
+   * malformed URIs or context misconfiguration and leave the instance marked as failed.
    *
    * @param context client context supplying caches, temp bucket factories, and scheduler access
    * @throws FetchException if initial validation or network scheduling fails before fetching starts
@@ -350,8 +345,8 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
    * @return True if it was found, and we don't need to start the request.
    */
   private boolean checkCache(ClientContext context) {
-    // Fproxy uses lookupInstant() with mustCopy = false. I.e. it can reuse stuff unsafely. If the
-    // user frees it's their fault.
+    // Fproxy uses lookupInstant() with mustCopy = false. I.e., it can reuse stuff unsafely. If the
+    // user frees, it's their fault.
     if (bogusUSK(context)) return false;
 
     CacheFetchResult result = lookupCachedResult(context);
@@ -465,8 +460,8 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   }
 
   /**
-   * If the key is a USK and a) we are requested to do an exhaustive search, or b) there is a later
-   * version, then we can't use the download queue as a cache.
+   * If the key is a USK and (a) we are requested to do an exhaustive search, or (b) there is a
+   * later version, then we can't use the download queue as a cache.
    *
    * @return True if we can't use the download queue, false if we can.
    */
@@ -749,7 +744,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
       hasNotifiedFailure = true;
       return true;
     }
-    // Once for javascript and once for the user when it re-pulls.
+    // Once for JavaScript and once for the user when it re-pulls.
     return failed != null && (System.currentTimeMillis() - timeFailed < 1000 || fetched < 2);
   }
 
@@ -770,7 +765,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   /**
    * Returns whether any waiter has already waited for progress, used to throttle UI refreshes.
    *
-   * <p>The flag is set when a waiter first signals it is blocking so subsequent HTTP refreshes can
+   * <p>The flag is set when a waiter first signals it is blocking, so later HTTP refreshes can
    * avoid duplicate latency compensation. It remains true for the lifetime of the fetch because a
    * single wait indicates user interest that should not be throttled twice.
    *
@@ -797,7 +792,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
    *
    * <p>Listeners are invoked outside the synchronized blocks but may still be called from worker
    * threads that deliver {@link ClientEvent}s, so implementations must be thread-safe and quick. If
-   * a listener slows down excessively it can delay UI refresh notifications for other watchers.
+   * a listener slows down excessively, it can delay UI refresh notifications for other watchers.
    *
    * @param listener the callback to add; must be thread-safe because notifications may cross
    *     threads
@@ -843,7 +838,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
    * Returns the timestamp (milliseconds since epoch) of the most recent waiter or result access.
    *
    * <p>The tracker uses this value to decide when the fetch entry has been idle long enough to
-   * cancel. It is updated on waiter creation and result reads; callers should treat it as a
+   * cancel. It is updated on waiter creation, and the result reads; callers should treat it as a
    * monotonic indicator of user interest.
    *
    * @return epoch millisecond timestamp of the last interaction with this fetch
@@ -910,8 +905,8 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
    * Returns a diagnostic string containing the identifier, URI, and initial client context.
    *
    * <p>The format is stable enough for logging and troubleshooting but not intended as a
-   * serialization contract. It avoids revealing internal mutable state and therefore remains safe
-   * to print even while callbacks mutate other fields.
+   * serialization contract. It avoids revealing the internal mutable state and therefore remains
+   * safe to print even while callbacks mutate other fields.
    *
    * @return human-readable summary suitable for debug logging and progress pages
    */

--- a/src/main/java/network/crypta/clients/http/FProxyFetchTracker.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchTracker.java
@@ -20,10 +20,10 @@ import org.slf4j.LoggerFactory;
  * of stale work. Internally the registry is guarded by the {@code fetchers} monitor while lifecycle
  * state changes rely on {@link ClientContext#ticker} to avoid blocking the calling thread.
  *
- * <p>Typical call flow: a servlet asks for a fetcher via {@link #makeFetcher(FreenetURI, long,
- * FetchContext, REFILTER_POLICY)}, obtains a waiter, and later the tracker culls abandoned
- * instances through {@link #run()}. Instances are intentionally short-lived; they are cancelled
- * when a fetch completes, fails fatally, or the scheduled cleanup fires.
+ * <p>Typical call flow: a servlet asks for a fetcher via {@link #makeFetcher(FProxyFetchCriteria,
+ * REFILTER_POLICY)}, obtains a waiter, and later the tracker culls abandoned instances through
+ * {@link #run()}. Instances are intentionally short-lived; they are cancelled when a fetch
+ * completes, fails fatally, or the scheduled cleanup fires.
  *
  * <ul>
  *   <li>Responsibility: deduplicate fetch requests and manage their lifetime.
@@ -77,53 +77,51 @@ public class FProxyFetchTracker implements Runnable {
    * holding the registry lock to avoid races; network work is started after releasing the lock to
    * minimize contention.
    *
-   * @param key content key to retrieve; must uniquely identify the desired resource.
-   * @param maxSize maximum allowed size in bytes; the fetch is reused only when this matches an
-   *     existing task.
-   * @param fctx optional override fetch context; {@code null} falls back to the tracker's default
-   *     context.
+   * @param criteria immutable criteria containing URI, size limit, and optional fetch context. When
+   *     the context is {@code null}, the tracker default context is used.
    * @param refilterPolicy policy describing how client-side refiltering should be applied when the
    *     fetch completes.
    * @return waiter that exposes progress and completion for the matching or newly created fetch.
    * @throws FetchException if the underlying fetch cannot be started or the request client rejects
    *     the parameters.
    */
-  public FProxyFetchWaiter makeFetcher(
-      FreenetURI key, long maxSize, FetchContext fctx, REFILTER_POLICY refilterPolicy)
+  public FProxyFetchWaiter makeFetcher(FProxyFetchCriteria criteria, REFILTER_POLICY refilterPolicy)
       throws FetchException {
     FProxyFetchInProgress progress;
+    FProxyFetchCriteria effectiveCriteria = resolveCriteria(criteria);
     /* LOCKING:
      * Call getWaiter() inside the fetchers lock, since we will purge old
      * fetchers inside that lock, hence avoid a race condition. FetchInProgress
      * lock is always taken last. */
     synchronized (fetchers) {
-      FProxyFetchWaiter waiter =
-          makeWaiterForFetchInProgress(key, maxSize, fctx != null ? fctx : this.fctx);
+      FProxyFetchWaiter waiter = makeWaiterForFetchInProgress(effectiveCriteria);
       if (waiter != null) {
         return waiter;
       }
       progress =
           new FProxyFetchInProgress(
-              this,
-              key,
-              maxSize,
-              fetchIdentifiers++,
-              context,
-              fctx != null ? fctx : this.fctx,
-              rc,
-              refilterPolicy);
-      fetchers.put(key, progress);
+              this, effectiveCriteria, fetchIdentifiers++, context, rc, refilterPolicy);
+      fetchers.put(effectiveCriteria.key(), progress);
     }
     try {
       progress.start(context);
     } catch (FetchException e) {
       synchronized (fetchers) {
-        fetchers.removeElement(key, progress);
+        fetchers.removeElement(effectiveCriteria.key(), progress);
       }
       throw e;
     }
     if (LOG.isDebugEnabled()) LOG.debug("Created new fetcher: {}", progress);
     return progress.getWaiter();
+  }
+
+  private FProxyFetchCriteria resolveCriteria(FProxyFetchCriteria criteria) {
+    FetchContext resolvedContext =
+        criteria.fetchContext() != null ? criteria.fetchContext() : this.fctx;
+    if (resolvedContext == criteria.fetchContext()) {
+      return criteria;
+    }
+    return new FProxyFetchCriteria(criteria.key(), criteria.maxSize(), resolvedContext);
   }
 
   void removeFetcher(FProxyFetchInProgress progress) {
@@ -139,16 +137,11 @@ public class FProxyFetchTracker implements Runnable {
    * is equivalent according to {@link FProxyFetchInProgress#fetchContextEquivalent(FetchContext)}.
    * Callers use this to piggyback on in-flight work instead of launching a duplicate download.
    *
-   * @param key URI identifying the target object; {@code null} is not supported.
-   * @param maxSize required maximum payload size in bytes; must equal the running fetch size to
-   *     match.
-   * @param fctx optional {@link FetchContext} to compare against existing fetches; {@code null}
-   *     means any context is acceptable.
+   * @param criteria immutable criteria containing URI, size limit, and optional fetch context.
    * @return waiter for the matching fetch, or {@code null} when no acceptable fetch exists.
    */
-  public FProxyFetchWaiter makeWaiterForFetchInProgress(
-      FreenetURI key, long maxSize, FetchContext fctx) {
-    FProxyFetchInProgress progress = getFetchInProgress(key, maxSize, fctx);
+  public FProxyFetchWaiter makeWaiterForFetchInProgress(FProxyFetchCriteria criteria) {
+    FProxyFetchInProgress progress = getFetchInProgress(criteria);
     if (progress != null) {
       return progress.getWaiter();
     }
@@ -163,18 +156,14 @@ public class FProxyFetchTracker implements Runnable {
    * size and context constraints are returned. This helper underpins both waiter lookups and fetch
    * reuse decisions elsewhere in the tracker.
    *
-   * @param key URI of the fetch to locate; must match exactly the stored key.
-   * @param maxSize maximum size in bytes that the caller is willing to accept; mismatched sizes do
-   *     not reuse the fetch.
-   * @param fctx optional {@link FetchContext} describing filters and parameters; {@code null}
-   *     accepts any context.
+   * @param criteria immutable criteria containing URI, size limit, and optional fetch context.
    * @return an active {@link FProxyFetchInProgress} if one matches, otherwise {@code null} when
    *     none qualify.
    */
-  public FProxyFetchInProgress getFetchInProgress(FreenetURI key, long maxSize, FetchContext fctx) {
+  public FProxyFetchInProgress getFetchInProgress(FProxyFetchCriteria criteria) {
     synchronized (fetchers) {
-      for (FProxyFetchInProgress fetch : fetchers.getAllAsList(key)) {
-        if (matchesFetch(fetch, maxSize, fctx)) {
+      for (FProxyFetchInProgress fetch : fetchers.getAllAsList(criteria.key())) {
+        if (matchesFetch(fetch, criteria.maxSize(), criteria.fetchContext())) {
           return fetch;
         }
       }

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -872,7 +872,8 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
     private void fetchContent() throws FetchException, ToadletContextClosedException, IOException {
       FProxyFetchWaiter fetch =
-          fetchTracker.makeFetcher(key, maxSize, fctx, ctx.getReFilterPolicy());
+          fetchTracker.makeFetcher(
+              new FProxyFetchCriteria(key, maxSize, fctx), ctx.getReFilterPolicy());
       boolean waitingForFetch = true;
       while (waitingForFetch && fetch != null) {
         fetchResult = fetch.getResult(!canSendProgress);
@@ -881,7 +882,9 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
             LOG.info("Loading later edition...");
             fetch.progress.requestImmediateCancel();
             fetchResult.close();
-            fetch = fetchTracker.makeFetcher(key, maxSize, fctx, ctx.getReFilterPolicy());
+            fetch =
+                fetchTracker.makeFetcher(
+                    new FProxyFetchCriteria(key, maxSize, fctx), ctx.getReFilterPolicy());
             waitingForFetch = fetch != null;
           } else {
             cacheFetcherData(fetch);
@@ -1269,7 +1272,8 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
     private void reuseInProgressFetch() {
       boolean needsFetch = true;
-      FProxyFetchInProgress progress = fetchTracker.getFetchInProgress(key, maxSize, fctx);
+      FProxyFetchInProgress progress =
+          fetchTracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, fctx));
       if (progress == null) {
         return;
       }

--- a/src/main/java/network/crypta/clients/http/updateableelements/ImageElement.java
+++ b/src/main/java/network/crypta/clients/http/updateableelements/ImageElement.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import network.crypta.client.FetchException;
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
+import network.crypta.clients.http.FProxyFetchCriteria;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.FProxyFetchResult;
@@ -222,17 +223,20 @@ public class ImageElement extends BaseUpdatableElement {
               try {
                 FProxyFetchWaiter waiter =
                     ImageElement.this.tracker.makeFetcher(
-                        ImageElement.this.key,
-                        ImageElement.this.maxSize,
-                        null,
+                        new FProxyFetchCriteria(
+                            ImageElement.this.key, ImageElement.this.maxSize, null),
                         REFILTER_POLICY.RE_FILTER);
                 ImageElement.this
                     .tracker
-                    .getFetchInProgress(ImageElement.this.key, ImageElement.this.maxSize, null)
+                    .getFetchInProgress(
+                        new FProxyFetchCriteria(
+                            ImageElement.this.key, ImageElement.this.maxSize, null))
                     .addListener(fetchListener);
                 ImageElement.this
                     .tracker
-                    .getFetchInProgress(ImageElement.this.key, ImageElement.this.maxSize, null)
+                    .getFetchInProgress(
+                        new FProxyFetchCriteria(
+                            ImageElement.this.key, ImageElement.this.maxSize, null))
                     .close(waiter);
               } catch (FetchException fe) {
                 if (fe.newURI != null) {
@@ -240,17 +244,20 @@ public class ImageElement extends BaseUpdatableElement {
                     ImageElement.this.key = fe.newURI;
                     FProxyFetchWaiter waiter =
                         ImageElement.this.tracker.makeFetcher(
-                            ImageElement.this.key,
-                            ImageElement.this.maxSize,
-                            null,
+                            new FProxyFetchCriteria(
+                                ImageElement.this.key, ImageElement.this.maxSize, null),
                             REFILTER_POLICY.RE_FILTER);
                     ImageElement.this
                         .tracker
-                        .getFetchInProgress(ImageElement.this.key, ImageElement.this.maxSize, null)
+                        .getFetchInProgress(
+                            new FProxyFetchCriteria(
+                                ImageElement.this.key, ImageElement.this.maxSize, null))
                         .addListener(fetchListener);
                     ImageElement.this
                         .tracker
-                        .getFetchInProgress(ImageElement.this.key, ImageElement.this.maxSize, null)
+                        .getFetchInProgress(
+                            new FProxyFetchCriteria(
+                                ImageElement.this.key, ImageElement.this.maxSize, null))
                         .close(waiter);
                   } catch (FetchException _) {
                     wasError = true;
@@ -285,7 +292,8 @@ public class ImageElement extends BaseUpdatableElement {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Disposing ImageElement");
     }
-    FProxyFetchInProgress progress = tracker.getFetchInProgress(key, maxSize, null);
+    FProxyFetchInProgress progress =
+        tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, null));
     if (progress != null) {
       progress.removeListener(fetchListener);
       if (LOG.isDebugEnabled()) {
@@ -455,7 +463,9 @@ public class ImageElement extends BaseUpdatableElement {
   private FetchResources fetchResources(HTMLNode whenJsEnabled) {
     FetchResources resources = new FetchResources();
     try {
-      resources.waiter = tracker.makeFetcher(key, maxSize, null, REFILTER_POLICY.RE_FILTER);
+      resources.waiter =
+          tracker.makeFetcher(
+              new FProxyFetchCriteria(key, maxSize, null), REFILTER_POLICY.RE_FILTER);
       resources.result = resources.waiter.getResultFast();
     } catch (FetchException _) {
       whenJsEnabled.addChild("div", "error");
@@ -467,7 +477,8 @@ public class ImageElement extends BaseUpdatableElement {
     if (fetchResources == null) {
       return;
     }
-    FProxyFetchInProgress progress = tracker.getFetchInProgress(key, maxSize, null);
+    FProxyFetchInProgress progress =
+        tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, null));
     if (progress == null) {
       return;
     }

--- a/src/main/java/network/crypta/clients/http/updateableelements/ProgressBarElement.java
+++ b/src/main/java/network/crypta/clients/http/updateableelements/ProgressBarElement.java
@@ -2,6 +2,7 @@ package network.crypta.clients.http.updateableelements;
 
 import java.text.NumberFormat;
 import network.crypta.client.FetchContext;
+import network.crypta.clients.http.FProxyFetchCriteria;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchResult;
 import network.crypta.clients.http.FProxyFetchTracker;
@@ -68,9 +69,9 @@ public class ProgressBarElement extends BaseUpdatableElement {
    * element still renders on demand but no listener is registered and {@link #dispose()} becomes a
    * no-op.
    *
-   * <p>The {@code key}, {@code maxSize}, and {@code fctx} arguments are forwarded to {@link
-   * FProxyFetchTracker#getFetchInProgress(FreenetURI, long, FetchContext)} to select the correct
-   * in-progress fetch instance.
+   * <p>The {@code key}, {@code maxSize}, and {@code fctx} arguments are forwarded via {@link
+   * FProxyFetchCriteria} to {@link FProxyFetchTracker#getFetchInProgress(FProxyFetchCriteria)} to
+   * select the correct in-progress fetch instance.
    *
    * @param tracker tracker used to locate and observe the fetch progress for the given URI.
    * @param key URI identifying the fetch whose progress is displayed by this element.
@@ -103,7 +104,9 @@ public class ProgressBarElement extends BaseUpdatableElement {
     fetchListener =
         new NotifierFetchListener(
             ((SimpleToadletServer) ctx.getContainer()).getPushDataManager(), this);
-    tracker.getFetchInProgress(key, maxSize, fctx).addListener(fetchListener);
+    tracker
+        .getFetchInProgress(new FProxyFetchCriteria(key, maxSize, fctx))
+        .addListener(fetchListener);
   }
 
   /**
@@ -126,7 +129,8 @@ public class ProgressBarElement extends BaseUpdatableElement {
   public void updateState(boolean initial) {
     children.clear();
 
-    FProxyFetchInProgress progress = tracker.getFetchInProgress(key, maxSize, fctx);
+    FProxyFetchInProgress progress =
+        tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, fctx));
     FProxyFetchWaiter waiter = progress == null ? null : progress.getWaiter();
     FProxyFetchResult fr = waiter == null ? null : waiter.getResult();
     try {
@@ -259,7 +263,8 @@ public class ProgressBarElement extends BaseUpdatableElement {
   @Override
   public void dispose() {
     // Deregisters the FetchListener
-    FProxyFetchInProgress progress = tracker.getFetchInProgress(key, maxSize, fctx);
+    FProxyFetchInProgress progress =
+        tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, fctx));
     if (progress != null) {
       progress.removeListener(fetchListener);
     }

--- a/src/main/java/network/crypta/clients/http/updateableelements/ProgressInfoElement.java
+++ b/src/main/java/network/crypta/clients/http/updateableelements/ProgressInfoElement.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.http.updateableelements;
 
 import network.crypta.client.FetchContext;
+import network.crypta.clients.http.FProxyFetchCriteria;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchResult;
 import network.crypta.clients.http.FProxyFetchTracker;
@@ -87,7 +88,9 @@ public class ProgressInfoElement extends BaseUpdatableElement {
     fetchListener =
         new NotifierFetchListener(
             ((SimpleToadletServer) ctx.getContainer()).getPushDataManager(), this);
-    tracker.getFetchInProgress(key, maxSize, fctx).addListener(fetchListener);
+    tracker
+        .getFetchInProgress(new FProxyFetchCriteria(key, maxSize, fctx))
+        .addListener(fetchListener);
   }
 
   /**
@@ -108,7 +111,8 @@ public class ProgressInfoElement extends BaseUpdatableElement {
   public void updateState(boolean initial) {
     children.clear();
 
-    FProxyFetchWaiter waiter = tracker.makeWaiterForFetchInProgress(key, maxSize, fctx);
+    FProxyFetchWaiter waiter =
+        tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(key, maxSize, fctx));
     FProxyFetchResult fr = waiter == null ? null : waiter.getResult();
     if (fr == null) {
       addChild("div", "No fetcher found");
@@ -152,8 +156,8 @@ public class ProgressInfoElement extends BaseUpdatableElement {
     else addChild("p", FProxyToadlet.l10n("progressCheckingStore"));
     if (!fr.finalizedBlocks) addChild("p", FProxyToadlet.l10n("progressNotFinalized"));
 
-    tracker.getFetchInProgress(key, maxSize, fctx).close(waiter);
-    tracker.getFetchInProgress(key, maxSize, fctx).close(fr);
+    tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, fctx)).close(waiter);
+    tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, fctx)).close(fr);
   }
 
   /**
@@ -198,7 +202,8 @@ public class ProgressInfoElement extends BaseUpdatableElement {
    */
   @Override
   public void dispose() {
-    FProxyFetchInProgress progress = tracker.getFetchInProgress(key, maxSize, fctx);
+    FProxyFetchInProgress progress =
+        tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, fctx));
     if (progress != null) {
       progress.removeListener(fetchListener);
     }

--- a/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
@@ -132,8 +132,9 @@ class FProxyFetchInProgressTest {
     RequestClient requestClient = Mockito.mock(RequestClient.class);
     FreenetURI uri = new FreenetURI("KSK", "doc");
 
+    FProxyFetchCriteria criteria = new FProxyFetchCriteria(uri, 1024L, context);
     return new FProxyFetchInProgress(
-        tracker, uri, 1024L, 1L, clientContext, context, requestClient, REFILTER_POLICY.ACCEPT_OLD);
+        tracker, criteria, 1L, clientContext, requestClient, REFILTER_POLICY.ACCEPT_OLD);
   }
 
   private static FetchContext newFetchContext() {

--- a/src/test/java/network/crypta/clients/http/FProxyFetchTrackerTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchTrackerTest.java
@@ -47,7 +47,8 @@ class FProxyFetchTrackerTest {
 
     getFetchers(tracker).put(key, fetch);
 
-    FProxyFetchInProgress result = tracker.getFetchInProgress(key, 1024L, fetchContext);
+    FProxyFetchInProgress result =
+        tracker.getFetchInProgress(new FProxyFetchCriteria(key, 1024L, fetchContext));
 
     assertSame(fetch, result);
   }
@@ -67,7 +68,8 @@ class FProxyFetchTrackerTest {
 
     getFetchers(tracker).put(key, fetch);
 
-    FProxyFetchInProgress result = tracker.getFetchInProgress(key, 123L, null);
+    FProxyFetchInProgress result =
+        tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, null));
 
     assertSame(fetch, result);
   }
@@ -89,7 +91,8 @@ class FProxyFetchTrackerTest {
 
     getFetchers(tracker).put(key, fetch);
 
-    FProxyFetchInProgress result = tracker.getFetchInProgress(key, 512L, requestedContext);
+    FProxyFetchInProgress result =
+        tracker.getFetchInProgress(new FProxyFetchCriteria(key, 512L, requestedContext));
 
     assertNull(result);
   }
@@ -114,7 +117,8 @@ class FProxyFetchTrackerTest {
 
     FProxyFetchWaiter result =
         tracker.makeFetcher(
-            key, 1024L, fetchContext, FProxyFetchInProgress.REFILTER_POLICY.RE_FETCH);
+            new FProxyFetchCriteria(key, 1024L, fetchContext),
+            FProxyFetchInProgress.REFILTER_POLICY.RE_FETCH);
 
     assertSame(waiter, result);
     verify(fetch, never()).start(context);
@@ -146,7 +150,8 @@ class FProxyFetchTrackerTest {
               FetchException.class,
               () ->
                   tracker.makeFetcher(
-                      key, 2048L, fetchContext, FProxyFetchInProgress.REFILTER_POLICY.RE_FILTER));
+                      new FProxyFetchCriteria(key, 2048L, fetchContext),
+                      FProxyFetchInProgress.REFILTER_POLICY.RE_FILTER));
 
       assertSame(failure, thrown);
       assertTrue(getFetchers(tracker).values().isEmpty(), "fetcher should be removed on failure");
@@ -204,8 +209,8 @@ class FProxyFetchTrackerTest {
     tracker.run();
 
     verify(cancellable, times(1)).finishCancel();
-    assertNull(tracker.getFetchInProgress(key1, 0L, null));
-    assertSame(persistent, tracker.getFetchInProgress(key2, 0L, null));
+    assertNull(tracker.getFetchInProgress(new FProxyFetchCriteria(key1, 0L, null)));
+    assertSame(persistent, tracker.getFetchInProgress(new FProxyFetchCriteria(key2, 0L, null)));
     verify(ticker, times(2)).queueTimedJob(tracker, FProxyFetchInProgress.LIFETIME);
   }
 

--- a/src/test/java/network/crypta/clients/http/updateableelements/ImageElementTest.java
+++ b/src/test/java/network/crypta/clients/http/updateableelements/ImageElementTest.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.clients.http.FProxyFetchCriteria;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.FProxyFetchResult;
@@ -217,7 +218,7 @@ class ImageElementTest {
       throws FetchException {
     // Arrange
     ImageElement element = ImageElement.createImageElement(tracker, key, 123L, ctx, false);
-    when(tracker.makeFetcher(key, 123L, null, REFILTER_POLICY.RE_FILTER))
+    when(tracker.makeFetcher(new FProxyFetchCriteria(key, 123L, null), REFILTER_POLICY.RE_FILTER))
         .thenThrow(new FetchException(FetchExceptionMode.DATA_NOT_FOUND));
 
     // Act
@@ -242,9 +243,12 @@ class ImageElementTest {
     when(bucket.size()).thenReturn(123L);
     FProxyFetchResult result = newFinishedResultWithData(progress, bucket);
 
-    when(tracker.makeFetcher(key, maxSize, null, REFILTER_POLICY.RE_FILTER)).thenReturn(waiter);
+    when(tracker.makeFetcher(
+            new FProxyFetchCriteria(key, maxSize, null), REFILTER_POLICY.RE_FILTER))
+        .thenReturn(waiter);
     when(waiter.getResultFast()).thenReturn(result);
-    when(tracker.getFetchInProgress(key, maxSize, null)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, null)))
+        .thenReturn(progress);
 
     // Act
     element.updateState(false);
@@ -270,9 +274,12 @@ class ImageElementTest {
     FetchException failure = new FetchException(FetchExceptionMode.DATA_NOT_FOUND);
     FProxyFetchResult result = newProgressOrFailureResult(progress, 10, 1, failure);
 
-    when(tracker.makeFetcher(key, maxSize, null, REFILTER_POLICY.RE_FILTER)).thenReturn(waiter);
+    when(tracker.makeFetcher(
+            new FProxyFetchCriteria(key, maxSize, null), REFILTER_POLICY.RE_FILTER))
+        .thenReturn(waiter);
     when(waiter.getResultFast()).thenReturn(result);
-    when(tracker.getFetchInProgress(key, maxSize, null)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, null)))
+        .thenReturn(progress);
 
     // Act
     element.updateState(false);
@@ -298,9 +305,12 @@ class ImageElementTest {
     FProxyFetchWaiter waiter = mock(FProxyFetchWaiter.class);
     FProxyFetchResult result = newProgressOrFailureResult(progress, 20, 5, null);
 
-    when(tracker.makeFetcher(key, maxSize, null, REFILTER_POLICY.RE_FILTER)).thenReturn(waiter);
+    when(tracker.makeFetcher(
+            new FProxyFetchCriteria(key, maxSize, null), REFILTER_POLICY.RE_FILTER))
+        .thenReturn(waiter);
     when(waiter.getResultFast()).thenReturn(result);
-    when(tracker.getFetchInProgress(key, maxSize, null)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, null)))
+        .thenReturn(progress);
 
     // Act
     element.updateState(false);
@@ -326,7 +336,7 @@ class ImageElementTest {
   void dispose_whenNoFetchInProgress_doesNothing() {
     // Arrange
     ImageElement element = ImageElement.createImageElement(tracker, key, 123L, ctx, false);
-    when(tracker.getFetchInProgress(key, 123L, null)).thenReturn(null);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, null))).thenReturn(null);
 
     // Act
     element.dispose();
@@ -341,7 +351,8 @@ class ImageElementTest {
     long maxSize = 123L;
     ImageElement element = ImageElement.createImageElement(tracker, key, maxSize, ctx, false);
     FProxyFetchInProgress progress = mock(FProxyFetchInProgress.class);
-    when(tracker.getFetchInProgress(key, maxSize, null)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, null)))
+        .thenReturn(progress);
     when(progress.canCancel()).thenReturn(true);
 
     // Act

--- a/src/test/java/network/crypta/clients/http/updateableelements/ProgressBarElementTest.java
+++ b/src/test/java/network/crypta/clients/http/updateableelements/ProgressBarElementTest.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
+import network.crypta.clients.http.FProxyFetchCriteria;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchListener;
 import network.crypta.clients.http.FProxyFetchResult;
@@ -88,7 +89,8 @@ class ProgressBarElementTest {
     // Arrange
     when(key.toString()).thenReturn(KEY_STRING);
     when(toadletContext.getUniqueId()).thenReturn(REQUEST_ID);
-    when(tracker.getFetchInProgress(key, 123L, fetchContext)).thenReturn(null);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext)))
+        .thenReturn(null);
 
     // Act
     ProgressBarElement element =
@@ -104,7 +106,8 @@ class ProgressBarElementTest {
     // Arrange
     when(key.toString()).thenReturn(KEY_STRING);
     when(toadletContext.getUniqueId()).thenReturn(REQUEST_ID);
-    when(tracker.getFetchInProgress(key, 123L, fetchContext)).thenReturn(null);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext)))
+        .thenReturn(null);
 
     ProgressBarElement element =
         new ProgressBarElement(tracker, key, fetchContext, 123L, toadletContext, false);
@@ -122,7 +125,7 @@ class ProgressBarElementTest {
     HTMLNode messageText = getSingleChild(messageDiv);
     assertEquals("#", messageText.getName());
     assertEquals("No fetcher found", messageText.getContent());
-    verify(tracker).getFetchInProgress(key, 123L, fetchContext);
+    verify(tracker).getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext));
   }
 
   @Test
@@ -133,7 +136,8 @@ class ProgressBarElementTest {
     when(toadletContext.getUniqueId()).thenReturn(REQUEST_ID);
 
     AtomicReference<FProxyFetchInProgress> progressRef = new AtomicReference<>(null);
-    when(tracker.getFetchInProgress(key, 123L, fetchContext)).thenAnswer(i -> progressRef.get());
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext)))
+        .thenAnswer(i -> progressRef.get());
 
     ProgressBarElement element =
         new ProgressBarElement(tracker, key, fetchContext, 123L, toadletContext, false);
@@ -162,7 +166,8 @@ class ProgressBarElementTest {
     when(key.toString()).thenReturn(KEY_STRING);
     when(toadletContext.getUniqueId()).thenReturn(REQUEST_ID);
 
-    when(tracker.getFetchInProgress(key, 123L, fetchContext)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext)))
+        .thenReturn(progress);
     when(progress.getWaiter()).thenReturn(waiter);
     AtomicReference<FProxyFetchResult> resultRef = new AtomicReference<>();
     when(waiter.getResult()).thenAnswer(i -> resultRef.get());
@@ -213,7 +218,8 @@ class ProgressBarElementTest {
     when(key.toString()).thenReturn(KEY_STRING);
     when(toadletContext.getUniqueId()).thenReturn(REQUEST_ID);
 
-    when(tracker.getFetchInProgress(key, 123L, fetchContext)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext)))
+        .thenReturn(progress);
     when(progress.getWaiter()).thenReturn(waiter);
 
     FProxyFetchResult result =
@@ -276,7 +282,8 @@ class ProgressBarElementTest {
     when(toadletContext.getContainer()).thenReturn(server);
     when(server.getPushDataManager()).thenReturn(pushDataManager);
 
-    when(tracker.getFetchInProgress(key, 123L, fetchContext)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext)))
+        .thenReturn(progress);
     when(progress.getWaiter()).thenReturn(waiter);
     when(waiter.getResult())
         .thenReturn(
@@ -322,7 +329,8 @@ class ProgressBarElementTest {
     // Arrange
     when(key.toString()).thenReturn(KEY_STRING);
     when(toadletContext.getUniqueId()).thenReturn(REQUEST_ID);
-    when(tracker.getFetchInProgress(key, 123L, fetchContext)).thenReturn(null);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext)))
+        .thenReturn(null);
     ProgressBarElement element =
         new ProgressBarElement(tracker, key, fetchContext, 123L, toadletContext, false);
 
@@ -338,7 +346,8 @@ class ProgressBarElementTest {
     // Arrange
     when(key.toString()).thenReturn(KEY_STRING);
     when(toadletContext.getUniqueId()).thenReturn(REQUEST_ID);
-    when(tracker.getFetchInProgress(key, 123L, fetchContext)).thenReturn(null);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext)))
+        .thenReturn(null);
     long maxSize = 123L;
     ProgressBarElement element =
         new ProgressBarElement(tracker, key, fetchContext, maxSize, toadletContext, false);

--- a/src/test/java/network/crypta/clients/http/updateableelements/ProgressInfoElementTest.java
+++ b/src/test/java/network/crypta/clients/http/updateableelements/ProgressInfoElementTest.java
@@ -14,6 +14,7 @@ import java.util.Deque;
 import java.util.function.Predicate;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
+import network.crypta.clients.http.FProxyFetchCriteria;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchResult;
 import network.crypta.clients.http.FProxyFetchTracker;
@@ -59,7 +60,8 @@ class ProgressInfoElementTest {
   void getUpdaterId_whenCalled_expectDerivedFromKey() {
     FreenetURI uri = ksk("doc");
     stubUniqueId();
-    when(tracker.makeWaiterForFetchInProgress(uri, 123L, fetchContext)).thenReturn(null);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, 123L, fetchContext)))
+        .thenReturn(null);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, 123L, false, toadletContext, false);
@@ -73,7 +75,8 @@ class ProgressInfoElementTest {
   void getUpdaterType_whenCalled_expectReplacerUpdater() {
     FreenetURI uri = ksk("doc");
     stubUniqueId();
-    when(tracker.makeWaiterForFetchInProgress(uri, 1L, fetchContext)).thenReturn(null);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, 1L, fetchContext)))
+        .thenReturn(null);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, 1L, false, toadletContext, false);
@@ -87,7 +90,8 @@ class ProgressInfoElementTest {
     FreenetURI uri = ksk("doc");
     long maxSize = 42L;
     stubUniqueId();
-    when(tracker.makeWaiterForFetchInProgress(uri, maxSize, fetchContext)).thenReturn(null);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(null);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, maxSize, false, toadletContext, false);
@@ -108,14 +112,15 @@ class ProgressInfoElementTest {
   void updateState_whenNoWaiter_expectNoFetcherFoundMessage() {
     FreenetURI uri = ksk("no-waiter");
     stubUniqueId();
-    when(tracker.makeWaiterForFetchInProgress(uri, 1024L, fetchContext)).thenReturn(null);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, 1024L, fetchContext)))
+        .thenReturn(null);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, 1024L, false, toadletContext, false);
 
     assertTrue(element.generate().contains("No fetcher found"));
-    verify(tracker).makeWaiterForFetchInProgress(uri, 1024L, fetchContext);
-    verify(tracker, never()).getFetchInProgress(uri, 1024L, fetchContext);
+    verify(tracker).makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, 1024L, fetchContext));
+    verify(tracker, never()).getFetchInProgress(new FProxyFetchCriteria(uri, 1024L, fetchContext));
   }
 
   @Test
@@ -125,7 +130,8 @@ class ProgressInfoElementTest {
     FreenetURI uri = ksk("null-result");
     stubUniqueId();
     FProxyFetchWaiter waiter = mock(FProxyFetchWaiter.class);
-    when(tracker.makeWaiterForFetchInProgress(uri, 1024L, fetchContext)).thenReturn(waiter);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, 1024L, fetchContext)))
+        .thenReturn(waiter);
     when(waiter.getResult()).thenReturn(null);
 
     ProgressInfoElement element =
@@ -133,7 +139,7 @@ class ProgressInfoElementTest {
 
     assertTrue(element.generate().contains("No fetcher found"));
     verify(waiter).getResult();
-    verify(tracker, never()).getFetchInProgress(uri, 1024L, fetchContext);
+    verify(tracker, never()).getFetchInProgress(new FProxyFetchCriteria(uri, 1024L, fetchContext));
   }
 
   @Test
@@ -160,11 +166,13 @@ class ProgressInfoElementTest {
                 .eta(etaTotal));
 
     FProxyFetchWaiter waiter = mock(FProxyFetchWaiter.class);
-    when(tracker.makeWaiterForFetchInProgress(uri, maxSize, fetchContext)).thenReturn(waiter);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(waiter);
     when(waiter.getResult()).thenReturn(result);
 
     FProxyFetchInProgress progress = mock(FProxyFetchInProgress.class);
-    when(tracker.getFetchInProgress(uri, maxSize, fetchContext)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(progress);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, maxSize, false, toadletContext, false);
@@ -204,11 +212,13 @@ class ProgressInfoElementTest {
                 .eta(-1L));
 
     FProxyFetchWaiter waiter = mock(FProxyFetchWaiter.class);
-    when(tracker.makeWaiterForFetchInProgress(uri, maxSize, fetchContext)).thenReturn(waiter);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(waiter);
     when(waiter.getResult()).thenReturn(result);
 
     FProxyFetchInProgress progress = mock(FProxyFetchInProgress.class);
-    when(tracker.getFetchInProgress(uri, maxSize, fetchContext)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(progress);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, maxSize, false, toadletContext, false);
@@ -241,11 +251,13 @@ class ProgressInfoElementTest {
                 .eta(-1L));
 
     FProxyFetchWaiter waiter = mock(FProxyFetchWaiter.class);
-    when(tracker.makeWaiterForFetchInProgress(uri, maxSize, fetchContext)).thenReturn(waiter);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(waiter);
     when(waiter.getResult()).thenReturn(result);
 
     FProxyFetchInProgress progress = mock(FProxyFetchInProgress.class);
-    when(tracker.getFetchInProgress(uri, maxSize, fetchContext)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(progress);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, maxSize, false, toadletContext, false);
@@ -283,11 +295,13 @@ class ProgressInfoElementTest {
                 .eta(-1L));
 
     FProxyFetchWaiter waiter = mock(FProxyFetchWaiter.class);
-    when(tracker.makeWaiterForFetchInProgress(uri, maxSize, fetchContext)).thenReturn(waiter);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(waiter);
     when(waiter.getResult()).thenReturn(result);
 
     FProxyFetchInProgress progress = mock(FProxyFetchInProgress.class);
-    when(tracker.getFetchInProgress(uri, maxSize, fetchContext)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(progress);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, maxSize, true, toadletContext, false);
@@ -306,10 +320,12 @@ class ProgressInfoElementTest {
     FreenetURI uri = ksk("dispose");
     long maxSize = 10L;
     stubUniqueId();
-    when(tracker.makeWaiterForFetchInProgress(uri, maxSize, fetchContext)).thenReturn(null);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(null);
 
     FProxyFetchInProgress progress = mock(FProxyFetchInProgress.class);
-    when(tracker.getFetchInProgress(uri, maxSize, fetchContext)).thenReturn(progress);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(progress);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, maxSize, false, toadletContext, false);
@@ -324,14 +340,16 @@ class ProgressInfoElementTest {
     FreenetURI uri = ksk("dispose-null");
     long maxSize = 10L;
     stubUniqueId();
-    when(tracker.makeWaiterForFetchInProgress(uri, maxSize, fetchContext)).thenReturn(null);
-    when(tracker.getFetchInProgress(uri, maxSize, fetchContext)).thenReturn(null);
+    when(tracker.makeWaiterForFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(null);
+    when(tracker.getFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext)))
+        .thenReturn(null);
 
     ProgressInfoElement element =
         new ProgressInfoElement(tracker, uri, fetchContext, maxSize, false, toadletContext, false);
     element.dispose();
 
-    verify(tracker).getFetchInProgress(uri, maxSize, fetchContext);
+    verify(tracker).getFetchInProgress(new FProxyFetchCriteria(uri, maxSize, fetchContext));
   }
 
   private void stubUniqueId() {


### PR DESCRIPTION
## Summary
- introduce an immutable FProxy fetch criteria record for reuse
- refactor fetch tracker/in-progress flow to use criteria objects
- update FProxy UI elements and tests to pass criteria consistently