### PR TITLE
refactor(store): bundle fetch parameters

### DIFF
--- a/.opencode/skills/cryptad-build-test/SKILL.md
+++ b/.opencode/skills/cryptad-build-test/SKILL.md
@@ -30,6 +30,8 @@ Use this skill when you need to:
 
 ## Testing
 Always give enough running time (more than 15 minutes) for Gradle to complete tests.
+When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 900,000 ms).
+
 - Run all tests:
   - `./gradlew test`
 - Run one test class:
@@ -60,7 +62,7 @@ Always give enough running time (more than 15 minutes) for Gradle to complete te
 ## Test helpers (test sources only)
 - Package: `network.crypta.testsupport`
 - Utility: `FileTestUtils` provides deterministic fill helpers for `OutputStream` / `Bucket` / `RandomAccessBuffer`.
-- Do **not** call these helpers from production (`src/main`) code. If production code needs fill helpers, use the non-test utilities (for example `FileUtil.fill(OutputStream, long)`).
+- Do **not** call these helpers from production (`src/main`) code. If production code needs to fill helpers, use the non-test utilities (for example `FileUtil.fill(OutputStream, long)`).
 
 ## Tip: GitHub API rate limits during builds
 If builds hit GitHub API rate limits, set `GITHUB_TOKEN` in the environment.

