### PR TITLE
refactor(node): centralize request sender context

### DIFF
--- a/src/main/java/network/crypta/io/xfer/BlockReceiver.java
+++ b/src/main/java/network/crypta/io/xfer/BlockReceiver.java
@@ -37,8 +37,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>In particular, an attacker might connect, saturate the link with transfers, then disconnect to
  * avoid receiving the data, reconnect later with a new identity (on opennet), and rely on the
- * transfers having been canceled. Downstream bandwidth is comparatively cheap for small attackers,
- * so this can act as a multiplier if not mitigated.
+ * transfers having been canceled. Downstream bandwidth is comparatively inexpensive for small
+ * attackers, so this can act as a multiplier if not mitigated.
  *
  * <p>Keeping receiver cancels does increase code complexity (e.g., around {@code
  * ReceiverAbortHandler}), but improves reliability of transfers when applied carefully with
@@ -117,13 +117,8 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
   /**
    * Creates a receiver for one block transfer.
    *
-   * @param usm message core used to send/receive protocol messages
-   * @param sender remote peer providing the block
-   * @param uid transfer identifier unique to this exchange
-   * @param prb target {@link PartiallyReceivedBlock} that accumulates packets
-   * @param ctr byte counter for accounting and rate tracking
-   * @param ticker time source used by higher layers; may be unused here
-   * @param realTime when true, use realtime timeouts; otherwise use bulk timeouts
+   * @param transferContext shared transfer context (message core, peer, uid, PRB, accounting, and
+   *     timing settings)
    * @param timeoutHandler callback invoked on first and fatal timeouts; may be {@code null}
    * @param completeAfterAckedAllReceived if true, complete only after the sender acknowledges
    *     {@code allReceived}; if false, complete as soon as all data is present locally. Handlers
@@ -131,13 +126,7 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
    *     reusing a slot before the handler finishes.
    */
   public BlockReceiver(
-      MessageCore usm,
-      PeerContext sender,
-      long uid,
-      PartiallyReceivedBlock prb,
-      ByteCounter ctr,
-      Ticker ticker,
-      boolean realTime,
+      BlockTransferContext transferContext,
       BlockReceiverTimeoutHandler timeoutHandler,
       boolean completeAfterAckedAllReceived) {
     BlockReceiverTimeoutHandler nullTimeoutHandler =
@@ -154,13 +143,13 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
           }
         };
     this.timeoutHandler = timeoutHandler == null ? nullTimeoutHandler : timeoutHandler;
-    this.sender = sender;
-    this.prb = prb;
-    this.uid = uid;
-    this.usm = usm;
-    this.ctr = ctr;
-    this.ticker = ticker;
-    this.realTime = realTime;
+    this.sender = transferContext.peer();
+    this.prb = transferContext.block();
+    this.uid = transferContext.uid();
+    this.usm = transferContext.messageCore();
+    this.ctr = transferContext.byteCounter();
+    this.ticker = transferContext.ticker();
+    this.realTime = transferContext.realTime();
     this.completeAfterAckedAllReceived = completeAfterAckedAllReceived;
     receiptTimeout = this.realTime ? RECEIPT_TIMEOUT_REALTIME : RECEIPT_TIMEOUT_BULK;
     maxRoundTripTime = receiptTimeout;
@@ -196,7 +185,7 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
   private long startTime;
 
   // If false, do not check for duplicate packets from the sender.
-  // Can be disabled when the PRB is already partially received at start. Dupe checks prevent
+  // Can be disabled when the PRB is already partially received at the start. Dupe checks prevent
   // malicious or broken nodes from trickling forever by resending the same packets.
   static final boolean CHECK_DUPES = true;
 
@@ -360,12 +349,12 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
             complete(RetrievalException.SENDER_DIED, "Sender unresponsive to resend requests");
 
             timeoutHandler.onFirstTimeout();
-            // If upstream caused the problem, then sender will itself timeout
+            // If upstream caused the problem, then the sender will itself timeout
             // and will tell us. So wait for a timeout.
             // It is important for load management that the two sides agree on the number of
             // transfers happening.
             // Therefore, we need to not complete until the other side has acknowledged that the
-            // transfer has been cancelled.
+            // transfer has been canceled.
             MessageFilter mfSendAborted =
                 MessageFilter.create()
                     .setTimeout(ACK_TRANSFER_FAILED_TIMEOUT)
@@ -404,7 +393,7 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
           try {
             sender.transport().sendSync(m, ctr, realTime);
           } catch (SyncSendWaitedTooLongException _) {
-            // Synchronous send exceeded wait threshold; proceed with completion regardless.
+            // Synchronous send exceeded the wait threshold; proceed with completion regardless.
           }
         }
 
@@ -442,7 +431,8 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
                   @Override
                   public void onTimeout() {
                     LOG.error(
-                        "Other side did not acknowlege transfer failure on {}", BlockReceiver.this);
+                        "Other side did not acknowledge transfer failure on {}",
+                        BlockReceiver.this);
                     timeoutHandler.onFatalTimeout(sender);
                   }
 
