### PR TITLE
refactor(node): group session key material

### DIFF
--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -1631,13 +1631,14 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     private SessionKey buildSessionKey(HandshakeParams p) {
       return new SessionKey(
           selfPeerNode(),
-          p.outgoingCipher,
-          p.outgoingKey,
-          p.incommingCipher,
-          p.incommingKey,
-          p.ivCipher,
-          p.ivNonce,
-          p.hmacKey,
+          new SessionKeyCryptoMaterial(
+              p.outgoingCipher,
+              p.outgoingKey,
+              p.incommingCipher,
+              p.incommingKey,
+              p.ivCipher,
+              p.ivNonce,
+              p.hmacKey),
           new NewPacketFormatKeyContext(p.ourInitialSeqNum, p.theirInitialSeqNum),
           p.trackerID);
     }

--- a/src/main/java/network/crypta/node/SessionKey.java
+++ b/src/main/java/network/crypta/node/SessionKey.java
@@ -6,9 +6,9 @@ import network.crypta.crypt.BlockCipher;
  * Holds the cryptographic materials and per-key context for a single peer session.
  *
  * <p>The fields expose the block ciphers and raw key bytes used by the {@link NewPacketFormat}
- * pipeline for encrypting/decrypting packets and computing message authentication. Array fields are
- * stored by reference; they are not defensively copied. Treat all keying material as sensitive and
- * avoid modifying it after construction.
+ * pipeline for encrypting/decrypting packets and computing message authentication. Reference stores
+ * array fields; they are not defensively copied. Treat all keying material as sensitive and avoid
+ * modifying it after construction.
  *
  * <p>Thread safety: instances are immutable with respect to field references. The referenced arrays
  * themselves are mutable. The {@link #packetContext} manages its own synchronization.
@@ -72,36 +72,35 @@ public class SessionKey {
    * avoid modifying them after construction.
    *
    * @param parent owning peer (may be {@code null} in tests).
-   * @param outgoingCipher cipher for encrypting outgoing packets.
-   * @param outgoingKey raw key bytes for {@code outgoingCipher}; stored by reference.
-   * @param incommingCipher cipher for decrypting incoming packets.
-   * @param incommingKey raw key bytes for {@code incommingCipher}; stored by reference.
-   * @param ivCipher cipher used for IV-related operations.
-   * @param ivNonce base nonce used with {@code ivCipher}; stored by reference.
-   * @param hmacKey key material used for message authentication; stored by reference.
+   * @param cryptoMaterial ciphers and key bytes for packet encryption/decryption; arrays stored by
+   *     reference.
    * @param context per-key packet context; must be non-null if {@link #disconnected()} will be
    *     called.
    * @param trackerID opaque identifier for diagnostics.
    */
   SessionKey(
       PeerNode parent,
-      BlockCipher outgoingCipher,
-      byte[] outgoingKey,
-      BlockCipher incommingCipher,
-      byte[] incommingKey,
-      BlockCipher ivCipher,
-      byte[] ivNonce,
-      byte[] hmacKey,
+      SessionKeyCryptoMaterial cryptoMaterial,
       NewPacketFormatKeyContext context,
       long trackerID) {
     this.pn = parent;
-    this.outgoingCipher = outgoingCipher;
-    this.outgoingKey = outgoingKey;
-    this.incommingCipher = incommingCipher;
-    this.incommingKey = incommingKey;
-    this.ivCipher = ivCipher;
-    this.ivNonce = ivNonce;
-    this.hmacKey = hmacKey;
+    if (cryptoMaterial == null) {
+      this.outgoingCipher = null;
+      this.outgoingKey = null;
+      this.incommingCipher = null;
+      this.incommingKey = null;
+      this.ivCipher = null;
+      this.ivNonce = null;
+      this.hmacKey = null;
+    } else {
+      this.outgoingCipher = cryptoMaterial.outgoingCipher();
+      this.outgoingKey = cryptoMaterial.outgoingKey();
+      this.incommingCipher = cryptoMaterial.incommingCipher();
+      this.incommingKey = cryptoMaterial.incommingKey();
+      this.ivCipher = cryptoMaterial.ivCipher();
+      this.ivNonce = cryptoMaterial.ivNonce();
+      this.hmacKey = cryptoMaterial.hmacKey();
+    }
     this.packetContext = context;
     this.trackerID = trackerID;
   }

--- a/src/main/java/network/crypta/node/SessionKeyCryptoMaterial.java
+++ b/src/main/java/network/crypta/node/SessionKeyCryptoMaterial.java
@@ -1,0 +1,127 @@
+package network.crypta.node;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.crypt.BlockCipher;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Groups the ciphers and key bytes used by a {@link SessionKey}.
+ *
+ * <p>This record represents the negotiated packet-encryption material for a peer session. It is
+ * typically assembled during handshake processing and then passed as a single unit when a {@code
+ * SessionKey} is created. The record is a simple carrier: it performs no validation and does not
+ * derive new keys, so callers are responsible for ensuring the material is consistent and ready for
+ * use. Array components are stored by reference rather than copied. This keeps construction
+ * lightweight, but it means callers must treat the arrays as mutable, shared state. Mutating the
+ * arrays after construction affects any consumer that reads them.
+ *
+ * <p>Instances are immutable with respect to their component references and are safe to share
+ * across threads when the underlying arrays are not modified. To avoid leaking secrets, do not log
+ * the contained key material.
+ *
+ * <ul>
+ *   <li>Captures the outgoing, incoming, and IV ciphers needed by packet processing.
+ *   <li>Holds raw key bytes and nonces without defensive copying.
+ *   <li>Bundles the material for reuse across constructors and tests.
+ * </ul>
+ *
+ * @param outgoingCipher cipher used to encrypt outgoing packets; may be {@code null} in tests.
+ * @param outgoingKey raw key bytes for {@code outgoingCipher}; stored by reference and mutable.
+ * @param incommingCipher cipher used to decrypt incoming packets; may be {@code null} in tests.
+ * @param incommingKey raw key bytes for {@code incommingCipher}; stored by reference and mutable.
+ * @param ivCipher cipher used to derive per-packet IV material; may be {@code null} in tests.
+ * @param ivNonce base nonce bytes paired with {@code ivCipher}; stored by reference and mutable.
+ * @param hmacKey key bytes for message authentication; stored by reference and mutable.
+ * @see SessionKey
+ */
+public record SessionKeyCryptoMaterial(
+    BlockCipher outgoingCipher,
+    byte[] outgoingKey,
+    BlockCipher incommingCipher,
+    byte[] incommingKey,
+    BlockCipher ivCipher,
+    byte[] ivNonce,
+    byte[] hmacKey) {
+  /**
+   * Determines whether another object represents the same cryptographic material.
+   *
+   * <p>This comparison checks cipher references using {@link Objects#equals(Object, Object)} and
+   * compares each byte array by content. It is intended for diagnostics and test assertions rather
+   * than for constant-time security checks. The result is consistent with {@link #hashCode()} as
+   * long as the array contents remain unchanged after construction. If any array is mutated, the
+   * equality result may change accordingly.
+   *
+   * @param o object to compare; may be {@code null} or a different type.
+   * @return {@code true} when all cipher references and array contents match.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o
+        instanceof
+        SessionKeyCryptoMaterial(
+            var otherOutgoingCipher,
+            var otherOutgoingKey,
+            var otherIncommingCipher,
+            var otherIncommingKey,
+            var otherIvCipher,
+            var otherIvNonce,
+            var otherHmacKey))) return false;
+    return Objects.equals(outgoingCipher, otherOutgoingCipher)
+        && Arrays.equals(outgoingKey, otherOutgoingKey)
+        && Objects.equals(incommingCipher, otherIncommingCipher)
+        && Arrays.equals(incommingKey, otherIncommingKey)
+        && Objects.equals(ivCipher, otherIvCipher)
+        && Arrays.equals(ivNonce, otherIvNonce)
+        && Arrays.equals(hmacKey, otherHmacKey);
+  }
+
+  /**
+   * Computes a hash based on cipher references and the contents of the byte arrays.
+   *
+   * <p>The hash incorporates the three cipher components and each array's contents. It is stable as
+   * long as the underlying arrays are not mutated. If callers change the array contents after
+   * construction, the hash code can change, so instances should not be used as keys in hashed
+   * collections when mutation is possible.
+   *
+   * @return hash code derived from cipher references and key material contents.
+   */
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(outgoingCipher, incommingCipher, ivCipher);
+    result = 31 * result + Arrays.hashCode(outgoingKey);
+    result = 31 * result + Arrays.hashCode(incommingKey);
+    result = 31 * result + Arrays.hashCode(ivNonce);
+    result = 31 * result + Arrays.hashCode(hmacKey);
+    return result;
+  }
+
+  /**
+   * Formats a diagnostic string including cipher references and key material bytes.
+   *
+   * <p>The output includes {@link Arrays#toString(byte[])} for each array component. This is useful
+   * for tests and debugging but may expose sensitive material if logged. Callers should avoid
+   * emitting the returned value to persistent logs or telemetry in production environments.
+   *
+   * @return human-readable representation of the cipher references and key bytes.
+   */
+  @Override
+  public @NotNull String toString() {
+    return "SessionKeyCryptoMaterial[outgoingCipher="
+        + outgoingCipher
+        + ", outgoingKey="
+        + Arrays.toString(outgoingKey)
+        + ", incommingCipher="
+        + incommingCipher
+        + ", incommingKey="
+        + Arrays.toString(incommingKey)
+        + ", ivCipher="
+        + ivCipher
+        + ", ivNonce="
+        + Arrays.toString(ivNonce)
+        + ", hmacKey="
+        + Arrays.toString(hmacKey)
+        + "]";
+  }
+}

--- a/src/test/java/network/crypta/node/NewPacketFormatKeyContextTest.java
+++ b/src/test/java/network/crypta/node/NewPacketFormatKeyContextTest.java
@@ -33,7 +33,7 @@ class NewPacketFormatKeyContextTest {
   @Mock private PacketThrottle throttle;
 
   private static SessionKey dummyKey(NewPacketFormatKeyContext ctx) {
-    return new SessionKey(null, null, null, null, null, null, null, null, ctx, /*trackerId*/ 0L);
+    return new SessionKey(null, null, ctx, /*trackerId*/ 0L);
   }
 
   private static TreeMap<Integer, Long> acksOf(NewPacketFormatKeyContext ctx) throws Exception {

--- a/src/test/java/network/crypta/node/NewPacketFormatTest.java
+++ b/src/test/java/network/crypta/node/NewPacketFormatTest.java
@@ -42,9 +42,7 @@ class NewPacketFormatTest {
     // Arrange
     NewPacketFormat npf = new NewPacketFormat(null, 0, 0);
     PeerMessageQueue pmq = new PeerMessageQueue(new DummyRandomSource(1234));
-    SessionKey s =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey s = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
     // Act
     NPFPacket p = npf.createPacket(1400, pmq, s, false);
@@ -59,9 +57,7 @@ class NewPacketFormatTest {
     BasePeerNode pn = new NullBasePeerNode();
     NewPacketFormat npf = new NewPacketFormat(pn, 0, 0);
     PeerMessageQueue pmq = new PeerMessageQueue(new DummyRandomSource(1234));
-    SessionKey s =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey s = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
     NPFPacket generated = new NPFPacket();
     generated.addMessageFragment(
@@ -108,13 +104,9 @@ class NewPacketFormatTest {
     NullBasePeerNode receiverNode = new NullBasePeerNode();
     NewPacketFormat receiver = new NewPacketFormat(receiverNode, 0, 0);
     PeerMessageQueue receiverQueue = new PeerMessageQueue(new DummyRandomSource(1234));
-    SessionKey senderKey =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey senderKey = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
     senderNode.currentKey = senderKey;
-    SessionKey receiverKey =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey receiverKey = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
     senderQueue.queueAndEstimateSize(
         new MessageItem(new byte[1024], null, false, null, (short) 0), 1024);
@@ -162,12 +154,8 @@ class NewPacketFormatTest {
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
     NullBasePeerNode receiverNode = new NullBasePeerNode();
     NewPacketFormat receiver = new NewPacketFormat(receiverNode, 0, 0);
-    SessionKey senderKey =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
-    SessionKey receiverKey =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey senderKey = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey receiverKey = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
     senderQueue.queueAndEstimateSize(
         new MessageItem(new byte[1024], null, false, null, (short) 0), 1024);
@@ -199,12 +187,8 @@ class NewPacketFormatTest {
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
     NullBasePeerNode receiverNode = new NullBasePeerNode();
     NewPacketFormat receiver = new NewPacketFormat(receiverNode, 0, 0);
-    SessionKey senderKey =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
-    SessionKey receiverKey =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey senderKey = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey receiverKey = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
     senderQueue.queueAndEstimateSize(
         new MessageItem(new byte[1024], null, false, null, (short) 0), 1024);
@@ -234,12 +218,8 @@ class NewPacketFormatTest {
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
     NullBasePeerNode receiverNode = new NullBasePeerNode();
     NewPacketFormat receiver = new NewPacketFormat(receiverNode, 0, 0);
-    SessionKey senderKey =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
-    SessionKey receiverKey =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey senderKey = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey receiverKey = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
     // Queue two messages so the total queued size exceeds maxPacketSize (512) and triggers
     // immediate
@@ -287,7 +267,12 @@ class NewPacketFormatTest {
         });
 
     SessionKey sessionKey =
-        new SessionKey(null, null, null, incommingCipher, null, ivCipher, ivNonce, null, null, -1);
+        new SessionKey(
+            null,
+            new SessionKeyCryptoMaterial(
+                null, null, incommingCipher, null, ivCipher, ivNonce, null),
+            null,
+            -1);
 
     // Act
     byte[] encrypted = NewPacketFormat.encryptSequenceNumber(0, sessionKey);
@@ -332,26 +317,28 @@ class NewPacketFormatTest {
     SessionKey senderSessionKey =
         new SessionKey(
             null,
-            outgoingCipher,
-            outgoingKey,
-            incomingCipher,
-            incomingKey,
-            ivCipher,
-            ivNonce,
-            hmacKey,
+            new SessionKeyCryptoMaterial(
+                outgoingCipher,
+                outgoingKey,
+                incomingCipher,
+                incomingKey,
+                ivCipher,
+                ivNonce,
+                hmacKey),
             senderContext,
             0);
 
     SessionKey receiverSessionKey =
         new SessionKey(
             null,
-            incomingCipher,
-            incomingKey,
-            outgoingCipher,
-            outgoingKey,
-            ivCipher,
-            ivNonce,
-            hmacKey,
+            new SessionKeyCryptoMaterial(
+                incomingCipher,
+                incomingKey,
+                outgoingCipher,
+                outgoingKey,
+                ivCipher,
+                ivNonce,
+                hmacKey),
             receiverContext,
             0);
 
@@ -404,9 +391,7 @@ class NewPacketFormatTest {
     // Queue a single small message and build a packet fragment to move it into startedByPrio.
     byte[] payload = new byte[1024];
     q.queueAndEstimateSize(new MessageItem(payload, null, false, null, (short) 0), 1024);
-    SessionKey key =
-        new SessionKey(
-            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
+    SessionKey key = new SessionKey(null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
     NPFPacket p = npf.createPacket(512, q, key, /*ackOnly*/ false);
     assertNotNull(p, "Expected a packet with one fragment before disconnect");
@@ -442,7 +427,7 @@ class NewPacketFormatTest {
     NullBasePeerNode pn = new NullBasePeerNode();
     NewPacketFormat npf = new NewPacketFormat(pn, 0, 0);
     NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
-    SessionKey key = new SessionKey(null, null, null, null, null, null, null, null, ctx, 1);
+    SessionKey key = new SessionKey(null, null, ctx, 1);
     pn.currentKey = key; // So timeSendAcks() can see the same ctx
 
     NPFPacket empty = new NPFPacket();
@@ -477,7 +462,12 @@ class NewPacketFormatTest {
     iv.initialize(ivKey);
 
     NewPacketFormatKeyContext prevCtx = new NewPacketFormatKeyContext(10, 20);
-    SessionKey prev = new SessionKey(null, out, keyA, in, keyB, iv, ivNonce, hmac, prevCtx, 99);
+    SessionKey prev =
+        new SessionKey(
+            null,
+            new SessionKeyCryptoMaterial(out, keyA, in, keyB, iv, ivNonce, hmac),
+            prevCtx,
+            99);
     pn.previousKey = prev;
 
     // Ack something on the previous key by simulating a decrypted packet with one fragment.
@@ -536,25 +526,27 @@ class NewPacketFormatTest {
     SessionKey senderSessionKey =
         new SessionKey(
             null,
-            outgoingCipher,
-            outgoingKey,
-            incomingCipher,
-            incomingKey,
-            ivCipher,
-            ivNonce,
-            hmacKey,
+            new SessionKeyCryptoMaterial(
+                outgoingCipher,
+                outgoingKey,
+                incomingCipher,
+                incomingKey,
+                ivCipher,
+                ivNonce,
+                hmacKey),
             senderCtx,
             0);
     SessionKey receiverSessionKey =
         new SessionKey(
             null,
-            incomingCipher,
-            incomingKey,
-            outgoingCipher,
-            outgoingKey,
-            ivCipher,
-            ivNonce,
-            hmacKey,
+            new SessionKeyCryptoMaterial(
+                incomingCipher,
+                incomingKey,
+                outgoingCipher,
+                outgoingKey,
+                ivCipher,
+                ivNonce,
+                hmacKey),
             receiverCtx,
             0);
     senderNode.currentKey = senderSessionKey;
@@ -640,7 +632,7 @@ class NewPacketFormatTest {
 
     NewPacketFormat npf = new NewPacketFormat(mockPeer, 0, 0);
     NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
-    SessionKey key = new SessionKey(null, null, null, null, null, null, null, null, ctx, 1);
+    SessionKey key = new SessionKey(null, null, ctx, 1);
 
     // Simulate one in-flight packet so countSentPackets() == 1 and equals the window size.
     NewPacketFormat.SentPacket sp = new NewPacketFormat.SentPacket(npf, key);

--- a/src/test/java/network/crypta/node/SessionKeyTest.java
+++ b/src/test/java/network/crypta/node/SessionKeyTest.java
@@ -2,6 +2,7 @@ package network.crypta.node;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
@@ -35,13 +36,8 @@ class SessionKeyTest {
     SessionKey key =
         new SessionKey(
             parent,
-            outgoing,
-            outgoingKey,
-            incoming,
-            incomingKey,
-            iv,
-            ivNonce,
-            hmacKey,
+            new SessionKeyCryptoMaterial(
+                outgoing, outgoingKey, incoming, incomingKey, iv, ivNonce, hmacKey),
             ctx,
             trackerId);
 
@@ -63,17 +59,7 @@ class SessionKeyTest {
     // Arrange
     NewPacketFormatKeyContext ctx = mock(NewPacketFormatKeyContext.class);
     SessionKey key =
-        new SessionKey(
-            /*parent*/ null,
-            /*outgoingCipher*/ null,
-            /*outgoingKey*/ null,
-            /*incommingCipher*/ null,
-            /*incommingKey*/ null,
-            /*ivCipher*/ null,
-            /*ivNonce*/ null,
-            /*hmacKey*/ null,
-            /*context*/ ctx,
-            /*trackerID*/ 7L);
+        new SessionKey(/*parent*/ null, /*cryptoMaterial*/ null, /*context*/ ctx, /*trackerID*/ 7L);
 
     // Act
     key.disconnected();
@@ -91,17 +77,7 @@ class SessionKeyTest {
 
     // Act
     SessionKey key =
-        new SessionKey(
-            /*parent*/ null,
-            /*outgoingCipher*/ null,
-            /*outgoingKey*/ null,
-            /*incommingCipher*/ null,
-            /*incommingKey*/ null,
-            /*ivCipher*/ null,
-            /*ivNonce*/ null,
-            /*hmacKey*/ null,
-            /*context*/ null,
-            trackerId);
+        new SessionKey(/*parent*/ null, /*cryptoMaterial*/ null, /*context*/ null, trackerId);
 
     // Assert
     assertNull(key.pn, "Parent should be null");
@@ -126,7 +102,11 @@ class SessionKeyTest {
 
     SessionKey key =
         new SessionKey(
-            null, null, outgoingKey, null, incomingKey, null, ivNonce, hmacKey, null, 0L);
+            null,
+            new SessionKeyCryptoMaterial(
+                null, outgoingKey, null, incomingKey, null, ivNonce, hmacKey),
+            null,
+            0L);
 
     // Act
     outgoingKey[0] = 99;
@@ -135,6 +115,10 @@ class SessionKeyTest {
     hmacKey[3] = 66;
 
     // Assert
+    assertNotNull(key.outgoingKey, "Outgoing key reference should not be null");
+    assertNotNull(key.incommingKey, "Incoming key reference should not be null");
+    assertNotNull(key.ivNonce, "IV nonce reference should not be null");
+    assertNotNull(key.hmacKey, "HMAC key reference should not be null");
     assertEquals(99, key.outgoingKey[0], "Outgoing key reference should not be copied");
     assertEquals(88, key.incommingKey[1], "Incoming key reference should not be copied");
     assertEquals(77, key.ivNonce[0], "IV nonce reference should not be copied");


### PR DESCRIPTION
## Summary
- introduce `SessionKeyCryptoMaterial` to bundle session ciphers/keys and reduce constructor parameter lists
- update `SessionKey` construction in handshake and node tests to use the shared record
- add long-form Javadoc for the new record and null-safety assertions in tests