### PR TITLE
refactor(node): bundle fragment params

### DIFF
--- a/src/main/java/network/crypta/node/MessageFragment.java
+++ b/src/main/java/network/crypta/node/MessageFragment.java
@@ -30,35 +30,21 @@ class MessageFragment {
   /**
    * Creates a new immutable fragment description.
    *
-   * @param shortMessage {@code true} when the message uses single-byte size fields
-   * @param isFragmented {@code true} when the message is split across multiple fragments
-   * @param firstFragment {@code true} when this is the first fragment of the message
-   * @param messageID identifier of the logical message this fragment belongs to
-   * @param fragmentLength declared fragment length (may differ from {@code fragmentData.length})
-   * @param messageLength total message length for first fragments; otherwise ignored
-   * @param fragmentOffset byte offset of this fragment within the full message (0-based)
-   * @param fragmentData payload bytes of this fragment; used for size and transmission
-   * @param wrapper originating wrapper when sending; {@code null} when created by a receiver
+   * @param header header flags and message identifier metadata
+   * @param sizes length and offset metadata for the fragment
+   * @param payload payload bytes and originating wrapper reference
    */
   public MessageFragment(
-      boolean shortMessage,
-      boolean isFragmented,
-      boolean firstFragment,
-      int messageID,
-      int fragmentLength,
-      int messageLength,
-      int fragmentOffset,
-      byte[] fragmentData,
-      MessageWrapper wrapper) {
-    this.shortMessage = shortMessage;
-    this.isFragmented = isFragmented;
-    this.firstFragment = firstFragment;
-    this.messageID = messageID;
-    this.fragmentLength = fragmentLength;
-    this.messageLength = messageLength;
-    this.fragmentOffset = fragmentOffset;
-    this.fragmentData = fragmentData;
-    this.wrapper = wrapper;
+      MessageFragmentHeader header, MessageFragmentSizes sizes, MessageFragmentPayload payload) {
+    this.shortMessage = header.shortMessage();
+    this.isFragmented = header.isFragmented();
+    this.firstFragment = header.firstFragment();
+    this.messageID = header.messageID();
+    this.fragmentLength = sizes.fragmentLength();
+    this.messageLength = sizes.messageLength();
+    this.fragmentOffset = sizes.fragmentOffset();
+    this.fragmentData = payload.fragmentData();
+    this.wrapper = payload.wrapper();
   }
 
   /**
@@ -75,7 +61,7 @@ class MessageFragment {
     int messageIdAndFlagsBytes = 2; // 2 bytes for message id and flags
     int fragmentLengthBytes = shortMessage ? 1 : 2; // size of the fragment-length field
 
-    // Size of the additional header field present only when the message is fragmented.
+    // The size of the additional header field present only when the message is fragmented.
     // The field carries either the total message length (first fragment) or the fragment offset.
     int offsetOrMessageLengthBytes = 0;
     if (isFragmented) {

--- a/src/main/java/network/crypta/node/MessageFragmentHeader.java
+++ b/src/main/java/network/crypta/node/MessageFragmentHeader.java
@@ -1,0 +1,15 @@
+package network.crypta.node;
+
+/**
+ * Bundles the header flags and message identifier for a fragment.
+ *
+ * <p>The record is an immutable carrier used when constructing {@link MessageFragment} instances.
+ * It performs no validation; callers must supply consistent values.
+ *
+ * @param shortMessage {@code true} when the message uses single-byte size fields
+ * @param isFragmented {@code true} when the message is split across multiple fragments
+ * @param firstFragment {@code true} when this is the first fragment of the message
+ * @param messageID identifier of the logical message this fragment belongs to
+ */
+record MessageFragmentHeader(
+    boolean shortMessage, boolean isFragmented, boolean firstFragment, int messageID) {}

--- a/src/main/java/network/crypta/node/MessageFragmentPayload.java
+++ b/src/main/java/network/crypta/node/MessageFragmentPayload.java
@@ -1,0 +1,91 @@
+package network.crypta.node;
+
+import java.util.Arrays;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Encapsulates a fragment payload buffer together with its optional origin wrapper.
+ *
+ * <p>This record bundles the raw fragment bytes and a reference back to the {@link MessageWrapper}
+ * that produced them, if any. It exists to keep {@link MessageFragment} construction succinct while
+ * still preserving the protocol metadata and payload as separate concepts. The record does not
+ * validate sizes or copy the buffer, so callers must honor the owning message's invariants and
+ * avoid mutating the array after construction if immutability is expected. Instances are
+ * lightweight and may be shared across threads as long as the underlying {@code fragmentData}
+ * remains stable. Equality and hashing are defined in terms of the buffer contents and wrapper
+ * identity, which preserves protocol correctness without forcing wrapper equality semantics.
+ *
+ * <ul>
+ *   <li>Stores the payload bytes used for sizing and transmission.
+ *   <li>Tracks the sender-side wrapper when available, otherwise {@code null}.
+ *   <li>Leaves lifecycle and threading guarantees to the caller and referenced wrapper.
+ * </ul>
+ *
+ * @param fragmentData payload bytes of this fragment; used for size and transmission
+ * @param wrapper originating wrapper when sending; {@code null} when created by a receiver
+ * @see MessageFragment
+ * @see MessageWrapper
+ */
+record MessageFragmentPayload(byte[] fragmentData, MessageWrapper wrapper) {
+  /**
+   * Compares this payload to another object using buffer contents and wrapper identity.
+   *
+   * <p>The comparison is content-based for the byte array, so two payloads with identical {@code
+   * fragmentData} values are considered equal even if the arrays are distinct instances. The
+   * wrapper comparison uses reference equality to avoid invoking any wrapper-level semantics. This
+   * makes the method suitable for cache keys or test assertions where the payload bytes are the
+   * primary concern and wrapper ownership must remain stable.
+   *
+   * @param obj object to compare against; may be {@code null} or another payload instance
+   * @return {@code true} when the other object is a payload with matching bytes and wrapper
+   *     identity
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj
+        instanceof MessageFragmentPayload(byte[] otherFragmentData, MessageWrapper otherWrapper))) {
+      return false;
+    }
+    return Arrays.equals(fragmentData, otherFragmentData) && wrapper == otherWrapper;
+  }
+
+  /**
+   * Computes a hash code based on payload bytes and wrapper identity.
+   *
+   * <p>The hash uses {@link Arrays#hashCode(byte[])} for the buffer contents and combines it with
+   * the wrapper's identity hash. This mirrors {@link #equals(Object)} so that two payloads that are
+   * equal in terms of bytes and wrapper reference produce the same hash. The computation is
+   * deterministic and does not allocate beyond the array walk.
+   *
+   * @return a hash suitable for hash-based collections that track payload equality
+   */
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(fragmentData);
+    result = 31 * result + System.identityHashCode(wrapper);
+    return result;
+  }
+
+  /**
+   * Formats a readable summary containing the payload bytes and wrapper reference.
+   *
+   * <p>The output embeds {@link Arrays#toString(byte[])} for the payload and the wrapper's {@code
+   * toString()} representation (or {@code null} when no wrapper exists). This method is intended
+   * for diagnostics and tests; it does not redact content and therefore should not be used for
+   * logging sensitive payloads. The returned string is non-null and can be safely used in
+   * assertions or debug output.
+   *
+   * @return a non-null string containing the byte contents and wrapper reference
+   */
+  @Override
+  public @NotNull String toString() {
+    return "MessageFragmentPayload[fragmentData="
+        + Arrays.toString(fragmentData)
+        + ", wrapper="
+        + wrapper
+        + ']';
+  }
+}

