### PR TITLE
refactor(fcp): extract client get helpers

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -27,24 +27,31 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates a single FCP GET request over the asynchronous client interface.
  *
- * <p>The request owns its {@link FetchContext}, {@link ClientGetter}, progress caches, and
- * persistence metadata so it can migrate cleanly between the connection queue, the global queue,
- * and durable storage across node restarts. It translates raw client events into the higher-level
- * FCP messages required by remote clients, tracks retry policy, and resolves whatever output
- * strategy the caller selected (direct bucket, disk file, chunked stream, or acknowledgement only).
- * The class is therefore the boundary between long-lived persistent jobs and transient FCP
- * sessions.
+ * <p>This request owns its {@link FetchContext}, {@link ClientGetter}, progress caches, and
+ * persistence metadata so it can migrate cleanly between a connection queue, the global queue, and
+ * durable storage across node restarts. It translates client-side events into higher-level FCP
+ * messages, tracks retry and restart policy, and resolves the selected delivery strategy (direct
+ * bucket, disk file, chunked stream, or acknowledgement only). The class therefore acts as the
+ * boundary between long-lived persistent jobs and transient FCP sessions.
  *
  * <p>The implementation is largely thread-safe through fine-grained {@code synchronized} sections.
- * State transitions such as success, failure, or cancellation update cached progress snapshots and
- * immediately propagate notifications to any registered event listeners. During restarts, it
- * rehydrates buckets, metadata, and compatibility hints from the serialized form before delegating
- * back to {@link ClientGetter}.
+ * State transitions such as success, failure, cancellation, or restart update cached progress
+ * snapshots and immediately propagate notifications to any registered listeners. During restarts,
+ * it rehydrates buckets, metadata, and compatibility hints from the serialized form before
+ * delegating back to {@link ClientGetter}.
+ *
+ * <p>Typical usage is to construct the request from a {@link ClientGetMessage}, register it with
+ * the owning client queue, and then invoke {@link #start(ClientContext)}. The request may persist
+ * across reconnections, and callers should treat it as a long-lived state machine whose outputs are
+ * FCP messages rather than synchronous return values.
  *
  * <ul>
- *   <li>Queueing and persistence: registers against either the connection-scoped or global queue.
- *   <li>Progress and metadata: consumes splitter events to project hashes, sizes, and MIME types.
- *   <li>Delivery: enforces {@link ReturnType} semantics when writing buckets or emitting AllData.
+ *   <li><strong>Queueing and persistence</strong>: registers against either the connection-scoped
+ *       or global queue and emits persistent tags.
+ *   <li><strong>Progress and metadata</strong>: consumes splitfile events to project hashes, sizes,
+ *       and MIME types for status reporting.
+ *   <li><strong>Delivery</strong>: enforces {@link ReturnType} semantics when writing buckets or
+ *       emitting {@link AllDataMessage} payloads.
  * </ul>
  *
  * @see ClientRequest
@@ -84,6 +91,10 @@ public class ClientGet extends ClientRequest {
   /** Metadata bucket supplied at creation time, relayed untouched to the {@link ClientGetter}. */
   @SuppressWarnings("java:S1948")
   private final Bucket initialMetadata;
+
+  private transient ClientGetMessageReplay messageReplay;
+  private transient ClientGetLifecycle lifecycle;
+  private transient ClientGetStatusSnapshotBuilder statusSnapshotBuilder;
 
   // Verbosity bitmasks
   static final int VERBOSITY_SPLITFILE_PROGRESS = 1;
@@ -333,6 +344,7 @@ public class ClientGet extends ClientRequest {
     this.extensionCheck = setup.extension();
     this.initialMetadata = null;
     getter = makeGetter(core, returnBucket);
+    initHelpers();
   }
 
   /**
@@ -400,6 +412,7 @@ public class ClientGet extends ClientRequest {
     } catch (IOException e) {
       throw bucketCreationFailure(e);
     }
+    initHelpers();
   }
 
   private MessageInvalidException bucketCreationFailure(IOException e) {
@@ -456,6 +469,33 @@ public class ClientGet extends ClientRequest {
     initialMetadata = null;
   }
 
+  private void initHelpers() {
+    if (messageReplay == null) {
+      messageReplay = new ClientGetMessageReplay(this);
+    }
+    if (lifecycle == null) {
+      lifecycle = new ClientGetLifecycle(this);
+    }
+    if (statusSnapshotBuilder == null) {
+      statusSnapshotBuilder = new ClientGetStatusSnapshotBuilder(this);
+    }
+  }
+
+  private ClientGetMessageReplay messageReplay() {
+    initHelpers();
+    return messageReplay;
+  }
+
+  private ClientGetLifecycle lifecycle() {
+    initHelpers();
+    return lifecycle;
+  }
+
+  private ClientGetStatusSnapshotBuilder statusSnapshotBuilder() {
+    initHelpers();
+    return statusSnapshotBuilder;
+  }
+
   /**
    * Must be called just after construction but within a transaction.
    *
@@ -489,7 +529,12 @@ public class ClientGet extends ClientRequest {
    * {@link FetchException} instances and routed through {@link #onFailure(FetchException)} to
    * ensure consistent cleanup.
    *
-   * @param context client context providing schedulers and bucket factories for execution.
+   * <p>On success, this call merely schedules work; it does not block for results. If a failure is
+   * raised before progress events fire, the request is still marked as started so external status
+   * caches remain consistent. Callers may invoke this multiple times safely; only the first call
+   * before completion has any effect.
+   *
+   * @param context client context providing schedulers, bucket factories, and execution lanes.
    */
   @Override
   public void start(ClientContext context) {
@@ -539,7 +584,11 @@ public class ClientGet extends ClientRequest {
    * method does not attempt to resume or restart; it only decides whether the request remains
    * active based on the persistence model. The call is safe to invoke multiple times.
    *
-   * @param context client context owning the request; unused but retained for parity.
+   * <p>The method has no effect on finished requests and does not modify request metadata beyond a
+   * possible cancellation. It exists primarily so connection handlers can dispose of
+   * connection-scoped work without leaking persistent tasks.
+   *
+   * @param context client context owning the request and its scheduler association.
    */
   @Override
   public void onLostConnection(ClientContext context) {
@@ -557,35 +606,15 @@ public class ClientGet extends ClientRequest {
    * caches, and informs the owning {@link FCPConnectionHandler} or {@link PersistentRequestClient}.
    * Any secondary calls are ignored defensively to prevent double frees or duplicate notifications.
    *
-   * @param result result wrapper exposing MIME metadata and bucket accessors.
-   * @param state client getter instance used for blob access during BinaryBlob transfers.
+   * <p>For BinaryBlob requests, the MIME type is forced to the blob MIME and the bucket length is
+   * derived from the blob bucket rather than the decoded metadata bucket. The method always updates
+   * completion time before any outbound messages so that emitted timestamps remain consistent.
+   *
+   * @param result result wrapper providing MIME metadata and the decoded data bucket.
+   * @param state client getter instance used to access BinaryBlob payload buckets.
    */
   public void onSuccess(FetchResult result, ClientGetter state) {
-    LOG.debug("Succeeded: {}", identifier);
-    Bucket data = binaryBlob ? state.getBlobBucket() : result.asBucket();
-    synchronized (this) {
-      if (succeeded) {
-        LOG.error("onSuccess called twice for {} ({})", this, identifier);
-        return; // We might be called twice; ignore it if so.
-      }
-      started = true;
-      if (!binaryBlob) this.foundDataMimeType = result.getMimeType();
-      else this.foundDataMimeType = ClientGetGetterFactory.binaryBlobMimeType();
-
-      // completionTime is set here rather than in finish() for two reasons:
-      // 1. It must be set inside the lock.
-      // 2. It must be set before AllData is sent so it is consistent.
-      completionTime = System.currentTimeMillis();
-      progressPending = null;
-      this.foundDataLength = data.size();
-      this.succeeded = true;
-      finished = true;
-      if (returnType == ReturnType.DIRECT) returnBucketDirect = data;
-    }
-    trySendDataFoundOrGetFailed(null, null);
-    trySendAllDataMessage(null, null);
-    finish();
-    if (client != null) client.notifySuccess(this);
+    lifecycle().onSuccess(result, state);
   }
 
   /**
@@ -598,111 +627,32 @@ public class ClientGet extends ClientRequest {
    * {@link ResumeFailedException}, forcing the caller to restart the download rather than trusting
    * potentially corrupted state. This method is intended for controlled migration flows only.
    *
-   * @param context client context performing the migration and validation checks.
-   * @param completionTime epoch milliseconds representing the recorded completion instant.
-   * @param data bucket already holding the downloaded payload for direct returns.
-   * @throws ResumeFailedException validation failed because existing output looked inconsistent.
+   * <p>The method does not trigger network activity and does not emit FCP messages; it only updates
+   * cached fields so that later status queries and persistence writes reflect the migrated success
+   * state.
+   *
+   * @param context client context performing migration validation and bucket operations.
+   * @param completionTime epoch milliseconds for the recorded completion instant.
+   * @param data bucket containing the downloaded payload for direct delivery.
+   * @throws ResumeFailedException when stored output does not match recorded metadata.
    */
   @SuppressWarnings("unused")
   public void setSuccessForMigration(ClientContext context, long completionTime, Bucket data)
       throws ResumeFailedException {
-    if (context == null) {
-      throw new NullPointerException("context");
-    }
-    synchronized (this) {
-      succeeded = true;
-      started = true;
-      finished = true;
-      this.completionTime = completionTime;
-      switch (returnType) {
-        case ReturnType type when type == ReturnType.NONE -> {
-          // Nothing to validate.
-        }
-        case ReturnType type
-            when type == ReturnType.DISK
-                && (!targetFile.exists() || targetFile.length() != foundDataLength) ->
-            throw new ResumeFailedException("Success but target file doesn't exist or isn't valid");
-        case ReturnType type when type == ReturnType.DISK -> {
-          // Validation already passed.
-        }
-        case ReturnType type when type == ReturnType.DIRECT && data.size() != foundDataLength -> {
-          returnBucketDirect = data;
-          throw new ResumeFailedException(
-              "Success but temporary data bucket doesn't exist or isn't valid");
-        }
-        case ReturnType type when type == ReturnType.DIRECT -> returnBucketDirect = data;
-        case ReturnType type when type == ReturnType.CHUNKED ->
-            throw new ResumeFailedException("Chunked return type not supported for migration");
-        default -> throw new IllegalStateException("Unexpected return type: " + returnType);
-      }
-    }
+    lifecycle().setSuccessForMigration(context, completionTime, data);
   }
 
-  private void trySendDataFoundOrGetFailed(
+  void trySendDataFoundOrGetFailed(
       FCPConnectionOutputHandler handler, String listRequestIdentifier) {
-    FCPMessage msg;
-
-    // Don't need to lock. succeeded is only ever set, never unset.
-    // and succeeded and getFailedMessage are both atomic.
-    if (succeeded) {
-      // Mirrors AllDataMessage so connection-scoped clients receive DataFound with consistent
-      // timestamps even if completionTime was not set by finish().
-      msg =
-          new DataFoundMessage(
-              foundDataLength,
-              foundDataMimeType,
-              identifier,
-              global,
-              startupTime,
-              completionTime != 0 ? completionTime : System.currentTimeMillis());
-    } else {
-      msg = getFailedMessage;
-    }
-
-    if (handler == null && persistence == Persistence.CONNECTION) {
-      if (origHandler != null)
-        origHandler.send(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
-    } else if (handler != null) {
-      handler.handler.send(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
-    } else
-      client.queueClientRequestMessage(
-          FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier), 0);
+    messageReplay().trySendDataFoundOrGetFailed(handler, listRequestIdentifier);
   }
 
-  private synchronized AllDataMessage getAllDataMessage() {
-    if (returnType != ReturnType.DIRECT) return null;
-    AllDataMessage msg =
-        new AllDataMessage(
-            returnBucketDirect, identifier, global, startupTime, completionTime, foundDataMimeType);
-    if (persistence == Persistence.CONNECTION) msg.setFreeOnSent();
-    return msg;
-  }
-
-  private void trySendAllDataMessage(
-      FCPConnectionOutputHandler handler, String listRequestIdentifier) {
-    if (persistence == Persistence.CONNECTION && handler == null) {
-      if (origHandler != null) {
-        FCPMessage allData =
-            FCPMessage.withListRequestIdentifier(getAllDataMessage(), listRequestIdentifier);
-        if (allData != null) origHandler.send(allData);
-      }
-      return;
-    }
-    if (handler != null) {
-      FCPMessage allData =
-          FCPMessage.withListRequestIdentifier(getAllDataMessage(), listRequestIdentifier);
-      if (allData != null) handler.handler.send(allData);
-    }
+  void trySendAllDataMessage(FCPConnectionOutputHandler handler, String listRequestIdentifier) {
+    messageReplay().trySendAllDataMessage(handler, listRequestIdentifier);
   }
 
   void queueProgressMessageInner(FCPMessage msg, int verbosityMask) {
-    if (persistence == Persistence.CONNECTION) {
-      if (origHandler != null) {
-        origHandler.send(msg);
-      }
-      return;
-    }
-    client.queueClientRequestMessage(msg, verbosityMask);
+    messageReplay().queueProgressMessageInner(msg, verbosityMask);
   }
 
   /**
@@ -716,10 +666,14 @@ public class ClientGet extends ClientRequest {
    * {@link ProtocolErrorMessage}. The method is idempotent and only reflects the cached request
    * state at the time of invocation.
    *
-   * @param handler output handler representing the destination connection to replay into.
-   * @param listRequestIdentifier optional secondary identifier for multi-request list operations.
-   * @param includeData true to include {@link AllDataMessage} bodies when available.
-   * @param onlyData true to request data frames exclusively, skipping metadata messages.
+   * <p>The call does not mutate the request state; it simply replays cached snapshots and queued
+   * flags. Callers should ensure the handler is ready to accept messages because the method may
+   * emit multiple frames in quick succession.
+   *
+   * @param handler output handler representing the destination connection for replay.
+   * @param listRequestIdentifier optional identifier for list or batch operations.
+   * @param includeData {@code true} to include {@link AllDataMessage} bodies when present.
+   * @param onlyData {@code true} to send only payload frames, skipping metadata.
    */
   @Override
   public void sendPendingMessages(
@@ -727,81 +681,15 @@ public class ClientGet extends ClientRequest {
       String listRequestIdentifier,
       boolean includeData,
       boolean onlyData) {
-    if (!onlyData) {
-      FCPMessage msg = persistentTagMessage();
-      handler.handler.send(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
-      if (progressPending != null) {
-        handler.handler.send(
-            FCPMessage.withListRequestIdentifier(progressPending, listRequestIdentifier));
-      }
-      if (sentToNetwork)
-        handler.handler.send(
-            FCPMessage.withListRequestIdentifier(
-                new SendingToNetworkMessage(identifier, global), listRequestIdentifier));
-      if (finished) trySendDataFoundOrGetFailed(handler, listRequestIdentifier);
-    } else if (returnType != ReturnType.DIRECT) {
-      FCPMessage msg =
-          new ProtocolErrorMessage(
-              ProtocolErrorMessage.WRONG_RETURN_TYPE, false, "No AllData", identifier, global);
-      handler.handler.send(msg);
-      return;
-    }
-
-    if (includeData) {
-      trySendAllDataMessage(handler, listRequestIdentifier);
-    }
-
-    CompatibilityMode cmsg;
-    ExpectedHashes hashesMessage;
-    ExpectedMIME mimeMsg = null;
-    ExpectedDataLength lengthMsg = null;
-    synchronized (this) {
-      cmsg = new CompatibilityMode(identifier, global, compatMode);
-      hashesMessage = this.expectedHashes;
-      if (foundDataMimeType != null)
-        mimeMsg = new ExpectedMIME(identifier, global, foundDataMimeType);
-      if (foundDataLength > 0)
-        lengthMsg = new ExpectedDataLength(identifier, global, foundDataLength);
-    }
-    handler.handler.send(FCPMessage.withListRequestIdentifier(cmsg, listRequestIdentifier));
-
-    if (hashesMessage != null) {
-      handler.handler.send(
-          FCPMessage.withListRequestIdentifier(hashesMessage, listRequestIdentifier));
-    }
-
-    if (mimeMsg != null) {
-      handler.handler.send(FCPMessage.withListRequestIdentifier(mimeMsg, listRequestIdentifier));
-    }
-    if (lengthMsg != null) {
-      handler.handler.send(FCPMessage.withListRequestIdentifier(lengthMsg, listRequestIdentifier));
-    }
+    messageReplay().sendPendingMessages(handler, listRequestIdentifier, includeData, onlyData);
   }
 
-  private FCPMessage persistentTagMessage() {
-    ClientRequestParams requestParams =
-        new ClientRequestParams(
-            uri,
-            identifier,
-            verbosity,
-            priorityClass,
-            persistence,
-            isRealTime(),
-            clientToken,
-            client.isGlobalQueue);
-    PersistentGetDescriptor descriptor =
-        new PersistentGetDescriptor(
-            returnType,
-            targetFile,
-            started,
-            fctx.getMaxNonSplitfileRetries(),
-            binaryBlob,
-            fctx.getMaxOutputLength());
-    return new PersistentGet(requestParams, descriptor);
+  FCPMessage persistentTagMessage() {
+    return statusSnapshotBuilder().persistentTagMessage();
   }
 
   // Mirrors ClientPut/ClientPutDir to keep low-level scheduling flags accessible to subclasses.
-  private boolean isRealTime() {
+  boolean isRealTime() {
     if (lowLevelClient == null) {
       // This can happen but only due to data corruption - old databases on which various bugs have
       // resulted in it getting deleted and also possibly failed deletions.
@@ -820,25 +708,13 @@ public class ClientGet extends ClientRequest {
    * equivalents, intentionally leaving buckets intact so restart attempts can reuse cached blocks.
    * Secondary invocations after completion are ignored to preserve idempotency.
    *
-   * @param e detailed {@link FetchException} describing the failure classification.
+   * <p>Callers should treat this as terminal for the current attempt; a later restart will clear
+   * the cached failure and reinitialize progress tracking.
+   *
+   * @param e failure descriptor that supplies the expected size, MIME type, and mode.
    */
   public void onFailure(FetchException e) {
-    if (finished) return;
-    synchronized (this) {
-      if (e.getExpectedSize() != 0) this.foundDataLength = e.getExpectedSize();
-      if (e.getExpectedMimeType() != null) this.foundDataMimeType = e.getExpectedMimeType();
-      succeeded = false;
-      getFailedMessage = new GetFailedMessage(e, identifier, global);
-      finished = true;
-      started = true;
-      completionTime = System.currentTimeMillis();
-    }
-    if (LOG.isDebugEnabled()) LOG.debug("Caught {}", e, e);
-    trySendDataFoundOrGetFailed(null, null);
-    // We do not want the data to be removed on failure, because the request
-    // may be restarted, and the bucket persists on the getter, even if we get rid of it here.
-    finish();
-    if (client != null) client.notifyFailure(this);
+    lifecycle().onFailure(e);
   }
 
   /**
@@ -850,28 +726,14 @@ public class ClientGet extends ClientRequest {
    * the superclass hook so shared accounting (such as tag persistence) also runs. This method is
    * safe to invoke once per removal event.
    *
+   * <p>The removal path does not attempt to stop network activity directly; it assumes the owning
+   * scheduler has already detached the underlying {@link ClientGetter}.
+   *
    * @param context client context invoking the removal for lifecycle bookkeeping.
    */
   @Override
   public void requestWasRemoved(ClientContext context) {
-    // if the request is still running, send a GetFailed with code=canceled
-    if (!finished) {
-      synchronized (this) {
-        succeeded = false;
-        finished = true;
-        FetchException cancelled = new FetchException(FetchExceptionMode.CANCELLED);
-        getFailedMessage = new GetFailedMessage(cancelled, identifier, global);
-      }
-      trySendDataFoundOrGetFailed(null, null);
-    }
-    // notify client that the request was removed
-    FCPMessage msg = new PersistentRequestRemovedMessage(getIdentifier(), global);
-    if (persistence != Persistence.CONNECTION) {
-      client.queueClientRequestMessage(msg, 0);
-    }
-
-    freeData();
-
+    lifecycle().requestWasRemoved();
     super.requestWasRemoved(context);
   }
 
@@ -924,6 +786,75 @@ public class ClientGet extends ClientRequest {
     }
   }
 
+  ReturnType returnTypeForReplay() {
+    return returnType;
+  }
+
+  Bucket returnBucketDirectForReplay() {
+    return returnBucketDirect;
+  }
+
+  void setReturnBucketDirect(Bucket bucket) {
+    returnBucketDirect = bucket;
+  }
+
+  boolean hasSucceededForReplay() {
+    return succeeded;
+  }
+
+  void setSucceeded(boolean succeeded) {
+    this.succeeded = succeeded;
+  }
+
+  long foundDataLengthForReplay() {
+    return foundDataLength;
+  }
+
+  void setFoundDataLength(long foundDataLength) {
+    this.foundDataLength = foundDataLength;
+  }
+
+  String foundDataMimeTypeForReplay() {
+    return foundDataMimeType;
+  }
+
+  void setFoundDataMimeType(String foundDataMimeType) {
+    this.foundDataMimeType = foundDataMimeType;
+  }
+
+  SimpleProgressMessage progressPendingForReplay() {
+    return progressPending;
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  void setProgressPending(SimpleProgressMessage progressPending) {
+    this.progressPending = progressPending;
+  }
+
+  boolean sentToNetworkForReplay() {
+    return sentToNetwork;
+  }
+
+  CompatibilityAnalyser compatModeForReplay() {
+    return compatMode;
+  }
+
+  ExpectedHashes expectedHashesForReplay() {
+    return expectedHashes;
+  }
+
+  GetFailedMessage getFailedMessageForReplay() {
+    return getFailedMessage;
+  }
+
+  void setFailedMessage(GetFailedMessage message) {
+    getFailedMessage = message;
+  }
+
+  File targetFileForLifecycle() {
+    return targetFile;
+  }
+
   /**
    * Exposes the underlying {@link ClientRequester} for base-class scheduling operations.
    *
@@ -969,6 +900,10 @@ public class ClientGet extends ClientRequest {
    * is set when {@link #onSuccess(FetchResult, ClientGetter)} records the terminal state and never
    * reset unless a restart is initiated.
    *
+   * <p>This flag is a snapshot of the most recent attempt; it does not imply that payload data is
+   * still available in memory. Callers should consult {@link #getBucket()} or {@link
+   * #getDestFilename()} if they need access to the payload itself.
+   *
    * @return {@code true} once final success has been recorded for this request.
    */
   @Override
@@ -984,6 +919,8 @@ public class ClientGet extends ClientRequest {
    * back through the queue once the transfer has completed. This flag is informational and does not
    * initiate any I/O.
    *
+   * <p>Use this as a hint when deciding whether to request replayed data from a persistent queue.
+   *
    * @return {@code true} when AllData messages should be emitted upon completion.
    */
   public boolean isDirect() {
@@ -996,6 +933,8 @@ public class ClientGet extends ClientRequest {
    * <p>{@link ReturnType#DISK} requests rely on {@link #targetFile} for their lifecycle checks,
    * including restart validation to ensure partially written files are safe to reuse. This flag
    * mirrors the configured return type and does not check whether the file already exists.
+   *
+   * <p>Callers should treat this as configuration metadata, not proof of a completed download.
    *
    * @return {@code true} when this request writes into a caller-specified file.
    */
@@ -1010,6 +949,8 @@ public class ClientGet extends ClientRequest {
    * returned instance is the live reference used by this request, so callers should treat it as
    * read-only and avoid mutating it. This accessor is side-effect free and can be called at any
    * time, but it does not synchronize with concurrent updates beyond the request's own locking.
+   *
+   * <p>Use this value for status displays or persistence serialization rather than for mutation.
    *
    * @return current {@link FreenetURI} reference describing the active fetch target.
    */
@@ -1070,6 +1011,9 @@ public class ClientGet extends ClientRequest {
    * value of {@code -1} means the size is still unknown. This accessor does not trigger any network
    * activity and simply returns the latest cached estimate.
    *
+   * <p>The reported value may be provisional early in the fetch and should be treated as an
+   * estimate rather than a guarantee of final size.
+   *
    * @return recorded payload length in bytes, or {@code -1} when unknown.
    */
   public long getDataSize() {
@@ -1085,6 +1029,9 @@ public class ClientGet extends ClientRequest {
    * store results. The value can be {@code null} if no MIME information has been reported yet. This
    * accessor returns the latest cached value without forcing any additional validation.
    *
+   * <p>Callers should be prepared for {@code null} or generic MIME types when content is still
+   * being discovered.
+   *
    * @return MIME type reported for the payload, or {@code null} if undetermined.
    */
   public String getMIMEType() {
@@ -1099,6 +1046,8 @@ public class ClientGet extends ClientRequest {
    * restarts. It may not exist until the download succeeds, and callers should not assume it is
    * created or populated. When the return type is not {@link ReturnType#DISK}, this method returns
    * {@code null}.
+   *
+   * <p>Use this to locate persisted output only after completion has been reported.
    *
    * @return destination file for disk downloads, or {@code null} otherwise.
    */
@@ -1254,7 +1203,10 @@ public class ClientGet extends ClientRequest {
    * which typically means the request is still running or has completed successfully. The returned
    * text is suitable for UI display and is not guaranteed to be stable across versions.
    *
-   * @param longDescription {@code true} to include any extended diagnostic text when available.
+   * <p>This accessor does not alter the request state. Callers should treat the value as a snapshot
+   * of the last recorded failure rather than a live view of the underlying fetcher.
+   *
+   * @param longDescription {@code true} to append extended diagnostic detail when available.
    * @return human-readable failure summary, or {@code null} when no failure exists.
    */
   @Override
@@ -1279,6 +1231,8 @@ public class ClientGet extends ClientRequest {
    * or if no failure has been recorded yet. Callers should treat the value as a snapshot rather
    * than a live view of the underlying fetcher.
    *
+   * <p>The returned value is useful for UI classification or retry policy decisions.
+   *
    * @return failure classification mode, or {@code null} when no failure exists.
    */
   public FetchExceptionMode getFailureReasonCode() {
@@ -1293,6 +1247,8 @@ public class ClientGet extends ClientRequest {
    * count is stable and suitable for percent-based UI calculations. Completed successful requests
    * are treated as finalized even if no explicit progress snapshot is present. The value may be
    * {@code false} early in a fetch when metadata is incomplete.
+   *
+   * <p>This method does not force any progress updates; it reports only cached values.
    *
    * @return {@code true} once progress reporting marked the total as finalized or upon success.
    */
@@ -1312,6 +1268,8 @@ public class ClientGet extends ClientRequest {
    * other return types yield {@code null}. Callers should treat the returned bucket as read-only
    * and should not assume it is non-null unless the return type requires it. The returned instance
    * reflects the most recent stored payload and does not trigger additional disk or network work.
+   *
+   * <p>For disk-based downloads, the returned bucket is a lightweight wrapper over the file path.
    *
    * @return bucket containing the payload, or {@code null} when no bucket form exists.
    */
@@ -1339,6 +1297,9 @@ public class ClientGet extends ClientRequest {
    * attempt. This method performs the minimal checks needed to decide if {@link
    * #restart(ClientContext, boolean)} is likely to proceed without immediate failure.
    *
+   * <p>This method does not modify the state; it is intended for UI or scheduler decisions before
+   * initiating a restart.
+   *
    * @return {@code true} when {@link #restart(ClientContext, boolean)} may be invoked.
    */
   @Override
@@ -1363,8 +1324,11 @@ public class ClientGet extends ClientRequest {
    * If the underlying getter fails to restart, the failure is routed through {@link
    * #onFailure(FetchException)} and the method returns {@code false}.
    *
-   * @param context client context providing schedulers and persistent storage for restart logic.
-   * @param disableFilterData {@code true} to temporarily disable filtering for the next attempt.
+   * <p>Restarting does not guarantee success; it merely schedules a new attempt with the updated
+   * parameters. The method returns quickly once the getter acknowledges the restart request.
+   *
+   * @param context client context providing schedulers and bucket factories for restart logic.
+   * @param disableFilterData {@code true} to disable filtering for the next attempt.
    * @return {@code true} when the restart was initiated successfully.
    */
   @Override
@@ -1439,6 +1403,8 @@ public class ClientGet extends ClientRequest {
    * inference is attempted here. The method is synchronized to read the cached failure state
    * consistently.
    *
+   * <p>Callers should treat the result as a hint rather than a definitive redirect requirement.
+   *
    * @return {@code true} when {@link GetFailedMessage#redirectURI} is non-null.
    */
   public synchronized boolean hasPermRedirect() {
@@ -1453,6 +1419,8 @@ public class ClientGet extends ClientRequest {
    * current {@link FetchContext} setting and does not alter any state. Because restarts can change
    * the flag between attempts, callers should treat the value as a point-in-time snapshot rather
    * than a promise about future retries.
+   *
+   * <p>Use this to reflect the current filtering state in status reporting.
    *
    * @return {@code true} when payloads should be filtered before delivery.
    */
@@ -1495,9 +1463,12 @@ public class ClientGet extends ClientRequest {
    * so restarts can resume without re-downloading already verified blocks. Callers should provide a
    * stream already framed by the persistence layer.
    *
-   * @param dos destination stream receiving the serialized form with embedded checksums.
+   * <p>The serialization format is versioned; if it changes, the version constants in this class
+   * must be updated in lockstep with the restore logic.
+   *
+   * @param dos destination stream receiving the serialized form with checksums embedded.
    * @param checker checksum helper that wraps streams to guard against corruption.
-   * @throws IOException if serialization fails or a bucket cannot be stored.
+   * @throws IOException when serialization fails or a bucket cannot be stored.
    */
   @Override
   public void getClientDetail(DataOutputStream dos, ChecksumChecker checker) throws IOException {
@@ -1569,14 +1540,16 @@ public class ClientGet extends ClientRequest {
    * incomplete or inconsistent, it throws a {@link ResumeFailedException} to signal that the
    * request should restart rather than trust corrupted state.
    *
+   * <p>The returned request is fully initialized and ready to re-register with queues.
+   *
    * @param dis input stream positioned at the serialized client detail block.
    * @param reqID identifier tuple describing the owner and reference type.
    * @param context client context supplying factories used during restoration.
    * @param checker checksum helper verifying the integrity of embedded buckets.
    * @return fully reconstructed {@link ClientRequest} instance ready for resumption.
-   * @throws StorageFormatException serialized data failed validation or used unknown versions.
-   * @throws IOException stream IO failed while reading buckets or metadata.
-   * @throws ResumeFailedException request could not be reconstructed and must restart.
+   * @throws StorageFormatException when serialized data fails validation or version checks.
+   * @throws IOException when stream IO fails while reading buckets or metadata.
+   * @throws ResumeFailedException when the request must restart due to inconsistencies.
    */
   public static ClientRequest restartFrom(
       DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
@@ -1605,6 +1578,7 @@ public class ClientGet extends ClientRequest {
       restoredGetter = makeGetter(makeBucket(false));
     }
     this.getter = restoredGetter;
+    initHelpers();
   }
 
   private void validateClientDetailHeader(DataInputStream dis)
@@ -1707,6 +1681,8 @@ public class ClientGet extends ClientRequest {
    * does not trigger network activity; it only rebinds state so later status queries are
    * consistent.
    *
+   * <p>Callers should invoke this only during resume flows and not during normal execution.
+   *
    * @param context client context used for bucket resume callbacks and defaults.
    * @throws ResumeFailedException if bucket resume logic reports unrecoverable failure.
    */
@@ -1731,6 +1707,8 @@ public class ClientGet extends ClientRequest {
    * can continue without restarting. It delegates to {@link ClientGetter#resumedFetcher()} and also
    * ensures the getter itself is present. A {@code false} return indicates that the request should
    * be restarted or rebuilt.
+   *
+   * <p>The method has no side effects and should be safe to call repeatedly.
    *
    * @return {@code true} when {@link ClientGetter#resumedFetcher()} confirms a valid resume.
    */

--- a/src/main/java/network/crypta/clients/fcp/ClientGetLifecycle.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetLifecycle.java
@@ -1,0 +1,223 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchResult;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ResumeFailedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies lifecycle transitions for {@link ClientGet} without exposing additional API surface.
+ *
+ * <p>This helper centralizes success, failure, migration, and removal paths so that the surrounding
+ * request stays focused on message wiring and persistence. It mutates the owning request under
+ * synchronization, updates cached fields such as MIME type, payload length, and completion time,
+ * and then triggers the appropriate outbound notifications. Callers generally construct this helper
+ * once per request and delegate lifecycle events as they occur.
+ *
+ * <p>Thread-safety is inherited from the request: most state transitions are synchronized on the
+ * {@code ClientGet} instance, and the helper never retains mutable state of its own. It is
+ * intentionally not reusable across requests and assumes it will only be invoked by the owning
+ * request instance.
+ *
+ * <ul>
+ *   <li><strong>Success handling</strong>: captures result metadata and notifies clients.
+ *   <li><strong>Failure handling</strong>: records failure context and triggers cleanup.
+ *   <li><strong>Removal</strong>: synthesizes cancellation and releases retained buckets.
+ * </ul>
+ *
+ * @see ClientGet
+ */
+final class ClientGetLifecycle {
+  /** Logger used for lifecycle diagnostics and duplicate-callback guards. */
+  private static final Logger LOG = LoggerFactory.getLogger(ClientGetLifecycle.class);
+
+  /** The owning request whose state is updated by lifecycle transitions. */
+  private final ClientGet request;
+
+  /**
+   * Creates a lifecycle helper bound to a single request.
+   *
+   * <p>The helper keeps only a reference to the request and relies on the request's own locking
+   * discipline for thread safety. Callers should create one helper per request and avoid sharing it
+   * across instances.
+   *
+   * @param request request whose state transitions are managed by this helper.
+   */
+  ClientGetLifecycle(ClientGet request) {
+    this.request = request;
+  }
+
+  /**
+   * Records a successful completion and emits completion messages.
+   *
+   * <p>The method snapshots MIME type, payload length, and completion time, stores the payload
+   * bucket when {@link ClientGet.ReturnType#DIRECT} applies, and then forwards completion events to
+   * interested clients. Duplicate invocations are ignored to preserve idempotency. For BinaryBlob
+   * requests, the payload length and MIME type are derived from the blob bucket.
+   *
+   * @param result result wrapper providing MIME metadata and the decoded data bucket.
+   * @param state client getter instance used to access BinaryBlob buckets when required.
+   */
+  void onSuccess(FetchResult result, ClientGetter state) {
+    LOG.debug("Succeeded: {}", request.identifier);
+    Bucket data = request.binaryBlobRequested() ? state.getBlobBucket() : result.asBucket();
+    synchronized (request) {
+      if (request.hasSucceededForReplay()) {
+        LOG.error("onSuccess called twice for {} ({})", request, request.identifier);
+        return; // We might be called twice; ignore it if so.
+      }
+      request.started = true;
+      if (!request.binaryBlobRequested()) {
+        request.setFoundDataMimeType(result.getMimeType());
+      } else {
+        request.setFoundDataMimeType(ClientGetGetterFactory.binaryBlobMimeType());
+      }
+
+      // completionTime is set here rather than in finish() for two reasons:
+      // 1. It must be set inside the lock.
+      // 2. It must be set before AllData is sent so it is consistent.
+      request.completionTime = System.currentTimeMillis();
+      request.setProgressPending(null);
+      request.setFoundDataLength(data.size());
+      request.setSucceeded(true);
+      request.finished = true;
+      if (request.returnTypeForReplay() == ClientGet.ReturnType.DIRECT) {
+        request.setReturnBucketDirect(data);
+      }
+    }
+    request.trySendDataFoundOrGetFailed(null, null);
+    request.trySendAllDataMessage(null, null);
+    request.finish();
+    if (request.client != null) {
+      request.client.notifySuccess(request);
+    }
+  }
+
+  /**
+   * Forces a successful state during migration validation.
+   *
+   * <p>This method is intended for controlled migration flows that replay the persisted state. It
+   * validates that disk or direct bucket outputs match the recorded length, stores the bucket when
+   * appropriate, and records the provided completion timestamp. Any mismatch results in a {@link
+   * ResumeFailedException} to signal that the request should restart instead of trusting corrupted
+   * state.
+   *
+   * @param context client context used for migration validation callbacks.
+   * @param completionTime epoch milliseconds to record as the completion timestamp.
+   * @param data bucket holding the payload when {@link ClientGet.ReturnType#DIRECT} applies.
+   * @throws ResumeFailedException when stored output does not match the recorded metadata.
+   * @throws NullPointerException when {@code context} is {@code null}.
+   */
+  void setSuccessForMigration(ClientContext context, long completionTime, Bucket data)
+      throws ResumeFailedException {
+    if (context == null) {
+      throw new NullPointerException("context");
+    }
+    synchronized (request) {
+      request.setSucceeded(true);
+      request.started = true;
+      request.finished = true;
+      request.completionTime = completionTime;
+      ClientGet.ReturnType returnType = request.returnTypeForReplay();
+      switch (returnType) {
+        case ClientGet.ReturnType type when type == ClientGet.ReturnType.NONE -> {
+          // Nothing to validate.
+        }
+        case ClientGet.ReturnType type
+            when type == ClientGet.ReturnType.DISK
+                && (!request.targetFileForLifecycle().exists()
+                    || request.targetFileForLifecycle().length()
+                        != request.foundDataLengthForReplay()) ->
+            throw new ResumeFailedException("Success but target file doesn't exist or isn't valid");
+        case ClientGet.ReturnType type when type == ClientGet.ReturnType.DISK -> {
+          // Validation already passed.
+        }
+        case ClientGet.ReturnType type
+            when type == ClientGet.ReturnType.DIRECT
+                && data.size() != request.foundDataLengthForReplay() -> {
+          request.setReturnBucketDirect(data);
+          throw new ResumeFailedException(
+              "Success but temporary data bucket doesn't exist or isn't valid");
+        }
+        case ClientGet.ReturnType type when type == ClientGet.ReturnType.DIRECT ->
+            request.setReturnBucketDirect(data);
+        case ClientGet.ReturnType type when type == ClientGet.ReturnType.CHUNKED ->
+            throw new ResumeFailedException("Chunked return type not supported for migration");
+        default -> throw new IllegalStateException("Unexpected return type: " + returnType);
+      }
+    }
+  }
+
+  /**
+   * Records a failure outcome and notifies listeners.
+   *
+   * <p>The method caches expected size and MIME hints from the exception, constructs the failure
+   * message, and marks the request as finished so restart logic can take over. If the request was
+   * already finished, it returns immediately without side effects. The request's payload buckets
+   * are intentionally preserved for potential restart attempts.
+   *
+   * @param e failure descriptor that supplies mode, size, and MIME hints.
+   */
+  void onFailure(FetchException e) {
+    if (request.finished) {
+      return;
+    }
+    synchronized (request) {
+      if (e.getExpectedSize() != 0) {
+        request.setFoundDataLength(e.getExpectedSize());
+      }
+      if (e.getExpectedMimeType() != null) {
+        request.setFoundDataMimeType(e.getExpectedMimeType());
+      }
+      request.setSucceeded(false);
+      request.setFailedMessage(new GetFailedMessage(e, request.identifier, request.global));
+      request.finished = true;
+      request.started = true;
+      request.completionTime = System.currentTimeMillis();
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Caught {}", e, e);
+    }
+    request.trySendDataFoundOrGetFailed(null, null);
+    // We do not want the data to be removed on failure, because the request
+    // may be restarted, and the bucket persists on the getter, even if we get rid of it here.
+    request.finish();
+    if (request.client != null) {
+      request.client.notifyFailure(request);
+    }
+  }
+
+  /**
+   * Handles removal of a request from its owning queue.
+   *
+   * <p>If the request is still running, this method synthesizes a cancellation failure so that
+   * observers receive a terminal status. It then emits a removal notification to persistent clients
+   * and frees any retained in-memory buckets. The method does not attempt to stop network activity;
+   * it assumes the scheduler already detached the underlying fetcher.
+   */
+  void requestWasRemoved() {
+    // if the request is still running, send a GetFailed with code=canceled
+    if (!request.finished) {
+      synchronized (request) {
+        request.setSucceeded(false);
+        request.finished = true;
+        FetchException cancelled = new FetchException(FetchExceptionMode.CANCELLED);
+        request.setFailedMessage(
+            new GetFailedMessage(cancelled, request.identifier, request.global));
+      }
+      request.trySendDataFoundOrGetFailed(null, null);
+    }
+    // notify client that the request was removed
+    FCPMessage msg = new PersistentRequestRemovedMessage(request.getIdentifier(), request.global);
+    if (request.persistence != ClientRequest.Persistence.CONNECTION) {
+      request.client.queueClientRequestMessage(msg, 0);
+    }
+
+    request.freeData();
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetMessageReplay.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetMessageReplay.java
@@ -1,0 +1,258 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Replays or dispatches FCP messages for {@link ClientGet} instances.
+ *
+ * <p>This helper is responsible for turning cached request state into outbound protocol messages
+ * when a client reconnects or when queued updates must be delivered. It keeps message sequencing
+ * and replay logic separate from the request lifecycle so that {@link ClientGet} can focus on state
+ * transitions, persistence, and retry policy. Typical call sites construct one helper per request
+ * and delegate message emission from queueing or resume flows.
+ *
+ * <p>The helper does not retain a mutable state beyond the reference to its request. It
+ * synchronizes with the request when reading composite state, and it never mutates the request
+ * directly. All methods are designed to be idempotent with respect to message replay; they emit
+ * messages based on the current cached snapshot only.
+ *
+ * <ul>
+ *   <li><strong>Replay sequencing</strong>: emits tags, progress, metadata, and completion
+ *       messages.
+ *   <li><strong>Delivery routing</strong>: chooses the correct destination based on persistence.
+ *   <li><strong>Payload handling</strong>: assembles {@link AllDataMessage} when applicable.
+ * </ul>
+ *
+ * @see ClientGet
+ */
+final class ClientGetMessageReplay {
+  /** Owning request whose cached state is replayed to FCP clients. */
+  private final ClientGet request;
+
+  /**
+   * Creates a replay helper bound to a single request instance.
+   *
+   * <p>The helper keeps only a reference to the request and relies on the request's own
+   * synchronization for consistent snapshots. Callers should create a new helper for each request
+   * and avoid sharing instances between requests.
+   *
+   * @param request owning request providing cached message state; must be non-null.
+   */
+  ClientGetMessageReplay(ClientGet request) {
+    this.request = Objects.requireNonNull(request, "request");
+  }
+
+  /**
+   * Sends cached state to a reconnecting client.
+   *
+   * <p>The method emits persistent tags, progress messages, compatibility metadata, and optional
+   * payloads in the same sequence used for live updates. When {@code onlyData} is true, the method
+   * enforces {@link ClientGet.ReturnType#DIRECT} and otherwise emits a protocol error. The method
+   * is idempotent and uses only cached request state; it does not trigger additional network
+   * activity or alter the underlying request.
+   *
+   * @param handler output handler used to enqueue messages to the destination connection.
+   * @param listRequestIdentifier optional identifier added to replayed messages; may be null.
+   * @param includeData {@code true} to include {@link AllDataMessage} bodies when present.
+   * @param onlyData {@code true} to suppress metadata and send only payload frames.
+   */
+  void sendPendingMessages(
+      FCPConnectionOutputHandler handler,
+      String listRequestIdentifier,
+      boolean includeData,
+      boolean onlyData) {
+    if (!onlyData) {
+      FCPMessage msg = request.persistentTagMessage();
+      handler.handler.send(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
+      SimpleProgressMessage progress = request.progressPendingForReplay();
+      if (progress != null) {
+        handler.handler.send(FCPMessage.withListRequestIdentifier(progress, listRequestIdentifier));
+      }
+      if (request.sentToNetworkForReplay()) {
+        handler.handler.send(
+            FCPMessage.withListRequestIdentifier(
+                new SendingToNetworkMessage(request.identifier, request.global),
+                listRequestIdentifier));
+      }
+      if (request.finished) {
+        request.trySendDataFoundOrGetFailed(handler, listRequestIdentifier);
+      }
+    } else if (request.returnTypeForReplay() != ClientGet.ReturnType.DIRECT) {
+      FCPMessage msg =
+          new ProtocolErrorMessage(
+              ProtocolErrorMessage.WRONG_RETURN_TYPE,
+              false,
+              "No AllData",
+              request.identifier,
+              request.global);
+      handler.handler.send(msg);
+      return;
+    }
+
+    if (includeData) {
+      request.trySendAllDataMessage(handler, listRequestIdentifier);
+    }
+
+    CompatibilityMode cmsg;
+    ExpectedHashes hashesMessage;
+    ExpectedMIME mimeMsg = null;
+    ExpectedDataLength lengthMsg = null;
+    synchronized (request) {
+      cmsg =
+          new CompatibilityMode(request.identifier, request.global, request.compatModeForReplay());
+      hashesMessage = request.expectedHashesForReplay();
+      if (request.foundDataMimeTypeForReplay() != null) {
+        mimeMsg =
+            new ExpectedMIME(
+                request.identifier, request.global, request.foundDataMimeTypeForReplay());
+      }
+      if (request.foundDataLengthForReplay() > 0) {
+        lengthMsg =
+            new ExpectedDataLength(
+                request.identifier, request.global, request.foundDataLengthForReplay());
+      }
+    }
+    handler.handler.send(FCPMessage.withListRequestIdentifier(cmsg, listRequestIdentifier));
+
+    if (hashesMessage != null) {
+      handler.handler.send(
+          FCPMessage.withListRequestIdentifier(hashesMessage, listRequestIdentifier));
+    }
+
+    if (mimeMsg != null) {
+      handler.handler.send(FCPMessage.withListRequestIdentifier(mimeMsg, listRequestIdentifier));
+    }
+    if (lengthMsg != null) {
+      handler.handler.send(FCPMessage.withListRequestIdentifier(lengthMsg, listRequestIdentifier));
+    }
+  }
+
+  /**
+   * Queues a progress message using the appropriate connection or persistent queue.
+   *
+   * <p>Connection-scoped requests send directly to the original handler when available. Persistent
+   * requests queue the message on the owning {@link PersistentRequestClient} so that reconnections
+   * and watchers receive consistent updates.
+   *
+   * @param msg progress message to deliver; must already be fully constructed.
+   * @param verbosityMask verbosity bitmask used when queueing to persistent clients.
+   */
+  void queueProgressMessageInner(FCPMessage msg, int verbosityMask) {
+    if (request.persistence == ClientRequest.Persistence.CONNECTION) {
+      if (request.origHandler != null) {
+        request.origHandler.send(msg);
+      }
+      return;
+    }
+    request.client.queueClientRequestMessage(msg, verbosityMask);
+  }
+
+  /**
+   * Emits a terminal {@link DataFoundMessage} or {@link GetFailedMessage} based on cached state.
+   *
+   * <p>The method chooses the correct destination based on persistence and whether a handler was
+   * supplied. When a success is recorded, it mirrors {@link AllDataMessage} timing so clients
+   * receive consistent timestamps even if completion time was recorded later in the lifecycle.
+   *
+   * @param handler optional handler to target directly; may be null to use queue routing.
+   * @param listRequestIdentifier optional list identifier to attach to outgoing messages.
+   */
+  void trySendDataFoundOrGetFailed(
+      FCPConnectionOutputHandler handler, String listRequestIdentifier) {
+    FCPMessage msg;
+
+    // Don't need to lock. succeeded is only ever set, never unset.
+    // and succeeded and getFailedMessage are both atomic.
+    if (request.hasSucceededForReplay()) {
+      // Mirrors AllDataMessage so connection-scoped clients receive DataFound with consistent
+      // timestamps even if completionTime was not set by finish().
+      msg =
+          new DataFoundMessage(
+              request.foundDataLengthForReplay(),
+              request.foundDataMimeTypeForReplay(),
+              request.identifier,
+              request.global,
+              request.startupTime,
+              request.completionTime != 0 ? request.completionTime : System.currentTimeMillis());
+    } else {
+      msg = request.getFailedMessageForReplay();
+    }
+
+    if (handler == null && request.persistence == ClientRequest.Persistence.CONNECTION) {
+      if (request.origHandler != null) {
+        request.origHandler.send(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
+      }
+    } else if (handler != null) {
+      handler.handler.send(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
+    } else {
+      request.client.queueClientRequestMessage(
+          FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier), 0);
+    }
+  }
+
+  /**
+   * Emits an {@link AllDataMessage} payload when available.
+   *
+   * <p>For connection-scoped requests without an explicit handler, the message is sent to the
+   * original handler. For other cases, it is sent through the provided handler. When the request is
+   * not in {@link ClientGet.ReturnType#DIRECT} mode, this method is a no-op.
+   *
+   * @param handler handler to send through when non-null; may be null for connection replay.
+   * @param listRequestIdentifier optional list identifier added to the outgoing message.
+   */
+  void trySendAllDataMessage(FCPConnectionOutputHandler handler, String listRequestIdentifier) {
+    if (request.persistence == ClientRequest.Persistence.CONNECTION && handler == null) {
+      if (request.origHandler != null) {
+        FCPMessage allData =
+            FCPMessage.withListRequestIdentifier(getAllDataMessage(), listRequestIdentifier);
+        if (allData != null) {
+          request.origHandler.send(allData);
+        }
+      }
+      return;
+    }
+    if (handler != null) {
+      FCPMessage allData =
+          FCPMessage.withListRequestIdentifier(getAllDataMessage(), listRequestIdentifier);
+      if (allData != null) {
+        handler.handler.send(allData);
+      }
+    }
+  }
+
+  /**
+   * Builds an {@link AllDataMessage} snapshot when direct delivery is enabled.
+   *
+   * <p>The method reads cached bucket, MIME type, and completion time under synchronization and
+   * returns {@code null} when the request is not configured for direct delivery. For connection
+   * scope, it marks the message for freeing after sending.
+   *
+   * @return a new {@link AllDataMessage} snapshot, or {@code null} when unavailable.
+   */
+  private AllDataMessage getAllDataMessage() {
+    if (request.returnTypeForReplay() != ClientGet.ReturnType.DIRECT) {
+      return null;
+    }
+    Bucket bucket;
+    String mimeType;
+    long completionTime;
+    synchronized (request) {
+      bucket = request.returnBucketDirectForReplay();
+      mimeType = request.foundDataMimeTypeForReplay();
+      completionTime = request.completionTime;
+    }
+    AllDataMessage msg =
+        new AllDataMessage(
+            bucket,
+            request.identifier,
+            request.global,
+            request.startupTime,
+            completionTime,
+            mimeType);
+    if (request.persistence == ClientRequest.Persistence.CONNECTION) {
+      msg.setFreeOnSent();
+    }
+    return msg;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshotBuilder.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshotBuilder.java
@@ -1,0 +1,76 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+import network.crypta.client.FetchContext;
+
+/**
+ * Builds persistent tag and status snapshot messages for {@link ClientGet}.
+ *
+ * <p>This helper assembles the metadata required for persistent request tags without exposing the
+ * formatting details to the request itself. It gathers identifiers, scheduling flags, return-type
+ * metadata, and fetch-context limits, then packages them into a {@link PersistentGet} message. The
+ * resulting message is suitable for queueing on persistent clients and for replay to reconnecting
+ * listeners.
+ *
+ * <p>The builder is intentionally small and stateless beyond the request reference. It relies on
+ * the request for synchronization and assumes its callers have already established the desired
+ * state. Because it only reads state and does not mutate it, the builder can be reused safely for
+ * multiple tag emissions on the same request.
+ *
+ * <ul>
+ *   <li><strong>Message composition</strong>: assembles {@link ClientRequestParams} and {@link
+ *       PersistentGetDescriptor} into a {@link PersistentGet}.
+ *   <li><strong>Persistence fidelity</strong>: preserves return type and size limits verbatim.
+ * </ul>
+ *
+ * @see ClientGet
+ */
+final class ClientGetStatusSnapshotBuilder {
+  /** The owning request whose cached metadata is rendered into persistent tags. */
+  private final ClientGet request;
+
+  /**
+   * Creates a snapshot builder for a single request.
+   *
+   * <p>The builder stores only a reference to the request and expects the request to remain valid
+   * for the lifetime of the builder. Callers should create one builder per request and avoid
+   * sharing instances between unrelated requests.
+   *
+   * @param request request whose fields are sampled for persistent tag creation.
+   */
+  ClientGetStatusSnapshotBuilder(ClientGet request) {
+    this.request = Objects.requireNonNull(request, "request");
+  }
+
+  /**
+   * Builds the persistent tag message for the current request state.
+   *
+   * <p>The message captures identity, persistence settings, scheduling flags, and return-type
+   * metadata so that persistent queues can restore the request after restarts. The returned message
+   * is a fresh instance and can be queued or replayed without mutating the builder or request.
+   *
+   * @return {@link PersistentGet} message describing the request's current persistent metadata.
+   */
+  FCPMessage persistentTagMessage() {
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            request.uri,
+            request.identifier,
+            request.verbosity,
+            request.priorityClass,
+            request.persistence,
+            request.isRealTime(),
+            request.clientToken,
+            request.client.isGlobalQueue);
+    FetchContext fetchContext = request.fetchContextForGetter();
+    PersistentGetDescriptor descriptor =
+        new PersistentGetDescriptor(
+            request.returnTypeForReplay(),
+            request.targetFileForLifecycle(),
+            request.started,
+            fetchContext.getMaxNonSplitfileRetries(),
+            request.binaryBlobRequested(),
+            fetchContext.getMaxOutputLength());
+    return new PersistentGet(requestParams, descriptor);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetLifecycleTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetLifecycleTest.java
@@ -1,0 +1,226 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchResult;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.clients.fcp.ClientGet.ReturnType;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ResumeFailedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetLifecycleTest {
+
+  @Test
+  void onSuccess_whenDirectReturn_expectStateUpdatedAndNotifications() throws Exception {
+    // Arrange
+    ClientGet request = newSpyRequest(ReturnType.DIRECT, false);
+    Bucket bucket = Mockito.mock(Bucket.class);
+    when(bucket.size()).thenReturn(123L);
+    FetchResult result = new FetchResult(new ClientMetadata("text/plain"), bucket);
+    ClientGetter getter = Mockito.mock(ClientGetter.class);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    setField(request, "client", client);
+    doNothing().when(request).trySendDataFoundOrGetFailed(null, null);
+    doNothing().when(request).trySendAllDataMessage(null, null);
+    doNothing().when(request).finish();
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    // Act
+    lifecycle.onSuccess(result, getter);
+
+    // Assert
+    assertTrue(getBooleanField(request, "started"));
+    assertTrue(getBooleanField(request, "finished"));
+    assertTrue(getBooleanField(request, "succeeded"));
+    assertEquals(123L, (long) getField(request, "foundDataLength"));
+    assertEquals("text/plain", getField(request, "foundDataMimeType"));
+    assertEquals(bucket, getField(request, "returnBucketDirect"));
+    verify(request).trySendDataFoundOrGetFailed(null, null);
+    verify(request).trySendAllDataMessage(null, null);
+    verify(request).finish();
+    verify(client).notifySuccess(request);
+  }
+
+  @Test
+  void onSuccess_whenBinaryBlob_expectBlobMimeTypeAndBlobBucketSize() throws Exception {
+    // Arrange
+    ClientGet request = newSpyRequest(ReturnType.DIRECT, true);
+    Bucket resultBucket = Mockito.mock(Bucket.class);
+    Bucket blobBucket = Mockito.mock(Bucket.class);
+    when(blobBucket.size()).thenReturn(50L);
+    FetchResult result = new FetchResult(new ClientMetadata("text/plain"), resultBucket);
+    ClientGetter getter = Mockito.mock(ClientGetter.class);
+    when(getter.getBlobBucket()).thenReturn(blobBucket);
+    doNothing().when(request).trySendDataFoundOrGetFailed(null, null);
+    doNothing().when(request).trySendAllDataMessage(null, null);
+    doNothing().when(request).finish();
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    // Act
+    lifecycle.onSuccess(result, getter);
+
+    // Assert
+    assertEquals(50L, (long) getField(request, "foundDataLength"));
+    assertEquals(
+        ClientGetGetterFactory.binaryBlobMimeType(), getField(request, "foundDataMimeType"));
+  }
+
+  @Test
+  void setSuccessForMigration_whenContextNull_expectNullPointerException() {
+    // Arrange
+    ClientGet request = new ClientGet();
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+    //noinspection resource
+    Bucket bucket = Mockito.mock(Bucket.class);
+
+    // Act + Assert
+    assertThrows(
+        NullPointerException.class, () -> lifecycle.setSuccessForMigration(null, 1L, bucket));
+  }
+
+  @Test
+  void setSuccessForMigration_whenDirectMismatch_expectResumeFailedExceptionAndBucketStored()
+      throws Exception {
+    // Arrange
+    ClientGet request = new ClientGet();
+    Bucket bucket = Mockito.mock(Bucket.class);
+    when(bucket.size()).thenReturn(7L);
+    setField(request, "returnType", ReturnType.DIRECT);
+    setField(request, "foundDataLength", 5L);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    // Act + Assert
+    assertThrows(
+        ResumeFailedException.class, () -> lifecycle.setSuccessForMigration(context, 10L, bucket));
+    assertEquals(bucket, getField(request, "returnBucketDirect"));
+  }
+
+  @Test
+  void setSuccessForMigration_whenChunked_expectResumeFailedException() throws Exception {
+    // Arrange
+    ClientGet request = new ClientGet();
+    //noinspection resource
+    Bucket bucket = Mockito.mock(Bucket.class);
+    setField(request, "returnType", ReturnType.CHUNKED);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    // Act + Assert
+    assertThrows(
+        ResumeFailedException.class, () -> lifecycle.setSuccessForMigration(context, 10L, bucket));
+  }
+
+  @Test
+  void onFailure_whenExpectedSizeAndMime_expectFailureRecordedAndNotified() throws Exception {
+    // Arrange
+    ClientGet request = newSpyRequest(ReturnType.NONE, false);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    setField(request, "client", client);
+    FetchException failure =
+        new FetchException(FetchExceptionMode.INTERNAL_ERROR, 256L, true, "text/plain");
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    // Act
+    lifecycle.onFailure(failure);
+
+    // Assert
+    assertTrue(getBooleanField(request, "finished"));
+    assertTrue(getBooleanField(request, "started"));
+    assertEquals(256L, (long) getField(request, "foundDataLength"));
+    assertEquals("text/plain", getField(request, "foundDataMimeType"));
+    assertNotNull(getField(request, "getFailedMessage"));
+    verify(request).trySendDataFoundOrGetFailed(null, null);
+    verify(request).finish();
+    verify(client).notifyFailure(request);
+  }
+
+  @Test
+  void requestWasRemoved_whenNotFinished_expectCancelledAndQueuedRemovalMessage() throws Exception {
+    // Arrange
+    ClientGet request = newSpyRequest(ReturnType.NONE, false);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    setField(request, "client", client);
+    setField(request, "persistence", Persistence.REBOOT);
+    setField(request, "identifier", "req-7");
+    setField(request, "global", true);
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    // Act
+    lifecycle.requestWasRemoved();
+
+    // Assert
+    verify(request).trySendDataFoundOrGetFailed(null, null);
+    verify(client).queueClientRequestMessage(any(PersistentRequestRemovedMessage.class), eq(0));
+    verify(request).freeData();
+    assertTrue(getBooleanField(request, "finished"));
+  }
+
+  private static ClientGet newSpyRequest(ReturnType returnType, boolean binaryBlob)
+      throws Exception {
+    ClientGet request = Mockito.spy(new ClientGet());
+    setField(request, "returnType", returnType);
+    setField(request, "binaryBlob", binaryBlob);
+    setField(request, "identifier", "req-1");
+    setField(request, "global", false);
+    setField(request, "started", false);
+    setField(request, "finished", false);
+    setField(request, "succeeded", false);
+    setField(request, "foundDataLength", -1L);
+    setField(request, "targetFile", new File("target.bin"));
+    return request;
+  }
+
+  private static Object getField(Object target, String fieldName) throws Exception {
+    Field field = findField(target, fieldName);
+    return field.get(target);
+  }
+
+  private static boolean getBooleanField(Object target, String fieldName) throws Exception {
+    Field field = findField(target, fieldName);
+    return field.getBoolean(target);
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = findField(target, fieldName);
+    field.set(target, value);
+  }
+
+  private static Field findField(Object target, String fieldName) throws Exception {
+    Field field = null;
+    Class<?> type = target.getClass();
+    while (type != null && field == null) {
+      try {
+        field = type.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException _) {
+        type = type.getSuperclass();
+      }
+    }
+    if (field == null) {
+      throw new NoSuchFieldException(fieldName);
+    }
+    field.setAccessible(true);
+    return field;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetMessageReplayTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetMessageReplayTest.java
@@ -1,0 +1,295 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Date;
+import java.util.List;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.async.CompatibilityAnalyser;
+import network.crypta.client.events.SplitfileProgressCounts;
+import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
+import network.crypta.clients.fcp.ClientGet.ReturnType;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.crypt.HashResult;
+import network.crypta.crypt.HashType;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetMessageReplayTest {
+
+  @Test
+  void sendPendingMessages_whenOnlyDataFalse_expectTagProgressAndMetadataMessages()
+      throws Exception {
+    // Arrange
+    FetchContext fetchContext = Mockito.mock(FetchContext.class);
+    when(fetchContext.getMaxNonSplitfileRetries()).thenReturn(3);
+    when(fetchContext.getMaxOutputLength()).thenReturn(1_000L);
+    RequestClient requestClient = Mockito.mock(RequestClient.class);
+    when(requestClient.realTimeFlag()).thenReturn(false);
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient client = root.getGlobalForeverClient();
+    FreenetURI uri = new FreenetURI("SSK@");
+    SplitfileProgressCounts counts = new SplitfileProgressCounts(10, 5, 1, 0, 5, 5, true);
+    SplitfileProgressTimestamps timestamps = new SplitfileProgressTimestamps(new Date(0), null);
+    SimpleProgressMessage progressMessage =
+        new SimpleProgressMessage("req-1", true, new SplitfileProgressEvent(counts, timestamps));
+    HashResult[] hashes = {new HashResult(HashType.SHA256, new byte[32])};
+    ExpectedHashes expectedHashes = new ExpectedHashes(hashes, "req-1", true);
+    ClientGet request =
+        newRequest(
+            uri,
+            "req-1",
+            true,
+            Persistence.FOREVER,
+            client,
+            fetchContext,
+            requestClient,
+            ReturnType.DIRECT);
+    setField(request, "progressPending", progressMessage);
+    setField(request, "sentToNetwork", true);
+    setField(request, "finished", false);
+    setField(request, "compatMode", new CompatibilityAnalyser());
+    setField(request, "expectedHashes", expectedHashes);
+    setField(request, "foundDataMimeType", "text/plain");
+    setField(request, "foundDataLength", 64L);
+    ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
+    FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
+    FCPConnectionOutputHandler outputHandler = new FCPConnectionOutputHandler(handler);
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+
+    // Act
+    replay.sendPendingMessages(outputHandler, "list-1", false, false);
+
+    // Assert
+    verify(handler, times(7)).send(captor.capture());
+    List<String> names = captor.getAllValues().stream().map(FCPMessage::getName).toList();
+    assertTrue(
+        names.containsAll(
+            List.of(
+                "PersistentGet",
+                "SimpleProgress",
+                "SendingToNetwork",
+                "CompatibilityMode",
+                "ExpectedHashes",
+                "ExpectedMIME",
+                "ExpectedDataLength")));
+    SimpleFieldSet fieldSet = captor.getAllValues().getFirst().getFieldSet();
+    assertEquals("list-1", fieldSet.get("ListRequestIdentifier"));
+  }
+
+  @Test
+  void sendPendingMessages_whenOnlyDataTrueAndNonDirect_expectProtocolErrorOnly() throws Exception {
+    // Arrange
+    FetchContext fetchContext = Mockito.mock(FetchContext.class);
+    RequestClient requestClient = Mockito.mock(RequestClient.class);
+    PersistentRequestClient client =
+        new PersistentRequestClient("client", null, false, null, Persistence.REBOOT, null);
+    ClientGet request =
+        newRequest(
+            FreenetURI.EMPTY_CHK_URI,
+            "req-2",
+            false,
+            Persistence.REBOOT,
+            client,
+            fetchContext,
+            requestClient,
+            ReturnType.NONE);
+    ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
+    FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
+    FCPConnectionOutputHandler outputHandler = new FCPConnectionOutputHandler(handler);
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+
+    // Act
+    replay.sendPendingMessages(outputHandler, "list-2", false, true);
+
+    // Assert
+    verify(handler).send(captor.capture());
+    assertEquals("ProtocolError", captor.getValue().getName());
+  }
+
+  @Test
+  void queueProgressMessageInner_whenConnectionPersistence_expectSentToOriginHandler()
+      throws Exception {
+    // Arrange
+    ClientGet request = new ClientGet();
+    FCPConnectionHandler origHandler = Mockito.mock(FCPConnectionHandler.class);
+    setField(request, "persistence", Persistence.CONNECTION);
+    setField(request, "origHandler", origHandler);
+    ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
+    FCPMessage message = Mockito.mock(FCPMessage.class);
+
+    // Act
+    replay.queueProgressMessageInner(message, 0);
+
+    // Assert
+    verify(origHandler).send(message);
+  }
+
+  @Test
+  void queueProgressMessageInner_whenPersistent_expectQueuedOnClient() throws Exception {
+    // Arrange
+    ClientGet request = new ClientGet();
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    setField(request, "persistence", Persistence.REBOOT);
+    setField(request, "client", client);
+    ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
+    FCPMessage message = Mockito.mock(FCPMessage.class);
+
+    // Act
+    replay.queueProgressMessageInner(message, 4);
+
+    // Assert
+    verify(client).queueClientRequestMessage(message, 4);
+  }
+
+  @Test
+  void trySendDataFoundOrGetFailed_whenSucceededConnection_expectDataFoundSentToHandler()
+      throws Exception {
+    // Arrange
+    ClientGet request = new ClientGet();
+    FCPConnectionHandler origHandler = Mockito.mock(FCPConnectionHandler.class);
+    setField(request, "identifier", "req-3");
+    setField(request, "global", false);
+    setField(request, "persistence", Persistence.CONNECTION);
+    setField(request, "origHandler", origHandler);
+    setField(request, "startupTime", 5L);
+    setField(request, "completionTime", 12L);
+    setField(request, "foundDataLength", 99L);
+    setField(request, "foundDataMimeType", "text/plain");
+    setField(request, "succeeded", true);
+    ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+
+    // Act
+    replay.trySendDataFoundOrGetFailed(null, "list-3");
+
+    // Assert
+    verify(origHandler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    assertEquals("DataFound", sent.getName());
+    SimpleFieldSet fieldSet = sent.getFieldSet();
+    assertEquals("req-3", fieldSet.get("Identifier"));
+    assertEquals(99L, fieldSet.getLong("DataLength", -1L));
+    assertEquals("text/plain", fieldSet.get("Metadata.ContentType"));
+    assertEquals(12L, fieldSet.getLong("CompletionTime", -1L));
+    assertEquals("list-3", fieldSet.get("ListRequestIdentifier"));
+  }
+
+  @Test
+  void trySendDataFoundOrGetFailed_whenFailedPersistent_expectQueuedFailedMessage()
+      throws Exception {
+    // Arrange
+    ClientGet request = new ClientGet();
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    FetchException failure = new FetchException(FetchExceptionMode.INTERNAL_ERROR);
+    GetFailedMessage failedMessage = new GetFailedMessage(failure, "req-4", true);
+    setField(request, "identifier", "req-4");
+    setField(request, "global", true);
+    setField(request, "persistence", Persistence.REBOOT);
+    setField(request, "client", client);
+    setField(request, "succeeded", false);
+    setField(request, "getFailedMessage", failedMessage);
+    ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
+
+    // Act
+    replay.trySendDataFoundOrGetFailed(null, "list-4");
+
+    // Assert
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(client).queueClientRequestMessage(captor.capture(), eq(0));
+    assertEquals("GetFailed", captor.getValue().getName());
+    assertEquals("list-4", captor.getValue().getFieldSet().get("ListRequestIdentifier"));
+  }
+
+  @Test
+  void trySendAllDataMessage_whenDirectAndHandlerProvided_expectAllDataSent() throws Exception {
+    // Arrange
+    ClientGet request = new ClientGet();
+    Bucket bucket = Mockito.mock(Bucket.class);
+    when(bucket.size()).thenReturn(55L);
+    setField(request, "identifier", "req-5");
+    setField(request, "global", false);
+    setField(request, "startupTime", 1L);
+    setField(request, "completionTime", 2L);
+    setField(request, "foundDataMimeType", "application/octet-stream");
+    setField(request, "returnType", ReturnType.DIRECT);
+    setField(request, "returnBucketDirect", bucket);
+    setField(request, "persistence", Persistence.REBOOT);
+    ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
+    FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
+    FCPConnectionOutputHandler outputHandler = new FCPConnectionOutputHandler(handler);
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+
+    // Act
+    replay.trySendAllDataMessage(outputHandler, "list-5");
+
+    // Assert
+    verify(handler).send(captor.capture());
+    assertEquals("AllData", captor.getValue().getName());
+    assertEquals("list-5", captor.getValue().getFieldSet().get("ListRequestIdentifier"));
+  }
+
+  private static ClientGet newRequest(
+      FreenetURI uri,
+      String identifier,
+      boolean global,
+      Persistence persistence,
+      PersistentRequestClient client,
+      FetchContext fetchContext,
+      RequestClient requestClient,
+      ReturnType returnType)
+      throws Exception {
+    ClientGet request = new ClientGet();
+    setField(request, "uri", uri);
+    setField(request, "identifier", identifier);
+    setField(request, "verbosity", 1);
+    setField(request, "priorityClass", (short) 1);
+    setField(request, "persistence", persistence);
+    setField(request, "clientToken", "token");
+    setField(request, "started", true);
+    setField(request, "client", client);
+    setField(request, "returnType", returnType);
+    setField(request, "targetFile", new File("target.bin"));
+    setField(request, "binaryBlob", false);
+    setField(request, "fctx", fetchContext);
+    setField(request, "lowLevelClient", requestClient);
+    setField(request, "global", global);
+    return request;
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = null;
+    Class<?> type = target.getClass();
+    while (type != null && field == null) {
+      try {
+        field = type.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException _) {
+        type = type.getSuperclass();
+      }
+    }
+    if (field == null) {
+      throw new NoSuchFieldException(fieldName);
+    }
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetStatusSnapshotBuilderTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetStatusSnapshotBuilderTest.java
@@ -1,0 +1,200 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import network.crypta.client.FetchContext;
+import network.crypta.clients.fcp.ClientGet.ReturnType;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetStatusSnapshotBuilderTest {
+
+  @Test
+  void persistentTagMessage_whenDiskReturnType_expectFieldSetContainsDiskFilenameAndValues()
+      throws Exception {
+    // Arrange
+    FetchContext fetchContext = Mockito.mock(FetchContext.class);
+    when(fetchContext.getMaxNonSplitfileRetries()).thenReturn(7);
+    when(fetchContext.getMaxOutputLength()).thenReturn(12_345L);
+    RequestClient requestClient = Mockito.mock(RequestClient.class);
+    when(requestClient.realTimeFlag()).thenReturn(true);
+    File targetFile = new File("target.bin");
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient client = root.getGlobalForeverClient();
+    ClientGet request =
+        newRequest(
+            FreenetURI.EMPTY_CHK_URI,
+            "id-1",
+            11,
+            (short) 3,
+            Persistence.FOREVER,
+            "token",
+            true,
+            client,
+            ReturnType.DISK,
+            targetFile,
+            true,
+            fetchContext,
+            requestClient);
+    ClientGetStatusSnapshotBuilder builder = new ClientGetStatusSnapshotBuilder(request);
+
+    // Act
+    FCPMessage message = builder.persistentTagMessage();
+
+    // Assert
+    SimpleFieldSet fieldSet = message.getFieldSet();
+    assertEquals("id-1", fieldSet.get("Identifier"));
+    assertEquals(FreenetURI.EMPTY_CHK_URI.toString(false, false), fieldSet.get("URI"));
+    assertEquals("disk", fieldSet.get("ReturnType"));
+    assertEquals("forever", fieldSet.get("Persistence"));
+    assertEquals(targetFile.getAbsolutePath(), fieldSet.get("Filename"));
+    assertEquals(11, fieldSet.getInt("Verbosity", -1));
+    assertEquals(3, fieldSet.getInt("PriorityClass", -1));
+    assertEquals("token", fieldSet.get("ClientToken"));
+    assertTrue(fieldSet.getBoolean("Global", false));
+    assertTrue(fieldSet.getBoolean("Started", false));
+    assertEquals(7, fieldSet.getInt("MaxRetries", -1));
+    assertTrue(fieldSet.getBoolean("BinaryBlob", false));
+    assertEquals(12_345L, fieldSet.getLong("MaxSize", -1L));
+    assertTrue(fieldSet.getBoolean("RealTime", false));
+  }
+
+  @Test
+  void persistentTagMessage_whenClientTokenNull_expectFieldSetOmitsClientTokenAndFilename()
+      throws Exception {
+    // Arrange
+    FetchContext fetchContext = Mockito.mock(FetchContext.class);
+    when(fetchContext.getMaxNonSplitfileRetries()).thenReturn(1);
+    when(fetchContext.getMaxOutputLength()).thenReturn(42L);
+    RequestClient requestClient = Mockito.mock(RequestClient.class);
+    when(requestClient.realTimeFlag()).thenReturn(false);
+    PersistentRequestClient client =
+        new PersistentRequestClient("client", null, false, null, Persistence.REBOOT, null);
+    ClientGet request =
+        newRequest(
+            FreenetURI.EMPTY_CHK_URI,
+            "id-2",
+            2,
+            (short) 1,
+            Persistence.REBOOT,
+            null,
+            false,
+            client,
+            ReturnType.DIRECT,
+            null,
+            false,
+            fetchContext,
+            requestClient);
+    ClientGetStatusSnapshotBuilder builder = new ClientGetStatusSnapshotBuilder(request);
+
+    // Act
+    FCPMessage message = builder.persistentTagMessage();
+
+    // Assert
+    SimpleFieldSet fieldSet = message.getFieldSet();
+    assertNull(fieldSet.get("ClientToken"));
+    assertNull(fieldSet.get("Filename"));
+    assertEquals("direct", fieldSet.get("ReturnType"));
+    assertFalse(fieldSet.getBoolean("Global", true));
+    assertFalse(fieldSet.getBoolean("Started", true));
+    assertEquals(1, fieldSet.getInt("MaxRetries", -1));
+    assertFalse(fieldSet.getBoolean("BinaryBlob", true));
+    assertEquals(42L, fieldSet.getLong("MaxSize", -1L));
+    assertFalse(fieldSet.getBoolean("RealTime", true));
+  }
+
+  @Test
+  void persistentTagMessage_whenUriNull_expectThrowsNullPointerException() throws Exception {
+    // Arrange
+    FetchContext fetchContext = Mockito.mock(FetchContext.class);
+    when(fetchContext.getMaxNonSplitfileRetries()).thenReturn(1);
+    when(fetchContext.getMaxOutputLength()).thenReturn(1L);
+    RequestClient requestClient = Mockito.mock(RequestClient.class);
+    when(requestClient.realTimeFlag()).thenReturn(false);
+    PersistentRequestClient client =
+        new PersistentRequestClient("client", null, true, null, Persistence.REBOOT, null);
+    ClientGet request =
+        newRequest(
+            null,
+            "id-3",
+            1,
+            (short) 1,
+            Persistence.REBOOT,
+            "token",
+            false,
+            client,
+            ReturnType.NONE,
+            null,
+            false,
+            fetchContext,
+            requestClient);
+    ClientGetStatusSnapshotBuilder builder = new ClientGetStatusSnapshotBuilder(request);
+
+    // Act + Assert
+    assertThrows(NullPointerException.class, builder::persistentTagMessage);
+  }
+
+  private static ClientGet newRequest(
+      FreenetURI uri,
+      String identifier,
+      int verbosity,
+      short priorityClass,
+      Persistence persistence,
+      String clientToken,
+      boolean started,
+      PersistentRequestClient client,
+      ReturnType returnType,
+      File targetFile,
+      boolean binaryBlob,
+      FetchContext fetchContext,
+      RequestClient requestClient)
+      throws Exception {
+    ClientGet request = new ClientGet();
+    setField(request, "uri", uri);
+    setField(request, "identifier", identifier);
+    setField(request, "verbosity", verbosity);
+    setField(request, "priorityClass", priorityClass);
+    setField(request, "persistence", persistence);
+    setField(request, "clientToken", clientToken);
+    setField(request, "started", started);
+    setField(request, "client", client);
+    setField(request, "returnType", returnType);
+    setField(request, "targetFile", targetFile);
+    setField(request, "binaryBlob", binaryBlob);
+    setField(request, "fctx", fetchContext);
+    setField(request, "lowLevelClient", requestClient);
+    return request;
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = null;
+    Class<?> type = target.getClass();
+    while (type != null && field == null) {
+      try {
+        field = type.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException _) {
+        type = type.getSuperclass();
+      }
+    }
+    if (field == null) {
+      throw new NoSuchFieldException(fieldName);
+    }
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}


### PR DESCRIPTION
## Summary
- extract lifecycle, replay, and snapshot builder helpers from `ClientGet`
- centralize success/failure/removal handling and cached message replay paths
- add focused unit tests for lifecycle, replay sequencing, and snapshot tags

## Testing
- `./gradlew spotlessApply`