### PR TITLE
refactor(useralerts): bundle n2n alert params

### DIFF
--- a/src/main/java/network/crypta/node/DarknetPeerNode.java
+++ b/src/main/java/network/crypta/node/DarknetPeerNode.java
@@ -43,6 +43,7 @@ import network.crypta.node.useralerts.AbstractNodeToNodeFileOfferUserAlert;
 import network.crypta.node.useralerts.BookmarkFeedUserAlert;
 import network.crypta.node.useralerts.DownloadFeedUserAlert;
 import network.crypta.node.useralerts.N2NTMUserAlert;
+import network.crypta.node.useralerts.NodeToNodeAlertContext;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.support.Base64;
 import network.crypta.support.HTMLNode;
@@ -68,7 +69,10 @@ import org.slf4j.LoggerFactory;
  * flows. Methods that modify persisted peer metadata notify {@link PeerManager} so the on-disk
  * peers list remains consistent.
  */
-@SuppressWarnings("java:S2160") // hashCode() is inherited; equals() restricts to subclass type
+@SuppressWarnings({
+  "java:S2160",
+  "java:S1206"
+}) // hashCode() is inherited; equals() restricts to subclass type
 public class DarknetPeerNode extends PeerNode {
   private static final Logger LOG = LoggerFactory.getLogger(DarknetPeerNode.class);
 
@@ -96,7 +100,7 @@ public class DarknetPeerNode extends PeerNode {
   // Sonar: de-duplicate repeated HTML literals
   private static final String HTML_TAG_INPUT = "input";
   private static final String HTML_ATTR_VALUE = "value";
-  // Sonar: de-duplicate repeated SimpleFieldSet keys
+  // Sonar: deduplicate repeated SimpleFieldSet keys
   private static final String FS_KEY_COMPOSED_TIME = "composedTime";
   private static final String FS_KEY_DESCRIPTION = "Description";
   private static final String ERR_BAD_BASE64_N2NTM =
@@ -217,7 +221,7 @@ public class DarknetPeerNode extends PeerNode {
     }
 
     /**
-     * Resolves a visibility by its stable serialized code.
+     * Resolves visibility by its stable serialized code.
      *
      * @param code stable on-the-wire code.
      * @return the matching visibility, or {@code null} if unknown.
@@ -538,7 +542,7 @@ public class DarknetPeerNode extends PeerNode {
    * Sets burst-only mode.
    *
    * <p>When enabled, handshakes are attempted in occasional bursts. Enabling burst-only clears
-   * listen-only. Disabling resets any long handshake delay accrued under burst-only.
+   * listen-only. Disabling resets any long handshake delay grew under burst-only.
    *
    * @param setting {@code true} to enable, {@code false} to disable.
    */
@@ -678,7 +682,7 @@ public class DarknetPeerNode extends PeerNode {
   }
 
   /**
-   * Re-reads a single extra peer data file from disk and re-applies its effect.
+   * Re-reads a single extra peer data file from the disk and re-applies its effect.
    *
    * @param fileNumber file identifier within the peer's extra-data directory.
    * @return {@code true} on success; {@code false} if the file was missing or invalid.
@@ -1185,7 +1189,7 @@ public class DarknetPeerNode extends PeerNode {
   // Note: Consider refactoring so file transfers can be initiated outside of fproxy.
   // Note: Future enhancement: allow interaction with plugins on other nodes.
   // Note: Types exist already; wider support is currently not implemented.
-  // See also e.g. fcp/SendTextMessage.
+  // See also e.g., fcp/SendTextMessage.
   /**
    * Represents a single file offer exchanged over node-to-node messaging.
    *
@@ -1231,7 +1235,7 @@ public class DarknetPeerNode extends PeerNode {
      *
      * @param fs serialized offer fields.
      * @param amIOffering whether this side originated the offer.
-     * @throws FSParseException if required fields are missing or invalid.
+     * @throws FSParseException if required, fields are missing or invalid.
      */
     public FileOffer(SimpleFieldSet fs, boolean amIOffering) throws FSParseException {
       uid = fs.getLong("uid");
@@ -1262,7 +1266,7 @@ public class DarknetPeerNode extends PeerNode {
       fs.put("size", size);
     }
 
-    /** Accepts the offer and starts receiving the file to the downloads directory. */
+    /** Accepts the offer and starts receiving the file to the downloads' directory. */
     @SuppressWarnings("java:S1181")
     public void accept() {
       acceptedOrRejected = true;
@@ -1563,7 +1567,7 @@ public class DarknetPeerNode extends PeerNode {
 
         @Override
         public String dismissButtonText() {
-          return null; // Cannot hide, but can reject
+          return null; // Cannot hide but can reject
         }
 
         @Override
@@ -1577,7 +1581,7 @@ public class DarknetPeerNode extends PeerNode {
 
           // Accept/reject form
 
-          // Hopefully we will have a container when this function is called!
+          // Hopefully, we will have a container when this function is called!
           HTMLNode form =
               node.services()
                   .clientCore()
@@ -1791,7 +1795,7 @@ public class DarknetPeerNode extends PeerNode {
    */
   public int sendTextFeed(String message) {
     long now = System.currentTimeMillis();
-    // Avoid Math.abs on nextLong(): Long.MIN_VALUE overflows; use original value.
+    // Avoid Math.abs on nextLong(): Long.MIN_VALUE overflows; use the original value.
     long msgid = random.nextLong();
     // split large messages
     int requiredN2nCount = 1 + ((message.length() - 1) / 1024);
@@ -1884,6 +1888,7 @@ public class DarknetPeerNode extends PeerNode {
    * @return updated peer status code after the message is queued.
    * @throws IOException if the file cannot be read.
    */
+  @SuppressWarnings("UnusedReturnValue")
   public int sendFileOffer(File file, String message) throws IOException {
     String fnam = file.getName();
     String mime = DefaultMIMETypes.guessMIMEType(fnam, false);
@@ -1899,6 +1904,7 @@ public class DarknetPeerNode extends PeerNode {
    * @return updated peer status code after the message is queued.
    * @throws IOException if the upload buffer cannot be read.
    */
+  @SuppressWarnings("UnusedReturnValue")
   public int sendFileOffer(HTTPUploadedFile file, String message) throws IOException {
     String fnam = file.getFilename();
     String mime = file.getContentType();
@@ -1941,7 +1947,7 @@ public class DarknetPeerNode extends PeerNode {
   private String mergeExistingN2NTMAlerts(
       long msgid, long composedTime, String currentText, List<UserAlert> merged) {
     String newText = currentText;
-    // NOTE: Merge is linear time over existing alerts; keep alert list bounded upstream.
+    // NOTE: Merge is linear time over existing alerts; keep an alert list bounded upstream.
     synchronized (node.services().clientCore().getAlerts()) {
       for (UserAlert userAlert : node.services().clientCore().getAlerts().getAlerts()) {
         if (!(userAlert instanceof N2NTMUserAlert alert) || msgid != alert.getMsgid()) {
@@ -2012,9 +2018,9 @@ public class DarknetPeerNode extends PeerNode {
       long receivedTime,
       long msgid,
       List<UserAlert> merged) {
-    N2NTMUserAlert userAlert =
-        new N2NTMUserAlert(
-            this, newText, newFileNumber, composedTime, sentTime, receivedTime, msgid);
+    NodeToNodeAlertContext alertContext =
+        new NodeToNodeAlertContext(this, newFileNumber, composedTime, sentTime, receivedTime);
+    N2NTMUserAlert userAlert = new N2NTMUserAlert(alertContext, newText, msgid);
     node.services().clientCore().getAlerts().register(userAlert);
     for (UserAlert alert : merged) {
       node.services().clientCore().getAlerts().dismissAlert(alert.hashCode());
@@ -2141,17 +2147,10 @@ public class DarknetPeerNode extends PeerNode {
       LOG.error(ERR_BAD_BASE64_N2NTM, e);
       return;
     }
+    NodeToNodeAlertContext alertContext =
+        new NodeToNodeAlertContext(this, fileNumber, composedTime, sentTime, receivedTime);
     BookmarkFeedUserAlert userAlert =
-        new BookmarkFeedUserAlert(
-            this,
-            name,
-            description,
-            hasAnActiveLink,
-            fileNumber,
-            uri,
-            composedTime,
-            sentTime,
-            receivedTime);
+        new BookmarkFeedUserAlert(alertContext, name, description, hasAnActiveLink, uri);
     node.services().clientCore().getAlerts().register(userAlert);
   }
 
@@ -2172,9 +2171,9 @@ public class DarknetPeerNode extends PeerNode {
       LOG.error(ERR_BAD_BASE64_N2NTM, e);
       return;
     }
-    DownloadFeedUserAlert userAlert =
-        new DownloadFeedUserAlert(
-            this, description, fileNumber, uri, composedTime, sentTime, receivedTime);
+    NodeToNodeAlertContext alertContext =
+        new NodeToNodeAlertContext(this, fileNumber, composedTime, sentTime, receivedTime);
+    DownloadFeedUserAlert userAlert = new DownloadFeedUserAlert(alertContext, description, uri);
     node.services().clientCore().getAlerts().register(userAlert);
   }
 
@@ -2238,7 +2237,7 @@ public class DarknetPeerNode extends PeerNode {
 
   /**
    * Darknet nodes *do* export the peer added time. However, it gets cleared on connecting: It is
-   * only kept for never-connected peers so we can see that we haven't had a connection in a long
+   * only kept for never-connected peers, so we can see that we haven't had a connection in a long
    * time and offer to get rid of them.
    */
   @Override
@@ -2283,7 +2282,7 @@ public class DarknetPeerNode extends PeerNode {
   }
 
   /**
-   * Returns whether to route according to the peer's location for a given HTL.
+   * Returns whether to route, according to the peer's location for a given HTL.
    *
    * @param htl hop-to-live value.
    * @return {@code true} unless globally disabled or trust is {@link FRIEND_TRUST#LOW}.

--- a/src/main/java/network/crypta/node/useralerts/BookmarkFeedUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/BookmarkFeedUserAlert.java
@@ -33,8 +33,8 @@ import network.crypta.support.HTMLNode;
  *
  * <pre>{@code
  * // Example: build and render the alert
- * var alert = new BookmarkFeedUserAlert(peer, name, desc,
- *     true, fileNo, uri, composed, sent, received);
+ * var context = new NodeToNodeAlertContext(peer, fileNo, composed, sent, received);
+ * var alert = new BookmarkFeedUserAlert(context, name, desc, true, uri);
  * HTMLNode view = alert.getHTMLText();
  * BookmarkFeed fcp = alert.getFCPMessage();
  * }</pre>
@@ -65,45 +65,34 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
    * strong ownership; the alert may still render correctly even if the peer object is later
    * collected. Times are expressed as epoch milliseconds as provided by the caller.
    *
-   * @param sourcePeerNode the originating {@link DarknetPeerNode}; held weakly to avoid leaks; may
-   *     be {@code null} by the time the alert is rendered.
+   * @param alertContext bundled peer, file number, and timing metadata for this alert; the peer is
+   *     held weakly to avoid leaks and may be {@code null} by the time the alert is rendered
    * @param name the human-readable bookmark name to display; should be concise and safe for UI
-   *     titles; must not be {@code null}.
+   *     titles; must not be {@code null}
    * @param description optional longer description text; may be {@code null} or empty; newline
-   *     characters are preserved and rendered as line breaks.
+   *     characters are preserved and rendered as line breaks
    * @param hasAnActivelink whether an explicit “add bookmark” action should be presented in the
-   *     HTML rendering; influences the presence of the actionable link parameter.
-   * @param fileNumber per-peer temporary file number to remove when the alert is dismissed; used
-   *     only by {@link #onDismiss()} for cleanup.
+   *     HTML rendering; influences the presence of the actionable link parameter
    * @param uri the {@link FreenetURI} of the bookmark target; must be a valid, fully-formed URI
-   *     string understood by clients.
-   * @param composed timestamp when the message was composed on the sender, in epoch milliseconds;
-   *     informational only.
-   * @param sent timestamp when the message was transmitted by the sender, in epoch milliseconds;
-   *     informational only.
-   * @param received timestamp when the message was received locally, in epoch milliseconds; used by
-   *     display logic to order or age alerts.
+   *     string understood by clients
    */
   public BookmarkFeedUserAlert(
-      DarknetPeerNode sourcePeerNode,
+      NodeToNodeAlertContext alertContext,
       String name,
       String description,
       boolean hasAnActivelink,
-      int fileNumber,
-      FreenetURI uri,
-      long composed,
-      long sent,
-      long received) {
+      FreenetURI uri) {
     super(
         true, null, null, UserAlert.MINOR, true, new AbstractUserAlert.DismissOptions(null, true));
+    DarknetPeerNode sourcePeerNode = alertContext.sourcePeerNode();
     this.name = name;
     this.description = description;
     this.uri = uri;
-    this.fileNumber = fileNumber;
+    this.fileNumber = alertContext.fileNumber();
     this.hasAnActivelink = hasAnActivelink;
-    this.composed = composed;
-    this.sent = sent;
-    this.received = received;
+    this.composed = alertContext.composedTime();
+    this.sent = alertContext.sentTime();
+    this.received = alertContext.receivedTime();
     this.peerRef = sourcePeerNode.getWeakRef();
     this.sourceNodeName = sourcePeerNode.getName();
   }
@@ -129,8 +118,8 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
    * peer’s display name, the bookmark URI, and the optional description when provided. Newlines in
    * the description are preserved to keep author-intended formatting. This output is
    * audience-focused and primarily intended for display; consumers that need structured data should
-   * prefer {@link #getFCPMessage()} instead of parsing this text. The method does not alter object
-   * state and can be called multiple times without side effects.
+   * prefer {@link #getFCPMessage()} instead of parsing this text. The method does not alter the
+   * object state and can be called multiple times without side effects.
    *
    * @return a human-readable, plain-text body with stable keys and values; never {@code null},
    *     though the description section may be omitted when empty.
@@ -205,7 +194,7 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
    * item that removes the alert from view and is kept short to fit compact controls. The label is
    * resolved via the alert’s localization keys to match the rest of the UI.
    *
-   * @return a localized, single-word or short-phrase label for the dismiss button; never {@code
+   * @return a localized, single-word or short-phrase label for the Dismiss button; never {@code
    *     null}.
    */
   @Override
@@ -223,9 +212,9 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
   }
 
   /**
-   * Performs cleanup when the alert is dismissed by the user. If the originating peer is still
-   * available, the method requests removal of the associated temporary peer data file identified by
-   * {@code fileNumber}. If the peer is gone, the method silently does nothing.
+   * Performs cleanup when the user dismisses the alert. If the originating peer is still available,
+   * the method requests removal of the associated temporary peer data file identified by {@code
+   * fileNumber}. If the peer is gone, the method silently does nothing.
    */
   @Override
   public void onDismiss() {

--- a/src/main/java/network/crypta/node/useralerts/DownloadFeedUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/DownloadFeedUserAlert.java
@@ -57,36 +57,22 @@ public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNo
    * {@code fileNumber} identifies peer-scoped temporary metadata that can be deleted on dismissal.
    * Time fields are forwarded as-is to clients; this class does not interpret their units.
    *
-   * @param sourcePeerNode the originating darknet peer; referenced weakly and queried for a name;
-   *     must not be {@code null} when constructing the alert
+   * @param alertContext bundled peer, file number, and timing metadata for this alert
    * @param description optional human-readable description; may be {@code null} or empty;
    *     multi-line values are split on {@code \n} when rendered as HTML
-   * @param fileNumber peer-local identifier for auxiliary data associated with this alert; used
-   *     during {@link #onDismiss()} to request cleanup
    * @param uri the target content address to present to the user; must not be {@code null}; the
    *     instance is not modified
-   * @param composed timestamp provided by the sender for when the entry was composed; opaque to
-   *     this class and preserved verbatim
-   * @param sent timestamp provided by the sender for when the entry was sent; opaque to this class
-   *     and preserved verbatim
-   * @param received timestamp for when the local node received the entry; opaque and preserved
-   *     verbatim
    */
   public DownloadFeedUserAlert(
-      DarknetPeerNode sourcePeerNode,
-      String description,
-      int fileNumber,
-      FreenetURI uri,
-      long composed,
-      long sent,
-      long received) {
+      NodeToNodeAlertContext alertContext, String description, FreenetURI uri) {
     super(true, null, null, UserAlert.MINOR, true, new DismissOptions(null, true));
+    DarknetPeerNode sourcePeerNode = alertContext.sourcePeerNode();
     this.description = description;
     this.uri = uri;
-    this.fileNumber = fileNumber;
-    this.composed = composed;
-    this.sent = sent;
-    this.received = received;
+    this.fileNumber = alertContext.fileNumber();
+    this.composed = alertContext.composedTime();
+    this.sent = alertContext.sentTime();
+    this.received = alertContext.receivedTime();
     this.peerRef = sourcePeerNode.getWeakRef();
     this.sourceNodeName = sourcePeerNode.getName();
   }

--- a/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
@@ -56,44 +56,31 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
   /**
    * Creates a new alert for a Node-to-Node text message with an explicit message identifier.
    *
-   * <p>All timestamps are expressed as milliseconds since the Unix epoch. The {@code fileNumber}
-   * refers to a peer-specific extra data file used for persistence and cleanup on dismissal. The
-   * supplied {@code sourcePeerNode} is stored as a {@link WeakReference} to avoid retaining peers
-   * beyond their lifetime.
+   * <p>All timestamps have been expressed as milliseconds since the Unix epoch. The {@code
+   * fileNumber} refers to a peer-specific extra data file used for persistence and cleanup on
+   * dismissal. The supplied {@code sourcePeerNode} is stored as a {@link WeakReference} to avoid
+   * retaining peers beyond their lifetime.
    *
    * <pre>{@code
    * // Example: construct an alert from an inbound message
-   * var alert = new N2NTMUserAlert(peer, text, fileNo, tComposed, tSent, tReceived, msgId);
+   * var context = new NodeToNodeAlertContext(peer, fileNo, tComposed, tSent, tReceived);
+   * var alert = new N2NTMUserAlert(context, text, msgId);
    * }</pre>
    *
-   * @param sourcePeerNode non-null darknet peer that originated the message; used for display and
-   *     dismissal logic when still reachable
+   * @param alertContext bundled peer, file number, and timing metadata for this alert
    * @param message full message text; may contain newlines that will be preserved in HTML output
-   * @param fileNumber identifier of the extra peer data file to delete on dismissal; non-negative
-   *     values are expected by the caller
-   * @param composedTime time the sender composed the message, in epoch milliseconds; may predate
-   *     network transmission
-   * @param sentTime time the sender sent the message, in epoch milliseconds; used for display only
-   * @param receivedTime local receipt time in epoch milliseconds; also used as {@link
-   *     #getUpdatedTime()} for alert freshness
    * @param msgid opaque message identifier supplied by the sender or transport; negative values
    *     indicate no identifier was provided
    */
-  public N2NTMUserAlert(
-      DarknetPeerNode sourcePeerNode,
-      String message,
-      int fileNumber,
-      long composedTime,
-      long sentTime,
-      long receivedTime,
-      long msgid) {
+  public N2NTMUserAlert(NodeToNodeAlertContext alertContext, String message, long msgid) {
     super(
         true, null, null, UserAlert.MINOR, true, new AbstractUserAlert.DismissOptions(null, true));
+    DarknetPeerNode sourcePeerNode = alertContext.sourcePeerNode();
     this.messageText = message;
-    this.fileNumber = fileNumber;
-    this.composedTime = composedTime;
-    this.sentTime = sentTime;
-    this.receivedTime = receivedTime;
+    this.fileNumber = alertContext.fileNumber();
+    this.composedTime = alertContext.composedTime();
+    this.sentTime = alertContext.sentTime();
+    this.receivedTime = alertContext.receivedTime();
     this.peerRef = sourcePeerNode.getWeakRef();
     this.sourceNodeName = sourcePeerNode.getName();
     this.sourcePeer = sourcePeerNode.getPeer().toString();
@@ -106,25 +93,11 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
    * <p>This constructor is equivalent to the full constructor with {@code msgid} set to {@code -1}.
    * All other parameters have the same meaning and units.
    *
-   * @param sourcePeerNode non-null darknet peer that originated the message; used for display and
-   *     dismissal logic when still reachable
+   * @param alertContext bundled peer, file number, and timing metadata for this alert
    * @param message full message text; may contain newlines that will be preserved in HTML output
-   * @param fileNumber identifier of the extra peer data file to delete on dismissal; non-negative
-   *     values are expected by the caller
-   * @param composedTime time the sender composed the message, in epoch milliseconds; may predate
-   *     network transmission
-   * @param sentTime time the sender sent the message, in epoch milliseconds; used for display only
-   * @param receivedTime local receipt time in epoch milliseconds; also used as {@link
-   *     #getUpdatedTime()} for alert freshness
    */
-  public N2NTMUserAlert(
-      DarknetPeerNode sourcePeerNode,
-      String message,
-      int fileNumber,
-      long composedTime,
-      long sentTime,
-      long receivedTime) {
-    this(sourcePeerNode, message, fileNumber, composedTime, sentTime, receivedTime, -1);
+  public N2NTMUserAlert(NodeToNodeAlertContext alertContext, String message) {
+    this(alertContext, message, -1);
   }
 
   /**
@@ -215,7 +188,7 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
   }
 
   /**
-   * Returns the localized label to use on the dismiss button for this alert.
+   * Returns the localized label to use on the Dismiss button for this alert.
    *
    * @return a short action string such as "delete"; never {@code null}
    */
@@ -232,14 +205,12 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
     return NodeL10n.getBase().getString(L10N_PREFIX + key, patterns, values);
   }
 
-  // No 3-arg l10n helper: the only usage is the fixed pattern in getShortText()
-
   /**
    * Handles alert dismissal by removing the associated extra peer data file when the source peer is
    * still available.
    *
-   * <p>If the peer has already been collected or disconnected, the operation becomes a no-op. No
-   * exceptions are thrown by this method.
+   * <p>If the peer has already been collected or disconnected, the operation becomes a no-op. This
+   * method throws no exceptions.
    */
   @Override
   public void onDismiss() {
@@ -335,7 +306,7 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
   }
 
   /**
-   * Indicates whether the alert remains valid for display, and refreshes cached peer display data
+   * Indicates whether the alert remains valid for display and refreshes cached peer display data
    * when possible.
    *
    * <p>This implementation always returns {@code true}. When the peer reference is still alive, the

--- a/src/main/java/network/crypta/node/useralerts/NodeToNodeAlertContext.java
+++ b/src/main/java/network/crypta/node/useralerts/NodeToNodeAlertContext.java
@@ -1,0 +1,46 @@
+package network.crypta.node.useralerts;
+
+import network.crypta.node.DarknetPeerNode;
+
+/**
+ * Bundles peer and timing metadata for node-to-node alert creation.
+ *
+ * <p>This record captures the minimal state required to build user alerts that represent
+ * node-to-node feeds or messages. It keeps a reference to the originating {@link DarknetPeerNode},
+ * the peer-local file number used for cleanup on dismissal, and the trio of timestamps supplied by
+ * the sender and receiver. Callers typically create one context per incoming message and pass it to
+ * alert constructors so the alert implementations can remain focused on presentation logic instead
+ * of repetitive wiring.
+ *
+ * <p>The record is an immutable value carrier: it does not validate input, perform I/O, or adjust
+ * timestamps. Consumers should treat the contained values as verbatim metadata. The peer reference
+ * is expected to remain live while alerts are rendered, but no additional synchronization is
+ * performed here. This type is therefore thread-safe for sharing across threads as long as the
+ * referenced peer is managed safely elsewhere.
+ *
+ * <ul>
+ *   <li>Groups message timing metadata with its source peer.
+ *   <li>Provides a stable, reuse-oriented parameter set for alert constructors.
+ *   <li>Leaves validation and lifecycle decisions to the alert implementations.
+ * </ul>
+ *
+ * @param sourcePeerNode originating darknet peer for the alert; must be non-null and is expected to
+ *     remain valid while the alert reads its name or reference
+ * @param fileNumber peer-local identifier of extra data to delete on dismissal; non-negative values
+ *     are typical and are treated as opaque by this record
+ * @param composedTime sender-provided composition time in epoch milliseconds; use {@code -1} when
+ *     the time is unknown or intentionally omitted
+ * @param sentTime sender-provided transmission time in epoch milliseconds; use {@code -1} when
+ *     unavailable or not meaningful for the feed
+ * @param receivedTime local receipt time in epoch milliseconds; often used as the alert updated
+ *     time and should reflect when the data arrived
+ * @see BookmarkFeedUserAlert
+ * @see DownloadFeedUserAlert
+ * @see N2NTMUserAlert
+ */
+public record NodeToNodeAlertContext(
+    DarknetPeerNode sourcePeerNode,
+    int fileNumber,
+    long composedTime,
+    long sentTime,
+    long receivedTime) {}

--- a/src/test/java/network/crypta/node/useralerts/BookmarkFeedUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/BookmarkFeedUserAlertTest.java
@@ -16,7 +16,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import network.crypta.clients.fcp.BookmarkFeed;
 import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.HTMLNode;
@@ -29,13 +28,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @SuppressWarnings("java:S100") // descriptive test method names
 class BookmarkFeedUserAlertTest {
 
+  private static NodeToNodeAlertContext alertContext(
+      DarknetPeerNode peer, int fileNumber, long composed, long sent, long received) {
+    return new NodeToNodeAlertContext(peer, fileNumber, composed, sent, received);
+  }
+
   @Test
   void title_text_html_whenDescriptionPresent_expectLocalizedAndStructured()
       throws MalformedURLException {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Alice");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
 
     String name = "My Site";
     String description = "Line1\nLine2";
@@ -43,7 +47,7 @@ class BookmarkFeedUserAlertTest {
     FreenetURI uri = new FreenetURI("KSK@mysite");
     BookmarkFeedUserAlert alert =
         new BookmarkFeedUserAlert(
-            peer, name, description, hasAnActivelink, 42, uri, 1111L, 2222L, 3333L);
+            alertContext(peer, 42, 1111L, 2222L, 3333L), name, description, hasAnActivelink, uri);
 
     // Act
     String title = alert.getTitle();
@@ -108,12 +112,12 @@ class BookmarkFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Bob");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
 
     String name = "Site";
     FreenetURI uri = new FreenetURI("KSK@file.txt");
     BookmarkFeedUserAlert alert =
-        new BookmarkFeedUserAlert(peer, name, null, false, 7, uri, 1L, -1L, -1L);
+        new BookmarkFeedUserAlert(alertContext(peer, 7, 1L, -1L, -1L), name, null, false, uri);
 
     // Act
     String text = alert.getText();
@@ -123,7 +127,7 @@ class BookmarkFeedUserAlertTest {
     assertEquals("Name: " + name + "\n" + "URI: " + uri + "\n", text);
     assertEquals("div", html.getName());
     var children = html.getChildren();
-    // Only the two anchors should be present when description is null
+    // Only the two anchors should be present when the description is null
     assertEquals(2, children.size());
     assertEquals("a", children.get(0).getName());
     assertEquals("a", children.get(1).getName());
@@ -134,10 +138,10 @@ class BookmarkFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Carol");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
     FreenetURI uri = new FreenetURI("KSK@x.txt");
     BookmarkFeedUserAlert alert =
-        new BookmarkFeedUserAlert(peer, "X", "", false, 3, uri, -1L, -1L, -1L);
+        new BookmarkFeedUserAlert(alertContext(peer, 3, -1L, -1L, -1L), "X", "", false, uri);
 
     // Act
     HTMLNode html = alert.getHTMLText();
@@ -153,11 +157,12 @@ class BookmarkFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Dave");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
     FreenetURI uri = new FreenetURI("KSK@offer.txt");
     int fileNumber = 99;
     BookmarkFeedUserAlert alert =
-        new BookmarkFeedUserAlert(peer, "Title", "desc", true, fileNumber, uri, 10L, 20L, 30L);
+        new BookmarkFeedUserAlert(
+            alertContext(peer, fileNumber, 10L, 20L, 30L), "Title", "desc", true, uri);
 
     // Act
     alert.onDismiss();
@@ -172,10 +177,10 @@ class BookmarkFeedUserAlertTest {
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Eve");
     // The weak reference resolves to null
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(null));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(null));
     FreenetURI uri = new FreenetURI("KSK@abc.txt");
     BookmarkFeedUserAlert alert =
-        new BookmarkFeedUserAlert(peer, "S", null, false, 5, uri, -1L, -1L, -1L);
+        new BookmarkFeedUserAlert(alertContext(peer, 5, -1L, -1L, -1L), "S", null, false, uri);
 
     // Act
     alert.onDismiss();
@@ -189,10 +194,10 @@ class BookmarkFeedUserAlertTest {
     // Arrange: first call returns initial name (constructor), second call returns updated name
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Alice", "Mallory");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
     FreenetURI uri = new FreenetURI("KSK@z.txt");
     BookmarkFeedUserAlert alert =
-        new BookmarkFeedUserAlert(peer, "S", null, false, 1, uri, -1L, -1L, -1L);
+        new BookmarkFeedUserAlert(alertContext(peer, 1, -1L, -1L, -1L), "S", null, false, uri);
 
     // Sanity: initial title uses first name
     assertEquals("Alice recommends you a freesite", alert.getTitle());
@@ -210,14 +215,14 @@ class BookmarkFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Frank");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
     FreenetURI uri = new FreenetURI("KSK@data.bin");
     String description = "hello"; // 5 bytes in UTF-8
     String name = "Title";
     boolean hasAnActivelink = false;
     BookmarkFeedUserAlert alert =
         new BookmarkFeedUserAlert(
-            peer, name, description, hasAnActivelink, 11, uri, 123L, -1L, 789L);
+            alertContext(peer, 11, 123L, -1L, 789L), name, description, hasAnActivelink, uri);
 
     long updatedTime = alert.getUpdatedTime();
     String expectedTitle = alert.getTitle();
@@ -248,7 +253,8 @@ class BookmarkFeedUserAlertTest {
     assertNull(fs.get("TimeSent"));
     assertEquals(Long.toString(789L), fs.get("TimeReceived"));
 
-    // DataLength is sum of bucket sizes; at least check it's >= text length + description length
+    // DataLength is the sum of bucket sizes; at least check it's >= text length + description
+    // length
     int textLen = alert.getText().getBytes(StandardCharsets.UTF_8).length;
     int dataLen = Integer.parseInt(fs.get("DataLength"));
     assertEquals(textLen + descriptionLen, dataLen);

--- a/src/test/java/network/crypta/node/useralerts/DownloadFeedUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/DownloadFeedUserAlertTest.java
@@ -16,7 +16,6 @@ import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.URIFeedMessage;
-import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.HTMLNode;
@@ -29,18 +28,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @SuppressWarnings("java:S100") // descriptive test method names
 class DownloadFeedUserAlertTest {
 
+  private static NodeToNodeAlertContext alertContext(
+      DarknetPeerNode peer, int fileNumber, long composed, long sent, long received) {
+    return new NodeToNodeAlertContext(peer, fileNumber, composed, sent, received);
+  }
+
   @Test
   void title_text_html_whenDescriptionPresent_expectLocalizedAndStructured()
       throws MalformedURLException {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Alice");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
 
     FreenetURI uri = new FreenetURI("KSK@readme.txt");
     String description = "Line1\nLine2";
     DownloadFeedUserAlert alert =
-        new DownloadFeedUserAlert(peer, description, 42, uri, 1111L, 2222L, 3333L);
+        new DownloadFeedUserAlert(alertContext(peer, 42, 1111L, 2222L, 3333L), description, uri);
 
     // Act
     String title = alert.getTitle();
@@ -89,10 +93,11 @@ class DownloadFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Bob");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
 
     FreenetURI uri = new FreenetURI("KSK@file.txt");
-    DownloadFeedUserAlert alert = new DownloadFeedUserAlert(peer, null, 7, uri, 1L, -1L, -1L);
+    DownloadFeedUserAlert alert =
+        new DownloadFeedUserAlert(alertContext(peer, 7, 1L, -1L, -1L), null, uri);
 
     // Act
     String text = alert.getText();
@@ -102,7 +107,7 @@ class DownloadFeedUserAlertTest {
     assertEquals("URI: " + uri + "\n", text);
     assertEquals("div", html.getName());
     var children = html.getChildren();
-    // Only anchor should be present when description is null
+    // Only anchor should be present when the description is null
     assertEquals(1, children.size());
     assertEquals("a", children.getFirst().getName());
   }
@@ -112,14 +117,15 @@ class DownloadFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Carol");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
     FreenetURI uri = new FreenetURI("KSK@x.txt");
-    DownloadFeedUserAlert alert = new DownloadFeedUserAlert(peer, "", 3, uri, -1L, -1L, -1L);
+    DownloadFeedUserAlert alert =
+        new DownloadFeedUserAlert(alertContext(peer, 3, -1L, -1L, -1L), "", uri);
 
     // Act
     HTMLNode html = alert.getHTMLText();
 
-    // Assert: only the anchor element present
+    // Assert: only the anchor element presents
     assertEquals(1, html.getChildren().size());
     assertEquals("a", html.getChildren().getFirst().getName());
   }
@@ -129,11 +135,11 @@ class DownloadFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Dave");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
     FreenetURI uri = new FreenetURI("KSK@offer.txt");
     int fileNumber = 99;
     DownloadFeedUserAlert alert =
-        new DownloadFeedUserAlert(peer, "desc", fileNumber, uri, 10L, 20L, 30L);
+        new DownloadFeedUserAlert(alertContext(peer, fileNumber, 10L, 20L, 30L), "desc", uri);
 
     // Act
     alert.onDismiss();
@@ -148,9 +154,10 @@ class DownloadFeedUserAlertTest {
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Eve");
     // The weak reference resolves to null
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(null));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(null));
     FreenetURI uri = new FreenetURI("KSK@abc.txt");
-    DownloadFeedUserAlert alert = new DownloadFeedUserAlert(peer, null, 5, uri, -1L, -1L, -1L);
+    DownloadFeedUserAlert alert =
+        new DownloadFeedUserAlert(alertContext(peer, 5, -1L, -1L, -1L), null, uri);
 
     // Act
     alert.onDismiss();
@@ -164,9 +171,10 @@ class DownloadFeedUserAlertTest {
     // Arrange: first call returns initial name (constructor), second call returns updated name
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Alice", "Mallory");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
     FreenetURI uri = new FreenetURI("KSK@z.txt");
-    DownloadFeedUserAlert alert = new DownloadFeedUserAlert(peer, null, 1, uri, -1L, -1L, -1L);
+    DownloadFeedUserAlert alert =
+        new DownloadFeedUserAlert(alertContext(peer, 1, -1L, -1L, -1L), null, uri);
 
     // Sanity: initial title uses first name
     assertEquals("Alice recommends you a file", alert.getTitle());
@@ -184,11 +192,11 @@ class DownloadFeedUserAlertTest {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Frank");
-    when(peer.getWeakRef()).thenReturn(new WeakReference<PeerContext>(peer));
+    when(peer.getWeakRef()).thenReturn(new WeakReference<>(peer));
     FreenetURI uri = new FreenetURI("KSK@data.bin");
     String description = "hello"; // 5 bytes in UTF-8
     DownloadFeedUserAlert alert =
-        new DownloadFeedUserAlert(peer, description, 11, uri, 123L, -1L, 789L);
+        new DownloadFeedUserAlert(alertContext(peer, 11, 123L, -1L, 789L), description, uri);
 
     long updatedTime = alert.getUpdatedTime();
     String expectedTitle = alert.getTitle();
@@ -217,7 +225,8 @@ class DownloadFeedUserAlertTest {
     assertNull(fs.get("TimeSent"));
     assertEquals(Long.toString(789L), fs.get("TimeReceived"));
 
-    // DataLength is sum of bucket sizes; at least check it's >= text length + description length
+    // DataLength is the sum of bucket sizes; at least check it's >= text length + description
+    // length
     int textLen = alert.getText().getBytes(StandardCharsets.UTF_8).length;
     int dataLen = Integer.parseInt(fs.get("DataLength"));
     assertEquals(textLen + descriptionLen, dataLen);

--- a/src/test/java/network/crypta/node/useralerts/N2NTMUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/N2NTMUserAlertTest.java
@@ -15,7 +15,6 @@ import java.util.TimeZone;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.TextFeedMessage;
 import network.crypta.io.comm.Peer;
-import network.crypta.io.comm.PeerContext;
 import network.crypta.l10n.BaseL10n.LANGUAGE;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
@@ -30,6 +29,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100") // Allow method names like method_whenCondition_expectOutcome
 class N2NTMUserAlertTest {
+
+  private NodeToNodeAlertContext alertContext(
+      int fileNumber, long composedTime, long sentTime, long receivedTime) {
+    return new NodeToNodeAlertContext(
+        mockPeerNode, fileNumber, composedTime, sentTime, receivedTime);
+  }
 
   @Mock private DarknetPeerNode mockPeerNode;
 
@@ -57,11 +62,11 @@ class N2NTMUserAlertTest {
   void getTitle_whenInitialized_expectLocalizedTitle() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 
-    N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "Hello", 7, 0L, 1_000L, 2_000L, 123L);
+    N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(7, 0L, 1_000L, 2_000L), "Hello", 123L);
 
     // Act
     String title = alert.getTitle();
@@ -77,11 +82,11 @@ class N2NTMUserAlertTest {
   void getText_and_getShortText_whenInitialized_expectHeaderAndSummary() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 
-    N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "Hello", 7, 0L, 1_000L, 2_000L, 123L);
+    N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(7, 0L, 1_000L, 2_000L), "Hello", 123L);
 
     // Act
     String text = alert.getText();
@@ -99,12 +104,12 @@ class N2NTMUserAlertTest {
   void getHTMLText_whenPeerPresent_expectReplyLinkAndLineBreaks() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 
     String message = "Line1\nLine2";
-    N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, message, 42, 0L, 1_000L, 2_000L, 999L);
+    N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(42, 0L, 1_000L, 2_000L), message, 999L);
 
     // Act
     HTMLNode html = alert.getHTMLText();
@@ -123,10 +128,10 @@ class N2NTMUserAlertTest {
   void getHTMLText_whenPeerMissing_expectNoReplyLink() throws Exception {
     // Arrange
     Peer peer = new Peer("example.net:4321", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(null));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(null));
     when(mockPeerNode.getName()).thenReturn("Bob");
     when(mockPeerNode.getPeer()).thenReturn(peer);
-    N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "Msg", 5, 0L, 1_000L, 2_000L, 111L);
+    N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(5, 0L, 1_000L, 2_000L), "Msg", 111L);
 
     // Act
     String rendered = alert.getHTMLText().generate();
@@ -142,10 +147,10 @@ class N2NTMUserAlertTest {
   void onDismiss_whenPeerPresent_expectDeleteCalled() throws Exception {
     // Arrange
     Peer peer = new Peer("node.local:5555", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Carol");
     when(mockPeerNode.getPeer()).thenReturn(peer);
-    N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "X", 77, 0L, 1_000L, 2_000L, 1L);
+    N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(77, 0L, 1_000L, 2_000L), "X", 1L);
 
     // Act
     alert.onDismiss();
@@ -158,10 +163,10 @@ class N2NTMUserAlertTest {
   void onDismiss_whenPeerMissing_expectDeleteNotCalled() throws Exception {
     // Arrange
     Peer peer = new Peer("node.local:5555", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(null));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(null));
     when(mockPeerNode.getName()).thenReturn("Carol");
     when(mockPeerNode.getPeer()).thenReturn(peer);
-    N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "X", 88, 0L, 1_000L, 2_000L, 1L);
+    N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(88, 0L, 1_000L, 2_000L), "X", 1L);
 
     // Act
     alert.onDismiss();
@@ -174,7 +179,7 @@ class N2NTMUserAlertTest {
   void getFCPMessage_whenConstructed_expectFieldSetContainsSourceAndTimes() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 
@@ -184,7 +189,7 @@ class N2NTMUserAlertTest {
     String messageText = "Hello";
 
     N2NTMUserAlert alert =
-        new N2NTMUserAlert(mockPeerNode, messageText, 7, composed, sent, received, 123L);
+        new N2NTMUserAlert(alertContext(7, composed, sent, received), messageText, 123L);
 
     // Act
     FCPMessage fcp = alert.getFCPMessage();
@@ -205,10 +210,10 @@ class N2NTMUserAlertTest {
   void getFCPMessage_whenMessageNull_expectZeroLengthMessageTextBucket() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
-    N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, null, 7, 0L, 1_000L, 2_000L, 123L);
+    N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(7, 0L, 1_000L, 2_000L), null, 123L);
 
     // Act
     FCPMessage fcp = alert.getFCPMessage();
@@ -221,10 +226,10 @@ class N2NTMUserAlertTest {
   void isValid_whenPeerUpdates_expectTitleReflectsNewNameAndPeer() throws Exception {
     // Arrange
     Peer peer1 = new Peer("old.example:100", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("OldName");
     when(mockPeerNode.getPeer()).thenReturn(peer1);
-    N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "Msg", 3, 0L, 1_000L, 2_000L, 55L);
+    N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(3, 0L, 1_000L, 2_000L), "Msg", 55L);
 
     // Sanity check initial title
     assertTrue(alert.getTitle().contains("OldName"));
@@ -251,12 +256,12 @@ class N2NTMUserAlertTest {
   void constructor_withoutMsgId_expectMsgIdNegativeOne() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
-    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<PeerContext>(mockPeerNode));
+    when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
     when(mockPeerNode.getName()).thenReturn("Alice");
     when(mockPeerNode.getPeer()).thenReturn(peer);
 
     // Act
-    N2NTMUserAlert alert = new N2NTMUserAlert(mockPeerNode, "Hello", 1, 0L, 1L, 2L);
+    N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(1, 0L, 1L, 2L), "Hello");
 
     // Assert
     assertEquals(-1L, alert.getMsgid());


### PR DESCRIPTION
## Summary
- Introduce `NodeToNodeAlertContext` to group peer and timing metadata for node-to-node alerts.
- Update N2N alert constructors and `DarknetPeerNode` handlers to use the shared context.
- Adjust user alert tests to build alerts from the shared context.

## Testing
- `./gradlew test`
- `./gradlew test --tests "network.crypta.node.useralerts.N2NTMUserAlertTest"`
