### PR TITLE
chore(build): trust Groovy signing key

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -93,6 +93,7 @@
          <trusted-key id="7C7271B83AAE727A2941690666F8E4860BF74983" group="org.jooq"/>
          <trusted-key id="839323A4780D5BF9A6978970152888E10EF880B3" group="org.unbescape" name="unbescape" version="1.1.6.RELEASE"/>
          <trusted-key id="84789D24DF77A32433CE1F079EB80E92EB2135B1" group="org.apache" name="apache"/>
+         <trusted-key id="34441E504A937F43EB0DAEF96A65176A0FB1CD0B" group="org.apache.groovy"/>
          <trusted-key id="8756C4F765C9AC3CB6B85D62379CE192D401AB61">
             <trusting group="com.diffplug.durian"/>
             <trusting group="org.jetbrains.intellij.deps" name="trove4j" version="1.0.20200330"/>


### PR DESCRIPTION
## Summary
- Trust Groovy signing key in dependency verification metadata to unblock Gradle sync.

## Testing
- `./gradlew help`
- `./gradlew spotlessApply`