### PR TITLE
refactor(node): bundle async get options

### DIFF
--- a/src/main/java/network/crypta/client/async/OfferedKeysList.java
+++ b/src/main/java/network/crypta/client/async/OfferedKeysList.java
@@ -19,6 +19,7 @@ import network.crypta.node.RequestScheduler;
 import network.crypta.node.SendableRequestItem;
 import network.crypta.node.SendableRequestItemKey;
 import network.crypta.node.SendableRequestSender;
+import network.crypta.node.subsystem.NodeRoutingSubsystem;
 import network.crypta.support.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * if the key failed recently elsewhere.
  *
  * <p>Typical usage is: enqueue on offer, pop when scheduling, and remove when a key is found or no
- * longer relevant. The list is de-duplicated and internally represented by a {@code HashSet} for
+ * longer relevant. The list is deduplicated and internally represented by a {@code HashSet} for
  * membership and an {@code ArrayList} to enable low-overhead random selection. The two structures
  * are kept in lockstep; all mutating operations are synchronized on the instance to provide simple
  * thread-safety for callers that access the list from different threads in the client layer.
@@ -56,7 +57,7 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
   private static final Logger LOG = LoggerFactory.getLogger(OfferedKeysList.class);
 
   /**
-   * Set of currently offered keys used for efficient membership tests and de-duplication. The set
+   * Set of currently offered keys used for efficient membership tests and deduplication. The set
    * and the list below always contain the same elements.
    */
   private final HashSet<Key> keys;
@@ -107,7 +108,7 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
   /**
    * Returns whether the offered-keys list is empty at the time of the call.
    *
-   * <p>No synchronization beyond the method's own monitor is required by callers. The result is a
+   * <p>Callers require no synchronization beyond the method's own monitor. The result is a
    * point-in-time observation that may change immediately after return if other threads add or
    * remove keys.
    *
@@ -149,12 +150,12 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
   }
 
   /**
-   * Chooses an offered key to attempt, removing it from the internal structures.
+   * Chooses an offered key to attempt removing it from the internal structures.
    *
-   * <p>If only one key is available it is returned directly (unless the key is already being
-   * fetched locally). Otherwise, up to ten random candidates are sampled to find a key that is not
-   * currently in the local fetching set. When a key is chosen it is removed from the list/set so
-   * subsequent calls will not return it again.
+   * <p>If only one key is available, it is returned directly (unless the key is already being
+   * fetched locally). Otherwise, up to ten random candidates are sampled to find a key not
+   * currently in the local fetching set. When a key is chosen, it is removed from the list/set so
+   * later calls will not return it again.
    *
    * <p>Offered keys deliberately bypass any "recently failed" heuristics so that a fresh peer offer
    * can be tried immediately. If no acceptable key is found, the method returns {@code null}.
@@ -245,7 +246,7 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
    * <p>The sender invokes {@code NodeClientCoreTransfers.asyncGet(...)} with parameters suitable
    * for an opportunistic attempt: it checks the datastore and briefly accepts peer offers; it does
    * not escalate into a full client request and does not write to the client cache. Upon completion
-   * (success or failure) the sender removes the key from the fetching set and wakes the starter so
+   * (success or failure), the sender removes the key from the fetching set and wakes the starter so
    * other work can proceed.
    *
    * @param context the client context from which the sender may derive environment or configuration
@@ -267,11 +268,13 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
         // Don't let a node force us to start a real request for a specific key.
         // We check the datastore, take up offers if any (on a short timeout), and then quit if we
         // still haven't fetched the data.
-        // Obviously this may have a marginal impact on load, but it should only be marginal.
+        // Obviously, this may have a marginal impact on the load, but it should only be marginal.
+        NodeRoutingSubsystem.RequestSenderOptions options =
+            NodeRoutingSubsystem.RequestSenderOptions.of(
+                false, false, true, true, false, realTimeFlag);
         core.getTransfers()
             .asyncGet(
                 key,
-                true,
                 new RequestCompletionListener() {
 
                   @Override
@@ -287,17 +290,13 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
                     // We don't use ChosenBlockImpl so have to remove the keys from the fetching set
                     // ourselves.
                     sched.removeFetchingKey(key);
-                    // Something might be waiting for a request to complete (e.g. if we have two
+                    // Something might be waiting for a request to complete (e.g., if we have two
                     // requests for the same key),
                     // so wake the starter thread.
                     sched.wakeStarter();
                   }
                 },
-                true,
-                false,
-                realTimeFlag,
-                false,
-                false);
+                options);
         // canWriteClientCache remains false intentionally here.
         return true;
       }
@@ -318,7 +317,7 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
   /**
    * Enqueues an offered key if it is not already present.
    *
-   * <p>Keys are de-duplicated across calls. The method is synchronized and maintains the invariant
+   * <p>Keys are deduplicated across calls. The method is synchronized and maintains the invariant
    * that the internal list and set contain identical elements.
    *
    * @param key the key that was offered by a peer and should be considered for an opportunistic
@@ -366,7 +365,7 @@ public class OfferedKeysList extends BaseSendableGet implements RequestClient {
    * Returns the scheduler responsible for handling attempts for this list based on the key type and
    * real-time flag.
    *
-   * @param context the client context used to obtain the appropriate scheduler instance.
+   * @param context the client context used to get the appropriate scheduler instance.
    * @return the SSK or CHK fetch scheduler, selected according to {@link #isSSK()} and {@code
    *     realTimeFlag}.
    */

