### PR TITLE
refactor(http): bundle reply headers

### DIFF
--- a/src/main/java/network/crypta/clients/http/BrowserTestToadlet.java
+++ b/src/main/java/network/crypta/clients/http/BrowserTestToadlet.java
@@ -266,7 +266,8 @@ public class BrowserTestToadlet extends Toadlet {
         .addChild(
             "%", "document.getElementById('JSTEST').src = '/static/themes/clean/warning.png';");
 
-    this.writeHTMLReply(ctx, 200, "OK", null, page.generate(), true);
+    this.writeHTMLReply(
+        ctx, ReplyHeaders.of(200, "OK", "text/html; charset=utf-8", null, true), page.generate());
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -416,7 +416,10 @@ public abstract class ConnectionsToadlet extends Toadlet {
       String noderefString = fs.toOrderedStringWithBase64();
       MultiValueTable<String, String> extraHeaders =
           MultiValueTable.from("Content-Disposition", "attachment; filename=myref.fref");
-      writeReply(ctx, 200, "application/x-freenet-reference", "OK", extraHeaders, noderefString);
+      writeReply(
+          ctx,
+          ReplyHeaders.of(200, "OK", "application/x-freenet-reference", extraHeaders),
+          noderefString);
       return true;
     }
 

--- a/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
@@ -173,7 +173,7 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
 
     contentNode.addChild(createContent(pageMaker, ctx));
 
-    writeHTMLReply(ctx, 200, "OK", null, page.generate());
+    writeHTMLReply(ctx, ReplyHeaders.of(200, "OK", "text/html; charset=utf-8"), page.generate());
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
@@ -104,7 +104,7 @@ public class DarknetAddRefToadlet extends Toadlet {
       File installer = node.services().nodeUpdater().getInstallerWindows();
       if (installer != null) {
         FileBucket bucket = new FileBucket(installer, true, false, false, false);
-        this.writeReply(ctx, 200, "application/x-msdownload", "OK", bucket);
+        this.writeReply(ctx, ReplyHeaders.of(200, "OK", "application/x-msdownload"), bucket);
         return;
       }
     }
@@ -113,7 +113,7 @@ public class DarknetAddRefToadlet extends Toadlet {
       File installer = node.services().nodeUpdater().getInstallerNonWindows();
       if (installer != null) {
         FileBucket bucket = new FileBucket(installer, true, false, false, false);
-        this.writeReply(ctx, 200, "application/x-java-archive", "OK", bucket);
+        this.writeReply(ctx, ReplyHeaders.of(200, "OK", "application/x-java-archive"), bucket);
         return;
       }
     }

--- a/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -899,7 +899,8 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
         MultiValueTable.from(
             // Force download to disk
             "Content-Disposition", "attachment; filename=" + filename);
-    this.writeReply(ctx, 200, "application/x-freenet-reference", "OK", extraHeaders, content);
+    this.writeReply(
+        ctx, ReplyHeaders.of(200, "OK", "application/x-freenet-reference", extraHeaders), content);
     return true;
   }
 

--- a/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
@@ -171,7 +171,8 @@ public class ExternalLinkToadlet extends Toadlet {
         new String[] {"type", "name", ATTR_VALUE},
         new String[] {"submit", "Go", l10n("goToExternalLink")});
 
-    this.writeHTMLReply(ctx, 200, "OK", null, page.generate(), true);
+    this.writeHTMLReply(
+        ctx, ReplyHeaders.of(200, "OK", "text/html; charset=utf-8", null, true), page.generate());
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -102,121 +102,134 @@ final class FProxyRegistrar {
 
     server.register(
         fproxy,
-        FProxyToadlet.CATEGORY_BROWSING,
-        "/",
-        false,
-        "FProxyToadlet.welcomeTitle",
-        "FProxyToadlet.welcome",
-        false,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_BROWSING,
+            "/",
+            false,
+            "FProxyToadlet.welcomeTitle",
+            "FProxyToadlet.welcome",
+            false,
+            null));
 
     DecodeToadlet decodeKeywordURL = new DecodeToadlet(client, core);
-    server.register(decodeKeywordURL, null, "/decode/", true, false);
+    server.register(decodeKeywordURL, ToadletRegistration.basic(null, "/decode/", true, false));
 
     InsertFreesiteToadlet siteinsert = new InsertFreesiteToadlet(client);
     server.register(
         siteinsert,
-        FProxyToadlet.CATEGORY_BROWSING,
-        "/insertsite/",
-        true,
-        "FProxyToadlet.insertFreesiteTitle",
-        "FProxyToadlet.insertFreesite",
-        false,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_BROWSING,
+            "/insertsite/",
+            true,
+            "FProxyToadlet.insertFreesiteTitle",
+            "FProxyToadlet.insertFreesite",
+            false,
+            null));
 
     UserAlertsToadlet alerts = new UserAlertsToadlet(client);
     server.register(
         alerts,
-        FProxyToadlet.CATEGORY_STATUS,
-        "/alerts/",
-        true,
-        "FProxyToadlet.alertsTitle",
-        "FProxyToadlet.alerts",
-        true,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_STATUS,
+            "/alerts/",
+            true,
+            "FProxyToadlet.alertsTitle",
+            "FProxyToadlet.alerts",
+            true,
+            null));
 
     QueueToadlet downloadToadlet =
         new QueueToadlet(core, core.getEndpoints().getFCPServer(), client, false);
     server.register(
         downloadToadlet,
-        FProxyToadlet.CATEGORY_QUEUE,
-        QueueToadlet.PATH_DOWNLOADS,
-        true,
-        "FProxyToadlet.downloadsTitle",
-        "FProxyToadlet.downloads",
-        false,
-        downloadToadlet);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_QUEUE,
+            QueueToadlet.PATH_DOWNLOADS,
+            true,
+            "FProxyToadlet.downloadsTitle",
+            "FProxyToadlet.downloads",
+            false,
+            downloadToadlet));
     LocalDownloadDirectoryToadlet localDownloadDirectoryToadlet =
         new LocalDownloadDirectoryToadlet(core, client, QueueToadlet.PATH_DOWNLOADS);
     server.register(
-        localDownloadDirectoryToadlet, null, localDownloadDirectoryToadlet.path(), true, false);
+        localDownloadDirectoryToadlet,
+        ToadletRegistration.basic(null, localDownloadDirectoryToadlet.path(), true, false));
     QueueToadlet uploadToadlet =
         new QueueToadlet(core, core.getEndpoints().getFCPServer(), client, true);
     server.register(
         uploadToadlet,
-        FProxyToadlet.CATEGORY_QUEUE,
-        QueueToadlet.PATH_UPLOADS,
-        true,
-        "FProxyToadlet.uploadsTitle",
-        "FProxyToadlet.uploads",
-        false,
-        uploadToadlet);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_QUEUE,
+            QueueToadlet.PATH_UPLOADS,
+            true,
+            "FProxyToadlet.uploadsTitle",
+            "FProxyToadlet.uploads",
+            false,
+            uploadToadlet));
 
     FileInsertWizardToadlet fiw = new FileInsertWizardToadlet(client, core);
     server.register(
         fiw,
-        FProxyToadlet.CATEGORY_QUEUE,
-        FileInsertWizardToadlet.PATH,
-        true,
-        "FProxyToadlet.uploadFileWizardTitle",
-        "FProxyToadlet.uploadFileWizard",
-        false,
-        fiw);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_QUEUE,
+            FileInsertWizardToadlet.PATH,
+            true,
+            "FProxyToadlet.uploadFileWizardTitle",
+            "FProxyToadlet.uploadFileWizard",
+            false,
+            fiw));
     uploadToadlet.setFIW(fiw);
 
     LocalFileInsertToadlet localFileInsertToadlet = new LocalFileInsertToadlet(core, client);
     server.register(
-        localFileInsertToadlet, null, LocalFileInsertToadlet.INSERT_BROWSE_PATH, true, false);
+        localFileInsertToadlet,
+        ToadletRegistration.basic(null, LocalFileInsertToadlet.INSERT_BROWSE_PATH, true, false));
 
     ContentFilterToadlet contentFilterToadlet = new ContentFilterToadlet(client, core);
     server.register(
         contentFilterToadlet,
-        FProxyToadlet.CATEGORY_QUEUE,
-        ContentFilterToadlet.CONTENT_FILTER_PATH,
-        true,
-        "FProxyToadlet.filterFileTitle",
-        "FProxyToadlet.filterFile",
-        false,
-        contentFilterToadlet);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_QUEUE,
+            ContentFilterToadlet.CONTENT_FILTER_PATH,
+            true,
+            "FProxyToadlet.filterFileTitle",
+            "FProxyToadlet.filterFile",
+            false,
+            contentFilterToadlet));
 
     LocalFileFilterToadlet localFileFilterToadlet = new LocalFileFilterToadlet(core, client);
-    server.register(localFileFilterToadlet, null, LocalFileFilterToadlet.BROWSE_PATH, true, false);
+    server.register(
+        localFileFilterToadlet,
+        ToadletRegistration.basic(null, LocalFileFilterToadlet.BROWSE_PATH, true, false));
 
     SymlinkerToadlet symlinkToadlet = new SymlinkerToadlet(client, node);
-    server.register(symlinkToadlet, null, "/sl/", true, false);
+    server.register(symlinkToadlet, ToadletRegistration.basic(null, "/sl/", true, false));
 
     SecurityLevelsToadlet seclevels = new SecurityLevelsToadlet(client, node, core);
     server.register(
         seclevels,
-        FProxyToadlet.CATEGORY_CONFIG,
-        "/seclevels/",
-        true,
-        "FProxyToadlet.seclevelsTitle",
-        "FProxyToadlet.seclevels",
-        true,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_CONFIG,
+            "/seclevels/",
+            true,
+            "FProxyToadlet.seclevelsTitle",
+            "FProxyToadlet.seclevels",
+            true,
+            null));
 
     if (node.services().pluginManager().isEnabled()) {
       PproxyToadlet pproxy = new PproxyToadlet(client, node);
       server.register(
           pproxy,
-          FProxyToadlet.CATEGORY_CONFIG,
-          "/plugins/",
-          true,
-          "FProxyToadlet.pluginsTitle",
-          "FProxyToadlet.plugins",
-          true,
-          null);
+          ToadletRegistration.menuLink(
+              FProxyToadlet.CATEGORY_CONFIG,
+              "/plugins/",
+              true,
+              "FProxyToadlet.pluginsTitle",
+              "FProxyToadlet.plugins",
+              true,
+              null));
     }
 
     SubConfig[] sc = config.getConfigs();
@@ -231,163 +244,199 @@ final class FProxyRegistrar {
           new ConfigToadlet(localDirectoryConfigToadlet.path(), client, config, cfg, node, core);
       server.register(
           configtoadlet,
-          FProxyToadlet.CATEGORY_CONFIG,
-          FProxyToadlet.CONFIG_PATH + prefix,
-          true,
-          "ConfigToadlet." + prefix,
-          "ConfigToadlet.title." + prefix,
-          true,
-          configtoadlet);
+          ToadletRegistration.menuLink(
+              FProxyToadlet.CATEGORY_CONFIG,
+              FProxyToadlet.CONFIG_PATH + prefix,
+              true,
+              "ConfigToadlet." + prefix,
+              "ConfigToadlet.title." + prefix,
+              true,
+              configtoadlet));
       server.register(
-          localDirectoryConfigToadlet, null, localDirectoryConfigToadlet.path(), true, false);
+          localDirectoryConfigToadlet,
+          ToadletRegistration.basic(null, localDirectoryConfigToadlet.path(), true, false));
     }
 
     WelcomeToadlet welcometoadlet = new WelcomeToadlet(client, node);
-    server.register(welcometoadlet, null, FProxyToadlet.WELCOME_PATH, true, false);
+    server.register(
+        welcometoadlet, ToadletRegistration.basic(null, FProxyToadlet.WELCOME_PATH, true, false));
 
     ExternalLinkToadlet externalLinkToadlet = new ExternalLinkToadlet(client, node);
-    server.register(externalLinkToadlet, null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false);
+    server.register(
+        externalLinkToadlet,
+        ToadletRegistration.basic(null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false));
 
     CoreActionToadlet coreActionToadlet = new CoreActionToadlet(client, node);
-    server.register(coreActionToadlet, null, CORE_UPDATE_PATH, true, false);
+    server.register(
+        coreActionToadlet, ToadletRegistration.basic(null, CORE_UPDATE_PATH, true, false));
 
     DarknetConnectionsToadlet friendsToadlet = new DarknetConnectionsToadlet(node, core, client);
     server.register(
         friendsToadlet,
-        FProxyToadlet.CATEGORY_FRIENDS,
-        FProxyToadlet.FRIENDS_PATH,
-        true,
-        "FProxyToadlet.friendsTitle",
-        "FProxyToadlet.friends",
-        true,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_FRIENDS,
+            FProxyToadlet.FRIENDS_PATH,
+            true,
+            "FProxyToadlet.friendsTitle",
+            "FProxyToadlet.friends",
+            true,
+            null));
 
     DarknetAddRefToadlet addRefToadlet = new DarknetAddRefToadlet(node, client, friendsToadlet);
     server.register(
         addRefToadlet,
-        FProxyToadlet.CATEGORY_FRIENDS,
-        "/addfriend/",
-        true,
-        "FProxyToadlet.addFriendTitle",
-        "FProxyToadlet.addFriend",
-        true,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_FRIENDS,
+            "/addfriend/",
+            true,
+            "FProxyToadlet.addFriendTitle",
+            "FProxyToadlet.addFriend",
+            true,
+            null));
 
     OpennetConnectionsToadlet opennetToadlet = new OpennetConnectionsToadlet(node, core, client);
     server.register(
         opennetToadlet,
-        FProxyToadlet.CATEGORY_STATUS,
-        "/strangers/",
-        true,
-        "FProxyToadlet.opennetTitle",
-        "FProxyToadlet.opennet",
-        true,
-        opennetToadlet);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_STATUS,
+            "/strangers/",
+            true,
+            "FProxyToadlet.opennetTitle",
+            "FProxyToadlet.opennet",
+            true,
+            opennetToadlet));
 
     ChatForumsToadlet chatForumsToadlet =
         new ChatForumsToadlet(client, node.services().pluginManager());
     server.register(
         chatForumsToadlet,
-        "FProxyToadlet.categoryChat",
-        "/chat/",
-        true,
-        "FProxyToadlet.chatForumsTitle",
-        "FProxyToadlet.chatForums",
-        true,
-        chatForumsToadlet);
+        ToadletRegistration.menuLink(
+            "FProxyToadlet.categoryChat",
+            "/chat/",
+            true,
+            "FProxyToadlet.chatForumsTitle",
+            "FProxyToadlet.chatForums",
+            true,
+            chatForumsToadlet));
 
     N2NTMToadlet n2ntmToadlet = new N2NTMToadlet(node, core, client);
-    server.register(n2ntmToadlet, null, "/send_n2ntm/", true, true);
+    server.register(n2ntmToadlet, ToadletRegistration.basic(null, "/send_n2ntm/", true, true));
     LocalFileN2NMToadlet localFileN2NMToadlet = new LocalFileN2NMToadlet(core, client);
-    server.register(localFileN2NMToadlet, null, LocalFileN2NMToadlet.BROWSE_PATH, true, false);
+    server.register(
+        localFileN2NMToadlet,
+        ToadletRegistration.basic(null, LocalFileN2NMToadlet.BROWSE_PATH, true, false));
 
     BookmarkEditorToadlet bookmarkEditorToadlet = new BookmarkEditorToadlet(client, core);
