### PR TITLE
refactor(node): bundle routing report params

### DIFF
--- a/src/main/java/network/crypta/node/AnnounceSender.java
+++ b/src/main/java/network/crypta/node/AnnounceSender.java
@@ -188,7 +188,10 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
     if (LOG.isDebugEnabled()) LOG.debug("Routing request to {}", next);
     if (onlyNode == null)
       PeerNodeRoutingReporter.reportRoutedTo(
-          node, next, target, source == null, false, source, nodesRoutedTo, htl);
+          node,
+          next,
+          new PeerNodeRoutingReportParams(
+              target, source == null, false, source, nodesRoutedTo, htl));
     nodesRoutedTo.add(next);
 
     long transferUID = sendTo(next);

--- a/src/main/java/network/crypta/node/BaseSender.java
+++ b/src/main/java/network/crypta/node/BaseSender.java
@@ -244,12 +244,8 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
       PeerNodeRoutingReporter.reportRoutedTo(
           node,
           next,
-          key.toNormalizedDouble(),
-          source == null,
-          realTimeFlag,
-          source,
-          nodesRoutedTo,
-          htl);
+          new PeerNodeRoutingReportParams(
+              key.toNormalizedDouble(), source == null, realTimeFlag, source, nodesRoutedTo, htl));
       node.network().peers().incrementSelectionSamples(next);
     } catch (NotConnectedException _) {
       LOG.debug("Not connected");
@@ -631,12 +627,8 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
       PeerNodeRoutingReporter.reportRoutedTo(
           node,
           state.next,
-          key.toNormalizedDouble(),
-          source == null,
-          realTimeFlag,
-          source,
-          nodesRoutedTo,
-          htl);
+          new PeerNodeRoutingReportParams(
+              key.toNormalizedDouble(), source == null, realTimeFlag, source, nodesRoutedTo, htl));
       node.network().peers().incrementSelectionSamples(state.next);
       return true;
     } catch (NotConnectedException _) {

--- a/src/main/java/network/crypta/node/PeerNodeRoutingReportParams.java
+++ b/src/main/java/network/crypta/node/PeerNodeRoutingReportParams.java
@@ -1,0 +1,28 @@
+package network.crypta.node;
+
+import java.util.Set;
+
+/**
+ * Immutable parameter bundle for peer-routing miss distance reporting.
+ *
+ * <p>This record groups the routing-decision context used by {@link
+ * PeerNodeRoutingReporter#reportRoutedTo(Node, PeerNode, PeerNodeRoutingReportParams)} so callers
+ * can pass a single value instead of a long argument list. The record performs no validation or
+ * defensive copies; callers must ensure locations are valid keyspace coordinates and the routed-to
+ * set is treated as read-only for the reporting operation.
+ *
+ * @param target target keyspace location for the routing decision
+ * @param isLocal whether this decision is classified as local routing
+ * @param realTime whether this decision is classified as realtime routing
+ * @param prev the previous hop peer, or {@code null} when no prior hop exists
+ * @param routedTo peers already tried for this route; never {@code null}
+ * @param htl hop-to-live value used to decide peer-published routing behavior
+ * @see PeerNodeRoutingReporter#reportRoutedTo(Node, PeerNode, PeerNodeRoutingReportParams)
+ */
+public record PeerNodeRoutingReportParams(
+    double target,
+    boolean isLocal,
+    boolean realTime,
+    PeerNode prev,
+    Set<PeerNode> routedTo,
+    int htl) {}

--- a/src/main/java/network/crypta/node/PeerNodeRoutingReporter.java
+++ b/src/main/java/network/crypta/node/PeerNodeRoutingReporter.java
@@ -62,32 +62,22 @@ final class PeerNodeRoutingReporter {
    *
    * @param node the local node providing location and stats; must be non-null
    * @param peerNode the candidate peer whose location is evaluated; must be non-null
-   * @param target the target keyspace location, in the range {@code [0.0, 1.0]}
-   * @param isLocal whether this decision is classified as local routing
-   * @param realTime whether this decision is classified as realtime routing
-   * @param prev the previous hop peer, or {@code null} when no prior hop exists
-   * @param routedTo peers already tried for this route; never {@code null}
-   * @param htl hop-to-live value used to decide peer-published routing behavior
+   * @param routingParams routing context including target, policy flags, and peer history
    * @throws IllegalArgumentException if any required location is outside {@code [0.0, 1.0]}
    */
   static void reportRoutedTo(
-      Node node,
-      PeerNode peerNode,
-      double target,
-      boolean isLocal,
-      boolean realTime,
-      PeerNode prev,
-      Set<PeerNode> routedTo,
-      int htl) {
-    double distance = Location.distance(target, peerNode.getLocation());
+      Node node, PeerNode peerNode, PeerNodeRoutingReportParams routingParams) {
+    double distance = Location.distance(routingParams.target(), peerNode.getLocation());
 
     var stats = node.network().stats();
     if (stats == null) return;
 
-    Set<Double> excludeLocations = buildExcludeLocations(node, prev, routedTo);
+    Set<Double> excludeLocations =
+        buildExcludeLocations(node, routingParams.prev(), routingParams.routedTo());
     double adjustedDistance =
-        adjustDistanceForPublishedPeers(peerNode, target, htl, excludeLocations, distance);
-    reportToStats(stats, adjustedDistance, isLocal, realTime);
+        adjustDistanceForPublishedPeers(
+            peerNode, routingParams.target(), routingParams.htl(), excludeLocations, distance);
+    reportToStats(stats, adjustedDistance, routingParams.isLocal(), routingParams.realTime());
   }
 
   /**
@@ -118,7 +108,7 @@ final class PeerNodeRoutingReporter {
    * @param peerNode the peer providing published locations for consideration
    * @param target the target keyspace location, in the range {@code [0.0, 1.0]}
    * @param htl hop-to-live value that gates peer-published routing behavior
-   * @param excludeLocations locations that must be ignored when searching published peers
+   * @param excludeLocations locations that must be ignored when searching for published peers
    * @param distance the current best distance before considering published locations
    * @return the adjusted distance, possibly unchanged if no closer location is found
    * @throws IllegalArgumentException if a published location is invalid for {@link

--- a/src/test/java/network/crypta/node/PeerNodeRoutingReporterTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeRoutingReporterTest.java
@@ -36,7 +36,9 @@ class PeerNodeRoutingReporterTest {
     assertDoesNotThrow(
         () ->
             PeerNodeRoutingReporter.reportRoutedTo(
-                node, peerNode, 0.1, true, true, null, Set.of(), 1));
+                node,
+                peerNode,
+                new PeerNodeRoutingReportParams(0.1, true, true, null, Set.of(), 1)));
   }
 
   @ParameterizedTest
@@ -62,7 +64,9 @@ class PeerNodeRoutingReporterTest {
     when(peerNode.shallWeRouteAccordingToOurPeersLocation(2)).thenReturn(false);
 
     PeerNodeRoutingReporter.reportRoutedTo(
-        node, peerNode, target, isLocal, realTime, null, Set.of(), 2);
+        node,
+        peerNode,
+        new PeerNodeRoutingReportParams(target, isLocal, realTime, null, Set.of(), 2));
 
     verify(overall).report(expectedDistance);
     if (isLocal) {
@@ -103,7 +107,8 @@ class PeerNodeRoutingReporterTest {
     when(peerNode.shallWeRouteAccordingToOurPeersLocation(3)).thenReturn(true);
     when(peerNode.getClosestPeerLocation(eq(target), anySet())).thenReturn(closestLocation);
 
-    PeerNodeRoutingReporter.reportRoutedTo(node, peerNode, target, true, true, null, Set.of(), 3);
+    PeerNodeRoutingReporter.reportRoutedTo(
+        node, peerNode, new PeerNodeRoutingReportParams(target, true, true, null, Set.of(), 3));
 
     verify(overall).report(expectedDistance);
     verify(local).report(expectedDistance);
@@ -135,7 +140,8 @@ class PeerNodeRoutingReporterTest {
     when(peerNode.shallWeRouteAccordingToOurPeersLocation(4)).thenReturn(true);
     when(peerNode.getClosestPeerLocation(eq(target), anySet())).thenReturn(closestLocation);
 
-    PeerNodeRoutingReporter.reportRoutedTo(node, peerNode, target, true, false, null, Set.of(), 4);
+    PeerNodeRoutingReporter.reportRoutedTo(
+        node, peerNode, new PeerNodeRoutingReportParams(target, true, false, null, Set.of(), 4));
 
     verify(overall).report(expectedDistance);
     verify(local).report(expectedDistance);
@@ -161,7 +167,9 @@ class PeerNodeRoutingReporterTest {
         IllegalArgumentException.class,
         () ->
             PeerNodeRoutingReporter.reportRoutedTo(
-                node, peerNode, target, true, true, null, routedTo, 5));
+                node,
+                peerNode,
+                new PeerNodeRoutingReportParams(target, true, true, null, routedTo, 5)));
 
     verifyNoInteractions(overall, local, remote, rt, bulk);
   }
@@ -199,7 +207,8 @@ class PeerNodeRoutingReporterTest {
     routedTo.add(routedToA);
     routedTo.add(routedToB);
 
-    PeerNodeRoutingReporter.reportRoutedTo(node, peerNode, target, false, true, prev, routedTo, 6);
+    PeerNodeRoutingReporter.reportRoutedTo(
+        node, peerNode, new PeerNodeRoutingReportParams(target, false, true, prev, routedTo, 6));
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<Set<Double>> captor =


### PR DESCRIPTION
## Summary
- add `PeerNodeRoutingReportParams` to bundle routing miss report context
- refactor `PeerNodeRoutingReporter.reportRoutedTo` to accept the params record
- update routing report call sites and tests to construct the params object

## Testing
- `./gradlew test`