--- a/src/main/java/network/crypta/node/MessageFragmentSizes.java
+++ b/src/main/java/network/crypta/node/MessageFragmentSizes.java
@@ -1,0 +1,13 @@
+package network.crypta.node;
+
+/**
+ * Captures the length and position metadata for a message fragment.
+ *
+ * <p>The record is an immutable carrier used when constructing {@link MessageFragment} instances.
+ * It performs no validation; callers must supply consistent values.
+ *
+ * @param fragmentLength declared fragment length (may differ from {@code fragmentData.length})
+ * @param messageLength total message length for first fragments; otherwise ignored
+ * @param fragmentOffset byte offset of this fragment within the full message (0-based)
+ */
+record MessageFragmentSizes(int fragmentLength, int messageLength, int fragmentOffset) {}

--- a/src/main/java/network/crypta/node/MessageWrapper.java
+++ b/src/main/java/network/crypta/node/MessageWrapper.java
@@ -193,8 +193,8 @@ public class MessageWrapper {
 
   /**
    * Returns a {@code MessageFragment} with a length of {@code maxLength} or less, or {@code null}
-   * if there is nothing to send. Ranges that have been returned by this function, and not marked as
-   * lost, and data that has been acked is never returned.
+   * if there is nothing to send. Ranges that have been returned by this function and are not marked
+   * as lost, and data that has been acked is never returned.
    *
    * <p>The returned range is inclusive with respect to the source buffer.
    *
@@ -246,15 +246,9 @@ public class MessageWrapper {
 
     boolean isFragmented = !((start == 0) && (dataLength == item.buf.length));
     return new MessageFragment(
-        isShortMessage,
-        isFragmented,
-        start == 0,
-        messageID,
-        dataLength,
-        item.buf.length,
-        start,
-        fragmentData,
-        this);
+        new MessageFragmentHeader(isShortMessage, isFragmented, start == 0, messageID),
+        new MessageFragmentSizes(dataLength, item.buf.length, start),
+        new MessageFragmentPayload(fragmentData, this));
   }
 
   /**
@@ -323,7 +317,7 @@ public class MessageWrapper {
     } else {
       report = everSent.notOverlapping(start, end);
       resent = end - start + 1 - report;
-      // Distribute overhead deterministically between report and resent without allocations
+      // Distribute overhead deterministically between the report and resent without allocations
       if (overhead != 0) {
         if (report > 0 && resent == 0) {
           report += overhead;

--- a/src/main/java/network/crypta/node/NPFPacket.java
+++ b/src/main/java/network/crypta/node/NPFPacket.java
@@ -235,15 +235,9 @@ class NPFPacket {
 
     packet.fragments.add(
         new MessageFragment(
-            shortMessage,
-            isFragmented,
-            firstFragment,
-            messageID,
-            lens.fragmentLength,
-            outMessageLength,
-            outFragmentOffset,
-            fragmentData,
-            null));
+            new MessageFragmentHeader(shortMessage, isFragmented, firstFragment, messageID),
+            new MessageFragmentSizes(lens.fragmentLength, outMessageLength, outFragmentOffset),
+            new MessageFragmentPayload(fragmentData, null)));
 
     return offset;
   }
@@ -303,7 +297,8 @@ class NPFPacket {
       }
 
       // Caller already decoded flags from the header and knows whether this is the first fragment.
-      // Expose both values; the caller uses messageLength for first fragments, and fragmentOffset
+      // Expose both values; the caller uses messageLength for the first fragments, and
+      // fragmentOffset
       // otherwise.
 
       // By contract with caller: first fragment uses messageLength=value, otherwise fragmentOffset
@@ -418,7 +413,8 @@ class NPFPacket {
         int rangeSize = r.end - r.start + 1;
         buf[offset++] = (byte) rangeSize;
       }
-      // Edge case: if the last ack does not fit into previous range, the algorithm above already
+      // Edge case: if the last ack does not fit into the previous range, the algorithm above
+      // already
       // created a separate range for it, so no extra handling is required here.
     }
     return offset;
@@ -504,7 +500,8 @@ class NPFPacket {
     }
 
     if (fragment.isFragmented) {
-      // If firstFragment is true, encode total message length; otherwise encode fragment offset.
+      // If the firstFragment is true, encode total message length; otherwise encode fragment
+      // offset.
       int value;
       if (fragment.firstFragment) {
         value = fragment.messageLength;
@@ -541,10 +538,11 @@ class NPFPacket {
   }
 
   private static void writePadding(byte[] buf, int offset, Random paddingGen) {
-    // Fill remaining space with random padding when capacity remains.
+    // Fill the remaining space with random padding when capacity remains.
     Util.randomBytes(paddingGen, buf, offset, buf.length - offset);
 
-    byte b = (byte) (buf[offset] & 0x9F); // Clear firstFragment/isFragmented bits in padding byte.
+    byte b =
+        (byte) (buf[offset] & 0x9F); // Clear the firstFragment / isFragmented bits in padding byte.
     if (b == 0x1F) b = (byte) 0x9F; // Avoid the lossy message marker (0x1F) in padding.
     buf[offset] = b;
   }
@@ -697,7 +695,7 @@ class NPFPacket {
   }
 
   /**
-   * Return parsed message fragments in send order.
+   * Return parsed message fragments in sending order.
    *
    * @return a mutable list of message fragments
    */

--- a/src/test/java/network/crypta/node/MessageFragmentTest.java
+++ b/src/test/java/network/crypta/node/MessageFragmentTest.java
@@ -22,7 +22,7 @@ class MessageFragmentTest {
     "true,  false,  10, 13", // 2 + 1 + 0 + 10 = 13
     "false, true,   10, 16", // 2 + 2 + 2 + 10 = 16
     "false, false,  10, 14", // 2 + 2 + 0 + 10 = 14
-    "true,  true,    0,  4", // 2 + 1 + 1 + 0  = 4 (empty payload)
+    "true,  true,    0,  4", // 2 + 1 + 1 + 0 = 4 (empty payload)
   })
   @DisplayName("length() computes header + payload size for all flag combinations")
   void length_whenFlagsVary_expectCalculatedSize(
@@ -32,15 +32,9 @@ class MessageFragmentTest {
     MessageWrapper wrapper = mock(MessageWrapper.class);
     MessageFragment fragment =
         new MessageFragment(
-            shortMessage,
-            isFragmented,
-            /* firstFragment= */ true,
-            /* messageID= */ 123,
-            /* fragmentLength= */ dataLen,
-            /* messageLength= */ dataLen,
-            /* fragmentOffset= */ 0,
-            data,
-            wrapper);
+            new MessageFragmentHeader(shortMessage, isFragmented, /* firstFragment= */ true, 123),
+            new MessageFragmentSizes(dataLen, dataLen, 0),
+            new MessageFragmentPayload(data, wrapper));
 
     // Act
     int actual = fragment.length();
@@ -58,15 +52,9 @@ class MessageFragmentTest {
     MessageWrapper wrapper = mock(MessageWrapper.class);
     MessageFragment fragment =
         new MessageFragment(
-            /* shortMessage= */ true,
-            /* isFragmented= */ true,
-            /* firstFragment= */ false,
-            /* messageID= */ 42,
-            /* fragmentLength= */ 999,
-            /* messageLength= */ 12345,
-            /* fragmentOffset= */ 1234,
-            data,
-            wrapper);
+            new MessageFragmentHeader(true, true, /* firstFragment= */ false, 42),
+            new MessageFragmentSizes(999, 12345, 1234),
+            new MessageFragmentPayload(data, wrapper));
 
     // Act
     String s = fragment.toString();
@@ -85,15 +73,9 @@ class MessageFragmentTest {
     MessageWrapper wrapper = mock(MessageWrapper.class);
     MessageFragment fragment =
         new MessageFragment(
-            /* shortMessage= */ false,
-            /* isFragmented= */ false,
-            /* firstFragment= */ true,
-            /* messageID= */ 77,
-            /* fragmentLength= */ 100,
-            /* messageLength= */ 1000,
-            /* fragmentOffset= */ 0,
-            data,
-            wrapper);
+            new MessageFragmentHeader(false, false, /* firstFragment= */ true, 77),
+            new MessageFragmentSizes(100, 1000, 0),
+            new MessageFragmentPayload(data, wrapper));
 
     // Act
     int actual = fragment.length();

--- a/src/test/java/network/crypta/node/NPFPacketTest.java
+++ b/src/test/java/network/crypta/node/NPFPacketTest.java
@@ -212,7 +212,7 @@ class NPFPacketTest {
     assertEquals(0, r.getAcks().size());
     assertEquals(2, r.getFragments().size());
 
-    // Check first fragment
+    // Check the first fragment
     MessageFragment frag = r.getFragments().getFirst();
     assertTrue(frag.shortMessage);
     assertFalse(frag.isFragmented);
@@ -234,7 +234,7 @@ class NPFPacketTest {
         },
         frag.fragmentData);
 
-    // Check second fragment
+    // Check the second fragment
     frag = r.getFragments().get(1);
     assertTrue(frag.shortMessage);
     assertFalse(frag.isFragmented);
@@ -698,24 +698,20 @@ class NPFPacketTest {
     p.setSequenceNumber(100);
     p.addMessageFragment(
         new MessageFragment(
-            true,
-            false,
-            true,
-            0,
-            8,
-            8,
-            0,
-            new byte[] {
-              (byte) 0x01,
-              (byte) 0x23,
-              (byte) 0x45,
-              (byte) 0x67,
-              (byte) 0x89,
-              (byte) 0xAB,
-              (byte) 0xCD,
-              (byte) 0xEF
-            },
-            null));
+            new MessageFragmentHeader(true, false, true, 0),
+            new MessageFragmentSizes(8, 8, 0),
+            new MessageFragmentPayload(
+                new byte[] {
+                  (byte) 0x01,
+                  (byte) 0x23,
+                  (byte) 0x45,
+                  (byte) 0x67,
+                  (byte) 0x89,
+                  (byte) 0xAB,
+                  (byte) 0xCD,
+                  (byte) 0xEF
+                },
+                null)));
 
     byte[] correctData =
         new byte[] {
@@ -768,40 +764,32 @@ class NPFPacketTest {
 
     p.addMessageFragment(
         new MessageFragment(
-            true,
-            false,
-            true,
-            0,
-            8,
-            8,
-            0,
-            new byte[] {
-              (byte) 0x01,
-              (byte) 0x23,
-              (byte) 0x45,
-              (byte) 0x67,
-              (byte) 0x89,
-              (byte) 0xAB,
-              (byte) 0xCD,
-              (byte) 0xEF
-            },
-            null));
+            new MessageFragmentHeader(true, false, true, 0),
+            new MessageFragmentSizes(8, 8, 0),
+            new MessageFragmentPayload(
+                new byte[] {
+                  (byte) 0x01,
+                  (byte) 0x23,
+                  (byte) 0x45,
+                  (byte) 0x67,
+                  (byte) 0x89,
+                  (byte) 0xAB,
+                  (byte) 0xCD,
+                  (byte) 0xEF
+                },
+                null)));
     p.addMessageFragment(
         new MessageFragment(
-            false,
-            true,
-            false,
-            4095,
-            14,
-            1024,
-            256,
-            new byte[] {
-              (byte) 0xfd, (byte) 0x47, (byte) 0xc2, (byte) 0x30,
-              (byte) 0x41, (byte) 0x53, (byte) 0x57, (byte) 0x56,
-              (byte) 0x0e, (byte) 0x56, (byte) 0x69, (byte) 0xf5,
-              (byte) 0x00, (byte) 0x0d
-            },
-            null));
+            new MessageFragmentHeader(false, true, false, 4095),
+            new MessageFragmentSizes(14, 1024, 256),
+            new MessageFragmentPayload(
+                new byte[] {
+                  (byte) 0xfd, (byte) 0x47, (byte) 0xc2, (byte) 0x30,
+                  (byte) 0x41, (byte) 0x53, (byte) 0x57, (byte) 0x56,
+                  (byte) 0x0e, (byte) 0x56, (byte) 0x69, (byte) 0xf5,
+                  (byte) 0x00, (byte) 0x0d
+                },
+                null)));
 
     byte[] correctData =
         new byte[] {
@@ -871,19 +859,29 @@ class NPFPacketTest {
     // Arrange
     NPFPacket p = new NPFPacket();
 
-    p.addMessageFragment(new MessageFragment(true, false, true, 0, 10, 10, 0, new byte[10], null));
+    p.addMessageFragment(
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 0),
+            new MessageFragmentSizes(10, 10, 0),
+            new MessageFragmentPayload(new byte[10], null)));
     // Act & Assert
     assertEquals(20, p.getLength()); // Seqnum (4), numAcks (1), msgID (4), length (1), data (10)
 
     p.addMessageFragment(
-        new MessageFragment(true, false, true, 5000, 10, 10, 0, new byte[10], null));
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 5000),
+            new MessageFragmentSizes(10, 10, 0),
+            new MessageFragmentPayload(new byte[10], null)));
     assertEquals(35, p.getLength()); // + msgID (4), length (1), data (10)
 
     // This fragment adds 13, but the next won't need a full message id anymore, so this should only
     // add 11
     // bytes
     p.addMessageFragment(
-        new MessageFragment(true, false, true, 2500, 10, 10, 0, new byte[10], null));
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 2500),
+            new MessageFragmentSizes(10, 10, 0),
+            new MessageFragmentPayload(new byte[10], null)));
     assertEquals(46, p.getLength());
   }
 
