### PR TITLE
refactor(config): unify option metadata handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,28 @@ Load only what you need. It’s normal to load multiple skills for one task.
 5. Run the relevant Gradle checks (see `cryptad-build-test` / `cryptad-build-tooling`).
 6. Update docs/tests when needed.
 
+## JetBrains IDE inspections (required after every edit)
+
+After **any** action that creates or modifies a file, immediately run JetBrains IDE inspections on that file via the IDE MCP server (`jetbrains`) tool `get_file_problems`.
+
+- Use `filePath` relative to the project root.
+- Always pass `projectPath` (repo root / current working directory) to reduce ambiguous calls.
+- Default to `errorsOnly: true` (errors only). If you are chasing quality issues, re-run with `errorsOnly: false` to include warnings.
+- If problems are reported, fix them and **re-run `get_file_problems` until the file is clean** before moving on.
+
+Example call:
+
+```
+get_file_problems({
+  "projectPath": "<repo-root>",
+  "filePath": "src/main/kotlin/…",
+  "errorsOnly": true,
+  "timeout": 30000
+})
+```
+
+If the IDE MCP server is unavailable, fall back to the relevant Gradle compile/test task but treat IDE inspections as the default fast feedback loop.
+
 ## Always-on rules (keep these in mind)
 
 - **Languages:** Kotlin + Java.

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -25,6 +25,7 @@ import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.FCPPluginConnection.SendDirection;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.SSL;
 import network.crypta.io.AllowedHosts;
@@ -558,57 +559,39 @@ public class FCPServer implements Runnable, DownloadCache {
     fcpConfig.register(
         "enabled",
         true,
-        sortOrder++,
-        true,
-        false,
-        "FcpServer.isEnabled",
-        "FcpServer.isEnabledLong",
+        new Option.Meta(sortOrder++, true, false, "FcpServer.isEnabled", "FcpServer.isEnabledLong"),
         new FCPEnabledCallback(core));
     fcpConfig.register(
         "ssl",
         false,
-        sortOrder++,
-        true,
-        true,
-        "FcpServer.ssl",
-        "FcpServer.sslLong",
+        new Option.Meta(sortOrder++, true, true, "FcpServer.ssl", "FcpServer.sslLong"),
         new FCPSSLCallback());
     fcpConfig.register(
         "port",
         FCPServer.DEFAULT_FCP_PORT /* anagram of 1984, and 1000 up from old number */,
-        2,
-        true,
-        true,
-        "FcpServer.portNumber",
-        "FcpServer.portNumberLong",
+        new Option.Meta(2, true, true, "FcpServer.portNumber", "FcpServer.portNumberLong"),
         new FCPPortNumberCallback(core),
         false);
     fcpConfig.register(
         "bindTo",
         NetworkInterface.DEFAULT_BIND_TO,
-        sortOrder++,
-        true,
-        true,
-        "FcpServer.bindTo",
-        "FcpServer.bindToLong",
+        new Option.Meta(sortOrder++, true, true, "FcpServer.bindTo", "FcpServer.bindToLong"),
         new FCPBindtoCallback(core));
     fcpConfig.register(
         "allowedHosts",
         NetworkInterface.DEFAULT_BIND_TO,
-        sortOrder++,
-        true,
-        true,
-        "FcpServer.allowedHosts",
-        "FcpServer.allowedHostsLong",
+        new Option.Meta(
+            sortOrder++, true, true, "FcpServer.allowedHosts", "FcpServer.allowedHostsLong"),
         new FCPAllowedHostsCallback(core));
     fcpConfig.register(
         "allowedHostsFullAccess",
         NetworkInterface.DEFAULT_BIND_TO,
-        sortOrder++,
-        true,
-        true,
-        "FcpServer.allowedHostsFullAccess",
-        "FcpServer.allowedHostsFullAccessLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            true,
+            "FcpServer.allowedHostsFullAccess",
+            "FcpServer.allowedHostsFullAccessLong"),
         new FCPAllowedHostsFullAccessCallback(core));
 
     AssumeDDADownloadIsAllowedCallback cb4 = new AssumeDDADownloadIsAllowedCallback();
@@ -618,39 +601,43 @@ public class FCPServer implements Runnable, DownloadCache {
     fcpConfig.register(
         "assumeDownloadDDAIsAllowed",
         false,
-        sortOrder++,
-        true,
-        false,
-        "FcpServer.assumeDownloadDDAIsAllowed",
-        "FcpServer.assumeDownloadDDAIsAllowedLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "FcpServer.assumeDownloadDDAIsAllowed",
+            "FcpServer.assumeDownloadDDAIsAllowedLong"),
         cb4);
     fcpConfig.register(
         "assumeUploadDDAIsAllowed",
         false,
-        sortOrder++,
-        true,
-        false,
-        "FcpServer.assumeUploadDDAIsAllowed",
-        "FcpServer.assumeUploadDDAIsAllowedLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "FcpServer.assumeUploadDDAIsAllowed",
+            "FcpServer.assumeUploadDDAIsAllowedLong"),
         cb5);
     fcpConfig.register(
         "maxMessageQueueLength",
         1024,
-        sortOrder++,
-        true,
-        false,
-        "FcpServer.maxMessageQueueLength",
-        "FcpServer.maxMessageQueueLengthLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "FcpServer.maxMessageQueueLength",
+            "FcpServer.maxMessageQueueLengthLong"),
         cb7,
         false);
     fcpConfig.register(
         "neverDropAMessage",
         false,
-        sortOrder,
-        true,
-        false,
-        "FcpServer.neverDropAMessage",
-        "FcpServer.neverDropAMessageLong",
+        new Option.Meta(
+            sortOrder,
+            true,
+            false,
+            "FcpServer.neverDropAMessage",
+            "FcpServer.neverDropAMessageLong"),
         cb6);
 
     if (SSL.available()) {

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
@@ -23,6 +23,7 @@ import network.crypta.clients.http.wizardsteps.SecurityPhysical;
 import network.crypta.clients.http.wizardsteps.Step;
 import network.crypta.clients.http.wizardsteps.Welcome;
 import network.crypta.config.Config;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
@@ -197,20 +198,22 @@ public class FirstTimeWizardToadlet extends Toadlet {
     wizardConfiguration.register(
         "loadUPnPPlugin",
         true,
-        0,
-        true,
-        false,
-        "FirstTimeWizardToadlet.loadUPnPPlugin",
-        "FirstTimeWizardToadlet.loadUPnPPluginLong",
+        new Option.Meta(
+            0,
+            true,
+            false,
+            "FirstTimeWizardToadlet.loadUPnPPlugin",
+            "FirstTimeWizardToadlet.loadUPnPPluginLong"),
         createLoadUPnPPluginCallback());
     wizardConfiguration.register(
         "enableAutoUpdater",
         true,
-        1,
-        true,
-        false,
-        "FirstTimeWizardToadlet.enableAutoUpdater",
-        "FirstTimeWizardToadlet.enableAutoUpdaterLong",
+        new Option.Meta(
+            1,
+            true,
+            false,
+            "FirstTimeWizardToadlet.enableAutoUpdater",
+            "FirstTimeWizardToadlet.enableAutoUpdaterLong"),
         createEnableAutoUpdaterCallback());
     loadUPnPPlugin = wizardConfiguration.getBoolean("loadUPnPPlugin");
     enableAutoUpdater = wizardConfiguration.getBoolean("enableAutoUpdater");

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -18,6 +18,7 @@ import network.crypta.clients.http.updateableelements.PushDataManager;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.SSL;
 import network.crypta.io.AllowedHosts;
@@ -559,11 +560,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "fetchKeyBoxAboveBookmarks",
         cssTheme.fetchKeyBoxAboveBookmarks,
-        configItemOrder,
-        false,
-        false,
-        "SimpleToadletServer.fetchKeyBoxAboveBookmarks",
-        "SimpleToadletServer.fetchKeyBoxAboveBookmarksLong",
+        new Option.Meta(
+            configItemOrder,
+            false,
+            false,
+            "SimpleToadletServer.fetchKeyBoxAboveBookmarks",
+            "SimpleToadletServer.fetchKeyBoxAboveBookmarksLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -610,67 +612,74 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "enabled",
         true,
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.enabled",
-        "SimpleToadletServer.enabledLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.enabled",
+            "SimpleToadletServer.enabledLong"),
         new FProxyEnabledCallback());
 
     fproxyConfig.register(
         "ssl",
         false,
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.ssl",
-        "SimpleToadletServer.sslLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.ssl",
+            "SimpleToadletServer.sslLong"),
         new FProxySSLCallback());
     fproxyConfig.register(
         "port",
         DEFAULT_FPROXY_PORT,
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.port",
-        "SimpleToadletServer.portLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.port",
+            "SimpleToadletServer.portLong"),
         new FProxyPortCallback(),
         false);
     fproxyConfig.register(
         "bindTo",
         NetworkInterface.DEFAULT_BIND_TO,
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.bindTo",
-        "SimpleToadletServer.bindToLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.bindTo",
+            "SimpleToadletServer.bindToLong"),
         new FProxyBindtoCallback());
     fproxyConfig.register(
         "css",
         PageMaker.THEME.getDefault().code,
-        configItemOrder++,
-        false,
-        false,
-        "SimpleToadletServer.cssName",
-        "SimpleToadletServer.cssNameLong",
+        new Option.Meta(
+            configItemOrder++,
+            false,
+            false,
+            "SimpleToadletServer.cssName",
+            "SimpleToadletServer.cssNameLong"),
         new FProxyCSSNameCallback());
     fproxyConfig.register(
         CSS_OVERRIDE_KEY,
         "",
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.cssOverride",
-        "SimpleToadletServer.cssOverrideLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.cssOverride",
+            "SimpleToadletServer.cssOverrideLong"),
         new FProxyCSSOverrideCallback());
     fproxyConfig.register(
         "sendAllThemes",
         false,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.sendAllThemes",
-        "SimpleToadletServer.sendAllThemesLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.sendAllThemes",
+            "SimpleToadletServer.sendAllThemesLong"),
         new BooleanCallback() {
 
           @Override
@@ -688,21 +697,23 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "advancedModeEnabled",
         false,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.advancedMode",
-        "SimpleToadletServer.advancedModeLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.advancedMode",
+            "SimpleToadletServer.advancedModeLong"),
         new FProxyAdvancedModeEnabledCallback(this));
 
     fproxyConfig.register(
         "enableExtendedMethodHandling",
         false,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.enableExtendedMethodHandling",
-        "SimpleToadletServer.enableExtendedMethodHandlingLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.enableExtendedMethodHandling",
+            "SimpleToadletServer.enableExtendedMethodHandlingLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -718,29 +729,32 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "javascriptEnabled",
         true,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.enableJS",
-        "SimpleToadletServer.enableJSLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.enableJS",
+            "SimpleToadletServer.enableJSLong"),
         new FProxyJavascriptEnabledCallback(this));
     fproxyConfig.register(
         "webPushingEnabled",
         false,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.enableWP",
-        "SimpleToadletServer.enableWPLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.enableWP",
+            "SimpleToadletServer.enableWPLong"),
         new FProxyWebPushingEnabledCallback(this));
     fproxyConfig.register(
         "hasCompletedWizard",
         false,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.hasCompletedWizard",
-        "SimpleToadletServer.hasCompletedWizardLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.hasCompletedWizard",
+            "SimpleToadletServer.hasCompletedWizardLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -756,11 +770,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "disableProgressPage",
         false,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.disableProgressPage",
-        "SimpleToadletServer.disableProgressPageLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.disableProgressPage",
+            "SimpleToadletServer.disableProgressPageLong"),
         new BooleanCallback() {
 
           @Override
@@ -786,11 +801,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "showPanicButton",
         false,
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.panicButton",
-        "SimpleToadletServer.panicButtonLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.panicButton",
+            "SimpleToadletServer.panicButtonLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -810,11 +826,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "noConfirmPanic",
         false,
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.noConfirmPanic",
-        "SimpleToadletServer.noConfirmPanicLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.noConfirmPanic",
+            "SimpleToadletServer.noConfirmPanicLong"),
         new BooleanCallback() {
 
           @Override
@@ -835,11 +852,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "publicGatewayMode",
         false,
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.publicGatewayMode",
-        "SimpleToadletServer.publicGatewayModeLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.publicGatewayMode",
+            "SimpleToadletServer.publicGatewayModeLong"),
         new BooleanCallback() {
 
           @Override
@@ -864,11 +882,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "enablePersistentConnections",
         false,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.enablePersistentConnections",
-        "SimpleToadletServer.enablePersistentConnectionsLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.enablePersistentConnections",
+            "SimpleToadletServer.enablePersistentConnectionsLong"),
         new BooleanCallback() {
 
           @Override
@@ -890,11 +909,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "enableInlinePrefetch",
         false,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.enableInlinePrefetch",
-        "SimpleToadletServer.enableInlinePrefetchLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.enableInlinePrefetch",
+            "SimpleToadletServer.enableInlinePrefetchLong"),
         new BooleanCallback() {
 
           @Override
@@ -916,11 +936,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "enableActivelinks",
         false,
-        configItemOrder++,
-        false,
-        false,
-        "SimpleToadletServer.enableActivelinks",
-        "SimpleToadletServer.enableActivelinksLong",
+        new Option.Meta(
+            configItemOrder++,
+            false,
+            false,
+            "SimpleToadletServer.enableActivelinks",
+            "SimpleToadletServer.enableActivelinksLong"),
         new BooleanCallback() {
 
           @Override
@@ -938,22 +959,24 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "passthroughMaxSize",
         FProxyToadlet.getMaxLengthNoProgress(),
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.passthroughMaxSize",
-        "SimpleToadletServer.passthroughMaxSizeLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.passthroughMaxSize",
+            "SimpleToadletServer.passthroughMaxSizeLong"),
         new FProxyPassthruMaxSizeNoProgress(),
         true);
     FProxyToadlet.setMaxLengthNoProgress(fproxyConfig.getLong("passthroughMaxSize"));
     fproxyConfig.register(
         PASSTHROUGH_MAX_SIZE_PROGRESS_KEY,
         FProxyToadlet.getMaxLengthWithProgress(),
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.passthroughMaxSizeProgress",
-        "SimpleToadletServer.passthroughMaxSizeProgressLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.passthroughMaxSizeProgress",
+            "SimpleToadletServer.passthroughMaxSizeProgressLong"),
         new FProxyPassthruMaxSizeProgress(),
         true);
     FProxyToadlet.setMaxLengthWithProgress(fproxyConfig.getLong(PASSTHROUGH_MAX_SIZE_PROGRESS_KEY));
