### PR TITLE
Refactor simulator fetch contexts

### DIFF
--- a/src/main/java/network/crypta/node/simulator/FetchRequestContext.java
+++ b/src/main/java/network/crypta/node/simulator/FetchRequestContext.java
@@ -1,0 +1,37 @@
+package network.crypta.node.simulator;
+
+import network.crypta.client.FetchContext;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.RequestClient;
+
+/**
+ * Bundles the inputs needed to perform a single-block fetch.
+ *
+ * <p>This record groups the client instance, the mutable {@link FetchContext}, and the {@link
+ * RequestClient} that supplies request scheduling metadata. It exists to reduce long parameter
+ * lists in the long-term simulator while keeping call sites explicit about which objects are shared
+ * across a run. Typical usage is to create one instance in the harness setup, then pass it to
+ * helper methods that perform repeated fetches for different URIs. The record is intentionally
+ * simple: it does not validate inputs or copy state, and callers remain responsible for configuring
+ * the {@code FetchContext} before use.
+ *
+ * <p>All components are held by reference and may be reused across multiple fetches. The record
+ * itself is immutable, but it does not guarantee thread safety because the {@code FetchContext} can
+ * be mutated by callers. The harness currently uses it from a single thread and treats the fetch
+ * context as read-only once configured.
+ *
+ * <ul>
+ *   <li><b>Responsibility:</b> Provide a concise carrier for fetch-related collaborators.
+ *   <li><b>Lifecycle:</b> Construct once per run and reuse for every fetch attempt.
+ *   <li><b>Threading:</b> Safe to share only if callers avoid mutating the context.
+ * </ul>
+ *
+ * @param client client used to issue fetch requests; must be non-null and ready to use
+ * @param fetchContext fetch context configured for retries, limits, and policies; treated as
+ *     mutable by callers
+ * @param requestClient request client used to schedule fetch work and provide priority settings;
+ *     must be non-null
+ * @see FetchRunContext
+ */
+public record FetchRequestContext(
+    HighLevelSimpleClient client, FetchContext fetchContext, RequestClient requestClient) {}

--- a/src/main/java/network/crypta/node/simulator/FetchRunContext.java
+++ b/src/main/java/network/crypta/node/simulator/FetchRunContext.java
@@ -1,0 +1,31 @@
+package network.crypta.node.simulator;
+
+import java.util.List;
+
+/**
+ * Groups per-run state used during long-term fetch replay.
+ *
+ * <p>This record combines the mutable CSV output buffer with the {@link FetchRequestContext}
+ * required to fetch historical single-block URIs. It is designed for the long-term simulator
+ * harness, where a single execution reads existing status rows and appends new results while
+ * reusing shared fetch collaborators. Callers typically create one instance in the main flow after
+ * configuring the fetch context, then pass it through the status-processing helpers that append CSV
+ * tokens and issue fetches.
+ *
+ * <p>The record itself is immutable, but it references mutable structures: the {@code csvLine} list
+ * accumulates output tokens and is expected to be appended in order, and the {@code
+ * FetchRequestContext} holds a {@code FetchContext} that may be modified during setup. The harness
+ * currently treats both as single-threaded resources; if multiple threads append or modify the
+ * context, external synchronization is required.
+ *
+ * <ul>
+ *   <li><b>Responsibility:</b> Carry the per-run CSV buffer and fetch collaborators together.
+ *   <li><b>Lifecycle:</b> Construct once per simulator run and pass through parsing helpers.
+ *   <li><b>Threading:</b> Safe to share only with coordinated mutation of referenced state.
+ * </ul>
+ *
+ * @param csvLine ordered CSV tokens collected for the current run; appended to as work proceeds
+ * @param fetchRequestContext shared client, context, and request client used for fetch attempts
+ * @see FetchRequestContext
+ */
+public record FetchRunContext(List<String> csvLine, FetchRequestContext fetchRequestContext) {}

