### PR TITLE
refactor(node): group request tracking params

### DIFF
--- a/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
@@ -97,7 +97,8 @@ public final class NodeClientCoreTransfers {
         new RequestTag(isSSK, RequestTag.START.ASYNC_GET, null, options.realTimeFlag(), uid, node);
     if (!node.routing()
         .tracker()
-        .lockUID(uid, isSSK, false, false, true, options.realTimeFlag(), tag)) {
+        .lockUID(
+            uid, RequestAdmissionMode.of(true, isSSK, false, false, options.realTimeFlag()), tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       listener.onFailed(
           new LowLevelGetException(
@@ -404,7 +405,9 @@ public final class NodeClientCoreTransfers {
     long startTime = System.currentTimeMillis();
     long uid = makeUID();
     RequestTag tag = new RequestTag(false, RequestTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!node.routing().tracker().lockUID(uid, false, false, false, true, realTimeFlag, tag)) {
+    if (!node.routing()
+        .tracker()
+        .lockUID(uid, RequestAdmissionMode.of(true, false, false, false, realTimeFlag), tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
     }
@@ -545,7 +548,9 @@ public final class NodeClientCoreTransfers {
     long startTime = System.currentTimeMillis();
     long uid = makeUID();
     RequestTag tag = new RequestTag(true, RequestTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!node.routing().tracker().lockUID(uid, true, false, false, true, realTimeFlag, tag)) {
+    if (!node.routing()
+        .tracker()
+        .lockUID(uid, RequestAdmissionMode.of(true, true, false, false, realTimeFlag), tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       throw new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR);
     }
@@ -705,7 +710,9 @@ public final class NodeClientCoreTransfers {
     CHKInsertSender is;
     long uid = makeUID();
     InsertTag tag = new InsertTag(false, InsertTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!node.routing().tracker().lockUID(uid, false, true, false, true, realTimeFlag, tag)) {
+    if (!node.routing()
+        .tracker()
+        .lockUID(uid, RequestAdmissionMode.of(true, false, true, false, realTimeFlag), tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
     }
@@ -868,7 +875,9 @@ public final class NodeClientCoreTransfers {
     SSKInsertSender is;
     long uid = makeUID();
     InsertTag tag = new InsertTag(true, InsertTag.START.LOCAL, null, realTimeFlag, uid, node);
-    if (!node.routing().tracker().lockUID(uid, true, true, false, true, realTimeFlag, tag)) {
+    if (!node.routing()
+        .tracker()
+        .lockUID(uid, RequestAdmissionMode.of(true, true, true, false, realTimeFlag), tag)) {
       LOG.error(MSG_CANNOT_LOCK_UID + "{}" + MSG_BROKEN_PRNG, uid);
       throw new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
     }

--- a/src/main/java/network/crypta/node/NodeDataRequestHandler.java
+++ b/src/main/java/network/crypta/node/NodeDataRequestHandler.java
@@ -168,7 +168,8 @@ final class NodeDataRequestHandler {
             Key key,
             short htl,
             RequestTag tag) {
-          if (tracker.lockUID(id, isSSK, false, false, false, tag.realTimeFlag, tag)) {
+          if (tracker.lockUID(
+              id, RequestAdmissionMode.of(false, isSSK, false, false, tag.realTimeFlag), tag)) {
             if (LOG.isDebugEnabled()) LOG.debug("Lock acquired for id {}", id);
             return false;
           }

--- a/src/main/java/network/crypta/node/NodeInsertRequestHandler.java
+++ b/src/main/java/network/crypta/node/NodeInsertRequestHandler.java
@@ -183,7 +183,9 @@ final class NodeInsertRequestHandler {
    */
   private boolean rejectAlreadyRunningInsert(
       long id, boolean isSSK, PeerNode source, ByteCounter ctr, InsertTag tag) {
-    if (tracker.lockUID(id, isSSK, true, false, false, tag.realTimeFlag, tag)) return false;
+    if (tracker.lockUID(
+        id, RequestAdmissionMode.of(false, isSSK, true, false, tag.realTimeFlag), tag))
+      return false;
     if (LOG.isDebugEnabled()) LOG.debug(LOG_ALREADY_RUNNING, id);
     Message rejected = DMT.createFNPRejectedLoop(id);
     try {

--- a/src/main/java/network/crypta/node/NodeOfferMessageHandler.java
+++ b/src/main/java/network/crypta/node/NodeOfferMessageHandler.java
@@ -210,7 +210,8 @@ final class NodeOfferMessageHandler {
    */
   private boolean rejectAlreadyRunning(
       long uid, boolean isSSK, PeerNode source, OfferReplyTag tag) {
-    if (tracker.lockUID(uid, isSSK, false, true, false, tag.realTimeFlag, tag)) {
+    if (tracker.lockUID(
+        uid, RequestAdmissionMode.of(false, isSSK, false, true, tag.realTimeFlag), tag)) {
       if (LOG.isDebugEnabled()) LOG.debug("Lock acquired for id {}", uid);
       return false;
     }

--- a/src/main/java/network/crypta/node/RequestAdmissionMode.java
+++ b/src/main/java/network/crypta/node/RequestAdmissionMode.java
@@ -10,4 +10,34 @@ package network.crypta.node;
  * @param realTimeFlag whether the request uses real-time scheduling
  */
 public record RequestAdmissionMode(
-    boolean isLocal, boolean isInsert, boolean isSSK, boolean isOfferReply, boolean realTimeFlag) {}
+    boolean isLocal, boolean isInsert, boolean isSSK, boolean isOfferReply, boolean realTimeFlag) {
+
+  /**
+   * Create a mode using the flag order commonly used by request tracking APIs.
+   *
+   * @param isLocal whether the request originated locally
+   * @param isSSK whether the request targets an SSK key
+   * @param isInsert whether the request is an insert
+   * @param isOfferReply whether the request is an offer reply
+   * @param realTimeFlag whether the request uses real-time scheduling
+   * @return a new {@link RequestAdmissionMode} with the supplied flags
+   */
+  public static RequestAdmissionMode of(
+      boolean isLocal,
+      boolean isSSK,
+      boolean isInsert,
+      boolean isOfferReply,
+      boolean realTimeFlag) {
+    return new RequestAdmissionMode(isLocal, isInsert, isSSK, isOfferReply, realTimeFlag);
+  }
+
+  /**
+   * Create a mode from the properties of a {@link UIDTag}.
+   *
+   * @param tag tag providing request characteristics
+   * @return a new {@link RequestAdmissionMode} describing the tag
+   */
+  public static RequestAdmissionMode fromTag(UIDTag tag) {
+    return of(tag.wasLocal(), tag.isSSK(), tag.isInsert(), tag.isOfferReply(), tag.realTimeFlag);
+  }
+}

--- a/src/main/java/network/crypta/node/RequestTracker.java
+++ b/src/main/java/network/crypta/node/RequestTracker.java
@@ -118,14 +118,7 @@ public class RequestTracker {
    *     same tag), {@code false} when the UID is owned by a different tag.
    */
   public boolean lockUID(UIDTag tag) {
-    return lockUID(
-        tag.uid,
-        tag.isSSK(),
-        tag.isInsert(),
-        tag.isOfferReply(),
-        tag.wasLocal(),
-        tag.realTimeFlag,
-        tag);
+    return lockUID(tag.uid, RequestAdmissionMode.fromTag(tag), tag);
   }
 
   /**
@@ -139,43 +132,34 @@ public class RequestTracker {
    * accessed while holding the overall map lock.
    *
    * @param uid Unique request identifier.
-   * @param ssk {@code true} for SSK, {@code false} for CHK.
-   * @param insert {@code true} for inserts, {@code false} for requests (gets).
-   * @param offerReply {@code true} to operate on offer replies (takes precedence over {@code
-   *     insert}).
-   * @param local {@code true} if the request originated locally.
-   * @param realTimeFlag {@code true} for real-time mode, {@code false} for bulk mode.
+   * @param mode Admission mode describing key type, operation, and scheduling flags.
    * @param tag The tag instance to record for this UID.
    * @return {@code true} if recorded (or already present for the same tag), {@code false} if a
    *     different tag already owns the UID.
    */
-  public boolean lockUID(
-      long uid,
-      boolean ssk,
-      boolean insert,
-      boolean offerReply,
-      boolean local,
-      boolean realTimeFlag,
-      UIDTag tag) {
+  public boolean lockUID(long uid, RequestAdmissionMode mode, UIDTag tag) {
     // If these are switched around, we must remember to remove from both.
-    if (offerReply) {
+    if (mode.isOfferReply()) {
       // local irrelevant for OfferReplyTag's.
-      HashMap<Long, OfferReplyTag> map = getOfferTracker(ssk, realTimeFlag);
+      HashMap<Long, OfferReplyTag> map = getOfferTracker(mode.isSSK(), mode.realTimeFlag());
       synchronized (map) {
         return doLock(map, null, (OfferReplyTag) tag, uid, false);
       }
-    } else if (insert) {
-      HashMap<Long, InsertTag> overallMap = getInsertTracker(ssk, false, realTimeFlag);
-      HashMap<Long, InsertTag> localMap = local ? getInsertTracker(ssk, true, realTimeFlag) : null;
+    } else if (mode.isInsert()) {
+      HashMap<Long, InsertTag> overallMap =
+          getInsertTracker(mode.isSSK(), false, mode.realTimeFlag());
+      HashMap<Long, InsertTag> localMap =
+          mode.isLocal() ? getInsertTracker(mode.isSSK(), true, mode.realTimeFlag()) : null;
       synchronized (overallMap) {
-        return doLock(overallMap, localMap, (InsertTag) tag, uid, local);
+        return doLock(overallMap, localMap, (InsertTag) tag, uid, mode.isLocal());
       }
     } else {
-      HashMap<Long, RequestTag> overallMap = getRequestTracker(ssk, false, realTimeFlag);
+      HashMap<Long, RequestTag> overallMap =
+          getRequestTracker(mode.isSSK(), false, mode.realTimeFlag());
       HashMap<Long, RequestTag> localMap =
-          local ? getRequestTracker(ssk, true, realTimeFlag) : null;
+          mode.isLocal() ? getRequestTracker(mode.isSSK(), true, mode.realTimeFlag()) : null;
       synchronized (overallMap) {
-        return doLock(overallMap, localMap, (RequestTag) tag, uid, local);
+        return doLock(overallMap, localMap, (RequestTag) tag, uid, mode.isLocal());
       }
     }
   }
@@ -241,16 +225,7 @@ public class RequestTracker {
    * @param noRecord When {@code true}, do not record completion for peer cleanup.
    */
   void unlockUID(UIDTag tag, boolean canFail, boolean noRecord) {
-    unlockUID(
-        tag.uid,
-        tag.isSSK(),
-        tag.isInsert(),
-        canFail,
-        tag.isOfferReply(),
-        tag.wasLocal(),
-        tag.realTimeFlag,
-        tag,
-        noRecord);
+    unlockUID(tag.uid, RequestAdmissionMode.fromTag(tag), tag, canFail, noRecord);
   }
 
   /**
@@ -261,59 +236,49 @@ public class RequestTracker {
    * debug message is emitted instead of an error.
    *
    * @param uid Unique request identifier.
-   * @param ssk {@code true} for SSK, {@code false} for CHK.
-   * @param insert {@code true} for inserts, {@code false} for requests (gets).
-   * @param canFail When {@code true}, tolerate missing or mismatched entries.
-   * @param offerReply {@code true} to operate on offer replies (takes precedence over {@code
-   *     insert}).
-   * @param local {@code true} if the request originated locally.
-   * @param realTimeFlag {@code true} for real-time mode, {@code false} for bulk mode.
+   * @param mode Admission mode describing key type, operation, and scheduling flags.
    * @param tag The tag instance to remove for this UID.
+   * @param canFail When {@code true}, tolerate missing or mismatched entries.
    * @param noRecord When {@code true}, do not record completion for peer cleanup.
    */
   protected void unlockUID(
-      long uid,
-      boolean ssk,
-      boolean insert,
-      boolean canFail,
-      boolean offerReply,
-      boolean local,
-      boolean realTimeFlag,
-      UIDTag tag,
-      boolean noRecord) {
+      long uid, RequestAdmissionMode mode, UIDTag tag, boolean canFail, boolean noRecord) {
     if (!noRecord) completed(uid);
 
-    if (offerReply) {
-      HashMap<Long, OfferReplyTag> map = getOfferTracker(ssk, realTimeFlag);
+    if (mode.isOfferReply()) {
+      HashMap<Long, OfferReplyTag> map = getOfferTracker(mode.isSSK(), mode.realTimeFlag());
       synchronized (map) {
         doUnlock(map, null, (OfferReplyTag) tag, uid, false, canFail);
       }
-    } else if (insert) {
-      HashMap<Long, InsertTag> overallMap = getInsertTracker(ssk, false, realTimeFlag);
-      HashMap<Long, InsertTag> localMap = local ? getInsertTracker(ssk, true, realTimeFlag) : null;
+    } else if (mode.isInsert()) {
+      HashMap<Long, InsertTag> overallMap =
+          getInsertTracker(mode.isSSK(), false, mode.realTimeFlag());
+      HashMap<Long, InsertTag> localMap =
+          mode.isLocal() ? getInsertTracker(mode.isSSK(), true, mode.realTimeFlag()) : null;
       synchronized (overallMap) {
-        doUnlock(overallMap, localMap, (InsertTag) tag, uid, local, canFail);
+        doUnlock(overallMap, localMap, (InsertTag) tag, uid, mode.isLocal(), canFail);
       }
     } else {
-      HashMap<Long, RequestTag> overallMap = getRequestTracker(ssk, false, realTimeFlag);
+      HashMap<Long, RequestTag> overallMap =
+          getRequestTracker(mode.isSSK(), false, mode.realTimeFlag());
       HashMap<Long, RequestTag> localMap =
-          local ? getRequestTracker(ssk, true, realTimeFlag) : null;
+          mode.isLocal() ? getRequestTracker(mode.isSSK(), true, mode.realTimeFlag()) : null;
       synchronized (overallMap) {
-        doUnlock(overallMap, localMap, (RequestTag) tag, uid, local, canFail);
+        doUnlock(overallMap, localMap, (RequestTag) tag, uid, mode.isLocal(), canFail);
       }
     }
   }
 
   /**
-   * Do the actual unlock.
+   * Do the actual unlocking.
    *
    * @param <T> The type of the tag.
    * @param overallMap The overall map for this group of requests. LOCKING: We use the overallMap as
-   *     lock for both.
-   * @param localMap The local map if any. We check on overallMap and then remove from both.
+   *     a lock for both.
+   * @param localMap The local map, if any. We check on the overallMap and then remove from both.
    * @param tag The tag to remove.
    * @param uid The UID of the tag.
-   * @param local Whether it is local. If it is local we use both maps. If it is not we expect the
+   * @param local Whether it is local. If it is local, we use both maps. If it is not, we expect the
    *     latter to be null.
    * @param canFail If true, tolerate missing entries and log at debug level instead of error.
    */
@@ -402,32 +367,27 @@ public class RequestTracker {
   /**
    * Count all running requests that match the given filters and accumulate transfer estimates.
    *
-   * @param local If true, include only locally originated requests; otherwise include all.
-   * @param ssk If true, count SSK; if false, count CHK.
-   * @param insert If true, count inserts; otherwise count gets (requests).
-   * @param offer If true, count offer replies (takes precedence over {@code insert}).
-   * @param realTimeFlag If true, count real-time requests; otherwise count bulk.
-   * @param transfersPerInsert Average outgoing transfers to assume per insert.
-   * @param ignoreLocalVsRemote If true, treat local requests as remote for transfer estimation.
+   * @param mode Request admission mode selecting which requests to count.
+   * @param transferOptions Options affecting transfer estimation while counting.
    * @param counter Accumulator for totals and transfer estimates.
    * @param counterSourceRestarted Optional accumulator for requests counted as source-restarted.
    */
   public void countRequests(
-      boolean local,
-      boolean ssk,
-      boolean insert,
-      boolean offer,
-      boolean realTimeFlag,
-      int transfersPerInsert,
-      boolean ignoreLocalVsRemote,
+      RequestAdmissionMode mode,
+      RequestTransferOptions transferOptions,
       CountedRequests counter,
       CountedRequests counterSourceRestarted) {
-    HashMap<Long, ? extends UIDTag> map = getTracker(local, ssk, insert, offer, realTimeFlag);
+    HashMap<Long, ? extends UIDTag> map = getTracker(mode);
+    RequestAdmissionMode nonLocal = nonLocalMode(mode);
     // Map is locked by the non-local version, although we're counting from the local version.
-    synchronized (local ? getTracker(false, ssk, insert, offer, realTimeFlag) : map) {
+    synchronized (mode.isLocal() ? getTracker(nonLocal) : map) {
       CountTotals totals =
           accumulateCounts(
-              map, local, ignoreLocalVsRemote, transfersPerInsert, counterSourceRestarted != null);
+              map,
+              mode.isLocal(),
+              transferOptions.ignoreLocalVsRemote(),
+              transferOptions.transfersPerInsert(),
+              counterSourceRestarted != null);
       counter.total += totals.count;
       counter.expectedTransfersIn += totals.in;
       counter.expectedTransfersOut += totals.out;
@@ -485,64 +445,49 @@ public class RequestTracker {
    * @param source Peer from which requests were accepted or to which they were routed.
    * @param requestsToNode If true, count requests sent to {@code source} and currently running;
    *     otherwise count requests originating from {@code source}.
-   * @param local If true, include only locally originated requests; otherwise include all.
-   * @param ssk If true, count SSK; if false, count CHK.
-   * @param insert If true, count inserts; otherwise count gets (requests).
-   * @param offer If true, count offer replies (takes precedence over {@code insert}).
-   * @param realTimeFlag If true, count real-time; otherwise count bulk.
-   * @param transfersPerInsert Average outgoing transfers to assume per insert.
-   * @param ignoreLocalVsRemote If true, treat local requests as remote for transfer estimation.
+   * @param mode Request admission mode selecting which requests to count.
+   * @param transferOptions Options affecting transfer estimation while counting.
    * @param counter Accumulator for totals and transfer estimates.
    * @param counterSR Optional accumulator for requests counted as source-restarted.
    */
   public void countRequests(
       PeerNode source,
       boolean requestsToNode,
-      boolean local,
-      boolean ssk,
-      boolean insert,
-      boolean offer,
-      boolean realTimeFlag,
-      int transfersPerInsert,
-      boolean ignoreLocalVsRemote,
+      RequestAdmissionMode mode,
+      RequestTransferOptions transferOptions,
       CountedRequests counter,
       CountedRequests counterSR) {
-    HashMap<Long, ? extends UIDTag> map = getTracker(local, ssk, insert, offer, realTimeFlag);
+    HashMap<Long, ? extends UIDTag> map = getTracker(mode);
+    RequestAdmissionMode nonLocal = nonLocalMode(mode);
     // Map is locked by the non-local version, although we're counting from the local version.
-    synchronized (local ? getTracker(false, ssk, insert, offer, realTimeFlag) : map) {
+    synchronized (mode.isLocal() ? getTracker(nonLocal) : map) {
       if (!requestsToNode) {
-        countRequestsFromSource(
-            map, local, source, ignoreLocalVsRemote, transfersPerInsert, counter, counterSR);
+        countRequestsFromSource(map, mode, source, transferOptions, counter, counterSR);
       } else {
-        countRequestsToNode(
-            map,
-            local,
-            source,
-            ignoreLocalVsRemote,
-            transfersPerInsert,
-            counter,
-            ssk,
-            insert,
-            offer);
+        countRequestsToNode(map, mode, source, transferOptions, counter);
       }
     }
   }
 
   private void countRequestsFromSource(
       Map<Long, ? extends UIDTag> map,
-      boolean local,
+      RequestAdmissionMode mode,
       PeerNode source,
-      boolean ignoreLocalVsRemote,
-      int transfersPerInsert,
+      RequestTransferOptions transferOptions,
       CountedRequests counter,
       CountedRequests counterSR) {
-    // If a request is adopted by us as a result of a timeout, it can be in the
+    // If we adopt a request as a result of a timeout, it can be in the
     // remote map despite having source == null. However, if a request is in the
-    // local map it will always have source == null.
-    if (source != null && local) return;
+    // local map, it will always have source == null.
+    if (source != null && mode.isLocal()) return;
     CountTotals totals =
         accumulateCountsFromSource(
-            map, local, source, ignoreLocalVsRemote, transfersPerInsert, counterSR != null);
+            map,
+            mode.isLocal(),
+            source,
+            transferOptions.ignoreLocalVsRemote(),
+            transferOptions.transfersPerInsert(),
+            counterSR != null);
     if (LOG.isDebugEnabled())
       LOG.debug("Count totals count={} in={} out={}", totals.count, totals.in, totals.out);
     counter.total += totals.count;
@@ -557,25 +502,26 @@ public class RequestTracker {
 
   private void countRequestsToNode(
       Map<Long, ? extends UIDTag> map,
-      boolean local,
+      RequestAdmissionMode mode,
       PeerNode source,
-      boolean ignoreLocalVsRemote,
-      int transfersPerInsert,
-      CountedRequests counter,
-      boolean ssk,
-      boolean insert,
-      boolean offer) {
+      RequestTransferOptions transferOptions,
+      CountedRequests counter) {
     // hasSourceRestarted is irrelevant for requests *to* a node.
     // Consider improving efficiency if measurements indicate a bottleneck.
     CountTotals totals =
-        accumulateCountsToNode(map, local, source, ignoreLocalVsRemote, transfersPerInsert);
+        accumulateCountsToNode(
+            map,
+            mode.isLocal(),
+            source,
+            transferOptions.ignoreLocalVsRemote(),
+            transferOptions.transfersPerInsert());
     if (LOG.isDebugEnabled())
       LOG.debug(
           "Count to node scope={} keyType={} opType={} offer={} count={} of={} peer={}",
-          local ? "local" : "remote",
-          ssk ? "ssk" : "chk",
-          insert ? "insert" : "request",
-          offer ? "offer" : "",
+          mode.isLocal() ? "local" : "remote",
+          mode.isSSK() ? "ssk" : "chk",
+          mode.isInsert() ? "insert" : "request",
+          mode.isOfferReply() ? "offer" : "",
           totals.count,
           map.size(),
           source);
@@ -654,13 +600,8 @@ public class RequestTracker {
    *
    * @param requestsToNode If true, count requests sent to the node; otherwise count those
    *     originating from peers.
-   * @param local If true, include only locally originated requests; otherwise include all.
-   * @param ssk If true, count SSK; if false, count CHK.
-   * @param insert If true, count inserts; otherwise count gets (requests).
-   * @param offer If true, count offer replies (takes precedence over {@code insert}).
-   * @param realTimeFlag If true, count real-time; otherwise count bulk.
-   * @param transfersPerInsert Average outgoing transfers to assume per insert.
-   * @param ignoreLocalVsRemote If true, treat local requests as remote for transfer estimation.
+   * @param mode Request admission mode selecting which requests to count.
+   * @param transferOptions Options affecting transfer estimation while counting.
    * @param counterMap Destination map from {@link PeerNode} (may be {@code null}) to counters.
    *     {@code null} is used for local requests, adopted requests after source restart, and
    *     requests whose originator is not currently in the routing table.
@@ -668,29 +609,33 @@ public class RequestTracker {
   @SuppressWarnings("unused")
   public void countAllRequestsByIncomingPeer(
       boolean requestsToNode,
-      boolean local,
-      boolean ssk,
-      boolean insert,
-      boolean offer,
-      boolean realTimeFlag,
-      int transfersPerInsert,
-      boolean ignoreLocalVsRemote,
+      RequestAdmissionMode mode,
+      RequestTransferOptions transferOptions,
       Map<PeerNode, CountedRequests> counterMap) {
-    HashMap<Long, ? extends UIDTag> map = getTracker(local, ssk, insert, offer, realTimeFlag);
+    HashMap<Long, ? extends UIDTag> map = getTracker(mode);
+    RequestAdmissionMode nonLocal = nonLocalMode(mode);
     // Map is locked by the non-local version, although we're counting from the local version.
-    synchronized (local ? getTracker(false, ssk, insert, offer, realTimeFlag) : map) {
+    synchronized (mode.isLocal() ? getTracker(nonLocal) : map) {
       if (!requestsToNode) {
-        // If a request is adopted by us as a result of a timeout, it can be in the
+        // If we adopt a request as a result of a timeout, it can be in the
         // remote map despite having source == null. However, if a request is in the
-        // local map it will always have source == null.
+        // local map, it will always have source == null.
         for (Map.Entry<Long, ? extends UIDTag> entry : map.entrySet()) {
           UIDTag tag = entry.getValue();
           // The overall running* map can include local. But the local map can't include non-local.
-          if ((!local) && tag.wasLocal) continue;
+          if ((!mode.isLocal()) && tag.wasLocal) continue;
           PeerNode source = tag.getSource(); // Can be null in various cases
           CountedRequests counter = counterMap.computeIfAbsent(source, k -> new CountedRequests());
-          int out = tag.expectedTransfersOut(ignoreLocalVsRemote, transfersPerInsert, true);
-          int in = tag.expectedTransfersIn(ignoreLocalVsRemote, transfersPerInsert, true);
+          int out =
+              tag.expectedTransfersOut(
+                  transferOptions.ignoreLocalVsRemote(),
+                  transferOptions.transfersPerInsert(),
+                  true);
+          int in =
+              tag.expectedTransfersIn(
+                  transferOptions.ignoreLocalVsRemote(),
+                  transferOptions.transfersPerInsert(),
+                  true);
           counter.total++;
           counter.expectedTransfersIn += in;
           counter.expectedTransfersOut += out;
@@ -764,11 +709,17 @@ public class RequestTracker {
     tag.reassignToSelf();
   }
 
-  private HashMap<Long, ? extends UIDTag> getTracker(
-      boolean local, boolean ssk, boolean insert, boolean offer, boolean realTimeFlag) {
-    if (offer) return getOfferTracker(ssk, realTimeFlag);
-    else if (insert) return getInsertTracker(ssk, local, realTimeFlag);
-    else return getRequestTracker(ssk, local, realTimeFlag);
+  private RequestAdmissionMode nonLocalMode(RequestAdmissionMode mode) {
+    if (!mode.isLocal()) return mode;
+    return RequestAdmissionMode.of(
+        false, mode.isSSK(), mode.isInsert(), mode.isOfferReply(), mode.realTimeFlag());
+  }
+
+  private HashMap<Long, ? extends UIDTag> getTracker(RequestAdmissionMode mode) {
+    if (mode.isOfferReply()) return getOfferTracker(mode.isSSK(), mode.realTimeFlag());
+    else if (mode.isInsert())
+      return getInsertTracker(mode.isSSK(), mode.isLocal(), mode.realTimeFlag());
+    else return getRequestTracker(mode.isSSK(), mode.isLocal(), mode.realTimeFlag());
   }
 
   private HashMap<Long, RequestTag> getRequestTracker(
@@ -1032,7 +983,7 @@ public class RequestTracker {
   /**
    * Count all SSK requests currently running (local and remote, real-time and bulk).
    *
-   * @return Number of running SSK gets.
+   * @return Amount of running SSK gets.
    */
   public int getNumSSKRequests() {
     int total = 0;
@@ -1346,7 +1297,7 @@ public class RequestTracker {
 
   private final ArrayList<Long> completedBuffer = new ArrayList<>();
 
-  // Every this many slots, we tell all the PeerMessageQueue's to remove the old Items for the ID's
+  // Every this many slots, we tell all the PeerMessageQueue to remove the old Items for the ID's
   // in question.
   // This prevents memory DoS amongst other things.
   static final int COMPLETED_THRESHOLD = 128;

--- a/src/main/java/network/crypta/node/RequestTransferOptions.java
+++ b/src/main/java/network/crypta/node/RequestTransferOptions.java
@@ -1,0 +1,9 @@
+package network.crypta.node;
+
+/**
+ * Options that influence transfer estimates while counting requests.
+ *
+ * @param transfersPerInsert average outgoing transfers assumed per insert
+ * @param ignoreLocalVsRemote whether to treat local requests as remote for estimation
+ */
+public record RequestTransferOptions(int transfersPerInsert, boolean ignoreLocalVsRemote) {}

--- a/src/main/java/network/crypta/node/RunningRequestsSnapshot.java
+++ b/src/main/java/network/crypta/node/RunningRequestsSnapshot.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Snapshot of running request counts and estimated transfer liabilities at a point in time.
+ * Snapshot of a running request counts and estimated transfer liabilities at a point in time.
  *
  * <p>This type aggregates counts for CHK and SSK operations and exposes them as immutable fields,
  * along with derived totals and transfer-weighted estimates. Instances are created from a {@link
@@ -36,12 +36,12 @@ class RunningRequestsSnapshot {
 
   // Look plausible from my node-throttle.dat stats as of 01/11/2010.
   /**
-   * Output bytes required for an inbound transfer. Includes e.g. sending the request in the first
+   * Output bytes required for an inbound transfer. Includes e.g., sending the request in the first
    * place.
    */
   private static final int TRANSFER_IN_OUT_OVERHEAD = 256;
 
-  /** Input bytes required for an outbound transfer. Includes e.g. sending the insert etc. */
+  /** Input bytes required for an outbound transfer. Includes e.g., sending the insert etc. */
   private static final int TRANSFER_OUT_IN_OVERHEAD = 256;
 
   /**
@@ -113,7 +113,7 @@ class RunningRequestsSnapshot {
   final int expectedTransfersInSSKSR;
 
   /**
-   * Total number of source-restarted requests represented by this snapshot.
+   * The total number of source-restarted requests represented by this snapshot.
    *
    * <p>When source-restarted requests are not tracked, the value is zero.
    */
@@ -160,104 +160,56 @@ class RunningRequestsSnapshot {
     CountedRequests countSSK = new CountedRequests();
     CountedRequests countCHKSR = new CountedRequests();
     CountedRequests countSSKSR = new CountedRequests();
+    RequestTransferOptions transferOptions =
+        new RequestTransferOptions(transfersPerInsert, ignoreLocalVsRemote);
     tracker.countRequests(
-        true,
-        false,
-        false,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(true, false, false, false, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
-        true,
-        true,
-        false,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(true, true, false, false, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     tracker.countRequests(
-        true,
-        false,
-        true,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(true, false, true, false, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
-        true,
-        true,
-        true,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(true, true, true, false, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     tracker.countRequests(
-        false,
-        false,
-        false,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, false, false, false, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
-        false,
-        true,
-        false,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, true, false, false, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     tracker.countRequests(
-        false,
-        false,
-        true,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, false, true, false, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
-        false,
-        true,
-        true,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, true, true, false, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     tracker.countRequests(
-        false,
-        false,
-        false,
-        true,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, false, false, true, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
-        false,
-        true,
-        false,
-        true,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, true, false, true, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     this.expectedTransfersInCHK = countCHK.expectedTransfersIn();
@@ -282,8 +234,8 @@ class RunningRequestsSnapshot {
    * transfers are treated as remote regardless of the supplied {@code ignoreLocalVsRemote}
    * argument, because the peer experiences them as remote usage.
    *
-   * <p>Use this constructor when enforcing per-peer limits or when communicating current load to a
-   * connected peer.
+   * <p>Use this constructor when enforcing per-peer limits or when communicating the current load
+   * to a connected peer.
    *
    * @param tracker Request tracker supplying current counts; must not be {@code null}.
    * @param source Peer whose requests are counted; may be {@code null} for adopted requests.
@@ -314,124 +266,76 @@ class RunningRequestsSnapshot {
       countCHKSR = new CountedRequests();
       countSSKSR = new CountedRequests();
     }
+    RequestTransferOptions transferOptions =
+        new RequestTransferOptions(transfersPerInsert, ignoreLocalVsRemote);
     tracker.countRequests(
         source,
         requestsToNode,
-        true,
-        false,
-        false,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(true, false, false, false, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
         source,
         requestsToNode,
-        true,
-        true,
-        false,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(true, true, false, false, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     tracker.countRequests(
         source,
         requestsToNode,
-        true,
-        false,
-        true,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(true, false, true, false, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
         source,
         requestsToNode,
-        true,
-        true,
-        true,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(true, true, true, false, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     tracker.countRequests(
         source,
         requestsToNode,
-        false,
-        false,
-        false,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, false, false, false, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
         source,
         requestsToNode,
-        false,
-        true,
-        false,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, true, false, false, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     tracker.countRequests(
         source,
         requestsToNode,
-        false,
-        false,
-        true,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, false, true, false, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
         source,
         requestsToNode,
-        false,
-        true,
-        true,
-        false,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, true, true, false, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     tracker.countRequests(
         source,
         requestsToNode,
-        false,
-        false,
-        false,
-        true,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, false, false, true, realTimeFlag),
+        transferOptions,
         countCHK,
         countCHKSR);
     tracker.countRequests(
         source,
         requestsToNode,
-        false,
-        true,
-        false,
-        true,
-        realTimeFlag,
-        transfersPerInsert,
-        ignoreLocalVsRemote,
+        RequestAdmissionMode.of(false, true, false, true, realTimeFlag),
+        transferOptions,
         countSSK,
         countSSKSR);
     if (!requestsToNode) {
@@ -490,8 +394,8 @@ class RunningRequestsSnapshot {
    *
    * <p>The message includes CHK/SSK transfer counts, total requests, and whether the snapshot
    * covers real-time or bulk traffic. If any transfer count is negative, the message is logged at
-   * error level to highlight inconsistent accounting; otherwise it is emitted at debug level when
-   * enabled. The method has no side effects beyond logging.
+   * the error level to highlight inconsistent accounting; otherwise it is emitted at debug level
+   * when enabled. The method has no side effects beyond logging.
    */
   void log() {
     log(null);

--- a/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
@@ -97,15 +97,7 @@ class NodeClientCoreTransfersTest {
     when(node.maxHTL()).thenReturn((short) 5);
     lenient().when(random.nextLong()).thenReturn(123L);
     lenient()
-        .when(
-            tracker.lockUID(
-                anyLong(),
-                anyBoolean(),
-                anyBoolean(),
-                anyBoolean(),
-                anyBoolean(),
-                anyBoolean(),
-                any()))
+        .when(tracker.lockUID(anyLong(), any(RequestAdmissionMode.class), any()))
         .thenReturn(true);
 
     stats = mock(NodeStats.class);
@@ -140,9 +132,7 @@ class NodeClientCoreTransfersTest {
   @Test
   void asyncGet_whenUidLockFails_expectListenerFailedInternalError() {
     Key key = mock(Key.class);
-    when(tracker.lockUID(
-            anyLong(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any()))
-        .thenReturn(false);
+    when(tracker.lockUID(anyLong(), any(RequestAdmissionMode.class), any())).thenReturn(false);
 
     transfers.asyncGet(
         key,
@@ -321,9 +311,7 @@ class NodeClientCoreTransfersTest {
   void realPutChk_whenUidLockFails_expectInternalError() throws Exception {
     ClientCHKBlock clientBlock = encodeSampleChkBlock("chk-fail");
     CHKBlock block = clientBlock.getBlock();
-    when(tracker.lockUID(
-            anyLong(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any()))
-        .thenReturn(false);
+    when(tracker.lockUID(anyLong(), any(RequestAdmissionMode.class), any())).thenReturn(false);
 
     LowLevelPutException ex =
         assertThrows(

--- a/src/test/java/network/crypta/node/NodeDataRequestHandlerTest.java
+++ b/src/test/java/network/crypta/node/NodeDataRequestHandlerTest.java
@@ -148,11 +148,7 @@ class NodeDataRequestHandlerTest {
     when(routing.failureTable()).thenReturn(failureTable);
     when(tracker.lockUID(
             eq(REQUEST_ID),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false),
+            eq(RequestAdmissionMode.of(false, false, false, false, false)),
             any(RequestTag.class)))
         .thenReturn(false);
 
@@ -184,11 +180,7 @@ class NodeDataRequestHandlerTest {
     when(node.storage()).thenReturn(storage);
     when(tracker.lockUID(
             eq(REQUEST_ID),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false),
+            eq(RequestAdmissionMode.of(false, false, false, false, false)),
             any(RequestTag.class)))
         .thenReturn(true);
     when(storage.fetch(eq(key), eq(false), eq(false), eq(false), eq(false), any()))
@@ -244,11 +236,7 @@ class NodeDataRequestHandlerTest {
     when(node.storage()).thenReturn(storage);
     when(tracker.lockUID(
             eq(REQUEST_ID),
-            eq(true),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false),
+            eq(RequestAdmissionMode.of(false, true, false, false, false)),
             any(RequestTag.class)))
         .thenReturn(true);
     when(storage.fetch(eq(key), eq(false), eq(false), eq(false), eq(false), any()))

--- a/src/test/java/network/crypta/node/NodeInsertRequestHandlerTest.java
+++ b/src/test/java/network/crypta/node/NodeInsertRequestHandlerTest.java
@@ -82,7 +82,8 @@ class NodeInsertRequestHandlerTest {
     when(message.getSubMessage(DMT.FNPRealTimeFlag)).thenReturn(null);
     stubNodeBasics();
     stubTransport();
-    when(tracker.lockUID(eq(uid), eq(false), eq(true), eq(false), eq(false), eq(false), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, false, true, false, false)), any()))
         .thenReturn(false);
 
     NodeInsertRequestHandler handler = new NodeInsertRequestHandler(node);
@@ -100,7 +101,9 @@ class NodeInsertRequestHandlerTest {
     ArgumentCaptor<InsertTag> tagCaptor = ArgumentCaptor.forClass(InsertTag.class);
     verify(tracker)
         .lockUID(
-            eq(uid), eq(false), eq(true), eq(false), eq(false), eq(false), tagCaptor.capture());
+            eq(uid),
+            eq(RequestAdmissionMode.of(false, false, true, false, false)),
+            tagCaptor.capture());
     InsertTag tag = tagCaptor.getValue();
     assertFalse(tag.isSSK());
     assertFalse(tag.realTimeFlag);
@@ -115,7 +118,8 @@ class NodeInsertRequestHandlerTest {
     when(message.getSubMessage(DMT.FNPRealTimeFlag)).thenReturn(null);
     stubNodeBasics();
     stubTransport();
-    when(tracker.lockUID(eq(uid), eq(false), eq(true), eq(false), eq(false), eq(false), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, false, true, false, false)), any()))
         .thenReturn(true);
     when(nodeStats.shouldRejectRequest(any(RequestAdmissionContext.class)))
         .thenReturn(new RejectReason("hard", false));
@@ -143,7 +147,8 @@ class NodeInsertRequestHandlerTest {
     when(message.getSubMessage(DMT.FNPRealTimeFlag)).thenReturn(null);
     stubNodeBasics();
     stubTransport();
-    when(tracker.lockUID(eq(uid), eq(false), eq(true), eq(false), eq(false), eq(false), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, false, true, false, false)), any()))
         .thenReturn(true);
     when(nodeStats.shouldRejectRequest(any(RequestAdmissionContext.class)))
         .thenReturn(new RejectReason("soft", true));
@@ -170,7 +175,8 @@ class NodeInsertRequestHandlerTest {
     when(message.getSubMessage(DMT.FNPRealTimeFlag)).thenReturn(null);
     stubNodeBasics();
     stubTransport();
-    when(tracker.lockUID(eq(uid), eq(false), eq(true), eq(false), eq(false), eq(false), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, false, true, false, false)), any()))
         .thenReturn(true);
     when(nodeStats.shouldRejectRequest(any(RequestAdmissionContext.class)))
         .thenReturn(new RejectReason("soft", true));
@@ -201,7 +207,8 @@ class NodeInsertRequestHandlerTest {
     when(routingSubsystem.canWriteDatastoreInsert(anyShort())).thenReturn(true);
     when(sskKey.getPubKeyHash()).thenReturn(new byte[] {1, 2, 3});
     when(nodeGetPubkey.getKey(any(), eq(false), eq(false), isNull())).thenReturn(null);
-    when(tracker.lockUID(eq(uid), eq(true), eq(true), eq(false), eq(false), eq(true), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, true, true, false, true)), any()))
         .thenReturn(true);
     when(nodeStats.shouldRejectRequest(any(RequestAdmissionContext.class))).thenReturn(null);
     when(message.getSubMessage(DMT.FNPSubInsertForkControl))
@@ -255,7 +262,8 @@ class NodeInsertRequestHandlerTest {
     when(routingSubsystem.canWriteDatastoreInsert(anyShort())).thenReturn(true);
     when(sskKey.getPubKeyHash()).thenReturn(new byte[] {9, 9, 9});
     when(nodeGetPubkey.getKey(any(), eq(false), eq(false), isNull())).thenReturn(null);
-    when(tracker.lockUID(eq(uid), eq(true), eq(true), eq(false), eq(false), eq(false), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, true, true, false, false)), any()))
         .thenReturn(true);
     when(nodeStats.shouldRejectRequest(any(RequestAdmissionContext.class))).thenReturn(null);
     when(message.getSubMessage(DMT.FNPRealTimeFlag)).thenReturn(null);
@@ -287,7 +295,8 @@ class NodeInsertRequestHandlerTest {
     stubNodeBasics();
     stubExecutor();
     when(routingSubsystem.canWriteDatastoreInsert(anyShort())).thenReturn(true);
-    when(tracker.lockUID(eq(uid), eq(false), eq(true), eq(false), eq(false), eq(false), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, false, true, false, false)), any()))
         .thenReturn(true);
     when(nodeStats.shouldRejectRequest(any(RequestAdmissionContext.class))).thenReturn(null);
     when(message.getSubMessage(DMT.FNPRealTimeFlag)).thenReturn(null);

--- a/src/test/java/network/crypta/node/NodeOfferMessageHandlerTest.java
+++ b/src/test/java/network/crypta/node/NodeOfferMessageHandlerTest.java
@@ -156,9 +156,7 @@ class NodeOfferMessageHandlerTest {
     assertEquals(DMT.FNPGetOfferedKeyInvalid, sent.getSpec());
     assertEquals(uid, sent.getLong(DMT.UID));
     assertEquals(DMT.GET_OFFERED_KEY_REJECTED_BAD_AUTHENTICATOR, sent.getShort(DMT.REASON));
-    verify(tracker, never())
-        .lockUID(
-            anyLong(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any());
+    verify(tracker, never()).lockUID(anyLong(), any(RequestAdmissionMode.class), any());
     verify(failureTable, never())
         .sendOfferedKey(
             any(Key.class), anyBoolean(), anyBoolean(), anyLong(), any(), any(), anyBoolean());
@@ -177,7 +175,8 @@ class NodeOfferMessageHandlerTest {
     doReturn(null)
         .when(transport)
         .sendAsync(any(Message.class), isNull(), same(failureTable.senderCounter));
-    when(tracker.lockUID(eq(uid), eq(false), eq(false), eq(true), eq(false), eq(false), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, false, false, true, false)), any()))
         .thenReturn(false);
 
     boolean handled = handler.handle(msg, peer);
@@ -207,7 +206,8 @@ class NodeOfferMessageHandlerTest {
     doReturn(null)
         .when(transport)
         .sendAsync(any(Message.class), isNull(), same(failureTable.senderCounter));
-    when(tracker.lockUID(eq(uid), eq(false), eq(false), eq(true), eq(false), eq(false), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, false, false, true, false)), any()))
         .thenReturn(true);
     when(nodeStats.shouldRejectRequest(
             argThat(
@@ -248,7 +248,8 @@ class NodeOfferMessageHandlerTest {
     Message msg = offeredKeyMessage(key, authenticator, uid, true, true);
 
     when(peer.transport()).thenReturn(transport);
-    when(tracker.lockUID(eq(uid), eq(true), eq(false), eq(true), eq(false), eq(true), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, true, false, true, true)), any()))
         .thenReturn(true);
     when(nodeStats.shouldRejectRequest(
             argThat(
@@ -294,7 +295,8 @@ class NodeOfferMessageHandlerTest {
     doReturn(null)
         .when(transport)
         .sendAsync(any(Message.class), isNull(), same(failureTable.senderCounter));
-    when(tracker.lockUID(eq(uid), eq(false), eq(false), eq(true), eq(false), eq(false), any()))
+    when(tracker.lockUID(
+            eq(uid), eq(RequestAdmissionMode.of(false, false, false, true, false)), any()))
         .thenReturn(true);
     when(replacementStats.shouldRejectRequest(
             argThat(

--- a/src/test/java/network/crypta/node/RequestTrackerTest.java
+++ b/src/test/java/network/crypta/node/RequestTrackerTest.java
@@ -50,7 +50,7 @@ class RequestTrackerTest {
     RequestTag remoteChkBulk =
         new RequestTag(
             false, START.REMOTE, org.mockito.Mockito.mock(PeerNode.class), false, 2L, node);
-    // Remote tags need to be marked accepted explicitly (local are accepted in constructor)
+    // Remote tags need to be marked accepted explicitly (local is accepted in constructor)
     remoteChkBulk.setAccepted();
 
     // Act
@@ -83,19 +83,11 @@ class RequestTrackerTest {
     // Arrange: a tag that was never locked
     RequestTag tag = new RequestTag(false, START.LOCAL, null, true, 200L, node);
 
-    // Act: unlock against empty tracker (canFail = true)
+    // Act: unlock against an empty tracker (canFail = true)
     tracker.unlockUID(
-        200L, /*ssk*/
-        false, /*insert*/
-        false, /*canFail*/
-        true,
-        /*offerReply*/ false, /*local*/
-        true, /*realTime*/
-        true,
-        tag, /*noRecord*/
-        true);
+        200L, RequestAdmissionMode.of(true, false, false, false, true), tag, true, true);
 
-    // Assert: counts remain zero
+    // Assert: the counts remain zero
     assertEquals(0, tracker.getNumCHKRequests());
     assertEquals(0, tracker.getNumTransferringRequestHandlers());
   }
@@ -142,7 +134,7 @@ class RequestTrackerTest {
     verify(ticker, times(1)).queueTimedJob(runCaptor.capture(), delayCaptor.capture());
     assertEquals(RequestTracker.TIMEOUT, delayCaptor.getValue().longValue());
 
-    // Run the checker and expect a reschedule with ~60s
+    // Run the checker and expect a rescheduling with ~60s
     Runnable checker = runCaptor.getValue();
     assertNotNull(checker);
     checker.run();
@@ -171,30 +163,18 @@ class RequestTrackerTest {
 
     RequestTracker.CountedRequests allNonLocal = new RequestTracker.CountedRequests();
     RequestTracker.CountedRequests locals = new RequestTracker.CountedRequests();
+    RequestTransferOptions transferOptions = new RequestTransferOptions(3, false);
 
     // Act: Count remote (local=false) CHK gets
     tracker.countRequests(
-        /*local*/ false,
-        /*ssk*/ false,
-        /*insert*/ false,
-        /*offer*/ false,
-        /*rt*/ false,
-        /*transfersPerInsert*/ 3,
-        /*ignoreLocalVsRemote*/ false,
+        RequestAdmissionMode.of(false, false, false, false, false),
+        transferOptions,
         allNonLocal,
-        /*counterSR*/ null);
+        null);
 
     // Act: Count local (local=true) CHK gets
     tracker.countRequests(
-        /*local*/ true,
-        /*ssk*/ false,
-        /*insert*/ false,
-        /*offer*/ false,
-        /*rt*/ false,
-        /*transfersPerInsert*/ 3,
-        /*ignoreLocalVsRemote*/ false,
-        locals,
-        /*counterSR*/ null);
+        RequestAdmissionMode.of(true, false, false, false, false), transferOptions, locals, null);
 
     // Assert
     assertEquals(1, allNonLocal.total());

--- a/src/test/java/network/crypta/node/RunningRequestsSnapshotTest.java
+++ b/src/test/java/network/crypta/node/RunningRequestsSnapshotTest.java
@@ -3,7 +3,6 @@ package network.crypta.node;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -203,22 +202,18 @@ class RunningRequestsSnapshotTest {
   private static void stubCountRequestsWithoutPeer(RequestTracker tracker) {
     doAnswer(
             invocation -> {
-              boolean sskFlag = invocation.getArgument(1);
-              CountedRequests counter = invocation.getArgument(7);
-              CountedRequests counterSr = invocation.getArgument(8);
+              RequestAdmissionMode mode = invocation.getArgument(0);
+              boolean sskFlag = mode.isSSK();
+              CountedRequests counter = invocation.getArgument(2);
+              CountedRequests counterSr = invocation.getArgument(3);
               setCounter(counter, sskFlag ? SSK_MAIN : CHK_MAIN);
               setCounter(counterSr, sskFlag ? SSK_SR : CHK_SR);
               return null;
             })
         .when(tracker)
         .countRequests(
-            anyBoolean(),
-            anyBoolean(),
-            anyBoolean(),
-            anyBoolean(),
-            anyBoolean(),
-            anyInt(),
-            anyBoolean(),
+            any(RequestAdmissionMode.class),
+            any(RequestTransferOptions.class),
             any(CountedRequests.class),
             any(CountedRequests.class));
   }
@@ -226,9 +221,10 @@ class RunningRequestsSnapshotTest {
   private static void stubCountRequestsWithPeer(RequestTracker tracker) {
     doAnswer(
             invocation -> {
-              boolean sskFlag = invocation.getArgument(3);
-              CountedRequests counter = invocation.getArgument(9);
-              CountedRequests counterSr = invocation.getArgument(10);
+              RequestAdmissionMode mode = invocation.getArgument(2);
+              boolean sskFlag = mode.isSSK();
+              CountedRequests counter = invocation.getArgument(4);
+              CountedRequests counterSr = invocation.getArgument(5);
               setCounter(counter, sskFlag ? SSK_MAIN : CHK_MAIN);
               if (counterSr != null) {
                 setCounter(counterSr, sskFlag ? SSK_SR : CHK_SR);
@@ -239,13 +235,8 @@ class RunningRequestsSnapshotTest {
         .countRequests(
             any(PeerNode.class),
             anyBoolean(),
-            anyBoolean(),
-            anyBoolean(),
-            anyBoolean(),
-            anyBoolean(),
-            anyBoolean(),
-            anyInt(),
-            anyBoolean(),
+            any(RequestAdmissionMode.class),
+            any(RequestTransferOptions.class),
             any(CountedRequests.class),
             nullable(CountedRequests.class));
   }


### PR DESCRIPTION
## Summary
- replace RequestTracker lock/count signatures with RequestAdmissionMode and RequestTransferOptions parameter objects
- update request handlers and snapshots to pass shared parameter objects
- align node request tests with the new request tracking APIs

## Testing
- ./gradlew test