@@ -966,11 +989,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "enableCachingForChkAndSskKeys",
         false,
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.enableCachingForChkAndSskKeys",
-        "SimpleToadletServer.enableCachingForChkAndSskKeysLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.enableCachingForChkAndSskKeys",
+            "SimpleToadletServer.enableCachingForChkAndSskKeysLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -990,20 +1014,22 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "allowedHosts",
         "127.0.0.1,0:0:0:0:0:0:0:1",
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.allowedHosts",
-        "SimpleToadletServer.allowedHostsLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.allowedHosts",
+            "SimpleToadletServer.allowedHostsLong"),
         new FProxyAllowedHostsCallback());
     fproxyConfig.register(
         "allowedHostsFullAccess",
         "127.0.0.1,0:0:0:0:0:0:0:1",
-        configItemOrder++,
-        true,
-        true,
-        "SimpleToadletServer.allowedFullAccess",
-        "SimpleToadletServer.allowedFullAccessLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            true,
+            "SimpleToadletServer.allowedFullAccess",
+            "SimpleToadletServer.allowedFullAccessLong"),
         new StringCallback() {
 
           @Override
@@ -1023,11 +1049,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "doRobots",
         false,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.doRobots",
-        "SimpleToadletServer.doRobotsLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.doRobots",
+            "SimpleToadletServer.doRobotsLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -1047,11 +1074,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "maxFproxyConnections",
         100,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.maxFproxyConnections",
-        "SimpleToadletServer.maxFproxyConnectionsLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.maxFproxyConnections",
+            "SimpleToadletServer.maxFproxyConnectionsLong"),
         new IntCallback() {
 
           @Override
@@ -1075,11 +1103,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "metaRefreshSamePageInterval",
         1,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.metaRefreshSamePageInterval",
-        "SimpleToadletServer.metaRefreshSamePageIntervalLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.metaRefreshSamePageInterval",
+            "SimpleToadletServer.metaRefreshSamePageIntervalLong"),
         new IntCallback() {
 
           @Override
@@ -1102,11 +1131,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "metaRefreshRedirectInterval",
         1,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.metaRefreshRedirectInterval",
-        "SimpleToadletServer.metaRefreshRedirectIntervalLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.metaRefreshRedirectInterval",
+            "SimpleToadletServer.metaRefreshRedirectIntervalLong"),
         new IntCallback() {
 
           @Override
@@ -1129,11 +1159,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "embedM3uPlayerInFreesites",
         true,
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.embedM3uPlayerInFreesites",
-        "SimpleToadletServer.embedM3uPlayerInFreesitesLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.embedM3uPlayerInFreesites",
+            "SimpleToadletServer.embedM3uPlayerInFreesitesLong"),
         new BooleanCallback() {
 
           @Override
@@ -1151,11 +1182,12 @@ public final class SimpleToadletServer
     fproxyConfig.register(
         "refilterPolicy",
         "RE_FILTER",
-        configItemOrder++,
-        true,
-        false,
-        "SimpleToadletServer.refilterPolicy",
-        "SimpleToadletServer.refilterPolicyLong",
+        new Option.Meta(
+            configItemOrder++,
+            true,
+            false,
+            "SimpleToadletServer.refilterPolicy",
+            "SimpleToadletServer.refilterPolicyLong"),
         new ReFilterCallback());
 
     this.refilterPolicy = REFILTER_POLICY.valueOf(fproxyConfig.getString("refilterPolicy"));

--- a/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
+++ b/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
@@ -63,11 +64,8 @@ public class SymlinkerToadlet extends Toadlet {
     tslconfig.register(
         "symlinks",
         null,
-        9,
-        true,
-        false,
-        "SymlinkerToadlet.symlinks",
-        "SymlinkerToadlet.symlinksLong",
+        new Option.Meta(
+            9, true, false, "SymlinkerToadlet.symlinks", "SymlinkerToadlet.symlinksLong"),
         new StringArrCallback() {
           @Override
           public String[] get() {

--- a/src/main/java/network/crypta/config/BandwidthOption.java
+++ b/src/main/java/network/crypta/config/BandwidthOption.java
@@ -30,33 +30,16 @@ public class BandwidthOption extends IntOption {
    * @param conf owning sub‑configuration.
    * @param optionName stable key used to persist and retrieve the option.
    * @param defaultValueString textual default; interpreted as a size and converted to bytes.
-   * @param sortOrder relative ordering hint for UIs.
-   * @param expert whether the option targets advanced users.
-   * @param forceWrite whether to always write the option, even when equal to the default.
-   * @param shortDesc single‑line description suitable for lists.
-   * @param longDesc extended help text; may contain localization tokens.
+   * @param meta option metadata (sort order, expert flag, descriptions).
    * @param cb callback invoked on value change; may be {@code null} when no side effect is needed.
    */
   public BandwidthOption(
       SubConfig conf,
       String optionName,
       String defaultValueString,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       IntCallback cb) {
-    this(
-        conf,
-        optionName,
-        Fields.parseInt(defaultValueString),
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
-        cb);
+    this(conf, optionName, Fields.parseInt(defaultValueString), meta, cb);
   }
 
   /**
@@ -65,32 +48,20 @@ public class BandwidthOption extends IntOption {
    * @param conf owning sub‑configuration.
    * @param optionName stable key used to persist and retrieve the option.
    * @param defaultValue default value in bytes per second.
-   * @param sortOrder relative ordering hint for UIs.
-   * @param expert whether the option targets advanced users.
-   * @param forceWrite whether to always write the option, even when equal to the default.
-   * @param shortDesc single‑line description suitable for lists.
-   * @param longDesc extended help text; may contain localization tokens.
+   * @param meta option metadata (sort order, expert flag, descriptions).
    * @param cb callback invoked on value change; may be {@code null} when no side effect is needed.
    */
   public BandwidthOption(
-      SubConfig conf,
-      String optionName,
-      Integer defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      IntCallback cb) {
+      SubConfig conf, String optionName, Integer defaultValue, Option.Meta meta, IntCallback cb) {
     super(
         conf,
         optionName,
         defaultValue,
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
+        meta.sortOrder(),
+        meta.expert(),
+        meta.forceWrite(),
+        meta.shortDesc(),
+        meta.longDesc(),
         cb,
         Dimension.SIZE);
   }

--- a/src/main/java/network/crypta/config/BandwidthOption.java
+++ b/src/main/java/network/crypta/config/BandwidthOption.java
@@ -53,17 +53,7 @@ public class BandwidthOption extends IntOption {
    */
   public BandwidthOption(
       SubConfig conf, String optionName, Integer defaultValue, Option.Meta meta, IntCallback cb) {
-    super(
-        conf,
-        optionName,
-        defaultValue,
-        meta.sortOrder(),
-        meta.expert(),
-        meta.forceWrite(),
-        meta.shortDesc(),
-        meta.longDesc(),
-        cb,
-        Dimension.SIZE);
+    super(conf, optionName, defaultValue, meta, cb, Dimension.SIZE);
   }
 
   /**

--- a/src/main/java/network/crypta/config/BooleanOption.java
+++ b/src/main/java/network/crypta/config/BooleanOption.java
@@ -23,29 +23,16 @@ public class BooleanOption extends Option<Boolean> {
    * @param conf owning {@link SubConfig}; typically non-null for registered options
    * @param optionName canonical name used in config files and APIs
    * @param defaultValue default and initial value
-   * @param sortOrder relative ordering within the parent {@link SubConfig}
-   * @param expert whether this option targets advanced users
-   * @param forceWrite whether to persist even when equal to the default
-   * @param shortDesc localization key for a brief label
-   * @param longDesc localization key for a detailed description
+   * @param meta descriptive and ordering metadata for the option
    * @param cb callback used to read/apply values
    */
   public BooleanOption(
       SubConfig conf,
       String optionName,
       boolean defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       BooleanCallback cb) {
-    super(
-        conf,
-        optionName,
-        cb,
-        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
-        Option.DataType.BOOLEAN);
+    super(conf, optionName, cb, meta, Option.DataType.BOOLEAN);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;
   }

--- a/src/main/java/network/crypta/config/Config.java
+++ b/src/main/java/network/crypta/config/Config.java
@@ -89,7 +89,7 @@ public class Config {
   public void finishedInit() {
     SubConfig[] configs;
     synchronized (this) {
-      // FIXME: Consider caching the array if this method is hot; profile before adding state.
+      // Note: Consider caching the array if this method is hot; profile before adding state.
       configs = configsByPrefix.values().toArray(new SubConfig[0]);
     }
     for (SubConfig config : configs) {
@@ -155,7 +155,7 @@ public class Config {
    * @param subConfig the source sub-config
    * @param key the option key
    * @return the numeric option
-   * @throws ClassCastException if the option exists but is not of numeric type
+   * @throws ClassCastException if the option exists but is not of a numeric type
    */
   @SuppressWarnings("unchecked")
   public static Option<Long> longOption(SubConfig subConfig, String key) {

--- a/src/main/java/network/crypta/config/ConfigException.java
+++ b/src/main/java/network/crypta/config/ConfigException.java
@@ -17,7 +17,7 @@ public abstract class ConfigException extends Exception {
    *
    * @param msg human-readable detail describing the configuration failure.
    */
-  public ConfigException(String msg) {
+  protected ConfigException(String msg) {
     super(msg);
   }
 
@@ -26,7 +26,7 @@ public abstract class ConfigException extends Exception {
    *
    * @param cause the underlying cause; may be {@code null}.
    */
-  public ConfigException(Throwable cause) {
+  protected ConfigException(Throwable cause) {
     super(cause);
   }
 }

--- a/src/main/java/network/crypta/config/IntOption.java
+++ b/src/main/java/network/crypta/config/IntOption.java
@@ -31,11 +31,7 @@ public class IntOption extends Option<Integer> {
    * @param conf owning sub-configuration.
    * @param optionName stable key used to persist and retrieve the option.
    * @param defaultValueString textual default; interpreted using {@code dimension}.
-   * @param sortOrder relative ordering hint for UIs.
-   * @param expert whether the option targets advanced users.
-   * @param forceWrite whether to always write the option, even when equal to the default.
-   * @param shortDesc single-line description suitable for lists.
-   * @param longDesc extended help text; may contain localization tokens.
+   * @param meta option metadata (sort order, expert flag, descriptions).
    * @param cb callback invoked on value change; may be {@code null} when no side effect is needed.
    * @param dimension interpretation of numeric text and preferred display format.
    */
@@ -43,24 +39,10 @@ public class IntOption extends Option<Integer> {
       SubConfig conf,
       String optionName,
       String defaultValueString,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       IntCallback cb,
       Dimension dimension) {
-    this(
-        conf,
-        optionName,
-        parseString(defaultValueString, dimension),
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
-        cb,
-        dimension);
+    this(conf, optionName, parseString(defaultValueString, dimension), meta, cb, dimension);
   }
 
   /**
@@ -69,11 +51,7 @@ public class IntOption extends Option<Integer> {
    * @param conf owning sub-configuration.
    * @param optionName stable key used to persist and retrieve the option.
    * @param defaultValue default value stored as an {@link Integer}.
-   * @param sortOrder relative ordering hint for UIs.
-   * @param expert whether the option targets advanced users.
-   * @param forceWrite whether to always write the option, even when equal to the default.
-   * @param shortDesc single-line description suitable for lists.
-   * @param longDesc extended help text; may contain localization tokens.
+   * @param meta option metadata (sort order, expert flag, descriptions).
    * @param cb callback invoked on value change; may be {@code null} when no side effect is needed.
    * @param dimension interpretation of numeric text and preferred display format.
    */
@@ -81,19 +59,10 @@ public class IntOption extends Option<Integer> {
       SubConfig conf,
       String optionName,
       Integer defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       IntCallback cb,
       Dimension dimension) {
-    super(
-        conf,
-        optionName,
-        cb,
-        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
-        Option.DataType.NUMBER);
+    super(conf, optionName, cb, meta, Option.DataType.NUMBER);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;
     this.dimension = dimension;

--- a/src/main/java/network/crypta/config/LongOption.java
+++ b/src/main/java/network/crypta/config/LongOption.java
@@ -38,11 +38,7 @@ public class LongOption extends Option<Long> {
    * @param conf Owning {@link SubConfig}.
    * @param optionName Canonical option name within {@code conf}.
    * @param defaultValueString Default value in text form.
-   * @param sortOrder Relative order among sibling options in UIs/exports.
-   * @param expert Whether the option targets advanced users.
-   * @param forceWrite Whether to persist even when equal to the default.
-   * @param shortDesc Message key for a short label.
-   * @param longDesc Message key for a detailed description.
+   * @param meta Presentation and ordering metadata.
    * @param cb Callback used to read/apply values.
    * @param isSize Enables IEC size formatting for display when {@code true}.
    */
@@ -50,24 +46,10 @@ public class LongOption extends Option<Long> {
       SubConfig conf,
       String optionName,
       String defaultValueString,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       LongCallback cb,
       boolean isSize) {
-    this(
-        conf,
-        optionName,
-        Fields.parseLong(defaultValueString),
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
-        cb,
-        isSize);
+    this(conf, optionName, Fields.parseLong(defaultValueString), meta, cb, isSize);
   }
 
   /**
@@ -76,11 +58,7 @@ public class LongOption extends Option<Long> {
    * @param conf Owning {@link SubConfig}.
    * @param optionName Canonical option name within {@code conf}.
    * @param defaultValue Default numeric value.
-   * @param sortOrder Relative order among sibling options in UIs/exports.
-   * @param expert Whether the option targets advanced users.
-   * @param forceWrite Whether to persist even when equal to the default.
-   * @param shortDesc Message key for a short label.
-   * @param longDesc Message key for a detailed description.
+   * @param meta Presentation and ordering metadata.
    * @param cb Callback used to read/apply values.
    * @param isSize Enables IEC size formatting for display when {@code true}.
    */
@@ -88,19 +66,10 @@ public class LongOption extends Option<Long> {
       SubConfig conf,
       String optionName,
       Long defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       LongCallback cb,
       boolean isSize) {
-    super(
-        conf,
-        optionName,
-        cb,
-        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
-        Option.DataType.NUMBER);
+    super(conf, optionName, cb, meta, Option.DataType.NUMBER);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;
     this.isSize = isSize;

--- a/src/main/java/network/crypta/config/ShortOption.java
+++ b/src/main/java/network/crypta/config/ShortOption.java
@@ -29,14 +29,10 @@ public class ShortOption extends Option<Short> {
   /**
    * Creates a short-valued configuration option.
    *
-   * @param conf owning configuration section
+   * @param conf the owning configuration section
    * @param optionName unique key within {@code conf}
    * @param defaultValue value used when no explicit value is set
-   * @param sortOrder display order hint for UIs
-   * @param expert whether the option is intended for advanced users
-   * @param forceWrite whether the option should be written even when set to the default
-   * @param shortDesc concise description (single line, localized key or text)
-   * @param longDesc detailed description (may span multiple sentences)
+   * @param meta option metadata (ordering, expert flag, descriptions)
    * @param cb optional callback invoked when the value changes
    * @param isSize whether display formatting should treat values as sizes
    */
@@ -44,19 +40,10 @@ public class ShortOption extends Option<Short> {
       SubConfig conf,
       String optionName,
       short defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       ShortCallback cb,
       boolean isSize) {
-    super(
-        conf,
-        optionName,
-        cb,
-        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
-        Option.DataType.NUMBER);
+    super(conf, optionName, cb, meta, Option.DataType.NUMBER);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;
     this.isSize = isSize;

--- a/src/main/java/network/crypta/config/StringArrOption.java
+++ b/src/main/java/network/crypta/config/StringArrOption.java
@@ -17,7 +17,7 @@ import network.crypta.support.api.StringArrCallback;
  * token {@code ":"}.
  *
  * <p>Parsing accepts the format produced by {@link #toString(String[])} and tolerates certain
- * malformed escapes only until the first successful decode (see {@link URLDecoder}). Truncated or
+ * malformed escapes only until the first successful decoding (see {@link URLDecoder}). Truncated or
  * otherwise invalid encodings result in {@link InvalidConfigValueException}.
  *
  * <p>Unless coordinated by the surrounding configuration subsystem, this class performs no internal
@@ -41,29 +41,16 @@ public class StringArrOption extends Option<String[]> {
    * @param optionName canonical option name used in config and APIs
    * @param defaultValue default sequence when unspecified; {@code null} is treated as an empty
    *     array
-   * @param sortOrder relative ordering among sibling options
-   * @param expert whether the option targets advanced users
-   * @param forceWrite whether to persist even when equal to the default
-   * @param shortDesc localization key for a short label
-   * @param longDesc localization key for a detailed description
+   * @param meta descriptive and ordering metadata
    * @param cb callback that provides and accepts the effective value
    */
   public StringArrOption(
       SubConfig conf,
       String optionName,
       String[] defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       StringArrCallback cb) {
-    super(
-        conf,
-        optionName,
-        cb,
-        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
-        Option.DataType.STRING_ARRAY);
+    super(conf, optionName, cb, meta, Option.DataType.STRING_ARRAY);
     this.defaultValue = (defaultValue == null) ? new String[0] : defaultValue;
     this.currentValue = (defaultValue == null) ? new String[0] : defaultValue;
   }

--- a/src/main/java/network/crypta/config/StringOption.java
+++ b/src/main/java/network/crypta/config/StringOption.java
@@ -21,29 +21,12 @@ public class StringOption extends Option<String> {
    * @param conf Owning {@link SubConfig} that manages registration and lookups.
    * @param optionName Canonical name used in configuration files and APIs.
    * @param defaultValue Initial value used before callbacks become authoritative.
-   * @param sortOrder Relative ordering among sibling options in UI and exports.
-   * @param expert Whether intended for advanced users (UIs may hide by default).
-   * @param forceWrite Whether to persist even when equal to the default value.
-   * @param shortDesc Message key for a short label (not the translated text).
-   * @param longDesc Message key for a longer description (not translated text).
+   * @param meta Presentation, description, and ordering metadata.
    * @param cb Callback used to read/apply values for this option.
    */
   public StringOption(
-      SubConfig conf,
-      String optionName,
-      String defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      StringCallback cb) {
-    super(
-        conf,
-        optionName,
-        cb,
-        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
-        Option.DataType.STRING);
+      SubConfig conf, String optionName, String defaultValue, Option.Meta meta, StringCallback cb) {
+    super(conf, optionName, cb, meta, Option.DataType.STRING);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;
   }

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -260,18 +260,7 @@ public class SubConfig implements Comparable<SubConfig> {
       String optionName, short defaultValue, Option.Meta meta, ShortCallback cb, boolean isSize) {
     Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullShortCallback();
-    register(
-        new ShortOption(
-            this,
-            optionName,
-            defaultValue,
-            normalizedMeta.sortOrder(),
-            normalizedMeta.expert(),
-            normalizedMeta.forceWrite(),
-            normalizedMeta.shortDesc(),
-            normalizedMeta.longDesc(),
-            cb,
-            isSize));
+    register(new ShortOption(this, optionName, defaultValue, normalizedMeta, cb, isSize));
   }
 
   /**

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -121,11 +121,7 @@ public class SubConfig implements Comparable<SubConfig> {
             this,
             optionName,
             defaultValue,
-            normalizedMeta.sortOrder(),
-            normalizedMeta.expert(),
-            normalizedMeta.forceWrite(),
-            normalizedMeta.shortDesc(),
-            normalizedMeta.longDesc(),
+            normalizedMeta,
             cb,
             isSize ? Dimension.SIZE : Dimension.NOT));
   }
@@ -187,18 +183,7 @@ public class SubConfig implements Comparable<SubConfig> {
     if (cb == null) {
       cb = new NullIntCallback();
     }
-    register(
-        new IntOption(
-            this,
-            optionName,
-            defaultValueString,
-            normalizedMeta.sortOrder(),
-            normalizedMeta.expert(),
-            normalizedMeta.forceWrite(),
-            normalizedMeta.shortDesc(),
-            normalizedMeta.longDesc(),
-            cb,
-            dimension));
+    register(new IntOption(this, optionName, defaultValueString, normalizedMeta, cb, dimension));
   }
 
   /**

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -274,17 +274,7 @@ public class SubConfig implements Comparable<SubConfig> {
   public void register(
       String optionName, String[] defaultValue, Option.Meta meta, StringArrCallback cb) {
     Option.Meta normalizedMeta = normalizeMeta(meta);
-    register(
-        new StringArrOption(
-            this,
-            optionName,
-            defaultValue,
-            normalizedMeta.sortOrder(),
-            normalizedMeta.expert(),
-            normalizedMeta.forceWrite(),
-            normalizedMeta.shortDesc(),
-            normalizedMeta.longDesc(),
-            cb));
+    register(new StringArrOption(this, optionName, defaultValue, normalizedMeta, cb));
   }
 
   private static Option.Meta normalizeMeta(Option.Meta meta) {

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -199,11 +199,7 @@ public class SubConfig implements Comparable<SubConfig> {
             this,
             optionName,
             defaultValue,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
             cb));
   }
 
@@ -305,11 +301,7 @@ public class SubConfig implements Comparable<SubConfig> {
             this,
             optionName,
             defaultValueString,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
             cb));
   }
 

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -108,35 +108,24 @@ public class SubConfig implements Comparable<SubConfig> {
    *
    * @param optionName Name of the option (no prefix).
    * @param defaultValue Default value used until changed.
-   * @param sortOrder Presentation order for UI/export.
-   * @param expert Marks option as expert-only in UIs.
-   * @param forceWrite If {@code true}, the value is always written even when equal to the default.
-   * @param shortDesc Localized short description.
-   * @param longDesc Localized long description.
+   * @param meta Presentation, description, and ordering metadata.
    * @param cb Callback invoked on value changes; {@code NullIntCallback} when {@code null}.
    * @param isSize When {@code true}, treat as a size (bytes) for units handling.
    */
   public void register(
-      String optionName,
-      int defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      IntCallback cb,
-      boolean isSize) {
+      String optionName, int defaultValue, Option.Meta meta, IntCallback cb, boolean isSize) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullIntCallback();
     register(
         new IntOption(
             this,
             optionName,
             defaultValue,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            normalizedMeta.sortOrder(),
+            normalizedMeta.expert(),
+            normalizedMeta.forceWrite(),
+            normalizedMeta.shortDesc(),
+            normalizedMeta.longDesc(),
             cb,
             isSize ? Dimension.SIZE : Dimension.NOT));
   }
@@ -146,35 +135,24 @@ public class SubConfig implements Comparable<SubConfig> {
    *
    * @param optionName Name of the option (no prefix).
    * @param defaultValue Default value used until changed.
-   * @param sortOrder Presentation order for UI/export.
-   * @param expert Marks option as expert-only in UIs.
-   * @param forceWrite If {@code true}, the value is always written even when equal to the default.
-   * @param shortDesc Localized short description.
-   * @param longDesc Localized long description.
+   * @param meta Presentation, description, and ordering metadata.
    * @param cb Callback invoked on value changes; {@code NullLongCallback} when {@code null}.
    * @param isSize When {@code true}, treat as a size (bytes) for units handling.
    */
   public void register(
-      String optionName,
-      long defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      LongCallback cb,
-      boolean isSize) {
+      String optionName, long defaultValue, Option.Meta meta, LongCallback cb, boolean isSize) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullLongCallback();
     register(
         new LongOption(
             this,
             optionName,
             defaultValue,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            normalizedMeta.sortOrder(),
+            normalizedMeta.expert(),
+            normalizedMeta.forceWrite(),
+            normalizedMeta.shortDesc(),
+            normalizedMeta.longDesc(),
             cb,
             isSize));
   }
@@ -184,23 +162,10 @@ public class SubConfig implements Comparable<SubConfig> {
    *
    * @see BandwidthOption
    */
-  public void register(
-      String optionName,
-      int defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      IntCallback cb) {
+  public void register(String optionName, int defaultValue, Option.Meta meta, IntCallback cb) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullIntCallback();
-    register(
-        new BandwidthOption(
-            this,
-            optionName,
-            defaultValue,
-            new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
-            cb));
+    register(new BandwidthOption(this, optionName, defaultValue, normalizedMeta, cb));
   }
 
   /**
@@ -208,24 +173,17 @@ public class SubConfig implements Comparable<SubConfig> {
    *
    * @param optionName Name of the option (no prefix).
    * @param defaultValueString Default value as string (parsed to {@code int}).
-   * @param sortOrder Presentation order for UI/export.
-   * @param expert Marks option as expert-only in UIs.
-   * @param forceWrite If {@code true}, the value is always written even when equal to the default.
-   * @param shortDesc Localized short description.
-   * @param longDesc Localized long description.
+   * @param meta Presentation, description, and ordering metadata.
    * @param cb Callback invoked on value changes; {@code NullIntCallback} when {@code null}.
    * @param dimension Logical dimension for unit handling.
    */
   public void register(
       String optionName,
       String defaultValueString,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       IntCallback cb,
       Dimension dimension) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) {
       cb = new NullIntCallback();
     }
@@ -234,11 +192,11 @@ public class SubConfig implements Comparable<SubConfig> {
             this,
             optionName,
             defaultValueString,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            normalizedMeta.sortOrder(),
+            normalizedMeta.expert(),
+            normalizedMeta.forceWrite(),
+            normalizedMeta.shortDesc(),
+            normalizedMeta.longDesc(),
             cb,
             dimension));
   }
@@ -248,35 +206,28 @@ public class SubConfig implements Comparable<SubConfig> {
    *
    * @param optionName Name of the option (no prefix).
    * @param defaultValueString Default value as string (parsed to {@code long}).
-   * @param sortOrder Presentation order for UI/export.
-   * @param expert Marks option as expert-only in UIs.
-   * @param forceWrite If {@code true}, the value is always written even when equal to the default.
-   * @param shortDesc Localized short description.
-   * @param longDesc Localized long description.
+   * @param meta Presentation, description, and ordering metadata.
    * @param cb Callback invoked on value changes; {@code NullLongCallback} when {@code null}.
    * @param isSize When {@code true}, treat as a size (bytes) for units handling.
    */
   public void register(
       String optionName,
       String defaultValueString,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
+      Option.Meta meta,
       LongCallback cb,
       boolean isSize) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullLongCallback();
     register(
         new LongOption(
             this,
             optionName,
             defaultValueString,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            normalizedMeta.sortOrder(),
+            normalizedMeta.expert(),
+            normalizedMeta.forceWrite(),
+            normalizedMeta.shortDesc(),
+            normalizedMeta.longDesc(),
             cb,
             isSize));
   }
@@ -287,22 +238,10 @@ public class SubConfig implements Comparable<SubConfig> {
    * @see BandwidthOption
    */
   public void register(
-      String optionName,
-      String defaultValueString,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      IntCallback cb) {
+      String optionName, String defaultValueString, Option.Meta meta, IntCallback cb) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullIntCallback();
-    register(
-        new BandwidthOption(
-            this,
-            optionName,
-            defaultValueString,
-            new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
-            cb));
+    register(new BandwidthOption(this, optionName, defaultValueString, normalizedMeta, cb));
   }
 
   /**
@@ -310,33 +249,23 @@ public class SubConfig implements Comparable<SubConfig> {
    *
    * @param optionName Name of the option (no prefix).
    * @param defaultValue Default value used until changed.
-   * @param sortOrder Presentation order for UI/export.
-   * @param expert Marks option as expert-only in UIs.
-   * @param forceWrite If {@code true}, the value is always written even when equal to the default.
-   * @param shortDesc Localized short description.
-   * @param longDesc Localized long description.
+   * @param meta Presentation, description, and ordering metadata.
    * @param cb Callback invoked on value changes; {@code NullBooleanCallback} when {@code null}.
    */
   public void register(
-      String optionName,
-      boolean defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      BooleanCallback cb) {
+      String optionName, boolean defaultValue, Option.Meta meta, BooleanCallback cb) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullBooleanCallback();
     register(
         new BooleanOption(
             this,
             optionName,
             defaultValue,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            normalizedMeta.sortOrder(),
+            normalizedMeta.expert(),
+            normalizedMeta.forceWrite(),
+            normalizedMeta.shortDesc(),
+            normalizedMeta.longDesc(),
             cb));
   }
 
@@ -345,33 +274,23 @@ public class SubConfig implements Comparable<SubConfig> {
    *
    * @param optionName Name of the option (no prefix).
    * @param defaultValue Default value used until changed.
-   * @param sortOrder Presentation order for UI/export.
-   * @param expert Marks option as expert-only in UIs.
-   * @param forceWrite If {@code true}, the value is always written even when equal to the default.
-   * @param shortDesc Localized short description.
-   * @param longDesc Localized long description.
+   * @param meta Presentation, description, and ordering metadata.
    * @param cb Callback invoked on value changes; {@code NullStringCallback} when {@code null}.
    */
   public void register(
-      String optionName,
-      String defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      StringCallback cb) {
+      String optionName, String defaultValue, Option.Meta meta, StringCallback cb) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullStringCallback();
     register(
         new StringOption(
             this,
             optionName,
             defaultValue,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            normalizedMeta.sortOrder(),
+            normalizedMeta.expert(),
+            normalizedMeta.forceWrite(),
+            normalizedMeta.shortDesc(),
+            normalizedMeta.longDesc(),
             cb));
   }
 
@@ -380,35 +299,24 @@ public class SubConfig implements Comparable<SubConfig> {
    *
    * @param optionName Name of the option (no prefix).
    * @param defaultValue Default value used until changed.
-   * @param sortOrder Presentation order for UI/export.
-   * @param expert Marks option as expert-only in UIs.
-   * @param forceWrite If {@code true}, the value is always written even when equal to the default.
-   * @param shortDesc Localized short description.
-   * @param longDesc Localized long description.
+   * @param meta Presentation, description, and ordering metadata.
    * @param cb Callback invoked on value changes; {@code NullShortCallback} when {@code null}.
    * @param isSize When {@code true}, treat as a size (bytes) for units handling.
    */
   public void register(
-      String optionName,
-      short defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      ShortCallback cb,
-      boolean isSize) {
+      String optionName, short defaultValue, Option.Meta meta, ShortCallback cb, boolean isSize) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullShortCallback();
     register(
         new ShortOption(
             this,
             optionName,
             defaultValue,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            normalizedMeta.sortOrder(),
+            normalizedMeta.expert(),
+            normalizedMeta.forceWrite(),
+            normalizedMeta.shortDesc(),
+            normalizedMeta.longDesc(),
             cb,
             isSize));
   }
@@ -418,39 +326,33 @@ public class SubConfig implements Comparable<SubConfig> {
    *
    * @param optionName Name of the option (no prefix).
    * @param defaultValue Default value used until changed.
-   * @param sortOrder Presentation order for UI/export.
-   * @param expert Marks option as expert-only in UIs.
-   * @param forceWrite If {@code true}, the value is always written even when equal to the default.
-   * @param shortDesc Localized short description.
-   * @param longDesc Localized long description.
+   * @param meta Presentation, description, and ordering metadata.
    * @param cb Callback invoked on value changes; may be {@code null}.
    */
   public void register(
-      String optionName,
-      String[] defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      StringArrCallback cb) {
+      String optionName, String[] defaultValue, Option.Meta meta, StringArrCallback cb) {
+    Option.Meta normalizedMeta = normalizeMeta(meta);
     register(
         new StringArrOption(
             this,
             optionName,
             defaultValue,
-            sortOrder,
-            expert,
-            forceWrite,
-            shortDesc,
-            longDesc,
+            normalizedMeta.sortOrder(),
+            normalizedMeta.expert(),
+            normalizedMeta.forceWrite(),
+            normalizedMeta.shortDesc(),
+            normalizedMeta.longDesc(),
             cb));
+  }
+
+  private static Option.Meta normalizeMeta(Option.Meta meta) {
+    return meta == null ? new Option.Meta(0, false, false, null, null) : meta;
   }
 
   /**
    * Registers an option that cannot be used.
    *
-   * <p>It is not listed, it is not exported, it is not persisted, it doesn’t have a value, you
+   * <p>It is not listed, it is not exported, it is not persisted, it doesn’t have a value. You
    * cannot change the value. It only exists so that Fred doesn’t log an error message if this
    * particular option is used in a config file.
    *
@@ -831,7 +733,7 @@ public class SubConfig implements Comparable<SubConfig> {
    * <p>Returns {@code 0} for identical instances to satisfy the {@link Comparable} contract; for
    * different instances the comparison delegates to {@link String#compareTo(String)} on prefixes.
    *
-   * @param second Other subsection (non-null).
+   * @param second Another subsection (non-null).
    * @return negative, zero, or positive per {@link String#compareTo(String)}.
    */
   @Override
@@ -886,7 +788,7 @@ public class SubConfig implements Comparable<SubConfig> {
 
             @Override
             public void set(Void value) {
-              // Intentionally no-op: ignored option accepts no value updates.
+              // Intentionally no-op: the ignored option accepts no value updates.
             }
           },
           new Option.Meta(-1, false, false, null, null),

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -234,17 +234,7 @@ public class SubConfig implements Comparable<SubConfig> {
       String optionName, String defaultValue, Option.Meta meta, StringCallback cb) {
     Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullStringCallback();
-    register(
-        new StringOption(
-            this,
-            optionName,
-            defaultValue,
-            normalizedMeta.sortOrder(),
-            normalizedMeta.expert(),
-            normalizedMeta.forceWrite(),
-            normalizedMeta.shortDesc(),
-            normalizedMeta.longDesc(),
-            cb));
+    register(new StringOption(this, optionName, defaultValue, normalizedMeta, cb));
   }
 
   /**

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -256,17 +256,7 @@ public class SubConfig implements Comparable<SubConfig> {
       String optionName, boolean defaultValue, Option.Meta meta, BooleanCallback cb) {
     Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullBooleanCallback();
-    register(
-        new BooleanOption(
-            this,
-            optionName,
-            defaultValue,
-            normalizedMeta.sortOrder(),
-            normalizedMeta.expert(),
-            normalizedMeta.forceWrite(),
-            normalizedMeta.shortDesc(),
-            normalizedMeta.longDesc(),
-            cb));
+    register(new BooleanOption(this, optionName, defaultValue, normalizedMeta, cb));
   }
 
   /**

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -139,18 +139,7 @@ public class SubConfig implements Comparable<SubConfig> {
       String optionName, long defaultValue, Option.Meta meta, LongCallback cb, boolean isSize) {
     Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullLongCallback();
-    register(
-        new LongOption(
-            this,
-            optionName,
-            defaultValue,
-            normalizedMeta.sortOrder(),
-            normalizedMeta.expert(),
-            normalizedMeta.forceWrite(),
-            normalizedMeta.shortDesc(),
-            normalizedMeta.longDesc(),
-            cb,
-            isSize));
+    register(new LongOption(this, optionName, defaultValue, normalizedMeta, cb, isSize));
   }
 
   /**
@@ -203,18 +192,7 @@ public class SubConfig implements Comparable<SubConfig> {
       boolean isSize) {
     Option.Meta normalizedMeta = normalizeMeta(meta);
     if (cb == null) cb = new NullLongCallback();
-    register(
-        new LongOption(
-            this,
-            optionName,
-            defaultValueString,
-            normalizedMeta.sortOrder(),
-            normalizedMeta.expert(),
-            normalizedMeta.forceWrite(),
-            normalizedMeta.shortDesc(),
-            normalizedMeta.longDesc(),
-            cb,
-            isSize));
+    register(new LongOption(this, optionName, defaultValueString, normalizedMeta, cb, isSize));
   }
 
   /**

--- a/src/main/java/network/crypta/crypt/SSL.java
+++ b/src/main/java/network/crypta/crypt/SSL.java
@@ -24,6 +24,7 @@ import javax.net.ServerSocketFactory;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.node.NodeStarter;
 import network.crypta.support.api.BooleanCallback;
@@ -128,45 +129,32 @@ public class SSL {
     sslConfig.register(
         "sslEnable",
         false,
-        configItemOrder++,
-        true,
-        true,
-        "SSL.enable",
-        "SSL.enable",
+        new Option.Meta(configItemOrder++, true, true, "SSL.enable", "SSL.enable"),
         enableCallback());
 
     sslConfig.register(
         "sslKeyStore",
         "datastore/certs",
-        configItemOrder++,
-        true,
-        true,
-        "SSL.keyStore",
-        "SSL.keyStoreLong",
+        new Option.Meta(configItemOrder++, true, true, "SSL.keyStore", "SSL.keyStoreLong"),
         keyStorePathCallback());
 
     sslConfig.register(
         "sslKeyStorePass",
         DEFAULT_SECRET,
-        configItemOrder++,
-        true,
-        true,
-        "SSL.keyStorePass",
-        "SSL.keyStorePass",
+        new Option.Meta(configItemOrder++, true, true, "SSL.keyStorePass", "SSL.keyStorePass"),
         keyStorePassCallback());
 
     sslConfig.register(
         "sslKeyPass",
         DEFAULT_SECRET,
-        configItemOrder++,
-        true,
-        true,
-        "SSL.keyPass",
-        "SSL.keyPass",
+        new Option.Meta(configItemOrder++, true, true, "SSL.keyPass", "SSL.keyPass"),
         keyPassCallback());
 
     sslConfig.register(
-        "sslHSTS", 0, configItemOrder, true, true, "SSL.HSTS", "SSL.HSTSLong", hstsCallback());
+        "sslHSTS",
+        0,
+        new Option.Meta(configItemOrder, true, true, "SSL.HSTS", "SSL.HSTSLong"),
+        hstsCallback());
 
     enable = sslConfig.getBoolean("sslEnable");
     keyStorePath = sslConfig.getString("sslKeyStore");

--- a/src/main/java/network/crypta/node/ConfigurablePersister.java
+++ b/src/main/java/network/crypta/node/ConfigurablePersister.java
@@ -3,6 +3,7 @@ package network.crypta.node;
 import java.io.File;
 import java.io.IOException;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.Ticker;
@@ -68,11 +69,7 @@ public class ConfigurablePersister extends Persister {
     nodeConfig.register(
         optionName,
         new File(baseDir, defaultFilename).toString(),
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
+        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
         new StringCallback() {
           @Override
           public String get() {

--- a/src/main/java/network/crypta/node/LoggingConfigHandler.java
+++ b/src/main/java/network/crypta/node/LoggingConfigHandler.java
@@ -22,6 +22,7 @@ import network.crypta.config.Dimension;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.OptionFormatException;
 import network.crypta.config.SubConfig;
 import network.crypta.support.ModuloTimeTriggeringPolicy;
@@ -187,11 +188,7 @@ public class LoggingConfigHandler {
     loggingConfig.register(
         "enabled",
         true,
-        1,
-        true,
-        false,
-        "LogConfigHandler.enabled",
-        "LogConfigHandler.enabledLong",
+        new Option.Meta(1, true, false, "LogConfigHandler.enabled", "LogConfigHandler.enabledLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -216,11 +213,7 @@ public class LoggingConfigHandler {
     loggingConfig.register(
         "dirname",
         "logs",
-        2,
-        true,
-        false,
-        "LogConfigHandler.dirName",
-        "LogConfigHandler.dirNameLong",
+        new Option.Meta(2, true, false, "LogConfigHandler.dirName", "LogConfigHandler.dirNameLong"),
         new StringCallback() {
           @Override
           public String get() {
@@ -257,11 +250,12 @@ public class LoggingConfigHandler {
     config.register(
         CONF_LOGS_TOTAL_SIZE_CAP,
         "200M",
-        3,
-        true,
-        true,
-        "LogConfigHandler.logsTotalSizeCap",
-        "LogConfigHandler.logsTotalSizeCapLong",
+        new Option.Meta(
+            3,
+            true,
+            true,
+            "LogConfigHandler.logsTotalSizeCap",
+            "LogConfigHandler.logsTotalSizeCapLong"),
         new LongCallback() {
           @Override
           public Long get() {
@@ -292,11 +286,12 @@ public class LoggingConfigHandler {
     config.register(
         CONF_PRIORITY,
         LVL_WARN,
-        4,
-        false,
-        false,
-        "LogConfigHandler.minLoggingPriority",
-        "LogConfigHandler.minLoggingPriorityLong",
+        new Option.Meta(
+            4,
+            false,
+            false,
+            "LogConfigHandler.minLoggingPriority",
+            "LogConfigHandler.minLoggingPriorityLong"),
         new PriorityCallback());
   }
 
@@ -304,11 +299,12 @@ public class LoggingConfigHandler {
     config.register(
         "priorityDetail",
         "",
-        5,
-        true,
-        false,
-        "LogConfigHandler.detailedPriorityThreshold",
-        "LogConfigHandler.detailedPriorityThresholdLong",
+        new Option.Meta(
+            5,
+            true,
+            false,
+            "LogConfigHandler.detailedPriorityThreshold",
+            "LogConfigHandler.detailedPriorityThresholdLong"),
         new StringCallback() {
           @Override
           public String get() {
@@ -327,11 +323,12 @@ public class LoggingConfigHandler {
     config.register(
         "interval",
         "1HOUR",
-        5,
-        true,
-        false,
-        "LogConfigHandler.rotationInterval",
-        "LogConfigHandler.rotationIntervalLong",
+        new Option.Meta(
+            5,
+            true,
+            false,
+            "LogConfigHandler.rotationInterval",
+            "LogConfigHandler.rotationIntervalLong"),
         new StringCallback() {
           @Override
           public String get() {
@@ -356,11 +353,12 @@ public class LoggingConfigHandler {
     config.register(
         "maxCachedBytes",
         "1M",
-        6,
-        true,
-        false,
-        "LogConfigHandler.maxCachedBytes",
-        "LogConfigHandler.maxCachedBytesLong",
+        new Option.Meta(
+            6,
+            true,
+            false,
+            "LogConfigHandler.maxCachedBytes",
+            "LogConfigHandler.maxCachedBytesLong"),
         new LongCallback() {
           @Override
           public Long get() {
@@ -385,11 +383,12 @@ public class LoggingConfigHandler {
     config.register(
         "maxCachedLines",
         "10k",
-        7,
-        true,
-        false,
-        "LogConfigHandler.maxCachedLines",
-        "LogConfigHandler.maxCachedLinesLong",
+        new Option.Meta(
+            7,
+            true,
+            false,
+            "LogConfigHandler.maxCachedLines",
+            "LogConfigHandler.maxCachedLinesLong"),
         new IntCallback() {
           @Override
           public Integer get() {
@@ -413,11 +412,12 @@ public class LoggingConfigHandler {
     config.register(
         "maxBacklogNotBusy",
         "60000",
-        8,
-        true,
-        false,
-        "LogConfigHandler.maxBacklogNotBusy",
-        "LogConfigHandler.maxBacklogNotBusy",
+        new Option.Meta(
+            8,
+            true,
+            false,
+            "LogConfigHandler.maxBacklogNotBusy",
+            "LogConfigHandler.maxBacklogNotBusy"),
         new LongCallback() {
 
           @Override

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -22,6 +22,7 @@ import network.crypta.client.FetchContext;
 import network.crypta.config.FreenetFilePersistentConfig;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.MasterSecret;
@@ -700,11 +701,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "name",
         myName,
-        sortOrder++,
-        false,
-        true,
-        "Node.nodeName",
-        "Node.nodeNameLong",
+        new Option.Meta(sortOrder++, false, true, "Node.nodeName", "Node.nodeNameLong"),
         configManager.new NodeNameCallback());
     myName = nodeConfig.getString("name");
 
@@ -712,11 +709,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "storeForceBigShrinks",
         false,
-        sortOrder++,
-        true,
-        false,
-        "Node.forceBigShrink",
-        "Node.forceBigShrinkLong",
+        new Option.Meta(sortOrder++, true, false, "Node.forceBigShrink", "Node.forceBigShrinkLong"),
         new BooleanCallback() {
 
           @Override
@@ -735,11 +728,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "storeType",
         "ram",
-        sortOrder++,
-        true,
-        true,
-        "Node.storeType",
-        "Node.storeTypeLong",
+        new Option.Meta(sortOrder++, true, true, "Node.storeType", "Node.storeTypeLong"),
         configManager.new StoreTypeCallback());
 
     storage.setStoreType(nodeConfig.getString("storeType"));
@@ -751,11 +740,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "storeSize",
         NodeStorageSubsystem.DEFAULT_STORE_SIZE,
-        sortOrder++,
-        false,
-        true,
-        "Node.storeSize",
-        "Node.storeSizeLong",
+        new Option.Meta(sortOrder++, false, true, "Node.storeSize", "Node.storeSizeLong"),
         new LongCallback() {
 
           @Override
@@ -775,11 +760,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "storeUseSlotFilters",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.storeUseSlotFilters",
-        "Node.storeUseSlotFiltersLong",
+        new Option.Meta(
+            sortOrder++, true, false, "Node.storeUseSlotFilters", "Node.storeUseSlotFiltersLong"),
         new BooleanCallback() {
 
           public Boolean get() {
@@ -796,11 +778,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "storeSaltHashSlotFilterPersistenceTime",
         NodeStorageSubsystem.DEFAULT_SALT_HASH_SLOT_FILTER_PERSISTENCE_TIME,
-        sortOrder++,
-        true,
-        false,
-        "Node.storeSaltHashSlotFilterPersistenceTime",
-        "Node.storeSaltHashSlotFilterPersistenceTimeLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.storeSaltHashSlotFilterPersistenceTime",
+            "Node.storeSaltHashSlotFilterPersistenceTimeLong"),
         new IntCallback() {
 
           @Override
@@ -820,11 +803,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "storeSaltHashResizeOnStart",
         false,
-        sortOrder++,
-        true,
-        false,
-        "Node.storeSaltHashResizeOnStart",
-        "Node.storeSaltHashResizeOnStartLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.storeSaltHashResizeOnStart",
+            "Node.storeSaltHashResizeOnStartLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -866,11 +850,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         STORE_PREALLOCATE_KEY,
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.storePreallocate",
-        "Node.storePreallocateLong",
+        new Option.Meta(
+            sortOrder++, true, true, "Node.storePreallocate", "Node.storePreallocateLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -895,11 +876,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "cachingFreenetStoreMaxSize",
         defaultCacheSize,
-        sortOrder++,
-        true,
-        false,
-        "Node.cachingCryptaStoreMaxSize",
-        "Node.cachingCryptaStoreMaxSizeLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.cachingCryptaStoreMaxSize",
+            "Node.cachingCryptaStoreMaxSizeLong"),
         new LongCallback() {
           @Override
           public Long get() {
@@ -918,11 +900,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "cachingFreenetStorePeriod",
         "300k",
-        sortOrder++,
-        true,
-        false,
-        "Node.cachingCryptaStorePeriod",
-        "Node.cachingCryptaStorePeriod",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.cachingCryptaStorePeriod",
+            "Node.cachingCryptaStorePeriod"),
         new LongCallback() {
           @Override
           public Long get() {
@@ -948,11 +931,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "clientCacheType",
         "ram",
-        sortOrder++,
-        true,
-        true,
-        "Node.clientCacheType",
-        "Node.clientCacheTypeLong",
+        new Option.Meta(
+            sortOrder++, true, true, "Node.clientCacheType", "Node.clientCacheTypeLong"),
         configManager.new ClientCacheTypeCallback());
 
     storage.setClientCacheType(nodeConfig.getString("clientCacheType"));
@@ -960,11 +940,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "clientCacheSize",
         NodeStorageSubsystem.DEFAULT_CLIENT_CACHE_SIZE,
-        sortOrder++,
-        false,
-        true,
-        "Node.clientCacheSize",
-        "Node.clientCacheSizeLong",
+        new Option.Meta(
+            sortOrder++, false, true, "Node.clientCacheSize", "Node.clientCacheSizeLong"),
         new LongCallback() {
 
           @Override
@@ -987,11 +964,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "useSlashdotCache",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.useSlashdotCache",
-        "Node.useSlashdotCacheLong",
+        new Option.Meta(
+            sortOrder++, true, false, "Node.useSlashdotCache", "Node.useSlashdotCacheLong"),
         new BooleanCallback() {
 
           @Override
@@ -1009,11 +983,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "writeLocalToDatastore",
         false,
-        sortOrder++,
-        true,
-        false,
-        "Node.writeLocalToDatastore",
-        "Node.writeLocalToDatastoreLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.writeLocalToDatastore",
+            "Node.writeLocalToDatastoreLong"),
         new BooleanCallback() {
 
           @Override
@@ -1036,11 +1011,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "slashdotCacheLifetime",
         MINUTES.toMillis(30),
-        sortOrder++,
-        true,
-        false,
-        "Node.slashdotCacheLifetime",
-        "Node.slashdotCacheLifetimeLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.slashdotCacheLifetime",
+            "Node.slashdotCacheLifetimeLong"),
         new LongCallback() {
 
           @Override
@@ -1060,11 +1036,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "slashdotCacheSize",
         NodeStorageSubsystem.DEFAULT_SLASHDOT_CACHE_SIZE,
-        sortOrder++,
-        false,
-        true,
-        "Node.slashdotCacheSize",
-        "Node.slashdotCacheSizeLong",
+        new Option.Meta(
+            sortOrder++, false, true, "Node.slashdotCacheSize", "Node.slashdotCacheSizeLong"),
         new LongCallback() {
 
           @Override
@@ -1179,11 +1152,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "masterKeyFile",
         "master.keys",
-        sortOrder++,
-        true,
-        true,
-        "Node.masterKeyFile",
-        "Node.masterKeyFileLong",
+        new Option.Meta(sortOrder++, true, true, "Node.masterKeyFile", "Node.masterKeyFileLong"),
         new StringCallback() {
 
           @Override
@@ -1224,11 +1193,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "showFriendsVisibilityAlert",
         false,
-        sortOrder++,
-        true,
-        false,
-        "Node.showFriendsVisibilityAlert",
-        "Node.showFriendsVisibilityAlert",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.showFriendsVisibilityAlert",
+            "Node.showFriendsVisibilityAlert"),
         new BooleanCallback() {
 
           @Override
@@ -1253,11 +1223,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "disableProbabilisticHTLs",
         false,
-        sortOrder++,
-        true,
-        false,
-        "Node.disablePHTLS",
-        "Node.disablePHTLSLong",
+        new Option.Meta(sortOrder++, true, false, "Node.disablePHTLS", "Node.disablePHTLSLong"),
         new BooleanCallback() {
 
           @Override
@@ -1279,11 +1245,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "maxHTL",
         DEFAULT_MAX_HTL,
-        sortOrder++,
-        true,
-        false,
-        "Node.maxHTL",
-        "Node.maxHTLLong",
+        new Option.Meta(sortOrder++, true, false, "Node.maxHTL", "Node.maxHTLLong"),
         new ShortCallback() {
 
           @Override
@@ -1307,11 +1269,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "enableARKs",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.enableARKs",
-        "Node.enableARKsLong",
+        new Option.Meta(sortOrder++, true, false, "Node.enableARKs", "Node.enableARKsLong"),
         new BooleanCallback() {
 
           @Override
@@ -1332,11 +1290,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "enablePerNodeFailureTables",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.enablePerNodeFailureTables",
-        "Node.enablePerNodeFailureTablesLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.enablePerNodeFailureTables",
+            "Node.enablePerNodeFailureTablesLong"),
         new BooleanCallback() {
 
           @Override
@@ -1357,11 +1316,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "enableULPRDataPropagation",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.enableULPRDataPropagation",
-        "Node.enableULPRDataPropagationLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.enableULPRDataPropagation",
+            "Node.enableULPRDataPropagationLong"),
         new BooleanCallback() {
 
           @Override
@@ -1382,11 +1342,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "enableSwapping",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.enableSwapping",
-        "Node.enableSwappingLong",
+        new Option.Meta(sortOrder++, true, false, "Node.enableSwapping", "Node.enableSwappingLong"),
         new BooleanCallback() {
 
           @Override
@@ -1411,11 +1367,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "publishOurPeersLocation",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.publishOurPeersLocation",
-        "Node.publishOurPeersLocationLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.publishOurPeersLocation",
+            "Node.publishOurPeersLocationLong"),
         new BooleanCallback() {
 
           @Override
@@ -1433,11 +1390,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "routeAccordingToOurPeersLocation",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.routeAccordingToOurPeersLocation",
-        "Node.routeAccordingToOurPeersLocation",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.routeAccordingToOurPeersLocation",
+            "Node.routeAccordingToOurPeersLocation"),
         new BooleanCallback() {
 
           @Override
@@ -1455,11 +1413,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "enableSwapQueueing",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.enableSwapQueueing",
-        "Node.enableSwapQueueingLong",
+        new Option.Meta(
+            sortOrder++, true, false, "Node.enableSwapQueueing", "Node.enableSwapQueueingLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -1476,11 +1431,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "enablePacketCoalescing",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.enablePacketCoalescing",
-        "Node.enablePacketCoalescingLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.enablePacketCoalescing",
+            "Node.enablePacketCoalescingLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -1582,11 +1538,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "skipWrapperWarning",
         false,
-        sortOrder++,
-        true,
-        false,
-        "Node.skipWrapperWarning",
-        "Node.skipWrapperWarningLong",
+        new Option.Meta(
+            sortOrder++, true, false, "Node.skipWrapperWarning", "Node.skipWrapperWarningLong"),
         new BooleanCallback() {
 
           @Override
@@ -1608,11 +1561,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "maxPacketSize",
         1280,
-        sortOrder++,
-        true,
-        true,
-        "Node.maxPacketSize",
-        "Node.maxPacketSizeLong",
+        new Option.Meta(sortOrder++, true, true, "Node.maxPacketSize", "Node.maxPacketSizeLong"),
         new IntCallback() {
 
           @Override
@@ -1645,11 +1594,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "enableRoutedPing",
         false,
-        sortOrder++,
-        true,
-        false,
-        "Node.enableRoutedPing",
-        "Node.enableRoutedPingLong",
+        new Option.Meta(
+            sortOrder++, true, false, "Node.enableRoutedPing", "Node.enableRoutedPingLong"),
         new BooleanCallback() {
 
           @Override
@@ -1674,11 +1620,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "enableNodeDiagnostics",
         false,
-        sortOrder++,
-        true,
-        false,
-        "Node.enableDiagnostics",
-        "Node.enableDiagnosticsLong",
+        new Option.Meta(
+            sortOrder++, true, false, "Node.enableDiagnostics", "Node.enableDiagnosticsLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -1707,11 +1650,12 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     nodeConfig.register(
         "datastoreTooSmallDismissed",
         -1,
-        sortOrder++,
-        true,
-        false,
-        "Node.datastoreTooSmallDismissed",
-        "Node.datastoreTooSmallDismissedLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.datastoreTooSmallDismissed",
+            "Node.datastoreTooSmallDismissedLong"),
         new IntCallback() {
 
           @Override
@@ -2116,7 +2060,10 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     int sortOrder = ProgramDirectory.nextOrder();
     // forceWrite=true because currently it can't be changed on the fly, also for packages
     installConfig.register(
-        cfgKey, defaultValue, sortOrder, true, true, shortdesc, longdesc, dir.getStringCallback());
+        cfgKey,
+        defaultValue,
+        new Option.Meta(sortOrder, true, true, shortdesc, longdesc),
+        dir.getStringCallback());
     String dirName = installConfig.getString(cfgKey);
     try {
       dir.move(dirName);

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -12,6 +12,7 @@ import network.crypta.client.async.USKManager;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.Key;
@@ -441,11 +442,12 @@ public class NodeClientCore implements Persistable {
         .register(
             "minDiskFreeLongTerm",
             "1G",
-            sortOrder++,
-            true,
-            true,
-            "NodeClientCore.minDiskFreeLongTerm",
-            "NodeClientCore.minDiskFreeLongTermLong",
+            new Option.Meta(
+                sortOrder++,
+                true,
+                true,
+                "NodeClientCore.minDiskFreeLongTerm",
+                "NodeClientCore.minDiskFreeLongTermLong"),
             new LongCallback() {
 
               @Override
@@ -473,11 +475,12 @@ public class NodeClientCore implements Persistable {
         .register(
             "minDiskFreeShortTerm",
             "512M",
-            sortOrder + 1,
-            true,
-            true,
-            "NodeClientCore.minDiskFreeShortTerm",
-            "NodeClientCore.minDiskFreeShortTermLong",
+            new Option.Meta(
+                sortOrder + 1,
+                true,
+                true,
+                "NodeClientCore.minDiskFreeShortTerm",
+                "NodeClientCore.minDiskFreeShortTermLong"),
             new LongCallback() {
 
               @Override
@@ -755,11 +758,12 @@ public class NodeClientCore implements Persistable {
         .register(
             "maxBackgroundUSKFetchers",
             64,
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.maxUSKFetchers",
-            "NodeClientCore.maxUSKFetchersLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                false,
+                "NodeClientCore.maxUSKFetchers",
+                "NodeClientCore.maxUSKFetchersLong"),
             new IntCallback() {
 
               @Override
@@ -786,11 +790,12 @@ public class NodeClientCore implements Persistable {
         .register(
             "memoryLimitedJobThreadLimit",
             maxMemoryLimitedJobThreads,
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.memoryLimitedJobThreadLimit",
-            "NodeClientCore.memoryLimitedJobThreadLimitLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                false,
+                "NodeClientCore.memoryLimitedJobThreadLimit",
+                "NodeClientCore.memoryLimitedJobThreadLimitLong"),
             new IntCallback() {
 
               @Override
@@ -816,11 +821,12 @@ public class NodeClientCore implements Persistable {
         .register(
             "alwaysCommit",
             false,
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.alwaysCommit",
-            "NodeClientCore.alwaysCommitLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                false,
+                "NodeClientCore.alwaysCommit",
+                "NodeClientCore.alwaysCommitLong"),
             new BooleanCallback() {
 
               @Override
@@ -841,11 +847,12 @@ public class NodeClientCore implements Persistable {
         .register(
             "maxRAMBucketSize",
             SizeUtil.formatSizeWithoutSpace(maxBucketSize),
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.maxRAMBucketSize",
-            "NodeClientCore.maxRAMBucketSizeLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                false,
+                "NodeClientCore.maxRAMBucketSize",
+                "NodeClientCore.maxRAMBucketSizeLong"),
             new LongCallback() {
 
               @Override
@@ -869,11 +876,12 @@ public class NodeClientCore implements Persistable {
         .register(
             "RAMBucketPoolSize",
             defaultRamBucketPoolSize + "MiB",
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.ramBucketPoolSize",
-            "NodeClientCore.ramBucketPoolSizeLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                false,
+                "NodeClientCore.ramBucketPoolSize",
+                "NodeClientCore.ramBucketPoolSizeLong"),
             new LongCallback() {
 
               @Override
@@ -897,11 +905,12 @@ public class NodeClientCore implements Persistable {
         .register(
             "encryptTempBuckets",
             true,
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.encryptTempBuckets",
-            "NodeClientCore.encryptTempBucketsLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                false,
+                "NodeClientCore.encryptTempBuckets",
+                "NodeClientCore.encryptTempBucketsLong"),
             new BooleanCallback() {
 
               @Override
@@ -923,11 +932,12 @@ public class NodeClientCore implements Persistable {
         .register(
             CFG_ENCRYPT_PERSISTENT_TEMP_BUCKETS,
             true,
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.encryptPersistentTempBuckets",
-            "NodeClientCore.encryptPersistentTempBucketsLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                false,
+                "NodeClientCore.encryptPersistentTempBuckets",
+                "NodeClientCore.encryptPersistentTempBucketsLong"),
             new BooleanCallback() {
 
               @Override
@@ -963,11 +973,12 @@ public class NodeClientCore implements Persistable {
         .register(
             "lazyStartDatastoreChecker",
             false,
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.lazyStartDatastoreChecker",
-            "NodeClientCore.lazyStartDatastoreCheckerLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                false,
+                "NodeClientCore.lazyStartDatastoreChecker",
+                "NodeClientCore.lazyStartDatastoreCheckerLong"),
             new BooleanCallback() {
 
               @Override

--- a/src/main/java/network/crypta/node/NodeClientCoreSupport.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreSupport.java
@@ -14,6 +14,7 @@ import network.crypta.client.async.HealingDecisionSupplier;
 import network.crypta.client.async.SimpleHealingQueue;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.RandomSource;
 import network.crypta.fs.AppDirs;
@@ -289,11 +290,12 @@ public final class NodeClientCoreSupport {
         .register(
             "memoryLimitedJobMemoryLimit",
             defaultMemoryLimitedJobMemoryLimit,
-            sortOrder,
-            true,
-            false,
-            "NodeClientCore.memoryLimitedJobMemoryLimit",
-            "NodeClientCore.memoryLimitedJobMemoryLimitLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                false,
+                "NodeClientCore.memoryLimitedJobMemoryLimit",
+                "NodeClientCore.memoryLimitedJobMemoryLimitLong"),
             new LongCallback() {
 
               @Override

--- a/src/main/java/network/crypta/node/NodeClientCoreTransferPolicy.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreTransferPolicy.java
@@ -2,6 +2,7 @@ package network.crypta.node;
 
 import java.io.File;
 import java.util.Arrays;
+import network.crypta.config.Option;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.support.api.StringArrCallback;
 import network.crypta.support.io.FileUtil;
@@ -114,11 +115,12 @@ final class NodeClientCoreTransferPolicy {
         .register(
             "downloadAllowedDirs",
             new String[] {"all"},
-            sortOrder,
-            true,
-            true,
-            "NodeClientCore.downloadAllowedDirs",
-            "NodeClientCore.downloadAllowedDirsLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                true,
+                "NodeClientCore.downloadAllowedDirs",
+                "NodeClientCore.downloadAllowedDirsLong"),
             new StringArrCallback() {
 
               @Override
@@ -162,11 +164,12 @@ final class NodeClientCoreTransferPolicy {
         .register(
             "uploadAllowedDirs",
             new String[] {"all"},
-            sortOrder,
-            true,
-            true,
-            "NodeClientCore.uploadAllowedDirs",
-            "NodeClientCore.uploadAllowedDirsLong",
+            new Option.Meta(
+                sortOrder,
+                true,
+                true,
+                "NodeClientCore.uploadAllowedDirs",
+                "NodeClientCore.uploadAllowedDirsLong"),
             new StringArrCallback() {
 
               @Override

--- a/src/main/java/network/crypta/node/NodeCryptoConfig.java
+++ b/src/main/java/network/crypta/node/NodeCryptoConfig.java
@@ -2,6 +2,7 @@ package network.crypta.node;
 
 import java.net.UnknownHostException;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.io.comm.FreenetInetAddress;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
@@ -112,11 +113,12 @@ public class NodeCryptoConfig {
     config.register(
         "listenPort",
         -1 /* means random */,
-        sortOrder++,
-        true,
-        true,
-        isOpennet ? "Node.opennetPort" : "Node.port",
-        isOpennet ? "Node.opennetPortLong" : "Node.portLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            true,
+            isOpennet ? "Node.opennetPort" : "Node.port",
+            isOpennet ? "Node.opennetPortLong" : "Node.portLong"),
         new IntCallback() {
           @Override
           public Integer get() {
@@ -166,11 +168,7 @@ public class NodeCryptoConfig {
     config.register(
         KEY_BIND_TO,
         "0.0.0.0",
-        sortOrder++,
-        true,
-        true,
-        "Node.bindTo",
-        "Node.bindToLong",
+        new Option.Meta(sortOrder++, true, true, "Node.bindTo", "Node.bindToLong"),
         new NodeBindtoCallback());
     return sortOrder;
   }
@@ -189,11 +187,8 @@ public class NodeCryptoConfig {
     config.register(
         "testingDropPacketsEvery",
         0,
-        sortOrder++,
-        true,
-        false,
-        "Node.dropPacketEvery",
-        "Node.dropPacketEveryLong",
+        new Option.Meta(
+            sortOrder++, true, false, "Node.dropPacketEvery", "Node.dropPacketEveryLong"),
         new IntCallback() {
           @Override
           public Integer get() {
@@ -226,11 +221,12 @@ public class NodeCryptoConfig {
     config.register(
         "oneConnectionPerIP",
         isOpennet,
-        sortOrder++,
-        true,
-        false,
-        (isOpennet ? "OpennetManager" : "Node") + ".oneConnectionPerIP",
-        (isOpennet ? "OpennetManager" : "Node") + ".oneConnectionPerIPLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            (isOpennet ? "OpennetManager" : "Node") + ".oneConnectionPerIP",
+            (isOpennet ? "OpennetManager" : "Node") + ".oneConnectionPerIPLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -273,11 +269,12 @@ public class NodeCryptoConfig {
     config.register(
         "alwaysAllowLocalAddresses",
         !isOpennet,
-        sortOrder++,
-        true,
-        false,
-        "Node.alwaysAllowLocalAddresses",
-        "Node.alwaysAllowLocalAddressesLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.alwaysAllowLocalAddresses",
+            "Node.alwaysAllowLocalAddressesLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -304,11 +301,7 @@ public class NodeCryptoConfig {
     config.register(
         "assumeNATed",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.assumeNATed",
-        "Node.assumeNATedLong",
+        new Option.Meta(sortOrder++, true, true, "Node.assumeNATed", "Node.assumeNATedLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -333,11 +326,12 @@ public class NodeCryptoConfig {
     config.register(
         "includeLocalAddressesInNoderefs",
         !isOpennet,
-        sortOrder++,
-        true,
-        false,
-        "NodeIPDectector.inclLocalAddress",
-        "NodeIPDectector.inclLocalAddressLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "NodeIPDectector.inclLocalAddress",
+            "NodeIPDectector.inclLocalAddressLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -361,11 +355,7 @@ public class NodeCryptoConfig {
     config.register(
         "paddDataPackets",
         true,
-        sortOrder,
-        true,
-        false,
-        "Node.paddDataPackets",
-        "Node.paddDataPacketsLong",
+        new Option.Meta(sortOrder, true, false, "Node.paddDataPackets", "Node.paddDataPacketsLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {

--- a/src/main/java/network/crypta/node/NodeIPDetector.java
+++ b/src/main/java/network/crypta/node/NodeIPDetector.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.Set;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.io.comm.FreenetInetAddress;
 import network.crypta.io.comm.Peer;
@@ -581,11 +582,12 @@ public class NodeIPDetector {
     nodeConfig.register(
         "ipAddressOverride",
         "",
-        sortOrder++,
-        true,
-        false,
-        "NodeIPDectector.ipOverride",
-        "NodeIPDectector.ipOverrideLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "NodeIPDectector.ipOverride",
+            "NodeIPDectector.ipOverrideLong"),
         new IpOverrideCallback());
 
     initIpAddressOverride(nodeConfig);
@@ -690,11 +692,12 @@ public class NodeIPDetector {
     nodeConfig.register(
         "tempIPAddressHint",
         "",
-        sortOrder++,
-        true,
-        false,
-        "NodeIPDectector.tempAddressHint",
-        "NodeIPDectector.tempAddressHintLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "NodeIPDectector.tempAddressHint",
+            "NodeIPDectector.tempAddressHintLong"),
         new StringCallback() {
 
           @Override
@@ -735,11 +738,12 @@ public class NodeIPDetector {
     nodeConfig.register(
         "allowBindToLocalhost",
         false,
-        sortOrder++,
-        true,
-        false,
-        "NodeIPDetector.allowBindToLocalhost",
-        "NodeIPDetector.allowBindToLocalhostLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "NodeIPDetector.allowBindToLocalhost",
+            "NodeIPDetector.allowBindToLocalhostLong"),
         BooleanCallback.from(
             () -> allowBindToLocalhost,
             value -> {

--- a/src/main/java/network/crypta/node/NodeStatsConfig.java
+++ b/src/main/java/network/crypta/node/NodeStatsConfig.java
@@ -1,6 +1,7 @@
 package network.crypta.node;
 
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.SimpleFieldSet;
@@ -129,11 +130,8 @@ public final class NodeStatsConfig {
     statsConfig.register(
         "threadLimit",
         defaultThreadLimit,
-        sortOrder++,
-        true,
-        true,
-        "NodeStat.threadLimit",
-        "NodeStat.threadLimitLong",
+        new Option.Meta(
+            sortOrder++, true, true, "NodeStat.threadLimit", "NodeStat.threadLimitLong"),
         new IntCallback() {
           @Override
           public Integer get() {
@@ -183,11 +181,12 @@ public final class NodeStatsConfig {
     statsConfig.register(
         "ignoreLocalVsRemoteBandwidthLiability",
         false,
-        sortOrder++,
-        true,
-        false,
-        "NodeStat.ignoreLocalVsRemoteBandwidthLiability",
-        "NodeStat.ignoreLocalVsRemoteBandwidthLiabilityLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "NodeStat.ignoreLocalVsRemoteBandwidthLiability",
+            "NodeStat.ignoreLocalVsRemoteBandwidthLiabilityLong"),
         new BooleanCallback() {
 
           @Override
@@ -219,11 +218,8 @@ public final class NodeStatsConfig {
     statsConfig.register(
         "maxPingTime",
         NodeStats.DEFAULT_MAX_PING_TIME,
-        sortOrder++,
-        true,
-        true,
-        "NodeStat.maxPingTime",
-        "NodeStat.maxPingTimeLong",
+        new Option.Meta(
+            sortOrder++, true, true, "NodeStat.maxPingTime", "NodeStat.maxPingTimeLong"),
         new LongCallback() {
 
           @Override
@@ -242,11 +238,8 @@ public final class NodeStatsConfig {
     statsConfig.register(
         "subMaxPingTime",
         NodeStats.DEFAULT_SUB_MAX_PING_TIME,
-        sortOrder++,
-        true,
-        true,
-        "NodeStat.subMaxPingTime",
-        "NodeStat.subMaxPingTimeLong",
+        new Option.Meta(
+            sortOrder++, true, true, "NodeStat.subMaxPingTime", "NodeStat.subMaxPingTimeLong"),
         new LongCallback() {
 
           @Override

--- a/src/main/java/network/crypta/node/RequestStarterGroup.java
+++ b/src/main/java/network/crypta/node/RequestStarterGroup.java
@@ -8,6 +8,7 @@ import network.crypta.client.async.ClientRequestScheduler.SchedulerMode;
 import network.crypta.config.Config;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.Key;
@@ -341,13 +342,14 @@ public class RequestStarterGroup {
     schedulerConfig.register(
         name + "_priority_policy",
         ClientRequestScheduler.PRIORITY_SOFT,
-        name.hashCode(),
-        true,
-        false,
-        "RequestStarterGroup.scheduler"
-            + (forSSKs ? "SSK" : "CHK")
-            + (forInserts ? "Inserts" : "Requests"),
-        "RequestStarterGroup.schedulerLong",
+        new Option.Meta(
+            name.hashCode(),
+            true,
+            false,
+            "RequestStarterGroup.scheduler"
+                + (forSSKs ? "SSK" : "CHK")
+                + (forInserts ? "Inserts" : "Requests"),
+            "RequestStarterGroup.schedulerLong"),
         callback);
     callback.init(csRT, csBulk, schedulerConfig.getString(name + "_priority_policy"));
   }

--- a/src/main/java/network/crypta/node/SecurityLevels.java
+++ b/src/main/java/network/crypta/node/SecurityLevels.java
@@ -3,6 +3,7 @@ package network.crypta.node;
 import java.util.ArrayList;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
@@ -174,11 +175,12 @@ public class SecurityLevels {
     myConfig.register(
         KEY_NETWORK_THREAT_LEVEL,
         "HIGH",
-        sortOrder++,
-        false,
-        true,
-        "SecurityLevels.networkThreatLevelShort",
-        "SecurityLevels.networkThreatLevel",
+        new Option.Meta(
+            sortOrder++,
+            false,
+            true,
+            "SecurityLevels.networkThreatLevelShort",
+            "SecurityLevels.networkThreatLevel"),
         networkThreatLevelCallback);
     NETWORK_THREAT_LEVEL netLevel =
         NETWORK_THREAT_LEVEL.valueOf(myConfig.getString(KEY_NETWORK_THREAT_LEVEL));
@@ -237,11 +239,12 @@ public class SecurityLevels {
     myConfig.register(
         KEY_PHYSICAL_THREAT_LEVEL,
         "NORMAL",
-        sortOrder,
-        false,
-        true,
-        "SecurityLevels.physicalThreatLevelShort",
-        "SecurityLevels.physicalThreatLevel",
+        new Option.Meta(
+            sortOrder,
+            false,
+            true,
+            "SecurityLevels.physicalThreatLevelShort",
+            "SecurityLevels.physicalThreatLevel"),
         physicalThreatLevelCallback);
     PHYSICAL_THREAT_LEVEL physLevel =
         PHYSICAL_THREAT_LEVEL.valueOf(myConfig.getString(KEY_PHYSICAL_THREAT_LEVEL));

--- a/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
+++ b/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.RandomSource;
 import network.crypta.crypt.SSL;
@@ -141,57 +142,63 @@ public class TextModeClientInterfaceServer implements Runnable {
     tmciConfig.register(
         "enabled",
         false,
-        1,
-        true,
-        true /* only because can't be changed on the fly */,
-        "TextModeClientInterfaceServer.enabled",
-        "TextModeClientInterfaceServer.enabledLong",
+        new Option.Meta(
+            1,
+            true,
+            true /* only because can't be changed on the fly */,
+            "TextModeClientInterfaceServer.enabled",
+            "TextModeClientInterfaceServer.enabledLong"),
         new TMCIEnabledCallback(core));
     tmciConfig.register(
         "ssl",
         false,
-        1,
-        true,
-        true,
-        "TextModeClientInterfaceServer.ssl",
-        "TextModeClientInterfaceServer.sslLong",
+        new Option.Meta(
+            1,
+            true,
+            true,
+            "TextModeClientInterfaceServer.ssl",
+            "TextModeClientInterfaceServer.sslLong"),
         new TMCISSLCallback());
     tmciConfig.register(
         "bindTo",
         NetworkInterface.DEFAULT_BIND_TO,
-        2,
-        true,
-        false,
-        "TextModeClientInterfaceServer.bindTo",
-        "TextModeClientInterfaceServer.bindToLong",
+        new Option.Meta(
+            2,
+            true,
+            false,
+            "TextModeClientInterfaceServer.bindTo",
+            "TextModeClientInterfaceServer.bindToLong"),
         new TMCIBindtoCallback(core));
     tmciConfig.register(
         "allowedHosts",
         NetworkInterface.DEFAULT_BIND_TO,
-        2,
-        true,
-        false,
-        "TextModeClientInterfaceServer.allowedHosts",
-        "TextModeClientInterfaceServer.allowedHostsLong",
+        new Option.Meta(
+            2,
+            true,
+            false,
+            "TextModeClientInterfaceServer.allowedHosts",
+            "TextModeClientInterfaceServer.allowedHostsLong"),
         new TMCIAllowedHostsCallback(core));
     tmciConfig.register(
         "port",
         2323,
-        1,
-        true,
-        false,
-        "TextModeClientInterfaceServer.telnetPortNumber",
-        "TextModeClientInterfaceServer.telnetPortNumberLong",
+        new Option.Meta(
+            1,
+            true,
+            false,
+            "TextModeClientInterfaceServer.telnetPortNumber",
+            "TextModeClientInterfaceServer.telnetPortNumberLong"),
         new TCMIPortNumberCallback(core),
         false);
     tmciConfig.register(
         "directEnabled",
         false,
-        1,
-        true,
-        false,
-        "TextModeClientInterfaceServer.enableInputOutput",
-        "TextModeClientInterfaceServer.enableInputOutputLong",
+        new Option.Meta(
+            1,
+            true,
+            false,
+            "TextModeClientInterfaceServer.enableInputOutput",
+            "TextModeClientInterfaceServer.enableInputOutputLong"),
         new TMCIDirectEnabledCallback(core));
 
     boolean tmciEnabled = tmciConfig.getBoolean("enabled");

--- a/src/main/java/network/crypta/node/probe/Probe.java
+++ b/src/main/java/network/crypta/node/probe/Probe.java
@@ -11,6 +11,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.io.comm.AsyncMessageFilterCallback;
 import network.crypta.io.comm.ByteCounter;
@@ -237,11 +238,8 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         "probeBandwidth",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.probeBandwidthShort",
-        "Node.probeBandwidthLong",
+        new Option.Meta(
+            sortOrder++, true, true, "Node.probeBandwidthShort", "Node.probeBandwidthLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -257,11 +255,7 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         "probeBuild",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.probeBuildShort",
-        "Node.probeBuildLong",
+        new Option.Meta(sortOrder++, true, true, "Node.probeBuildShort", "Node.probeBuildLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -277,11 +271,12 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         "probeIdentifier",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.probeRespondIdentifierShort",
-        "Node.probeRespondIdentifierLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            true,
+            "Node.probeRespondIdentifierShort",
+            "Node.probeRespondIdentifierLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -297,11 +292,8 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         "probeLinkLengths",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.probeLinkLengthsShort",
-        "Node.probeLinkLengthsLong",
+        new Option.Meta(
+            sortOrder++, true, true, "Node.probeLinkLengthsShort", "Node.probeLinkLengthsLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -317,11 +309,8 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         "probeLocation",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.probeLocationShort",
-        "Node.probeLocationLong",
+        new Option.Meta(
+            sortOrder++, true, true, "Node.probeLocationShort", "Node.probeLocationLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -337,11 +326,8 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         "probeStoreSize",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.probeStoreSizeShort",
-        "Node.probeStoreSizeLong",
+        new Option.Meta(
+            sortOrder++, true, true, "Node.probeStoreSizeShort", "Node.probeStoreSizeLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -357,11 +343,7 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         "probeUptime",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.probeUptimeShort",
-        "Node.probeUptimeLong",
+        new Option.Meta(sortOrder++, true, true, "Node.probeUptimeShort", "Node.probeUptimeLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -377,11 +359,8 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         "probeRejectStats",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.probeRejectStatsShort",
-        "Node.probeRejectStatsLong",
+        new Option.Meta(
+            sortOrder++, true, true, "Node.probeRejectStatsShort", "Node.probeRejectStatsLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -398,11 +377,12 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         "probeOverallBulkOutputCapacityUsage",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.respondOverallBulkOutputCapacityUsage",
-        "Node.respondOverallBulkOutputCapacityUsageLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            true,
+            "Node.respondOverallBulkOutputCapacityUsage",
+            "Node.respondOverallBulkOutputCapacityUsageLong"),
         new BooleanCallback() {
 
           @Override
@@ -421,11 +401,8 @@ public class Probe implements ByteCounter {
     nodeConfig.register(
         IDENTIFIER_KEY,
         -1,
-        sortOrder,
-        true,
-        true,
-        "Node.probeIdentifierShort",
-        "Node.probeIdentifierLong",
+        new Option.Meta(
+            sortOrder, true, true, "Node.probeIdentifierShort", "Node.probeIdentifierLong"),
         new LongCallback() {
           @Override
           public Long get() {

--- a/src/main/java/network/crypta/node/subsystem/NodeConfigManager.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeConfigManager.java
@@ -5,6 +5,7 @@ import java.util.MissingResourceException;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
@@ -75,11 +76,7 @@ public final class NodeConfigManager {
     nodeConfig.register(
         "l10n",
         Locale.getDefault().getLanguage().toLowerCase(),
-        sortOrder++,
-        false,
-        true,
-        "Node.l10nLanguage",
-        "Node.l10nLanguageLong",
+        new Option.Meta(sortOrder++, false, true, "Node.l10nLanguage", "Node.l10nLanguageLong"),
         new L10nCallback());
 
     try {

--- a/src/main/java/network/crypta/node/subsystem/NodeNetworkSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeNetworkSubsystem.java
@@ -15,6 +15,7 @@ import network.crypta.config.Dimension;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.io.comm.AsyncMessageFilterCallback;
@@ -402,11 +403,7 @@ public final class NodeNetworkSubsystem {
     nodeConfig.register(
         "trafficClass",
         TrafficClass.getDefault().name(),
-        sortOrder++,
-        true,
-        false,
-        "Node.trafficClass",
-        "Node.trafficClassLong",
+        new Option.Meta(sortOrder++, true, false, "Node.trafficClass", "Node.trafficClassLong"),
         new TrafficClassCallback());
     String trafficClassValue = nodeConfig.getString("trafficClass");
     try {
@@ -499,11 +496,7 @@ public final class NodeNetworkSubsystem {
     nodeConfig.register(
         "outputBandwidthLimit",
         "15K",
-        sortOrder++,
-        false,
-        true,
-        "Node.outBWLimit",
-        "Node.outBWLimitLong",
+        new Option.Meta(sortOrder++, false, true, "Node.outBWLimit", "Node.outBWLimitLong"),
         new IntCallback() {
           @Override
           public Integer get() {
@@ -553,11 +546,7 @@ public final class NodeNetworkSubsystem {
     nodeConfig.register(
         "inputBandwidthLimit",
         "-1",
-        sortOrder++,
-        false,
-        true,
-        "Node.inBWLimit",
-        "Node.inBWLimitLong",
+        new Option.Meta(sortOrder++, false, true, "Node.inBWLimit", "Node.inBWLimitLong"),
         new IntCallback() {
           @Override
           public Integer get() {
@@ -602,11 +591,12 @@ public final class NodeNetworkSubsystem {
     nodeConfig.register(
         "amountOfDataToCheckCompressionRatio",
         "8MiB",
-        sortOrder++,
-        true,
-        true,
-        "Node.amountOfDataToCheckCompressionRatio",
-        "Node.amountOfDataToCheckCompressionRatioLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            true,
+            "Node.amountOfDataToCheckCompressionRatio",
+            "Node.amountOfDataToCheckCompressionRatioLong"),
         new LongCallback() {
           @Override
           public Long get() {
@@ -632,11 +622,12 @@ public final class NodeNetworkSubsystem {
     nodeConfig.register(
         "minimumCompressionPercentage",
         "10",
-        sortOrder++,
-        true,
-        true,
-        "Node.minimumCompressionPercentage",
-        "Node.minimumCompressionPercentageLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            true,
+            "Node.minimumCompressionPercentage",
+            "Node.minimumCompressionPercentageLong"),
         new IntCallback() {
           @Override
           public Integer get() {
@@ -669,11 +660,12 @@ public final class NodeNetworkSubsystem {
     nodeConfig.register(
         "connectionSpeedDetection",
         true,
-        sortOrder++,
-        true,
-        true,
-        "Node.connectionSpeedDetection",
-        "Node.connectionSpeedDetectionLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            true,
+            "Node.connectionSpeedDetection",
+            "Node.connectionSpeedDetectionLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -694,11 +686,8 @@ public final class NodeNetworkSubsystem {
     nodeConfig.register(
         "throttleLocalTraffic",
         false,
-        sortOrder++,
-        true,
-        false,
-        "Node.throttleLocalTraffic",
-        "Node.throttleLocalTrafficLong",
+        new Option.Meta(
+            sortOrder++, true, false, "Node.throttleLocalTraffic", "Node.throttleLocalTrafficLong"),
         new BooleanCallback() {
 
           @Override
@@ -763,11 +752,7 @@ public final class NodeNetworkSubsystem {
     opennetConfig.register(
         "connectToSeednodes",
         true,
-        0,
-        true,
-        false,
-        "Node.withAnnouncement",
-        "Node.withAnnouncementLong",
+        new Option.Meta(0, true, false, "Node.withAnnouncement", "Node.withAnnouncementLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -789,11 +774,7 @@ public final class NodeNetworkSubsystem {
     opennetConfig.register(
         "enabled",
         false,
-        0,
-        true,
-        true,
-        "Node.opennetEnabled",
-        "Node.opennetEnabledLong",
+        new Option.Meta(0, true, true, "Node.opennetEnabled", "Node.opennetEnabledLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {
@@ -833,11 +814,7 @@ public final class NodeNetworkSubsystem {
     opennetConfig.register(
         "maxOpennetPeers",
         OpennetManager.MAX_PEERS_FOR_SCALING,
-        1,
-        true,
-        false,
-        "Node.maxOpennetPeers",
-        "Node.maxOpennetPeersLong",
+        new Option.Meta(1, true, false, "Node.maxOpennetPeers", "Node.maxOpennetPeersLong"),
         new IntCallback() {
           @Override
           public Integer get() {
@@ -939,11 +916,8 @@ public final class NodeNetworkSubsystem {
     opennetConfig.register(
         "acceptSeedConnections",
         false,
-        2,
-        true,
-        true,
-        "Node.acceptSeedConnectionsShort",
-        "Node.acceptSeedConnections",
+        new Option.Meta(
+            2, true, true, "Node.acceptSeedConnectionsShort", "Node.acceptSeedConnections"),
         new BooleanCallback() {
 
           @Override
@@ -967,11 +941,12 @@ public final class NodeNetworkSubsystem {
     nodeConfig.register(
         "passOpennetPeersThroughDarknet",
         true,
-        sortOrder++,
-        true,
-        false,
-        "Node.passOpennetPeersThroughDarknet",
-        "Node.passOpennetPeersThroughDarknetLong",
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "Node.passOpennetPeersThroughDarknet",
+            "Node.passOpennetPeersThroughDarknetLong"),
         new BooleanCallback() {
 
           @Override

--- a/src/main/java/network/crypta/node/subsystem/NodeServicesSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeServicesSubsystem.java
@@ -3,6 +3,7 @@ package network.crypta.node.subsystem;
 import java.io.File;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
@@ -432,11 +433,8 @@ public final class NodeServicesSubsystem {
     nodeConfig.register(
         "peersOffersDismissed",
         false,
-        sortOrder,
-        true,
-        true,
-        "Node.peersOffersDismissed",
-        "Node.peersOffersDismissedLong",
+        new Option.Meta(
+            sortOrder, true, true, "Node.peersOffersDismissed", "Node.peersOffersDismissedLong"),
         new BooleanCallback() {
           @Override
           public Boolean get() {

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -21,6 +21,7 @@ import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.io.comm.ByteCounter;
 import network.crypta.io.comm.DMT;
@@ -195,11 +196,8 @@ public class NodeUpdateManager {
     updaterConfig.register(
         "enabled",
         true,
-        1,
-        false,
-        false,
-        "NodeUpdateManager.enabled",
-        "NodeUpdateManager.enabledLong",
+        new Option.Meta(
+            1, false, false, "NodeUpdateManager.enabled", "NodeUpdateManager.enabledLong"),
         new UpdaterEnabledCallback());
 
     wasEnabledOnStartup = updaterConfig.getBoolean("enabled");
@@ -208,11 +206,12 @@ public class NodeUpdateManager {
     updaterConfig.register(
         "autoupdate",
         false,
-        2,
-        false,
-        true,
-        "NodeUpdateManager.installNewVersions",
-        "NodeUpdateManager.installNewVersionsLong",
+        new Option.Meta(
+            2,
+            false,
+            true,
+            "NodeUpdateManager.installNewVersions",
+            "NodeUpdateManager.installNewVersionsLong"),
         new AutoUpdateAllowedCallback());
     isAutoUpdateAllowed = updaterConfig.getBoolean("autoupdate");
 
@@ -220,11 +219,8 @@ public class NodeUpdateManager {
     updaterConfig.register(
         "URI",
         UPDATE_URI,
-        3,
-        true,
-        true,
-        "NodeUpdateManager.updateURI",
-        "NodeUpdateManager.updateURILong",
+        new Option.Meta(
+            3, true, true, "NodeUpdateManager.updateURI", "NodeUpdateManager.updateURILong"),
         new UpdateURICallback());
 
     try {
@@ -245,11 +241,12 @@ public class NodeUpdateManager {
     updaterConfig.register(
         "revocationURI",
         REVOCATION_URI,
-        4,
-        true,
-        false,
-        "NodeUpdateManager.revocationURI",
-        "NodeUpdateManager.revocationURILong",
+        new Option.Meta(
+            4,
+            true,
+            false,
+            "NodeUpdateManager.revocationURI",
+            "NodeUpdateManager.revocationURILong"),
         new UpdateRevocationURICallback());
 
     try {

--- a/src/main/java/network/crypta/pluginmanager/PluginManager.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginManager.java
@@ -37,6 +37,7 @@ import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.ToadletRegistration;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.HashType;
 import network.crypta.keys.FreenetURI;
@@ -172,11 +173,7 @@ public class PluginManager {
     pmconfig.register(
         "enabled",
         true,
-        0,
-        true,
-        true,
-        "PluginManager.enabled",
-        "PluginManager.enabledLong",
+        new Option.Meta(0, true, true, "PluginManager.enabled", "PluginManager.enabledLong"),
         new BooleanCallback() {
 
           @Override
@@ -196,11 +193,8 @@ public class PluginManager {
     pmconfig.register(
         "loadplugin",
         null,
-        0,
-        true,
-        false,
-        "PluginManager.loadedOnStartup",
-        "PluginManager.loadedOnStartupLong",
+        new Option.Meta(
+            0, true, false, "PluginManager.loadedOnStartup", "PluginManager.loadedOnStartupLong"),
         new StringArrCallback() {
 
           @Override

--- a/src/test/java/network/crypta/client/async/InsertCompressorTest.java
+++ b/src/test/java/network/crypta/client/async/InsertCompressorTest.java
@@ -21,6 +21,7 @@ import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.config.Config;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.HashResult;
 import network.crypta.crypt.HashType;
@@ -385,15 +386,15 @@ class InsertCompressorTest {
     SubConfig node = cfg.get("node");
     // Register options so getLong/getInt return configured values
     node.register(
-        "amountOfDataToCheckCompressionRatio", 32768L, 0, false, false, "", "", null, true);
+        "amountOfDataToCheckCompressionRatio",
+        32768L,
+        new Option.Meta(0, false, false, "", ""),
+        null,
+        true);
     node.register(
         "minimumCompressionPercentage",
         100,
-        0,
-        false,
-        false,
-        "",
-        "",
+        new Option.Meta(0, false, false, "", ""),
         new network.crypta.support.api.IntCallback() {
           @Override
           public Integer get() {

--- a/src/test/java/network/crypta/clients/fcp/ModifyConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyConfigTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.StringOption;
 import network.crypta.config.SubConfig;
@@ -89,7 +90,8 @@ class ModifyConfigTest {
     SubConfig subConfig = config.createSubConfig("node");
     CountingStringCallback callback = new CountingStringCallback("5");
     StringOption option =
-        new StringOption(subConfig, "maxPeers", "5", 0, false, false, null, null, callback);
+        new StringOption(
+            subConfig, "maxPeers", "5", new Option.Meta(0, false, false, null, null), callback);
     subConfig.register(option);
     when(node.getConfig()).thenReturn(config);
     network.crypta.node.subsystem.NodeServicesSubsystem services =
@@ -122,7 +124,8 @@ class ModifyConfigTest {
     SubConfig subConfig = config.createSubConfig("ui");
     CountingStringCallback callback = new CountingStringCallback("light");
     StringOption option =
-        new StringOption(subConfig, "theme", "light", 0, false, false, null, null, callback);
+        new StringOption(
+            subConfig, "theme", "light", new Option.Meta(0, false, false, null, null), callback);
     subConfig.register(option);
     when(node.getConfig()).thenReturn(config);
     network.crypta.node.subsystem.NodeServicesSubsystem services =
@@ -149,7 +152,8 @@ class ModifyConfigTest {
     SubConfig subConfig = config.createSubConfig("net");
     ThrowingStringCallback callback = new ThrowingStringCallback("8080");
     StringOption failingOption =
-        new StringOption(subConfig, "port", "8080", 0, false, false, null, null, callback);
+        new StringOption(
+            subConfig, "port", "8080", new Option.Meta(0, false, false, null, null), callback);
     subConfig.register(failingOption);
     when(node.getConfig()).thenReturn(config);
     network.crypta.node.subsystem.NodeServicesSubsystem services =

--- a/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.util.List;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
@@ -380,47 +381,36 @@ class DatastoreSizeTest {
     node.register(
         KEY_OUTPUT_BANDWIDTH_LIMIT,
         upstreamLimit,
-        0,
-        false,
-        false,
-        "",
-        "",
+        new Option.Meta(0, false, false, "", ""),
         (network.crypta.support.api.IntCallback) null,
         false);
     node.register(
         KEY_INPUT_BANDWIDTH_LIMIT,
         downstreamLimit,
-        0,
-        false,
-        false,
-        "",
-        "",
+        new Option.Meta(0, false, false, "", ""),
         (network.crypta.support.api.IntCallback) null,
         false);
     node.register(
-        KEY_SLASHDOT_CACHE_LIFETIME, slashdotLifetimeMs, 0, false, false, "", "", null, false);
+        KEY_SLASHDOT_CACHE_LIFETIME,
+        slashdotLifetimeMs,
+        new Option.Meta(0, false, false, "", ""),
+        null,
+        false);
 
-    node.register(KEY_STORE_SIZE, 0L, 0, false, false, "", "", null, true);
-    node.register(KEY_CLIENT_CACHE_SIZE, 0L, 0, false, false, "", "", null, true);
-    node.register(KEY_SLASHDOT_CACHE_SIZE, 0L, 0, false, false, "", "", null, true);
+    node.register(KEY_STORE_SIZE, 0L, new Option.Meta(0, false, false, "", ""), null, true);
+    node.register(KEY_CLIENT_CACHE_SIZE, 0L, new Option.Meta(0, false, false, "", ""), null, true);
+    node.register(
+        KEY_SLASHDOT_CACHE_SIZE, 0L, new Option.Meta(0, false, false, "", ""), null, true);
 
     node.register(
         KEY_STORE_TYPE,
         VALUE_DEFAULT,
-        0,
-        false,
-        false,
-        "",
-        "",
+        new Option.Meta(0, false, false, "", ""),
         (network.crypta.support.api.StringCallback) null);
     node.register(
         KEY_CLIENT_CACHE_TYPE,
         VALUE_DEFAULT,
-        0,
-        false,
-        false,
-        "",
-        "",
+        new Option.Meta(0, false, false, "", ""),
         (network.crypta.support.api.StringCallback) null);
 
     return config;

--- a/src/test/java/network/crypta/clients/http/wizardsteps/WelcomeTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/WelcomeTest.java
@@ -20,6 +20,7 @@ import network.crypta.config.Config;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.BooleanCallback;
@@ -58,11 +59,7 @@ class WelcomeTest {
         .register(
             OPTION_JAVASCRIPT_ENABLED,
             true,
-            0,
-            false,
-            false,
-            UNUSED,
-            UNUSED,
+            new Option.Meta(0, false, false, UNUSED, UNUSED),
             BooleanCallback.from(() -> true, ignored -> {}));
 
     HTMLNode contentNode = new HTMLNode("div");
@@ -96,11 +93,7 @@ class WelcomeTest {
         .register(
             OPTION_JAVASCRIPT_ENABLED,
             false,
-            0,
-            false,
-            false,
-            UNUSED,
-            UNUSED,
+            new Option.Meta(0, false, false, UNUSED, UNUSED),
             BooleanCallback.from(() -> false, ignored -> {}));
 
     HTMLNode contentNode = new HTMLNode("div");
@@ -127,11 +120,7 @@ class WelcomeTest {
         .register(
             OPTION_JAVASCRIPT_ENABLED,
             false,
-            0,
-            false,
-            false,
-            UNUSED,
-            UNUSED,
+            new Option.Meta(0, false, false, UNUSED, UNUSED),
             BooleanCallback.from(() -> false, ignored -> {}));
 
     HTMLNode contentNode = new HTMLNode("div");
@@ -167,11 +156,7 @@ class WelcomeTest {
         .register(
             OPTION_JAVASCRIPT_ENABLED,
             false,
-            0,
-            false,
-            false,
-            UNUSED,
-            UNUSED,
+            new Option.Meta(0, false, false, UNUSED, UNUSED),
             BooleanCallback.from(() -> false, ignored -> {}));
 
     HTMLNode contentNode = new HTMLNode("div");
@@ -212,11 +197,7 @@ class WelcomeTest {
         .register(
             OPTION_JAVASCRIPT_ENABLED,
             false,
-            0,
-            false,
-            false,
-            UNUSED,
-            UNUSED,
+            new Option.Meta(0, false, false, UNUSED, UNUSED),
             BooleanCallback.from(() -> false, ignored -> {}));
 
     HTMLNode contentNode = new HTMLNode("div");
@@ -321,11 +302,7 @@ class WelcomeTest {
     node.register(
         "l10n",
         initialLanguage,
-        0,
-        false,
-        false,
-        UNUSED,
-        UNUSED,
+        new Option.Meta(0, false, false, UNUSED, UNUSED),
         new EnumerableStringCallback(possibleLanguages, initialLanguage, behavior));
 
     config.createSubConfig(SUBCONFIG_FPROXY);

--- a/src/test/java/network/crypta/config/BandwidthOptionTest.java
+++ b/src/test/java/network/crypta/config/BandwidthOptionTest.java
@@ -35,7 +35,11 @@ class BandwidthOptionTest {
 
   private BandwidthOption newOptionWithDefault(int defaultValue) {
     return new BandwidthOption(
-        subConfig, "bandwidth", defaultValue, 10, false, false, "short", "long", callback);
+        subConfig,
+        "bandwidth",
+        defaultValue,
+        new Option.Meta(10, false, false, "short", "long"),
+        callback);
   }
 
   // no helper for String default to avoid Sonar warning about always-constant parameter values
@@ -68,7 +72,7 @@ class BandwidthOptionTest {
       throws Exception {
     BandwidthOption opt = newOptionWithDefault(0);
 
-    // Act: parse without invoking callback
+    // Act: parse without invoking a callback
     opt.setInitialValue(input);
 
     // Assert: current value and string forms
@@ -88,7 +92,7 @@ class BandwidthOptionTest {
     assertEquals(2048, opt.getValue());
     // UI display uses Dimension.SIZE (may compact when evenly divisible)
     assertEquals("2KiB", opt.getValueDisplayString());
-    // Persistence always uses plain number
+    // Persistence always uses a plain number
     assertEquals("2048", opt.getValueString());
   }
 
@@ -98,7 +102,7 @@ class BandwidthOptionTest {
 
     assertThrows(InvalidConfigValueException.class, () -> opt.setValue("bogus/s"));
 
-    // Value unchanged after failed set
+    // Value unchanged after a failed set
     assertEquals(1000, opt.getValue());
     assertEquals("1000", opt.getValueString());
   }
@@ -111,7 +115,7 @@ class BandwidthOptionTest {
 
     assertThrows(NodeNeedRestartException.class, () -> opt.setValue(TWO_KIB_PER_S));
 
-    // Even though a restart is required, Option updates currentValue before rethrowing
+    // Even though a restart is required, Option updates the currentValue before rethrowing
     assertEquals(2048, opt.getValue());
     verify(callback, times(1)).set(2048);
   }
@@ -124,7 +128,7 @@ class BandwidthOptionTest {
 
     assertThrows(InvalidConfigValueException.class, () -> opt.setValue(TWO_KIB_PER_S));
 
-    // Current value should remain the default (unchanged)
+    // The current value should remain the default (unchanged)
     assertEquals(2000, opt.getValue());
     String expectedPersist = network.crypta.support.Fields.intToString(2000, Dimension.NOT);
     assertEquals(expectedPersist, opt.getValueString());
@@ -138,12 +142,8 @@ class BandwidthOptionTest {
             subConfig,
             "bandwidth",
             "2MiB",
-            10,
-            false,
-            false,
-            "short",
-            "long",
-            callback); // 2 * 1<<20 = 2097152 bytes
+            new Option.Meta(10, false, false, "short", "long"),
+            callback); // 2 * 1<<20 = 2,097,152 bytes
 
     // Default (and initial current) value
     assertEquals(2 * 1024 * 1024, opt.getValue());

--- a/src/test/java/network/crypta/config/BooleanOptionTest.java
+++ b/src/test/java/network/crypta/config/BooleanOptionTest.java
@@ -40,7 +40,11 @@ class BooleanOptionTest {
 
   private BooleanOption newOption(boolean defaultValue) {
     return new BooleanOption(
-        subConfig, "flag", defaultValue, 1, false, false, "short", "long", callback);
+        subConfig,
+        "flag",
+        defaultValue,
+        new Option.Meta(1, false, false, "short", "long"),
+        callback);
   }
 
   @ParameterizedTest

--- a/src/test/java/network/crypta/config/ConfigTest.java
+++ b/src/test/java/network/crypta/config/ConfigTest.java
@@ -88,7 +88,11 @@ class ConfigTest {
   void longOption_whenNonNumeric_throwsClassCastException() {
     // Arrange
     SubConfig local = conf.createSubConfig("strings");
-    local.register("greeting", "hello", 0, false, false, "short", "long", new NullStringCallback());
+    local.register(
+        "greeting",
+        "hello",
+        new Option.Meta(0, false, false, "short", "long"),
+        new NullStringCallback());
     // Act + Assert
     assertThrows(ClassCastException.class, () -> Config.longOption(local, "greeting"));
   }
@@ -97,7 +101,12 @@ class ConfigTest {
   void longOption_whenLongOption_returnsSameInstance() {
     // Arrange
     SubConfig local = conf.createSubConfig("numbers2");
-    local.register("answer", 42L, 0, false, false, "short", "long", new NullLongCallback(), false);
+    local.register(
+        "answer",
+        42L,
+        new Option.Meta(0, false, false, "short", "long"),
+        new NullLongCallback(),
+        false);
 
     // Act
     Option<?> expected = local.getOption("answer");
@@ -112,7 +121,12 @@ class ConfigTest {
   void longOption_whenIntOption_valueAccessCausesClassCast() {
     // Arrange
     SubConfig local = conf.createSubConfig("ints");
-    local.register("seven", 7, 0, false, false, "short", "long", new NullIntCallback(), false);
+    local.register(
+        "seven",
+        7,
+        new Option.Meta(0, false, false, "short", "long"),
+        new NullIntCallback(),
+        false);
 
     Option<Long> numeric = Config.longOption(local, "seven");
 

--- a/src/test/java/network/crypta/config/FilePersistentConfigTest.java
+++ b/src/test/java/network/crypta/config/FilePersistentConfigTest.java
@@ -43,11 +43,7 @@ class FilePersistentConfigTest {
     sc.register(
         "key",
         "default-value",
-        10,
-        false,
-        false,
-        SHORT_DESC,
-        LONG_DESC,
+        new Option.Meta(10, false, false, SHORT_DESC, LONG_DESC),
         new network.crypta.support.api.StringCallback() {
           private String v = "default-value";
 
@@ -82,11 +78,7 @@ class FilePersistentConfigTest {
     sc.register(
         "name",
         "default",
-        1,
-        false,
-        false,
-        SHORT_DESC,
-        LONG_DESC,
+        new Option.Meta(1, false, false, SHORT_DESC, LONG_DESC),
         new network.crypta.support.api.StringCallback() {
           private String v = "default";
 
@@ -134,11 +126,7 @@ class FilePersistentConfigTest {
     sc.register(
         "opt",
         "def",
-        1,
-        false,
-        false,
-        SHORT_DESC,
-        LONG_DESC,
+        new Option.Meta(1, false, false, SHORT_DESC, LONG_DESC),
         new network.crypta.support.api.StringCallback() {
           private String v = "def";
 
@@ -192,11 +180,7 @@ class FilePersistentConfigTest {
     sc.register(
         "k",
         "d",
-        0,
-        false,
-        false,
-        "s",
-        "l",
+        new Option.Meta(0, false, false, "s", "l"),
         new network.crypta.support.api.StringCallback() {
           private String v = "d";
 

--- a/src/test/java/network/crypta/config/IntOptionTest.java
+++ b/src/test/java/network/crypta/config/IntOptionTest.java
@@ -36,11 +36,7 @@ class IntOptionTest {
             null,
             "duration",
             "5m",
-            0,
-            false,
-            false,
-            "short",
-            "long",
+            new Option.Meta(0, false, false, "short", "long"),
             new NullIntCallback(),
             Dimension.DURATION);
 
@@ -50,11 +46,7 @@ class IntOptionTest {
             null,
             "duration",
             optDurationFromDisplay.toString(optDurationFromDisplay.currentValue),
-            0,
-            false,
-            false,
-            "short",
-            "long",
+            new Option.Meta(0, false, false, "short", "long"),
             new NullIntCallback(),
             Dimension.DURATION);
 
@@ -67,11 +59,7 @@ class IntOptionTest {
             null,
             "duration",
             optDurationFromDisplay.toDisplayString(optDurationFromDisplay.currentValue),
-            0,
-            false,
-            false,
-            "short",
-            "long",
+            new Option.Meta(0, false, false, "short", "long"),
             new NullIntCallback(),
             Dimension.DURATION);
 
@@ -90,11 +78,7 @@ class IntOptionTest {
             subConfig,
             "size",
             defaultValue,
-            1,
-            false,
-            false,
-            "short",
-            "long",
+            new Option.Meta(1, false, false, "short", "long"),
             mockCb,
             Dimension.SIZE);
 
@@ -114,7 +98,12 @@ class IntOptionTest {
     // Arrange
     IntOption option =
         new IntOption(
-            subConfig, "num", 10, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+            subConfig,
+            "num",
+            10,
+            new Option.Meta(1, false, false, "short", "long"),
+            mockCb,
+            Dimension.NOT);
 
     // Act + Assert
     assertThrows(InvalidConfigValueException.class, () -> option.setValue("not_a_number"));
@@ -128,7 +117,13 @@ class IntOptionTest {
   void setInitialValue_whenInvalid_throwsInvalidConfigValueException_withoutCallback() {
     // Arrange
     IntOption option =
-        new IntOption(subConfig, "num", 7, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+        new IntOption(
+            subConfig,
+            "num",
+            7,
+            new Option.Meta(1, false, false, "short", "long"),
+            mockCb,
+            Dimension.NOT);
 
     // Act + Assert
     assertThrows(InvalidConfigValueException.class, () -> option.setInitialValue("garbage"));
@@ -141,7 +136,12 @@ class IntOptionTest {
     // Arrange
     IntOption option =
         new IntOption(
-            subConfig, "num", 123, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+            subConfig,
+            "num",
+            123,
+            new Option.Meta(1, false, false, "short", "long"),
+            mockCb,
+            Dimension.NOT);
     // Callback throws validation error
     org.mockito.Mockito.doThrow(new InvalidConfigValueException("bad")).when(mockCb).set(anyInt());
 
@@ -156,7 +156,12 @@ class IntOptionTest {
     // Arrange
     IntOption option =
         new IntOption(
-            subConfig, "num", 0, 1, false, false, "short", "long", mockCb, Dimension.SIZE);
+            subConfig,
+            "num",
+            0,
+            new Option.Meta(1, false, false, "short", "long"),
+            mockCb,
+            Dimension.SIZE);
     org.mockito.Mockito.doThrow(new NodeNeedRestartException("restart")).when(mockCb).set(1024);
 
     // Act + Assert
@@ -173,7 +178,12 @@ class IntOptionTest {
     // Arrange
     IntOption option =
         new IntOption(
-            subConfig, "num", 10, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+            subConfig,
+            "num",
+            10,
+            new Option.Meta(1, false, false, "short", "long"),
+            mockCb,
+            Dimension.NOT);
     when(mockCb.get()).thenReturn(42);
     subConfig.finishedInitialization();
 
@@ -191,7 +201,12 @@ class IntOptionTest {
     // Arrange
     IntOption option =
         new IntOption(
-            subConfig, "num", 77, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+            subConfig,
+            "num",
+            77,
+            new Option.Meta(1, false, false, "short", "long"),
+            mockCb,
+            Dimension.NOT);
 
     // Act
     int value = option.getValue();
@@ -209,11 +224,7 @@ class IntOptionTest {
             subConfig,
             "size",
             1024,
-            1,
-            false,
-            false,
-            "short",
-            "long",
+            new Option.Meta(1, false, false, "short", "long"),
             new NullIntCallback(),
             Dimension.SIZE);
 

--- a/src/test/java/network/crypta/config/LongOptionTest.java
+++ b/src/test/java/network/crypta/config/LongOptionTest.java
@@ -32,17 +32,8 @@ class LongOptionTest {
 
   private LongOption newOption(
       String name, long defaultValue, boolean isSize, LongCallback callback) {
-    return new LongOption(
-        subConfig,
-        name,
-        defaultValue,
-        /* sortOrder */ 10,
-        /* expert */ false,
-        /* forceWrite */ false,
-        /* shortDesc */ "short.key",
-        /* longDesc */ "long.key",
-        callback,
-        isSize);
+    Option.Meta meta = new Option.Meta(10, false, false, "short.key", "long.key");
+    return new LongOption(subConfig, name, defaultValue, meta, callback, isSize);
   }
 
   @Test
@@ -50,18 +41,8 @@ class LongOptionTest {
   void constructorStringDefault_whenValid_expectDefaultAndCurrentSet() {
     // Arrange
     // "3M" uses IEC upper-case M => 3 * 2^20
-    LongOption opt =
-        new LongOption(
-            subConfig,
-            "alpha",
-            "3M",
-            /* sortOrder */ 10,
-            /* expert */ false,
-            /* forceWrite */ false,
-            /* shortDesc */ "short.key",
-            /* longDesc */ "long.key",
-            cb,
-            /* isSize */ false);
+    Option.Meta meta = new Option.Meta(10, false, false, "short.key", "long.key");
+    LongOption opt = new LongOption(subConfig, "alpha", "3M", meta, cb, /* isSize */ false);
 
     // Act & Assert
     assertEquals(Option.DataType.NUMBER, opt.getDataType());
@@ -79,7 +60,7 @@ class LongOptionTest {
     // Act: parse a human-size value and set as initial without invoking callback
     opt.setInitialValue("2048");
 
-    // Assert: display string uses IEC (KiB) while value string stays raw
+    // Assert: the display string uses IEC (KiB) while the value string stays raw
     assertEquals("2048", opt.getValueString());
     assertEquals("2KiB", opt.getValueDisplayString());
   }
@@ -94,7 +75,7 @@ class LongOptionTest {
     InvalidConfigValueException ex =
         assertThrows(InvalidConfigValueException.class, () -> opt.setInitialValue("not a number"));
 
-    // Assert: message comes from l10n and contains the offending value
+    // Assert: the message comes from l10n and contains the offending value
     String msg = ex.getMessage();
     assertNotNull(msg);
     assertTrue(msg.contains("64-bit integer"), msg);

--- a/src/test/java/network/crypta/config/PersistentConfigTest.java
+++ b/src/test/java/network/crypta/config/PersistentConfigTest.java
@@ -154,7 +154,11 @@ class PersistentConfigTest {
         capturePersistentConfigLogs(
             () ->
                 sub.register(
-                    "intOpt", 7, 0, false, false, "short", "long", new NullIntCallback(), false));
+                    "intOpt",
+                    7,
+                    new Option.Meta(0, false, false, "short", "long"),
+                    new NullIntCallback(),
+                    false));
 
     // Assert: error logged and value is default (7)
     boolean sawParseError =
@@ -198,7 +202,7 @@ class PersistentConfigTest {
     // Act + Assert
     assertThrows(
         IllegalStateException.class,
-        () -> sub.register("o", 1, 0, false, false, "sd", "ld", cb, false));
+        () -> sub.register("o", 1, new Option.Meta(0, false, false, "sd", "ld"), cb, false));
   }
 
   @Test
@@ -231,8 +235,10 @@ class PersistentConfigTest {
     sfs.putSingle(KEY_EXP_X, "9"); // will be applied on register
     PersistentConfig cfg = new PersistentConfig(sfs);
     SubConfig sub = cfg.createSubConfig("exp");
-    sub.register("x", 5, 0, false, false, "sd", "ld", new NullIntCallback(), false);
-    sub.register("y", 1, 0, false, false, "sd", "ld", new NullIntCallback(), false);
+    sub.register(
+        "x", 5, new Option.Meta(0, false, false, "sd", "ld"), new NullIntCallback(), false);
+    sub.register(
+        "y", 1, new Option.Meta(0, false, false, "sd", "ld"), new NullIntCallback(), false);
 
     // Act
     SimpleFieldSet noDefaults = cfg.exportFieldSet(false);
@@ -254,7 +260,8 @@ class PersistentConfigTest {
     SubConfig sub = cfg.createSubConfig("p");
 
     // Act
-    sub.register("count", 11, 0, false, false, "sd", "ld", new NullIntCallback(), false);
+    sub.register(
+        "count", 11, new Option.Meta(0, false, false, "sd", "ld"), new NullIntCallback(), false);
 
     // Assert: value remains default and getSimpleFieldSet() is null since no SFS was provided
     assertEquals(11, sub.getInt("count"));

--- a/src/test/java/network/crypta/config/ShortOptionTest.java
+++ b/src/test/java/network/crypta/config/ShortOptionTest.java
@@ -27,11 +27,12 @@ class ShortOptionTest {
         sc,
         "test.short",
         defaultValue,
-        42,
-        true,
-        false,
-        "ShortOption.unrecognisedShort", // any key; not used in happy paths
-        "ShortOption.unrecognisedShort",
+        new Option.Meta(
+            42,
+            true,
+            false,
+            "ShortOption.unrecognisedShort", // any key; not used in happy paths
+            "ShortOption.unrecognisedShort"),
         cb,
         isSize);
   }
@@ -74,10 +75,9 @@ class ShortOptionTest {
   void setValue_whenInvalidNumber_expectInvalidConfigValueExceptionWithL10n(
       @Mock ShortCallback cb) {
     // Arrange
-    // Reset global translations to production bundle. Other tests may install
+    // Reset global translations to a production bundle. Other tests may install
     // a test-only bundle via L10nTestUtils.useTestTranslation(), which would
     // make this localized message assertion nondeterministic.
-    //noinspection InstantiationOfUtilityClass
     new NodeL10n();
     Config config = new Config();
     SubConfig sc = config.createSubConfig("core");
@@ -149,7 +149,7 @@ class ShortOptionTest {
     SubConfig sc = config.createSubConfig("core");
     ShortOption opt = newOption(sc, cb, false, (short) 11);
     doAnswer(
-            invocation -> {
+            _ -> {
               // simulate successful apply; underlying state would become 1234
               return null;
             })

--- a/src/test/java/network/crypta/config/StringArrOptionTest.java
+++ b/src/test/java/network/crypta/config/StringArrOptionTest.java
@@ -30,11 +30,7 @@ class StringArrOptionTest {
         subConfig,
         "test.string.array",
         deflt,
-        10,
-        false,
-        false,
-        "short.desc.key",
-        "long.desc.key",
+        new Option.Meta(10, false, false, "short.desc.key", "long.desc.key"),
         callback);
   }
 
@@ -74,7 +70,7 @@ class StringArrOptionTest {
   @Test
   void parseString_whenMalformedAfterSuccessfulDecode_throwsInvalidConfigValue() {
     StringArrOption opt = newOption(new String[] {});
-    // First escape decodes (":"), second is malformed — tolerant mode now throws
+    // The first escape decoded (":"), the second is malformed — tolerant mode now throws
     String malformed = "%3a%zz";
     assertThrows(InvalidConfigValueException.class, () -> opt.parseString(malformed));
   }

--- a/src/test/java/network/crypta/config/StringOptionTest.java
+++ b/src/test/java/network/crypta/config/StringOptionTest.java
@@ -27,7 +27,11 @@ class StringOptionTest {
 
   private static StringOption newOption(SubConfig subConfig, StringCallback cb) {
     return new StringOption(
-        subConfig, "test.option", DEFAULT_VAL, 42, true, true, SHORT_KEY, LONG_KEY, cb);
+        subConfig,
+        "test.option",
+        DEFAULT_VAL,
+        new Option.Meta(42, true, true, SHORT_KEY, LONG_KEY),
+        cb);
   }
 
   @Test
@@ -87,7 +91,7 @@ class StringOptionTest {
     InvalidConfigValueException ex =
         assertThrows(InvalidConfigValueException.class, () -> opt.setValue(BAD_VALUE));
     assertEquals("bad", ex.getMessage());
-    // current value must remain the default because set() failed before updating
+    // the current value must remain the default because set() failed before updating
     assertEquals("def", opt.getValueString());
     Mockito.verify(cb).set(BAD_VALUE);
   }
@@ -104,7 +108,7 @@ class StringOptionTest {
     NodeNeedRestartException ex =
         assertThrows(NodeNeedRestartException.class, () -> opt.setValue(RESTART_VALUE));
     assertEquals("restart", ex.getMessage());
-    // For restart, currentValue is still updated
+    // For restart, the currentValue is still updated
     assertEquals(RESTART_VALUE, opt.getValueString());
     Mockito.verify(cb).set(RESTART_VALUE);
   }
@@ -128,7 +132,7 @@ class StringOptionTest {
     StringCallback cb = Mockito.mock(StringCallback.class);
     StringOption opt = newOption(sc, cb);
 
-    // simulate value parsed from config file without calling callback
+    // simulate value parsed from the config file without calling callback
     opt.setDefault();
     assertEquals("def", opt.getValue());
     Mockito.verify(cb, Mockito.never()).get();

--- a/src/test/java/network/crypta/config/SubConfigTest.java
+++ b/src/test/java/network/crypta/config/SubConfigTest.java
@@ -3,7 +3,15 @@ package network.crypta.config;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -60,10 +68,10 @@ class SubConfigTest {
     // Arrange
     String invalidName = "has.dot";
     IntCallback cb = new NullIntCallback();
+    Option.Meta meta = new Option.Meta(0, false, false, "s", "l");
     // Act + Assert
     assertThrows(
-        IllegalArgumentException.class,
-        () -> subConfig.register(invalidName, 1, 0, false, false, "s", "l", cb, false));
+        IllegalArgumentException.class, () -> subConfig.register(invalidName, 1, meta, cb, false));
   }
 
   @Test
@@ -72,11 +80,12 @@ class SubConfigTest {
     String name = "dup";
     IntCallback firstCb = new NullIntCallback();
     IntCallback secondCb = new NullIntCallback();
-    subConfig.register(name, 1, 0, false, false, "s", "l", firstCb, false);
+    subConfig.register(name, 1, new Option.Meta(0, false, false, "s", "l"), firstCb, false);
+    Option.Meta secondMeta = new Option.Meta(1, false, false, "s2", "l2");
     // Act + Assert
     assertThrows(
         IllegalArgumentException.class,
-        () -> subConfig.register(name, 2, 1, false, false, "s2", "l2", secondCb, false));
+        () -> subConfig.register(name, 2, secondMeta, secondCb, false));
   }
 
   @Test
@@ -109,13 +118,22 @@ class SubConfigTest {
   @Test
   void getters_whenDefaults_expectTrimmedValues() {
     // Arrange
-    subConfig.register("i", 42, 1, false, false, "sd", "ld", new NullIntCallback(), false);
-    subConfig.register("l", 100L, 1, false, false, "sd", "ld", new NullLongCallback(), false);
-    subConfig.register("b", true, 1, false, false, "sd", "ld", new NullBooleanCallback());
-    subConfig.register("s", "  value  ", 1, false, false, "sd", "ld", new NullStringCallback());
     subConfig.register(
-        "sh", (short) 7, 1, false, false, "sd", "ld", new NullShortCallback(), false);
-    subConfig.register("arr", new String[] {"x", "", "a b"}, 1, false, false, "sd", "ld", null);
+        "i", 42, new Option.Meta(1, false, false, "sd", "ld"), new NullIntCallback(), false);
+    subConfig.register(
+        "l", 100L, new Option.Meta(1, false, false, "sd", "ld"), new NullLongCallback(), false);
+    subConfig.register(
+        "b", true, new Option.Meta(1, false, false, "sd", "ld"), new NullBooleanCallback());
+    subConfig.register(
+        "s", "  value  ", new Option.Meta(1, false, false, "sd", "ld"), new NullStringCallback());
+    subConfig.register(
+        "sh",
+        (short) 7,
+        new Option.Meta(1, false, false, "sd", "ld"),
+        new NullShortCallback(),
+        false);
+    subConfig.register(
+        "arr", new String[] {"x", "", "a b"}, new Option.Meta(1, false, false, "sd", "ld"), null);
 
     // Act + Assert
     assertEquals(42, subConfig.getInt("i"));
@@ -129,8 +147,10 @@ class SubConfigTest {
   @Test
   void set_whenBooleanAndString_expectApplied() throws Exception {
     // Arrange
-    subConfig.register("bool", false, 1, false, false, "sd", "ld", new NullBooleanCallback());
-    subConfig.register("str", "default", 1, false, false, "sd", "ld", new NullStringCallback());
+    subConfig.register(
+        "bool", false, new Option.Meta(1, false, false, "sd", "ld"), new NullBooleanCallback());
+    subConfig.register(
+        "str", "default", new Option.Meta(1, false, false, "sd", "ld"), new NullStringCallback());
     // Act
     subConfig.set("bool", true);
     subConfig.set("str", "  hi  ");
@@ -144,7 +164,7 @@ class SubConfigTest {
     // Arrange
     IntCallback cb = mock(IntCallback.class);
     when(cb.get()).thenReturn(123);
-    subConfig.register("val", 7, 1, false, false, "sd", "ld", cb, false);
+    subConfig.register("val", 7, new Option.Meta(1, false, false, "sd", "ld"), cb, false);
 
     // Before finish: default is returned
     assertEquals(7, subConfig.getInt("val"));
@@ -160,32 +180,36 @@ class SubConfigTest {
   void forceUpdate_whenUnchanged_stillInvokesCallback() throws Exception {
     // Arrange
     IntCallback cb = mock(IntCallback.class);
-    subConfig.register("x", 5, 1, false, false, "sd", "ld", cb, false);
+    subConfig.register("x", 5, new Option.Meta(1, false, false, "sd", "ld"), cb, false);
 
     // Act
     subConfig.forceUpdate("x");
 
-    // Assert: callback.set called with current value
+    // Assert: callback.set called with the current value
     verify(cb, times(1)).set(5);
   }
 
   @Test
   void setOptions_whenValidValues_expectApplied() {
     // Arrange
-    subConfig.register("i", 0, 1, false, false, "sd", "ld", new NullIntCallback(), false);
-    subConfig.register("l", 1L, 1, false, false, "sd", "ld", new NullLongCallback(), false);
-    subConfig.register("b", false, 1, false, false, "sd", "ld", new NullBooleanCallback());
-    subConfig.register("s", "d", 1, false, false, "sd", "ld", new NullStringCallback());
     subConfig.register(
-        "sh", (short) 1, 1, false, false, "sd", "ld", new NullShortCallback(), false);
+        "i", 0, new Option.Meta(1, false, false, "sd", "ld"), new NullIntCallback(), false);
+    subConfig.register(
+        "l", 1L, new Option.Meta(1, false, false, "sd", "ld"), new NullLongCallback(), false);
+    subConfig.register(
+        "b", false, new Option.Meta(1, false, false, "sd", "ld"), new NullBooleanCallback());
+    subConfig.register(
+        "s", "d", new Option.Meta(1, false, false, "sd", "ld"), new NullStringCallback());
+    subConfig.register(
+        "sh",
+        (short) 1,
+        new Option.Meta(1, false, false, "sd", "ld"),
+        new NullShortCallback(),
+        false);
     subConfig.register(
         "arr",
         new String[] {"abc"},
-        1,
-        false,
-        false,
-        "sd",
-        "ld",
+        new Option.Meta(1, false, false, "sd", "ld"),
         new network.crypta.support.api.StringArrCallback() {
           @Override
           public String[] get() {
@@ -221,7 +245,8 @@ class SubConfigTest {
   @Test
   void setOptions_whenInvalidValue_expectErrorLoggedAndValueUnchanged() {
     // Arrange
-    subConfig.register("i", 10, 1, false, false, "sd", "ld", new NullIntCallback(), false);
+    subConfig.register(
+        "i", 10, new Option.Meta(1, false, false, "sd", "ld"), new NullIntCallback(), false);
     Option<?> opt = subConfig.getOption("i");
     String before = opt.getValueString();
     SimpleFieldSet sfs = new SimpleFieldSet(true);
@@ -243,7 +268,8 @@ class SubConfigTest {
       logger.setLevel(prev);
     }
 
-    // Assert: value unchanged from before and not set to the invalid input; error was printed
+    // Assert: the value unchanged from before and not set to the invalid input; the error was
+    // printed
     assertEquals(before, opt.getValueString());
     assertNotEquals("abc", opt.getValueString());
     String combined =
@@ -259,7 +285,7 @@ class SubConfigTest {
     // Arrange
     IntCallback cb = mock(IntCallback.class);
     doThrow(new NodeNeedRestartException("needs restart")).when(cb).set(123);
-    subConfig.register("j", 0, 1, false, false, "sd", "ld", cb, false);
+    subConfig.register("j", 0, new Option.Meta(1, false, false, "sd", "ld"), cb, false);
     SimpleFieldSet sfs = new SimpleFieldSet(true);
     sfs.putSingle("j", "123");
 
@@ -274,10 +300,14 @@ class SubConfigTest {
   @Test
   void exportFieldSet_whenCurrentSettings_respectsDefaultsAndForceWrite() {
     // Arrange
-    subConfig.register("i", 10, 1, false, false, "sd", "ld", new NullIntCallback(), false);
-    subConfig.register("force", "def", 2, false, true, "sd", "ld", new NullStringCallback());
-    subConfig.register("b", false, 3, false, false, "sd", "ld", new NullBooleanCallback());
-    subConfig.register("l", 100L, 4, true, false, "sd", "ld", new NullLongCallback(), false);
+    subConfig.register(
+        "i", 10, new Option.Meta(1, false, false, "sd", "ld"), new NullIntCallback(), false);
+    subConfig.register(
+        "force", "def", new Option.Meta(2, false, true, "sd", "ld"), new NullStringCallback());
+    subConfig.register(
+        "b", false, new Option.Meta(3, false, false, "sd", "ld"), new NullBooleanCallback());
+    subConfig.register(
+        "l", 100L, new Option.Meta(4, true, false, "sd", "ld"), new NullLongCallback(), false);
     // change two values
     assertDoesNotThrow(() -> subConfig.set("b", true));
     assertDoesNotThrow(() -> subConfig.set("l", "1000"));
@@ -297,7 +327,8 @@ class SubConfigTest {
   @Test
   void exportFieldSet_whenWithDefaultsTrue_includesDefaults() {
     // Arrange
-    subConfig.register("i", 10, 1, false, false, "sd", "ld", new NullIntCallback(), false);
+    subConfig.register(
+        "i", 10, new Option.Meta(1, false, false, "sd", "ld"), new NullIntCallback(), false);
     // Act
     SimpleFieldSet fs = subConfig.exportFieldSet(Config.RequestType.CURRENT_SETTINGS, true);
     // Assert
@@ -307,16 +338,18 @@ class SubConfigTest {
   @Test
   void exportFieldSet_whenMetadataRequested_containsExpectedValues() {
     // Arrange
-    subConfig.register("i", 10, 42, true, false, "short.i", "long.i", new NullIntCallback(), false);
-    subConfig.register("s", "x", 7, false, true, "short.s", "long.s", new NullStringCallback());
+    subConfig.register(
+        "i",
+        10,
+        new Option.Meta(42, true, false, "short.i", "long.i"),
+        new NullIntCallback(),
+        false);
+    subConfig.register(
+        "s", "x", new Option.Meta(7, false, true, "short.s", "long.s"), new NullStringCallback());
     subConfig.register(
         "arr",
         new String[] {"a", "b"},
-        11,
-        false,
-        false,
-        "short.arr",
-        "long.arr",
+        new Option.Meta(11, false, false, "short.arr", "long.arr"),
         new network.crypta.support.api.StringArrCallback() {
           @Override
           public String[] get() {
@@ -364,7 +397,8 @@ class SubConfigTest {
   @Test
   void removeOption_whenPresent_expectRemovedAndFallbacks() {
     // Arrange
-    subConfig.register("toRemove", 1, 0, false, false, "sd", "ld", new NullIntCallback(), false);
+    subConfig.register(
+        "toRemove", 1, new Option.Meta(0, false, false, "sd", "ld"), new NullIntCallback(), false);
     assertNotNull(subConfig.getOption("toRemove"));
     // Act
     Option<?> removed = subConfig.removeOption("toRemove");
@@ -389,7 +423,7 @@ class SubConfigTest {
   @DisplayName("getRawOption lifecycle around PersistentConfig init")
   @Test
   void getRawOption_whenLifecycleTransitions_behavesAsSpecified() {
-    // Arrange: prepare PersistentConfig with initial value for key
+    // Arrange: prepare PersistentConfig with an initial value for the key
     SimpleFieldSet initial = new SimpleFieldSet(true);
     initial.putSingle("pfx.key", "123");
     PersistentConfig pc = new PersistentConfig(initial);
@@ -399,7 +433,8 @@ class SubConfigTest {
     assertEquals("123", sc.getRawOption("key"));
 
     // After registering: PersistentConfig.onRegister consumes the raw value
-    sc.register("key", 0, 0, false, false, "sd", "ld", new NullIntCallback(), false);
+    sc.register(
+        "key", 0, new Option.Meta(0, false, false, "sd", "ld"), new NullIntCallback(), false);
     assertNull(sc.getRawOption("key"));
 
     // After finishedInit: calling getRawOption throws
@@ -414,7 +449,8 @@ class SubConfigTest {
   void getOptions_whenRegisteredMultiple_preservesInsertionOrder(String[] names) {
     // Arrange
     for (String n : names) {
-      subConfig.register(n, 0, 0, false, false, "sd", "ld", new NullIntCallback(), false);
+      subConfig.register(
+          n, 0, new Option.Meta(0, false, false, "sd", "ld"), new NullIntCallback(), false);
     }
     // Act
     String[] actual =

--- a/src/test/java/network/crypta/node/NodeClientCoreTransferPolicyTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTransferPolicyTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
+import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.subsystem.NodeServicesSubsystem;
@@ -175,11 +176,7 @@ class NodeClientCoreTransferPolicyTest {
         .register(
             eq(DOWNLOAD_ALLOWED_DIRS_KEY),
             any(String[].class),
-            eq(4),
-            eq(true),
-            eq(true),
-            eq(DOWNLOAD_ALLOWED_DIRS_SHORT),
-            eq(DOWNLOAD_ALLOWED_DIRS_LONG),
+            any(Option.Meta.class),
             any(StringArrCallback.class));
     assertEquals(5, nextSortOrder);
   }
@@ -199,11 +196,7 @@ class NodeClientCoreTransferPolicyTest {
         .register(
             eq(DOWNLOAD_ALLOWED_DIRS_KEY),
             any(String[].class),
-            eq(0),
-            eq(true),
-            eq(true),
-            eq(DOWNLOAD_ALLOWED_DIRS_SHORT),
-            eq(DOWNLOAD_ALLOWED_DIRS_LONG),
+            any(Option.Meta.class),
             callbackCaptor.capture());
 
     assertArrayEquals(
@@ -225,11 +218,7 @@ class NodeClientCoreTransferPolicyTest {
         .register(
             eq(DOWNLOAD_ALLOWED_DIRS_KEY),
             any(String[].class),
-            eq(0),
-            eq(true),
-            eq(true),
-            eq(DOWNLOAD_ALLOWED_DIRS_SHORT),
-            eq(DOWNLOAD_ALLOWED_DIRS_LONG),
+            any(Option.Meta.class),
             callbackCaptor.capture());
 
     assertDoesNotThrow(() -> callbackCaptor.getValue().set(new String[] {"all"}));
@@ -250,11 +239,7 @@ class NodeClientCoreTransferPolicyTest {
         .register(
             eq(UPLOAD_ALLOWED_DIRS_KEY),
             any(String[].class),
-            eq(3),
-            eq(true),
-            eq(true),
-            eq(UPLOAD_ALLOWED_DIRS_SHORT),
-            eq(UPLOAD_ALLOWED_DIRS_LONG),
+            any(Option.Meta.class),
             any(StringArrCallback.class));
     assertEquals(4, nextSortOrder);
   }
@@ -274,11 +259,7 @@ class NodeClientCoreTransferPolicyTest {
         .register(
             eq(UPLOAD_ALLOWED_DIRS_KEY),
             any(String[].class),
-            eq(0),
-            eq(true),
-            eq(true),
-            eq(UPLOAD_ALLOWED_DIRS_SHORT),
-            eq(UPLOAD_ALLOWED_DIRS_LONG),
+            any(Option.Meta.class),
             callbackCaptor.capture());
 
     assertArrayEquals(new String[] {allowedDir.getPath()}, callbackCaptor.getValue().get());
@@ -297,11 +278,7 @@ class NodeClientCoreTransferPolicyTest {
         .register(
             eq(UPLOAD_ALLOWED_DIRS_KEY),
             any(String[].class),
-            eq(0),
-            eq(true),
-            eq(true),
-            eq(UPLOAD_ALLOWED_DIRS_SHORT),
-            eq(UPLOAD_ALLOWED_DIRS_LONG),
+            any(Option.Meta.class),
             callbackCaptor.capture());
 
     assertDoesNotThrow(() -> callbackCaptor.getValue().set(new String[] {"all"}));

--- a/src/test/java/network/crypta/node/subsystem/NodeConfigManagerTest.java
+++ b/src/test/java/network/crypta/node/subsystem/NodeConfigManagerTest.java
@@ -72,11 +72,7 @@ class NodeConfigManagerTest {
         .register(
             eq("l10n"),
             eq(Locale.getDefault().getLanguage().toLowerCase()),
-            eq(startOrder),
-            eq(false),
-            eq(true),
-            eq("Node.l10nLanguage"),
-            eq("Node.l10nLanguageLong"),
+            any(Option.Meta.class),
             callbackCaptor.capture());
     assertInstanceOf(EnumerableOptionCallback.class, callbackCaptor.getValue());
   }

--- a/src/test/java/network/crypta/node/subsystem/NodeServicesSubsystemTest.java
+++ b/src/test/java/network/crypta/node/subsystem/NodeServicesSubsystemTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
@@ -213,15 +214,7 @@ class NodeServicesSubsystemTest {
     subsystem.configurePeersOffersFrefFiles(subConfig, 7);
 
     verify(subConfig)
-        .register(
-            eq(PEERS_OFFERS_DISMISSED),
-            eq(false),
-            eq(7),
-            eq(true),
-            eq(true),
-            eq(PEERS_OFFERS_DISMISSED_SHORT),
-            eq(PEERS_OFFERS_DISMISSED_LONG),
-            captor.capture());
+        .register(eq(PEERS_OFFERS_DISMISSED), eq(false), any(Option.Meta.class), captor.capture());
 
     captor.getValue().set(Boolean.TRUE);
 
@@ -240,14 +233,7 @@ class NodeServicesSubsystemTest {
 
       verify(subConfig)
           .register(
-              eq(PEERS_OFFERS_DISMISSED),
-              eq(false),
-              eq(3),
-              eq(true),
-              eq(true),
-              eq(PEERS_OFFERS_DISMISSED_SHORT),
-              eq(PEERS_OFFERS_DISMISSED_LONG),
-              captor.capture());
+              eq(PEERS_OFFERS_DISMISSED), eq(false), any(Option.Meta.class), captor.capture());
 
       captor.getValue().set(Boolean.FALSE);
 

--- a/src/test/java/network/crypta/node/useralerts/DatastoreTooSmallAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/DatastoreTooSmallAlertTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.lenient;
 import java.nio.file.Path;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.FeedMessage;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
@@ -50,15 +51,21 @@ class DatastoreTooSmallAlertTest {
 
   private void registerSizeOptions(long storeSizeBytes, long clientCacheBytes, long slashdotBytes) {
     // Register the three size options (as sizes)
-    nodeConfig.register("storeSize", storeSizeBytes, 0, false, true, "", "", null, true);
-    nodeConfig.register("clientCacheSize", clientCacheBytes, 0, false, true, "", "", null, true);
-    nodeConfig.register("slashdotCacheSize", slashdotBytes, 0, false, true, "", "", null, true);
+    nodeConfig.register(
+        "storeSize", storeSizeBytes, new Option.Meta(0, false, true, "", ""), null, true);
+    nodeConfig.register(
+        "clientCacheSize", clientCacheBytes, new Option.Meta(0, false, true, "", ""), null, true);
+    nodeConfig.register(
+        "slashdotCacheSize", slashdotBytes, new Option.Meta(0, false, true, "", ""), null, true);
 
     // Also required by DATASTORE_SIZE._setDatastoreSize but not directly used here; harmless to
     // set.
-    nodeConfig.register("inputBandwidthLimit", 0, 0, false, true, "", "", null /* IntCallback */);
-    nodeConfig.register("outputBandwidthLimit", 0, 0, false, true, "", "", null /* IntCallback */);
-    nodeConfig.register("slashdotCacheLifetime", 0L, 0, false, true, "", "", null, false);
+    nodeConfig.register(
+        "inputBandwidthLimit", 0, new Option.Meta(0, false, true, "", ""), null /* IntCallback */);
+    nodeConfig.register(
+        "outputBandwidthLimit", 0, new Option.Meta(0, false, true, "", ""), null /* IntCallback */);
+    nodeConfig.register(
+        "slashdotCacheLifetime", 0L, new Option.Meta(0, false, true, "", ""), null, false);
   }
 
   private void registerDismissed(String initial) {
@@ -69,7 +76,10 @@ class DatastoreTooSmallAlertTest {
       initVal = 0;
     }
     nodeConfig.register(
-        "datastoreTooSmallDismissed", initVal, 0, false, true, "", "", null /* IntCallback */);
+        "datastoreTooSmallDismissed",
+        initVal,
+        new Option.Meta(0, false, true, "", ""),
+        null /* IntCallback */);
   }
 
   private static long expectedCurrentGiB(long store, long client, long slashdot) {

--- a/src/test/java/network/crypta/node/useralerts/MeaningfulNodeNameUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/MeaningfulNodeNameUserAlertTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.StringOption;
 import network.crypta.config.SubConfig;
@@ -70,11 +71,7 @@ class MeaningfulNodeNameUserAlertTest {
             nodeSc,
             "name",
             "DefaultName",
-            /*sortOrder*/ 0,
-            /*expert*/ false,
-            /*forceWrite*/ false,
-            /*shortDescKey*/ "node.name.short",
-            /*longDescKey*/ "node.name.long",
+            new Option.Meta(0, false, false, "node.name.short", "node.name.long"),
             new StringCallback() {
               private String v = "DefaultName";
 

--- a/src/test/java/network/crypta/node/useralerts/PeersOffersUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/PeersOffersUserAlertTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
@@ -147,7 +148,8 @@ class PeersOffersUserAlertTest {
     PersistentConfig cfg = new PersistentConfig(null);
     SubConfig nodeCfg = cfg.createSubConfig("node");
     // Register the boolean option with default=false
-    nodeCfg.register("peersOffersDismissed", false, 0, false, true, "short", "long", null);
+    nodeCfg.register(
+        "peersOffersDismissed", false, new Option.Meta(0, false, true, "short", "long"), null);
     // SubConfig registers itself with the owning config in its constructor.
     when(node.getConfig()).thenReturn(cfg);
 

--- a/src/test/java/network/crypta/node/useralerts/UpgradeConnectionSpeedUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/UpgradeConnectionSpeedUserAlertTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import network.crypta.clients.http.wizardsteps.BandwidthLimit;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
@@ -48,21 +49,13 @@ class UpgradeConnectionSpeedUserAlertTest {
     nodeConfig.register(
         "inputBandwidthLimit",
         4096, // 4 KiB/s
-        0,
-        false,
-        false,
-        "",
-        "",
+        new Option.Meta(0, false, false, "", ""),
         (network.crypta.support.api.IntCallback) null,
         false);
     nodeConfig.register(
         "outputBandwidthLimit",
         2048, // 2 KiB/s
-        0,
-        false,
-        false,
-        "",
-        "",
+        new Option.Meta(0, false, false, "", ""),
         (network.crypta.support.api.IntCallback) null,
         false);
 

--- a/src/test/java/network/crypta/pluginmanager/PluginManagerTest.java
+++ b/src/test/java/network/crypta/pluginmanager/PluginManagerTest.java
@@ -27,6 +27,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
@@ -354,11 +355,7 @@ class PluginManagerTest {
     fproxy.register(
         FPROXY_CSS_OPTION,
         THEME_CRYPTAFORGE,
-        0,
-        true,
-        true,
-        FPROXY_CSS_SHORT_DESC,
-        FPROXY_CSS_LONG_DESC,
+        new Option.Meta(0, true, true, FPROXY_CSS_SHORT_DESC, FPROXY_CSS_LONG_DESC),
         (StringCallback) null);
     fproxy.finishedInitialization();
     when(node.getConfig()).thenReturn(config);
@@ -382,11 +379,7 @@ class PluginManagerTest {
     fproxy.register(
         FPROXY_CSS_OPTION,
         THEME_CRYPTAFORGE,
-        0,
-        true,
-        true,
-        FPROXY_CSS_SHORT_DESC,
-        FPROXY_CSS_LONG_DESC,
+        new Option.Meta(0, true, true, FPROXY_CSS_SHORT_DESC, FPROXY_CSS_LONG_DESC),
         (StringCallback) null);
     fproxy.finishedInitialization();
     when(node.getConfig()).thenReturn(config);
@@ -409,11 +402,7 @@ class PluginManagerTest {
     fproxy.register(
         FPROXY_CSS_OPTION,
         THEME_CRYPTAFORGE,
-        0,
-        true,
-        true,
-        FPROXY_CSS_SHORT_DESC,
-        FPROXY_CSS_LONG_DESC,
+        new Option.Meta(0, true, true, FPROXY_CSS_SHORT_DESC, FPROXY_CSS_LONG_DESC),
         (StringCallback) null);
     fproxy.finishedInitialization();
     when(node.getConfig()).thenReturn(config);


### PR DESCRIPTION
## Summary
- replace config option registration signatures with `Option.Meta` across subsystems
- update option classes and `SubConfig` to normalize metadata
- adjust tests/docs for the new metadata constructors

## Testing
- Not run (not requested)
