### PR TITLE
refactor(pluginmanager): group plugin description data

### DIFF
--- a/src/main/java/network/crypta/pluginmanager/OfficialPlugins.java
+++ b/src/main/java/network/crypta/pluginmanager/OfficialPlugins.java
@@ -343,20 +343,26 @@ public class OfficialPlugins {
 
     private OfficialPluginDescription createOfficialPluginDescription() {
       return new OfficialPluginDescription(
-          name,
-          group,
-          essential,
-          minimumVersion,
-          recommendedVersion,
-          alwaysFetchLatestVersion,
-          usesXml,
-          uri,
-          deprecated,
-          experimental,
-          advanced,
-          unsupported);
+          new OfficialPluginDefinition(name, group, uri),
+          new OfficialPluginVersionPolicy(
+              minimumVersion, recommendedVersion, alwaysFetchLatestVersion),
+          new OfficialPluginFlags(
+              essential, usesXml, deprecated, experimental, advanced, unsupported));
     }
   }
+
+  public record OfficialPluginDefinition(String name, String group, FreenetURI uri) {}
+
+  public record OfficialPluginVersionPolicy(
+      long minimumVersion, long recommendedVersion, boolean alwaysFetchLatestVersion) {}
+
+  public record OfficialPluginFlags(
+      boolean essential,
+      boolean usesXml,
+      boolean deprecated,
+      boolean experimental,
+      boolean advanced,
+      boolean unsupported) {}
 
   /**
    * Descriptor for an official plugin known to the node.
@@ -414,8 +420,8 @@ public class OfficialPlugins {
     /**
      * Minimum accepted plugin-reported version.
      *
-     * <p>If the plugin is older than this value, loading is rejected. A negative value may be used
-     * by the catalog to indicate that no explicit minimum was configured.
+     * <p>If the plugin is older than this value, loading is rejected. The catalog may use a
+     * negative value to indicate that no explicit minimum was configured.
      */
     public final long minimumVersion;
 