--- a/src/main/java/network/crypta/node/simulator/LongTermManySingleBlocksTest.java
+++ b/src/main/java/network/crypta/node/simulator/LongTermManySingleBlocksTest.java
@@ -266,14 +266,14 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
    * <p>This entry point expects a stable identifier that becomes part of the output filenames. On a
    * fresh run it creates a dedicated working directory, starts a local test node, inserts {@link
    * #INSERTED_BLOCKS} single-block CHKs, and writes a row capturing timing and URI data. On later
-   * runs with the same identifier it reads the existing status file and, when the current run's
+   * runs with the same identifier, it reads the existing status file and, when the current run's
    * date is close to a target offset, performs a single fetch attempt for each previously inserted
    * URI with retries disabled.
    *
    * <p>This method exits the JVM with a status code that is also recorded in logs. It is designed
    * for execution as a standalone process rather than as a library call.
    *
-   * @param args command-line arguments; first element is a unique identifier used in filenames
+   * @param args command-line arguments; the first element is a unique identifier used in filenames
    */
   public static void main(String[] args) {
     if (args.length < 1 || args.length > 2) {
@@ -318,7 +318,10 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
       FetchContext fctx = configureFetchContext(client);
       RequestClient requestContext = new RequestClientBuilder().build();
       FetchTotals totals = new FetchTotals(MAX_N + 1);
-      processExistingStatusFile(statusFile, csvLine, client, fctx, requestContext, totals);
+      FetchRequestContext fetchRequestContext =
+          new FetchRequestContext(client, fctx, requestContext);
+      FetchRunContext runContext = new FetchRunContext(csvLine, fetchRequestContext);
+      processExistingStatusFile(statusFile, runContext, totals);
       logTotals(totals);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -342,7 +345,7 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
     ensureSeednodesReadable(seednodes);
 
     File innerDir = new File(dir, Integer.toString(DARKNET_PORT1));
-    // We only need best-effort directory creation; subsequent operations will fail clearly if it
+    // We only need best-effort directory creation; later operations will fail clearly if it
     // doesn't exist.
     //noinspection ResultOfMethodCallIgnored
     innerDir.mkdir();
@@ -443,31 +446,20 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
   }
 
   private static void processExistingStatusFile(
-      File statusFile,
-      List<String> csvLine,
-      HighLevelSimpleClient client,
-      FetchContext fctx,
-      RequestClient requestContext,
-      FetchTotals totals)
+      File statusFile, FetchRunContext runContext, FetchTotals totals)
       throws IOException, ParseException {
     GregorianCalendar[] targets = computeTargets();
     try (FileInputStream fis = new FileInputStream(statusFile);
         BufferedReader br = new BufferedReader(new InputStreamReader(fis, ENCODING))) {
       String line;
       while ((line = br.readLine()) != null) {
-        processExistingStatusLine(line, csvLine, client, fctx, requestContext, targets, totals);
+        processExistingStatusLine(line, runContext, targets, totals);
       }
     }
   }
 
   private static void processExistingStatusLine(
-      String line,
-      List<String> csvLine,
-      HighLevelSimpleClient client,
-      FetchContext fctx,
-      RequestClient requestContext,
-      GregorianCalendar[] targets,
-      FetchTotals totals)
+      String line, FetchRunContext runContext, GregorianCalendar[] targets, FetchTotals totals)
       throws ParseException {
     String[] split = line.split("!");
     if (split.length < 4) {
@@ -502,8 +494,7 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
     }
 
     int tokenAfterInserts = token + INSERTED_BLOCKS * 2;
-    maybeFetchTargets(
-        split[1], calendar, inserted.insertedUris, csvLine, client, fctx, requestContext, targets);
+    maybeFetchTargets(split[1], calendar, inserted.insertedUris, runContext, targets);
     processDeltaSection(split, tokenAfterInserts, calendar, date, totals);
   }
 
@@ -524,10 +515,7 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
       String versionToken,
       GregorianCalendar calendar,
       FreenetURI[] insertedURIs,
-      List<String> csvLine,
-      HighLevelSimpleClient client,
-      FetchContext fctx,
-      RequestClient requestContext,
+      FetchRunContext runContext,
       GregorianCalendar[] targets) {
     for (int i = 0; i < targets.length; i++) {
       if (!isNearTargetDate(targets[i], calendar)) {
@@ -535,8 +523,8 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
       }
       LOGGER.info("Found row for target date {} days ago.", (1 << i) - 1);
       LOGGER.info("Version: {}", versionToken);
-      csvLine.add(Integer.toString(i));
-      fetchInsertedBlocks(i, insertedURIs, csvLine, client, fctx, requestContext);
+      runContext.csvLine().add(Integer.toString(i));
+      fetchInsertedBlocks(i, insertedURIs, runContext);
     }
   }
 
@@ -545,12 +533,9 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
   }
 
   private static void fetchInsertedBlocks(
-      int deltaIndex,
-      FreenetURI[] insertedURIs,
-      List<String> csvLine,
-      HighLevelSimpleClient client,
-      FetchContext fctx,
-      RequestClient requestContext) {
+      int deltaIndex, FreenetURI[] insertedURIs, FetchRunContext runContext) {
+    List<String> csvLine = runContext.csvLine();
+    FetchRequestContext fetchRequestContext = runContext.fetchRequestContext();
     int pulled = 0;
     int inserted = 0;
     for (int j = 0; j < INSERTED_BLOCKS; j++) {
@@ -561,7 +546,7 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
       }
 
       inserted++;
-      FetchResult result = fetchOneBlock(uri, j, client, fctx, requestContext);
+      FetchResult result = fetchOneBlock(uri, j, fetchRequestContext);
       csvLine.add(result.csvToken());
       if (result.succeeded()) {
         pulled++;
@@ -573,15 +558,11 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
   }
 
   private static FetchResult fetchOneBlock(
-      FreenetURI uri,
-      int blockIndex,
-      HighLevelSimpleClient client,
-      FetchContext fctx,
-      RequestClient requestContext) {
+      FreenetURI uri, int blockIndex, FetchRequestContext fetchRequestContext) {
     long start = System.currentTimeMillis();
     try {
-      FetchWaiter fw = new FetchWaiter(requestContext);
-      client.fetch(uri, fw, fctx);
+      FetchWaiter fw = new FetchWaiter(fetchRequestContext.requestClient());
+      fetchRequestContext.client().fetch(uri, fw, fetchRequestContext.fetchContext());
       fw.waitForCompletion();
       long fetchTime = System.currentTimeMillis() - start;
       LOGGER.info("PULL-TIME FOR BLOCK {}: {}", blockIndex, fetchTime);


### PR DESCRIPTION
## Summary
- introduce shared fetch/run context records for the long-term simulator helpers
- reduce parameter lists in status processing and block fetch helpers
- keep fetch behavior and CSV output flow unchanged