### PR TITLE
refactor(keys): centralize encode parameters

### DIFF
--- a/src/main/java/network/crypta/client/async/SingleBlockInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleBlockInserter.java
@@ -11,6 +11,7 @@ import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.crypt.RandomSource;
+import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKEncodeException;
 import network.crypta.keys.ClientCHKBlock;
 import network.crypta.keys.ClientKey;
@@ -105,13 +106,13 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
   /**
    * Target URI that determines the key type (e.g., {@code CHK}, {@code SSK}, or {@code KSK}).
    *
-   * <p>Uses essentially no RAM in the common case of a CHK because we use {@link
+   * <p>Essentially uses no RAM in the common case of a CHK because we use {@link
    * FreenetURI#EMPTY_CHK_URI}.
    */
-  final FreenetURI uri; // uses essentially no RAM in the common case of a CHK because we use
+  final FreenetURI uri; // essentially uses no RAM in the common case of a CHK because we use
 
   // FreenetURI.EMPTY_CHK_URI
-  /** The client key produced by a successful encode, or {@code null} until available. */
+  /** The client key produced by a successful encoding, or {@code null} until available. */
   private ClientKey resultingKey;
 
   /**
@@ -142,7 +143,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
   private final boolean dontSendEncoded;
 
   /** Per-block integer token used by higher-level constructs (e.g., splitfiles). */
-  final int token; // for e.g. splitfiles
+  final int token; // for e.g., splitfiles
 
   /** Opaque scheduling token returned by {@link #getToken()} to identify this request. */
   private final Object tokenObject;
@@ -182,8 +183,8 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
    * Creates a new inserter for a single block.
    *
    * <p>The instance is single-use. After construction, invoke {@link #schedule(ClientContext)} to
-   * register it with the scheduler or {@link #tryEncode(ClientContext)} to trigger an early encode
-   * when the context enables it.
+   * register it with the scheduler or {@link #tryEncode(ClientContext)} to trigger an early
+   * encoding when the context enables it.
    *
    * @param payload block data and encoding parameters for this insert
    * @param params shared inserter parameters including parent, callbacks, and insert context
@@ -260,11 +261,11 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
   /**
    * Static helper to encode the provided data and parameters into a {@link ClientKeyBlock}.
    *
-   * <p>For {@code CHK} URIs, this delegates to {@link
-   * ClientCHKBlock#encode(network.crypta.support.api.Bucket, boolean, boolean, short, long, String,
+   * <p>For {@code CHK} URIs, this delegates to {@link ClientCHKBlock#encode(BlockEncodeParams,
    * byte[], byte)}. For {@code SSK} and {@code KSK} URIs, it creates an {@link InsertableClientSSK}
-   * and delegates to its encoder. The {@code compressionCodec} of {@code -1} indicates that the
-   * implementation may choose whether to compress. Callers must provide a non-null {@code random}.
+   * and delegates to {@link InsertableClientSSK#encode(BlockEncodeParams)}. The {@code
+   * compressionCodec} of {@code -1} indicates that the implementation may choose whether to
+   * compress. Callers must provide a non-null {@code random}.
    *
    * @param random Randomness provider required by the encoders; must not be {@code null}.
    * @param payload Block payload and encoding parameters; must not be {@code null}.
@@ -285,25 +286,19 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
           InvalidCompressionCodecException {
     Objects.requireNonNull(random, "random");
     String uriType = payload.uri().getKeyType();
+    BlockEncodeParams encodeParams =
+        new BlockEncodeParams(
+            payload.data(),
+            payload.isMetadata(),
+            payload.compressionCodec() == -1,
+            payload.compressionCodec(),
+            payload.sourceLength(),
+            compressorDescriptor);
     if (uriType.equals("CHK")) {
-      return ClientCHKBlock.encode(
-          payload.data(),
-          payload.isMetadata(),
-          payload.compressionCodec() == -1,
-          payload.compressionCodec(),
-          payload.sourceLength(),
-          compressorDescriptor,
-          payload.cryptoKey(),
-          payload.cryptoAlgorithm());
+      return ClientCHKBlock.encode(encodeParams, payload.cryptoKey(), payload.cryptoAlgorithm());
     } else if (uriType.equals("SSK") || uriType.equals("KSK")) {
       InsertableClientSSK ik = InsertableClientSSK.create(payload.uri());
-      return ik.encode(
-          payload.data(),
-          payload.isMetadata(),
-          payload.compressionCodec() == -1,
-          payload.compressionCodec(),
-          payload.sourceLength(),
-          compressorDescriptor);
+      return ik.encode(encodeParams);
     } else {
       throw new InsertException(
           InsertExceptionMode.INVALID_URI, "Unknown keytype " + uriType, null);
@@ -516,7 +511,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
    * <p>If the key has not yet been derived, this method triggers encoding by calling {@link
    * #getBlock(ClientContext)} and then returns the URI once available.
    *
-   * @param context Runtime context used to perform an on-demand encode.
+   * @param context Runtime context used to perform an on-demand encoding.
    * @return The final content URI for the inserted block.
    */
   public FreenetURI getURI(ClientContext context) {
@@ -532,7 +527,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
   }
 
   /**
-   * Returns the resulting URI if already known without triggering a new encode.
+   * Returns the resulting URI if already known without triggering a new encoding.
    *
    * @return The content URI or {@code null} when encoding has not yet produced a key.
    */
@@ -541,7 +536,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
   }
 
   /**
-   * Returns the resulting {@link ClientKey} if already known without triggering a new encode.
+   * Returns the resulting {@link ClientKey} if already known without triggering a new encoding.
    *
    * @return The client key instance or {@code null} when not yet derived.
    */
@@ -572,7 +567,8 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     if (LOG.isDebugEnabled()) LOG.debug("Calling onSuccess for {}", cb);
     if (shouldSendKey)
       cb.onEncode(
-          key, this, context); // In case of race conditions etc., especially for LocalRequestOnly.
+          key, this,
+          context); // In the case of race conditions etc., especially for LocalRequestOnly.
     cb.onSuccess(this, context);
   }
 

--- a/src/main/java/network/crypta/keys/BlockEncodeParams.java
+++ b/src/main/java/network/crypta/keys/BlockEncodeParams.java
@@ -1,0 +1,21 @@
+package network.crypta.keys;
+
+import network.crypta.support.api.Bucket;
+
+/**
+ * Bundles common compression inputs for CHK/SSK encoding operations.
+ *
+ * @param sourceData bucket containing the input bytes
+ * @param asMetadata whether the resulting key should be flagged as metadata
+ * @param dontCompress whether compression should be skipped
+ * @param alreadyCompressedCodec codec identifier if the input is already compressed
+ * @param sourceLength expected number of bytes to read from the source
+ * @param compressorDescriptor optional compressor selection/hint
+ */
+public record BlockEncodeParams(
+    Bucket sourceData,
+    boolean asMetadata,
+    boolean dontCompress,
+    short alreadyCompressedCodec,
+    long sourceLength,
+    String compressorDescriptor) {}

--- a/src/main/java/network/crypta/keys/ClientCHKBlock.java
+++ b/src/main/java/network/crypta/keys/ClientCHKBlock.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * headers; no I/O is performed until a decode method is invoked. Decoding performs integrity checks
  * and optional decompression depending on the key metadata.
  *
- * <p>For AES/CTR, the 16-byte counter nonce is derived deterministically from an HMAC of the
+ * <p>For AES/CTR, the 16-byte counter-nonce is derived deterministically from an HMAC of the
  * plaintext (plus length bytes) under the encryption key. This preserves CHK determinism: identical
  * plaintext with the same key yields identical ciphertext and key material.
  *
@@ -123,7 +123,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
    * @param data the encrypted payload as stored on disk or received over the network.
    * @param header the block header bytes (algorithm marker, HMAC, and length encoding).
    * @param key2 the client key associated with the block.
-   * @param verify whether to verify invariants available without a full decode.
+   * @param verify whether to verify invariants available without a full decoding.
    * @throws CHKVerifyException if the header or overall hash check fails during verification.
    */
   public ClientCHKBlock(byte[] data, byte[] header, ClientCHK key2, boolean verify)
