### PR TITLE
refactor(http): bundle fetch snapshot params

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
@@ -279,28 +279,21 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
 
   synchronized FProxyFetchResult innerGetResult(boolean hasWaited) {
     lastTouched = System.currentTimeMillis();
+    FProxyFetchSnapshotInfo info =
+        new FProxyFetchSnapshotInfo(mimeType, timeStarted, goneToNetwork, getETA(), hasWaited);
     FProxyFetchResult res;
-    if (data != null)
-      res =
-          new FProxyFetchResult(
-              this, data, mimeType, timeStarted, goneToNetwork, getETA(), hasWaited);
-    else {
-      res =
-          new FProxyFetchResult(
-              this,
-              mimeType,
-              size,
-              timeStarted,
-              goneToNetwork,
+    if (data != null) {
+      res = new FProxyFetchResult(this, data, info);
+    } else {
+      FProxyFetchProgressCounts counts =
+          new FProxyFetchProgressCounts(
               totalBlocks,
               requiredBlocks,
               fetchedBlocks,
               failedBlocks,
               fatallyFailedBlocks,
-              finalizedBlocks,
-              failed,
-              getETA(),
-              hasWaited);
+              finalizedBlocks);
+      res = new FProxyFetchResult(this, info, size, counts, failed);
     }
     results.add(res);
     if (data != null || failed != null) {

--- a/src/main/java/network/crypta/clients/http/FProxyFetchProgressCounts.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchProgressCounts.java
@@ -1,0 +1,23 @@
+package network.crypta.clients.http;
+
+/**
+ * Captures block-level progress counters for an FProxy fetch snapshot.
+ *
+ * <p>The counts describe how many blocks have been discovered, fetched, or failed at the moment the
+ * snapshot is created. The {@code finalizedBlocks} flag indicates whether the total block count is
+ * final or still subject to discovery.
+ *
+ * @param totalBlocks total number of blocks known at snapshot time
+ * @param requiredBlocks minimum blocks required to finish successfully
+ * @param fetchedBlocks blocks fetched successfully at snapshot time
+ * @param failedBlocks retryable failures at snapshot time
+ * @param fatallyFailedBlocks permanent failures at snapshot time
+ * @param finalizedBlocks whether the total block count is final
+ */
+public record FProxyFetchProgressCounts(
+    int totalBlocks,
+    int requiredBlocks,
+    int fetchedBlocks,
+    int failedBlocks,
+    int fatallyFailedBlocks,
+    boolean finalizedBlocks) {}

--- a/src/main/java/network/crypta/clients/http/FProxyFetchResult.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchResult.java
@@ -56,8 +56,8 @@ public class FProxyFetchResult {
   public final boolean goneToNetwork;
 
   /**
-   * Total number of data blocks expected for the fetch according to the manifest at the time this
-   * snapshot was produced; useful for progress percentages when combined with block counters.
+   * The total number of data blocks expected for the fetch according to the manifest at the time
+   * this snapshot was produced; useful for progress percentages when combined with block counters.
    */
   public final int totalBlocks;
 
@@ -104,8 +104,8 @@ public class FProxyFetchResult {
   final boolean hasWaited;
 
   /**
-   * Estimated remaining time in milliseconds at snapshot creation; negative or zero values can be
-   * used by callers to signal that no reliable estimate is currently available.
+   * Estimated remaining time in milliseconds at snapshot creation; callers can use negative or zero
+   * values to signal that no reliable estimate is currently available.
    */
   public final long eta;
 
@@ -113,60 +113,44 @@ public class FProxyFetchResult {
   private final boolean finished;
 
   /** Constructor when we are returning the data */
-  FProxyFetchResult(
-      FProxyFetchInProgress parent,
-      Bucket data,
-      String mimeType,
-      long timeStarted,
-      boolean goneToNetwork,
-      long eta,
-      boolean hasWaited) {
+  FProxyFetchResult(FProxyFetchInProgress parent, Bucket data, FProxyFetchSnapshotInfo info) {
     assert (data != null);
     this.data = data;
-    this.mimeType = mimeType;
+    this.mimeType = info.mimeType();
     this.size = data.size();
-    this.timeStarted = timeStarted;
-    this.goneToNetwork = goneToNetwork;
+    this.timeStarted = info.timeStarted();
+    this.goneToNetwork = info.goneToNetwork();
     totalBlocks = requiredBlocks = fetchedBlocks = failedBlocks = fatallyFailedBlocks = 0;
     finalizedBlocks = true;
     failed = null;
     this.progress = parent;
-    this.eta = eta;
-    this.hasWaited = hasWaited;
+    this.eta = info.eta();
+    this.hasWaited = info.hasWaited();
     finished = true;
   }
 
   /** Constructor when we are not returning the data, because it is still running, or it failed */
   FProxyFetchResult(
       FProxyFetchInProgress parent,
-      String mimeType,
+      FProxyFetchSnapshotInfo info,
       long size,
-      long timeStarted,
-      boolean goneToNetwork,
-      int totalBlocks,
-      int requiredBlocks,
-      int fetchedBlocks,
-      int failedBlocks,
-      int fatallyFailedBlocks,
-      boolean finalizedBlocks,
-      FetchException failed,
-      long eta,
-      boolean hasWaited) {
+      FProxyFetchProgressCounts counts,
+      FetchException failed) {
     this.data = null;
-    this.mimeType = mimeType;
+    this.mimeType = info.mimeType();
     this.size = size;
-    this.timeStarted = timeStarted;
-    this.goneToNetwork = goneToNetwork;
-    this.totalBlocks = totalBlocks;
-    this.requiredBlocks = requiredBlocks;
-    this.fetchedBlocks = fetchedBlocks;
-    this.failedBlocks = failedBlocks;
-    this.fatallyFailedBlocks = fatallyFailedBlocks;
-    this.finalizedBlocks = finalizedBlocks;
+    this.timeStarted = info.timeStarted();
+    this.goneToNetwork = info.goneToNetwork();
+    this.totalBlocks = counts.totalBlocks();
+    this.requiredBlocks = counts.requiredBlocks();
+    this.fetchedBlocks = counts.fetchedBlocks();
+    this.failedBlocks = counts.failedBlocks();
+    this.fatallyFailedBlocks = counts.fatallyFailedBlocks();
+    this.finalizedBlocks = counts.finalizedBlocks();
     this.failed = failed;
     this.progress = parent;
-    this.eta = eta;
-    this.hasWaited = hasWaited;
+    this.eta = info.eta();
+    this.hasWaited = info.hasWaited();
     finished = (failed != null);
   }
 
@@ -231,9 +215,9 @@ public class FProxyFetchResult {
    * generated.
    *
    * <p>A finished snapshot may contain data, an exception, or neither if the operation concluded
-   * without payload. Use {@link #hasData()} to check for successful completion and {@link #failed}
-   * to inspect failures. Because the value is captured at creation time, callers polling for
-   * progress should request a new snapshot to observe later state changes.
+   * without a payload. Use {@link #hasData()} to check for successful completion and {@link
+   * #failed} to inspect failures. Because the value is captured at creation time, callers polling
+   * for progress should request a new snapshot to observe later state changes.
    *
    * @return {@code true} if the fetch was marked finished at snapshot time; otherwise {@code
    *     false}.
@@ -262,7 +246,7 @@ public class FProxyFetchResult {
    * reused across polling cycles. The value defaults to zero until explicitly set via {@link
    * #setFetchCount(int)}.
    *
-   * @return current fetch-count marker associated with this snapshot instance.
+   * @return the current fetch-count marker associated with this snapshot instance.
    */
   public int getFetchCount() {
     return fetchedCount;

--- a/src/main/java/network/crypta/clients/http/FProxyFetchSnapshotInfo.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchSnapshotInfo.java
@@ -1,0 +1,17 @@
+package network.crypta.clients.http;
+
+/**
+ * Captures the shared metadata for a single FProxy fetch snapshot.
+ *
+ * <p>The snapshot info records timing, network, and MIME metadata captured when a snapshot is
+ * created. It intentionally excludes block counts and payload data so it can be reused for both
+ * completed and in-progress fetch results.
+ *
+ * @param mimeType MIME type recorded for the snapshot; may be null if unknown
+ * @param timeStarted epoch milliseconds when the fetch started
+ * @param goneToNetwork whether the fetch hit the network
+ * @param eta estimated remaining time in milliseconds at snapshot creation
+ * @param hasWaited whether the caller was forced to wait before receiving the snapshot
+ */
+public record FProxyFetchSnapshotInfo(
+    String mimeType, long timeStarted, boolean goneToNetwork, long eta, boolean hasWaited) {}

--- a/src/test/java/network/crypta/clients/http/FProxyFetchResultTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchResultTest.java
@@ -30,7 +30,8 @@ class FProxyFetchResultTest {
     Mockito.when(bucket.size()).thenReturn(expectedSize);
 
     FProxyFetchResult result =
-        new FProxyFetchResult(progress, bucket, "text/plain", 100L, true, 200L, false);
+        new FProxyFetchResult(
+            progress, bucket, new FProxyFetchSnapshotInfo("text/plain", 100L, true, 200L, false));
 
     // Act & Assert
     assertTrue(result.hasData());
@@ -52,19 +53,10 @@ class FProxyFetchResultTest {
     FProxyFetchResult result =
         new FProxyFetchResult(
             progress,
-            "application/octet-stream",
+            new FProxyFetchSnapshotInfo("application/octet-stream", 50L, false, 500L, true),
             128L,
-            50L,
-            false,
-            10,
-            6,
-            4,
-            1,
-            0,
-            true,
-            exception,
-            500L,
-            true);
+            new FProxyFetchProgressCounts(10, 6, 4, 1, 0, true),
+            exception);
 
     assertFalse(result.hasData());
     assertTrue(result.isFinished());
@@ -85,7 +77,11 @@ class FProxyFetchResultTest {
 
     FProxyFetchResult result =
         new FProxyFetchResult(
-            progress, "text/html", -1L, 75L, true, 20, 15, 5, 0, 0, false, null, 1000L, false);
+            progress,
+            new FProxyFetchSnapshotInfo("text/html", 75L, true, 1000L, false),
+            -1L,
+            new FProxyFetchProgressCounts(20, 15, 5, 0, 0, false),
+            null);
 
     assertFalse(result.hasData());
     assertFalse(result.isFinished());
@@ -102,7 +98,8 @@ class FProxyFetchResultTest {
     Mockito.when(bucket.size()).thenReturn(1L);
 
     FProxyFetchResult result =
-        new FProxyFetchResult(progress, bucket, "text/plain", 0L, false, -1L, true);
+        new FProxyFetchResult(
+            progress, bucket, new FProxyFetchSnapshotInfo("text/plain", 0L, false, -1L, true));
 
     result.close();
 
@@ -115,7 +112,11 @@ class FProxyFetchResultTest {
 
     FProxyFetchResult result =
         new FProxyFetchResult(
-            progress, "text/plain", 0L, 0L, false, 0, 0, 0, 0, 0, true, null, -1L, false);
+            progress,
+            new FProxyFetchSnapshotInfo("text/plain", 0L, false, -1L, false),
+            0L,
+            new FProxyFetchProgressCounts(0, 0, 0, 0, 0, true),
+            null);
 
     result.setFetchCount(7);
 

--- a/src/test/java/network/crypta/clients/http/updateableelements/ImageElementTest.java
+++ b/src/test/java/network/crypta/clients/http/updateableelements/ImageElementTest.java
@@ -20,7 +20,9 @@ import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.clients.http.FProxyFetchCriteria;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
+import network.crypta.clients.http.FProxyFetchProgressCounts;
 import network.crypta.clients.http.FProxyFetchResult;
+import network.crypta.clients.http.FProxyFetchSnapshotInfo;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.FProxyFetchWaiter;
 import network.crypta.clients.http.ToadletContext;
@@ -417,7 +419,7 @@ class ImageElementTest {
       FProxyFetchInProgress parent, Bucket bucket) {
     try {
       return RESULT_CTOR_FINISHED_WITH_DATA.newInstance(
-          parent, bucket, "image/png", 1000L, true, 0L, false);
+          parent, bucket, new FProxyFetchSnapshotInfo("image/png", 1000L, true, 0L, false));
     } catch (ReflectiveOperationException e) {
       throw new AssertionError("Failed to construct FProxyFetchResult (finished-with-data)", e);
     }
@@ -428,19 +430,10 @@ class ImageElementTest {
     try {
       return RESULT_CTOR_PROGRESS_OR_FAILURE.newInstance(
           parent,
-          "image/png",
+          new FProxyFetchSnapshotInfo("image/png", 1000L, true, 0L, false),
           -1L,
-          1000L,
-          true,
-          requiredBlocks,
-          requiredBlocks,
-          fetchedBlocks,
-          0,
-          0,
-          false,
-          failure,
-          0L,
-          false);
+          new FProxyFetchProgressCounts(requiredBlocks, requiredBlocks, fetchedBlocks, 0, 0, false),
+          failure);
     } catch (ReflectiveOperationException e) {
       throw new AssertionError("Failed to construct FProxyFetchResult (progress-or-failure)", e);
     }
@@ -450,13 +443,7 @@ class ImageElementTest {
     try {
       Constructor<FProxyFetchResult> ctor =
           FProxyFetchResult.class.getDeclaredConstructor(
-              FProxyFetchInProgress.class,
-              Bucket.class,
-              String.class,
-              long.class,
-              boolean.class,
-              long.class,
-              boolean.class);
+              FProxyFetchInProgress.class, Bucket.class, FProxyFetchSnapshotInfo.class);
       ctor.setAccessible(true);
       return ctor;
     } catch (ReflectiveOperationException e) {
@@ -470,19 +457,10 @@ class ImageElementTest {
       Constructor<FProxyFetchResult> ctor =
           FProxyFetchResult.class.getDeclaredConstructor(
               FProxyFetchInProgress.class,
-              String.class,
+              FProxyFetchSnapshotInfo.class,
               long.class,
-              long.class,
-              boolean.class,
-              int.class,
-              int.class,
-              int.class,
-              int.class,
-              int.class,
-              boolean.class,
-              FetchException.class,
-              long.class,
-              boolean.class);
+              FProxyFetchProgressCounts.class,
+              FetchException.class);
       ctor.setAccessible(true);
       return ctor;
     } catch (ReflectiveOperationException e) {

--- a/src/test/java/network/crypta/clients/http/updateableelements/ProgressBarElementTest.java
+++ b/src/test/java/network/crypta/clients/http/updateableelements/ProgressBarElementTest.java
@@ -23,7 +23,9 @@ import network.crypta.client.FetchException;
 import network.crypta.clients.http.FProxyFetchCriteria;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchListener;
+import network.crypta.clients.http.FProxyFetchProgressCounts;
 import network.crypta.clients.http.FProxyFetchResult;
+import network.crypta.clients.http.FProxyFetchSnapshotInfo;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.FProxyFetchWaiter;
 import network.crypta.clients.http.SimpleToadletServer;
@@ -137,7 +139,7 @@ class ProgressBarElementTest {
 
     AtomicReference<FProxyFetchInProgress> progressRef = new AtomicReference<>(null);
     when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, 123L, fetchContext)))
-        .thenAnswer(i -> progressRef.get());
+        .thenAnswer(_ -> progressRef.get());
 
     ProgressBarElement element =
         new ProgressBarElement(tracker, key, fetchContext, 123L, toadletContext, false);
@@ -170,7 +172,7 @@ class ProgressBarElementTest {
         .thenReturn(progress);
     when(progress.getWaiter()).thenReturn(waiter);
     AtomicReference<FProxyFetchResult> resultRef = new AtomicReference<>();
-    when(waiter.getResult()).thenAnswer(i -> resultRef.get());
+    when(waiter.getResult()).thenAnswer(_ -> resultRef.get());
 
     resultRef.set(
         newFetchResultSnapshot(
@@ -400,34 +402,22 @@ class ProgressBarElementTest {
     Constructor<FProxyFetchResult> ctor =
         FProxyFetchResult.class.getDeclaredConstructor(
             FProxyFetchInProgress.class,
-            String.class,
+            FProxyFetchSnapshotInfo.class,
             long.class,
-            long.class,
-            boolean.class,
-            int.class,
-            int.class,
-            int.class,
-            int.class,
-            int.class,
-            boolean.class,
-            FetchException.class,
-            long.class,
-            boolean.class);
+            FProxyFetchProgressCounts.class,
+            FetchException.class);
     ctor.setAccessible(true);
     return ctor.newInstance(
         progress,
-        "text/plain",
+        new FProxyFetchSnapshotInfo("text/plain", 0L, false, -1L, false),
         /* size= */ 0L,
-        /* timeStarted= */ 0L,
-        /* goneToNetwork= */ false,
-        /* totalBlocks= */ requiredBlocks,
-        requiredBlocks,
-        fetchedBlocks,
-        failedBlocks,
-        fatallyFailedBlocks,
-        finalizedBlocks,
-        failedException,
-        /* eta= */ -1L,
-        /* hasWaited= */ false);
+        new FProxyFetchProgressCounts(
+            /* totalBlocks= */ requiredBlocks,
+            requiredBlocks,
+            fetchedBlocks,
+            failedBlocks,
+            fatallyFailedBlocks,
+            finalizedBlocks),
+        failedException);
   }
 }

--- a/src/test/java/network/crypta/clients/http/updateableelements/ProgressInfoElementTest.java
+++ b/src/test/java/network/crypta/clients/http/updateableelements/ProgressInfoElementTest.java
@@ -16,7 +16,9 @@ import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
 import network.crypta.clients.http.FProxyFetchCriteria;
 import network.crypta.clients.http.FProxyFetchInProgress;
+import network.crypta.clients.http.FProxyFetchProgressCounts;
 import network.crypta.clients.http.FProxyFetchResult;
+import network.crypta.clients.http.FProxyFetchSnapshotInfo;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.FProxyFetchWaiter;
 import network.crypta.clients.http.ToadletContainer;
@@ -405,19 +407,10 @@ class ProgressInfoElementTest {
       Constructor<FProxyFetchResult> ctor =
           FProxyFetchResult.class.getDeclaredConstructor(
               FProxyFetchInProgress.class,
-              String.class,
+              FProxyFetchSnapshotInfo.class,
               long.class,
-              long.class,
-              boolean.class,
-              int.class,
-              int.class,
-              int.class,
-              int.class,
-              int.class,
-              boolean.class,
-              FetchException.class,
-              long.class,
-              boolean.class);
+              FProxyFetchProgressCounts.class,
+              FetchException.class);
       ctor.setAccessible(true);
       return ctor;
     } catch (ReflectiveOperationException e) {
@@ -512,19 +505,17 @@ class ProgressInfoElementTest {
     try {
       return PROGRESS_RESULT_CTOR.newInstance(
           mock(FProxyFetchInProgress.class),
-          spec.mimeType,
+          new FProxyFetchSnapshotInfo(
+              spec.mimeType, spec.timeStarted, spec.goneToNetwork, spec.eta, spec.hasWaited),
           spec.size,
-          spec.timeStarted,
-          spec.goneToNetwork,
-          spec.totalBlocks,
-          spec.requiredBlocks,
-          spec.fetchedBlocks,
-          spec.failedBlocks,
-          spec.fatallyFailedBlocks,
-          spec.finalizedBlocks,
-          spec.failed,
-          spec.eta,
-          spec.hasWaited);
+          new FProxyFetchProgressCounts(
+              spec.totalBlocks,
+              spec.requiredBlocks,
+              spec.fetchedBlocks,
+              spec.failedBlocks,
+              spec.fatallyFailedBlocks,
+              spec.finalizedBlocks),
+          spec.failed);
     } catch (ReflectiveOperationException e) {
       throw new AssertionError("Failed to create FProxyFetchResult via reflection", e);
     }


### PR DESCRIPTION
## Summary
- replace long FProxyFetchResult constructor parameter lists with shared snapshot/progress records
- build snapshot info/progress counts in FProxyFetchInProgress for consistent construction
- update HTTP client tests and reflection helpers for the new parameter objects

## Testing
- ./gradlew test