### PR TITLE
refactor(fcp): extract client put helpers

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -1,42 +1,25 @@
 package network.crypta.clients.fcp;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Objects;
 import network.crypta.client.ClientMetadata;
-import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.InsertException;
-import network.crypta.client.InsertException.InsertExceptionMode;
-import network.crypta.client.Metadata;
-import network.crypta.client.Metadata.DocumentType;
 import network.crypta.client.MetadataUnresolvedException;
-import network.crypta.client.async.BinaryBlob;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientPutterOptions;
 import network.crypta.client.async.ClientPutterRequest;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
-import network.crypta.crypt.SHA256;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
-import network.crypta.support.Base64;
-import network.crypta.support.IllegalBase64Exception;
-import network.crypta.support.api.Bucket;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.ResumeFailedException;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,9 +140,7 @@ public class ClientPut extends ClientPutBase {
     RandomAccessBucket tempData = upload.data();
 
     if (uploadFromType == UploadFrom.DISK) {
-      if (!core.allowUploadFrom(uploadOrigFilename)) throw new NotAllowedException();
-      if (!(uploadOrigFilename.exists() && uploadOrigFilename.canRead()))
-        throw new FileNotFoundException();
+      ClientPutDiskUploadValidator.validatePersistentDiskUpload(core, uploadOrigFilename);
     }
 
     this.binaryBlob = upload.binaryBlob();
@@ -171,26 +152,24 @@ public class ClientPut extends ClientPutBase {
     String mimeType = contentType;
     this.clientToken = request.clientToken();
     ClientMetadata cm = new ClientMetadata(mimeType);
-    boolean isMetadata = false;
     if (LOG.isDebugEnabled()) LOG.debug(DATA_UPLOAD_LOG_TEMPLATE, tempData, uploadFrom);
-    if (uploadFrom == UploadFrom.REDIRECT) {
-      this.targetURI = upload.redirectTarget();
-      Metadata m = new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, targetURI, cm);
-      tempData = m.toBucket(core.getClientContext().getBucketFactory(isPersistentForever()));
-      isMetadata = true;
-    } else targetURI = null;
-
-    this.data = tempData;
+    PreparedData preparedData =
+        ClientPutPreparedDataFactory.prepareForPersistentUpload(
+            uploadFrom, cm, tempData, upload.redirectTarget(), core, isPersistentForever());
+    this.data = preparedData.bucket();
     this.clientMetadata = cm;
+    this.targetURI = preparedData.targetUri();
 
-    putter =
-        new ClientPutter(
-            new ClientPutterRequest(this, data, this.uri, cm, ctx, priorityClass, isMetadata),
-            new ClientPutterOptions(
-                this.uri.getDocName() == null ? uploadTargetFilename : null,
-                this.binaryBlob,
-                options.overrideSplitfileCryptoKey(),
-                -1));
+    ClientPutterRequest putterRequest =
+        new ClientPutterRequest(
+            this, data, this.uri, cm, ctx, priorityClass, preparedData.isMetadata());
+    ClientPutterOptions putterOptions =
+        new ClientPutterOptions(
+            this.uri.getDocName() == null ? uploadTargetFilename : null,
+            this.binaryBlob,
+            options.overrideSplitfileCryptoKey(),
+            -1);
+    putter = ClientPutPutterFactory.create(putterRequest, putterOptions);
   }
 
   /**
@@ -247,14 +226,15 @@ public class ClientPut extends ClientPutBase {
     binaryBlob = message.binaryBlob;
 
     DiskUploadContext diskContext =
-        validateDiskUpload(handler, message, message.identifier, message.global);
+        ClientPutDiskUploadValidator.validateDiskUpload(
+            handler, message, message.identifier, message.global);
 
     this.targetFilename = message.targetFilename;
     this.uploadFrom = message.uploadFromType;
     this.origFilename = message.origFilename;
 
     String mimeType =
-        resolveMimeType(
+        ClientPutMimeResolver.resolve(
             message,
             this.origFilename,
             this.targetFilename,
@@ -264,23 +244,26 @@ public class ClientPut extends ClientPutBase {
 
     clientToken = message.clientToken;
     ClientMetadata cm = new ClientMetadata(mimeType);
-    PreparedData preparedData = prepareDataForUpload(message, cm, server, isPersistentForever());
+    PreparedData preparedData =
+        ClientPutPreparedDataFactory.prepareForMessage(
+            message, cm, server, isPersistentForever(), uploadFrom, identifier, global);
     this.data = preparedData.bucket();
     this.clientMetadata = cm;
     this.targetURI = preparedData.targetUri();
 
-    verifySaltedHash(diskContext, data, message.identifier, message.global);
+    ClientPutDiskUploadValidator.verifySaltedHash(diskContext, data, identifier, global);
 
     if (LOG.isDebugEnabled()) LOG.debug(DATA_UPLOAD_LOG_TEMPLATE, data, uploadFrom);
-    putter =
-        new ClientPutter(
-            new ClientPutterRequest(
-                this, data, this.uri, cm, ctx, priorityClass, preparedData.isMetadata()),
-            new ClientPutterOptions(
-                this.uri.getDocName() == null ? targetFilename : null,
-                binaryBlob,
-                message.overrideSplitfileCryptoKey,
-                message.metadataThreshold));
+    ClientPutterRequest putterRequest =
+        new ClientPutterRequest(
+            this, data, this.uri, cm, ctx, priorityClass, preparedData.isMetadata());
+    ClientPutterOptions putterOptions =
+        new ClientPutterOptions(
+            this.uri.getDocName() == null ? targetFilename : null,
+            binaryBlob,
+            message.overrideSplitfileCryptoKey,
+            message.metadataThreshold);
+    putter = ClientPutPutterFactory.create(putterRequest, putterOptions);
   }
 
   private static String ensureConnectionIdentifierAvailable(
@@ -308,192 +291,6 @@ public class ClientPut extends ClientPutBase {
 
   private synchronized boolean shouldQueuePersistentTag() {
     return persistence != Persistence.CONNECTION && !finished;
-  }
-
-  private PreparedData prepareDataForUpload(
-      ClientPutMessage message,
-      ClientMetadata metadata,
-      FCPServer server,
-      boolean persistentForever)
-      throws MessageInvalidException, IOException {
-    RandomAccessBucket tempData = message.getRandomAccessBucket();
-    if (LOG.isDebugEnabled()) LOG.debug(DATA_UPLOAD_LOG_TEMPLATE, tempData, uploadFrom);
-    if (uploadFrom == UploadFrom.REDIRECT) {
-      FreenetURI redirectTarget = message.redirectTarget;
-      Metadata metadataDoc =
-          new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, redirectTarget, metadata);
-      try {
-        RandomAccessBucket redirectData =
-            metadataDoc.toBucket(
-                server.getCore().getClientContext().getBucketFactory(persistentForever));
-        return new PreparedData(redirectData, true, redirectTarget);
-      } catch (MetadataUnresolvedException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INTERNAL_ERROR,
-            "Impossible: metadata unresolved: " + e,
-            identifier,
-            global);
-      }
-    }
-    return new PreparedData(tempData, false, null);
-  }
-
-  private void verifySaltedHash(
-      DiskUploadContext diskContext, RandomAccessBucket bucket, String identifier, boolean global)
-      throws MessageInvalidException {
-    if (!diskContext.hasSalt()) {
-      return;
-    }
-    MessageDigest md = SHA256.getMessageDigest();
-    md.update(diskContext.salt().getBytes(StandardCharsets.UTF_8));
-    byte[] foundHash;
-    try (InputStream is = bucket.getInputStream()) {
-      SHA256.hash(is, md);
-      foundHash = md.digest();
-    } catch (IOException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.COULD_NOT_READ_FILE,
-          "Unable to access file: " + e,
-          identifier,
-          global);
-    }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(
-          "FileHash result : we found {} and were given {}.",
-          Base64.encode(foundHash),
-          Base64.encode(diskContext.saltedHash()));
-    }
-    if (!Arrays.equals(diskContext.saltedHash(), foundHash)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED,
-          "The hash doesn't match! (salt used : \"" + diskContext.salt() + "\")",
-          identifier,
-          global);
-    }
-  }
-
-  private static DiskUploadContext validateDiskUpload(
-      FCPConnectionHandler handler, ClientPutMessage message, String identifier, boolean global)
-      throws MessageInvalidException {
-    if (message.uploadFromType != UploadFrom.DISK) {
-      return DiskUploadContext.empty();
-    }
-    if (!handler.getServer().getCore().allowUploadFrom(message.origFilename)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED,
-          "Not allowed to upload from " + message.origFilename,
-          identifier,
-          global);
-    }
-    if (message.fileHash != null) {
-      String salt =
-          handler.getConnectionIdentifierUUID().toString() + '-' + message.identifier + '-';
-      byte[] saltedHash = decodeFileHash(message.fileHash, identifier, global);
-      return new DiskUploadContext(salt, saltedHash);
-    }
-    if (!handler.ddaAccessController().allowDDAFrom(message.origFilename, false)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED,
-          "Not allowed to upload from "
-              + message.origFilename
-              + ". Have you done a testDDA previously ?",
-          identifier,
-          global);
-    }
-    return DiskUploadContext.empty();
-  }
-
-  private static byte[] decodeFileHash(String encoded, String identifier, boolean global)
-      throws MessageInvalidException {
-    try {
-      return Base64.decodeStandard(encoded);
-    } catch (IllegalBase64Exception _) {
-      try {
-        return Base64.decode(encoded);
-      } catch (IllegalBase64Exception _) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INVALID_FIELD,
-            "Can't base64 decode " + ClientPutBase.FILE_HASH,
-            identifier,
-            global);
-      }
-    }
-  }
-
-  private static String resolveMimeType(
-      ClientPutMessage message,
-      File origFilename,
-      String targetFilename,
-      boolean binaryBlob,
-      String identifier,
-      boolean global)
-      throws MessageInvalidException {
-    String mimeType = message.contentType;
-    if (binaryBlob && mimeType != null && !mimeType.equals(BinaryBlob.MIME_TYPE)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_FIELD,
-          "No MIME type allowed when inserting a binary blob",
-          identifier,
-          global);
-    }
-    if (mimeType == null && origFilename != null) {
-      mimeType = DefaultMIMETypes.guessMIMEType(origFilename.getName(), true);
-    }
-    if (mimeType == null && targetFilename != null) {
-      mimeType = DefaultMIMETypes.guessMIMEType(targetFilename, true);
-    }
-    if (mimeType != null && mimeType.isEmpty()) {
-      mimeType = null;
-    }
-    if (mimeType != null && !DefaultMIMETypes.isPlausibleMIMEType(mimeType)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.BAD_MIME_TYPE,
-          "Bad MIME type in Metadata.ContentType",
-          identifier,
-          global);
-    }
-    return mimeType;
-  }
-
-  private record DiskUploadContext(String salt, byte[] saltedHash) {
-    private static final DiskUploadContext EMPTY = new DiskUploadContext(null, null);
-
-    static DiskUploadContext empty() {
-      return EMPTY;
-    }
-
-    boolean hasSalt() {
-      return salt != null;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof DiskUploadContext(String otherSalt, byte[] otherHash))) return false;
-      return Objects.equals(salt, otherSalt) && Arrays.equals(saltedHash, otherHash);
-    }
-
-    @Override
-    public int hashCode() {
-      int result = Objects.hash(salt);
-      result = 31 * result + Arrays.hashCode(saltedHash);
-      return result;
-    }
-
-    @Override
-    public @NotNull String toString() {
-      return "DiskUploadContext[salt="
-          + salt
-          + ", saltedHash="
-          + (saltedHash == null ? "null" : Arrays.toString(saltedHash))
-          + ']';
-    }
-  }
-
-  private record PreparedData(RandomAccessBucket bucket, boolean metadata, FreenetURI targetUri) {
-    boolean isMetadata() {
-      return metadata;
-    }
   }
 
   /**
@@ -594,13 +391,14 @@ public class ClientPut extends ClientPutBase {
       synchronized (this) {
         started = true;
       }
-      onFailure(new InsertException(InsertExceptionMode.INTERNAL_ERROR, t, null), null);
+      onFailure(
+          new InsertException(InsertException.InsertExceptionMode.INTERNAL_ERROR, t, null), null);
     }
   }
 
   @Override
   protected void freeData() {
-    Bucket d;
+    RandomAccessBucket d;
     synchronized (this) {
       d = data;
       data = null;
@@ -755,6 +553,10 @@ public class ClientPut extends ClientPutBase {
    */
   public String getMIMEType() {
     return clientMetadata.getMIMEType();
+  }
+
+  ClientMetadata clientMetadataForStatus() {
+    return clientMetadata;
   }
 
   /**
@@ -937,64 +739,7 @@ public class ClientPut extends ClientPutBase {
 
   @Override
   RequestStatus getStatus() {
-    FreenetURI finalURI = getFinalURI();
-    InsertExceptionMode failureCode = null;
-    String failureReasonShort = null;
-    String failureReasonLong = null;
-    if (putFailedMessage != null) {
-      failureCode = putFailedMessage.failureMode;
-      failureReasonShort = putFailedMessage.getShortFailedMessage();
-      failureReasonLong = putFailedMessage.getLongFailedMessage();
-    }
-    String mimeType = null;
-    if (persistence == Persistence.FOREVER) {
-      mimeType = clientMetadata.getMIMEType();
-    }
-    File fnam = getOrigFilename();
-    if (fnam != null) fnam = new File(fnam.getPath());
-
-    int total = 0;
-    int min = 0;
-    int fetched = 0;
-    int fatal = 0;
-    int failed = 0;
-    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
-    Date latestSuccess = new Date();
-    Date latestFailure = null;
-    boolean totalFinalized = false;
-
-    if (progressMessage instanceof SimpleProgressMessage msg) {
-      total = (int) msg.getTotalBlocks();
-      min = (int) msg.getMinBlocks();
-      fetched = (int) msg.getFetchedBlocks();
-      latestSuccess = msg.getLatestSuccess();
-      fatal = (int) msg.getFatalyFailedBlocks();
-      failed = (int) msg.getFailedBlocks();
-      latestFailure = msg.getLatestFailure();
-      totalFinalized = msg.isTotalFinalized();
-    }
-
-    RequestStatusSnapshot statusSnapshot =
-        new RequestStatusSnapshot(
-            identifier,
-            persistence,
-            started,
-            finished,
-            succeeded,
-            total,
-            min,
-            fetched,
-            latestSuccess,
-            fatal,
-            failed,
-            latestFailure,
-            totalFinalized,
-            priorityClass);
-    UploadRequestStatusDetails details =
-        new UploadRequestStatusDetails(
-            finalURI, uri, failureCode, failureReasonShort, failureReasonLong);
-    return new UploadFileRequestStatus(
-        statusSnapshot, details, getDataSize(), mimeType, fnam, isCompressing());
+    return ClientPutStatusSnapshotBuilder.build(this);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -24,33 +24,38 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Drives a single insert issued through the FCP interface, wrapping validation, upload preparation,
- * and {@link ClientPutter} lifecycle management for one file or metadata object.
+ * Drives a single insert issued through the FCP interface, coordinating validation and scheduling
+ * for a single payload or redirect.
  *
- * <p>The class mediates between user requests and the asynchronous node core: it verifies disk
- * permissions, synthesizes redirect metadata, builds MIME-aware {@link ClientMetadata}, and feeds
- * bytes to the low-level {@link ClientRequester}. Instances are stateful and survive restarts when
- * configured for persistent queues, persisting identifiers, retry budgets, and compression status
- * to ensure idempotent progress reports.
+ * <p>The class mediates between user requests and the asynchronous node core: it validates disk
+ * access, synthesizes redirect metadata, resolves MIME metadata, and constructs the underlying
+ * {@link ClientPutter}. Instances encapsulate all mutable states needed to monitor progress,
+ * respond to retries, and surface status updates across reconnections. Persistent requests are
+ * serialized so the node can resume in-flight inserts after restart without reloading the client’s
+ * original configuration.
  *
- * <p>Thread-safety follows the contract of {@link ClientPutBase}: the object is primarily accessed
- * from the asynchronous worker threads, yet several accessors are synchronized to guard progress
- * flags shared with client UI components. Completion and failure callbacks may arrive concurrently,
- * so callers should not mutate externally visible buckets once construction finishes.
+ * <p>Thread-safety follows the contract of {@link ClientPutBase}. Most state is mutated by worker
+ * threads, while a handful of accessors synchronize on {@code this} to guard shared progress flags
+ * used by UIs and status caches. Callers should treat the request as owning its buckets once
+ * construction finishes and avoid mutating those buckets directly.
  *
  * <ul>
  *   <li>Prepares uploads originating from disk, memory buckets, or redirect metadata.
  *   <li>Captures per-request metadata so status polling exposes MIME type and filenames.
- *   <li>Publishes persistent tag messages whenever the queue requires bookkeeping updates.
+ *   <li>Publishes persistent tag messages whenever queue bookkeeping updates are required.
  * </ul>
  *
  * @see ClientPutBase
  * @see ClientRequester
  */
 public class ClientPut extends ClientPutBase {
+  /** Logger for lifecycle and diagnostic messages. */
   private static final Logger LOG = LoggerFactory.getLogger(ClientPut.class);
+
+  /** Debugging template that logs bucket identity and upload source. */
   private static final String DATA_UPLOAD_LOG_TEMPLATE = "data = {}, uploadFrom = {}";
 
+  /** Serialization version for persistent request snapshots. */
   @Serial private static final long serialVersionUID = 1L;
 
   /**
@@ -91,27 +96,27 @@ public class ClientPut extends ClientPutBase {
   // Legacy threshold callback removed.
 
   /**
-   * Creates a persistent insert originating from FProxy or another long-lived client, wiring the
-   * request into {@link ClientPutBase}'s bookkeeping structures.
+   * Creates a persistent insert originating from a long-lived client or FProxy.
    *
    * <p>The constructor enforces disk-access policy, builds redirect metadata when needed, captures
-   * MIME hints, and sets up {@link ClientPutter} with the correct retry and redundancy policies.
-   * Use it whenever an external client wants the node to own persistence, resume points, and retry
-   * state for an upload that might span restarts. Callers remain responsible for supplying buckets
-   * that stay readable for the lifetime of the insert. Compression configuration is honored exactly
-   * as supplied, so callers can trade throughput for determinism.
+   * MIME hints, and sets up {@link ClientPutter} with the retry and redundancy settings supplied by
+   * the caller. It is intended for uploads that must survive restarts, so the node takes ownership
+   * of persistence and retry state while the caller keeps the backing bucket readable for the
+   * request’s lifetime. Compression settings are honored exactly as supplied, allowing clients to
+   * trade throughput for deterministic behavior.
    *
-   * @param request Persistent request metadata including URI, identifier, and queue settings.
-   * @param options Insert tuning options such as retries, compression, and redundancy.
-   * @param upload Upload payload metadata describing source and content hints.
-   * @param core Owning {@link NodeClientCore} providing policies, factories, and scheduler hooks.
-   * @throws IdentifierCollisionException Thrown when the chosen identifier already exists within
-   *     the persistence scope.
-   * @throws NotAllowedException Raised when a configured upload source violates server-side safety
-   *     policies.
-   * @throws MetadataUnresolvedException Bubble-up if redirect metadata cannot serialize into a
-   *     bucket factory.
-   * @throws IOException Propagated for filesystem or bucket reads when preparing payload streams.
+   * @param request persistent request metadata including URI, identifier, and queue settings; must
+   *     not be {@code null} and should reflect the intended persistence scope.
+   * @param options insert tuning options such as retries, compression, and redundancy; must not be
+   *     {@code null} and should be consistent with the request type.
+   * @param upload upload payload metadata describing source and content hints; must not be {@code
+   *     null} and should include a readable bucket if required.
+   * @param core owning {@link NodeClientCore} providing policies, factories, and scheduler hooks;
+   *     must not be {@code null}.
+   * @throws IdentifierCollisionException when the chosen identifier already exists in persistence.
+   * @throws NotAllowedException when the configured upload source violates server-side policy.
+   * @throws MetadataUnresolvedException when redirect metadata cannot serialize into a bucket.
+   * @throws IOException when filesystem or bucket reads fail during preparation.
    */
   public ClientPut(
       FcpInsertRequest request,
@@ -183,16 +188,17 @@ public class ClientPut extends ClientPutBase {
    * happen before {@link ClientPutter} starts so any validation errors surface immediately to the
    * client.
    *
-   * @param handler Live FCP connection handler coordinating per-connection identifiers and DDA
-   *     rights.
-   * @param message Parsed {@link ClientPutMessage} containing payload descriptors, policy flags,
-   *     and metadata.
-   * @param server Owning server providing {@link NodeClientCore} accessors and capability checks.
-   * @throws IdentifierCollisionException If another request on the connection already uses the
+   * @param handler live FCP connection handler coordinating per-connection identifiers and DDA
+   *     rights; must not be {@code null} and should represent the active socket.
+   * @param message parsed {@link ClientPutMessage} containing payload descriptors and metadata;
+   *     must not be {@code null} and should already have validated field syntax.
+   * @param server owning server providing {@link NodeClientCore} accessors and capability checks;
+   *     must not be {@code null}.
+   * @throws IdentifierCollisionException if another request on the connection already uses the
    *     identifier.
-   * @throws MessageInvalidException Throw when client supplied fields (hashes, MIME, permissions)
-   *     prove invalid.
-   * @throws IOException If message-provided buckets cannot be read to compute salted hashes.
+   * @throws MessageInvalidException when client supplied fields (hashes, MIME, permissions) are
+   *     invalid or violate protocol constraints.
+   * @throws IOException when message-provided buckets cannot be read to compute salted hashes.
    */
   public ClientPut(FCPConnectionHandler handler, ClientPutMessage message, FCPServer server)
       throws IdentifierCollisionException, MessageInvalidException, IOException {
@@ -266,6 +272,15 @@ public class ClientPut extends ClientPutBase {
     putter = ClientPutPutterFactory.create(putterRequest, putterOptions);
   }
 
+  /**
+   * Ensures the request identifier is unused within a connection-scoped persistence map.
+   *
+   * @param handler connection handler tracking in-flight requests; must not be {@code null}.
+   * @param message parsed put message containing the requested identifier; must not be {@code
+   *     null}.
+   * @return the validated identifier string when no collision exists.
+   * @throws IdentifierCollisionException when the identifier already exists for the connection.
+   */
   private static String ensureConnectionIdentifierAvailable(
       FCPConnectionHandler handler, ClientPutMessage message) throws IdentifierCollisionException {
     if (message.persistence != Persistence.CONNECTION) {
@@ -277,6 +292,14 @@ public class ClientPut extends ClientPutBase {
     return message.identifier;
   }
 
+  /**
+   * Ensures the identifier is free within the persistent request client, if present.
+   *
+   * @param client persistent request client, or {@code null} when not applicable.
+   * @param identifier identifier requested by the caller; must not be {@code null}.
+   * @return the identifier when it is not already in use.
+   * @throws IdentifierCollisionException when the identifier already exists in persistence.
+   */
   private static String ensurePersistentIdentifierAvailable(
       PersistentRequestClient client, String identifier) throws IdentifierCollisionException {
     if (client != null && client.getRequest(identifier) != null) {
@@ -285,10 +308,20 @@ public class ClientPut extends ClientPutBase {
     return identifier;
   }
 
+  /**
+   * Returns whether the request is already marked finished.
+   *
+   * @return {@code true} when the request has completed or failed.
+   */
   private synchronized boolean isFinishedRequest() {
     return finished;
   }
 
+  /**
+   * Determines whether a persistent tag message should be queued now.
+   *
+   * @return {@code true} when persistence is enabled and the request is not finished.
+   */
   private synchronized boolean shouldQueuePersistentTag() {
     return persistence != Persistence.CONNECTION && !finished;
   }
@@ -353,13 +386,14 @@ public class ClientPut extends ClientPutBase {
    * request.
    *
    * <p>The method is idempotent: if the request already finished or the putter previously started,
-   * it simply refreshes the persistent tag. Otherwise, it schedules the insert, updates
-   * bookkeeping, and emits persistent-queue tags if necessary so external monitors observe the
-   * in-flight status. Callers should invoke this once after construction or resume to reattach the
-   * UI state.
+   * it refreshes the persistent tag and returns. Otherwise, it schedules the insert, updates
+   * bookkeeping, and emits persistent-queue tags so external monitors observe the in-flight status.
+   * Callers should invoke this once after construction or resume to reattach the UI state. Any
+   * startup failures are routed through the standard failure handler so retry logic stays
+   * consistent.
    *
-   * @param context Client execution context providing schedulers, bucket factories, and thread
-   *     pools.
+   * @param context client execution context providing schedulers, bucket factories, and thread
+   *     pools; must not be {@code null} and should be the active runtime context.
    */
   @Override
   public void start(ClientContext context) {
@@ -447,6 +481,11 @@ public class ClientPut extends ClientPutBase {
     return new PersistentPut(requestParams, upload, metadata, getDataSize());
   }
 
+  /**
+   * Returns whether the low-level request is scheduled as real-time work.
+   *
+   * @return {@code true} when the underlying request uses the real-time flag.
+   */
   private boolean isRealTime() {
     if (lowLevelClient == null) {
       // This can happen but only due to data corruption - old databases on which various bugs have
@@ -458,15 +497,14 @@ public class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Reports whether the put operation permanently succeeded, meaning the final URI is committed and
-   * any waiting clients may fetch it.
+   * Reports whether the put operation permanently succeeded, meaning the final URI is committed.
    *
    * <p>The flag flips to {@code true} only after {@link ClientPutter} notifies completion and
    * remains {@code true} even if future retries occur, allowing UIs to treat the request as
-   * immutable history. It is safe to poll frequently; the backing field is volatile through {@link
-   * ClientPutBase} synchronization.
+   * immutable history. It is safe to poll frequently because the underlying field is synchronized
+   * via {@link ClientPutBase} access patterns.
    *
-   * @return True, once the insert commits and the node has acknowledged durable storage.
+   * @return {@code true} once the insert commits and the node has acknowledged durable storage.
    */
   @Override
   public boolean hasSucceeded() {
@@ -478,33 +516,52 @@ public class ClientPut extends ClientPutBase {
    *
    * <p>The URI is generated lazily after encoding finishes, so callers should expect {@code null}
    * until the insert either succeeds or yields enough information (such as a CHK) to finalize the
-   * address. Consumers typically surface this in status tables or completion callbacks.
+   * address. Consumers typically surface this value in status tables or completion callbacks and
+   * should treat it as immutable once set.
    *
-   * @return Finalized URI when known; {@code null} until the node produces one.
+   * @return finalized URI when known, or {@code null} until the node produces one.
    */
   public FreenetURI getFinalURI() {
     return generatedURI;
   }
 
   /**
-   * Indicates whether the payload bytes were supplied inline via the FCP connection rather than
-   * read from disk or synthesized from metadata.
+   * Indicates whether the payload bytes were supplied inline via the FCP connection.
    *
    * <p>This mirrors the original {@link UploadFrom} choice. Direct uploads are useful for clients
    * that already hold data in memory and do not require DDA permissions. Disk-based inserts return
    * {@code false} so the UI can display security-sensitive origin information.
    *
-   * @return {@code true} if {@link UploadFrom#DIRECT} initiated the request; {@code false} else.
+   * @return {@code true} if {@link UploadFrom#DIRECT} initiated the request; {@code false}
+   *     otherwise.
    */
   public boolean isDirect() {
     return uploadFrom == UploadFrom.DIRECT;
   }
 
+  /**
+   * Compares this request with another object for identity equality.
+   *
+   * <p>This implementation preserves {@link Object#equals(Object)} semantics by delegating to the
+   * base class. Requests are treated as identity objects, so two distinct instances are not equal
+   * even if they carry the same identifier.
+   *
+   * @param obj object to compare against; may be {@code null}.
+   * @return {@code true} only when {@code obj} is the same instance as this request.
+   */
   @Override
   public boolean equals(Object obj) {
     return super.equals(obj);
   }
 
+  /**
+   * Returns the stable hash code assigned to this request instance.
+   *
+   * <p>The value is computed once and preserved across serialization by the base class, allowing
+   * hashed collections to remain stable even when requests are persisted and resumed.
+   *
+   * @return stable hash code derived from {@link Object#hashCode()} at construction time.
+   */
   @Override
   public int hashCode() {
     return super.hashCode();
@@ -517,7 +574,7 @@ public class ClientPut extends ClientPutBase {
    * information. When present, callers typically show it to the operator so they can match queued
    * requests with local files and confirm DDA permissions before allowing restarts.
    *
-   * @return Source filename for disk uploads; {@code null} in other cases.
+   * @return source filename for disk uploads, or {@code null} for non-disk sources.
    */
   public File getOrigFilename() {
     if (uploadFrom != UploadFrom.DISK) return null;
@@ -525,14 +582,13 @@ public class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Reports the size of the payload in bytes, falling back to the last known finished size if the
-   * current bucket has already been released.
+   * Reports the size of the payload in bytes, falling back to the last known finished size.
    *
    * <p>The method enables status pages to compute completion ratios even after {@link
    * RandomAccessBucket} resources were freed to save memory. When {@code data} becomes {@code
    * null}, callers still receive the last committed length so the UI never regresses to zero.
    *
-   * @return Number of bytes scheduled for upload, or the last completed size snapshot.
+   * @return number of bytes scheduled for upload, or the last completed size snapshot.
    */
   public long getDataSize() {
     if (data == null) return finishedSize;
@@ -542,8 +598,7 @@ public class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Returns the MIME type recorded for this request, which may be inferred from filenames or
-   * explicitly set by the client.
+   * Returns the MIME type recorded for this request, which may be inferred or explicitly set.
    *
    * <p>The metadata is used to populate {@link UploadFileRequestStatus} responses so GUI clients
    * can provide better UX. Binary blob inserts return {@code null} because they decline MIME
@@ -555,6 +610,11 @@ public class ClientPut extends ClientPutBase {
     return clientMetadata.getMIMEType();
   }
 
+  /**
+   * Exposes metadata for status assemblies without exposing it publicly.
+   *
+   * @return the {@link ClientMetadata} associated with this request.
+   */
   ClientMetadata clientMetadataForStatus() {
     return clientMetadata;
   }
@@ -564,7 +624,8 @@ public class ClientPut extends ClientPutBase {
    *
    * <p>The method enforces the lifecycle contract: only completed yet failed requests are eligible,
    * and {@link ClientPutter} must agree that cached state still exists. Operators typically call
-   * this before surfacing a “Retry” action in the UI.
+   * this before surfacing a retry action in the UI. The check is read-only and does not mutate any
+   * request state.
    *
    * @return {@code true} when the request finished unsuccessfully and the putter retained restart
    *     data.
@@ -583,17 +644,17 @@ public class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Replays the insert after a failure, optionally skipping filter-data regeneration when
-   * configured.
+   * Replays the insert after a failure, optionally skipping filter-data regeneration.
    *
    * <p>Before scheduling the new attempt, the method resets the local state, updates status caches,
    * and notifies observers that the request left the finished state. Failures during {@link
    * ClientPutter} startup are handed to {@link ClientPutBase#onFailure(InsertException,
    * network.crypta.client.async.BaseClientPutter)} so retry logic remains consistent with the
-   * normal start path.
+   * normal start path. The method returns immediately if the request is not eligible for restart.
    *
-   * @param context Execution context containing shared schedulers and crypto factories.
-   * @param disableFilterData Whether client filtering data should be bypassed for this retry.
+   * @param context execution context containing shared schedulers and crypto factories; must not be
+   *     {@code null} and should be active.
+   * @param disableFilterData whether client filtering data should be bypassed for this retry.
    * @return {@code true} when the restart was scheduled successfully; {@code false} otherwise.
    */
   @Override
@@ -631,7 +692,8 @@ public class ClientPut extends ClientPutBase {
    *
    * <p>The override extends {@link ClientPutBase#setVarsRestart()} by also pushing compression
    * indicators into the {@link RequestStatusCache} so user interfaces render accurate status after
-   * a manual retry.
+   * a manual retry. The method is synchronized to keep compression flags consistent with other
+   * state updates.
    */
   @Override
   public synchronized void setVarsRestart() {
@@ -645,14 +707,15 @@ public class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Handles cleanup when the request leaves the queue completely, freeing heavyweight helpers when
-   * possible.
+   * Handles cleanup when the request leaves the queue completely.
    *
    * <p>FOREVER-persistent inserts null the {@link ClientPutter} reference so the object graph can
-   * be GC’d while the serialized form remains on disk. Subclasses may extend this point to release
-   * more resources.
+   * be garbage-collected while the serialized form remains on disk. Subclasses may extend this
+   * point to release more resources. The provided context is the one supplied by the queue at
+   * removal time.
    *
-   * @param context Context supplied by the queue notifying removal time hooks.
+   * @param context context supplied by the queue notifying removal time hooks; must not be {@code
+   *     null}.
    */
   @Override
   public void requestWasRemoved(ClientContext context) {
@@ -663,11 +726,11 @@ public class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Lists the user-visible compression lifecycle so status polling can expose intuitive progress
-   * wording.
+   * Lists the user-visible compression lifecycle so status polling can expose intuitive progress.
    *
    * <p>The values summarize scheduler queues, CPU-bound work, and downstream insertion so clients
-   * quickly understand whether throughput bottlenecks stem from contention or routing.
+   * quickly understand whether throughput bottlenecks stem from contention or routing. The enum is
+   * used only for UI reporting and does not affect scheduling decisions.
    */
   public enum COMPRESS_STATE {
     /**
@@ -688,14 +751,14 @@ public class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Reports the current {@link COMPRESS_STATE}, allowing UI callers to describe whether the request
-   * is queued, compressing, or already uploading.
+   * Reports the current {@link COMPRESS_STATE}, describing whether the request is queued or active.
    *
    * <p>The method inspects runtime flags so it reflects state across restarts: if compression ran
    * to completion previously, the state returns {@link COMPRESS_STATE#WORKING} even when the
-   * request is being resumed.
+   * request is being resumed. When compression is disabled entirely, the method always reports
+   * {@link COMPRESS_STATE#WORKING}.
    *
-   * @return Compression state describing scheduler waits, active compression, or working uploads.
+   * @return compression state describing scheduler waits, active compression, or working uploads.
    */
   public COMPRESS_STATE isCompressing() {
     if (ctx.isDontCompress()) return COMPRESS_STATE.WORKING;

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
@@ -18,17 +18,48 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Validates disk upload permissions and salted hash constraints for {@link ClientPut}.
+ * Validates disk-backed upload permissions and salted hash constraints for {@link ClientPut}.
  *
- * <p>The validator centralizes DDA checks, salted hash decoding, and checksum verification so the
- * request class can focus on lifecycle management. Methods are stateless and reusable across
- * transient and persistent inserts.
+ * <p>This helper consolidates the checks that gate disk uploads for FCP requests. Callers use it to
+ * enforce server-side DDA policy, to decode and validate the optional salted hash submitted by a
+ * client, and to confirm that a disk file is readable before a persistent insert is accepted. The
+ * API is intentionally stateless: each method reads inputs, performs synchronous validation, and
+ * reports success or failure through exceptions rather than maintaining internal state.
+ *
+ * <p>All methods assume they are invoked by trusted request handlers that already constructed the
+ * relevant {@link ClientPutMessage} or request metadata. The validation work is CPU-bound and uses
+ * streaming reads only when a salted hash must be verified, so it is safe to call from request
+ * setup code without additional synchronization.
+ *
+ * <ul>
+ *   <li>Checks whether a disk upload is allowed by node policy and DDA rules.
+ *   <li>Decodes and verifies salted SHA-256 hashes when provided by clients.
+ *   <li>Produces {@link DiskUploadContext} instances for downstream verification steps.
+ * </ul>
+ *
+ * @see ClientPut
+ * @see DiskUploadContext
  */
 final class ClientPutDiskUploadValidator {
+  /** Logger used for optional salted hash verification diagnostics. */
   private static final Logger LOG = LoggerFactory.getLogger(ClientPutDiskUploadValidator.class);
 
+  /** Prevents instantiation; this class only exposes static validators. */
   private ClientPutDiskUploadValidator() {}
 
+  /**
+   * Validates a persistent disk upload against core permissions and file readability.
+   *
+   * <p>This method is used for persistent inserts where the node must be able to reopen the source
+   * file across restarts. It first checks the node policy via {@link
+   * NodeClientCore#allowUploadFrom} and then verifies that the file exists and can be read. It
+   * performs no hashing and does not mutate the input file.
+   *
+   * @param core node core used to evaluate disk upload policy; must not be {@code null}.
+   * @param origFilename original file submitted by the client; must not be {@code null}.
+   * @throws NotAllowedException when the node policy disallows the requested disk upload.
+   * @throws IOException when the file does not exist or cannot be read.
+   */
   static void validatePersistentDiskUpload(NodeClientCore core, File origFilename)
       throws NotAllowedException, IOException {
     if (!core.allowUploadFrom(origFilename)) {
@@ -39,6 +70,23 @@ final class ClientPutDiskUploadValidator {
     }
   }
 
+  /**
+   * Validates a disk upload request coming from a live FCP connection.
+   *
+   * <p>The method enforces DDA rules for connection-scoped inserts. If the request does not use a
+   * disk source, an empty context is returned immediately. When a client provides a file hash, the
+   * hash is decoded and returned in a {@link DiskUploadContext} so later steps can verify it
+   * against the upload bucket. When no hash is provided, DDA access is validated directly.
+   *
+   * @param handler active connection handler that supplies policy and identifiers; must not be
+   *     {@code null}.
+   * @param message parsed FCP put message containing upload fields; must not be {@code null}.
+   * @param identifier request identifier used for error reporting; must not be {@code null}.
+   * @param global whether the request is in the global queue for error context reporting.
+   * @return a {@link DiskUploadContext} containing salted hash data or an empty context when
+   *     unused.
+   * @throws MessageInvalidException when the request violates DDA rules or contains bad hash data.
+   */
   static DiskUploadContext validateDiskUpload(
       FCPConnectionHandler handler, ClientPutMessage message, String identifier, boolean global)
       throws MessageInvalidException {
@@ -70,6 +118,19 @@ final class ClientPutDiskUploadValidator {
     return DiskUploadContext.empty();
   }
 
+  /**
+   * Verifies a salted hash by reading the provided bucket and comparing the digest.
+   *
+   * <p>If the {@link DiskUploadContext} does not include a salt, the method returns immediately. If
+   * a salt is present, the bucket is read once to compute the SHA-256 digest and compared to the
+   * provided salted hash. The bucket is not mutated; only an input stream is opened and closed.
+   *
+   * @param diskContext salted hash context created during validation; must not be {@code null}.
+   * @param bucket random-access bucket containing the upload payload; must not be {@code null}.
+   * @param identifier request identifier used for error reporting; must not be {@code null}.
+   * @param global whether the request is in the global queue for error context reporting.
+   * @throws MessageInvalidException when the bucket cannot be read or the hash does not match.
+   */
   static void verifySaltedHash(
       DiskUploadContext diskContext, RandomAccessBucket bucket, String identifier, boolean global)
       throws MessageInvalidException {
@@ -104,6 +165,19 @@ final class ClientPutDiskUploadValidator {
     }
   }
 
+  /**
+   * Decodes a client-provided hash using the supported base64 variants.
+   *
+   * <p>The method first attempts standard base64 decoding, then falls back to the alternate decoder
+   * used by older clients. Any decoding failure results in a {@link MessageInvalidException} with a
+   * protocol error suitable for forwarding to the requester.
+   *
+   * @param encoded base64-encoded hash string supplied by the client; must not be {@code null}.
+   * @param identifier request identifier used for error reporting; must not be {@code null}.
+   * @param global whether the request is in the global queue for error context reporting.
+   * @return decoded hash bytes suitable for comparison with computed digests.
+   * @throws MessageInvalidException when the hash cannot be decoded by any supported variant.
+   */
   private static byte[] decodeFileHash(String encoded, String identifier, boolean global)
       throws MessageInvalidException {
     try {
@@ -122,17 +196,43 @@ final class ClientPutDiskUploadValidator {
   }
 }
 
+/**
+ * Encapsulates the salted hash metadata for disk-based uploads.
+ *
+ * <p>The context is created when a client provides a file hash for DDA validation. It stores the
+ * generated salt and the decoded hash bytes so downstream verification can re-compute the digest
+ * without re-deriving the salt. Instances are immutable and safe to pass between threads.
+ *
+ * <p>When no hash was supplied, callers use {@link #empty()} to get a shared instance with {@code
+ * null} components. Downstream checks can call {@link #hasSalt()} to determine whether verification
+ * should occur.
+ *
+ * @param salt per-request salt string used when computing the digest, or {@code null} when absent.
+ * @param saltedHash hash bytes computed by the client, or {@code null} when not provided.
+ */
 record DiskUploadContext(String salt, byte[] saltedHash) {
+  /** Shared empty context used when no salted hash was supplied. */
   private static final DiskUploadContext EMPTY = new DiskUploadContext(null, null);
 
+  /**
+   * Returns a shared empty context that indicates no salted hash is available.
+   *
+   * @return shared instance representing the absence of a salted hash.
+   */
   static DiskUploadContext empty() {
     return EMPTY;
   }
 
+  /**
+   * Reports whether this context contains a salt and therefore expects hash verification.
+   *
+   * @return {@code true} when a salt is present and verification should proceed.
+   */
   boolean hasSalt() {
     return salt != null;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -140,6 +240,7 @@ record DiskUploadContext(String salt, byte[] saltedHash) {
     return Objects.equals(salt, otherSalt) && Arrays.equals(saltedHash, otherHash);
   }
 
+  /** {@inheritDoc} */
   @Override
   public int hashCode() {
     int result = Objects.hash(salt);
@@ -147,6 +248,7 @@ record DiskUploadContext(String salt, byte[] saltedHash) {
     return result;
   }
 
+  /** {@inheritDoc} */
   @Override
   public @NotNull String toString() {
     return "DiskUploadContext[salt="

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
@@ -1,0 +1,158 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.crypt.SHA256;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.Base64;
+import network.crypta.support.IllegalBase64Exception;
+import network.crypta.support.api.RandomAccessBucket;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates disk upload permissions and salted hash constraints for {@link ClientPut}.
+ *
+ * <p>The validator centralizes DDA checks, salted hash decoding, and checksum verification so the
+ * request class can focus on lifecycle management. Methods are stateless and reusable across
+ * transient and persistent inserts.
+ */
+final class ClientPutDiskUploadValidator {
+  private static final Logger LOG = LoggerFactory.getLogger(ClientPutDiskUploadValidator.class);
+
+  private ClientPutDiskUploadValidator() {}
+
+  static void validatePersistentDiskUpload(NodeClientCore core, File origFilename)
+      throws NotAllowedException, IOException {
+    if (!core.allowUploadFrom(origFilename)) {
+      throw new NotAllowedException();
+    }
+    if (!(origFilename.exists() && origFilename.canRead())) {
+      throw new FileNotFoundException();
+    }
+  }
+
+  static DiskUploadContext validateDiskUpload(
+      FCPConnectionHandler handler, ClientPutMessage message, String identifier, boolean global)
+      throws MessageInvalidException {
+    if (message.uploadFromType != ClientPutBase.UploadFrom.DISK) {
+      return DiskUploadContext.empty();
+    }
+    if (!handler.getServer().getCore().allowUploadFrom(message.origFilename)) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "Not allowed to upload from " + message.origFilename,
+          identifier,
+          global);
+    }
+    if (message.fileHash != null) {
+      String salt =
+          handler.getConnectionIdentifierUUID().toString() + '-' + message.identifier + '-';
+      byte[] saltedHash = decodeFileHash(message.fileHash, identifier, global);
+      return new DiskUploadContext(salt, saltedHash);
+    }
+    if (!handler.ddaAccessController().allowDDAFrom(message.origFilename, false)) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED,
+          "Not allowed to upload from "
+              + message.origFilename
+              + ". Have you done a testDDA previously ?",
+          identifier,
+          global);
+    }
+    return DiskUploadContext.empty();
+  }
+
+  static void verifySaltedHash(
+      DiskUploadContext diskContext, RandomAccessBucket bucket, String identifier, boolean global)
+      throws MessageInvalidException {
+    if (!diskContext.hasSalt()) {
+      return;
+    }
+    MessageDigest md = SHA256.getMessageDigest();
+    md.update(diskContext.salt().getBytes(StandardCharsets.UTF_8));
+    byte[] foundHash;
+    try (InputStream is = bucket.getInputStream()) {
+      SHA256.hash(is, md);
+      foundHash = md.digest();
+    } catch (IOException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.COULD_NOT_READ_FILE,
+          "Unable to access file: " + e,
+          identifier,
+          global);
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(
+          "FileHash result : we found {} and were given {}.",
+          Base64.encode(foundHash),
+          Base64.encode(diskContext.saltedHash()));
+    }
+    if (!Arrays.equals(diskContext.saltedHash(), foundHash)) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED,
+          "The hash doesn't match! (salt used : \"" + diskContext.salt() + "\")",
+          identifier,
+          global);
+    }
+  }
+
+  private static byte[] decodeFileHash(String encoded, String identifier, boolean global)
+      throws MessageInvalidException {
+    try {
+      return Base64.decodeStandard(encoded);
+    } catch (IllegalBase64Exception _) {
+      try {
+        return Base64.decode(encoded);
+      } catch (IllegalBase64Exception _) {
+        throw new MessageInvalidException(
+            ProtocolErrorMessage.INVALID_FIELD,
+            "Can't base64 decode " + ClientPutBase.FILE_HASH,
+            identifier,
+            global);
+      }
+    }
+  }
+}
+
+record DiskUploadContext(String salt, byte[] saltedHash) {
+  private static final DiskUploadContext EMPTY = new DiskUploadContext(null, null);
+
+  static DiskUploadContext empty() {
+    return EMPTY;
+  }
+
+  boolean hasSalt() {
+    return salt != null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof DiskUploadContext(String otherSalt, byte[] otherHash))) return false;
+    return Objects.equals(salt, otherSalt) && Arrays.equals(saltedHash, otherHash);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(salt);
+    result = 31 * result + Arrays.hashCode(saltedHash);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "DiskUploadContext[salt="
+        + salt
+        + ", saltedHash="
+        + (saltedHash == null ? "null" : Arrays.toString(saltedHash))
+        + ']';
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientPutMimeResolver.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutMimeResolver.java
@@ -7,12 +7,55 @@ import network.crypta.client.async.BinaryBlob;
 /**
  * Resolves and validates MIME types for {@link ClientPut} requests.
  *
- * <p>The resolver enforces binary blob constraints, applies filename-based MIME inference, and
- * rejects implausible MIME strings to keep FCP validation consistent across request types.
+ * <p>This helper centralizes MIME selection for single-file puts, so callers do not duplicate
+ * validation logic across constructors and message handlers. The resolver first considers the
+ * explicit {@code Metadata.ContentType} provided by the client, then falls back to filename-based
+ * inference when the client omitted a type. It enforces the binary-blob rule that forbids arbitrary
+ * content types and rejects implausible MIME strings before they reach deeper metadata pipelines.
+ *
+ * <p>All logic is deterministic and side-effect free. The method returns a normalized MIME string
+ * or {@code null} when no type should be attached. It does not alter the {@link ClientPutMessage};
+ * it only inspects its already-parsed fields. The helper is safe to call from any thread because it
+ * reads immutable inputs and performs no I/O.
+ *
+ * <ul>
+ *   <li>Enforces the binary blob constraint defined by {@link BinaryBlob#MIME_TYPE}.
+ *   <li>Infers MIME types from filenames using {@link DefaultMIMETypes} heuristics.
+ *   <li>Rejects empty or implausible MIME values before request creation.
+ * </ul>
+ *
+ * @see ClientPut
+ * @see DefaultMIMETypes
  */
 final class ClientPutMimeResolver {
+  /** Prevents instantiation; this class only exposes static helpers. */
   private ClientPutMimeResolver() {}
 
+  /**
+   * Resolves the effective MIME type for a put request and validates its plausibility.
+   *
+   * <p>The method respects explicit client input first and only performs filename inference when no
+   * content type was supplied. If the request is flagged as a binary blob, only {@link
+   * BinaryBlob#MIME_TYPE} is accepted, and any other non-null value triggers a protocol error. When
+   * the resulting MIME string is empty, the method normalizes it to {@code null} so downstream
+   * metadata handling can treat the absence of a type consistently.
+   *
+   * <p>Use this during request construction to ensure that invalid MIME strings are rejected before
+   * any insert work is scheduled. The method is idempotent for the same inputs and does not mutate
+   * the supplied message or filenames.
+   *
+   * @param message parsed {@link ClientPutMessage} holding the optional content type; must not be
+   *     {@code null} and should already contain validated fields.
+   * @param origFilename original disk filename, used for inference when content type is absent; may
+   *     be {@code null} when the upload did not originate from disk.
+   * @param targetFilename optional target filename hint used when no content type or disk filename
+   *     is available; may be {@code null}.
+   * @param binaryBlob whether the request is a binary blob insert and thus restricts MIME values.
+   * @param identifier request identifier used for error reporting; must not be {@code null}.
+   * @param global whether the request is in the global queue for error context reporting.
+   * @return normalized MIME type string, or {@code null} when no type is applicable.
+   * @throws MessageInvalidException when a disallowed or implausible MIME value is supplied.
+   */
   static String resolve(
       ClientPutMessage message,
       File origFilename,

--- a/src/main/java/network/crypta/clients/fcp/ClientPutMimeResolver.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutMimeResolver.java
@@ -1,0 +1,50 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import network.crypta.client.DefaultMIMETypes;
+import network.crypta.client.async.BinaryBlob;
+
+/**
+ * Resolves and validates MIME types for {@link ClientPut} requests.
+ *
+ * <p>The resolver enforces binary blob constraints, applies filename-based MIME inference, and
+ * rejects implausible MIME strings to keep FCP validation consistent across request types.
+ */
+final class ClientPutMimeResolver {
+  private ClientPutMimeResolver() {}
+
+  static String resolve(
+      ClientPutMessage message,
+      File origFilename,
+      String targetFilename,
+      boolean binaryBlob,
+      String identifier,
+      boolean global)
+      throws MessageInvalidException {
+    String mimeType = message.contentType;
+    if (binaryBlob && mimeType != null && !mimeType.equals(BinaryBlob.MIME_TYPE)) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_FIELD,
+          "No MIME type allowed when inserting a binary blob",
+          identifier,
+          global);
+    }
+    if (mimeType == null && origFilename != null) {
+      mimeType = DefaultMIMETypes.guessMIMEType(origFilename.getName(), true);
+    }
+    if (mimeType == null && targetFilename != null) {
+      mimeType = DefaultMIMETypes.guessMIMEType(targetFilename, true);
+    }
+    if (mimeType != null && mimeType.isEmpty()) {
+      mimeType = null;
+    }
+    if (mimeType != null && !DefaultMIMETypes.isPlausibleMIMEType(mimeType)) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.BAD_MIME_TYPE,
+          "Bad MIME type in Metadata.ContentType",
+          identifier,
+          global);
+    }
+    return mimeType;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientPutPreparedDataFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutPreparedDataFactory.java
@@ -14,15 +14,56 @@ import org.slf4j.LoggerFactory;
 /**
  * Prepares upload buckets and redirect metadata for {@link ClientPut} requests.
  *
- * <p>This helper encapsulates redirect metadata creation and bucket resolution so the request class
- * can focus on lifecycle and scheduling behavior.
+ * <p>This helper centralizes the staging of payload data before a put request is scheduled. Callers
+ * use it to translate message or persistent-request inputs into a {@link PreparedData} bundle that
+ * records the bucket holding the upload bytes, whether the bucket contains redirect metadata, and
+ * the redirect target URI if applicable. The logic is deterministic and avoids mutating the input
+ * buckets beyond any work required to serialize redirect metadata.
+ *
+ * <p>When the upload is a redirect, the factory serializes a {@link Metadata} document into a new
+ * bucket created by the appropriate bucket factory. For direct uploads the original bucket is
+ * returned unchanged. This separation keeps the request constructors focused on lifecycle wiring
+ * while ensuring consistent redirect behavior across persistent and connection-scoped flows.
+ *
+ * <ul>
+ *   <li>Builds redirect metadata buckets when {@link ClientPutBase.UploadFrom#REDIRECT} is chosen.
+ *   <li>Returns original buckets for direct or disk uploads without extra copying.
+ *   <li>Captures the redirect target URI for downstream status reporting.
+ * </ul>
+ *
+ * @see ClientPut
+ * @see PreparedData
  */
 final class ClientPutPreparedDataFactory {
+  /** Logger used for optional debug tracing of upload sources. */
   private static final Logger LOG = LoggerFactory.getLogger(ClientPutPreparedDataFactory.class);
+
+  /** Template for debug logs that include bucket and upload source information. */
   private static final String DATA_UPLOAD_LOG_TEMPLATE = "data = {}, uploadFrom = {}";
 
+  /** Prevents instantiation; this class exposes only static factories. */
   private ClientPutPreparedDataFactory() {}
 
+  /**
+   * Prepares data for persistent inserts, optionally serializing redirect metadata.
+   *
+   * <p>When the upload source is {@link ClientPutBase.UploadFrom#REDIRECT}, the method constructs a
+   * {@link Metadata} document that points at the supplied target and serializes it into a new
+   * bucket created by the persistent bucket factory. For all other sources, the original bucket is
+   * returned and the target URI is cleared. The method does not modify the contents of the original
+   * bucket.
+   *
+   * @param uploadFrom upload source describing whether this is a redirect or direct upload.
+   * @param metadata client metadata used when generating redirect documents; must not be null.
+   * @param data bucket holding the raw upload payload; must not be {@code null}.
+   * @param redirectTarget redirect target URI used when {@code uploadFrom} is redirect; may be
+   *     {@code null} when unused.
+   * @param core node core providing the persistent bucket factory; must not be {@code null}.
+   * @param persistentForever whether to use a forever-persistent bucket factory.
+   * @return a {@link PreparedData} bundle describing the bucket to insert and redirect metadata.
+   * @throws MetadataUnresolvedException when redirect metadata cannot serialize.
+   * @throws IOException when bucket allocation or serialization fails.
+   */
   static PreparedData prepareForPersistentUpload(
       ClientPutBase.UploadFrom uploadFrom,
       ClientMetadata metadata,
@@ -41,6 +82,25 @@ final class ClientPutPreparedDataFactory {
     return new PreparedData(data, false, null);
   }
 
+  /**
+   * Prepares to upload data for a live FCP message, translating redirects when requested.
+   *
+   * <p>The method reads the bucket supplied by {@link ClientPutMessage} and emits a debug trace of
+   * the upload source. For redirect uploads, it serializes redirect metadata into a new bucket
+   * using the server’s bucket factory. Any metadata serialization failure is reported as a protocol
+   * error, so the client receives a deterministic failure response.
+   *
+   * @param message parsed FCP message containing the data bucket; must not be {@code null}.
+   * @param metadata client metadata attached to the upload; must not be {@code null}.
+   * @param server server instance providing access to the node core; must not be {@code null}.
+   * @param persistentForever whether to use a forever-persistent bucket factory.
+   * @param uploadFrom upload source describing whether this is a redirect or direct upload.
+   * @param identifier request identifier used for error reporting; must not be {@code null}.
+   * @param global whether the request is in the global queue for error context reporting.
+   * @return a {@link PreparedData} bundle with the bucket to insert and redirect metadata details.
+   * @throws MessageInvalidException when metadata serialization fails and a protocol error is used.
+   * @throws IOException when the message bucket cannot be accessed or serialized.
+   */
   static PreparedData prepareForMessage(
       ClientPutMessage message,
       ClientMetadata metadata,
@@ -73,7 +133,24 @@ final class ClientPutPreparedDataFactory {
   }
 }
 
+/**
+ * Bundles the prepared upload bucket and redirect metadata details.
+ *
+ * <p>The bucket contains either raw upload bytes or serialized redirect metadata. The {@code
+ * metadata} flag signals whether the bucket should be treated as metadata (redirect) by downstream
+ * components. The optional {@code targetUri} preserves the redirect target for reporting and
+ * persistence.
+ *
+ * @param bucket bucket containing upload data or redirect metadata; never {@code null}.
+ * @param metadata {@code true} when the bucket holds redirect metadata rather than raw bytes.
+ * @param targetUri redirect target URI, or {@code null} when not applicable.
+ */
 record PreparedData(RandomAccessBucket bucket, boolean metadata, FreenetURI targetUri) {
+  /**
+   * Reports whether the prepared bucket contains redirect metadata.
+   *
+   * @return {@code true} when the bucket should be treated as metadata for an insert.
+   */
   boolean isMetadata() {
     return metadata;
   }

--- a/src/main/java/network/crypta/clients/fcp/ClientPutPreparedDataFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutPreparedDataFactory.java
@@ -1,0 +1,80 @@
+package network.crypta.clients.fcp;
+
+import java.io.IOException;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.Metadata;
+import network.crypta.client.Metadata.DocumentType;
+import network.crypta.client.MetadataUnresolvedException;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.api.RandomAccessBucket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Prepares upload buckets and redirect metadata for {@link ClientPut} requests.
+ *
+ * <p>This helper encapsulates redirect metadata creation and bucket resolution so the request class
+ * can focus on lifecycle and scheduling behavior.
+ */
+final class ClientPutPreparedDataFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(ClientPutPreparedDataFactory.class);
+  private static final String DATA_UPLOAD_LOG_TEMPLATE = "data = {}, uploadFrom = {}";
+
+  private ClientPutPreparedDataFactory() {}
+
+  static PreparedData prepareForPersistentUpload(
+      ClientPutBase.UploadFrom uploadFrom,
+      ClientMetadata metadata,
+      RandomAccessBucket data,
+      FreenetURI redirectTarget,
+      NodeClientCore core,
+      boolean persistentForever)
+      throws MetadataUnresolvedException, IOException {
+    if (uploadFrom == ClientPutBase.UploadFrom.REDIRECT) {
+      Metadata redirectMetadata =
+          new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, redirectTarget, metadata);
+      RandomAccessBucket redirectData =
+          redirectMetadata.toBucket(core.getClientContext().getBucketFactory(persistentForever));
+      return new PreparedData(redirectData, true, redirectTarget);
+    }
+    return new PreparedData(data, false, null);
+  }
+
+  static PreparedData prepareForMessage(
+      ClientPutMessage message,
+      ClientMetadata metadata,
+      FCPServer server,
+      boolean persistentForever,
+      ClientPutBase.UploadFrom uploadFrom,
+      String identifier,
+      boolean global)
+      throws MessageInvalidException, IOException {
+    RandomAccessBucket tempData = message.getRandomAccessBucket();
+    if (LOG.isDebugEnabled()) LOG.debug(DATA_UPLOAD_LOG_TEMPLATE, tempData, uploadFrom);
+    if (uploadFrom == ClientPutBase.UploadFrom.REDIRECT) {
+      FreenetURI redirectTarget = message.redirectTarget;
+      Metadata metadataDoc =
+          new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, redirectTarget, metadata);
+      try {
+        RandomAccessBucket redirectData =
+            metadataDoc.toBucket(
+                server.getCore().getClientContext().getBucketFactory(persistentForever));
+        return new PreparedData(redirectData, true, redirectTarget);
+      } catch (MetadataUnresolvedException e) {
+        throw new MessageInvalidException(
+            ProtocolErrorMessage.INTERNAL_ERROR,
+            "Impossible: metadata unresolved: " + e,
+            identifier,
+            global);
+      }
+    }
+    return new PreparedData(tempData, false, null);
+  }
+}
+
+record PreparedData(RandomAccessBucket bucket, boolean metadata, FreenetURI targetUri) {
+  boolean isMetadata() {
+    return metadata;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientPutPutterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutPutterFactory.java
@@ -4,10 +4,47 @@ import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientPutterOptions;
 import network.crypta.client.async.ClientPutterRequest;
 
-/** Creates {@link ClientPutter} instances for single-file inserts. */
+/**
+ * Creates {@link ClientPutter} instances for single-file insert requests.
+ *
+ * <p>This factory centralizes the final assembly of {@link ClientPutter} objects after higher-level
+ * request logic has already prepared a {@link ClientPutterRequest} and {@link ClientPutterOptions}.
+ * Keeping the construction in one place makes it easier to enforce consistent wiring when request
+ * constructors evolve, and it isolates the putter instantiation details from the surrounding FCP
+ * request classes.
+ *
+ * <p>The factory performs no validation beyond delegating to the {@link ClientPutter} constructor;
+ * callers are expected to pass fully configured, non-null request and options objects. The method
+ * is deterministic and side-effect free, so it is safe to call from any thread that is building a
+ * request.
+ *
+ * <ul>
+ *   <li>Constructs a {@link ClientPutter} from prepared request and option objects.
+ *   <li>Preserves all wiring performed by the caller without additional mutation.
+ * </ul>
+ *
+ * @see ClientPutter
+ * @see ClientPutterRequest
+ * @see ClientPutterOptions
+ */
 final class ClientPutPutterFactory {
+  /** Prevents instantiation; this class provides a single static factory method. */
   private ClientPutPutterFactory() {}
 
+  /**
+   * Creates a new {@link ClientPutter} using the supplied request and options.
+   *
+   * <p>The method simply delegates to the {@link ClientPutter} constructor and returns the result.
+   * It does not mutate the request or options and performs no I/O. Callers should ensure that the
+   * request object already contains the target URI, bucket, metadata, and any persistence flags
+   * required by the insert pipeline.
+   *
+   * @param request prepared {@link ClientPutterRequest} containing callback, bucket, and metadata;
+   *     must not be {@code null}.
+   * @param options prepared {@link ClientPutterOptions} describing filename, binary-blob state, and
+   *     metadata thresholds; must not be {@code null}.
+   * @return a new {@link ClientPutter} instance wired to the given request and options.
+   */
   static ClientPutter create(ClientPutterRequest request, ClientPutterOptions options) {
     return new ClientPutter(request, options);
   }

--- a/src/main/java/network/crypta/clients/fcp/ClientPutPutterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutPutterFactory.java
@@ -1,0 +1,14 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.async.ClientPutter;
+import network.crypta.client.async.ClientPutterOptions;
+import network.crypta.client.async.ClientPutterRequest;
+
+/** Creates {@link ClientPutter} instances for single-file inserts. */
+final class ClientPutPutterFactory {
+  private ClientPutPutterFactory() {}
+
+  static ClientPutter create(ClientPutterRequest request, ClientPutterOptions options) {
+    return new ClientPutter(request, options);
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilder.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilder.java
@@ -1,0 +1,80 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.util.Date;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Builds status snapshots for {@link ClientPut} without bloating the request class.
+ *
+ * <p>The builder mirrors the original in-request status assembly, preserving failure reporting,
+ * progress metadata, and MIME visibility rules.
+ */
+final class ClientPutStatusSnapshotBuilder {
+  private ClientPutStatusSnapshotBuilder() {}
+
+  static UploadFileRequestStatus build(ClientPut request) {
+    FreenetURI finalURI = request.getFinalURI();
+    InsertExceptionMode failureCode = null;
+    String failureReasonShort = null;
+    String failureReasonLong = null;
+    if (request.putFailedMessage != null) {
+      failureCode = request.putFailedMessage.failureMode;
+      failureReasonShort = request.putFailedMessage.getShortFailedMessage();
+      failureReasonLong = request.putFailedMessage.getLongFailedMessage();
+    }
+    String mimeType = null;
+    if (request.persistence == ClientRequest.Persistence.FOREVER) {
+      mimeType = request.clientMetadataForStatus().getMIMEType();
+    }
+    File fnam = request.getOrigFilename();
+    if (fnam != null) fnam = new File(fnam.getPath());
+
+    RequestStatusSnapshot statusSnapshot = buildStatusSnapshot(request);
+    UploadRequestStatusDetails details =
+        new UploadRequestStatusDetails(
+            finalURI, request.uri, failureCode, failureReasonShort, failureReasonLong);
+    return new UploadFileRequestStatus(
+        statusSnapshot, details, request.getDataSize(), mimeType, fnam, request.isCompressing());
+  }
+
+  private static RequestStatusSnapshot buildStatusSnapshot(ClientPut request) {
+    int total = 0;
+    int min = 0;
+    int fetched = 0;
+    int fatal = 0;
+    int failed = 0;
+    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
+    Date latestSuccess = new Date();
+    Date latestFailure = null;
+    boolean totalFinalized = false;
+
+    if (request.progressMessage instanceof SimpleProgressMessage msg) {
+      total = (int) msg.getTotalBlocks();
+      min = (int) msg.getMinBlocks();
+      fetched = (int) msg.getFetchedBlocks();
+      latestSuccess = msg.getLatestSuccess();
+      fatal = (int) msg.getFatalyFailedBlocks();
+      failed = (int) msg.getFailedBlocks();
+      latestFailure = msg.getLatestFailure();
+      totalFinalized = msg.isTotalFinalized();
+    }
+
+    return new RequestStatusSnapshot(
+        request.identifier,
+        request.persistence,
+        request.started,
+        request.finished,
+        request.succeeded,
+        total,
+        min,
+        fetched,
+        latestSuccess,
+        fatal,
+        failed,
+        latestFailure,
+        totalFinalized,
+        request.priorityClass);
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilder.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilder.java
@@ -6,14 +6,53 @@ import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.keys.FreenetURI;
 
 /**
- * Builds status snapshots for {@link ClientPut} without bloating the request class.
+ * Builds upload status snapshots from a live {@link ClientPut} request.
  *
- * <p>The builder mirrors the original in-request status assembly, preserving failure reporting,
- * progress metadata, and MIME visibility rules.
+ * <p>This helper centralizes the logic for turning the mutable request state into immutable status
+ * objects that can be cached, displayed, or serialized to clients. Callers typically invoke {@link
+ * #build(ClientPut)} when a request needs to be exposed outside the core worker thread, for
+ * example, when the request cache is refreshed or a client polls for progress. The method mirrors
+ * the original in-request assembly logic, so failure details, progress metrics, and MIME visibility
+ * stay consistent with historical behavior.
+ *
+ * <p>The builder does not mutate the request. It reads the current fields, captures counts and
+ * timestamps, and returns a new {@link UploadFileRequestStatus} instance that safely encapsulates
+ * the snapshot. Any mutable values such as {@link Date} are either cloned by downstream types or
+ * copied into immutable records, so callers can keep the result without additional synchronization.
+ *
+ * <ul>
+ *   <li>Preserves failure metadata reported by {@link PutFailedMessage} when available.
+ *   <li>Uses the latest {@link SimpleProgressMessage} to fill progress counters if present.
+ *   <li>Limits MIME exposure to forever-persistent requests, matching legacy UI behavior.
+ * </ul>
+ *
+ * @see ClientPut
+ * @see UploadFileRequestStatus
+ * @see RequestStatusSnapshot
  */
 final class ClientPutStatusSnapshotBuilder {
+  /** Prevents instantiation; this class only provides static builders. */
   private ClientPutStatusSnapshotBuilder() {}
 
+  /**
+   * Builds a file-upload status snapshot from the current request state.
+   *
+   * <p>The snapshot captures the request identifier, persistence mode, progress counters, failure
+   * metadata, and compression state in a single immutable {@link UploadFileRequestStatus}. It
+   * preserves the same semantics as the original request-owned status assembly, including default
+   * progress counts of zero when no {@link SimpleProgressMessage} has been observed yet. The method
+   * is idempotent for a given request state and performs no I/O beyond reading the request fields.
+   *
+   * <p>Callers should pass a fully initialized {@link ClientPut} that has already set any metadata
+   * fields used for reporting, such as {@link ClientPut#clientMetadataForStatus()} and the
+   * compression flags. The returned status is safe to expose to other threads because the snapshot
+   * captures defensive copies of mutable timestamps through {@link RequestStatusSnapshot}.
+   *
+   * @param request active {@link ClientPut} containing identifiers, progress data, and metadata;
+   *     must not be {@code null} and should be fully initialized before snapshotting.
+   * @return new {@link UploadFileRequestStatus} containing a consistent, immutable view of the
+   *     request at the time of invocation, suitable for caching or UI display.
+   */
   static UploadFileRequestStatus build(ClientPut request) {
     FreenetURI finalURI = request.getFinalURI();
     InsertExceptionMode failureCode = null;
@@ -39,6 +78,20 @@ final class ClientPutStatusSnapshotBuilder {
         statusSnapshot, details, request.getDataSize(), mimeType, fnam, request.isCompressing());
   }
 
+  /**
+   * Builds the base {@link RequestStatusSnapshot} for the provided request.
+   *
+   * <p>The snapshot contains counters, timestamps, and scheduling flags shared across request
+   * types. When no progress message has been recorded yet, the counts remain at zero and the latest
+   * success time defaults to the current time to preserve historical behavior in downstream
+   * consumers. This helper does not interpret or clamp values; it simply mirrors the request’s
+   * latest known progress state.
+   *
+   * @param request active {@link ClientPut} holding progress counters and lifecycle flags; must not
+   *     be {@code null} and should reflect the current worker state.
+   * @return {@link RequestStatusSnapshot} populated with the request’s progress counters and
+   *     timestamps, ready to be wrapped by higher-level status objects.
+   */
   private static RequestStatusSnapshot buildStatusSnapshot(ClientPut request) {
     int total = 0;
     int min = 0;

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDiskUploadValidatorTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDiskUploadValidatorTest.java
@@ -1,0 +1,298 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.UUID;
+import network.crypta.crypt.SHA256;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.Base64;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"java:S100", "resource"})
+class ClientPutDiskUploadValidatorTest {
+  @TempDir private Path tempDir;
+
+  @Test
+  void validatePersistentDiskUpload_whenNotAllowed_throwsNotAllowed() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    File file = tempDir.resolve("upload.dat").toFile();
+    when(core.allowUploadFrom(file)).thenReturn(false);
+
+    assertThrows(
+        NotAllowedException.class,
+        () -> ClientPutDiskUploadValidator.validatePersistentDiskUpload(core, file));
+  }
+
+  @Test
+  void validatePersistentDiskUpload_whenMissingFile_throwsFileNotFound() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    File file = tempDir.resolve("missing.dat").toFile();
+    when(core.allowUploadFrom(file)).thenReturn(true);
+
+    assertThrows(
+        FileNotFoundException.class,
+        () -> ClientPutDiskUploadValidator.validatePersistentDiskUpload(core, file));
+  }
+
+  @Test
+  void validatePersistentDiskUpload_whenReadableFile_allowsUpload() throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    File file = tempDir.resolve("data.bin").toFile();
+    assertTrue(file.createNewFile());
+    when(core.allowUploadFrom(file)).thenReturn(true);
+
+    ClientPutDiskUploadValidator.validatePersistentDiskUpload(core, file);
+  }
+
+  @Test
+  void validateDiskUpload_whenNotDisk_returnsEmptyContext() throws Exception {
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    ClientPutMessage message =
+        buildMessage(ClientPutBase.UploadFrom.DIRECT, tempDir.resolve("direct.dat").toFile(), null);
+
+    DiskUploadContext context =
+        ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", false);
+
+    assertSame(DiskUploadContext.empty(), context);
+  }
+
+  @Test
+  void validateDiskUpload_whenUploadNotAllowed_throwsMessageInvalid() throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    FCPServer server = mock(FCPServer.class);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    File file = createFile("blocked.dat");
+
+    ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, null);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.allowUploadFrom(file)).thenReturn(false);
+
+    MessageInvalidException error =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", true));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, error.protocolCode);
+  }
+
+  @Test
+  void validateDiskUpload_whenFileHashProvided_buildsSaltedContext() throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    FCPServer server = mock(FCPServer.class);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    File file = createFile("file.dat");
+    UUID connectionId = UUID.fromString("f81d4fae-7dec-11d0-a765-00a0c91e6bf6");
+    byte[] expectedHash = new byte[] {1, 2, 3, 4};
+
+    ClientPutMessage message =
+        buildMessage(ClientPutBase.UploadFrom.DISK, file, Base64.encodeStandard(expectedHash));
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(handler.getConnectionIdentifierUUID()).thenReturn(connectionId);
+
+    DiskUploadContext context =
+        ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "request-1", false);
+
+    assertEquals(connectionId + "-request-1-", context.salt());
+    assertArrayEquals(expectedHash, context.saltedHash());
+  }
+
+  @Test
+  void validateDiskUpload_whenDdaDenied_throwsMessageInvalid() throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    FCPServer server = mock(FCPServer.class);
+    DdaAccessController ddaController = mock(DdaAccessController.class);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    File file = createFile("file.dat");
+
+    ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, null);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(handler.ddaAccessController()).thenReturn(ddaController);
+    when(ddaController.allowDDAFrom(file, false)).thenReturn(false);
+
+    MessageInvalidException error =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", true));
+
+    assertEquals(ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED, error.protocolCode);
+  }
+
+  @Test
+  void validateDiskUpload_whenDdaAllowed_returnsEmptyContext() throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    FCPServer server = mock(FCPServer.class);
+    DdaAccessController ddaController = mock(DdaAccessController.class);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    File file = createFile("file.dat");
+
+    ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, null);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(handler.ddaAccessController()).thenReturn(ddaController);
+    when(ddaController.allowDDAFrom(file, false)).thenReturn(true);
+
+    DiskUploadContext context =
+        ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", false);
+
+    assertSame(DiskUploadContext.empty(), context);
+  }
+
+  @Test
+  void validateDiskUpload_whenInvalidFileHash_throwsMessageInvalid() throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    FCPServer server = mock(FCPServer.class);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    File file = createFile("file.dat");
+    ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, "@@@");
+
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(handler.getConnectionIdentifierUUID())
+        .thenReturn(UUID.fromString("f81d4fae-7dec-11d0-a765-00a0c91e6bf6"));
+
+    MessageInvalidException error =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", false));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, error.protocolCode);
+  }
+
+  @Test
+  void verifySaltedHash_whenNoSalt_returnsWithoutError() throws Exception {
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    DiskUploadContext context = DiskUploadContext.empty();
+
+    ClientPutDiskUploadValidator.verifySaltedHash(context, bucket, "id", false);
+  }
+
+  @Test
+  void verifySaltedHash_whenHashesMatch_allowsUpload() throws Exception {
+    String salt = "salt";
+    byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
+    byte[] hash = hashPayload(salt, payload);
+    DiskUploadContext context = new DiskUploadContext(salt, hash);
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    when(bucket.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+    ClientPutDiskUploadValidator.verifySaltedHash(context, bucket, "id", false);
+  }
+
+  @Test
+  void verifySaltedHash_whenHashesDiffer_throwsMessageInvalid() throws Exception {
+    String salt = "salt";
+    byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
+    DiskUploadContext context = new DiskUploadContext(salt, new byte[] {9, 9, 9});
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    when(bucket.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+    MessageInvalidException error =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> ClientPutDiskUploadValidator.verifySaltedHash(context, bucket, "id", true));
+
+    assertEquals(ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED, error.protocolCode);
+  }
+
+  @Test
+  void verifySaltedHash_whenBucketFails_throwsMessageInvalid() throws Exception {
+    String salt = "salt";
+    DiskUploadContext context = new DiskUploadContext(salt, new byte[] {1, 2});
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    doThrow(new IOException("fail")).when(bucket).getInputStream();
+
+    MessageInvalidException error =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> ClientPutDiskUploadValidator.verifySaltedHash(context, bucket, "id", true));
+
+    assertEquals(ProtocolErrorMessage.COULD_NOT_READ_FILE, error.protocolCode);
+  }
+
+  @Test
+  void diskUploadContext_equalsAndHashCode_matchOnState() {
+    byte[] hash = new byte[] {1, 2, 3};
+    DiskUploadContext first = new DiskUploadContext("salt", hash);
+    DiskUploadContext second = new DiskUploadContext("salt", new byte[] {1, 2, 3});
+    DiskUploadContext different = new DiskUploadContext("other", new byte[] {1, 2, 3});
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+    assertNotEquals(first, different);
+  }
+
+  @Test
+  void diskUploadContext_toString_includesFields() {
+    DiskUploadContext context = new DiskUploadContext("salt", new byte[] {1, 2});
+
+    String value = context.toString();
+
+    assertNotNull(value);
+    assertTrue(value.contains("salt"));
+  }
+
+  private static byte[] hashPayload(String salt, byte[] payload) throws IOException {
+    MessageDigest digest = SHA256.getMessageDigest();
+    digest.update(salt.getBytes(StandardCharsets.UTF_8));
+    try (ByteArrayInputStream stream = new ByteArrayInputStream(payload)) {
+      SHA256.hash(stream, digest);
+    }
+    return digest.digest();
+  }
+
+  private ClientPutMessage buildMessage(
+      ClientPutBase.UploadFrom uploadFrom, File file, String fileHash)
+      throws MessageInvalidException {
+    SimpleFieldSet fields = new SimpleFieldSet(true);
+    fields.putSingle("Identifier", "request-1");
+    fields.putSingle("URI", "CHK@");
+    if (uploadFrom == ClientPutBase.UploadFrom.DIRECT) {
+      fields.putSingle("UploadFrom", "direct");
+      fields.putSingle("DataLength", "4");
+    } else if (uploadFrom == ClientPutBase.UploadFrom.DISK) {
+      if (file != null) {
+        fields.putSingle("Filename", file.getPath());
+      }
+      fields.putSingle("UploadFrom", "disk");
+    }
+    if (fileHash != null) {
+      fields.putSingle(ClientPutBase.FILE_HASH, fileHash);
+    }
+    return new ClientPutMessage(fields);
+  }
+
+  private File createFile(String name) throws IOException {
+    File file = tempDir.resolve(name).toFile();
+    assertTrue(file.createNewFile());
+    return file;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutMimeResolverTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutMimeResolverTest.java
@@ -1,0 +1,107 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import network.crypta.client.DefaultMIMETypes;
+import network.crypta.client.async.BinaryBlob;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientPutMimeResolverTest {
+  @TempDir private Path tempDir;
+
+  @Test
+  void resolve_whenBinaryBlobWithMime_throwsInvalidField() throws Exception {
+    ClientPutMessage message = buildMessage("text/plain", true);
+
+    MessageInvalidException error =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> ClientPutMimeResolver.resolve(message, null, null, true, "id", true));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, error.protocolCode);
+  }
+
+  @Test
+  void resolve_whenBinaryBlobWithBinaryMime_allows() throws Exception {
+    ClientPutMessage message = buildMessage(BinaryBlob.MIME_TYPE, true);
+
+    String mime = ClientPutMimeResolver.resolve(message, null, null, true, "id", false);
+
+    assertEquals(BinaryBlob.MIME_TYPE, mime);
+  }
+
+  @Test
+  void resolve_whenOrigFilenamePresent_guessesMime() throws Exception {
+    ClientPutMessage message = buildMessage(null, false);
+    String filename = "photo" + ".jpg";
+    File file = createFile(filename);
+
+    String mime = ClientPutMimeResolver.resolve(message, file, null, false, "id", false);
+
+    assertEquals(DefaultMIMETypes.guessMIMEType(filename, true), mime);
+  }
+
+  @Test
+  void resolve_whenTargetFilenamePresent_guessesMime() throws Exception {
+    ClientPutMessage message = buildMessage(null, false);
+
+    String mime = ClientPutMimeResolver.resolve(message, null, "index.html", false, "id", false);
+
+    assertEquals(DefaultMIMETypes.guessMIMEType("index.html", true), mime);
+  }
+
+  @Test
+  void resolve_whenEmptyMime_returnsNull() throws Exception {
+    ClientPutMessage message = buildMessage("", false);
+
+    String mime = ClientPutMimeResolver.resolve(message, null, null, false, "id", false);
+
+    assertNull(mime);
+  }
+
+  @Test
+  void resolve_whenBadMime_throwsMessageInvalid() throws Exception {
+    ClientPutMessage message = buildMessage("not a mime", false);
+
+    MessageInvalidException error =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> ClientPutMimeResolver.resolve(message, null, null, false, "id", false));
+
+    assertEquals(ProtocolErrorMessage.BAD_MIME_TYPE, error.protocolCode);
+  }
+
+  private File createFile(String name) throws Exception {
+    File file = tempDir.resolve(name).toFile();
+    assertTrue(file.createNewFile());
+    return file;
+  }
+
+  private ClientPutMessage buildMessage(String contentType, boolean binaryBlob)
+      throws MessageInvalidException {
+    SimpleFieldSet fields = new SimpleFieldSet(true);
+    fields.putSingle("Identifier", "request-1");
+    fields.putSingle("UploadFrom", "direct");
+    fields.putSingle("DataLength", "4");
+    if (binaryBlob) {
+      fields.putSingle("BinaryBlob", "true");
+    } else {
+      fields.putSingle("URI", "CHK@");
+    }
+    if (contentType != null) {
+      fields.putSingle("Metadata.ContentType", contentType);
+    }
+    return new ClientPutMessage(fields);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutPreparedDataFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutPreparedDataFactoryTest.java
@@ -1,0 +1,159 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.async.ClientContext;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.ArrayBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientPutPreparedDataFactoryTest {
+  private static final String VALID_CHK =
+      "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,"
+          + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
+
+  @Test
+  void prepareForPersistentUpload_whenNotRedirect_returnsOriginalBucket() throws Exception {
+    ClientMetadata metadata = new ClientMetadata("text/plain");
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+
+    PreparedData prepared =
+        ClientPutPreparedDataFactory.prepareForPersistentUpload(
+            ClientPutBase.UploadFrom.DIRECT,
+            metadata,
+            bucket,
+            null,
+            mock(NodeClientCore.class),
+            false);
+
+    assertSame(bucket, prepared.bucket());
+    assertFalse(prepared.isMetadata());
+    assertNull(prepared.targetUri());
+  }
+
+  @Test
+  void prepareForPersistentUpload_whenRedirect_buildsMetadataBucket() throws Exception {
+    ClientMetadata metadata = new ClientMetadata("text/plain");
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    FreenetURI target = new FreenetURI(VALID_CHK);
+    ClientContext context = mock(ClientContext.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+
+    when(core.getClientContext()).thenReturn(context);
+    when(context.getBucketFactory(true)).thenReturn(new ArrayBucketFactory());
+
+    PreparedData prepared =
+        ClientPutPreparedDataFactory.prepareForPersistentUpload(
+            ClientPutBase.UploadFrom.REDIRECT, metadata, bucket, target, core, true);
+
+    assertNotNull(prepared.bucket());
+    assertNotSame(bucket, prepared.bucket());
+    assertEquals(target, prepared.targetUri());
+    assertTrue(prepared.isMetadata());
+  }
+
+  @Test
+  void prepareForPersistentUpload_whenBucketFactoryFails_throwsIOException() throws Exception {
+    ClientMetadata metadata = new ClientMetadata("text/plain");
+    //noinspection resource
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    FreenetURI target = new FreenetURI(VALID_CHK);
+    ClientContext context = mock(ClientContext.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    BucketFactory bucketFactory = mock(BucketFactory.class);
+
+    when(core.getClientContext()).thenReturn(context);
+    when(context.getBucketFactory(false)).thenReturn(bucketFactory);
+    when(bucketFactory.makeBucket(-1)).thenThrow(new IOException("fail"));
+
+    assertThrows(
+        IOException.class,
+        () ->
+            ClientPutPreparedDataFactory.prepareForPersistentUpload(
+                ClientPutBase.UploadFrom.REDIRECT, metadata, bucket, target, core, false));
+  }
+
+  @Test
+  void prepareForMessage_whenNotRedirect_returnsMessageBucket() throws Exception {
+    ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DIRECT, null);
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    message.bucket = bucket;
+
+    PreparedData prepared =
+        ClientPutPreparedDataFactory.prepareForMessage(
+            message,
+            new ClientMetadata("text/plain"),
+            mock(FCPServer.class),
+            false,
+            ClientPutBase.UploadFrom.DIRECT,
+            "id",
+            false);
+
+    assertSame(bucket, prepared.bucket());
+    assertFalse(prepared.isMetadata());
+    assertNull(prepared.targetUri());
+  }
+
+  @Test
+  void prepareForMessage_whenRedirect_buildsMetadataBucket() throws Exception {
+    ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.REDIRECT, VALID_CHK);
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    message.bucket = bucket;
+    ClientContext context = mock(ClientContext.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    FCPServer server = mock(FCPServer.class);
+
+    when(server.getCore()).thenReturn(core);
+    when(core.getClientContext()).thenReturn(context);
+    when(context.getBucketFactory(true)).thenReturn(new ArrayBucketFactory());
+
+    PreparedData prepared =
+        ClientPutPreparedDataFactory.prepareForMessage(
+            message,
+            new ClientMetadata("text/plain"),
+            server,
+            true,
+            ClientPutBase.UploadFrom.REDIRECT,
+            "id",
+            false);
+
+    assertNotNull(prepared.bucket());
+    assertNotSame(bucket, prepared.bucket());
+    assertEquals(message.redirectTarget, prepared.targetUri());
+    assertTrue(prepared.isMetadata());
+  }
+
+  private ClientPutMessage buildMessage(ClientPutBase.UploadFrom uploadFrom, String targetUri)
+      throws MessageInvalidException {
+    SimpleFieldSet fields = new SimpleFieldSet(true);
+    fields.putSingle("Identifier", "request-1");
+    fields.putSingle("URI", "CHK@");
+    if (uploadFrom == ClientPutBase.UploadFrom.DIRECT) {
+      fields.putSingle("UploadFrom", "direct");
+      fields.putSingle("DataLength", "4");
+    } else {
+      fields.putSingle("UploadFrom", "redirect");
+      fields.putSingle("TargetURI", targetUri);
+    }
+    return new ClientPutMessage(fields);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutPutterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutPutterFactoryTest.java
@@ -1,0 +1,68 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
+import network.crypta.client.async.ClientPutCallback;
+import network.crypta.client.async.ClientPutter;
+import network.crypta.client.async.ClientPutterOptions;
+import network.crypta.client.async.ClientPutterRequest;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientPutPutterFactoryTest {
+  private static final String VALID_CHK =
+      "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,"
+          + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
+
+  @Test
+  void create_whenValidInput_returnsConfiguredPutter() throws Exception {
+    ClientPutCallback callback = mock(ClientPutCallback.class);
+    RequestClient requestClient = mock(RequestClient.class);
+    when(callback.getRequestClient()).thenReturn(requestClient);
+
+    ClientMetadata metadata = new ClientMetadata("text/plain");
+    ArrayBucket data = new ArrayBucket();
+    FreenetURI targetUri = new FreenetURI(VALID_CHK);
+    InsertContext insertContext = new InsertContext(InsertContextOptions.builder().build());
+    ClientPutterRequest request =
+        new ClientPutterRequest(
+            callback, data, targetUri, metadata, insertContext, (short) 3, true);
+    byte[] overrideCrypto = new byte[] {1, 2, 3};
+    ClientPutterOptions options = new ClientPutterOptions("file.txt", true, overrideCrypto, 42L);
+
+    ClientPutter putter = ClientPutPutterFactory.create(request, options);
+
+    assertNotNull(putter);
+    assertSame(callback, getField(putter, "callback"));
+    assertSame(data, getField(putter, "data"));
+    assertSame(targetUri, getField(putter, "targetURI"));
+    assertSame(metadata, getField(putter, "cm"));
+    assertSame(insertContext, getField(putter, "ctx"));
+    assertEquals("file.txt", getField(putter, "targetFilename"));
+    assertTrue((Boolean) getField(putter, "binaryBlob"));
+    assertSame(overrideCrypto, getField(putter, "overrideSplitfileCrypto"));
+    assertEquals(42L, getField(putter, "metadataThreshold"));
+    assertTrue((Boolean) getField(putter, "isMetadata"));
+  }
+
+  private static Object getField(ClientPutter putter, String name) throws Exception {
+    Field field = ClientPutter.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(putter);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilderTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilderTest.java
@@ -1,0 +1,157 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Date;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
+import network.crypta.client.InsertException;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.client.events.SplitfileProgressCounts;
+import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"java:S100", "java:S3011"})
+class ClientPutStatusSnapshotBuilderTest {
+  private static final String VALID_CHK =
+      "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,"
+          + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
+
+  @TempDir private java.nio.file.Path tempDir;
+
+  @Test
+  void build_whenNoProgress_usesDefaultsAndMime() throws Exception {
+    ClientPut request = new ClientPut();
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    when(bucket.size()).thenReturn(123L);
+    ClientMetadata metadata = new ClientMetadata("text/plain");
+    String filename = "data" + ".bin";
+    File origFile = createFile(filename);
+    InsertContext context = new InsertContext(InsertContextOptions.builder().build());
+
+    setField(request, "identifier", "id");
+    setField(request, "uri", new FreenetURI(VALID_CHK));
+    setField(request, "persistence", ClientRequest.Persistence.FOREVER);
+    setField(request, "started", true);
+    setField(request, "finished", false);
+    setField(request, "succeeded", false);
+    setField(request, "priorityClass", (short) 2);
+    setField(request, "clientMetadata", metadata);
+    setField(request, "data", bucket);
+    setField(request, "uploadFrom", ClientPutBase.UploadFrom.DISK);
+    setField(request, "origFilename", origFile);
+    setField(request, "ctx", context);
+    setField(request, "compressed", true);
+    setField(request, "compressing", false);
+
+    UploadFileRequestStatus status = ClientPutStatusSnapshotBuilder.build(request);
+
+    assertEquals("id", status.getIdentifier());
+    assertEquals(0, status.getTotalBlocks());
+    assertEquals(0, status.getMinBlocks());
+    assertEquals(0, status.getFetchedBlocks());
+    assertEquals(0, status.getFailedBlocks());
+    assertEquals(0, status.getFatalyFailedBlocks());
+    assertFalse(status.isTotalFinalized());
+    assertEquals(123L, status.getDataSize());
+    assertEquals("text/plain", status.getMIMEType());
+    assertNotNull(status.getOrigFilename());
+    assertNotSame(origFile, status.getOrigFilename());
+    assertEquals(origFile.getPath(), status.getOrigFilename().getPath());
+    assertEquals(ClientPut.COMPRESS_STATE.WORKING, status.isCompressing());
+  }
+
+  @Test
+  void build_whenProgressAndFailure_populatesStatusDetails() throws Exception {
+    ClientPut request = new ClientPut();
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+    when(bucket.size()).thenReturn(42L);
+    InsertContext context = new InsertContext(InsertContextOptions.builder().build());
+    Date success = new Date(1000L);
+    Date failure = new Date(2000L);
+    SplitfileProgressCounts counts = new SplitfileProgressCounts(10, 3, 2, 1, 5, 0, true);
+    SplitfileProgressTimestamps timestamps = new SplitfileProgressTimestamps(success, failure);
+    SplitfileProgressEvent event = new SplitfileProgressEvent(counts, timestamps);
+    SimpleProgressMessage progressMessage = new SimpleProgressMessage("id", false, event);
+    InsertException exception =
+        new InsertException(InsertExceptionMode.INTERNAL_ERROR, "oops", null);
+    PutFailedMessage failureMessage = new PutFailedMessage(exception, "id", false);
+    FreenetURI targetUri = new FreenetURI(VALID_CHK);
+    FreenetURI finalUri = new FreenetURI(VALID_CHK);
+
+    setField(request, "identifier", "id");
+    setField(request, "uri", targetUri);
+    setField(request, "persistence", ClientRequest.Persistence.CONNECTION);
+    setField(request, "started", true);
+    setField(request, "finished", true);
+    setField(request, "succeeded", false);
+    setField(request, "priorityClass", (short) 1);
+    setField(request, "data", bucket);
+    setField(request, "progressMessage", progressMessage);
+    setField(request, "putFailedMessage", failureMessage);
+    setField(request, "generatedURI", finalUri);
+    setField(request, "ctx", context);
+    setField(request, "compressed", true);
+    setField(request, "compressing", true);
+
+    UploadFileRequestStatus status = ClientPutStatusSnapshotBuilder.build(request);
+
+    assertEquals(10, status.getTotalBlocks());
+    assertEquals(5, status.getMinBlocks());
+    assertEquals(3, status.getFetchedBlocks());
+    assertEquals(2, status.getFailedBlocks());
+    assertEquals(1, status.getFatalyFailedBlocks());
+    assertTrue(status.isTotalFinalized());
+    assertEquals(success, status.getLastSuccess());
+    assertEquals(failure, status.getLastFailure());
+    assertEquals(failureMessage.getShortFailedMessage(), status.getFailureReason(false));
+    assertEquals(failureMessage.getLongFailedMessage(), status.getFailureReason(true));
+    assertSame(finalUri, status.getFinalURI());
+    assertEquals(targetUri, status.getTargetURI());
+    assertEquals(42L, status.getDataSize());
+    assertNull(status.getMIMEType());
+    assertEquals(ClientPut.COMPRESS_STATE.COMPRESSING, status.isCompressing());
+  }
+
+  private File createFile(String name) throws Exception {
+    File file = tempDir.resolve(name).toFile();
+    assertTrue(file.createNewFile());
+    return file;
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = findField(target.getClass(), name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Field findField(Class<?> type, String name) throws NoSuchFieldException {
+    Class<?> current = type;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(name);
+      } catch (NoSuchFieldException _) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(name);
+  }
+}


### PR DESCRIPTION
## Summary
- extract ClientPut helper components (putter factory, mime resolver, disk upload validator, status snapshot builder)
- reduce ClientPut constructor and status complexity by delegating to new helpers
- add focused tests covering putter, prepared data, mime resolver, and status snapshots
- expand FCP put documentation for new helper flow