-    server.register(bookmarkEditorToadlet, null, "/bookmarkEditor/", true, false);
+    server.register(
+        bookmarkEditorToadlet, ToadletRegistration.basic(null, "/bookmarkEditor/", true, false));
 
     BrowserTestToadlet browserTestToadlet = new BrowserTestToadlet(client);
-    server.register(browserTestToadlet, null, "/test/", true, false);
+    server.register(browserTestToadlet, ToadletRegistration.basic(null, "/test/", true, false));
 
     StatisticsToadlet statisticsToadlet = new StatisticsToadlet(node, core, client);
     server.register(
         statisticsToadlet,
-        FProxyToadlet.CATEGORY_STATUS,
-        "/stats/",
-        true,
-        "FProxyToadlet.statsTitle",
-        "FProxyToadlet.stats",
-        true,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_STATUS,
+            "/stats/",
+            true,
+            "FProxyToadlet.statsTitle",
+            "FProxyToadlet.stats",
+            true,
+            null));
 
     DiagnosticToadlet diagnosticToadlet =
         new DiagnosticToadlet(node, core.getEndpoints().getFCPServer(), client);
     server.register(
         diagnosticToadlet,
-        FProxyToadlet.CATEGORY_STATUS,
-        "/diagnostic/",
-        true,
-        "FProxyToadlet.diagnosticTitle",
-        "FProxyToadlet.diagnostic",
-        true,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_STATUS,
+            "/diagnostic/",
+            true,
+            "FProxyToadlet.diagnosticTitle",
+            "FProxyToadlet.diagnostic",
+            true,
+            null));
 
     ConnectivityToadlet connectivityToadlet = new ConnectivityToadlet(client, node);
     server.register(
         connectivityToadlet,
-        FProxyToadlet.CATEGORY_STATUS,
-        "/connectivity/",
-        true,
-        "ConnectivityToadlet.connectivityTitle",
-        "ConnectivityToadlet.connectivity",
-        true,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_STATUS,
+            "/connectivity/",
+            true,
+            "ConnectivityToadlet.connectivityTitle",
+            "ConnectivityToadlet.connectivity",
+            true,
+            null));
 
     TranslationToadlet translationToadlet = new TranslationToadlet(client, core);
     server.register(
         translationToadlet,
-        FProxyToadlet.CATEGORY_CONFIG,
-        TranslationToadlet.TOADLET_URL,
-        true,
-        "TranslationToadlet.title",
-        "TranslationToadlet.titleLong",
-        true,
-        null);
+        ToadletRegistration.menuLink(
+            FProxyToadlet.CATEGORY_CONFIG,
+            TranslationToadlet.TOADLET_URL,
+            true,
+            "TranslationToadlet.title",
+            "TranslationToadlet.titleLong",
+            true,
+            null));
 
     FirstTimeWizardToadlet firstTimeWizardToadlet = new FirstTimeWizardToadlet(client, node, core);
-    server.register(firstTimeWizardToadlet, null, FirstTimeWizardToadlet.TOADLET_URL, true, false);
+    server.register(
+        firstTimeWizardToadlet,
+        ToadletRegistration.basic(null, FirstTimeWizardToadlet.TOADLET_URL, true, false));
 
     FirstTimeWizardNewToadlet firstTimeWizardNewToadlet =
         new FirstTimeWizardNewToadlet(client, core, config);
     server.register(
-        firstTimeWizardNewToadlet, null, FirstTimeWizardNewToadlet.TOADLET_URL, true, false);
+        firstTimeWizardNewToadlet,
+        ToadletRegistration.basic(null, FirstTimeWizardNewToadlet.TOADLET_URL, true, false));
 
     SimpleHelpToadlet simpleHelpToadlet = new SimpleHelpToadlet(client, core);
-    server.register(simpleHelpToadlet, null, "/help/", true, false);
+    server.register(simpleHelpToadlet, ToadletRegistration.basic(null, "/help/", true, false));
 
     PushDataToadlet pushDataToadlet = new PushDataToadlet(client);
-    server.register(pushDataToadlet, null, pushDataToadlet.path(), true, false);
+    server.register(
+        pushDataToadlet, ToadletRegistration.basic(null, pushDataToadlet.path(), true, false));
 
     PushNotificationToadlet pushNotificationToadlet = new PushNotificationToadlet(client);
-    server.register(pushNotificationToadlet, null, pushNotificationToadlet.path(), true, false);
+    server.register(
+        pushNotificationToadlet,
+        ToadletRegistration.basic(null, pushNotificationToadlet.path(), true, false));
 
     PushKeepaliveToadlet pushKeepaliveToadlet = new PushKeepaliveToadlet(client);
-    server.register(pushKeepaliveToadlet, null, pushKeepaliveToadlet.path(), true, false);
+    server.register(
+        pushKeepaliveToadlet,
+        ToadletRegistration.basic(null, pushKeepaliveToadlet.path(), true, false));
 
     PushFailoverToadlet pushFailoverToadlet = new PushFailoverToadlet(client);
-    server.register(pushFailoverToadlet, null, pushFailoverToadlet.path(), true, false);
+    server.register(
+        pushFailoverToadlet,
+        ToadletRegistration.basic(null, pushFailoverToadlet.path(), true, false));
 
     PushTesterToadlet pushTesterToadlet = new PushTesterToadlet(client);
-    server.register(pushTesterToadlet, null, pushTesterToadlet.path(), true, false);
+    server.register(
+        pushTesterToadlet, ToadletRegistration.basic(null, pushTesterToadlet.path(), true, false));
 
     PushLeavingToadlet pushLeavingToadlet = new PushLeavingToadlet(client);
-    server.register(pushLeavingToadlet, null, pushLeavingToadlet.path(), true, false);
+    server.register(
+        pushLeavingToadlet,
+        ToadletRegistration.basic(null, pushLeavingToadlet.path(), true, false));
 
     ImageCreatorToadlet imageCreatorToadlet = new ImageCreatorToadlet(client);
-    server.register(imageCreatorToadlet, null, imageCreatorToadlet.path(), true, false);
+    server.register(
+        imageCreatorToadlet,
+        ToadletRegistration.basic(null, imageCreatorToadlet.path(), true, false));
 
     LogWritebackToadlet logWritebackToadlet = new LogWritebackToadlet(client);
-    server.register(logWritebackToadlet, null, logWritebackToadlet.path(), true, false);
+    server.register(
+        logWritebackToadlet,
+        ToadletRegistration.basic(null, logWritebackToadlet.path(), true, false));
 
     DismissAlertToadlet dismissAlertToadlet = new DismissAlertToadlet(client);
-    server.register(dismissAlertToadlet, null, dismissAlertToadlet.path(), true, false);
+    server.register(
+        dismissAlertToadlet,
+        ToadletRegistration.basic(null, dismissAlertToadlet.path(), true, false));
   }
 }

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -990,7 +990,8 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
               l10n(ABORT_TO_HOMEPAGE_KEY));
 
       MultiValueTable<String, String> retHeaders = new MultiValueTable<>();
-      writeHTMLReply(ctx, 200, "OK", retHeaders, page.generate());
+      writeHTMLReply(
+          ctx, ReplyHeaders.of(200, "OK", "text/html; charset=utf-8", retHeaders), page.generate());
       fetchResult.close();
       fetch.close();
     }

--- a/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
@@ -144,7 +144,7 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
     contentNode.addChild(createInsertBox(pageMaker, ctx, ctx.isAdvancedModeEnabled()));
     if (ctx.isAdvancedModeEnabled()) contentNode.addChild(createFilterBox(pageMaker, ctx));
 
