### PR TITLE
refactor(geometry): centralize vector combinations

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/geometry/LinearCombination.java
+++ b/src/main/java/org/spaceroots/mantissa/geometry/LinearCombination.java
@@ -1,0 +1,75 @@
+package org.spaceroots.mantissa.geometry;
+
+import java.util.Arrays;
+
+/**
+ * Immutable parameter object for linear combinations of vectors.
+ *
+ * <p>The combination stores parallel arrays of scale factors and vectors. Instances are immutable
+ * and intended to reduce long parameter lists in vector constructors.
+ */
+public final class LinearCombination {
+
+  private final double[] factors;
+  private final Vector3D[] vectors;
+
+  private LinearCombination(double[] factors, Vector3D[] vectors) {
+    this.factors = factors;
+    this.vectors = vectors;
+  }
+
+  public static LinearCombination of(Term... terms) {
+    double[] factors = new double[terms.length];
+    Vector3D[] vectors = new Vector3D[terms.length];
+    for (int i = 0; i < terms.length; i++) {
+      factors[i] = terms[i].factor;
+      vectors[i] = terms[i].vector;
+    }
+    return new LinearCombination(factors, vectors);
+  }
+
+  public static Term term(double factor, Vector3D vector) {
+    return new Term(factor, vector);
+  }
+
+  public int size() {
+    return factors.length;
+  }
+
+  public double factorAt(int index) {
+    return factors[index];
+  }
+
+  public Vector3D vectorAt(int index) {
+    return vectors[index];
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LinearCombination other)) {
+      return false;
+    }
+    return Arrays.equals(factors, other.factors) && Arrays.equals(vectors, other.vectors);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(factors);
+    result = 31 * result + Arrays.hashCode(vectors);
+    return result;
+  }
+
+  public static final class Term {
+
+    private final double factor;
+    private final Vector3D vector;
+
+    private Term(double factor, Vector3D vector) {
+      this.factor = factor;
+      this.vector = vector;
+    }
+  }
+}

