### PR TITLE
refactor(node): bundle routing selection params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,32 +31,12 @@ Load only what you need. It’s normal to load multiple skills for one task.
 5. Run the relevant Gradle checks (see `cryptad-build-test` / `cryptad-build-tooling`).
 6. Update docs/tests when needed.
 
-## JetBrains IDE inspections (required after every edit)
-
-After **any** action that creates or modifies a file, immediately run JetBrains IDE inspections on that file via the IDE MCP server (`jetbrains`) tool `get_file_problems`.
-
-- Use `filePath` relative to the project root.
-- Always pass `projectPath` (repo root / current working directory) to reduce ambiguous calls.
-- Default to `errorsOnly: true` (errors only). If you are chasing quality issues, re-run with `errorsOnly: false` to include warnings.
-- If problems are reported, fix them and **re-run `get_file_problems` until the file is clean** before moving on.
-
-Example call:
-
-```
-get_file_problems({
-  "projectPath": "<repo-root>",
-  "filePath": "src/main/kotlin/…",
-  "errorsOnly": true,
-  "timeout": 30000
-})
-```
-
-If the IDE MCP server is unavailable, fall back to the relevant Gradle compile/test task but treat IDE inspections as the default fast feedback loop.
-
 ## Always-on rules (keep these in mind)
 
 - **Languages:** Kotlin + Java.
   - Kotlin sources must live under `src/*/kotlin` (including tests). Do not add Kotlin files under `src/*/java/`.
+- **OpenCode LSP:** Treat LSP/typechecker diagnostics as blockers for touched files.
+  - If the OpenCode `lsp` tool is enabled, prefer it for definition/reference/hover instead of guessing
 - **Compatibility:** Avoid breaking persistent formats, on-disk layouts, and wire protocols without an explicit migration plan.
   - For AEAD stream / format changes, load `cryptad-crypto-aead` first.
 - **Environment detection:** Treat `AppEnv` as the single source of truth. Load `cryptad-appenv` before touching OS/arch/sandbox/service detection code.