@@ -902,41 +900,11 @@ class NPFPacketTest {
           (byte) 0xCD,
           (byte) 0xEF
         };
-    p.addMessageFragment(new MessageFragment(true, false, true, 0, 8, 8, 0, fragData, null));
-    byte[] lossyFragment =
-        new byte[] {(byte) 0xFF, (byte) 0xEE, (byte) 0xDD, (byte) 0xCC, (byte) 0xBB, (byte) 0xAA};
-    p.addLossyMessage(lossyFragment);
-    byte[] encoded = new byte[p.getLength()];
-    p.toBytes(encoded, 0, null);
-    // Act
-    NPFPacket received = NPFPacket.create(encoded, pn);
-    // Assert
-    assertEquals(1, received.getFragments().size());
-    assertEquals(0, received.countAcks());
-    assertEquals(1, received.getLossyMessages().size());
-    assertEquals(encoded.length, received.getLength());
-    byte[] decodedFragData = received.getFragments().getFirst().fragmentData;
-    checkEquals(fragData, decodedFragData);
-    byte[] decodedLossyMessage = received.getLossyMessages().getFirst();
-    checkEquals(lossyFragment, decodedLossyMessage);
-  }
-
-  @Test
-  void lossyMessages_whenTwoMessages_expectRoundTripBoth() {
-    // Arrange
-    NPFPacket p = new NPFPacket();
-    byte[] fragData =
-        new byte[] {
-          (byte) 0x01,
-          (byte) 0x23,
-          (byte) 0x45,
-          (byte) 0x67,
-          (byte) 0x89,
-          (byte) 0xAB,
-          (byte) 0xCD,
-          (byte) 0xEF
-        };
-    p.addMessageFragment(new MessageFragment(true, false, true, 0, 8, 8, 0, fragData, null));
+    p.addMessageFragment(
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 0),
+            new MessageFragmentSizes(8, 8, 0),
+            new MessageFragmentPayload(fragData, null)));
     byte[] lossyFragment =
         new byte[] {(byte) 0xFF, (byte) 0xEE, (byte) 0xDD, (byte) 0xCC, (byte) 0xBB, (byte) 0xAA};
     byte[] lossyFragment2 =