--- a/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
@@ -64,6 +64,14 @@ public final class NodeClientCoreTransfers {
     this.requestStarters = core.getRequestStarters();
   }
 
+  private record AsyncGetContext(
+      Key key,
+      long uid,
+      RequestCompletionListener listener,
+      RequestTag tag,
+      boolean isSSK,
+      long startTime) {}
+
   /**
    * Schedules a non-blocking fetch for the supplied key and arranges completion callbacks.
    *
@@ -75,28 +83,21 @@ public final class NodeClientCoreTransfers {
    * does not wait for completion. Each invocation is independent, even for repeated keys.
    *
    * @param key key to fetch; typically a {@link Key} or {@link NodeSSK}.
-   * @param offersOnly true to fetch only from offered-key sources.
    * @param listener callback notified for success, failure, or local-store hits.
-   * @param canReadClientCache whether the request may read from the client cache.
-   * @param canWriteClientCache whether the request may write into the client cache.
-   * @param realTimeFlag true for latency-optimized routing; false for bulk throughput.
-   * @param localOnly true to consult only local storage and skip routing.
-   * @param ignoreStore true to bypass the datastore and always create a request.
+   * @param options request flags controlling store access, cache usage, offered-key handling, and
+   *     real-time scheduling.
    */
   public void asyncGet(
       final Key key,
-      boolean offersOnly,
       final RequestCompletionListener listener,
-      boolean canReadClientCache,
-      boolean canWriteClientCache,
-      final boolean realTimeFlag,
-      boolean localOnly,
-      boolean ignoreStore) {
+      NodeRoutingSubsystem.RequestSenderOptions options) {
     final long uid = makeUID();
     final boolean isSSK = key instanceof NodeSSK;
     final RequestTag tag =
-        new RequestTag(isSSK, RequestTag.START.ASYNC_GET, null, realTimeFlag, uid, node);
-    if (!node.routing().tracker().lockUID(uid, isSSK, false, false, true, realTimeFlag, tag)) {
+        new RequestTag(isSSK, RequestTag.START.ASYNC_GET, null, options.realTimeFlag(), uid, node);
+    if (!node.routing()
+        .tracker()
+        .lockUID(uid, isSSK, false, false, true, options.realTimeFlag(), tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       listener.onFailed(
           new LowLevelGetException(
@@ -108,26 +109,14 @@ public final class NodeClientCoreTransfers {
     short htl = node.maxHTL();
     // If another node requested it within the ULPR period at a lower HTL, that may allow
     // us to cache it in the datastore. Find the lowest HTL fetching the key in that period,
-    // and use that for purposes of deciding whether to cache it in the store.
-    if (offersOnly) {
+    // and use that to decide whether to cache it in the store.
+    if (options.offersOnly()) {
       htl = node.routing().failureTable().minOfferedHTL(key, htl);
       if (LOG.isDebugEnabled()) LOG.debug("Using old HTL for GetOfferedKey: {}", htl);
     }
-    final long startTime = System.currentTimeMillis();
-    startAsyncGet(
-        key,
-        offersOnly,
-        uid,
-        listener,
-        tag,
-        canReadClientCache,
-        canWriteClientCache,
-        htl,
-        realTimeFlag,
-        localOnly,
-        ignoreStore,
-        isSSK,
-        startTime);
+    AsyncGetContext context =
+        new AsyncGetContext(key, uid, listener, tag, isSSK, System.currentTimeMillis());
+    startAsyncGet(context, htl, options);
   }
 
   /**
@@ -135,40 +124,21 @@ public final class NodeClientCoreTransfers {
    * will not decode the data because we don't provide a ClientKey. It will not return anything and
    * will run asynchronously. Caller is responsible for unlocking the UID.
    *
-   * @param key The key being fetched.
-   * @param offersOnly If true, only fetch the key from nodes that have offered it, using
-   *     GetOfferedKeys, don't do a normal fetch for it.
-   * @param uid The UID of the request. This should already be locked before calling.
-   * @param requestTag The RequestTag for the request; used for request lifecycle callbacks.
-   * @param listener Will be called by the request sender, if a request is started. However, for
-   *     example, if we fetch it from the store, it will be returned via the tripPendingKeys
-   *     mechanism.
-   * @param canReadClientCache Can this request read the client-cache?
-   * @param canWriteClientCache Can this request write the client-cache?
-   * @param htl The HTL to start the request at. See the caller, this can be modified in the case of
+   * @param context request-specific context (key, UID, listener, and tag) created by the caller.
+   * @param htl The HTL to start the request at. See the caller; this can be modified in the case of
    *     fetching an offered key.
-   * @param realTimeFlag Is this a real-time request? False = this is a bulk request.
-   * @param localOnly If true, only check the datastore, don't create a request if nothing is found.
-   * @param ignoreStore If true, don't check the datastore, create a request immediately.
-   * @param isSSK Whether the request targets an SSK key type.
-   * @param startTime Start time in milliseconds since epoch for metrics.
+   * @param options flags controlling local store access, cache usage, offered-key handling, and
+   *     real-time scheduling.
    */
   @SuppressWarnings("java:S1181")
   private void startAsyncGet(
-      Key key,
-      boolean offersOnly,
-      long uid,
-      RequestCompletionListener listener,
-      Object requestTag,
-      boolean canReadClientCache,
-      boolean canWriteClientCache,
-      short htl,
-      boolean realTimeFlag,
-      boolean localOnly,
-      boolean ignoreStore,
-      boolean isSSK,
-      long startTime) {
-    RequestTag tag = (RequestTag) requestTag;
+      AsyncGetContext context, short htl, NodeRoutingSubsystem.RequestSenderOptions options) {
+    Key key = context.key();
+    RequestCompletionListener listener = context.listener();
+    RequestTag tag = context.tag();
+    boolean isSSK = context.isSSK();
+    long uid = context.uid();
+    boolean realTimeFlag = options.realTimeFlag();
     RequestSenderListener senderListener =
         new RequestSenderListener() {
 
@@ -210,8 +180,7 @@ public final class NodeClientCoreTransfers {
             synchronized (this) {
               rejectedOverloadLocal = this.rejectedOverload;
             }
-            handleAsyncGetFinished(
-                isSSK, listener, startTime, key, realTimeFlag, rs, rejectedOverloadLocal);
+            handleAsyncGetFinished(context, realTimeFlag, rs, rejectedOverloadLocal);
           }
 
           @Override
@@ -224,21 +193,7 @@ public final class NodeClientCoreTransfers {
           }
         };
     try {
-      Object o =
-          node.routing()
-              .makeRequestSender(
-                  key,
-                  htl,
-                  uid,
-                  tag,
-                  null,
-                  NodeRoutingSubsystem.RequestSenderOptions.of(
-                      localOnly,
-                      ignoreStore,
-                      offersOnly,
-                      canReadClientCache,
-                      canWriteClientCache,
-                      realTimeFlag));
+      Object o = node.routing().makeRequestSender(key, htl, uid, tag, null, options);
       if (o instanceof KeyBlock) {
         tag.setServedFromDatastore();
         senderListener.onDataFoundLocally();
@@ -261,13 +216,11 @@ public final class NodeClientCoreTransfers {
   }
 
   private void handleAsyncGetFinished(
-      boolean isSSK,
-      RequestCompletionListener listener,
-      long startTime,
-      Key key,
-      boolean realTimeFlag,
-      RequestSender rs,
-      boolean rejectedOverload) {
+      AsyncGetContext context, boolean realTimeFlag, RequestSender rs, boolean rejectedOverload) {
+    boolean isSSK = context.isSSK();
+    RequestCompletionListener listener = context.listener();
+    long startTime = context.startTime();
+    Key key = context.key();
     int status = rs.getStatus();
     if (status == RequestSender.NOT_FINISHED) {
       LOG.error("Bogus status in onRequestSenderFinished for {}", rs, new Exception("error"));
@@ -769,7 +722,7 @@ public final class NodeClientCoreTransfers {
       maybeReportChkCompleted(is, uid, startTime, realTimeFlag, block);
 
       // Get status explicitly, *after* completed(), so that it will be RECEIVE_FAILED if the
-      // receive failed.
+      // receiver failed.
       int status = is.getStatus();
       reportChkInsertCosts(status, is);
       storeChkLocally(is, block, canWriteClientCache);
@@ -862,7 +815,7 @@ public final class NodeClientCoreTransfers {
     while (!is.completed()) {
       is.waitIfNotCompleted(SECONDS.toMillis(10));
       if (is.anyTransfersFailed() && (!hasReceivedRejectedOverload)) {
-        hasReceivedRejectedOverload = true; // not strictly true but same effect
+        hasReceivedRejectedOverload = true; // not strictly true but the same effect
         requestStarters.rejectedOverload(false, true, realTimeFlag);
       }
     }
@@ -1097,10 +1050,10 @@ public final class NodeClientCoreTransfers {
   }
 
   /**
-   * Queues a low-priority reinsert of a key block.
+   * Queues a low-priority reinserting of a key block.
    *
    * <p>The block is wrapped in a {@link SimpleSendableInsert} and scheduled on the request starters
-   * at the maximum priority class for reinserts. The operation is asynchronous: it enqueues work
+   * at the maximum priority class for reinserting. The operation is asynchronous: it enqueues work
    * and returns immediately without waiting for completion. Use this method to refresh availability
    * for already known data without blocking the caller.
    *

--- a/src/main/java/network/crypta/node/SendableGetRequestSender.java
+++ b/src/main/java/network/crypta/node/SendableGetRequestSender.java
@@ -4,6 +4,7 @@ import network.crypta.client.async.ChosenBlock;
 import network.crypta.client.async.ClientContext;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.Key;
+import network.crypta.node.subsystem.NodeRoutingSubsystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,7 +12,8 @@ import org.slf4j.LoggerFactory;
  * Sends GET requests to the node asynchronously.
  *
  * <p>This implementation submits the request to {@link NodeClientCoreTransfers#asyncGet(Key,
- * boolean, RequestCompletionListener, boolean, boolean, boolean, boolean, boolean)} and returns
+ * RequestCompletionListener,
+ * network.crypta.node.subsystem.NodeRoutingSubsystem.RequestSenderOptions)} and returns
  * immediately. It delivers results via the provided {@link RequestCompletionListener} callbacks
  * which, in turn, notify the originating {@link SendableRequest}.
  *
@@ -44,13 +46,14 @@ public class SendableGetRequestSender implements SendableRequestSender {
   /**
    * Submits an asynchronous GET for the provided block.
    *
-   * <p>Validates the request, then calls {@link NodeClientCoreTransfers#asyncGet(Key, boolean,
-   * RequestCompletionListener, boolean, boolean, boolean, boolean, boolean)}. Completion is
+   * <p>Validates the request, then calls {@link NodeClientCoreTransfers#asyncGet(Key,
+   * RequestCompletionListener,
+   * network.crypta.node.subsystem.NodeRoutingSubsystem.RequestSenderOptions)}. Completion is
    * reported via the supplied listener which delegates to {@code req.onFetchSuccess(context)} or
    * {@code req.onFailure(e, context)}.
    *
    * <p>Return semantics: - Returns {@code false} when no request is submitted (e.g., missing key,
-   * cancelled request) so the scheduler can try another. - Returns {@code true} once a request is
+   * canceled request) so the scheduler can try another. - Returns {@code true} once a request is
    * submitted or when an internal error is converted to a failure callback.
    *
    * <p>Exceptions are handled internally and reported to the request as {@link
@@ -91,14 +94,20 @@ public class SendableGetRequestSender implements SendableRequestSender {
     try {
       /*
        * Resolve the node-level key and submit the asynchronous GET.
-       * Flags control local store usage, client cache writes, realtime priority,
-       * and whether the request is local-only; they are forwarded unchanged.
+       * Options control store usage, client cache writes, and realtime priority.
        */
       final Key k = key.getNodeKey();
+      NodeRoutingSubsystem.RequestSenderOptions options =
+          NodeRoutingSubsystem.RequestSenderOptions.of(
+              req.localRequestOnly,
+              req.ignoreStore,
+              false,
+              !req.ignoreStore,
+              req.canWriteClientCache,
+              req.realTimeFlag);
       core.getTransfers()
           .asyncGet(
               k,
-              false,
               new RequestCompletionListener() {
 
                 @Override
@@ -111,11 +120,7 @@ public class SendableGetRequestSender implements SendableRequestSender {
                   req.onFailure(e, context);
                 }
               },
-              !req.ignoreStore,
-              req.canWriteClientCache,
-              req.realTimeFlag,
-              req.localRequestOnly,
-              req.ignoreStore);
+              options);
     } catch (RuntimeException | Error t) {
       // Convert unexpected throwables into a failure callback to keep the scheduler healthy.
       LOG.error("Unhandled throwable in send: {}", t, t);

--- a/src/test/java/network/crypta/client/async/OfferedKeysListTest.java
+++ b/src/test/java/network/crypta/client/async/OfferedKeysListTest.java
@@ -29,6 +29,7 @@ import network.crypta.node.RequestCompletionListener;
 import network.crypta.node.RequestScheduler;
 import network.crypta.node.SendableRequestItem;
 import network.crypta.node.SendableRequestSender;
+import network.crypta.node.subsystem.NodeRoutingSubsystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -129,7 +130,7 @@ class OfferedKeysListTest {
 
   @Test
   void chooseKey_whenAllCandidatesFetching_returnsNullAfterAttempts() {
-    // Always return index 0 to keep picking the same fetching key until loop limit.
+    // Always return index 0 to keep picking the same fetching key until the loop limit.
     RandomSource rnd = new SeqRandomSource(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     OfferedKeysList list = new OfferedKeysList(rnd, PRIO, false, false);
     Key a = keyWithByte((byte) 0x66);
@@ -172,20 +173,15 @@ class OfferedKeysListTest {
     ArgumentCaptor<RequestCompletionListener> captor =
         ArgumentCaptor.forClass(RequestCompletionListener.class);
     doAnswer(
-            invocation -> {
+            _ -> {
               // No-op stub: we drive completion via captured listener after verification.
               return null;
             })
         .when(transfers)
         .asyncGet(
             any(Key.class),
-            any(Boolean.class),
             any(RequestCompletionListener.class),
-            any(Boolean.class),
-            any(Boolean.class),
-            any(Boolean.class),
-            any(Boolean.class),
-            any(Boolean.class));
+            any(NodeRoutingSubsystem.RequestSenderOptions.class));
 
     // Use sender directly with a minimal ChosenBlock carrying the token
     var sender = list.getSender(null);
@@ -195,30 +191,19 @@ class OfferedKeysListTest {
 
     // Verify asyncGet was invoked and capture arguments to assert values without eq(...)
     ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
-    ArgumentCaptor<Boolean> offersOnlyCap = ArgumentCaptor.forClass(Boolean.class);
-    ArgumentCaptor<Boolean> canReadCap = ArgumentCaptor.forClass(Boolean.class);
-    ArgumentCaptor<Boolean> canWriteCap = ArgumentCaptor.forClass(Boolean.class);
-    ArgumentCaptor<Boolean> rtCap = ArgumentCaptor.forClass(Boolean.class);
-    ArgumentCaptor<Boolean> localOnlyCap = ArgumentCaptor.forClass(Boolean.class);
-    ArgumentCaptor<Boolean> ignoreStoreCap = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<NodeRoutingSubsystem.RequestSenderOptions> optionsCaptor =
+        ArgumentCaptor.forClass(NodeRoutingSubsystem.RequestSenderOptions.class);
     verify(transfers, times(1))
-        .asyncGet(
-            keyCaptor.capture(),
-            offersOnlyCap.capture(),
-            captor.capture(),
-            canReadCap.capture(),
-            canWriteCap.capture(),
-            rtCap.capture(),
-            localOnlyCap.capture(),
-            ignoreStoreCap.capture());
+        .asyncGet(keyCaptor.capture(), captor.capture(), optionsCaptor.capture());
 
     assertSame(k, keyCaptor.getValue());
-    assertTrue(offersOnlyCap.getValue());
-    assertTrue(canReadCap.getValue());
-    assertFalse(canWriteCap.getValue());
-    assertEquals(realTime, rtCap.getValue());
-    assertFalse(localOnlyCap.getValue());
-    assertFalse(ignoreStoreCap.getValue());
+    NodeRoutingSubsystem.RequestSenderOptions options = optionsCaptor.getValue();
+    assertTrue(options.offersOnly());
+    assertTrue(options.canReadClientCache());
+    assertFalse(options.canWriteClientCache());
+    assertEquals(realTime, options.realTimeFlag());
+    assertFalse(options.localOnly());
+    assertFalse(options.ignoreStore());
 
     // Simulate success callback
     RequestCompletionListener listener = captor.getValue();
@@ -293,7 +278,7 @@ class OfferedKeysListTest {
 
   /**
    * Deterministic RandomSource that returns a fixed sequence from nextInt(bound). Values are taken
-   * modulo bound to satisfy API contract.
+   * modulo bound to satisfy the API contract.
    */
   private static final class SeqRandomSource extends DummyRandomSource {
     private final int[] seq;
@@ -346,12 +331,12 @@ class OfferedKeysListTest {
 
     @Override
     public void onFailure(LowLevelGetException e, ClientContext context) {
-      // Intentionally empty: callbacks are tested indirectly via scheduler interactions above.
+      // Intentionally empty: callbacks are tested indirectly via the scheduler interactions above.
     }
 
     @Override
     public void onFetchSuccess(ClientContext context) {
-      // Intentionally empty: fetch success triggers are not invoked by these unit tests.
+      // Intentionally empty: these unit tests do not invoke fetch success triggers.
     }
 
     @Override

--- a/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
@@ -144,7 +144,10 @@ class NodeClientCoreTransfersTest {
             anyLong(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any()))
         .thenReturn(false);
 
-    transfers.asyncGet(key, false, completionListener, true, true, false, false, false);
+    transfers.asyncGet(
+        key,
+        completionListener,
+        NodeRoutingSubsystem.RequestSenderOptions.of(false, false, false, true, true, false));
 
     ArgumentCaptor<LowLevelGetException> captor =
         ArgumentCaptor.forClass(LowLevelGetException.class);
@@ -160,7 +163,10 @@ class NodeClientCoreTransfersTest {
     when(node.routing().makeRequestSender(any(), anyShort(), anyLong(), any(), any(), any()))
         .thenReturn(mock(KeyBlock.class));
 
-    transfers.asyncGet(key, false, completionListener, true, true, false, false, false);
+    transfers.asyncGet(
+        key,
+        completionListener,
+        NodeRoutingSubsystem.RequestSenderOptions.of(false, false, false, true, true, false));
 
     verify(completionListener).onSucceeded();
     verify(completionListener, never()).onFailed(any());
@@ -185,7 +191,10 @@ class NodeClientCoreTransfersTest {
         .when(sender)
         .addListener(any());
 
-    transfers.asyncGet(key, false, completionListener, true, true, true, false, false);
+    transfers.asyncGet(
+        key,
+        completionListener,
+        NodeRoutingSubsystem.RequestSenderOptions.of(false, false, false, true, true, true));
 
     RequestSenderListener senderListener = listenerRef.get();
     assertNotNull(senderListener);

--- a/src/test/java/network/crypta/node/SendableGetRequestSenderTest.java
+++ b/src/test/java/network/crypta/node/SendableGetRequestSenderTest.java
@@ -18,6 +18,7 @@ import network.crypta.client.async.ChosenBlock;
 import network.crypta.client.async.ClientContext;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.Key;
+import network.crypta.node.subsystem.NodeRoutingSubsystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,14 +51,14 @@ class SendableGetRequestSenderTest {
       boolean ignoreStore,
       boolean canWriteClientCache,
       boolean realTimeFlag) {
-    // Create a mock that calls the real constructor to set the final fields,
+    // Create a mock that calls the real constructor to set the final fields
     // and lets us verify abstract callback invocations via Mockito.
     return mock(
         ChosenBlock.class,
         org.mockito.Mockito.withSettings()
             .useConstructor(
                 token,
-                null, // node-level key not used for SendableGet
+                null, // a node-level key isn't used for SendableGet
                 clientKey,
                 new ChosenBlock.Options(
                     localOnly, ignoreStore, canWriteClientCache, false, realTimeFlag))
@@ -151,24 +152,18 @@ class SendableGetRequestSenderTest {
     ChosenBlock req = newChosenBlock(token, ckey, false, false, true, true);
     when(req.isCancelled()).thenReturn(false);
 
+    NodeRoutingSubsystem.RequestSenderOptions options =
+        NodeRoutingSubsystem.RequestSenderOptions.of(false, false, false, true, true, true);
     // Capture the listener passed to asyncGet
     doAnswer(
             invocation -> {
-              RequestCompletionListener l = invocation.getArgument(2);
+              RequestCompletionListener l = invocation.getArgument(1);
               // Simulate success
               l.onSucceeded();
               return null;
             })
         .when(transfers)
-        .asyncGet(
-            eq(nodeKey),
-            eq(false),
-            any(RequestCompletionListener.class),
-            eq(true), // canReadClientCache = !ignoreStore(false)
-            eq(true), // canWriteClientCache
-            eq(true), // realTimeFlag
-            eq(false), // localOnly
-            eq(false)); // ignoreStore
+        .asyncGet(eq(nodeKey), any(RequestCompletionListener.class), eq(options));
 
     // Act
     boolean result = sender.send(core, scheduler, context, req);
@@ -192,22 +187,16 @@ class SendableGetRequestSenderTest {
 
     LowLevelGetException failure = new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND);
 
+    NodeRoutingSubsystem.RequestSenderOptions options =
+        NodeRoutingSubsystem.RequestSenderOptions.of(true, true, false, false, false, false);
     doAnswer(
             invocation -> {
-              RequestCompletionListener l = invocation.getArgument(2);
+              RequestCompletionListener l = invocation.getArgument(1);
               l.onFailed(failure);
               return null;
             })
         .when(transfers)
-        .asyncGet(
-            eq(nodeKey),
-            eq(false),
-            any(RequestCompletionListener.class),
-            eq(false), // canReadClientCache = !ignoreStore(true)
-            eq(false), // canWriteClientCache
-            eq(false), // realTimeFlag
-            eq(true), // localOnly
-            eq(true)); // ignoreStore
+        .asyncGet(eq(nodeKey), any(RequestCompletionListener.class), eq(options));
 
     // Act
     boolean result = sender.send(core, scheduler, context, req);
@@ -280,17 +269,11 @@ class SendableGetRequestSenderTest {
     ChosenBlock req = newChosenBlock(token, ckey, false, false, false, false);
     when(req.isCancelled()).thenReturn(false);
 
+    NodeRoutingSubsystem.RequestSenderOptions options =
+        NodeRoutingSubsystem.RequestSenderOptions.of(false, false, false, true, false, false);
     doThrow(new RuntimeException("asyncGet blew up"))
         .when(transfers)
-        .asyncGet(
-            eq(nodeKey),
-            eq(false),
-            any(RequestCompletionListener.class),
-            eq(true),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false));
+        .asyncGet(eq(nodeKey), any(RequestCompletionListener.class), eq(options));
 
     // Act
     boolean result = sender.send(core, scheduler, context, req);


### PR DESCRIPTION
## Summary
- replace async-get parameter lists with `RequestSenderOptions` and a compact context carrier
- update async-get callers/tests to build and assert the shared options record
- align related async-get documentation wording after refactor