### PR TITLE
test(async): cover splitfile storage helpers

### DIFF
--- a/src/test/java/network/crypta/client/async/SplitFileFetcherSegmentsBuilderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherSegmentsBuilderTest.java
@@ -1,0 +1,357 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Random;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.Metadata;
+import network.crypta.client.async.SplitFileFetcherSegmentsBuilder.SegmentsBuildContext;
+import network.crypta.client.async.SplitFileFetcherStorageLayout.AccumulatedSizes;
+import network.crypta.crypt.EntropySource;
+import network.crypta.crypt.RandomSource;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.ClientCHK;
+import network.crypta.keys.NodeCHK;
+import network.crypta.node.KeysFetchingLocally;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.io.StorageFormatException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SplitFileFetcherSegmentsBuilderTest {
+
+  @Mock private SplitFileFetcherStorageCallback fetcherCallback;
+
+  @Mock private PersistentJobRunner jobRunner;
+
+  @Mock private MemoryLimitedJobRunner memoryLimitedJobRunner;
+
+  @Mock private SplitFileFetcherKeyListener keyListener;
+
+  @Test
+  void initSegmentsAndKeys_whenValidContext_registersKeysAndOffsets() throws Exception {
+    SplitFileSegmentKeys keysA = newSegmentKeys(2, 1);
+    SplitFileSegmentKeys keysB = newSegmentKeys(3, 0);
+    SplitFileSegmentKeys[] segmentKeys = new SplitFileSegmentKeys[] {keysA, keysB};
+
+    int crossCheckBlocks = 0;
+    int checksumLength = 4;
+    boolean persistent = true;
+    int maxRetries = 2;
+    boolean hasSplitfileSingleCryptoKey = false;
+    AccumulatedSizes acc =
+        SplitFileFetcherStorageLayout.accumulateSizes(
+            segmentKeys,
+            crossCheckBlocks,
+            hasSplitfileSingleCryptoKey,
+            checksumLength,
+            maxRetries,
+            persistent);
+    long storedBlocksLength = (long) acc.splitfileDataBlocks() * CHKBlock.DATA_LENGTH;
+
+    SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[2];
+    SplitFileFetcherStorage parent =
+        newMinimalParent(segments, storedBlocksLength, storedBlocksLength + acc.storedKeysLength());
+    setFinalOnParent(parent, "keyListener", keyListener);
+    setFinalOnParent(parent, "fetcher", fetcherCallback);
+
+    FetchContext fetchContext = Mockito.mock(FetchContext.class);
+    Mockito.when(fetchContext.getMaxDataBlocksPerSegment()).thenReturn(10);
+    Mockito.when(fetchContext.getMaxCheckBlocksPerSegment()).thenReturn(10);
+
+    KeySalter salter = _ -> new byte[] {1, 2, 3, 4};
+
+    SegmentsBuildContext ctx = new SegmentsBuildContext();
+    ctx.parent = parent;
+    ctx.segments = segments;
+    ctx.segmentKeys = segmentKeys;
+    ctx.metadata = Mockito.mock(Metadata.class);
+    ctx.crossCheckBlocks = crossCheckBlocks;
+    ctx.blocksPerSegment = 3;
+    ctx.checkBlocksPerSegment = 1;
+    ctx.origFetchContext = fetchContext;
+    ctx.salt = salter;
+    ctx.keysFetching = Mockito.mock(KeysFetchingLocally.class);
+    ctx.acc = acc;
+    ctx.storedBlocksLength = storedBlocksLength;
+    ctx.storedCrossCheckBlocksLength = 0;
+    ctx.completeViaTruncation = false;
+    ctx.persistent = persistent;
+    ctx.hasSplitfileSingleCryptoKey = hasSplitfileSingleCryptoKey;
+    ctx.checksumLength = checksumLength;
+
+    SplitFileFetcherSegmentsInit init = SplitFileFetcherSegmentsBuilder.initSegmentsAndKeys(ctx);
+
+    assertNotNull(init);
+    assertEquals(2, init.segments.length);
+    assertNotNull(init.crossSegments);
+    assertEquals(0, init.crossSegments.length);
+
+    SplitFileFetcherSegmentStorage seg0 = init.segments[0];
+    SplitFileFetcherSegmentStorage seg1 = init.segments[1];
+    assertEquals(0L, seg0.segmentBlockDataOffset);
+    assertEquals(2L * CHKBlock.DATA_LENGTH, seg0.segmentCrossCheckBlockDataOffset);
+    assertEquals(2L * CHKBlock.DATA_LENGTH, seg1.segmentBlockDataOffset);
+    assertEquals(5L * CHKBlock.DATA_LENGTH, seg1.segmentCrossCheckBlockDataOffset);
+
+    //noinspection PointlessArithmeticExpression
+    int totalKeys = (2 + 1) + (3 + 0);
+    verify(keyListener, times(totalKeys)).addKey(any(), anyInt(), eq(salter));
+    verify(keyListener, times(1)).finishedSetup();
+    verify(fetcherCallback, times(1))
+        .setSplitfileBlocks(acc.splitfileDataBlocks(), acc.splitfileCheckBlocks());
+  }
+
+  @Test
+  void initSegmentsAndKeys_whenBlockLimitExceeded_throwsFetchException() throws Exception {
+    SplitFileSegmentKeys keys = newSegmentKeys(4, 1);
+    SplitFileSegmentKeys[] segmentKeys = new SplitFileSegmentKeys[] {keys};
+
+    AccumulatedSizes acc =
+        SplitFileFetcherStorageLayout.accumulateSizes(segmentKeys, 0, false, 4, 1, true);
+    long storedBlocksLength = (long) acc.splitfileDataBlocks() * CHKBlock.DATA_LENGTH;
+
+    SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[1];
+    SplitFileFetcherStorage parent =
+        newMinimalParent(segments, storedBlocksLength, storedBlocksLength + acc.storedKeysLength());
+    setFinalOnParent(parent, "keyListener", keyListener);
+
+    FetchContext fetchContext = Mockito.mock(FetchContext.class);
+    Mockito.when(fetchContext.getMaxDataBlocksPerSegment()).thenReturn(2);
+
+    SegmentsBuildContext ctx = new SegmentsBuildContext();
+    ctx.parent = parent;
+    ctx.segments = segments;
+    ctx.segmentKeys = segmentKeys;
+    ctx.metadata = Mockito.mock(Metadata.class);
+    ctx.crossCheckBlocks = 0;
+    ctx.blocksPerSegment = 4;
+    ctx.checkBlocksPerSegment = 1;
+    ctx.origFetchContext = fetchContext;
+    ctx.salt = _ -> new byte[] {7, 8};
+    ctx.keysFetching = null;
+    ctx.acc = acc;
+    ctx.storedBlocksLength = storedBlocksLength;
+    ctx.storedCrossCheckBlocksLength = 0;
+    ctx.completeViaTruncation = false;
+    ctx.persistent = true;
+    ctx.hasSplitfileSingleCryptoKey = false;
+    ctx.checksumLength = 4;
+
+    FetchException ex =
+        assertThrows(
+            FetchException.class, () -> SplitFileFetcherSegmentsBuilder.initSegmentsAndKeys(ctx));
+    assertEquals(FetchExceptionMode.TOO_MANY_BLOCKS_PER_SEGMENT, ex.mode);
+  }
+
+  @Test
+  void initSegmentsFromStream_whenTotalsMatch_returnsSegmentsAndStream() throws Exception {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    dos.writeInt(2);
+    dos.writeInt(1);
+    dos.writeInt(1);
+    dos.writeInt(0);
+    dos.close();
+
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bos.toByteArray()));
+    SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[1];
+    SplitFileFetcherStorage parent = newMinimalParent(segments, 0L, 0L);
+
+    SplitFileFetcherSegmentsLoadParams params =
+        new SplitFileFetcherSegmentsLoadParams(
+            parent,
+            2,
+            1,
+            1,
+            dis,
+            false,
+            Mockito.mock(KeysFetchingLocally.class),
+            segments,
+            4,
+            false,
+            0L,
+            0L,
+            3L * CHKBlock.DATA_LENGTH + 1);
+
+    SplitFileFetcherSegmentsInit init =
+        SplitFileFetcherSegmentsBuilder.initSegmentsFromStream(params);
+
+    assertNotNull(init.segments[0]);
+    assertSame(dis, init.remainingStream);
+    assertEquals(2, init.segments[0].dataBlocks);
+    assertEquals(1, init.segments[0].checkBlocks);
+    assertEquals(1, init.segments[0].crossSegmentCheckBlocks);
+    assertEquals(0L, init.segments[0].segmentBlockDataOffset);
+    assertEquals(2L * CHKBlock.DATA_LENGTH, init.segments[0].segmentCrossCheckBlockDataOffset);
+  }
+
+  @Test
+  void initSegmentsFromStream_whenTotalsMismatch_throwsStorageFormatException() throws Exception {
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(buildSegmentStream(1, 0)));
+
+    SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[1];
+    SplitFileFetcherStorage parent = newMinimalParent(segments, 0L, 0L);
+
+    SplitFileFetcherSegmentsLoadParams params =
+        new SplitFileFetcherSegmentsLoadParams(
+            parent,
+            2,
+            0,
+            0,
+            dis,
+            false,
+            null,
+            segments,
+            4,
+            false,
+            0L,
+            0L,
+            CHKBlock.DATA_LENGTH * 2L);
+
+    StorageFormatException ex =
+        assertThrows(
+            StorageFormatException.class,
+            () -> SplitFileFetcherSegmentsBuilder.initSegmentsFromStream(params));
+    assertEquals("Total data blocks 1 but expected 2", ex.getMessage());
+  }
+
+  @Test
+  void initSegmentsFromStream_whenOffsetsPastRaf_throwsStorageFormatException() throws Exception {
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(buildSegmentStream(2, 1)));
+
+    SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[1];
+    SplitFileFetcherStorage parent = newMinimalParent(segments, 0L, 0L);
+
+    SplitFileFetcherSegmentsLoadParams params =
+        new SplitFileFetcherSegmentsLoadParams(
+            parent, 2, 0, 1, dis, false, null, segments, 4, false, 0L, 0L, CHKBlock.DATA_LENGTH);
+
+    StorageFormatException ex =
+        assertThrows(
+            StorageFormatException.class,
+            () -> SplitFileFetcherSegmentsBuilder.initSegmentsFromStream(params));
+    long expectedOffset = 3L * CHKBlock.DATA_LENGTH;
+    assertEquals(
+        "Data offset past end of file " + expectedOffset + " of " + CHKBlock.DATA_LENGTH,
+        ex.getMessage());
+  }
+
+  private SplitFileFetcherStorage newMinimalParent(
+      SplitFileFetcherSegmentStorage[] segments, long offsetKeyList, long offsetSegmentStatus) {
+    SplitFileFetcherStorage parent = Mockito.mock(SplitFileFetcherStorage.class);
+    setFinalOnParent(parent, "segments", segments);
+    setFinalOnParent(parent, "random", new DeterministicRandomSource(42L));
+    setFinalOnParent(parent, "maxRetries", 1);
+    setFinalOnParent(parent, "cooldownTries", 2);
+    setFinalOnParent(parent, "cooldownLength", 1000L);
+    setFinalOnParent(parent, "checksumLength", 4);
+    setFinalOnParent(parent, "persistent", true);
+    setFinalOnParent(parent, "splitfileSingleCryptoAlgorithm", (byte) 2);
+    setFinalOnParent(parent, "splitfileSingleCryptoKey", null);
+    setFinalOnParent(parent, "jobRunner", jobRunner);
+    setFinalOnParent(parent, "memoryLimitedJobRunner", memoryLimitedJobRunner);
+    setFinalOnParent(parent, "offsetKeyList", offsetKeyList);
+    setFinalOnParent(parent, "offsetSegmentStatus", offsetSegmentStatus);
+    setFinalOnParent(parent, "fecCodec", Mockito.mock(network.crypta.client.FECCodec.class));
+    Mockito.lenient().when(parent.lastBlockMightNotBePadded()).thenReturn(false);
+    return parent;
+  }
+
+  private static void setFinalOnParent(Object parent, String fieldName, Object value) {
+    try {
+      Field f = SplitFileFetcherStorage.class.getDeclaredField(fieldName);
+      f.setAccessible(true);
+      f.set(parent, value);
+    } catch (Exception e) {
+      throw new AssertionError("Failed to set final field '" + fieldName + "'", e);
+    }
+  }
+
+  private static SplitFileSegmentKeys newSegmentKeys(int dataBlocks, int checkBlocks)
+      throws Exception {
+    byte algo = (byte) 2;
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(dataBlocks, checkBlocks, null, algo);
+    for (int i = 0; i < dataBlocks + checkBlocks; i++) {
+      byte[] rk = new byte[NodeCHK.KEY_LENGTH];
+      rk[0] = (byte) (11 + i);
+      byte[] ck = new byte[ClientCHK.CRYPTO_KEY_LENGTH];
+      ck[0] = (byte) (77 + i);
+      ClientCHK key = new ClientCHK(rk, ck, ClientCHK.getExtra(algo, (short) -1, false));
+      keys.setKey(i, key);
+    }
+    return keys;
+  }
+
+  private static byte[] buildSegmentStream(int dataBlocks, int crossCheckBlocks)
+      throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    dos.writeInt(dataBlocks);
+    dos.writeInt(crossCheckBlocks);
+    dos.writeInt(0);
+    dos.writeInt(0);
+    dos.close();
+    return bos.toByteArray();
+  }
+
+  private static final class DeterministicRandomSource extends RandomSource {
+    private final Random rnd;
+
+    private DeterministicRandomSource(long seed) {
+      this.rnd = new Random(seed);
+    }
+
+    @Override
+    protected synchronized int next(int bits) {
+      return rnd.nextInt(1 << bits);
+    }
+
+    @Override
+    public int acceptEntropy(EntropySource source, long data, int entropyGuess) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(EntropySource timer) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(EntropySource fnpTimingSource, double bias) {
+      return 0;
+    }
+
+    @Override
+    public int acceptEntropyBytes(
+        EntropySource myPacketDataSource, byte[] buf, int offset, int length, double bias) {
+      return 0;
+    }
+
+    @Override
+    public void close() {
+      // No-op test stub.
+    }
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageLayoutTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageLayoutTest.java
@@ -1,0 +1,217 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.NodeCHK;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("java:S100")
+class SplitFileFetcherStorageLayoutTest {
+
+  @Test
+  void accumulateSizes_whenMultipleSegmentsWithCrossChecks_returnsAggregatedSizes() {
+    // Arrange
+    SplitFileSegmentKeys[] segmentKeys =
+        new SplitFileSegmentKeys[] {newSegmentKeys(5, 2, true), newSegmentKeys(7, 3, true)};
+    int crossCheckBlocks = 1;
+    boolean hasSplitfileSingleCryptoKey = true;
+    int checksumLength = 4;
+    int maxRetries = 3;
+    boolean persistent = true;
+
+    int expectedDataBlocks = (5 + 7) - (2 * crossCheckBlocks);
+    int expectedCheckBlocks = 2 + 3;
+    long expectedStoredKeysLength =
+        expectedStoredKeysLength(5, 2, true, checksumLength)
+            + expectedStoredKeysLength(7, 3, true, checksumLength);
+    long expectedStoredSegmentStatusLength =
+        expectedStoredSegmentStatusLength(4, 2, crossCheckBlocks, true, checksumLength)
+            + expectedStoredSegmentStatusLength(6, 3, crossCheckBlocks, true, checksumLength);
+
+    // Act
+    SplitFileFetcherStorageLayout.AccumulatedSizes sizes =
+        SplitFileFetcherStorageLayout.accumulateSizes(
+            segmentKeys,
+            crossCheckBlocks,
+            hasSplitfileSingleCryptoKey,
+            checksumLength,
+            maxRetries,
+            persistent);
+
+    // Assert
+    assertEquals(expectedDataBlocks, sizes.splitfileDataBlocks());
+    assertEquals(expectedCheckBlocks, sizes.splitfileCheckBlocks());
+    assertEquals(expectedStoredKeysLength, sizes.storedKeysLength());
+    assertEquals(expectedStoredSegmentStatusLength, sizes.storedSegmentStatusLength());
+  }
+
+  @Test
+  void accumulateSizes_whenRetriesDisabled_omitsRetryBytesInStatusLength() {
+    // Arrange
+    SplitFileSegmentKeys[] segmentKeys = new SplitFileSegmentKeys[] {newSegmentKeys(4, 1, false)};
+    int crossCheckBlocks = 0;
+    boolean hasSplitfileSingleCryptoKey = false;
+    int checksumLength = 2;
+    int maxRetries = -1;
+    boolean persistent = true;
+
+    int expectedDataBlocks = 4;
+    int expectedCheckBlocks = 1;
+    long expectedStoredKeysLength = expectedStoredKeysLength(4, 1, false, checksumLength);
+    long expectedStoredSegmentStatusLength =
+        expectedStoredSegmentStatusLength(4, 1, 0, false, checksumLength);
+
+    // Act
+    SplitFileFetcherStorageLayout.AccumulatedSizes sizes =
+        SplitFileFetcherStorageLayout.accumulateSizes(
+            segmentKeys,
+            crossCheckBlocks,
+            hasSplitfileSingleCryptoKey,
+            checksumLength,
+            maxRetries,
+            persistent);
+
+    // Assert
+    assertEquals(expectedDataBlocks, sizes.splitfileDataBlocks());
+    assertEquals(expectedCheckBlocks, sizes.splitfileCheckBlocks());
+    assertEquals(expectedStoredKeysLength, sizes.storedKeysLength());
+    assertEquals(expectedStoredSegmentStatusLength, sizes.storedSegmentStatusLength());
+  }
+
+  @Test
+  void accumulateSizes_whenNonPersistent_returnsZeroStatusLength() {
+    // Arrange
+    SplitFileSegmentKeys[] segmentKeys =
+        new SplitFileSegmentKeys[] {newSegmentKeys(2, 2, false), newSegmentKeys(1, 0, false)};
+    int crossCheckBlocks = 0;
+    boolean hasSplitfileSingleCryptoKey = false;
+    int checksumLength = 3;
+    int maxRetries = 2;
+    boolean persistent = false;
+
+    int expectedDataBlocks = 3;
+    int expectedCheckBlocks = 2;
+    long expectedStoredKeysLength =
+        expectedStoredKeysLength(2, 2, false, checksumLength)
+            + expectedStoredKeysLength(1, 0, false, checksumLength);
+
+    // Act
+    SplitFileFetcherStorageLayout.AccumulatedSizes sizes =
+        SplitFileFetcherStorageLayout.accumulateSizes(
+            segmentKeys,
+            crossCheckBlocks,
+            hasSplitfileSingleCryptoKey,
+            checksumLength,
+            maxRetries,
+            persistent);
+
+    // Assert
+    assertEquals(expectedDataBlocks, sizes.splitfileDataBlocks());
+    assertEquals(expectedCheckBlocks, sizes.splitfileCheckBlocks());
+    assertEquals(expectedStoredKeysLength, sizes.storedKeysLength());
+    assertEquals(0, sizes.storedSegmentStatusLength());
+  }
+
+  @Test
+  void validateCheckLength_whenNotExceedingFinalLength_doesNotThrow() {
+    // Arrange
+    long checkLength = 100L;
+    long finalLength = 100L;
+
+    // Act + Assert
+    assertDoesNotThrow(
+        () -> SplitFileFetcherStorageLayout.validateCheckLength(checkLength, finalLength));
+  }
+
+  @Test
+  void validateCheckLength_whenWithinTolerance_doesNotThrow() {
+    // Arrange
+    long finalLength = 100L;
+    long checkLength = finalLength + CHKBlock.DATA_LENGTH;
+
+    // Act + Assert
+    assertDoesNotThrow(
+        () -> SplitFileFetcherStorageLayout.validateCheckLength(checkLength, finalLength));
+  }
+
+  @Test
+  void validateCheckLength_whenExceedsTolerance_throwsFetchException() {
+    // Arrange
+    long finalLength = 100L;
+    long checkLength = finalLength + CHKBlock.DATA_LENGTH + 1L;
+
+    // Act
+    FetchException exception =
+        assertThrows(
+            FetchException.class,
+            () -> SplitFileFetcherStorageLayout.validateCheckLength(checkLength, finalLength));
+
+    // Assert
+    assertEquals(FetchExceptionMode.INVALID_METADATA, exception.mode);
+    assertTrue(
+        exception.getMessage().contains("Splitfile is"),
+        "Expected failure message to mention splitfile length");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, -1})
+  void validateSegmentCount_whenNonPositive_throwsAssertionError(int segmentCount) {
+    // Arrange
+
+    // Act
+    AssertionError error =
+        assertThrows(
+            AssertionError.class,
+            () -> SplitFileFetcherStorageLayout.validateSegmentCount(segmentCount));
+
+    // Assert
+    assertEquals("A splitfile has to have at least one segment", error.getMessage());
+  }
+
+  @Test
+  void validateSegmentCount_whenPositive_doesNotThrow() {
+    // Arrange
+
+    // Act + Assert
+    assertDoesNotThrow(() -> SplitFileFetcherStorageLayout.validateSegmentCount(1));
+  }
+
+  private static SplitFileSegmentKeys newSegmentKeys(
+      int dataBlocks, int checkBlocks, boolean hasCommonKey) {
+    byte[] commonKey = hasCommonKey ? new byte[32] : null;
+    byte algorithm = (byte) 1;
+    return new SplitFileSegmentKeys(dataBlocks, checkBlocks, commonKey, algorithm);
+  }
+
+  private static int expectedStoredKeysLength(
+      int dataBlocks, int checkBlocks, boolean commonKey, int checksumLength) {
+    int blocks = dataBlocks + checkBlocks;
+    int keyBytes;
+    if (commonKey) {
+      keyBytes = blocks * NodeCHK.KEY_LENGTH;
+    } else {
+      keyBytes = blocks * (SplitFileSegmentKeys.EXTRA_BYTES_LENGTH + NodeCHK.KEY_LENGTH * 2);
+    }
+    return keyBytes + checksumLength;
+  }
+
+  private static int expectedStoredSegmentStatusLength(
+      int dataBlocks,
+      int checkBlocks,
+      int crossCheckBlocks,
+      boolean trackRetries,
+      int checksumLength) {
+    int fetchedBlocks = dataBlocks + crossCheckBlocks;
+    int totalBlocks = dataBlocks + checkBlocks + crossCheckBlocks;
+    int base = fetchedBlocks * 4 + (trackRetries ? totalBlocks * 4 : 0);
+    return base + checksumLength;
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStoragePersistenceWriterTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStoragePersistenceWriterTest.java
@@ -1,0 +1,175 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SplitFileFetcherStoragePersistenceWriterTest {
+
+  @Test
+  void writeToRaf_whenPersistentFalse_writesKeysOnly() throws Exception {
+    SplitFileFetcherSegmentStorage first = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage second = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage[] segments =
+        new SplitFileFetcherSegmentStorage[] {first, second};
+    SplitFileFetcherKeyListener keyListener = mock(SplitFileFetcherKeyListener.class);
+    LockableRandomAccessBuffer raf = mock(LockableRandomAccessBuffer.class);
+    SplitFileFetcherStorage storage = mockStorage(false, segments, keyListener);
+    SplitFileFetcherStorage.AutoCloseableRafLock lock =
+        mock(SplitFileFetcherStorage.AutoCloseableRafLock.class);
+    when(storage.autoLockOpen()).thenReturn(lock);
+
+    SplitFileSegmentKeys[] keys =
+        new SplitFileSegmentKeys[] {
+          mock(SplitFileSegmentKeys.class), mock(SplitFileSegmentKeys.class)
+        };
+
+    SplitFileFetcherStoragePersistenceWriter.writeToRaf(
+        storage, keys, null, null, new byte[] {1}, 0L);
+
+    verify(first).writeKeysWithChecksum(keys[0]);
+    verify(second).writeKeysWithChecksum(keys[1]);
+    verify(first, never()).writeMetadata();
+    verify(second, never()).writeMetadata();
+    verifyNoInteractions(keyListener);
+    verifyNoInteractions(raf);
+    verify(lock).close();
+  }
+
+  @Test
+  void writeToRaf_whenPersistentTrue_writesMetadataAndFooter() throws Exception {
+    SplitFileFetcherSegmentStorage first = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage second = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage[] segments =
+        new SplitFileFetcherSegmentStorage[] {first, second};
+    SplitFileFetcherKeyListener keyListener = mock(SplitFileFetcherKeyListener.class);
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+    LockableRandomAccessBuffer raf = mock(LockableRandomAccessBuffer.class);
+    SplitFileFetcherStorage storage =
+        mockStorage(true, segments, keyListener, checksumChecker, 40L, 60L, 80L, 100L);
+    SplitFileFetcherStorage.AutoCloseableRafLock lock =
+        mock(SplitFileFetcherStorage.AutoCloseableRafLock.class);
+    when(storage.autoLockOpen()).thenReturn(lock);
+    when(storage.getRAF()).thenReturn(raf);
+
+    SplitFileFetcherStoragePersistence.PreparedMetadata prepared =
+        mock(SplitFileFetcherStoragePersistence.PreparedMetadata.class);
+    byte[] encodedBasicSettings = new byte[] {4, 5, 6};
+    byte[] generalProgress = new byte[] {7, 8};
+    long totalLength = 256L;
+    SplitFileSegmentKeys[] keys =
+        new SplitFileSegmentKeys[] {
+          mock(SplitFileSegmentKeys.class), mock(SplitFileSegmentKeys.class)
+        };
+
+    try (MockedStatic<SplitFileFetcherStoragePersistence> mocked =
+        mockStatic(SplitFileFetcherStoragePersistence.class)) {
+      SplitFileFetcherStoragePersistenceWriter.writeToRaf(
+          storage, keys, prepared, encodedBasicSettings, generalProgress, totalLength);
+
+      verify(first).writeKeysWithChecksum(keys[0]);
+      verify(second).writeKeysWithChecksum(keys[1]);
+      verify(first).writeMetadata();
+      verify(second).writeMetadata();
+      verify(raf).pwrite(40L, generalProgress, 0, generalProgress.length);
+      verify(keyListener).innerWriteMainBloomFilter(60L);
+      verify(keyListener).initialWriteSegmentBloomFilters(80L);
+      mocked.verify(
+          () ->
+              SplitFileFetcherStoragePersistence.writePersistentMetadata(
+                  raf, 100L, prepared, encodedBasicSettings, checksumChecker, totalLength));
+      verify(lock).close();
+    }
+  }
+
+  @Test
+  void writeToRaf_whenKeyWriteFails_propagatesIOException() throws Exception {
+    SplitFileFetcherSegmentStorage first = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage second = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage[] segments =
+        new SplitFileFetcherSegmentStorage[] {first, second};
+    SplitFileFetcherKeyListener keyListener = mock(SplitFileFetcherKeyListener.class);
+    SplitFileFetcherStorage storage = mockStorage(true, segments, keyListener);
+    SplitFileFetcherStorage.AutoCloseableRafLock lock =
+        mock(SplitFileFetcherStorage.AutoCloseableRafLock.class);
+    when(storage.autoLockOpen()).thenReturn(lock);
+
+    SplitFileSegmentKeys[] keys =
+        new SplitFileSegmentKeys[] {
+          mock(SplitFileSegmentKeys.class), mock(SplitFileSegmentKeys.class)
+        };
+    IOException failure = new IOException("boom");
+    org.mockito.Mockito.doThrow(failure).when(first).writeKeysWithChecksum(keys[0]);
+
+    assertThrows(
+        IOException.class,
+        () ->
+            SplitFileFetcherStoragePersistenceWriter.writeToRaf(
+                storage, keys, null, null, new byte[] {1}, 0L));
+
+    verify(lock).close();
+    verifyNoInteractions(keyListener);
+  }
+
+  private static SplitFileFetcherStorage mockStorage(
+      boolean persistent,
+      SplitFileFetcherSegmentStorage[] segments,
+      SplitFileFetcherKeyListener keyListener) {
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+    return mockStorage(persistent, segments, keyListener, checksumChecker, 0L, 0L, 0L, 0L);
+  }
+
+  private static SplitFileFetcherStorage mockStorage(
+      boolean persistent,
+      SplitFileFetcherSegmentStorage[] segments,
+      SplitFileFetcherKeyListener keyListener,
+      ChecksumChecker checksumChecker,
+      long offsetGeneralProgress,
+      long offsetMainBloomFilter,
+      long offsetSegmentBloomFilters,
+      long offsetOriginalMetadata) {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    setField(storage, "segments", segments);
+    setField(storage, "persistent", persistent);
+    setField(storage, "offsetGeneralProgress", offsetGeneralProgress);
+    setField(storage, "offsetMainBloomFilter", offsetMainBloomFilter);
+    setField(storage, "offsetSegmentBloomFilters", offsetSegmentBloomFilters);
+    setField(storage, "offsetOriginalMetadata", offsetOriginalMetadata);
+    setField(storage, "checksumChecker", checksumChecker);
+    setField(storage, "keyListener", keyListener);
+    return storage;
+  }
+
+  private static void setField(Object target, String fieldName, Object value) {
+    try {
+      Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (NoSuchFieldException _) {
+      try {
+        Field field = target.getClass().getSuperclass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+      } catch (ReflectiveOperationException ex) {
+        throw new AssertionError(ex);
+      }
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageRecoveryTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageRecoveryTest.java
@@ -1,0 +1,325 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.client.FailureCodeTracker;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.crypt.ChecksumFailedException;
+import network.crypta.keys.ClientCHK;
+import network.crypta.keys.Key;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.io.StorageFormatException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SplitFileFetcherStorageRecoveryTest {
+
+  @Test
+  void postInitReadSegmentState_whenSegmentNeedsDecode_queuesDecodeAndChecksCrossSegments()
+      throws Exception {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    SplitFileFetcherSegmentStorage segment = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage otherSegment = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage[] segments =
+        new SplitFileFetcherSegmentStorage[] {segment, otherSegment};
+    SplitFileFetcherCrossSegmentStorage crossSegment =
+        mock(SplitFileFetcherCrossSegmentStorage.class);
+
+    setField(storage, "segments", segments);
+    setField(storage, "crossSegments", new SplitFileFetcherCrossSegmentStorage[] {crossSegment});
+    setField(storage, "segmentsToTryDecode", null);
+
+    when(segment.hasFailed()).thenReturn(false);
+    when(segment.needsDecode()).thenReturn(true);
+    when(otherSegment.hasFailed()).thenReturn(false);
+    when(otherSegment.needsDecode()).thenReturn(false);
+
+    when(segment.readSegmentKeys()).thenReturn(mock(SplitFileSegmentKeys.class));
+    when(otherSegment.readSegmentKeys()).thenReturn(mock(SplitFileSegmentKeys.class));
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    recovery.postInitReadSegmentState();
+
+    @SuppressWarnings("unchecked")
+    List<SplitFileFetcherSegmentStorage> queued =
+        (List<SplitFileFetcherSegmentStorage>) getField(storage, "segmentsToTryDecode");
+    assertNotNull(queued);
+    assertEquals(1, queued.size());
+    assertSame(segment, queued.getFirst());
+    verify(segment).readMetadata();
+    verify(otherSegment).readMetadata();
+    verify(segment).readSegmentKeys();
+    verify(otherSegment).readSegmentKeys();
+    verify(crossSegment).checkBlocks();
+  }
+
+  @Test
+  void postInitReadSegmentState_whenSegmentFailed_throwsFetchExceptionAndFreesRaf()
+      throws Exception {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    SplitFileFetcherSegmentStorage segment = mock(SplitFileFetcherSegmentStorage.class);
+    LockableRandomAccessBuffer raf = mock(LockableRandomAccessBuffer.class);
+    setField(storage, "segments", new SplitFileFetcherSegmentStorage[] {segment});
+    setField(storage, "errors", new FailureCodeTracker(false));
+    when(storage.getRAF()).thenReturn(raf);
+    when(segment.hasFailed()).thenReturn(true);
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    FetchException exception =
+        assertThrows(FetchException.class, recovery::postInitReadSegmentState);
+
+    assertEquals(FetchExceptionMode.SPLITFILE_ERROR, exception.mode);
+    verify(raf).close();
+    verify(raf).free();
+    verify(segment, never()).readSegmentKeys();
+  }
+
+  @Test
+  void postInitReadSegmentState_whenKeysCorrupted_throwsStorageFormatException() throws Exception {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    SplitFileFetcherSegmentStorage segment = mock(SplitFileFetcherSegmentStorage.class);
+    setField(storage, "segments", new SplitFileFetcherSegmentStorage[] {segment});
+    when(segment.hasFailed()).thenReturn(false);
+    when(segment.needsDecode()).thenReturn(false);
+    when(segment.readSegmentKeys()).thenThrow(new ChecksumFailedException());
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    assertThrows(StorageFormatException.class, recovery::postInitReadSegmentState);
+
+    assertNull(getField(storage, "segmentsToTryDecode"));
+  }
+
+  @Test
+  void readGeneralProgress_whenValidData_setsFlagsAndErrors() throws Exception {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    FailureCodeTracker tracker = new FailureCodeTracker(false);
+    tracker.inc(FetchExceptionMode.TOO_BIG);
+    byte[] progress =
+        buildProgressPayload(SplitFileFetcherStorage.HAS_CHECKED_DATASTORE_FLAG, tracker);
+
+    setField(storage, "offsetGeneralProgress", 128L);
+    setField(storage, "hasCheckedDatastore", false);
+    setField(storage, "errors", new FailureCodeTracker(false));
+    when(storage.preadChecksummedWithLength(128L)).thenReturn(progress);
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    recovery.readGeneralProgress();
+
+    assertTrue((boolean) getField(storage, "hasCheckedDatastore"));
+    FailureCodeTracker result = (FailureCodeTracker) getField(storage, "errors");
+    assertEquals(1, result.getErrorCount(FetchExceptionMode.TOO_BIG));
+    verify(storage).preadChecksummedWithLength(128L);
+  }
+
+  @Test
+  void readGeneralProgress_whenFlagNotSet_keepsCheckedFalse() throws Exception {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    FailureCodeTracker tracker = new FailureCodeTracker(false);
+    byte[] progress = buildProgressPayload(0L, tracker);
+
+    setField(storage, "offsetGeneralProgress", 96L);
+    setField(storage, "hasCheckedDatastore", false);
+    setField(storage, "errors", new FailureCodeTracker(false));
+    when(storage.preadChecksummedWithLength(96L)).thenReturn(progress);
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    recovery.readGeneralProgress();
+
+    assertFalse((boolean) getField(storage, "hasCheckedDatastore"));
+    FailureCodeTracker result = (FailureCodeTracker) getField(storage, "errors");
+    assertEquals(0, result.getErrorCount(FetchExceptionMode.TOO_BIG));
+  }
+
+  @Test
+  void readGeneralProgress_whenChecksumFails_resetsProgress() throws Exception {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    FailureCodeTracker originalErrors = new FailureCodeTracker(false);
+    originalErrors.inc(FetchExceptionMode.TOO_BIG);
+    setField(storage, "offsetGeneralProgress", 64L);
+    setField(storage, "hasCheckedDatastore", true);
+    setField(storage, "errors", originalErrors);
+    when(storage.preadChecksummedWithLength(64L)).thenThrow(new ChecksumFailedException());
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    recovery.readGeneralProgress();
+
+    assertFalse((boolean) getField(storage, "hasCheckedDatastore"));
+    FailureCodeTracker result = (FailureCodeTracker) getField(storage, "errors");
+    assertNotSame(originalErrors, result);
+    assertEquals(0, result.getErrorCount(FetchExceptionMode.TOO_BIG));
+  }
+
+  @Test
+  void regenerateKeysAsync_whenPersistenceDisabled_returnsFalse() throws Exception {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
+    setField(storage, "jobRunner", jobRunner);
+    doThrow(new PersistenceDisabledException()).when(jobRunner).queue(any(), anyInt());
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    assertFalse(recovery.regenerateKeysAsync());
+
+    verify(jobRunner).queue(any(), anyInt());
+  }
+
+  @Test
+  void regenerateKeysAsync_whenJobRuns_rebuildsBloomFiltersAndNotifies() throws Exception {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
+    SplitFileFetcherKeyListener keyListener = mock(SplitFileFetcherKeyListener.class);
+    SplitFileFetcherStorageCallback fetcher = mock(SplitFileFetcherStorageCallback.class);
+    SplitFileFetcherSegmentStorage segment = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileSegmentKeys keys = mock(SplitFileSegmentKeys.class);
+    ClientCHK clientKey = mock(ClientCHK.class);
+    Key nodeKey = mock(Key.class);
+    KeySalter salter = _ -> new byte[] {1, 2, 3};
+
+    setField(storage, "jobRunner", jobRunner);
+    setField(storage, "segments", new SplitFileFetcherSegmentStorage[] {segment});
+    setField(storage, "keyListener", keyListener);
+    setField(storage, "fetcher", fetcher);
+    setField(storage, "persistent", true);
+    setField(storage, "offsetSegmentBloomFilters", 20L);
+    setField(storage, "offsetMainBloomFilter", 40L);
+
+    when(fetcher.getSalter()).thenReturn(salter);
+    when(segment.readSegmentKeys()).thenReturn(keys);
+    when(keys.totalKeys()).thenReturn(2);
+    when(keys.getKey(anyInt(), isNull(), eq(false))).thenReturn(clientKey);
+    when(clientKey.getNodeKey(false)).thenReturn(nodeKey);
+
+    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
+    doNothing().when(jobRunner).queue(jobCaptor.capture(), anyInt());
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    assertFalse(recovery.regenerateKeysAsync());
+
+    PersistentJob job = jobCaptor.getValue();
+    assertNotNull(job);
+    assertFalse(job.run(mock(ClientContext.class)));
+
+    verify(keyListener, times(2)).addKey(any(Key.class), eq(0), eq(salter));
+    verify(keyListener).addedAllKeys();
+    verify(keyListener).initialWriteSegmentBloomFilters(20L);
+    verify(keyListener).innerWriteMainBloomFilter(40L);
+    verify(fetcher).restartedAfterDataCorruption();
+    verify(storage, never()).failOnDiskError(any(IOException.class));
+  }
+
+  @Test
+  void restartCrossSegments_whenPresent_invokesRestart() {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    SplitFileFetcherCrossSegmentStorage first = mock(SplitFileFetcherCrossSegmentStorage.class);
+    SplitFileFetcherCrossSegmentStorage second = mock(SplitFileFetcherCrossSegmentStorage.class);
+    setField(storage, "crossSegments", new SplitFileFetcherCrossSegmentStorage[] {first, second});
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    recovery.restartCrossSegments();
+
+    verify(first).restart();
+    verify(second).restart();
+  }
+
+  @Test
+  void scheduleTryDecodeForBrokenSegments_whenListPresent_startsAndClears() {
+    SplitFileFetcherStorage storage = mock(SplitFileFetcherStorage.class);
+    SplitFileFetcherSegmentStorage first = mock(SplitFileFetcherSegmentStorage.class);
+    SplitFileFetcherSegmentStorage second = mock(SplitFileFetcherSegmentStorage.class);
+    List<SplitFileFetcherSegmentStorage> broken = new ArrayList<>();
+    broken.add(first);
+    broken.add(second);
+    setField(storage, "segmentsToTryDecode", broken);
+
+    SplitFileFetcherStorageRecovery recovery = new SplitFileFetcherStorageRecovery(storage);
+
+    recovery.scheduleTryDecodeForBrokenSegments();
+
+    verify(first).tryStartDecode();
+    verify(second).tryStartDecode();
+    assertNull(getField(storage, "segmentsToTryDecode"));
+  }
+
+  private static byte[] buildProgressPayload(long flags, FailureCodeTracker tracker)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeLong(flags);
+      tracker.writeFixedLengthTo(dos);
+    }
+    return baos.toByteArray();
+  }
+
+  private static void setField(Object target, String fieldName, Object value) {
+    try {
+      Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (NoSuchFieldException _) {
+      try {
+        Field field = target.getClass().getSuperclass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+      } catch (ReflectiveOperationException ex) {
+        throw new AssertionError(ex);
+      }
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static Object getField(Object target, String fieldName) {
+    try {
+      Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.get(target);
+    } catch (NoSuchFieldException _) {
+      try {
+        Field field = target.getClass().getSuperclass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+      } catch (ReflectiveOperationException ex) {
+        throw new AssertionError(ex);
+      }
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageResumeReaderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageResumeReaderTest.java
@@ -1,0 +1,341 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.Metadata.SplitfileAlgorithm;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import network.crypta.support.io.StorageFormatException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings({"java:S100", "resource"})
+@ExtendWith(MockitoExtension.class)
+class SplitFileFetcherStorageResumeReaderTest {
+
+  @Test
+  void readParsedSettings_whenFooterValid_returnsParsedSettings() throws Exception {
+    int checksumLength = 4;
+    int basicSettingsLength = 32;
+    long rafLength = 200L;
+    ResumeLayout layout =
+        ResumeLayout.create(
+            rafLength,
+            basicSettingsLength,
+            checksumLength,
+            0,
+            ChecksumChecker.CHECKSUM_CRC,
+            SplitFileFetcherStorage.VERSION,
+            SplitFileFetcherStorage.END_MAGIC);
+    LockableRandomAccessBuffer raf = mockRaf(layout.data, rafLength);
+
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+    when(checksumChecker.checkChecksum(any(byte[].class), anyInt(), anyInt(), any(byte[].class)))
+        .thenReturn(true);
+
+    ParsedBasicSettings expected =
+        new ParsedBasicSettings(
+            SplitfileAlgorithm.ONION_STANDARD,
+            (byte) 0,
+            null,
+            100L,
+            200L,
+            new ClientMetadata("text/plain"),
+            List.of(COMPRESSOR_TYPE.GZIP),
+            10L,
+            20L,
+            30L,
+            40L,
+            50L,
+            60L,
+            70L,
+            80L,
+            CompatibilityMode.COMPAT_1250,
+            2,
+            3,
+            4,
+            0,
+            new DataInputStream(new ByteArrayInputStream(new byte[0])));
+
+    try (MockedStatic<SplitFileFetcherStorageSettingsCodec> mocked =
+        mockStatic(SplitFileFetcherStorageSettingsCodec.class)) {
+      ArgumentCaptor<byte[]> bufferCaptor = ArgumentCaptor.forClass(byte[].class);
+      mocked
+          .when(
+              () ->
+                  SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
+                      bufferCaptor.capture(),
+                      eq(layout.basicSettingsOffset),
+                      eq(true),
+                      eq(rafLength)))
+          .thenReturn(expected);
+
+      ParsedBasicSettings result =
+          SplitFileFetcherStorageResumeReader.readParsedSettings(
+              raf, checksumChecker, checksumLength, rafLength, true);
+
+      assertSame(expected, result);
+      assertEquals(layout.basicSettingsLength, bufferCaptor.getValue().length);
+      assertEquals(layout.payloadSignature, bufferCaptor.getValue()[0]);
+      verify(checksumChecker).checkChecksum(any(byte[].class), eq(0), eq(14), any(byte[].class));
+      verify(checksumChecker)
+          .checkChecksum(any(byte[].class), eq(0), eq(basicSettingsLength), any(byte[].class));
+    }
+  }
+
+  @Test
+  void readParsedSettings_whenTooShort_throwsStorageFormatException() {
+    LockableRandomAccessBuffer raf = mock(LockableRandomAccessBuffer.class);
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageResumeReader.readParsedSettings(
+                raf, checksumChecker, 4, 7L, false));
+  }
+
+  @Test
+  void readParsedSettings_whenMagicMismatch_throwsStorageFormatException() throws Exception {
+    ResumeLayout layout =
+        ResumeLayout.create(
+            200L, 16, 4, 0, ChecksumChecker.CHECKSUM_CRC, SplitFileFetcherStorage.VERSION, 0L);
+    LockableRandomAccessBuffer raf = mockRaf(layout.data, layout.rafLength);
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageResumeReader.readParsedSettings(
+                raf, checksumChecker, layout.checksumLength, layout.rafLength, false));
+  }
+
+  @Test
+  void readParsedSettings_whenVersionMismatch_throwsStorageFormatException() throws Exception {
+    ResumeLayout layout =
+        ResumeLayout.create(
+            200L,
+            16,
+            4,
+            0,
+            ChecksumChecker.CHECKSUM_CRC,
+            SplitFileFetcherStorage.VERSION + 1,
+            SplitFileFetcherStorage.END_MAGIC);
+    LockableRandomAccessBuffer raf = mockRaf(layout.data, layout.rafLength);
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageResumeReader.readParsedSettings(
+                raf, checksumChecker, layout.checksumLength, layout.rafLength, false));
+  }
+
+  @Test
+  void readParsedSettings_whenChecksumTypeUnknown_throwsStorageFormatException() throws Exception {
+    ResumeLayout layout =
+        ResumeLayout.create(
+            200L, 16, 4, 0, 99, SplitFileFetcherStorage.VERSION, SplitFileFetcherStorage.END_MAGIC);
+    LockableRandomAccessBuffer raf = mockRaf(layout.data, layout.rafLength);
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageResumeReader.readParsedSettings(
+                raf, checksumChecker, layout.checksumLength, layout.rafLength, false));
+  }
+
+  @Test
+  void readParsedSettings_whenFlagsNonZero_throwsStorageFormatException() throws Exception {
+    ResumeLayout layout =
+        ResumeLayout.create(
+            200L,
+            16,
+            4,
+            42,
+            ChecksumChecker.CHECKSUM_CRC,
+            SplitFileFetcherStorage.VERSION,
+            SplitFileFetcherStorage.END_MAGIC);
+    LockableRandomAccessBuffer raf = mockRaf(layout.data, layout.rafLength);
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageResumeReader.readParsedSettings(
+                raf, checksumChecker, layout.checksumLength, layout.rafLength, false));
+  }
+
+  @Test
+  void readParsedSettings_whenLengthChecksumFails_throwsStorageFormatException() throws Exception {
+    ResumeLayout layout =
+        ResumeLayout.create(
+            200L,
+            32,
+            4,
+            0,
+            ChecksumChecker.CHECKSUM_CRC,
+            SplitFileFetcherStorage.VERSION,
+            SplitFileFetcherStorage.END_MAGIC);
+    LockableRandomAccessBuffer raf = mockRaf(layout.data, layout.rafLength);
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+    when(checksumChecker.checkChecksum(any(byte[].class), anyInt(), anyInt(), any(byte[].class)))
+        .thenAnswer(invocation -> !invocation.getArgument(2).equals(14));
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageResumeReader.readParsedSettings(
+                raf, checksumChecker, layout.checksumLength, layout.rafLength, false));
+  }
+
+  @Test
+  void readParsedSettings_whenBasicSettingsLengthTooLarge_throwsStorageFormatException()
+      throws Exception {
+    int checksumLength = 4;
+    int basicSettingsLength = 1_048_577;
+    long rafLength = basicSettingsLength + 200L;
+    ResumeLayout layout =
+        ResumeLayout.create(
+            rafLength,
+            basicSettingsLength,
+            checksumLength,
+            0,
+            ChecksumChecker.CHECKSUM_CRC,
+            SplitFileFetcherStorage.VERSION,
+            SplitFileFetcherStorage.END_MAGIC);
+    LockableRandomAccessBuffer raf = mockRaf(layout.data, layout.rafLength);
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+    when(checksumChecker.checkChecksum(any(byte[].class), anyInt(), anyInt(), any(byte[].class)))
+        .thenReturn(true);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageResumeReader.readParsedSettings(
+                raf, checksumChecker, checksumLength, rafLength, false));
+  }
+
+  @Test
+  void readParsedSettings_whenBasicSettingsChecksumInvalid_throwsStorageFormatException()
+      throws Exception {
+    ResumeLayout layout =
+        ResumeLayout.create(
+            200L,
+            32,
+            4,
+            0,
+            ChecksumChecker.CHECKSUM_CRC,
+            SplitFileFetcherStorage.VERSION,
+            SplitFileFetcherStorage.END_MAGIC);
+    LockableRandomAccessBuffer raf = mockRaf(layout.data, layout.rafLength);
+    ChecksumChecker checksumChecker = mock(ChecksumChecker.class);
+    when(checksumChecker.checkChecksum(any(byte[].class), anyInt(), anyInt(), any(byte[].class)))
+        .thenAnswer(invocation -> invocation.getArgument(2).equals(14));
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            SplitFileFetcherStorageResumeReader.readParsedSettings(
+                raf, checksumChecker, layout.checksumLength, layout.rafLength, false));
+  }
+
+  private static LockableRandomAccessBuffer mockRaf(byte[] data, long length) throws Exception {
+    LockableRandomAccessBuffer raf = mock(LockableRandomAccessBuffer.class);
+    lenient().when(raf.size()).thenReturn(length);
+    doAnswer(
+            invocation -> {
+              long fileOffset = invocation.getArgument(0);
+              byte[] buffer = invocation.getArgument(1);
+              int bufOffset = invocation.getArgument(2);
+              int readLength = invocation.getArgument(3);
+              System.arraycopy(data, (int) fileOffset, buffer, bufOffset, readLength);
+              return null;
+            })
+        .when(raf)
+        .pread(anyLong(), any(byte[].class), anyInt(), anyInt());
+    return raf;
+  }
+
+  private record ResumeLayout(
+      byte[] data,
+      long rafLength,
+      int basicSettingsLength,
+      int checksumLength,
+      long basicSettingsOffset,
+      byte payloadSignature) {
+    private static ResumeLayout create(
+        long rafLength,
+        int basicSettingsLength,
+        int checksumLength,
+        int flags,
+        int checksumType,
+        int version,
+        long magic) {
+      byte[] data = new byte[(int) rafLength];
+      byte payloadSignature = (byte) 0x5A;
+      byte[] payload = new byte[basicSettingsLength];
+      Arrays.fill(payload, payloadSignature);
+      long basicSettingsOffset = rafLength - (18 + 4 + checksumLength * 2L + basicSettingsLength);
+      System.arraycopy(payload, 0, data, (int) basicSettingsOffset, basicSettingsLength);
+      int checksumOffset = (int) (basicSettingsOffset + basicSettingsLength);
+      for (int i = 0; i < checksumLength; i++) {
+        data[checksumOffset + i] = (byte) 0x1;
+      }
+      writeInt(data, (int) (rafLength - (22 + checksumLength)), basicSettingsLength);
+      for (int i = 0; i < checksumLength; i++) {
+        data[(int) (rafLength - (18 + checksumLength)) + i] = (byte) 0x2;
+      }
+      writeInt(data, (int) (rafLength - 18), flags);
+      writeShort(data, (int) (rafLength - 14), (short) checksumType);
+      writeInt(data, (int) (rafLength - 12), version);
+      writeLong(data, (int) (rafLength - 8), magic);
+      return new ResumeLayout(
+          data,
+          rafLength,
+          basicSettingsLength,
+          checksumLength,
+          basicSettingsOffset,
+          payloadSignature);
+    }
+  }
+
+  private static void writeInt(byte[] data, int offset, int value) {
+    byte[] encoded = ByteBuffer.allocate(4).putInt(value).array();
+    System.arraycopy(encoded, 0, data, offset, 4);
+  }
+
+  private static void writeShort(byte[] data, int offset, short value) {
+    byte[] encoded = ByteBuffer.allocate(2).putShort(value).array();
+    System.arraycopy(encoded, 0, data, offset, 2);
+  }
+
+  private static void writeLong(byte[] data, int offset, long value) {
+    byte[] encoded = ByteBuffer.allocate(8).putLong(value).array();
+    System.arraycopy(encoded, 0, data, offset, 8);
+  }
+}


### PR DESCRIPTION
## Summary
- add unit coverage for splitfile fetcher segment initialization and storage layout sizing
- exercise persistence writer, resume reader, and recovery paths with mocks and edge cases
- validate error handling for invalid metadata, offsets, and checksum failures