--- a/src/main/java/network/crypta/store/CHKStore.java
+++ b/src/main/java/network/crypta/store/CHKStore.java
@@ -79,7 +79,7 @@ public class CHKStore extends StoreCallback<CHKBlock> {
   public CHKBlock fetch(
       NodeCHK chk, boolean dontPromote, boolean ignoreOldBlocks, BlockMetadata meta)
       throws IOException {
-    // FIXME: Optimize the API to pass the crypto algorithm explicitly instead of requiring a
+    // NOTE: Optimize the API to pass the crypto algorithm explicitly instead of requiring a
     // materialized full key here; avoids allocating the .keys representation on read paths.
     return store.fetch(
         chk.getRoutingKey(), chk.getFullKey(), dontPromote, false, false, ignoreOldBlocks, meta);

--- a/src/main/java/network/crypta/store/CHKStore.java
+++ b/src/main/java/network/crypta/store/CHKStore.java
@@ -28,7 +28,7 @@ public class CHKStore extends StoreCallback<CHKBlock> {
    * Report whether distinct blocks can share a key.
    *
    * <p>Because a CHK key is derived from an SHA‑256 hash of the content, two different blocks
-   * having the same key is treated as impossible.
+   * having the same key are treated as impossible.
    *
    * @return {@code false} — collisions are not expected for CHK.
    */
@@ -45,33 +45,20 @@ public class CHKStore extends StoreCallback<CHKBlock> {
    * block is instantiated via {@link CHKBlock#construct(byte[], byte[], byte)}. The {@code
    * DSAPublicKey} parameter is unused for CHK and may be {@code null}.
    *
-   * @param data payload bytes of length {@link CHKBlock#DATA_LENGTH}.
-   * @param headers header bytes of length {@link CHKBlock#TOTAL_HEADERS_LENGTH}.
-   * @param routingKey ignored for CHK; may be {@code null}.
-   * @param fullKey CHK full key whose low 8 bits of type encode the crypto algorithm; must follow
-   *     {@link NodeCHK#getFullKey()} format.
-   * @param canReadClientCache ignored for CHK.
-   * @param canReadSlashdotCache ignored for CHK.
-   * @param meta optional metadata filled during fetch; not used here.
+   * @param payload payload bytes, headers, and key material for the block.
+   * @param options cache flags and metadata; ignored for CHK.
    * @param ignored unused for CHK.
    * @return a verified {@link CHKBlock} instance.
    * @throws KeyVerifyException if {@code data} or {@code headers} is {@code null}, or if header
    *     validation within {@link CHKBlock} fails.
    */
   @Override
-  public CHKBlock construct(
-      byte[] data,
-      byte[] headers,
-      byte[] routingKey,
-      byte[] fullKey,
-      boolean canReadClientCache,
-      boolean canReadSlashdotCache,
-      BlockMetadata meta,
-      DSAPublicKey ignored)
+  public CHKBlock construct(BlockPayload payload, ConstructOptions options, DSAPublicKey ignored)
       throws KeyVerifyException {
-    if (data == null || headers == null)
+    if (payload.data() == null || payload.headers() == null)
       throw new CHKVerifyException("Need either data and headers");
-    return CHKBlock.construct(data, headers, NodeCHK.cryptoAlgorithmFromFullKey(fullKey));
+    return CHKBlock.construct(
+        payload.data(), payload.headers(), NodeCHK.cryptoAlgorithmFromFullKey(payload.fullKey()));
   }
 
   /**

--- a/src/main/java/network/crypta/store/FetchOptions.java
+++ b/src/main/java/network/crypta/store/FetchOptions.java
@@ -1,0 +1,19 @@
+package network.crypta.store;
+
+/**
+ * Options controlling store fetch behavior.
+ *
+ * <p>This record bundles cache permission flags and metadata collectors used during reads.
+ *
+ * @param dontPromote when {@code true}, do not promote the entry in any recency structure
+ * @param canReadClientCache whether lookups may consult the client cache (e.g., to get SSK keys)
+ * @param canReadSlashdotCache whether lookups may consult the slashdot cache for prerequisites
+ * @param ignoreOldBlocks when {@code true}, suppress returning blocks flagged as old
+ * @param meta optional metadata sink populated during the fetch
+ */
+public record FetchOptions(
+    boolean dontPromote,
+    boolean canReadClientCache,
+    boolean canReadSlashdotCache,
+    boolean ignoreOldBlocks,
+    BlockMetadata meta) {}

--- a/src/main/java/network/crypta/store/FreenetStore.java
+++ b/src/main/java/network/crypta/store/FreenetStore.java
@@ -31,8 +31,8 @@ public interface FreenetStore<T extends StorableBlock> extends Closeable {
    * @param routingKey non-null routing key used to locate the entry.
    * @param fullKey optional full key; may be {@code null} for block types that do not require it.
    * @param dontPromote when {@code true}, do not promote the entry in any recency structure.
-   * @param canReadClientCache whether lookups may consult the client cache (e.g., to obtain SSK
-   *     public keys).
+   * @param canReadClientCache whether lookups may consult the client cache (e.g., to get SSK public
+   *     keys).
    * @param canReadSlashdotCache whether lookups may consult the Slashdot cache when resolving
    *     prerequisites such as public keys.
    * @param ignoreOldBlocks when {@code true}, suppress returning blocks flagged as old.
@@ -50,6 +50,32 @@ public interface FreenetStore<T extends StorableBlock> extends Closeable {
       boolean ignoreOldBlocks,
       BlockMetadata meta)
       throws IOException;
+
+  /**
+   * Retrieve a block by the routing key with a parameter object.
+   *
+   * <p>The default implementation delegates to {@link #fetch(byte[], byte[], boolean, boolean,
+   * boolean, boolean, BlockMetadata)} using values from {@code options}.
+   *
+   * @param routingKey non-null routing key used to locate the entry.
+   * @param fullKey optional full key; may be {@code null} for block types that do not require it.
+   * @param options grouped fetch options; must not be {@code null}.
+   * @return the block instance, or {@code null} if not found.
+   * @throws IOException on I/O errors encountered during the operation.
+   */
+  default T fetch(byte[] routingKey, byte[] fullKey, FetchOptions options) throws IOException {
+    if (options == null) {
+      throw new IllegalArgumentException("options must not be null");
+    }
+    return fetch(
+        routingKey,
+        fullKey,
+        options.dontPromote(),
+        options.canReadClientCache(),
+        options.canReadSlashdotCache(),
+        options.ignoreOldBlocks(),
+        options.meta());
+  }
 
   /**
    * Store a block.
@@ -76,10 +102,10 @@ public interface FreenetStore<T extends StorableBlock> extends Closeable {
    *
    * <p>Adjust the maximum number of keys the store retains. Implementations may perform expensive
    * maintenance when shrinking; if {@code shrinkNow} is {@code false}, the implementation may defer
-   * compaction/eviction while still honoring the new limit for subsequent operations.
+   * compaction/eviction while still honoring the new limit for later operations.
    *
    * @param maxStoreKeys new maximum number of keys the store may hold.
-   * @param shrinkNow when {@code true}, perform any required shrinking immediately if feasible.
+   * @param shrinkNow when {@code true}, perform any required shrinking immediately if possible.
    * @throws IOException on configuration persistence or resize failures.
    */
   void setMaxKeys(long maxStoreKeys, boolean shrinkNow) throws IOException;
@@ -106,7 +132,7 @@ public interface FreenetStore<T extends StorableBlock> extends Closeable {
   long misses();
 
   /**
-   * Return the number of write attempts accepted by this store.
+   * Return the number of writing attempts accepted by this store.
    *
    * @return count of {@link #put} operations.
    */
@@ -163,7 +189,7 @@ public interface FreenetStore<T extends StorableBlock> extends Closeable {
    * {@code longStart} is {@code true}, the caller permits longer initialization (e.g., rebuilding
    * auxiliary structures).
    *
-   * @param ticker progress/heartbeat helper; may be ignored by implementations.
+   * @param ticker implementations; may ignore progress/heartbeat helper.
    * @param longStart whether long-running initialization is permitted.
    * @return {@code true} if initialization completed; {@code false} otherwise.
    * @throws IOException on initialization failure.

--- a/src/main/java/network/crypta/store/NullFreenetStore.java
+++ b/src/main/java/network/crypta/store/NullFreenetStore.java
@@ -11,7 +11,7 @@ import network.crypta.support.Ticker;
  * <p>This store accepts all operations but does not persist or retrieve any data. Reads always
  * return {@code null} or {@code false}, counters report {@code 0}, and mutating operations are
  * effective no-ops. This is useful in configurations where a store is required by the surrounding
- * API but storage must be disabled, such as tests, dry runs, or memory-constrained environments.
+ * API, but storage must be disabled, such as tests, dry runs, or memory-constrained environments.
  *
  * <p>Threading: this class keeps no internal state and performs no I/O; calls may be made from any
  * thread without additional synchronization.
@@ -24,7 +24,7 @@ public class NullFreenetStore<T extends StorableBlock> implements FreenetStore<T
    * Constructs a null store and registers it with the provided callback.
    *
    * <p>The callback is informed about this store via {@code callback.setStore(this)} so callers can
-   * obtain a reference to the effective store instance.
+   * get a reference to the effective store instance.
    *
    * @param callback initialization callback that receives the store reference; must not be null
    */
@@ -49,6 +49,7 @@ public class NullFreenetStore<T extends StorableBlock> implements FreenetStore<T
    * @throws IOException never thrown by this implementation
    */
   @Override
+  @SuppressWarnings("java:S107") // delegator to FetchOptions overload
   public T fetch(
       byte[] routingKey,
       byte[] fullKey,
@@ -58,6 +59,15 @@ public class NullFreenetStore<T extends StorableBlock> implements FreenetStore<T
       boolean ignoreOldBlocks,
       BlockMetadata meta)
       throws IOException {
+    return fetch(
+        routingKey,
+        fullKey,
+        new FetchOptions(
+            dontPromote, canReadClientCache, canReadSlashdotCache, ignoreOldBlocks, meta));
+  }
+
+  @Override
+  public T fetch(byte[] routingKey, byte[] fullKey, FetchOptions options) throws IOException {
     // No block is available; leave {@code meta} unchanged.
     return null;
   }
@@ -207,7 +217,7 @@ public class NullFreenetStore<T extends StorableBlock> implements FreenetStore<T
     return this;
   }
 
-  /** Closes the store; no resources are held so this is a no-op. */
+  /** Closes the store; no resources are held, so this is a no-op. */
   @Override
   public void close() {
     // No-op

--- a/src/main/java/network/crypta/store/ProxyFreenetStore.java
+++ b/src/main/java/network/crypta/store/ProxyFreenetStore.java
@@ -121,6 +121,11 @@ public abstract class ProxyFreenetStore<T extends StorableBlock> implements Free
         meta);
   }
 
+  @Override
+  public T fetch(byte[] routingKey, byte[] fullKey, FetchOptions options) throws IOException {
+    return backDatastore.fetch(routingKey, fullKey, options);
+  }
+
   /** {@inheritDoc} Delegates to the underlying store. */
   @Override
   public void put(T block, byte[] data, byte[] header, boolean overwrite, boolean oldBlock)

--- a/src/main/java/network/crypta/store/PubkeyStore.java
+++ b/src/main/java/network/crypta/store/PubkeyStore.java
@@ -33,31 +33,19 @@ public class PubkeyStore extends StoreCallback<DSAPublicKey> {
    * contains the padded serialization as produced by {@link DSAPublicKey#asPaddedBytes()} but the
    * factory tolerates trailing zeros.
    *
-   * @param data serialized key bytes (padded or unpadded). Must not be {@code null}.
-   * @param headers ignored.
-   * @param routingKey ignored.
-   * @param fullKey ignored.
-   * @param canReadClientCache ignored.
-   * @param canReadSlashdotCache ignored.
-   * @param meta metadata collected during fetch; ignored here.
+   * @param payload payload bytes and key material for the block.
+   * @param options cache flags and metadata; ignored here.
    * @param ignored preconstructed value (from callers that already resolved a key); ignored here.
    * @return a new {@link DSAPublicKey} instance parsed from {@code data}.
    * @throws KeyVerifyException if the byte sequence cannot be parsed as a public key.
    */
   @Override
   public DSAPublicKey construct(
-      byte[] data,
-      byte[] headers,
-      byte[] routingKey,
-      byte[] fullKey,
-      boolean canReadClientCache,
-      boolean canReadSlashdotCache,
-      BlockMetadata meta,
-      DSAPublicKey ignored)
+      BlockPayload payload, ConstructOptions options, DSAPublicKey ignored)
       throws KeyVerifyException {
-    if (data == null) throw new PubkeyVerifyException("Need data to construct pubkey");
+    if (payload.data() == null) throw new PubkeyVerifyException("Need data to construct pubkey");
     try {
-      return DSAPublicKey.create(data);
+      return DSAPublicKey.create(payload.data());
     } catch (CryptFormatException e) {
       throw new PubkeyVerifyException(e);
     }

--- a/src/main/java/network/crypta/store/RAMFreenetStore.java
+++ b/src/main/java/network/crypta/store/RAMFreenetStore.java
@@ -13,9 +13,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * LRU in memory store.
+ * In-memory LRU store for {@link StorableBlock} instances keyed by routing key.
  *
- * <p>For debugging / simulation only
+ * <p>This implementation is intended for debugging or simulation scenarios where a full persistent
+ * store is unnecessary. Entries are kept in an {@link LRUMap} capped by {@code maxKeys}; the store
+ * evicts least-recently used entries on insertion and tracks hits, misses, and writes for
+ * lightweight reporting. Retrieval delegates block construction to the configured {@link
+ * StoreCallback}, which also decides whether full keys are stored.
+ *
+ * <p>Most accessors and mutating operations are synchronized on the store instance. Operations that
+ * bypass synchronization, such as {@link #clear()} and {@link #migrateTo(StoreCallback, boolean)},
+ * should not be interleaved with concurrent reads or writes without external coordination.
+ *
+ * <ul>
+ *   <li>Provides an LRU-backed, in-memory key/value store.
+ *   <li>Records basic access statistics for the current session.
+ *   <li>Supports optional migration into another {@link StoreCallback}.
+ * </ul>
+ *
+ * @param <T> concrete {@link StorableBlock} type constructed by the callback
  */
 public class RAMFreenetStore<T extends StorableBlock> implements FreenetStore<T> {
   private static final Logger LOG = LoggerFactory.getLogger(RAMFreenetStore.class);
@@ -37,6 +53,21 @@ public class RAMFreenetStore<T extends StorableBlock> implements FreenetStore<T>
   private long misses;
   private long writes;
 
+  /**
+   * Create an in-memory store with a fixed maximum number of keys.
+   *
+   * <p>The store registers itself with the supplied {@link StoreCallback} and uses the callback for
+   * block construction, collision handling, and optional full-key retention. The maximum size is
+   * enforced by evicting least-recently used entries as new blocks are inserted.
+   *
+   * <p>This constructor does not allocate storage beyond the internal map; entries are only created
+   * when {@link #put(StorableBlock, byte[], byte[], boolean, boolean)} is called.
+   *
+   * @param callback callback that constructs blocks and receives the store reference; must not be
+   *     {@code null}
+   * @param maxKeys maximum number of routing keys to retain before evicting; values are treated as
+   *     a simple count and should be positive
+   */
   public RAMFreenetStore(StoreCallback<T> callback, int maxKeys) {
     this.callback = callback;
     this.blocksByRoutingKey = LRUMap.createSafeMap(ByteArrayWrapper.FAST_COMPARATOR);
@@ -212,10 +243,35 @@ public class RAMFreenetStore<T extends StorableBlock> implements FreenetStore<T>
     return blocksByRoutingKey.get(key) != null;
   }
 
+  /**
+   * Remove all entries from the in-memory map immediately.
+   *
+   * <p>This clears routing-key mappings without adjusting hit/miss counters. Callers should ensure
+   * no concurrent readers or writers are active, because this method is not synchronized and does
+   * not coordinate with ongoing {@link #fetch(byte[], byte[], boolean, boolean, boolean, boolean,
+   * BlockMetadata)} or {@link #put(StorableBlock, byte[], byte[], boolean, boolean)} operations.
+   */
   public void clear() {
     blocksByRoutingKey.clear();
   }
 
+  /**
+   * Copy every stored block into another store callback.
+   *
+   * <p>Each entry is reconstructed using the current callback and then written into the target
+   * store. Collisions in the target store are ignored, and any block that fails verification is
+   * skipped. The operation iterates over the current key enumeration and does not update this
+   * store's counters or ordering.
+   *
+   * <p>Callers should treat this as a snapshot-like transfer: changes to this store during the
+   * migration can lead to missed or duplicated entries, so coordinate externally if consistency
+   * matters.
+   *
+   * @param target destination callback whose underlying store receives the reconstructed blocks
+   * @param canReadClientCache whether reconstructed blocks may read from the client cache during
+   *     construction
+   * @throws IOException if the target store rejects the writing with an I/O failure
+   */
   public void migrateTo(StoreCallback<T> target, boolean canReadClientCache) throws IOException {
     Enumeration<ByteArrayWrapper> keys = blocksByRoutingKey.keys();
     while (keys.hasMoreElements()) {

--- a/src/main/java/network/crypta/store/RAMFreenetStore.java
+++ b/src/main/java/network/crypta/store/RAMFreenetStore.java
@@ -76,6 +76,7 @@ public class RAMFreenetStore<T extends StorableBlock> implements FreenetStore<T>
   }
 
   @Override
+  @SuppressWarnings("java:S107") // delegator to FetchOptions overload
   public synchronized T fetch(
       byte[] routingKey,
       byte[] fullKey,
@@ -85,13 +86,23 @@ public class RAMFreenetStore<T extends StorableBlock> implements FreenetStore<T>
       boolean ignoreOldBlocks,
       BlockMetadata meta)
       throws IOException {
+    return fetch(
+        routingKey,
+        fullKey,
+        new FetchOptions(
+            dontPromote, canReadClientCache, canReadSlashdotCache, ignoreOldBlocks, meta));
+  }
+
+  @Override
+  public synchronized T fetch(byte[] routingKey, byte[] fullKey, FetchOptions options)
+      throws IOException {
     ByteArrayWrapper key = new ByteArrayWrapper(routingKey);
     Block block = blocksByRoutingKey.get(key);
     if (block == null) {
       misses++;
       return null;
     }
-    if (ignoreOldBlocks && block.oldBlock) {
+    if (options.ignoreOldBlocks() && block.oldBlock) {
       LOG.info("Ignoring old block");
       return null;
     }
@@ -99,11 +110,12 @@ public class RAMFreenetStore<T extends StorableBlock> implements FreenetStore<T>
       T ret =
           callback.construct(
               new StoreCallback.BlockPayload(block.data, block.header, routingKey, block.fullKey),
-              new StoreCallback.ConstructOptions(canReadClientCache, canReadSlashdotCache, meta),
+              new StoreCallback.ConstructOptions(
+                  options.canReadClientCache(), options.canReadSlashdotCache(), options.meta()),
               null);
       hits++;
-      if (!dontPromote) blocksByRoutingKey.push(key, block);
-      if (meta != null && block.oldBlock) meta.setOldBlock();
+      if (!options.dontPromote()) blocksByRoutingKey.push(key, block);
+      if (options.meta() != null && block.oldBlock) options.meta().setOldBlock();
       return ret;
     } catch (KeyVerifyException _) {
       blocksByRoutingKey.removeKey(key);

--- a/src/main/java/network/crypta/store/RAMFreenetStore.java
+++ b/src/main/java/network/crypta/store/RAMFreenetStore.java
@@ -67,13 +67,8 @@ public class RAMFreenetStore<T extends StorableBlock> implements FreenetStore<T>
     try {
       T ret =
           callback.construct(
-              block.data,
-              block.header,
-              routingKey,
-              block.fullKey,
-              canReadClientCache,
-              canReadSlashdotCache,
-              meta,
+              new StoreCallback.BlockPayload(block.data, block.header, routingKey, block.fullKey),
+              new StoreCallback.ConstructOptions(canReadClientCache, canReadSlashdotCache, meta),
               null);
       hits++;
       if (!dontPromote) blocksByRoutingKey.push(key, block);
@@ -234,13 +229,9 @@ public class RAMFreenetStore<T extends StorableBlock> implements FreenetStore<T>
         try {
           ret =
               callback.construct(
-                  block.data,
-                  block.header,
-                  routingKey,
-                  block.fullKey,
-                  canReadClientCache,
-                  false,
-                  null,
+                  new StoreCallback.BlockPayload(
+                      block.data, block.header, routingKey, block.fullKey),
+                  new StoreCallback.ConstructOptions(canReadClientCache, false, null),
                   null);
         } catch (KeyVerifyException e) {
           LOG.error("Caught while migrating: {}", e, e);

--- a/src/main/java/network/crypta/store/SSKStore.java
+++ b/src/main/java/network/crypta/store/SSKStore.java
@@ -47,14 +47,8 @@ public class SSKStore extends StoreCallback<SSKBlock> {
    *   <li>{@code fullKey.length == } {@link NodeSSK#FULL_KEY_LENGTH}
    * </ul>
    *
-   * @param data raw SSK payload bytes.
-   * @param headers raw SSK header bytes.
-   * @param routingKey optional routing key (unused here).
-   * @param fullKey full serialized SSK key (type + E(H(docname)) + pubkey hash).
-   * @param canReadClientCache whether client cache reads are allowed when resolving the public key.
-   * @param canReadSlashdotCache forwarded to {@link GetPubkey#getKey(byte[], boolean, boolean,
-   *     BlockMetadata)} as its {@code forULPR} hint.
-   * @param meta metadata collected during the fetch; forwarded to the public-key lookup.
+   * @param payload payload bytes, headers, and key material for the block.
+   * @param options cache flags and metadata used for public-key lookup.
    * @param knownPublicKey optional known public key to attach to the {@link NodeSSK}.
    * @return a verified {@link SSKBlock} instance.
    * @throws SSKVerifyException if any input is missing or invalid, if the public key cannot be
@@ -62,23 +56,19 @@ public class SSKStore extends StoreCallback<SSKBlock> {
    */
   @Override
   public SSKBlock construct(
-      byte[] data,
-      byte[] headers,
-      byte[] routingKey,
-      byte[] fullKey,
-      boolean canReadClientCache,
-      boolean canReadSlashdotCache,
-      BlockMetadata meta,
-      DSAPublicKey knownPublicKey)
+      BlockPayload payload, ConstructOptions options, DSAPublicKey knownPublicKey)
       throws SSKVerifyException {
-    if (data == null || headers == null) throw new SSKVerifyException("Need data and headers");
-    if (fullKey == null) throw new SSKVerifyException("Need full key to reconstruct an SSK");
+    if (payload.data() == null || payload.headers() == null)
+      throw new SSKVerifyException("Need data and headers");
+    if (payload.fullKey() == null)
+      throw new SSKVerifyException("Need full key to reconstruct an SSK");
     NodeSSK key;
-    key = NodeSSK.construct(fullKey);
+    key = NodeSSK.construct(payload.fullKey());
     if (knownPublicKey != null) key.setPubKey(knownPublicKey);
-    else if (!key.grabPubkey(pubkeyCache, canReadClientCache, canReadSlashdotCache, meta))
+    else if (!key.grabPubkey(
+        pubkeyCache, options.canReadClientCache(), options.canReadSlashdotCache(), options.meta()))
       throw new SSKVerifyException("No pubkey found");
-    return new SSKBlock(data, headers, key, false);
+    return new SSKBlock(payload.data(), payload.headers(), key, false);
   }
 
   /**

--- a/src/main/java/network/crypta/store/SlashdotStore.java
+++ b/src/main/java/network/crypta/store/SlashdotStore.java
@@ -135,6 +135,7 @@ public class SlashdotStore<T extends StorableBlock> implements FreenetStore<T> {
    * @throws IOException on I/O errors while reading the bucket
    */
   @Override
+  @SuppressWarnings("java:S107") // delegator to FetchOptions overload
   public T fetch(
       byte[] routingKey,
       byte[] fullKey,
@@ -144,6 +145,15 @@ public class SlashdotStore<T extends StorableBlock> implements FreenetStore<T> {
       boolean ignoreOldBlocks,
       BlockMetadata meta)
       throws IOException {
+    return fetch(
+        routingKey,
+        fullKey,
+        new FetchOptions(
+            dontPromote, canReadClientCache, canReadSlashdotCache, ignoreOldBlocks, meta));
+  }
+
+  @Override
+  public T fetch(byte[] routingKey, byte[] fullKey, FetchOptions options) throws IOException {
     ByteArrayWrapper key = new ByteArrayWrapper(routingKey);
     DiskBlock block;
     long timeAccessed;
@@ -168,11 +178,12 @@ public class SlashdotStore<T extends StorableBlock> implements FreenetStore<T> {
       T ret =
           callback.construct(
               new StoreCallback.BlockPayload(data, header, routingKey, fk),
-              new StoreCallback.ConstructOptions(canReadClientCache, canReadSlashdotCache, null),
+              new StoreCallback.ConstructOptions(
+                  options.canReadClientCache(), options.canReadSlashdotCache(), null),
               null);
       synchronized (this) {
         hits++;
-        if (!dontPromote) {
+        if (!options.dontPromote()) {
           block.lastAccessed = System.currentTimeMillis();
           blocksByRoutingKey.push(key, block);
         }

--- a/src/main/java/network/crypta/store/SlashdotStore.java
+++ b/src/main/java/network/crypta/store/SlashdotStore.java
@@ -167,7 +167,9 @@ public class SlashdotStore<T extends StorableBlock> implements FreenetStore<T> {
     try {
       T ret =
           callback.construct(
-              data, header, routingKey, fk, canReadClientCache, canReadSlashdotCache, null, null);
+              new StoreCallback.BlockPayload(data, header, routingKey, fk),
+              new StoreCallback.ConstructOptions(canReadClientCache, canReadSlashdotCache, null),
+              null);
       synchronized (this) {
         hits++;
         if (!dontPromote) {
@@ -190,7 +192,7 @@ public class SlashdotStore<T extends StorableBlock> implements FreenetStore<T> {
 
   @Override
   public long getBloomFalsePositive() {
-    // No Bloom filter is used by this cache; indicate unsupported value.
+    // This cache uses no Bloom filter; indicate unsupported value.
     return -1;
   }
 
@@ -234,7 +236,7 @@ public class SlashdotStore<T extends StorableBlock> implements FreenetStore<T> {
    *
    * <p>The method persists {@code fullKey + header + data} into a temporary bucket and inserts the
    * new {@code DiskBlock} at the head of the LRU. If an entry already exists, the previous bucket
-   * is released during the subsequent purge step.
+   * is released during the later purge step.
    *
    * @param block block providing routing and full keys for indexing
    * @param data payload bytes (length must match {@link StoreCallback#dataLength()})

--- a/src/main/java/network/crypta/store/StoreCallback.java
+++ b/src/main/java/network/crypta/store/StoreCallback.java
@@ -4,50 +4,80 @@ import java.io.IOException;
 import network.crypta.crypt.DSAPublicKey;
 import network.crypta.keys.KeyVerifyException;
 import network.crypta.node.stats.StoreAccessStats;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * Strategy interface that adapts a concrete block type to a {@link FreenetStore}.
+ * Adapts a concrete block type for use by a {@link FreenetStore}.
  *
- * <p>A {@code StoreCallback} defines the fixed sizes for data, headers, routing keys, and full keys
- * for a particular block type; it constructs a {@link StorableBlock} from raw bytes when fetching;
- * and it provides conversions between full and routing keys. An instance is typically bound to a
- * store via {@link #setStore(FreenetStore)} and may be reused with store wrappers; the last call to
- * {@code setStore} determines the active target.
+ * <p>A {@code StoreCallback} supplies the datastore with the fixed sizes for block data, headers,
+ * routing keys, and full keys, and it translates raw byte arrays into a {@link StorableBlock}
+ * instance during fetch. Callers typically create one callback per block family (such as CHK or
+ * SSK) and bind it to a store using {@link #setStore(FreenetStore)}. The callback may be reused
+ * across wrapper stores, and the most recent {@code setStore} call becomes the active delegate for
+ * accessors like {@link #hits()} or {@link #getSessionAccessStats()}.
  *
- * <p>Unless otherwise stated, returned byte arrays should be treated as read-only. Implementations
- * may return internal buffers for efficiency.
+ * <p>Implementations should treat the callback as a lightweight policy object rather than a storage
+ * container. The instance usually holds minimal mutable state, but it does retain a reference to
+ * the current store, so it is not inherently thread-safe without external synchronization. Most
+ * getters are simple delegations; consequently, callers should avoid assuming cached values when
+ * they mutate the underlying store configuration. Unless otherwise stated, byte arrays returned
+ * from callback methods or constructed blocks should be treated as read-only views and may share
+ * backing buffers for efficiency.
  *
- * @param <T> block type handled by this callback.
+ * <ul>
+ *   <li>Defines the fixed byte lengths used for store layout and validation.
+ *   <li>Constructs {@link StorableBlock} instances from persisted bytes and metadata.
+ *   <li>Converts between routing keys and full keys for lookups.
+ * </ul>
+ *
+ * @param <T> concrete block type handled by this callback implementation.
  * @author toad
  */
 public abstract class StoreCallback<T extends StorableBlock> {
 
   /**
+   * Creates a new callback instance with no bound store.
+   *
+   * <p>The constructor performs no initialization beyond the default field values. Callers are
+   * expected to bind a store using {@link #setStore(FreenetStore)} before invoking delegation
+   * methods. Subclasses may add their own initialization logic while still respecting the contract
+   * that the callback starts unbound.
+   */
+  protected StoreCallback() {}
+
+  /**
    * Returns the length in bytes of the data section for this block type.
    *
-   * <p>The value is constant for the lifetime of the associated store and is used for buffer
-   * allocation and on-disk layout.
+   * <p>This value is fixed for a given callback implementation and should not change after the
+   * callback is bound to a store. Stores use it to size buffers, validate payload lengths, and
+   * compute on-disk record layouts. Callers may cache the result, but they should treat it as an
+   * invariant of the block type rather than a mutable configuration value.
    *
-   * @return data length in bytes.
+   * @return the immutable payload length in bytes for this block type.
    */
   public abstract int dataLength();
 
   /**
    * Returns the length in bytes of the header section for this block type.
    *
-   * <p>The value is constant for the lifetime of the associated store.
+   * <p>The header length is fixed for the block family and remains constant for the lifetime of any
+   * store using this callback. Stores rely on this size to allocate header buffers and validate
+   * persisted records. Implementations should return a non-negative value that matches the layout
+   * expected by {@link StorableBlock} reconstruction.
    *
-   * @return header length in bytes.
+   * @return the immutable header length in bytes for this block type.
    */
   public abstract int headerLength();
 
   /**
    * Returns the length in bytes of the routing key used for lookups in the datastore.
    *
-   * <p>The routing key length is fixed and must match the arrays produced by {@link
-   * #routingKeyFromFullKey(byte[])} and returned by {@link StorableBlock#getRoutingKey()}.
+   * <p>The routing key length is fixed for the block type. It must match the arrays produced by
+   * {@link #routingKeyFromFullKey(byte[])} and returned by {@link StorableBlock#getRoutingKey()}.
+   * Stores use this value to normalize lookups and to validate that keys provided by callers have
+   * the expected size before hashing or indexing.
    *
-   * @return routing key length in bytes.
+   * @return the immutable routing key length in bytes for this block type.
    */
   public abstract int routingKeyLength();
 
@@ -56,21 +86,25 @@ public abstract class StoreCallback<T extends StorableBlock> {
    * .keys}).
    *
    * <p>When {@code true}, the store writes the full key for each entry so blocks can be
-   * reconstructed or validated without recomputing it from the payload. See {@link
-   * #fullKeyLength()} for the expected size.
+   * reconstructed or validated without recomputing it from the payload. This setting influences
+   * disk usage and enables operations that need the original full key later in the lifecycle, such
+   * as certain verification or migration flows. See {@link #fullKeyLength()} for the expected size
+   * when full keys are stored.
    *
-   * @return {@code true} if full keys are persisted.
+   * @return {@code true} when full keys must be persisted alongside stored blocks.
    */
   public abstract boolean storeFullKeys();
 
   /**
-   * Indicates whether reconstruction requires the key material.
+   * Indicates whether reconstruction requires key material.
    *
-   * <p>When {@code true}, callers must supply either the routing key or the full key (or both) to
-   * {@link #construct(byte[], byte[], byte[], byte[], boolean, boolean, BlockMetadata,
-   * DSAPublicKey)}.
+   * <p>When {@code true}, callers must supply either the routing key or the full key (or both) in
+   * {@link BlockPayload} when calling {@link #construct(BlockPayload, ConstructOptions,
+   * DSAPublicKey)}. Implementations that can reconstruct blocks without key material may return
+   * {@code false}, which allows store callers to omit missing keys when retrieving data from
+   * alternate sources. The value should remain stable for a given callback instance.
    *
-   * @return {@code true} if a key is required to construct a block instance.
+   * @return {@code true} if key material is required to construct a block instance.
    */
   @SuppressWarnings("unused")
   public abstract boolean constructNeedsKey();
@@ -78,34 +112,47 @@ public abstract class StoreCallback<T extends StorableBlock> {
   /**
    * Returns the length in bytes of the full key for this block type.
    *
-   * <p>The value is fixed and is used when persisting to/reading from the optional {@code .keys}
-   * file.
+   * <p>The full key length is fixed for the block family and is used when persisting to or reading
+   * from the optional {@code .keys} file. Implementations should return a non-negative size that
+   * matches the serialized full key layout used by the corresponding {@link StorableBlock}.
    *
-   * @return full key length in bytes.
+   * @return the immutable full key length in bytes for this block type.
    */
   public abstract int fullKeyLength();
 
   /**
    * Reports whether two different blocks can legitimately share the same key.
    *
-   * <p>If {@code true}, stores may throw {@link KeyCollisionException} on insert unless explicitly
-   * told to overwrite. If {@code false}, a duplicate key implies identical content for this block
-   * type.
+   * <p>If {@code true}, the store must treat duplicate keys as potential collisions and may throw
+   * {@link KeyCollisionException} on insert unless explicitly told to overwrite. If {@code false},
+   * a duplicate key implies identical content for this block type, allowing the store to keep the
+   * first copy without additional checks. The result should reflect the block format's collision
+   * semantics and remain constant for the callback's lifetime.
    *
    * @return {@code true} if key collisions between distinct blocks are possible.
    */
   public abstract boolean collisionPossible();
 
-  /** Store currently associated with this callback and used for delegation. */
+  /**
+   * Store currently associated with this callback and used for delegation.
+   *
+   * <p>This reference is assigned by {@link #setStore(FreenetStore)} and accessed by convenience
+   * methods such as {@link #hits()} and {@link #setMaxKeys(long, boolean)}. It is mutable and not
+   * inherently thread-safe; callers should coordinate access if the callback is shared across
+   * threads that rebind the store.
+   */
   protected FreenetStore<T> store;
 
   /**
    * Binds this callback to a {@link FreenetStore} instance.
    *
-   * <p>If the provided store is a wrapper, this method may be called multiple times; the most
-   * recent call determines the effective store used by delegation methods.
+   * <p>This method configures the store used by delegation methods such as {@link #hits()} and
+   * {@link #setMaxKeys(long, boolean)}. If the provided store is a wrapper, the callback may be
+   * re-bound multiple times as the wrapper stack is assembled; the most recent call determines the
+   * effective target. Callers should ensure they publish the updated callback to all threads that
+   * will use it, because this mutation is not synchronized.
    *
-   * @param store target store to associate with this callback.
+   * @param store target store to associate with this callback; must not be {@code null}.
    */
   public void setStore(FreenetStore<T> store) {
     this.store = store;
@@ -114,7 +161,11 @@ public abstract class StoreCallback<T extends StorableBlock> {
   /**
    * Returns the store currently associated with this callback.
    *
-   * @return the bound {@link FreenetStore}.
+   * <p>The returned reference is the most recent value supplied to {@link #setStore(FreenetStore)}.
+   * Callers should treat the result as a mutable shared state and avoid assuming it is constant
+   * across threads or over time.
+   *
+   * @return the bound {@link FreenetStore}, or {@code null} if uninitialized.
    */
   public FreenetStore<T> getStore() {
     return store;
@@ -123,73 +174,224 @@ public abstract class StoreCallback<T extends StorableBlock> {
   // Reconstruction entry point
 
   /**
+   * Packages raw block bytes and optional key material for reconstruction.
+   *
+   * <p>This record is a value carrier used when constructing blocks via {@link
+   * #construct(BlockPayload, ConstructOptions, DSAPublicKey)}. The byte arrays are not defensively
+   * copied; callers should treat them as read-only views of store buffers or caller-managed byte
+   * arrays. Implementations may accept {@code null} for {@code routingKey} or {@code fullKey} when
+   * the key material is unavailable, but they should enforce their own preconditions by throwing
+   * {@link KeyVerifyException} as needed.
+   *
+   * @param data raw payload bytes of length {@link #dataLength()}; may be {@code null} if
+   *     reconstruction is expected to fail fast.
+   * @param headers raw header bytes of length {@link #headerLength()}; may be {@code null} if the
+   *     implementation validates presence at construction time.
+   * @param routingKey routing key bytes, or {@code null} when unavailable or not required.
+   * @param fullKey full key bytes, or {@code null} when unavailable or not required.
+   */
+  public record BlockPayload(byte[] data, byte[] headers, byte[] routingKey, byte[] fullKey) {
+    /**
+     * Compares payloads by array contents rather than reference identity.
+     *
+     * <p>The comparison is null-safe and uses {@link java.util.Arrays#equals(byte[], byte[])} for
+     * each array field. This ensures two payloads with identical bytes are treated as equal even if
+     * they point at different buffers.
+     *
+     * @param obj the object to compare with this payload instance.
+     * @return {@code true} when all array fields are equal by content.
+     */
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          BlockPayload(
+              byte[] otherData,
+              byte[] otherHeaders,
+              byte[] otherRoutingKey,
+              byte[] otherFullKey))) {
+        return false;
+      }
+      return java.util.Arrays.equals(data, otherData)
+          && java.util.Arrays.equals(headers, otherHeaders)
+          && java.util.Arrays.equals(routingKey, otherRoutingKey)
+          && java.util.Arrays.equals(fullKey, otherFullKey);
+    }
+
+    /**
+     * Computes a hash code based on the contents of the byte array fields.
+     *
+     * <p>The hash combines {@link java.util.Arrays#hashCode(byte[])} for each field so it remains
+     * consistent with {@link #equals(Object)} for content-based comparisons.
+     *
+     * @return a hash derived from the payload byte contents.
+     */
+    @Override
+    public int hashCode() {
+      int result = java.util.Arrays.hashCode(data);
+      result = 31 * result + java.util.Arrays.hashCode(headers);
+      result = 31 * result + java.util.Arrays.hashCode(routingKey);
+      result = 31 * result + java.util.Arrays.hashCode(fullKey);
+      return result;
+    }
+
+    /**
+     * Returns a human-readable representation of the payload contents.
+     *
+     * <p>The string renders each byte array using {@link java.util.Arrays#toString(byte[])} and is
+     * intended for debugging and logging rather than stable serialization.
+     *
+     * @return a string containing the array contents for inspection.
+     */
+    @Override
+    public @NotNull String toString() {
+      return "BlockPayload{data="
+          + java.util.Arrays.toString(data)
+          + ", headers="
+          + java.util.Arrays.toString(headers)
+          + ", routingKey="
+          + java.util.Arrays.toString(routingKey)
+          + ", fullKey="
+          + java.util.Arrays.toString(fullKey)
+          + "}";
+    }
+  }
+
+  /**
+   * Groups cache access flags and metadata passed during reconstruction.
+   *
+   * <p>This record carries fetch-time context used by {@link #construct(BlockPayload,
+   * ConstructOptions, DSAPublicKey)} implementations. The boolean flags tell implementations
+   * whether they may consult client or slashdot caches, while {@code meta} carries store-provided
+   * metadata such as old-block markers or caller-specific hints. The record is immutable and may be
+   * reused across multiple reconstruction calls for the same fetch operation.
+   *
+   * @param canReadClientCache {@code true} when client cache reads are permitted for this fetch.
+   * @param canReadSlashdotCache {@code true} when slashdot cache reads are permitted for this
+   *     fetch.
+   * @param meta metadata collected during the fetch; may be {@code null} if unused.
+   */
+  public record ConstructOptions(
+      boolean canReadClientCache, boolean canReadSlashdotCache, BlockMetadata meta) {}
+
+  /**
    * Constructs a block instance from raw data and headers, with optional key material.
    *
-   * <p>Supplying {@code routingKey} or {@code fullKey} is optional and used only when required by
-   * the implementation. If a key is provided but not used, it is not validated here; the caller is
-   * responsible for checking that the resulting block matches the expected key.
+   * <p>This is the primary reconstruction hook used by {@link FreenetStore} implementations when
+   * loading blocks from disk or cache. Implementations should validate the supplied bytes, enforce
+   * any required key material, and either return a fully verified {@link StorableBlock} or throw a
+   * {@link KeyVerifyException}. The method should be free of side effects beyond the reconstruction
+   * itself, so callers can safely retry or fallback. If a key is supplied but not required, it is
+   * not validated here; callers remain responsible for ensuring the constructed block matches the
+   * expected key.
    *
-   * @param data raw payload bytes of length {@link #dataLength()}.
-   * @param headers raw header bytes of length {@link #headerLength()}.
-   * @param routingKey routing key bytes or {@code null} if unavailable.
-   * @param fullKey full key bytes or {@code null} if unavailable.
-   * @param canReadClientCache whether the client cache may be read during reconstruction.
-   * @param canReadSlashdotCache whether the slashdot cache may be read during reconstruction.
-   * @param meta metadata collected during fetch; may be used to guide reconstruction.
-   * @param knownPubKey optional known public key information (e.g., for SSK).
-   * @return a newly constructed block instance.
-   * @throws KeyVerifyException if integrity or signature checks fail during reconstruction.
+   * <p>Implementations should assume the input arrays may be shared buffers and must not mutate
+   * them. When {@code knownPubKey} is provided, implementations may bypass key lookup logic, but
+   * they should still validate any signatures or bindings implied by the block format.
+   *
+   * @param payload raw payload, headers, and optional key material for reconstruction; may contain
+   *     {@code null} keys depending on {@link #constructNeedsKey()}.
+   * @param options cache flags and metadata that guide cache lookups and reconstruction decisions.
+   * @param knownPubKey optional public key information supplied by the caller; may be {@code null}.
+   * @return a newly constructed block instance, ready for use by the caller.
+   * @throws KeyVerifyException if required data is missing or validation fails during
+   *     reconstruction.
    */
   public abstract T construct(
-      byte[] data,
-      byte[] headers,
-      byte[] routingKey,
-      byte[] fullKey,
-      boolean canReadClientCache,
-      boolean canReadSlashdotCache,
-      BlockMetadata meta,
-      DSAPublicKey knownPubKey)
+      BlockPayload payload, ConstructOptions options, DSAPublicKey knownPubKey)
       throws KeyVerifyException;
 
   /**
    * Sets the maximum number of keys the associated store should keep.
    *
-   * <p>Delegates to {@link FreenetStore#setMaxKeys(long, boolean)} on the bound store.
+   * <p>This convenience method delegates to {@link FreenetStore#setMaxKeys(long, boolean)} on the
+   * bound store. Implementations typically enforce the new limit lazily; when {@code shrinkNow} is
+   * {@code true}, the store may attempt to evict entries immediately. Callers should treat this as
+   * a potentially expensive operation that can trigger disk I/O and eviction work.
    *
-   * @param maxStoreKeys new capacity in keys.
-   * @param shrinkNow if {@code true}, requests an immediate shrink when supported by the store.
-   * @throws IOException if the underlying store reports an I/O error.
+   * @param maxStoreKeys new capacity in keys; must be non-negative for most implementations.
+   * @param shrinkNow {@code true} to request immediate shrinking when supported by the store.
+   * @throws IOException if the underlying store reports an I/O error while resizing.
    */
   public void setMaxKeys(long maxStoreKeys, boolean shrinkNow) throws IOException {
     store.setMaxKeys(maxStoreKeys, shrinkNow);
   }
 
-  /** Returns the configured key capacity from the underlying store. */
+  /**
+   * Returns the configured key capacity from the underlying store.
+   *
+   * <p>The returned value reflects the store's current configuration and may change if {@link
+   * #setMaxKeys(long, boolean)} is called. Callers should not assume the value is cached in the
+   * callback; it is fetched from the underlying store each time.
+   *
+   * @return the maximum number of keys the store is configured to keep.
+   */
   public long getMaxKeys() {
     return store.getMaxKeys();
   }
 
-  /** Returns the number of successful lookups reported by the underlying store. */
+  /**
+   * Returns the number of successful lookups reported by the underlying store.
+   *
+   * <p>This counter typically increases when {@link FreenetStore#fetch(byte[], byte[], boolean,
+   * boolean, boolean, boolean, BlockMetadata)} returns a block. It is intended for monitoring and
+   * does not reset automatically between sessions unless the store implementation does so.
+   *
+   * @return the number of successful lookup operations recorded by the store.
+   */
   public long hits() {
     return store.hits();
   }
 
-  /** Returns the number of failed lookups reported by the underlying store. */
+  /**
+   * Returns the number of failed lookups reported by the underlying store.
+   *
+   * <p>This counter increases when a lookup fails due to missing data or verification failures,
+   * depending on store policy. It is useful for tracking cache hit rates and eviction behavior.
+   *
+   * @return the number of failed lookup operations recorded by the store.
+   */
   public long misses() {
     return store.misses();
   }
 
-  /** Returns the number of completed writes reported by the underlying store. */
+  /**
+   * Returns the number of completed writes reported by the underlying store.
+   *
+   * <p>The value typically increments when a {@link FreenetStore#put(StorableBlock, byte[], byte[],
+   * boolean, boolean)} completes successfully. It can be used alongside {@link #hits()} and {@link
+   * #misses()} to estimate workload patterns.
+   *
+   * @return the number of write operations recorded by the store.
+   */
   public long writes() {
     return store.writes();
   }
 
-  /** Returns the current number of keys tracked by the underlying store. */
+  /**
+   * Returns the current number of keys tracked by the underlying store.
+   *
+   * <p>Implementations may return an approximate count when the store is large or uses
+   * probabilistic structures. The value can change rapidly as keys are added or evicted.
+   *
+   * @return the current number of keys tracked by the store.
+   */
   public long keyCount() {
     return store.keyCount();
   }
 
-  /** Returns the false-positive count reported by the store's Bloom filter, if available. */
+  /**
+   * Returns the false-positive count reported by the store's Bloom filter, if available.
+   *
+   * <p>Some stores track Bloom filter false positives for diagnostics. When unsupported, the store
+   * may return a sentinel value such as {@code -1}. Callers should treat the value as a best-effort
+   * diagnostic rather than a precise metric.
+   *
+   * @return the Bloom filter false-positive count or a sentinel value if unsupported.
+   */
   public long getBloomFalsePositive() {
     return store.getBloomFalsePositive();
   }
@@ -197,10 +399,14 @@ public abstract class StoreCallback<T extends StorableBlock> {
   /**
    * Computes the routing key corresponding to a given full key.
    *
-   * <p>The returned array's length equals {@link #routingKeyLength()}.
+   * <p>This method provides the inverse of full-key generation for lookup operations. The returned
+   * array's length equals {@link #routingKeyLength()}, and callers should treat the result as
+   * read-only. Implementations may return a newly allocated array or a view onto an internal
+   * buffer, so callers must not mutate the returned bytes.
    *
-   * @param keyBuf full key bytes.
-   * @return routing key bytes derived from {@code keyBuf}.
+   * @param keyBuf full key bytes whose length should match {@link #fullKeyLength()}; must not be
+   *     {@code null} for valid conversion.
+   * @return routing key bytes derived from {@code keyBuf} for datastore lookups.
    */
   @SuppressWarnings("unused")
   public abstract byte[] routingKeyFromFullKey(byte[] keyBuf);
@@ -208,7 +414,11 @@ public abstract class StoreCallback<T extends StorableBlock> {
   /**
    * Returns per-session access statistics from the underlying store.
    *
-   * @return a {@link StoreAccessStats} instance.
+   * <p>The returned {@link StoreAccessStats} instance tracks counters that reset when the store
+   * restarts or when a new stats object is allocated. Use this to report short-term hit/miss trends
+   * without mixing data across restarts.
+   *
+   * @return a {@link StoreAccessStats} snapshot for the current session.
    */
   public StoreAccessStats getSessionAccessStats() {
     return store.getSessionAccessStats();
@@ -217,10 +427,12 @@ public abstract class StoreCallback<T extends StorableBlock> {
   /**
    * Returns overall access statistics across sessions when supported by the store.
    *
-   * <p>The datastore may not persist uptime; callers can combine this with their own uptime
-   * accounting when needed.
+   * <p>Some implementations persist these counters across restarts to provide long-term metrics.
+   * When unsupported, {@code null} is returned and callers should fall back to {@link
+   * #getSessionAccessStats()}. The datastore may not persist uptime, so callers can combine the
+   * stats with their own uptime accounting when needed.
    *
-   * @return the stats object, or {@code null} if unsupported by the store.
+   * @return the cumulative stats object, or {@code null} if unsupported by the store.
    */
   public StoreAccessStats getTotalAccessStats() {
     return store.getTotalAccessStats();
@@ -229,7 +441,12 @@ public abstract class StoreCallback<T extends StorableBlock> {
   /**
    * Returns the total in-memory size of a block including data, headers, full key, and routing key.
    *
-   * @return total size in bytes.
+   * <p>This convenience method sums the fixed lengths reported by {@link #dataLength()}, {@link
+   * #headerLength()}, {@link #fullKeyLength()}, and {@link #routingKeyLength()}. It is useful for
+   * estimating cache or buffer sizes, but it does not account for object headers or per-entry
+   * metadata in store implementations.
+   *
+   * @return total size in bytes for a single block payload and its keys.
    */
   public int getTotalBlockSize() {
     return dataLength() + headerLength() + fullKeyLength() + routingKeyLength();

--- a/src/main/java/network/crypta/store/caching/CachingFreenetStore.java
+++ b/src/main/java/network/crypta/store/caching/CachingFreenetStore.java
@@ -7,6 +7,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import network.crypta.keys.KeyVerifyException;
 import network.crypta.node.SemiOrderedShutdownHook;
 import network.crypta.store.BlockMetadata;
+import network.crypta.store.FetchOptions;
 import network.crypta.store.FreenetStore;
 import network.crypta.store.KeyCollisionException;
 import network.crypta.store.ProxyFreenetStore;
@@ -115,6 +116,7 @@ public class CachingFreenetStore<T extends StorableBlock> extends ProxyFreenetSt
    * @throws IOException if the underlying store throws while reading
    */
   @Override
+  @SuppressWarnings("java:S107") // delegator to FetchOptions overload
   public T fetch(
       byte[] routingKey,
       byte[] fullKey,
@@ -124,6 +126,15 @@ public class CachingFreenetStore<T extends StorableBlock> extends ProxyFreenetSt
       boolean ignoreOldBlocks,
       BlockMetadata meta)
       throws IOException {
+    return fetch(
+        routingKey,
+        fullKey,
+        new FetchOptions(
+            dontPromote, canReadClientCache, canReadSlashdotCache, ignoreOldBlocks, meta));
+  }
+
+  @Override
+  public T fetch(byte[] routingKey, byte[] fullKey, FetchOptions options) throws IOException {
     ByteArrayWrapper key = new ByteArrayWrapper(routingKey);
 
     Block<T> block;
@@ -140,21 +151,15 @@ public class CachingFreenetStore<T extends StorableBlock> extends ProxyFreenetSt
         return this.callback.construct(
             new StoreCallback.BlockPayload(
                 block.data, block.header, routingKey, block.storable.getFullKey()),
-            new StoreCallback.ConstructOptions(canReadClientCache, canReadSlashdotCache, meta),
+            new StoreCallback.ConstructOptions(
+                options.canReadClientCache(), options.canReadSlashdotCache(), options.meta()),
             null);
       } catch (KeyVerifyException e) {
         LOG.error("Error in fetching for CachingFreenetStore: {}", e, e);
       }
     }
 
-    return backDatastore.fetch(
-        routingKey,
-        fullKey,
-        dontPromote,
-        canReadClientCache,
-        canReadSlashdotCache,
-        ignoreOldBlocks,
-        meta);
+    return backDatastore.fetch(routingKey, fullKey, options);
   }
 
   /**

--- a/src/main/java/network/crypta/store/caching/CachingFreenetStore.java
+++ b/src/main/java/network/crypta/store/caching/CachingFreenetStore.java
@@ -138,13 +138,9 @@ public class CachingFreenetStore<T extends StorableBlock> extends ProxyFreenetSt
     if (block != null) {
       try {
         return this.callback.construct(
-            block.data,
-            block.header,
-            routingKey,
-            block.storable.getFullKey(),
-            canReadClientCache,
-            canReadSlashdotCache,
-            meta,
+            new StoreCallback.BlockPayload(
+                block.data, block.header, routingKey, block.storable.getFullKey()),
+            new StoreCallback.ConstructOptions(canReadClientCache, canReadSlashdotCache, meta),
             null);
       } catch (KeyVerifyException e) {
         LOG.error("Error in fetching for CachingFreenetStore: {}", e, e);
@@ -252,7 +248,7 @@ public class CachingFreenetStore<T extends StorableBlock> extends ProxyFreenetSt
   }
 
   /*
-   * Decide whether to cache, write through, or skip the backing-store write. The result depends on
+   * Decide whether to cache, write through, or skip the backing-store writing. The result depends on
    * whether we are shutting down, whether collisions are possible, current LRU state, and the
    * overwrite flag.
    */
@@ -280,11 +276,11 @@ public class CachingFreenetStore<T extends StorableBlock> extends ProxyFreenetSt
   }
 
   /**
-   * Flushes the least-recently-used cached entry to the backing store.
+   * Flushes the least-recently used cached entry to the backing store.
    *
    * <p>This method peeks the LRU entry, writes it to {@code backDatastore}, and then attempts to
    * remove the exact same version from the cache. If the entry changed concurrently (e.g., an
-   * overwrite occurred while writing), the removal is skipped to avoid dropping updated data.
+   * overwriting occurred while writing), the removal is skipped to avoid dropping updated data.
    *
    * @return {@code sizeBlock} (bytes) when a block is written and removed; {@code 0} when a block
    *     was written but not removed due to a concurrent change; {@code -1} when the cache is empty
@@ -347,8 +343,8 @@ public class CachingFreenetStore<T extends StorableBlock> extends ProxyFreenetSt
   /**
    * Closes this store and then the underlying store.
    *
-   * <p>Idempotent: only the first invocation performs work. Sets the shutdown guard so subsequent
-   * puts are rejected for caching.
+   * <p>Idempotent: only the first invocation performs work. Sets the shutdown guard so later puts
+   * are rejected for caching.
    */
   @Override
   public void close() {

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
@@ -42,6 +42,7 @@ import network.crypta.node.useralerts.AbstractUserAlert;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.store.BlockMetadata;
+import network.crypta.store.FetchOptions;
 import network.crypta.store.FreenetStore;
 import network.crypta.store.KeyCollisionException;
 import network.crypta.store.StorableBlock;
@@ -54,6 +55,7 @@ import network.crypta.support.WrapperKeepalive;
 import network.crypta.support.io.Fallocate;
 import network.crypta.support.io.FileUtil;
 import network.crypta.support.io.NativeThread;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -68,12 +70,13 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * no match and to avoid scanning slots known to be free.
  *
  * <p>All payload bytes are encrypted with a key derived from the routing key and salt; without the
- * routing key the content is unrecoverable. For debugging only, {@code OPTION_SAVE_PLAINKEY} can be
- * enabled to persist the plain routing key alongside the entry; this must never be enabled in a
+ * routing key, the content is unrecoverable. For debugging only, {@code OPTION_SAVE_PLAINKEY} can
+ * be enabled to persist the plain routing key alongside the entry; this must never be enabled in a
  * client cache.
  *
  * <p>The store optionally overflows writes to a secondary “alt” store when the primary is full. The
- * cleaner thread periodically completes resizes and rebuilds the slot filter after format changes.
+ * cleaner thread periodically completes, resizes, and rebuilds the slot filter after format
+ * changes.
  *
  * @author sdiz
  */
@@ -154,7 +157,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     noCleanerSleep = value;
   }
 
-  /** true if close() hase been called */
+  /** true if close() has been called */
   private final AtomicBoolean closeCalled = new AtomicBoolean(false);
 
   /**
@@ -182,11 +185,24 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
   }
 
   /**
+   * Factory for constructing a salted-hash store from grouped parameters.
+   *
+   * @param params parameter object describing the store instance to create
+   * @return the created store
+   * @throws IOException on I/O errors creating or opening the store
+   */
+  public static <T extends StorableBlock> SaltedHashFreenetStore<T> construct(
+      SaltedHashStoreParams<T> params) throws IOException {
+    Objects.requireNonNull(params, "params");
+    return new SaltedHashFreenetStore<>(params);
+  }
+
+  /**
    * Factory for constructing a salted-hash store.
    *
    * @param baseDir directory where the store files live; created if missing
-   * @param name logical name; also used as filename prefix
-   * @param callback callback used to obtain header/data lengths and to (de-)serialize blocks
+   * @param name logical name; also used as a filename prefix
+   * @param callback callback used to get header/data lengths and to (de-)serialize blocks
    * @param random randomness source for encryption and placement tie-breakers
    * @param maxKeys number of slots in the store (capacity)
    * @param useSlotFilter whether to enable the on-disk slot filter index
@@ -197,6 +213,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    * @return the created store
    * @throws IOException on I/O errors creating or opening the store
    */
+  @SuppressWarnings("java:S107") // legacy delegator to params object
   public static <T extends StorableBlock> SaltedHashFreenetStore<T> construct(
       File baseDir,
       String name,
@@ -209,37 +226,25 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
       boolean resizeOnStart,
       byte[] masterKey)
       throws IOException {
-    return new SaltedHashFreenetStore<>(
-        baseDir,
-        name,
-        callback,
-        random,
-        maxKeys,
-        useSlotFilter,
-        shutdownHook,
-        preallocate,
-        resizeOnStart,
-        masterKey);
+    return construct(
+        SaltedHashStoreParams.of(
+            baseDir,
+            name,
+            callback,
+            random,
+            maxKeys,
+            useSlotFilter,
+            shutdownHook,
+            preallocate,
+            resizeOnStart,
+            masterKey));
   }
 
-  private SaltedHashFreenetStore(
-      File baseDir,
-      String name,
-      StoreCallback<T> callback,
-      Random random,
-      long maxKeys,
-      boolean enableSlotFilters,
-      SemiOrderedShutdownHook shutdownHook,
-      boolean preallocate,
-      boolean resizeOnStart,
-      byte[] masterKey)
-      throws IOException {
-    // Initialize; callers should use LOG.isDebugEnabled() instead of cached flags.
+  private SaltedHashFreenetStore(SaltedHashStoreParams<T> params) throws IOException {
+    this.baseDir = params.baseDir();
+    this.name = params.name();
 
-    this.baseDir = baseDir;
-    this.name = name;
-
-    this.callback = callback;
+    this.callback = params.callback();
     collisionPossible = callback.collisionPossible();
     headerBlockLength = callback.headerLength();
     callback.fullKeyLength(); // ensure callback is initialized; length not needed here
@@ -249,9 +254,9 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
         ((headerBlockLength + dataBlockLength + 512 - 1) & -512)
             - (headerBlockLength + dataBlockLength);
 
-    this.random = random;
-    storeSize = maxKeys;
-    this.preallocate = preallocate;
+    this.random = params.random();
+    storeSize = params.maxKeys();
+    this.preallocate = params.preallocate();
 
     lockManager = new LockManager();
 
@@ -260,7 +265,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     validateStoreSizeLimit();
 
     configFile = new File(this.baseDir, name + ".config");
-    boolean newStore = loadConfigAndMaybeResize(masterKey, maxKeys);
+    boolean newStore = loadConfigAndMaybeResize(params.masterKey(), params.maxKeys());
 
     // Open/lock the backing files.
     newStore |= openStoreFiles(baseDir, name);
@@ -270,7 +275,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     initializeBloom(bloomFile);
 
     // Initialize or drop the on-disk slot filter structure.
-    slotFilterDisabled = !enableSlotFilters;
+    slotFilterDisabled = !params.useSlotFilter();
     slotFilter = initializeSlotFilter((int) Math.max(storeSize, prevStoreSize), newStore);
 
     if ((flags & FLAG_DIRTY) != 0) LOG.warn("Datastore({}) is dirty.", name);
@@ -279,13 +284,13 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     writeConfigFile();
 
     callback.setStore(this);
-    registerShutdown(shutdownHook);
+    registerShutdown(params.shutdownHook());
 
     cleanerThread = new Cleaner();
     cleanerStatusUserAlert = new CleanerStatusUserAlert(cleanerThread);
 
     // Finish all resizing before continue if requested.
-    maybeCompleteResizeOnStart(resizeOnStart);
+    maybeCompleteResizeOnStart(params.resizeOnStart());
 
     // Decide whether to rebuild the slot filter now.
     maybeScheduleSlotFilterRebuild(newStore);
@@ -302,7 +307,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 
   /** Ensures {@code baseDir} exists and is a directory. */
   private void createBaseDirIfMissing() throws IOException {
-    // Create the directory tree if missing; throw if creation fails or path is not a directory.
+    // Create the directory tree if missing; throw if creation fails or the path is not a directory.
     if (baseDir == null) {
       throw new IOException("Base directory is null");
     }
@@ -466,14 +471,15 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
   /**
    * Fetches a block by its routing key.
    *
-   * <p>The lookup uses the salted-hash slots and the slot filter to minimize disk I/O. On a hit the
-   * entry is decrypted and verified. This implementation does not promote entries, so {@code
+   * <p>The lookup uses the salted-hash slots and the slot filter to minimize disk I/O. On a hit,
+   * the entry is decrypted and verified. This implementation does not promote entries, so {@code
    * dontPromote} is accepted for interface compatibility and ignored.
    *
    * @param routingKey plain routing key used to derive encryption and placement
    * @param fullKey full key material provided by the caller
    * @param dontPromote ignored by this implementation
-   * @param canReadClientCache whether the caller may read from client cache (passed to callback)
+   * @param canReadClientCache whether the caller may read from the client cache (passed to
+   *     callback)
    * @param canReadSlashdotCache whether the caller may read from the slashdot cache (callback)
    * @param ignoreOldBlocks when {@code true}, entries marked as old are treated as misses
    * @param meta optional metadata sink that is populated on success
@@ -481,6 +487,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    * @throws IOException on I/O errors
    */
   @Override
+  @SuppressWarnings("java:S107") // delegator to FetchOptions overload
   public T fetch(
       byte[] routingKey,
       byte[] fullKey,
@@ -490,6 +497,16 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
       boolean ignoreOldBlocks,
       BlockMetadata meta)
       throws IOException {
+    return fetch(
+        routingKey,
+        fullKey,
+        new FetchOptions(
+            dontPromote, canReadClientCache, canReadSlashdotCache, ignoreOldBlocks, meta));
+  }
+
+  @Override
+  public T fetch(byte[] routingKey, byte[] fullKey, FetchOptions options) throws IOException {
+    Objects.requireNonNull(options, "options");
     if (LOG.isDebugEnabled())
       LOG.debug("Fetch {} for {}", HexUtil.bytesToHex(routingKey), callback);
 
@@ -503,14 +520,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
         return null;
       }
       try {
-        return fetchLocked(
-            digestedKey,
-            routingKey,
-            fullKey,
-            canReadClientCache,
-            canReadSlashdotCache,
-            ignoreOldBlocks,
-            meta);
+        return fetchLocked(digestedKey, routingKey, fullKey, options);
       } finally {
         unlockDigestedKey(digestedKey, true, lockMap);
       }
@@ -534,14 +544,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     }
   }
 
-  private T fetchLocked(
-      byte[] digestedKey,
-      byte[] routingKey,
-      byte[] fullKey,
-      boolean canReadClientCache,
-      boolean canReadSlashdotCache,
-      boolean ignoreOldBlocks,
-      BlockMetadata meta)
+  private T fetchLocked(byte[] digestedKey, byte[] routingKey, byte[] fullKey, FetchOptions options)
       throws IOException {
     Entry entry = probeEntry(digestedKey, routingKey, true);
     if (entry == null) {
@@ -550,17 +553,22 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     }
 
     if ((entry.flag & Entry.ENTRY_NEW_BLOCK) == 0) {
-      if (ignoreOldBlocks) {
+      if (options.ignoreOldBlocks()) {
         LOG.info("Ignoring old block");
         return null;
       }
-      if (meta != null) meta.setOldBlock();
+      if (options.meta() != null) options.meta().setOldBlock();
     }
 
     try {
       T block =
           entry.getStorableBlock(
-              routingKey, fullKey, canReadClientCache, canReadSlashdotCache, meta, null);
+              routingKey,
+              fullKey,
+              options.canReadClientCache(),
+              options.canReadSlashdotCache(),
+              options.meta(),
+              null);
       if (block == null) {
         misses.incrementAndGet();
         return null;
@@ -626,7 +634,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    * Inserts or updates a block in the store.
    *
    * <p>If an entry with the same key exists, the behavior depends on {@code overwrite}. When the
-   * store is full, the write may be directed to the alternate store (if configured). The {@code
+   * store is full, the writing may be directed to the alternate store (if configured). The {@code
    * isOldBlock} flag controls how the “new block” bit is set in metadata.
    *
    * @param block storable block being persisted
@@ -693,16 +701,9 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
         Entry oldEntry = probeEntry(digestedKey, routingKey, false);
         if (oldEntry != null && !oldEntry.isFree()) {
           return handleExistingEntryWhenPresent(
-              oldEntry,
-              digestedKey,
-              routingKey,
-              fullKey,
-              overwrite,
-              isOldBlock,
-              wrongStore,
-              header,
-              data,
-              block);
+              new ExistingEntryParams<>(oldEntry, block, overwrite, isOldBlock, wrongStore),
+              new KeyContext(digestedKey, routingKey, fullKey),
+              new EntryData(header, data));
         }
 
         Entry entry = new Entry(routingKey, header, data, !isOldBlock, wrongStore);
@@ -719,7 +720,8 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 
         Integer indexToOverwrite =
             chooseOverwriteIndex(wrongStore, scan.wrongStoreCount(), scan.firstWrongStoreIndex());
-        if (indexToOverwrite == null) return false; // Force overwrite to happen in right store.
+        if (indexToOverwrite == null)
+          return false; // Force overwriting to happen in the right store.
 
         overwriteAtIndex(offset, indexToOverwrite, entry, digestedKey);
         return true;
@@ -732,48 +734,53 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
   }
 
   private boolean handleExistingEntryWhenPresent(
-      Entry oldEntry,
-      byte[] digestedKey,
-      byte[] routingKey,
-      byte[] fullKey,
-      boolean overwrite,
-      boolean isOldBlock,
-      boolean wrongStore,
-      byte[] header,
-      byte[] data,
-      T block)
+      ExistingEntryParams<T> params, KeyContext keyContext, EntryData entryData)
       throws IOException, KeyCollisionException {
-    long oldOffset = oldEntry.curOffset;
+    long oldOffset = params.oldEntry().curOffset;
     try {
       if (!collisionPossible) {
-        // When collisions are impossible, confirming the existing entry is sufficient for callers
+        // When collisions are impossible, confirming the existing entry is enough for callers
         // (including alt-store writes) to consider the operation successful. Update metadata if
         // needed, but always report success to avoid duplicate writes in the primary store.
-        updateNewBlockFlagIfNeeded(oldEntry, digestedKey, routingKey, oldOffset, isOldBlock);
+        updateNewBlockFlagIfNeeded(
+            params.oldEntry(),
+            keyContext.digestedKey(),
+            keyContext.routingKey(),
+            oldOffset,
+            params.isOldBlock());
         return true;
       }
-      oldEntry.setHD(readHD(oldOffset)); // read from disk
+      params.oldEntry().setHD(readHD(oldOffset)); // read from disk
       T oldBlock =
-          oldEntry.getStorableBlock(
-              routingKey,
-              fullKey,
-              false,
-              false,
-              null,
-              (block instanceof SSKBlock sskb) ? sskb.getPubKey() : null);
-      if (block.equals(oldBlock)) {
-        return handleAlreadyStored(oldEntry, isOldBlock, digestedKey, oldOffset);
-      } else if (!overwrite) {
+          params
+              .oldEntry()
+              .getStorableBlock(
+                  keyContext.routingKey(),
+                  keyContext.fullKey(),
+                  false,
+                  false,
+                  null,
+                  (params.block() instanceof SSKBlock sskb) ? sskb.getPubKey() : null);
+      if (params.block().equals(oldBlock)) {
+        return handleAlreadyStored(
+            params.oldEntry(), params.isOldBlock(), keyContext.digestedKey(), oldOffset);
+      } else if (!params.overwrite()) {
         throw new KeyCollisionException();
       }
     } catch (KeyVerifyException _) {
       // ignore
     }
 
-    // Overwrite old offset with same key
-    Entry entry = new Entry(routingKey, header, data, !isOldBlock, wrongStore);
-    writeEntry(entry, digestedKey, oldOffset);
-    if (oldEntry.generation != generation) keyCount.incrementAndGet();
+    // Overwrite the old offset with the same key
+    Entry entry =
+        new Entry(
+            keyContext.routingKey(),
+            entryData.header(),
+            entryData.data(),
+            !params.isOldBlock(),
+            params.wrongStore());
+    writeEntry(entry, keyContext.digestedKey(), oldOffset);
+    if (params.oldEntry().generation != generation) keyCount.incrementAndGet();
     return true;
   }
 
@@ -858,16 +865,16 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
   private Integer chooseOverwriteIndex(
       boolean wrongStore, int wrongStoreCount, int firstWrongStoreIndex) {
     if (wrongStore) {
-      // Distribute overwrites evenly between the right store and the wrong store.
+      // Distribute overwriting evenly between the right store and the wrong store.
       if (random.nextInt(OPTION_MAX_PROBE + wrongStoreCount) < wrongStoreCount) {
-        // Allow the overwrite to happen in the wrong store.
+        // Allow the overwriting to happen in the wrong store.
         return firstWrongStoreIndex;
       } else {
-        // Force the overwrite to happen in the right store.
+        // Force the overwriting to happen in the right store.
         return null;
       }
     } else {
-      // By default, overwrite offset[0] when not writing to wrong store.
+      // By default, overwrite offset[0] when not writing to the wrong store.
       return 0;
     }
   }
@@ -934,13 +941,13 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     /** Flag for occupied space */
     private static final long ENTRY_FLAG_OCCUPIED = 0x00000001L;
 
-    /** Flag for plain key available */
+    /** Flag for a plain key available */
     private static final long ENTRY_FLAG_PLAINKEY = 0x00000002L;
 
     /** Flag for block added after we stopped caching local (and high htl) requests */
     private static final long ENTRY_NEW_BLOCK = 0x00000004L;
 
-    /** Flag set if the block was stored in the wrong datastore i.e. store instead of cache */
+    /** Flag set if the block was stored in the wrong datastore i.e., store instead of cache */
     private static final long ENTRY_WRONG_STORE = 0x00000008L;
 
     /** Control block length */
@@ -1004,7 +1011,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     }
 
     /**
-     * Creates a new entry from plain routing key and serialized payload.
+     * Creates a new entry from the plain routing key and serialized payload.
      *
      * @param plainRoutingKey plain routing key (un-digested)
      * @param header serialized header bytes (copied)
@@ -1058,7 +1065,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     private ByteBuffer toHDBuffer() {
       if (header == null || data == null) return null;
 
-      assert isEncrypted; // should have encrypted to get dataEncryptIV in control buffer
+      assert isEncrypted; // should have encrypted to get dataEncryptIV in the control buffer
       assert header.length == headerBlockLength;
       assert data.length == dataBlockLength;
 
@@ -1211,7 +1218,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
   }
 
   /**
-   * Reads an entry's metadata (and optionally payload) from disk at a given slot.
+   * Reads an entry's metadata (and optionally payload) from the disk at a given slot.
    *
    * <p>Callers must acquire the necessary slot locks before invoking. When {@code routingKey} is
    * non-{@code null}, a free slot or a digested-key mismatch returns {@code null}. When {@code
@@ -1351,6 +1358,71 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 
   private record CacheState(int cache, boolean valid, boolean likelyMatch) {}
 
+  private record KeyContext(byte[] digestedKey, byte[] routingKey, byte[] fullKey) {
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) return true;
+      if (!(other
+          instanceof
+          KeyContext(byte[] otherDigestedKey, byte[] otherRoutingKey, byte[] otherFullKey)))
+        return false;
+      return Arrays.equals(digestedKey, otherDigestedKey)
+          && Arrays.equals(routingKey, otherRoutingKey)
+          && Arrays.equals(fullKey, otherFullKey);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Arrays.hashCode(digestedKey);
+      result = 31 * result + Arrays.hashCode(routingKey);
+      result = 31 * result + Arrays.hashCode(fullKey);
+      return result;
+    }
+
+    @Override
+    public @NotNull String toString() {
+      return "KeyContext[digestedKey="
+          + Arrays.toString(digestedKey)
+          + ", routingKey="
+          + Arrays.toString(routingKey)
+          + ", fullKey="
+          + Arrays.toString(fullKey)
+          + "]";
+    }
+  }
+
+  private record EntryData(byte[] header, byte[] data) {
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) return true;
+      if (!(other instanceof EntryData(byte[] otherHeader, byte[] otherData))) return false;
+      return Arrays.equals(header, otherHeader) && Arrays.equals(data, otherData);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Arrays.hashCode(header);
+      result = 31 * result + Arrays.hashCode(data);
+      return result;
+    }
+
+    @Override
+    public @NotNull String toString() {
+      return "EntryData[header="
+          + Arrays.toString(header)
+          + ", data="
+          + Arrays.toString(data)
+          + "]";
+    }
+  }
+
+  private record ExistingEntryParams<T extends StorableBlock>(
+      SaltedHashFreenetStore<T>.Entry oldEntry,
+      T block,
+      boolean overwrite,
+      boolean isOldBlock,
+      boolean wrongStore) {}
+
   /**
    * Reads the header+data region for a slot.
    *
@@ -1378,7 +1450,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    * Returns a slot's flags, consulting the slot filter when available.
    *
    * <p>When the slot filter marks a slot as “checked”, its bits are translated to entry flags
-   * without reading from disk. Otherwise, the entry metadata is read. Note that {@code
+   * without reading from the disk. Otherwise, the entry metadata is read. Note that {@code
    * ENTRY_FLAG_PLAINKEY} is not represented in the slot filter and is only visible when reading
    * metadata.
    *
@@ -1497,7 +1569,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
         try (WrapperKeepalive wrapperKeepalive = new WrapperKeepalive()) {
           wrapperKeepalive.start();
           if (oldMetaLen < newMetaLen) {
-            // freenet-mobile-changed: Passing file descriptor to avoid using reflection
+            // freenet-mobile-changed: Passing a file descriptor to avoid using reflection
             Fallocate.forChannel(metaFC, metaRAF.getFD(), newMetaLen)
                 .fromOffset(oldMetaLen)
                 .execute();
@@ -1612,7 +1684,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 
       if (((flags & FLAG_DIRTY) != 0)
           &&
-          // Note: When slot-filter persistence is enabled we conservatively request a rebuild.
+          // Note: When slot-filter persistence is enabled, we conservatively request a rebuild.
           ResizablePersistentIntBuffer.getPersistenceTime() != -1) flags |= FLAG_REBUILD_BLOOM;
 
       readOptionalTrailingCounters(raf);
@@ -1721,7 +1793,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     // return false to abort
     boolean batch(long entriesLeft);
 
-    // call this on abort (e.g. node shutdown)
+    // call this on abort (e.g., node shutdown)
     void abort();
 
     void finish();
@@ -1884,12 +1956,12 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
           }
         }
 
-        // remove from store, prepare for relocation
+        // remove from the store, prepare for relocation
         if (oldGeneration == generation) {
           // should be impossible
           LOG.atError()
-              .addArgument(() -> HexUtil.bytesToHex(entry.getDigestedRoutingKey()))
-              .addArgument(() -> entry.curOffset)
+              .addArgument(HexUtil.bytesToHex(entry.getDigestedRoutingKey()))
+              .addArgument(entry.curOffset)
               .log("new generation object with wrong storeSize. DigestedRoutingKey={}, Offset={}");
         }
         try {
@@ -1913,7 +1985,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
           writeConfigFile();
         }
 
-        // shrink data file to current size
+        // shrink data file to the current size
         if (storeSize < previousStoreSize) {
           setStoreFileSize(Math.max(storeSize, entriesLeft));
         }
@@ -1984,7 +2056,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
           entry.storeSize = storeSize;
           long[] offsets = entry.getOffset();
 
-          // Check for occupied entry with same key
+          // Check for occupied entry with the same key
           for (long offset : offsets) {
             try {
               if (!isFree(offset)
@@ -2542,7 +2614,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    * @param usePrevStoreSize whether to include offsets computed against {@code prevStoreSize} to
    *     cover in‑progress resizes
    * @return a map of {@code offset → Condition} for each acquired lock; empty when acquisition did
-   *     not obtain all required locks
+   *     not get all required locks
    */
   private Map<Long, Condition> lockDigestedKey(byte[] digestedKey, boolean usePrevStoreSize) {
     // use a set to prevent duplicated offsets,
@@ -2589,7 +2661,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     }
   }
 
-  /** Runnable that closes the store during application shutdown. */
+  /** Runnable that closes the store during an application shutdown. */
   public class ShutdownDB implements Runnable {
     @Override
     public void run() {
@@ -2658,7 +2730,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
       // h + 141 i^2 + 13 i
       offsets[i] = ((keyValue + 141 * (i * i) + 13 * i) & Long.MAX_VALUE) % storeSize;
       // Make sure the slots are all unique.
-      // Important for very small stores e.g. in unit tests.
+      // Important for very small stores e.g., in unit tests.
       while (true) {
         boolean clear = true;
         for (int j = 0; j < i; j++) {
@@ -2704,7 +2776,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     return writes.get();
   }
 
-  /** Current number of keys known in the store (best effort during resizes). */
+  /** Current number of keys known in the store (the best effort during resizes). */
   @Override
   public long keyCount() {
     return keyCount.get();

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
@@ -1083,13 +1083,8 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 
       T block =
           callback.construct(
-              data,
-              header,
-              routingKey,
-              fullKey,
-              canReadClientCache,
-              canReadSlashdotCache,
-              meta,
+              new StoreCallback.BlockPayload(data, header, routingKey, fullKey),
+              new StoreCallback.ConstructOptions(canReadClientCache, canReadSlashdotCache, meta),
               knownKey);
       byte[] blockRoutingKey = block.getRoutingKey();
 

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreParams.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreParams.java
@@ -1,0 +1,186 @@
+package network.crypta.store.saltedhash;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Random;
+import network.crypta.node.SemiOrderedShutdownHook;
+import network.crypta.store.StorableBlock;
+import network.crypta.store.StoreCallback;
+import org.jetbrains.annotations.NotNull;
+
+/// Parameters required to construct a salted-hash store instance.
+///
+/// This record bundles the full initialization surface used by [SaltedHashFreenetStore]
+/// factories, ensuring callers can pass around a single value object without losing
+/// configurability.
+/// It is intended for code that wires stores from configuration files or dependency injection,
+/// where
+/// keeping related arguments together avoids long parameter lists and makes auditing easier. The
+/// values are treated as immutable once created; callers should construct a new instance to change
+/// any option or to target a different store directory.
+///
+/// The record is a pure data carrier: it does not validate the filesystem, does not read the
+/// store, and does not mutate the referenced [StoreCallback]. The caller
+/// manages the lifetime of the referenced objects. Use this object to keep the construction inputs
+/// in sync between
+/// primary and alternate stores, or to cache a template of initialization values for repeated store
+/// creation.
+///
+///     - Captures filesystem and naming details for the store files.
+///     - Captures crypto and sizing inputs that must be consistent across runs.
+///     - Captures lifecycle wiring such as shutdown hooks and preallocation policy.
+///
+///
+/// @param <T> concrete [StorableBlock] type produced by the callback.
+/// @param baseDir directory where the store files live; created if missing by the store.
+/// @param name logical name; also used as a filename prefix for store files.
+/// @param callback callback used to get header/data lengths and to (de-)serialize blocks.
+/// @param random randomness source for encryption and placement tie-breakers.
+/// @param maxKeys number of slots in the store (capacity), treated as a non-negative count.
+/// @param useSlotFilter whether to enable the on-disk slot filter index for lookups.
+/// @param shutdownHook hook on which the store registers a close task during initialization.
+/// @param preallocate whether to preallocate files up to `maxKeys` for startup latency.
+/// @param resizeOnStart when true, finishes any in-progress resize before returning to the caller.
+/// @param masterKey master key used to derive per-store salts; reference copies contents.
+public record SaltedHashStoreParams<T extends StorableBlock>(
+    File baseDir,
+    String name,
+    StoreCallback<T> callback,
+    Random random,
+    long maxKeys,
+    boolean useSlotFilter,
+    SemiOrderedShutdownHook shutdownHook,
+    boolean preallocate,
+    boolean resizeOnStart,
+    byte[] masterKey) {
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) return true;
+    if (!(other
+        instanceof
+        SaltedHashStoreParams(
+            File otherBaseDir,
+            String otherName,
+            StoreCallback<?> otherCallback,
+            Random otherRandom,
+            long otherMaxKeys,
+            boolean otherUseSlotFilter,
+            SemiOrderedShutdownHook otherShutdownHook,
+            boolean otherPreallocate,
+            boolean otherResizeOnStart,
+            byte[] otherMasterKey))) return false;
+    return maxKeys == otherMaxKeys
+        && useSlotFilter == otherUseSlotFilter
+        && preallocate == otherPreallocate
+        && resizeOnStart == otherResizeOnStart
+        && Objects.equals(baseDir, otherBaseDir)
+        && Objects.equals(name, otherName)
+        && Objects.equals(callback, otherCallback)
+        && Objects.equals(random, otherRandom)
+        && Objects.equals(shutdownHook, otherShutdownHook)
+        && Arrays.equals(masterKey, otherMasterKey);
+  }
+
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            baseDir,
+            name,
+            callback,
+            random,
+            maxKeys,
+            useSlotFilter,
+            shutdownHook,
+            preallocate,
+            resizeOnStart);
+    result = 31 * result + Arrays.hashCode(masterKey);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "SaltedHashStoreParams[baseDir="
+        + baseDir
+        + ", name="
+        + name
+        + ", callback="
+        + callback
+        + ", random="
+        + random
+        + ", maxKeys="
+        + maxKeys
+        + ", useSlotFilter="
+        + useSlotFilter
+        + ", shutdownHook="
+        + shutdownHook
+        + ", preallocate="
+        + preallocate
+        + ", resizeOnStart="
+        + resizeOnStart
+        + ", masterKey=<redacted>"
+        + "]";
+  }
+
+  /**
+   * Creates a {@link SaltedHashStoreParams} instance from discrete inputs.
+   *
+   * <p>This factory mirrors the record components so callers can migrate from older constructor
+   * signatures without manually repeating the type name. It performs no validation and preserves
+   * object identity for inputs such as {@code callback} and {@code masterKey}; callers remain
+   * responsible for ensuring those values remain valid for the lifetime of the store. The returned
+   * instance is immutable and safe to reuse for repeated store creation when inputs are stable.
+   *
+   * <pre>{@code
+   * SaltedHashStoreParams<CHKBlock> params = SaltedHashStoreParams.of(
+   *     baseDir,
+   *     "datastore",
+   *     callback,
+   *     random,
+   *     maxKeys,
+   *     true,
+   *     shutdownHook,
+   *     false,
+   *     true,
+   *     masterKey);
+   * }</pre>
+   *
+   * @param <T> concrete {@link StorableBlock} type produced by the callback.
+   * @param baseDir directory where the store files live; created if missing by the store.
+   * @param name logical name; also used as a filename prefix for store files.
+   * @param callback callback used to get header/data lengths and to (de-)serialize blocks.
+   * @param random randomness source for encryption and placement tie-breakers.
+   * @param maxKeys number of slots in the store (capacity), treated as a non-negative count.
+   * @param useSlotFilter whether to enable the on-disk slot filter index for lookups.
+   * @param shutdownHook hook on which the store registers a close task during initialization.
+   * @param preallocate whether to preallocate files up to {@code maxKeys} for startup latency.
+   * @param resizeOnStart when true, finishes any in-progress resize before returning to the caller.
+   * @param masterKey master key used to derive per-store salts; reference copies contents.
+   * @return immutable parameters object encapsulating the provided store configuration values.
+   */
+  public static <T extends StorableBlock> SaltedHashStoreParams<T> of(
+      File baseDir,
+      String name,
+      StoreCallback<T> callback,
+      Random random,
+      long maxKeys,
+      boolean useSlotFilter,
+      SemiOrderedShutdownHook shutdownHook,
+      boolean preallocate,
+      boolean resizeOnStart,
+      byte[] masterKey) {
+    return new SaltedHashStoreParams<>(
+        baseDir,
+        name,
+        callback,
+        random,
+        maxKeys,
+        useSlotFilter,
+        shutdownHook,
+        preallocate,
+        resizeOnStart,
+        masterKey);
+  }
+}

--- a/src/test/java/network/crypta/store/CHKStoreTest.java
+++ b/src/test/java/network/crypta/store/CHKStoreTest.java
@@ -106,13 +106,9 @@ class CHKStoreTest {
             CHKVerifyException.class,
             () ->
                 sut.construct(
-                    null,
-                    newHeadersSha256(),
-                    null,
-                    validFullKey((byte) Key.ALGO_AES_PCFB_256_SHA256),
-                    false,
-                    false,
-                    new BlockMetadata(),
+                    new StoreCallback.BlockPayload(
+                        null, newHeadersSha256(), null, validFullKey(Key.ALGO_AES_PCFB_256_SHA256)),
+                    new StoreCallback.ConstructOptions(false, false, new BlockMetadata()),
                     null));
     assertEquals("Need either data and headers", ex.getMessage());
   }
@@ -124,13 +120,12 @@ class CHKStoreTest {
             CHKVerifyException.class,
             () ->
                 sut.construct(
-                    new byte[CHKBlock.DATA_LENGTH],
-                    null,
-                    null,
-                    validFullKey((byte) Key.ALGO_AES_PCFB_256_SHA256),
-                    false,
-                    false,
-                    new BlockMetadata(),
+                    new StoreCallback.BlockPayload(
+                        new byte[CHKBlock.DATA_LENGTH],
+                        null,
+                        null,
+                        validFullKey(Key.ALGO_AES_PCFB_256_SHA256)),
+                    new StoreCallback.ConstructOptions(false, false, new BlockMetadata()),
                     null));
     assertEquals("Need either data and headers", ex.getMessage());
   }
@@ -143,7 +138,10 @@ class CHKStoreTest {
     byte[] fullKey = validFullKey(algo);
 
     CHKBlock block =
-        sut.construct(data, headers, null, fullKey, false, false, new BlockMetadata(), null);
+        sut.construct(
+            new StoreCallback.BlockPayload(data, headers, null, fullKey),
+            new StoreCallback.ConstructOptions(false, false, new BlockMetadata()),
+            null);
 
     assertNotNull(block);
     // CHKBlock holds the same backing arrays; verify identity to ensure no copies were made.
@@ -186,7 +184,7 @@ class CHKStoreTest {
     assertNotNull(out);
     assertEquals(NodeCHK.KEY_LENGTH, out.length);
     assertArrayEquals(slice(bogusFullKey, 0, NodeCHK.KEY_LENGTH), out);
-    // Not the same reference because NodeCHK returns a copy in this recovery path
+    // Different reference because NodeCHK returns a copy in this recovery path
     Assertions.assertNotSame(bogusFullKey, out);
   }
 
@@ -282,7 +280,7 @@ class CHKStoreTest {
     byte[] fk = new byte[NodeCHK.FULL_KEY_LENGTH];
     fk[0] = NodeCHK.BASE_TYPE; // base type = CHK
     fk[1] = algo; // algorithm
-    // remaining 32 bytes are the routing key; left as zeros for simplicity
+    // the remaining 32 bytes are the routing key; left as zeros for simplicity
     return fk;
   }
 

--- a/src/test/java/network/crypta/store/NullFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/NullFreenetStoreTest.java
@@ -69,14 +69,7 @@ class NullFreenetStoreTest {
 
     @Override
     public StorableBlock construct(
-        byte[] data,
-        byte[] headers,
-        byte[] routingKey,
-        byte[] fullKey,
-        boolean canReadClientCache,
-        boolean canReadSlashdotCache,
-        BlockMetadata meta,
-        DSAPublicKey knownPubKey) {
+        BlockPayload payload, ConstructOptions options, DSAPublicKey knownPubKey) {
       return null;
     }
 

--- a/src/test/java/network/crypta/store/PubkeyStoreTest.java
+++ b/src/test/java/network/crypta/store/PubkeyStoreTest.java
@@ -82,7 +82,9 @@ class PubkeyStoreTest {
             PubkeyVerifyException.class,
             () ->
                 sut.construct(
-                    null, null, null, null, false, false, /*meta*/ null, /*knownPubKey*/ null));
+                    new StoreCallback.BlockPayload(null, null, null, null),
+                    new StoreCallback.ConstructOptions(false, false, /*meta*/ null),
+                    /*knownPubKey*/ null));
     assertEquals("Need data to construct pubkey", ex.getMessage());
   }
 
@@ -97,7 +99,9 @@ class PubkeyStoreTest {
         PubkeyVerifyException.class,
         () ->
             sut.construct(
-                invalid, null, null, null, false, false, /*meta*/ null, /*knownPubKey*/ null));
+                new StoreCallback.BlockPayload(invalid, null, null, null),
+                new StoreCallback.ConstructOptions(false, false, /*meta*/ null),
+                /*knownPubKey*/ null));
   }
 
   @Test
@@ -109,7 +113,10 @@ class PubkeyStoreTest {
 
     // Act
     DSAPublicKey parsed =
-        sut.construct(bytes, null, null, null, false, false, /*meta*/ null, /*knownPubKey*/ null);
+        sut.construct(
+            new StoreCallback.BlockPayload(bytes, null, null, null),
+            new StoreCallback.ConstructOptions(false, false, /*meta*/ null),
+            /*knownPubKey*/ null);
 
     // Assert
     assertEquals(original, parsed);

--- a/src/test/java/network/crypta/store/RAMFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/RAMFreenetStoreTest.java
@@ -85,7 +85,10 @@ class RAMFreenetStoreTest {
     when(cb.collisionPossible()).thenReturn(true);
 
     StorableBlock toReturn = mock(StorableBlock.class);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(toReturn);
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 16)) {
@@ -105,25 +108,14 @@ class RAMFreenetStoreTest {
       assertEquals(0, store.misses());
 
       // Verify construct received the raw arrays we stored
-      ArgumentCaptor<byte[]> dataCap = ArgumentCaptor.forClass(byte[].class);
-      ArgumentCaptor<byte[]> headerCap = ArgumentCaptor.forClass(byte[].class);
-      ArgumentCaptor<byte[]> rkCap = ArgumentCaptor.forClass(byte[].class);
-      ArgumentCaptor<byte[]> fkCap = ArgumentCaptor.forClass(byte[].class);
-      verify(cb)
-          .construct(
-              dataCap.capture(),
-              headerCap.capture(),
-              rkCap.capture(),
-              fkCap.capture(),
-              anyBoolean(),
-              anyBoolean(),
-              any(),
-              any());
-      assertArrayEquals(data, dataCap.getValue());
-      assertArrayEquals(header, headerCap.getValue());
-      assertArrayEquals(bytes(1, 2), rkCap.getValue());
+      ArgumentCaptor<StoreCallback.BlockPayload> payloadCap =
+          ArgumentCaptor.forClass(StoreCallback.BlockPayload.class);
+      verify(cb).construct(payloadCap.capture(), any(StoreCallback.ConstructOptions.class), any());
+      assertArrayEquals(data, payloadCap.getValue().data());
+      assertArrayEquals(header, payloadCap.getValue().headers());
+      assertArrayEquals(bytes(1, 2), payloadCap.getValue().routingKey());
       // Full key is only stored when callback.storeFullKeys() is true (false in this test)
-      assertNull(fkCap.getValue());
+      assertNull(payloadCap.getValue().fullKey());
     }
   }
 
@@ -144,7 +136,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(false);
     when(cb.collisionPossible()).thenReturn(true);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(mock(StorableBlock.class));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 8)) {
@@ -165,7 +160,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(false);
     when(cb.collisionPossible()).thenReturn(true);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(mock(StorableBlock.class));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 8)) {
@@ -186,7 +184,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(false);
     when(cb.collisionPossible()).thenReturn(true);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenThrow(new KeyVerifyException("bad"));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 8)) {
@@ -207,7 +208,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(false);
     when(cb.collisionPossible()).thenReturn(true);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(mock(StorableBlock.class));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 8)) {
@@ -236,7 +240,10 @@ class RAMFreenetStoreTest {
     when(cb.collisionPossible()).thenReturn(true);
 
     StorableBlock ret = mock(StorableBlock.class);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(ret);
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 8)) {
@@ -250,22 +257,13 @@ class RAMFreenetStoreTest {
           KeyCollisionException.class,
           () -> store.put(b2, bytes(9, 9), bytes(8, 8), /* overwrite= */ false, false));
 
-      // Original bytes should still be returned by fetch
-      ArgumentCaptor<byte[]> dataCap = ArgumentCaptor.forClass(byte[].class);
-      ArgumentCaptor<byte[]> headerCap = ArgumentCaptor.forClass(byte[].class);
+      // Fetch should still return original bytes
+      ArgumentCaptor<StoreCallback.BlockPayload> payloadCap =
+          ArgumentCaptor.forClass(StoreCallback.BlockPayload.class);
       store.fetch(rk, fk, false, false, false, false, null);
-      verify(cb)
-          .construct(
-              dataCap.capture(),
-              headerCap.capture(),
-              any(),
-              any(),
-              anyBoolean(),
-              anyBoolean(),
-              any(),
-              any());
-      assertArrayEquals(bytes(1, 1), dataCap.getValue());
-      assertArrayEquals(bytes(2, 2), headerCap.getValue());
+      verify(cb).construct(payloadCap.capture(), any(StoreCallback.ConstructOptions.class), any());
+      assertArrayEquals(bytes(1, 1), payloadCap.getValue().data());
+      assertArrayEquals(bytes(2, 2), payloadCap.getValue().headers());
     }
   }
 
@@ -274,7 +272,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(false);
     when(cb.collisionPossible()).thenReturn(true);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(mock(StorableBlock.class));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 8)) {
@@ -299,7 +300,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(true);
     when(cb.collisionPossible()).thenReturn(true);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(mock(StorableBlock.class));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 8)) {
@@ -319,7 +323,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(false);
     when(cb.collisionPossible()).thenReturn(false);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(mock(StorableBlock.class));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 8)) {
@@ -327,7 +334,7 @@ class RAMFreenetStoreTest {
       byte[] fk = bytes(8, 8);
       store.put(mockBlock(rk, fk), bytes(1, 1, 1), bytes(2, 2), false, /* old= */ true);
 
-      // Second put with different content and not old must not replace the stored bytes
+      // Second, put with different content and not old must not replace the stored bytes
       store.put(mockBlock(rk, fk), bytes(5, 5), bytes(6), false, /* old= */ false);
 
       BlockMetadata meta = new BlockMetadata();
@@ -341,7 +348,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(false);
     when(cb.collisionPossible()).thenReturn(true);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(mock(StorableBlock.class));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 3)) {
@@ -353,7 +363,7 @@ class RAMFreenetStoreTest {
       store.setMaxKeys(2, /* shrinkNow= */ false);
       assertEquals(2, store.getMaxKeys());
 
-      // After shrinking, K1 should be evicted, K2 and K3 remain
+      // After shrinking, K1 should be evicted; K2 and K3 remain
       assertFalse(store.probablyInStore(bytes(1)));
       assertTrue(store.probablyInStore(bytes(2)));
       assertTrue(store.probablyInStore(bytes(3)));
@@ -367,7 +377,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(false);
     when(cb.collisionPossible()).thenReturn(true);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(mock(StorableBlock.class));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 2)) {
@@ -402,7 +415,10 @@ class RAMFreenetStoreTest {
     StoreCallback<StorableBlock> cb = baseCallback();
     when(cb.storeFullKeys()).thenReturn(false);
     when(cb.collisionPossible()).thenReturn(true);
-    when(cb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(cb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(mock(StorableBlock.class));
 
     try (RAMFreenetStore<StorableBlock> store = new RAMFreenetStore<>(cb, 10)) {
@@ -458,7 +474,10 @@ class RAMFreenetStoreTest {
     when(sourceCb.storeFullKeys()).thenReturn(false);
     when(sourceCb.collisionPossible()).thenReturn(true);
     StorableBlock ret = mock(StorableBlock.class);
-    when(sourceCb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(sourceCb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenReturn(ret);
 
     try (RAMFreenetStore<StorableBlock> source = new RAMFreenetStore<>(sourceCb, 10)) {
@@ -513,7 +532,10 @@ class RAMFreenetStoreTest {
     when(sourceCb.collisionPossible()).thenReturn(true);
 
     // First construct throws, second succeeds
-    when(sourceCb.construct(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any()))
+    when(sourceCb.construct(
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
+            any()))
         .thenThrow(new KeyVerifyException("oops"))
         .thenReturn(mock(StorableBlock.class));
 

--- a/src/test/java/network/crypta/store/SSKStoreTest.java
+++ b/src/test/java/network/crypta/store/SSKStoreTest.java
@@ -74,7 +74,7 @@ class SSKStoreTest {
     x += NodeSSK.E_H_DOCNAME_SIZE;
     final int ENCRYPTED_HEADERS_LENGTH = 36;
     for (int i = 0; i < ENCRYPTED_HEADERS_LENGTH; i++) headers[x++] = (byte) (0xA0 + i);
-    // Leave signature area zeroed for signing
+    // Leave the signature area zeroed for signing
     return headers;
   }
 
@@ -133,13 +133,12 @@ class SSKStoreTest {
             SSKVerifyException.class,
             () ->
                 sut.construct(
-                    /*data*/ null,
-                    new byte[SSKBlock.TOTAL_HEADERS_LENGTH],
-                    /*routingKey*/ null,
-                    new byte[NodeSSK.FULL_KEY_LENGTH],
-                    false,
-                    false,
-                    /*meta*/ null,
+                    new StoreCallback.BlockPayload(
+                        /*data*/ null,
+                        new byte[SSKBlock.TOTAL_HEADERS_LENGTH],
+                        /*routingKey*/ null,
+                        new byte[NodeSSK.FULL_KEY_LENGTH]),
+                    new StoreCallback.ConstructOptions(false, false, /*meta*/ null),
                     /*knownPub*/ null));
     assertEquals("Need data and headers", ex1.getMessage());
 
@@ -148,13 +147,12 @@ class SSKStoreTest {
             SSKVerifyException.class,
             () ->
                 sut.construct(
-                    new byte[SSKBlock.DATA_LENGTH],
-                    /*headers*/ null,
-                    /*routingKey*/ null,
-                    new byte[NodeSSK.FULL_KEY_LENGTH],
-                    false,
-                    false,
-                    /*meta*/ null,
+                    new StoreCallback.BlockPayload(
+                        new byte[SSKBlock.DATA_LENGTH],
+                        /*headers*/ null,
+                        /*routingKey*/ null,
+                        new byte[NodeSSK.FULL_KEY_LENGTH]),
+                    new StoreCallback.ConstructOptions(false, false, /*meta*/ null),
                     /*knownPub*/ null));
     assertEquals("Need data and headers", ex2.getMessage());
   }
@@ -171,13 +169,12 @@ class SSKStoreTest {
             SSKVerifyException.class,
             () ->
                 sut.construct(
-                    new byte[SSKBlock.DATA_LENGTH],
-                    new byte[SSKBlock.TOTAL_HEADERS_LENGTH],
-                    /*routingKey*/ null,
-                    /*fullKey*/ null,
-                    false,
-                    false,
-                    /*meta*/ null,
+                    new StoreCallback.BlockPayload(
+                        new byte[SSKBlock.DATA_LENGTH],
+                        new byte[SSKBlock.TOTAL_HEADERS_LENGTH],
+                        /*routingKey*/ null,
+                        /*fullKey*/ null),
+                    new StoreCallback.ConstructOptions(false, false, /*meta*/ null),
                     /*knownPub*/ null));
     assertEquals("Need full key to reconstruct an SSK", ex.getMessage());
   }
@@ -201,13 +198,9 @@ class SSKStoreTest {
     // Act
     SSKBlock block =
         sut.construct(
-            data,
-            headers,
-            /*routingKey*/ null,
-            fullKey,
-            /*canReadClientCache*/ false,
-            /*canReadSlashdotCache*/ false,
-            /*meta*/ null,
+            new StoreCallback.BlockPayload(data, headers, /*routingKey*/ null, fullKey),
+            new StoreCallback.ConstructOptions(
+                /*canReadClientCache*/ false, /*canReadSlashdotCache*/ false, /*meta*/ null),
             /*knownPublicKey*/ pub);
 
     // Assert
@@ -234,7 +227,7 @@ class SSKStoreTest {
     NodeSSK noPub = newNodeSSKWithoutPub(pkHash, ehDocname);
     byte[] fullKey = noPub.getFullKey();
 
-    // SSKBlock verification still needs valid signature and the real pubkey; however pubkeyCache
+    // SSKBlock verification still needs a valid signature and the real pubkey; however, pubkeyCache
     // returns null to trigger the error path inside SSKStore.construct
     byte[] data = newData();
     byte[] headers = signedHeaders(ehDocname, data, priv);
@@ -251,13 +244,11 @@ class SSKStoreTest {
             SSKVerifyException.class,
             () ->
                 sut.construct(
-                    data,
-                    headers,
-                    /*routingKey*/ null,
-                    fullKey,
-                    /*canReadClientCache*/ true,
-                    /*canReadSlashdotCache (forULPR)*/ false,
-                    /*meta*/ null,
+                    new StoreCallback.BlockPayload(data, headers, /*routingKey*/ null, fullKey),
+                    new StoreCallback.ConstructOptions(
+                        /*canReadClientCache*/ true,
+                        /*canReadSlashdotCache (forULPR)*/ false,
+                        /*meta*/ null),
                     /*knownPublicKey*/ null));
     assertEquals("No pubkey found", ex.getMessage());
     verify(pubkeyCache, times(1))
@@ -290,13 +281,9 @@ class SSKStoreTest {
     // Act
     SSKBlock block =
         sut.construct(
-            data,
-            headers,
-            /*routingKey*/ null,
-            fullKey,
-            /*canReadClientCache*/ false,
-            /*canReadSlashdotCache (forULPR)*/ true,
-            meta,
+            new StoreCallback.BlockPayload(data, headers, /*routingKey*/ null, fullKey),
+            new StoreCallback.ConstructOptions(
+                /*canReadClientCache*/ false, /*canReadSlashdotCache (forULPR)*/ true, meta),
             /*knownPublicKey*/ null);
 
     // Assert

--- a/src/test/java/network/crypta/store/SlashdotStoreTest.java
+++ b/src/test/java/network/crypta/store/SlashdotStoreTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -197,13 +196,8 @@ class SlashdotStoreTest {
     when(cb.dataLength()).thenReturn(3);
     when(cb.fullKeyLength()).thenReturn(4);
     when(cb.construct(
-            any(byte[].class),
-            any(byte[].class),
-            any(byte[].class),
-            any(byte[].class),
-            anyBoolean(),
-            anyBoolean(),
-            any(),
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
             any()))
         .thenThrow(new KeyVerifyException("bad"));
 
@@ -379,16 +373,11 @@ class SlashdotStoreTest {
 
     @Override
     public TestBlock construct(
-        byte[] data,
-        byte[] headers,
-        byte[] routingKey,
-        byte[] fullKey,
-        boolean canReadClientCache,
-        boolean canReadSlashdotCache,
-        BlockMetadata meta,
+        BlockPayload payload,
+        ConstructOptions options,
         network.crypta.crypt.DSAPublicKey knownPubKey) {
       // For tests, just return a block echoing the keys we were asked for
-      return new TestBlock(routingKey, fullKey);
+      return new TestBlock(payload.routingKey(), payload.fullKey());
     }
 
     @Override

--- a/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
@@ -1,5 +1,6 @@
 package network.crypta.store.caching;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1477,13 +1478,8 @@ class CachingFreenetStoreTest {
     org.mockito.Mockito.doReturn(constructed)
         .when(callback)
         .construct(
-            any(byte[].class),
-            any(byte[].class),
-            any(byte[].class),
-            any(byte[].class),
-            anyBoolean(),
-            anyBoolean(),
-            org.mockito.ArgumentMatchers.isNull(),
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
             any());
 
     CachingFreenetStore<TestBlock> store = new CachingFreenetStore<>(callback, back, tracker);
@@ -1498,20 +1494,20 @@ class CachingFreenetStoreTest {
     // Assert
     assertEquals(constructed, fetched);
     // Ensure construct() saw the routingKey we requested and the cached fullKey
-    ArgumentCaptor<byte[]> rkCap = ArgumentCaptor.forClass(byte[].class);
-    ArgumentCaptor<byte[]> fkCap = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<StoreCallback.BlockPayload> payloadCap =
+        ArgumentCaptor.forClass(StoreCallback.BlockPayload.class);
+    ArgumentCaptor<StoreCallback.ConstructOptions> optionsCap =
+        ArgumentCaptor.forClass(StoreCallback.ConstructOptions.class);
     verify(callback, times(1))
         .construct(
-            eq(data),
-            eq(header),
-            rkCap.capture(),
-            fkCap.capture(),
-            eq(false),
-            eq(false),
-            org.mockito.ArgumentMatchers.isNull(),
-            org.mockito.ArgumentMatchers.isNull());
-    org.junit.jupiter.api.Assertions.assertArrayEquals(rk, rkCap.getValue());
-    org.junit.jupiter.api.Assertions.assertArrayEquals(fk, fkCap.getValue());
+            payloadCap.capture(), optionsCap.capture(), org.mockito.ArgumentMatchers.isNull());
+    org.junit.jupiter.api.Assertions.assertArrayEquals(rk, payloadCap.getValue().routingKey());
+    org.junit.jupiter.api.Assertions.assertArrayEquals(fk, payloadCap.getValue().fullKey());
+    assertArrayEquals(data, payloadCap.getValue().data());
+    assertArrayEquals(header, payloadCap.getValue().headers());
+    assertFalse(optionsCap.getValue().canReadClientCache());
+    assertFalse(optionsCap.getValue().canReadSlashdotCache());
+    assertNull(optionsCap.getValue().meta());
     verify(back, never())
         .fetch(any(), any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any());
   }
@@ -1538,13 +1534,8 @@ class CachingFreenetStoreTest {
     when(callback.collisionPossible()).thenReturn(false);
     when(tracker.add(org.mockito.ArgumentMatchers.anyLong())).thenReturn(true);
     when(callback.construct(
-            eq(data),
-            eq(header),
-            any(),
-            any(),
-            anyBoolean(),
-            anyBoolean(),
-            org.mockito.ArgumentMatchers.isNull(),
+            any(StoreCallback.BlockPayload.class),
+            any(StoreCallback.ConstructOptions.class),
             any()))
         .thenThrow(new network.crypta.keys.KeyVerifyException("boom"));
     when(back.fetch(

--- a/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
@@ -51,6 +51,7 @@ import network.crypta.keys.SSKEncodeException;
 import network.crypta.keys.SSKVerifyException;
 import network.crypta.node.SemiOrderedShutdownHook;
 import network.crypta.store.CHKStore;
+import network.crypta.store.FetchOptions;
 import network.crypta.store.FreenetStore;
 import network.crypta.store.GetPubkey;
 import network.crypta.store.KeyCollisionException;
@@ -1541,11 +1542,7 @@ class CachingFreenetStoreTest {
     when(back.fetch(
             eq(rk),
             org.mockito.ArgumentMatchers.isNull(),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false),
-            org.mockito.ArgumentMatchers.isNull()))
+            eq(new FetchOptions(false, false, false, false, null))))
         .thenReturn(delegateResult);
 
     CachingFreenetStore<TestBlock> store = new CachingFreenetStore<>(callback, back, tracker);
@@ -1560,11 +1557,7 @@ class CachingFreenetStoreTest {
         .fetch(
             eq(rk),
             org.mockito.ArgumentMatchers.isNull(),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false),
-            org.mockito.ArgumentMatchers.isNull());
+            eq(new FetchOptions(false, false, false, false, null)));
   }
 
   @Test
@@ -1582,11 +1575,7 @@ class CachingFreenetStoreTest {
     when(back.fetch(
             eq(rk),
             org.mockito.ArgumentMatchers.isNull(),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false),
-            org.mockito.ArgumentMatchers.isNull()))
+            eq(new FetchOptions(false, false, false, false, null))))
         .thenReturn(delegateResult);
     when(callback.getTotalBlockSize()).thenReturn(0);
     when(callback.collisionPossible()).thenReturn(false);
@@ -1598,11 +1587,7 @@ class CachingFreenetStoreTest {
         .fetch(
             eq(rk),
             org.mockito.ArgumentMatchers.isNull(),
-            eq(false),
-            eq(false),
-            eq(false),
-            eq(false),
-            org.mockito.ArgumentMatchers.isNull());
+            eq(new FetchOptions(false, false, false, false, null)));
   }
 
   @Test

--- a/src/test/java/network/crypta/store/saltedhash/CipherManagerTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/CipherManagerTest.java
@@ -1,6 +1,13 @@
 package network.crypta.store.saltedhash;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -10,7 +17,6 @@ import java.util.Arrays;
 import java.util.Random;
 import network.crypta.crypt.SHA256;
 import network.crypta.node.SemiOrderedShutdownHook;
-import network.crypta.store.BlockMetadata;
 import network.crypta.store.StorableBlock;
 import network.crypta.store.StoreCallback;
 import org.junit.jupiter.api.Test;
@@ -158,7 +164,7 @@ class CipherManagerTest {
     byte[] c1 = data.clone();
     cm1.makeCipher(iv1, key).blockEncipher(c1, 0, c1.length);
 
-    // Different IV with same salt
+    // Different IV with the same salt
     byte[] iv2 = seq(16, 0x02);
     byte[] c2 = data.clone();
     cm1.makeCipher(iv2, key).blockEncipher(c2, 0, c2.length);
@@ -323,15 +329,10 @@ class CipherManagerTest {
 
     @Override
     public StubBlock construct(
-        byte[] data,
-        byte[] headers,
-        byte[] routingKey,
-        byte[] fullKey,
-        boolean canReadClientCache,
-        boolean canReadSlashdotCache,
-        BlockMetadata meta,
+        BlockPayload payload,
+        ConstructOptions options,
         network.crypta.crypt.DSAPublicKey knownPubKey) {
-      return new StubBlock(routingKey, fullKey);
+      return new StubBlock(payload.routingKey(), payload.fullKey());
     }
 
     @Override

--- a/src/test/java/network/crypta/store/saltedhash/SaltedHashFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/SaltedHashFreenetStoreTest.java
@@ -72,7 +72,7 @@ class SaltedHashFreenetStoreTest {
             /*resizeOnStart*/ true,
             /*masterKey*/ new byte[32])) {
 
-      // First call with longStart=false should return true (cannot complete quickly).
+      // The first call with longStart=false should return true (cannot complete quickly).
       boolean deferred = store.start(ticker, /*longStart*/ false);
       assertTrue(deferred, "start() should defer when longStart=false and files need padding");
 
@@ -82,7 +82,7 @@ class SaltedHashFreenetStoreTest {
       assertEquals(0L, meta.length(), "metadata length should be 0 before long start");
       assertEquals(0L, hd.length(), "hd length should be 0 before long start");
 
-      // Now start with longStart=true; this pads/resizes and schedules cleaner through the ticker.
+      // Now start with longStart=true; these pads/resizes and schedules cleaner through the ticker.
       boolean nowStarted = store.start(ticker, /*longStart*/ true);
       assertFalse(nowStarted, "start(longStart=true) should complete and return false");
 
@@ -160,7 +160,7 @@ class SaltedHashFreenetStoreTest {
 
       store.put(block, data, hdr, /*overwrite*/ false, /*isOldBlock*/ false);
 
-      // Quick presence signal should be true after put when slot filter is enabled.
+      // Quick presence signal should be true after put when the slot filter is enabled.
       assertTrue(store.probablyInStore(rk));
 
       TestBlock fetched =
@@ -191,7 +191,7 @@ class SaltedHashFreenetStoreTest {
             cb,
             rnd,
             /*maxKeys*/ 8,
-            /*useSlotFilter*/ false, // disable to simplify read path
+            /*useSlotFilter*/ false, // disable to simplify the read path
             SemiOrderedShutdownHook.get(),
             /*preallocate*/ false,
             /*resizeOnStart*/ true,
@@ -266,7 +266,7 @@ class SaltedHashFreenetStoreTest {
       b.start(ticker, true);
       c.start(ticker, true);
 
-      // First association is valid.
+      // The first association is valid.
       b.setAltStore(a);
       // Now A -> B should fail because B already has an alt store.
       assertThrows(IllegalArgumentException.class, () -> a.setAltStore(b));
@@ -353,7 +353,7 @@ class SaltedHashFreenetStoreTest {
       assertArrayEquals(d2, got2.data);
       assertArrayEquals(h2, got2.header);
 
-      // Stats: A has one write; B has one write.
+      // Stats: A has one writing; B has one writing.
       assertEquals(1L, a.writes(), "primary writes");
       assertEquals(1L, b.writes(), "alt writes");
       assertEquals(1L, a.keyCount(), "primary keys");
@@ -520,16 +520,12 @@ class SaltedHashFreenetStoreTest {
 
     @Override
     public TestBlock construct(
-        byte[] data,
-        byte[] headers,
-        byte[] routingKey,
-        byte[] fullKey,
-        boolean canReadClientCache,
-        boolean canReadSlashdotCache,
-        BlockMetadata meta,
+        BlockPayload payload,
+        ConstructOptions options,
         network.crypta.crypt.DSAPublicKey knownPubKey) {
       // Just wrap provided values; verification is performed earlier by the store.
-      return new TestBlock(routingKey, fullKey, data, headers);
+      return new TestBlock(
+          payload.routingKey(), payload.fullKey(), payload.data(), payload.headers());
     }
 
     @Override


### PR DESCRIPTION
## Summary
- bundle store fetch options into a `FetchOptions` record and add overloads to core store interfaces
- update store implementations and callbacks to use the new payload/option objects for construction
- expand store and callback Javadocs to document the new parameter objects and behaviors