--- a/src/main/java/network/crypta/node/AnnounceSender.java
+++ b/src/main/java/network/crypta/node/AnnounceSender.java
@@ -231,19 +231,24 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
           .peers()
           .routingSelector()
           .closerPeer(
-              source,
-              routed,
-              target,
-              true,
-              node.isAdvancedModeEnabled(),
-              -1,
-              null,
-              null,
-              htl,
-              0,
-              source == null,
-              false,
-              false);
+              new PeerRoutingSelectionParams(
+                  source,
+                  routed,
+                  target,
+                  true,
+                  node.isAdvancedModeEnabled(),
+                  -1,
+                  null,
+                  2.0,
+                  null,
+                  htl,
+                  0L,
+                  source == null,
+                  false,
+                  null,
+                  false,
+                  System.currentTimeMillis(),
+                  false));
     }
     if (routed.contains(onlyNode)) {
       rnf(onlyNode);

--- a/src/main/java/network/crypta/node/BaseSender.java
+++ b/src/main/java/network/crypta/node/BaseSender.java
@@ -145,11 +145,11 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
   /** Set of peers this sender has attempted to route to during the current operation. */
   protected HashSet<PeerNode> nodesRoutedTo = new HashSet<>();
 
-  /** Timestamp of the most recent send attempt used for timeout accounting (milliseconds). */
+  /** Timestamp of the most recent sending attempt used for timeout accounting (milliseconds). */
   private long timeSentRequest;
 
   /**
-   * Milliseconds elapsed since the most recent send attempt recorded by this sender.
+   * Milliseconds have elapsed since the most recent sending attempt recorded by this sender.
    *
    * @return elapsed time in milliseconds
    */
@@ -174,8 +174,8 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
   private HashMap<PeerNode, Integer> softRejectCount;
 
   /**
-   * When set, the next reroute must not decrement {@link #htl}. The flag is reset by the caller
-   * after it observes the reroute condition.
+   * When set, the next rerouting must not decrement {@link #htl}. The caller resets the flag after
+   * it observes the rerouting condition.
    */
   protected boolean dontDecrementHTLThisTime;
 
@@ -196,7 +196,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
    *
    * <p>This method routes to {@code next} (or a better alternative chosen by NLM), waits for an
    * early response (Accepted/reject), and either calls {@link #onAccepted(PeerNode)} or requests a
-   * reroute by invoking {@link #routeRequests()}.
+   * rerouting by invoking {@link #routeRequests()}.
    *
    * @param next initial peer to try
    * @param origTag routing tag used to correlate messages (may be updated in child flows)
@@ -225,7 +225,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
     Message req = createDataRequest();
 
     // Record the earliest time we attempted to send. The sent() callback may arrive after an
-    // acknowledgement under heavy load, so this is the most conservative upper bound used by
+    // acknowledgement under a heavy load, so this is the most conservative upper bound used by
     // timeout/RecentlyFailed logic.
     synchronized (this) {
       timeSentRequest = System.currentTimeMillis();
@@ -234,10 +234,10 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
     origTag.addRoutedTo(next, false);
 
     try {
-      // First contact to a peer is more likely to time out. Prefer sendSync over sendAsync:
-      // - sendSync measures ACCEPTED_TIMEOUT from the actual send time and avoids inflating
+      // First contact with a peer is more likely to time out. Prefer sendSync over sendAsync:
+      // - sendSync measures ACCEPTED_TIMEOUT from the actual sending time and avoids inflating
       //   unclaimed FIFO queues; it may, however, consume part of the request time budget while
-      //   waiting in the peer’s send queue.
+      //   waiting in the peer’s sending queue.
       // - sendAsync would increase ACCEPTED_TIMEOUT risk and leave many hanging requests, further
       //   overloading peers. Hence, we do NOT use sendAsync here.
       next.transport().sendSync(req, this, realTimeFlag);
@@ -270,7 +270,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
 
     while (true) {
       DO action = waitForAccepted(null, next, origTag);
-      // Here FINISHED means accepted, WAIT means try again (soft reject).
+      // Here FINISHED means accepted; WAIT means try again (soft reject).
       if (action != DO.WAIT) {
         if (action == DO.NEXT_PEER) {
           routeRequests();
@@ -292,11 +292,11 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
   }
 
   /**
-   * Limit the number of nodes that we route to that reject the request due to looping, while
-   * waiting for a peer. This ensures that if there is a slow node, we don't route to all the other
-   * nodes and DNF, rather than waiting, and possibly timing out, for the slow node. Note that this
-   * does not cause us to stop routing, only to stop adding more nodes to wait for while waiting.
-   * This is particularly an issue if we have a fast network connected to a slow network.
+   * Limit the number of nodes that we route to that reject the request due to looping while waiting
+   * for a peer. This ensures that if there is a slow node, we don't route to all the other nodes
+   * and DNF, rather than waiting, and possibly timing out, for the slow node. Note that this does
+   * not cause us to stop routing, only to stop adding more nodes to wait for while waiting. This is
+   * particularly an issue if we have a fast network connected to a slow network.
    */
   private static final int MAX_REJECTED_LOOPS = 3;
 
@@ -307,12 +307,12 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
    *
    * <p>Starts with the provided {@code next} peer but may select a different one while waiting for
    * capacity. This method either calls {@link #onAccepted(PeerNode)} once accepted or requests a
-   * reroute via {@link #routeRequests()}.
+   * rerouting via {@link #routeRequests()}.
    *
-   * <p>IMPORTANT: When this method triggers a reroute and {@link #dontDecrementHTLThisTime} is set,
-   * the caller must not decrement HTL on the next attempt. This flag is used when the proposed peer
-   * becomes unsuitable before we actually route to it; RecentlyFailed handling remains in the outer
-   * selection loop.
+   * <p>IMPORTANT: When this method triggers a rerouting and {@link #dontDecrementHTLThisTime} is
+   * set, the caller must not decrement HTL on the next attempt. This flag is used when the proposed
+   * peer becomes unsuitable before we actually route to it; RecentlyFailed handling remains in the
+   * outer selection loop.
    */
   protected void innerRouteRequestsNew(PeerNode next, UIDTag origTag) {
     NlmState state = new NlmState();
@@ -327,7 +327,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
 
       NextStep step = preWaitPhase(state, origTag);
       if (step == NextStep.REROUTED_OR_FINISHED) return;
-      if (step != NextStep.PROCEED) continue; // one allowed continue
+      if (step != NextStep.PROCEED) continue; // one allowed continuing
 
       SendOutcome outcome = sendAndAwait(state, origTag);
       if (outcome == SendOutcome.ACCEPTED) {
@@ -338,14 +338,14 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
         LOG.debug("Got Accepted");
         gotMessages = 0;
         lastMessage = null;
-        // We may have widened the waiting window earlier; reset for subsequent iterations.
+        // We may have widened the waiting window earlier; reset for later iterations.
         addedExtraNode = false;
         state.next.acceptedAny(realTimeFlag);
         onAccepted(state.next);
         return;
       }
       if (outcome == SendOutcome.HARD_REROUTE) return;
-      // SOFT_RETRY: fall through for next tick
+      // SOFT_RETRY: fall through for the next tick
     }
   }
 
@@ -415,7 +415,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
     }
   }
 
-  // Ensure a candidate peer is present; if not, request a reroute without consuming HTL.
+  // Ensure a candidate peer is present; if not, request a rerouting without consuming HTL.
   private boolean ensureNextPeerPresent(NlmState state) {
     if (state.next != null) return true;
     dontDecrementHTLThisTime = true;
@@ -458,7 +458,8 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
     REROUTED_OR_FINISHED
   }
 
-  // Prepare waiter state and optionally widen the window by adding another candidate while waiting.
+  // Prepare a waiter state and optionally widen the window by adding another candidate while
+  // waiting.
   private NextStep prepareAndMaybeWait(NlmState state, UIDTag origTag) {
     // Reset per-iteration latch so a prior CONTINUE_LOOP does not spin forever.
     state.shouldContinueLoop = false;
@@ -508,7 +509,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
     if (!state.waiter.addWaitingFor(state.next)) {
       dontDecrementHTLThisTime = true;
       routeRequests();
-      // We attempted to queue a waiter but the peer cannot accept us (unroutable/mandatory backoff
+      // We attempted to queue a waiter, but the peer cannot accept us (unroutable/mandatory backoff
       // or queueing failed). This must short-circuit the NLM loop so the caller can pick another
       // peer instead of falling through to an empty-waiter timeout path.
       state.rerouted = true;
@@ -540,7 +541,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
     tryAddAnother(state, canWaitFor);
   }
 
-  // Opportunistically add another candidate to the waiter to reduce latency under load.
+  // Opportunistically, add another candidate to the waiter to reduce latency under load.
   private void tryAddAnother(NlmState state, int canWaitFor) {
     if (!state.canRerouteWhileWaiting) return;
     if (state.waiter.waitingForCount() > canWaitFor) return;
@@ -618,7 +619,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
         state.next);
   }
 
-  // Send synchronously to the chosen peer. On failure, request a reroute.
+  // Sending synchronously to the chosen peer. On failure, request a rerouting.
   private boolean sendToPeer(NlmState state, UIDTag origTag, Message req) {
     if (origTag.hasSourceReallyRestarted()) {
       origTag.removeRoutingTo(state.next);
@@ -658,7 +659,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
       case WAIT:
         // Soft local overload: break out to re-enter the NLM block and try again.
         state.retriedForLoadManagement = true;
-        state.expectedAcceptState = null; // force prepare/wait on next outer tick
+        state.expectedAcceptState = null; // force prepare/wait on the next outer tick
         state.shouldContinueLoop = true;
         return false;
       case NEXT_PEER:
@@ -671,10 +672,8 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
   }
 
   private PeerNode closerPeer(Set<PeerNode> exclude, long now) {
-    return node.network()
-        .peers()
-        .routingSelector()
-        .closerPeer(
+    PeerRoutingSelectionParams params =
+        new PeerRoutingSelectionParams(
             sourceForRouting(),
             exclude,
             target,
@@ -692,6 +691,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
             false,
             now,
             newLoadManagement);
+    return node.network().peers().routingSelector().closerPeer(params);
   }
 
   /**
@@ -769,7 +769,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
 
   private int rejectedLoops;
 
-  /** Here FINISHED means accepted, WAIT means try again (soft reject). */
+  /** Here FINISHED means accepted; WAIT means try again (soft reject). */
   private DO waitForAccepted(
       RequestLikelyAcceptedState expectedAcceptState, PeerNode next, UIDTag origTag) {
     MessageFilter mf = makeAcceptedRejectedFilter(next, getAcceptedTimeout(), origTag);
@@ -917,8 +917,8 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
   /**
    * Called when waiting for capacity across candidate peers times out.
    *
-   * @param load average proportion of fatal timeouts reported by the peers we waited for; used by
-   *     callers to tune RecentlyFailed persistence
+   * @param load the average proportion of fatal timeouts reported by the peers we waited for; used
+   *     by callers to tune RecentlyFailed persistence
    */
   protected abstract void timedOutWhileWaiting(double load);
 

--- a/src/main/java/network/crypta/node/CHKInsertSender.java
+++ b/src/main/java/network/crypta/node/CHKInsertSender.java
@@ -614,10 +614,8 @@ public final class CHKInsertSender extends BaseSender
   }
 
   private PeerNode findNextPeer() {
-    return node.network()
-        .peers()
-        .routingSelector()
-        .closerPeer(
+    PeerRoutingSelectionParams params =
+        new PeerRoutingSelectionParams(
             forkedRequestTag == null ? source : null,
             nodesRoutedTo,
             target,
@@ -625,12 +623,17 @@ public final class CHKInsertSender extends BaseSender
             node.isAdvancedModeEnabled(),
             -1,
             null,
+            2.0,
             null,
             htl,
-            ignoreLowBackoff ? Node.LOW_BACKOFF : 0,
+            ignoreLowBackoff ? Node.LOW_BACKOFF : 0L,
             source == null,
             realTimeFlag,
+            null,
+            false,
+            System.currentTimeMillis(),
             newLoadManagement);
+    return node.network().peers().routingSelector().closerPeer(params);
   }
 
   private void sendReceiveFailedNotice(PeerNode next) {

--- a/src/main/java/network/crypta/node/NodeClientCoreSupport.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreSupport.java
@@ -272,8 +272,8 @@ public final class NodeClientCoreSupport {
    * <p>This registers the {@code memoryLimitedJobMemoryLimit} configuration key using the provided
    * default and sort order. The associated {@link LongCallback} enforces {@link
    * FECCodec#MIN_MEMORY_ALLOCATION} and updates the shared runner capacity when the value changes.
-   * Callers should use the returned sort order when registering subsequent settings to preserve
-   * stable UI ordering.
+   * Callers should use the returned sort order when registering later settings to preserve stable
+   * UI ordering.
    *
    * @param init initialization helper providing access to node configuration.
    * @param sortOrder current sort order index used for config registration.
@@ -342,8 +342,8 @@ public final class NodeClientCoreSupport {
    *
    * <p>This variant accepts raw payload and header buffers and forwards them to the {@link
    * ClientCHKBlock} constructor along with the supplied key. Verification happens during
-   * construction, and invalid inputs result in a checked exception. Use this helper when the
-   * encoded block has already been split into data and header components by upstream logic.
+   * construction, and invalid inputs result in a checked exception. Use this helper when upstream
+   * logic has already split the encoded block into data and header components.
    *
    * @param data raw data bytes of the CHK payload.
    * @param header raw header bytes associated with the CHK payload.
@@ -437,15 +437,13 @@ public final class NodeClientCoreSupport {
    * @param node node providing routing selector and HTL configuration.
    * @param key routing key used to select the closest peers.
    * @param realTime whether to apply real-time scheduling constraints.
-   * @return recently-failed value reported by the routing selector.
+   * @return recently failed value reported by the routing selector.
    */
   public static long checkRecentlyFailed(Node node, Key key, boolean realTime) {
     RecentlyFailedReturn result = new RecentlyFailedReturn();
     short origHtl = node.routing().decrementHTL(null, node.maxHTL());
-    node.network()
-        .peers()
-        .routingSelector()
-        .closerPeer(
+    PeerRoutingSelectionParams params =
+        new PeerRoutingSelectionParams(
             null,
             new HashSet<>(),
             key.toNormalizedDouble(),
@@ -456,13 +454,14 @@ public final class NodeClientCoreSupport {
             2.0,
             key,
             origHtl,
-            0,
+            0L,
             true,
             realTime,
             result,
             false,
             System.currentTimeMillis(),
             node.network().enableNewLoadManagement(realTime));
+    node.network().peers().routingSelector().closerPeer(params);
     return result.recentlyFailed();
   }
 
@@ -485,10 +484,9 @@ public final class NodeClientCoreSupport {
   /**
    * Registers the core FProxy alerts, including the persistence-broken warning.
    *
-   * <p>This registers the provided startup alert and then adds the persistence-broken alert that is
-   * derived from the core's state. It centralizes the alert wiring sequence so the calling code can
-   * remain focused on higher-level initialization flow. It does not remove or replace existing
-   * alerts.
+   * <p>This registers the provided startup alert and then adds the persistence-broken alert derived
+   * from the core's state. It centralizes the alert wiring sequence so the calling code can remain
+   * focused on the higher-level initialization flow. It does not remove or replace existing alerts.
    *
    * @param alerts alert manager that receives the registrations.
    * @param core core used to build the persistence-broken alert.
@@ -521,8 +519,8 @@ public final class NodeClientCoreSupport {
    *
    * <p>This helper prefixes the provided key with {@code "NodeClientCore."} and looks it up using
    * {@link NodeL10n#getBase()}. It is intended for simple string lookups without parameter
-   * substitution; callers that need substitutions should obtain the base bundle directly. It does
-   * not perform caching; each call performs a bundle lookup.
+   * substitution; callers that need substitutions should get the base bundle directly. It does not
+   * perform caching; each call performs a bundle lookup.
    *
    * @param key key suffix appended to the {@code NodeClientCore.} prefix.
    * @return localized string for the composed NodeClientCore key.

--- a/src/main/java/network/crypta/node/NodeRoutedMessageRouter.java
+++ b/src/main/java/network/crypta/node/NodeRoutedMessageRouter.java
@@ -56,7 +56,7 @@ final class NodeRoutedMessageRouter implements Runnable {
   /** Logger for routed message handling diagnostics. */
   private static final Logger LOG = LoggerFactory.getLogger(NodeRoutedMessageRouter.class);
 
-  /** Owning node used for network access and configuration. */
+  /** The owning node used for network access and configuration. */
   private final Node node;
 
   /** Per-UID routed contexts used to forward replies and detect duplicates. */
@@ -235,7 +235,7 @@ final class NodeRoutedMessageRouter implements Runnable {
    * the message is forwarded using the routing selection flow and the routed context.
    *
    * @param m routed message to handle; must be non-null
-   * @param source source peer that sent the message, or {@code null} if locally originated
+   * @param source source peer that sent the message or {@code null} if locally originated
    * @param id routed request UID extracted from the message
    * @param htl current hops-to-live value after any source adjustments
    * @param target target location for routing decisions
@@ -286,7 +286,7 @@ final class NodeRoutedMessageRouter implements Runnable {
    * locally originated request, in which case no rejection is sent.
    *
    * @param source peer to notify, or {@code null} for locally originated requests
-   * @param id routed request UID to include in the rejection payload
+   * @param id routed request UID to include it in the rejection payload
    * @param m original routed message, used only for diagnostic logging
    */
   private void sendRoutedReject(PeerNode source, long id, Message m) {
@@ -302,11 +302,10 @@ final class NodeRoutedMessageRouter implements Runnable {
   /**
    * Forwards a routed reply (FNPRoutedPong) back to the recorded origin peer.
    *
-   * <p>The reply is looked up by UID in the routed context map. If no context exists, the method
-   * logs an error and returns {@code false} so callers can observe that the reply was unexpected.
-   * When a context exists but has no source (locally originated), the method returns {@code false}
-   * without sending any message. Forwarding clones and strips sub-messages to avoid metadata
-   * leakage.
+   * <p>UID looks up the reply in the routed context map. If no context exists, the method logs an
+   * error and returns {@code false} so callers can observe that the reply was unexpected. When a
+   * context exists but has no source (locally originated), the method returns {@code false} without
+   * sending any message. Forwarding clones and strips sub-messages to avoid metadata leakage.
    *
    * @param m routed reply message containing UID and payload; must be non-null
    * @return {@code true} if the reply was forwarded; {@code false} otherwise
@@ -333,9 +332,9 @@ final class NodeRoutedMessageRouter implements Runnable {
   /**
    * Forwards a routed message to the next hop or reports a dead-end rejection.
    *
-   * <p>The method prepares the message for forwarding, then repeatedly selects a next hop and
-   * attempts to send. If a candidate is disconnected, selection repeats. When no candidate exists,
-   * a rejection is sent to the source peer if present.
+   * <p>The method prepares the message for forwarding, then repeatedly selects the next hop, and
+   * attempts to send it. If a candidate is disconnected, selection repeats. When no candidate
+   * exists, a rejection is sent to the source peer if present.
    *
    * @param m original routed message; must be non-null
    * @param id routed request UID used for rejections
@@ -392,38 +391,41 @@ final class NodeRoutedMessageRouter implements Runnable {
       LOG.error("Target found but disconnected: {}", next);
       next = null;
     }
-    if (next == null)
-      next =
-          node.network()
-              .peers()
-              .routingSelector()
-              .closerPeer(
-                  pn,
-                  ctx.routedTo,
-                  target,
-                  true,
-                  node.isAdvancedModeEnabled(),
-                  -1,
-                  null,
-                  null,
-                  htl,
-                  0,
-                  pn == null,
-                  false,
-                  false);
+    if (next == null) {
+      PeerRoutingSelectionParams params =
+          new PeerRoutingSelectionParams(
+              pn,
+              ctx.routedTo,
+              target,
+              true,
+              node.isAdvancedModeEnabled(),
+              -1,
+              null,
+              2.0,
+              null,
+              htl,
+              0L,
+              pn == null,
+              false,
+              null,
+              false,
+              System.currentTimeMillis(),
+              false);
+      next = node.network().peers().routingSelector().closerPeer(params);
+    }
     return next;
   }
 
   /**
    * Sends a routed message to the chosen next hop.
    *
-   * <p>The send is asynchronous and may fail immediately if the peer is disconnected. In that case
-   * the caller is expected to retry selection. This method does not mutate state beyond the
-   * attempted send and never throws on connection failure.
+   * <p>The sending is asynchronous and may fail immediately if the peer is disconnected. In that
+   * case the caller is expected to retry selection. This method does not mutate the state beyond
+   * the attempted sending and never throws on connection failure.
    *
    * @param next selected next hop peer; must be non-null
    * @param m message to send; must be non-null and fully populated
-   * @return {@code true} if the send was enqueued; {@code false} if the peer was disconnected
+   * @return {@code true} if the sending was enqueued; {@code false} if the peer was disconnected
    */
   private boolean trySendToNext(PeerNode next, Message m) {
     try {
@@ -438,7 +440,7 @@ final class NodeRoutedMessageRouter implements Runnable {
    * Sends a routed rejection when no eligible next hop exists.
    *
    * <p>This is a best-effort notification to the origin peer. If the origin peer is {@code null}
-   * (locally originated), the method performs no send. Connection failures are logged at error
+   * (locally originated), the method performs no send. Connection failures are logged at the error
    * level because the rejection could not be delivered.
    *
    * @param pn origin peer to notify, or {@code null} for local originators
@@ -467,7 +469,7 @@ final class NodeRoutedMessageRouter implements Runnable {
    *
    * @param m original routed message to forward; must be non-null
    * @param newHTL updated hops-to-live value to store in the forwarded message
-   * @return a cloned message with updated HTL and counter fields
+   * @return a cloned message with updated HTL and counter-fields
    */
   private Message preForward(Message m, short newHTL) {
     m = m.cloneAndDropSubMessages();
@@ -550,7 +552,8 @@ final class NodeRoutedMessageRouter implements Runnable {
       this.identity = identity;
     }
 
-    // Tracks peers the message has been forwarded to; used to avoid loops when choosing next hop.
+    // Tracks peers the message has been forwarded to; used to avoid loops when choosing the next
+    // hop.
     /**
      * Records that a peer was selected as a forwarding target for this UID.
      *

--- a/src/main/java/network/crypta/node/PeerRoutingSelectionParams.java
+++ b/src/main/java/network/crypta/node/PeerRoutingSelectionParams.java
@@ -1,0 +1,71 @@
+package network.crypta.node;
+
+import java.util.List;
+import java.util.Set;
+import network.crypta.keys.Key;
+
+/**
+ * Immutable parameter bundle for peer-routing selection decisions.
+ *
+ * <p>This record centralizes the inputs required by the routing selector so call sites can pass a
+ * single, self-describing value instead of long argument lists. Callers populate the request
+ * origin, the set of already routed peers, and policy flags that control distance checks, backoff
+ * behavior, and timeout handling. The record performs no validation or defensive copying; it simply
+ * captures the values supplied at construction. Treat the referenced collections as read-only for
+ * the life of a selection and keep the time-based values consistent with the selector's clock.
+ *
+ * <p>Because instances are immutable, they are safe to share across threads as long as the
+ * contained collections are not mutated concurrently. Typical usage is to construct a new instance
+ * per routing decision, then pass it to {@link
+ * PeerRoutingSelector#closerPeer(PeerRoutingSelectionParams)}.
+ *
+ * <ul>
+ *   <li>Bundles request context, routing limits, and policy flags in one value.
+ *   <li>Maintains selection timing inputs without imposing defaults.
+ *   <li>Supports optional reporting of recently failed outcomes.
+ * </ul>
+ *
+ * <pre>{@code
+ * PeerRoutingSelectionParams params =
+ *     new PeerRoutingSelectionParams(origin, routedTo, target, true, false, -1,
+ *         null, 2.0, key, htl, 0L, isLocal, realTime, null, false, now, false);
+ * PeerNode nextHop = selector.closerPeer(params);
+ * }</pre>
+ *
+ * @param origin origin peer for this routing decision, or {@code null} for local originators
+ * @param routedTo peers already routed to for this request, used to avoid loops
+ * @param target target location on the ring, expressed in normalized location units
+ * @param ignoreSelf whether to ignore the local node when comparing distance to target
+ * @param calculateMisrouting whether to report misrouting statistics during selection
+ * @param minVersion minimum acceptable peer build version, inclusive; non-positive disables checks
+ * @param addUnpickedLocsTo optional list to collect unpicked candidate locations, or {@code null}
+ * @param maxDistance maximum allowable distance from {@code target}, in normalized units
+ * @param key failure-table key used for timeout tracking, or {@code null} when disabled
+ * @param outgoingHTL hop-to-live value for the outgoing request, in hops
+ * @param ignoreBackoffUnder backoff window to ignore, in milliseconds from the current time
+ * @param isLocal whether the request originated locally, affecting policy choices
+ * @param realTime whether to enforce real-time routing constraints and backoff rules
+ * @param recentlyFailed optional holder for recently failed timing feedback, or {@code null}
+ * @param ignoreTimeout whether to bypass timeout-based exclusion checks for candidates
+ * @param now current time in milliseconds used for timeout comparisons and scheduling
+ * @param newLoadManagement whether to apply new load-management heuristics to candidates
+ * @see PeerRoutingSelector#closerPeer(PeerRoutingSelectionParams)
+ */
+public record PeerRoutingSelectionParams(
+    PeerNode origin,
+    Set<PeerNode> routedTo,
+    double target,
+    boolean ignoreSelf,
+    boolean calculateMisrouting,
+    int minVersion,
+    List<Double> addUnpickedLocsTo,
+    double maxDistance,
+    Key key,
+    short outgoingHTL,
+    long ignoreBackoffUnder,
+    boolean isLocal,
+    boolean realTime,
+    RecentlyFailedReturn recentlyFailed,
+    boolean ignoreTimeout,
+    long now,
+    boolean newLoadManagement) {}

--- a/src/main/java/network/crypta/node/PeerRoutingSelector.java
+++ b/src/main/java/network/crypta/node/PeerRoutingSelector.java
@@ -1,10 +1,12 @@
 package network.crypta.node;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import network.crypta.keys.Key;
 import network.crypta.support.TimeUtil;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,8 +15,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This class centralizes the peer-selection policy that was previously spread across {@link
  * PeerManager}. Callers provide the candidate set and routing context, and the selector evaluates
- * peer distance, routing backoff state, timeouts, and optional recently-failed handling to produce
- * a single best peer. The selector does not mutate peer state directly; instead it reports
+ * peer distance, routing backoff state, timeouts, and optional recently failed handling to produce
+ * the single best peer. The selector does not mutate peer state directly; instead it reports
  * selection statistics and returns the chosen {@link PeerNode} for the caller to route to.
  *
  * <p>Selection is stateful only within a single call and is safe for repeated use as long as
@@ -27,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>Filtering peers by eligibility (version, backoff, routing status).
  *   <li>Computing distance and load-based weighting.
- *   <li>Optionally incorporating recently-failed retry timing.
+ *   <li>Optionally incorporating recently failed retry timing.
  * </ul>
  */
 public class PeerRoutingSelector {
@@ -56,152 +58,31 @@ public class PeerRoutingSelector {
   }
 
   /**
-   * Selects the closest eligible peer using default selection parameters.
-   *
-   * <p>This overload provides a simplified entry point for common routing decisions. It applies a
-   * default maximum distance of {@code 2.0}, uses the current wall-clock time for timeout checks,
-   * and does not request recently-failed handling. The method is side-effect free with respect to
-   * peer state; it only reports backoff statistics when requested.
-   *
-   * @param pn the origin peer for this routing decision, or {@code null}
-   * @param routedTo peers already selected for this request path
-   * @param target target location on the ring, in normalized location units
-   * @param ignoreSelf whether to ignore the local node when selecting
-   * @param calculateMisrouting whether to record misrouting and backoff metrics
-   * @param minVersion minimum acceptable peer version, inclusive, in build units
-   * @param addUnpickedLocsTo optional list to collect alternative locations
-   * @param key key for per-node failure tracking, or {@code null}
-   * @param outgoingHTL hop-to-live for the outgoing request, in hops
-   * @param ignoreBackoffUnder backoff window to ignore, in milliseconds
-   * @param isLocal whether the request originates locally, affecting policy
-   * @param realTime whether to enforce real-time routing constraints
-   * @param excludeMandatoryBackoff whether to exclude mandatory-backoff peers from selection
-   * @return the selected peer, or {@code null} if none qualifies
-   */
-  public PeerNode closerPeer(
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double target,
-      boolean ignoreSelf,
-      boolean calculateMisrouting,
-      int minVersion,
-      List<Double> addUnpickedLocsTo,
-      Key key,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      boolean excludeMandatoryBackoff) {
-    return closerPeer(
-        pn,
-        routedTo,
-        target,
-        ignoreSelf,
-        calculateMisrouting,
-        minVersion,
-        addUnpickedLocsTo,
-        2.0,
-        key,
-        outgoingHTL,
-        ignoreBackoffUnder,
-        isLocal,
-        realTime,
-        null,
-        false,
-        System.currentTimeMillis(),
-        excludeMandatoryBackoff);
-  }
-
-  /**
-   * Selects the closest eligible peer using fully specified routing parameters.
+   * Selects the closest eligible peer using routing parameters.
    *
    * <p>This method evaluates all connected peers against distance, routing backoff, timeout, and
-   * load-management constraints to produce a single best candidate. It can optionally integrate
-   * recently-failed information to delay retries until an appropriate wake-up time. The selection
+   * load-management constraints to produce the single best candidate. It can optionally integrate
+   * recently failed information to delay retries until an appropriate wake-up time. The selection
    * is deterministic for the given inputs and does not mutate peers; callers remain responsible for
    * updating per-request state and for respecting a {@code null} result.
    *
-   * @param pn the origin peer for this routing decision, or {@code null}
-   * @param routedTo peers already selected for this request path
-   * @param target target location on the ring, in normalized location units
-   * @param ignoreSelf whether to ignore the local node when selecting
-   * @param calculateMisrouting whether to record misrouting and backoff metrics
-   * @param minVersion minimum acceptable peer version, inclusive, in build units
-   * @param addUnpickedLocsTo optional list to collect alternative locations
-   * @param maxDistance maximum allowable distance from the target location
-   * @param key key for per-node failure tracking, or {@code null}
-   * @param outgoingHTL hop-to-live for the outgoing request, in hops
-   * @param ignoreBackoffUnder backoff window to ignore, in milliseconds
-   * @param isLocal whether the request originates locally, affecting policy
-   * @param realTime whether to enforce real-time routing constraints
-   * @param recentlyFailed optional holder for recently-failed timing feedback
-   * @param ignoreTimeout whether to ignore timeout-based exclusion checks
-   * @param now current time in milliseconds used for timeout comparisons
-   * @param newLoadManagement whether to use new load-management heuristics
+   * @param params routing selection parameters describing the request and policy
    * @return the selected peer, or {@code null} if none qualifies
    */
-  public PeerNode closerPeer(
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double target,
-      boolean ignoreSelf,
-      boolean calculateMisrouting,
-      int minVersion,
-      List<Double> addUnpickedLocsTo,
-      double maxDistance,
-      Key key,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      RecentlyFailedReturn recentlyFailed,
-      boolean ignoreTimeout,
-      long now,
-      boolean newLoadManagement) {
-    CloserPeerContext ctx = initCloserPeerContext(pn, routedTo, target, ignoreSelf, key);
-    evaluateCandidatesInContext(
-        ctx,
-        pn,
-        routedTo,
-        minVersion,
-        now,
-        realTime,
-        ignoreTimeout,
-        outgoingHTL,
-        target,
-        maxDistance,
-        ignoreSelf,
-        addUnpickedLocsTo,
-        ignoreBackoffUnder,
-        newLoadManagement);
+  public PeerNode closerPeer(PeerRoutingSelectionParams params) {
+    CloserPeerContext ctx = initCloserPeerContext(params);
+    evaluateCandidatesInContext(ctx, params);
 
     BestCandidate bestCand = selectBestCandidate(ctx.st, ctx.key);
-    if (recentlyFailed != null && LOG.isDebugEnabled()) {
+    if (params.recentlyFailed() != null && LOG.isDebugEnabled()) {
       LOG.debug("Count waiting: {}", ctx.st.countWaiting);
     }
 
-    PeerNode best =
-        handleRecentlyFailedIfNeeded(
-            bestCand.best,
-            bestCand.bestDistance,
-            recentlyFailed,
-            ctx,
-            pn,
-            routedTo,
-            target,
-            ignoreSelf,
-            minVersion,
-            maxDistance,
-            outgoingHTL,
-            ignoreBackoffUnder,
-            isLocal,
-            realTime,
-            now,
-            newLoadManagement);
+    PeerNode best = handleRecentlyFailedIfNeeded(bestCand, ctx, params);
     if (best == null) return null;
 
-    reportBackoffPercentIfNeeded(calculateMisrouting);
-    postSelectionUpdate(best, calculateMisrouting, addUnpickedLocsTo, ctx.st);
+    reportBackoffPercentIfNeeded(params.calculateMisrouting());
+    postSelectionUpdate(best, params.calculateMisrouting(), params.addUnpickedLocsTo(), ctx.st);
     return best;
   }
 
@@ -225,6 +106,82 @@ public class PeerRoutingSelector {
     }
   }
 
+  private record CloserPeerContextData(
+      PeerNode[] peers,
+      Key key,
+      double myLoc,
+      double maxDiff,
+      double prevLoc,
+      TimedOutNodesList entry,
+      SelectionRates selection,
+      boolean enableFOAFMitigationHack,
+      Set<Double> excludeLocations) {
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (!(obj
+          instanceof
+          CloserPeerContextData(
+              PeerNode[] otherPeers,
+              Key otherKey,
+              double otherMyLoc,
+              double otherMaxDiff,
+              double otherPrevLoc,
+              TimedOutNodesList otherEntry,
+              SelectionRates otherSelection,
+              boolean otherEnableFOAFMitigationHack,
+              Set<Double> otherExcludeLocations))) {
+        return false;
+      }
+      return Arrays.equals(peers, otherPeers)
+          && java.util.Objects.equals(key, otherKey)
+          && Double.compare(myLoc, otherMyLoc) == 0
+          && Double.compare(maxDiff, otherMaxDiff) == 0
+          && Double.compare(prevLoc, otherPrevLoc) == 0
+          && java.util.Objects.equals(entry, otherEntry)
+          && java.util.Objects.equals(selection, otherSelection)
+          && enableFOAFMitigationHack == otherEnableFOAFMitigationHack
+          && java.util.Objects.equals(excludeLocations, otherExcludeLocations);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Arrays.hashCode(peers);
+      result = 31 * result + java.util.Objects.hashCode(key);
+      result = 31 * result + Double.hashCode(myLoc);
+      result = 31 * result + Double.hashCode(maxDiff);
+      result = 31 * result + Double.hashCode(prevLoc);
+      result = 31 * result + java.util.Objects.hashCode(entry);
+      result = 31 * result + java.util.Objects.hashCode(selection);
+      result = 31 * result + Boolean.hashCode(enableFOAFMitigationHack);
+      result = 31 * result + java.util.Objects.hashCode(excludeLocations);
+      return result;
+    }
+
+    @Override
+    public @NotNull String toString() {
+      return "CloserPeerContextData[peers="
+          + Arrays.toString(peers)
+          + ", key="
+          + key
+          + ", myLoc="
+          + myLoc
+          + ", maxDiff="
+          + maxDiff
+          + ", prevLoc="
+          + prevLoc
+          + ", entry="
+          + entry
+          + ", selection="
+          + selection
+          + ", enableFOAFMitigationHack="
+          + enableFOAFMitigationHack
+          + ", excludeLocations="
+          + excludeLocations
+          + "]";
+    }
+  }
+
   private static final class CloserPeerContext {
     private final PeerNode[] peers;
     private final Key key;
@@ -237,48 +194,69 @@ public class PeerRoutingSelector {
     private final Set<Double> excludeLocations;
     private final PeerSelectionState st = new PeerSelectionState();
 
-    private CloserPeerContext(
-        PeerNode[] peers,
-        Key key,
-        double myLoc,
-        double maxDiff,
-        double prevLoc,
-        TimedOutNodesList entry,
-        SelectionRates selection,
-        boolean enableFOAFMitigationHack,
-        Set<Double> excludeLocations) {
-      this.peers = peers;
-      this.key = key;
-      this.myLoc = myLoc;
-      this.maxDiff = maxDiff;
-      this.prevLoc = prevLoc;
-      this.entry = entry;
-      this.selection = selection;
-      this.enableFOAFMitigationHack = enableFOAFMitigationHack;
-      this.excludeLocations = excludeLocations;
+    private CloserPeerContext(CloserPeerContextData data) {
+      this.peers = data.peers();
+      this.key = data.key();
+      this.myLoc = data.myLoc();
+      this.maxDiff = data.maxDiff();
+      this.prevLoc = data.prevLoc();
+      this.entry = data.entry();
+      this.selection = data.selection();
+      this.enableFOAFMitigationHack = data.enableFOAFMitigationHack();
+      this.excludeLocations = data.excludeLocations();
     }
   }
 
-  private CloserPeerContext initCloserPeerContext(
-      PeerNode pn, Set<PeerNode> routedTo, double target, boolean ignoreSelf, Key key) {
+  private static final class CandidateEvaluationContext {
+    private final PeerSelectionState st;
+    private final PeerNode origin;
+    private final Set<PeerNode> routedTo;
+    private final int minVersion;
+    private final boolean enableFOAFMitigationHack;
+    private final double[] selectionRates;
+    private final double totalSelectionRate;
+    private final TimedOutNodesList entry;
+    private final Set<Double> excludeLocations;
+    private final double maxDiff;
+    private final PeerRoutingSelectionParams params;
+
+    private CandidateEvaluationContext(CloserPeerContext ctx, PeerRoutingSelectionParams params) {
+      this.st = ctx.st;
+      this.origin = params.origin();
+      this.routedTo = params.routedTo();
+      this.minVersion = params.minVersion();
+      this.enableFOAFMitigationHack = ctx.enableFOAFMitigationHack;
+      this.selectionRates = ctx.selection.rates;
+      this.totalSelectionRate = ctx.selection.total;
+      this.entry = ctx.entry;
+      this.excludeLocations = ctx.excludeLocations;
+      this.maxDiff = ctx.maxDiff;
+      this.params = params;
+    }
+  }
+
+  private CloserPeerContext initCloserPeerContext(PeerRoutingSelectionParams params) {
     PeerNode[] peers = roster.connectedPeers();
-    Key effectiveKey = node.isEnablePerNodeFailureTables() ? key : null;
+    Key effectiveKey = node.isEnablePerNodeFailureTables() ? params.key() : null;
     if (LOG.isDebugEnabled()) {
       LOG.debug("Choosing closest peer (connectedPeers={}, key={})", peers.length, effectiveKey);
     }
 
     double myLoc = node.network().location();
-    double maxDiff = ignoreSelf ? Double.MAX_VALUE : Location.distance(myLoc, target);
-    double prevLoc = pn != null ? pn.getLocation() : -1.0;
+    double maxDiff =
+        params.ignoreSelf() ? Double.MAX_VALUE : Location.distance(myLoc, params.target());
+    double prevLoc = params.origin() != null ? params.origin().getLocation() : -1.0;
     TimedOutNodesList entry =
         effectiveKey != null
             ? node.routing().failureTable().getTimedOutNodesList(effectiveKey)
             : null;
     SelectionRates selection = computeSelectionRates(peers);
     boolean enableFOAF = peers.length >= PeerNode.SELECTION_MIN_PEERS && selection.total > 0.0;
-    Set<Double> exclude = buildExcludeLocations(myLoc, prevLoc, routedTo);
-    return new CloserPeerContext(
-        peers, effectiveKey, myLoc, maxDiff, prevLoc, entry, selection, enableFOAF, exclude);
+    Set<Double> exclude = buildExcludeLocations(myLoc, prevLoc, params.routedTo());
+    CloserPeerContextData data =
+        new CloserPeerContextData(
+            peers, effectiveKey, myLoc, maxDiff, prevLoc, entry, selection, enableFOAF, exclude);
+    return new CloserPeerContext(data);
   }
 
   private SelectionRates computeSelectionRates(PeerNode[] peers) {
@@ -292,88 +270,21 @@ public class PeerRoutingSelector {
   }
 
   private void evaluateCandidatesInContext(
-      CloserPeerContext ctx,
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      int minVersion,
-      long now,
-      boolean realTime,
-      boolean ignoreTimeout,
-      short outgoingHTL,
-      double target,
-      double maxDistance,
-      boolean ignoreSelf,
-      List<Double> addUnpickedLocsTo,
-      long ignoreBackoffUnder,
-      boolean newLoadManagement) {
+      CloserPeerContext ctx, PeerRoutingSelectionParams params) {
+    CandidateEvaluationContext evalContext = new CandidateEvaluationContext(ctx, params);
     for (int i = 0; i < ctx.peers.length; i++) {
-      evaluateCandidate(
-          ctx.st,
-          ctx.peers[i],
-          i,
-          pn,
-          routedTo,
-          minVersion,
-          ctx.enableFOAFMitigationHack,
-          ctx.selection.rates,
-          ctx.selection.total,
-          now,
-          realTime,
-          ctx.entry,
-          ignoreTimeout,
-          outgoingHTL,
-          target,
-          ctx.excludeLocations,
-          maxDistance,
-          ignoreSelf,
-          ctx.maxDiff,
-          addUnpickedLocsTo,
-          ignoreBackoffUnder,
-          newLoadManagement);
+      evaluateCandidate(evalContext, ctx.peers[i], i);
     }
   }
 
   private PeerNode handleRecentlyFailedIfNeeded(
-      PeerNode best,
-      double bestDistance,
-      RecentlyFailedReturn recentlyFailed,
-      CloserPeerContext ctx,
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double target,
-      boolean ignoreSelf,
-      int minVersion,
-      double maxDistance,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      long now,
-      boolean newLoadManagement) {
-    if (recentlyFailed == null) return best;
+      BestCandidate bestCand, CloserPeerContext ctx, PeerRoutingSelectionParams params) {
+    PeerNode best = bestCand.best;
+    if (params.recentlyFailed() == null) return best;
     if (ctx.st.countWaiting < maxCountWaiting(ctx.peers)) return best;
     if (!node.isEnableULPRDataPropagation()) return best;
     return maybeHandleRecentlyFailed(
-        pn,
-        routedTo,
-        target,
-        ignoreSelf,
-        minVersion,
-        maxDistance,
-        ctx.key,
-        outgoingHTL,
-        ignoreBackoffUnder,
-        isLocal,
-        realTime,
-        now,
-        newLoadManagement,
-        ctx.entry,
-        ctx.st,
-        best,
-        bestDistance,
-        ctx.myLoc,
-        ctx.prevLoc,
-        recentlyFailed);
+        params, ctx, best, bestCand.bestDistance, params.recentlyFailed());
   }
 
   private static final class PeerSelectionState {
@@ -415,94 +326,61 @@ public class PeerRoutingSelector {
     return excludeLocations;
   }
 
-  private void evaluateCandidate(
-      PeerSelectionState st,
-      PeerNode p,
-      int index,
-      PeerNode origin,
-      Set<PeerNode> routedTo,
-      int minVersion,
-      boolean enableFOAFMitigationHack,
-      double[] selectionRates,
-      double totalSelectionRate,
-      long now,
-      boolean realTime,
-      TimedOutNodesList entry,
-      boolean ignoreTimeout,
-      short outgoingHTL,
-      double target,
-      Set<Double> excludeLocations,
-      double maxDistance,
-      boolean ignoreSelf,
-      double maxDiff,
-      List<Double> addUnpickedLocsTo,
-      long ignoreBackoffUnder,
-      boolean newLoadManagement) {
-    if (shouldSkipCandidate(
-        p,
-        origin,
-        routedTo,
-        newLoadManagement,
-        realTime,
-        minVersion,
-        enableFOAFMitigationHack,
-        selectionRates,
-        totalSelectionRate,
-        index,
-        now)) {
+  private void evaluateCandidate(CandidateEvaluationContext ctx, PeerNode p, int index) {
+    if (shouldSkipCandidate(ctx, p, index)) {
       return;
     }
 
-    TimeoutInfo t = computeTimeoutInfo(st, entry, ignoreTimeout, now, outgoingHTL, p);
-    DiffInfo d = computeDiffInfo(p, target, outgoingHTL, excludeLocations);
+    TimeoutInfo t = computeTimeoutInfo(ctx, p);
+    DiffInfo d = computeDiffInfo(ctx, p);
 
-    if (d.diff > maxDistance) return;
-    if (!ignoreSelf && d.diff > maxDiff) {
-      if (LOG.isDebugEnabled()) LOG.debug("Ignore; farther than self; maxDiff={}", maxDiff);
+    if (d.diff > ctx.params.maxDistance()) return;
+    if (!ctx.params.ignoreSelf() && d.diff > ctx.maxDiff) {
+      if (LOG.isDebugEnabled()) LOG.debug("Ignore; farther than self; maxDiff={}", ctx.maxDiff);
       return;
     }
     if (LOG.isDebugEnabled()) {
       LOG.debug(
           "p.loc={}, target={}, d={} usedD={} timedOut={} for {}",
           d.loc,
-          target,
-          Location.distance(d.loc, target),
+          ctx.params.target(),
+          Location.distance(d.loc, ctx.params.target()),
           d.diff,
           t.timedOut,
           p.getPeer());
     }
 
     boolean chosen =
-        updateBestTracking(st, p, d, t.timedOut, t.timeoutFT, ignoreBackoffUnder, realTime);
+        updateBestTracking(
+            ctx.st,
+            p,
+            d,
+            t.timedOut,
+            t.timeoutFT,
+            ctx.params.ignoreBackoffUnder(),
+            ctx.params.realTime());
+    List<Double> addUnpickedLocsTo = ctx.params.addUnpickedLocsTo();
     if (addUnpickedLocsTo != null && !chosen) {
       double locD = d.loc;
       if (!addUnpickedLocsTo.contains(locD)) addUnpickedLocsTo.add(locD);
     }
   }
 
-  private boolean shouldSkipCandidate(
-      PeerNode p,
-      PeerNode origin,
-      Set<PeerNode> routedTo,
-      boolean newLoadManagement,
-      boolean realTime,
-      int minVersion,
-      boolean enableFOAFMitigationHack,
-      double[] selectionRates,
-      double totalSelectionRate,
-      int index,
-      long now) {
-    boolean skip = isAlreadyRoutedTo(p, routedTo);
-    skip = skip || isOrigin(p, origin);
+  private boolean shouldSkipCandidate(CandidateEvaluationContext ctx, PeerNode p, int index) {
+    boolean skip = isAlreadyRoutedTo(p, ctx.routedTo);
+    skip = skip || isOrigin(p, ctx.origin);
     skip = skip || isNotRoutable(p);
     skip = skip || isDisconnecting(p);
-    skip = skip || lacksLoadStats(p, newLoadManagement, realTime);
-    skip = skip || isOldVersion(p, minVersion);
+    skip = skip || lacksLoadStats(p, ctx.params.newLoadManagement(), ctx.params.realTime());
+    skip = skip || isOldVersion(p, ctx.minVersion);
     skip =
         skip
             || isOverSelectedPeer(
-                enableFOAFMitigationHack, selectionRates, totalSelectionRate, index, p);
-    skip = skip || isInMandatoryBackoff(p, newLoadManagement, realTime, now);
+                ctx.enableFOAFMitigationHack, ctx.selectionRates, ctx.totalSelectionRate, index, p);
+    skip =
+        skip
+            || isInMandatoryBackoff(
+                p, ctx.params.newLoadManagement(), ctx.params.realTime(), ctx.params.now());
     return skip;
   }
 
@@ -595,24 +473,18 @@ public class PeerRoutingSelector {
     }
   }
 
-  private TimeoutInfo computeTimeoutInfo(
-      PeerSelectionState st,
-      TimedOutNodesList entry,
-      boolean ignoreTimeout,
-      long now,
-      short outgoingHTL,
-      PeerNode p) {
+  private TimeoutInfo computeTimeoutInfo(CandidateEvaluationContext ctx, PeerNode p) {
     long timeoutRF;
     long timeoutFT = -1L;
-    if (entry != null && !ignoreTimeout) {
-      timeoutFT = entry.getTimeoutTime(p, outgoingHTL, now, true);
-      timeoutRF = entry.getTimeoutTime(p, outgoingHTL, now, false);
-      if (timeoutRF > now) {
-        st.soonestTimeoutWakeup = Math.min(st.soonestTimeoutWakeup, timeoutRF);
-        st.countWaiting++;
+    if (ctx.entry != null && !ctx.params.ignoreTimeout()) {
+      timeoutFT = ctx.entry.getTimeoutTime(p, ctx.params.outgoingHTL(), ctx.params.now(), true);
+      timeoutRF = ctx.entry.getTimeoutTime(p, ctx.params.outgoingHTL(), ctx.params.now(), false);
+      if (timeoutRF > ctx.params.now()) {
+        ctx.st.soonestTimeoutWakeup = Math.min(ctx.st.soonestTimeoutWakeup, timeoutRF);
+        ctx.st.countWaiting++;
       }
     }
-    boolean timedOut = timeoutFT > now;
+    boolean timedOut = timeoutFT > ctx.params.now();
     return new TimeoutInfo(timedOut, timeoutFT);
   }
 
@@ -628,6 +500,10 @@ public class PeerRoutingSelector {
       this.realDiff = realDiff;
       this.direct = direct;
     }
+  }
+
+  private DiffInfo computeDiffInfo(CandidateEvaluationContext ctx, PeerNode p) {
+    return computeDiffInfo(p, ctx.params.target(), ctx.params.outgoingHTL(), ctx.excludeLocations);
   }
 
   private DiffInfo computeDiffInfo(
@@ -774,73 +650,34 @@ public class PeerRoutingSelector {
   }
 
   private PeerNode maybeHandleRecentlyFailed(
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double target,
-      boolean ignoreSelf,
-      int minVersion,
-      double maxDistance,
-      Key key,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      long now,
-      boolean newLoadManagement,
-      TimedOutNodesList entry,
-      PeerSelectionState st,
+      PeerRoutingSelectionParams params,
+      CloserPeerContext ctx,
       PeerNode best,
       double bestDistance,
-      double myLoc,
-      double prevLoc,
       RecentlyFailedReturn recentlyFailed) {
-    FirstSecondChoice choice =
-        computeFirstSecondChoice(
-            pn,
-            routedTo,
-            target,
-            ignoreSelf,
-            minVersion,
-            maxDistance,
-            key,
-            outgoingHTL,
-            ignoreBackoffUnder,
-            isLocal,
-            realTime,
-            now,
-            newLoadManagement,
-            entry);
+    FirstSecondChoice choice = computeFirstSecondChoice(params, ctx.entry);
     if (choice == null) return best;
-    long until = computeUntil(choice.firstTime, choice.secondTime, st, now);
+    long until = computeUntil(choice.firstTime, choice.secondTime, ctx.st, params.now());
     long check =
-        best == st.closestNotBackedOff
+        best == ctx.st.closestNotBackedOff
             ? Long.MAX_VALUE
-            : checkBackoffsForRecentlyFailed(
-                roster.connectedPeers(),
-                best,
-                target,
-                bestDistance,
-                myLoc,
-                prevLoc,
-                now,
-                entry,
-                outgoingHTL);
+            : checkBackoffsForRecentlyFailed(ctx, best, bestDistance, params);
     if (check < until) {
       if (LOG.isDebugEnabled()) {
         LOG.debug(
             "Reducing RecentlyFailed from {} ms to {} ms due to wake-up check",
-            until - now,
-            check - now);
+            until - params.now(),
+            check - params.now());
       }
       until = check;
     }
-    long decidedUntil = decideRecentlyFailedUntil(until, now, key);
+    long decidedUntil = decideRecentlyFailedUntil(until, params.now(), ctx.key);
     if (decidedUntil >= 0) {
       recentlyFailed.fail(decidedUntil);
       return null;
     }
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Not sending RecentlyFailed because will wake up in {}ms", check - now);
+      LOG.debug("Not sending RecentlyFailed because will wake up in {}ms", check - params.now());
     }
     return best;
   }
@@ -881,70 +718,43 @@ public class PeerRoutingSelector {
   }
 
   private FirstSecondChoice computeFirstSecondChoice(
-      PeerNode pn,
-      Set<PeerNode> routedTo,
-      double target,
-      boolean ignoreSelf,
-      int minVersion,
-      double maxDistance,
-      Key key,
-      short outgoingHTL,
-      long ignoreBackoffUnder,
-      boolean isLocal,
-      boolean realTime,
-      long now,
-      boolean newLoadManagement,
-      TimedOutNodesList entry) {
+      PeerRoutingSelectionParams params, TimedOutNodesList entry) {
     if (entry == null) return null;
-    PeerNode first =
-        closerPeer(
-            pn,
-            routedTo,
-            target,
-            ignoreSelf,
-            false,
-            minVersion,
-            null,
-            maxDistance,
-            key,
-            outgoingHTL,
-            ignoreBackoffUnder,
-            isLocal,
-            realTime,
-            null,
-            true,
-            now,
-            newLoadManagement);
+    PeerNode first = closerPeer(buildRetryParams(params, params.routedTo()));
     if (first == null) return null;
-    long firstTime = entry.getTimeoutTime(first, outgoingHTL, now, false);
-    if (firstTime <= now) return null;
+    long firstTime = entry.getTimeoutTime(first, params.outgoingHTL(), params.now(), false);
+    if (firstTime <= params.now()) return null;
     if (LOG.isDebugEnabled()) LOG.debug("First choice timeout already passed");
 
-    HashSet<PeerNode> newRoutedTo = new HashSet<>(routedTo);
+    HashSet<PeerNode> newRoutedTo = new HashSet<>(params.routedTo());
     newRoutedTo.add(first);
-    PeerNode second =
-        closerPeer(
-            pn,
-            newRoutedTo,
-            target,
-            ignoreSelf,
-            false,
-            minVersion,
-            null,
-            maxDistance,
-            key,
-            outgoingHTL,
-            ignoreBackoffUnder,
-            isLocal,
-            realTime,
-            null,
-            true,
-            now,
-            newLoadManagement);
+    PeerNode second = closerPeer(buildRetryParams(params, newRoutedTo));
     if (second == null) return null;
-    long secondTime = entry.getTimeoutTime(second, outgoingHTL, now, false);
-    if (secondTime <= now) return null;
+    long secondTime = entry.getTimeoutTime(second, params.outgoingHTL(), params.now(), false);
+    if (secondTime <= params.now()) return null;
     return new FirstSecondChoice(firstTime, secondTime);
+  }
+
+  private PeerRoutingSelectionParams buildRetryParams(
+      PeerRoutingSelectionParams params, Set<PeerNode> routedTo) {
+    return new PeerRoutingSelectionParams(
+        params.origin(),
+        routedTo,
+        params.target(),
+        params.ignoreSelf(),
+        false,
+        params.minVersion(),
+        null,
+        params.maxDistance(),
+        params.key(),
+        params.outgoingHTL(),
+        params.ignoreBackoffUnder(),
+        params.isLocal(),
+        params.realTime(),
+        null,
+        true,
+        params.now(),
+        params.newLoadManagement());
   }
 
   private void postSelectionUpdate(
@@ -987,24 +797,18 @@ public class PeerRoutingSelector {
   }
 
   private long checkBackoffsForRecentlyFailed(
-      PeerNode[] peers,
+      CloserPeerContext ctx,
       PeerNode best,
-      double target,
       double bestDistance,
-      double myLoc,
-      double prevLoc,
-      long now,
-      TimedOutNodesList entry,
-      short outgoingHTL) {
-    if (entry == null) return Long.MAX_VALUE;
+      PeerRoutingSelectionParams params) {
+    if (ctx.entry == null) return Long.MAX_VALUE;
     long overallWakeup = Long.MAX_VALUE;
-    Set<Double> excludeLocations = buildExcludeLocations(myLoc, prevLoc, Set.of());
-    for (PeerNode p : peers) {
+    Set<Double> excludeLocations = buildExcludeLocations(ctx.myLoc, ctx.prevLoc, Set.of());
+    for (PeerNode p : ctx.peers) {
       long wake =
-          wakeupTimeIfBetterAlternative(
-              p, best, target, bestDistance, outgoingHTL, excludeLocations, now, entry);
+          wakeupTimeIfBetterAlternative(p, best, bestDistance, params, excludeLocations, ctx.entry);
       if (wake == Long.MIN_VALUE) continue;
-      if (wake > now && wake < overallWakeup) overallWakeup = wake;
+      if (wake > params.now() && wake < overallWakeup) overallWakeup = wake;
     }
     return overallWakeup;
   }
@@ -1012,22 +816,22 @@ public class PeerRoutingSelector {
   private long wakeupTimeIfBetterAlternative(
       PeerNode p,
       PeerNode best,
-      double target,
       double bestDistance,
-      short outgoingHTL,
+      PeerRoutingSelectionParams params,
       Set<Double> excludeLocations,
-      long now,
       TimedOutNodesList entry) {
     if (p == best || !p.isRoutable()) return Long.MIN_VALUE;
-    DiffInfo d = computeDiffInfo(p, target, outgoingHTL, excludeLocations);
+    DiffInfo d = computeDiffInfo(p, params.target(), params.outgoingHTL(), excludeLocations);
     if (d.diff >= bestDistance) return Long.MIN_VALUE;
-    long wakeup = computeWakeupDeadline(entry, outgoingHTL, now, p);
-    if (wakeup <= now) {
+    long wakeup = computeWakeupDeadline(entry, params.outgoingHTL(), params.now(), p);
+    if (wakeup <= params.now()) {
       if (LOG.isDebugEnabled())
         LOG.debug("Better node available during RecentlyFailed check: {}", p);
       return Long.MIN_VALUE;
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Peer {} exits backoff/timeout in {} ms", p, wakeup - now);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Peer {} exits backoff/timeout in {} ms", p, wakeup - params.now());
+    }
     return wakeup;
   }
 

--- a/src/main/java/network/crypta/node/RequestSender.java
+++ b/src/main/java/network/crypta/node/RequestSender.java
@@ -324,28 +324,26 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     long now = System.currentTimeMillis();
 
     // Route it
-    next =
-        node.network()
-            .peers()
-            .routingSelector()
-            .closerPeer(
-                source,
-                nodesRoutedTo,
-                target,
-                true,
-                node.isAdvancedModeEnabled(),
-                -1,
-                null,
-                2.0,
-                key,
-                htl,
-                0,
-                source == null,
-                realTimeFlag,
-                r,
-                false,
-                now,
-                newLoadManagement);
+    PeerRoutingSelectionParams params =
+        new PeerRoutingSelectionParams(
+            source,
+            nodesRoutedTo,
+            target,
+            true,
+            node.isAdvancedModeEnabled(),
+            -1,
+            null,
+            2.0,
+            key,
+            htl,
+            0L,
+            source == null,
+            realTimeFlag,
+            r,
+            false,
+            now,
+            newLoadManagement);
+    next = node.network().peers().routingSelector().closerPeer(params);
 
     if (handleRecentlyFailedDecision(r, now)) return;
 
@@ -1676,8 +1674,8 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
   /**
    * Forwards a {@code RejectedOverload} signal to the request originator once per request.
    *
-   * <p>Only the first call forwards; subsequent calls are ignored. Wakes up any waiter blocked in
-   * {@link #waitUntilStatusChange(short)} via {@link #notifyAll()}.
+   * <p>Only the first call forwards; later calls are ignored. Wakes up any waiter blocked in {@link
+   * #waitUntilStatusChange(short)} via {@link #notifyAll()}.
    */
   protected void forwardRejectedOverload() {
     synchronized (this) {
@@ -1729,7 +1727,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
    * @param mask Bit mask describing states to ignore (i.e., those already observed by the caller).
    *     See {@link #WAIT_REJECTED_OVERLOAD}, {@link #WAIT_TRANSFERRING_DATA}, and {@link
    *     #WAIT_FINISHED}. Passing {@link #WAIT_ALL} is invalid.
-   * @return A mask that includes any newly observed states; may be passed to a subsequent call.
+   * @return A mask that includes any newly observed states; may be passed to a later call.
    * @throws IllegalArgumentException if {@code mask == WAIT_ALL}.
    */
   public synchronized short waitUntilStatusChange(short mask) {

--- a/src/main/java/network/crypta/node/SSKInsertSender.java
+++ b/src/main/java/network/crypta/node/SSKInsertSender.java
@@ -16,6 +16,7 @@ import network.crypta.io.comm.SlowAsyncMessageFilterCallback;
 import network.crypta.keys.NodeSSK;
 import network.crypta.keys.SSKBlock;
 import network.crypta.keys.SSKVerifyException;
+import network.crypta.node.subsystem.NodeRoutingSubsystem.SskInsertOptions;
 import network.crypta.support.ShortBuffer;
 import network.crypta.support.io.NativeThread;
 import org.slf4j.Logger;
@@ -29,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>SSKs can collide: a different payload may already exist at the same key, requiring
  *       collision handling and potential block replacement.
- *   <li>The payload is small (approximately 1 KiB), so headers and data are sent eagerly and the
+ *   <li>The payload is small (approximately 1 KiB), so headers and data are sent eagerly, and the
  *       final reply does not require a long transfer window.
  *   <li>Verification depends on the publisher’s public key; the peer may request the public key and
  *       confirm it separately from the payload.
@@ -59,7 +60,7 @@ public class SSKInsertSender extends BaseSender
   final byte[] pubKeyHash;
 
   /**
-   * Raw payload bytes. Initially the local payload; may be replaced if a collision is discovered
+   * Raw payload bytes. Initially, the local payload; may be replaced if a collision is discovered
    * and the remote block is accepted instead.
    */
   byte[] data;
@@ -116,13 +117,9 @@ public class SSKInsertSender extends BaseSender
       short htl,
       PeerNode source,
       Node node,
-      boolean fromStore,
-      boolean forkOnCacheable,
-      boolean preferInsert,
-      boolean ignoreLowBackoff,
-      boolean realTimeFlag) {
-    super(block.getKey(), realTimeFlag, source, node, htl, uid);
-    this.fromStore = fromStore;
+      SskInsertOptions opts) {
+    super(block.getKey(), opts.realTimeFlag, source, node, htl, uid);
+    this.fromStore = opts.fromStore;
     this.origUID = uid;
     this.origTag = tag;
     myKey = block.getKey();
@@ -134,9 +131,9 @@ public class SSKInsertSender extends BaseSender
     byte[] pubKeyAsBytes = pubKey.asBytes();
     pubKeyHash = SHA256.digest(pubKeyAsBytes);
     this.block = block;
-    this.forkOnCacheable = forkOnCacheable;
-    this.preferInsert = preferInsert;
-    this.ignoreLowBackoff = ignoreLowBackoff;
+    this.forkOnCacheable = opts.forkOnCacheable;
+    this.preferInsert = opts.preferInsert;
+    this.ignoreLowBackoff = opts.ignoreLowBackoff;
   }
 
   /**
@@ -179,7 +176,7 @@ public class SSKInsertSender extends BaseSender
     }
   }
 
-  // Routing entry point. Chooses next peer and handles optional forking when the local node
+  // Routing entry point. Chooses the next peer and handles optional forking when the local node
   // is allowed to cache inserts at the current HTL.
 
   /** Performs one routing step: adjust HTL, optionally fork, pick a peer, and continue. */
@@ -374,7 +371,7 @@ public class SSKInsertSender extends BaseSender
    */
   @Override
   protected void handleAcceptedRejectedTimeout(final PeerNode next, final UIDTag tag) {
-    // Log as WARN rather than ERROR because the send may still be queued (async path).
+    // Log as WARN rather than ERROR because the sending may still be queued (async path).
     LOG.warn("Timeout awaiting Accepted/Rejected {} to {}", this, next);
     // Use the right UID here, in case we fork.
     final long uid = tag.uid;
@@ -513,7 +510,7 @@ public class SSKInsertSender extends BaseSender
    *     false} to keep waiting for a non-local outcome.
    */
   private boolean handleRejectedOverload(Message msg, PeerNode next, InsertTag thisTag) {
-    // Probably non-fatal, if so, we have time left, can try next one
+    // Probably non-fatal, if so, we have time left, can try the next one
     if (msg.getBoolean(DMT.IS_LOCAL)) {
       next.localRejectedOverload("ForwardRejectedOverload4", realTimeFlag);
       if (LOG.isDebugEnabled()) LOG.debug("Local RejectedOverload, moving on to next peer");
@@ -553,8 +550,8 @@ public class SSKInsertSender extends BaseSender
   /**
    * Handles an SSK collision signaled by {@code FNPSSKDataFoundHeaders}.
    *
-   * @return {@link DO#WAIT} when remote headers and data were accepted and we are waiting for the
-   *     final outcome; {@link DO#NEXT_PEER} if the peer disconnected or timed out; otherwise {@link
+   * @return {@link DO#WAIT} when remote headers and data were accepted, and we are waiting for the
+   *     outcome; {@link DO#NEXT_PEER} if the peer disconnected or timed out; otherwise {@link
    *     DO#FINISHED} on unrecoverable error.
    */
   private DO handleSSKDataFoundHeaders(Message msg, PeerNode next, InsertTag thisTag) {
@@ -732,8 +729,8 @@ public class SSKInsertSender extends BaseSender
   /**
    * Waits up to {@code millis} for the sender to transition out of {@link #NOT_FINISHED}.
    *
-   * <p>Uses the sender's intrinsic monitor and mirrors the notify pattern within this class to
-   * avoid external synchronization on the parameter object.
+   * <p>Uses the sender's intrinsic monitor and mirrors the notification pattern within this class
+   * to avoid external synchronization on the parameter object.
    */
   @SuppressWarnings(
       "java:S2142") // Intentionally ignore interrupts to avoid busy-spin of polling loops
@@ -775,7 +772,7 @@ public class SSKInsertSender extends BaseSender
   }
 
   /**
-   * Returns whether this sender has forwarded the request to any peer yet.
+   * Returns whether this sender hasn't forwarded the request to any peer yet.
    *
    * <p>Useful to distinguish {@link #ROUTE_NOT_FOUND} from {@link #ROUTE_REALLY_NOT_FOUND}.
    */
@@ -785,7 +782,7 @@ public class SSKInsertSender extends BaseSender
   }
 
   /**
-   * Returns and clears a sticky flag indicating that a collision occurred since the last call.
+   * Returns and clears a sticky flag indicating that a collision has occurred since the last call.
    * Thread‑safe.
    */
   public synchronized boolean hasRecentlyCollided() {
@@ -867,7 +864,7 @@ public class SSKInsertSender extends BaseSender
     }
   }
 
-  /** Records {@code x} payload bytes sent (separate from header/counter accounting). */
+  /** Records {@code x} payload bytes sent (separate from header- / counter-accounting). */
   @Override
   public void sentPayload(int x) {
     node.sentPayload(x);

--- a/src/main/java/network/crypta/node/SSKInsertSender.java
+++ b/src/main/java/network/crypta/node/SSKInsertSender.java
@@ -240,10 +240,8 @@ public class SSKInsertSender extends BaseSender
   }
 
   private PeerNode findNextPeer() {
-    return node.network()
-        .peers()
-        .routingSelector()
-        .closerPeer(
+    PeerRoutingSelectionParams params =
+        new PeerRoutingSelectionParams(
             forkedRequestTag == null ? source : null,
             nodesRoutedTo,
             target,
@@ -251,12 +249,17 @@ public class SSKInsertSender extends BaseSender
             node.isAdvancedModeEnabled(),
             -1,
             null,
+            2.0,
             null,
             htl,
-            ignoreLowBackoff ? Node.LOW_BACKOFF : 0,
+            ignoreLowBackoff ? Node.LOW_BACKOFF : 0L,
             source == null,
             realTimeFlag,
+            null,
+            false,
+            System.currentTimeMillis(),
             newLoadManagement);
+    return node.network().peers().routingSelector().closerPeer(params);
   }
 
   private void handleNoNextPeer() {

--- a/src/main/java/network/crypta/node/subsystem/NodeRoutingSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeRoutingSubsystem.java
@@ -886,19 +886,7 @@ public final class NodeRoutingSubsystem {
     if (LOG.isDebugEnabled())
       LOG.debug("makeInsertSender({},{},{},{},...,{}", key, htl, uid, source, opts.fromStore);
     SSKInsertSender is;
-    is =
-        new SSKInsertSender(
-            block,
-            uid,
-            tag,
-            htl,
-            source,
-            node,
-            opts.fromStore,
-            opts.forkOnCacheable,
-            opts.preferInsert,
-            opts.ignoreLowBackoff,
-            opts.realTimeFlag);
+    is = new SSKInsertSender(block, uid, tag, htl, source, node, opts);
     is.start();
     return is;
   }

--- a/src/test/java/network/crypta/node/AnnounceSenderTest.java
+++ b/src/test/java/network/crypta/node/AnnounceSenderTest.java
@@ -2,11 +2,8 @@ package network.crypta.node;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeast;
@@ -67,7 +64,7 @@ class AnnounceSenderTest {
     when(network.usm()).thenReturn(usm);
     when(network.stats()).thenReturn(stats);
     when(network.executor()).thenReturn(executor);
-    // Run runnables inline for determinism when used.
+    // Run runnable inline for determinism when used.
     Mockito.doAnswer(
             inv -> {
               Runnable r = inv.getArgument(0);
@@ -187,21 +184,7 @@ class AnnounceSenderTest {
     when(network.isOpennetEnabled()).thenReturn(true);
     when(node.maxHTL()).thenReturn((short) 3);
     when(node.routing().decrementHTL(isNull(), anyShort())).thenReturn((short) 1);
-    when(routingSelector.closerPeer(
-            isNull(),
-            anySet(),
-            anyDouble(),
-            anyBoolean(),
-            anyBoolean(),
-            anyInt(),
-            isNull(),
-            isNull(),
-            anyShort(),
-            anyLong(),
-            anyBoolean(),
-            anyBoolean(),
-            anyBoolean()))
-        .thenReturn(null);
+    when(routingSelector.closerPeer(any(PeerRoutingSelectionParams.class))).thenReturn(null);
 
     AnnounceSender sender = new AnnounceSender(0.25, om, node, cb, null);
 
@@ -232,20 +215,7 @@ class AnnounceSenderTest {
 
     PeerNode p1 = Mockito.mock(PeerNode.class);
     PeerNode p2 = Mockito.mock(PeerNode.class);
-    when(routingSelector.closerPeer(
-            isNull(),
-            anySet(),
-            anyDouble(),
-            anyBoolean(),
-            anyBoolean(),
-            anyInt(),
-            isNull(),
-            isNull(),
-            anyShort(),
-            anyLong(),
-            anyBoolean(),
-            anyBoolean(),
-            anyBoolean()))
+    when(routingSelector.closerPeer(any(PeerRoutingSelectionParams.class)))
         .thenReturn(p1, p2, null);
 
     // Decrement HTL returns a sequence to keep iterations going
@@ -260,7 +230,7 @@ class AnnounceSenderTest {
         // Second attempt on p2: fail to start transfer
         .thenThrow(new NotConnectedException("send fail"));
 
-    // Accepted wait: first call returns null (timeout/try another), no further waits because p2
+    // Accepted wait: the first call returns null (timeout/try another), no further waits because p2
     // send fails
     when(usm.waitFor(any(MessageFilter.class), any())).thenReturn(null);
 
@@ -269,7 +239,8 @@ class AnnounceSenderTest {
     // Act
     sender.run();
 
-    // Assert: verify decrementHTL was called with p2 as the 'from' on the iteration after send
+    // Assert: to verify decrementHTL was called with p2 as the 'from' on the iteration after
+    // sending
     // failure
     ArgumentCaptor<PeerNode> fromCaptor = ArgumentCaptor.forClass(PeerNode.class);
     verify(node.routing(), atLeast(3)).decrementHTL(fromCaptor.capture(), anyShort());

--- a/src/test/java/network/crypta/node/NodeClientCoreSupportTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreSupportTest.java
@@ -7,11 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -304,29 +299,12 @@ class NodeClientCoreSupportTest {
 
     doAnswer(
             invocation -> {
-              RecentlyFailedReturn recent = invocation.getArgument(13);
-              recent.fail(wakeup);
+              PeerRoutingSelectionParams params = invocation.getArgument(0);
+              params.recentlyFailed().fail(wakeup);
               return null;
             })
         .when(routingSelector)
-        .closerPeer(
-            isNull(),
-            anySet(),
-            eq(0.25),
-            eq(true),
-            eq(false),
-            eq(-1),
-            isNull(),
-            eq(2.0),
-            same(key),
-            eq(decremented),
-            eq(0L),
-            eq(true),
-            eq(realTime),
-            any(RecentlyFailedReturn.class),
-            eq(false),
-            anyLong(),
-            eq(true));
+        .closerPeer(any(PeerRoutingSelectionParams.class));
 
     long result = NodeClientCoreSupport.checkRecentlyFailed(node, key, realTime);
 
@@ -352,25 +330,7 @@ class NodeClientCoreSupportTest {
     when(key.toNormalizedDouble()).thenReturn(0.7);
     when(node.network().enableNewLoadManagement(realTime)).thenReturn(false);
 
-    when(routingSelector.closerPeer(
-            isNull(),
-            anySet(),
-            eq(0.7),
-            eq(true),
-            eq(false),
-            eq(-1),
-            isNull(),
-            eq(2.0),
-            same(key),
-            eq(decremented),
-            eq(0L),
-            eq(true),
-            eq(realTime),
-            any(RecentlyFailedReturn.class),
-            eq(false),
-            anyLong(),
-            eq(false)))
-        .thenReturn(null);
+    when(routingSelector.closerPeer(any(PeerRoutingSelectionParams.class))).thenReturn(null);
 
     long result = NodeClientCoreSupport.checkRecentlyFailed(node, key, realTime);
 

--- a/src/test/java/network/crypta/node/NodeRoutedMessageRouterTest.java
+++ b/src/test/java/network/crypta/node/NodeRoutedMessageRouterTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
@@ -245,21 +246,7 @@ class NodeRoutedMessageRouterTest {
         new NodeRoutedMessageRouter.RoutedContext(original, source, IDENTITY);
     ctx.lastHtl = 2;
     routedContexts(router).put(UID, ctx);
-    when(routingSelector.closerPeer(
-            source,
-            ctx.routedTo,
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            null,
-            (short) 1,
-            0L,
-            false,
-            false,
-            false))
-        .thenReturn(null);
+    when(routingSelector.closerPeer(any(PeerRoutingSelectionParams.class))).thenReturn(null);
     Message reject = DMT.createFNPRoutedRejected(UID, (short) 5);
 
     boolean handled = router.handle(reject, null);

--- a/src/test/java/network/crypta/node/PeerRoutingSelectorTest.java
+++ b/src/test/java/network/crypta/node/PeerRoutingSelectorTest.java
@@ -59,23 +59,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertNull(selected);
@@ -90,23 +91,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertNull(selected);
@@ -122,23 +124,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertEquals(secondClosest, selected);
@@ -147,7 +150,7 @@ class PeerRoutingSelectorTest {
   @Test
   void closerPeer_whenIgnoreSelfFalseAndOnlyPeersBeyondSelf_expectNull() {
     // Arrange
-    when(node.network().location()).thenReturn(0.0); // self distance to target=0.25 is 0.25
+    when(node.network().location()).thenReturn(0.0); // self-distance to target=0.25 is 0.25
 
     PeerNode closerBeyondSelf = routablePeerAt(0.60); // diff=0.35 (> 0.25)
     PeerNode fartherBeyondSelf = routablePeerAt(0.80); // diff=0.45 (> 0.25)
@@ -157,23 +160,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            false,
-            false,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                false,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertNull(selected);
@@ -182,7 +186,7 @@ class PeerRoutingSelectorTest {
   @Test
   void closerPeer_whenIgnoreSelfTrueAndOnlyPeersBeyondSelf_expectSelectsSecond() {
     // Arrange
-    when(node.network().location()).thenReturn(0.0); // self distance to target=0.25 is 0.25
+    when(node.network().location()).thenReturn(0.0); // self-distance to target=0.25 is 0.25
 
     PeerNode closerBeyondSelf = routablePeerAt(0.60); // diff=0.35
     PeerNode fartherBeyondSelf = routablePeerAt(0.80); // diff=0.45
@@ -192,23 +196,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertEquals(fartherBeyondSelf, selected);
@@ -232,23 +237,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            true,
-            null,
-            false,
-            NOW,
-            true);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                true,
+                null,
+                false,
+                NOW,
+                true));
 
     // Assert
     assertEquals(selectedExpected, selected);
@@ -273,23 +279,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            true,
-            null,
-            false,
-            NOW,
-            true);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                true,
+                null,
+                false,
+                NOW,
+                true));
 
     // Assert
     assertEquals(selectedExpected, selected);
@@ -318,23 +325,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertEquals(selectedExpected, selected);
@@ -362,23 +370,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            minVersion,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                minVersion,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertEquals(selectedExpected, selected);
@@ -403,23 +412,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            origin,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            maxDistance,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                origin,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                maxDistance,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertEquals(direct, selected);
@@ -448,23 +458,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertEquals(secondBackedOff, selected);
@@ -489,23 +500,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            addUnpickedLocsTo,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                addUnpickedLocsTo,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertEquals(selectedExpected, selected);
@@ -539,23 +551,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            key,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            recentlyFailed,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                key,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                recentlyFailed,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertEquals(selectedExpected, selected);
@@ -591,23 +604,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            2.0,
-            key,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            recentlyFailed,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                false,
+                -1,
+                null,
+                2.0,
+                key,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                recentlyFailed,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertNull(selected);
@@ -629,23 +643,24 @@ class PeerRoutingSelectorTest {
     // Act
     PeerNode selected =
         selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            true,
-            -1,
-            null,
-            2.0,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            null,
-            false,
-            NOW,
-            false);
+            new PeerRoutingSelectionParams(
+                null,
+                identityPeerSet(),
+                TARGET,
+                true,
+                true,
+                -1,
+                null,
+                2.0,
+                null,
+                OUTGOING_HTL,
+                0L,
+                true,
+                false,
+                null,
+                false,
+                NOW,
+                false));
 
     // Assert
     assertEquals(selectedExpected, selected);
@@ -661,13 +676,43 @@ class PeerRoutingSelectorTest {
     // Arrange
     when(roster.connectedPeers()).thenReturn(new PeerNode[0]);
 
+    PeerRoutingSelectionParams params =
+        new PeerRoutingSelectionParams(
+            null,
+            null,
+            TARGET,
+            true,
+            false,
+            -1,
+            null,
+            2.0,
+            null,
+            OUTGOING_HTL,
+            0L,
+            true,
+            false,
+            null,
+            false,
+            NOW,
+            false);
+
     // Act + Assert
-    assertThrows(
-        NullPointerException.class,
-        () ->
-            selector.closerPeer(
+    assertThrows(NullPointerException.class, () -> selector.closerPeer(params));
+  }
+
+  @Test
+  void closerPeer_whenUsingConvenienceOverload_expectSameSelectionRulesApply() {
+    // Arrange
+    PeerNode closest = routablePeerAt(0.24);
+    PeerNode selectedExpected = routablePeerAt(0.30);
+    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closest, selectedExpected});
+
+    // Act
+    PeerNode selected =
+        selector.closerPeer(
+            new PeerRoutingSelectionParams(
                 null,
-                null,
+                identityPeerSet(),
                 TARGET,
                 true,
                 false,
@@ -683,31 +728,6 @@ class PeerRoutingSelectorTest {
                 false,
                 NOW,
                 false));
-  }
-
-  @Test
-  void closerPeer_whenUsingConvenienceOverload_expectSameSelectionRulesApply() {
-    // Arrange
-    PeerNode closest = routablePeerAt(0.24);
-    PeerNode selectedExpected = routablePeerAt(0.30);
-    when(roster.connectedPeers()).thenReturn(new PeerNode[] {closest, selectedExpected});
-
-    // Act
-    PeerNode selected =
-        selector.closerPeer(
-            null,
-            identityPeerSet(),
-            TARGET,
-            true,
-            false,
-            -1,
-            null,
-            null,
-            OUTGOING_HTL,
-            0L,
-            true,
-            false,
-            false);
 
     // Assert
     assertEquals(selectedExpected, selected);

--- a/src/test/java/network/crypta/node/SSKInsertSenderTest.java
+++ b/src/test/java/network/crypta/node/SSKInsertSenderTest.java
@@ -15,6 +15,7 @@ import network.crypta.io.comm.MessageCore;
 import network.crypta.io.comm.MessageFilter;
 import network.crypta.keys.NodeSSK;
 import network.crypta.keys.SSKBlock;
+import network.crypta.node.subsystem.NodeRoutingSubsystem.SskInsertOptions;
 import network.crypta.support.io.NativeThread;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -70,18 +71,14 @@ class SSKInsertSenderTest {
       boolean forkOnCacheable, boolean preferInsert, boolean ignoreLowBackoff, boolean realTime) {
     prepareCommonStubs();
     // uid=42, htl=10, fromStore=false, canWriteClientCache=false
-    return new SSKInsertSender(
-        block,
-        42L,
-        insertTag,
-        (short) 10,
-        source,
-        node,
-        false,
-        forkOnCacheable,
-        preferInsert,
-        ignoreLowBackoff,
-        realTime);
+    SskInsertOptions options =
+        SskInsertOptions.of()
+            .withFromStore(false)
+            .withForkOnCacheable(forkOnCacheable)
+            .withPreferInsert(preferInsert)
+            .withIgnoreLowBackoff(ignoreLowBackoff)
+            .withRealTimeFlag(realTime);
+    return new SSKInsertSender(block, 42L, insertTag, (short) 10, source, node, options);
   }
 
   @ParameterizedTest
@@ -151,7 +148,7 @@ class SSKInsertSenderTest {
     Message prefer = req.getSubMessage(DMT.FNPSubInsertPreferInsert);
     assertTrue(prefer != null && prefer.getBoolean(DMT.PREFER_INSERT));
 
-    // Ignore-low-backoff present and true
+    // Ignore-low backoff present and true
     Message ignore = req.getSubMessage(DMT.FNPSubInsertIgnoreLowBackoff);
     assertTrue(ignore != null && ignore.getBoolean(DMT.IGNORE_LOW_BACKOFF));
 
@@ -285,19 +282,15 @@ class SSKInsertSenderTest {
         .thenReturn(finalReply);
 
     // Construct the sender with uid=42 and realtime=false (bulk)
+    SskInsertOptions options =
+        SskInsertOptions.of()
+            .withFromStore(false)
+            .withForkOnCacheable(true)
+            .withPreferInsert(false)
+            .withIgnoreLowBackoff(false)
+            .withRealTimeFlag(false);
     SSKInsertSender sender =
-        new SSKInsertSender(
-            block,
-            42L,
-            tag,
-            (short) 10,
-            source,
-            node,
-            /* fromStore */ false,
-            /* forkOnCacheable */ true,
-            /* preferInsert */ false,
-            /* ignoreLowBackoff */ false,
-            /* realtime */ false);
+        new SSKInsertSender(block, 42L, tag, (short) 10, source, node, options);
 
     // Act: drive a single routing attempt directly
     sender.innerRouteRequests(next, tag);
@@ -319,7 +312,7 @@ class SSKInsertSenderTest {
     Mockito.verify(next).resetMandatoryBackoff(false);
     Mockito.verify(olt).clearDontSendUnlessGuaranteed();
 
-    // Final outcome should be success
+    // The final outcome should be success
     assertEquals("SUCCESS", sender.getStatusString());
   }
 


### PR DESCRIPTION
## Summary
- Introduce `PeerRoutingSelectionParams` to bundle routing selector inputs and refactor `PeerRoutingSelector.closerPeer`/internals around the new parameter object.
- Update routing senders/subsystem call sites to build and pass the new params, plus minor documentation wording tweaks.
- Align node routing tests with the new API and remove the JetBrains inspections section from `AGENTS.md`.

## Testing
- Not run (not requested)