@@ -975,7 +943,11 @@ class NPFPacketTest {
           (byte) 0xCD,
           (byte) 0xEF
         };
-    p.addMessageFragment(new MessageFragment(true, false, true, 0, 8, 8, 0, fragData, null));
+    p.addMessageFragment(
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 0),
+            new MessageFragmentSizes(8, 8, 0),
+            new MessageFragmentPayload(fragData, null)));
     byte[] lossyFragment =
         new byte[] {(byte) 0xFF, (byte) 0xEE, (byte) 0xDD, (byte) 0xCC, (byte) 0xBB, (byte) 0xAA};
     byte[] lossyFragment2 =
@@ -1115,7 +1087,11 @@ class NPFPacketTest {
     p.setSequenceNumber(123);
     p.addAck(7, 1400);
     byte[] data = new byte[] {9, 8, 7};
-    p.addMessageFragment(new MessageFragment(true, false, true, 100, 3, 3, 0, data, null));
+    p.addMessageFragment(
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 100),
+            new MessageFragmentSizes(3, 3, 0),
+            new MessageFragmentPayload(data, null)));
 
     // Act
     String s = p.toString();
@@ -1145,9 +1121,16 @@ class NPFPacketTest {
     byte[] d2 = new byte[] {(byte) 0x11, (byte) 0x22, (byte) 0x33};
 
     // First fragment: full id (0x10) for message 5000
-    p.addMessageFragment(new MessageFragment(true, false, true, 5000, 3, 3, 0, d1, null));
-    // Second fragment: new message id close to previous (delta 200 < 4096) -> compressed id
-    p.addMessageFragment(new MessageFragment(true, false, true, 5200, 3, 3, 0, d2, null));
+    p.addMessageFragment(
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 5000),
+            new MessageFragmentSizes(3, 3, 0),
+            new MessageFragmentPayload(d1, null)));
+    p.addMessageFragment(
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 5200),
+            new MessageFragmentSizes(3, 3, 0),
+            new MessageFragmentPayload(d2, null)));
 
     // Act
     byte[] encoded = new byte[p.getLength()];