@@ -502,7 +492,7 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
     prb.removeListener(myListener);
     byte[] block = prb.abort(reason, description, false);
     if (block == null) {
-      // Expected behaviour.
+      // Expected behavior.
       // Send the abort whether we have received one or not.
       // If we are cancelling due to failing to turtle, we need to tell the sender
       // this otherwise he will keep sending, wasting a lot of bandwidth on packets
@@ -565,7 +555,7 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
   PartiallyReceivedBlock.PacketReceivedListener myListener;
 
   /**
-   * Starts the asynchronous receive flow for this transfer.
+   * Starts the asynchronous receiving flow for this transfer.
    *
    * <p>Registers a listener on the {@link PartiallyReceivedBlock}, installs message filters, and
    * begins waiting for packets. The callback is invoked on success with the full block, or on

--- a/src/main/java/network/crypta/io/xfer/BlockTransferContext.java
+++ b/src/main/java/network/crypta/io/xfer/BlockTransferContext.java
@@ -1,0 +1,15 @@
+package network.crypta.io.xfer;
+
+import network.crypta.io.comm.ByteCounter;
+import network.crypta.io.comm.MessageCore;
+import network.crypta.io.comm.PeerContext;
+import network.crypta.support.Ticker;
+
+public record BlockTransferContext(
+    MessageCore messageCore,
+    Ticker ticker,
+    PeerContext peer,
+    long uid,
+    PartiallyReceivedBlock block,
+    ByteCounter byteCounter,
+    boolean realTime) {}

--- a/src/main/java/network/crypta/io/xfer/BlockTransferContext.java
+++ b/src/main/java/network/crypta/io/xfer/BlockTransferContext.java
@@ -5,6 +5,36 @@ import network.crypta.io.comm.MessageCore;
 import network.crypta.io.comm.PeerContext;
 import network.crypta.support.Ticker;
 
+/**
+ * Carries the shared services and per-transfer inputs needed to send a single block to a peer.
+ *
+ * <p>This record is a lightweight, immutable bundle that keeps the block transmitter wiring
+ * explicit. Callers populate it once, pass it into transfer setup, and then treat it as a read-only
+ * state for the life of the transfer. The record does not perform work itself; it simply groups
+ * together the core messaging, scheduling, and accounting objects alongside the block metadata and
+ * peer identity. Invariants are established by the producer (for example, the block and counters
+ * must be consistent with each other), and consumers assume they are stable for the duration of a
+ * transfer attempt.
+ *
+ * <p>Instances are typically created just before constructing a {@link BlockTransmitter} and are
+ * not reused across unrelated transfers. Concurrency safety depends on the referenced objects: the
+ * record itself is immutable, but any stateful collaborators may have their own threading rules.
+ *
+ * <ul>
+ *   <li>Collects all inputs required to initiate block transmission.
+ *   <li>Preserves the logical identity of the transfer via the UID and peer context.
+ *   <li>Exposes byte accounting and real-time behavior flags to downstream stages.
+ * </ul>
+ *
+ * @param messageCore message dispatcher used to send or receive transfer messages during this run
+ * @param ticker timing source for scheduling retries and time-based callbacks in the transfer
+ * @param peer destination peer context that identifies the remote endpoint for the transfer
+ * @param uid unique transfer identifier shared across logs and protocol messages for correlation
+ * @param block partially received block metadata that describes packet sizing and progress
+ * @param byteCounter counter that tracks transfer bytes and supports aggregated accounting
+ * @param realTime {@code true} to prioritize low latency scheduling, {@code false} for bulk mode
+ * @see BlockTransmitter
+ */
 public record BlockTransferContext(
     MessageCore messageCore,
     Ticker ticker,

--- a/src/main/java/network/crypta/io/xfer/BlockTransmitter.java
+++ b/src/main/java/network/crypta/io/xfer/BlockTransmitter.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Thread safety: internal transfer state ({@code unsent}, {@code sentPackets}, completion flags
  * and counters) is guarded by the {@code senderThread} monitor. Callers must respect the locking
- * notes in method Javadoc.
+ * notes in the method Javadoc.
  */
 public class BlockTransmitter {
   private static final Logger LOG = LoggerFactory.getLogger(BlockTransmitter.class);
@@ -102,7 +102,7 @@ public class BlockTransmitter {
   /** Reports the observed inter-packet interval for metrics/telemetry. */
   public interface BlockTimeCallback {
     /**
-     * Called with the measured interval between consecutive packet sends.
+     * Called with the measured interval between consecutive packet sending.
      *
      * @param interval time in milliseconds since the previous packet was sent; negative when not
      *     applicable (e.g., for the first packet).
@@ -119,13 +119,13 @@ public class BlockTransmitter {
    */
   private boolean receivedSendCompletion;
 
-  /** Was it an allReceived? */
+  /** Was it allReceived? */
   private boolean receivedSendSuccess;
 
-  /** Have we completed i.e. called the callback? */
+  /** Have we completed i.e., called the callback? */
   private boolean completed;
 
-  /** Have we failed e.g. due to PRB abort, disconnection? */
+  /** Have we failed e.g., due to PRB abort, disconnection? */
   private boolean failed;
 
   static int runningBlockTransmits = 0;
@@ -171,7 +171,7 @@ public class BlockTransmitter {
             copy = sentPackets.copy();
             sentPackets.setBit(packetNo, true);
             // Apply a small random delay before the final two packets at high HTL.
-            // Uses 'count' to detect the last two sends (packets 31 and 32 of the block).
+            // Uses 'count' to detect the last two sending (packets 31 and 32 of the block).
             count++;
             if (isHighHtl() && count >= (Node.PACKETS_IN_BLOCK - 2)) {
               state.set(STATE_WAITING);
@@ -211,7 +211,7 @@ public class BlockTransmitter {
             DMT.createPacketTransmit(uid, packetNo, copied, prb.getPacket(packetNo), realTime);
         MyAsyncMessageCallback cb = new MyAsyncMessageCallback();
         MessageItem item;
-        // All sends are throttled via the shared ByteCounter.
+        // All sending are throttled via the shared ByteCounter.
         item = destination.transport().sendAsync(msg, cb, ctr);
         synchronized (itemsPending) {
           itemsPending.add(item);
@@ -264,39 +264,28 @@ public class BlockTransmitter {
   /**
    * Creates a new transmitter for sending a partially received block to a specific peer.
    *
-   * @param usm message core used to send control/data messages.
-   * @param ticker scheduler providing the executor and timed jobs.
-   * @param destination remote peer that will receive the packets.
-   * @param uid transfer identifier shared with the receiver.
-   * @param source source block providing packet data and readiness notifications.
-   * @param ctr byte counter used for throttling and accounting; must be non-null.
+   * @param transferContext shared transfer context (message core, peer, uid, PRB, accounting, and
+   *     timing settings)
    * @param abortHandler callback invoked when the receiver cancels; determines whether to cascade
    *     the cancel to the {@code PartiallyReceivedBlock}.
    * @param callback completion callback invoked once per transfer with success status.
-   * @param realTime if {@code true}, use realtime timeouts; otherwise use bulk settings.
    * @param blockTimes optional callback for inter-packet timing metrics; may be {@code null}.
    */
   public BlockTransmitter(
-      MessageCore usm,
-      Ticker ticker,
-      PeerContext destination,
-      long uid,
-      PartiallyReceivedBlock source,
-      ByteCounter ctr,
+      BlockTransferContext transferContext,
       ReceiverAbortHandler abortHandler,
       BlockTransmitterCompletion callback,
-      boolean realTime,
       BlockTimeCallback blockTimes) {
-    this.realTime = realTime;
-    this.ticker = ticker;
+    this.realTime = transferContext.realTime();
+    this.ticker = transferContext.ticker();
     this.executor = this.ticker.getExecutor();
     this.callback = callback;
     this.abortHandler = abortHandler;
-    messageCore = usm;
-    this.destination = destination;
-    this.uid = uid;
-    prb = source;
-    this.ctr = ctr;
+    messageCore = transferContext.messageCore();
+    this.destination = transferContext.peer();
+    this.uid = transferContext.uid();
+    prb = transferContext.block();
+    this.ctr = transferContext.byteCounter();
     if (this.ctr == null) throw new NullPointerException();
     packetSize = DMT.packetTransmitSize(prb.packetSize, prb.packets);
     try {
@@ -311,7 +300,7 @@ public class BlockTransmitter {
           "Starting block transmit for {} to {} realtime={}",
           uid,
           destination.shortToString(),
-          realTime);
+          this.realTime);
   }
 
   private Runnable timeoutJob;
@@ -379,7 +368,7 @@ public class BlockTransmitter {
   }
 
   /**
-   * Determines whether all packets have been sent, and records the time if so.
+   * Determines whether all packets have been sent and records the time if so.
    *
    * <p>LOCKING: Must be called with the {@code senderThread} monitor held.
    *
@@ -424,7 +413,7 @@ public class BlockTransmitter {
     if (!receivedSendCompletion) {
       if (LOG.isDebugEnabled())
         LOG.debug("maybeComplete() not completing because send not completed on {}", this);
-      // All the block sends have completed, wait for the other side to acknowledge or timeout.
+      // All the block sending have completed, wait for the other side to acknowledge or timeout.
       scheduleTimeoutAfterBlockSends();
       return false;
     }
@@ -479,7 +468,7 @@ public class BlockTransmitter {
   }
 
   private Future handleFailBeforeAck(final int reason, final String description) {
-    // Don't actually time out until after we have an acknowledgement of the transfer cancel.
+    // Don't time out until after we have an acknowledgement of the transfer cancel.
     // This is important for keeping track of how many transfers are actually running, which will be
     // important for load management later on.
     // The caller will immediately call prepareSendAbort() then innerSendAborted().
@@ -555,9 +544,6 @@ public class BlockTransmitter {
     boolean onAbort();
   }
 
-  /** Cascades receiver aborts to the source block. */
-  public static final ReceiverAbortHandler ALWAYS_CASCADE = () -> true;
-
   /** Never cascades receiver aborts to the source block. */
   public static final ReceiverAbortHandler NEVER_CASCADE = () -> false;
 
@@ -602,7 +588,7 @@ public class BlockTransmitter {
         @Override
         public boolean shouldTimeout() {
           synchronized (senderThread) {
-            // We are waiting for the send completion, which is set on timeout as well as on
+            // We are waiting for the sending completion, which is set on timeout as well as on
             // receiving a message.
             // In some corner cases we might want to get the allReceived after setting _failed, so
             // don't time out on _failed.
@@ -657,7 +643,7 @@ public class BlockTransmitter {
         @Override
         public boolean shouldTimeout() {
           synchronized (senderThread) {
-            // We are waiting for the send completion, which is set on timeout as well as on
+            // We are waiting for the sending completion, which is set on timeout as well as on
             // receiving a message.
             // We don't want to timeout on _failed because we can set _failed, send sendAborted, and
             // then wait for the acknowledging sendAborted.
@@ -783,7 +769,7 @@ public class BlockTransmitter {
             };
         unsent = prb.addListener(myListener);
       }
-      // If all 32 packets are ready at once and HTL is high, shuffle to mix the send order.
+      // If all 32 packets are ready at once and HTL is high, shuffle to mix the sending order.
       if (isHighHtl() && unsent.size() == Node.PACKETS_IN_BLOCK) {
         List<Integer> temp = new ArrayList<>(unsent);
         unsent.clear();
@@ -901,7 +887,7 @@ public class BlockTransmitter {
         }
       }
       if (!failed)
-        // Everything is throttled, but payload is not reported.
+        // Everything is throttled, but the payload is not reported.
         ctr.sentPayload(packetSize);
       if (callCallback) {
         callCallback(success);

--- a/src/main/java/network/crypta/node/CHKInsertHandler.java
+++ b/src/main/java/network/crypta/node/CHKInsertHandler.java
@@ -15,6 +15,7 @@ import network.crypta.io.xfer.AbortedException;
 import network.crypta.io.xfer.BlockReceiver;
 import network.crypta.io.xfer.BlockReceiver.BlockReceiverCompletion;
 import network.crypta.io.xfer.BlockReceiver.BlockReceiverTimeoutHandler;
+import network.crypta.io.xfer.BlockTransferContext;
 import network.crypta.io.xfer.PartiallyReceivedBlock;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKVerifyException;
@@ -237,13 +238,14 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
                       .withRealTimeFlag(realTimeFlag));
     br =
         new BlockReceiver(
-            node.network().usm(),
-            source,
-            uid,
-            prb,
-            this,
-            node.network().ticker(),
-            realTimeFlag,
+            new BlockTransferContext(
+                node.network().usm(),
+                node.network().ticker(),
+                source,
+                uid,
+                prb,
+                this,
+                realTimeFlag),
             myTimeoutHandler,
             false);
 
@@ -443,13 +445,14 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
       prb = new PartiallyReceivedBlock(Node.PACKETS_IN_BLOCK, Node.PACKET_SIZE);
       br =
           new BlockReceiver(
-              node.network().usm(),
-              source,
-              uid,
-              prb,
-              this,
-              node.network().ticker(),
-              realTimeFlag,
+              new BlockTransferContext(
+                  node.network().usm(),
+                  node.network().ticker(),
+                  source,
+                  uid,
+                  prb,
+                  this,
+                  realTimeFlag),
               null,
               false);
       prb.abort(RetrievalException.NO_DATAINSERT, "No DataInsert", true);

--- a/src/main/java/network/crypta/node/CHKInsertHandler.java
+++ b/src/main/java/network/crypta/node/CHKInsertHandler.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * <p>Lifecycle and threading: - An instance is executed once via {@link #run()} on a worker thread
  * (implements {@link PrioRunnable}). - A separate {@code DataReceiver} task is posted to the node's
  * executor to receive the block in parallel with downstream routing progress. - Completion and
- * error paths synchronize on internal locks to avoid double-finishing and to ensure that commit
+ * error paths synchronize on internal locks to avoid double-finishing and to ensure that the commit
  * happens only after downstream completion signals are observed.
  *
  * <p>Timeouts and retries: - Waits up to {@link #DATA_INSERT_TIMEOUT} milliseconds for the initial
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * by {@link #canWriteDatastore}.
  *
  * <p>Nullability and units: - All timeouts are expressed in milliseconds unless otherwise
- * documented. - {@code realTimeFlag} selects real-time vs bulk timeouts for transfer completion.
+ * documented. - {@code realTimeFlag} selects real-time vs. bulk timeouts for transfer completion.
  *
  * @author amphibian
  */
@@ -88,30 +88,20 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
   private final boolean ignoreLowBackoff;
   private final boolean realTimeFlag;
 
-  CHKInsertHandler(
-      NodeCHK key,
-      short htl,
-      PeerNode source,
-      long id,
-      Node node,
-      long startTime,
-      InsertTag tag,
-      boolean forkOnCacheable,
-      boolean preferInsert,
-      boolean ignoreLowBackoff,
-      boolean realTimeFlag) {
-    this.node = node;
-    this.uid = id;
-    this.source = source;
-    this.startTime = startTime;
-    this.tag = tag;
+  CHKInsertHandler(NodeCHK key, short htl, InsertHandlerContext context) {
+    this.node = context.node();
+    this.uid = context.uid();
+    this.source = context.source();
+    this.startTime = context.startTime();
+    this.tag = context.tag();
     this.key = key;
     this.htl = htl;
     canWriteDatastore = node.routing().canWriteDatastoreInsert(htl);
-    this.forkOnCacheable = forkOnCacheable;
-    this.preferInsert = preferInsert;
-    this.ignoreLowBackoff = ignoreLowBackoff;
-    this.realTimeFlag = realTimeFlag;
+    InsertRoutingOptions options = context.routingOptions();
+    this.forkOnCacheable = options.forkOnCacheable();
+    this.preferInsert = options.preferInsert();
+    this.ignoreLowBackoff = options.ignoreLowBackoff();
+    this.realTimeFlag = context.realTimeFlag();
   }
 
   /**
@@ -125,14 +115,14 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
   }
 
   /**
-   * Entry point for the handler. Performs the upstream accept, waits for the data insert, starts
-   * the receiver task, and drives downstream routing until a terminal status is reached.
+   * Entry point for the handler. Performs the upstream acceptance, waits for the data insert,
+   * starts the receiver task, and drives downstream routing until a terminal status is reached.
    *
    * <p>All exceptions are caught and reported to the associated {@link InsertTag}; the tag is
    * unlocked in a {@code finally} block to avoid deadlocks on upstream cancellation.
    */
   @Override
-  @SuppressWarnings("java:S1181")
+  @SuppressWarnings({"java:S1181", "ResultOfMethodCallIgnored"})
   public void run() {
     try {
       realRun();
@@ -176,11 +166,11 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
   }
 
   private boolean sendAccepted() {
-    // Consider inserting rate limiting here if the accept path requires backpressure.
+    // Consider inserting rate limiting here if the acceptance path requires backpressure.
     Message accepted = DMT.createFNPAccepted(uid);
     try {
       // Synchronous send here ensures the next message filter does not spuriously time out; we
-      // either block here, or inside the filter, but we prefer to fail early on send.
+      // either block here, or inside the filter, but we prefer to fail early on sending.
       source.transport().sendSync(accepted, this, realTimeFlag);
       return true;
     } catch (NotConnectedException _) {
@@ -364,7 +354,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
     finish(status);
   }
 
-  /** Finalizes the insert as a receive failure without sending additional messages. */
+  /** Finalizes the insert as a receiving failure without sending additional messages. */
   private void handleReceiveFailed() {
     finish(CHKInsertSender.RECEIVE_FAILED);
   }
@@ -492,7 +482,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
                       source.getBuildNumber());
                   // Fatal timeout. Something is seriously busted.
                   // We've waited long enough that we know it's not just a connectivity problem - if
-                  // it was we'd have disconnected by now.
+                  // it was, we'd have disconnected by now.
                   source.fatalTimeout();
                 }
 
@@ -545,7 +535,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
 
     if ((sender == null) && (!sentCompletionWasSet) && (canCommit)) {
       // There are no downstream senders, but we stored the data locally, report successful
-      // transfer. Note that this is done even if the verify fails.
+      // transfer. Note that this is done even if the verifying fails.
       m = DMT.createFNPInsertTransfersCompleted(uid, false /* no timeouts */);
     }
 
@@ -711,7 +701,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
         toSend = DMT.createFNPDataInsertRejected(uid, DMT.DATA_INSERT_REJECTED_VERIFY_FAILED);
       } catch (AbortedException e) {
         LOG.error("Receive failed: {}", String.valueOf(e));
-        // Receiver thread (below) will handle sending the failure notice
+        // The receiver thread (below) will handle sending the failure notice
       }
     }
     if (toSend != null) {
@@ -743,23 +733,23 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
     if (LOG.isDebugEnabled()) LOG.debug("Committed");
   }
 
-  /** Has the receive failed? If so, there's not much more that can be done... */
+  /** Has the receiving failed? If so, there's not much more that can be done... */
   private boolean receiveFailed;
 
   private boolean receiveStarted;
   private boolean receiveCompleted;
 
   /**
-   * Runnable that performs the actual block receive for this insert. Executed on the node's
-   * executor so downstream routing can proceed concurrently on the caller thread.
+   * Runnable that performs the actual block receiving for this insert. Executed on the node's
+   * executor, so downstream routing can proceed concurrently on the caller thread.
    */
   public class DataReceiver implements PrioRunnable {
 
     @Override
     public void run() {
       if (LOG.isDebugEnabled()) LOG.debug("Receiving data for {}", CHKInsertHandler.this);
-      // Don't log whether the transfer succeeded or failed as the transfer was initiated by the
-      // source therefore could be unreliable evidence.
+      // Don't log whether the transfer succeeded or failed as the source initiated the transfer,
+      // therefore, could be unreliable evidence.
       br.receive(new DataReceiveCompletion());
     }
 
@@ -795,15 +785,15 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
       // Cancel the sender
       if (sender != null)
         sender.onReceiveFailed(); // tell it to stop if it hasn't already failed... unless
-      // it's sending from store
+      // it's sending it from the store
       runThread.interrupt();
-      tag.timedOutToHandlerButContinued(); // sender is finished, or will be very soon; we
-      // may however be waiting for the sendAborted downstream.
+      tag.timedOutToHandlerButContinued(); // sender is finished or will be very soon; we
+      // may, however, be waiting for the sendAborted downstream.
       Message msg = DMT.createFNPDataInsertRejected(uid, DMT.DATA_INSERT_REJECTED_RECEIVE_FAILED);
       try {
         source.transport().sendSync(msg, CHKInsertHandler.this, realTimeFlag);
       } catch (NotConnectedException ex) {
-        // If they are not connected, that's probably why the receive failed!
+        // If they are not connected, that's probably why the receiving failed!
         if (LOG.isDebugEnabled()) LOG.debug("Can't send {} to {}: {}", msg, source, ex, ex);
       } catch (SyncSendWaitedTooLongException _) {
         LOG.error(TOO_LONG_TO_SEND + PLACEHOLDER_TO_TO, msg, source);
@@ -910,9 +900,9 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
       new BlockReceiverTimeoutHandler() {
 
         /**
-         * We timed out waiting for a block from the request sender. We do not know whether it is
-         * the fault of the request sender or that of some previous node. The PRB will be cancelled,
-         * resulting in all outgoing transfers for this insert being cancelled quickly. If the
+         * We timed-out waiting for a block from the request sender. We do not know whether it is
+         * the fault of the request sender or that of some previous node. The PRB will be canceled,
+         * resulting in all outgoing transfers for this insert being canceled quickly. If the
          * problem occurred on a previous node, we will receive a cancel. So we are consistent with
          * the nodes we routed to, and it is safe to wait for the node that routed to us to send an
          * explicit cancel. We do not need to do anything yet.

--- a/src/main/java/network/crypta/node/CHKInsertSender.java
+++ b/src/main/java/network/crypta/node/CHKInsertSender.java
@@ -22,6 +22,7 @@ import network.crypta.io.xfer.PartiallyReceivedBlock;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKVerifyException;
 import network.crypta.keys.NodeCHK;
+import network.crypta.node.subsystem.NodeRoutingSubsystem.ChkInsertOptions;
 import network.crypta.support.io.NativeThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,9 +33,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This sender performs routing, transmits the {@code DataInsert} payload, and then waits for a
  * terminal outcome from the next hop (e.g., {@code InsertReply}, {@code RouteNotFound}, {@code
- * RejectedOverload}, or {@code RejectedTimeout}). The data transfer proceeds in the background and
+ * RejectedOverload}, or {@code RejectedTimeout}). The data transfer proceeds in the background, and
  * completion is tracked via a dedicated listener. A two‑stage timeout model is used: a first
- * timeout unlocks downstream routing and a second timeout is treated as fatal for the misbehaving
+ * timeout unlocks downstream routing, and a second timeout is treated as fatal for the misbehaving
  * peer.
  *
  * <p>Thread-safety: routing and state transitions are coordinated using the inherited sender lock
@@ -58,18 +59,18 @@ public final class CHKInsertSender extends BaseSender
     BlockTransmitter bt;
 
     /**
-     * Have we received notice of the downstream success or failure of dependant transfers from that
+     * Have we received notice of the downstream success or failure of dependent transfers from that
      * node? Includes timing out.
      */
     boolean receivedCompletionNotice;
 
-    /** Set on fatal timeout or on any non-timeout completion. */
+    /** Set on the fatal timeout or on any non-timeout completion. */
     boolean finishedWaiting;
 
-    /** Was the notification of successful transfer? */
+    /** Was the notification of a successful transfer? */
     boolean completionSucceeded;
 
-    /** True once the payload stream to the peer finishes (success or failure). */
+    /** True, once the payload stream to the peer finishes (success or failure). */
     boolean completedTransfer;
 
     /** Whether an {@code InsertReply}, RNF, or similar completion has been received. */
@@ -125,7 +126,7 @@ public final class CHKInsertSender extends BaseSender
     /**
      * Starts waiting for an acknowledgement or timeout.
      *
-     * <p>Preconditions: the data transfer to the peer succeeded and an RNF/InsertReply (or
+     * <p>Preconditions: the data transfer to the peer succeeded, and an RNF/InsertReply (or
      * equivalent) has been observed. The timeout is relative to this point to avoid counting time
      * spent routing.
      */
@@ -264,7 +265,7 @@ public final class CHKInsertSender extends BaseSender
         finishedWaiting = true;
         return new NoticeOutcome(false, false);
       }
-      // First timeout but not yet fatal: unlock downstream and wait for fatal timeout.
+      // First timeout but not yet fatal: unlock downstream and wait for the fatal timeout.
       // Safe to call the tag within the lock since UIDTag is taken last.
       thisTag.handlingTimeout(pn);
       return new NoticeOutcome(true, false);
@@ -312,7 +313,7 @@ public final class CHKInsertSender extends BaseSender
           "Timed out waiting for a final ack from: {} on {}", pn, this, new Exception("debug"));
       if (receivedNotice(false, true, false)) {
         pn.localRejectedOverload("InsertTimeoutNoFinalAck", realTimeFlag);
-        // First timeout. Wait for second timeout.
+        // First timeout. Wait for the second timeout.
         try {
           node.network()
               .usm()
@@ -375,27 +376,21 @@ public final class CHKInsertSender extends BaseSender
       NodeCHK myKey,
       long uid,
       InsertTag tag,
-      byte[] headers,
       short htl,
       PeerNode source,
       Node node,
-      PartiallyReceivedBlock prb,
-      boolean fromStore,
-      boolean forkOnCacheable,
-      boolean preferInsert,
-      boolean ignoreLowBackoff,
-      boolean realTimeFlag) {
-    super(myKey, realTimeFlag, source, node, htl, uid);
+      ChkInsertOptions opts) {
+    super(myKey, opts.realTimeFlag, source, node, htl, uid);
     this.origUID = uid;
     this.origTag = tag;
-    this.headers = headers;
-    this.prb = prb;
-    this.fromStore = fromStore;
+    this.headers = opts.headers;
+    this.prb = opts.prb;
+    this.fromStore = opts.fromStore;
     this.backgroundTransfers = new ArrayList<>();
-    this.forkOnCacheable = forkOnCacheable;
-    this.preferInsert = preferInsert;
-    this.ignoreLowBackoff = ignoreLowBackoff;
-    if (realTimeFlag) {
+    this.forkOnCacheable = opts.forkOnCacheable;
+    this.preferInsert = opts.preferInsert;
+    this.ignoreLowBackoff = opts.ignoreLowBackoff;
+    if (opts.realTimeFlag) {
       transferCompletionTimeout = TRANSFER_COMPLETION_ACK_TIMEOUT_REALTIME;
     } else {
       transferCompletionTimeout = TRANSFER_COMPLETION_ACK_TIMEOUT_BULK;
@@ -653,7 +648,7 @@ public final class CHKInsertSender extends BaseSender
   private void handleRejectedTimeout(Message msg, PeerNode next) {
     // Some severe lag problem.
     // However, it is not fatal because we can be confident now that even if the DataInsert
-    // is delivered late, it will not be acted on. I.e. we are certain how many requests
+    // is delivered late, it will not be acted on. I.e., we are certain how many requests
     // are running, which is what fatal timeouts are designed to deal with.
     LOG.warn(
         "Node timed out waiting for our DataInsert ({} from {}) after Accepted in insert - treating"
@@ -670,10 +665,10 @@ public final class CHKInsertSender extends BaseSender
   }
 
   /**
-   * @return True if fatal i.e. we should try another node.
+   * @return True if fatal, i.e., we should try another node.
    */
   private boolean handleRejectedOverload(Message msg, PeerNode next) {
-    // Probably non-fatal, if so, we have time left, can try next one
+    // Probably non-fatal, if so, we have time left, can try the next one
     if (msg.getBoolean(DMT.IS_LOCAL)) {
       next.localRejectedOverload("ForwardRejectedOverload6", realTimeFlag);
       if (LOG.isDebugEnabled()) LOG.debug("Local RejectedOverload, moving on to next peer");
@@ -745,7 +740,7 @@ public final class CHKInsertSender extends BaseSender
     try {
       if (prb.allReceived()) {
         // Probably caused by transient connectivity problems.
-        // Only fatal timeouts warrant ERROR's because they indicate something seriously wrong
+        // Only fatal timeouts warrant ERROR because they indicate something seriously wrong
         // that didn't result in a disconnection, and because they cause disconnections.
         LOG.warn("Received all data but send failed to {}", next);
       } else {
@@ -768,7 +763,7 @@ public final class CHKInsertSender extends BaseSender
    *
    * @param next peer from which an early outcome is expected
    * @param acceptedTimeout timeout (ms) for awaiting the outcome
-   * @param tag current routing tag carrying the UID; may differ when forking
+   * @param tag the current routing tag carrying the UID; may differ when forking
    * @return a configured {@link MessageFilter}
    */
   @Override
@@ -816,8 +811,8 @@ public final class CHKInsertSender extends BaseSender
   @Override
   protected void handleAcceptedRejectedTimeout(final PeerNode next, final UIDTag tag) {
     // It could still be running. So the timeout is fatal to the node.
-    // This is a WARNING not an ERROR because it's possible that the problem is we simply haven't
-    // been able to send the message yet, because we don't use sendSync().
+    // This is a WARNING, not an ERROR because it's possible that the problem is we simply haven't
+    // been able to send the message yet because we don't use sendSync().
     LOG.warn("Timeout awaiting Accepted/Rejected {} to {}", this, next);
     // Use the right UID here, in case we fork.
     final long uid = tag.uid;
@@ -848,7 +843,7 @@ public final class CHKInsertSender extends BaseSender
                           CHKInsertSender.this);
                     // We are not going to send the DataInsert.
                     // We have moved on, and we don't want inserts to fork unnecessarily.
-                    // However, we need to send a DataInsertRejected, or two-stage timeout will
+                    // However, we need to send a DataInsertRejected, or a two-stage timeout will
                     // happen.
                     sendTimeoutRejectedAfterAccepted(next, tag, uid);
                   } else {
@@ -1064,7 +1059,7 @@ public final class CHKInsertSender extends BaseSender
     return true;
   }
 
-  /** Called by CHKInsertHandler to notify that the receive has failed. */
+  /** Called by CHKInsertHandler to notify that the receiving has failed. */
   public void onReceiveFailed() {
     if (LOG.isDebugEnabled()) LOG.debug("Receive failed on {}", this);
     synchronized (backgroundTransfers) {
@@ -1082,7 +1077,7 @@ public final class CHKInsertSender extends BaseSender
       allTransfersCompleted = true;
       notifyAll();
     }
-    // Do not call finish(), that can only be called on the main thread and it will block.
+    // Do not call finish(), that can only be called on the main thread, and it will block.
   }
 
   /**
@@ -1147,7 +1142,7 @@ public final class CHKInsertSender extends BaseSender
           backgroundTransfers.wait(SECONDS.toMillis(100));
         } catch (InterruptedException _) {
           // Record and break out so higher-level shutdown paths can react promptly.
-          // Re-assert interrupt here to satisfy static analysis and preserve signal.
+          // Re-assert interrupt here to satisfy static analysis and preserve the signal.
           Thread.currentThread().interrupt();
           // We'll exit the loop and return promptly; callers can decide how to react.
           interrupted = true;
@@ -1211,8 +1206,8 @@ public final class CHKInsertSender extends BaseSender
   }
 
   /**
-   * Returns the header bytes that accompany the block; callers historically used this as a
-   * public‑key hash.
+   * Returns the header bytes that go with the block; callers historically used this as a public‑key
+   * hash.
    *
    * @return header bytes (non-null)
    */
@@ -1223,7 +1218,7 @@ public final class CHKInsertSender extends BaseSender
   /**
    * Waits up to {@code millis} for the sender to transition out of {@link #NOT_FINISHED}.
    *
-   * <p>Thread-safety: uses the sender's intrinsic monitor which is also used for notify/notifyAll
+   * <p>Thread-safety: uses the sender's intrinsic monitor, which is also used for notify/notifyAll
    * in this class. Callers should not synchronize on the sender instance directly; use this helper
    * instead to avoid synchronizing on parameters.
    */
@@ -1237,7 +1232,7 @@ public final class CHKInsertSender extends BaseSender
           try {
             this.wait(0); // indefinite wait
           } catch (InterruptedException _) {
-            // See rationale above: ignore to avoid busy-spin in polling callers.
+            // See the rationale above: ignore to avoid busy-spin in polling callers.
           }
         }
         return;
@@ -1257,7 +1252,7 @@ public final class CHKInsertSender extends BaseSender
             this.wait(waitMillis, waitNanos);
           }
         } catch (InterruptedException _) {
-          // Intentionally swallow interrupts here so callers that poll using wait/notify
+          // Intentionally swallow interrupts here, so callers that poll using wait/notify
           // do not busy-spin with an already-set interrupt flag. Shutdown/cancellation paths
           // may interrupt these threads; we still prefer to wait for a terminal status.
         }
@@ -1512,7 +1507,7 @@ public final class CHKInsertSender extends BaseSender
       return;
     } catch (SyncSendWaitedTooLongException _) {
       LOG.error("Unable to send {} to {} in a reasonable time", dataInsert, next);
-      // Other side will fail. No need to do anything.
+      // Another side will fail. No need to do anything.
       next.noLongerRoutingTo(thisTag, false);
       routeRequests();
       return;

--- a/src/main/java/network/crypta/node/CHKInsertSender.java
+++ b/src/main/java/network/crypta/node/CHKInsertSender.java
@@ -15,6 +15,7 @@ import network.crypta.io.comm.NotConnectedException;
 import network.crypta.io.comm.PeerContext;
 import network.crypta.io.comm.SlowAsyncMessageFilterCallback;
 import network.crypta.io.xfer.AbortedException;
+import network.crypta.io.xfer.BlockTransferContext;
 import network.crypta.io.xfer.BlockTransmitter;
 import network.crypta.io.xfer.BlockTransmitter.BlockTransmitterCompletion;
 import network.crypta.io.xfer.PartiallyReceivedBlock;
@@ -88,12 +89,14 @@ public final class CHKInsertSender extends BaseSender
       this.thisTag = thisTag;
       bt =
           new BlockTransmitter(
-              node.network().usm(),
-              node.network().ticker(),
-              pn,
-              uid,
-              prb,
-              CHKInsertSender.this,
+              new BlockTransferContext(
+                  node.network().usm(),
+                  node.network().ticker(),
+                  pn,
+                  uid,
+                  prb,
+                  CHKInsertSender.this,
+                  realTimeFlag),
               BlockTransmitter.NEVER_CASCADE,
               new BlockTransmitterCompletion() {
 
@@ -116,7 +119,6 @@ public final class CHKInsertSender extends BaseSender
                   }
                 }
               },
-              realTimeFlag,
               node.network().stats());
     }
 

--- a/src/main/java/network/crypta/node/FailureTable.java
+++ b/src/main/java/network/crypta/node/FailureTable.java
@@ -10,6 +10,7 @@ import network.crypta.io.comm.ByteCounter;
 import network.crypta.io.comm.DMT;
 import network.crypta.io.comm.Message;
 import network.crypta.io.comm.NotConnectedException;
+import network.crypta.io.xfer.BlockTransferContext;
 import network.crypta.io.xfer.BlockTransmitter;
 import network.crypta.io.xfer.PartiallyReceivedBlock;
 import network.crypta.keys.CHKBlock;
@@ -30,7 +31,7 @@ import org.slf4j.LoggerFactory;
 // authenticated using an HMAC carried with the offer.
 
 // LOCKING: Always take the FailureTable lock first if you need both. Take the
-// FailureTableEntry lock only for cheap internal operations to avoid deadlocks.
+// FailureTableEntry lock only for inexpensive internal operations to avoid deadlocks.
 
 /**
  * Maintains recent failures and lightweight interest for keys to improve routing and enable
@@ -69,14 +70,14 @@ public class FailureTable {
 
   /**
    * Terminate a request if there was a DNF on the same key less than this time ago. Maximum time
-   * for any FailureTable i.e. for this period after a DNF, we will avoid the node that DNFed.
+   * for any FailureTable i.e., for this period after a DNF, we will avoid the node that DNFed.
    */
   static final long REJECT_TIME = MINUTES.toMillis(3);
 
   static final long REJECT_TIME_BEFORE_BUILD_1498 = MINUTES.toMillis(5);
 
   /**
-   * Maximum time for a RecentlyFailed. I.e. until this period expires, we take a request into
+   * Maximum time for a RecentlyFailed. I.e., until this period expires, we take a request into
    * account when deciding whether we have recently failed to this peer. If we get a DNF, we use
    * this figure. If we get an RF, we use what it tells us, which can be less than this. Most other
    * failures use shorter periods.
@@ -131,7 +132,7 @@ public class FailureTable {
    * @param key the requested key (non-null)
    * @param routedTo the peer that failed for this attempt
    * @param htl the HTL at the time of failure
-   * @param rfTimeout recently-failed window in milliseconds; clamped to {@link
+   * @param rfTimeout recently failed window in milliseconds; clamped to {@link
    *     #RECENTLY_FAILED_TIME}
    * @param ftTimeout refusal window in milliseconds; clamped to {@link #REJECT_TIME}
    */
@@ -179,14 +180,14 @@ public class FailureTable {
    * is not lost. Locking: Never synchronize on {@link PeerNode} before calling this method.
    *
    * @param key the requested key (non-null)
-   * @param routedTo the peer that failed the request, or {@code null}
+   * @param routedTo the peer that failed the request or {@code null}
    * @param htl the HTL at failure
    * @param origHTL the original HTL at request creation (used for offer decisions)
-   * @param rfTimeout recently-failed window in milliseconds; clamped to {@link
+   * @param rfTimeout recently failed window in milliseconds; clamped to {@link
    *     #RECENTLY_FAILED_TIME}
    * @param ftTimeout refusal window in milliseconds; {@code -1} is a no-op; otherwise clamped to
    *     {@link #REJECT_TIME}
-   * @param requestor the peer that originated the request, or {@code null}
+   * @param requestor the peer that originated the request or {@code null}
    */
   public void onFinalFailure(
       Key key,
@@ -434,7 +435,7 @@ public class FailureTable {
     // NB: node.storage().hasKey() executes a datastore fetch
     // If we have the key in the datastore (store or cache), we don't want it.
     // If we have the key in the client cache, we might want it for other nodes,
-    // although hopefully the client layer was tripped when we got it.
+    // although hopefully, the client layer was tripped when we got it.
     if (node.storage().hasKey(key, false, true)) {
       LOG.debug("Already have key");
       return;
@@ -466,14 +467,14 @@ public class FailureTable {
      * Not relevant with CHKs anyway.
      *
      * On the plus side, propagation to nodes that have asked is worthwhile because reduced polling
-     * cost enables more secure messaging systems e.g. outbox polling...
+     * cost enables more secure messaging systems e.g., outbox polling...
      * - Social engineering: If a key is unpopular, you can put a different copy of it on different
-     * nodes. You can then use this to trace the requestor - identify that he is or isn't on the target.
+     * nodes. You can then use this to trace the requestor - to identify that he is or isn't on the target.
      * You can't do this with a regular insert because it will often go several nodes even at htl 0.
      * With subscriptions, you might be able to bypass this - but only if you know no other nodes in the
-     * neighbourhood are subscribed. Easier with SSKs; with CHKs you have only binary information of
+     * neighborhood are subscribed. Easier with SSKs; with CHKs you have only binary information of
      * whether the person got the key (with social engineering). Hard to exploit on darknet; if you're
-     * that close to the suspect there are easier ways to get at them e.g. correlation attacks.
+     * that close to the suspect, there are easier ways to get at them, e.g., correlation attacks.
      *
      * Conclusion: We should accept the request if:
      * - We asked for it from that node. (Note that a node might both have asked us and been asked).
@@ -493,7 +494,7 @@ public class FailureTable {
 
     // Valid offer.
 
-    // Add to offers list
+    // Add to the offers list
 
     synchronized (blockOfferListByKey) {
       if (LOG.isDebugEnabled()) LOG.debug("Valid offer");
@@ -523,7 +524,7 @@ public class FailureTable {
         if (blockOfferListByKey.isEmpty()) return;
         BlockOfferList bl = blockOfferListByKey.peekValue();
         if (bl == null) {
-          // Defensive: map reported non-empty but has no head value; drop head key.
+          // Defensive: the map reported non-empty but has no head value; drop the head key.
           blockOfferListByKey.popKey();
           continue;
         }
@@ -562,7 +563,7 @@ public class FailureTable {
    * @param needPubKey whether to send the publisher key (SSK only)
    * @param uid the per-request UID used on the wire
    * @param source the requesting peer
-   * @param tag unlock handler associated with this send
+   * @param tag unlock the handler associated with this sending
    * @param realTimeFlag whether to mark payload packets as realtime
    * @throws NotConnectedException if the sender is no longer connected
    */
@@ -592,7 +593,7 @@ public class FailureTable {
   }
 
   /**
-   * Implements the send logic on the {@link #offerExecutor} thread.
+   * Implements the sending logic on the {@link #offerExecutor} thread.
    *
    * <p>Performs datastore fetches and emits the appropriate DMT messages. Network sends that may
    * block are delegated to the node executor.
@@ -602,7 +603,7 @@ public class FailureTable {
    * @param needPubKey whether to include the publisher key (SSK only)
    * @param uid the per-request UID used on the wire
    * @param source the requesting peer
-   * @param tag unlock handler associated with this send
+   * @param tag unlock the handler associated with this sending
    * @param realTimeFlag whether to mark payload packets as realtime
    * @throws NotConnectedException if the sender is no longer connected
    */
@@ -682,15 +683,16 @@ public class FailureTable {
           new PartiallyReceivedBlock(Node.PACKETS_IN_BLOCK, Node.PACKET_SIZE, block.getRawData());
       final BlockTransmitter bt =
           new BlockTransmitter(
-              node.network().usm(),
-              node.network().ticker(),
-              source,
-              uid,
-              prb,
-              senderCounter,
+              new BlockTransferContext(
+                  node.network().usm(),
+                  node.network().ticker(),
+                  source,
+                  uid,
+                  prb,
+                  senderCounter,
+                  realTimeFlag),
               BlockTransmitter.NEVER_CASCADE,
-              success -> tag.unlockHandler(),
-              realTimeFlag,
+              _ -> tag.unlockHandler(),
               node.network().stats());
       node.network()
           .executor()
@@ -798,7 +800,7 @@ public class FailureTable {
       lastOffer = null;
     }
 
-    /** Releases the claim on the last returned offer without deleting it so it may be retried. */
+    /** Releases the claim on the last returned offer without deleting it, so it may be retried. */
     public void keepLastOffer() {
       lastOffer = null;
     }

--- a/src/main/java/network/crypta/node/InsertHandlerContext.java
+++ b/src/main/java/network/crypta/node/InsertHandlerContext.java
@@ -1,0 +1,21 @@
+package network.crypta.node;
+
+/**
+ * Shared context for insert handlers derived from the original request.
+ *
+ * @param node node owning the handler
+ * @param source upstream peer that initiated the insert
+ * @param uid unique insert identifier
+ * @param startTime timestamp in milliseconds when the handler was scheduled
+ * @param tag insert tag guarding UID lifecycle for this request
+ * @param routingOptions routing option snapshot for the insert
+ * @param realTimeFlag whether the request should be treated as real-time traffic
+ */
+public record InsertHandlerContext(
+    Node node,
+    PeerNode source,
+    long uid,
+    long startTime,
+    InsertTag tag,
+    InsertRoutingOptions routingOptions,
+    boolean realTimeFlag) {}

--- a/src/main/java/network/crypta/node/InsertRoutingOptions.java
+++ b/src/main/java/network/crypta/node/InsertRoutingOptions.java
@@ -1,0 +1,15 @@
+package network.crypta.node;
+
+/**
+ * Immutable insert routing option bundle derived from optional submessages.
+ *
+ * <p>Each flag mirrors a dedicated submessage and defaults to {@link Node} constants when the
+ * submessage is absent. The values are captured once per request to keep the scheduling logic
+ * simple and avoid repeated message parsing.
+ *
+ * @param preferInsert true when the peer prefers insert routing over fetch-friendly behavior
+ * @param ignoreLowBackoff true when low-backoff suppression should be bypassed
+ * @param forkOnCacheable true when cacheable inserts are allowed to fork
+ */
+public record InsertRoutingOptions(
+    boolean preferInsert, boolean ignoreLowBackoff, boolean forkOnCacheable) {}

--- a/src/main/java/network/crypta/node/NodeDataRequestHandler.java
+++ b/src/main/java/network/crypta/node/NodeDataRequestHandler.java
@@ -55,7 +55,7 @@ final class NodeDataRequestHandler {
   private static final String LOG_ALREADY_RUNNING =
       "Lock contention for id {}; reject (already running)";
 
-  /** Owning node used for network, routing, and storage dependencies. */
+  /** The owning node used for network, routing, and storage dependencies. */
   private final Node node;
 
   /**
@@ -101,7 +101,7 @@ final class NodeDataRequestHandler {
         @Override
         public int getPriority() {
           // Slightly less than the actual requests themselves because accepting requests increases
-          // load.
+          // loads.
           return NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1;
         }
 
@@ -125,8 +125,9 @@ final class NodeDataRequestHandler {
           nodeStats.reportIncomingRequestLocation(key.toNormalizedDouble());
 
           boolean needsPubKey = key instanceof NodeSSK && m.getBoolean(DMT.NEED_PUB_KEY);
-          RequestHandler rh =
-              new RequestHandler(source, id, node, htl, key, tag, block, realTimeFlag, needsPubKey);
+          RequestHandlerContext context =
+              RequestHandlerContext.of(node, source, id, htl, key, tag, realTimeFlag);
+          RequestHandler rh = new RequestHandler(context, block, needsPubKey);
           rh.receivedBytes(m.receivedByteCount());
           node.network()
               .executor()
@@ -247,7 +248,7 @@ final class NodeDataRequestHandler {
    * not start background processing; callers should invoke {@link #start(NodeStats)} after the node
    * executor and statistics subsystem are available.
    *
-   * @param node owning node that provides routing, network, and storage subsystems; must be
+   * @param node The owning node that provides routing, network, and storage subsystems; must be
    *     non-null
    */
   NodeDataRequestHandler(Node node) {
@@ -317,7 +318,7 @@ final class NodeDataRequestHandler {
    * <p>The rejection is sent asynchronously to the message source. If the peer disconnects before
    * sending, the rejection is silently ignored as the request is already invalid.
    *
-   * @param m request message being rejected; used to obtain UID and source peer
+   * @param m request message being rejected; used to get UID and source peer
    * @param ctr byte counter used for accounting of the rejection message on the wire
    */
   private void rejectRequest(Message m, ByteCounter ctr) {

--- a/src/main/java/network/crypta/node/NodeInsertRequestHandler.java
+++ b/src/main/java/network/crypta/node/NodeInsertRequestHandler.java
@@ -53,10 +53,10 @@ final class NodeInsertRequestHandler {
   private static final String LOG_ALREADY_RUNNING =
       "Lock contention for id {}; reject (already running)";
 
-  /** Owning node used for routing, network, and storage interactions. */
+  /** The owning node used for routing, network, and storage interactions. */
   private final Node node;
 
-  /** UID tracker for insert de-duplication and lifecycle bookkeeping. */
+  /** UID tracker for insert deduplication and lifecycle bookkeeping. */
   private final RequestTracker tracker;
 
   /** Current statistics instance used for overload checks and counters. */
@@ -82,7 +82,7 @@ final class NodeInsertRequestHandler {
    *
    * <p>This is a lightweight setter used when the networking subsystem swaps or initializes the
    * stats component. It is expected to be called during node startup and does not retroactively
-   * affect in-flight insert handlers; only subsequent admissions use the new reference.
+   * affect in-flight insert handlers; only later admissions use the new reference.
    *
    * @param stats active statistics instance; must be non-null for admission decisions
    */
@@ -116,7 +116,7 @@ final class NodeInsertRequestHandler {
 
   /**
    * Handle an incoming insert. We should parse it and determine whether it is valid before we
-   * accept it. However, in the case of inserts it *IS* possible for the request sender to cause it
+   * accept it. However, in the case of inserts, it *IS* possible for the request sender to cause it
    * to fail later during the receiving of the data or the DataInsert.
    *
    * @param m The incoming message.
@@ -131,11 +131,20 @@ final class NodeInsertRequestHandler {
     InsertTag tag = new InsertTag(isSSK, InsertTag.START.REMOTE, source, realTimeFlag, id, node);
     if (rejectAlreadyRunningInsert(id, isSSK, source, ctr, tag)) return;
 
-    InsertOptions opts = parseInsertOptions(m);
+    InsertRoutingOptions opts = parseInsertOptions(m);
     // SSKs don't fix bwlimitDelayTime so shouldn't be accepted when overloaded.
     RejectReason rejectReason =
         nodeStats.shouldRejectRequest(
-            !isSSK, true, isSSK, false, false, source, false, opts.preferInsert, realTimeFlag, tag);
+            !isSSK,
+            true,
+            isSSK,
+            false,
+            false,
+            source,
+            false,
+            opts.preferInsert(),
+            realTimeFlag,
+            tag);
     if (rejectReason != null) {
       LOG.info("Reject insert preemptively (peer={}, reason={})", source.getPeer(), rejectReason);
       Message rejected = DMT.createFNPRejectedOverload(id, true);
@@ -168,7 +177,7 @@ final class NodeInsertRequestHandler {
    * @param isSSK whether the insert targets an SSK key (otherwise CHK)
    * @param source upstream peer to notify when rejection is required
    * @param ctr byte counter used to attribute rejection overhead
-   * @param tag insert tag representing the UID lifecycle for this request
+   * @param tag the insert tag representing the UID lifecycle for this request
    * @return {@code true} if the insert was rejected due to a duplicate UID
    */
   private boolean rejectAlreadyRunningInsert(
@@ -188,30 +197,16 @@ final class NodeInsertRequestHandler {
   }
 
   /**
-   * Immutable insert option bundle derived from optional submessages.
-   *
-   * <p>Each flag mirrors a dedicated submessage and defaults to {@link Node} constants when the
-   * submessage is absent. The values are captured once per request to keep scheduling logic simple
-   * and avoid repeated message parsing.
-   *
-   * @param preferInsert true when the peer prefers insert routing over fetch-friendly behavior
-   * @param ignoreLowBackoff true when low-backoff suppression should be bypassed
-   * @param forkOnCacheable true when cacheable inserts are allowed to fork
-   */
-  private record InsertOptions(
-      boolean preferInsert, boolean ignoreLowBackoff, boolean forkOnCacheable) {}
-
-  /**
    * Parses insert option submessages into a consolidated option record.
    *
    * <p>Each option is optional and, when absent, falls back to the node defaults. This method does
    * not validate option consistency and performs no side effects beyond reading the message; it is
    * safe to call multiple times but is typically invoked once per request.
    *
-   * @param m insert request message that may carry option submessages
+   * @param m the insert request message that may carry option submessages
    * @return immutable option snapshot representing defaults plus any overrides present
    */
-  private InsertOptions parseInsertOptions(Message m) {
+  private InsertRoutingOptions parseInsertOptions(Message m) {
     boolean preferInsert = Node.PREFER_INSERT_DEFAULT;
     boolean ignoreLowBackoff = Node.IGNORE_LOW_BACKOFF_DEFAULT;
     boolean forkOnCacheable = Node.FORK_ON_CACHEABLE_DEFAULT;
@@ -222,7 +217,7 @@ final class NodeInsertRequestHandler {
     if (lowBackoff != null) ignoreLowBackoff = lowBackoff.getBoolean(DMT.IGNORE_LOW_BACKOFF);
     Message preference = m.getSubMessage(DMT.FNPSubInsertPreferInsert);
     if (preference != null) preferInsert = preference.getBoolean(DMT.PREFER_INSERT);
-    return new InsertOptions(preferInsert, ignoreLowBackoff, forkOnCacheable);
+    return new InsertRoutingOptions(preferInsert, ignoreLowBackoff, forkOnCacheable);
   }
 
   /**
@@ -246,8 +241,10 @@ final class NodeInsertRequestHandler {
       long id,
       boolean realTimeFlag,
       InsertTag tag,
-      InsertOptions opts) {
+      InsertRoutingOptions opts) {
     long now = System.currentTimeMillis();
+    InsertHandlerContext context =
+        new InsertHandlerContext(node, source, id, now, tag, opts, realTimeFlag);
     if (m.getSpec().equals(DMT.FNPSSKInsertRequest)) {
       NodeSSK key = (NodeSSK) m.getObject(DMT.FREENET_ROUTING_KEY);
       byte[] data = ((ShortBuffer) m.getObject(DMT.DATA)).getData();
@@ -256,20 +253,7 @@ final class NodeInsertRequestHandler {
       if (htl <= 0) htl = 1;
       SSKInsertHandler rh =
           new SSKInsertHandler(
-              key,
-              data,
-              headers,
-              htl,
-              source,
-              id,
-              node,
-              now,
-              tag,
-              node.routing().canWriteDatastoreInsert(htl),
-              opts.forkOnCacheable,
-              opts.preferInsert,
-              opts.ignoreLowBackoff,
-              realTimeFlag);
+              key, data, headers, htl, context, node.routing().canWriteDatastoreInsert(htl));
       rh.receivedBytes(m.receivedByteCount());
       node.network()
           .executor()
@@ -280,20 +264,7 @@ final class NodeInsertRequestHandler {
       if (htl <= 0) htl = 1;
       SSKInsertHandler rh =
           new SSKInsertHandler(
-              key,
-              null,
-              null,
-              htl,
-              source,
-              id,
-              node,
-              now,
-              tag,
-              node.routing().canWriteDatastoreInsert(htl),
-              opts.forkOnCacheable,
-              opts.preferInsert,
-              opts.ignoreLowBackoff,
-              realTimeFlag);
+              key, null, null, htl, context, node.routing().canWriteDatastoreInsert(htl));
       rh.receivedBytes(m.receivedByteCount());
       node.network()
           .executor()
@@ -302,19 +273,7 @@ final class NodeInsertRequestHandler {
       NodeCHK key = (NodeCHK) m.getObject(DMT.FREENET_ROUTING_KEY);
       short htl = m.getShort(DMT.HTL);
       if (htl <= 0) htl = 1;
-      CHKInsertHandler rh =
-          new CHKInsertHandler(
-              key,
-              htl,
-              source,
-              id,
-              node,
-              now,
-              tag,
-              opts.forkOnCacheable,
-              opts.preferInsert,
-              opts.ignoreLowBackoff,
-              realTimeFlag);
+      CHKInsertHandler rh = new CHKInsertHandler(key, htl, context);
       rh.receivedBytes(m.receivedByteCount());
       node.network()
           .executor()

--- a/src/main/java/network/crypta/node/RequestHandler.java
+++ b/src/main/java/network/crypta/node/RequestHandler.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * node references) and ensures final bookkeeping and slot release.
  *
  * <p>Threading: callbacks invoked by I/O subsystems may occur off the handler thread; methods that
- * record final outcomes ensure idempotent cleanup.
+ * record outcomes ensure idempotent cleanup.
  */
 public class RequestHandler
     implements PrioRunnable, HighHtlAware, ByteCounter, RequestSenderListener {
@@ -66,8 +66,8 @@ public class RequestHandler
       if (current != null && current.uid != RequestHandler.this.uid) {
         if (LOG.isDebugEnabled())
           LOG.debug("Do not cancel transfer; coalesced on {}", RequestHandler.this);
-        // No need to reassign tag since this UID will end immediately; the RequestSender is on a
-        // different one.
+        // No need to reassign the tag since this UID will end immediately; the RequestSender is on
+        // different.
         return false;
       }
       if (node.storage().hasKey(key, false, false)) return true; // Don't want it
@@ -156,35 +156,21 @@ public class RequestHandler
   /**
    * Creates a handler for a single incoming request.
    *
-   * @param source the upstream peer that sent the request to this node
-   * @param id unique request identifier (UID) assigned by the sender
-   * @param n the local {@link Node} that will coordinate the request
-   * @param htl hop-to-live value for the request (routing depth remaining)
-   * @param key the {@link Key} being requested (CHK or SSK)
-   * @param tag tracking tag used for accounting, slot management, and completion callbacks
+   * @param context request metadata including routing and accounting state
    * @param passedInKeyBlock if non-null, the block already fetched from the datastore to be
    *     returned locally; We ALWAYS look up in the datastore before starting a request. SECURITY:
-   *     Do not pass messages into handler constructors. See note at top of NodeDispatcher.
-   * @param realTimeFlag whether this request should use real-time prioritization
+   *     Do not pass messages into handler constructors. See the note at the top of NodeDispatcher.
    * @param needsPubKey whether an SSK response should include the publisher's public key
    */
   public RequestHandler(
-      PeerNode source,
-      long id,
-      Node n,
-      short htl,
-      Key key,
-      RequestTag tag,
-      KeyBlock passedInKeyBlock,
-      boolean realTimeFlag,
-      boolean needsPubKey) {
-    node = n;
-    uid = id;
-    this.realTimeFlag = realTimeFlag;
-    this.source = source;
-    this.htl = htl;
-    this.tag = tag;
-    this.key = key;
+      RequestHandlerContext context, KeyBlock passedInKeyBlock, boolean needsPubKey) {
+    node = context.node();
+    uid = context.uid();
+    this.realTimeFlag = context.realTimeFlag();
+    this.source = context.source();
+    this.htl = context.htl();
+    this.tag = context.tag();
+    this.key = context.key();
     this.passedInKeyBlock = passedInKeyBlock;
     this.needsPubKey = needsPubKey;
   }
@@ -340,7 +326,7 @@ public class RequestHandler
         // being false. (!IS_LOCAL)->!Terminal
         Message msg = DMT.createFNPRejectedOverload(uid, false);
         source.transport().sendAsync(msg, null, this);
-        // If the status changes (e.g. to SUCCESS), there is little need to send yet another reject
+        // If the status changes (e.g., to SUCCESS), there is little need to send yet another reject
         // overload.
         sentRejectedOverload = true;
       }
@@ -534,7 +520,7 @@ public class RequestHandler
               return rl == null ? "null" : rl.shortToString();
             })
         .log();
-    // We need to send the RejectedOverload (or whatever) anyway, for two-stage timeout.
+    // We need to send the RejectedOverload (or whatever) anyway, for a two-stage timeout.
     // Otherwise, the downstream node will assume it's our fault.
   }
 
@@ -565,7 +551,7 @@ public class RequestHandler
       RequestSender.TIMED_OUT,
       RequestSender.INTERNAL_ERROR:
         {
-          // Locally generated. Propagate back to source who needs to reduce send rate
+          // Locally generated. Propagate back to the source who needs to reduce send rate
           // @bug: we may not want to translate fatal timeouts into non-fatal timeouts.
           Message reject = DMT.createFNPRejectedOverload(uid, true);
           sendTerminal(reject);
@@ -647,7 +633,8 @@ public class RequestHandler
       else if (bt == null) {
         // Bug! This is impossible!
         LOG.error("Status {} but no transfer started for {}", status, uid);
-        // Obviously this node is confused, send a terminal reject to make sure the requestor is not
+        // Obviously, this node is confused, send a terminal reject to make sure the requestor is
+        // not
         // waiting forever.
         reject = DMT.createFNPRejectedOverload(uid, true);
       } else {
@@ -683,18 +670,19 @@ public class RequestHandler
             // As soon as the originator receives the messages, he can reuse the slot.
             // Unlocking on sent is a reasonable compromise between:
             // 1. Unlocking immediately avoids problems with the recipient reusing the slot when
-            // he's received the data, therefore us rejecting the request and getting a mandatory
+            // he's received the data, therefore, us rejecting the request and getting a mandatory
             // backoff, and
             // 2. However, we do want SSK requests from the datastore to be counted towards the
             // total when accepting requests.
             // This is safe, however.
-            // We have already done the request so there is no outgoing request.
+            // We have already done the request, so there is no outgoing request.
             // A node might be able to get a few more slots in flight by not acking the SSK
             // messages, but it would quickly stall.
-            // Furthermore, we would start sending hard rejections when the send queue gets past a
+            // Furthermore, we would start sending hard rejections when the sending queue gets past
+            // a
             // certain point.
             // So it is neither beneficial for the node nor a viable DoS.
-            // Alternative solution would be to wait until the pubkey and data have been acked
+            // An alternative solution would be to wait until the pubkey and data have been acked
             // before unlocking and sending the headers, but this appears not to be necessary.
             tag.unlockHandler();
           }
@@ -808,14 +796,14 @@ public class RequestHandler
       throw new IllegalStateException("sendTerminal should only be called once");
     else sendTerminalCalled = true;
 
-    // Unlock handler immediately.
+    // Unlock the handler immediately.
     // Otherwise, the request sender will think the slot is free as soon as it
     // receives it, but we won't, so we may reject his requests and get a mandatory backoff.
     tag.unlockHandler();
     try {
       source.transport().sendAsync(msg, new TerminalMessageByteCountCollector(), this);
     } catch (NotConnectedException _) {
-      // Will have called the callback, so caller doesn't need to worry about it.
+      // Will have called the callback, so the caller doesn't need to worry about it.
     }
   }
 
@@ -891,7 +879,7 @@ public class RequestHandler
 
   /**
    * There is no noderef to pass downstream. If we want a connection, send our noderef and wait for
-   * a reply, otherwise just send an ack.
+   * a reply, otherwise send an ack.
    */
   private void finishOpennetNoRelay() {
     OpennetManager om = node.network().opennet();
@@ -904,7 +892,7 @@ public class RequestHandler
   }
 
   /**
-   * Acknowledge the opennet path folding attempt without sending a reference. Once the send
+   * Acknowledge the opennet path folding attempt without sending a reference. Once the sending
    * completes (asynchronously), unlock everything.
    */
   private void ackOpennet() {
@@ -1035,8 +1023,8 @@ public class RequestHandler
   }
 
   /**
-   * Called when the node we routed the request to returned a valid noderef, and we don't want it.
-   * So we relay it downstream to somebody who does, and wait to relay the response back upstream.
+   * Called when the node we routed the request to return a valid noderef, and we don't want it. So
+   * we relay it downstream to somebody who does, and wait to relay the response back upstream.
    *
    * <p>Completion: Will call applyByteCounts(); unregisterRequestHandlerWithNode() asynchronously
    * after this method returns.
@@ -1054,13 +1042,13 @@ public class RequestHandler
       om.sendOpennetRef(false, uid, source, noderef, this);
     } catch (NotConnectedException _) {
       rs.ackOpennet(dataSource);
-      // Lost contact with request source, nothing we can do
+      // Lost contact with the request source, nothing we can do
       applyByteCounts();
       unregisterRequestHandlerWithNode();
       return;
     }
 
-    // Now wait for reply from the request source.
+    // Now wait for a reply from the request source.
 
     // We do not need to worry about timeouts here, because we have already sent our noderef.
 
@@ -1085,7 +1073,7 @@ public class RequestHandler
         // Null reply: acknowledge upstream but still finish bookkeeping below.
         rs.ackOpennet(dataSource);
       } else {
-        // Send it forward to the data source, if it is valid.
+        // Send it forward to the data source if it is valid.
         if (OpennetNoderefValidator.validateNoderef(newNoderef, source, false) != null) {
           try {
             if (LOG.isDebugEnabled())
@@ -1096,7 +1084,7 @@ public class RequestHandler
                 dataSource,
                 newNoderef,
                 RequestHandler.this,
-                anyFailed -> {
+                _ -> {
                   // As soon as the originator receives the three blocks, he can reuse the slot.
                   tag.finishedWaitingForOpennet(dataSource);
                   tag.unlockHandler();
@@ -1191,7 +1179,7 @@ public class RequestHandler
   /**
    * Priority used by {@link NativeThread} when scheduling this handler.
    *
-   * @return high-priority scheduling value
+   * @return The high priority scheduling value
    */
   @Override
   public int getPriority() {

--- a/src/main/java/network/crypta/node/RequestHandler.java
+++ b/src/main/java/network/crypta/node/RequestHandler.java
@@ -6,6 +6,7 @@ import network.crypta.io.comm.ByteCounter;
 import network.crypta.io.comm.DMT;
 import network.crypta.io.comm.Message;
 import network.crypta.io.comm.NotConnectedException;
+import network.crypta.io.xfer.BlockTransferContext;
 import network.crypta.io.xfer.BlockTransmitter;
 import network.crypta.io.xfer.BlockTransmitter.BlockTransmitterCompletion;
 import network.crypta.io.xfer.BlockTransmitter.ReceiverAbortHandler;
@@ -374,15 +375,16 @@ public class RequestHandler
       PartiallyReceivedBlock prb = rs.getPRB();
       bt =
           new BlockTransmitter(
-              node.network().usm(),
-              node.network().ticker(),
-              source,
-              uid,
-              prb,
-              this,
+              new BlockTransferContext(
+                  node.network().usm(),
+                  node.network().ticker(),
+                  source,
+                  uid,
+                  prb,
+                  this,
+                  realTimeFlag),
               new CHKReceiverAbortHandler(),
               new CHKBlockTransmitterCompletion(),
-              realTimeFlag,
               node.network().stats());
       tag.handlerTransferBegins();
       bt.sendAsync();
@@ -749,12 +751,14 @@ public class RequestHandler
           new PartiallyReceivedBlock(Node.PACKETS_IN_BLOCK, Node.PACKET_SIZE, block.getRawData());
       BlockTransmitter localBt =
           new BlockTransmitter(
-              node.network().usm(),
-              node.network().ticker(),
-              source,
-              uid,
-              prb,
-              this,
+              new BlockTransferContext(
+                  node.network().usm(),
+                  node.network().ticker(),
+                  source,
+                  uid,
+                  prb,
+                  this,
+                  realTimeFlag),
               BlockTransmitter.NEVER_CASCADE,
               success -> {
                 if (success) {
@@ -775,7 +779,6 @@ public class RequestHandler
                     .remoteRequest(
                         false, success, true, htl, key.toNormalizedDouble(), realTimeFlag, false);
               },
-              realTimeFlag,
               node.network().stats());
       tag.handlerTransferBegins();
       source.transport().sendAsync(df, null, this);

--- a/src/main/java/network/crypta/node/RequestHandlerContext.java
+++ b/src/main/java/network/crypta/node/RequestHandlerContext.java
@@ -1,0 +1,47 @@
+package network.crypta.node;
+
+import network.crypta.keys.Key;
+
+/**
+ * Shared context for inbound request handlers.
+ *
+ * @param node node coordinating the request
+ * @param source upstream peer that sent the request to this node
+ * @param uid unique request identifier (UID) assigned by the sender
+ * @param htl hop-to-live value for the request (routing depth remaining)
+ * @param key the {@link Key} being requested (CHK or SSK)
+ * @param tag tracking tag used for accounting, slot management, and completion callbacks
+ * @param realTimeFlag whether this request should use real-time prioritization
+ */
+public record RequestHandlerContext(
+    Node node,
+    PeerNode source,
+    long uid,
+    short htl,
+    Key key,
+    RequestTag tag,
+    boolean realTimeFlag) {
+
+  /**
+   * Creates a handler context from the request metadata.
+   *
+   * @param node node coordinating the request
+   * @param source upstream peer that sent the request to this node
+   * @param uid unique request identifier (UID) assigned by the sender
+   * @param htl hop-to-live value for the request (routing depth remaining)
+   * @param key the {@link Key} being requested (CHK or SSK)
+   * @param tag tracking tag used for accounting, slot management, and completion callbacks
+   * @param realTimeFlag whether this request should use real-time prioritization
+   * @return new immutable {@link RequestHandlerContext} instance
+   */
+  public static RequestHandlerContext of(
+      Node node,
+      PeerNode source,
+      long uid,
+      short htl,
+      Key key,
+      RequestTag tag,
+      boolean realTimeFlag) {
+    return new RequestHandlerContext(node, source, uid, htl, key, tag, realTimeFlag);
+  }
+}

--- a/src/main/java/network/crypta/node/RequestSender.java
+++ b/src/main/java/network/crypta/node/RequestSender.java
@@ -20,6 +20,7 @@ import network.crypta.io.comm.SlowAsyncMessageFilterCallback;
 import network.crypta.io.xfer.BlockReceiver;
 import network.crypta.io.xfer.BlockReceiver.BlockReceiverCompletion;
 import network.crypta.io.xfer.BlockReceiver.BlockReceiverTimeoutHandler;
+import network.crypta.io.xfer.BlockTransferContext;
 import network.crypta.io.xfer.PartiallyReceivedBlock;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.Key;
@@ -885,13 +886,14 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
       final long tStart = System.currentTimeMillis();
       final BlockReceiver br =
           new BlockReceiver(
-              node.network().usm(),
-              next,
-              uid,
-              localPrb,
-              RequestSender.this,
-              node.network().ticker(),
-              realTimeFlag,
+              new BlockTransferContext(
+                  node.network().usm(),
+                  node.network().ticker(),
+                  next,
+                  uid,
+                  localPrb,
+                  RequestSender.this,
+                  realTimeFlag),
               myTimeoutHandler,
               true);
       if (failNow) {
@@ -1488,13 +1490,8 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
       fireCHKTransferBegins();
       BlockReceiver br =
           new BlockReceiver(
-              node.network().usm(),
-              pn,
-              uid,
-              prb,
-              this,
-              node.network().ticker(),
-              realTimeFlag,
+              new BlockTransferContext(
+                  node.network().usm(), node.network().ticker(), pn, uid, prb, this, realTimeFlag),
               myTimeoutHandler,
               true);
       if (LOG.isDebugEnabled()) LOG.debug("Receiving data (for offer reply)");

--- a/src/main/java/network/crypta/node/RequestSender.java
+++ b/src/main/java/network/crypta/node/RequestSender.java
@@ -13,8 +13,6 @@ import network.crypta.io.comm.Message;
 import network.crypta.io.comm.MessageFilter;
 import network.crypta.io.comm.NotConnectedException;
 import network.crypta.io.comm.PeerContext;
-import network.crypta.io.comm.PeerParseException;
-import network.crypta.io.comm.ReferenceSignatureVerificationException;
 import network.crypta.io.comm.RetrievalException;
 import network.crypta.io.comm.SlowAsyncMessageFilterCallback;
 import network.crypta.io.xfer.BlockReceiver;
@@ -23,7 +21,6 @@ import network.crypta.io.xfer.BlockReceiver.BlockReceiverTimeoutHandler;
 import network.crypta.io.xfer.BlockTransferContext;
 import network.crypta.io.xfer.PartiallyReceivedBlock;
 import network.crypta.keys.CHKBlock;
-import network.crypta.keys.Key;
 import network.crypta.keys.KeyVerifyException;
 import network.crypta.keys.NodeCHK;
 import network.crypta.keys.NodeSSK;
@@ -33,6 +30,7 @@ import network.crypta.node.FailureTable.BlockOffer;
 import network.crypta.node.FailureTable.OfferList;
 import network.crypta.node.OpennetManager.ConnectionType;
 import network.crypta.node.OpennetNoderefWaiter.WaitedTooLongForOpennetNoderefException;
+import network.crypta.node.subsystem.NodeRoutingSubsystem.RequestSenderOptions;
 import network.crypta.store.KeyCollisionException;
 import network.crypta.support.ShortBuffer;
 import network.crypta.support.SimpleFieldSet;
@@ -83,7 +81,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 
   // Constants
   static final long ACCEPTED_TIMEOUT = SECONDS.toMillis(10);
-  // After a get offered key fails, wait this long for two stage timeout. Probably we will
+  // After a get-offered key fails, wait this long for two stage timeout. Probably we will
   // have disconnected by then.
   static final long GET_OFFER_LONG_TIMEOUT = SECONDS.toMillis(60);
   final long getOfferedTimeout;
@@ -93,7 +91,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 
   /**
    * One in this many successful requests is randomly reinserted. This is probably a good idea
-   * anyway but with the split store it's essential.
+   * anyway, but with the split store it's essential.
    */
   static final int RANDOM_REINSERT_INTERVAL = 200;
 
@@ -164,45 +162,28 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
   /**
    * Creates a new sender for a single key fetch.
    *
-   * @param key The target key. For SSKs the public key should already be known; this class does not
-   *     perform a lookup.
-   * @param pubKey Optional SSK public key used for verification. Ignored for CHKs; when {@code
-   *     null} and the protocol allows, a peer may provide it during the exchange.
-   * @param htl Initial hop-to-live. The value is decremented during routing according to node
-   *     policy.
-   * @param uid Unique message ID shared with downstream peers for correlating responses.
-   * @param tag Request-scoped tag used for coordination and coalescing with other components.
-   * @param n Owning node.
-   * @param source Originating peer for forwarded requests, or {@code null} for local requests.
-   * @param offersOnly When {@code true}, try only advertised offers and do not start regular
-   *     routing if none succeed.
-   * @param canWriteClientCache Whether verified data may be stored in the client cache.
+   * @param context Request metadata for the fetch, including key, HTL, UID, and tag references.
+   * @param options Policy flags governing offers, cache handling, and realtime scheduling.
    * @param canWriteDatastore Whether verified data may be stored in the main datastore.
-   * @param realTimeFlag When {@code true}, apply real-time timeouts and accounting; otherwise use
-   *     bulk/latency-tolerant settings.
    */
   public RequestSender(
-      Key key,
-      DSAPublicKey pubKey,
-      short htl,
-      long uid,
-      RequestTag tag,
-      Node n,
-      PeerNode source,
-      boolean offersOnly,
-      boolean canWriteClientCache,
-      boolean canWriteDatastore,
-      boolean realTimeFlag) {
-    super(key, realTimeFlag, source, n, htl, uid);
-    if (realTimeFlag) {
+      RequestSenderContext context, RequestSenderOptions options, boolean canWriteDatastore) {
+    super(
+        context.key(),
+        options.realTimeFlag(),
+        context.source(),
+        context.node(),
+        context.htl(),
+        context.uid());
+    if (options.realTimeFlag()) {
       getOfferedTimeout = BlockReceiver.RECEIPT_TIMEOUT_REALTIME;
     } else {
       getOfferedTimeout = BlockReceiver.RECEIPT_TIMEOUT_BULK;
     }
-    this.pubKey = pubKey;
-    this.origTag = tag;
-    this.tryOffersOnly = offersOnly;
-    this.canWriteClientCache = canWriteClientCache;
+    this.pubKey = context.pubKey();
+    this.origTag = context.tag();
+    this.tryOffersOnly = options.offersOnly();
+    this.canWriteClientCache = options.canWriteClientCache();
     this.canWriteDatastore = canWriteDatastore;
   }
 
@@ -243,7 +224,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
               }
 
               // We are still routing, yet we have exceeded the per-peer timeout, probably due to
-              // routing to multiple nodes e.g. RNFs and accepted timeouts.
+              // routing to multiple nodes e.g., RNFs and accepted timeouts.
               LOG.info("Reassigning to self on timeout: {}", RequestSender.this);
 
               reassignToSelfOnTimeout(fromOfferedKey);
@@ -256,7 +237,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
       finish(INTERNAL_ERROR, null, false);
     } finally {
       // LOCKING: Normally receivingAsync is set by this thread, so there is no need to synchronize.
-      // If it is set by another thread it will only be after it was set by this thread.
+      // If it is set by another thread, it will only be after it was set by this thread.
       if (status == NOT_FINISHED && !receivingAsync) {
         LOG.error("Not finished: {}", this);
         finish(INTERNAL_ERROR, null, false);
@@ -302,8 +283,8 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
   private boolean killedByRecentlyFailed = false;
 
   /**
-   * Route requests. Method is responsible for its own completion, e.g. finish or chaining to
-   * MainLoopCallback, i.e. the caller isn't going to do more stuff relevant to the request
+   * Route requests. Method is responsible for its own completion, e.g., finish or chaining to
+   * MainLoopCallback, i.e., the caller isn't going to do more stuff relevant to the request
    * afterward.
    */
   protected void routeRequests() {
@@ -432,7 +413,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
       rfAnyway = killedByRecentlyFailed;
     }
     if (rfAnyway) {
-      // See comment in original code for rationale.
+      // See comment in the original code for rationale.
       synchronized (this) {
         recentlyFailedTimeLeft = 0;
       }
@@ -525,7 +506,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 
     private DO handleMessage(
         Message msg, boolean wasFork, PeerNode source, MainLoopCallback waiter) {
-      // For debugging purposes, remember the number of responses AFTER the insert, and the last
+      // For debugging purposes, remember the number of responses AFTER the insert and the last
       // message type we received.
       gotMessages++;
       lastMessage = msg.getSpec().getName();
@@ -633,13 +614,13 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         int t = timeSinceSent();
         node.routing().failureTable().onFailed(key, next, htl, t, t);
         next.noLongerRoutingTo(origTag, false);
-        return false; // try next node
+        return false; // try the next node
       } catch (CryptFormatException e) {
         LOG.error("Invalid pubkey from {} on {} ({})", next, uid, e.getMessage(), e);
         int t = timeSinceSent();
         node.routing().failureTable().onFailed(key, next, htl, t, t);
         next.noLongerRoutingTo(origTag, false);
-        return false; // try next node
+        return false; // try the next node
       }
     }
 
@@ -712,7 +693,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         finish(TIMED_OUT, waitingFor, false);
       }
 
-      // Wait for second timeout synchronously.
+      // Wait for the second timeout synchronously.
       long secondDeadline = System.currentTimeMillis() + searchTimeout;
       while (true) {
 
@@ -1445,10 +1426,10 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 
   /**
    * @return True if we successfully received the offer or failed fatally, or we started to receive
-   *     a block transfer asynchronously (in which case receivingAsync will be set, and if it fails
+   *     a block transfer asynchronously (in which case receivingAsync will be set, and if it fails,
    *     the whole request will fail). False if we should try the next offer and/or normal fetches.
    * @param offers The list of offered keys. Only used if we complete asynchronously. Null indicates
-   *     this is a fork due to two stage timeout.
+   *     this is a fork due to a two-stage timeout.
    */
   private OFFER_STATUS handleCHKOfferReply(
       Message reply, final PeerNode pn, final BlockOffer offer, final OfferList offers) {
@@ -1606,13 +1587,13 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
             .setTimeout(acceptedTimeout)
             .setType(DMT.FNPRejectedOverload);
 
-    // The order of these filters is performance critical. The last or-filter is checked first.
-    // So the last filter in the or-"chain" must be the filter which matches most frequently.
+    // The order of these filters is performance-critical. The last or-filter is checked first.
+    // So the last filter in the "or-chain" must be the filter that matches most frequently.
     return mfRejectedOverload.or(mfRejectedLoop.or(mfAccepted));
   }
 
   /**
-   * Finish fetching an SSK. We must have received the data, the headers and the pubkey by this
+   * Finish fetching an SSK. We must have received the data, the headers, and the pubkey by this
    * point.
    *
    * @param next The node we received the data from.
@@ -1670,7 +1651,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
       // Cache only in the cache, not the store. The reason for this is that
       // requests don't go to the full distance, and therefore pollute the
       // store; simulations it is best to only include data from requests
-      // which go all the way i.e. inserts.
+      // which go all the way i.e., inserts.
       node.storage().storeShallow(chkBlock, canWriteClientCache, canWriteDatastore, tryOffersOnly);
       if (node.bootstrap().random().nextInt(RANDOM_REINSERT_INTERVAL) == 0)
         node.services().clientCore().getTransfers().queueRandomReinsert(chkBlock);
@@ -1821,7 +1802,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
    * Complete the request. Note that if the request was forked (which unfortunately is possible
    * because of timeouts awaiting Accepted/Rejected), it is *possible* that there are other forks
    * still running; UIDTag will wait for them. Hence, a fork that fails should NOT call this method,
-   * however a fork that succeeds SHOULD call it.
+   * however, a fork that succeeds SHOULD call it.
    *
    * @param code The completion code.
    * @param next The node being routed to.
@@ -1847,7 +1828,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
       doOpennet = code == SUCCESS && !(fromOfferedKey || isSSK);
       if (doOpennet) origTag.waitingForOpennet(next); // Call this first so we don't unlock.
       if (next != null) next.noLongerRoutingTo(origTag, fromOfferedKey);
-      // After calling both, THEN tell handler.
+      // After calling both, THEN tell the handler.
       status = code;
       if (status == SUCCESS) successFrom = next;
       notifyAll();
@@ -1944,12 +1925,12 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
   }
 
   /**
-   * Acknowledge the opennet path folding attempt without sending a reference. Once the send
+   * Acknowledge the opennet path folding attempt without sending a reference. Once the sending
    * completes (asynchronously), unlock everything.
    */
   void ackOpennet(final PeerNode next) {
     Message msg = DMT.createFNPOpennetCompletedAck(uid);
-    // We probably should set opennetFinished after the send completes.
+    // We probably should set opennetFinished after the sending completes.
     try {
       next.transport().sendAsync(msg, finishOpennetOnAck(next), this);
     } catch (NotConnectedException _) {
@@ -1986,14 +1967,6 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     try {
       byte[] noderef = OpennetNoderefWaiter.waitForOpennetNoderef(false, next, uid, this, node);
       return handleNoderefResult(next, noderef);
-    } catch (FSParseException | PeerParseException e) {
-      LOG.error("Could not parse opennet noderef for {} from {}", this, next, e);
-      ackOpennet(next);
-      return false;
-    } catch (ReferenceSignatureVerificationException e) {
-      LOG.error("Bad signature on opennet noderef for {} from {} : {}", this, next, e, e);
-      ackOpennet(next);
-      return false;
     } catch (NotConnectedException _) {
       if (LOG.isDebugEnabled())
         LOG.debug("Not connected sending ConnectReply on {} to {}", this, next);
@@ -2009,11 +1982,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     return false;
   }
 
-  private boolean handleNoderefResult(PeerNode next, byte[] noderef)
-      throws FSParseException,
-          PeerParseException,
-          ReferenceSignatureVerificationException,
-          NotConnectedException {
+  private boolean handleNoderefResult(PeerNode next, byte[] noderef) throws NotConnectedException {
     if (noderef == null || noderef.length == 0) {
       ackOpennet(next);
       return false;
@@ -2101,7 +2070,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
   /** Have we finished all opennet-related activities? */
   private boolean opennetFinished;
 
-  /** Did we timeout waiting for opennet noderef? */
+  /** Did we time out when waiting for opennet noderef? */
   private boolean opennetTimedOut;
 
   /** Opennet noderef from next node */
@@ -2402,10 +2371,10 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
       new BlockReceiverTimeoutHandler() {
 
         /**
-         * The data receive has failed. A block timed out. The PRB will be cancelled as soon as we
+         * The data receiving has failed. A block timed out. The PRB will be canceled as soon as we
          * return, and that will cause the source node to consider the request finished. Meantime we
          * don't know whether the upstream node has finished or not. So we reassign the request to
-         * ourselves, and then wait for the second timeout.
+         * ourselves and then wait for the second timeout.
          */
         @Override
         public void onFirstTimeout() {
@@ -2414,7 +2383,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 
         /**
          * The timeout appears to have been caused by the node we are directly connected to. So we
-         * need to disconnect the node, or take other fairly strong sanctions, to avoid load
+         * need to disconnect the node or take other fairly strong sanctions to avoid load
          * management problems.
          */
         @Override
@@ -2424,14 +2393,14 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         }
       };
 
-  // Note: This may be temporary; ideally listeners would provide this information directly.
+  // Note: This may be temporary; ideally, listeners would provide this information directly.
   // At present, NodeClientCore's realGetCHK and realGetSSK (blocking fetches) do not register a
   // RequestSenderListener. Future refactoring is expected to replace these usages.
 
   // Also consider whether a local RequestSenderListener added after the request starts should
   // impact
   // the decision; this may risk over-disclosure. Given existing signals, it is probably acceptable.
-  // When starting the request locally we still want to finish it even if incoming RequestHandler's
+  // When starting the request locally, we still want to finish it even if incoming RequestHandler's
   // are coalesced with it, and they fail onward transfers.
 
   private boolean transferCoalesced;
@@ -2456,7 +2425,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     onAccepted(next, false, htl);
   }
 
-  /** If we handled a timeout, and forked, we need to know the original HTL. */
+  /** If we handled a timeout and forked, we need to know the original HTL. */
   private void onAccepted(PeerNode next, boolean forked, short htl) {
     MainLoopCallback cb;
     synchronized (this) {
@@ -2482,9 +2451,9 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     if (htl < 0) htl = 0;
     // Timeouts while waiting for a slot are relatively normal.
     // That is, in an ideal world they wouldn't happen.
-    // They happen when the network is very small, or when there is a capacity bottleneck.
+    // They happen when the network is very small or when there is a capacity bottleneck.
     // They are best considered statistically, see the stats page.
-    // Individual timeouts are therefore not very interesting...
+    // Individual timeouts are, therefore, not very interesting...
     if (LOG.isDebugEnabled()) {
       if (source != null) LOG.debug("Timed out while waiting for a slot on {}", this);
       else LOG.debug("Local request timed out while waiting for a slot on {}", this);

--- a/src/main/java/network/crypta/node/RequestSenderContext.java
+++ b/src/main/java/network/crypta/node/RequestSenderContext.java
@@ -1,0 +1,24 @@
+package network.crypta.node;
+
+import network.crypta.crypt.DSAPublicKey;
+import network.crypta.keys.Key;
+
+/**
+ * Aggregates the core request metadata needed to construct a {@link RequestSender}.
+ *
+ * @param key target key for the request
+ * @param pubKey optional SSK public key used for verification
+ * @param htl hop-to-live value for routing
+ * @param uid unique request identifier
+ * @param tag request-scoped coordination tag
+ * @param node owning node
+ * @param source originating peer, or {@code null} for local requests
+ */
+public record RequestSenderContext(
+    Key key,
+    DSAPublicKey pubKey,
+    short htl,
+    long uid,
+    RequestTag tag,
+    Node node,
+    PeerNode source) {}

--- a/src/main/java/network/crypta/node/SSKInsertHandler.java
+++ b/src/main/java/network/crypta/node/SSKInsertHandler.java
@@ -69,34 +69,27 @@ public class SSKInsertHandler implements PrioRunnable, ByteCounter {
       byte[] data,
       byte[] headers,
       short htl,
-      PeerNode source,
-      long id,
-      Node node,
-      long startTime,
-      InsertTag tag,
-      boolean canWriteDatastore,
-      boolean forkOnCacheable,
-      boolean preferInsert,
-      boolean ignoreLowBackoff,
-      boolean realTimeFlag) {
-    this.node = node;
-    this.uid = id;
-    this.source = source;
-    this.startTime = startTime;
+      InsertHandlerContext context,
+      boolean canWriteDatastore) {
+    this.node = context.node();
+    this.uid = context.uid();
+    this.source = context.source();
+    this.startTime = context.startTime();
     this.key = key;
     this.htl = htl;
     this.data = data;
     this.headers = headers;
-    this.tag = tag;
+    this.tag = context.tag();
     this.canWriteDatastore = canWriteDatastore;
     byte[] pubKeyHash = key.getPubKeyHash();
     pubKey = node.storage().getPubKey().getKey(pubKeyHash, false, false, null);
     canCommit = false;
 
-    this.forkOnCacheable = forkOnCacheable;
-    this.preferInsert = preferInsert;
-    this.ignoreLowBackoff = ignoreLowBackoff;
-    this.realTimeFlag = realTimeFlag;
+    InsertRoutingOptions options = context.routingOptions();
+    this.forkOnCacheable = options.forkOnCacheable();
+    this.preferInsert = options.preferInsert();
+    this.ignoreLowBackoff = options.ignoreLowBackoff();
+    this.realTimeFlag = context.realTimeFlag();
   }
 
   @Override
@@ -108,7 +101,7 @@ public class SSKInsertHandler implements PrioRunnable, ByteCounter {
    * Executes the insert flow.
    *
    * <p>Behavior: - Acknowledges the insert, receives remaining parts (headers, data, public key),
-   * assembles and verifies the block, and if needed forwards the insert. - Responds to the peer
+   * assembles and verifies the block, and if needed, forwards the insert. - Responds to the peer
    * with success, route-not-found, or overload messages as dictated by the sender status. - Always
    * unlocks the associated {@link InsertTag} on exit.
    *

--- a/src/main/java/network/crypta/node/subsystem/NodeRoutingSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeRoutingSubsystem.java
@@ -14,6 +14,7 @@ import network.crypta.node.Location;
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
 import network.crypta.node.RequestSender;
+import network.crypta.node.RequestSenderContext;
 import network.crypta.node.RequestTag;
 import network.crypta.node.RequestTracker;
 import network.crypta.node.SSKInsertSender;
@@ -301,17 +302,9 @@ public final class NodeRoutingSubsystem {
 
     RequestSender created =
         new RequestSender(
-            key,
-            null,
-            htl,
-            uid,
-            tag,
-            node,
-            source,
-            offersOnly,
-            canWriteClientCache,
-            canWriteDatastore,
-            realTimeFlag);
+            new RequestSenderContext(key, null, htl, uid, tag, node, source),
+            opts,
+            canWriteDatastore);
     tag.setSender(created, false);
     created.start();
     if (LOG.isDebugEnabled()) LOG.debug("Created new sender: {}", created);

--- a/src/main/java/network/crypta/node/subsystem/NodeRoutingSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeRoutingSubsystem.java
@@ -31,8 +31,8 @@ import org.slf4j.LoggerFactory;
  * startup, then route each request or insert through {@link #makeRequestSender(Key, short, long,
  * RequestTag, PeerNode, RequestSenderOptions)} or the appropriate insert factory.
  *
- * <p>The class maintains simple mutable state (tracker, failure table, and decrement policy flags)
- * but does not implement its own synchronization. It relies on the thread-safety of the
+ * <p>The class maintains a simple mutable state (tracker, failure table, and decrement policy
+ * flags) but does not implement its own synchronization. It relies on the thread-safety of the
  * collaborating components and the node's startup sequencing. The routing decisions are
  * deterministic given inputs, except for the probabilistic HTL decrement flags which are fixed at
  * initialization time and reused thereafter.
@@ -71,7 +71,7 @@ public final class NodeRoutingSubsystem {
    *
    * <p>This method constructs a {@link RequestTracker} using the node's peer manager and ticker,
    * and it constructs a {@link FailureTable} bound to the node. Call it once during startup before
-   * any routing operations are attempted. Re-invoking it replaces existing instances and may
+   * any routing operations are attempted. Re-invoking, it replaces existing instances and may
    * discard in-flight tracking state, so it is not intended to be idempotent.
    */
   public void init() {
@@ -103,7 +103,7 @@ public final class NodeRoutingSubsystem {
    *
    * @param key the target key used for distance calculations; must be non-null and normalized.
    * @param source the previous hop peer, or {@code null} for locally originated requests.
-   * @param routedTo peers selected for onward routing; array may be empty but not null.
+   * @param routedTo peers selected for onward routing; an array may be empty but not null.
    * @return {@code true} when this node is strictly closer than all high-uptime peers considered,
    *     indicating deep storage eligibility; {@code false} otherwise.
    */
@@ -254,7 +254,7 @@ public final class NodeRoutingSubsystem {
    * @param key the target key to request; must be a CHK or SSK key instance.
    * @param htl hop-to-live value, typically positive and bounded by {@link Node#maxHTL()}.
    * @param uid unique request identifier used by tracking and logging; must be stable per request.
-   * @param tag request tag that is populated with the created or coalesced sender reference.
+   * @param tag the request tag that is populated with the created or coalesced sender reference.
    * @param source previous hop peer, or {@code null} when the request originates locally.
    * @param opts policy flags governing storage, cache usage, and routing mode.
    * @return a {@link KeyBlock} for local hits, a {@link RequestSender} for routed requests, or
@@ -459,7 +459,7 @@ public final class NodeRoutingSubsystem {
      * Partially received block used to seed the insert, or {@code null} if not applicable.
      *
      * <p>This value allows the sender to reuse previously received data. When {@code null}, the
-     * sender behaves as a full insert without partial reuse.
+     * sender behaves as a full insert without a partial reuse.
      */
     public final PartiallyReceivedBlock prb;
 
@@ -474,23 +474,24 @@ public final class NodeRoutingSubsystem {
     /**
      * Whether the client cache may be updated as part of this insert.
      *
-     * <p>This flag is advisory to the sender and may be ignored when cache writes are unavailable.
-     * The value is fixed in the options instance and is not mutated after construction.
+     * <p>This flag is an advisory to the sender and may be ignored when cache writes are
+     * unavailable. The value is fixed in the options instance and is not mutated after
+     * construction.
      */
     public final boolean canWriteClientCache;
 
     /**
      * Whether to fork the insert when a cacheable response is detected.
      *
-     * <p>Forking can improve throughput but may increase network load. The flag is immutable and
-     * should be enabled only when the caller expects cacheable results.
+     * <p>Forking can improve throughput but may increase the network load. The flag is immutable
+     * and should be enabled only when the caller expects cacheable results.
      */
     public final boolean forkOnCacheable;
 
     /**
      * Whether to prefer inserting locally over forwarding the request onward.
      *
-     * <p>This hint is used by the sender to bias its behavior. It is immutable and is applied
+     * <p>The sender uses this hint to bias its behavior. It is immutable and is applied
      * consistently throughout the insert lifecycle.
      */
     public final boolean preferInsert;
@@ -562,7 +563,7 @@ public final class NodeRoutingSubsystem {
      * Returns a new options instance with the {@code fromStore} flag updated.
      *
      * <p>This method does not mutate the current instance; it returns a copy with the requested
-     * flag set or cleared. All other fields, including headers and partial block, are preserved.
+     * flag set or cleared. All other fields, including headers and partial blocks, are preserved.
      *
      * @param v {@code true} to mark the insert as store-originated; {@code false} otherwise.
      * @return a new options instance with the updated {@code fromStore} flag value.
@@ -588,7 +589,7 @@ public final class NodeRoutingSubsystem {
      * Returns a new options instance with the {@code forkOnCacheable} flag updated.
      *
      * <p>Forking behavior can affect routing fan-out; this method updates only that flag while
-     * preserving all other state.
+     * preserving all other states.
      *
      * @param v {@code true} to fork when cacheable; {@code false} to disable forking.
      * @return a new options instance with updated fork-on-cacheable behavior.
@@ -613,7 +614,7 @@ public final class NodeRoutingSubsystem {
     /**
      * Returns a new options instance with the {@code ignoreLowBackoff} flag updated.
      *
-     * <p>The method preserves all other fields and returns a new instance so callers can reuse the
+     * <p>The method preserves all other fields and returns a new instance, so callers can reuse the
      * original options safely.
      *
      * @param v {@code true} to ignore low-backoff signals; {@code false} to respect them.
@@ -626,11 +627,11 @@ public final class NodeRoutingSubsystem {
     /**
      * Returns a new options instance with the {@code realTimeFlag} value updated.
      *
-     * <p>Real-time inserts may be prioritized differently by schedulers. This method updates only
-     * that flag and keeps all other fields intact.
+     * <p>Schedulers may prioritize real-time inserts differently. This method updates only that
+     * flag and keeps all other fields intact.
      *
      * @param v {@code true} for real-time scheduling; {@code false} for bulk scheduling.
-     * @return a new options instance with updated real-time flag.
+     * @return a new options instance with the updated real-time flag.
      */
     public ChkInsertOptions withRealTimeFlag(boolean v) {
       return withFlag(F_REALTIME, v);
@@ -648,7 +649,7 @@ public final class NodeRoutingSubsystem {
    * @param key CHK key identifying the content to insert; must be non-null and valid.
    * @param htl hop-to-live for routing; typically positive and bounded by {@link Node#maxHTL()}.
    * @param uid unique insert identifier used for tracking and logging; must be stable per insert.
-   * @param tag insert tag that tracks lifecycle and success/failure outcomes.
+   * @param tag an insert tag that tracks lifecycle and success/failure outcomes.
    * @param source previous hop peer, or {@code null} for locally originated inserts.
    * @param opts immutable insert options controlling cache and routing behavior.
    * @return the started {@link CHKInsertSender} instance responsible for the insert.
@@ -658,21 +659,7 @@ public final class NodeRoutingSubsystem {
     if (LOG.isDebugEnabled())
       LOG.debug("makeInsertSender({},{},{},{},...,{}", key, htl, uid, source, opts.fromStore);
     CHKInsertSender is;
-    is =
-        new CHKInsertSender(
-            key,
-            uid,
-            tag,
-            opts.headers,
-            htl,
-            source,
-            node,
-            opts.prb,
-            opts.fromStore,
-            opts.forkOnCacheable,
-            opts.preferInsert,
-            opts.ignoreLowBackoff,
-            opts.realTimeFlag);
+    is = new CHKInsertSender(key, uid, tag, htl, source, node, opts);
     is.start();
     return is;
   }
@@ -838,7 +825,7 @@ public final class NodeRoutingSubsystem {
      * <p>Prefer-insert biases routing toward local insertion without guaranteeing it.
      *
      * @param v {@code true} to prefer inserts locally; {@code false} to remove the bias.
-     * @return a new options instance with updated preference value.
+     * @return a new options instance with an updated preference value.
      */
     public SskInsertOptions withPreferInsert(boolean v) {
       return withFlag(F_PREFER_INSERT, v);
@@ -862,7 +849,7 @@ public final class NodeRoutingSubsystem {
      * <p>Real-time scheduling may affect priorities and timeouts compared to bulk inserts.
      *
      * @param v {@code true} to mark the insert as real-time; {@code false} for bulk mode.
-     * @return a new options instance with updated real-time flag value.
+     * @return a new options instance with an updated real-time flag value.
      */
     public SskInsertOptions withRealTimeFlag(boolean v) {
       return withFlag(F_REALTIME, v);
@@ -880,7 +867,7 @@ public final class NodeRoutingSubsystem {
    * @param block SSK block containing the key and payload to insert; must be non-null.
    * @param htl hop-to-live for routing; typically positive and bounded by {@link Node#maxHTL()}.
    * @param uid unique insert identifier used for tracking and logging; must be stable per insert.
-   * @param tag insert tag that tracks lifecycle and success/failure outcomes.
+   * @param tag an insert tag that tracks lifecycle and success/failure outcomes.
    * @param source previous hop peer, or {@code null} for locally originated inserts.
    * @param opts immutable insert options controlling cache and routing behavior.
    * @return the started {@link SSKInsertSender} instance responsible for the insert.

--- a/src/test/java/network/crypta/io/xfer/BlockReceiverTest.java
+++ b/src/test/java/network/crypta/io/xfer/BlockReceiverTest.java
@@ -111,7 +111,7 @@ class BlockReceiverTest {
     AtomicReference<byte[]> received = new AtomicReference<>();
     AtomicReference<RetrievalException> failed = new AtomicReference<>();
 
-    // Capture sendAsync to verify that an allReceived was emitted.
+    // Capture sendAsync to verify that allReceived was emitted.
     doAnswer(
             inv -> {
               Message msg = inv.getArgument(0, Message.class);
@@ -123,7 +123,7 @@ class BlockReceiverTest {
         .when(transport)
         .sendAsync(any(Message.class), eq(null), eq(byteCounter));
 
-    // Act: start receive
+    // Act: start to receive
     receiver.receive(
         new BlockReceiver.BlockReceiverCompletion() {
           @Override
@@ -168,13 +168,7 @@ class BlockReceiverTest {
     PartiallyReceivedBlock prb = new PartiallyReceivedBlock(2, 3);
     BlockReceiver receiver =
         new BlockReceiver(
-            messageCore,
-            senderPeer,
-            UID,
-            prb,
-            byteCounter,
-            ticker,
-            false,
+            new BlockTransferContext(messageCore, ticker, senderPeer, UID, prb, byteCounter, false),
             new NoopTimeoutHandler(),
             false);
 
@@ -224,7 +218,7 @@ class BlockReceiverTest {
     assertEquals(reason, ack.getInt(DMT.REASON));
     // Description is prefixed by the receiver code if it doesn't contain "Upstream"
     assertTrue(ack.getString(DMT.DESCRIPTION).contains("Upstream transmit error:"));
-    // Diagnostic counter not asserted; see note above.
+    // Diagnostic counter isn't asserted; see the note above.
   }
 
   @Test
@@ -235,13 +229,7 @@ class BlockReceiverTest {
 
     BlockReceiver receiver =
         new BlockReceiver(
-            messageCore,
-            sender,
-            UID,
-            prb,
-            byteCounter,
-            ticker,
-            true,
+            new BlockTransferContext(messageCore, ticker, sender, UID, prb, byteCounter, true),
             new NoopTimeoutHandler(),
             false);
 
@@ -250,7 +238,7 @@ class BlockReceiverTest {
     // Assert
     assertNotNull(failed.get(), "Expected immediate failure due to disconnection");
     assertEquals(RetrievalException.SENDER_DISCONNECTED, failed.get().getReason());
-    // Diagnostic counter not asserted; see note above.
+    // Diagnostic counter isn't asserted; see the note above.
   }
 
   @Test
@@ -266,7 +254,7 @@ class BlockReceiverTest {
     WeakReference<PeerContext> ref = new WeakReference<>(sender);
     org.mockito.Mockito.lenient().when(sender.getWeakRef()).thenReturn(ref);
 
-    // For all sends that happen outside sendSync (none expected here), return a MessageItem
+    // For all sending that happen outside sendSync (none expected here), return a MessageItem
 
     // Make sendSync throw the timeout to exercise the catch path; completion should still occur
     org.mockito.Mockito.doThrow(new SyncSendWaitedTooLongException())
@@ -304,7 +292,7 @@ class BlockReceiverTest {
     assertNotNull(received.get(), "Expected block completion");
     assertArrayEquals(data, received.get());
     verify(transport, times(1)).sendSync(any(Message.class), eq(byteCounter), eq(true));
-    // Diagnostic counter not asserted; see note above.
+    // Diagnostic counter isn't asserted; see the note above.
   }
 
   // --- helpers ---
@@ -314,18 +302,12 @@ class BlockReceiverTest {
    *
    * <p>Extraction keeps test methods concise and focused while centralizing the wiring of
    * frequently repeated constructor arguments. It returns only the created receiver (single output)
-   * and requires just two inputs plus a flag, keeping parameter count low.
+   * and requires just two inputs plus a flag, keeping the parameter count low.
    */
   private BlockReceiver newRealtimeReceiver(
       PeerContext sender, PartiallyReceivedBlock prb, boolean completeAfterAcked) {
     return new BlockReceiver(
-        messageCore,
-        sender,
-        UID,
-        prb,
-        byteCounter,
-        ticker,
-        true, // realtime path
+        new BlockTransferContext(messageCore, ticker, sender, UID, prb, byteCounter, true),
         new NoopTimeoutHandler(),
         completeAfterAcked);
   }
@@ -363,7 +345,7 @@ class BlockReceiverTest {
   }
 
   /**
-   * Starts a receive and returns a reference that will be set on failure.
+   * Starts receiving and returns a reference that will be set on failure.
    *
    * <p>This extracts the repeated callback wiring used by tests that only care about failure
    * outcomes, keeping the calling methods concise. The returned {@link AtomicReference} is the sole

--- a/src/test/java/network/crypta/io/xfer/BlockTransmitterTest.java
+++ b/src/test/java/network/crypta/io/xfer/BlockTransmitterTest.java
@@ -119,7 +119,7 @@ class BlockTransmitterTest {
     }
   }
 
-  // ByteCounter that records payload sends and exposes high-HTL flag
+  // ByteCounter that records payload sends and exposes the high-HTL flag
   static final class TestCounter implements ByteCounter, HighHtlAware {
     final AtomicInteger payloadBytes = new AtomicInteger();
     volatile boolean highHtl;
@@ -184,7 +184,7 @@ class BlockTransmitterTest {
     counter.highHtl = false;
 
     when(peer.getBootID()).thenReturn(1L);
-    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenAnswer(_ -> new WeakReference<>(peer));
     when(peer.shortToString()).thenReturn("peer#manual");
     when(peer.isConnected()).thenReturn(true);
 
@@ -195,15 +195,9 @@ class BlockTransmitterTest {
     long uid = 100L;
     BlockTransmitter tx =
         new BlockTransmitter(
-            usm,
-            ticker,
-            peer,
-            uid,
-            prb,
-            counter,
+            new BlockTransferContext(usm, ticker, peer, uid, prb, counter, false),
             BlockTransmitter.NEVER_CASCADE,
             completion,
-            false,
             null);
 
     // Force internal state to "all sent" and "completion acknowledged"
@@ -237,7 +231,7 @@ class BlockTransmitterTest {
       assertTrue(tx.maybeAllSent(), "All sent should be detected");
       assertTrue(tx.maybeComplete(), "maybeComplete should return true when ready");
     }
-    // Act: caller must invoke callback outside the lock per contract
+    // Act: the caller must invoke callback outside the lock per contract
     tx.callCallback(true);
 
     // Assert
@@ -258,7 +252,7 @@ class BlockTransmitterTest {
 
     when(peer.getBootID()).thenReturn(1L);
     when(peer.isConnected()).thenReturn(true);
-    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenAnswer(_ -> new WeakReference<>(peer));
     when(peer.shortToString()).thenReturn("peer#sendAborted");
 
     // Accumulate pending items so cancelItemsPending() will attempt to unqueue them on abort
@@ -304,15 +298,9 @@ class BlockTransmitterTest {
     long uid = 7L;
     BlockTransmitter tx =
         new BlockTransmitter(
-            usmSpy,
-            ticker,
-            peer,
-            uid,
-            prb,
-            counter,
-            BlockTransmitter.ALWAYS_CASCADE,
+            new BlockTransferContext(usmSpy, ticker, peer, uid, prb, counter, false),
+            BlockTransmitter.NEVER_CASCADE,
             completion,
-            /*realTime*/ false,
             null);
 
     // Act
@@ -337,10 +325,10 @@ class BlockTransmitterTest {
 
     when(peer.getBootID()).thenReturn(1L);
     when(peer.isConnected()).thenReturn(true);
-    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenAnswer(_ -> new WeakReference<>(peer));
     when(peer.shortToString()).thenReturn("peer#disc");
 
-    // Let the first send succeed, then immediately simulate a disconnect on filters
+    // Let the first sending succeed, then immediately simulate a disconnect on filters
     doAnswer(
             inv -> {
               Message msg = inv.getArgument(0, Message.class);
@@ -357,15 +345,10 @@ class BlockTransmitterTest {
     long uid = 999L;
     BlockTransmitter tx =
         new BlockTransmitter(
-            usm,
-            new ImmediateTicker(executor, true),
-            peer,
-            uid,
-            prb,
-            counter,
+            new BlockTransferContext(
+                usm, new ImmediateTicker(executor, true), peer, uid, prb, counter, false),
             BlockTransmitter.NEVER_CASCADE,
             completion,
-            false,
             null);
 
     // Act
@@ -389,10 +372,10 @@ class BlockTransmitterTest {
 
     when(peer.getBootID()).thenReturn(1L);
     when(peer.isConnected()).thenReturn(true);
-    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenAnswer(_ -> new WeakReference<>(peer));
     when(peer.shortToString()).thenReturn("peer#timeout");
 
-    // Immediately acknowledge each send, but do NOT send allReceived
+    // Immediately acknowledge each sending, but do NOT send allReceived
     doAnswer(
             inv -> {
               Message msg = inv.getArgument(0, Message.class);
@@ -413,20 +396,14 @@ class BlockTransmitterTest {
     long uid = 2024L;
     BlockTransmitter tx =
         new BlockTransmitter(
-            usm,
-            ticker,
-            peer,
-            uid,
-            prb,
-            counter,
+            new BlockTransferContext(usm, ticker, peer, uid, prb, counter, false),
             BlockTransmitter.NEVER_CASCADE,
             completion,
-            false,
             null);
 
     // Act
     tx.sendAsync();
-    // Ensure a timeout is enqueued even if completion path didn't check yet
+    // Ensure a timeout is enqueued even if the completion path didn't check yet
     tx.scheduleTimeoutAfterBlockSends();
     // The transmitter will send a sendAborted; now simulate the receiver's acknowledging
     // sendAborted so completion can finalize immediately.

--- a/src/test/java/network/crypta/node/CHKInsertHandlerTest.java
+++ b/src/test/java/network/crypta/node/CHKInsertHandlerTest.java
@@ -56,19 +56,11 @@ class CHKInsertHandlerTest {
       long uid,
       long startTime,
       boolean realTime) {
-    // Constructor is package-private; test resides in the same package.
-    return new CHKInsertHandler(
-        key,
-        htl,
-        source,
-        uid,
-        node,
-        startTime,
-        tag,
-        /* forkOnCacheable= */ false,
-        /* preferInsert= */ true,
-        /* ignoreLowBackoff= */ false,
-        realTime);
+    // Constructor is package-private; the test resides in the same package.
+    InsertRoutingOptions options = new InsertRoutingOptions(true, false, false);
+    InsertHandlerContext context =
+        new InsertHandlerContext(node, source, uid, startTime, tag, options, realTime);
+    return new CHKInsertHandler(key, htl, context);
   }
 
   @BeforeEach
@@ -94,10 +86,10 @@ class CHKInsertHandlerTest {
     // Arrange: waitFor() returns null to simulate timeout waiting for FNPDataInsert
     when(usm.waitFor(any(MessageFilter.class), any(ByteCounter.class))).thenReturn(null);
 
-    // Peer interactions: allow sends without throwing
+    // Peer interactions: allow sending without throwing
     doNothing().when(transport).sendSync(any(Message.class), any(ByteCounter.class), anyBoolean());
     when(transport.sendAsync(any(Message.class), any(), any(ByteCounter.class)))
-        .thenAnswer(inv -> null);
+        .thenAnswer(_ -> null);
 
     long uid = 42L;
     CHKInsertHandler handler =
@@ -165,7 +157,7 @@ class CHKInsertHandlerTest {
 
     doNothing().when(transport).sendSync(any(Message.class), any(ByteCounter.class), anyBoolean());
     when(transport.sendAsync(any(Message.class), any(), any(ByteCounter.class)))
-        .thenAnswer(inv -> null);
+        .thenAnswer(_ -> null);
 
     CHKInsertHandler handler =
         newHandler(

--- a/src/test/java/network/crypta/node/CHKInsertSenderTest.java
+++ b/src/test/java/network/crypta/node/CHKInsertSenderTest.java
@@ -16,6 +16,7 @@ import network.crypta.io.comm.Message;
 import network.crypta.io.xfer.PartiallyReceivedBlock;
 import network.crypta.keys.Key;
 import network.crypta.keys.NodeCHK;
+import network.crypta.node.subsystem.NodeRoutingSubsystem.ChkInsertOptions;
 import network.crypta.support.io.NativeThread;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -61,20 +62,14 @@ class CHKInsertSenderTest {
 
   private CHKInsertSender newSender(
       boolean forkOnCacheable, boolean preferInsert, boolean ignoreLowBackoff, boolean realtime) {
-    return new CHKInsertSender(
-        key,
-        uid,
-        insertTag,
-        headers,
-        htl,
-        sourcePeer,
-        node,
-        prb,
-        /* fromStore= */ false,
-        forkOnCacheable,
-        preferInsert,
-        ignoreLowBackoff,
-        realtime);
+    ChkInsertOptions options =
+        ChkInsertOptions.of(headers, prb)
+            .withFromStore(false)
+            .withForkOnCacheable(forkOnCacheable)
+            .withPreferInsert(preferInsert)
+            .withIgnoreLowBackoff(ignoreLowBackoff)
+            .withRealTimeFlag(realtime);
+    return new CHKInsertSender(key, uid, insertTag, htl, sourcePeer, node, options);
   }
 
   @Test

--- a/src/test/java/network/crypta/node/RequestHandlerTest.java
+++ b/src/test/java/network/crypta/node/RequestHandlerTest.java
@@ -3,7 +3,12 @@ package network.crypta.node;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
@@ -78,17 +83,11 @@ class RequestHandlerTest {
 
     RequestHandler rh =
         new RequestHandler(
-            source,
-            UID,
-            node,
-            HTL_ZERO,
-            key,
-            tag, /*passedInKeyBlock*/
+            RequestHandlerContext.of(node, source, UID, HTL_ZERO, key, tag, REAL_TIME),
             null,
-            REAL_TIME,
             NEEDS_PUBKEY);
 
-    // By default the mocked node will return null from makeRequestSender(..) which is what we need
+    // By default, the mocked node will return null from makeRequestSender(..) which is what we need
 
     // Act
     rh.run();
@@ -128,11 +127,13 @@ class RequestHandlerTest {
 
     RequestHandler rh =
         new RequestHandler(
-            source, UID, node, HTL, key, tag, /*passedInKeyBlock*/ null, REAL_TIME, NEEDS_PUBKEY);
+            RequestHandlerContext.of(node, source, UID, HTL, key, tag, REAL_TIME),
+            null,
+            NEEDS_PUBKEY);
 
     // Act
     rh.onReceivedRejectOverload();
-    rh.onReceivedRejectOverload(); // second call must be ignored
+    rh.onReceivedRejectOverload(); // the second call must be ignored
 
     // Assert
     assertEquals(1, sent.size(), "Only one RejectedOverload should be forwarded");
@@ -161,7 +162,9 @@ class RequestHandlerTest {
 
     RequestHandler rh =
         new RequestHandler(
-            source, UID, node, HTL, key, tag, /*passedInKeyBlock*/ null, REAL_TIME, NEEDS_PUBKEY);
+            RequestHandlerContext.of(node, source, UID, HTL, key, tag, REAL_TIME),
+            null,
+            NEEDS_PUBKEY);
 
     // Act: SUCCESS for CHK with no transfer started → maybeCompleteTransfer() sends local reject
     rh.onRequestSenderFinished(RequestSender.SUCCESS, /*fromOfferedKey*/ false, /*rs*/ null);
@@ -173,7 +176,7 @@ class RequestHandlerTest {
     assertTrue(terminal.getBoolean(DMT.IS_LOCAL), "Terminal reject must have isLocal=true");
     verify(tag, atLeastOnce()).unlockHandler();
 
-    // Also records success in remoteRequest accounting (not from offered key)
+    // Also records success in remoteRequest accounting (not from an offered key)
     verify(nodeStats, times(1))
         .remoteRequest(
             eq(false), eq(true), eq(false), anyShort(), anyDouble(), eq(REAL_TIME), eq(false));
@@ -185,9 +188,15 @@ class RequestHandlerTest {
     Key key = anyChkKey();
 
     RequestHandler high =
-        new RequestHandler(source, UID, node, (short) 9, key, tag, null, REAL_TIME, NEEDS_PUBKEY);
+        new RequestHandler(
+            RequestHandlerContext.of(node, source, UID, (short) 9, key, tag, REAL_TIME),
+            null,
+            NEEDS_PUBKEY);
     RequestHandler low =
-        new RequestHandler(source, UID, node, (short) 8, key, tag, null, REAL_TIME, NEEDS_PUBKEY);
+        new RequestHandler(
+            RequestHandlerContext.of(node, source, UID, (short) 8, key, tag, REAL_TIME),
+            null,
+            NEEDS_PUBKEY);
 
     assertTrue(high.isHighHtl());
     assertFalse(low.isHighHtl());
@@ -197,7 +206,10 @@ class RequestHandlerTest {
   void byteCounters_updateNodeStats_andSentPayloadAdjustsSign() {
     Key key = anyChkKey();
     RequestHandler rh =
-        new RequestHandler(source, UID, node, HTL, key, tag, null, REAL_TIME, NEEDS_PUBKEY);
+        new RequestHandler(
+            RequestHandlerContext.of(node, source, UID, HTL, key, tag, REAL_TIME),
+            null,
+            NEEDS_PUBKEY);
 
     rh.sentBytes(100);
     rh.receivedBytes(50);
@@ -214,7 +226,10 @@ class RequestHandlerTest {
   void getPriority_returnsHighPriority() {
     Key key = anyChkKey();
     RequestHandler rh =
-        new RequestHandler(source, UID, node, HTL, key, tag, null, REAL_TIME, NEEDS_PUBKEY);
+        new RequestHandler(
+            RequestHandlerContext.of(node, source, UID, HTL, key, tag, REAL_TIME),
+            null,
+            NEEDS_PUBKEY);
     assertEquals(NativeThread.PriorityLevel.HIGH_PRIORITY.value, rh.getPriority());
   }
 }

--- a/src/test/java/network/crypta/node/RequestSenderTest.java
+++ b/src/test/java/network/crypta/node/RequestSenderTest.java
@@ -18,6 +18,7 @@ import network.crypta.io.comm.Message;
 import network.crypta.keys.NodeCHK;
 import network.crypta.keys.NodeSSK;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.node.subsystem.NodeRoutingSubsystem.RequestSenderOptions;
 import network.crypta.support.PriorityAwareExecutor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,18 +46,11 @@ class RequestSenderTest {
     NodeCHK key = new NodeCHK(bytes(NodeCHK.KEY_LENGTH, 1), (byte) 1);
     when(node.maxHTL()).thenReturn((short) 18);
     when(node.network().enableNewLoadManagement(realtime)).thenReturn(false);
-    return new RequestSender(
-        key,
-        /* pubKey */ null,
-        htl,
-        uid,
-        mock(RequestTag.class),
-        node,
-        /* source */ null,
-        /* offersOnly */ false,
-        /* canWriteClientCache */ true,
-        /* canWriteDatastore */ true,
-        realtime);
+    RequestSenderContext context =
+        new RequestSenderContext(key, null, htl, uid, mock(RequestTag.class), node, null);
+    RequestSenderOptions options =
+        RequestSenderOptions.of(false, false, false, false, true, realtime);
+    return new RequestSender(context, options, true);
   }
 
   private RequestSender newSskSender(boolean realtime, long uid, short htl, DSAPublicKey pubKey) {
@@ -66,18 +60,18 @@ class RequestSenderTest {
     NodeSSK key = new NodeSSK(pkh, ehd, (byte) 1);
     when(node.maxHTL()).thenReturn((short) 18);
     when(node.network().enableNewLoadManagement(realtime)).thenReturn(false);
-    return new RequestSender(
-        key,
-        pubKey,
-        htl,
-        uid,
-        mock(RequestTag.class),
-        node,
-        /* source */ null,
-        /* offersOnly */ false,
-        /* canWriteClientCache */ true,
-        /* canWriteDatastore */ true,
-        realtime);
+    RequestSenderContext context =
+        new RequestSenderContext(key, pubKey, htl, uid, mock(RequestTag.class), node, null);
+    RequestSenderOptions options =
+        RequestSenderOptions.of(false, false, false, false, true, realtime);
+    return new RequestSender(context, options, true);
+  }
+
+  private void createSenderWithNullKey() {
+    RequestSenderContext context =
+        new RequestSenderContext(null, null, (short) 5, 99L, mock(RequestTag.class), node, null);
+    RequestSenderOptions options = RequestSenderOptions.of(false, false, false, false, true, false);
+    new RequestSender(context, options, true);
   }
 
   @ParameterizedTest
@@ -215,20 +209,6 @@ class RequestSenderTest {
 
   @Test
   void constructor_whenKeyIsNull_throwsNullPointerException() {
-    assertThrows(
-        NullPointerException.class,
-        () ->
-            new RequestSender(
-                /* key */ null,
-                /* pubKey */ null,
-                (short) 5,
-                99L,
-                mock(RequestTag.class),
-                node,
-                /* source */ null,
-                /* offersOnly */ false,
-                /* canWriteClientCache */ true,
-                /* canWriteDatastore */ true,
-                /* realtime */ false));
+    assertThrows(NullPointerException.class, this::createSenderWithNullKey);
   }
 }

--- a/src/test/java/network/crypta/node/SSKInsertHandlerTest.java
+++ b/src/test/java/network/crypta/node/SSKInsertHandlerTest.java
@@ -60,22 +60,11 @@ class SSKInsertHandlerTest {
       long startTime,
       boolean canWriteDatastore,
       boolean realTime) {
-    // Constructor is package-private; test resides in the same package.
-    return new SSKInsertHandler(
-        key,
-        data,
-        headers,
-        htl,
-        source,
-        uid,
-        node,
-        startTime,
-        tag,
-        canWriteDatastore,
-        /* forkOnCacheable= */ false,
-        /* preferInsert= */ true,
-        /* ignoreLowBackoff= */ false,
-        realTime);
+    // Constructor is package-private; the test resides in the same package.
+    InsertRoutingOptions options = new InsertRoutingOptions(true, false, false);
+    InsertHandlerContext context =
+        new InsertHandlerContext(node, source, uid, startTime, tag, options, realTime);
+    return new SSKInsertHandler(key, data, headers, htl, context, canWriteDatastore);
   }
 
   @BeforeEach
@@ -84,14 +73,14 @@ class SSKInsertHandlerTest {
     when(node.network().stats()).thenReturn(nodeStats);
     when(node.storage().getPubKey()).thenReturn(getPubKey);
     when(source.transport()).thenReturn(transport);
-    // Minimal required stubbing for constructor path
+    // Minimal required stubbing for the constructor path
     when(nodeSSK.getPubKeyHash()).thenReturn(new byte[32]);
   }
 
   @Test
   @DisplayName("run_whenSendAsyncNotConnected_returnsEarlyAndUnlocks")
   void run_whenSendAsyncNotConnected_returnsEarlyAndUnlocks() throws Exception {
-    // Arrange: pubkey not in cache; initial Accepted send throws NotConnected
+    // Arrange: pubkey not in cache; initially Accepted send throws NotConnected
     when(getPubKey.getKey(any(byte[].class), eq(false), eq(false), eq(null))).thenReturn(null);
     when(transport.sendAsync(any(Message.class), any(), any(ByteCounter.class)))
         .thenThrow(new NotConnectedException());
@@ -128,7 +117,7 @@ class SSKInsertHandlerTest {
         .thenReturn(org.mockito.Mockito.mock(network.crypta.crypt.DSAPublicKey.class));
     when(usm.waitFor(any(MessageFilter.class), any(ByteCounter.class))).thenReturn(null);
 
-    // Allow sends
+    // Allow sending
     when(transport.sendAsync(any(Message.class), any(), any(ByteCounter.class))).thenReturn(null);
     doNothing().when(transport).sendSync(any(Message.class), any(ByteCounter.class), anyBoolean());
 


### PR DESCRIPTION
## Summary
- introduce `BlockTransferContext` to bundle block transfer inputs for `BlockReceiver` and `BlockTransmitter`
- refactor CHK insert sender/handler wiring and failure-table transfers to use the shared context and options records
- polish transfer-related Javadoc and inline comments for clarity

## Testing
- not run (not requested)
