### PR TITLE
refactor(node): reuse peer status counts

### DIFF
--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -43,6 +43,7 @@ import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNode;
 import network.crypta.node.PeerNodeLoadTracker.IncomingLoadSummaryStats;
 import network.crypta.node.PeerNodeStatus;
+import network.crypta.node.PeerStatusCounts;
 import network.crypta.node.Version;
 import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
@@ -77,7 +78,7 @@ import org.slf4j.LoggerFactory;
  * <p>Thread-safety: instances rely on externally synchronized {@link Node}/{@link PeerManager}
  * methods. The toadlet itself holds no mutable request-scoped state except transient flags on the
  * stack, so it can service concurrent requests when the surrounding HTTP server invokes it in
- * parallel. Subclasses should preserve this behaviour when adding fields or caching.
+ * parallel. Subclasses should preserve this behavior when adding fields or caching.
  */
 public abstract class ConnectionsToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionsToadlet.class);
@@ -103,7 +104,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   /**
    * Comparator that orders {@link PeerNodeStatus} instances for table rendering.
    *
-   * <p>Sorting honours a user-selected column when present and otherwise falls back to status code
+   * <p>Sorting honors a user-selected column when present and otherwise falls back to status code
    * and peer hash for deterministic ordering. The {@code reversed} flag inverts the final result so
    * callers can reuse one comparator for ascending and descending views without allocating extra
    * helpers.
@@ -112,7 +113,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
     /** Column key requested by the client, may be {@code null} for default ordering. */
     protected final String sortBy;
 
-    /** Whether the comparator should invert its result for descending presentation. */
+    /** Whether the comparator should invert its result for the descending presentation. */
     protected final boolean reversed;
 
     /**
@@ -127,7 +128,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
 
     /**
-     * Orders two peer rows using configured sort behaviour.
+     * Orders two peer rows using configured sort behavior.
      *
      * @param firstNode the first peer candidate; never mutated by this comparator.
      * @param secondNode the second peer candidate; never mutated by this comparator.
@@ -160,7 +161,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
 
     // xor: check why we do not just return the result of (long1-long2)
-    // j16sdiz: (Long.MAX_VALUE - (-1) ) would overflow and become negative
+    // j16sdiz: (Long.MAX_VALUE - (-1)) would overflow and become negative
     private int compareLongs(long long1, long long2) {
       int diff = Long.compare(long1, long2);
       if (diff == 0) return 0;
@@ -264,7 +265,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
   }
 
-  /** Reference to the running node that backs all connection state and operations. */
+  /** Reference to the running node that backs all connection states and operations. */
   protected final Node node;
 
   /** Core services used for filesystem paths, configuration, and network integration. */
@@ -276,7 +277,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   /** Peer manager providing live peer state and addition helpers. */
   protected final PeerManager peers;
 
-  /** Tracks whether the current comparator reversed flag was requested by the user. */
+  /** Tracks whether the user requested the current comparator reversed flag. */
   protected boolean isReversed = false;
 
   /** Whether trivial FOAF connections should be displayed alongside non-trivial groups. */
@@ -340,9 +341,10 @@ public abstract class ConnectionsToadlet extends Toadlet {
    * Renders the connections page and optional message-type breakdowns.
    *
    * <p>The handler validates access, resolves download endpoints for the current node reference,
-   * builds sorted peer tables, and writes the resulting HTML response. When no peers exist it still
-   * renders guidance and, depending on mode, may redirect to friend-adding flows. Download requests
-   * for {@code myref.fref} or {@code myref.txt} are served directly with appropriate headers.
+   * builds sorted peer tables, and writes the resulting HTML response. When no peers exist, it
+   * still renders guidance and, depending on mode, may redirect to friend-adding flows. Download
+   * requests for {@code myref.fref} or {@code myref.txt} are served directly with appropriate
+   * headers.
    *
    * @param uri request target URI, used to detect message-type view and download paths.
    * @param request HTTP request wrapper supplying parameters such as {@code sortBy} and {@code
@@ -370,7 +372,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
         peerNodeStatuses,
         comparator(request.getParam("sortBy", null), request.isParameterSet("reversed")));
 
-    ConnectionCounts counts = computeConnectionCounts(peerNodeStatuses);
+    PeerStatusCounts counts = computePeerStatusCounts(peerNodeStatuses);
     String titleCountString = buildTitleCountString(counts);
 
     PageNode page = ctx.getPageMaker().getPageNode(getPageTitle(titleCountString), ctx);
@@ -427,37 +429,70 @@ public abstract class ConnectionsToadlet extends Toadlet {
     return false;
   }
 
-  private ConnectionCounts computeConnectionCounts(PeerNodeStatus[] peerNodeStatuses) {
-    return new ConnectionCounts(
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED),
+  private PeerStatusCounts computePeerStatusCounts(PeerNodeStatus[] peerNodeStatuses) {
+    int connected =
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED);
+    int routingBackedOff =
         PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF),
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW),
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD),
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF);
+    int tooNew =
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW);
+    int tooOld =
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD);
+    int disconnected =
         PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTED),
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTED);
+    int neverConnected =
         PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED),
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISABLED),
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_BURSTING),
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTENING),
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED);
+    int disabled =
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISABLED);
+    int bursting =
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_BURSTING);
+    int listening =
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTENING);
+    int listenOnly =
         PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTEN_ONLY),
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTEN_ONLY);
+    int routingDisabled =
         PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM),
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED);
+    int clockProblem =
         PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONN_ERROR),
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM);
+    int connError =
         PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTING),
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONN_ERROR);
+    int disconnecting =
         PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED),
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTING);
+    int noLoadStats =
         PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS));
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS);
+
+    return new PeerStatusCounts(
+        connected,
+        routingBackedOff,
+        tooNew,
+        tooOld,
+        disconnected,
+        neverConnected,
+        disabled,
+        bursting,
+        listening,
+        listenOnly,
+        0,
+        0,
+        routingDisabled,
+        clockProblem,
+        connError,
+        disconnecting,
+        noLoadStats);
   }
 