@@ -1189,7 +1172,11 @@ class NPFPacketTest {
     MessageWrapper wrapper = mock(MessageWrapper.class);
     byte[] payload = new byte[] {1, 2, 3, 4};
     // shortMessage=true, isFragmented=false, firstFragment=true, messageLength=4, offset=0
-    p.addMessageFragment(new MessageFragment(true, false, true, 7, 4, 4, 0, payload, wrapper));
+    p.addMessageFragment(
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 7),
+            new MessageFragmentSizes(4, 4, 0),
+            new MessageFragmentPayload(payload, wrapper)));
     NullBasePeerNode peer = pn;
 
     // Act: totalPacketLength larger than payload by 96 -> overhead/size with size==2

--- a/src/test/java/network/crypta/node/NewPacketFormatKeyContextTest.java
+++ b/src/test/java/network/crypta/node/NewPacketFormatKeyContextTest.java
@@ -92,7 +92,7 @@ class NewPacketFormatKeyContextTest {
     NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(5, 0);
     // First allocation sets firstSeqNumUsed to 5
     assertEquals(5, ctx.allocateSequenceNumber(pn));
-    // Force wrap back to first to simulate reuse condition
+    // Force wrap back to first to simulate the reuse condition
     ctx.nextSeqNum = ctx.firstSeqNumUsed;
     assertFalse(ctx.canAllocateSeqNum());
   }