--- a/src/main/java/org/spaceroots/mantissa/geometry/Vector3D.java
+++ b/src/main/java/org/spaceroots/mantissa/geometry/Vector3D.java
@@ -49,7 +49,7 @@ public class Vector3D implements Serializable {
    * Unit vector pointing along the negative X axis (coordinates: -1, 0, 0).
    *
    * <p>Useful as a ready-made left-directed axis when constructing orthogonal frames or applying
-   * reflections. The vector length is exactly one and the instance is immutable.
+   * reflections. The vector length is exactly one, and the instance is immutable.
    */
   public static final Vector3D minusI = new Vector3D(-1, 0, 0);
 
@@ -156,70 +156,27 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Builds a vector as a linear combination of two input vectors.
+   * Builds a vector from a linear combination parameter object.
    *
-   * <p>The constructed vector equals {@code a1 * u1 + a2 * u2}. This is a convenience for
-   * expressing affine transforms or barycentric coordinates without mutating intermediate data.
+   * <p>The supplied {@link LinearCombination} provides matched scaling factors and vectors. Each
+   * term contributes {@code factor * vector} to the resulting coordinates.
    *
-   * @param a1 scale factor applied to {@code u1}; finite double recommended
-   * @param u1 first base vector; treated as immutable input and not copied defensively
-   * @param a2 scale factor applied to {@code u2}; finite double recommended
-   * @param u2 second base vector; treated as immutable input and not copied defensively
+   * @param combination linear combination terms defining the result
    */
-  public Vector3D(double a1, Vector3D u1, double a2, Vector3D u2) {
-    this.x = a1 * u1.x + a2 * u2.x;
-    this.y = a1 * u1.y + a2 * u2.y;
-    this.z = a1 * u1.z + a2 * u2.z;
-  }
-
-  /**
-   * Builds a vector as a linear combination of three input vectors.
-   *
-   * <p>The resulting coordinates follow {@code a1 * u1 + a2 * u2 + a3 * u3} and are computed
-   * directly from the supplied factors. Inputs are assumed valid and are not normalized
-   * automatically.
-   *
-   * @param a1 scale factor applied to {@code u1}; finite double recommended
-   * @param u1 first base vector contributing to the linear combination
-   * @param a2 scale factor applied to {@code u2}; finite double recommended
-   * @param u2 second base vector contributing to the linear combination
-   * @param a3 scale factor applied to {@code u3}; finite double recommended
-   * @param u3 third base vector contributing to the linear combination
-   */
-  public Vector3D(double a1, Vector3D u1, double a2, Vector3D u2, double a3, Vector3D u3) {
-    this.x = a1 * u1.x + a2 * u2.x + a3 * u3.x;
-    this.y = a1 * u1.y + a2 * u2.y + a3 * u3.y;
-    this.z = a1 * u1.z + a2 * u2.z + a3 * u3.z;
-  }
-
-  /**
-   * Builds a vector as a linear combination of four input vectors.
-   *
-   * <p>The coordinates are computed as {@code a1 * u1 + a2 * u2 + a3 * u3 + a4 * u4}. No
-   * normalization or overflow guarding is performed; callers should ensure the provided
-   * coefficients match their numeric expectations.
-   *
-   * @param a1 scale factor applied to {@code u1}; finite double recommended
-   * @param u1 first base vector contributing to the linear combination
-   * @param a2 scale factor applied to {@code u2}; finite double recommended
-   * @param u2 second base vector contributing to the linear combination
-   * @param a3 scale factor applied to {@code u3}; finite double recommended
-   * @param u3 third base vector contributing to the linear combination
-   * @param a4 scale factor applied to {@code u4}; finite double recommended
-   * @param u4 fourth base vector contributing to the linear combination
-   */
-  public Vector3D(
-      double a1,
-      Vector3D u1,
-      double a2,
-      Vector3D u2,
-      double a3,
-      Vector3D u3,
-      double a4,
-      Vector3D u4) {
-    this.x = a1 * u1.x + a2 * u2.x + a3 * u3.x + a4 * u4.x;
-    this.y = a1 * u1.y + a2 * u2.y + a3 * u3.y + a4 * u4.y;
-    this.z = a1 * u1.z + a2 * u2.z + a3 * u3.z + a4 * u4.z;
+  public Vector3D(LinearCombination combination) {
+    double sumX = 0;
+    double sumY = 0;
+    double sumZ = 0;
+    for (int i = 0; i < combination.size(); i++) {
+      double factor = combination.factorAt(i);
+      Vector3D vector = combination.vectorAt(i);
+      sumX += factor * vector.x;
+      sumY += factor * vector.y;
+      sumZ += factor * vector.z;
+    }
+    this.x = sumX;
+    this.y = sumY;
+    this.z = sumZ;
   }
 
   /**
@@ -278,8 +235,8 @@ public class Vector3D implements Serializable {
    * Returns the azimuth angle of the vector around the Z axis.
    *
    * <p>The azimuth {@code alpha} is produced via {@link Math#atan2(double, double)} and lies in the
-   * range -{@code Math.PI} to +{@code Math.PI}. When both X and Y are zero, the result is platform
-   * dependent but follows {@code atan2(0, 0)} semantics.
+   * range -{@code Math.PI} to +{@code Math.PI}. When both X and Y are zero, the result is
+   * platform-dependent but follows {@code atan2(0, 0)} semantics.
    *
    * @return azimuth in radians measured from +X toward +Y; range [-{@code PI}, {@code PI}]
    * @see #Vector3D(double, double)
@@ -360,7 +317,7 @@ public class Vector3D implements Serializable {
   /**
    * Returns a normalized version of this vector.
    *
-   * <p>The result has a norm of 1 while preserving direction. If the norm is zero, an {@link
+   * <p>The result has a norm of 1 while preserving the direction. If the norm is zero, an {@link
    * ArithmeticException} is thrown to signal the undefined operation. Because a new instance is
    * created, the original vector remains unchanged and safe to reuse.
    *
@@ -380,7 +337,7 @@ public class Vector3D implements Serializable {
    *
    * <p>Because infinitely many orthogonal vectors exist, the implementation selects one
    * deterministically based on the largest coordinate magnitude to maintain numerical stability.
-   * The returned vector always has unit length and is suitable for building local coordinate
+   * The returned vector always has a unit length and is suitable for building local coordinate
    * frames.
    *
    * <pre>{@code
@@ -418,8 +375,8 @@ public class Vector3D implements Serializable {
    * calculation for nearly aligned vectors to maintain numeric accuracy. Inputs must both have
    * non-zero norms; otherwise an {@link ArithmeticException} is raised.
    *
-   * @param v1 first vector; must be non-null and have non-zero norm
-   * @param v2 second vector; must be non-null and have non-zero norm
+   * @param v1 first vector; must be non-null and have a non-zero norm
+   * @param v2 second vector; must be non-null and have a non-zero norm
    * @return angle in radians between {@code v1} and {@code v2}; range [0, {@code PI}]
    * @throws ArithmeticException if either vector has a zero norm and the angle is undefined
    */
@@ -485,9 +442,9 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Computes the cross product of two vectors.
+   * Computes the cross-product of two vectors.
    *
-   * <p>The cross product yields a vector perpendicular to both inputs following the right-hand
+   * <p>The cross-product yields a vector perpendicular to both inputs following the right-hand
    * rule. Its magnitude equals the area of the parallelogram spanned by the operands.
    *
    * @param v1 first operand; expected non-null and expressed in the same units as {@code v2}

--- a/src/test/java/org/spaceroots/mantissa/geometry/Vector3DTest.java
+++ b/src/test/java/org/spaceroots/mantissa/geometry/Vector3DTest.java
@@ -60,7 +60,11 @@ class Vector3DTest {
 
   @Test
   void linearConstructor_twoVectors_combinesCorrectly() {
-    Vector3D result = new Vector3D(2, Vector3D.plusI, -3, Vector3D.minusJ);
+    Vector3D result =
+        new Vector3D(
+            LinearCombination.of(
+                LinearCombination.term(2, Vector3D.plusI),
+                LinearCombination.term(-3, Vector3D.minusJ)));
 
     assertEquals(2.0, result.getX(), EPS);
     assertEquals(3.0, result.getY(), EPS);
@@ -69,7 +73,12 @@ class Vector3DTest {
 
   @Test
   void linearConstructor_threeVectors_combinesCorrectly() {
-    Vector3D result = new Vector3D(1, Vector3D.plusI, 2, Vector3D.plusJ, 3, Vector3D.plusK);
+    Vector3D result =
+        new Vector3D(
+            LinearCombination.of(
+                LinearCombination.term(1, Vector3D.plusI),
+                LinearCombination.term(2, Vector3D.plusJ),
+                LinearCombination.term(3, Vector3D.plusK)));
 
     assertEquals(1.0, result.getX(), EPS);
     assertEquals(2.0, result.getY(), EPS);
@@ -79,7 +88,12 @@ class Vector3DTest {
   @Test
   void linearConstructor_fourVectors_combinesCorrectly() {
     Vector3D result =
-        new Vector3D(1, Vector3D.plusI, 1, Vector3D.plusJ, 1, Vector3D.plusK, -2, Vector3D.minusK);
+        new Vector3D(
+            LinearCombination.of(
+                LinearCombination.term(1, Vector3D.plusI),
+                LinearCombination.term(1, Vector3D.plusJ),
+                LinearCombination.term(1, Vector3D.plusK),
+                LinearCombination.term(-2, Vector3D.minusK)));
 
     assertEquals(1.0, result.getX(), EPS);
     assertEquals(1.0, result.getY(), EPS);


### PR DESCRIPTION
## Summary
- introduce `LinearCombination` to group vector scale factors and operands
- update `Vector3D` to accept the parameter object instead of long constructors
- adjust `Vector3D` tests to build combinations via `LinearCombination.term`

## Testing
- ./gradlew test