### PR TITLE
refactor(useralerts): bundle event details

### DIFF
--- a/.opencode/skills/cryptad-build-test/SKILL.md
+++ b/.opencode/skills/cryptad-build-test/SKILL.md
@@ -29,6 +29,7 @@ Use this skill when you need to:
 - The build prints the SHA-256 of `build/libs/cryptad.jar`.
 
 ## Testing
+Always give enough running time (more than 15 minutes) for Gradle to complete tests.
 - Run all tests:
   - `./gradlew test`
 - Run one test class:

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -4840,16 +4840,14 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
       public GetCompletedEvent(String identifier, FreenetURI uri, long size) {
         super(
-            Type.GET_COMPLETED,
-            true,
-            null,
-            null,
-            null,
-            null,
-            UserAlert.MINOR,
-            true,
-            NodeL10n.getBase().getString(USER_ALERT_HIDE),
-            true,
+            new UserEventDetails(
+                Type.GET_COMPLETED,
+                true,
+                null,
+                Body.of(null, null, null),
+                UserAlert.MINOR,
+                true,
+                new DismissOptions(NodeL10n.getBase().getString(USER_ALERT_HIDE), true)),
             completedGets);
         this.identifier = identifier;
         this.uri = uri;
@@ -4916,16 +4914,14 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
       public PutCompletedEvent(String identifier, FreenetURI uri, long size) {
         super(
-            Type.PUT_COMPLETED,
-            true,
-            null,
-            null,
-            null,
-            null,
-            UserAlert.MINOR,
-            true,
-            NodeL10n.getBase().getString(USER_ALERT_HIDE),
-            true,
+            new UserEventDetails(
+                Type.PUT_COMPLETED,
+                true,
+                null,
+                Body.of(null, null, null),
+                UserAlert.MINOR,
+                true,
+                new DismissOptions(NodeL10n.getBase().getString(USER_ALERT_HIDE), true)),
             completedPuts);
         this.identifier = identifier;
         this.uri = uri;
@@ -4992,16 +4988,14 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
       public PutDirCompletedEvent(String identifier, FreenetURI uri, long size, int files) {
         super(
-            Type.PUT_DIR_COMPLETED,
-            true,
-            null,
-            null,
-            null,
-            null,
-            UserAlert.MINOR,
-            true,
-            NodeL10n.getBase().getString(USER_ALERT_HIDE),
-            true,
+            new UserEventDetails(
+                Type.PUT_DIR_COMPLETED,
+                true,
+                null,
+                Body.of(null, null, null),
+                UserAlert.MINOR,
+                true,
+                new DismissOptions(NodeL10n.getBase().getString(USER_ALERT_HIDE), true)),
             completedPutDirs);
         this.identifier = identifier;
         this.uri = uri;

--- a/src/main/java/network/crypta/node/useralerts/AbstractUserEvent.java
+++ b/src/main/java/network/crypta/node/useralerts/AbstractUserEvent.java
@@ -34,6 +34,30 @@ package network.crypta.node.useralerts;
  */
 public abstract class AbstractUserEvent extends AbstractUserAlert implements UserEvent {
 
+  /**
+   * Bundles presentation, severity, and dismissal metadata for user events.
+   *
+   * <p>This record consolidates parameters commonly supplied when constructing events, including
+   * the {@link UserEvent.Type}, display content, priority, validity, and dismissal options.
+   *
+   * @param eventType categorical type used for grouping and suppression decisions
+   * @param userCanDismiss whether a user interface should show a Dismiss control
+   * @param title localized event title; may be {@code null}
+   * @param body bundle containing full text, short text, and optional HTML fragment; may be {@code
+   *     null}
+   * @param priorityClass severity class such as {@link UserAlert#CRITICAL_ERROR}
+   * @param valid initial visibility flag
+   * @param dismissOptions label and unregister policy for dismissal
+   */
+  public record UserEventDetails(
+      Type eventType,
+      boolean userCanDismiss,
+      String title,
+      Body body,
+      short priorityClass,
+      boolean valid,
+      DismissOptions dismissOptions) {}
+
   private Type eventType;
 
   /**
@@ -79,6 +103,25 @@ public abstract class AbstractUserEvent extends AbstractUserAlert implements Use
       DismissOptions dismissOptions) {
     super(userCanDismiss, title, body, priorityClass, valid, dismissOptions);
     this.eventType = eventType;
+  }
+
+  /**
+   * Creates an event using a consolidated parameter bundle.
+   *
+   * <p>This constructor mirrors the explicit argument constructor but accepts a {@link
+   * UserEventDetails} so callers can share common parameter groupings across event types.
+   *
+   * @param details bundled event presentation and dismissal metadata
+   */
+  protected AbstractUserEvent(UserEventDetails details) {
+    this(
+        details.eventType(),
+        details.userCanDismiss(),
+        details.title(),
+        details.body(),
+        details.priorityClass(),
+        details.valid(),
+        details.dismissOptions());
   }
 
   /**

--- a/src/main/java/network/crypta/node/useralerts/StoringUserEvent.java
+++ b/src/main/java/network/crypta/node/useralerts/StoringUserEvent.java
@@ -29,7 +29,7 @@ import network.crypta.support.HTMLNode;
  * <ul>
  *   <li>Aggregates HTML for all stored events in the order reported by the map.
  *   <li>Builds a minimal {@code FeedMessage} from the plain-text representation.
- *   <li>Removes all events on dismiss, invoking per-event cleanup hooks.
+ *   <li>Removes all events on dismissing, invoking per-event cleanup hooks.
  * </ul>
  *
  * @param <T> the concrete subtype, enabling type-safe storage of homogeneous events
@@ -53,7 +53,7 @@ public abstract class StoringUserEvent<T extends StoringUserEvent<T>> extends Ab
    * Convenience constructor for subclasses that supply only the storage map and configure the
    * remaining metadata elsewhere.
    *
-   * <p>The supplied map is not defensively copied. This instance will synchronize on it when
+   * <p>The supplied map is not defensively copied. This instance will synchronize with it when
    * iterating or removing elements. Passing a non-null, consistently used map is required for
    * correct behavior.
    *
@@ -66,46 +66,13 @@ public abstract class StoringUserEvent<T extends StoringUserEvent<T>> extends Ab
   }
 
   /**
-   * Full constructor used by subclasses to populate user-visible metadata and supply the event
-   * collection.
+   * Constructor that accepts a consolidated event description and the backing map.
    *
-   * <p>All arguments are consumed as-is and are not validated beyond normal Java nullability
-   * contracts. The {@code events} map is kept by reference and is used as the synchronization
-   * monitor when aggregating HTML, checking validity, and dismissing entries.
-   *
-   * @param eventType the high-level event type used by the alert system for categorization
-   * @param userCanDismiss whether the UI should expose a dismiss control for the user
-   * @param title short title shown to users; kept verbatim and may be null when not applicable
-   * @param text plain-text body; used in feed messages; may be null when HTML is provided
-   * @param shortText concise summary variant; shown in compact contexts; may be null
-   * @param htmlText structured HTML body for richer rendering; may be null when text is sufficient
-   * @param priorityClass small integer describing display priority; higher values surface earlier
-   * @param valid initial validity flag; invalid events are typically hidden from presentation
-   * @param dismissButtonText label for the dismiss control; null selects a default provided by UI
-   * @param shouldUnregisterOnDismiss when true, unregisters the source upon dismissal where
-   *     supported
+   * @param details bundled event presentation and dismissal metadata
    * @param events storage of active events; must be non-null; synchronized on by this instance
    */
-  protected StoringUserEvent(
-      Type eventType,
-      boolean userCanDismiss,
-      String title,
-      String text,
-      String shortText,
-      HTMLNode htmlText,
-      short priorityClass,
-      boolean valid,
-      String dismissButtonText,
-      boolean shouldUnregisterOnDismiss,
-      Map<String, T> events) {
-    super(
-        eventType,
-        userCanDismiss,
-        title,
-        Body.of(text, shortText, htmlText),
-        priorityClass,
-        valid,
-        new DismissOptions(dismissButtonText, shouldUnregisterOnDismiss));
+  protected StoringUserEvent(UserEventDetails details, Map<String, T> events) {
+    super(details);
     this.events = events;
   }
 
@@ -200,8 +167,8 @@ public abstract class StoringUserEvent<T extends StoringUserEvent<T>> extends Ab
   /**
    * Cleanup hook invoked when this individual event is being dismissed.
    *
-   * <p>Subclasses should release resources, unregister any listeners, or update related state so
-   * the event can be safely discarded. Implementations should be idempotent and must not throw
+   * <p>Subclasses should release resources, unregister any listeners, or update the related state
+   * so the event can be safely discarded. Implementations should be idempotent and must not throw
    * unchecked exceptions; failures should be handled internally where possible.
    */
   public abstract void onEventDismiss();


### PR DESCRIPTION
## Summary
- bundle common user event metadata into a `UserEventDetails` record
- switch queue completion events to the bundled constructor
- simplify `StoringUserEvent` constructor docs and usage

## Testing
- not run (formatting only via `./gradlew spotlessApply`)