### PR TITLE
chore(build): ignore build-logic bin output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ qodana*
 multipass-client-certificate
 out/jreleaser
 build-logic/build/
+build-logic/bin/
 tmp*
 # WiX/jpackage debug artifacts (decompiled MSI and relink outputs)
 /Crypta-*.wxs


### PR DESCRIPTION
## Summary
- ignore `build-logic/bin/` artifacts in `.gitignore`

## Testing
- `./gradlew spotlessApply`