-  private String buildTitleCountString(ConnectionCounts counts) {
+  private String buildTitleCountString(PeerStatusCounts counts) {
     if (!node.isAdvancedModeEnabled()) {
-      int numberOfSimpleConnected = counts.connected + counts.routingBackedOff;
+      int numberOfSimpleConnected = counts.connected() + counts.routingBackedOff();
       int numberOfNotConnected = counts.notConnected();
       return (numberOfNotConnected + numberOfSimpleConnected) > 0
           ? String.valueOf(numberOfSimpleConnected)
@@ -465,17 +500,17 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
 
     return "("
-        + counts.connected
+        + counts.connected()
         + '/'
-        + counts.routingBackedOff
+        + counts.routingBackedOff()
         + '/'
-        + counts.tooNew
+        + counts.tooNew()
         + '/'
-        + counts.tooOld
+        + counts.tooOld()
         + '/'
-        + counts.noLoadStats
+        + counts.noLoadStats()
         + '/'
-        + counts.routingDisabled
+        + counts.routingDisabled()
         + '/'
         + counts.notConnected()
         + ')';
@@ -498,7 +533,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   private void addOverviewSection(
-      HTMLNode contentNode, DecimalFormat percentageFormat, long now, ConnectionCounts counts) {
+      HTMLNode contentNode, DecimalFormat percentageFormat, long now, PeerStatusCounts counts) {
     long nodeUptimeSeconds = SECONDS.convert(now - node.getStartupTime(), MILLISECONDS);
     int bwlimitDelayTime = (int) stats.getBwlimitDelayTime();
     int nodeAveragePingTime = (int) stats.getNodeAveragePingTime();
@@ -571,29 +606,9 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
   }
 
-  private void addPeerStatsSection(HTMLNode tableCell, ConnectionCounts counts) {
+  private void addPeerStatsSection(HTMLNode tableCell, PeerStatusCounts counts) {
     HTMLNode peerStatsInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
-    StatisticsToadlet.drawPeerStatsBox(
-        peerStatsInfobox,
-        true,
-        counts.connected,
-        counts.routingBackedOff,
-        counts.tooNew,
-        counts.tooOld,
-        counts.disconnected,
-        counts.neverConnected,
-        counts.disabled,
-        counts.bursting,
-        counts.listening,
-        counts.listenOnly,
-        0,
-        0,
-        counts.routingDisabled,
-        counts.clockProblem,
-        counts.connError,
-        counts.disconnecting,
-        counts.noLoadStats,
-        node);
+    StatisticsToadlet.drawPeerStatsBox(peerStatsInfobox, true, counts, node);
 
     addBackoffReasonBoxes(tableCell);
   }
@@ -1061,38 +1076,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
     throw new RedirectException(URI.create("/addfriend/"));
   }
 
-  private record ConnectionCounts(
-      int connected,
-      int routingBackedOff,
-      int tooNew,
-      int tooOld,
-      int disconnected,
-      int neverConnected,
-      int disabled,
-      int bursting,
-      int listening,
-      int listenOnly,
-      int clockProblem,
-      int connError,
-      int disconnecting,
-      int routingDisabled,
-      int noLoadStats) {
-
-    int notConnected() {
-      return tooNew
-          + tooOld
-          + noLoadStats
-          + disconnected
-          + neverConnected
-          + disabled
-          + bursting
-          + listening
-          + listenOnly
-          + clockProblem
-          + connError;
-    }
-  }
-
   private record PeerTableContext(
       HTMLNode peerForm, HTMLNode peerTable, List<SimpleColumn> endCols) {}
 
@@ -1122,7 +1105,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
       boolean advancedMode,
       HTMLNode contentNode,
       long now,
-      ConnectionCounts counts) {
+      PeerStatusCounts counts) {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
@@ -1217,7 +1200,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
    *
    * <p>The handler verifies permissions, checks whether uploads are permitted, and dispatches to
    * add-peer logic or alternate actions based on submitted form parts. It logs debug detail only
-   * when enabled and leaves state unchanged if validation fails.
+   * when enabled and leaves the state unchanged if validation fails.
    *
    * @param uri target URI, used to route auxiliary POST actions.
    * @param request HTTP request containing multipart fields such as {@code add}, {@code ref}, or
@@ -1225,7 +1208,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
    * @param ctx toadlet context supplying authorization checks and response builders.
    * @throws ToadletContextClosedException if the client connection is already closed.
    * @throws IOException on I/O failures while reading parts or writing responses.
-   * @throws ConfigException when submitted trust or visibility values violate constraints.
+   * @throws ConfigException when submitted, trust or visibility values violate constraints.
    * @throws RedirectException when processing elects to redirect instead of generating a page.
    */
   public void handleMethodPOST(URI uri, final HTTPRequest request, ToadletContext ctx)
@@ -1573,7 +1556,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   /**
    * Delegates POST actions not handled by {@link #handleMethodPOST} to subclass-specific logic.
    *
-   * <p>Default behaviour proxies the POST to the GET handler so subclasses only implementing GET
+   * <p>Default behavior proxies the POST to the GET handler, so subclasses only implementing GET
    * still behave correctly. Override to support extra form actions such as bulk operations.
    *
    * @param uri original request URI that determines routing of alternative actions.
@@ -1624,8 +1607,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
    * <p>A form and per-peer checkboxes are already present. Implementations should add controls and
    * submit buttons appropriate for their network mode.
    *
-   * @param peerForm form node that already wraps the peer table and checkboxes; implementations add
-   *     controls directly to this element.
+   * @param peerForm form a node that already wraps the peer table and checkboxes; implementations
+   *     add controls directly to this element.
    * @param advancedModeEnabled whether the UI is in advanced mode, enabling additional actions or
    *     diagnostics.
    */
@@ -1635,7 +1618,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
    * Determines whether the noderef textarea/download box should be displayed.
    *
    * <p>Darknet pages often show noderef exchange controls even for new users, whereas opennet pages
-   * may hide them unless advanced mode is active. Implementations should keep behaviour stable
+   * may hide them unless the advanced mode is active. Implementations should keep behavior stable
    * within a session so users are not surprised by disappearing controls.
    *
    * @param advancedModeEnabled whether the user requested advanced UI features.
@@ -1707,7 +1690,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
    * append the supplied count string or replace it entirely to match opennet/darknet conventions.
    * The method should remain deterministic for a given count input to aid testing.
    *
-   * @param titleCountString preformatted count string built from {@link ConnectionCounts}.
+   * @param titleCountString preformatted count string built from {@link PeerStatusCounts}.
    * @return complete title text to render for the current request.
    */
   protected abstract String getPageTitle(String titleCountString);
@@ -1715,7 +1698,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   /**
    * Draws the add-a-peer box that follows the main peers table.
    *
-   * <p>The box includes textarea input, file upload control, and optional private note field.
+   * <p>The box includes textarea input, file upload control, and an optional private note field.
    * Subclasses may override to hide or extend the UI but should avoid altering form names to keep
    * POST handling compatible.
    *
@@ -1730,7 +1713,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
    * Static helper that renders the add-peer form with configurable target and mode.
    *
    * <p>Used by both opennet and darknet views to avoid code duplication. The contents include
-   * textarea paste input, file chooser, optional private note, and a submit button. The form posts
+   * textarea paste input, file chooser, optional private note, and a Submit button. The form posts
    * to {@code formTarget} using multipart encoding.
    *
    * @param contentNode HTML container receiving the generated infobox and form.
@@ -2205,7 +2188,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
     messageCountRow.addChild("td", "colspan", "2");
     HTMLNode messageCountCell =
         messageCountRow.addChild(
-            "td", "colspan", "9"); // = total table row width - 2 from above colspan
+            "td", "colspan", "9"); // = total table row width - 2 from the above colspan
     HTMLNode messageCountTable =
         messageCountCell.addChild(ELEMENT_TABLE, ATTR_CLASS, "message-count");
     HTMLNode countHeaderRow = messageCountTable.addChild("tr");

--- a/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
@@ -32,6 +32,7 @@ import network.crypta.node.NodeStatsHtmlRenderer;
 import network.crypta.node.OpennetManager;
 import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNodeStatus;
+import network.crypta.node.PeerStatusCounts;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.RequestTracker;
@@ -84,30 +85,15 @@ public class StatisticsToadlet extends Toadlet {
 
   private static class PeerStatusSummary {
     final PeerNodeStatus[] peerNodeStatuses;
-    int numberOfConnected;
-    int numberOfRoutingBackedOff;
-    int numberOfTooNew;
-    int numberOfTooOld;
-    int numberOfDisconnected;
-    int numberOfNeverConnected;
-    int numberOfDisabled;
-    int numberOfBursting;
-    int numberOfListening;
-    int numberOfListenOnly;
-    int numberOfSeedServers;
-    int numberOfSeedClients;
-    int numberOfRoutingDisabled;
-    int numberOfClockProblem;
-    int numberOfConnError;
-    int numberOfDisconnecting;
-    int numberOfNoLoadStats;
+    final PeerStatusCounts counts;
 
-    PeerStatusSummary(PeerNodeStatus[] peerNodeStatuses) {
+    PeerStatusSummary(PeerNodeStatus[] peerNodeStatuses, PeerStatusCounts counts) {
       this.peerNodeStatuses = peerNodeStatuses;
+      this.counts = counts;
     }
 
     boolean hasConnectedOrBackedOffPeers() {
-      return numberOfConnected + numberOfRoutingBackedOff > 0;
+      return counts.connected() + counts.routingBackedOff() > 0;
     }
   }
 
@@ -170,7 +156,7 @@ public class StatisticsToadlet extends Toadlet {
   /**
    * Builds a statistics toadlet tied to the supplied node state and client wiring so it can
    * assemble runtime metrics on demand. The constructor caches frequently used collaborators
-   * (statistics snapshotter and peer manager) so individual requests avoid repeated lookups while
+   * (statistics snapshotter and peer manager), so individual requests avoid repeated lookups while
    * still reflecting the live node through fresh data pulls performed inside each handler.
    *
    * @param n node instance that owns the peer set, configuration, and counters displayed by the
@@ -230,7 +216,7 @@ public class StatisticsToadlet extends Toadlet {
    *
    * @param uri full request URI used mainly for consistency with the {@link Toadlet} contract; the
    *     path segment is inspected indirectly through {@code request}.
-   * @param request incoming HTTP request providing path, parameters, and user context for the
+   * @param request the incoming HTTP request providing path, parameters, and user context for the
    *     statistics view; must already be parsed by the calling toadlet framework.
    * @param ctx toadlet context that supplies page construction helpers, localization, and access
    *     control flags such as advanced mode; also used to emit the final response.
@@ -278,42 +264,59 @@ public class StatisticsToadlet extends Toadlet {
     PeerNodeStatus[] peerNodeStatuses = peers.statusBook().getPeerNodeStatuses(true);
     Arrays.sort(peerNodeStatuses, Comparator.comparingInt(PeerNodeStatus::getStatusValue));
 
-    PeerStatusSummary summary = new PeerStatusSummary(peerNodeStatuses);
-    summary.numberOfConnected =
+    int numberOfConnected =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED);
-    summary.numberOfRoutingBackedOff =
+    int numberOfRoutingBackedOff =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF);
-    summary.numberOfTooNew =
-        getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW);
-    summary.numberOfTooOld =
-        getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD);
-    summary.numberOfDisconnected =
+    int numberOfTooNew = getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW);
+    int numberOfTooOld = getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD);
+    int numberOfDisconnected =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTED);
-    summary.numberOfNeverConnected =
+    int numberOfNeverConnected =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED);
-    summary.numberOfDisabled =
+    int numberOfDisabled =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISABLED);
-    summary.numberOfBursting =
+    int numberOfBursting =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_BURSTING);
-    summary.numberOfListening =
+    int numberOfListening =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTENING);
-    summary.numberOfListenOnly =
+    int numberOfListenOnly =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTEN_ONLY);
-    summary.numberOfSeedServers = getCountSeedServers(peerNodeStatuses);
-    summary.numberOfSeedClients = getCountSeedClients(peerNodeStatuses);
-    summary.numberOfRoutingDisabled =
+    int numberOfSeedServers = getCountSeedServers(peerNodeStatuses);
+    int numberOfSeedClients = getCountSeedClients(peerNodeStatuses);
+    int numberOfRoutingDisabled =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED);
-    summary.numberOfClockProblem =
+    int numberOfClockProblem =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM);
-    summary.numberOfConnError =
+    int numberOfConnError =
         getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONN_ERROR);
-    summary.numberOfDisconnecting =
+    int numberOfDisconnecting =
         PeerNodeStatus.getPeerStatusCount(
             peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTING);
-    summary.numberOfNoLoadStats =
+    int numberOfNoLoadStats =
         PeerNodeStatus.getPeerStatusCount(
             peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS);
-    return summary;
+
+    PeerStatusCounts counts =
+        new PeerStatusCounts(
+            numberOfConnected,
+            numberOfRoutingBackedOff,
+            numberOfTooNew,
+            numberOfTooOld,
+            numberOfDisconnected,
+            numberOfNeverConnected,
+            numberOfDisabled,
+            numberOfBursting,
+            numberOfListening,
+            numberOfListenOnly,
+            numberOfSeedServers,
+            numberOfSeedClients,
+            numberOfRoutingDisabled,
+            numberOfClockProblem,
+            numberOfConnError,
+            numberOfDisconnecting,
+            numberOfNoLoadStats);
+    return new PeerStatusSummary(peerNodeStatuses, counts);
   }
 
   private void renderStatisticsPage(
@@ -478,27 +481,7 @@ public class StatisticsToadlet extends Toadlet {
 
     HTMLNode peerStatsInfobox = rightColumn.addChild("div", ATTR_CLASS, CLASS_INFOBOX);
 
-    drawPeerStatsBox(
-        peerStatsInfobox,
-        advancedMode,
-        peerStatusSummary.numberOfConnected,
-        peerStatusSummary.numberOfRoutingBackedOff,
-        peerStatusSummary.numberOfTooNew,
-        peerStatusSummary.numberOfTooOld,
-        peerStatusSummary.numberOfDisconnected,
-        peerStatusSummary.numberOfNeverConnected,
-        peerStatusSummary.numberOfDisabled,
-        peerStatusSummary.numberOfBursting,
-        peerStatusSummary.numberOfListening,
-        peerStatusSummary.numberOfListenOnly,
-        peerStatusSummary.numberOfSeedServers,
-        peerStatusSummary.numberOfSeedClients,
-        peerStatusSummary.numberOfRoutingDisabled,
-        peerStatusSummary.numberOfClockProblem,
-        peerStatusSummary.numberOfConnError,
-        peerStatusSummary.numberOfDisconnecting,
-        peerStatusSummary.numberOfNoLoadStats,
-        node);
+    drawPeerStatsBox(peerStatsInfobox, advancedMode, peerStatusSummary.counts, node);
 
     HTMLNode bandwidthInfobox = rightColumn.addChild("div", ATTR_CLASS, CLASS_INFOBOX);
     drawBandwidthBox(bandwidthInfobox, nodeUptimeSeconds, advancedMode);
@@ -750,7 +733,7 @@ public class StatisticsToadlet extends Toadlet {
 
   private void drawLoadBalancingBox(HTMLNode loadStatsInfobox, boolean realTime) {
     // Load balancing box
-    // Include overall window, and RTTs for each
+    // Include an overall window, and RTTs for each
 
     loadStatsInfobox.addChild(
         "div",
@@ -1265,7 +1248,7 @@ public class StatisticsToadlet extends Toadlet {
    * Builds the peer statistics infobox, adding a localized header and list entries for every peer
    * status bucket that currently has a non-zero count. Routing back-off wording adapts to advanced
    * mode, while the other buckets always render their short and long labels. Entries use distinct
-   * CSS classes so the statistics page can visually differentiate states such as connected,
+   * CSS classes, so the statistics page can visually differentiate states such as connected,
    * disconnected, listen-only, or routing-disabled peers.
    *
    * <p>Counts of seed servers and seed clients are displayed using the listening class for visual
@@ -1275,112 +1258,82 @@ public class StatisticsToadlet extends Toadlet {
    *
    * @param peerStatsInfobox infobox root node receiving the generated header and list entries.
    * @param advancedModeEnabled whether advanced wording is allowed for routing back-off buckets.
-   * @param numberOfConnected peers currently connected and exchanging traffic with this node.
-   * @param numberOfRoutingBackedOff peers throttled due to routing limits or recent back-off.
-   * @param numberOfTooNew peers rejected because their software version is newer than supported.
-   * @param numberOfTooOld peers rejected because their software version predates the minimum.
-   * @param numberOfDisconnected peers known but currently disconnected from the node.
-   * @param numberOfNeverConnected peers configured but that have never completed a connection.
-   * @param numberOfDisabled peers manually disabled by the operator or configuration.
-   * @param numberOfBursting peers temporarily exceeding normal throughput allowances.
-   * @param numberOfListening peers accepting inbound connections and not otherwise restricted.
-   * @param numberOfListenOnly peers unable to accept incoming connections but still listed.
-   * @param numberOfSeedServers seed servers counted separately for advanced diagnostics.
-   * @param numberOfSeedClients seed clients counted separately for advanced diagnostics.
-   * @param numberOfRoutingDisabled peers explicitly prevented from routing traffic for this node.
-   * @param numberOfClockProblem peers flagged because of detected clock synchronization issues.
-   * @param numberOfConnError peers whose last connection attempts failed with errors.
-   * @param numberOfDisconnecting peers currently transitioning away from active connections.
-   * @param numberOfNoLoadStats peers missing current load statistics or refusing to provide them.
+   * @param counts peer status bucket counts for the current node snapshot.
    * @param node node whose opennet manager supplies configured target counts for display.
    */
   protected static void drawPeerStatsBox(
-      HTMLNode peerStatsInfobox,
-      boolean advancedModeEnabled,
-      int numberOfConnected,
-      int numberOfRoutingBackedOff,
-      int numberOfTooNew,
-      int numberOfTooOld,
-      int numberOfDisconnected,
-      int numberOfNeverConnected,
-      int numberOfDisabled,
-      int numberOfBursting,
-      int numberOfListening,
-      int numberOfListenOnly,
-      int numberOfSeedServers,
-      int numberOfSeedClients,
-      int numberOfRoutingDisabled,
-      int numberOfClockProblem,
-      int numberOfConnError,
-      int numberOfDisconnecting,
-      int numberOfNoLoadStats,
-      Node node) {
+      HTMLNode peerStatsInfobox, boolean advancedModeEnabled, PeerStatusCounts counts, Node node) {
 
     peerStatsInfobox.addChild("div", ATTR_CLASS, CLASS_INFOBOX_HEADER, l10n("peerStatsTitle"));
     HTMLNode peerStatsContent = peerStatsInfobox.addChild("div", ATTR_CLASS, CLASS_INFOBOX_CONTENT);
     HTMLNode peerStatsList = peerStatsContent.addChild("ul");
     addPeerStat(
-        peerStatsList, numberOfConnected, "peer_connected", CLASS_CONNECTED, "connectedShort");
+        peerStatsList, counts.connected(), "peer_connected", CLASS_CONNECTED, "connectedShort");
     addPeerStat(
         peerStatsList,
-        numberOfRoutingBackedOff,
+        counts.routingBackedOff(),
         "peer_backed_off",
         advancedModeEnabled ? "backedOff" : "busy",
         advancedModeEnabled ? "backedOffShort" : "busyShort");
-    addPeerStat(peerStatsList, numberOfTooNew, "peer_too_new", "tooNew", "tooNewShort");
-    addPeerStat(peerStatsList, numberOfTooOld, "peer_too_old", "tooOld", "tooOldShort");
+    addPeerStat(peerStatsList, counts.tooNew(), "peer_too_new", "tooNew", "tooNewShort");
+    addPeerStat(peerStatsList, counts.tooOld(), "peer_too_old", "tooOld", "tooOldShort");
     addPeerStat(
         peerStatsList,
-        numberOfDisconnected,
+        counts.disconnected(),
         "peer_disconnected",
         "notConnected",
         "notConnectedShort");
     addPeerStat(
         peerStatsList,
-        numberOfNeverConnected,
+        counts.neverConnected(),
         "peer_never_connected",
         "neverConnected",
         "neverConnectedShort");
-    addPeerStat(peerStatsList, numberOfDisabled, "peer_disabled", "disabled", "disabledShort");
-    addPeerStat(peerStatsList, numberOfBursting, "peer_bursting", "bursting", "burstingShort");
+    addPeerStat(peerStatsList, counts.disabled(), "peer_disabled", "disabled", "disabledShort");
+    addPeerStat(peerStatsList, counts.bursting(), "peer_bursting", "bursting", "burstingShort");
     addPeerStat(
-        peerStatsList, numberOfListening, PEER_LISTENING_CLASS, "listening", "listeningShort");
-    addPeerStat(
-        peerStatsList, numberOfListenOnly, PEER_LISTEN_ONLY_CLASS, "listenOnly", "listenOnlyShort");
+        peerStatsList, counts.listening(), PEER_LISTENING_CLASS, "listening", "listeningShort");
     addPeerStat(
         peerStatsList,
-        numberOfSeedServers,
+        counts.listenOnly(),
+        PEER_LISTEN_ONLY_CLASS,
+        "listenOnly",
+        "listenOnlyShort");
+    addPeerStat(
+        peerStatsList,
+        counts.seedServers(),
         PEER_LISTENING_CLASS,
         "seedServers",
         "seedServersShort");
     addPeerStat(
         peerStatsList,
-        numberOfSeedClients,
+        counts.seedClients(),
         PEER_LISTENING_CLASS,
         "seedClients",
         "seedClientsShort");
     addPeerStat(
         peerStatsList,
-        numberOfRoutingDisabled,
+        counts.routingDisabled(),
         "peer_routing_disabled",
         "routingDisabled",
         "routingDisabledShort");
     addPeerStat(
         peerStatsList,
-        numberOfClockProblem,
+        counts.clockProblem(),
         "peer_clock_problem",
         "clockProblem",
         "clockProblemShort");
-    addPeerStat(peerStatsList, numberOfConnError, "peer_conn_error", "connError", "connErrorShort");
+    addPeerStat(
+        peerStatsList, counts.connError(), "peer_conn_error", "connError", "connErrorShort");
     addPeerStat(
         peerStatsList,
-        numberOfDisconnecting,
+        counts.disconnecting(),
         "peer_disconnecting",
         "disconnecting",
         "disconnectingShort");
     addPeerStat(
         peerStatsList,
-        numberOfNoLoadStats,
+        counts.noLoadStats(),
         "peer_no_load_stats",
         "noLoadStats",
         "noLoadStatsShort");

--- a/src/main/java/network/crypta/node/PeerStatusBook.java
+++ b/src/main/java/network/crypta/node/PeerStatusBook.java
@@ -56,7 +56,7 @@ public class PeerStatusBook {
    * <p>The provided roster supplies peer snapshots for status queries and periodic summaries. The
    * lock must be the same monitor used by the owning manager when it mutates or snapshots the
    * roster; this ensures that time-gated updates observe a consistent roster and timer state. The
-   * instance starts with empty counters and inactive timers; first updates occur on the first
+   * instance starts with empty counters and inactive timers; the first updates occur on the first
    * relevant method call.
    *
    * <pre>{@code
@@ -64,7 +64,7 @@ public class PeerStatusBook {
    * book.onPeerAdded(peer);
    * }</pre>
    *
-   * @param roster peer roster used to obtain peer snapshots; must be non-null
+   * @param roster peer roster used to get peer snapshots; must be non-null
    * @param lock shared monitor guarding roster snapshots and timer updates; must be non-null
    */
   public PeerStatusBook(PeerRoster roster, Object lock) {
@@ -228,7 +228,7 @@ public class PeerStatusBook {
    *
    * <p>The method iterates over the current roster snapshot and calls {@link
    * PeerNode#getStatus(boolean)} on each peer. The resulting array preserves the roster order and
-   * is independent of subsequent roster changes. The method performs no filtering beyond the roster
+   * is independent of later roster changes. The method performs no filtering beyond the roster
    * snapshot it receives.
    *
    * @param noHeavy whether to omit heavy-weight fields from the status snapshot
@@ -359,56 +359,7 @@ public class PeerStatusBook {
     return true;
   }
 
-  private static final class PeerStatusSummary {
-    private final int connected;
-    private final int routingBackedOff;
-    private final int tooNew;
-    private final int tooOld;
-    private final int disconnected;
-    private final int neverConnected;
-    private final int disabled;
-    private final int bursting;
-    private final int listening;
-    private final int listenOnly;
-    private final int clockProblem;
-    private final int connError;
-    private final int disconnecting;
-    private final int routingDisabled;
-    private final int noLoadStats;
-
-    private PeerStatusSummary(
-        int connected,
-        int routingBackedOff,
-        int tooNew,
-        int tooOld,
-        int disconnected,
-        int neverConnected,
-        int disabled,
-        int bursting,
-        int listening,
-        int listenOnly,
-        int clockProblem,
-        int connError,
-        int disconnecting,
-        int routingDisabled,
-        int noLoadStats) {
-      this.connected = connected;
-      this.routingBackedOff = routingBackedOff;
-      this.tooNew = tooNew;
-      this.tooOld = tooOld;
-      this.disconnected = disconnected;
-      this.neverConnected = neverConnected;
-      this.disabled = disabled;
-      this.bursting = bursting;
-      this.listening = listening;
-      this.listenOnly = listenOnly;
-      this.clockProblem = clockProblem;
-      this.connError = connError;
-      this.disconnecting = disconnecting;
-      this.routingDisabled = routingDisabled;
-      this.noLoadStats = noLoadStats;
-    }
-  }
+  private record PeerStatusSummary(PeerStatusCounts counts) {}
 
   private PeerStatusSummary computePeerStatusSummary(PeerNode[] peers) {
     int numberOfConnected = 0;
@@ -449,22 +400,26 @@ public class PeerStatusBook {
       }
     }
 
-    return new PeerStatusSummary(
-        numberOfConnected,
-        numberOfRoutingBackedOff,
-        numberOfTooNew,
-        numberOfTooOld,
-        numberOfDisconnected,
-        numberOfNeverConnected,
-        numberOfDisabled,
-        numberOfBursting,
-        numberOfListening,
-        numberOfListenOnly,
-        numberOfClockProblem,
-        numberOfConnError,
-        numberOfDisconnecting,
-        numberOfRoutingDisabled,
-        numberOfNoLoadStats);
+    PeerStatusCounts counts =
+        new PeerStatusCounts(
+            numberOfConnected,
+            numberOfRoutingBackedOff,
+            numberOfTooNew,
+            numberOfTooOld,
+            numberOfDisconnected,
+            numberOfNeverConnected,
+            numberOfDisabled,
+            numberOfBursting,
+            numberOfListening,
+            numberOfListenOnly,
+            0,
+            0,
+            numberOfRoutingDisabled,
+            numberOfClockProblem,
+            numberOfConnError,
+            numberOfDisconnecting,
+            numberOfNoLoadStats);
+    return new PeerStatusSummary(counts);
   }
 
   private void logPeerStatusSummary(PeerStatusSummary summary) {
@@ -472,21 +427,21 @@ public class PeerStatusBook {
         "Connected={} RoutingBackedOff={} TooNew={} TooOld={} Disconnected={} NeverConnected={}"
             + " Disabled={} Bursting={} Listening={} ListenOnly={} ClockProblem={}"
             + " ConnectionProblem={} Disconnecting={} RoutingDisabled={} NoLoadStats={}",
-        summary.connected,
-        summary.routingBackedOff,
-        summary.tooNew,
-        summary.tooOld,
-        summary.disconnected,
-        summary.neverConnected,
-        summary.disabled,
-        summary.bursting,
-        summary.listening,
-        summary.listenOnly,
-        summary.clockProblem,
-        summary.connError,
-        summary.disconnecting,
-        summary.routingDisabled,
-        summary.noLoadStats);
+        summary.counts.connected(),
+        summary.counts.routingBackedOff(),
+        summary.counts.tooNew(),
+        summary.counts.tooOld(),
+        summary.counts.disconnected(),
+        summary.counts.neverConnected(),
+        summary.counts.disabled(),
+        summary.counts.bursting(),
+        summary.counts.listening(),
+        summary.counts.listenOnly(),
+        summary.counts.clockProblem(),
+        summary.counts.connError(),
+        summary.counts.disconnecting(),
+        summary.counts.routingDisabled(),
+        summary.counts.noLoadStats());
   }
 
   /**

--- a/src/main/java/network/crypta/node/PeerStatusCounts.java
+++ b/src/main/java/network/crypta/node/PeerStatusCounts.java
@@ -1,0 +1,83 @@
+package network.crypta.node;
+
+/**
+ * Immutable snapshot of the peer status bucket counts for a node at a single point in time.
+ *
+ * <p>This record groups the counts that are routinely computed from peer manager status snapshots
+ * so HTTP toadlets, status loggers, and field exporters can pass a single value object instead of
+ * long parameter lists. It is intended for short-lived snapshots created during request handling or
+ * periodic logging; the record carries only integers and has no back-references to peer objects.
+ * Because it is immutable and contains only primitive values, it is thread-safe, inexpensive to
+ * copy, and safe to cache within a request scope when the underlying peer set is not expected to
+ * change mid-render.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Counts represent mutually exclusive status buckets as defined by the peer manager.
+ *   <li>Seed server/client counts may be zero when not tracked by the caller.
+ *   <li>{@link #notConnected()} summarizes the non-connected buckets for display.
+ * </ul>
+ *
+ * @param connected number of peers currently connected and exchanging traffic.
+ * @param routingBackedOff a number of peers temporarily backed off from routing.
+ * @param tooNew a number of peers rejected due to being too new.
+ * @param tooOld a number of peers rejected due to being too old.
+ * @param disconnected number of peers known but currently disconnected.
+ * @param neverConnected a number of peers configured but never connected.
+ * @param disabled number of peers explicitly disabled by configuration.
+ * @param bursting the number of peers temporarily exceeding throughput allowances.
+ * @param listening number of peers accepting inbound connections.
+ * @param listenOnly number of peers listed but not accepting inbound connections.
+ * @param seedServers number of seed servers tracked for diagnostics.
+ * @param seedClients number of seed clients tracked for diagnostics.
+ * @param routingDisabled a number of peers prevented from routing traffic.
+ * @param clockProblem number of peers flagged for clock synchronization issues.
+ * @param connError number of peers whose last connection attempt failed.
+ * @param disconnecting number of peers transitioning away from active connections.
+ * @param noLoadStats number of peers missing current load statistics.
+ */
+public record PeerStatusCounts(
+    int connected,
+    int routingBackedOff,
+    int tooNew,
+    int tooOld,
+    int disconnected,
+    int neverConnected,
+    int disabled,
+    int bursting,
+    int listening,
+    int listenOnly,
+    int seedServers,
+    int seedClients,
+    int routingDisabled,
+    int clockProblem,
+    int connError,
+    int disconnecting,
+    int noLoadStats) {
+
+  /**
+   * Returns the total count of peers that are not currently connected.
+   *
+   * <p>This method sums the bucket values that represent known peers without an active connection,
+   * including peers that are too new, too old, disabled, or otherwise not connected. It performs a
+   * simple arithmetic aggregation over immutable fields, so it is deterministic, side-effect free,
+   * and safe to call repeatedly while rendering UI summaries. Callers typically use the result to
+   * render concise totals or to decide whether a detailed breakdown should be displayed.
+   *
+   * @return total number of peers in non-connected status buckets at the snapshot time.
+   */
+  public int notConnected() {
+    return tooNew
+        + tooOld
+        + noLoadStats
+        + disconnected
+        + neverConnected
+        + disabled
+        + bursting
+        + listening
+        + listenOnly
+        + clockProblem
+        + connError;
+  }
+}

--- a/src/test/java/network/crypta/clients/http/StatisticsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/StatisticsToadletTest.java
@@ -16,6 +16,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeStats;
 import network.crypta.node.OpennetManager;
 import network.crypta.node.PeerManager;
+import network.crypta.node.PeerStatusCounts;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,23 +80,7 @@ class StatisticsToadletTest {
     StatisticsToadlet.drawPeerStatsBox(
         infobox,
         false,
-        0, // connected
-        0, // routingBackedOff
-        0, // tooNew
-        0, // tooOld
-        0, // disconnected
-        0, // neverConnected
-        0, // disabled
-        0, // bursting
-        0, // listening
-        0, // listenOnly
-        0, // seedServers
-        0, // seedClients
-        0, // routingDisabled
-        0, // clockProblem
-        0, // connError
-        0, // disconnecting
-        0, // noLoadStats
+        new PeerStatusCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         nodeWithoutOpennet);
 
     String rendered = infobox.generate();
@@ -120,23 +105,7 @@ class StatisticsToadletTest {
     StatisticsToadlet.drawPeerStatsBox(
         infobox,
         true,
-        2, // connected
-        1, // routingBackedOff
-        1, // tooNew
-        0, // tooOld
-        0, // disconnected
-        0, // neverConnected
-        0, // disabled
-        0, // bursting
-        0, // listening
-        0, // listenOnly
-        0, // seedServers
-        1, // seedClients
-        0, // routingDisabled
-        0, // clockProblem
-        0, // connError
-        0, // disconnecting
-        0, // noLoadStats
+        new PeerStatusCounts(2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0),
         nodeWithOpennet);
 
     String rendered = infobox.generate();


### PR DESCRIPTION
## Summary
- add shared PeerStatusCounts snapshot record for peer status buckets
- refactor statistics and connections toadlets to pass shared counts object
- update peer status logging/tests to use shared counts

## Testing
- ./gradlew test