@@ -213,7 +213,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
    */
   public Bucket decodeOld(BucketFactory bf, int maxLength, boolean dontCompress)
       throws CHKDecodeException, IOException {
-    // Overall hash already verified, so first job is to decrypt.
+    // Overall hash already verified, so the first job is to decrypt.
     if (key.cryptoAlgorithm != Key.ALGO_AES_PCFB_256_SHA256)
       throw new UnsupportedOperationException();
     BlockCipher cipher;
@@ -233,7 +233,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
     byte[] data = block.data;
     byte[] hbuf = Arrays.copyOfRange(headers, 2, headers.length);
     byte[] dbuf = Arrays.copyOf(data, data.length);
-    // Decrypt header first: it acts as the IV for PCFB.
+    // Decrypt the header first: it acts as the IV for PCFB.
     pcfb.blockDecipher(hbuf, 0, hbuf.length);
     pcfb.blockDecipher(dbuf, 0, dbuf.length);
     MessageDigest md256 = SHA256.getMessageDigest();
@@ -470,31 +470,23 @@ public class ClientCHKBlock implements ClientKeyBlock {
     if (cryptoKey == null) {
       cryptoKey = md256.digest(data);
     }
-    if (cryptoAlgorithm == Key.ALGO_AES_PCFB_256_SHA256)
-      return innerEncode(
-          data, CHKBlock.DATA_LENGTH, md256, cryptoKey, false, (short) -1, cryptoAlgorithm);
+    ClientCHKEncodeParams encodeParams =
+        new ClientCHKEncodeParams(
+            data,
+            CHKBlock.DATA_LENGTH,
+            md256,
+            cryptoKey,
+            false,
+            (short) -1,
+            cryptoAlgorithm,
+            KeyBlock.HASH_SHA256);
+    if (cryptoAlgorithm == Key.ALGO_AES_PCFB_256_SHA256) return innerEncode(encodeParams);
     else if (cryptoAlgorithm != Key.ALGO_AES_CTR_256_SHA256)
       throw new IllegalArgumentException("Unknown crypto algorithm: " + cryptoAlgorithm);
     if (Rijndael.getAesCtrProvider() == null) {
-      return encodeNewNoJCA(
-          data,
-          CHKBlock.DATA_LENGTH,
-          md256,
-          cryptoKey,
-          false,
-          (short) -1,
-          cryptoAlgorithm,
-          KeyBlock.HASH_SHA256);
+      return encodeNewNoJCA(encodeParams);
     } else {
-      return encodeNew(
-          data,
-          CHKBlock.DATA_LENGTH,
-          md256,
-          cryptoKey,
-          false,
-          (short) -1,
-          cryptoAlgorithm,
-          KeyBlock.HASH_SHA256);
+      return encodeNew(encodeParams);
     }
   }
 
@@ -505,14 +497,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
    * CHKBlock#DATA_LENGTH}. The {@code cryptoKey} may be {@code null} to derive a key from the
    * padded data. The {@code cryptoAlgorithm} selects AES/PCFB or AES/CTR.
    *
-   * @param sourceData bucket containing the input bytes.
-   * @param asMetadata whether the resulting key should be flagged as metadata.
-   * @param dontCompress when {@code true}, disables compression regardless of {@code
-   *     alreadyCompressedCodec}.
-   * @param alreadyCompressedCodec when {@code dontCompress} is {@code false} and this value is
-   *     {@code >= 0}, signals that {@code sourceData} is already compressed using the given codec.
-   * @param sourceLength expected number of bytes to read from {@code sourceData}.
-   * @param compressorDescriptor optional compressor selection/hint; implementation specific.
+   * @param params bundle containing the compression inputs
    * @param cryptoKey optional encryption key (may be {@code null}).
    * @param cryptoAlgorithm algorithm selector; one of {@link Key#ALGO_AES_PCFB_256_SHA256} or
    *     {@link Key#ALGO_AES_CTR_256_SHA256}.
@@ -521,39 +506,21 @@ public class ClientCHKBlock implements ClientKeyBlock {
    * @throws IOException if reading from the bucket fails.
    */
   public static ClientCHKBlock encode(
-      Bucket sourceData,
-      boolean asMetadata,
-      boolean dontCompress,
-      short alreadyCompressedCodec,
-      long sourceLength,
-      String compressorDescriptor,
-      byte[] cryptoKey,
-      byte cryptoAlgorithm)
+      BlockEncodeParams params, byte[] cryptoKey, byte cryptoAlgorithm)
       throws CHKEncodeException, IOException {
-    return encode(
-        sourceData,
-        asMetadata,
-        dontCompress,
-        alreadyCompressedCodec,
-        sourceLength,
-        compressorDescriptor,
-        cryptoKey,
-        cryptoAlgorithm,
-        false);
+    return encode(params, cryptoKey, cryptoAlgorithm, false);
   }
 
   // Unit-test hook: forces use of the pure-Java AES/CTR path.
   static ClientCHKBlock encode(
-      Bucket sourceData,
-      boolean asMetadata,
-      boolean dontCompress,
-      short alreadyCompressedCodec,
-      long sourceLength,
-      String compressorDescriptor,
-      byte[] cryptoKey,
-      byte cryptoAlgorithm,
-      boolean forceNoJCA)
+      BlockEncodeParams params, byte[] cryptoKey, byte cryptoAlgorithm, boolean forceNoJCA)
       throws CHKEncodeException, IOException {
+    Bucket sourceData = params.sourceData();
+    boolean asMetadata = params.asMetadata();
+    boolean dontCompress = params.dontCompress();
+    short alreadyCompressedCodec = params.alreadyCompressedCodec();
+    long sourceLength = params.sourceLength();
+    String compressorDescriptor = params.compressorDescriptor();
     byte[] finalData;
     byte[] data;
     short compressionAlgorithm;
@@ -573,7 +540,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
     } catch (KeyEncodeException | InvalidCompressionCodecException e2) {
       throw new CHKEncodeException(e2.getMessage(), e2);
     }
-    // Now do the actual encode
+    // Now do the actual encoding
 
     MessageDigest md256 = SHA256.getMessageDigest();
     // First pad it
@@ -597,12 +564,8 @@ public class ClientCHKBlock implements ClientKeyBlock {
       LOG.warn("Passed in 0 crypto algorithm");
       cryptoAlgorithm = Key.ALGO_AES_PCFB_256_SHA256;
     }
-    if (cryptoAlgorithm == Key.ALGO_AES_PCFB_256_SHA256)
-      return innerEncode(
-          data, dataLength, md256, encKey, asMetadata, compressionAlgorithm, cryptoAlgorithm);
-    else {
-      if (Rijndael.getAesCtrProvider() == null || forceNoJCA)
-        return encodeNewNoJCA(
+    ClientCHKEncodeParams encodeParams =
+        new ClientCHKEncodeParams(
             data,
             dataLength,
             md256,
@@ -611,17 +574,9 @@ public class ClientCHKBlock implements ClientKeyBlock {
             compressionAlgorithm,
             cryptoAlgorithm,
             KeyBlock.HASH_SHA256);
-      else
-        return encodeNew(
-            data,
-            dataLength,
-            md256,
-            encKey,
-            asMetadata,
-            compressionAlgorithm,
-            cryptoAlgorithm,
-            KeyBlock.HASH_SHA256);
-    }
+    if (cryptoAlgorithm == Key.ALGO_AES_PCFB_256_SHA256) return innerEncode(encodeParams);
+    if (Rijndael.getAesCtrProvider() == null || forceNoJCA) return encodeNewNoJCA(encodeParams);
+    return encodeNew(encodeParams);
   }
 
   /**
@@ -631,43 +586,27 @@ public class ClientCHKBlock implements ClientKeyBlock {
    * [34..35]=lengthBytes}. The CTR IV is the first 16 bytes of the HMAC value, making it
    * deterministic for identical content and key (required for CHK determinism).
    *
-   * @param data padded data (exactly {@link CHKBlock#DATA_LENGTH} bytes).
-   * @param dataLength original, unpadded length in bytes (0..32768).
-   * @param md256 reusable SHA-256 instance.
-   * @param encKey encryption key to use.
-   * @param asMetadata whether the resulting key is metadata.
-   * @param compressionAlgorithm compression algorithm identifier stored in the key.
-   * @param cryptoAlgorithm must be {@link Key#ALGO_AES_CTR_256_SHA256}.
-   * @param blockHashAlgorithm block-hash identifier to store in the header.
+   * @param params bundle containing the encoding inputs
    * @return the encoded client block.
    * @throws CHKEncodeException if encoding fails.
    * @throws IllegalArgumentException if an unsupported algorithm is requested.
    */
   @SuppressWarnings("java:S3329")
-  public static ClientCHKBlock encodeNew(
-      byte[] data,
-      int dataLength,
-      MessageDigest md256,
-      byte[] encKey,
-      boolean asMetadata,
-      short compressionAlgorithm,
-      byte cryptoAlgorithm,
-      int blockHashAlgorithm)
-      throws CHKEncodeException {
+  public static ClientCHKBlock encodeNew(ClientCHKEncodeParams params) throws CHKEncodeException {
+    byte cryptoAlgorithm = params.cryptoAlgorithm();
     if (cryptoAlgorithm != Key.ALGO_AES_CTR_256_SHA256)
       throw new IllegalArgumentException("Unsupported crypto algorithm " + cryptoAlgorithm);
     if (Rijndael.getAesCtrProvider() == null) {
       // Fallback when no provider is available.
-      return encodeNewNoJCA(
-          data,
-          dataLength,
-          md256,
-          encKey,
-          asMetadata,
-          compressionAlgorithm,
-          cryptoAlgorithm,
-          blockHashAlgorithm);
+      return encodeNewNoJCA(params);
     }
+    byte[] data = params.data();
+    int dataLength = params.dataLength();
+    MessageDigest md256 = params.md256();
+    byte[] encKey = params.encKey();
+    boolean asMetadata = params.asMetadata();
+    short compressionAlgorithm = params.compressionAlgorithm();
+    int blockHashAlgorithm = params.blockHashAlgorithm();
     try {
       // IV = HMAC<cryptokey>(plaintext || lengthBytes).
       // Deterministic IV preserves CHK determinism across identical content and key.
@@ -730,37 +669,30 @@ public class ClientCHKBlock implements ClientKeyBlock {
   /**
    * Encodes one block using the built-in AES/CTR implementation (no external provider).
    *
-   * <p>Semantics and header format match {@link #encodeNew(byte[], int, MessageDigest, byte[],
-   * boolean, short, byte, int)}. AES uses a 128-bit block size in this path.
+   * <p>Semantics and header format match {@link #encodeNew(ClientCHKEncodeParams)}. AES uses a
+   * 128-bit block size in this path.
    *
-   * @param data padded data (exactly {@link CHKBlock#DATA_LENGTH} bytes).
-   * @param dataLength original, unpadded length in bytes (0..32768).
-   * @param md256 reusable SHA-256 instance.
-   * @param encKey encryption key to use.
-   * @param asMetadata whether the resulting key is metadata.
-   * @param compressionAlgorithm compression algorithm identifier stored in the key.
-   * @param cryptoAlgorithm must be {@link Key#ALGO_AES_CTR_256_SHA256}.
-   * @param blockHashAlgorithm block-hash identifier to store in the header.
+   * @param params bundle containing the encoding inputs
    * @return the encoded client block.
    * @throws CHKEncodeException if encoding fails.
    * @throws IllegalArgumentException if an unsupported algorithm is requested.
    */
-  public static ClientCHKBlock encodeNewNoJCA(
-      byte[] data,
-      int dataLength,
-      MessageDigest md256,
-      byte[] encKey,
-      boolean asMetadata,
-      short compressionAlgorithm,
-      byte cryptoAlgorithm,
-      int blockHashAlgorithm)
+  public static ClientCHKBlock encodeNewNoJCA(ClientCHKEncodeParams params)
       throws CHKEncodeException {
+    byte cryptoAlgorithm = params.cryptoAlgorithm();
     if (cryptoAlgorithm != Key.ALGO_AES_CTR_256_SHA256)
       throw new IllegalArgumentException("Unsupported crypto algorithm " + cryptoAlgorithm);
+    byte[] data = params.data();
+    int dataLength = params.dataLength();
+    MessageDigest md256 = params.md256();
+    byte[] encKey = params.encKey();
+    boolean asMetadata = params.asMetadata();
+    short compressionAlgorithm = params.compressionAlgorithm();
+    int blockHashAlgorithm = params.blockHashAlgorithm();
     try {
       // IV = HMAC<cryptokey>(plaintext).
       // It's okay that this is the same for 2 blocks with the same key and the same content.
-      // In fact that's the point; this is still a Content Hash Key.
+      // In fact, that's the point; this is still a Content Hash Key.
       // Note: identical content with the same key yields identical IV by design.
       Mac hmac = Mac.getInstance(HMAC_SHA256, hmacProvider);
       hmac.init(new SecretKeySpec(encKey, HMAC_SHA256));
@@ -806,26 +738,19 @@ public class ClientCHKBlock implements ClientKeyBlock {
    * and the original content length. The resulting key records the compression and crypto
    * algorithms used.
    *
-   * @param data padded data (exactly {@link CHKBlock#DATA_LENGTH} bytes). The array is cloned; the
-   *     input is not modified.
-   * @param dataLength original, unpadded length in bytes (0..32768).
-   * @param md256 reusable SHA-256 instance.
-   * @param encKey encryption key to use.
-   * @param asMetadata whether the resulting key is metadata.
-   * @param compressionAlgorithm compression algorithm identifier stored in the key.
-   * @param cryptoAlgorithm must be {@link Key#ALGO_AES_PCFB_256_SHA256}.
+   * @param params bundle containing the encoding inputs
    * @return the encoded client block.
    * @throws IllegalArgumentException if an unsupported algorithm is requested.
    */
-  public static ClientCHKBlock innerEncode(
-      byte[] data,
-      int dataLength,
-      MessageDigest md256,
-      byte[] encKey,
-      boolean asMetadata,
-      short compressionAlgorithm,
-      byte cryptoAlgorithm) {
-    data = data.clone(); // Will overwrite otherwise. Callers expect data not to be clobbered.
+  public static ClientCHKBlock innerEncode(ClientCHKEncodeParams params) {
+    byte[] data =
+        params.data().clone(); // Will overwrite otherwise. Callers expect data not to be clobbered.
+    int dataLength = params.dataLength();
+    MessageDigest md256 = params.md256();
+    byte[] encKey = params.encKey();
+    boolean asMetadata = params.asMetadata();
+    short compressionAlgorithm = params.compressionAlgorithm();
+    byte cryptoAlgorithm = params.cryptoAlgorithm();
     if (cryptoAlgorithm != Key.ALGO_AES_PCFB_256_SHA256)
       throw new IllegalArgumentException("Unsupported crypto algorithm " + cryptoAlgorithm);
     byte[] header;
@@ -872,9 +797,8 @@ public class ClientCHKBlock implements ClientKeyBlock {
   /**
    * Convenience overload to encode a byte array as a {@link ClientCHKBlock}.
    *
-   * <p>Behavior matches the {@link #encode(Bucket, boolean, boolean, short, long, String, byte[],
-   * byte)} variant, using the AES/CTR algorithm and deriving the encryption key from the padded
-   * data.
+   * <p>Behavior matches {@link #encode(BlockEncodeParams, byte[], byte)}, using the AES/CTR
+   * algorithm and deriving the encryption key from the padded data.
    *
    * @param sourceData the input bytes.
    * @param asMetadata whether the resulting key should be flagged as metadata.
@@ -897,12 +821,13 @@ public class ClientCHKBlock implements ClientKeyBlock {
       throws CHKEncodeException {
     try {
       return encode(
-          new ArrayBucket(sourceData),
-          asMetadata,
-          dontCompress,
-          alreadyCompressedCodec,
-          sourceLength,
-          compressorDescriptor,
+          new BlockEncodeParams(
+              new ArrayBucket(sourceData),
+              asMetadata,
+              dontCompress,
+              alreadyCompressedCodec,
+              sourceLength,
+              compressorDescriptor),
           null,
           Key.ALGO_AES_CTR_256_SHA256);
     } catch (IOException e) {

--- a/src/main/java/network/crypta/keys/ClientCHKBlock.java
+++ b/src/main/java/network/crypta/keys/ClientCHKBlock.java
@@ -250,13 +250,14 @@ public class ClientCHKBlock implements ClientKeyBlock {
       throw new CHKDecodeException("Invalid size: " + size);
     }
     return Key.decompress(
-        !dontCompress && key.isCompressed(),
-        dbuf,
-        size,
-        bf,
-        maxLength,
-        key.compressionAlgorithm,
-        false);
+        new DecompressionParams(
+            !dontCompress && key.isCompressed(),
+            dbuf,
+            size,
+            bf,
+            maxLength,
+            key.compressionAlgorithm,
+            false));
   }
 
   private static final Provider hmacProvider;
@@ -366,13 +367,14 @@ public class ClientCHKBlock implements ClientKeyBlock {
         throw new CHKDecodeException("HMAC is wrong, wrong decryption key?");
       }
       return Key.decompress(
-          !dontCompress && key.isCompressed(),
-          plaintext,
-          size,
-          bf,
-          maxLength,
-          key.compressionAlgorithm,
-          false);
+          new DecompressionParams(
+              !dontCompress && key.isCompressed(),
+              plaintext,
+              size,
+              bf,
+              maxLength,
+              key.compressionAlgorithm,
+              false));
     } catch (GeneralSecurityException e) {
       throw new CHKDecodeException("Problem with JCA, should be impossible!", e);
     }
@@ -436,13 +438,14 @@ public class ClientCHKBlock implements ClientKeyBlock {
       throw new CHKDecodeException("Problem with JCA, should be impossible!", e);
     }
     return Key.decompress(
-        !dontCompress && key.isCompressed(),
-        plaintext,
-        size,
-        bf,
-        maxLength,
-        key.compressionAlgorithm,
-        false);
+        new DecompressionParams(
+            !dontCompress && key.isCompressed(),
+            plaintext,
+            size,
+            bf,
+            maxLength,
+            key.compressionAlgorithm,
+            false));
   }
 
   /**
@@ -515,26 +518,16 @@ public class ClientCHKBlock implements ClientKeyBlock {
   static ClientCHKBlock encode(
       BlockEncodeParams params, byte[] cryptoKey, byte cryptoAlgorithm, boolean forceNoJCA)
       throws CHKEncodeException, IOException {
-    Bucket sourceData = params.sourceData();
     boolean asMetadata = params.asMetadata();
-    boolean dontCompress = params.dontCompress();
-    short alreadyCompressedCodec = params.alreadyCompressedCodec();
-    long sourceLength = params.sourceLength();
-    String compressorDescriptor = params.compressorDescriptor();
     byte[] finalData;
     byte[] data;
     short compressionAlgorithm;
     try {
       Compressed comp =
           Key.compress(
-              sourceData,
-              dontCompress,
-              alreadyCompressedCodec,
-              sourceLength,
-              CHKBlock.MAX_LENGTH_BEFORE_COMPRESSION,
-              CHKBlock.DATA_LENGTH,
-              false,
-              compressorDescriptor);
+              params,
+              new CompressionLimits(
+                  CHKBlock.MAX_LENGTH_BEFORE_COMPRESSION, CHKBlock.DATA_LENGTH, false));
       finalData = comp.compressedData;
       compressionAlgorithm = comp.compressionAlgorithm;
     } catch (KeyEncodeException | InvalidCompressionCodecException e2) {

--- a/src/main/java/network/crypta/keys/ClientCHKEncodeParams.java
+++ b/src/main/java/network/crypta/keys/ClientCHKEncodeParams.java
@@ -1,0 +1,90 @@
+package network.crypta.keys;
+
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Bundles the parameters needed to build a client-side CHK block.
+ *
+ * @param data padded data (exactly {@link CHKBlock#DATA_LENGTH} bytes)
+ * @param dataLength original, unpadded length in bytes
+ * @param md256 reusable SHA-256 instance
+ * @param encKey encryption key to use
+ * @param asMetadata whether the resulting key is metadata
+ * @param compressionAlgorithm compression algorithm identifier stored in the key
+ * @param cryptoAlgorithm crypto algorithm identifier
+ * @param blockHashAlgorithm block-hash identifier to store in the header
+ */
+public record ClientCHKEncodeParams(
+    byte[] data,
+    int dataLength,
+    MessageDigest md256,
+    byte[] encKey,
+    boolean asMetadata,
+    short compressionAlgorithm,
+    byte cryptoAlgorithm,
+    int blockHashAlgorithm) {
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj
+        instanceof
+        ClientCHKEncodeParams(
+            byte[] otherData,
+            int otherDataLength,
+            MessageDigest otherMd256,
+            byte[] otherEncKey,
+            boolean otherAsMetadata,
+            short otherCompressionAlgorithm,
+            byte otherCryptoAlgorithm,
+            int otherBlockHashAlgorithm))) return false;
+    return dataLength == otherDataLength
+        && asMetadata == otherAsMetadata
+        && compressionAlgorithm == otherCompressionAlgorithm
+        && cryptoAlgorithm == otherCryptoAlgorithm
+        && blockHashAlgorithm == otherBlockHashAlgorithm
+        && Arrays.equals(data, otherData)
+        && Objects.equals(md256, otherMd256)
+        && Arrays.equals(encKey, otherEncKey);
+  }
+
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            md256,
+            dataLength,
+            asMetadata,
+            compressionAlgorithm,
+            cryptoAlgorithm,
+            blockHashAlgorithm);
+    result = 31 * result + Arrays.hashCode(data);
+    result = 31 * result + Arrays.hashCode(encKey);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "ClientCHKEncodeParams["
+        + "data="
+        + Arrays.toString(data)
+        + ", dataLength="
+        + dataLength
+        + ", md256="
+        + md256
+        + ", encKey="
+        + Arrays.toString(encKey)
+        + ", asMetadata="
+        + asMetadata
+        + ", compressionAlgorithm="
+        + compressionAlgorithm
+        + ", cryptoAlgorithm="
+        + cryptoAlgorithm
+        + ", blockHashAlgorithm="
+        + blockHashAlgorithm
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/keys/ClientSSKBlock.java
+++ b/src/main/java/network/crypta/keys/ClientSSKBlock.java
@@ -17,11 +17,11 @@ import org.slf4j.LoggerFactory;
  * Client-side view of a Signed Subspace Key (SSK) block.
  *
  * <p>This type decrypts and optionally decompresses the payload of an {@link SSKBlock} using the
- * material contained in a {@link ClientSSK}. A successful decode exposes whether the block carries
- * metadata (see {@link #isMetadata()}) and which compression codec was indicated in the encrypted
- * headers (see {@link #getCompressionCodec()}).
+ * material contained in a {@link ClientSSK}. A successful decoding exposes whether the block
+ * carries metadata (see {@link #isMetadata()}) and which compression codec was indicated in the
+ * encrypted headers (see {@link #getCompressionCodec()}).
  *
- * <p>Thread-safety: instances are not thread-safe. Use one instance per decode or externally
+ * <p>Thread-safety: instances are not thread-safe. Use one instance per decoding or externally
  * synchronize access.
  */
 public class ClientSSKBlock implements ClientKeyBlock {
@@ -34,16 +34,16 @@ public class ClientSSKBlock implements ClientKeyBlock {
   /** Underlying encoded SSK block (immutable). */
   private final SSKBlock block;
 
-  /** True when the high-bit metadata flag is set; value becomes known after decoding. */
+  /** True, when the high-bit metadata flag is set; value becomes known after decoding. */
   private boolean isMetadata;
 
-  /** True after a successful decode; guards access to decode-dependent properties. */
+  /** True, after a successful decoding; guards access to decode-dependent properties. */
   private boolean decoded;
 
   /** Client key holding the decryption material and (optionally) the public key. */
   private final ClientSSK key;
 
-  /** Compression code read from headers on last decode; {@code -1} means "none/unknown". */
+  /** Compression code read from headers on last decoding; {@code -1} means "none/unknown". */
   private short compressionAlgorithm = -1;
 
   /**
@@ -114,25 +114,25 @@ public class ClientSSKBlock implements ClientKeyBlock {
       LOG.debug("cryptoAlgorithm={} for {}", key.cryptoAlgorithm, getClientKey().getURI());
       aes = new Rijndael(256, 256);
     } catch (UnsupportedCipherException e) {
-      // Surface cipher support problems as a decode failure rather than a generic error.
+      // Surface cipher supporting problems as a decoding failure rather than a generic error.
       throw new KeyDecodeException(e);
     }
     aes.initialize(key.cryptoKey);
     // Initialize PCFB stream using E(H(docname)) as the initial vector/seed.
     PCFBMode pcfb = PCFBMode.create(aes, key.ehDocname);
     pcfb.blockDecipher(decryptedHeaders, 0, decryptedHeaders.length);
-    // First 32 bytes of decrypted headers form the per-block data key.
+    // The first 32 bytes of decrypted headers form the per-block data key.
     byte[] dataDecryptKey = Arrays.copyOf(decryptedHeaders, DATA_DECRYPT_KEY_LENGTH);
     aes.initialize(dataDecryptKey);
     byte[] dataOutput = block.data.clone();
     // Use the derived data key as the PCFB IV for the data section; it is unique per block.
     pcfb.reset(dataDecryptKey);
     pcfb.blockDecipher(dataOutput, 0, dataOutput.length);
-    // Next two header bytes encode the data length; high bit indicates "metadata".
+    // The next two header bytes encode the data length; the high bit indicates "metadata".
     int dataLength =
         ((decryptedHeaders[DATA_DECRYPT_KEY_LENGTH] & 0xff) << 8)
             + (decryptedHeaders[DATA_DECRYPT_KEY_LENGTH + 1] & 0xff);
-    // Clear metadata flag and remember it for callers once decoding completes.
+    // Clear the metadata flag and remember it for callers once decoding completes.
     if ((dataLength & 32768) != 0) {
       dataLength = dataLength & ~32768;
       isMetadata = true;
@@ -159,20 +159,21 @@ public class ClientSSKBlock implements ClientKeyBlock {
     }
 
     return Key.decompress(
-        compressionAlgorithm >= 0,
-        dataOutput,
-        dataLength,
-        factory,
-        Math.min(MAX_DECOMPRESSED_DATA_LENGTH, maxLength),
-        compressionAlgorithm,
-        true);
+        new DecompressionParams(
+            compressionAlgorithm >= 0,
+            dataOutput,
+            dataLength,
+            factory,
+            Math.min(MAX_DECOMPRESSED_DATA_LENGTH, maxLength),
+            compressionAlgorithm,
+            true));
   }
 
   /**
    * Returns whether the decoded payload is marked as metadata.
    *
    * @return {@code true} if the metadata flag was set in the headers
-   * @throws IllegalStateException if invoked before a successful decode
+   * @throws IllegalStateException if invoked before a successful decoding
    */
   @Override
   public boolean isMetadata() {
@@ -193,7 +194,7 @@ public class ClientSSKBlock implements ClientKeyBlock {
   /**
    * Returns the compression code extracted from the headers during decoding.
    *
-   * @return a non-negative codec identifier when present; a negative value indicates no codec or
+   * @return a non-negative codec identifier when present; a negative value indicates no codec, or
    *     that decoding has not yet been attempted
    */
   public short getCompressionCodec() {
@@ -229,7 +230,7 @@ public class ClientSSKBlock implements ClientKeyBlock {
       // Extract the decoded content as a byte array for in-memory use.
       return BucketTools.toByteArray(a);
     } catch (IOException e) {
-      // Propagate I/O problems as a decode failure consistent with the method contract.
+      // Propagate I/O problems as a decoding failure consistent with the method contract.
       throw new KeyDecodeException(e);
     }
   }

--- a/src/main/java/network/crypta/keys/CompressionLimits.java
+++ b/src/main/java/network/crypta/keys/CompressionLimits.java
@@ -1,0 +1,12 @@
+package network.crypta.keys;
+
+/**
+ * Compression size limits and header layout hints.
+ *
+ * @param maxLengthBeforeCompression upper bound on {@code sourceData.size()} before compression is
+ *     attempted
+ * @param maxCompressedLengthLimit hard limit on the compressed byte array length
+ * @param shortLength whether the precompressed-length header uses 2 bytes instead of 4
+ */
+public record CompressionLimits(
+    long maxLengthBeforeCompression, int maxCompressedLengthLimit, boolean shortLength) {}

--- a/src/main/java/network/crypta/keys/DecompressionParams.java
+++ b/src/main/java/network/crypta/keys/DecompressionParams.java
@@ -1,0 +1,136 @@
+package network.crypta.keys;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.support.api.BucketFactory;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Bundles the inputs required to decode and optionally decompress block data.
+ *
+ * <p>This record acts as a compact carrier for the flags, buffers, and limits that shape a single
+ * decompression attempt. It is typically assembled close to the call site that already has the raw
+ * bytes, then passed into {@link Key#decompress(DecompressionParams)} to keep method signatures
+ * concise and consistent across call paths. The record is shallowly immutable, but it holds a
+ * mutable {@code byte[]} reference; callers should treat the array as read-only for the lifetime of
+ * the decode operation to avoid surprising results.
+ *
+ * <p>Instances are inexpensive to allocate and intended to be short-lived. The values capture size
+ * constraints, codec identifiers, and header sizing behavior so that the decompressor can validate
+ * bounds consistently across different key types. The record itself performs no validation; all
+ * preconditions are enforced by the decode method that consumes it.
+ *
+ * <ul>
+ *   <li>Encapsulates compression flags, limits, and byte buffers for a single decoding.
+ *   <li>Documents the expected header length policy through {@code shortLength}.
+ *   <li>Centralizes bounds and codec metadata for consistent error handling.
+ * </ul>
+ *
+ * @param isCompressed whether the payload uses compression for this decode operation
+ * @param input raw input bytes to read from; the array is not copied and should be treated as
+ *     immutable while decoding
+ * @param inputLength number of bytes from {@code input} that are valid for this decoding, in bytes
+ * @param bf bucket factory used to allocate the decoded output bucket; may be reused by callers
+ * @param maxLength upper bound on the decompressed output size, in bytes; the decoder rejects
+ *     negative values
+ * @param compressionAlgorithm compression codec identifier expected by the decoder; negative values
+ *     mean no compression
+ * @param shortLength whether the precompressed-length header uses 2 bytes instead of 4 for this
+ *     payload
+ * @see Key#decompress(DecompressionParams)
+ */
+public record DecompressionParams(
+    boolean isCompressed,
+    byte[] input,
+    int inputLength,
+    BucketFactory bf,
+    long maxLength,
+    short compressionAlgorithm,
+    boolean shortLength) {
+  /**
+   * Compares this parameter bundle with another for structural equality.
+   *
+   * <p>The comparison treats {@code input} as a content-bearing buffer and therefore uses {@link
+   * Arrays#equals(byte[], byte[])} rather than reference equality. All scalar fields are compared
+   * directly, while {@code bf} is compared using {@link Objects#equals(Object, Object)} so that a
+   * {@code null} factory is handled consistently. This method performs no validation; it simply
+   * reflects the values stored in the record components at the time of comparison.
+   *
+   * @param obj the object to compare against; may be {@code null} or of another type
+   * @return {@code true} when all fields, including the byte contents, match exactly
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj
+        instanceof
+        DecompressionParams(
+            boolean otherIsCompressed,
+            byte[] otherInput,
+            int otherInputLength,
+            BucketFactory otherBf,
+            long otherMaxLength,
+            short otherCompressionAlgorithm,
+            boolean otherShortLength))) return false;
+    return isCompressed == otherIsCompressed
+        && inputLength == otherInputLength
+        && maxLength == otherMaxLength
+        && compressionAlgorithm == otherCompressionAlgorithm
+        && shortLength == otherShortLength
+        && Objects.equals(bf, otherBf)
+        && Arrays.equals(input, otherInput);
+  }
+
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash incorporates the content of {@code input} via {@link Arrays#hashCode(byte[])} and
+   * then mixes in the remaining scalar fields. The bucket factory contributes its own hash code
+   * when present; a {@code null} factory contributes {@code 0}. This makes the hash stable for
+   * identical parameter sets while remaining inexpensive for short-lived comparisons in
+   * collections.
+   *
+   * @return a hash code derived from the buffer contents and all other fields
+   */
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(input);
+    result = 31 * result + Boolean.hashCode(isCompressed);
+    result = 31 * result + Integer.hashCode(inputLength);
+    result = 31 * result + (bf == null ? 0 : bf.hashCode());
+    result = 31 * result + Long.hashCode(maxLength);
+    result = 31 * result + Short.hashCode(compressionAlgorithm);
+    result = 31 * result + Boolean.hashCode(shortLength);
+    return result;
+  }
+
+  /**
+   * Returns a diagnostic string describing this parameter bundle.
+   *
+   * <p>The output lists every component, including the full byte content of {@code input} via
+   * {@link Arrays#toString(byte[])}. Because the byte array is rendered eagerly, callers should
+   * avoid invoking this method on very large buffers in hot paths. The returned value is never
+   * {@code null} and is suitable for logs or debugging output when a full buffer dump is
+   * acceptable.
+   *
+   * @return a non-null string containing all fields and the input byte contents
+   */
+  @Override
+  public @NotNull String toString() {
+    return "DecompressionParams[isCompressed="
+        + isCompressed
+        + ", input="
+        + Arrays.toString(input)
+        + ", inputLength="
+        + inputLength
+        + ", bf="
+        + bf
+        + ", maxLength="
+        + maxLength
+        + ", compressionAlgorithm="
+        + compressionAlgorithm
+        + ", shortLength="
+        + shortLength
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/keys/InsertableClientSSK.java
+++ b/src/main/java/network/crypta/keys/InsertableClientSSK.java
@@ -136,7 +136,7 @@ public class InsertableClientSSK extends ClientSSK {
   }
 
   /**
-   * Validate the URI type and extras, and return the SSK crypto algorithm byte.
+   * Validate the URI type and extras and return the SSK crypto algorithm byte.
    *
    * <p>Throws {@link MalformedURLException} with a descriptive message when the URI is not an SSK
    * insert URI or when its extras are missing/invalid.
@@ -163,29 +163,23 @@ public class InsertableClientSSK extends ClientSSK {
    * overall hash over headers and encrypted data hash; (6) sign with DSA using deterministic {@code
    * k} derived via HMAC-SHA-256; (7) return the block.
    *
-   * <p>This method reads from {@code sourceData} but does not close it.
+   * <p>This method reads from {@code params.sourceData()} but does not close it.
    *
-   * @param sourceData the data to encode
-   * @param asMetadata whether the block is metadata (sets the high bit of the stored length)
-   * @param dontCompress if {@code true}, skip compression regardless of content
-   * @param alreadyCompressedCodec codec identifier if the input is already compressed; {@code 0}
-   *     when unknown
-   * @param sourceLength byte length of the input; used by compression
-   * @param compressordescriptor optional compressor configuration string
+   * @param params bundle containing compression inputs
    * @return a {@link ClientSSKBlock} containing encrypted data and headers
    * @throws SSKEncodeException on compression or encoding failures
-   * @throws IOException on I/O errors while reading {@code sourceData}
-   * @throws InvalidCompressionCodecException if {@code alreadyCompressedCodec} is invalid or
-   *     unsupported
+   * @throws IOException on I/O errors while reading {@code params.sourceData()}
+   * @throws InvalidCompressionCodecException if {@code params.alreadyCompressedCodec()} is invalid
+   *     or unsupported
    */
-  public ClientSSKBlock encode(
-      Bucket sourceData,
-      boolean asMetadata,
-      boolean dontCompress,
-      short alreadyCompressedCodec,
-      long sourceLength,
-      String compressordescriptor)
+  public ClientSSKBlock encode(BlockEncodeParams params)
       throws SSKEncodeException, IOException, InvalidCompressionCodecException {
+    Bucket sourceData = params.sourceData();
+    boolean asMetadata = params.asMetadata();
+    boolean dontCompress = params.dontCompress();
+    short alreadyCompressedCodec = params.alreadyCompressedCodec();
+    long sourceLength = params.sourceLength();
+    String compressorDescriptor = params.compressorDescriptor();
     byte[] compressedData;
     short compressionAlgo;
     try {
@@ -198,7 +192,7 @@ public class InsertableClientSSK extends ClientSSK {
               ClientSSKBlock.MAX_DECOMPRESSED_DATA_LENGTH,
               SSKBlock.DATA_LENGTH,
               true,
-              compressordescriptor);
+              compressorDescriptor);
       compressedData = comp.compressedData;
       compressionAlgo = comp.compressionAlgorithm;
     } catch (KeyEncodeException e) {
@@ -246,7 +240,7 @@ public class InsertableClientSSK extends ClientSSK {
     // Create headers: algo IDs, E(H(docname)), and encrypted metadata.
 
     byte[] headers = new byte[SSKBlock.TOTAL_HEADERS_LENGTH];
-    // First two bytes = hash algorithm ID.
+    // The first two bytes = hash algorithm ID.
     int x = 0;
     headers[x++] = 0;
     headers[x++] = (byte) (KeyBlock.HASH_SHA256);
@@ -272,7 +266,7 @@ public class InsertableClientSSK extends ClientSSK {
     pcfb.blockEncipher(encryptedHeaders, 0, encryptedHeaders.length);
     System.arraycopy(encryptedHeaders, 0, headers, x, encryptedHeaders.length);
     x += encryptedHeaders.length;
-    // Generate implicit overall hash that is signed below.
+    // Generate an implicit overall hash signed below.
     md256.update(headers, 0, x);
     md256.update(encryptedDataHash);
     byte[] overallHash = md256.digest();

--- a/src/main/java/network/crypta/keys/InsertableClientSSK.java
+++ b/src/main/java/network/crypta/keys/InsertableClientSSK.java
@@ -17,7 +17,6 @@ import network.crypta.crypt.UnsupportedCipherException;
 import network.crypta.crypt.Util;
 import network.crypta.crypt.ciphers.Rijndael;
 import network.crypta.keys.Key.Compressed;
-import network.crypta.support.api.Bucket;
 import network.crypta.support.compress.InvalidCompressionCodecException;
 import network.crypta.support.math.MersenneTwister;
 import org.bouncycastle.crypto.digests.SHA256Digest;
@@ -174,25 +173,15 @@ public class InsertableClientSSK extends ClientSSK {
    */
   public ClientSSKBlock encode(BlockEncodeParams params)
       throws SSKEncodeException, IOException, InvalidCompressionCodecException {
-    Bucket sourceData = params.sourceData();
     boolean asMetadata = params.asMetadata();
-    boolean dontCompress = params.dontCompress();
-    short alreadyCompressedCodec = params.alreadyCompressedCodec();
-    long sourceLength = params.sourceLength();
-    String compressorDescriptor = params.compressorDescriptor();
     byte[] compressedData;
     short compressionAlgo;
     try {
       Compressed comp =
           Key.compress(
-              sourceData,
-              dontCompress,
-              alreadyCompressedCodec,
-              sourceLength,
-              ClientSSKBlock.MAX_DECOMPRESSED_DATA_LENGTH,
-              SSKBlock.DATA_LENGTH,
-              true,
-              compressorDescriptor);
+              params,
+              new CompressionLimits(
+                  ClientSSKBlock.MAX_DECOMPRESSED_DATA_LENGTH, SSKBlock.DATA_LENGTH, true));
       compressedData = comp.compressedData;
       compressionAlgo = comp.compressionAlgorithm;
     } catch (KeyEncodeException e) {
@@ -229,7 +218,7 @@ public class InsertableClientSSK extends ClientSSK {
       throw new IllegalStateException("256/256 Rijndael not supported!", e);
     }
 
-    // Encrypt data. Key = SHA-256(plaintext); IV/feedback state comes from PCFB construction.
+    // Encrypt data. Key = SHA-256 (plaintext); IV/feedback state comes from PCFB construction.
     aes.initialize(origDataHash);
     PCFBMode pcfb = PCFBMode.create(aes, origDataHash);
 

--- a/src/main/java/network/crypta/keys/Key.java
+++ b/src/main/java/network/crypta/keys/Key.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * with the corresponding {@code read*} methods and any on-disk structures that store keys.
  *
  * <p>Thread-safety: Instances are immutable except a lazily computed cache used by {@link
- * #toNormalizedDouble()}. That cache is updated under synchronization and read-only usage is safe
+ * #toNormalizedDouble()}. That cache is updated under synchronization, and read-only usage is safe
  * across threads.
  *
  * @author amphibian
@@ -175,7 +175,7 @@ public abstract class Key implements WritableToDataOutputStream, Comparable<Key>
    * Return a stable hash-derived position in the half-open interval {@code [0.0, 1.0)}.
    *
    * <p>The routing key and type are hashed with SHA‑256 and mapped uniformly to a double. The value
-   * is computed once and cached; subsequent calls return the cached value.
+   * is computed once and cached; later calls return the cached value.
    */
   public synchronized double toNormalizedDouble() {
     if (cachedNormalizedDouble > 0) return cachedNormalizedDouble;
@@ -214,22 +214,24 @@ public abstract class Key implements WritableToDataOutputStream, Comparable<Key>
   }
 
   /**
-   * Decompress a block into a {@link Bucket} when {@code isCompressed} is {@code true}; otherwise
-   * return an immutable bucket view over the input bytes.
+   * Decompress a block into a {@link Bucket} when compression is enabled; otherwise return an
+   * immutable bucket view over the input bytes.
    *
    * <p>When compressed, the input is expected to start with a precompressed-length header of 2 or 4
-   * bytes as selected by {@code shortLength}. The method enforces {@code maxLength} and the
-   * codec-specific maximum to protect against resource exhaustion.
+   * bytes as selected by {@link DecompressionParams#shortLength()}. The method enforces {@link
+   * DecompressionParams#maxLength()} and the codec-specific maximum to protect against resource
+   * exhaustion.
+   *
+   * @param params bundle of decompression inputs
    */
-  static Bucket decompress(
-      boolean isCompressed,
-      byte[] input,
-      int inputLength,
-      BucketFactory bf,
-      long maxLength,
-      short compressionAlgorithm,
-      boolean shortLength)
-      throws CHKDecodeException, IOException {
+  static Bucket decompress(DecompressionParams params) throws CHKDecodeException, IOException {
+    boolean isCompressed = params.isCompressed();
+    byte[] input = params.input();
+    int inputLength = params.inputLength();
+    BucketFactory bf = params.bf();
+    long maxLength = params.maxLength();
+    short compressionAlgorithm = params.compressionAlgorithm();
+    boolean shortLength = params.shortLength();
     if (maxLength < 0) throw new IllegalArgumentException("maxlength=" + maxLength);
     if (input.length < inputLength)
       throw new IndexOutOfBoundsException(input.length + "<" + inputLength);
@@ -320,53 +322,31 @@ public abstract class Key implements WritableToDataOutputStream, Comparable<Key>
    * Compress {@code sourceData} when allowed and beneficial.
    *
    * <p>If compression is applied, the returned byte array is prefixed with the original
-   * uncompressed length encoded in 2 or 4 bytes depending on {@code shortLength}. If compression is
-   * not applied, the returned bytes contain the original data without a length header.
+   * uncompressed length encoded in 2 or 4 bytes depending on {@link
+   * CompressionLimits#shortLength()}. If compression is not applied, the returned bytes contain the
+   * original data without a length header.
    *
-   * @param sourceData input bucket to read from.
-   * @param dontCompress when {@code true}, skip trying compressors unless {@code
-   *     alreadyCompressedCodec} is provided.
-   * @param alreadyCompressedCodec when non-negative, treat {@code sourceData} as already compressed
-   *     with the given codec and only add the length header.
-   * @param sourceLength logical uncompressed length to record in the header when compression is
-   *     used.
-   * @param maxLengthBeforeCompression upper bound on {@code sourceData.size()} before any
-   *     compression attempt; larger inputs fail fast.
-   * @param maxCompressedLengthLimit hard limit on the size of the byte array returned by this
-   *     method.
-   * @param shortLength if {@code true}, use a 2-byte length header; otherwise use 4 bytes.
-   * @param compressorDescriptor descriptor string used to select candidate compressors.
+   * @param params bundle of source data and compression flags
+   * @param limits size limits and header layout hints
    * @return a {@link Compressed} result containing the bytes to persist and the codec id (negative
    *     when uncompressed).
    * @throws KeyEncodeException if the input is larger than permitted after considering limits.
    * @throws IOException on I/O failure while materializing bucket contents.
-   * @throws InvalidCompressionCodecException if {@code compressorDescriptor} is invalid.
+   * @throws InvalidCompressionCodecException if {@code params.compressorDescriptor()} is invalid.
    */
-  public static Compressed compress(
-      Bucket sourceData,
-      boolean dontCompress,
-      short alreadyCompressedCodec,
-      long sourceLength,
-      long maxLengthBeforeCompression,
-      int maxCompressedLengthLimit,
-      boolean shortLength,
-      String compressorDescriptor)
+  public static Compressed compress(BlockEncodeParams params, CompressionLimits limits)
       throws KeyEncodeException, IOException, InvalidCompressionCodecException {
+    Bucket sourceData = params.sourceData();
+    long maxLengthBeforeCompression = limits.maxLengthBeforeCompression();
+    int maxCompressedLengthLimit = limits.maxCompressedLengthLimit();
+    boolean shortLength = limits.shortLength();
     byte[] finalData = null;
     short compressionAlgorithm = -1;
     int maxCompressedDataLength =
         adjustedMaxCompressedLength(maxCompressedLengthLimit, shortLength);
     if (sourceData.size() > maxLengthBeforeCompression) throw new KeyEncodeException("Too big");
 
-    CompressionPrep prep =
-        prepareCompressionData(
-            sourceData,
-            dontCompress,
-            alreadyCompressedCodec,
-            sourceLength,
-            maxLengthBeforeCompression,
-            maxCompressedDataLength,
-            compressorDescriptor);
+    CompressionPrep prep = prepareCompressionData(params, limits, maxCompressedDataLength);
     if (prep != null) {
       finalData = addLengthHeader(prep.cbuf(), prep.headerSourceLength(), shortLength);
       compressionAlgorithm = prep.algorithm();
@@ -415,14 +395,14 @@ public abstract class Key implements WritableToDataOutputStream, Comparable<Key>
   }
 
   private static CompressionPrep prepareCompressionData(
-      Bucket sourceData,
-      boolean dontCompress,
-      short alreadyCompressedCodec,
-      long sourceLength,
-      long maxLengthBeforeCompression,
-      int maxCompressedDataLength,
-      String compressorDescriptor)
+      BlockEncodeParams params, CompressionLimits limits, int maxCompressedDataLength)
       throws IOException, InvalidCompressionCodecException {
+    Bucket sourceData = params.sourceData();
+    boolean dontCompress = params.dontCompress();
+    short alreadyCompressedCodec = params.alreadyCompressedCodec();
+    long sourceLength = params.sourceLength();
+    String compressorDescriptor = params.compressorDescriptor();
+    long maxLengthBeforeCompression = limits.maxLengthBeforeCompression();
     if (dontCompress && alreadyCompressedCodec < 0) {
       return null;
     }
@@ -515,7 +495,7 @@ public abstract class Key implements WritableToDataOutputStream, Comparable<Key>
                 comp.compress(
                     sourceData, new ArrayBucketFactory(), Long.MAX_VALUE, maxCompressedDataLength);
       } catch (IOException _) {
-        // Ignore and try next compressor.
+        // Ignore and try the next compressor.
       }
       if (compressedData != null && compressedData.size() <= maxCompressedDataLength) {
         try {
@@ -549,8 +529,8 @@ public abstract class Key implements WritableToDataOutputStream, Comparable<Key>
    * Create a client-level block wrapper that corresponds to the provided key and node-level block.
    * The pair must be type-consistent (CHK with {@link CHKBlock}, SSK with {@link SSKBlock}).
    *
-   * @param key client key of matching type.
-   * @param block node-level block of matching type.
+   * @param key client key of the matching type.
+   * @param block node-level block of the matching type.
    * @return a {@link ClientCHKBlock} or {@link ClientSSKBlock} as appropriate.
    * @throws KeyVerifyException if construction fails (for example, due to a bad public key).
    */
@@ -577,7 +557,7 @@ public abstract class Key implements WritableToDataOutputStream, Comparable<Key>
   public abstract Key archivalCopy();
 
   /**
-   * Return whether the provided algorithm identifier is recognized by this implementation.
+   * Return whether this implementation recognizes the provided algorithm identifier.
    *
    * @param cryptoAlgorithm low 8-bit algorithm identifier as used in {@link #getType()}.
    * @return {@code true} if supported; {@code false} otherwise.

--- a/src/main/java/network/crypta/node/simulator/RealNodeRequestInsertTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeRequestInsertTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import network.crypta.crypt.DummyRandomSource;
 import network.crypta.crypt.RandomSource;
+import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKEncodeException;
 import network.crypta.keys.ClientCHKBlock;
 import network.crypta.keys.ClientKSK;
@@ -42,7 +43,7 @@ import org.slf4j.event.Level;
  * <p>This harness bootstraps a fixed-size darknet topology, inserts a small payload on a randomly
  * selected node, and attempts to fetch the same data from another node until a target number of
  * successful fetches is reached. It is intended for manual or batch execution to observe routing
- * health and basic data integrity in a controlled environment. The class owns all test state,
+ * health and basic data integrity in a controlled environment. The class owns all test states,
  * including node instances, request counters, and success tracking, and it is not thread-safe; run
  * it from a single driver thread and avoid sharing instances across concurrent tests.
  *
@@ -73,14 +74,14 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
   static final boolean ENABLE_FOAF = true;
   static final boolean FORK_ON_CACHEABLE = false;
   static final boolean DISABLE_PROBABILISTIC_HTLS = true;
-  // Set to true to cache everything. This depends on security level.
+  // Set to true to cache everything. This depends on the security level.
   static final boolean USE_SLASHDOT_CACHE = false;
   static final boolean REAL_TIME_FLAG = false;
 
   static final int TARGET_SUCCESSES = 20;
 
   // High bwlimit makes the "other" requests not affect the test requests.
-  // Real solution is to get rid of the "other" requests.
+  // The real solution is to get rid of the "other" requests.
   static final int BWLIMIT = 1000 * 1024;
 
   /**
@@ -110,13 +111,12 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
    * The method is not idempotent because it deletes and recreates the working directory on each
    * run. It is intended to be executed from the command line in a controlled environment.
    *
-   * @param args command-line arguments; unused and expected to be empty or ignored
    * @throws CHKEncodeException if CHK key generation fails for the test payload
    * @throws NodeInitException if node initialization fails during test setup
    * @throws InterruptedException if the test thread is interrupted while waiting
    */
-  public static void main(String[] args)
-      throws CHKEncodeException, NodeInitException, InterruptedException {
+  @SuppressWarnings("unused")
+  static void main() throws CHKEncodeException, NodeInitException, InterruptedException {
     String name = "realNodeRequestInsertTest";
     File wd = new File(name);
     if (!FileUtil.removeAll(wd)) {
@@ -235,7 +235,7 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
    * Executes a single insert and fetch attempt, updating success tracking.
    *
    * <p>The method selects a random insert node, generates an SSK-based key pair and encoded block,
-   * inserts the block, then selects a distinct fetch node and attempts to retrieve and decode the
+   * inserts the block, then selects a distinct fetch node, and attempts to retrieve and decode the
    * data. It returns {@code -1} to indicate the harness should continue, or a non-negative exit
    * code when a terminal success or failure condition is reached. Each call increments the request
    * counter and updates the running success average for reporting.
@@ -262,7 +262,7 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
       LOG.warn("Interrupted while pausing before insert attempt {}", requestNumber, e1);
     }
     String dataString = baseString + requestNumber;
-    // Pick random node to insert to
+    // Pick a random node to insert to
     int node1 = random.nextInt(NUMBER_OF_NODES);
     Node randomNode = nodes[node1];
 
@@ -292,7 +292,7 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
       LOG.error("Insert failed", putEx);
       return EXIT_INSERT_FAILED;
     }
-    // Pick random node to request from
+    // Pick a random node to request from
     int node2;
     do {
       node2 = random.nextInt(NUMBER_OF_NODES);
@@ -331,12 +331,13 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
       block =
           ((InsertableClientSSK) insertKey)
               .encode(
-                  new ArrayBucket(buf),
-                  false,
-                  false,
-                  (short) -1,
-                  buf.length,
-                  Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+                  new BlockEncodeParams(
+                      new ArrayBucket(buf),
+                      false,
+                      false,
+                      (short) -1,
+                      buf.length,
+                      Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
     } else {
       block =
           ClientCHKBlock.encode(

--- a/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
@@ -6,6 +6,7 @@ import network.crypta.crypt.DummyRandomSource;
 import network.crypta.io.comm.DMT;
 import network.crypta.io.comm.PeerParseException;
 import network.crypta.io.comm.ReferenceSignatureVerificationException;
+import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKEncodeException;
 import network.crypta.keys.ClientCHKBlock;
 import network.crypta.keys.ClientKSK;
@@ -47,7 +48,7 @@ import org.slf4j.event.Level;
  * to diversify routing while ULPRs replicate content to nodes that previously requested it.
  *
  * <p>The simulation starts nodes with their own background threads and uses a simple polling loop
- * with a one-second tick to measure propagation time. It is not designed to be run concurrently in
+ * with a one-second tick to measure propagation time. It is not designed to be run concurrently on
  * the same JVM because it exits the process on failure and uses shared static configuration.
  *
  * <p><b>Responsibilities:</b>
@@ -72,18 +73,18 @@ public class RealNodeULPRTest extends RealNodeTest {
    *
    * <p>This value is derived from {@link RealNodePingTest#DARKNET_PORT_END} so the ULPR test can
    * run alongside other simulator tests without colliding on port assignments. Nodes are assigned
-   * consecutive ports starting at this base, so the range is deterministic across runs.
+   * to consecutive ports starting at this base, so the range is deterministic across runs.
    */
   public static final int DARKNET_PORT_BASE = RealNodePingTest.DARKNET_PORT_END;
 
   /**
    * Creates a new ULPR test harness instance.
    *
-   * <p>The class is typically used via its {@link #main(String[])} entry point, but a public
-   * constructor is provided to satisfy doclint requirements for public types. The constructor is
-   * intentionally side-effect free: it does not allocate nodes, create files, or start background
-   * threads. Callers are expected to invoke static setup routines explicitly rather than relying on
-   * instance initialization.
+   * <p>The class is typically used via its {@link #main()} entry point, but a public constructor is
+   * provided to satisfy doclint requirements for public types. The constructor is intentionally
+   * side-effect-free: it does not allocate nodes, create files, or start background threads.
+   * Callers are expected to invoke static setup routines explicitly rather than relying on instance
+   * initialization.
    */
   public RealNodeULPRTest() {
     // Intentionally empty: the harness is driven via static entry points.
@@ -104,7 +105,6 @@ public class RealNodeULPRTest extends RealNodeTest {
    * }
    * }</pre>
    *
-   * @param args command-line arguments; unused but reserved for future flags and harnesses
    * @throws FSParseException if a node reference cannot be parsed during linking
    * @throws PeerParseException if a peer record is malformed while connecting nodes
    * @throws CHKEncodeException if a CHK block cannot be encoded for the test key
@@ -117,7 +117,7 @@ public class RealNodeULPRTest extends RealNodeTest {
    * @throws InvalidCompressionCodecException if the default compression descriptor is unsupported
    * @throws PeerTooOldException if a peer is rejected due to an incompatible version
    */
-  public static void main(String[] args)
+  public static void main()
       throws FSParseException,
           PeerParseException,
           CHKEncodeException,
@@ -292,12 +292,13 @@ public class RealNodeULPRTest extends RealNodeTest {
       fetchKey = ClientKSK.create(testKey);
       block =
           insertKey.encode(
-              new ArrayBucket(buf),
-              false,
-              false,
-              (short) -1,
-              buf.length,
-              Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+              new BlockEncodeParams(
+                  new ArrayBucket(buf),
+                  false,
+                  false,
+                  (short) -1,
+                  buf.length,
+                  Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
     } else {
       block =
           ClientCHKBlock.encode(

--- a/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
@@ -101,7 +101,7 @@ public class RealNodeULPRTest extends RealNodeTest {
    *
    * <pre>{@code
    * public static void main(String[] args) throws Exception {
-   *   RealNodeULPRTest.main(args);
+   *   RealNodeULPRTest.main();
    * }
    * }</pre>
    *

--- a/src/test/java/network/crypta/keys/ClientCHKBlockTest.java
+++ b/src/test/java/network/crypta/keys/ClientCHKBlockTest.java
@@ -83,12 +83,8 @@ class ClientCHKBlockTest {
     System.arraycopy(data, 0, copyOfData, 0, data.length);
     ClientCHKBlock encodedBlock =
         ClientCHKBlock.encode(
-            new ArrayBucket(data),
-            false,
-            false,
-            (short) -1,
-            data.length,
-            null,
+            new BlockEncodeParams(
+                new ArrayBucket(data), false, false, (short) -1, data.length, null),
             null,
             cryptoAlgorithm);
     // Not modified in-place.
@@ -98,12 +94,8 @@ class ClientCHKBlockTest {
       // Check with no JCA.
       ClientCHKBlock otherEncodedBlock =
           ClientCHKBlock.encode(
-              new ArrayBucket(data),
-              false,
-              false,
-              (short) -1,
-              data.length,
-              null,
+              new BlockEncodeParams(
+                  new ArrayBucket(data), false, false, (short) -1, data.length, null),
               null,
               cryptoAlgorithm,
               true);
@@ -257,18 +249,17 @@ class ClientCHKBlockTest {
     byte[] data = new byte[CHKBlock.DATA_LENGTH];
     byte[] encKey = new byte[Node.SYMMETRIC_KEY_LENGTH];
     MessageDigest md = network.crypta.crypt.SHA256.getMessageDigest();
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            ClientCHKBlock.encodeNew(
-                data,
-                /* dataLength= */ 0,
-                md,
-                encKey,
-                /* asMetadata= */ false,
-                (short) -1,
-                Key.ALGO_AES_PCFB_256_SHA256,
-                KeyBlock.HASH_SHA256));
+    ClientCHKEncodeParams params =
+        new ClientCHKEncodeParams(
+            data,
+            /* dataLength= */ 0,
+            md,
+            encKey,
+            /* asMetadata= */ false,
+            (short) -1,
+            Key.ALGO_AES_PCFB_256_SHA256,
+            KeyBlock.HASH_SHA256);
+    assertThrows(IllegalArgumentException.class, () -> ClientCHKBlock.encodeNew(params));
   }
 
   @Test
@@ -279,13 +270,15 @@ class ClientCHKBlockTest {
     MessageDigest md = network.crypta.crypt.SHA256.getMessageDigest();
     byte[] encKey = new byte[Node.SYMMETRIC_KEY_LENGTH];
     ClientCHKBlock.innerEncode(
-        data,
-        /* dataLength= */ 123,
-        md,
-        encKey,
-        /* asMetadata= */ false,
-        (short) -1,
-        Key.ALGO_AES_PCFB_256_SHA256);
+        new ClientCHKEncodeParams(
+            data,
+            /* dataLength= */ 123,
+            md,
+            encKey,
+            /* asMetadata= */ false,
+            (short) -1,
+            Key.ALGO_AES_PCFB_256_SHA256,
+            KeyBlock.HASH_SHA256));
     // Ensure the original input array was not mutated
     assertArrayEquals(original, data);
   }

--- a/src/test/java/network/crypta/keys/ClientSSKBlockTest.java
+++ b/src/test/java/network/crypta/keys/ClientSSKBlockTest.java
@@ -2,13 +2,9 @@ package network.crypta.keys;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -53,67 +49,8 @@ class ClientSSKBlockTest {
 
     ClientSSKBlock block =
         key.encode(
-            src,
-            false, // asMetadata
-            true, // dontCompress
-            (short) -1, // alreadyCompressedCodec
-            src.size(),
-            Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-
-    byte[] bytes;
-    try (Bucket decoded = block.decode(new ArrayBucketFactory(), 32 * 1024, true)) {
-      bytes = BucketTools.toByteArray(decoded);
-    }
-
-    assertArrayEquals(text.getBytes(StandardCharsets.UTF_8), bytes);
-    assertFalse(block.isMetadata());
-    assertEquals((short) -1, block.getCompressionCodec());
-    assertSame(key, block.getClientKey());
-    assertNotNull(block.getBlock());
-    assertNotNull(block.getKey());
-
-    // memoryDecode() with default path should match decode(..., dontDecompress=false) for
-    // uncompressed data
-    byte[] mem = block.memoryDecode();
-    assertArrayEquals(text.getBytes(StandardCharsets.UTF_8), mem);
-  }
-
-  @Test
-  @DisplayName("metadata flag: set during encode and observable after decode")
-  void decode_whenAsMetadata_expectIsMetadataTrue() throws Exception {
-    String docName = "doc-meta";
-    byte[] payload = {1, 2, 3};
-
-    InsertableClientSSK key = InsertableClientSSK.createRandom(rng, docName);
-    Bucket src = new SimpleReadOnlyArrayBucket(payload);
-
-    ClientSSKBlock block =
-        key.encode(
-            src,
-            true, // asMetadata
-            true, // dontCompress
-            (short) -1,
-            src.size(),
-            Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-
-    // Before decode, calling isMetadata() should throw
-    assertThrows(IllegalStateException.class, block::isMetadata);
-
-    // After decode, flag should be set
-    try (Bucket decoded = block.decode(new ArrayBucketFactory(), 32 * 1024, true)) {
-      assertNotNull(decoded);
-    }
-    assertTrue(block.isMetadata());
-  }
-
-  @Test
-  @DisplayName("isMetadata precondition: throws when called before decode")
-  void isMetadata_whenCalledBeforeDecode_expectIllegalStateException() throws Exception {
-    InsertableClientSSK key = InsertableClientSSK.createRandom(rng, "precondition");
-    Bucket src = new SimpleReadOnlyArrayBucket("x".getBytes(StandardCharsets.UTF_8));
-    ClientSSKBlock block =
-        key.encode(
-            src, false, true, (short) -1, src.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+            new BlockEncodeParams(
+                src, false, true, (short) -1, src.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
 
     assertThrows(IllegalStateException.class, block::isMetadata);
   }
@@ -126,11 +63,13 @@ class ClientSSKBlockTest {
 
     ClientSSKBlock a =
         key.encode(
-            src, false, true, (short) -1, src.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+            new BlockEncodeParams(
+                src, false, true, (short) -1, src.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
     // Re-encode the same source with the same key → deterministic block
     ClientSSKBlock b =
         key.encode(
-            src, false, true, (short) -1, src.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+            new BlockEncodeParams(
+                src, false, true, (short) -1, src.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
 
     assertNotSame(a, b);
     assertEquals(a, b);
@@ -140,7 +79,13 @@ class ClientSSKBlockTest {
     Bucket src2 = new SimpleReadOnlyArrayBucket("abcd".getBytes(StandardCharsets.UTF_8));
     ClientSSKBlock c =
         key.encode(
-            src2, false, true, (short) -1, src2.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+            new BlockEncodeParams(
+                src2,
+                false,
+                true,
+                (short) -1,
+                src2.size(),
+                Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
     assertNotEquals(a, c);
   }
 
@@ -185,7 +130,8 @@ class ClientSSKBlockTest {
     Bucket src = new SimpleReadOnlyArrayBucket(text.getBytes(StandardCharsets.UTF_8));
     ClientSSKBlock block =
         key.encode(
-            src, false, true, (short) -1, src.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+            new BlockEncodeParams(
+                src, false, true, (short) -1, src.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
 
     byte[] raw;
     try (Bucket b = block.decode(new ArrayBucketFactory(), 32768, true)) {
@@ -213,7 +159,7 @@ class ClientSSKBlockTest {
       boolean asMetadata,
       short compressionAlg)
       throws Exception {
-    // Prepare the decrypted header segment: [32] dataDecryptKey || [2] len+meta || [2] codec
+    // Prepare decrypted header segment: dataDecryptKey, length+meta, codec.
     byte[] decryptedHeader = new byte[SSKBlock.ENCRYPTED_HEADERS_LENGTH];
     byte[] dataDecryptKey = new byte[ClientSSKBlock.DATA_DECRYPT_KEY_LENGTH];
     Arrays.fill(dataDecryptKey, (byte) 0x42);
@@ -246,7 +192,7 @@ class ClientSSKBlockTest {
     System.arraycopy(encHeader, 0, headers, x, encHeader.length);
     x += encHeader.length;
 
-    // Construct the ciphertext payload: encrypt 1024 bytes using dataDecryptKey as key and IV
+    // Construct the ciphertext payload: encrypt 1024 bytes using dataDecryptKey as the key and IV
     byte[] data = new byte[SSKBlock.DATA_LENGTH];
     if (plaintext.length > data.length) throw new IllegalArgumentException("plaintext too long");
     System.arraycopy(plaintext, 0, data, 0, Math.min(plaintext.length, Math.max(0, dataLength)));

--- a/src/test/java/network/crypta/keys/InsertableClientSSKTest.java
+++ b/src/test/java/network/crypta/keys/InsertableClientSSKTest.java
@@ -200,12 +200,13 @@ class InsertableClientSSKTest {
     // Act
     ClientSSKBlock block =
         ssk.encode(
-            input,
-            /* asMetadata= */ false,
-            /* dontCompress= */ true,
-            /* alreadyCompressedCodec= */ (short) -1,
-            /* sourceLength= */ payload.length,
-            /* compressordescriptor= */ null);
+            new BlockEncodeParams(
+                input,
+                /* asMetadata= */ false,
+                /* dontCompress= */ true,
+                /* alreadyCompressedCodec= */ (short) -1,
+                /* sourceLength= */ payload.length,
+                /* compressordescriptor= */ null));
 
     byte[] decoded = block.memoryDecode(false);
 
@@ -233,12 +234,13 @@ class InsertableClientSSKTest {
 
     ClientSSKBlock block =
         ssk.encode(
-            input,
-            /* asMetadata= */ true,
-            /* dontCompress= */ true,
-            /* alreadyCompressedCodec= */ (short) -1,
-            /* sourceLength= */ payload.length,
-            /* compressordescriptor= */ null);
+            new BlockEncodeParams(
+                input,
+                /* asMetadata= */ true,
+                /* dontCompress= */ true,
+                /* alreadyCompressedCodec= */ (short) -1,
+                /* sourceLength= */ payload.length,
+                /* compressordescriptor= */ null));
 
     // Need to decode before isMetadata() is accessible
     block.memoryDecode(true);
@@ -259,7 +261,7 @@ class InsertableClientSSKTest {
   private static java.util.stream.Stream<Arguments> invalidInsertSskExtras() {
     byte[] base = ClientSSK.getExtraBytes(Key.ALGO_AES_PCFB_256_SHA256);
     byte[] notPrivate = base.clone();
-    notPrivate[1] = 0; // fetch/public, should be rejected for insert private URIs
+    notPrivate[1] = 0; // fetch/public should be rejected for insert private URIs
 
     byte[] wrongAlgo = base.clone();
     wrongAlgo[1] = 1;
@@ -278,7 +280,7 @@ class InsertableClientSSKTest {
     extras[1] = 1; // insert
     byte[] crypto = new byte[32];
 
-    // Missing routing key
+    // Missing the routing key
     FreenetURI noRouting = new FreenetURI("SSK", "d", null, null, crypto, extras);
     MalformedURLException ex1 =
         assertThrows(MalformedURLException.class, () -> InsertableClientSSK.create(noRouting));

--- a/src/test/java/network/crypta/node/NodeClientCoreSupportTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreSupportTest.java
@@ -31,6 +31,7 @@ import network.crypta.crypt.DummyRandomSource;
 import network.crypta.fs.AppDirs;
 import network.crypta.fs.Resolved;
 import network.crypta.fs.ServiceDirs;
+import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKEncodeException;
 import network.crypta.keys.CHKVerifyException;
@@ -526,6 +527,12 @@ class NodeClientCoreSupportTest {
     InsertableClientSSK key = InsertableClientSSK.createRandom(random, SSK_DOC_NAME);
     SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(SSK_SAMPLE_BYTES);
     return key.encode(
-        bucket, false, true, (short) -1, bucket.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+        new BlockEncodeParams(
+            bucket,
+            false,
+            true,
+            (short) -1,
+            bucket.size(),
+            Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
   }
 }

--- a/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.crypt.DummyRandomSource;
 import network.crypta.crypt.RandomSource;
+import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKEncodeException;
 import network.crypta.keys.ClientCHK;
@@ -413,7 +414,13 @@ class NodeClientCoreTransfersTest {
     InsertableClientSSK key = InsertableClientSSK.createRandom(rng, SSK_DOC_NAME);
     SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(SSK_SAMPLE_BYTES);
     return key.encode(
-        bucket, false, true, (short) -1, bucket.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+        new BlockEncodeParams(
+            bucket,
+            false,
+            true,
+            (short) -1,
+            bucket.size(),
+            Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
   }
 
   private static void setField(Object target, String fieldName, Object value) throws Exception {

--- a/src/test/java/network/crypta/node/simulator/RealNodeULPRTestTest.java
+++ b/src/test/java/network/crypta/node/simulator/RealNodeULPRTestTest.java
@@ -46,12 +46,12 @@ class RealNodeULPRTestTest {
 
   @Test
   void main_whenReflected_expectPublicStaticVoidSignature() throws Exception {
-    Method main = RealNodeULPRTest.class.getDeclaredMethod("main", String[].class);
+    Method main = RealNodeULPRTest.class.getDeclaredMethod("main");
 
     int modifiers = main.getModifiers();
     assertTrue(Modifier.isPublic(modifiers));
     assertTrue(Modifier.isStatic(modifiers));
     assertEquals(void.class, main.getReturnType());
-    assertArrayEquals(new Class<?>[] {String[].class}, main.getParameterTypes());
+    assertArrayEquals(new Class<?>[0], main.getParameterTypes());
   }
 }

--- a/src/test/java/network/crypta/store/RAMSaltMigrationTest.java
+++ b/src/test/java/network/crypta/store/RAMSaltMigrationTest.java
@@ -21,6 +21,7 @@ import java.util.function.BooleanSupplier;
 import java.util.stream.Stream;
 import network.crypta.crypt.DummyRandomSource;
 import network.crypta.crypt.RandomSource;
+import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKDecodeException;
 import network.crypta.keys.CHKEncodeException;
@@ -127,7 +128,7 @@ class RAMSaltMigrationTest {
   }
 
   /**
-   * Probe all inserted keys and see what is actually there, after collisions might have happend
+   * Probe all inserted keys and see what is actually there, after collisions might have happened
    * during insert or resize
    *
    * @param store to check for keys
@@ -162,7 +163,7 @@ class RAMSaltMigrationTest {
    * @param store to check
    * @param dummyValueActuallyStoredList of values expected
    * @param blockActuallyStoredList of blocks expecte
-   * @param expectAll true, if all keys must be in the store, or at least one will be sufficient to
+   * @param expectAll true, if all keys must be in the store, or at least one will be enough to
    *     succeed
    * @throws CHKVerifyException when block verification fails
    * @throws CHKDecodeException when block decoding fails
@@ -401,8 +402,7 @@ class RAMSaltMigrationTest {
 
       // Encode a block
       String test = "test" + i;
-      // Use new format for every other block to ensure they are mixed in the same
-      // store.
+      // Use a new format for every other block to ensure they are mixed in the same store.
       ClientCHKBlock block = encodeBlock(test, (i & 1) == 1);
       if (write) store.put(block.getBlock(), false);
 
@@ -482,7 +482,7 @@ class RAMSaltMigrationTest {
     innerTestSaltedStoreWithClose(persistenceTime, testName);
 
     // Assert
-    // Assertions are performed in innerTestSaltedStoreWithClose.
+    // Assertions are performed in the innerTestSaltedStoreWithClose.
   }
 
   @Test
@@ -811,8 +811,8 @@ class RAMSaltMigrationTest {
             null)) {
       saltStore.start(ticker, true);
 
-      // If we did open the new size we expect all previously matched keys to be present.
-      // If we opend the old size, it causes a resize again, which might create new collisions and
+      // If we did open the new size, we expect all previously matched keys to be present.
+      // If we open the old size, it causes a resize again, which might create new collisions and
       // keys might be lost again.
 
       checkStandardTestBlocks(
@@ -926,12 +926,13 @@ class RAMSaltMigrationTest {
     byte[] data = test.getBytes(StandardCharsets.UTF_8);
     SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(data);
     return ClientCHKBlock.encode(
-        bucket,
-        false,
-        false,
-        (short) -1,
-        bucket.size(),
-        Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
+        new BlockEncodeParams(
+            bucket,
+            false,
+            false,
+            (short) -1,
+            bucket.size(),
+            Compressor.DEFAULT_COMPRESSORDESCRIPTOR),
         null,
         newFormat ? Key.ALGO_AES_CTR_256_SHA256 : Key.ALGO_AES_PCFB_256_SHA256);
   }

--- a/src/test/java/network/crypta/store/SlashdotStoreTest.java
+++ b/src/test/java/network/crypta/store/SlashdotStoreTest.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKDecodeException;
 import network.crypta.keys.CHKEncodeException;
@@ -409,12 +410,13 @@ class SlashdotStoreTest {
     byte[] data = test.getBytes(StandardCharsets.UTF_8);
     SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(data);
     return ClientCHKBlock.encode(
-        bucket,
-        false,
-        false,
-        (short) -1,
-        bucket.size(),
-        Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
+        new BlockEncodeParams(
+            bucket,
+            false,
+            false,
+            (short) -1,
+            bucket.size(),
+            Compressor.DEFAULT_COMPRESSORDESCRIPTOR),
         null,
         (byte) 0);
   }

--- a/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
@@ -32,6 +32,7 @@ import network.crypta.crypt.DummyRandomSource;
 import network.crypta.crypt.Global;
 import network.crypta.crypt.RandomSource;
 import network.crypta.crypt.SHA256;
+import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKDecodeException;
 import network.crypta.keys.CHKEncodeException;
@@ -169,7 +170,7 @@ class CachingFreenetStoreTest {
           store.put(block.getBlock(), false);
 
           ClientCHK key = block.getClientKey();
-          // Assert: write-through to underlying store
+          // Assert: write-through to the underlying store
           assertNotNull(
               saltStore.fetch(
                   key.getRoutingKey(),
@@ -235,7 +236,7 @@ class CachingFreenetStoreTest {
         cachingStore.start(null, true);
         List<ClientCHKBlock> chkBlocks = new ArrayList<>();
         List<String> tests = new ArrayList<>();
-        // Act: insert enough blocks to exceed limit and trigger flush
+        // Act: insert enough blocks to exceed the limit and trigger flush
         store.put(block.getBlock(), false);
         chkBlocks.add(block);
         tests.add(test);
@@ -297,7 +298,7 @@ class CachingFreenetStoreTest {
       SSKStore store = new SSKStore(pubkeyCache);
       int sskBlockSize = store.getTotalBlockSize();
 
-      // Create a cache with size limit of 1.5 SSK's.
+      // Create a cache with a size limit of 1.5 SSK's.
       File f = getStorePath("testCollisionsOverMaximumSize");
       try (SaltedHashFreenetStore<SSKBlock> saltStore =
           SaltedHashFreenetStore.construct(
@@ -337,12 +338,14 @@ class CachingFreenetStoreTest {
               new SimpleReadOnlyArrayBucket(test.getBytes(StandardCharsets.UTF_8));
           ClientSSKBlock block =
               ik.encode(
-                  bucket,
-                  false,
-                  false,
-                  (short) -1,
-                  bucket.size(),
-                  Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+                  new BlockEncodeParams(
+                      bucket,
+                      false,
+                      false,
+                      (short) -1,
+                      bucket.size(),
+                      Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
+
           SSKBlock sskBlock = (SSKBlock) block.getBlock();
           pubkeyCache.cacheKey(
               sskBlock.getKey().getPubKeyHash(),
@@ -365,12 +368,14 @@ class CachingFreenetStoreTest {
           bucket = new SimpleReadOnlyArrayBucket(test.getBytes(StandardCharsets.UTF_8));
           block =
               ik.encode(
-                  bucket,
-                  false,
-                  false,
-                  (short) -1,
-                  bucket.size(),
-                  Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+                  new BlockEncodeParams(
+                      bucket,
+                      false,
+                      false,
+                      (short) -1,
+                      bucket.size(),
+                      Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
+
           sskBlock = (SSKBlock) block.getBlock();
           try {
             store.put(sskBlock, false, false);
@@ -387,7 +392,7 @@ class CachingFreenetStoreTest {
           // Size is still one key.
           assertEquals(sskBlockSize, tracker.getSizeOfCache());
 
-          // Write a second key, should trigger write to disk.
+          // Write a second key, should trigger writing to disk.
           DSAPrivateKey privKey2 = new DSAPrivateKey(g, random);
           DSAPublicKey pubKey2 = new DSAPublicKey(g, privKey2);
           byte[] pkHash2 = SHA256.digest(pubKey2.asBytes());
@@ -396,12 +401,13 @@ class CachingFreenetStoreTest {
                   docName, pkHash2, pubKey2, privKey2, ckey, Key.ALGO_AES_PCFB_256_SHA256);
           block =
               ik2.encode(
-                  bucket,
-                  false,
-                  false,
-                  (short) -1,
-                  bucket.size(),
-                  Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+                  new BlockEncodeParams(
+                      bucket,
+                      false,
+                      false,
+                      (short) -1,
+                      bucket.size(),
+                      Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
           SSKBlock sskBlock2 = (SSKBlock) block.getBlock();
           pubkeyCache.cacheKey(
               sskBlock2.getKey().getPubKeyHash(),
@@ -418,7 +424,7 @@ class CachingFreenetStoreTest {
             fail();
           }
 
-          // Assert: after flush both keys are accessible via cache/backing
+          // Assert: after a flush both keys are accessible via cache/backing
           tracker.waitForZero();
 
           assertEquals(store.fetch(sskBlock.getKey(), false, false, false, false, null), sskBlock);
@@ -479,12 +485,14 @@ class CachingFreenetStoreTest {
               new SimpleReadOnlyArrayBucket(test.getBytes(StandardCharsets.UTF_8));
           ClientSSKBlock block =
               ik.encode(
-                  bucket,
-                  false,
-                  false,
-                  (short) -1,
-                  bucket.size(),
-                  Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+                  new BlockEncodeParams(
+                      bucket,
+                      false,
+                      false,
+                      (short) -1,
+                      bucket.size(),
+                      Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
+
           SSKBlock sskBlock = (SSKBlock) block.getBlock();
           pubkeyCache.cacheKey(
               sskBlock.getKey().getPubKeyHash(),
@@ -500,7 +508,7 @@ class CachingFreenetStoreTest {
             fail();
           }
 
-          // Assert: push writes one and empties cache
+          // Assert: push writes one and empties the cache
           assertEquals(tracker.getSizeOfCache(), sskBlockSize);
           assertEquals(cachingStore.pushLeastRecentlyBlock(), sskBlockSize);
           // Assert: nothing left to write
@@ -544,7 +552,7 @@ class CachingFreenetStoreTest {
             true,
             true,
             null)) {
-      // Don't let the write complete until we say so...
+      // Don't let the writing complete until we say so...
       WriteBlockableFreenetStore<SSKBlock> delayStore =
           new WriteBlockableFreenetStore<>(saltStore, true);
       CachingFreenetStoreTracker tracker =
@@ -568,18 +576,19 @@ class CachingFreenetStoreTest {
         // Assert precondition: nothing to write yet
         assertEquals(0, tracker.getSizeOfCache());
         assertEquals(-1, cachingStore.pushLeastRecentlyBlock());
-        // Act: write one key to the cache. It will not be written through to disk.
+        // Act: write one key to the cache. It will not be written through to the disk.
         String test = "test";
         SimpleReadOnlyArrayBucket bucket =
             new SimpleReadOnlyArrayBucket(test.getBytes(StandardCharsets.UTF_8));
         ClientSSKBlock block =
             ik.encode(
-                bucket,
-                false,
-                false,
-                (short) -1,
-                bucket.size(),
-                Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+                new BlockEncodeParams(
+                    bucket,
+                    false,
+                    false,
+                    (short) -1,
+                    bucket.size(),
+                    Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
         SSKBlock sskBlock = (SSKBlock) block.getBlock();
         pubkeyCache.cacheKey(
             sskBlock.getKey().getPubKeyHash(),
@@ -603,7 +612,7 @@ class CachingFreenetStoreTest {
 
           delayStore.waitForSomeBlocked();
 
-          // Write colliding key. Should cause the write above to return 0: After it
+          // Write a colliding key. Should cause the writing above to return 0: After it
           // unlocks, it will see
           // there is a new, different block for that key, and therefore it cannot remove
           // the block, and
@@ -612,12 +621,14 @@ class CachingFreenetStoreTest {
           bucket = new SimpleReadOnlyArrayBucket(test.getBytes(StandardCharsets.UTF_8));
           block =
               ik.encode(
-                  bucket,
-                  false,
-                  false,
-                  (short) -1,
-                  bucket.size(),
-                  Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+                  new BlockEncodeParams(
+                      bucket,
+                      false,
+                      false,
+                      (short) -1,
+                      bucket.size(),
+                      Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
+
           SSKBlock sskBlock2 = (SSKBlock) block.getBlock();
           try {
             store.put(sskBlock2, false, false);
@@ -634,7 +645,7 @@ class CachingFreenetStoreTest {
           // Size is still one key.
           assertEquals(tracker.getSizeOfCache(), sskBlockSize);
 
-          // Act: now let the write through and assert results
+          // Act: now let the writing through and assert results
           delayStore.setBlocked(false);
 
           assertEquals(0L, future.get().longValue());
@@ -748,7 +759,7 @@ class CachingFreenetStoreTest {
           store.put(block.getBlock(), false);
           tests.add(test);
           chkBlocks.add(block);
-          // Assert during write phase: in cache only
+          // Assert during the write phase: in cache only
           assertNull(
               saltStore.fetch(
                   block.getKey().getRoutingKey(),
@@ -792,7 +803,7 @@ class CachingFreenetStoreTest {
           String test = tests.get(i);
           assertEquals(test, data);
 
-          // Check its really in the underlying store
+          // Check it's really in the underlying store
           assertNotNull(
               saltStore2.fetch(
                   block.getKey().getRoutingKey(),
@@ -840,7 +851,7 @@ class CachingFreenetStoreTest {
       try (CachingFreenetStore<CHKBlock> cachingStore =
           new CachingFreenetStore<>(store, saltStore, tracker)) {
         cachingStore.start(null, true);
-        // Act: put five blocks and wait for flush
+        // Act: put five blocks and wait for a flush
         List<ClientCHKBlock> chkBlocks = new ArrayList<>();
         List<String> tests = new ArrayList<>();
 
@@ -1046,7 +1057,7 @@ class CachingFreenetStoreTest {
           new CachingFreenetStore<>(store, saltStore, tracker)) {
         cachingStore.start(null, true);
         RandomSource random = new DummyRandomSource(12345);
-        // Act: enqueue blocks and wait for tracker to flush
+        // Act: enqueue blocks and wait for the tracker to flush
         List<ClientSSKBlock> sskBlocks = new ArrayList<>();
         List<String> tests = new ArrayList<>();
 
@@ -1108,7 +1119,7 @@ class CachingFreenetStoreTest {
           KeyDecodeException,
           KeyCollisionException {
     // Arrange/Act/Assert: helper covers AAA with useSlotFilter=true.
-    // With slot filters on, it should be cached and not throw if same block.
+    // With slot filters on, it should be cached and not thrown if they're the same block.
     checkOnCollisionsSSK(true);
   }
 
@@ -1166,12 +1177,13 @@ class CachingFreenetStoreTest {
     byte[] data = test.getBytes(StandardCharsets.UTF_8);
     SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(data);
     return ClientCHKBlock.encode(
-        bucket,
-        false,
-        false,
-        (short) -1,
-        bucket.size(),
-        Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
+        new BlockEncodeParams(
+            bucket,
+            false,
+            false,
+            (short) -1,
+            bucket.size(),
+            Compressor.DEFAULT_COMPRESSORDESCRIPTOR),
         null,
         (byte) 0);
   }
@@ -1231,16 +1243,17 @@ class CachingFreenetStoreTest {
             new SimpleReadOnlyArrayBucket(test.getBytes(StandardCharsets.UTF_8));
         ClientSSKBlock block =
             ik.encode(
-                bucket,
-                false,
-                false,
-                (short) -1,
-                bucket.size(),
-                Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+                new BlockEncodeParams(
+                    bucket,
+                    false,
+                    false,
+                    (short) -1,
+                    bucket.size(),
+                    Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
         SSKBlock sskBlock = (SSKBlock) block.getBlock();
         store.put(sskBlock, false, false);
 
-        // If the block is the same then there should not be a collision
+        // If the block is the same, then there should not be a collision
         try {
           store.put(sskBlock, false, false);
           assertTrue(true);
@@ -1252,15 +1265,16 @@ class CachingFreenetStoreTest {
             new SimpleReadOnlyArrayBucket(TEST_1.getBytes(StandardCharsets.UTF_8));
         ClientSSKBlock block1 =
             ik.encode(
-                bucket1,
-                false,
-                false,
-                (short) -1,
-                bucket1.size(),
-                Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+                new BlockEncodeParams(
+                    bucket1,
+                    false,
+                    false,
+                    (short) -1,
+                    bucket1.size(),
+                    Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
         SSKBlock sskBlock1 = (SSKBlock) block1.getBlock();
 
-        // if it's different (e.g. different content, same key), there should be a KCE
+        // if it's different (e.g., different content, same key), there should be a KCE
         // thrown
         try {
           store.put(sskBlock1, false, false);
@@ -1332,7 +1346,13 @@ class CachingFreenetStoreTest {
     SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(data);
     InsertableClientSSK ik = InsertableClientSSK.createRandom(random, test);
     return ik.encode(
-        bucket, false, false, (short) -1, bucket.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+        new BlockEncodeParams(
+            bucket,
+            false,
+            false,
+            (short) -1,
+            bucket.size(),
+            Compressor.DEFAULT_COMPRESSORDESCRIPTOR));
   }
 
   static class WaitableCachingFreenetStoreTracker extends CachingFreenetStoreTracker {
@@ -1357,7 +1377,7 @@ class CachingFreenetStoreTest {
       }
     }
 
-    /* Don't reuse (this), avoid changing locking behavior of parent class */
+    /* Don't reuse (this), avoid changing locking behavior of the parent class */
     private final Object sync = new Object();
   }
 
@@ -1874,7 +1894,7 @@ class CachingFreenetStoreTest {
     // While pushLeastRecentlyBlock() calls delegate.put(a,...), replace the cached block with b
     doAnswer(
             _ -> {
-              // Simulate overwrite happening while write is in progress
+              // Simulate overwriting happening while write is in progress
               TestBlock b = new TestBlock(rk, fkB);
               store.put(b, dataB, headerB, true, false);
               return null;
@@ -1885,7 +1905,7 @@ class CachingFreenetStoreTest {
     // Act
     long result = store.pushLeastRecentlyBlock();
 
-    // Assert: changed during write => return 0 and keep cached entry
+    // Assert: changed during writing => return 0 and keep cached entry
     assertEquals(0, result);
     assertFalse(store.isEmpty());
   }

--- a/src/test/java/network/crypta/store/saltedhash/SaltedHashSlotFilterTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/SaltedHashSlotFilterTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKBlock;
 import network.crypta.keys.CHKDecodeException;
 import network.crypta.keys.CHKEncodeException;
@@ -458,12 +459,13 @@ class SaltedHashSlotFilterTest {
     byte[] data = test.getBytes(StandardCharsets.UTF_8);
     SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(data);
     return ClientCHKBlock.encode(
-        bucket,
-        false,
-        false,
-        (short) -1,
-        bucket.size(),
-        Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
+        new BlockEncodeParams(
+            bucket,
+            false,
+            false,
+            (short) -1,
+            bucket.size(),
+            Compressor.DEFAULT_COMPRESSORDESCRIPTOR),
         null,
         (byte) 0);
   }


### PR DESCRIPTION
## Summary
- bundle CHK/SSK encode inputs into shared parameter records
- centralize compression/decompression limits and parameter handling
- update key encode/decode call sites and related tests

## Testing
- Not run (not requested)