@@ -423,7 +429,7 @@ public class OfficialPlugins {
      * Recommended plugin-reported version.
      *
      * <p>If the currently available plugin is older than this value, the node may download a newer
-     * version in the background. Applying the updated JAR typically happens on restart, or by
+     * version in the background. Applying the updated JAR typically happens on restart or by
      * offering the user an explicit reload action. This behavior is conceptually similar to a
      * USK-based update, but the specific update trigger depends on the plugin's distribution path.
      */
@@ -438,9 +444,9 @@ public class OfficialPlugins {
      * included in the main update USK monitored by {@link PluginJarUpdater}.
      *
      * <p>For plugins distributed via the main update USK, setting this is usually unnecessary
-     * because {@link PluginJarUpdater} will observe and apply updates. For plugins that are not
-     * tracked by the main update USK, re-fetching at startup can be the only automatic opportunity
-     * to observe a newly-inserted USK edition.
+     * because {@link PluginJarUpdater} will observe and apply updates. For plugins, which are not
+     * tracked by the main update, USK re-fetching at startup can be the only automatic opportunity
+     * to observe a newly inserted USK edition.
      */
     public final boolean alwaysFetchLatestVersion;
 
@@ -508,43 +514,35 @@ public class OfficialPlugins {
     public final boolean unsupported;
 
     OfficialPluginDescription(
-        String name,
-        String group,
-        boolean essential,
-        long minVer,
-        long recVer,
-        boolean alwaysFetchLatestVersion,
-        boolean usesXML,
-        FreenetURI uri,
-        boolean deprecated,
-        boolean experimental,
-        boolean advanced,
-        boolean unsupported) {
+        OfficialPluginDefinition definition,
+        OfficialPluginVersionPolicy versionPolicy,
+        OfficialPluginFlags flags) {
 
-      this.name = name;
-      this.group = group;
-      this.essential = essential;
-      this.minimumVersion = minVer;
-      this.recommendedVersion = recVer;
-      this.alwaysFetchLatestVersion = alwaysFetchLatestVersion;
-      this.usesXML = usesXML;
-      this.deprecated = deprecated;
-      this.experimental = experimental;
-      this.advanced = advanced;
-      this.unsupported = unsupported;
+      this.name = definition.name();
+      this.group = definition.group();
+      this.essential = flags.essential();
+      this.minimumVersion = versionPolicy.minimumVersion();
+      this.recommendedVersion = versionPolicy.recommendedVersion();
+      this.alwaysFetchLatestVersion = versionPolicy.alwaysFetchLatestVersion();
+      this.usesXML = flags.usesXml();
+      this.deprecated = flags.deprecated();
+      this.experimental = flags.experimental();
+      this.advanced = flags.advanced();
+      this.unsupported = flags.unsupported();
 
-      if (alwaysFetchLatestVersion && uri != null) {
-        assert (uri.isUSK()) : "Non-USK URIs do not support updates!";
+      FreenetURI resolvedUri = definition.uri();
+      if (this.alwaysFetchLatestVersion && resolvedUri != null) {
+        assert (resolvedUri.isUSK()) : "Non-USK URIs do not support updates!";
 
         // Force fetching the latest edition by setting a negative USK edition.
-        long edition = uri.getSuggestedEdition();
+        long edition = resolvedUri.getSuggestedEdition();
         if (edition >= 0) {
           edition = Math.min(-1, -edition);
         }
-        uri = uri.setSuggestedEdition(edition);
+        resolvedUri = resolvedUri.setSuggestedEdition(edition);
       }
 
-      this.uri = uri;
+      this.uri = resolvedUri;
     }
 
     /**

--- a/src/test/java/network/crypta/pluginmanager/OfficialPluginsTest.java
+++ b/src/test/java/network/crypta/pluginmanager/OfficialPluginsTest.java
@@ -14,7 +14,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 import network.crypta.keys.FreenetURI;
+import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginDefinition;
 import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginDescription;
+import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginFlags;
+import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginVersionPolicy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -133,18 +136,9 @@ class OfficialPluginsTest {
     // Act
     OfficialPluginDescription description =
         new OfficialPluginDescription(
-            "SomePlugin",
-            "someGroup",
-            false,
-            -1,
-            -1,
-            alwaysFetchLatestVersion,
-            false,
-            uri,
-            false,
-            false,
-            false,
-            false);
+            new OfficialPluginDefinition("SomePlugin", "someGroup", uri),
+            new OfficialPluginVersionPolicy(-1, -1, alwaysFetchLatestVersion),
+            new OfficialPluginFlags(false, false, false, false, false, false));
 
     // Assert
     assertEquals(expectedSuggestedEdition, description.uri.getSuggestedEdition());

--- a/src/test/java/network/crypta/pluginmanager/PluginDownLoaderOfficialFreenetTest.java
+++ b/src/test/java/network/crypta/pluginmanager/PluginDownLoaderOfficialFreenetTest.java
@@ -17,7 +17,10 @@ import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginDefinition;
 import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginDescription;
+import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginFlags;
+import network.crypta.pluginmanager.OfficialPlugins.OfficialPluginVersionPolicy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -79,7 +82,9 @@ class PluginDownLoaderOfficialFreenetTest {
     FreenetURI explicitUri = org.mockito.Mockito.mock(FreenetURI.class);
     OfficialPluginDescription desc =
         new OfficialPluginDescription(
-            source, GROUP, false, -1, 123, false, false, explicitUri, false, false, false, false);
+            new OfficialPluginDefinition(source, GROUP, explicitUri),
+            new OfficialPluginVersionPolicy(-1, 123, false),
+            new OfficialPluginFlags(false, false, false, false, false, false));
     when(pluginManager.getOfficialPlugin(source)).thenReturn(desc);
 
     PluginDownLoaderOfficialFreenet downloader =
@@ -111,18 +116,9 @@ class PluginDownLoaderOfficialFreenetTest {
     String source = "UPnP";
     OfficialPluginDescription desc =
         new OfficialPluginDescription(
-            source,
-            GROUP,
-            false,
-            -1,
-            recommendedVersion,
-            false,
-            false,
-            /* uri= */ null,
-            false,
-            false,
-            false,
-            false);
+            new OfficialPluginDefinition(source, GROUP, null),
+            new OfficialPluginVersionPolicy(-1, recommendedVersion, false),
+            new OfficialPluginFlags(false, false, false, false, false, false));
     when(pluginManager.getOfficialPlugin(source)).thenReturn(desc);
 
     FreenetURI updateUsk = org.mockito.Mockito.mock(FreenetURI.class);
@@ -183,7 +179,9 @@ class PluginDownLoaderOfficialFreenetTest {
     FreenetURI uri = org.mockito.Mockito.mock(FreenetURI.class);
     OfficialPluginDescription desc =
         new OfficialPluginDescription(
-            source, GROUP, false, -1, -1, false, false, uri, false, false, false, false);
+            new OfficialPluginDefinition(source, GROUP, uri),
+            new OfficialPluginVersionPolicy(-1, -1, false),
+            new OfficialPluginFlags(false, false, false, false, false, false));
     when(pluginManager.getOfficialPlugin(source)).thenReturn(desc);
 
     PluginDownLoaderOfficialFreenet downloader =


### PR DESCRIPTION
## Summary
- group official plugin description data into definition, version policy, and flags records
- simplify construction and URI normalization logic for official plugin descriptions
- update plugin manager tests to use the new grouped records