### PR TITLE
refactor(updater): bundle updater params

### DIFF
--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * Supervises auto‑update components for the node: core application updates and plugin updates.
  *
  * <p>This manager wires the package‑based core updater ({@link CoreUpdater}) and maintains
- * compatibility glue for historical Update‑Over‑Mandatory (UoM) behavior. Today, core updates are
+ * compatibility glue for historical Update‑Over‑Mandatory (UoM) behavior. Today core updates are
  * delivered as OS/arch‑specific packages (deb/rpm/dmg/exe/flatpak/snap). Serving or fetching the
  * main JAR via UoM is intentionally disabled; only revocation handling and announcements remain.
  * Plugin updates continue to use the existing JAR flow and are orchestrated by {@link
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
  *   <li>Build and hold configuration options under the {@code node.updater} subconfig.
  *   <li>Start/stop the {@link CoreUpdater} and per‑plugin updaters when enabled/disabled.
  *   <li>Track and react to revocation state via {@link RevocationChecker}, surfacing alerts.
- *   <li>Render core update status into the Alerts panel and broadcast UoM announcements.
+ *   <li>Render the core update status into the Alerts panel and broadcast UoM announcements.
  * </ul>
  *
  * <p>Threading and state: methods that mutate shared state are generally synchronized on the
@@ -142,8 +142,8 @@ public class NodeUpdateManager {
 
   /**
    * Currently deploying an update? Set when we start to deploy an update. Which means it should not
-   * be un-set, except in the case of a severe error causing a valid update to fail. However, it is
-   * un-set in this case, so that we can try again with another build.
+   * be unsetted, except in the case of a severe error causing a valid update to fail. However, it
+   * is unset in this case, so that we can try again with another build.
    */
   // Unused flag removed; deployment happens only via CoreUpdater
 
@@ -183,7 +183,7 @@ public class NodeUpdateManager {
    *
    * @param node the owning node; must remain valid for the lifetime of this manager (non‑null)
    * @param config global configuration; a {@code node.updater} subconfig is created and populated
-   * @throws InvalidConfigValueException if provided URIs are malformed or violate required shapes
+   * @throws InvalidConfigValueException if provided, URIs are malformed or violate required shapes
    */
   public NodeUpdateManager(Node node, Config config) throws InvalidConfigValueException {
     this.node = node;
@@ -202,7 +202,7 @@ public class NodeUpdateManager {
 
     wasEnabledOnStartup = updaterConfig.getBoolean("enabled");
 
-    // is the auto-update allowed ?
+    // is the auto-update allowed?
     updaterConfig.register(
         "autoupdate",
         false,
@@ -517,7 +517,7 @@ public class NodeUpdateManager {
 
   /**
    * Sends a UoM announcement to a newly connected peer when there is information worth broadcasting
-   * and the peer is sufficiently up‑to‑date to understand it.
+   * and the peer is up enough‑to‑date to understand it.
    *
    * @param peer the connected peer to which an announcement may be sent; ignored when announcements
    *     are not yet armed or local revocation state is inconsistent
@@ -567,7 +567,7 @@ public class NodeUpdateManager {
     // Note: wrapper gating removed in favor of CoreUpdater
     Map<String, PluginJarUpdater> oldPluginUpdaters = null;
     CoreUpdater stoppedCoreUpdater = null;
-    // We need to run the revocation checker even if auto-update is
+    // We need to run the revocation checker even if the auto-update is
     // disabled.
     // Two reasons:
     // 1. For the benefit of other nodes, and because even if auto-update is
@@ -591,7 +591,7 @@ public class NodeUpdateManager {
         // Start CoreUpdater and plugin updaters
         startCoreUpdater();
         pluginUpdaters = new HashMap<>();
-        // Suppress obsolete Update-ASAP form in alert; CoreUpdater renders its own buttons
+        // Suppress obsolete an Update-ASAP form in alert; CoreUpdater renders its own buttons
         armed = true;
       }
     }
@@ -650,17 +650,16 @@ public class NodeUpdateManager {
       minVer = Math.max(minVer, info.getPluginLongVersion());
     }
     FreenetURI uri = updateURI.setDocName(name).setSuggestedEdition(minVer);
-    PluginJarUpdater updater =
-        new PluginJarUpdater(
+    NodeUpdaterParams params =
+        new NodeUpdaterParams(
             this,
             uri,
             (int) minVer,
             -1,
             (plugin.essential ? (int) minVer : Integer.MAX_VALUE),
-            name + "-",
-            name,
-            node.services().pluginManager(),
-            false);
+            name + "-");
+    PluginJarUpdater updater =
+        new PluginJarUpdater(params, name, node.services().pluginManager(), false);
     synchronized (this) {
       if (pluginUpdaters == null) {
         if (LOG.isDebugEnabled()) {
@@ -765,7 +764,7 @@ public class NodeUpdateManager {
   /**
    * Add links to the changelog for the given version to the given node.
    *
-   * <p>Preference order: - Use CHK links provided by {@link CoreUpdater} when available (short +
+   * <p>Preference order: - Use CHK links provided by {@link CoreUpdater} when available (short and
    * full changelog). - Otherwise, fall back to the legacy SSK links derived from the update USK.
    *
    * <p>This avoids showing duplicate links (old SSK + new CHK) at the same time.
@@ -821,11 +820,11 @@ public class NodeUpdateManager {
   /**
    * Sets the update USK used for core and plugin update metadata.
    *
-   * <p>The provided {@link FreenetURI} must be a USK without meta strings. The suggested edition is
+   * <p>The provided {@link FreenetURI} must be a USK without meta-strings. The suggested edition is
    * normalized to the current build. Changing the URI restarts plugin updaters and notifies the
    * core updater.
    *
-   * @param uri the new USK; must be a valid USK without meta strings (non‑null)
+   * @param uri the new USK; must be a valid USK without meta-strings (non‑null)
    */
   public synchronized void setURI(FreenetURI uri) {
     // Note: plugins
@@ -929,8 +928,8 @@ public class NodeUpdateManager {
    * considered unsafe and related actions are disabled until the condition is cleared.
    *
    * <p>This method records the message, sets internal flags, raises a user alert, and issues a
-   * local broadcast so connected peers can react. It is safe to call repeatedly; subsequent calls
-   * will maintain the blown state.
+   * local broadcast so connected peers can react. It is safe to call repeatedly; later calls will
+   * maintain the blown state.
    *
    * @param msg a brief reason or diagnostic to include in user alerts and logs (may be empty)
    * @param disabledNotBlown {@code true} when the updater is disabled for local reasons only (not a
@@ -960,7 +959,7 @@ public class NodeUpdateManager {
     if (revocationAlert == null) {
       revocationAlert = new RevocationKeyFoundUserAlert(msg, disabledNotBlown);
       node.services().clientCore().getAlerts().register(revocationAlert);
-      // we don't need to advertize updates : we are not going to do them
+      // we don't need to advertise updates: we are not going to do them
       killUpdateAlerts();
     }
     getUpdateOverMandatory().killAlert();
@@ -1285,7 +1284,7 @@ public class NodeUpdateManager {
    * @return always {@code 0} in package‑based updater mode
    */
   public synchronized long timeRemainingOnCheck() {
-    // Legacy UOM final check not used; no pending timer
+    // Legacy UOM final check isn't used; no pending timer
     return 0L;
   }
 
@@ -1346,7 +1345,7 @@ public class NodeUpdateManager {
   }
 
   /**
-   * Returns whether UoM should be suppressed for this node (e.g. seednode or early startup).
+   * Returns whether UoM should be suppressed for this node (e.g., seednode or early startup).
    *
    * @return {@code true} when UoM must not be used due to node role or state
    */
@@ -1407,7 +1406,7 @@ public class NodeUpdateManager {
    * @return always {@code null}; serving the core JAR via UoM is disabled
    */
   public synchronized File getCurrentVersionBlobFile() {
-    // Serving main.jar over UOM is disabled in package-based updater.
+    // Serving the main.jar over UOM is disabled in package-based updater.
     return null;
   }
 
@@ -1454,14 +1453,15 @@ public class NodeUpdateManager {
   /** Create and wire the package‑based {@link CoreUpdater} if not already present. */
   public synchronized void startCoreUpdater() {
     if (coreUpdater != null) return;
-    coreUpdater =
-        new CoreUpdater(
+    NodeUpdaterParams params =
+        new NodeUpdaterParams(
             this,
             getCoreInfoURI(),
             Version.currentBuildNumber(),
             -1,
             Integer.MAX_VALUE,
             "core-info-");
+    coreUpdater = new CoreUpdater(params);
   }
 
   /**

--- a/src/main/java/network/crypta/node/updater/NodeUpdater.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdater.java
@@ -136,27 +136,21 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
    */
   public abstract String artifactName();
 
-  NodeUpdater(
-      NodeUpdateManager manager,
-      FreenetURI updateUri,
-      int current,
-      int min,
-      int max,
-      String blobFilenamePrefix) {
+  NodeUpdater(NodeUpdaterParams params) {
     // Debug gating derives from LOG.isDebugEnabled() where needed
-    this.manager = manager;
+    this.manager = params.manager();
     this.node = manager.getNode();
-    this.uri = updateUri.setSuggestedEdition(((long) Version.currentBuildNumber()) + 1);
+    this.uri = params.updateUri().setSuggestedEdition(((long) Version.currentBuildNumber()) + 1);
     this.ticker = node.network().ticker();
     this.core = node.services().clientCore();
-    this.currentVersion = current;
+    this.currentVersion = params.current();
     this.availableVersion = -1;
     this.isRunning = true;
     this.cg = null;
     this.isFetching = false;
-    this.blobFilenamePrefix = blobFilenamePrefix;
-    this.maxDeployVersion = max;
-    this.minDeployVersion = min;
+    this.blobFilenamePrefix = params.blobFilenamePrefix();
+    this.maxDeployVersion = params.max();
+    this.minDeployVersion = params.min();
 
     FetchContext tempContext = core.makeClient((short) 0, true, false).getFetchContext();
     tempContext.setAllowSplitfiles(true);
@@ -231,7 +225,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
   /**
    * Hook invoked just before a new fetch is scheduled and started.
    *
-   * <p>Implementations can use this callback to update UI, reset flags, or perform lightweight
+   * <p>Implementations can use this callback to update the UI, reset flags, or perform lightweight
    * bookkeeping. The method must be fast and non‑blocking; heavy work should run after fetch
    * completion.
    */
@@ -242,7 +236,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
    *
    * <p>The method skips when already fetching the same edition or when the edition is not newer. It
    * may cancel a stale fetch, prepare a new {@link ClientGetter}, and start it through the client
-   * context. Repeated calls are safe; a new request starts only when state warrants.
+   * context. Repeated calls are safe; a new request starts only when the state warrants.
    */
   public void maybeUpdate() {
     ClientGetter toStart = null;
@@ -549,8 +543,8 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
 
   /**
    * Wraps an {@link InputStream} and limits the total number of bytes that can be read. Once the
-   * limit is reached, subsequent reads return {@code -1} (EOF). This protects callers against zip
-   * bombs and other excessive input sizes when reading untrusted data.
+   * limit is reached, later reads return {@code -1} (EOF). This protects callers against zip bombs
+   * and other excessive input sizes when reading untrusted data.
    */
   private static final class BoundedInputStream extends java.io.FilterInputStream {
     private long remaining;
@@ -660,7 +654,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
    * Interprets a single manifest line parsed by {@link #parseManifest()} or {@link
    * #parseManifest(FetchResult)}.
    *
-   * <p>The base implementation is a no‑op. Subclasses override to capture values relevant to their
+   * <p>The base implementation is no‑op. Subclasses override to capture values relevant to their
    * compatibility or deployment logic. The {@code line} does not include a trailing newline.
    *
    * @param line a single raw manifest line to interpret; never {@code null}
@@ -737,7 +731,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
   }
 
   /**
-   * Called when the fetch URI has changed. No major locks are held by the caller.
+   * Called when the fetch URI has changed. The caller holds no major locks.
    *
    * @param newUri the new update key; its doc name is preserved when the argument omits one
    */
@@ -788,7 +782,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
    * @return an edition number used for progress reporting; never less than the current version
    */
   public int fetchingVersion() {
-    // We will not deploy currentVersion...
+    // We will not deploy the currentVersion...
     if (fetchingVersion <= currentVersion) return availableVersion;
     else return fetchingVersion;
   }
@@ -862,7 +856,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
               realAvailableVersion);
           callFinishedFound = availableVersion = realAvailableVersion;
         } else if (availableVersion < requiredExt) {
-          // Including if it hasn't been found at all
+          // Including if it hasn't been found at all,
           // Just try it ...
           callFinishedFound = availableVersion = requiredExt;
           LOG.info(

--- a/src/main/java/network/crypta/node/updater/NodeUpdaterParams.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdaterParams.java
@@ -1,0 +1,40 @@
+package network.crypta.node.updater;
+
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Immutable parameter bundle for constructing a {@link NodeUpdater} instance.
+ *
+ * <p>This record carries a concise snapshot of update-related settings that are already resolved by
+ * the calling {@link NodeUpdateManager}. It keeps the update target URI alongside the current node
+ * build and the allowed deployment range so the updater can decide what to fetch without consulting
+ * configuration again. Callers typically assemble these values once during updater startup and pass
+ * the record straight into the constructor, keeping the contract explicit and reducing the chance
+ * of stale reads.
+ *
+ * <p>The record is immutable and thread-safe to share between components. It does not validate
+ * ranges itself, so callers should ensure {@code min} and {@code max} reflect allowable versions
+ * and that {@code current} is the active build number at the moment of creation.
+ *
+ * <ul>
+ *   <li>Captures the update coordinator used for callbacks and lifecycle control.
+ *   <li>Defines version boundaries used to accept or reject deployments.
+ *   <li>Provides the blob file name prefix for persistent update artifacts.
+ * </ul>
+ *
+ * @param manager update manager coordinating state, alerts, and policy decisions.
+ * @param updateUri base URI used to resolve the update USK target.
+ * @param current current build number supplied to compute suggested editions.
+ * @param min minimum acceptable deployment build number for this node.
+ * @param max maximum acceptable deployment build number for this node.
+ * @param blobFilenamePrefix prefix for update blob filenames stored on disk.
+ * @see NodeUpdateManager
+ * @see NodeUpdater
+ */
+public record NodeUpdaterParams(
+    NodeUpdateManager manager,
+    FreenetURI updateUri,
+    int current,
+    int min,
+    int max,
+    String blobFilenamePrefix) {}

--- a/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
+++ b/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import network.crypta.client.FetchResult;
 import network.crypta.clients.http.PproxyToadlet;
-import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.RequestClient;
 import network.crypta.node.Version;
@@ -87,7 +86,7 @@ public class PluginJarUpdater extends NodeUpdater {
     }
     LOG.info("Deploying new version of {} : unloading old version...", pluginName);
     // Write the new version of the plugin before shutting down, so if there is a deadlock in
-    // terminate, we will still get the new version after a restart.
+    // terminating, we will still get the new version after a restart.
     try {
       writeJar();
     } catch (IOException e) {
@@ -107,16 +106,8 @@ public class PluginJarUpdater extends NodeUpdater {
   }
 
   PluginJarUpdater(
-      NodeUpdateManager manager,
-      FreenetURI updateUri,
-      int current,
-      int min,
-      int max,
-      String blobFilenamePrefix,
-      String pluginName,
-      PluginManager pm,
-      boolean autoDeployOnRestart) {
-    super(manager, updateUri, current, min, max, blobFilenamePrefix);
+      NodeUpdaterParams params, String pluginName, PluginManager pm, boolean autoDeployOnRestart) {
+    super(params);
     this.pluginName = pluginName;
     this.pluginManager = pm;
     if (LOG.isDebugEnabled()) {
@@ -162,7 +153,7 @@ public class PluginJarUpdater extends NodeUpdater {
     if (result != null && result.size() > 0) {
       parseManifest(result);
     } else {
-      // Fallback to the finalized blob if result is unexpectedly empty.
+      // Fallback to the finalized blob if the result is unexpectedly empty.
       parseManifest();
     }
     if (requiredNodeVersion != -1) {
@@ -247,7 +238,7 @@ public class PluginJarUpdater extends NodeUpdater {
       deleteTempBlobQuietly();
       return;
     }
-    // Create an useralert to ask the user to deploy the new version.
+    // Create a useralert to ask the user to deploy the new version.
     UserAlert toRegister;
     synchronized (this) {
       readyToDeploy = true;
@@ -337,10 +328,10 @@ public class PluginJarUpdater extends NodeUpdater {
    * Write the fetched plugin artifact to the destination JAR file.
    *
    * <p>The method performs a best-effort deletion of any existing file, then copies the content of
-   * {@code result} to {@code fNew}. The write is serialized using an internal monitor and followed
-   * by {@code FileDescriptor#sync()} to reduce the chance of partial updates after a crash or power
-   * loss. The method does not alter plugin state; callers typically invoke it immediately before
-   * unloading and restarting the plugin.
+   * {@code result} to {@code fNew}. The writing is serialized using an internal monitor and
+   * followed by {@code FileDescriptor#sync()} to reduce the chance of partial updates after a crash
+   * or power loss. The method does not alter the plugin state; callers typically invoke it
+   * immediately before unloading and restarting the plugin.
    *
    * @param result the successful fetch result supplying the new plugin bytes; must not be {@code
    *     null} and should remain valid for the duration of the copy operation
@@ -394,8 +385,8 @@ public class PluginJarUpdater extends NodeUpdater {
    *
    * <p>When the plugin was already running, deployment is deferred by one additional successful
    * revocation check to minimize churn in busy systems. Otherwise, it is scheduled for the very
-   * next successful check. This call only sets intent; the actual write and restart occur later in
-   * {@link #onNoRevocation()} when the gate condition is met.
+   * next successful check. This call only sets intent; the actual writing and restart occur later
+   * in {@link #onNoRevocation()} when the gate condition is met.
    *
    * @param wasRunning {@code true} when the plugin was running at arm time, in which case the
    *     update deploys after the next but one revocation check; {@code false} schedules deployment

--- a/src/main/kotlin/network/crypta/node/updater/CoreUpdater.kt
+++ b/src/main/kotlin/network/crypta/node/updater/CoreUpdater.kt
@@ -29,28 +29,17 @@ import org.slf4j.LoggerFactory
  * - Fetch the latest “core info” descriptor (JSON) and parse it.
  * - Detect the current OS/arch and available package managers.
  * - Choose a suitable artifact (e.g., amd64.deb → Flatpak/Snap preferred when present).
- * - On request (or when auto‑update is allowed), fetch the artifact’s CHK to the updates directory.
+ * - On request (or when auto‑update is allowed), fetch the artifact’s CHK to the updates'
+ *   directory.
  * - Render small UI controls on the Alerts page: Download/Install/Open in Store.
  *
  * Thread‑safety: public getters and UI state rely on `@Volatile` fields; long‑running work runs
  * through the client fetcher and event callbacks.
  *
- * @param manager owning [NodeUpdateManager] orchestrating update lifecycles.
- * @param uri USK used to fetch manifest editions.
- * @param current current edition at construction time.
- * @param min minimum edition bound for subscriptions.
- * @param max maximum edition bound for subscriptions.
- * @param blobFilenamePrefix prefix applied to manifest blobs written by the base class.
+ * @param params shared updater parameters (manager, URI, edition bounds, blob prefix).
  */
-class CoreUpdater(
-  manager: NodeUpdateManager,
-  uri: FreenetURI,
-  current: Int,
-  min: Int,
-  max: Int,
-  blobFilenamePrefix: String,
-) : NodeUpdater(manager, uri, current, min, max, blobFilenamePrefix) {
-  private val LOG = LoggerFactory.getLogger(CoreUpdater::class.java)
+class CoreUpdater(params: NodeUpdaterParams) : NodeUpdater(params) {
+  private val log = LoggerFactory.getLogger(CoreUpdater::class.java)
 
   /** Internal constants used for logging and filesystem defaults. */
   private companion object {
@@ -64,7 +53,7 @@ class CoreUpdater(
   /** Shared environment detector reused across lifecycle callbacks. */
   private val appEnv = AppEnv()
 
-  /** Latest descriptor fetched from the update USK, if available. */
+  /** The latest descriptor fetched from the update USK, if available. */
   @Volatile private var latestInfo: CoreInfo? = null
 
   /** Currently selected package key in the form `<arch>.<ext>` or null when undecided. */
@@ -85,13 +74,16 @@ class CoreUpdater(
 
   /** Emit a minor-level log message scoped to this updater. */
   private fun logInfo(message: String) {
-    LOG.info("$LOG_TAG $message")
+    log.info("$LOG_TAG $message")
   }
 
   /** Emit an error-level log message, optionally including a throwable. */
   private fun logError(message: String, throwable: Throwable? = null) {
-    if (throwable != null) LOG.error("$LOG_TAG $message", throwable)
-    else LOG.error("$LOG_TAG $message")
+    if (throwable != null) {
+      log.error("$LOG_TAG $message", throwable)
+    } else {
+      log.error("$LOG_TAG $message")
+    }
   }
 
   /**
@@ -109,14 +101,14 @@ class CoreUpdater(
   /**
    * Updates internal selection state when the manifest download completes.
    *
-   * @param result fetch result containing the manifest payload.
+   * @param result the fetch result containing the manifest payload.
    * @param build last known build number from the subscription (unused).
    */
   override fun maybeParseManifest(result: FetchResult, build: Int) {
     // Parse JSON (treat fetched blob as UTF-8 text)
     val info = parseInfo(result)
     latestInfo = info
-    // Detect environment and select an artifact to propose
+    // Detect the environment and select an artifact to propose
     val e = appEnv.detectEnvironment()
     env = e
     selectArtifact(info, e)
@@ -143,7 +135,7 @@ class CoreUpdater(
 
   /** No-op because all manifest information is retained in-memory. */
   override fun processSuccess(fetched: Int, result: FetchResult, blobFile: File?) {
-    // Nothing to persist from info JSON beyond in-memory state.
+    // Nothing to persist from info JSON beyond the in-memory state.
   }
 
   /** Short changelog CHK referenced by the descriptor, if available. */
@@ -220,7 +212,10 @@ class CoreUpdater(
     val preferred = mutableListOf<String>()
     val fallback = listOf("rpm", "deb", "flatpak", "snap")
     when (runCatching { appEnv.isFlatpak() }.getOrNull()) {
-      true -> preferred += "flatpak"
+      true -> {
+        preferred += "flatpak"
+      }
+
       else -> {
         if ("rpm" in managers) preferred += "rpm"
         if ("dpkg" in managers) preferred += "deb"
@@ -374,7 +369,7 @@ class CoreUpdater(
       links.addChild("a", "href", ExternalLinkToadlet.escape(info.releasePageUrl), "Release Notes")
       links.addChild("#", "  ")
     }
-    // Wire "Open in Store" as a POST form for Linux Flatpak/Snap; otherwise keep external link
+    // Wire "Open in Store" as a POST form for Linux Flatpak/Snap; otherwise keep an external link
     val storeUrl = spec?.storeUrl
     val ext = chosenKey?.substringAfterLast('.')?.lowercase()
     val isLinux =
@@ -415,16 +410,20 @@ class CoreUpdater(
       val segs = path.split('/')
       val last = segs.lastOrNull { it.isNotEmpty() } ?: return null
       when (kind.lowercase()) {
-        "snap" -> last // snapcraft.io/<name>
-        "flatpak" -> last // flathub.org/apps/<appId> (we also handle /apps/details/<appId>)
+        "snap" -> last
+
+        // snapcraft.io/<name>
+        "flatpak" -> last
+
+        // flathub.org/apps/<appId> (we also handle /apps/details/<appId>)
         else -> null
       }
     } catch (_: Throwable) {
       null
     }
 
-  /** Provides the node form password required by POST submissions. */
-  private fun formPassword(): String = manager.getNode().services().clientCore().getFormPassword()
+  /** Provides the node form the password required by POST submissions. */
+  private fun formPassword(): String = manager.getNode().services().clientCore().formPassword
 
   /** Creates a basic POST form addressed to [CORE_UPDATE_PATH]. */
   private fun newPostForm(): HTMLNode =
@@ -435,7 +434,7 @@ class CoreUpdater(
     addChild("input", arrayOf("type", "name", "value"), arrayOf("hidden", name, value))
   }
 
-  /** Adds a submit button input to the receiver with optional metadata. */
+  /** Adds a Submit button input to the receiver with optional metadata. */
   private fun HTMLNode.submitButton(
     value: String,
     name: String? = null,
@@ -474,8 +473,11 @@ class CoreUpdater(
   /** Calculates the label for download buttons, including optional size hints. */
   private fun defaultDownloadLabel(): String {
     val bytes = selectedSpec?.size
-    return if (bytes != null && bytes > 0) "Download (${SizeUtil.formatSize(bytes, true)})"
-    else "Download"
+    return if (bytes != null && bytes > 0) {
+      "Download (${SizeUtil.formatSize(bytes, true)})"
+    } else {
+      "Download"
+    }
   }
 
   /** Generates a progress paragraph summarizing current download status. */
@@ -486,14 +488,14 @@ class CoreUpdater(
       val text =
         when {
           f.isSuccess() -> "Download Completed"
-          pct >= 0 && blocks != null -> "Downloading: ${pct}% (${blocks.first}/${blocks.second})"
-          pct >= 0 -> "Downloading: ${pct}%"
+          pct >= 0 && blocks != null -> "Downloading: $pct% (${blocks.first}/${blocks.second})"
+          pct >= 0 -> "Downloading: $pct%"
           else -> "Downloading…"
         }
       addChild("#", text)
     }
 
-  /** Creates the Install button form, disabling it until the payload is available. */
+  /** Creates the Installation button form, disabling it until the payload is available. */
   private fun buildInstallForm(ready: Boolean, path: String?): HTMLNode =
     newPostForm().apply {
       hiddenInput("action", "install")
@@ -532,7 +534,7 @@ class CoreUpdater(
     /** Latest human-readable error message, if any. */
     @Volatile private var errorMsg: String? = null
 
-    /** Tracks whether the last failure was fatal according to the client API. */
+    /** Tracks whether the last failure was fatal, according to the client API. */
     @Volatile private var fatal: Boolean = false
 
     /** Begins the asynchronous fetch and registers this fetcher as an event listener. */
@@ -552,7 +554,7 @@ class CoreUpdater(
         )
       ctx.eventProducer.addEventListener(this)
       try {
-        manager.getNode().services().clientCore().getClientContext().start(getter)
+        manager.getNode().services().clientCore().clientContext.start(getter)
         this@CoreUpdater.logInfo(
           "download started (listener attached): target=${outFile.absolutePath}"
         )
@@ -588,7 +590,7 @@ class CoreUpdater(
     fun blockProgressOrNull(): Pair<Int, Int>? =
       if (lastNeed > 0 && lastDone >= 0) Pair(lastDone, lastNeed) else null
 
-    /** True only when the transfer completed successfully. */
+    /** True, only when the transfer completed successfully. */
     fun isSuccess(): Boolean = complete && !failed && successFile != null
 
     /** True when the transfer finished with an error. */
@@ -597,7 +599,7 @@ class CoreUpdater(
     /** Short error message when failed, if any. */
     fun errorMessage(): String? = errorMsg
 
-    /** True if the last failure was fatal according to FetchException.isFatal(). */
+    /** True if the last failure was fatal, according to FetchException.isFatal(). */
     fun isFatalFailure(): Boolean = failed && fatal
 
     /** Whether this fetcher corresponds to the supplied CHK string. */
@@ -659,7 +661,7 @@ class CoreUpdater(
             lastPct = pctNow
             lastDone = done
             lastNeed = need
-            this@CoreUpdater.logInfo("progress: ${pctNow}% ($done/$need, total=${ce.totalBlocks})")
+            this@CoreUpdater.logInfo("progress: $pctNow% ($done/$need, total=${ce.totalBlocks})")
           }
         }
       } catch (_: Throwable) {
@@ -691,7 +693,7 @@ internal object CoreJson {
   /** Parses raw JSON text into a [CoreInfo] structure. */
   fun parse(json: String): CoreInfo {
     // Very small, permissive parser: only handles strings, numbers, booleans, null, and nested
-    // objects with string keys. Arrays are not used by the schema.
+    // objects with string keys. The schema does not use arrays.
     val map = JsonMini.parseObject(json)
     val version = map["version"] as? String
     val release = map["release_page_url"] as? String
@@ -775,24 +777,41 @@ internal object JsonMini {
   private fun parseValue(p: P): Any? {
     skipWs(p)
     return when (val ch = peek(p)) {
-      '"' -> parseString(p)
-      '{' -> parseObjectInPlace(p)
-      '[' -> parseArrayInPlace(p)
+      '"' -> {
+        parseString(p)
+      }
+
+      '{' -> {
+        parseObjectInPlace(p)
+      }
+
+      '[' -> {
+        parseArrayInPlace(p)
+      }
+
       't' -> {
         expectWord(p, "true")
         true
       }
+
       'f' -> {
         expectWord(p, "false")
         false
       }
+
       'n' -> {
         expectWord(p, "null")
         null
       }
+
       '-',
-      in '0'..'9' -> parseNumber(p)
-      else -> error("Unexpected char '$ch' at ${p.i}")
+      in '0'..'9' -> {
+        parseNumber(p)
+      }
+
+      else -> {
+        error("Unexpected char '$ch' at ${p.i}")
+      }
     }
   }
 
@@ -816,29 +835,62 @@ internal object JsonMini {
     val sb = StringBuilder()
     while (true) {
       when (val ch = next(p)) {
-        '"' -> return sb.toString()
+        '"' -> {
+          return sb.toString()
+        }
+
         '\\' -> {
           val e = next(p)
           sb.append(
             when (e) {
-              '"' -> '"'
-              '\\' -> '\\'
-              '/' -> '/'
-              'b' -> '\b'
-              'f' -> '\u000C'
-              'n' -> '\n'
-              'r' -> '\r'
-              't' -> '\t'
+              '"' -> {
+                '"'
+              }
+
+              '\\' -> {
+                '\\'
+              }
+
+              '/' -> {
+                '/'
+              }
+
+              'b' -> {
+                '\b'
+              }
+
+              'f' -> {
+                '\u000C'
+              }
+
+              'n' -> {
+                '\n'
+              }
+
+              'r' -> {
+                '\r'
+              }
+
+              't' -> {
+                '\t'
+              }
+
               'u' -> {
                 val hex = p.s.substring(p.i, p.i + 4)
                 p.i += 4
                 hex.toInt(16).toChar()
               }
-              else -> error("Bad escape \\$e at ${p.i}")
+
+              else -> {
+                error("Bad escape \\$e at ${p.i}")
+              }
             }
           )
         }
-        else -> sb.append(ch)
+
+        else -> {
+          sb.append(ch)
+        }
       }
     }
   }

--- a/src/test/java/network/crypta/node/updater/PluginJarUpdaterTest.java
+++ b/src/test/java/network/crypta/node/updater/PluginJarUpdaterTest.java
@@ -112,16 +112,16 @@ class PluginJarUpdaterTest {
     doNothing().when(alerts).register(any(UserAlert.class));
     doNothing().when(alerts).unregister(any(UserAlert.class));
 
+    NodeUpdaterParams params =
+        new NodeUpdaterParams(
+            manager,
+            dummyUSK(),
+            /* current= */ 1,
+            /* min= */ 1,
+            /* max= */ 999999,
+            /* blobFilenamePrefix= */ "plugin-");
     return new PluginJarUpdater(
-        manager,
-        dummyUSK(),
-        /* current= */ 1,
-        /* min= */ 1,
-        /* max= */ 999999,
-        /* blobFilenamePrefix= */ "plugin-",
-        pluginName,
-        pluginManager,
-        /* autoDeployOnRestart= */ false);
+        params, pluginName, pluginManager, /* autoDeployOnRestart= */ false);
   }
 
   private static FetchContext makeFetchContext() {
@@ -148,16 +148,16 @@ class PluginJarUpdaterTest {
     byte[] jar = makeJarWithManifest(Integer.toString(tooHigh));
     FetchResult result = fetchResultFromBytes(jar);
 
-    // Simulate temp file created by fetcher
+    // Simulate the temp file created by fetcher
     File temp = Files.createTempFile(tmp, "plugin-", ".fblob.tmp").toFile();
     Files.write(temp.toPath(), new byte[] {1, 2, 3});
-    // Match NodeUpdater's protected field for delete path in PluginJarUpdater
+    // Match NodeUpdater's protected field for the delete path in PluginJarUpdater
     updater.tempBlobFile = temp;
 
     // Use a fetchedVersion newer than current so onSuccess proceeds
     updater.onSuccess(result, temp, /* fetchedVersion= */ Version.currentBuildNumber() + 1);
 
-    // Not ready to deploy as requirement is too high
+    // Not ready to deploy as the requirement is too high
     boolean shouldRestart = updater.onNoRevocation();
     assertFalse(shouldRestart, "Should not request restart when not ready");
 
@@ -178,7 +178,7 @@ class PluginJarUpdaterTest {
     byte[] jar = makeJarWithManifest(Integer.toString(requiredOk));
     FetchResult result = fetchResultFromBytes(jar);
 
-    // Simulate temp file created by fetcher
+    // Simulate the temp file created by fetcher
     File temp = Files.createTempFile(tmp, "plugin-", ".fblob.tmp").toFile();
     Files.write(temp.toPath(), new byte[] {9});
     updater.tempBlobFile = temp;
@@ -193,7 +193,7 @@ class PluginJarUpdaterTest {
     File dest = tmp.resolve(pluginName + ".jar").toFile();
     when(pluginManager.getPluginFilename(pluginName)).thenReturn(dest);
 
-    // Run success path
+    // Run a success path
     int fetched = Version.currentBuildNumber() + 1;
     updater.onSuccess(result, temp, fetched);
 
@@ -233,7 +233,7 @@ class PluginJarUpdaterTest {
     Files.write(temp.toPath(), new byte[] {7});
     updater.tempBlobFile = temp;
 
-    // Loaded plugin with older version
+    // Loaded plugin with the older version
     PluginInfoWrapper loaded = org.mockito.Mockito.mock(PluginInfoWrapper.class);
     when(loaded.getPluginLongVersion()).thenReturn(0L);
     when(pluginManager.findPluginByIdentifier(pluginName)).thenReturn(loaded);


### PR DESCRIPTION
## Summary
- introduce `NodeUpdaterParams` to bundle shared updater inputs
- update core and plugin updater constructors to use the params record
- apply Spotless-driven formatting/doc comment tweaks in updater classes

## Testing
- not run (formatting only)