@@ -100,28 +100,28 @@ class NewPacketFormatKeyContextTest {
   @Test
   void allocateSequenceNumber_whenAtFirstSeq_triggersRekeyAndReturnsMinusOne() {
     NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(5, 0);
-    // Establish first used
+    // Establish the first used one
     assertEquals(5, ctx.allocateSequenceNumber(pn));
     // Now next equals first => cannot allocate, rekey
     ctx.nextSeqNum = ctx.firstSeqNumUsed;
     int ret = ctx.allocateSequenceNumber(pn);
     assertEquals(-1, ret);
     verify(pn, times(1)).startRekeying();
-    // nextSeqNum should remain unchanged on failure
+    // the nextSeqNum should remain unchanged on failure
     assertEquals(ctx.firstSeqNumUsed, ctx.nextSeqNum);
   }
 
   @Test
   void allocateSequenceNumber_whenNearWrapWithinThreshold_triggersRekeyAndWrapsToZero() {
     NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(1, 0);
-    // Simulate many prior allocations so firstSeqNumUsed != -1
+    // Simulate many prior allocations so the firstSeqNumUsed != -1
     assertEquals(1, ctx.allocateSequenceNumber(pn));
     ctx.firstSeqNumUsed = 10; // pretend we began at 10 on this key
     ctx.nextSeqNum = Integer.MAX_VALUE; // 0x7fffffff
 
     int ret = ctx.allocateSequenceNumber(pn);
     assertEquals(Integer.MAX_VALUE, ret);
-    // After increment, it would overflow negative; implementation resets to 0
+    // After an increment, it would overflow negative; implementation resets to 0
     assertEquals(0, ctx.nextSeqNum);
     verify(pn, times(1)).startRekeying();
   }
@@ -252,7 +252,7 @@ class NewPacketFormatKeyContextTest {
     NewPacketFormat npf = new NewPacketFormat(null, 0, 0);
     SessionKey key = dummyKey(ctx);
 
-    // Build a SentPacket with at least one message so lostSentTimes is recorded on loss
+    // Build a SentPacket with at least one message, so lostSentTimes is recorded on loss
     SentPacket sp = getSentPacket(npf, key);
 
     // Add to in-flight and force an old sent time so it qualifies as lost
@@ -262,7 +262,7 @@ class NewPacketFormatKeyContextTest {
     long maxDelay = (long) (250 + NewPacketFormatKeyContext.MAX_ACK_DELAY * 1.1); // 470
     long now = 10_000L;
 
-    // Override sent time to be older than threshold
+    // Override sent time to be older than the threshold
     sp.sentTime = now - maxDelay - 1; // package-private field; same package access
 
     PeerTransport transport = mock(PeerTransport.class);
@@ -292,15 +292,9 @@ class NewPacketFormatKeyContextTest {
     MessageWrapper mw = new MessageWrapper(mi, /*messageID*/ 7);
     MessageFragment frag =
         new MessageFragment(
-            /*shortMessage*/ true,
-            /*isFragmented*/ false,
-            /*firstFragment*/ true,
-            /*messageID*/ 7,
-            /*fragmentLength*/ 4,
-            /*messageLength*/ 4,
-            /*fragmentOffset*/ 0,
-            new byte[] {1, 2, 3, 4},
-            mw);
+            new MessageFragmentHeader(true, false, true, 7),
+            new MessageFragmentSizes(4, 4, 0),
+            new MessageFragmentPayload(new byte[] {1, 2, 3, 4}, mw));
     sp.addFragment(frag);
     return sp;
   }
@@ -342,7 +336,7 @@ class NewPacketFormatKeyContextTest {
     assertTrue(sp1.lostCalled);
     assertTrue(sp2.lostCalled);
     assertEquals(0, ctx.countSentPackets());
-    // Internal map should also be empty
+    // The internal map should also be empty
     assertTrue(sentPacketsOf(ctx).isEmpty());
   }
 
@@ -367,7 +361,7 @@ class NewPacketFormatKeyContextTest {
     }
 
     ObservedSentPacket sp = new ObservedSentPacket(npf, key);
-    // Put directly into internal map so we can exercise sent(sequenceNumber, length)
+    // Put directly into the internal map so we can exercise sent(sequenceNumber, length)
     sentPacketsOf(ctx).put(77, sp);
 
     ctx.sent(77, 321);

--- a/src/test/java/network/crypta/node/NewPacketFormatTest.java
+++ b/src/test/java/network/crypta/node/NewPacketFormatTest.java
@@ -33,7 +33,7 @@ class NewPacketFormatTest {
   @BeforeEach
   void setUp() {
     // Because we don't call maybeSendPacket, the packet sent times are not updated,
-    // so lets turn off the keepalives.
+    // so let's turn off the keepalives.
     NewPacketFormat.doKeepalives = false;
   }
 
@@ -66,29 +66,25 @@ class NewPacketFormatTest {
     NPFPacket generated = new NPFPacket();
     generated.addMessageFragment(
         new MessageFragment(
-            true,
-            false,
-            true,
-            0,
-            8,
-            8,
-            0,
-            new byte[] {
-              (byte) 0x01,
-              (byte) 0x23,
-              (byte) 0x45,
-              (byte) 0x67,
-              (byte) 0x89,
-              (byte) 0xAB,
-              (byte) 0xCD,
-              (byte) 0xEF
-            },
-            null));
+            new MessageFragmentHeader(true, false, true, 0),
+            new MessageFragmentSizes(8, 8, 0),
+            new MessageFragmentPayload(
+                new byte[] {
+                  (byte) 0x01,
+                  (byte) 0x23,
+                  (byte) 0x45,
+                  (byte) 0x67,
+                  (byte) 0x89,
+                  (byte) 0xAB,
+                  (byte) 0xCD,
+                  (byte) 0xEF
+                },
+                null)));
 
     // Act
     assertEquals(1, npf.handleDecryptedPacket(generated, s).size());
     boolean keepalivesOrig = NewPacketFormat.doKeepalives;
-    NewPacketFormat.doKeepalives = true; // force send without sleeping
+    NewPacketFormat.doKeepalives = true; // force sending without sleeping
     NPFPacket ackOnly;
     try {
       ackOnly = npf.createPacket(1400, pmq, s, false);
@@ -245,7 +241,8 @@ class NewPacketFormatTest {
         new SessionKey(
             null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
-    // Queue two messages so total queued size exceeds maxPacketSize (512) and triggers immediate
+    // Queue two messages so the total queued size exceeds maxPacketSize (512) and triggers
+    // immediate
     // send.
     senderQueue.queueAndEstimateSize(
         new MessageItem(new byte[400], null, false, null, (short) 0), 1024);
@@ -371,7 +368,7 @@ class NewPacketFormatTest {
     random.nextBytes(message);
     byte[] copyOfMessage = Arrays.copyOf(message, message.length);
 
-    // Queue two messages so total exceeds maxPacketSize (1280) and triggers immediate send.
+    // Queue two messages so the total exceeds maxPacketSize (1280) and triggers immediate send.
     byte[] other = new byte[700];
     random.nextBytes(other);
     senderQueue.queueAndEstimateSize(new MessageItem(message, null, false, null, (short) 0), 4096);
@@ -415,7 +412,7 @@ class NewPacketFormatTest {
     assertNotNull(p, "Expected a packet with one fragment before disconnect");
     assertEquals(1, p.getFragments().size());
 
-    // Now disconnect and ensure the item is returned for requeueing by the caller.
+    // Now disconnect and ensure the caller returns the item for requeueing.
     List<MessageItem> returned = npf.onDisconnect();
     assertEquals(1, returned.size());
     assertEquals(payload.length, returned.getFirst().getLength());
@@ -488,7 +485,10 @@ class NewPacketFormatTest {
     NPFPacket received = new NPFPacket();
     received.setSequenceNumber(123);
     received.addMessageFragment(
-        new MessageFragment(true, false, true, 1, 1, 1, 0, new byte[] {1}, null));
+        new MessageFragment(
+            new MessageFragmentHeader(true, false, true, 1),
+            new MessageFragmentSizes(1, 1, 0),
+            new MessageFragmentPayload(new byte[] {1}, null)));
     List<byte[]> finished = npf.handleDecryptedPacket(received, prev);
     assertEquals(1, finished.size());
 
@@ -565,7 +565,7 @@ class NewPacketFormatTest {
         new NewPacketFormat(receiverNode, receiverStartSeq, senderStartSeq);
 
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
-    // Queue two messages so total exceeds maxPacketSize and triggers immediate send.
+    // Queue two messages so the total exceeds maxPacketSize and triggers immediate send.
     byte[] m1 = new byte[700];
     byte[] m2 = new byte[700];
     random.nextBytes(m1);
@@ -599,7 +599,8 @@ class NewPacketFormatTest {
       @SuppressWarnings("unchecked")
       java.util.HashMap<Integer, NewPacketFormat.SentPacket> map =
           (java.util.HashMap<Integer, NewPacketFormat.SentPacket>) f.get(ctx);
-      long newSent = System.currentTimeMillis() - 5000L; // ample to exceed retransmit threshold
+      long newSent =
+          System.currentTimeMillis() - 5000L; // ample to exceed the retransmitting threshold
       for (NewPacketFormat.SentPacket sp : map.values()) {
         java.lang.reflect.Field sf = NewPacketFormat.SentPacket.class.getDeclaredField("sentTime");
         sf.setAccessible(true);


### PR DESCRIPTION
## Summary
- introduce MessageFragmentHeader/Sizes/Payload records to group fragment constructor inputs
- update packet and wrapper call sites (plus tests) to build fragments with the shared records
- define payload equality/hash/toString based on byte content and wrapper identity

## Testing
- ./gradlew test