-    writeHTMLReply(ctx, 200, "OK", null, page.generate());
+    writeHTMLReply(ctx, ReplyHeaders.of(200, "OK", "text/html; charset=utf-8"), page.generate());
   }
 
   private HTMLNode createInsertBox(

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -2140,7 +2140,10 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     try {
       RequestStatus[] reqs = fcp.getGlobalRequests();
       HTMLNode pageNode = handleGetInner(pageMaker, reqs, request, ctx);
-      writeHTMLReply(ctx, 200, "OK", new MultiValueTable<>(), pageNode.generate());
+      writeHTMLReply(
+          ctx,
+          ReplyHeaders.of(200, "OK", "text/html; charset=utf-8", new MultiValueTable<>()),
+          pageNode.generate());
     } catch (PersistenceDisabledException _) {
       sendPersistenceDisabledError(ctx);
     }
@@ -2241,9 +2244,12 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private void writeOutput(ToadletContext ctx, OutputWrapper result)
       throws ToadletContextClosedException, IOException {
     if (result.pageNode != null) {
-      writeHTMLReply(ctx, 200, "OK", new MultiValueTable<>(), result.pageNode.generate());
+      writeHTMLReply(
+          ctx,
+          ReplyHeaders.of(200, "OK", "text/html; charset=utf-8", new MultiValueTable<>()),
+          result.pageNode.generate());
     } else if (result.plainText != null) {
-      this.writeReply(ctx, 200, "text/plain", "OK", result.plainText);
+      this.writeReply(ctx, ReplyHeaders.of(200, "OK", "text/plain"), result.plainText);
     } else if (core.killedDatabase()) {
       sendPersistenceDisabledError(ctx);
     } else {

--- a/src/main/java/network/crypta/clients/http/ReplyHeaders.java
+++ b/src/main/java/network/crypta/clients/http/ReplyHeaders.java
@@ -1,0 +1,100 @@
+package network.crypta.clients.http;
+
+import network.crypta.support.MultiValueTable;
+
+/**
+ * Immutable bundle of HTTP reply header metadata for toadlet responses.
+ *
+ * <p>This record consolidates status code, reason phrase, MIME type, and optional header overrides
+ * into a single value object that can be passed through reply helpers without long parameter lists.
+ * It is intended for use by {@link Toadlet} convenience methods and the {@link ToadletContext}
+ * header-writing APIs, keeping each call site explicit about status metadata while avoiding
+ * repetition. Instances are lightweight and carry no behavior beyond holding values.
+ *
+ * <p>All components are treated as request-scoped data; callers typically create a new instance per
+ * response and discard it after the reply is written. The record is immutable and therefore
+ * thread-safe, but any {@code headers} table supplied remains mutable and should not be shared
+ * between concurrent responses. No validation is performed here, so callers remain responsible for
+ * supplying valid HTTP status codes and MIME types.
+ *
+ * <ul>
+ *   <li><strong>Typical use:</strong> construct via {@link #of(int, String, String)} or an overload
+ *       and pass to a {@code writeReply} helper.
+ *   <li><strong>JavaScript control:</strong> set {@link #forceDisableJavascript()} only when a
+ *       stricter CSP is required than the container default.
+ * </ul>
+ *
+ * @param code HTTP status code for the response line; must be a valid numeric status.
+ * @param description Reason phrase paired with {@code code}; short, human-readable, non-null.
+ * @param mimeType MIME type string for the body; {@code null} when no content type applies.
+ * @param headers Optional header overrides; nullable and caller-owned if provided.
+ * @param forceDisableJavascript {@code true} to force a restrictive CSP for the response.
+ * @see Toadlet
+ * @see ToadletContext
+ */
+public record ReplyHeaders(
+    int code,
+    String description,
+    String mimeType,
+    MultiValueTable<String, String> headers,
+    boolean forceDisableJavascript) {
+  /**
+   * Creates header metadata with no custom headers and JavaScript allowed.
+   *
+   * <p>Use this overload for the common case where the response only needs a status code, reason
+   * phrase, and MIME type. The returned instance has {@code headers} set to {@code null} and does
+   * not force JavaScript suppression, so container defaults apply. It performs no validation and is
+   * suitable for per-request allocation.
+   *
+   * @param code HTTP status code for the response line; must be a valid numeric status.
+   * @param description Reason phrase paired with {@code code}; short, human-readable, non-null.
+   * @param mimeType MIME type string for the body; {@code null} when no content type applies.
+   * @return Immutable reply metadata with no extra headers and JavaScript allowed.
+   */
+  public static ReplyHeaders of(int code, String description, String mimeType) {
+    return new ReplyHeaders(code, description, mimeType, null, false);
+  }
+
+  /**
+   * Creates header metadata with caller-supplied extra headers and default JavaScript policy.
+   *
+   * <p>This overload is appropriate when the response needs additional headers such as {@code
+   * Content-Disposition} or redirect locations but should still honor the container's default
+   * JavaScript policy. The provided {@code headers} table is stored as-is and may be mutated by the
+   * caller before the response is written, so avoid sharing it across threads.
+   *
+   * @param code HTTP status code for the response line; must be a valid numeric status.
+   * @param description Reason phrase paired with {@code code}; short, human-readable, non-null.
+   * @param mimeType MIME type string for the body; {@code null} when no content type applies.
+   * @param headers Additional response headers to include; nullable and caller-owned.
+   * @return Immutable reply metadata, including custom headers and JavaScript allowed.
+   */
+  public static ReplyHeaders of(
+      int code, String description, String mimeType, MultiValueTable<String, String> headers) {
+    return new ReplyHeaders(code, description, mimeType, headers, false);
+  }
+
+  /**
+   * Creates header metadata with custom headers and an explicit JavaScript policy override.
+   *
+   * <p>Use this overload when a response must explicitly disable JavaScript or when a hardened CSP
+   * is required regardless of the container default. The returned instance captures all supplied
+   * values without validation; callers should ensure the status code and MIME type are appropriate
+   * for the response body. The {@code headers} table remains caller-owned and may be {@code null}.
+   *
+   * @param code HTTP status code for the response line; must be a valid numeric status.
+   * @param description Reason phrase paired with {@code code}; short, human-readable, non-null.
+   * @param mimeType MIME type string for the body; {@code null} when no content type applies.
+   * @param headers Additional response headers to include; nullable and caller-owned.
+   * @param forceDisableJavascript {@code true} to disable scripts regardless of defaults.
+   * @return Immutable reply metadata with custom headers and explicit JS policy.
+   */
+  public static ReplyHeaders of(
+      int code,
+      String description,
+      String mimeType,
+      MultiValueTable<String, String> headers,
+      boolean forceDisableJavascript) {
+    return new ReplyHeaders(code, description, mimeType, headers, forceDisableJavascript);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -1458,8 +1458,10 @@ public final class SimpleToadletServer
     public void run() {
       if (LOG.isDebugEnabled()) LOG.debug("Handling connection");
       try {
-        ToadletContextImpl.handle(
-            sock, SimpleToadletServer.this, pageMaker, getUserAlertManager(), bookmarkManager);
+        ToadletRequestServices services =
+            new ToadletRequestServices(
+                SimpleToadletServer.this, pageMaker, getUserAlertManager(), bookmarkManager);
+        ToadletContextImpl.handle(sock, services);
       } catch (Exception t) {
         LOG.error("Caught in SimpleToadletServer: {}", t, t);
       } finally {

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -60,14 +60,14 @@ import org.tanukisoftware.wrapper.WrapperManager;
  *
  * <p>Concurrency: the network listener and request handling threads read shared state such as the
  * {@link #core} reference, panic flags, and theme settings. The core reference is published through
- * a volatile write in {@link #setCore(NodeClientCore)} so request threads see it once set.
+ * a volatile write-in {@link #setCore(NodeClientCore)} so request threads see it once set.
  * Mutability: most configuration is thread-safe via synchronized blocks or volatile fields; URL
  * registration is guarded by the server monitor. Extended configuration callbacks are invoked on
  * the configuration thread; request handlers run on the executor.
  *
  * <ul>
  *   <li>Responsibilities: bind sockets, dispatch toadlets, surface configuration, and relay alerts.
- *   <li>Notable behaviors: preserves startup toadlet until replaced; honours gateway/public mode;
+ *   <li>Notable behaviors: preserves startup toadlet until replaced; honors gateway/public mode;
  *       mirrors theme changes to plugins; emits panic button state based on physical threat level.
  * </ul>
  *
@@ -141,7 +141,7 @@ public final class SimpleToadletServer
   private boolean enableCachingForChkAndSskKeys;
 
   // Something does not really belong to here
-  static volatile boolean isPanicButtonToBeShown; // move to QueueToadlet ?
+  static volatile boolean isPanicButtonToBeShown; // move to QueueToadlet?
   static volatile boolean noConfirmPanic;
 
   private static void setPanicButtonVisibility(boolean value) {
@@ -152,7 +152,7 @@ public final class SimpleToadletServer
     noConfirmPanic = value;
   }
 
-  private BookmarkManager bookmarkManager; // move to WelcomeToadlet / BookmarkEditorToadlet ?
+  private BookmarkManager bookmarkManager; // move to WelcomeToadlet / BookmarkEditorToadlet?
   private volatile boolean fProxyJavascriptEnabled; // ugh?
   private volatile boolean fProxyWebPushingEnabled; // ugh?
   private volatile boolean fproxyHasCompletedWizard; // hmmm..
@@ -327,7 +327,7 @@ public final class SimpleToadletServer
         // Prevents user from specifying root dir.
         // They can still shoot themselves in the foot, but only when developing themes/using custom
         // themes.
-        // Because of the .. check above, any malicious thing cannot break out of the dir anyway.
+        // Because of the ".." check above, any malicious thing cannot break out of the dir anyway.
         if (parent.getParentFile() == null)
           throw new InvalidConfigValueException(
               l10n("cssOverrideCantUseRootDir", FILENAME_KEY, parent.toString()));
@@ -457,7 +457,7 @@ public final class SimpleToadletServer
    *
    * <p>Call this after {@link #setCore(NodeClientCore)} and before accepting requests to install
    * bookmark handling, interval push scheduling, and UI registration against the active node. This
-   * method is idempotent; subsequent calls are ignored after the first successful invocation. It
+   * method is idempotent; later calls are ignored after the first successful invocation. It
    * captures the current {@link #core} and {@link Node} references, wires the push managers to the
    * shared {@link Ticker}, and delegates to {@link FProxyRegistrar} to create request handlers and
    * configuration entries.
@@ -528,11 +528,10 @@ public final class SimpleToadletServer
     publicGatewayMode = fproxyConfig.getBoolean("publicGatewayMode");
     wasPublicGatewayMode = publicGatewayMode;
 
-    // This is OFF BY DEFAULT
-    // This is OFF BY DEFAULT because for example firefox has a limit of 2 persistent
+    // This is OFF BY DEFAULT because, for example, firefox has a limit of 2 persistent
     // connections per server, but 8 non-persistent connections per server. We need 8 conns
-    // more than we need the efficiency gain of reusing connections - especially on first
-    // install.
+    // more than we need the efficiency gain of reusing connections - especially on the first
+    // installation.
 
     configItemOrder = registerConnectionOptions(fproxyConfig, configItemOrder);
     allowedFullAccess = new AllowedHosts(fproxyConfig.getString("allowedHostsFullAccess"));
@@ -599,11 +598,11 @@ public final class SimpleToadletServer
     // Register static toadlet and startup toadlet
 
     StaticToadlet statictoadlet = new StaticToadlet();
-    register(statictoadlet, null, "/static/", false, false);
+    register(statictoadlet, ToadletRegistration.basic(null, "/static/", false, false));
 
     // "Freenet is starting up..." page, to be removed at #removeStartupToadlet()
     startupToadlet = new StartupToadlet(statictoadlet);
-    register(startupToadlet, null, "/", false, false);
+    register(startupToadlet, ToadletRegistration.basic(null, "/", false, false));
   }
 
   private int registerInitialOptions(SubConfig fproxyConfig) {
@@ -1258,43 +1257,23 @@ public final class SimpleToadletServer
   }
 
   @Override
-  public void register(
-      Toadlet t, String menu, String urlPrefix, boolean atFront, boolean fullOnly) {
-    register(t, menu, urlPrefix, atFront, null, null, fullOnly, null, null);
-  }
-
-  @Override
-  public void register(
-      Toadlet t,
-      String menu,
-      String urlPrefix,
-      boolean atFront,
-      String name,
-      String title,
-      boolean fullOnly,
-      LinkEnabledCallback cb) {
-    register(t, menu, urlPrefix, atFront, name, title, fullOnly, cb, null);
-  }
-
-  @Override
-  public void register(
-      Toadlet t,
-      String menu,
-      String urlPrefix,
-      boolean atFront,
-      String name,
-      String title,
-      boolean fullOnly,
-      LinkEnabledCallback cb,
-      FredPluginL10n l10n) {
-    ToadletElement te = new ToadletElement(t, urlPrefix, menu, name);
+  public void register(Toadlet t, ToadletRegistration registration) {
+    ToadletElement te =
+        new ToadletElement(t, registration.urlPrefix(), registration.menu(), registration.name());
     synchronized (toadlets) {
-      if (atFront) toadlets.addFirst(te);
+      if (registration.atFront()) toadlets.addFirst(te);
       else toadlets.addLast(te);
       t.container = this;
     }
-    if (menu != null && name != null) {
-      pageMaker.addNavigationLink(menu, urlPrefix, name, title, fullOnly, cb, l10n);
+    if (registration.menu() != null && registration.name() != null) {
+      pageMaker.addNavigationLink(
+          registration.menu(),
+          registration.urlPrefix(),
+          registration.name(),
+          registration.title(),
+          registration.fullOnly(),
+          registration.callback(),
+          registration.l10n());
     }
   }
 
@@ -1578,7 +1557,7 @@ public final class SimpleToadletServer
    * Toggles push support for FProxy web interfaces.
    *
    * <p>When enabled, pages may initiate push data channels to deliver live updates. The flag is
-   * stored and read concurrently; synchronization guards writes. Existing connections will read the
+   * stored and read concurrently; synchronization guards write. Existing connections will read the
    * latest value on their next push attempt, so callers can flip this at runtime to triage load or
    * feature issues without restarting the node.
    *
@@ -1642,7 +1621,7 @@ public final class SimpleToadletServer
    *
    * <p>This mirrors whether the server thread was created at construction. It does not confirm the
    * socket bind succeeded; callers should also observe logs for binding errors when transitioning
-   * to running state.
+   * to the running state.
    *
    * @return {@code true} when the listener thread exists, {@code false} otherwise.
    */
@@ -1654,7 +1633,7 @@ public final class SimpleToadletServer
    * Returns the bookmark manager backing user bookmark operations.
    *
    * <p>The manager may be {@code null} before {@link #createFproxy()} wires the supporting
-   * components. Once available it manages storage, import/export, and UI synchronization for saved
+   * components. Once available, it manages storage, import/export, and UI synchronization for saved
    * bookmarks. Callers should treat the reference as owned by the server.
    *
    * @return {@link BookmarkManager} instance or {@code null} when not yet available.
@@ -1677,7 +1656,7 @@ public final class SimpleToadletServer
   /**
    * Returns the URIs of all currently stored bookmarks.
    *
-   * <p>The returned array is a snapshot; subsequent modifications to the bookmark store are not
+   * <p>The returned array is a snapshot; later modifications to the bookmark store are not
    * reflected. Callers should not mutate the array contents.
    *
    * @return array of {@link FreenetURI} entries; empty when no bookmarks exist.

--- a/src/main/java/network/crypta/clients/http/Toadlet.java
+++ b/src/main/java/network/crypta/clients/http/Toadlet.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.http;
 
+import com.onionnetworks.util.Buffer;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -8,7 +9,13 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import network.crypta.client.*;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchResult;
+import network.crypta.client.FetchWaiter;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.InsertBlock;
+import network.crypta.client.InsertException;
 import network.crypta.client.async.ClientGetter;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
@@ -69,7 +76,7 @@ public abstract class Toadlet {
 
   /**
    * Creates a toadlet bound to the high-level client helper used for fetch and insert operations.
-   * The client is typically shared across multiple toadlets so connection pooling, throttling, and
+   * The client is typically shared across multiple toadlets, so connection pooling, throttling, and
    * authentication remain consistent. Implementations should store configuration on the client
    * rather than subclass fields so that instances stay lightweight and easy to construct.
    *
@@ -151,7 +158,7 @@ public abstract class Toadlet {
    * @param ctx Execution context for writing replies, acquiring page builders, and tracking session
    *     state; guaranteed open when the method is entered.
    * @throws ToadletContextClosedException If the client disconnects before the response is written.
-   * @throws IOException If streaming the response fails or backing storage cannot be read.
+   * @throws IOException If streaming, the response fails or backing storage cannot be read.
    * @throws RedirectException If the handler deliberately triggers an HTTP redirect for navigation.
    */
   public abstract void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
@@ -160,7 +167,7 @@ public abstract class Toadlet {
   /**
    * Returns the canonical mount path for this toadlet within the HTTP namespace. The container uses
    * the value to route incoming requests and to build menu entries. Paths should start with a slash
-   * and remain stable so bookmarks and inter-toadlet links stay valid across releases.
+   * and remain stable, so bookmarks and inter-toadlet links stay valid across releases.
    *
    * @return Absolute path fragment (e.g., {@code "/welcome/"}) that uniquely identifies the
    *     toadlet.
@@ -168,21 +175,22 @@ public abstract class Toadlet {
   public abstract String path();
 
   /**
-   * Primary purpose of this function is being overridden in your Toadlet implementations - for the
-   * following purpose:
+   * The primary purpose of this function is being overridden in your Toadlet implementations - for
+   * the following purpose:
    *
    * <p>When displaying this Toadlet, the web interface should show the menu from which it was
-   * selected as opened, and mark the appropriate entry as selected in the menu. This function may
+   * selected as opened and mark the appropriate entry as selected in the menu. This function may
    * return the Toadlet whose menu shall be opened and whose entry shall be marked as selected in
    * the menu.
    *
    * <p>It is necessary to have this function instead of just marking <code>Toadlet.this</code> as
    * selected: Some Toadlets won't be added to a menu. They will be only accessible through other
-   * Toadlets. For example a Toadlet for deleting a single download might only be accessible through
-   * the Toadlet which shows all downloads. For still being able to figure out the menu entry
-   * through which those so-called invisible Toadlets where accessed, this function is necessary.
+   * Toadlets. For example, a Toadlet for deleting a single download might only be accessible
+   * through the Toadlet, which shows all downloads. For still being able to figure out the menu
+   * entry through which those so-called invisible Toadlets where accessed, this function is
+   * necessary.
    *
-   * @param context Can be used to decide the return value, for example to check session cookies
+   * @param context Can be used to decide the return value, for example, to check session cookies
    *     using {@link SessionManager}.
    * @return The result of {@link #showAsToadlet()}, which is <code>this</code> by default.<br>
    *     This behavior is for backwards compatibility with existing code which overrides that
@@ -196,17 +204,17 @@ public abstract class Toadlet {
   }
 
   /**
-   * Legacy compatibility hook; prefer {@link #showAsToadlet(ToadletContext)}. Internally fred will
-   * always call that function, which delegates to this legacy method by default so existing code
-   * continues to work. When removing this legacy function, change {@link
+   * Legacy compatibility hook; prefer {@link #showAsToadlet(ToadletContext)}. Internally, fred will
+   * always call that function, which delegates to this legacy method by default, so the existing
+   * code continues to work. When removing this legacy function, change {@link
    * #showAsToadlet(ToadletContext)} to return <code>this</code> by default, as already specified in
-   * its JavaDoc.
+   * its Javadoc.
    *
    * @return <code>this</code>
    */
   public Toadlet showAsToadlet() {
     // DO NOT CHANGE THIS ANYMORE: Otherwise showAsToadlet(ToadletContext) will not follow the
-    // contract of its JavaDoc.
+    // contract of its Javadoc.
     return resolveLegacyShowAsToadlet();
   }
 
@@ -263,7 +271,7 @@ public abstract class Toadlet {
   /**
    * Discovers the HTTP verbs implemented by this toadlet by scanning for methods whose names begin
    * with {@link #HANDLE_METHOD_PREFIX}. The result informs capability headers and tooling that
-   * enumerates available operations. Because reflection inspects inherited methods, subclasses can
+   * lists available operations. Because reflection inspects inherited methods, subclasses can
    * override this method to intentionally hide a parent implementation.
    *
    * @return Comma-separated list of supported verbs (e.g., {@code "GET, POST"}), cached per
@@ -339,29 +347,31 @@ public abstract class Toadlet {
    * when used for HTML or plain text bodies.
    *
    * @param ctx Request context that identifies the client connection receiving the payload.
-   * @param code HTTP status code to send, such as 200 or 500.
-   * @param mimeType MIME type string written verbatim to the response headers.
-   * @param desc Short reason phrase paired with the status code for debugging purposes.
-   * @param data Buffer containing the bytes to transmit; ownership is not transferred.
-   * @param offset Index of the first byte in {@code data} to include in the response.
-   * @param length Number of bytes to transmit starting at {@code offset}; must not exceed buffer
-   *     size.
+   * @param replyHeaders Status, MIME type, and header metadata for the response.
+   * @param data Buffer slice containing the bytes to transmit; ownership is not transferred.
    * @throws ToadletContextClosedException If the client disconnects before headers or body are
    *     sent.
    * @throws IOException If the underlying output stream fails during header or body transmission.
    */
-  @SuppressWarnings("SameParameterValue")
-  protected void writeReply(
-      ToadletContext ctx,
-      int code,
-      String mimeType,
-      String desc,
-      byte[] data,
-      int offset,
-      int length)
+  protected void writeReply(ToadletContext ctx, ReplyHeaders replyHeaders, Buffer data)
       throws ToadletContextClosedException, IOException {
-    ctx.sendReplyHeaders(code, desc, null, mimeType, length);
-    ctx.writeData(data, offset, length);
+    if (replyHeaders.forceDisableJavascript()) {
+      ctx.sendReplyHeaders(
+          replyHeaders.code(),
+          replyHeaders.description(),
+          replyHeaders.headers(),
+          replyHeaders.mimeType(),
+          data.len,
+          true);
+    } else {
+      ctx.sendReplyHeaders(
+          replyHeaders.code(),
+          replyHeaders.description(),
+          replyHeaders.headers(),
+          replyHeaders.mimeType(),
+          data.len);
+    }
+    ctx.writeData(data.b, data.off, data.len);
   }
 
   /**
@@ -370,47 +380,31 @@ public abstract class Toadlet {
    * bucket lifecycle and will free it after the response is transmitted; callers that need to
    * retain the bucket should wrap it in {@link NoFreeBucket} first.
    *
-   * @param ctx Context representing the active HTTP exchange that will receive the body.
-   * @param code HTTP status code to send to the client.
-   * @param mimeType MIME type string describing the bucket contents.
-   * @param desc Human-readable reason phrase aligned with {@code code} for logs and diagnostics.
-   * @param data Bucket containing the response payload; ownership is transferred to this method.
-   * @throws ToadletContextClosedException If the client closes the connection mid-transfer.
-   * @throws IOException If reading from the bucket or writing to the client fails.
-   * @see NoFreeBucket
-   */
-  @SuppressWarnings("SameParameterValue")
-  protected void writeReply(ToadletContext ctx, int code, String mimeType, String desc, Bucket data)
-      throws ToadletContextClosedException, IOException {
-    writeReply(ctx, code, mimeType, desc, null, data);
-  }
-
-  /**
-   * Writes a response backed by a {@link Bucket} while allowing custom headers such as {@code
-   * Content-Disposition} or redirects. This overload is useful when a caller needs fine-grained
-   * control over metadata but still wants the convenience of bucket streaming and lifecycle
-   * management handled by the toadlet.
-   *
    * @param context HTTP exchange context used to emit headers and stream the bucket data.
-   * @param code HTTP status code to transmit to the client.
-   * @param mimeType MIME type string describing the payload; written unchanged to the headers.
-   * @param desc Reason phrase accompanying the status code for readability.
-   * @param headers Optional additional headers; may be {@code null} when none are needed.
+   * @param replyHeaders Status, MIME type, and header metadata for the response.
    * @param data Bucket containing the response body; ownership is transferred and will be freed.
    * @throws ToadletContextClosedException If the client disconnects while headers or body are sent.
    * @throws IOException If reading from the bucket or writing to the output stream fails.
    * @see NoFreeBucket
    */
-  @SuppressWarnings("SameParameterValue")
-  protected void writeReply(
-      ToadletContext context,
-      int code,
-      String mimeType,
-      String desc,
-      MultiValueTable<String, String> headers,
-      Bucket data)
+  protected void writeReply(ToadletContext context, ReplyHeaders replyHeaders, Bucket data)
       throws ToadletContextClosedException, IOException {
-    context.sendReplyHeaders(code, desc, headers, mimeType, data.size());
+    if (replyHeaders.forceDisableJavascript()) {
+      context.sendReplyHeaders(
+          replyHeaders.code(),
+          replyHeaders.description(),
+          replyHeaders.headers(),
+          replyHeaders.mimeType(),
+          data.size(),
+          true);
+    } else {
+      context.sendReplyHeaders(
+          replyHeaders.code(),
+          replyHeaders.description(),
+          replyHeaders.headers(),
+          replyHeaders.mimeType(),
+          data.size());
+    }
     context.writeData(data);
   }
 
@@ -421,18 +415,15 @@ public abstract class Toadlet {
    * Bucket}-based overload.
    *
    * @param ctx Context representing the request whose response is being written.
-   * @param code HTTP status code that accompanies the response body.
-   * @param mimeType MIME type string, including charset when applicable.
-   * @param desc Human-readable reason phrase aligned with the status code.
+   * @param replyHeaders Status, MIME type, and header metadata for the response.
    * @param reply Textual body content to encode as UTF-8 before streaming.
    * @throws ToadletContextClosedException If the client closes the connection during the writing.
-   * @throws IOException If writing headers or encoding/streaming the body fails.
+   * @throws IOException If writing headers or encoding/streaming, the body fails.
    */
-  @SuppressWarnings("SameParameterValue")
-  protected void writeReply(
-      ToadletContext ctx, int code, String mimeType, String desc, String reply)
+  protected void writeReply(ToadletContext ctx, ReplyHeaders replyHeaders, String reply)
       throws ToadletContextClosedException, IOException {
-    writeReply(ctx, code, mimeType, desc, null, reply, false);
+    byte[] buffer = reply.getBytes(StandardCharsets.UTF_8);
+    writeReply(ctx, replyHeaders, new Buffer(buffer));
   }
 
   /**
@@ -445,11 +436,11 @@ public abstract class Toadlet {
    * @param desc Short reason phrase corresponding to {@code code}; appears in some browsers.
    * @param reply HTML markup to transmit; callers are responsible for ensuring it is well-formed.
    * @throws ToadletContextClosedException If the connection closes before headers or body finish.
-   * @throws IOException If writing headers or streaming the body fails.
+   * @throws IOException If writing headers or streaming, the body fails.
    */
   protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply)
       throws ToadletContextClosedException, IOException {
-    writeReply(ctx, code, "text/html; charset=utf-8", desc, null, reply, false);
+    writeHTMLReply(ctx, ReplyHeaders.of(code, desc, "text/html; charset=utf-8"), reply);
   }
 
   /**
@@ -466,56 +457,24 @@ public abstract class Toadlet {
    */
   protected void writeTextReply(ToadletContext ctx, int code, String desc, String reply)
       throws ToadletContextClosedException, IOException {
-    writeTextReply(ctx, code, desc, null, reply);
+    writeTextReply(
+        ctx, ReplyHeaders.of(code, desc, "text/plain; charset=utf-8", null, true), reply);
   }
 
   /**
-   * Sends an HTML response while allowing callers to supply extra headers such as cache controls or
-   * download hints. The body is encoded as UTF-8 and streamed after the supplied headers have been
+   * Sends an HTML response while allowing callers to supply extra headers and optional JavaScript
+   * suppression. The body is encoded as UTF-8 and streamed after the supplied headers have been
    * merged with the default ones produced by the context.
    *
    * @param ctx Request context that handles header emission and output buffering.
-   * @param code HTTP status code to send with the HTML body.
-   * @param desc Reason phrase corresponding to the status code.
-   * @param headers Additional headers to include; may be {@code null} for none.
+   * @param replyHeaders Status, MIME type, and header metadata for the response.
    * @param reply HTML markup to encode as UTF-8 and stream to the client.
    * @throws ToadletContextClosedException If the connection closes before the response completes.
    * @throws IOException If writing headers or body data fails.
    */
-  protected void writeHTMLReply(
-      ToadletContext ctx,
-      int code,
-      String desc,
-      MultiValueTable<String, String> headers,
-      String reply)
+  protected void writeHTMLReply(ToadletContext ctx, ReplyHeaders replyHeaders, String reply)
       throws ToadletContextClosedException, IOException {
-    writeHTMLReply(ctx, code, desc, headers, reply, false);
-  }
-
-  /**
-   * Sends an HTML response with optional headers and a flag to disable injected JavaScript helpers.
-   * Use this overload when serving markup that must not include convenience scripts (for example
-   * when embedding into untrusted contexts) or when adding headers such as CSP and caching
-   * directives.
-   *
-   * @param ctx Context managing the outgoing HTTP exchange; not {@code null}.
-   * @param code HTTP status code to return to the caller.
-   * @param desc Reason phrase paired with the status code for readability.
-   * @param headers Additional headers to merge into the response; nullable.
-   * @param reply HTML markup to stream after UTF-8 encoding.
-   * @param forceDisableJavascript When true, suppresses default script helpers during rendering.
-   * @throws ToadletContextClosedException If the client disconnects mid-response.
-   * @throws IOException If header writing or body streaming fails.
-   */
-  protected void writeHTMLReply(
-      ToadletContext ctx,
-      int code,
-      String desc,
-      MultiValueTable<String, String> headers,
-      String reply,
-      boolean forceDisableJavascript)
-      throws ToadletContextClosedException, IOException {
-    writeReply(ctx, code, "text/html; charset=utf-8", desc, headers, reply, forceDisableJavascript);
+    writeReply(ctx, replyHeaders, reply);
   }
 
   /**
@@ -524,111 +483,15 @@ public abstract class Toadlet {
    * return a lightweight textual payload.
    *
    * @param ctx Context identifying the in-progress HTTP request/response exchange.
-   * @param code HTTP status code to return.
-   * @param desc Reason phrase aligned with {@code code} for human readers.
-   * @param headers Additional headers to merge into the response; nullable.
+   * @param replyHeaders Status, MIME type, and header metadata for the response.
    * @param reply Plain-text body content to encode as UTF-8.
-   * @throws ToadletContextClosedException If the client disconnects before transmission completes.
-   * @throws IOException If writing headers or streaming the body fails.
+   * @throws ToadletContextClosedException If the client disconnects before the transmission
+   *     completes.
+   * @throws IOException If writing headers or streaming, the body fails.
    */
-  @SuppressWarnings("SameParameterValue")
-  protected void writeTextReply(
-      ToadletContext ctx,
-      int code,
-      String desc,
-      MultiValueTable<String, String> headers,
-      String reply)
+  protected void writeTextReply(ToadletContext ctx, ReplyHeaders replyHeaders, String reply)
       throws ToadletContextClosedException, IOException {
-    writeReply(ctx, code, "text/plain; charset=utf-8", desc, headers, reply, true);
-  }
-
-  /**
-   * Writes a textual response with optional custom headers. This overload exists for callers that
-   * need to control the MIME type while still providing a string body and optional header set. The
-   * body is encoded as UTF-8 before being handed to the lower-level writer.
-   *
-   * @param context Context representing the connection and request being served.
-   * @param code HTTP status code to use in the response line.
-   * @param mimeType MIME type string to advertise for the string body.
-   * @param desc Reason phrase associated with the status code.
-   * @param headers Optional extra headers to merge; may be {@code null}.
-   * @param reply Body content to encode as UTF-8 and stream to the client.
-   * @throws ToadletContextClosedException If the client disconnects during header or body write.
-   * @throws IOException If an I/O failure occurs while writing the response.
-   */
-  @SuppressWarnings("SameParameterValue")
-  protected void writeReply(
-      ToadletContext context,
-      int code,
-      String mimeType,
-      String desc,
-      MultiValueTable<String, String> headers,
-      String reply)
-      throws ToadletContextClosedException, IOException {
-    writeReply(context, code, mimeType, desc, headers, reply, false);
-  }
-
-  /**
-   * Core string-based writer that controls MIME type, optional headers, and whether JavaScript
-   * helper snippets are suppressed. This method performs UTF-8 encoding once and then delegates to
-   * the lowest-level byte-array writer, minimizing duplication across higher-level helpers.
-   *
-   * @param context Active request context used to send headers and body bytes.
-   * @param code HTTP status code to emit.
-   * @param mimeType MIME type string to advertise for the encoded body.
-   * @param desc Reason phrase corresponding to {@code code}.
-   * @param headers Additional headers to include; pass {@code null} to omit.
-   * @param reply Body content to encode as UTF-8 before streaming.
-   * @param forceDisableJavascript When true, prevents auto-injected helper scripts on the response.
-   * @throws ToadletContextClosedException If the client disconnects midstream.
-   * @throws IOException If encoding or writing the response fails.
-   */
-  protected void writeReply(
-      ToadletContext context,
-      int code,
-      String mimeType,
-      String desc,
-      MultiValueTable<String, String> headers,
-      String reply,
-      boolean forceDisableJavascript)
-      throws ToadletContextClosedException, IOException {
-    byte[] buffer = reply.getBytes(StandardCharsets.UTF_8);
-    if (headers == null && !forceDisableJavascript) {
-      writeReply(context, code, mimeType, desc, buffer, 0, buffer.length);
-      return;
-    }
-    writeReply(
-        context, code, mimeType, desc, headers, buffer, 0, buffer.length, forceDisableJavascript);
-  }
-
-  /**
-   * Write a generated HTTP response, e.g. a page, an image, an error message, possibly with custom
-   * headers, for example, we may want to send a redirect, or a file with a specified filename. This
-   * should not be used for fproxy content i.e. content downloaded from Freenet.
-   *
-   * @param context The specific request to reply to.
-   * @param code The HTTP reply code to use.
-   * @param mimeType The MIME type of the data we are returning.
-   * @param desc The HTTP response description for the code.
-   * @param headers The additional HTTP headers to send.
-   * @param buffer The data to write as the response body; ownership is not transferred.
-   * @param startIndex The offset within {@code buffer} of the first byte to send.
-   * @param length The number of bytes of data to send as the response body.
-   */
-  @SuppressWarnings("SameParameterValue")
-  private void writeReply(
-      ToadletContext context,
-      int code,
-      String mimeType,
-      String desc,
-      MultiValueTable<String, String> headers,
-      byte[] buffer,
-      int startIndex,
-      int length,
-      boolean forceDisableJavascript)
-      throws ToadletContextClosedException, IOException {
-    context.sendReplyHeaders(code, desc, headers, mimeType, length, forceDisableJavascript);
-    context.writeData(buffer, startIndex, length);
+    writeReply(ctx, replyHeaders, reply);
   }
 
   /**
@@ -676,7 +539,7 @@ public abstract class Toadlet {
    * @param message Human-readable explanation shown inside the error infobox; not HTML-escaped
    *     here.
    * @throws ToadletContextClosedException If the client disconnects before the page is delivered.
-   * @throws IOException If building or streaming the error page fails.
+   * @throws IOException If building or streaming, the error page fails.
    */
   protected void sendErrorPage(ToadletContext ctx, int code, String desc, String message)
       throws ToadletContextClosedException, IOException {
@@ -686,14 +549,14 @@ public abstract class Toadlet {
   /**
    * Renders a full error page using a pre-built {@link HTMLNode} fragment. The fragment is inserted
    * into a standard infobox, augmented with navigation links, and then streamed with the supplied
-   * HTTP status code. Callers can pass rich markup to tailor the user experience while keeping
+   * HTTP status code. Callers can pass rich markup to tailor the user experience while keeping the
    * layout consistent.
    *
    * @param ctx Active request context used for rendering and output.
-   * @param code HTTP status code that accompanies the error page.
+   * @param code HTTP status code that goes with the error page.
    * @param desc Title for the page and infobox heading.
    * @param message Markup describing the error details; ownership remains with the caller.
-   * @throws ToadletContextClosedException If the client disconnects before output completes.
+   * @throws ToadletContextClosedException If the client disconnects before the output completes.
    * @throws IOException If writing the generated page to the client fails.
    */
   protected void sendErrorPage(ToadletContext ctx, int code, String desc, HTMLNode message)

--- a/src/main/java/network/crypta/clients/http/ToadletContainer.java
+++ b/src/main/java/network/crypta/clients/http/ToadletContainer.java
@@ -5,7 +5,6 @@ import java.net.InetAddress;
 import java.net.URI;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.PageMaker.THEME;
-import network.crypta.pluginmanager.FredPluginL10n;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.BucketFactory;
 
@@ -36,81 +35,18 @@ import network.crypta.support.api.BucketFactory;
 public interface ToadletContainer {
 
   /**
-   * Register a {@link Toadlet} without adding a navigation link.
+   * Register a {@link Toadlet} and optionally expose it in the navigation menu.
    *
-   * <p>All incoming requests whose path begins with {@code urlPrefix} are routed to the supplied
-   * toadlet. The registration order controls precedence when prefixes overlap; placing a toadlet at
-   * the front allows it to shadow earlier registrations with the same prefix. This overload is
-   * useful for programmatic endpoints or internal hooks that do not need menu exposure but still
-   * need to be reachable through the HTTP surface.
+   * <p>All incoming requests whose path begins with {@code registration.urlPrefix()} are routed to
+   * the supplied toadlet. The registration order controls precedence when prefixes overlap; placing
+   * a toadlet at the front allows it shadowing earlier registrations with the same prefix. Menu
+   * metadata is honored when both {@code registration.menu()} and {@code registration.name()} are
+   * non-null.
    *
    * @param t the toadlet to register; must remain valid for the lifetime of the container
-   * @param menu menu category key that scopes navigation; ignored when no menu entry is created
-   * @param urlPrefix leading path segment (e.g., {@code /foo/bar}) used for handler resolution
-   * @param atFront whether this toadlet should win over earlier matching prefixes when resolving
-   * @param fullAccessOnly whether the link is hidden for reduced-permission clients; does not gate
-   *     dispatching, so handlers should still validate access before serving sensitive content
+   * @param registration immutable registration data (use {@link ToadletRegistration} factories)
    */
-  void register(Toadlet t, String menu, String urlPrefix, boolean atFront, boolean fullAccessOnly);
-
-  /**
-   * Register a {@link Toadlet} and, when possible, expose it in the navigation menu.
-   *
-   * <p>This overload allows callers to provide localized menu metadata and a callback that
-   * dynamically governs link visibility. Menu and name values may be {@code null} to suppress menu
-   * creation while still routing traffic. The registration process does not duplicate toadlets or
-   * mutate them; ownership and lifecycle stay with the caller. Overlapping prefixes follow the same
-   * precedence rules as the simpler overload.
-   *
-   * @param t the toadlet to register; must safely handle concurrent requests once exposed
-   * @param menu menu grouping key; {@code null} skips menu creation even when other metadata exists
-   * @param urlPrefix leading path segment (e.g., {@code /foo/bar}) used for request routing
-   * @param atFront whether this toadlet should be prioritized over earlier registrations
-   * @param name localization key that renders the menu label when a link is created
-   * @param title localization key that renders the tooltip for the link when present
-   * @param fullOnly whether the menu link is visible only to clients with full access permissions
-   * @param cb optional callback that can enable or hide the link based on runtime state
-   */
-  void register(
-      Toadlet t,
-      String menu,
-      String urlPrefix,
-      boolean atFront,
-      String name,
-      String title,
-      boolean fullOnly,
-      LinkEnabledCallback cb);
-
-  /**
-   * Register a {@link Toadlet} with menu metadata and localization support.
-   *
-   * <p>This variant mirrors {@link #register(Toadlet, String, String, boolean, String, String,
-   * boolean, LinkEnabledCallback)} while allowing localized strings to be resolved by the caller
-   * through a provided {@link FredPluginL10n}. Passing {@code null} for menu or name suppresses
-   * link creation and ignores presentation arguments. Implementations may cache translations or
-   * consult the callback for each render, so inputs should remain valid after registration.
-   *
-   * @param t the toadlet to register for the given prefix
-   * @param menu menu grouping key; {@code null} disables link creation regardless of other values
-   * @param urlPrefix leading path segment (e.g., {@code /foo/bar}) that this toadlet serves
-   * @param atFront whether this toadlet should override earlier registrations with matching
-   *     prefixes
-   * @param name localization key used for the visible link text when a menu entry is shown
-   * @param title localization key that supplies the link tooltip text where supported
-   * @param fullOnly whether the link is shown only to users with full access permissions enabled
-   * @param cb optional visibility callback consulted to decide whether the link is currently shown
-   * @param l10n optional localization provider used to resolve {@code name} and {@code title}
-   */
-  void register(
-      Toadlet t,
-      String menu,
-      String urlPrefix,
-      boolean atFront,
-      String name,
-      String title,
-      boolean fullOnly,
-      LinkEnabledCallback cb,
-      FredPluginL10n l10n);
+  void register(Toadlet t, ToadletRegistration registration);
 
   /**
    * Remove a previously registered toadlet and any associated navigation link metadata.
@@ -149,7 +85,7 @@ public interface ToadletContainer {
   THEME getTheme();
 
   /**
-   * Obtain the form password that protects sensitive POST submissions.
+   * Get the form password that protects sensitive POST submissions.
    *
    * <p>This value is commonly embedded into hidden fields by {@link #addFormChild(HTMLNode, String,
    * String)} to mitigate cross-site or automated attacks. Implementations should return a stable
@@ -311,7 +247,7 @@ public interface ToadletContainer {
    *
    * <p>When disabled, pages should fall back to polling or static updates to avoid relying on push
    * channels. Implementations can also use this signal to avoid allocating long-lived connections
-   * when the operator prefers strictly request/response traffic.
+   * when the operator prefers strict request/response traffic.
    *
    * @return {@code true} when push-style updates are permitted
    */
@@ -329,7 +265,7 @@ public interface ToadletContainer {
   boolean disableProgressPage();
 
   /**
-   * Obtain the page maker used to build HTML responses.
+   * Get the page maker used to build HTML responses.
    *
    * <p>Callers can reuse the returned {@link PageMaker} to assemble pages consistent with the
    * container's theme, localization, and layout conventions. The page maker may also embed common
@@ -353,10 +289,10 @@ public interface ToadletContainer {
   /**
    * Enable or disable advanced mode.
    *
-   * <p>Implementations should persist the chosen state and notify interested components as needed.
-   * Callers are expected to gate privileged UI elements on this value rather than direct authority
-   * checks. Changing this flag may have immediate UI effects, so consumers should re-render any
-   * cached views after toggling.
+   * <p>Implementations should persist in the chosen state and notify interested components as
+   * needed. Callers are expected to gate privileged UI elements on this value rather than direct
+   * authority checks. Changing this flag may have immediate UI effects, so consumers should
+   * re-render any cached views after toggling.
    *
    * @param enabled {@code true} to expose advanced mode features; {@code false} to hide them
    */

--- a/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -53,12 +53,11 @@ import org.slf4j.LoggerFactory;
  * have been parsed and stays bound to that socket conversation until the handler decides whether to
  * keep the connection alive.
  *
- * <p>Typical usage flows from {@link #handle(Socket, ToadletContainer, PageMaker, UserAlertManager,
- * BookmarkManager)}: the container builds a {@code ToadletContextImpl}, passes it to the selected
- * toadlet, and the toadlet invokes convenience helpers such as {@link #sendReplyHeaders(int,
- * String, MultiValueTable, String, long)} or {@link #writeData(Bucket)}. The context tracks
- * cookies, form-password validation, CSP/HSTS headers, and other protocol details so individual
- * toadlets can focus on rendering content.
+ * <p>Typical usage flows from {@link #handle(Socket, ToadletRequestServices)}: the container builds
+ * a {@code ToadletContextImpl}, passes it to the selected toadlet, and the toadlet invokes
+ * convenience helpers such as {@link #sendReplyHeaders(int, String, MultiValueTable, String, long)}
+ * or {@link #writeData(Bucket)}. The context tracks cookies, form-password validation, CSP/HSTS
+ * headers, and other protocol details so individual toadlets can focus on rendering content.
  *
  * <p>The object is not thread-safe and is intended for single-request, single-thread use. Once
  * {@link #close()} or {@link #forceDisconnect()} flips the internal state, further writes throw
@@ -136,28 +135,18 @@ public class ToadletContextImpl implements ToadletContext {
    *     as delivered by the client.
    * @param bf Bucket factory used for request bodies and outgoing payload buffering during this
    *     context's lifetime.
-   * @param pageMaker Shared page renderer and localization helper used when toadlets generate HTML
-   *     responses or redirects.
-   * @param container Owning toadlet container controlling policy decisions such as Javascript
-   *     enablement, access control, and persistent-connection support.
-   * @param userAlertManager Manager used to route user-facing alerts originating from toadlet
-   *     handlers during request processing.
-   * @param bookmarkManager Bookmark subsystem entry point used by toadlets that need access to
-   *     bookmark data scoped to this HTTP interaction.
+   * @param services Shared request-handling services bundled by the HTTP listener.
    * @param uri Fully parsed and normalized request URI associated with the incoming HTTP request
    *     line.
    * @param uniqueID Monotonic identifier supplied by the container to correlate logs and responses
    *     across asynchronous callbacks.
-   * @throws IOException If the socket output stream cannot be obtained for subsequent replies.
+   * @throws IOException If the socket output stream cannot be obtained for later replies.
    */
   public ToadletContextImpl(
       Socket sock,
       MultiValueTable<String, String> headers,
       BucketFactory bf,
-      PageMaker pageMaker,
-      ToadletContainer container,
-      UserAlertManager userAlertManager,
-      BookmarkManager bookmarkManager,
+      ToadletRequestServices services,
       URI uri,
       long uniqueID)
       throws IOException {
@@ -170,10 +159,10 @@ public class ToadletContextImpl implements ToadletContext {
     remoteAddr = sock.getInetAddress();
     if (LOG.isTraceEnabled()) LOG.trace("Connection from {}", remoteAddr);
     this.bf = bf;
-    this.pagemaker = pageMaker;
-    this.container = container;
-    this.userAlertManager = userAlertManager;
-    this.bookmarkManager = bookmarkManager;
+    this.pagemaker = services.pageMaker();
+    this.container = services.container();
+    this.userAlertManager = services.userAlertManager();
+    this.bookmarkManager = services.bookmarkManager();
     // Generate a unique id
     uniqueId = String.valueOf(uniqueID);
   }
@@ -230,7 +219,7 @@ public class ToadletContextImpl implements ToadletContext {
   }
 
   /**
-   * Send an error message, containing full HTML from a String.
+   * Send an error message containing full HTML from a String.
    *
    * @param os The OutputStream to send the message to.
    * @param code The HTTP status code.
@@ -251,17 +240,10 @@ public class ToadletContextImpl implements ToadletContext {
       throws IOException {
     if (mvt == null) mvt = new MultiValueTable<>();
     byte[] messageBytes = htmlMessage.getBytes(StandardCharsets.UTF_8);
-    sendReplyHeaders(
-        os,
-        code,
-        httpReason,
-        mvt,
-        "text/html; charset=UTF-8",
-        messageBytes.length,
-        null,
-        disconnect,
-        false,
-        false);
+    ReplyHeaders replyHeaders = ReplyHeaders.of(code, httpReason, "text/html; charset=UTF-8", mvt);
+    ReplyHeaderOptions options =
+        new ReplyHeaderOptions(messageBytes.length, null, disconnect, false, false);
+    sendReplyHeaders(os, replyHeaders, options);
     os.write(messageBytes);
   }
 
@@ -291,7 +273,7 @@ public class ToadletContextImpl implements ToadletContext {
    * keeps scripting enabled according to container policy and assumes no modification time for
    * caching. Callers typically use it when streaming simple bodies where chunking is unnecessary
    * and connection reuse is allowed. The method must be called before writing any response bytes
-   * and only once per context instance; subsequent attempts raise an error to prevent malformed
+   * and only once per context instance; later attempts raise an error to prevent malformed
    * responses.
    *
    * @param code HTTP status code to emit toward the client connection.
@@ -306,7 +288,11 @@ public class ToadletContextImpl implements ToadletContext {
   public void sendReplyHeaders(
       int code, String desc, MultiValueTable<String, String> mvt, String mimeType, long length)
       throws ToadletContextClosedException, IOException {
-    sendReplyHeaders(code, desc, mvt, mimeType, length, false);
+    ReplyHeaders replyHeaders = ReplyHeaders.of(code, desc, mimeType, mvt);
+    ReplyHeaderOptions options =
+        new ReplyHeaderOptions(
+            length, null, shouldDisconnect, container.isFProxyJavascriptEnabled(), false);
+    sendReplyHeaders(replyHeaders, options);
   }
 
   /**
@@ -334,8 +320,11 @@ public class ToadletContextImpl implements ToadletContext {
       long length,
       boolean forceDisableJavascript)
       throws ToadletContextClosedException, IOException {
+    ReplyHeaders replyHeaders = ReplyHeaders.of(code, desc, mimeType, mvt, forceDisableJavascript);
     boolean enableJavascript = (!forceDisableJavascript) && container.isFProxyJavascriptEnabled();
-    sendReplyHeaders(code, desc, mvt, mimeType, length, null, false, enableJavascript);
+    ReplyHeaderOptions options =
+        new ReplyHeaderOptions(length, null, shouldDisconnect, enableJavascript, false);
+    sendReplyHeaders(replyHeaders, options);
   }
 
   /**
@@ -345,7 +334,7 @@ public class ToadletContextImpl implements ToadletContext {
    * framing disabled to align with typical static resource expectations.
    *
    * @param replyCode HTTP status code to emit for the static response payload.
-   * @param replyDescription Reason phrase to accompany the status code for client readability.
+   * @param replyDescription Reason phrase to go with the status code for client readability.
    * @param mvt Additional headers to merge into the response; may be {@code null} for none.
    * @param mimeType MIME type string; {@code null} sends no content-type header.
    * @param contentLength Exact number of bytes that will be written after the headers.
@@ -362,8 +351,10 @@ public class ToadletContextImpl implements ToadletContext {
       Date mTime)
       throws ToadletContextClosedException, IOException {
     if (mTime == null) throw new IllegalArgumentException();
-    sendReplyHeaders(
-        replyCode, replyDescription, mvt, mimeType, contentLength, mTime, false, false);
+    ReplyHeaders replyHeaders = ReplyHeaders.of(replyCode, replyDescription, mimeType, mvt);
+    ReplyHeaderOptions options =
+        new ReplyHeaderOptions(contentLength, mTime, shouldDisconnect, false, false);
+    sendReplyHeaders(replyHeaders, options);
   }
 
   /**
@@ -391,22 +382,15 @@ public class ToadletContextImpl implements ToadletContext {
       String mimeType,
       long contentLength)
       throws ToadletContextClosedException, IOException {
-    boolean enableJavascript;
-    enableJavascript =
+    boolean enableJavascript =
         container.isFProxyWebPushingEnabled() && container.isFProxyJavascriptEnabled();
-    sendReplyHeaders(
-        replyCode, replyDescription, mvt, mimeType, contentLength, null, true, enableJavascript);
+    ReplyHeaders replyHeaders = ReplyHeaders.of(replyCode, replyDescription, mimeType, mvt);
+    ReplyHeaderOptions options =
+        new ReplyHeaderOptions(contentLength, null, shouldDisconnect, enableJavascript, true);
+    sendReplyHeaders(replyHeaders, options);
   }
 
-  private void sendReplyHeaders(
-      int replyCode,
-      String replyDescription,
-      MultiValueTable<String, String> mvt,
-      String mimeType,
-      long contentLength,
-      Date mTime,
-      boolean allowFrames,
-      boolean enableJavascript)
+  private void sendReplyHeaders(ReplyHeaders replyHeaders, ReplyHeaderOptions options)
       throws ToadletContextClosedException, IOException {
     if (closed) throw new ToadletContextClosedException();
     if (firstReplySendingException != null) {
@@ -414,6 +398,7 @@ public class ToadletContextImpl implements ToadletContext {
     }
     firstReplySendingException = new Exception();
 
+    MultiValueTable<String, String> mvt = replyHeaders.headers();
     if (mvt == null) {
       mvt = new MultiValueTable<>();
     }
@@ -432,22 +417,20 @@ public class ToadletContextImpl implements ToadletContext {
     if (container.isSSL()) {
       String hsts = SSL.getHSTSHeader();
       if (!hsts.isEmpty() && !mvt.containsKey("strict-transport-security")) {
-        // SSL enabled, set strict-transport-security so that the user agent upgrade future requests
+        // SSL enabled, set strict-transport-security so that the user agent upgrades future
+        // requests
         // to SSL.
         mvt.put("strict-transport-security", hsts);
       }
     }
-    sendReplyHeaders(
-        sockOutputStream,
-        replyCode,
-        replyDescription,
-        mvt,
-        mimeType,
-        contentLength,
-        mTime,
-        shouldDisconnect,
-        enableJavascript,
-        allowFrames);
+    ReplyHeaders resolvedHeaders =
+        new ReplyHeaders(
+            replyHeaders.code(),
+            replyHeaders.description(),
+            replyHeaders.mimeType(),
+            mvt,
+            replyHeaders.forceDisableJavascript());
+    sendReplyHeaders(sockOutputStream, resolvedHeaders, options);
   }
 
   /**
@@ -482,7 +465,7 @@ public class ToadletContextImpl implements ToadletContext {
   /**
    * Validates that the supplied request carries the correct form password, redirecting to the root
    * path on failure. This helper centralizes CSRF enforcement for POST handlers and ensures callers
-   * do not accidentally leak response bodies before verifying credentials. When validation fails
+   * do not accidentally leak response bodies before verifying credentials. When validation fails,
    * the caller should stop processing and rely on the redirect that was already emitted.
    *
    * @param request HTTP request object containing parsed parameters and body parts for validation.
@@ -490,7 +473,7 @@ public class ToadletContextImpl implements ToadletContext {
    *     redirect has been sent to the client.
    * @throws ToadletContextClosedException If the context is already closed before the redirect is
    *     written.
-   * @throws IOException If header transmission fails while issuing the redirect response.
+   * @throws IOException If the header transmission fails while issuing the redirect response.
    */
   @Override
   public boolean checkFormPassword(HTTPRequest request)
@@ -510,7 +493,7 @@ public class ToadletContextImpl implements ToadletContext {
    *     redirect has been sent to the target location.
    * @throws ToadletContextClosedException If the context is already closed before the redirect is
    *     written.
-   * @throws IOException If header transmission fails while issuing the redirect response.
+   * @throws IOException If the header transmission fails while issuing the redirect response.
    */
   @Override
   public boolean checkFormPassword(HTTPRequest request, String redirectTo)
@@ -628,12 +611,12 @@ public class ToadletContextImpl implements ToadletContext {
   }
 
   /**
-   * Looks up a previously received cookie by name after parsing all {@code Cookie} headers. Domain
-   * and path arguments are currently unused but retained for interface compatibility. Invalid
-   * cookies are skipped with logging so a malformed entry does not prevent other cookies from being
-   * resolved.
+   * It looks up a previously received cookie by name after parsing all {@code Cookie} headers.
+   * Domain and path arguments are currently unused but retained for interface compatibility.
+   * Invalid cookies are skipped with logging, so a malformed entry does not prevent other cookies
+   * from being resolved.
    *
-   * @param domain Ignored domain hint; callers should pass the request host for future use.
+   * @param domain The ignored domain hint; callers should pass the request host for future use.
    * @param path Ignored path hint; callers should pass the request path for future use.
    * @param name Case-insensitive cookie name to retrieve from the parsed collection.
    * @return Matching {@link ReceivedCookie} or {@code null} when absent or parsing produced no
@@ -667,7 +650,7 @@ public class ToadletContextImpl implements ToadletContext {
    * cookie added here remains pending until the next call to one of the {@code sendReplyHeaders*}
    * helpers, which serializes the collection in insertion order. Because the context is tied to a
    * single request and not thread-safe, callers should add cookies before handing control to any
-   * asynchronous writers. Modifications after headers have been emitted are ignored because
+   * asynchronous writers. Modifications after headers have been emitted are ignored because the
    * response state is then fixed by HTTP semantics.
    *
    * @param newCookie Cookie instance to serialize into the outbound headers; must not be {@code
@@ -681,51 +664,46 @@ public class ToadletContextImpl implements ToadletContext {
   }
 
   static void sendReplyHeaders(
-      OutputStream sockOutputStream,
-      int replyCode,
-      String replyDescription,
-      MultiValueTable<String, String> mvt,
-      String mimeType,
-      long contentLength,
-      Date mTime,
-      boolean disconnect,
-      boolean allowScripts,
-      boolean allowFrames)
+      OutputStream sockOutputStream, ReplyHeaders replyHeaders, ReplyHeaderOptions options)
       throws IOException {
 
-    // Construct headers
+    MultiValueTable<String, String> mvt = replyHeaders.headers();
     if (mvt == null) {
       mvt = new MultiValueTable<>();
     }
-    addContentTypeHeader(mvt, mimeType);
-    if (contentLength >= 0) {
-      mvt.put("content-length", Long.toString(contentLength));
+    // Construct headers
+    addContentTypeHeader(mvt, replyHeaders.mimeType());
+    if (options.contentLength() >= 0) {
+      mvt.put("content-length", Long.toString(options.contentLength()));
     }
 
-    addCachingHeaders(mvt, mTime);
+    addCachingHeaders(mvt, options.modifiedTime());
 
     String nowString = TimeUtil.makeHTTPDate(System.currentTimeMillis());
-    String lastModString = mTime == null ? nowString : TimeUtil.makeHTTPDate(mTime.getTime());
+    String lastModString =
+        options.modifiedTime() == null
+            ? nowString
+            : TimeUtil.makeHTTPDate(options.modifiedTime().getTime());
 
     mvt.put("last-modified", lastModString);
     mvt.put("date", nowString);
-    if (disconnect) {
+    if (options.disconnect()) {
       mvt.put(CONNECTION_HEADER, "close");
     } else {
       mvt.put(CONNECTION_HEADER, "keep-alive");
     }
     mvt.put("cross-origin-embedder-policy", "require-corp");
     mvt.put("cross-origin-opener-policy", "same-origin");
-    String contentSecurityPolicy = generateCSP(allowScripts, allowFrames);
+    String contentSecurityPolicy = generateCSP(options.allowScripts(), options.allowFrames());
     mvt.put("content-security-policy", contentSecurityPolicy);
     mvt.put("x-content-security-policy", contentSecurityPolicy);
     mvt.put("x-webkit-csp", contentSecurityPolicy);
-    mvt.put("x-frame-options", allowFrames ? "SAMEORIGIN" : "DENY");
+    mvt.put("x-frame-options", options.allowFrames() ? "SAMEORIGIN" : "DENY");
     StringBuilder buf = new StringBuilder(1024);
     buf.append("HTTP/1.1 ");
-    buf.append(replyCode);
+    buf.append(replyHeaders.code());
     buf.append(' ');
-    buf.append(replyDescription);
+    buf.append(replyHeaders.description());
     buf.append("\r\n");
     for (Map.Entry<String, List<String>> entry : mvt.entrySet()) {
       String key = entry.getKey();
@@ -826,25 +804,15 @@ public class ToadletContextImpl implements ToadletContext {
    * and unexpected exceptions mapped to {@code 500 Internal Failure}. This method blocks on I/O and
    * should be invoked from a dedicated worker thread per connection.
    *
-   * @param sock Open client socket carrying the HTTP conversation for this handler thread.
-   * @param container Owning container that resolves toadlets and enforces policy decisions.
-   * @param pageMaker Shared page renderer used for error pages and UI responses.
-   * @param userAlertManager Manager used to emit user-facing alerts encountered during handling.
-   * @param bookmarkManager Bookmark subsystem reference available to toadlets for request handling.
+   * @param sock Open the client socket carrying the HTTP conversation for this handler thread.
+   * @param services Shared container services required for request handling.
    */
-  public static void handle(
-      Socket sock,
-      ToadletContainer container,
-      PageMaker pageMaker,
-      UserAlertManager userAlertManager,
-      BookmarkManager bookmarkManager) {
+  public static void handle(Socket sock, ToadletRequestServices services) {
     try (InputStream is = new BufferedInputStream(sock.getInputStream(), 4096);
         LineReadingInputStream lis = new LineReadingInputStream(is)) {
-      boolean keepProcessing =
-          processRequest(sock, container, pageMaker, userAlertManager, bookmarkManager, is, lis);
+      boolean keepProcessing = processRequest(sock, services, is, lis);
       while (keepProcessing) {
-        keepProcessing =
-            processRequest(sock, container, pageMaker, userAlertManager, bookmarkManager, is, lis);
+        keepProcessing = processRequest(sock, services, is, lis);
       }
     } catch (ParseException e) {
       try {
@@ -878,17 +846,11 @@ public class ToadletContextImpl implements ToadletContext {
         pw.flush();
         msg = msg + sw + "</pre></body></html>";
         byte[] messageBytes = msg.getBytes(StandardCharsets.UTF_8);
-        sendReplyHeaders(
-            sock.getOutputStream(),
-            500,
-            "Internal failure",
-            null,
-            "text/html; charset=UTF-8",
-            messageBytes.length,
-            null,
-            true,
-            false,
-            false);
+        ReplyHeaders replyHeaders =
+            ReplyHeaders.of(500, "Internal failure", "text/html; charset=UTF-8");
+        ReplyHeaderOptions options =
+            new ReplyHeaderOptions(messageBytes.length, null, true, false, false);
+        sendReplyHeaders(sock.getOutputStream(), replyHeaders, options);
         sock.getOutputStream().write(messageBytes);
       } catch (IOException _) {
         // ignore and return
@@ -897,19 +859,14 @@ public class ToadletContextImpl implements ToadletContext {
   }
 
   private static boolean processRequest(
-      Socket sock,
-      ToadletContainer container,
-      PageMaker pageMaker,
-      UserAlertManager userAlertManager,
-      BookmarkManager bookmarkManager,
-      InputStream is,
-      LineReadingInputStream lis)
+      Socket sock, ToadletRequestServices services, InputStream is, LineReadingInputStream lis)
       throws IOException,
           ParseException,
           ToadletContextClosedException,
           NoSuchMethodException,
           IllegalAccessException,
           ToadletInvocationException {
+    ToadletContainer container = services.container();
     String firstLine = lis.readLine(32768, 128, false); // ISO-8859-1 or US-ASCII, _not_ UTF-8
     if (firstLine == null) {
       sock.close();
@@ -936,15 +893,7 @@ public class ToadletContextImpl implements ToadletContext {
 
     ToadletContextImpl ctx =
         new ToadletContextImpl(
-            sock,
-            requestHeaders,
-            bf,
-            pageMaker,
-            container,
-            userAlertManager,
-            bookmarkManager,
-            requestLine.uri,
-            container.generateUniqueID());
+            sock, requestHeaders, bf, services, requestLine.uri, container.generateUniqueID());
     ctx.shouldDisconnect = disconnect;
 
     DataReadResult dataResult =
@@ -1318,7 +1267,7 @@ public class ToadletContextImpl implements ToadletContext {
    * @param offset Offset within the array where the payload to send begins.
    * @param length Number of bytes to write starting at {@code offset}; must not exceed array size.
    * @throws ToadletContextClosedException If the context has been closed and cannot accept output.
-   * @throws IOException If the socket write fails or the connection drops mid-transfer.
+   * @throws IOException If the socket writing fails or the connection drops mid-transfer.
    */
   @Override
   public void writeData(byte[] data, int offset, int length)
@@ -1335,7 +1284,7 @@ public class ToadletContextImpl implements ToadletContext {
    *
    * @param data Byte array to write to the socket; must not be {@code null}.
    * @throws ToadletContextClosedException If the context has been closed and cannot accept output.
-   * @throws IOException If the socket write fails or the connection drops mid-transfer.
+   * @throws IOException If the socket writing fails or the connection drops mid-transfer.
    */
   @Override
   public void writeData(byte[] data) throws ToadletContextClosedException, IOException {
@@ -1346,7 +1295,7 @@ public class ToadletContextImpl implements ToadletContext {
    * Streams the contents of the supplied {@link Bucket} to the client and then frees the bucket.
    * Callers transfer ownership to the context; if the data must remain available afterward, wrap it
    * in a {@link NoFreeBucket} before calling. The method copies until the bucket reports end-of-
-   * stream or the socket write fails, making it suitable for large payloads without loading the
+   * stream or the socket writing fails, making it suitable for large payloads without loading the
    * entire content into memory at once. It keeps the order of writes unchanged, allowing response
    * bodies generated earlier to be piped directly.
    *
@@ -1507,3 +1456,19 @@ public class ToadletContextImpl implements ToadletContext {
     return container.getReFilterPolicy();
   }
 }
+
+/**
+ * Bundle of response header options used when emitting reply metadata.
+ *
+ * @param contentLength length of the response body, or {@code -1} to omit the header
+ * @param modifiedTime optional last-modified timestamp for cache handling
+ * @param disconnect whether to close the socket after the response
+ * @param allowScripts whether scripts are permitted by the CSP
+ * @param allowFrames whether framing is permitted by the CSP
+ */
+record ReplyHeaderOptions(
+    long contentLength,
+    Date modifiedTime,
+    boolean disconnect,
+    boolean allowScripts,
+    boolean allowFrames) {}

--- a/src/main/java/network/crypta/clients/http/ToadletRegistration.java
+++ b/src/main/java/network/crypta/clients/http/ToadletRegistration.java
@@ -1,0 +1,131 @@
+package network.crypta.clients.http;
+
+import network.crypta.pluginmanager.FredPluginL10n;
+
+/**
+ * Immutable registration payload describing how a {@link Toadlet} is exposed by a {@link
+ * ToadletContainer}.
+ *
+ * <p>This record groups the routing metadata and optional menu presentation data that a container
+ * needs when registering a toadlet. Callers typically assemble instances through the static factory
+ * methods in this type and then pass the result to {@link ToadletContainer#register(Toadlet,
+ * ToadletRegistration)}. The record itself is a simple data carrier: it does not validate inputs,
+ * perform lookups, or resolve localization keys; those responsibilities stay with the container or
+ * menu renderer that consumes the values.
+ *
+ * <p>The data is immutable and safe to share between threads once constructed. All fields may be
+ * null when the caller intentionally suppresses a menu entry (for example, by omitting a menu key
+ * or name). The caller enforces invariants: use a consistent prefix, keep menu identifiers stable
+ * across the node lifecycle, and choose whether a link should be visible to limited-access clients.
+ * The container interprets the values to determine registration order and menu exposure.
+ *
+ * <ul>
+ *   <li>Captures routing state: menu identifier, URL prefix, and ordering flag.
+ *   <li>Captures menu metadata: name/title keys, optional visibility callback, and localization.
+ *   <li>Remains immutable so registration decisions are repeatable and thread-safe.
+ * </ul>
+ *
+ * @param menu menu grouping key; {@code null} suppresses menu link creation entirely
+ * @param urlPrefix leading path segment used for routing and toadlet resolution
+ * @param atFront whether to prioritize this registration over earlier prefix matches
+ * @param name localization key for the visible menu label; {@code null} hides the link
+ * @param title localization key for tooltip text; may be {@code null} if unused
+ * @param fullOnly whether the menu link is limited to clients with full access
+ * @param callback optional callback that can enable or hide the link at runtime
+ * @param l10n optional localization helper to resolve {@code name} and {@code title}
+ */
+public record ToadletRegistration(
+    String menu,
+    String urlPrefix,
+    boolean atFront,
+    String name,
+    String title,
+    boolean fullOnly,
+    LinkEnabledCallback callback,
+    FredPluginL10n l10n) {
+
+  /**
+   * Create a registration that routes requests without defining a menu entry.
+   *
+   * <p>This factory is intended for internal endpoints or helper toadlets that must be reachable by
+   * URL but should not appear in navigation menus. The returned record carries only routing
+   * metadata and access scoping, leaving menu-related fields {@code null}. Callers should ensure
+   * the prefix is normalized to match the container’s routing rules and should decide whether to
+   * register the toadlet ahead of other handlers by setting {@code atFront}. The resulting record
+   * is immutable and can be cached or reused across registrations without additional
+   * synchronization.
+   *
+   * @param menu menu grouping key; {@code null} omits menu linkage entirely
+   * @param urlPrefix leading path segment used for routing and prefix matching
+   * @param atFront whether to register ahead of earlier matching prefixes
+   * @param fullOnly whether links would be limited to full-access clients
+   * @return immutable registration that carries routing data with no menu metadata
+   */
+  public static ToadletRegistration basic(
+      String menu, String urlPrefix, boolean atFront, boolean fullOnly) {
+    return new ToadletRegistration(menu, urlPrefix, atFront, null, null, fullOnly, null, null);
+  }
+
+  /**
+   * Create a registration that includes menu metadata without an explicit localization helper.
+   *
+   * <p>Use this factory when the menu label and tooltip keys are already resolved by the caller or
+   * when localization is handled elsewhere (for example, by the container’s default localization
+   * provider). The returned record will still instruct the container to add a navigation link so
+   * long as both {@code menu} and {@code name} are non-null. Set {@code fullOnly} when the link
+   * must be hidden from restricted clients; the toadlet itself still needs to enforce
+   * authorization. The menu renderer invokes optional callbacks to decide whether the link should
+   * be shown for the current runtime state.
+   *
+   * @param menu menu grouping key used to place the link in navigation
+   * @param urlPrefix leading path segment used for routing and prefix matching
+   * @param atFront whether to register ahead of earlier matching prefixes
+   * @param name localization key or label token for the menu entry
+   * @param title localization key or tooltip token for the menu entry
+   * @param fullOnly whether the menu link should require full-access permissions
+   * @param callback optional link-visibility callback invoked when rendering menus
+   * @return immutable registration including menu metadata without a localization helper
+   */
+  public static ToadletRegistration menuLink(
+      String menu,
+      String urlPrefix,
+      boolean atFront,
+      String name,
+      String title,
+      boolean fullOnly,
+      LinkEnabledCallback callback) {
+    return new ToadletRegistration(menu, urlPrefix, atFront, name, title, fullOnly, callback, null);
+  }
+
+  /**
+   * Create a registration that includes menu metadata and an explicit localization helper.
+   *
+   * <p>Use this factory when the caller owns the {@link FredPluginL10n} instance responsible for
+   * resolving menu labels and tooltips. The localization helper is stored alongside the menu keys,
+   * so the container can defer translation until render time. All routing inputs are retained
+   * as-is; callers should supply a stable {@code urlPrefix} and decide whether the toadlet should
+   * be prioritized ahead of earlier registrations. If {@code menu} or {@code name} is {@code null},
+   * the container will still register the toadlet but will omit the navigation link entirely.
+   *
+   * @param menu menu grouping key used to place the link in navigation
+   * @param urlPrefix leading path segment used for routing and prefix matching
+   * @param atFront whether to register ahead of earlier matching prefixes
+   * @param name localization key or label token for the menu entry
+   * @param title localization key or tooltip token for the menu entry
+   * @param fullOnly whether the menu link should require full-access permissions
+   * @param callback optional link-visibility callback invoked when rendering menus
+   * @param l10n localization helper used to resolve menu labels and tooltip text
+   * @return immutable registration including menu metadata and localization helper
+   */
+  public static ToadletRegistration menuLink(
+      String menu,
+      String urlPrefix,
+      boolean atFront,
+      String name,
+      String title,
+      boolean fullOnly,
+      LinkEnabledCallback callback,
+      FredPluginL10n l10n) {
+    return new ToadletRegistration(menu, urlPrefix, atFront, name, title, fullOnly, callback, l10n);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/ToadletRequestServices.java
+++ b/src/main/java/network/crypta/clients/http/ToadletRequestServices.java
@@ -1,0 +1,22 @@
+package network.crypta.clients.http;
+
+import network.crypta.clients.http.bookmark.BookmarkManager;
+import network.crypta.node.useralerts.UserAlertManager;
+
+/**
+ * Shared services needed to build per-request {@link ToadletContextImpl} instances.
+ *
+ * <p>This record groups the long-lived collaborators that are passed together whenever a new
+ * request context is created. It keeps request handling signatures compact while preserving the
+ * existing wiring between the HTTP listener and the toadlet container.
+ *
+ * @param container the owning toadlet container that enforces request policies
+ * @param pageMaker shared page renderer used by UI toadlets
+ * @param userAlertManager manager used to surface user-facing alerts
+ * @param bookmarkManager bookmark subsystem access point for request handlers
+ */
+public record ToadletRequestServices(
+    ToadletContainer container,
+    PageMaker pageMaker,
+    UserAlertManager userAlertManager,
+    BookmarkManager bookmarkManager) {}

--- a/src/main/java/network/crypta/pluginmanager/PluginManager.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginManager.java
@@ -34,6 +34,7 @@ import network.crypta.clients.http.PageMaker.THEME;
 import network.crypta.clients.http.ProgressCellContext;
 import network.crypta.clients.http.QueueToadlet;
 import network.crypta.clients.http.Toadlet;
+import network.crypta.clients.http.ToadletRegistration;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
 import network.crypta.config.SubConfig;
@@ -844,14 +845,15 @@ public class PluginManager {
             .getToadletContainer()
             .register(
                 toadlet,
-                "FProxyToadlet.categoryConfig",
-                toadlet.path(),
-                true,
-                "ConfigToadlet." + pi.getPluginClassName() + ".label",
-                "ConfigToadlet." + pi.getPluginClassName() + ".tooltip",
-                true,
-                null,
-                (FredPluginL10n) pi.getPlugin());
+                ToadletRegistration.menuLink(
+                    "FProxyToadlet.categoryConfig",
+                    toadlet.path(),
+                    true,
+                    "ConfigToadlet." + pi.getPluginClassName() + ".label",
+                    "ConfigToadlet." + pi.getPluginClassName() + ".tooltip",
+                    true,
+                    null,
+                    (FredPluginL10n) pi.getPlugin()));
       }
     }
 

--- a/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
+++ b/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
@@ -5,6 +5,7 @@ import java.net.URI
 import network.crypta.client.HighLevelSimpleClient
 import network.crypta.clients.http.PageMaker
 import network.crypta.clients.http.PageNode
+import network.crypta.clients.http.ReplyHeaders
 import network.crypta.clients.http.Toadlet
 import network.crypta.clients.http.ToadletContext
 import network.crypta.fs.AppEnv
@@ -185,7 +186,7 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
     val outcome = tryInstall(okPath)
     val logReplacements = outcome.message.replacements.filterKeys { it != "extra" }
     logInfo(
-      "install result: success=${outcome.success}, messageKey=${outcome.message.key}, replacements=${logReplacements}"
+      "install result: success=${outcome.success}, messageKey=${outcome.message.key}, replacements=$logReplacements"
     )
     writeInstallResult(ctx, outcome.success, outcome.message.render(), okPath)
   }
@@ -198,19 +199,32 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
     logInfo("POST /core-update action=openStore kind=$kind id=$id url=$url")
     val delegate =
       when (appEnv.osKind()) {
-        AppEnv.OsKind.LINUX -> linuxOpenStore(kind, id.ifBlank { null }, url.ifBlank { null })
-        AppEnv.OsKind.MAC ->
-          if (url.isNotBlank())
+        AppEnv.OsKind.LINUX -> {
+          linuxOpenStore(kind, id.ifBlank { null }, url.ifBlank { null })
+        }
+
+        AppEnv.OsKind.MAC -> {
+          if (url.isNotBlank()) {
             InstallerDelegate.Spawn(ProcessBuilder("open", url), msg("store.openingPage"))
-          else InstallerDelegate.Manual(msg("store.invalidUrl.mac"))
-        AppEnv.OsKind.WINDOWS ->
-          if (url.isNotBlank())
+          } else {
+            InstallerDelegate.Manual(msg("store.invalidUrl.mac"))
+          }
+        }
+
+        AppEnv.OsKind.WINDOWS -> {
+          if (url.isNotBlank()) {
             InstallerDelegate.Spawn(
               ProcessBuilder("rundll32", "url.dll,FileProtocolHandler", url),
               msg("store.openingPage"),
             )
-          else InstallerDelegate.Manual(msg("store.invalidUrl.windows"))
-        else -> InstallerDelegate.Manual(msg("store.unsupportedPlatform"))
+          } else {
+            InstallerDelegate.Manual(msg("store.invalidUrl.windows"))
+          }
+        }
+
+        else -> {
+          InstallerDelegate.Manual(msg("store.unsupportedPlatform"))
+        }
       }
     when (delegate) {
       is InstallerDelegate.Spawn -> {
@@ -222,7 +236,10 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
           writeMessage(ctx, false, msg("store.openFailed", mapOf("reason" to reason)).render())
         }
       }
-      is InstallerDelegate.Manual -> writeMessage(ctx, false, delegate.message.render())
+
+      is InstallerDelegate.Manual -> {
+        writeMessage(ctx, false, delegate.message.render())
+      }
     }
   }
 
@@ -230,6 +247,7 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
    * Ensure the provided file path resolves inside `nodeDir/updates/core`. Returns the canonical
    * `File` or null when invalid/untrusted.
    */
+
   /** Performs canonical path validation to ensure downloads reside under the node updates tree. */
   private fun validatePath(path: String): File? {
     if (path.isBlank()) return null
@@ -244,20 +262,31 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
    * Best‑effort attempt to launch the OS installer for the given file. Returns `(success, message)`
    * where message is suitable for user display.
    */
+
   /** Attempts to launch an OS-appropriate installer for the provided file. */
   private data class InstallOutcome(val success: Boolean, val message: LocalMessage)
 
   private fun tryInstall(file: File): InstallOutcome {
     val delegate =
       when (appEnv.osKind()) {
-        AppEnv.OsKind.WINDOWS ->
+        AppEnv.OsKind.WINDOWS -> {
           InstallerDelegate.Spawn(
             ProcessBuilder("cmd", "/c", "\"${file.absolutePath}\""),
             msg("installer.launched.windows"),
           )
-        AppEnv.OsKind.MAC -> macInstaller(file)
-        AppEnv.OsKind.LINUX -> linuxInstaller(file)
-        else -> InstallerDelegate.Manual(msg("installer.unsupportedOs"))
+        }
+
+        AppEnv.OsKind.MAC -> {
+          macInstaller(file)
+        }
+
+        AppEnv.OsKind.LINUX -> {
+          linuxInstaller(file)
+        }
+
+        else -> {
+          InstallerDelegate.Manual(msg("installer.unsupportedOs"))
+        }
       }
     return runCatching {
         when (delegate) {
@@ -265,7 +294,10 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
             delegate.pb.start()
             InstallOutcome(true, delegate.message)
           }
-          is InstallerDelegate.Manual -> InstallOutcome(false, delegate.message)
+
+          is InstallerDelegate.Manual -> {
+            InstallOutcome(false, delegate.message)
+          }
         }
       }
       .getOrElse { throwable ->
@@ -305,6 +337,7 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
    *   with a concrete command to run as root.
    * - Immutable rpm-ostree: suggest `rpm-ostree install` flow and note reboot.
    */
+
   /** Determines the appropriate Linux installation strategy for the provided file. */
   private fun linuxInstaller(file: File): InstallerDelegate {
     val lowerName = file.name.lowercase()
@@ -337,32 +370,47 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
     // Per-format fallbacks when GUI hand-off is unavailable.
     val fallback: InstallerDelegate =
       when {
-        lowerName.endsWith(".deb") -> debFallback(file)
-        lowerName.endsWith(".rpm") -> rpmFallback(file, ostree)
-        lowerName.endsWith(EXT_FLATPAKREF) || lowerName.endsWith(EXT_FLATPAK) ->
+        lowerName.endsWith(".deb") -> {
+          debFallback(file)
+        }
+
+        lowerName.endsWith(".rpm") -> {
+          rpmFallback(file, ostree)
+        }
+
+        lowerName.endsWith(EXT_FLATPAKREF) || lowerName.endsWith(EXT_FLATPAK) -> {
           flatpakFallback(file)
-        lowerName.endsWith(EXT_SNAP) -> snapFallback(file)
-        else ->
+        }
+
+        lowerName.endsWith(EXT_SNAP) -> {
+          snapFallback(file)
+        }
+
+        else -> {
           InstallerDelegate.Manual(msg("installer.unsupportedPackage", mapOf("name" to file.name)))
+        }
       }
 
     // Prefer GUI if we have a way to open it. Otherwise, return fallback command.
     return if (guiOpenCmd != null) {
       InstallerDelegate.Spawn(guiOpenCmd, msg("installer.guiHandOff"))
-    } else fallback
+    } else {
+      fallback
+    }
   }
 
   /** Try opening a local Flatpak bundle/ref via the host's app center. */
+
   /** Builds a command that launches the host software center for Flatpak content. */
   private fun hostSoftwareCenterOpen(file: File): ProcessBuilder {
     val path = file.absolutePath
     // Prefer GNOME Software, then Plasma Discover; fall back to xdg-open.
     val cmd =
       """
-        command -v gnome-software >/dev/null 2>&1 && exec gnome-software --local-filename '$path' ||
-        command -v plasma-discover >/dev/null 2>&1 && exec plasma-discover --local-filename '$path' ||
-        exec xdg-open '$path'
-      """
+            command -v gnome-software >/dev/null 2>&1 && exec gnome-software --local-filename '$path' ||
+            command -v plasma-discover >/dev/null 2>&1 && exec plasma-discover --local-filename '$path' ||
+            exec xdg-open '$path'
+            """
         .trimIndent()
     return ProcessBuilder("flatpak-spawn", ARG_HOST, "sh", "-lc", cmd)
   }
@@ -386,26 +434,26 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
    * Build a GUI "open this package" command, using host bridging when inside Flatpak. Returns null
    * when neither xdg-open nor gio is available.
    */
+
   /** Builds a GUI opener command for local files, considering sandbox constraints. */
-  private fun guiOpenCommand(file: File, preferHost: Boolean): ProcessBuilder? {
-    return guiOpenCommandForTarget(file.absolutePath, preferHost)
-  }
+  private fun guiOpenCommand(file: File, preferHost: Boolean): ProcessBuilder? =
+    guiOpenCommandForTarget(file.absolutePath, preferHost)
 
   /** Choose preferred GUI opener available on PATH, including subcommand args. */
+
   /** Chooses the first available GUI opener command from the current environment. */
-  private fun pickGuiOpener(): List<String>? {
-    return when {
+  private fun pickGuiOpener(): List<String>? =
+    when {
       appEnv.onPath("gio") -> listOf("gio", "open")
       appEnv.onPath(CMD_XDG_OPEN) -> listOf(CMD_XDG_OPEN)
       else -> null
     }
-  }
 
   /** Build a GUI opener for a URL (not a local file). */
+
   /** Builds a GUI opener for URLs, preferring portal-aware commands when sandboxed. */
-  private fun guiOpenUrlCommand(url: String, preferHost: Boolean): ProcessBuilder? {
-    return guiOpenCommandForTarget(url, preferHost)
-  }
+  private fun guiOpenUrlCommand(url: String, preferHost: Boolean): ProcessBuilder? =
+    guiOpenCommandForTarget(url, preferHost)
 
   /** Builds a GUI opener command for an arbitrary target string. */
   private fun guiOpenCommandForTarget(target: String, preferHost: Boolean): ProcessBuilder? {
@@ -425,24 +473,32 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
   private fun debFallback(file: File): InstallerDelegate {
     val path = file.absolutePath
     return when {
-      appEnv.onPath("pkcon") ->
+      appEnv.onPath("pkcon") -> {
         InstallerDelegate.Spawn(
           ProcessBuilder("pkcon", "install-local", "-y", path),
           msg("linux.packagekitInstall"),
         )
+      }
+
       // As a last resort: apt-get with pkexec, resolving deps via ./file.deb syntax
-      appEnv.onPath("pkexec") && appEnv.onPath("apt-get") ->
+      appEnv.onPath("pkexec") && appEnv.onPath("apt-get") -> {
         InstallerDelegate.Spawn(
           ProcessBuilder("pkexec", "apt-get", "install", "-y", "./${file.name}")
             .directory(file.parentFile),
           msg("linux.aptInstall"),
         )
-      appEnv.onPath("dpkg") ->
+      }
+
+      appEnv.onPath("dpkg") -> {
         InstallerDelegate.Spawn(
           ProcessBuilder("pkexec", "dpkg", "-i", path),
           msg("linux.dpkgInstall"),
         )
-      else -> InstallerDelegate.Manual(manualMsg("DEB", path))
+      }
+
+      else -> {
+        InstallerDelegate.Manual(manualMsg("DEB", path))
+      }
     }
   }
 
@@ -453,27 +509,37 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
       return InstallerDelegate.Manual(msg("linux.rpmOstreeManual", mapOf("path" to path)))
     }
     return when {
-      appEnv.onPath("pkcon") ->
+      appEnv.onPath("pkcon") -> {
         InstallerDelegate.Spawn(
           ProcessBuilder("pkcon", "install-local", "-y", path),
           msg("linux.packagekitInstall"),
         )
-      appEnv.onPath("pkexec") && appEnv.onPath("dnf") ->
+      }
+
+      appEnv.onPath("pkexec") && appEnv.onPath("dnf") -> {
         InstallerDelegate.Spawn(
           ProcessBuilder("pkexec", "dnf", "install", "-y", path),
           msg("linux.dnfInstall"),
         )
-      appEnv.onPath("pkexec") && appEnv.onPath("zypper") ->
+      }
+
+      appEnv.onPath("pkexec") && appEnv.onPath("zypper") -> {
         InstallerDelegate.Spawn(
           ProcessBuilder("pkexec", "zypper", "--non-interactive", "install", path),
           msg("linux.zypperInstall"),
         )
-      appEnv.onPath("rpm") && appEnv.onPath("pkexec") ->
+      }
+
+      appEnv.onPath("rpm") && appEnv.onPath("pkexec") -> {
         InstallerDelegate.Spawn(
           ProcessBuilder("pkexec", "rpm", "-Uvh", path),
           msg("linux.rpmInstall"),
         )
-      else -> InstallerDelegate.Manual(manualMsg("RPM", path))
+      }
+
+      else -> {
+        InstallerDelegate.Manual(manualMsg("RPM", path))
+      }
     }
   }
 
@@ -522,12 +588,12 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
       }
     val suggestion =
       when (tag) {
-        "DEB" -> "pkcon install-local -y '${path}'"
-        TAG_RPM_OSTREE -> "rpm-ostree install '${path}'"
-        "RPM" -> "pkcon install-local -y '${path}'"
-        "Flatpak" -> "flatpak install $ARG_ASSUME_YES --system '${path}'"
-        "Snap" -> "snap install --dangerous '${path}'"
-        else -> "<install-command> '${path}'"
+        "DEB" -> "pkcon install-local -y '$path'"
+        TAG_RPM_OSTREE -> "rpm-ostree install '$path'"
+        "RPM" -> "pkcon install-local -y '$path'"
+        "Flatpak" -> "flatpak install $ARG_ASSUME_YES --system '$path'"
+        "Snap" -> "snap install --dangerous '$path'"
+        else -> "<install-command> '$path'"
       }
     val extra = if (tag == TAG_RPM_OSTREE) " " + t("linux.headlessGuidanceExtra") else ""
     return msg("linux.headlessGuidance", mapOf("command" to suggestion, "extra" to extra))
@@ -550,7 +616,7 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
             p.waitFor()
             if (p.exitValue() == 0 && out.isNotEmpty()) out else null
           } ?: return null
-      val unit = "cryptad-core-install@${escaped}.service"
+      val unit = "cryptad-core-install@$escaped.service"
       val pb = ProcessBuilder("systemctl", "start", unit)
       InstallerDelegate.Spawn(pb, msg("linux.headlessUnit", mapOf("unit" to unit)))
     } catch (_: Throwable) {
@@ -569,39 +635,58 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
     }
     val targetUrl =
       when {
-        !url.isNullOrBlank() -> url
-        kind.equals("snap", ignoreCase = true) && !id.isNullOrBlank() -> "snap://${id}"
-        kind.equals("flatpak", ignoreCase = true) && !id.isNullOrBlank() ->
+        !url.isNullOrBlank() -> {
+          url
+        }
+
+        kind.equals("snap", ignoreCase = true) && !id.isNullOrBlank() -> {
+          "snap://$id"
+        }
+
+        kind.equals("flatpak", ignoreCase = true) && !id.isNullOrBlank() -> {
           // appstream is widely handled by GNOME/KDE software centers; fallback to flathub page
-          if (appEnv.onPath("gio") || appEnv.onPath(CMD_XDG_OPEN)) "appstream://${id}"
-          else "https://flathub.org/apps/${id}"
-        else -> null
+          if (appEnv.onPath("gio") || appEnv.onPath(CMD_XDG_OPEN)) {
+            "appstream://$id"
+          } else {
+            "https://flathub.org/apps/$id"
+          }
+        }
+
+        else -> {
+          null
+        }
       }
     if (targetUrl != null) {
       val opener = guiOpenUrlCommand(targetUrl, preferHost)
-      if (opener != null)
+      if (opener != null) {
         return InstallerDelegate.Spawn(
           opener,
           msg("store.openingSpecificPage", mapOf("url" to targetUrl)),
         )
+      }
     }
     // Fallback to CLI store install when GUI handoff isn't available
     return when {
-      kind.equals("flatpak", true) && !id.isNullOrBlank() && appEnv.onPath("flatpak") ->
+      kind.equals("flatpak", true) && !id.isNullOrBlank() && appEnv.onPath("flatpak") -> {
         InstallerDelegate.Spawn(
           ProcessBuilder("flatpak", "install", ARG_ASSUME_YES, ARG_USER, "flathub", id),
           msg("store.installFlathub", mapOf("id" to id)),
         )
+      }
+
       kind.equals("snap", true) &&
         !id.isNullOrBlank() &&
         appEnv.onPath("pkexec") &&
-        appEnv.onPath("snap") ->
+        appEnv.onPath("snap") -> {
         InstallerDelegate.Spawn(
           ProcessBuilder("pkexec", "snap", "install", id),
           msg("store.installSnap", mapOf("id" to id)),
         )
-      else ->
+      }
+
+      else -> {
         InstallerDelegate.Manual(msg("store.unableToOpen", mapOf("idOrUrl" to (id ?: url ?: "?"))))
+      }
     }
   }
 
@@ -616,7 +701,11 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
     val view = renderResultPage(ctx, success, msg)
     addHomepageLink(view.content)
     // Allow JS on result page; CSP was previously too strict here.
-    this.writeHTMLReply(ctx, 200, "OK", null, view.page.generate(), false)
+    this.writeHTMLReply(
+      ctx,
+      ReplyHeaders.of(200, "OK", "text/html; charset=utf-8"),
+      view.page.generate(),
+    )
   }
 
   /** Renders the installation result page, appending platform-specific guidance. */
@@ -627,7 +716,11 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
     addInstallGuidance(view.content, view.pageMaker, file)
 
     addHomepageLink(view.content)
-    this.writeHTMLReply(ctx, 200, "OK", null, view.page.generate(), false)
+    this.writeHTMLReply(
+      ctx,
+      ReplyHeaders.of(200, "OK", "text/html; charset=utf-8"),
+      view.page.generate(),
+    )
   }
 
   private data class ResultPage(
@@ -661,13 +754,23 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
   /** Appends guidance boxes for common edge cases (e.g., macOS Gatekeeper). */
   private fun addInstallGuidance(content: HTMLNode, pm: PageMaker, file: File) {
     when (appEnv.osKind()) {
-      AppEnv.OsKind.MAC -> if (file.name.lowercase().endsWith(".dmg")) macDmgGuidance(content, pm)
-      AppEnv.OsKind.LINUX ->
-        if (file.name.lowercase().endsWith(EXT_SNAP))
+      AppEnv.OsKind.MAC -> {
+        if (file.name.lowercase().endsWith(".dmg")) macDmgGuidance(content, pm)
+      }
+
+      AppEnv.OsKind.LINUX -> {
+        if (file.name.lowercase().endsWith(EXT_SNAP)) {
           linuxSnapGuidance(content, pm, file, appEnv.onPath("snap"))
-      AppEnv.OsKind.WINDOWS ->
+        }
+      }
+
+      AppEnv.OsKind.WINDOWS -> {
         if (file.name.lowercase().endsWith(".exe")) windowsExeGuidance(content, pm)
-      else -> Unit
+      }
+
+      else -> {
+        Unit
+      }
     }
   }
 

--- a/src/test/java/network/crypta/clients/http/DarknetAddRefToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetAddRefToadletTest.java
@@ -214,12 +214,11 @@ class DarknetAddRefToadletTest {
     }
 
     @Override
-    protected void writeReply(
-        ToadletContext ctx, int code, String mimeType, String desc, Bucket data) {
+    protected void writeReply(ToadletContext ctx, ReplyHeaders replyHeaders, Bucket data) {
       this.writeReplyCalled = true;
-      this.lastCode = code;
-      this.lastMimeType = mimeType;
-      this.lastDescription = desc;
+      this.lastCode = replyHeaders.code();
+      this.lastMimeType = replyHeaders.mimeType();
+      this.lastDescription = replyHeaders.description();
       this.lastBucket = data;
     }
 

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -205,7 +205,7 @@ class DarknetConnectionsToadletTest {
     doNothing()
         .when(ctx)
         .sendReplyHeaders(
-            eq(200), eq("OK"), any(), eq("application/x-freenet-reference"), anyLong(), eq(false));
+            eq(200), eq("OK"), any(), eq("application/x-freenet-reference"), anyLong());
     doNothing().when(ctx).writeData(any(byte[].class), eq(0), anyInt());
 
     boolean handled = invokeTryHandlePeerNoderef(uri);
@@ -223,8 +223,7 @@ class DarknetConnectionsToadletTest {
             eq("OK"),
             headersCaptor.capture(),
             eq("application/x-freenet-reference"),
-            eq((long) expectedLength),
-            eq(false));
+            eq((long) expectedLength));
     verify(ctx).writeData(bodyCaptor.capture(), eq(0), eq(expectedLength));
 
     String headerValue = headersCaptor.getValue().getFirst("Content-Disposition");

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -30,7 +30,7 @@ class SimpleToadletServerTest {
     SimpleToadletServer server = newServerWithDefaults();
     DummyToadlet toadlet = new DummyToadlet("/test/");
 
-    server.register(toadlet, null, "/test/", true, false);
+    server.register(toadlet, ToadletRegistration.basic(null, "/test/", true, false));
 
     Toadlet result = server.findToadlet(new URI("http://localhost/test/resource"));
 
@@ -41,7 +41,7 @@ class SimpleToadletServerTest {
   void findToadlet_whenMissingTrailingSlash_redirectsToNormalizedPrefix() throws Exception {
     SimpleToadletServer server = newServerWithDefaults();
     DummyToadlet toadlet = new DummyToadlet("/redirect/");
-    server.register(toadlet, null, "/redirect/", true, false);
+    server.register(toadlet, ToadletRegistration.basic(null, "/redirect/", true, false));
 
     PermanentRedirectException ex =
         assertThrows(
@@ -71,7 +71,7 @@ class SimpleToadletServerTest {
   void isLinkExcepted_whenToadletDeclaresException_usesToadletDecision() throws Exception {
     SimpleToadletServer server = newServerWithDefaults();
     ExceptedToadlet toadlet = new ExceptedToadlet("/except/");
-    server.register(toadlet, null, "/except/", true, false);
+    server.register(toadlet, ToadletRegistration.basic(null, "/except/", true, false));
 
     boolean result = server.isLinkExcepted(new URI("http://localhost/except/page"));
 

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -54,15 +54,14 @@ class ToadletContextImplTest {
     org.mockito.Mockito.when(container.isFProxyJavascriptEnabled()).thenReturn(false);
     org.mockito.Mockito.when(container.isSSL()).thenReturn(false);
 
+    ToadletRequestServices services =
+        new ToadletRequestServices(container, pageMaker, alertManager, bookmarkManager);
     context =
         new ToadletContextImpl(
             socket,
             new MultiValueTable<>(),
             bucketFactory,
-            pageMaker,
-            container,
-            alertManager,
-            bookmarkManager,
+            services,
             new URI("http://example.com/"),
             1L);
   }
@@ -130,8 +129,9 @@ class ToadletContextImplTest {
   void sendReplyHeaders_withoutModifiedTime_setsNoCacheAndCsp() throws Exception {
     MultiValueTable<String, String> headers = new MultiValueTable<>();
 
-    ToadletContextImpl.sendReplyHeaders(
-        outputStream, 200, "OK", headers, "text/plain", 10, null, true, false, false);
+    ReplyHeaders replyHeaders = ReplyHeaders.of(200, "OK", "text/plain", headers);
+    ReplyHeaderOptions options = new ReplyHeaderOptions(10, null, true, false, false);
+    ToadletContextImpl.sendReplyHeaders(outputStream, replyHeaders, options);
 
     Map<String, List<String>> parsed = parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
 
@@ -156,8 +156,9 @@ class ToadletContextImplTest {
     MultiValueTable<String, String> headers = new MultiValueTable<>();
     Date modified = new Date(0L);
 
-    ToadletContextImpl.sendReplyHeaders(
-        outputStream, 200, "OK", headers, "text/html", 5, modified, false, true, true);
+    ReplyHeaders replyHeaders = ReplyHeaders.of(200, "OK", "text/html", headers);
+    ReplyHeaderOptions options = new ReplyHeaderOptions(5, modified, false, true, true);
+    ToadletContextImpl.sendReplyHeaders(outputStream, replyHeaders, options);
 
     Map<String, List<String>> parsed = parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
 
@@ -221,7 +222,7 @@ class ToadletContextImplTest {
       if (idx <= 0) continue;
       String key = line.substring(0, idx).toLowerCase(Locale.ROOT);
       String value = line.substring(idx + 1).trim();
-      map.computeIfAbsent(key, k -> new java.util.ArrayList<>()).add(value);
+      map.computeIfAbsent(key, _ -> new java.util.ArrayList<>()).add(value);
     }
     return map;
   }


### PR DESCRIPTION
## Summary
- introduce ReplyHeaders to bundle response metadata for toadlet replies
- switch toadlet reply helpers and registrations to use ReplyHeaders/ToadletRegistration
- streamline request handling setup with ToadletRequestServices

## Testing
- Not run (not requested)