### PR TITLE
refactor(fcp): split FCPServer helpers

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -2,54 +2,21 @@ package network.crypta.clients.fcp;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.Socket;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
-import java.util.WeakHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.client.ClientMetadata;
-import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchResult;
 import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.DownloadCache;
 import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
-import network.crypta.clients.fcp.ClientGet.ReturnType;
-import network.crypta.clients.fcp.ClientRequest.Persistence;
-import network.crypta.clients.fcp.FCPPluginConnection.SendDirection;
 import network.crypta.config.Config;
-import network.crypta.config.InvalidConfigValueException;
-import network.crypta.config.Option;
-import network.crypta.config.SubConfig;
-import network.crypta.crypt.SSL;
 import network.crypta.io.AllowedHosts;
-import network.crypta.io.NetworkInterface;
-import network.crypta.io.SSLNetworkInterface;
 import network.crypta.keys.FreenetURI;
-import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import network.crypta.node.RequestStarter;
 import network.crypta.pluginmanager.FredPluginFCPMessageHandler.ClientSideFCPMessageHandler;
 import network.crypta.pluginmanager.PluginNotFoundException;
 import network.crypta.pluginmanager.PluginRespirator;
-import network.crypta.support.Base64;
-import network.crypta.support.api.BooleanCallback;
 import network.crypta.support.api.Bucket;
-import network.crypta.support.api.IntCallback;
-import network.crypta.support.api.StringCallback;
-import network.crypta.support.io.BucketTools;
-import network.crypta.support.io.NativeThread;
-import network.crypta.support.io.NoFreeBucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.tanukisoftware.wrapper.WrapperManager;
 
 /**
  * Server endpoint for the Freenet Client Protocol (FCP).
@@ -79,18 +46,12 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * start regardless of network enablement so non-networked plugins can still talk over FCP.
  */
 public class FCPServer implements Runnable, DownloadCache {
-  private static final Logger LOG = LoggerFactory.getLogger(FCPServer.class);
-
-  private final PersistentRequestRoot persistentRoot;
 
   /**
    * Default TCP port (9481) exposed by the FCP listener so clients can auto-discover the node
    * without extra configuration.
    */
   public static final int DEFAULT_FCP_PORT = 9481;
-
-  private static final String FPROXY_PREFIX = "FProxy:";
-  NetworkInterface networkInterface;
 
   /* It’s not the field that is deprecated but accessing it directly is. */
   private final NodeClientCore core;
@@ -99,28 +60,16 @@ public class FCPServer implements Runnable, DownloadCache {
   private final Node node;
 
   final int port;
-  private static boolean ssl = false;
 
   /* It’s not the field that is deprecated but accessing it directly is. */
-  private final boolean enabled;
+  final boolean enabled;
 
   String bindTo;
-  private final String allowedHosts;
-  AllowedHosts allowedHostsFullAccess;
+  final AllowedHosts allowedHostsFullAccess;
 
-  /**
-   * Stores {@link FCPPluginConnectionImpl} objects by ID and automatically garbage collects them so
-   * we don't have to bloat this class with that.
-   */
-  final FCPPluginConnectionTracker pluginConnectionTracker;
-
-  final WeakHashMap<String, PersistentRequestClient> rebootClientsByName;
-
-  /* It’s not the field that is deprecated but accessing it directly is. */
-  private final PersistentRequestClient globalRebootClient;
-
-  /* It’s not the field that is deprecated but accessing it directly is. */
-  private final PersistentRequestClient globalForeverClient;
+  private final FcpServerListener listener;
+  private final FcpServerPluginConnections pluginConnections;
+  private final FcpServerPersistentOps persistentOps;
 
   /**
    * Sentinel value used when building {@link ClientRequest} instances to permit unlimited retry
@@ -134,10 +83,10 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   public static final long QUEUE_MAX_DATA_SIZE = Long.MAX_VALUE;
 
-  private boolean assumeDownloadDDAIsAllowed;
-  private boolean assumeUploadDDAIsAllowed;
-  private boolean neverDropAMessage;
-  private int maxMessageQueueLength;
+  boolean assumeDownloadDDAIsAllowed;
+  boolean assumeUploadDDAIsAllowed;
+  boolean neverDropAMessage;
+  int maxMessageQueueLength;
 
   /**
    * Constructs a server instance from precomputed configuration and dependencies.
@@ -147,7 +96,6 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   public FCPServer(FcpServerConfig config, FcpServerDependencies dependencies) {
     this.bindTo = config.bindTo();
-    this.allowedHosts = config.allowedHosts();
     this.allowedHostsFullAccess = new AllowedHosts(config.allowedHostsFullAccess());
     this.port = config.port();
     this.enabled = config.enabled();
@@ -157,17 +105,9 @@ public class FCPServer implements Runnable, DownloadCache {
     this.assumeUploadDDAIsAllowed = config.assumeUploadDDAAllowed();
     this.neverDropAMessage = config.neverDropAMessage();
     this.maxMessageQueueLength = config.maxMessageQueueLength();
-    rebootClientsByName = new WeakHashMap<>();
-    this.persistentRoot = dependencies.persistentRoot();
-    globalForeverClient = persistentRoot.globalForeverClient;
-
-    pluginConnectionTracker = new FCPPluginConnectionTracker();
-    // pluginConnectionTracker.start() is called in maybeStart()
-
-    globalRebootClient =
-        new PersistentRequestClient("Global Queue", null, true, null, Persistence.REBOOT, null);
-
-    // Debug flag derives from SLF4J directly when needed
+    this.listener = new FcpServerListener(this, node, config);
+    this.pluginConnections = new FcpServerPluginConnections(node);
+    this.persistentOps = new FcpServerPersistentOps(this, core, dependencies.persistentRoot());
   }
 
   /**
@@ -230,22 +170,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * clients without requiring additional disk scans.
    */
   public void load() {
-    globalForeverClient.updateRequestStatusCache();
-  }
-
-  private void maybeGetNetworkInterface() {
-    if (this.networkInterface != null) return;
-
-    NetworkInterface tempNetworkInterface;
-    if (ssl) {
-      tempNetworkInterface =
-          SSLNetworkInterface.create(port, bindTo, allowedHosts, node.network().executor(), true);
-    } else {
-      tempNetworkInterface =
-          NetworkInterface.create(port, bindTo, allowedHosts, node.network().executor(), true);
-    }
-
-    this.networkInterface = tempNetworkInterface;
+    persistentOps.load();
   }
 
   /**
@@ -257,414 +182,18 @@ public class FCPServer implements Runnable, DownloadCache {
    * available. Repeated invocations are safe; only the first call performs initialization.
    */
   public void maybeStart() {
-    if (this.enabled) {
-      maybeGetNetworkInterface();
-
-      LOG.info("Starting FCP server on {}:{}.", bindTo, port);
-
-      if (this.networkInterface != null) {
-        Thread t = new Thread(this, "FCP server");
-        t.setDaemon(true);
-        t.start();
-      }
-    } else {
-      LOG.info("Not starting FCP server as it's disabled");
-      this.networkInterface = null;
-    }
-
-    if (node.services().pluginManager().isEnabled()) {
-      // We need to start the FCPPluginConnectionTracker no matter whether this.enabled == true:
-      // If networked FCP is disabled, plugins might still communicate via non-networked
-      // intra-node FCP.
-      pluginConnectionTracker.start();
-    }
+    listener.maybeStart();
+    pluginConnections.startTrackerIfEnabled();
   }
 
   @Override
   public void run() {
-    while (true) {
-      try {
-        networkInterface.waitBound();
-        realRun();
-      } catch (Exception e) {
-        LOG.error("Caught {}", e, e);
-      }
-      if (WrapperManager.hasShutdownHookBeenTriggered()) return;
-    }
+    listener.run();
   }
 
-  private void realRun() {
-    if (!node.isHasStarted()) return;
-    // Accept a connection
-    Socket s = networkInterface.accept();
-    FCPConnectionHandler ch = new FCPConnectionHandler(s, this);
-    ch.start();
-  }
-
-  static class FCPPortNumberCallback extends IntCallback {
-
-    private final NodeClientCore node;
-
-    FCPPortNumberCallback(NodeClientCore node) {
-      this.node = node;
-    }
-
-    @Override
-    public Integer get() {
-      return node.getEndpoints().getFCPServer().port;
-    }
-
-    @Override
-    public void set(Integer val) throws InvalidConfigValueException {
-      if (!get().equals(val)) {
-        throw new InvalidConfigValueException("Cannot change FCP port number on the fly");
-      }
-    }
-
-    @Override
-    public boolean isReadOnly() {
-      return true;
-    }
-  }
-
-  static class FCPEnabledCallback extends BooleanCallback {
-
-    final NodeClientCore node;
-
-    FCPEnabledCallback(NodeClientCore node) {
-      this.node = node;
-    }
-
-    @Override
-    public Boolean get() {
-      return node.getEndpoints().getFCPServer().enabled;
-    }
-
-    // Changing the enabled flag at runtime is not supported.
-    @Override
-    public void set(Boolean val) throws InvalidConfigValueException {
-      if (!get().equals(val)) {
-        throw new InvalidConfigValueException(
-            NodeL10n.getBase().getString("FcpServer.cannotStartOrStopOnTheFly"));
-      }
-    }
-
-    @Override
-    public boolean isReadOnly() {
-      return true;
-    }
-  }
-
-  static class FCPSSLCallback extends BooleanCallback {
-
-    private static void updateSslFlag(boolean val) throws InvalidConfigValueException {
-      if (ssl == val) {
-        return;
-      }
-      if (!SSL.available()) {
-        throw new InvalidConfigValueException("Enable SSL support before use ssl with FCP");
-      }
-      ssl = val;
-      throw new InvalidConfigValueException("Cannot change SSL on the fly, please restart freenet");
-    }
-
-    @Override
-    public Boolean get() {
-      return ssl;
-    }
-
-    @Override
-    public void set(Boolean val) throws InvalidConfigValueException {
-      updateSslFlag(val);
-    }
-
-    @Override
-    public boolean isReadOnly() {
-      return true;
-    }
-  }
-
-  // Configuration callbacks remain for bindTo to allow runtime updates; other fields are set in the
-  // constructor.
-
-  static class FCPBindtoCallback extends StringCallback {
-
-    final NodeClientCore node;
-
-    FCPBindtoCallback(NodeClientCore node) {
-      this.node = node;
-    }
-
-    @Override
-    public String get() {
-      return node.getEndpoints().getFCPServer().bindTo;
-    }
-
-    @Override
-    public void set(String val) throws InvalidConfigValueException {
-      String oldValue = get();
-      if (!val.equals(oldValue)) {
-        FCPServer server = node.getEndpoints().getFCPServer();
-
-        String[] failedAddresses = server.networkInterface.setBindTo(val, true);
-        if (failedAddresses != null) {
-          // This is an advanced option for reasons of reducing clutter,
-          // but it is expected to be used by regular users, not devs.
-          // So we translate the error messages.
-          server.networkInterface.setBindTo(oldValue, true);
-          throw new InvalidConfigValueException(
-              NodeL10n.getBase()
-                  .getString(
-                      "FcpServer.couldNotChangeBindTo",
-                      "failedInterfaces",
-                      Arrays.toString(failedAddresses)));
-        }
-
-        server.networkInterface.setBindTo(val, true);
-        server.bindTo = val;
-      }
-    }
-  }
-
-  static class FCPAllowedHostsCallback extends StringCallback {
-
-    private final NodeClientCore node;
-
-    public FCPAllowedHostsCallback(NodeClientCore node) {
-      this.node = node;
-    }
-
-    @Override
-    public String get() {
-      FCPServer server = node.getEndpoints().getFCPServer();
-      if (server == null) return NetworkInterface.DEFAULT_BIND_TO;
-      NetworkInterface netIface = server.networkInterface;
-      return (netIface == null ? NetworkInterface.DEFAULT_BIND_TO : netIface.getAllowedHosts());
-    }
-
-    @Override
-    public void set(String val) throws InvalidConfigValueException {
-      if (!val.equals(get())) {
-        try {
-          node.getEndpoints().getFCPServer().networkInterface.setAllowedHosts(val);
-        } catch (IllegalArgumentException e) {
-          throw new InvalidConfigValueException(e);
-        }
-      }
-    }
-  }
-
-  static class FCPAllowedHostsFullAccessCallback extends StringCallback {
-    private final NodeClientCore node;
-
-    public FCPAllowedHostsFullAccessCallback(NodeClientCore node) {
-      this.node = node;
-    }
-
-    @Override
-    public String get() {
-      return node.getEndpoints().getFCPServer().allowedHostsFullAccess.getAllowedHosts();
-    }
-
-    @Override
-    public void set(String val) throws InvalidConfigValueException {
-      if (!val.equals(get())) {
-        try {
-          node.getEndpoints().getFCPServer().allowedHostsFullAccess.setAllowedHosts(val);
-        } catch (IllegalArgumentException e) {
-          throw new InvalidConfigValueException(e);
-        }
-      }
-    }
-  }
-
-  static class AssumeDDADownloadIsAllowedCallback extends BooleanCallback {
-    FCPServer server;
-
-    @Override
-    public Boolean get() {
-      return server.assumeDownloadDDAIsAllowed;
-    }
-
-    @Override
-    public void set(Boolean val) throws InvalidConfigValueException {
-      if (get().equals(val)) return;
-      server.assumeDownloadDDAIsAllowed = val;
-    }
-  }
-
-  static class AssumeDDAUploadIsAllowedCallback extends BooleanCallback {
-    FCPServer server;
-
-    @Override
-    public Boolean get() {
-      return server.assumeUploadDDAIsAllowed;
-    }
-
-    @Override
-    public void set(Boolean val) throws InvalidConfigValueException {
-      if (get().equals(val)) return;
-      server.assumeUploadDDAIsAllowed = val;
-    }
-  }
-
-  static class NeverDropAMessageCallback extends BooleanCallback {
-    FCPServer server;
-
-    @Override
-    public Boolean get() {
-      return server.neverDropAMessage;
-    }
-
-    @Override
-    public void set(Boolean val) throws InvalidConfigValueException {
-      if (get().equals(val)) return;
-      server.neverDropAMessage = val;
-    }
-  }
-
-  static class MaxMessageQueueLengthCallback extends IntCallback {
-    FCPServer server;
-
-    @Override
-    public Integer get() {
-      return server.maxMessageQueueLength;
-    }
-
-    @Override
-    public void set(Integer val) throws InvalidConfigValueException {
-      if (get().equals(val)) return;
-      server.maxMessageQueueLength = val;
-    }
-  }
-
-  /**
-   * Registers FCP configuration keys and constructs a server instance wired to those settings.
-   *
-   * <p>The method derives the <code>fcp</code> subconfig, installs callbacks for mutable options
-   * such as bind address and allowed hosts, applies persisted SSL and DDA flags when present, and
-   * finally builds the {@link FCPServer}. Callers should invoke {@link #maybeStart()} after
-   * creation to begin listening for connections.
-   *
-   * @param node owning {@link Node} providing executors, plugin access, and lifecycle hooks.
-   * @param core client core exposing persistence utilities, job runners, and random sources.
-   * @param config root configuration object used to create and populate the FCP subconfig.
-   * @param root persistent request root shared across global clients.
-   * @return fully initialized server respecting the current configuration values.
-   */
   public static FCPServer maybeCreate(
       Node node, NodeClientCore core, Config config, PersistentRequestRoot root) {
-    SubConfig fcpConfig = config.createSubConfig("fcp");
-    short sortOrder = 0;
-    fcpConfig.register(
-        "enabled",
-        true,
-        new Option.Meta(sortOrder++, true, false, "FcpServer.isEnabled", "FcpServer.isEnabledLong"),
-        new FCPEnabledCallback(core));
-    fcpConfig.register(
-        "ssl",
-        false,
-        new Option.Meta(sortOrder++, true, true, "FcpServer.ssl", "FcpServer.sslLong"),
-        new FCPSSLCallback());
-    fcpConfig.register(
-        "port",
-        FCPServer.DEFAULT_FCP_PORT /* anagram of 1984, and 1000 up from old number */,
-        new Option.Meta(2, true, true, "FcpServer.portNumber", "FcpServer.portNumberLong"),
-        new FCPPortNumberCallback(core),
-        false);
-    fcpConfig.register(
-        "bindTo",
-        NetworkInterface.DEFAULT_BIND_TO,
-        new Option.Meta(sortOrder++, true, true, "FcpServer.bindTo", "FcpServer.bindToLong"),
-        new FCPBindtoCallback(core));
-    fcpConfig.register(
-        "allowedHosts",
-        NetworkInterface.DEFAULT_BIND_TO,
-        new Option.Meta(
-            sortOrder++, true, true, "FcpServer.allowedHosts", "FcpServer.allowedHostsLong"),
-        new FCPAllowedHostsCallback(core));
-    fcpConfig.register(
-        "allowedHostsFullAccess",
-        NetworkInterface.DEFAULT_BIND_TO,
-        new Option.Meta(
-            sortOrder++,
-            true,
-            true,
-            "FcpServer.allowedHostsFullAccess",
-            "FcpServer.allowedHostsFullAccessLong"),
-        new FCPAllowedHostsFullAccessCallback(core));
-
-    AssumeDDADownloadIsAllowedCallback cb4 = new AssumeDDADownloadIsAllowedCallback();
-    AssumeDDAUploadIsAllowedCallback cb5 = new AssumeDDAUploadIsAllowedCallback();
-    NeverDropAMessageCallback cb6 = new NeverDropAMessageCallback();
-    MaxMessageQueueLengthCallback cb7 = new MaxMessageQueueLengthCallback();
-    fcpConfig.register(
-        "assumeDownloadDDAIsAllowed",
-        false,
-        new Option.Meta(
-            sortOrder++,
-            true,
-            false,
-            "FcpServer.assumeDownloadDDAIsAllowed",
-            "FcpServer.assumeDownloadDDAIsAllowedLong"),
-        cb4);
-    fcpConfig.register(
-        "assumeUploadDDAIsAllowed",
-        false,
-        new Option.Meta(
-            sortOrder++,
-            true,
-            false,
-            "FcpServer.assumeUploadDDAIsAllowed",
-            "FcpServer.assumeUploadDDAIsAllowedLong"),
-        cb5);
-    fcpConfig.register(
-        "maxMessageQueueLength",
-        1024,
-        new Option.Meta(
-            sortOrder++,
-            true,
-            false,
-            "FcpServer.maxMessageQueueLength",
-            "FcpServer.maxMessageQueueLengthLong"),
-        cb7,
-        false);
-    fcpConfig.register(
-        "neverDropAMessage",
-        false,
-        new Option.Meta(
-            sortOrder,
-            true,
-            false,
-            "FcpServer.neverDropAMessage",
-            "FcpServer.neverDropAMessageLong"),
-        cb6);
-
-    if (SSL.available()) {
-      ssl = fcpConfig.getBoolean("ssl");
-    }
-
-    FcpServerConfig serverConfig =
-        new FcpServerConfig(
-            fcpConfig.getString("bindTo"),
-            fcpConfig.getString("allowedHosts"),
-            fcpConfig.getString("allowedHostsFullAccess"),
-            fcpConfig.getInt("port"),
-            fcpConfig.getBoolean("enabled"),
-            fcpConfig.getBoolean("assumeDownloadDDAIsAllowed"),
-            fcpConfig.getBoolean("assumeUploadDDAIsAllowed"),
-            fcpConfig.getBoolean("neverDropAMessage"),
-            fcpConfig.getInt("maxMessageQueueLength"));
-    FcpServerDependencies dependencies = new FcpServerDependencies(node, core, root);
-    FCPServer fcp = new FCPServer(serverConfig, dependencies);
-
-    cb4.server = fcp;
-    cb5.server = fcp;
-    cb6.server = fcp;
-    cb7.server = fcp;
-
-    fcpConfig.finishedInitialization();
-    return fcp;
+    return FcpServerConfigRegistrar.maybeCreate(node, core, config, root);
   }
 
   /**
@@ -703,12 +232,8 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   final FCPPluginConnectionImpl createFCPPluginConnectionForNetworkedFCP(
       String serverPluginName, FCPConnectionHandler messageHandler) throws PluginNotFoundException {
-    return FCPPluginConnectionImpl.constructForNetworkedFCP(
-        pluginConnectionTracker,
-        node.network().executor(),
-        node.services().pluginManager(),
-        serverPluginName,
-        messageHandler);
+    return pluginConnections.createFCPPluginConnectionForNetworkedFCP(
+        serverPluginName, messageHandler);
   }
 
   /**
@@ -718,7 +243,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * ClientSideFCPMessageHandler)} to establish a logical FCP link without leaving the process. The
    * connection is inserted into {@link FCPPluginConnectionTracker} and stays reachable as long as
    * the caller keeps a strong reference. To match the client perspective, the returned adapter
-   * defaults the send direction to {@link SendDirection#TO_SERVER}.
+   * defaults the send direction to {@link FCPPluginConnection.SendDirection#TO_SERVER}.
    *
    * @param serverPluginName name of the server-side plugin that will receive the messages.
    * @param messageHandler handler on the client-side plugin that processes responses.
@@ -728,15 +253,8 @@ public class FCPServer implements Runnable, DownloadCache {
   public final FCPPluginConnection createFCPPluginConnectionForIntraNodeFCP(
       String serverPluginName, ClientSideFCPMessageHandler messageHandler)
       throws PluginNotFoundException {
-
-    FCPPluginConnectionImpl connection =
-        FCPPluginConnectionImpl.constructForIntraNodeFCP(
-            pluginConnectionTracker,
-            node.network().executor(),
-            node.services().pluginManager(),
-            serverPluginName,
-            messageHandler);
-    return connection.getDefaultSendDirectionAdapter(SendDirection.TO_SERVER);
+    return pluginConnections.createFCPPluginConnectionForIntraNodeFCP(
+        serverPluginName, messageHandler);
   }
 
   /**
@@ -752,9 +270,7 @@ public class FCPServer implements Runnable, DownloadCache {
    *     inaccessible.
    */
   public final FCPPluginConnection getPluginConnectionByID(UUID connectionID) throws IOException {
-    return pluginConnectionTracker
-        .getConnection(connectionID)
-        .getDefaultSendDirectionAdapter(SendDirection.TO_CLIENT);
+    return pluginConnections.getPluginConnectionByID(connectionID);
   }
 
   /**
@@ -765,28 +281,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @return existing client after handler replacement, or a newly created client when absent.
    */
   public PersistentRequestClient registerRebootClient(String name, FCPConnectionHandler handler) {
-    PersistentRequestClient oldClient;
-    synchronized (this) {
-      oldClient = rebootClientsByName.get(name);
-      if (oldClient == null) {
-        // Create new client
-        PersistentRequestClient client =
-            new PersistentRequestClient(name, handler, false, null, Persistence.REBOOT, null);
-        rebootClientsByName.put(name, client);
-        return client;
-      } else {
-        FCPConnectionHandler oldConn = oldClient.getConnection();
-        // Have existing client
-        if (oldConn != null) {
-          // Kill old connection
-          oldConn.setKilledDupe();
-          oldConn.send(new CloseConnectionDuplicateClientNameMessage());
-          oldConn.close();
-        }
-        oldClient.setConnection(handler);
-        return oldClient;
-      }
-    }
+    return persistentOps.registerRebootClient(name, handler);
   }
 
   /**
@@ -797,7 +292,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @return client instance tied to the forever queue.
    */
   public PersistentRequestClient registerForeverClient(String name, FCPConnectionHandler handler) {
-    return persistentRoot.registerForeverClient(name, handler);
+    return persistentOps.registerForeverClient(name, handler);
   }
 
   /**
@@ -808,7 +303,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @return existing or newly created client.
    */
   public PersistentRequestClient getForeverClient(String name, FCPConnectionHandler handler) {
-    return persistentRoot.getForeverClient(name, handler);
+    return persistentOps.getForeverClient(name, handler);
   }
 
   /**
@@ -818,14 +313,7 @@ public class FCPServer implements Runnable, DownloadCache {
    *     delegate to {@link PersistentRequestRoot} for cleanup.
    */
   public void unregisterClient(PersistentRequestClient client) {
-    if (client.persistence == Persistence.REBOOT) {
-      synchronized (this) {
-        String name = client.name;
-        rebootClientsByName.remove(name);
-      }
-    } else {
-      persistentRoot.maybeUnregisterClient(client);
-    }
+    persistentOps.unregisterClient(client);
   }
 
   /**
@@ -835,11 +323,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @throws PersistenceDisabledException if persistence is unavailable while reading status.
    */
   public RequestStatus[] getGlobalRequests() throws PersistenceDisabledException {
-    if (core.killedDatabase()) throw new PersistenceDisabledException();
-    List<RequestStatus> v = new ArrayList<>();
-    globalRebootClient.addPersistentRequestStatus(v);
-    if (globalForeverClient != null) globalForeverClient.addPersistentRequestStatus(v);
-    return v.toArray(new RequestStatus[0]);
+    return persistentOps.getGlobalRequests();
   }
 
   /**
@@ -853,44 +337,7 @@ public class FCPServer implements Runnable, DownloadCache {
   @SuppressWarnings("UnusedReturnValue")
   public boolean removeGlobalRequestBlocking(final String identifier)
       throws PersistenceDisabledException {
-    if (!globalRebootClient.removeByIdentifier(identifier, true, this, core.getClientContext())) {
-      final CountDownLatch done = new CountDownLatch(1);
-      final AtomicBoolean success = new AtomicBoolean();
-      core.getClientContext()
-          .jobRunner
-          .queue(
-              new PersistentJob() {
-
-                @Override
-                public String toString() {
-                  return "FCP removeGlobalRequestBlocking";
-                }
-
-                @Override
-                public boolean run(ClientContext context) {
-                  boolean succeeded = false;
-                  try {
-                    succeeded =
-                        globalForeverClient.removeByIdentifier(
-                            identifier, true, FCPServer.this, core.getClientContext());
-                  } catch (Exception e) {
-                    LOG.error("Caught removing identifier {}: {}", identifier, e, e);
-                  } finally {
-                    success.set(succeeded);
-                    done.countDown();
-                  }
-                  return true;
-                }
-              },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-      try {
-        done.await();
-      } catch (InterruptedException _) {
-        Thread.currentThread().interrupt();
-        return success.get();
-      }
-      return success.get();
-    } else return true;
+    return persistentOps.removeGlobalRequestBlocking(identifier);
   }
 
   /**
@@ -902,42 +349,7 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   @SuppressWarnings("unused")
   public boolean removeAllGlobalRequestsBlocking() throws PersistenceDisabledException {
-    globalRebootClient.removeAll();
-    final CountDownLatch done = new CountDownLatch(1);
-    final AtomicBoolean success = new AtomicBoolean();
-    core.getClientContext()
-        .jobRunner
-        .queue(
-            new PersistentJob() {
-
-              @Override
-              public String toString() {
-                return "FCP removeAllGlobalRequestsBlocking";
-              }
-
-              @Override
-              public boolean run(ClientContext context) {
-                boolean succeeded = false;
-                try {
-                  globalForeverClient.removeAll();
-                  succeeded = true;
-                } catch (Exception e) {
-                  LOG.error("Caught while processing panic: {}", e, e);
-                } finally {
-                  success.set(succeeded);
-                  done.countDown();
-                }
-                return true;
-              }
-            },
-            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-    try {
-      done.await();
-    } catch (InterruptedException _) {
-      Thread.currentThread().interrupt();
-      return success.get();
-    }
-    return success.get();
+    return persistentOps.removeAllGlobalRequestsBlocking();
   }
 
   /**
@@ -956,50 +368,10 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   public void makePersistentGlobalRequestBlocking(PersistentGlobalRequestParams params)
       throws NotAllowedException, IOException, PersistenceDisabledException {
-    final CountDownLatch done = new CountDownLatch(1);
-    final AtomicReference<NotAllowedException> notAllowed = new AtomicReference<>();
-    final AtomicReference<IOException> ioException = new AtomicReference<>();
-    core.getClientContext()
-        .jobRunner
-        .queue(
-            new PersistentJob() {
-
-              @Override
-              public String toString() {
-                return "FCP makePersistentGlobalRequestBlocking";
-              }
-
-              @Override
-              public boolean run(ClientContext context) {
-                try {
-                  makePersistentGlobalRequest(params);
-                  return true;
-                } catch (NotAllowedException e) {
-                  notAllowed.set(e);
-                  return false;
-                } catch (IOException e) {
-                  ioException.set(e);
-                  return false;
-                } catch (Exception t) {
-                  // Unexpected and severe, might even be OOM, just log it.
-                  LOG.error("Failed to make persistent request: {}", t, t);
-                  return false;
-                } finally {
-                  done.countDown();
-                }
-              }
-            },
-            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-
-    try {
-      done.await();
-    } catch (InterruptedException _) {
-      Thread.currentThread().interrupt();
-    }
-    if (ioException.get() != null) throw ioException.get();
-    if (notAllowed.get() != null) throw notAllowed.get();
+    persistentOps.makePersistentGlobalRequestBlocking(params);
   }
 
+  @SuppressWarnings("unused")
   public void makePersistentGlobalRequestBlocking(
       FreenetURI fetchURI,
       boolean filterData,
@@ -1009,15 +381,14 @@ public class FCPServer implements Runnable, DownloadCache {
       boolean realTimeFlag,
       File downloadsDir)
       throws NotAllowedException, IOException, PersistenceDisabledException {
-    makePersistentGlobalRequestBlocking(
-        new PersistentGlobalRequestParams(
-            fetchURI,
-            filterData,
-            expectedMimeType,
-            persistenceTypeString,
-            returnTypeString,
-            realTimeFlag,
-            downloadsDir));
+    persistentOps.makePersistentGlobalRequestBlocking(
+        fetchURI,
+        filterData,
+        expectedMimeType,
+        persistenceTypeString,
+        returnTypeString,
+        realTimeFlag,
+        downloadsDir);
   }
 
   /**
@@ -1034,60 +405,7 @@ public class FCPServer implements Runnable, DownloadCache {
   public boolean modifyGlobalRequestBlocking(
       final String identifier, final String newToken, final short newPriority)
       throws PersistenceDisabledException {
-    ClientRequest req = this.globalRebootClient.getRequest(identifier);
-    if (req != null) {
-      req.modifyRequest(newToken, newPriority, this);
-      return true;
-    } else {
-      class OutputWrapper {
-        boolean success;
-        boolean done;
-      }
-      final OutputWrapper ow = new OutputWrapper();
-      core.getClientContext()
-          .jobRunner
-          .queue(
-              new PersistentJob() {
-
-                @Override
-                public String toString() {
-                  return "FCP modifyGlobalRequestBlocking";
-                }
-
-                @Override
-                public boolean run(ClientContext context) {
-                  boolean success = false;
-                  try {
-                    ClientRequest req = globalForeverClient.getRequest(identifier);
-                    if (req != null) req.modifyRequest(newToken, newPriority, FCPServer.this);
-                    success = true;
-                  } finally {
-                    synchronized (ow) {
-                      ow.success = success;
-                      ow.done = true;
-                      ow.notifyAll();
-                    }
-                  }
-                  return true;
-                }
-              },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-
-      synchronized (ow) {
-        while (true) {
-          if (!ow.done) {
-            try {
-              ow.wait();
-            } catch (InterruptedException _) {
-              Thread.currentThread().interrupt();
-              return ow.success;
-            }
-            continue;
-          }
-          return ow.success;
-        }
-      }
-    }
+    return persistentOps.modifyGlobalRequestBlocking(identifier, newToken, newPriority);
   }
 
   /**
@@ -1097,56 +415,10 @@ public class FCPServer implements Runnable, DownloadCache {
    * @throws NotAllowedException if local policy forbids creating the request.
    * @throws IOException if disk output setup fails or the downloads directory is invalid.
    */
+  @SuppressWarnings("unused")
   public void makePersistentGlobalRequest(PersistentGlobalRequestParams params)
       throws NotAllowedException, IOException {
-    boolean persistence = params.persistenceType().equalsIgnoreCase("reboot");
-    ReturnType returnType = ReturnType.valueOf(params.returnType().toUpperCase());
-    File returnFilename = null;
-    if (returnType == ReturnType.DISK) {
-      returnFilename =
-          makeReturnFilename(params.fetchURI(), params.expectedMimeType(), params.downloadsDir());
-    }
-    List<String> candidateIds = new ArrayList<>();
-    candidateIds.add(FPROXY_PREFIX + params.fetchURI().getPreferredFilename());
-    candidateIds.add(FPROXY_PREFIX + params.fetchURI().getDocName());
-    candidateIds.add(FPROXY_PREFIX + params.fetchURI().toString(false, false));
-    candidateIds.add("FProxy (" + System.currentTimeMillis() + ')');
-
-    for (String candidateId : candidateIds) {
-      if (candidateId == null) {
-        continue;
-      }
-      PersistentGlobalRequestSpec spec =
-          new PersistentGlobalRequestSpec(
-              params.fetchURI(),
-              params.filterData(),
-              persistence,
-              returnType,
-              candidateId,
-              returnFilename,
-              params.realTimeFlag());
-      if (tryPersistentGlobalRequest(spec)) {
-        return;
-      }
-    }
-
-    while (true) {
-      byte[] buf = new byte[8];
-      core.getRandom().nextBytes(buf);
-      String id = FPROXY_PREFIX + Base64.encode(buf);
-      PersistentGlobalRequestSpec spec =
-          new PersistentGlobalRequestSpec(
-              params.fetchURI(),
-              params.filterData(),
-              persistence,
-              returnType,
-              id,
-              returnFilename,
-              params.realTimeFlag());
-      if (tryPersistentGlobalRequest(spec)) {
-        return;
-      }
-    }
+    persistentOps.makePersistentGlobalRequest(params);
   }
 
   /**
@@ -1174,15 +446,13 @@ public class FCPServer implements Runnable, DownloadCache {
       String returnTypeString,
       boolean realTimeFlag)
       throws NotAllowedException, IOException {
-    makePersistentGlobalRequest(
-        new PersistentGlobalRequestParams(
-            fetchURI,
-            filterData,
-            expectedMimeType,
-            persistenceTypeString,
-            returnTypeString,
-            realTimeFlag,
-            core.getDownloadsDir()));
+    persistentOps.makePersistentGlobalRequest(
+        fetchURI,
+        filterData,
+        expectedMimeType,
+        persistenceTypeString,
+        returnTypeString,
+        realTimeFlag);
   }
 
   /**
@@ -1208,6 +478,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @throws NotAllowedException if local policy forbids creating the request.
    * @throws IOException if disk output setup fails or the downloads directory is invalid.
    */
+  @SuppressWarnings("unused")
   public void makePersistentGlobalRequest(
       FreenetURI fetchURI,
       boolean filterData,
@@ -1217,81 +488,14 @@ public class FCPServer implements Runnable, DownloadCache {
       boolean realTimeFlag,
       File downloadsDir)
       throws NotAllowedException, IOException {
-    makePersistentGlobalRequest(
-        new PersistentGlobalRequestParams(
-            fetchURI,
-            filterData,
-            expectedMimeType,
-            persistenceTypeString,
-            returnTypeString,
-            realTimeFlag,
-            downloadsDir));
-  }
-
-  private boolean tryPersistentGlobalRequest(PersistentGlobalRequestSpec spec)
-      throws NotAllowedException, IOException {
-    try {
-      innerMakePersistentGlobalRequest(spec);
-      return true;
-    } catch (IdentifierCollisionException _) {
-      return false;
-    }
-  }
-
-  private File makeReturnFilename(FreenetURI uri, String expectedMimeType, File downloadsDir) {
-    String ext;
-    if ((expectedMimeType != null)
-        && !expectedMimeType.isEmpty()
-        && !expectedMimeType.equals(DefaultMIMETypes.DEFAULT_MIME_TYPE)) {
-      ext = DefaultMIMETypes.getExtension(expectedMimeType);
-    } else ext = null;
-    String extAdd = (ext == null ? "" : '.' + ext);
-    String preferred = uri.getPreferredFilename();
-    String preferredWithExt = preferred;
-    if (!(ext != null && preferredWithExt.endsWith(ext))) preferredWithExt += extAdd;
-    File f = new File(downloadsDir, preferredWithExt);
-    int x = 0;
-    StringBuilder sb = new StringBuilder();
-    for (; f.exists(); sb.setLength(0)) {
-      sb.append(preferred);
-      sb.append('-');
-      sb.append(x);
-      sb.append(extAdd);
-      f = new File(downloadsDir, sb.toString());
-      x++;
-    }
-    return f;
-  }
-
-  private void innerMakePersistentGlobalRequest(PersistentGlobalRequestSpec spec)
-      throws IdentifierCollisionException, NotAllowedException, IOException {
-    FetchContext defaultFetchContext = core.getClientContext().getDefaultPersistentFetchContext();
-    ClientGet.GlobalRequestConfig requestConfig =
-        new ClientGet.GlobalRequestConfig(
-            defaultFetchContext.getLocalRequestOnly(),
-            defaultFetchContext.getIgnoreStore(),
-            spec.filterData(),
-            QUEUE_MAX_RETRIES,
-            QUEUE_MAX_RETRIES,
-            QUEUE_MAX_DATA_SIZE,
-            spec.returnType(),
-            spec.persistRebootOnly(),
-            spec.identifier(),
-            Integer.MAX_VALUE,
-            RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-            spec.returnFilename(),
-            null,
-            false,
-            spec.realTimeFlag(),
-            false);
-    final ClientGet cg =
-        new ClientGet(
-            spec.persistRebootOnly() ? globalRebootClient : globalForeverClient,
-            spec.fetchURI(),
-            requestConfig,
-            core);
-    cg.register(false);
-    cg.start(core.getClientContext());
+    persistentOps.makePersistentGlobalRequest(
+        fetchURI,
+        filterData,
+        expectedMimeType,
+        persistenceTypeString,
+        returnTypeString,
+        realTimeFlag,
+        downloadsDir);
   }
 
   /**
@@ -1301,7 +505,7 @@ public class FCPServer implements Runnable, DownloadCache {
    *     disabled.
    */
   public PersistentRequestClient getGlobalForeverClient() {
-    return globalForeverClient;
+    return persistentOps.getGlobalForeverClient();
   }
 
   /**
@@ -1311,9 +515,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @return matching request from the reboot or forever queue, or {@code null} if none exist.
    */
   public ClientRequest getGlobalRequest(String identifier) {
-    ClientRequest req = globalRebootClient.getRequest(identifier);
-    if (req == null) req = globalForeverClient.getRequest(identifier);
-    return req;
+    return persistentOps.getGlobalRequest(identifier);
   }
 
   /**
@@ -1340,8 +542,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @param cb callback to notify on completion events for both reboot and forever queues.
    */
   public void setCompletionCallback(RequestCompletionCallback cb) {
-    if (globalForeverClient != null) globalForeverClient.addRequestCompletionCallback(cb);
-    globalRebootClient.addRequestCompletionCallback(cb);
+    persistentOps.setCompletionCallback(cb);
   }
 
   /**
@@ -1359,46 +560,7 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   public void startBlocking(final ClientRequest req)
       throws IdentifierCollisionException, PersistenceDisabledException {
-    if (req.persistence == Persistence.REBOOT) {
-      req.start(core.getClientContext());
-    } else {
-      final CountDownLatch done = new CountDownLatch(1);
-      final AtomicReference<IdentifierCollisionException> collision = new AtomicReference<>();
-      core.getClientContext()
-          .jobRunner
-          .queue(
-              new PersistentJob() {
-
-                @Override
-                public String toString() {
-                  return "FCP startBlocking";
-                }
-
-                @Override
-                public boolean run(ClientContext context) {
-                  // Don't activate, it may not be stored yet.
-                  try {
-                    req.register(false);
-                    req.start(context);
-                  } catch (IdentifierCollisionException e) {
-                    collision.set(e);
-                  } finally {
-                    done.countDown();
-                  }
-                  return true;
-                }
-              },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-
-      try {
-        done.await();
-      } catch (InterruptedException _) {
-        Thread.currentThread().interrupt();
-      }
-      if (collision.get() != null) {
-        throw collision.get();
-      }
-    }
+    persistentOps.startBlocking(req);
   }
 
   /**
@@ -1414,52 +576,7 @@ public class FCPServer implements Runnable, DownloadCache {
   @SuppressWarnings("UnusedReturnValue")
   public boolean restartBlocking(final String identifier, final boolean disableFilterData)
       throws PersistenceDisabledException {
-    ClientRequest req = globalRebootClient.getRequest(identifier);
-    if (req != null) {
-      req.restart(core.getClientContext(), disableFilterData);
-      return true;
-    } else {
-      final CountDownLatch done = new CountDownLatch(1);
-      final AtomicBoolean success = new AtomicBoolean();
-      if (LOG.isDebugEnabled()) LOG.debug("Queueing restart of {}", identifier);
-      core.getClientContext()
-          .jobRunner
-          .queue(
-              new PersistentJob() {
-
-                @Override
-                public String toString() {
-                  return "FCP restartBlocking";
-                }
-
-                @Override
-                public boolean run(ClientContext context) {
-                  boolean restarted = false;
-                  try {
-                    ClientRequest req = globalForeverClient.getRequest(identifier);
-                    if (LOG.isDebugEnabled()) LOG.debug("Restarting {} for {}", req, identifier);
-                    if (req != null) {
-                      req.restart(context, disableFilterData);
-                      restarted = true;
-                    }
-                  } catch (PersistenceDisabledException e) {
-                    LOG.error("Failed to restart {}: {}", identifier, e.getMessage(), e);
-                  } finally {
-                    success.set(restarted);
-                    done.countDown();
-                  }
-                  return true;
-                }
-              },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-
-      try {
-        done.await();
-      } catch (InterruptedException _) {
-        Thread.currentThread().interrupt();
-      }
-      return success.get();
-    }
+    return persistentOps.restartBlocking(identifier, disableFilterData);
   }
 
   /**
@@ -1476,48 +593,7 @@ public class FCPServer implements Runnable, DownloadCache {
   @SuppressWarnings("unused")
   public FetchResult getCompletedRequestBlocking(final FreenetURI key)
       throws PersistenceDisabledException {
-    ClientGet get = globalRebootClient.getCompletedRequest(key);
-    if (get != null) {
-      // Potential race with free(); refcounting would avoid losing data here.
-      return new FetchResult(
-          new ClientMetadata(get.getMIMEType()), new NoFreeBucket(get.getBucket()));
-    }
-
-    FetchResult result = globalForeverClient.getRequestStatusCache().getShadowBucket(key, false);
-    if (result != null) {
-      return result;
-    }
-
-    final CountDownLatch done = new CountDownLatch(1);
-    final AtomicReference<FetchResult> resultRef = new AtomicReference<>();
-    core.getClientContext()
-        .jobRunner
-        .queue(
-            new PersistentJob() {
-
-              @Override
-              public String toString() {
-                return "FCP getCompletedRequestBlocking";
-              }
-
-              @Override
-              public boolean run(ClientContext context) {
-                try {
-                  resultRef.set(lookup(key, false, context, false, null));
-                } finally {
-                  done.countDown();
-                }
-                return false;
-              }
-            },
-            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-
-    try {
-      done.await();
-    } catch (InterruptedException _) {
-      Thread.currentThread().interrupt();
-    }
-    return resultRef.get();
+    return persistentOps.getCompletedRequestBlocking(key);
   }
 
   /**
@@ -1537,50 +613,7 @@ public class FCPServer implements Runnable, DownloadCache {
   @Override
   public CacheFetchResult lookupInstant(
       FreenetURI key, boolean noFilter, boolean mustCopy, Bucket preferred) {
-    ClientGet get = globalRebootClient.getCompletedRequest(key);
-
-    Bucket origData = null;
-    String mime = null;
-    boolean filtered = false;
-
-    if (get != null) {
-      boolean requestFiltered = get.filterData();
-      if ((!noFilter) || (!requestFiltered)) {
-        filtered = requestFiltered;
-        origData = new NoFreeBucket(get.getBucket());
-        mime = get.getMIMEType();
-      }
-    }
-
-    if (origData == null && globalForeverClient != null) {
-      CacheFetchResult result =
-          globalForeverClient.getRequestStatusCache().getShadowBucket(key, noFilter);
-      if (result != null) {
-        mime = result.getMimeType();
-        origData = result.asBucket();
-        filtered = result.alreadyFiltered;
-      }
-    }
-
-    if (origData == null) return null;
-
-    if (!mustCopy) return new CacheFetchResult(new ClientMetadata(mime), origData, filtered);
-
-    Bucket newData = preferred;
-    try {
-      if (newData == null) newData = core.getTempBucketFactory().makeBucket(origData.size());
-      BucketTools.copy(origData, newData);
-      if (origData.size() != newData.size()) {
-        LOG.info("Maybe it disappeared under us?");
-        newData.free();
-        return null;
-      }
-      return new CacheFetchResult(new ClientMetadata(mime), newData, filtered);
-    } catch (IOException e) {
-      // Maybe it was freed?
-      LOG.info("Unable to copy data: {}", e, e);
-      return null;
-    }
+    return persistentOps.lookupInstant(key, noFilter, mustCopy, preferred);
   }
 
   /**
@@ -1597,26 +630,7 @@ public class FCPServer implements Runnable, DownloadCache {
   @Override
   public CacheFetchResult lookup(
       FreenetURI key, boolean noFilter, ClientContext context, boolean mustCopy, Bucket preferred) {
-    if (globalForeverClient == null) return null;
-    ClientGet get = globalForeverClient.getCompletedRequest(key);
-    if (get != null) {
-      boolean filtered = get.filterData();
-      Bucket origData = get.getBucket();
-      Bucket newData = null;
-      if (!mustCopy) newData = origData.createShadow();
-      if (newData == null) {
-        try {
-          if (preferred != null) newData = preferred;
-          else newData = core.getTempBucketFactory().makeBucket(origData.size());
-          BucketTools.copy(origData, newData);
-        } catch (IOException e) {
-          LOG.error("Unable to copy data: {}", e, e);
-          return null;
-        }
-      }
-      return new CacheFetchResult(new ClientMetadata(get.getMIMEType()), newData, filtered);
-    }
-    return null;
+    return persistentOps.lookup(key, noFilter, context, mustCopy, preferred);
   }
 
   /**
@@ -1637,6 +651,14 @@ public class FCPServer implements Runnable, DownloadCache {
     return node;
   }
 
+  AllowedHosts getAllowedHostsFullAccess() {
+    return allowedHostsFullAccess;
+  }
+
+  FcpServerListener listener() {
+    return listener;
+  }
+
   /**
    * Reports whether the FCP network listener is configured to start.
    *
@@ -1652,6 +674,6 @@ public class FCPServer implements Runnable, DownloadCache {
    * @return client reference for the reboot queue.
    */
   public PersistentRequestClient getGlobalRebootClient() {
-    return globalRebootClient;
+    return persistentOps.getGlobalRebootClient();
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -25,10 +25,10 @@ import network.crypta.support.api.Bucket;
  * coordinates request lifecycle management for both external clients and in-process plugins. It
  * wires persistent request queues, plugin-to-plugin messaging via {@link FCPPluginConnection}, and
  * the download cache so clients can resume work across node restarts. The server is created from
- * configured defaults, started lazily through {@link #maybeStart()}, and runs a dedicated accept
- * loop on a daemon thread so shutdown does not block. Concurrency is managed through the executor
- * supplied by {@link Node}, request jobs are marshalled onto the {@link ClientContext} job runner,
- * and weakly referenced plugin connections are cleaned up automatically by {@link
+ * configured defaults, started lazily through {@link #maybeStart()}, and runs a dedicated
+ * accept-loop on a daemon thread so shutdown does not block. Concurrency is managed through the
+ * executor supplied by {@link Node}, request jobs are marshaled onto the {@link ClientContext} job
+ * runner, and weakly referenced plugin connections are cleaned up automatically by {@link
  * FCPPluginConnectionTracker} to avoid leaks.
  *
  * <p>Responsibilities include:
@@ -43,25 +43,28 @@ import network.crypta.support.api.Bucket;
  * <p>Instances are not thread-safe for direct field mutation; the class instead encapsulates the
  * mutable state (bind address, allowed hosts, queues) and uses synchronized sections or
  * thread-confined startup hooks. Network listeners are long-lived, while plugin connection trackers
- * start regardless of network enablement so non-networked plugins can still talk over FCP.
+ * start regardless of network enablement, so non-networked plugins can still talk over FCP.
  */
 public class FCPServer implements Runnable, DownloadCache {
 
   /**
-   * Default TCP port (9481) exposed by the FCP listener so clients can auto-discover the node
-   * without extra configuration.
+   * Default TCP port (9481) exposed by the FCP listener for network clients.
+   *
+   * <p>This value is used as the configuration default when a node does not override the port
+   * explicitly. It does not imply that the listener is enabled or bound; callers still decide when
+   * to create and start the server based on configuration and lifecycle state.
    */
   public static final int DEFAULT_FCP_PORT = 9481;
 
-  /* It’s not the field that is deprecated but accessing it directly is. */
+  /* It’s not the field that is deprecated, but accessing it directly is. */
   private final NodeClientCore core;
 
-  /* It’s not the field that is deprecated but accessing it directly is. */
+  /* It’s not the field that is deprecated, but accessing it directly is. */
   private final Node node;
 
   final int port;
 
-  /* It’s not the field that is deprecated but accessing it directly is. */
+  /* It’s not the field that is deprecated, but accessing it directly is. */
   final boolean enabled;
 
   String bindTo;
@@ -72,14 +75,21 @@ public class FCPServer implements Runnable, DownloadCache {
   private final FcpServerPersistentOps persistentOps;
 
   /**
-   * Sentinel value used when building {@link ClientRequest} instances to permit unlimited retry
-   * attempts instead of enforcing a cap.
+   * Sentinel value used when building {@link ClientRequest} instances to permit unlimited retries.
+   *
+   * <p>Passing this constant tells the request pipeline not to enforce a retry cap. It is treated
+   * as a special value by request builders rather than a literal retry count, so callers should not
+   * interpret the value numerically beyond its sentinel meaning.
    */
   public static final int QUEUE_MAX_RETRIES = -1;
 
   /**
    * Upper bound for data sizes in queued requests. The value {@link Long#MAX_VALUE} effectively
    * disables front-end size restrictions while still threading through validation APIs.
+   *
+   * <p>Use this constant when the server layer should enforce no explicit size limit. The request
+   * logic still accepts the value as a legitimate maximum, allowing validation and logging code
+   * paths to treat the setting uniformly.
    */
   public static final long QUEUE_MAX_DATA_SIZE = Long.MAX_VALUE;
 
@@ -91,8 +101,13 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Constructs a server instance from precomputed configuration and dependencies.
    *
-   * @param config immutable configuration values for the FCP server.
-   * @param dependencies node services required by the server.
+   * <p>The constructor copies the immutable configuration fields, initializes the mutable runtime
+   * flags, and wires helper components such as the listener, plugin connection tracker, and
+   * persistence operations. It does not bind sockets or spawn threads; callers must invoke {@link
+   * #maybeStart()} to begin accepting network connections or to activate plugin tracking.
+   *
+   * @param config immutable configuration values used to initialize server state.
+   * @param dependencies node services required to satisfy listener and persistence wiring.
    */
   public FCPServer(FcpServerConfig config, FcpServerDependencies dependencies) {
     this.bindTo = config.bindTo();
@@ -113,26 +128,24 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Constructs a server instance wired to the provided node components and policy flags.
    *
-   * <p>This constructor captures immutable configuration such as the bind address, allow-lists,
-   * port, and persistence roots; runtime toggles only adjust the dedicated mutable fields. It does
-   * not bind sockets or start background threads, so callers must invoke {@link #maybeStart()} to
-   * begin accepting connections.
+   * <p>This convenience overload packages the raw parameters into {@link FcpServerConfig} and
+   * {@link FcpServerDependencies}, then delegates to the primary constructor. It captures immutable
+   * configuration such as the bind address, allowlists, port, and persistence roots; runtime
+   * toggles only adjust the dedicated mutable fields. It does not bind sockets or start background
+   * threads, so callers must invoke {@link #maybeStart()} to begin accepting connections.
    *
-   * @param ipToBindTo textual bind address; use {@code 0.0.0.0} to listen on all interfaces.
-   * @param allowedHosts comma-separated allow-list enforced for standard FCP sockets.
-   * @param allowedHostsFullAccess allow-list used for privileged operations that bypass some
-   *     client-side restrictions.
-   * @param port TCP port number for the FCP listener.
+   * @param ipToBindTo textual bind address; {@code 0.0.0.0} listens on all interfaces.
+   * @param allowedHosts comma-separated allowlist enforced for standard FCP sockets.
+   * @param allowedHostsFullAccess allowlist used for privileged operations that bypass client-side
+   *     restrictions.
+   * @param port TCP port number for the FCP listener, in the host byte order.
    * @param node owning {@link Node} providing executors, plugin management, and lifecycle hooks.
    * @param core node client core exposing persistence, download directories, and cache factories.
-   * @param isEnabled whether networked FCP should start; intra-node plugin communication may still
-   *     be enabled when {@code false}.
-   * @param assumeDDADownloadAllowed flag to treat download DDA as preapproved.
-   * @param assumeDDAUploadAllowed flag to treat upload DDA as preapproved.
-   * @param neverDropAMessage whether outbound queues retain messages rather than dropping when
-   *     limits are reached.
-   * @param maxMessageQueueLength maximum messages buffered per connection before applying
-   *     backpressure.
+   * @param isEnabled whether networked FCP should start; plugin messaging may still operate.
+   * @param assumeDDADownloadAllowed flag to treat download DDA as preapproved globally.
+   * @param assumeDDAUploadAllowed flag to treat upload DDA as preapproved globally.
+   * @param neverDropAMessage whether outbound queues retain messages under backpressure.
+   * @param maxMessageQueueLength maximum messages buffered per connection before applying limits.
    * @param persistentRoot persistence root used to access global clients and caches.
    */
   @SuppressWarnings("java:S107")
@@ -164,10 +177,13 @@ public class FCPServer implements Runnable, DownloadCache {
   }
 
   /**
-   * Rebuilds cached request status for the forever-persistent client prior to serving queries.
+   * Rebuilds cached request status for the forever-persistent client before serving queries.
    *
-   * <p>This call is typically used during node startup so request state is readily available to FCP
-   * clients without requiring additional disk scans.
+   * <p>This call is typically used during node startup, so the request state is readily available
+   * to FCP clients without requiring additional disk scans. The implementation delegates to the
+   * persistence helper, which updates internal caches and prepares lookup state before any network
+   * or plugin clients start querying the queues. It performs no network activity and is safe to
+   * call multiple times, although repeated calls may incur extra disk or database work.
    */
   public void load() {
     persistentOps.load();
@@ -177,20 +193,45 @@ public class FCPServer implements Runnable, DownloadCache {
    * Starts the network listener and plugin connection tracker when configuration allows.
    *
    * <p>If {@link #enabled} is {@code true}, the method binds the configured interface, logs
-   * startup, and launches the accept loop on a daemon thread. When disabled, it skips binding but
+   * startup, and launches the accept-loop on a daemon thread. When disabled, it skips binding but
    * still starts {@link FCPPluginConnectionTracker} so intra-node plugin messaging remains
-   * available. Repeated invocations are safe; only the first call performs initialization.
+   * available. Repeated invocations are safe; only the first call performs initialization. The
+   * method does not block on socket acceptance, so callers can continue startup immediately after
+   * invoking it.
    */
   public void maybeStart() {
     listener.maybeStart();
     pluginConnections.startTrackerIfEnabled();
   }
 
+  /**
+   * Runs the FCP server listener loop on the current thread.
+   *
+   * <p>This method delegates to the listener implementation and typically blocks until the listener
+   * is shut down. It is generally invoked by the daemon thread created in {@link #maybeStart()},
+   * but may also be executed directly in tests or controlled environments. It performs no
+   * scheduling by itself and returns only after the listener stops.
+   */
   @Override
   public void run() {
     listener.run();
   }
 
+  /**
+   * Builds an {@link FCPServer} instance using configuration registered in the provided config.
+   *
+   * <p>This factory wires the FCP-related settings into the {@code fcp} configuration subtree and
+   * constructs the server with immutable values derived from that configuration. It does not start
+   * network listeners; callers still invoke {@link #maybeStart()} at the appropriate lifecycle
+   * point. The returned server is fully wired to the supplied node, client core, and persistence
+   * root, so it can immediately serve plugin-based FCP traffic once started.
+   *
+   * @param node owning node providing executors and plugin services for the server.
+   * @param core client core used for persistence and endpoint access.
+   * @param config configuration registry where the {@code fcp} subsection is registered.
+   * @param root persistence root used to back global request queues.
+   * @return configured server instance ready to be started by the caller.
+   */
   public static FCPServer maybeCreate(
       Node node, NodeClientCore core, Config config, PersistentRequestRoot root) {
     return FcpServerConfigRegistrar.maybeCreate(node, core, config, root);
@@ -199,8 +240,12 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Indicates whether outbound message queues should avoid dropping entries under pressure.
    *
-   * @return {@code true} when messages must be retained even if queues grow large; otherwise drop
-   *     policies may apply.
+   * <p>This is a policy flag that affects how connection handlers apply backpressure. When the
+   * value is {@code true}, handlers prefer retaining queued messages even if the queue grows large,
+   * which may increase memory usage but preserves message ordering and delivery. When {@code
+   * false}, implementations may drop older or lower-priority messages to maintain bounded queues.
+   *
+   * @return {@code true} when messages must be retained even if queues grow large.
    */
   public boolean neverDropAMessage() {
     return neverDropAMessage;
@@ -208,6 +253,10 @@ public class FCPServer implements Runnable, DownloadCache {
 
   /**
    * Returns the maximum number of messages buffered per connection.
+   *
+   * <p>The limit is applied by connection handlers that maintain outbound queues. It represents a
+   * hard cap used for backpressure decisions and is interpreted as a count of messages, not bytes.
+   * Callers can use this value to size buffers or to report the configuration state to clients.
    *
    * @return queue length limit used before enforcing backpressure or drop behavior.
    */
@@ -222,8 +271,8 @@ public class FCPServer implements Runnable, DownloadCache {
    * outside the node and communicates over the TCP listener. It is stored inside {@link
    * FCPPluginConnectionTracker} using a weak reference so callers do not need to explicitly
    * unregister; holding a strong reference keeps the connection alive. When the last strong
-   * reference is dropped, the tracker will automatically recycle the entry and subsequent lookups
-   * via {@link #getPluginConnectionByID(UUID)} will fail.
+   * reference is dropped, the tracker will automatically recycle the entry and later lookups via
+   * {@link #getPluginConnectionByID(UUID)} will fail.
    *
    * @param serverPluginName plugin name that should receive messages on the server side.
    * @param messageHandler handler associated with the network connection driving message flow.
@@ -243,11 +292,16 @@ public class FCPServer implements Runnable, DownloadCache {
    * ClientSideFCPMessageHandler)} to establish a logical FCP link without leaving the process. The
    * connection is inserted into {@link FCPPluginConnectionTracker} and stays reachable as long as
    * the caller keeps a strong reference. To match the client perspective, the returned adapter
-   * defaults the send direction to {@link FCPPluginConnection.SendDirection#TO_SERVER}.
+   * defaults the sending direction to {@link FCPPluginConnection.SendDirection#TO_SERVER}.
    *
-   * @param serverPluginName name of the server-side plugin that will receive the messages.
+   * <p>The method is synchronous and does not perform network I/O; it only consults the plugin
+   * manager and registers the resulting connection. Callers should retain the returned reference
+   * for as long as they intend to receive responses, because once the reference is lost, the
+   * tracker will allow the weakly referenced entry to expire.
+   *
+   * @param serverPluginName name of the server-side plugin that receives incoming messages.
    * @param messageHandler handler on the client-side plugin that processes responses.
-   * @return connection adapter configured for server-directed sends.
+   * @return connection adapter configured for server-directed sendings and tracking.
    * @throws PluginNotFoundException if the target plugin cannot be found or instantiated.
    */
   public final FCPPluginConnection createFCPPluginConnectionForIntraNodeFCP(
@@ -262,12 +316,16 @@ public class FCPServer implements Runnable, DownloadCache {
    *
    * <p>The lookup delegates to {@link FCPPluginConnectionTracker#getConnection(UUID)} and wraps the
    * result so the default send direction points to the client side. The connection must still be
-   * strongly referenced elsewhere; once only weakly reachable it will be absent from the tracker.
+   * strongly referenced elsewhere; once only weakly reachable, it will be absent from the tracker.
+   *
+   * <p>This method performs no network I/O; it resolves metadata from the in-memory tracking state
+   * and returns a lightweight adapter. The returned connection shares the underlying state with the
+   * tracked entry, so callers should treat it as a view rather than a copy.
    *
    * @param connectionID identifier returned when the corresponding connection was created.
-   * @return connection adapted to default-send toward the client side.
-   * @throws IOException if the connection metadata cannot be resolved or underlying state is
-   *     inaccessible.
+   * @return connection adapted to default-sending toward the client side.
+   * @throws IOException if the connection metadata cannot be resolved or the underlying state
+   *     fails.
    */
   public final FCPPluginConnection getPluginConnectionByID(UUID connectionID) throws IOException {
     return pluginConnections.getPluginConnectionByID(connectionID);
@@ -276,9 +334,14 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Registers or replaces a reboot-persistent client associated with the given name.
    *
-   * @param name stable client identifier kept across reconnects.
-   * @param handler active connection handler for the client.
-   * @return existing client after handler replacement, or a newly created client when absent.
+   * <p>The registration updates the reboot queue in memory so that reconnecting clients can resume
+   * in-flight work. If a client already exists for the provided name, the handler is replaced with
+   * the new connection. The method does not start any queued requests; it only updates ownership
+   * and tracking structures managed by the persistence helper.
+   *
+   * @param name stable client identifier kept across reconnections and status queries.
+   * @param handler active connection handler for the client; may be {@code null}.
+   * @return existing client after handler replacement, or a newly created client.
    */
   public PersistentRequestClient registerRebootClient(String name, FCPConnectionHandler handler) {
     return persistentOps.registerRebootClient(name, handler);
@@ -287,9 +350,14 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Registers a forever-persistent client and returns the associated queue owner.
    *
-   * @param name identifier used for persistence and status reporting.
+   * <p>This method ensures that the provided name maps to a forever queue entry, creating it if
+   * needed. The handler may be {@code null} to represent a headless client; in that case, queued
+   * requests remain associated with the name but no active connection is attached. The returned
+   * client object is a live reference to the persistence helper's bookkeeping.
+   *
+   * @param name identifier used for persistence and status reporting across restarts.
    * @param handler current connection handler, or {@code null} when registering headless.
-   * @return client instance tied to the forever queue.
+   * @return client instance tied to the forever queue and its request list.
    */
   public PersistentRequestClient registerForeverClient(String name, FCPConnectionHandler handler) {
     return persistentOps.registerForeverClient(name, handler);
@@ -298,9 +366,13 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Retrieves or creates a forever-persistent client for the provided name and handler.
    *
-   * @param name client name to look up.
+   * <p>If a client already exists for the name, its handler is updated to the supplied value. When
+   * no client exists, a new entry is created and associated with the provided handler. The method
+   * does not start requests; it only ensures that ownership and connection references are current.
+   *
+   * @param name client name to look up, used as the persistent queue identifier.
    * @param handler handler representing the active connection; may be {@code null} when resuming.
-   * @return existing or newly created client.
+   * @return existing or newly created client bound to the forever queue.
    */
   public PersistentRequestClient getForeverClient(String name, FCPConnectionHandler handler) {
     return persistentOps.getForeverClient(name, handler);
@@ -309,8 +381,13 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Unregisters the given persistent client from its queue.
    *
-   * @param client client to remove; reboot clients are removed from the local map, forever clients
-   *     delegate to {@link PersistentRequestRoot} for cleanup.
+   * <p>The behavior depends on the client type. Reboot-persistent clients are removed from the
+   * in-memory map, while forever clients delegate to {@link PersistentRequestRoot} for cleanup and
+   * persistence updates. The method does not cancel running requests; it only removes the client
+   * association from future lookups.
+   *
+   * @param client client to remove; reboot clients are removed locally, forever clients are
+   *     deregistered through persistence.
    */
   public void unregisterClient(PersistentRequestClient client) {
     persistentOps.unregisterClient(client);
@@ -318,6 +395,10 @@ public class FCPServer implements Runnable, DownloadCache {
 
   /**
    * Returns a snapshot of global persistent requests across reboot and forever queues.
+   *
+   * <p>The returned array is a point-in-time view for status reporting. It may include entries from
+   * both persistence classes, and callers should not mutate the returned objects. If persistence is
+   * unavailable, the method throws, allowing callers to surface the error to clients.
    *
    * @return array of request status entries; never {@code null}.
    * @throws PersistenceDisabledException if persistence is unavailable while reading status.
@@ -329,9 +410,13 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Removes a single global request by identifier, blocking until the operation completes.
    *
-   * @param identifier identifier of the request to remove.
-   * @return {@code true} if the request existed and removal was attempted; {@code false} if no
-   *     matching request was found.
+   * <p>The method consults both reboot and forever queues and attempts to remove a matching
+   * request. The call blocks until the persistence layer finishes processing the removal so that
+   * callers can report accurate status to clients. When no request matches the identifier, no
+   * removal work is attempted.
+   *
+   * @param identifier identifier of the request to remove, as stored in persistence.
+   * @return {@code true} if the request existed and removal was attempted.
    * @throws PersistenceDisabledException if persistence is disabled during removal.
    */
   @SuppressWarnings("UnusedReturnValue")
@@ -343,8 +428,11 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Removes all global requests, blocking until the forever queue has been cleared.
    *
-   * @return {@code true} if both reboot and forever queues were cleared successfully; {@code false}
-   *     otherwise.
+   * <p>This call clears both reboot and forever queues and blocks until persistence has completed
+   * the operation. It provides a synchronous way for admin or testing clients to reset the global
+   * request state. Errors in persistence are surfaced through {@link PersistenceDisabledException}.
+   *
+   * @return {@code true} if both reboot and forever queues were cleared successfully.
    * @throws PersistenceDisabledException if persistence is unavailable during removal.
    */
   @SuppressWarnings("unused")
@@ -361,7 +449,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * downloadsDir} with collision avoidance. Real-time and filtering flags are forwarded unchanged
    * to the underlying {@link ClientGet}.
    *
-   * @param params request parameters describing the fetch.
+   * @param params request parameters describing the fetch, return mode, and persistence class.
    * @throws NotAllowedException if policy or security checks reject the request.
    * @throws IOException if preparing disk output fails.
    * @throws PersistenceDisabledException if persistence layers are not available.
@@ -371,6 +459,25 @@ public class FCPServer implements Runnable, DownloadCache {
     persistentOps.makePersistentGlobalRequestBlocking(params);
   }
 
+  /**
+   * Enqueues a global persistent fetch using explicit parameter values and blocks for registration.
+   *
+   * <p>This overload mirrors the structured parameter version but exposes the raw fields used by
+   * FCP clients. It validates the persistence and return type strings, resolves the downloads
+   * directory for disk outputs, and ensures the request is registered before returning. The method
+   * does not wait for the fetch to complete; it only waits for the request to be safely enqueued.
+   *
+   * @param fetchURI URI representing the resource to fetch from the network.
+   * @param filterData whether content should be filtered prior to delivery.
+   * @param expectedMimeType MIME hint used when choosing output filenames; may be {@code null}.
+   * @param persistenceTypeString persistence mode string such as {@code reboot} or {@code forever}.
+   * @param returnTypeString return handling string such as {@code disk} or {@code direct}.
+   * @param realTimeFlag whether to mark the request as real-time for scheduling.
+   * @param downloadsDir directory used for disk outputs when the return type is disk.
+   * @throws NotAllowedException if policy or security checks reject the request.
+   * @throws IOException if preparing disk output fails or directory validation fails.
+   * @throws PersistenceDisabledException if persistence layers are not available.
+   */
   @SuppressWarnings("unused")
   public void makePersistentGlobalRequestBlocking(
       FreenetURI fetchURI,
@@ -394,11 +501,14 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Updates the token and priority of a global request, blocking until the change is applied.
    *
+   * <p>The method locates the request by identifier and updates its metadata in the persistence
+   * layer. It blocks until the update has been committed so callers can report success reliably. If
+   * no matching request exists, no update is performed and the method returns {@code false}.
+   *
    * @param identifier request identifier to modify; must correspond to an existing request.
-   * @param newToken replacement token value stored with the request.
+   * @param newToken replacement token value stored with the request for reporting.
    * @param newPriority updated priority class; larger values typically move the request sooner.
-   * @return {@code true} if the request existed and an update path executed; {@code false}
-   *     otherwise.
+   * @return {@code true} if the request existed and an update path executed.
    * @throws PersistenceDisabledException if persistence is unavailable while attempting the update.
    */
   @SuppressWarnings("UnusedReturnValue")
@@ -411,7 +521,11 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Creates a persistent globally queued fetch request with explicit return handling.
    *
-   * @param params request parameters describing the persistent fetch.
+   * <p>The request is created asynchronously and added to the appropriate persistence queue. This
+   * method does not block for completion; it only schedules the work. Disk return types will create
+   * output files under the configured downloads directory when the request completes.
+   *
+   * @param params request parameters describing the persistent fetch and return handling.
    * @throws NotAllowedException if local policy forbids creating the request.
    * @throws IOException if disk output setup fails or the downloads directory is invalid.
    */
@@ -426,13 +540,15 @@ public class FCPServer implements Runnable, DownloadCache {
    *
    * <p>All parameters mirror {@link #makePersistentGlobalRequest(PersistentGlobalRequestParams)},
    * substituting {@link NodeClientCore#getDownloadsDir()} for the target directory. The request is
-   * created synchronously but does not block on completion.
+   * created synchronously but does not block on completion. This method is suitable for callers
+   * that rely on the node's configured downloads directory and do not require fine-grained output
+   * path selection.
    *
    * @param fetchURI URI to fetch from the network.
    * @param filterData whether content should be filtered prior to delivery.
-   * @param expectedMimeType MIME hint used when choosing output filenames.
-   * @param persistenceTypeString persistence mode string (e.g., {@code reboot} or {@code forever}).
-   * @param returnTypeString return handling string (e.g., {@code disk} or {@code direct}).
+   * @param expectedMimeType MIME hint used when choosing output filenames; may be {@code null}.
+   * @param persistenceTypeString persistence mode string such as {@code reboot} or {@code forever}.
+   * @param returnTypeString return handling string such as {@code disk} or {@code direct}.
    * @param realTimeFlag whether to mark the request as real-time.
    * @throws NotAllowedException if download permissions deny the request.
    * @throws IOException if disk preparation fails while resolving the downloads directory.
@@ -463,6 +579,8 @@ public class FCPServer implements Runnable, DownloadCache {
    * #QUEUE_MAX_DATA_SIZE}, and registers the resulting {@link ClientGet} on the appropriate
    * persistent client. Disk return types derive filenames from {@link
    * FreenetURI#getPreferredFilename} while deduplicating existing files in {@code downloadsDir}.
+   * This overload allows callers to select a custom downloads directory while retaining the
+   * server's default queue behavior.
    *
    * @param fetchURI URI representing the resource to fetch.
    * @param filterData whether to filter the fetched data before exposure to the client.
@@ -471,7 +589,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @param persistenceTypeString string describing the persistence policy; {@code reboot} limits to
    *     reboot persistence while other values select forever persistence.
    * @param returnTypeString string describing where the result should be delivered, mapped to
-   *     {@link ReturnType} values.
+   *     {@code ReturnType} values.
    * @param realTimeFlag whether to request real-time handling of the fetch.
    * @param downloadsDir directory where disk results are stored when {@code returnTypeString}
    *     resolves to disk output.
@@ -501,6 +619,11 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Returns the forever-persistent global client used by this server instance.
    *
+   * <p>The returned client represents the global forever queue and may be {@code null} if
+   * persistence is disabled or not initialized. Callers should treat the reference as read-only and
+   * avoid storing it beyond the lifecycle of the owning server, because the persistence subsystem
+   * may replace or tear down the client during shutdown.
+   *
    * @return client reference for the forever queue; may be {@code null} when persistence is
    *     disabled.
    */
@@ -511,7 +634,12 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Retrieves a global request by identifier from either persistence class.
    *
-   * @param identifier request identifier to search for.
+   * <p>The lookup checks both reboot and forever queues and returns the first matching request
+   * found. The method does not trigger any network activity or state transitions; it only returns a
+   * reference to the tracked request if present. The returned request should be treated as a
+   * mutable state owned by the persistence layer.
+   *
+   * @param identifier request identifier to search for, as stored in persistence.
    * @return matching request from the reboot or forever queue, or {@code null} if none exist.
    */
   public ClientRequest getGlobalRequest(String identifier) {
@@ -520,6 +648,11 @@ public class FCPServer implements Runnable, DownloadCache {
 
   /**
    * Indicates whether download DDA permissions are assumed to be granted globally.
+   *
+   * <p>This flag influences whether the server asks for explicit DDA permissions before allowing
+   * direct directory access for downloads. It does not bypass any per-request security checks
+   * beyond the global policy setting. Callers should read this value to determine the default
+   * behavior for new requests.
    *
    * @return {@code true} if downloads are treated as preauthorized for direct directory access.
    */
@@ -530,6 +663,11 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Indicates whether upload DDA permissions are assumed to be granted globally.
    *
+   * <p>This flag informs the server's decision on whether to prompt or enforce explicit DDA
+   * permission checks for upload operations. It does not grant access by itself; it only controls
+   * the default assumption used by request setup. Clients should still validate the effective
+   * permissions for each request.
+   *
    * @return {@code true} if uploads are treated as preauthorized for direct directory access.
    */
   protected boolean isUploadDDAAlwaysAllowed() {
@@ -538,6 +676,11 @@ public class FCPServer implements Runnable, DownloadCache {
 
   /**
    * Registers a completion callback that will be invoked when persistent requests finish.
+   *
+   * <p>The callback is stored in the persistence helper and invoked when requests transition into
+   * terminal states. It may be called from worker threads associated with the persistence job
+   * runner, so implementations should be thread-safe and avoid blocking. Passing {@code null}
+   * clears any previously registered callback.
    *
    * @param cb callback to notify on completion events for both reboot and forever queues.
    */
@@ -553,7 +696,12 @@ public class FCPServer implements Runnable, DownloadCache {
    * via a latch to ensure registration succeeded before returning. Collisions are propagated to
    * callers so they can pick a new identifier.
    *
-   * @param req request to start; must already be fully configured and not yet registered.
+   * <p>The request must already be fully configured. For reboot-persistent requests, the start
+   * occurs on the caller's thread; forever-persistent requests are enqueued to the persistence job
+   * runner and awaited with a latch. The method throws if the identifier collides with an existing
+   * request or if persistence is disabled.
+   *
+   * @param req request to start; must already be configured and not yet registered.
    * @throws IdentifierCollisionException if another request with the same identifier exists.
    * @throws PersistenceDisabledException if persistence is unavailable while registering the
    *     request.
@@ -566,11 +714,14 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Restarts a global request identified by {@code identifier}, blocking until restart dispatches.
    *
-   * @param identifier request identifier to restart.
-   * @param disableFilterData when {@code true}, restarts the request without data filtering even if
-   *     the original requested filtering.
-   * @return {@code true} if a matching request was found and restart attempted; {@code false}
-   *     otherwise.
+   * <p>This method locates the request in either persistence queue and schedules a restart. When
+   * {@code disableFilterData} is {@code true}, the restarted request disables filtering even if the
+   * original request requested it. The method blocks until the restart is queued and reports
+   * whether a matching request was found.
+   *
+   * @param identifier request identifier to restart, as stored in persistence.
+   * @param disableFilterData when {@code true}, restarts the request without data filtering.
+   * @return {@code true} if a matching request was found and restart attempted.
    * @throws PersistenceDisabledException if persistence is unavailable during restart.
    */
   @SuppressWarnings("UnusedReturnValue")
@@ -586,7 +737,11 @@ public class FCPServer implements Runnable, DownloadCache {
    * and finally schedules a lookup job when data is not immediately present. Buckets returned to
    * callers are wrapped to avoid premature freeing.
    *
-   * @param key key originally requested by the client.
+   * <p>The lookup checks reboot completions, then forever-queue shadow buckets, and finally
+   * enqueues a lookup job if the data is not immediately present. Returned buckets are wrapped to
+   * prevent premature freeing while the caller inspects them.
+   *
+   * @param key key originally requested by the client, used as the lookup identifier.
    * @return fetch result containing metadata and data buckets, or {@code null} if not found.
    * @throws PersistenceDisabledException if persistence access fails during lookup.
    */
@@ -604,8 +759,13 @@ public class FCPServer implements Runnable, DownloadCache {
    * setting {@code mustCopy} to {@code false}. When copying is requested, data is duplicated into
    * the preferred bucket if supplied.
    *
-   * @param key key associated with the original request.
-   * @param noFilter {@code true} to bypass filtering guardrails and return raw data when available.
+   * <p>The method inspects completed reboot-persistent requests first, then consults the forever
+   * queue's shadow cache. Callers may request filtered or raw data and choose zero-copy access by
+   * setting {@code mustCopy} to {@code false}. When copying is requested, data is duplicated into
+   * the preferred bucket if supplied.
+   *
+   * @param key key associated with the original request, used for lookup.
+   * @param noFilter {@code true} to bypass filtering guardrails and return raw data.
    * @param mustCopy {@code true} to force a defensive copy of the data before returning.
    * @param preferred optional preallocated bucket used as the copy target.
    * @return cache fetch result when present; {@code null} if no completed request is available.
@@ -619,12 +779,16 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Performs a cache lookup scoped to the forever queue, optionally copying results.
    *
-   * @param key key originally requested by the client.
+   * <p>The lookup is restricted to the forever persistence queue and does not consult the reboot
+   * state. When {@code mustCopy} is {@code true}, the data is cloned into the preferred bucket if
+   * provided, or into a new temporary bucket otherwise. The {@code context} parameter is currently
+   * passed through for compatibility with the cache interface.
+   *
+   * @param key key originally requested by the client, used for lookup.
    * @param noFilter {@code true} to request unfiltered data even when stored as filtered.
-   * @param context client context used to resolve shadow buckets; currently unused directly.
+   * @param context client context used to resolve shadow buckets; not directly mutated.
    * @param mustCopy {@code true} to force cloning data into a separate bucket before returning.
-   * @param preferred optional bucket to reuse for copies; otherwise a new temporary bucket is
-   *     created.
+   * @param preferred optional bucket to reuse for copies; otherwise a new temporary bucket.
    * @return cache result when data exists in the forever queue; {@code null} otherwise.
    */
   @Override
@@ -636,6 +800,11 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Exposes the backing {@link NodeClientCore} for callers needing lower-level services.
    *
+   * <p>The returned reference is the same instance supplied at construction time. Callers should
+   * avoid mutating shared state on the core directly unless they own the broader node lifecycle. It
+   * is intended for subsystems that need access to shared services such as downloads directories or
+   * persistent storage.
+   *
    * @return node client core instance used by this server.
    */
   public NodeClientCore getCore() {
@@ -644,6 +813,10 @@ public class FCPServer implements Runnable, DownloadCache {
 
   /**
    * Returns the owning {@link Node} instance.
+   *
+   * <p>The owning node provides executors, configuration, and lifecycle coordination. The returned
+   * reference is the same instance passed to the constructor and should be treated as a shared
+   * mutable state. Callers should avoid long-lived synchronization on the node object.
    *
    * @return node that created and manages this server.
    */
@@ -662,6 +835,10 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Reports whether the FCP network listener is configured to start.
    *
+   * <p>This flag reflects the configuration value captured at construction time. It does not
+   * indicate whether the listener has actually been started, only whether it is configured to do so
+   * when {@link #maybeStart()} is invoked.
+   *
    * @return {@code true} when networked FCP is enabled in configuration.
    */
   public boolean isEnabled() {
@@ -670,6 +847,10 @@ public class FCPServer implements Runnable, DownloadCache {
 
   /**
    * Returns the reboot-persistent global client used by this server instance.
+   *
+   * <p>The returned client represents the reboot queue and is always present when persistence is
+   * enabled. Callers should treat the reference as read-only and avoid persisting it beyond the
+   * server's lifecycle, because the persistence helper owns its management.
    *
    * @return client reference for the reboot queue.
    */

--- a/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
@@ -1,0 +1,364 @@
+package network.crypta.clients.fcp;
+
+import java.util.Arrays;
+import network.crypta.config.Config;
+import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
+import network.crypta.config.SubConfig;
+import network.crypta.crypt.SSL;
+import network.crypta.io.NetworkInterface;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.api.BooleanCallback;
+import network.crypta.support.api.IntCallback;
+import network.crypta.support.api.StringCallback;
+
+final class FcpServerConfigRegistrar {
+  private FcpServerConfigRegistrar() {}
+
+  static FCPServer maybeCreate(
+      Node node, NodeClientCore core, Config config, PersistentRequestRoot root) {
+    SubConfig fcpConfig = config.createSubConfig("fcp");
+    short sortOrder = 0;
+    fcpConfig.register(
+        "enabled",
+        true,
+        new Option.Meta(sortOrder++, true, false, "FcpServer.isEnabled", "FcpServer.isEnabledLong"),
+        new FCPEnabledCallback(core));
+    fcpConfig.register(
+        "ssl",
+        false,
+        new Option.Meta(sortOrder++, true, true, "FcpServer.ssl", "FcpServer.sslLong"),
+        new FCPSSLCallback());
+    fcpConfig.register(
+        "port",
+        FCPServer.DEFAULT_FCP_PORT /* anagram of 1984, and 1000 up from old number */,
+        new Option.Meta(2, true, true, "FcpServer.portNumber", "FcpServer.portNumberLong"),
+        new FCPPortNumberCallback(core),
+        false);
+    fcpConfig.register(
+        "bindTo",
+        NetworkInterface.DEFAULT_BIND_TO,
+        new Option.Meta(sortOrder++, true, true, "FcpServer.bindTo", "FcpServer.bindToLong"),
+        new FCPBindtoCallback(core));
+    fcpConfig.register(
+        "allowedHosts",
+        NetworkInterface.DEFAULT_BIND_TO,
+        new Option.Meta(
+            sortOrder++, true, true, "FcpServer.allowedHosts", "FcpServer.allowedHostsLong"),
+        new FCPAllowedHostsCallback(core));
+    fcpConfig.register(
+        "allowedHostsFullAccess",
+        NetworkInterface.DEFAULT_BIND_TO,
+        new Option.Meta(
+            sortOrder++,
+            true,
+            true,
+            "FcpServer.allowedHostsFullAccess",
+            "FcpServer.allowedHostsFullAccessLong"),
+        new FCPAllowedHostsFullAccessCallback(core));
+
+    AssumeDDADownloadIsAllowedCallback cb4 = new AssumeDDADownloadIsAllowedCallback();
+    AssumeDDAUploadIsAllowedCallback cb5 = new AssumeDDAUploadIsAllowedCallback();
+    NeverDropAMessageCallback cb6 = new NeverDropAMessageCallback();
+    MaxMessageQueueLengthCallback cb7 = new MaxMessageQueueLengthCallback();
+    fcpConfig.register(
+        "assumeDownloadDDAIsAllowed",
+        false,
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "FcpServer.assumeDownloadDDAIsAllowed",
+            "FcpServer.assumeDownloadDDAIsAllowedLong"),
+        cb4);
+    fcpConfig.register(
+        "assumeUploadDDAIsAllowed",
+        false,
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "FcpServer.assumeUploadDDAIsAllowed",
+            "FcpServer.assumeUploadDDAIsAllowedLong"),
+        cb5);
+    fcpConfig.register(
+        "maxMessageQueueLength",
+        1024,
+        new Option.Meta(
+            sortOrder++,
+            true,
+            false,
+            "FcpServer.maxMessageQueueLength",
+            "FcpServer.maxMessageQueueLengthLong"),
+        cb7,
+        false);
+    fcpConfig.register(
+        "neverDropAMessage",
+        false,
+        new Option.Meta(
+            sortOrder,
+            true,
+            false,
+            "FcpServer.neverDropAMessage",
+            "FcpServer.neverDropAMessageLong"),
+        cb6);
+
+    if (SSL.available()) {
+      FcpServerListener.setSslEnabled(fcpConfig.getBoolean("ssl"));
+    }
+
+    FcpServerConfig serverConfig =
+        new FcpServerConfig(
+            fcpConfig.getString("bindTo"),
+            fcpConfig.getString("allowedHosts"),
+            fcpConfig.getString("allowedHostsFullAccess"),
+            fcpConfig.getInt("port"),
+            fcpConfig.getBoolean("enabled"),
+            fcpConfig.getBoolean("assumeDownloadDDAIsAllowed"),
+            fcpConfig.getBoolean("assumeUploadDDAIsAllowed"),
+            fcpConfig.getBoolean("neverDropAMessage"),
+            fcpConfig.getInt("maxMessageQueueLength"));
+    FcpServerDependencies dependencies = new FcpServerDependencies(node, core, root);
+    FCPServer fcp = new FCPServer(serverConfig, dependencies);
+
+    cb4.server = fcp;
+    cb5.server = fcp;
+    cb6.server = fcp;
+    cb7.server = fcp;
+
+    fcpConfig.finishedInitialization();
+    return fcp;
+  }
+
+  static class FCPPortNumberCallback extends IntCallback {
+
+    private final NodeClientCore node;
+
+    FCPPortNumberCallback(NodeClientCore node) {
+      this.node = node;
+    }
+
+    @Override
+    public Integer get() {
+      return node.getEndpoints().getFCPServer().port;
+    }
+
+    @Override
+    public void set(Integer val) throws InvalidConfigValueException {
+      if (!get().equals(val)) {
+        throw new InvalidConfigValueException("Cannot change FCP port number on the fly");
+      }
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return true;
+    }
+  }
+
+  static class FCPEnabledCallback extends BooleanCallback {
+
+    final NodeClientCore node;
+
+    FCPEnabledCallback(NodeClientCore node) {
+      this.node = node;
+    }
+
+    @Override
+    public Boolean get() {
+      return node.getEndpoints().getFCPServer().enabled;
+    }
+
+    @Override
+    public void set(Boolean val) throws InvalidConfigValueException {
+      if (!get().equals(val)) {
+        throw new InvalidConfigValueException(
+            NodeL10n.getBase().getString("FcpServer.cannotStartOrStopOnTheFly"));
+      }
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return true;
+    }
+  }
+
+  static class FCPSSLCallback extends BooleanCallback {
+
+    private static void updateSslFlag(boolean val) throws InvalidConfigValueException {
+      if (FcpServerListener.isSslEnabled() == val) {
+        return;
+      }
+      if (!SSL.available()) {
+        throw new InvalidConfigValueException("Enable SSL support before use ssl with FCP");
+      }
+      FcpServerListener.setSslEnabled(val);
+      throw new InvalidConfigValueException("Cannot change SSL on the fly, please restart freenet");
+    }
+
+    @Override
+    public Boolean get() {
+      return FcpServerListener.isSslEnabled();
+    }
+
+    @Override
+    public void set(Boolean val) throws InvalidConfigValueException {
+      updateSslFlag(val);
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return true;
+    }
+  }
+
+  static class FCPBindtoCallback extends StringCallback {
+
+    final NodeClientCore node;
+
+    FCPBindtoCallback(NodeClientCore node) {
+      this.node = node;
+    }
+
+    @Override
+    public String get() {
+      return node.getEndpoints().getFCPServer().bindTo;
+    }
+
+    @Override
+    public void set(String val) throws InvalidConfigValueException {
+      String oldValue = get();
+      if (!val.equals(oldValue)) {
+        FCPServer server = node.getEndpoints().getFCPServer();
+
+        String[] failedAddresses = server.listener().setBindTo(val, true);
+        if (failedAddresses != null) {
+          server.listener().setBindTo(oldValue, true);
+          throw new InvalidConfigValueException(
+              NodeL10n.getBase()
+                  .getString(
+                      "FcpServer.couldNotChangeBindTo",
+                      "failedInterfaces",
+                      Arrays.toString(failedAddresses)));
+        }
+
+        server.listener().setBindTo(val, true);
+        server.listener().updateBindTo(val);
+        server.bindTo = val;
+      }
+    }
+  }
+
+  static class FCPAllowedHostsCallback extends StringCallback {
+
+    private final NodeClientCore node;
+
+    public FCPAllowedHostsCallback(NodeClientCore node) {
+      this.node = node;
+    }
+
+    @Override
+    public String get() {
+      FCPServer server = node.getEndpoints().getFCPServer();
+      if (server == null) return NetworkInterface.DEFAULT_BIND_TO;
+      return server.listener().getAllowedHosts();
+    }
+
+    @Override
+    public void set(String val) throws InvalidConfigValueException {
+      if (!val.equals(get())) {
+        try {
+          node.getEndpoints().getFCPServer().listener().setAllowedHosts(val);
+        } catch (IllegalArgumentException e) {
+          throw new InvalidConfigValueException(e);
+        }
+      }
+    }
+  }
+
+  static class FCPAllowedHostsFullAccessCallback extends StringCallback {
+    private final NodeClientCore node;
+
+    public FCPAllowedHostsFullAccessCallback(NodeClientCore node) {
+      this.node = node;
+    }
+
+    @Override
+    public String get() {
+      return node.getEndpoints().getFCPServer().getAllowedHostsFullAccess().getAllowedHosts();
+    }
+
+    @Override
+    public void set(String val) throws InvalidConfigValueException {
+      if (!val.equals(get())) {
+        try {
+          node.getEndpoints().getFCPServer().getAllowedHostsFullAccess().setAllowedHosts(val);
+        } catch (IllegalArgumentException e) {
+          throw new InvalidConfigValueException(e);
+        }
+      }
+    }
+  }
+
+  static class AssumeDDADownloadIsAllowedCallback extends BooleanCallback {
+    FCPServer server;
+
+    @Override
+    public Boolean get() {
+      return server.assumeDownloadDDAIsAllowed;
+    }
+
+    @Override
+    public void set(Boolean val) throws InvalidConfigValueException {
+      if (get().equals(val)) return;
+      server.assumeDownloadDDAIsAllowed = val;
+    }
+  }
+
+  static class AssumeDDAUploadIsAllowedCallback extends BooleanCallback {
+    FCPServer server;
+
+    @Override
+    public Boolean get() {
+      return server.assumeUploadDDAIsAllowed;
+    }
+
+    @Override
+    public void set(Boolean val) throws InvalidConfigValueException {
+      if (get().equals(val)) return;
+      server.assumeUploadDDAIsAllowed = val;
+    }
+  }
+
+  static class NeverDropAMessageCallback extends BooleanCallback {
+    FCPServer server;
+
+    @Override
+    public Boolean get() {
+      return server.neverDropAMessage;
+    }
+
+    @Override
+    public void set(Boolean val) throws InvalidConfigValueException {
+      if (get().equals(val)) return;
+      server.neverDropAMessage = val;
+    }
+  }
+
+  static class MaxMessageQueueLengthCallback extends IntCallback {
+    FCPServer server;
+
+    @Override
+    public Integer get() {
+      return server.maxMessageQueueLength;
+    }
+
+    @Override
+    public void set(Integer val) throws InvalidConfigValueException {
+      if (get().equals(val)) return;
+      server.maxMessageQueueLength = val;
+    }
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
@@ -14,9 +14,55 @@ import network.crypta.support.api.BooleanCallback;
 import network.crypta.support.api.IntCallback;
 import network.crypta.support.api.StringCallback;
 
+/**
+ * Registers FCP server configuration options and constructs a configured {@link FCPServer}.
+ *
+ * <p>This helper centralizes the wiring between the {@code fcp} {@link SubConfig} and the runtime
+ * components that back the FCP listener and request lifecycle. It installs callbacks for mutable
+ * configuration values (such as bind address and allowed hosts), preserves the immutable defaults
+ * captured in {@link FcpServerConfig}, and creates the server instance that other subsystems use.
+ * The method is typically invoked during node startup or endpoint initialization and is expected to
+ * run once per process. It performs no network binding or background thread creation; callers still
+ * invoke {@link FCPServer#maybeStart()} to begin accepting connections.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Registering the {@code fcp} option set with deterministic ordering and defaults.
+ *   <li>Binding config callbacks that guard runtime changes and apply validation.
+ *   <li>Building the {@link FCPServer} with dependencies from the owning {@link Node}.
+ * </ul>
+ *
+ * @see FCPServer
+ * @see FcpServerConfig
+ * @see FcpServerListener
+ */
 final class FcpServerConfigRegistrar {
+  /** Creates a registrar utility; instances are not used. */
   private FcpServerConfigRegistrar() {}
 
+  /**
+   * Registers the FCP sub-configuration and returns a fully wired {@link FCPServer} instance.
+   *
+   * <p>The method creates (or retrieves) a {@link SubConfig} named {@code fcp}, registers all FCP
+   * options with their defaults, and attaches callbacks that enforce non-mutable fields such as the
+   * port and SSL toggle. If SSL support is available, the persisted SSL value is applied to the
+   * listener state; otherwise the setting remains disabled until restart. After building the {@link
+   * FcpServerConfig} and dependency container, the returned server is created and the config is
+   * marked initialized so later user changes trigger callbacks.
+   *
+   * <pre>{@code
+   * Config config = new Config();
+   * FCPServer server = FcpServerConfigRegistrar.maybeCreate(node, core, config, root);
+   * server.maybeStart();
+   * }</pre>
+   *
+   * @param node owning node providing executors and plugin services for the server.
+   * @param core client core used for endpoint access and persisted settings lookups.
+   * @param config root configuration registry where the {@code fcp} subsection is registered.
+   * @param root persistent request root used to wire global request queues.
+   * @return configured {@link FCPServer} instance ready for {@link FCPServer#maybeStart()}.
+   */
   static FCPServer maybeCreate(
       Node node, NodeClientCore core, Config config, PersistentRequestRoot root) {
     SubConfig fcpConfig = config.createSubConfig("fcp");
@@ -33,7 +79,7 @@ final class FcpServerConfigRegistrar {
         new FCPSSLCallback());
     fcpConfig.register(
         "port",
-        FCPServer.DEFAULT_FCP_PORT /* anagram of 1984, and 1000 up from old number */,
+        FCPServer.DEFAULT_FCP_PORT /* anagram of 1984, and 1000 up from the old number */,
         new Option.Meta(2, true, true, "FcpServer.portNumber", "FcpServer.portNumberLong"),
         new FCPPortNumberCallback(core),
         false);
@@ -132,10 +178,17 @@ final class FcpServerConfigRegistrar {
     return fcp;
   }
 
+  /** Callback that exposes the read-only FCP port configuration. */
   static class FCPPortNumberCallback extends IntCallback {
 
+    /** Node core used to access the active endpoint configuration. */
     private final NodeClientCore node;
 
+    /**
+     * Creates a callback bound to the provided node client core.
+     *
+     * @param node client core supplying the current endpoint configuration.
+     */
     FCPPortNumberCallback(NodeClientCore node) {
       this.node = node;
     }
@@ -158,10 +211,17 @@ final class FcpServerConfigRegistrar {
     }
   }
 
+  /** Callback that exposes the read-only enabled flag for networked FCP. */
   static class FCPEnabledCallback extends BooleanCallback {
 
+    /** Node core used to access the endpoint state for the enabled flag. */
     final NodeClientCore node;
 
+    /**
+     * Creates a callback bound to the provided node client core.
+     *
+     * @param node client core supplying the current endpoint configuration.
+     */
     FCPEnabledCallback(NodeClientCore node) {
       this.node = node;
     }
@@ -185,8 +245,18 @@ final class FcpServerConfigRegistrar {
     }
   }
 
+  /** Callback that reports and guards the SSL enablement flag for FCP. */
   static class FCPSSLCallback extends BooleanCallback {
 
+    /** Creates a callback instance for SSL configuration handling. */
+    FCPSSLCallback() {}
+
+    /**
+     * Updates the SSL flag when available and refuses runtime changes.
+     *
+     * @param val desired SSL enablement state for the listener.
+     * @throws InvalidConfigValueException when SSL is unavailable or a restart is required.
+     */
     private static void updateSslFlag(boolean val) throws InvalidConfigValueException {
       if (FcpServerListener.isSslEnabled() == val) {
         return;
@@ -214,10 +284,17 @@ final class FcpServerConfigRegistrar {
     }
   }
 
+  /** Callback that exposes the bind address and updates the listener when modified. */
   static class FCPBindtoCallback extends StringCallback {
 
+    /** Node core used to resolve the active FCP server instance. */
     final NodeClientCore node;
 
+    /**
+     * Creates a callback bound to the provided node client core.
+     *
+     * @param node client core supplying the current endpoint configuration.
+     */
     FCPBindtoCallback(NodeClientCore node) {
       this.node = node;
     }
@@ -251,10 +328,17 @@ final class FcpServerConfigRegistrar {
     }
   }
 
+  /** Callback that reads or updates the allowed-hosts list for the FCP listener. */
   static class FCPAllowedHostsCallback extends StringCallback {
 
+    /** Node core used to resolve the active FCP server instance. */
     private final NodeClientCore node;
 
+    /**
+     * Creates a callback bound to the provided node client core.
+     *
+     * @param node client core supplying the current endpoint configuration.
+     */
     public FCPAllowedHostsCallback(NodeClientCore node) {
       this.node = node;
     }
@@ -278,9 +362,16 @@ final class FcpServerConfigRegistrar {
     }
   }
 
+  /** Callback that manages the full-access allowlist for privileged operations. */
   static class FCPAllowedHostsFullAccessCallback extends StringCallback {
+    /** Node core used to resolve the active FCP server instance. */
     private final NodeClientCore node;
 
+    /**
+     * Creates a callback bound to the provided node client core.
+     *
+     * @param node client core supplying the current endpoint configuration.
+     */
     public FCPAllowedHostsFullAccessCallback(NodeClientCore node) {
       this.node = node;
     }
@@ -302,8 +393,13 @@ final class FcpServerConfigRegistrar {
     }
   }
 
+  /** Callback that toggles whether download DDA is treated as pre-approved. */
   static class AssumeDDADownloadIsAllowedCallback extends BooleanCallback {
+    /** Server instance that owns the download DDA policy flag. */
     FCPServer server;
+
+    /** Creates a callback instance for download DDA defaults. */
+    AssumeDDADownloadIsAllowedCallback() {}
 
     @Override
     public Boolean get() {
@@ -317,8 +413,13 @@ final class FcpServerConfigRegistrar {
     }
   }
 
+  /** Callback that toggles whether upload DDA is treated as pre-approved. */
   static class AssumeDDAUploadIsAllowedCallback extends BooleanCallback {
+    /** Server instance that owns the upload DDA policy flag. */
     FCPServer server;
+
+    /** Creates a callback instance for upload DDA defaults. */
+    AssumeDDAUploadIsAllowedCallback() {}
 
     @Override
     public Boolean get() {
@@ -332,8 +433,13 @@ final class FcpServerConfigRegistrar {
     }
   }
 
+  /** Callback that controls whether outbound message queues may drop entries. */
   static class NeverDropAMessageCallback extends BooleanCallback {
+    /** Server instance that owns the queue retention flag. */
     FCPServer server;
+
+    /** Creates a callback instance for queue retention defaults. */
+    NeverDropAMessageCallback() {}
 
     @Override
     public Boolean get() {
@@ -347,8 +453,13 @@ final class FcpServerConfigRegistrar {
     }
   }
 
+  /** Callback that exposes the maximum number of messages queued per connection. */
   static class MaxMessageQueueLengthCallback extends IntCallback {
+    /** Server instance that owns the queue length limit. */
     FCPServer server;
+
+    /** Creates a callback instance for queue length defaults. */
+    MaxMessageQueueLengthCallback() {}
 
     @Override
     public Integer get() {

--- a/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
@@ -1,0 +1,110 @@
+package network.crypta.clients.fcp;
+
+import java.net.Socket;
+import network.crypta.io.NetworkInterface;
+import network.crypta.io.SSLNetworkInterface;
+import network.crypta.node.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tanukisoftware.wrapper.WrapperManager;
+
+final class FcpServerListener implements Runnable {
+  private static final Logger LOG = LoggerFactory.getLogger(FcpServerListener.class);
+
+  private static boolean ssl = false;
+
+  private final FCPServer server;
+  private final Node node;
+  private final int port;
+  private final boolean enabled;
+  private final String allowedHosts;
+  private String bindTo;
+  private NetworkInterface networkInterface;
+
+  FcpServerListener(FCPServer server, Node node, FcpServerConfig config) {
+    this.server = server;
+    this.node = node;
+    this.port = config.port();
+    this.enabled = config.enabled();
+    this.allowedHosts = config.allowedHosts();
+    this.bindTo = config.bindTo();
+  }
+
+  static boolean isSslEnabled() {
+    return ssl;
+  }
+
+  static void setSslEnabled(boolean enabled) {
+    ssl = enabled;
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  String[] setBindTo(String value, boolean update) {
+    return networkInterface.setBindTo(value, update);
+  }
+
+  void updateBindTo(String value) {
+    this.bindTo = value;
+  }
+
+  String getAllowedHosts() {
+    NetworkInterface netIface = networkInterface;
+    return netIface == null ? NetworkInterface.DEFAULT_BIND_TO : netIface.getAllowedHosts();
+  }
+
+  void setAllowedHosts(String value) {
+    networkInterface.setAllowedHosts(value);
+  }
+
+  private void maybeGetNetworkInterface() {
+    if (this.networkInterface != null) return;
+
+    NetworkInterface tempNetworkInterface;
+    if (ssl) {
+      tempNetworkInterface =
+          SSLNetworkInterface.create(port, bindTo, allowedHosts, node.network().executor(), true);
+    } else {
+      tempNetworkInterface =
+          NetworkInterface.create(port, bindTo, allowedHosts, node.network().executor(), true);
+    }
+
+    this.networkInterface = tempNetworkInterface;
+  }
+
+  void maybeStart() {
+    if (this.enabled) {
+      maybeGetNetworkInterface();
+
+      LOG.info("Starting FCP server on {}:{}.", bindTo, port);
+
+      if (this.networkInterface != null) {
+        Thread t = new Thread(server, "FCP server");
+        t.setDaemon(true);
+        t.start();
+      }
+    } else {
+      LOG.info("Not starting FCP server as it's disabled");
+      this.networkInterface = null;
+    }
+  }
+
+  @Override
+  public void run() {
+    while (true) {
+      try {
+        networkInterface.waitBound();
+        realRun();
+      } catch (Exception e) {
+        LOG.error("Caught {}", e, e);
+      }
+      if (WrapperManager.hasShutdownHookBeenTriggered()) return;
+    }
+  }
+
+  private void realRun() {
+    if (!node.isHasStarted()) return;
+    Socket s = networkInterface.accept();
+    FCPConnectionHandler ch = new FCPConnectionHandler(s, server);
+    ch.start();
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
@@ -8,19 +8,70 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tanukisoftware.wrapper.WrapperManager;
 
+/**
+ * Runs the FCP listener loop and manages the active {@link NetworkInterface} binding.
+ *
+ * <p>This helper encapsulates the network-facing responsibilities of {@link FCPServer}, including
+ * creating the listening {@link NetworkInterface}, binding it to the configured addresses, and
+ * accepting incoming connections. Callers typically construct the listener during server
+ * initialization and invoke {@link #maybeStart()} once; the accept-loop then runs on a daemon
+ * thread, dispatching sockets to {@link FCPConnectionHandler} instances. Configuration updates such
+ * as {@link #updateBindTo(String)} and {@link #setAllowedHosts(String)} are delegated to the
+ * underlying interface when available, while SSL mode is tracked via static flag accessors.
+ *
+ * <p>The listener is intentionally conservative about re-binding: it caches the created interface
+ * and only creates a new one once per instance. Shutdown handling relies on the Tanuki Wrapper
+ * shutdown hook check to exit the accept-loop safely. The class is not thread-safe for arbitrary
+ * mutation; it assumes a single initialization path and a single accept-loop thread.
+ *
+ * <ul>
+ *   <li>Creates the appropriate {@link NetworkInterface} or {@link SSLNetworkInterface}.
+ *   <li>Starts the accept-loop and hands sockets to {@link FCPConnectionHandler}.
+ *   <li>Exposes helpers for bind address and allowlist updates.
+ * </ul>
+ *
+ * @see FCPServer
+ * @see NetworkInterface
+ */
 final class FcpServerListener implements Runnable {
+  /** Logger scoped to the listener lifecycle and accept loop. */
   private static final Logger LOG = LoggerFactory.getLogger(FcpServerListener.class);
 
+  /** Tracks whether SSL should be used when creating the network interface. */
   private static boolean ssl = false;
 
+  /** Owning server used to construct connection handlers for accepted sockets. */
   private final FCPServer server;
+
+  /** Node used to get executors and startup lifecycle information. */
   private final Node node;
+
+  /** TCP port to bind when creating the network interface. */
   private final int port;
+
+  /** Whether the listener should start based on configuration. */
   private final boolean enabled;
+
+  /** Allowed-hosts filter string provided at initialization time. */
   private final String allowedHosts;
+
+  /** Current bind address string used when initializing the interface. */
   private String bindTo;
+
+  /** Active network interface, lazily created when the listener starts. */
   private NetworkInterface networkInterface;
 
+  /**
+   * Creates a listener bound to the provided server, node, and configuration snapshot.
+   *
+   * <p>The constructor captures immutable configuration such as port, bind address, and allowed
+   * hosts. It does not create sockets or start threads; callers must invoke {@link #maybeStart()}
+   * to initialize the {@link NetworkInterface} and begin accepting connections.
+   *
+   * @param server the owning server that constructs connection handlers for clients.
+   * @param node node supplying executors and lifecycle state used by the accept-loop.
+   * @param config snapshot of listener configuration values at construction time.
+   */
   FcpServerListener(FCPServer server, Node node, FcpServerConfig config) {
     this.server = server;
     this.node = node;
@@ -30,32 +81,93 @@ final class FcpServerListener implements Runnable {
     this.bindTo = config.bindTo();
   }
 
+  /**
+   * Reports whether SSL is enabled for later network interface creation.
+   *
+   * <p>This flag is static because the SSL setting is global to the FCP listener. It affects only
+   * newly created {@link NetworkInterface} instances; existing interfaces remain unchanged.
+   *
+   * @return {@code true} when SSL should be used for future binds, {@code false} otherwise.
+   */
   static boolean isSslEnabled() {
     return ssl;
   }
 
+  /**
+   * Updates the global SSL enablement flag for future interface creation.
+   *
+   * <p>Callers should treat this as a configuration hook rather than a live toggle. Changing the
+   * value does not rebind existing sockets; it only influences the next call to {@link
+   * NetworkInterface#create(int, String, String, network.crypta.support.PriorityAwareExecutor,
+   * boolean)} or {@link SSLNetworkInterface#create(int, String, String,
+   * network.crypta.support.PriorityAwareExecutor, boolean)}.
+   *
+   * @param enabled {@code true} to create SSL interfaces, {@code false} otherwise.
+   */
   static void setSslEnabled(boolean enabled) {
     ssl = enabled;
   }
 
+  /**
+   * Delegates to the underlying {@link NetworkInterface} to update binding addresses.
+   *
+   * <p>This method assumes a listener has already been started and will throw a {@link
+   * NullPointerException} if the interface has not been initialized. It forwards the raw bind
+   * string to {@link NetworkInterface#setBindTo(String, boolean)} and returns any failed addresses.
+   *
+   * @param value comma-separated bind addresses or {@code null} to use defaults.
+   * @param update whether to update acceptors immediately for the new bindings.
+   * @return array of failed addresses, or {@code null} when all bindings succeed.
+   */
   @SuppressWarnings("SameParameterValue")
   String[] setBindTo(String value, boolean update) {
     return networkInterface.setBindTo(value, update);
   }
 
+  /**
+   * Updates the cached bind address string used for future interface creation.
+   *
+   * <p>This method does not rebind sockets or modify the active interface. It simply updates the
+   * stored value used when {@link #maybeStart()} or a future rebinding occurs.
+   *
+   * @param value new bind address string, typically a comma-separated list.
+   */
   void updateBindTo(String value) {
     this.bindTo = value;
   }
 
+  /**
+   * Returns the allowed-hosts string from the active interface, or the default when absent.
+   *
+   * <p>If the listener has not yet created its {@link NetworkInterface}, this method returns {@link
+   * NetworkInterface#DEFAULT_BIND_TO} to preserve legacy behavior during configuration discovery.
+   *
+   * @return current allowlist string, or the default bind list when no interface exists.
+   */
   String getAllowedHosts() {
     NetworkInterface netIface = networkInterface;
     return netIface == null ? NetworkInterface.DEFAULT_BIND_TO : netIface.getAllowedHosts();
   }
 
+  /**
+   * Applies a new allowed-hosts string to the active network interface.
+   *
+   * <p>The method assumes the listener has been initialized and delegates to {@link
+   * NetworkInterface#setAllowedHosts(String)}. It does not validate the input beyond the interface
+   * implementation.
+   *
+   * @param value new allowlist string for filtering inbound connections.
+   */
   void setAllowedHosts(String value) {
     networkInterface.setAllowedHosts(value);
   }
 
+  /**
+   * Lazily constructs the {@link NetworkInterface} if it has not been created yet.
+   *
+   * <p>The method chooses between SSL and plain interfaces based on the static SSL flag, binds to
+   * the configured addresses, and caches the created instance. Subsequent calls are no-ops.
+   */
   private void maybeGetNetworkInterface() {
     if (this.networkInterface != null) return;
 
@@ -71,6 +183,13 @@ final class FcpServerListener implements Runnable {
     this.networkInterface = tempNetworkInterface;
   }
 
+  /**
+   * Starts the listener thread when enabled, creating the network interface if needed.
+   *
+   * <p>When disabled, the method clears the cached interface so no sockets are bound. When enabled,
+   * it creates the interface if absent, logs startup, and launches the accept-loop on a daemon
+   * thread. Repeated calls are safe and will not recreate the interface once initialized.
+   */
   void maybeStart() {
     if (this.enabled) {
       maybeGetNetworkInterface();
@@ -88,6 +207,13 @@ final class FcpServerListener implements Runnable {
     }
   }
 
+  /**
+   * Runs the accept-loop until shutdown is requested.
+   *
+   * <p>The loop waits for the network interface to bind, accepts incoming sockets, and delegates
+   * each to {@link FCPConnectionHandler}. Any exception during binding or accept is logged, and the
+   * loop retries unless the Wrapper shutdown hook has been triggered.
+   */
   @Override
   public void run() {
     while (true) {
@@ -101,6 +227,12 @@ final class FcpServerListener implements Runnable {
     }
   }
 
+  /**
+   * Accepts a single connection and starts a handler when the node is running.
+   *
+   * <p>If the node has not yet started, the method returns without accepting. Otherwise, it accepts
+   * one socket and dispatches it to a new {@link FCPConnectionHandler} instance.
+   */
   private void realRun() {
     if (!node.isHasStarted()) return;
     Socket s = networkInterface.accept();

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -30,17 +30,67 @@ import network.crypta.support.io.NoFreeBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Coordinates persistent-request operations for the FCP server and exposes cache lookups.
+ *
+ * <p>This helper encapsulates the logic for managing reboot and forever queues, global request
+ * removal/modification, and the download cache read path. It is constructed once per {@link
+ * FCPServer} and holds references to the persistent request root and the global queue clients. The
+ * class is intentionally package-private, so the server façade can delegate to it while keeping
+ * persistence-specific details localized.
+ *
+ * <p>The instance uses the {@link ClientContext} job runner for operations that must be serialized
+ * against persistent state. Methods that call into {@link PersistentRequestClient} may block until
+ * a queued job completes, so callers should avoid invoking them from latency-sensitive threads.
+ * Synchronization is limited to the reboot-client map and does not cover the underlying request
+ * queues, which manage their own concurrency.
+ *
+ * <ul>
+ *   <li>Registers persistent clients and routes global queue operations.
+ *   <li>Schedules persistence-affecting work on the job runner.
+ *   <li>Implements {@link DownloadCache} lookups for completed requests.
+ * </ul>
+ *
+ * @see FCPServer
+ * @see PersistentRequestClient
+ * @see PersistentRequestRoot
+ */
 final class FcpServerPersistentOps implements DownloadCache {
+  /** Logger for persistence operations and cache lookup diagnostics. */
   private static final Logger LOG = LoggerFactory.getLogger(FcpServerPersistentOps.class);
+
+  /** Prefix used to construct global request identifiers for FProxy-backed fetches. */
   private static final String FPROXY_PREFIX = "FProxy:";
 
+  /** The owning server used for queue coordination and callback wiring. */
   private final FCPServer server;
+
+  /** Client core providing contexts, RNG, and bucket factories. */
   private final NodeClientCore core;
+
+  /** Root registry for forever-persistent clients. */
   private final PersistentRequestRoot persistentRoot;
+
+  /** Reboot-persistent clients keyed by name, weakly referenced. */
   private final WeakHashMap<String, PersistentRequestClient> rebootClientsByName;
+
+  /** Global reboot queue client; created eagerly during construction. */
   private final PersistentRequestClient globalRebootClient;
+
+  /** Global forever queue client sourced from the persistent root. */
   private final PersistentRequestClient globalForeverClient;
 
+  /**
+   * Creates a persistence helper bound to the provided server, core, and persistent root.
+   *
+   * <p>The constructor initializes the reboot-client map, wires the forever-global client from the
+   * provided root, and allocates the reboot-global client used for temporary persistence. No
+   * network operations occur here; the helper is ready for use immediately after construction.
+   *
+   * @param server owning server used when scheduling global queue operations.
+   * @param core client core supplying contexts, RNG, and storage factories.
+   * @param persistentRoot registry for forever-persistent clients and queues.
+   */
   FcpServerPersistentOps(
       FCPServer server, NodeClientCore core, PersistentRequestRoot persistentRoot) {
     this.server = server;
@@ -52,10 +102,27 @@ final class FcpServerPersistentOps implements DownloadCache {
         new PersistentRequestClient("Global Queue", null, true, null, Persistence.REBOOT, null);
   }
 
+  /**
+   * Reloads cached request status for the forever global queue.
+   *
+   * <p>This helper is typically invoked during startup to rebuild the status cache from the
+   * persisted request state. It is a no-op for reboot-only queues but will refresh in-memory status
+   * for forever persistence.
+   */
   void load() {
     globalForeverClient.updateRequestStatusCache();
   }
 
+  /**
+   * Registers or replaces a reboot-persistent client by name.
+   *
+   * <p>If a client with the same name already exists and is connected, the old connection is closed
+   * and replaced with the new handler. The returned client instance is stable across reconnections.
+   *
+   * @param name stable identifier for the reboot-persistent client; must not be {@code null}.
+   * @param handler active connection handler, or {@code null} when reconnecting headless.
+   * @return existing or newly created client bound to the provided handler.
+   */
   PersistentRequestClient registerRebootClient(String name, FCPConnectionHandler handler) {
     PersistentRequestClient oldClient;
     synchronized (this) {
@@ -78,14 +145,42 @@ final class FcpServerPersistentOps implements DownloadCache {
     }
   }
 
+  /**
+   * Registers a forever-persistent client with the global registry.
+   *
+   * <p>This delegates to {@link PersistentRequestRoot} to create or reuse the named client. The
+   * caller-supplied handler is attached when non-null.
+   *
+   * @param name stable client name used for persistence lookups; must not be {@code null}.
+   * @param handler current connection handler, or {@code null} when detached.
+   * @return persistent client instance representing the forever queue for the name.
+   */
   PersistentRequestClient registerForeverClient(String name, FCPConnectionHandler handler) {
     return persistentRoot.registerForeverClient(name, handler);
   }
 
+  /**
+   * Looks up a forever-persistent client and optionally refreshes its connection binding.
+   *
+   * <p>Returns {@code null} when no client with the given name exists. The supplied handler is
+   * stored when non-null to reattach an active connection.
+   *
+   * @param name stable client identifier used during registration.
+   * @param handler connection handler to attach, or {@code null} to leave unchanged.
+   * @return existing client, or {@code null} when no match exists.
+   */
   PersistentRequestClient getForeverClient(String name, FCPConnectionHandler handler) {
     return persistentRoot.getForeverClient(name, handler);
   }
 
+  /**
+   * Unregisters a client from persistence tracking when it is no longer active.
+   *
+   * <p>Reboot clients are removed from the local map, while forever clients delegate to the shared
+   * {@link PersistentRequestRoot} cleanup logic.
+   *
+   * @param client client to unregister; must not be {@code null}.
+   */
   void unregisterClient(PersistentRequestClient client) {
     if (client.persistence == Persistence.REBOOT) {
       synchronized (this) {
@@ -97,6 +192,16 @@ final class FcpServerPersistentOps implements DownloadCache {
     }
   }
 
+  /**
+   * Returns a snapshot of persistent request status entries across all global queues.
+   *
+   * <p>The method aggregates status from both reboot and forever queues. If persistence is disabled
+   * at the core, a {@link PersistenceDisabledException} is raised to signal that the cache cannot
+   * be read safely.
+   *
+   * @return array of request status entries; never {@code null}.
+   * @throws PersistenceDisabledException when persistence is unavailable or disabled.
+   */
   RequestStatus[] getGlobalRequests() throws PersistenceDisabledException {
     if (core.killedDatabase()) throw new PersistenceDisabledException();
     List<RequestStatus> v = new ArrayList<>();
@@ -105,6 +210,17 @@ final class FcpServerPersistentOps implements DownloadCache {
     return v.toArray(new RequestStatus[0]);
   }
 
+  /**
+   * Removes a single global request and blocks until completion.
+   *
+   * <p>The method first attempts removal from the reboot queue. If not found, it schedules a
+   * removal on the persistent job runner for the forever queue and waits for completion.
+   *
+   * @param identifier request identifier to remove; must not be {@code null}.
+   * @return {@code true} when the request was removed or removal was attempted; {@code false} when
+   *     the job failed.
+   * @throws PersistenceDisabledException when persistence is unavailable or disabled.
+   */
   boolean removeGlobalRequestBlocking(final String identifier) throws PersistenceDisabledException {
     if (!globalRebootClient.removeByIdentifier(identifier, true, server, core.getClientContext())) {
       final CountDownLatch done = new CountDownLatch(1);
@@ -146,6 +262,15 @@ final class FcpServerPersistentOps implements DownloadCache {
     } else return true;
   }
 
+  /**
+   * Removes all global requests and waits for the forever queue removal to complete.
+   *
+   * <p>The reboot queue is cleared immediately on the calling thread. The forever queue is cleared
+   * via a queued persistent job to maintain database consistency.
+   *
+   * @return {@code true} if both queues were cleared successfully; {@code false} otherwise.
+   * @throws PersistenceDisabledException when persistence is unavailable or disabled.
+   */
   boolean removeAllGlobalRequestsBlocking() throws PersistenceDisabledException {
     globalRebootClient.removeAll();
     final CountDownLatch done = new CountDownLatch(1);
@@ -185,6 +310,18 @@ final class FcpServerPersistentOps implements DownloadCache {
     return success.get();
   }
 
+  /**
+   * Updates the token and priority of a global request, blocking until applied.
+   *
+   * <p>Reboot queue updates occur immediately, while forever queue updates run on the persistent
+   * job runner and are synchronized using a wait/notify wrapper.
+   *
+   * @param identifier request identifier to locate in the queues.
+   * @param newToken replacement token string stored with the request; may be {@code null}.
+   * @param newPriority new priority class value for scheduling decisions.
+   * @return {@code true} when an update path executed; {@code false} when not found or failed.
+   * @throws PersistenceDisabledException when persistence is unavailable or disabled.
+   */
   boolean modifyGlobalRequestBlocking(
       final String identifier, final String newToken, final short newPriority)
       throws PersistenceDisabledException {
@@ -244,6 +381,17 @@ final class FcpServerPersistentOps implements DownloadCache {
     }
   }
 
+  /**
+   * Enqueues a persistent global request and blocks until registration completes.
+   *
+   * <p>The request creation runs on the persistent job runner to ensure a consistent database
+   * state. Exceptions are captured and rethrown once the job finishes.
+   *
+   * @param params request parameter bundle describing the fetch.
+   * @throws NotAllowedException when policy or DDA checks reject the request.
+   * @throws IOException when preparing disk output fails.
+   * @throws PersistenceDisabledException when persistence is unavailable or disabled.
+   */
   void makePersistentGlobalRequestBlocking(PersistentGlobalRequestParams params)
       throws NotAllowedException, IOException, PersistenceDisabledException {
     final CountDownLatch done = new CountDownLatch(1);
@@ -289,6 +437,23 @@ final class FcpServerPersistentOps implements DownloadCache {
     if (notAllowed.get() != null) throw notAllowed.get();
   }
 
+  /**
+   * Convenience overload that builds parameters for a persistent global request.
+   *
+   * <p>All arguments are forwarded into {@link PersistentGlobalRequestParams} and then queued via
+   * {@link #makePersistentGlobalRequestBlocking(PersistentGlobalRequestParams)}.
+   *
+   * @param fetchURI URI describing the content to fetch; must not be {@code null}.
+   * @param filterData whether to filter content before delivery to the client.
+   * @param expectedMimeType optional MIME hint for filename selection; may be {@code null}.
+   * @param persistenceTypeString persistence policy string such as {@code reboot}.
+   * @param returnTypeString return handling string such as {@code disk} or {@code none}.
+   * @param realTimeFlag whether to request real-time scheduling.
+   * @param downloadsDir directory for disk outputs when the return type is disk.
+   * @throws NotAllowedException when policy or DDA checks reject the request.
+   * @throws IOException when preparing disk output fails.
+   * @throws PersistenceDisabledException when persistence is unavailable or disabled.
+   */
   void makePersistentGlobalRequestBlocking(
       FreenetURI fetchURI,
       boolean filterData,

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -1,0 +1,698 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.WeakHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.DefaultMIMETypes;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchResult;
+import network.crypta.client.async.CacheFetchResult;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.DownloadCache;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.clients.fcp.ClientGet.ReturnType;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
+import network.crypta.support.Base64;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.BucketTools;
+import network.crypta.support.io.NativeThread;
+import network.crypta.support.io.NoFreeBucket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class FcpServerPersistentOps implements DownloadCache {
+  private static final Logger LOG = LoggerFactory.getLogger(FcpServerPersistentOps.class);
+  private static final String FPROXY_PREFIX = "FProxy:";
+
+  private final FCPServer server;
+  private final NodeClientCore core;
+  private final PersistentRequestRoot persistentRoot;
+  private final WeakHashMap<String, PersistentRequestClient> rebootClientsByName;
+  private final PersistentRequestClient globalRebootClient;
+  private final PersistentRequestClient globalForeverClient;
+
+  FcpServerPersistentOps(
+      FCPServer server, NodeClientCore core, PersistentRequestRoot persistentRoot) {
+    this.server = server;
+    this.core = core;
+    this.persistentRoot = persistentRoot;
+    this.rebootClientsByName = new WeakHashMap<>();
+    this.globalForeverClient = persistentRoot.globalForeverClient;
+    this.globalRebootClient =
+        new PersistentRequestClient("Global Queue", null, true, null, Persistence.REBOOT, null);
+  }
+
+  void load() {
+    globalForeverClient.updateRequestStatusCache();
+  }
+
+  PersistentRequestClient registerRebootClient(String name, FCPConnectionHandler handler) {
+    PersistentRequestClient oldClient;
+    synchronized (this) {
+      oldClient = rebootClientsByName.get(name);
+      if (oldClient == null) {
+        PersistentRequestClient client =
+            new PersistentRequestClient(name, handler, false, null, Persistence.REBOOT, null);
+        rebootClientsByName.put(name, client);
+        return client;
+      } else {
+        FCPConnectionHandler oldConn = oldClient.getConnection();
+        if (oldConn != null) {
+          oldConn.setKilledDupe();
+          oldConn.send(new CloseConnectionDuplicateClientNameMessage());
+          oldConn.close();
+        }
+        oldClient.setConnection(handler);
+        return oldClient;
+      }
+    }
+  }
+
+  PersistentRequestClient registerForeverClient(String name, FCPConnectionHandler handler) {
+    return persistentRoot.registerForeverClient(name, handler);
+  }
+
+  PersistentRequestClient getForeverClient(String name, FCPConnectionHandler handler) {
+    return persistentRoot.getForeverClient(name, handler);
+  }
+
+  void unregisterClient(PersistentRequestClient client) {
+    if (client.persistence == Persistence.REBOOT) {
+      synchronized (this) {
+        String name = client.name;
+        rebootClientsByName.remove(name);
+      }
+    } else {
+      persistentRoot.maybeUnregisterClient(client);
+    }
+  }
+
+  RequestStatus[] getGlobalRequests() throws PersistenceDisabledException {
+    if (core.killedDatabase()) throw new PersistenceDisabledException();
+    List<RequestStatus> v = new ArrayList<>();
+    globalRebootClient.addPersistentRequestStatus(v);
+    if (globalForeverClient != null) globalForeverClient.addPersistentRequestStatus(v);
+    return v.toArray(new RequestStatus[0]);
+  }
+
+  boolean removeGlobalRequestBlocking(final String identifier) throws PersistenceDisabledException {
+    if (!globalRebootClient.removeByIdentifier(identifier, true, server, core.getClientContext())) {
+      final CountDownLatch done = new CountDownLatch(1);
+      final AtomicBoolean success = new AtomicBoolean();
+      core.getClientContext()
+          .jobRunner
+          .queue(
+              new PersistentJob() {
+
+                @Override
+                public String toString() {
+                  return "FCP removeGlobalRequestBlocking";
+                }
+
+                @Override
+                public boolean run(ClientContext context) {
+                  boolean succeeded = false;
+                  try {
+                    succeeded =
+                        globalForeverClient.removeByIdentifier(
+                            identifier, true, server, core.getClientContext());
+                  } catch (Exception e) {
+                    LOG.error("Caught removing identifier {}: {}", identifier, e, e);
+                  } finally {
+                    success.set(succeeded);
+                    done.countDown();
+                  }
+                  return true;
+                }
+              },
+              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+      try {
+        done.await();
+      } catch (InterruptedException _) {
+        Thread.currentThread().interrupt();
+        return success.get();
+      }
+      return success.get();
+    } else return true;
+  }
+
+  boolean removeAllGlobalRequestsBlocking() throws PersistenceDisabledException {
+    globalRebootClient.removeAll();
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicBoolean success = new AtomicBoolean();
+    core.getClientContext()
+        .jobRunner
+        .queue(
+            new PersistentJob() {
+
+              @Override
+              public String toString() {
+                return "FCP removeAllGlobalRequestsBlocking";
+              }
+
+              @Override
+              public boolean run(ClientContext context) {
+                boolean succeeded = false;
+                try {
+                  globalForeverClient.removeAll();
+                  succeeded = true;
+                } catch (Exception e) {
+                  LOG.error("Caught while processing panic: {}", e, e);
+                } finally {
+                  success.set(succeeded);
+                  done.countDown();
+                }
+                return true;
+              }
+            },
+            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+    try {
+      done.await();
+    } catch (InterruptedException _) {
+      Thread.currentThread().interrupt();
+      return success.get();
+    }
+    return success.get();
+  }
+
+  boolean modifyGlobalRequestBlocking(
+      final String identifier, final String newToken, final short newPriority)
+      throws PersistenceDisabledException {
+    ClientRequest req = this.globalRebootClient.getRequest(identifier);
+    if (req != null) {
+      req.modifyRequest(newToken, newPriority, server);
+      return true;
+    } else {
+      class OutputWrapper {
+        boolean success;
+        boolean done;
+      }
+      final OutputWrapper ow = new OutputWrapper();
+      core.getClientContext()
+          .jobRunner
+          .queue(
+              new PersistentJob() {
+
+                @Override
+                public String toString() {
+                  return "FCP modifyGlobalRequestBlocking";
+                }
+
+                @Override
+                public boolean run(ClientContext context) {
+                  boolean success = false;
+                  try {
+                    ClientRequest req = globalForeverClient.getRequest(identifier);
+                    if (req != null) req.modifyRequest(newToken, newPriority, server);
+                    success = true;
+                  } finally {
+                    synchronized (ow) {
+                      ow.success = success;
+                      ow.done = true;
+                      ow.notifyAll();
+                    }
+                  }
+                  return true;
+                }
+              },
+              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+
+      synchronized (ow) {
+        while (true) {
+          if (!ow.done) {
+            try {
+              ow.wait();
+            } catch (InterruptedException _) {
+              Thread.currentThread().interrupt();
+              return ow.success;
+            }
+            continue;
+          }
+          return ow.success;
+        }
+      }
+    }
+  }
+
+  void makePersistentGlobalRequestBlocking(PersistentGlobalRequestParams params)
+      throws NotAllowedException, IOException, PersistenceDisabledException {
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicReference<NotAllowedException> notAllowed = new AtomicReference<>();
+    final AtomicReference<IOException> ioException = new AtomicReference<>();
+    core.getClientContext()
+        .jobRunner
+        .queue(
+            new PersistentJob() {
+
+              @Override
+              public String toString() {
+                return "FCP makePersistentGlobalRequestBlocking";
+              }
+
+              @Override
+              public boolean run(ClientContext context) {
+                try {
+                  makePersistentGlobalRequest(params);
+                  return true;
+                } catch (NotAllowedException e) {
+                  notAllowed.set(e);
+                  return false;
+                } catch (IOException e) {
+                  ioException.set(e);
+                  return false;
+                } catch (Exception t) {
+                  LOG.error("Failed to make persistent request: {}", t, t);
+                  return false;
+                } finally {
+                  done.countDown();
+                }
+              }
+            },
+            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+
+    try {
+      done.await();
+    } catch (InterruptedException _) {
+      Thread.currentThread().interrupt();
+    }
+    if (ioException.get() != null) throw ioException.get();
+    if (notAllowed.get() != null) throw notAllowed.get();
+  }
+
+  void makePersistentGlobalRequestBlocking(
+      FreenetURI fetchURI,
+      boolean filterData,
+      String expectedMimeType,
+      String persistenceTypeString,
+      String returnTypeString,
+      boolean realTimeFlag,
+      File downloadsDir)
+      throws NotAllowedException, IOException, PersistenceDisabledException {
+    makePersistentGlobalRequestBlocking(
+        new PersistentGlobalRequestParams(
+            fetchURI,
+            filterData,
+            expectedMimeType,
+            persistenceTypeString,
+            returnTypeString,
+            realTimeFlag,
+            downloadsDir));
+  }
+
+  void makePersistentGlobalRequest(PersistentGlobalRequestParams params)
+      throws NotAllowedException, IOException {
+    boolean persistence = params.persistenceType().equalsIgnoreCase("reboot");
+    ReturnType returnType = ReturnType.valueOf(params.returnType().toUpperCase());
+    File returnFilename = null;
+    if (returnType == ReturnType.DISK) {
+      returnFilename =
+          makeReturnFilename(params.fetchURI(), params.expectedMimeType(), params.downloadsDir());
+    }
+    List<String> candidateIds = new ArrayList<>();
+    candidateIds.add(FPROXY_PREFIX + params.fetchURI().getPreferredFilename());
+    candidateIds.add(FPROXY_PREFIX + params.fetchURI().getDocName());
+    candidateIds.add(FPROXY_PREFIX + params.fetchURI().toString(false, false));
+    candidateIds.add("FProxy (" + System.currentTimeMillis() + ')');
+
+    for (String candidateId : candidateIds) {
+      if (candidateId == null) {
+        continue;
+      }
+      PersistentGlobalRequestSpec spec =
+          new PersistentGlobalRequestSpec(
+              params.fetchURI(),
+              params.filterData(),
+              persistence,
+              returnType,
+              candidateId,
+              returnFilename,
+              params.realTimeFlag());
+      if (tryPersistentGlobalRequest(spec)) {
+        return;
+      }
+    }
+
+    while (true) {
+      byte[] buf = new byte[8];
+      core.getRandom().nextBytes(buf);
+      String id = FPROXY_PREFIX + Base64.encode(buf);
+      PersistentGlobalRequestSpec spec =
+          new PersistentGlobalRequestSpec(
+              params.fetchURI(),
+              params.filterData(),
+              persistence,
+              returnType,
+              id,
+              returnFilename,
+              params.realTimeFlag());
+      if (tryPersistentGlobalRequest(spec)) {
+        return;
+      }
+    }
+  }
+
+  void makePersistentGlobalRequest(
+      FreenetURI fetchURI,
+      boolean filterData,
+      String expectedMimeType,
+      String persistenceTypeString,
+      String returnTypeString,
+      boolean realTimeFlag)
+      throws NotAllowedException, IOException {
+    makePersistentGlobalRequest(
+        new PersistentGlobalRequestParams(
+            fetchURI,
+            filterData,
+            expectedMimeType,
+            persistenceTypeString,
+            returnTypeString,
+            realTimeFlag,
+            core.getDownloadsDir()));
+  }
+
+  void makePersistentGlobalRequest(
+      FreenetURI fetchURI,
+      boolean filterData,
+      String expectedMimeType,
+      String persistenceTypeString,
+      String returnTypeString,
+      boolean realTimeFlag,
+      File downloadsDir)
+      throws NotAllowedException, IOException {
+    makePersistentGlobalRequest(
+        new PersistentGlobalRequestParams(
+            fetchURI,
+            filterData,
+            expectedMimeType,
+            persistenceTypeString,
+            returnTypeString,
+            realTimeFlag,
+            downloadsDir));
+  }
+
+  private boolean tryPersistentGlobalRequest(PersistentGlobalRequestSpec spec)
+      throws NotAllowedException, IOException {
+    try {
+      innerMakePersistentGlobalRequest(spec);
+      return true;
+    } catch (IdentifierCollisionException _) {
+      return false;
+    }
+  }
+
+  private File makeReturnFilename(FreenetURI uri, String expectedMimeType, File downloadsDir) {
+    String ext;
+    if ((expectedMimeType != null)
+        && !expectedMimeType.isEmpty()
+        && !expectedMimeType.equals(DefaultMIMETypes.DEFAULT_MIME_TYPE)) {
+      ext = DefaultMIMETypes.getExtension(expectedMimeType);
+    } else ext = null;
+    String extAdd = (ext == null ? "" : '.' + ext);
+    String preferred = uri.getPreferredFilename();
+    String preferredWithExt = preferred;
+    if (!(ext != null && preferredWithExt.endsWith(ext))) preferredWithExt += extAdd;
+    File f = new File(downloadsDir, preferredWithExt);
+    int x = 0;
+    StringBuilder sb = new StringBuilder();
+    for (; f.exists(); sb.setLength(0)) {
+      sb.append(preferred);
+      sb.append('-');
+      sb.append(x);
+      sb.append(extAdd);
+      f = new File(downloadsDir, sb.toString());
+      x++;
+    }
+    return f;
+  }
+
+  private void innerMakePersistentGlobalRequest(PersistentGlobalRequestSpec spec)
+      throws IdentifierCollisionException, NotAllowedException, IOException {
+    FetchContext defaultFetchContext = core.getClientContext().getDefaultPersistentFetchContext();
+    ClientGet.GlobalRequestConfig requestConfig =
+        new ClientGet.GlobalRequestConfig(
+            defaultFetchContext.getLocalRequestOnly(),
+            defaultFetchContext.getIgnoreStore(),
+            spec.filterData(),
+            FCPServer.QUEUE_MAX_RETRIES,
+            FCPServer.QUEUE_MAX_RETRIES,
+            FCPServer.QUEUE_MAX_DATA_SIZE,
+            spec.returnType(),
+            spec.persistRebootOnly(),
+            spec.identifier(),
+            Integer.MAX_VALUE,
+            RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
+            spec.returnFilename(),
+            null,
+            false,
+            spec.realTimeFlag(),
+            false);
+    final ClientGet cg =
+        new ClientGet(
+            spec.persistRebootOnly() ? globalRebootClient : globalForeverClient,
+            spec.fetchURI(),
+            requestConfig,
+            core);
+    cg.register(false);
+    cg.start(core.getClientContext());
+  }
+
+  PersistentRequestClient getGlobalForeverClient() {
+    return globalForeverClient;
+  }
+
+  ClientRequest getGlobalRequest(String identifier) {
+    ClientRequest req = globalRebootClient.getRequest(identifier);
+    if (req == null) req = globalForeverClient.getRequest(identifier);
+    return req;
+  }
+
+  void setCompletionCallback(RequestCompletionCallback cb) {
+    if (globalForeverClient != null) globalForeverClient.addRequestCompletionCallback(cb);
+    globalRebootClient.addRequestCompletionCallback(cb);
+  }
+
+  void startBlocking(final ClientRequest req)
+      throws IdentifierCollisionException, PersistenceDisabledException {
+    if (req.persistence == Persistence.REBOOT) {
+      req.start(core.getClientContext());
+    } else {
+      final CountDownLatch done = new CountDownLatch(1);
+      final AtomicReference<IdentifierCollisionException> collision = new AtomicReference<>();
+      core.getClientContext()
+          .jobRunner
+          .queue(
+              new PersistentJob() {
+
+                @Override
+                public String toString() {
+                  return "FCP startBlocking";
+                }
+
+                @Override
+                public boolean run(ClientContext context) {
+                  try {
+                    req.register(false);
+                    req.start(context);
+                  } catch (IdentifierCollisionException e) {
+                    collision.set(e);
+                  } finally {
+                    done.countDown();
+                  }
+                  return true;
+                }
+              },
+              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+
+      try {
+        done.await();
+      } catch (InterruptedException _) {
+        Thread.currentThread().interrupt();
+      }
+      if (collision.get() != null) {
+        throw collision.get();
+      }
+    }
+  }
+
+  boolean restartBlocking(final String identifier, final boolean disableFilterData)
+      throws PersistenceDisabledException {
+    ClientRequest req = globalRebootClient.getRequest(identifier);
+    if (req != null) {
+      req.restart(core.getClientContext(), disableFilterData);
+      return true;
+    } else {
+      final CountDownLatch done = new CountDownLatch(1);
+      final AtomicBoolean success = new AtomicBoolean();
+      if (LOG.isDebugEnabled()) LOG.debug("Queueing restart of {}", identifier);
+      core.getClientContext()
+          .jobRunner
+          .queue(
+              new PersistentJob() {
+
+                @Override
+                public String toString() {
+                  return "FCP restartBlocking";
+                }
+
+                @Override
+                public boolean run(ClientContext context) {
+                  boolean restarted = false;
+                  try {
+                    ClientRequest req = globalForeverClient.getRequest(identifier);
+                    if (LOG.isDebugEnabled()) LOG.debug("Restarting {} for {}", req, identifier);
+                    if (req != null) {
+                      req.restart(context, disableFilterData);
+                      restarted = true;
+                    }
+                  } catch (PersistenceDisabledException e) {
+                    LOG.error("Failed to restart {}: {}", identifier, e.getMessage(), e);
+                  } finally {
+                    success.set(restarted);
+                    done.countDown();
+                  }
+                  return true;
+                }
+              },
+              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+
+      try {
+        done.await();
+      } catch (InterruptedException _) {
+        Thread.currentThread().interrupt();
+      }
+      return success.get();
+    }
+  }
+
+  FetchResult getCompletedRequestBlocking(final FreenetURI key)
+      throws PersistenceDisabledException {
+    ClientGet get = globalRebootClient.getCompletedRequest(key);
+    if (get != null) {
+      return new FetchResult(
+          new ClientMetadata(get.getMIMEType()), new NoFreeBucket(get.getBucket()));
+    }
+
+    FetchResult result = globalForeverClient.getRequestStatusCache().getShadowBucket(key, false);
+    if (result != null) {
+      return result;
+    }
+
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicReference<FetchResult> resultRef = new AtomicReference<>();
+    core.getClientContext()
+        .jobRunner
+        .queue(
+            new PersistentJob() {
+
+              @Override
+              public String toString() {
+                return "FCP getCompletedRequestBlocking";
+              }
+
+              @Override
+              public boolean run(ClientContext context) {
+                try {
+                  resultRef.set(lookup(key, false, context, false, null));
+                } finally {
+                  done.countDown();
+                }
+                return false;
+              }
+            },
+            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+
+    try {
+      done.await();
+    } catch (InterruptedException _) {
+      Thread.currentThread().interrupt();
+    }
+    return resultRef.get();
+  }
+
+  @Override
+  public CacheFetchResult lookupInstant(
+      FreenetURI key, boolean noFilter, boolean mustCopy, Bucket preferred) {
+    ClientGet get = globalRebootClient.getCompletedRequest(key);
+
+    Bucket origData = null;
+    String mime = null;
+    boolean filtered = false;
+
+    if (get != null) {
+      boolean requestFiltered = get.filterData();
+      if ((!noFilter) || (!requestFiltered)) {
+        filtered = requestFiltered;
+        origData = new NoFreeBucket(get.getBucket());
+        mime = get.getMIMEType();
+      }
+    }
+
+    if (origData == null && globalForeverClient != null) {
+      CacheFetchResult result =
+          globalForeverClient.getRequestStatusCache().getShadowBucket(key, noFilter);
+      if (result != null) {
+        mime = result.getMimeType();
+        origData = result.asBucket();
+        filtered = result.alreadyFiltered;
+      }
+    }
+
+    if (origData == null) return null;
+
+    if (!mustCopy) return new CacheFetchResult(new ClientMetadata(mime), origData, filtered);
+
+    Bucket newData = preferred;
+    try {
+      if (newData == null) newData = core.getTempBucketFactory().makeBucket(origData.size());
+      BucketTools.copy(origData, newData);
+      if (origData.size() != newData.size()) {
+        LOG.info("Maybe it disappeared under us?");
+        newData.free();
+        return null;
+      }
+      return new CacheFetchResult(new ClientMetadata(mime), newData, filtered);
+    } catch (IOException e) {
+      LOG.info("Unable to copy data: {}", e, e);
+      return null;
+    }
+  }
+
+  @Override
+  public CacheFetchResult lookup(
+      FreenetURI key, boolean noFilter, ClientContext context, boolean mustCopy, Bucket preferred) {
+    if (globalForeverClient == null) return null;
+    ClientGet get = globalForeverClient.getCompletedRequest(key);
+    if (get != null) {
+      boolean filtered = get.filterData();
+      Bucket origData = get.getBucket();
+      Bucket newData = null;
+      if (!mustCopy) newData = origData.createShadow();
+      if (newData == null) {
+        try {
+          if (preferred != null) newData = preferred;
+          else newData = core.getTempBucketFactory().makeBucket(origData.size());
+          BucketTools.copy(origData, newData);
+        } catch (IOException e) {
+          LOG.error("Unable to copy data: {}", e, e);
+          return null;
+        }
+      }
+      return new CacheFetchResult(new ClientMetadata(get.getMIMEType()), newData, filtered);
+    }
+    return null;
+  }
+
+  PersistentRequestClient getGlobalRebootClient() {
+    return globalRebootClient;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPluginConnections.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPluginConnections.java
@@ -7,21 +7,73 @@ import network.crypta.node.Node;
 import network.crypta.pluginmanager.FredPluginFCPMessageHandler.ClientSideFCPMessageHandler;
 import network.crypta.pluginmanager.PluginNotFoundException;
 
+/**
+ * Coordinates plugin-oriented FCP connections for both networked and in-process callers.
+ *
+ * <p>This helper owns a {@link FCPPluginConnectionTracker} and exposes factory methods that bridge
+ * plugin endpoints with FCP message handlers. It supports two modes: networked FCP connections that
+ * are backed by TCP sockets and intra-node connections that remain in process. Callers typically
+ * construct the helper alongside {@link FCPServer} startup and invoke {@link
+ * #startTrackerIfEnabled()} once, then create connections as plugins request them.
+ *
+ * <p>The tracker stores weak references to connection instances, so callers must hold a strong
+ * reference to keep a connection alive. This class is not responsible for plugin lifecycles; it
+ * simply wires the node’s plugin manager and executor into the connection factory methods.
+ *
+ * <ul>
+ *   <li>Starts the plugin connection tracker when plugins are enabled.
+ *   <li>Creates networked and intra-node plugin connections with proper direction adapters.
+ *   <li>Resolves existing connections by identifier for server-to-client messaging.
+ * </ul>
+ *
+ * @see FCPServer
+ * @see FCPPluginConnectionTracker
+ * @see FCPPluginConnectionImpl
+ */
 final class FcpServerPluginConnections {
+  /** Node providing executors and plugin management services. */
   private final Node node;
+
+  /** Tracker storing weak references to active plugin connections. */
   private final FCPPluginConnectionTracker pluginConnectionTracker;
 
+  /**
+   * Creates a plugin-connection helper for the given node.
+   *
+   * <p>The constructor instantiates a new tracker but does not start it; callers should invoke
+   * {@link #startTrackerIfEnabled()} after plugin services are initialized.
+   *
+   * @param node node supplying executors and plugin manager access; must not be {@code null}.
+   */
   FcpServerPluginConnections(Node node) {
     this.node = node;
     this.pluginConnectionTracker = new FCPPluginConnectionTracker();
   }
 
+  /**
+   * Starts the underlying tracker when the plugin manager is enabled.
+   *
+   * <p>When plugins are disabled, the method does nothing. It is safe to call repeatedly; the
+   * tracker will ignore redundant starts.
+   */
   void startTrackerIfEnabled() {
     if (node.services().pluginManager().isEnabled()) {
       pluginConnectionTracker.start();
     }
   }
 
+  /**
+   * Creates a network-backed plugin connection for an external FCP client.
+   *
+   * <p>The returned connection is registered with the tracker and must be held by the caller to
+   * keep it alive. It is configured so messages flow to the server-side plugin identified by {@code
+   * serverPluginName}.
+   *
+   * @param serverPluginName plugin name that will receive server-side messages.
+   * @param messageHandler network connection handler responsible for I/O.
+   * @return connection instance registered with the tracker and backed by the network handler.
+   * @throws PluginNotFoundException when the target plugin cannot be resolved or instantiated.
+   */
   FCPPluginConnectionImpl createFCPPluginConnectionForNetworkedFCP(
       String serverPluginName, FCPConnectionHandler messageHandler) throws PluginNotFoundException {
     return FCPPluginConnectionImpl.constructForNetworkedFCP(
@@ -32,6 +84,18 @@ final class FcpServerPluginConnections {
         messageHandler);
   }
 
+  /**
+   * Creates an in-process plugin connection for intra-node messaging.
+   *
+   * <p>The returned connection is adapted, so the default send direction is toward the server-side
+   * plugin, matching the expectations of a client-side plugin. Callers must keep a strong reference
+   * to prevent the tracker from discarding the connection.
+   *
+   * @param serverPluginName plugin name that will receive server-side messages.
+   * @param messageHandler client-side message handler that processes responses.
+   * @return adapter configured to send it toward the server-side plugin by default.
+   * @throws PluginNotFoundException when the target plugin cannot be resolved or instantiated.
+   */
   FCPPluginConnection createFCPPluginConnectionForIntraNodeFCP(
       String serverPluginName, ClientSideFCPMessageHandler messageHandler)
       throws PluginNotFoundException {
@@ -45,6 +109,13 @@ final class FcpServerPluginConnections {
     return connection.getDefaultSendDirectionAdapter(SendDirection.TO_SERVER);
   }
 
+  /**
+   * Resolves an existing plugin connection and adapts it for server-to-client messaging.
+   *
+   * @param connectionID identifier returned when the connection was created.
+   * @return connection adapter configured to send toward the client side by default.
+   * @throws IOException when the connection cannot be resolved or is inaccessible.
+   */
   FCPPluginConnection getPluginConnectionByID(UUID connectionID) throws IOException {
     return pluginConnectionTracker
         .getConnection(connectionID)

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPluginConnections.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPluginConnections.java
@@ -1,0 +1,53 @@
+package network.crypta.clients.fcp;
+
+import java.io.IOException;
+import java.util.UUID;
+import network.crypta.clients.fcp.FCPPluginConnection.SendDirection;
+import network.crypta.node.Node;
+import network.crypta.pluginmanager.FredPluginFCPMessageHandler.ClientSideFCPMessageHandler;
+import network.crypta.pluginmanager.PluginNotFoundException;
+
+final class FcpServerPluginConnections {
+  private final Node node;
+  private final FCPPluginConnectionTracker pluginConnectionTracker;
+
+  FcpServerPluginConnections(Node node) {
+    this.node = node;
+    this.pluginConnectionTracker = new FCPPluginConnectionTracker();
+  }
+
+  void startTrackerIfEnabled() {
+    if (node.services().pluginManager().isEnabled()) {
+      pluginConnectionTracker.start();
+    }
+  }
+
+  FCPPluginConnectionImpl createFCPPluginConnectionForNetworkedFCP(
+      String serverPluginName, FCPConnectionHandler messageHandler) throws PluginNotFoundException {
+    return FCPPluginConnectionImpl.constructForNetworkedFCP(
+        pluginConnectionTracker,
+        node.network().executor(),
+        node.services().pluginManager(),
+        serverPluginName,
+        messageHandler);
+  }
+
+  FCPPluginConnection createFCPPluginConnectionForIntraNodeFCP(
+      String serverPluginName, ClientSideFCPMessageHandler messageHandler)
+      throws PluginNotFoundException {
+    FCPPluginConnectionImpl connection =
+        FCPPluginConnectionImpl.constructForIntraNodeFCP(
+            pluginConnectionTracker,
+            node.network().executor(),
+            node.services().pluginManager(),
+            serverPluginName,
+            messageHandler);
+    return connection.getDefaultSendDirectionAdapter(SendDirection.TO_SERVER);
+  }
+
+  FCPPluginConnection getPluginConnectionByID(UUID connectionID) throws IOException {
+    return pluginConnectionTracker
+        .getConnection(connectionID)
+        .getDefaultSendDirectionAdapter(SendDirection.TO_CLIENT);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
@@ -1,0 +1,234 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import network.crypta.config.Config;
+import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.SubConfig;
+import network.crypta.io.NetworkInterface;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FcpServerConfigRegistrarTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private NodeClientCore core;
+
+  @Test
+  void maybeCreate_whenDefaults_expectConfiguredServerAndInitializedSubConfig() {
+    // Arrange
+    Config config = new Config();
+    PersistentRequestRoot root = new PersistentRequestRoot();
+
+    // Act
+    FCPServer server = FcpServerConfigRegistrar.maybeCreate(node, core, config, root);
+    SubConfig subConfig = config.get("fcp");
+
+    // Assert
+    assertNotNull(server);
+    assertNotNull(subConfig);
+    assertTrue(subConfig.hasFinishedInitialization());
+    assertEquals(FCPServer.DEFAULT_FCP_PORT, server.port);
+    assertTrue(server.enabled);
+    assertEquals(NetworkInterface.DEFAULT_BIND_TO, server.bindTo);
+    assertEquals(NetworkInterface.DEFAULT_BIND_TO, server.allowedHostsFullAccess.getAllowedHosts());
+    assertFalse(server.assumeDownloadDDAIsAllowed);
+    assertFalse(server.assumeUploadDDAIsAllowed);
+    assertFalse(server.neverDropAMessage);
+    assertEquals(1024, server.maxMessageQueueLength);
+    assertNotNull(subConfig.getOption("enabled"));
+    assertNotNull(subConfig.getOption("ssl"));
+    assertNotNull(subConfig.getOption("port"));
+  }
+
+  @Test
+  void fcpPortNumberCallback_whenValueUnchanged_expectNoException() {
+    // Arrange
+    FCPServer server = newServer();
+    when(core.getEndpoints().getFCPServer()).thenReturn(server);
+    FcpServerConfigRegistrar.FCPPortNumberCallback callback =
+        new FcpServerConfigRegistrar.FCPPortNumberCallback(core);
+
+    // Act & Assert
+    assertEquals(server.port, callback.get());
+    assertDoesNotThrow(() -> callback.set(server.port));
+  }
+
+  @Test
+  void fcpPortNumberCallback_whenValueChanged_expectInvalidConfigValueException() {
+    // Arrange
+    FCPServer server = newServer();
+    when(core.getEndpoints().getFCPServer()).thenReturn(server);
+    FcpServerConfigRegistrar.FCPPortNumberCallback callback =
+        new FcpServerConfigRegistrar.FCPPortNumberCallback(core);
+
+    // Act & Assert
+    assertThrows(InvalidConfigValueException.class, () -> callback.set(server.port + 1));
+  }
+
+  @Test
+  void fcpEnabledCallback_whenValueUnchanged_expectNoException() {
+    // Arrange
+    FCPServer server = newServer();
+    when(core.getEndpoints().getFCPServer()).thenReturn(server);
+    FcpServerConfigRegistrar.FCPEnabledCallback callback =
+        new FcpServerConfigRegistrar.FCPEnabledCallback(core);
+
+    // Act & Assert
+    assertEquals(server.enabled, callback.get());
+    assertDoesNotThrow(() -> callback.set(server.enabled));
+  }
+
+  @Test
+  void fcpSslCallback_whenValueUnchanged_expectNoException() {
+    // Arrange
+    FcpServerListener.setSslEnabled(false);
+    FcpServerConfigRegistrar.FCPSSLCallback callback =
+        new FcpServerConfigRegistrar.FCPSSLCallback();
+
+    // Act & Assert
+    assertFalse(callback.get());
+    assertDoesNotThrow(() -> callback.set(false));
+  }
+
+  @Test
+  void fcpAllowedHostsCallback_whenServerMissing_expectDefaultBind() {
+    // Arrange
+    when(core.getEndpoints().getFCPServer()).thenReturn(null);
+    FcpServerConfigRegistrar.FCPAllowedHostsCallback callback =
+        new FcpServerConfigRegistrar.FCPAllowedHostsCallback(core);
+
+    // Act & Assert
+    assertEquals(NetworkInterface.DEFAULT_BIND_TO, callback.get());
+  }
+
+  @Test
+  void fcpAllowedHostsCallback_whenValueUnchanged_expectNoException() {
+    // Arrange
+    FCPServer server = newServer();
+    when(core.getEndpoints().getFCPServer()).thenReturn(server);
+    FcpServerConfigRegistrar.FCPAllowedHostsCallback callback =
+        new FcpServerConfigRegistrar.FCPAllowedHostsCallback(core);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> callback.set(NetworkInterface.DEFAULT_BIND_TO));
+  }
+
+  @Test
+  void fcpBindToCallback_whenGetCalled_expectServerBindTo() {
+    // Arrange
+    FCPServer server = newServer();
+    when(core.getEndpoints().getFCPServer()).thenReturn(server);
+    FcpServerConfigRegistrar.FCPBindtoCallback callback =
+        new FcpServerConfigRegistrar.FCPBindtoCallback(core);
+
+    // Act & Assert
+    assertEquals(server.bindTo, callback.get());
+  }
+
+  @Test
+  void fcpAllowedHostsFullAccessCallback_whenValueUnchanged_expectNoException() {
+    // Arrange
+    FCPServer server = newServer();
+    when(core.getEndpoints().getFCPServer()).thenReturn(server);
+    FcpServerConfigRegistrar.FCPAllowedHostsFullAccessCallback callback =
+        new FcpServerConfigRegistrar.FCPAllowedHostsFullAccessCallback(core);
+
+    // Act & Assert
+    assertEquals(server.allowedHostsFullAccess.getAllowedHosts(), callback.get());
+    assertDoesNotThrow(() -> callback.set(server.allowedHostsFullAccess.getAllowedHosts()));
+  }
+
+  @Test
+  void assumeDDADownloadIsAllowedCallback_whenSet_expectServerUpdated() {
+    // Arrange
+    FCPServer server = newServer();
+    FcpServerConfigRegistrar.AssumeDDADownloadIsAllowedCallback callback =
+        new FcpServerConfigRegistrar.AssumeDDADownloadIsAllowedCallback();
+    callback.server = server;
+
+    // Act
+    assertDoesNotThrow(() -> callback.set(true));
+
+    // Assert
+    assertTrue(server.assumeDownloadDDAIsAllowed);
+  }
+
+  @Test
+  void assumeDDAUploadIsAllowedCallback_whenSet_expectServerUpdated() {
+    // Arrange
+    FCPServer server = newServer();
+    FcpServerConfigRegistrar.AssumeDDAUploadIsAllowedCallback callback =
+        new FcpServerConfigRegistrar.AssumeDDAUploadIsAllowedCallback();
+    callback.server = server;
+
+    // Act
+    assertDoesNotThrow(() -> callback.set(true));
+
+    // Assert
+    assertTrue(server.assumeUploadDDAIsAllowed);
+  }
+
+  @Test
+  void neverDropAMessageCallback_whenSet_expectServerUpdated() {
+    // Arrange
+    FCPServer server = newServer();
+    FcpServerConfigRegistrar.NeverDropAMessageCallback callback =
+        new FcpServerConfigRegistrar.NeverDropAMessageCallback();
+    callback.server = server;
+
+    // Act
+    assertDoesNotThrow(() -> callback.set(true));
+
+    // Assert
+    assertTrue(server.neverDropAMessage);
+  }
+
+  @Test
+  void maxMessageQueueLengthCallback_whenSet_expectServerUpdated() {
+    // Arrange
+    FCPServer server = newServer();
+    FcpServerConfigRegistrar.MaxMessageQueueLengthCallback callback =
+        new FcpServerConfigRegistrar.MaxMessageQueueLengthCallback();
+    callback.server = server;
+
+    // Act
+    assertDoesNotThrow(() -> callback.set(42));
+
+    // Assert
+    assertEquals(42, server.maxMessageQueueLength);
+    assertEquals(42, callback.get());
+  }
+
+  private FCPServer newServer() {
+    FcpServerConfig config =
+        new FcpServerConfig(
+            "127.0.0.1",
+            NetworkInterface.DEFAULT_BIND_TO,
+            NetworkInterface.DEFAULT_BIND_TO,
+            FCPServer.DEFAULT_FCP_PORT,
+            true,
+            false,
+            false,
+            false,
+            10);
+    return new FCPServer(
+        config, new FcpServerDependencies(node, core, new PersistentRequestRoot()));
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
@@ -1,0 +1,194 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import network.crypta.io.NetworkInterface;
+import network.crypta.node.Node;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tanukisoftware.wrapper.WrapperManager;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FcpServerListenerTest {
+
+  @Mock private Node node;
+
+  @Test
+  void isSslEnabled_whenToggled_expectUpdatedValue() {
+    // Arrange
+    FcpServerListener.setSslEnabled(false);
+
+    // Act
+    FcpServerListener.setSslEnabled(true);
+
+    // Assert
+    assertTrue(FcpServerListener.isSslEnabled());
+  }
+
+  @Test
+  void getAllowedHosts_whenNetworkInterfaceMissing_expectDefaultBind() {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+
+    // Act
+    String allowedHosts = listener.getAllowedHosts();
+
+    // Assert
+    assertEquals(NetworkInterface.DEFAULT_BIND_TO, allowedHosts);
+  }
+
+  @Test
+  void getAllowedHosts_whenNetworkInterfacePresent_expectConfiguredHosts() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+    NetworkInterface networkInterface = mock(NetworkInterface.class);
+    setNetworkInterface(listener, networkInterface);
+    when(networkInterface.getAllowedHosts()).thenReturn("127.0.0.1");
+
+    // Act
+    String allowedHosts = listener.getAllowedHosts();
+
+    // Assert
+    assertEquals("127.0.0.1", allowedHosts);
+  }
+
+  @Test
+  void setAllowedHosts_whenInvoked_expectDelegation() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+    NetworkInterface networkInterface = mock(NetworkInterface.class);
+    setNetworkInterface(listener, networkInterface);
+
+    // Act
+    listener.setAllowedHosts("127.0.0.1");
+
+    // Assert
+    verify(networkInterface).setAllowedHosts("127.0.0.1");
+  }
+
+  @Test
+  void setBindTo_whenInvoked_expectDelegationResult() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+    NetworkInterface networkInterface = mock(NetworkInterface.class);
+    String[] expected = new String[] {"failed"};
+    setNetworkInterface(listener, networkInterface);
+    when(networkInterface.setBindTo("0.0.0.0", true)).thenReturn(expected);
+
+    // Act
+    String[] result = listener.setBindTo("0.0.0.0", true);
+
+    // Assert
+    assertArrayEquals(expected, result);
+  }
+
+  @Test
+  void updateBindTo_whenInvoked_expectFieldUpdated() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+
+    // Act
+    listener.updateBindTo("0.0.0.0");
+
+    // Assert
+    assertEquals("0.0.0.0", getBindTo(listener));
+  }
+
+  @Test
+  void maybeStart_whenDisabled_expectNetworkInterfaceCleared() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(false);
+    NetworkInterface networkInterface = mock(NetworkInterface.class);
+    setNetworkInterface(listener, networkInterface);
+
+    // Act
+    listener.maybeStart();
+
+    // Assert
+    assertNull(getNetworkInterface(listener));
+  }
+
+  @Test
+  void maybeStart_whenEnabledAndInterfacePreset_expectInterfaceRetained() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+    NetworkInterface networkInterface = mock(NetworkInterface.class);
+    setNetworkInterface(listener, networkInterface);
+
+    // Act
+    listener.maybeStart();
+
+    // Assert
+    assertSame(networkInterface, getNetworkInterface(listener));
+  }
+
+  @Test
+  void run_whenWaitBoundThrowsAndShutdownTriggered_expectExit() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+    NetworkInterface networkInterface = mock(NetworkInterface.class);
+    setNetworkInterface(listener, networkInterface);
+    doThrow(new IllegalStateException("boom")).when(networkInterface).waitBound();
+
+    // Act
+    try (var wrapper = mockStatic(WrapperManager.class)) {
+      //noinspection ResultOfMethodCallIgnored
+      wrapper.when(WrapperManager::hasShutdownHookBeenTriggered).thenReturn(true);
+      listener.run();
+    }
+
+    // Assert
+    verify(networkInterface).waitBound();
+  }
+
+  private FcpServerListener newListener(boolean enabled) {
+    FCPServer server = mock(FCPServer.class);
+    FcpServerConfig config =
+        new FcpServerConfig(
+            "127.0.0.1",
+            NetworkInterface.DEFAULT_BIND_TO,
+            NetworkInterface.DEFAULT_BIND_TO,
+            FCPServer.DEFAULT_FCP_PORT,
+            enabled,
+            false,
+            false,
+            false,
+            10);
+    return new FcpServerListener(server, node, config);
+  }
+
+  private void setNetworkInterface(FcpServerListener listener, NetworkInterface value)
+      throws Exception {
+    Field field = FcpServerListener.class.getDeclaredField("networkInterface");
+    field.setAccessible(true);
+    field.set(listener, value);
+  }
+
+  private NetworkInterface getNetworkInterface(FcpServerListener listener) throws Exception {
+    Field field = FcpServerListener.class.getDeclaredField("networkInterface");
+    field.setAccessible(true);
+    return (NetworkInterface) field.get(listener);
+  }
+
+  private String getBindTo(FcpServerListener listener) throws Exception {
+    Field field = FcpServerListener.class.getDeclaredField("bindTo");
+    field.setAccessible(true);
+    Object value = field.get(listener);
+    assertNotNull(value);
+    return (String) value;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
@@ -1,0 +1,701 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.FetchResult;
+import network.crypta.client.async.CacheFetchResult;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FcpServerPersistentOpsTest {
+
+  @Mock private NodeClientCore core;
+
+  @Mock private FCPServer server;
+
+  @Test
+  void load_whenInvoked_expectNoException() {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+
+    // Act & Assert
+    assertDoesNotThrow(ops::load);
+  }
+
+  @Test
+  void registerRebootClient_whenNewName_expectConnectionStored() {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+
+    // Act
+    PersistentRequestClient client = ops.registerRebootClient("clientA", handler);
+
+    // Assert
+    assertSame(handler, client.getConnection());
+  }
+
+  @Test
+  void registerRebootClient_whenDuplicate_expectOldConnectionClosed() {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    FCPConnectionHandler first = mock(FCPConnectionHandler.class);
+    FCPConnectionHandler second = mock(FCPConnectionHandler.class);
+    PersistentRequestClient initial = ops.registerRebootClient("dup", first);
+
+    // Act
+    PersistentRequestClient returned = ops.registerRebootClient("dup", second);
+
+    // Assert
+    assertSame(initial, returned);
+    assertSame(second, returned.getConnection());
+    verify(first).setKilledDupe();
+    verify(first).send(any(CloseConnectionDuplicateClientNameMessage.class));
+    verify(first).close();
+  }
+
+  @Test
+  void unregisterClient_whenRebootClient_expectMappingRemoved() {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    PersistentRequestClient first = ops.registerRebootClient("clientA", handler);
+
+    // Act
+    ops.unregisterClient(first);
+    PersistentRequestClient second = ops.registerRebootClient("clientA", handler);
+
+    // Assert
+    assertNotSame(first, second);
+  }
+
+  @Test
+  void registerForeverClient_whenInvoked_expectDelegation() {
+    // Arrange
+    PersistentRequestRoot root = mock(PersistentRequestRoot.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    FcpServerPersistentOps ops = newOps(root);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(root.registerForeverClient("forever", handler)).thenReturn(client);
+
+    // Act
+    PersistentRequestClient result = ops.registerForeverClient("forever", handler);
+
+    // Assert
+    assertSame(client, result);
+    verify(root).registerForeverClient("forever", handler);
+  }
+
+  @Test
+  void getForeverClient_whenInvoked_expectDelegation() {
+    // Arrange
+    PersistentRequestRoot root = mock(PersistentRequestRoot.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    FcpServerPersistentOps ops = newOps(root);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(root.getForeverClient("forever", handler)).thenReturn(client);
+
+    // Act
+    PersistentRequestClient result = ops.getForeverClient("forever", handler);
+
+    // Assert
+    assertSame(client, result);
+    verify(root).getForeverClient("forever", handler);
+  }
+
+  @Test
+  void unregisterClient_whenForeverClient_expectRootNotified() {
+    // Arrange
+    PersistentRequestRoot root = spy(new PersistentRequestRoot());
+    FcpServerPersistentOps ops = newOps(root);
+    PersistentRequestClient client =
+        new PersistentRequestClient("forever", null, false, null, Persistence.FOREVER, root);
+
+    // Act
+    ops.unregisterClient(client);
+
+    // Assert
+    verify(root).maybeUnregisterClient(client);
+  }
+
+  @Test
+  void getGlobalRequests_whenDatabaseKilled_expectPersistenceDisabledException() {
+    // Arrange
+    when(core.killedDatabase()).thenReturn(true);
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+
+    // Act & Assert
+    assertThrows(PersistenceDisabledException.class, ops::getGlobalRequests);
+  }
+
+  @Test
+  void getGlobalRequests_whenCacheContainsEntry_expectStatusReturned() throws Exception {
+    // Arrange
+    when(core.killedDatabase()).thenReturn(false);
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = ops.getGlobalRebootClient();
+    FreenetURI uri = mock(FreenetURI.class);
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            "id-1",
+            Persistence.REBOOT,
+            false,
+            false,
+            false,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            false,
+            (short) 0);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(10, "text/plain", null, null, null, mock(Bucket.class), false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
+    DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
+    rebootClient.getRequestStatusCache().addDownload(status);
+
+    // Act
+    RequestStatus[] result = ops.getGlobalRequests();
+
+    // Assert
+    assertEquals(1, result.length);
+    assertEquals("id-1", result[0].getIdentifier());
+  }
+
+  @Test
+  void removeGlobalRequestBlocking_whenRebootRemoves_expectTrue() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
+    ClientContext context = mock(ClientContext.class);
+    when(core.getClientContext()).thenReturn(context);
+    when(rebootClient.removeByIdentifier("id", true, server, context)).thenReturn(true);
+    setField(ops, "globalRebootClient", rebootClient);
+    setField(ops, "globalForeverClient", foreverClient);
+
+    // Act
+    boolean result = ops.removeGlobalRequestBlocking("id");
+
+    // Assert
+    assertTrue(result);
+    verify(rebootClient).removeByIdentifier("id", true, server, context);
+  }
+
+  @Test
+  void removeGlobalRequestBlocking_whenRebootMissing_expectForeverRemoval() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
+    ClientContext context = clientContextWithJobRunner(new ImmediateJobRunner());
+    when(core.getClientContext()).thenReturn(context);
+    when(rebootClient.removeByIdentifier("id", true, server, context)).thenReturn(false);
+    when(foreverClient.removeByIdentifier("id", true, server, context)).thenReturn(true);
+    setField(ops, "globalRebootClient", rebootClient);
+    setField(ops, "globalForeverClient", foreverClient);
+
+    // Act
+    boolean result = ops.removeGlobalRequestBlocking("id");
+
+    // Assert
+    assertTrue(result);
+    verify(foreverClient).removeByIdentifier("id", true, server, context);
+  }
+
+  @Test
+  void removeAllGlobalRequestsBlocking_whenQueued_expectTrue() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
+    ClientContext context = clientContextWithJobRunner(new ImmediateJobRunner());
+    when(core.getClientContext()).thenReturn(context);
+    setField(ops, "globalRebootClient", rebootClient);
+    setField(ops, "globalForeverClient", foreverClient);
+
+    // Act
+    boolean result = ops.removeAllGlobalRequestsBlocking();
+
+    // Assert
+    assertTrue(result);
+    verify(rebootClient).removeAll();
+    verify(foreverClient).removeAll();
+  }
+
+  @Test
+  void modifyGlobalRequestBlocking_whenRebootRequestPresent_expectModified() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    ClientRequest request = mock(ClientRequest.class);
+    when(rebootClient.getRequest("id")).thenReturn(request);
+    setField(ops, "globalRebootClient", rebootClient);
+
+    // Act
+    boolean result = ops.modifyGlobalRequestBlocking("id", "token", (short) 2);
+
+    // Assert
+    assertTrue(result);
+    verify(request).modifyRequest("token", (short) 2, server);
+  }
+
+  @Test
+  void modifyGlobalRequestBlocking_whenRebootMissing_expectForeverModified() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
+    ClientRequest request = mock(ClientRequest.class);
+    ClientContext context = clientContextWithJobRunner(new ImmediateJobRunner());
+    when(core.getClientContext()).thenReturn(context);
+    when(rebootClient.getRequest("id")).thenReturn(null);
+    when(foreverClient.getRequest("id")).thenReturn(request);
+    setField(ops, "globalRebootClient", rebootClient);
+    setField(ops, "globalForeverClient", foreverClient);
+
+    // Act
+    boolean result = ops.modifyGlobalRequestBlocking("id", "token", (short) 2);
+
+    // Assert
+    assertTrue(result);
+    verify(request).modifyRequest("token", (short) 2, server);
+  }
+
+  @Test
+  void makePersistentGlobalRequestBlocking_whenJobSucceeds_expectNoException() throws Exception {
+    // Arrange
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    FcpServerPersistentOps ops = spy(newOps(root));
+    ClientContext context = clientContextWithJobRunner(new ImmediateJobRunner());
+    when(core.getClientContext()).thenReturn(context);
+    PersistentGlobalRequestParams params =
+        new PersistentGlobalRequestParams(
+            mock(FreenetURI.class), true, "text/plain", "reboot", "none", false, new File("/tmp"));
+    doNothing().when(ops).makePersistentGlobalRequest(params);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> ops.makePersistentGlobalRequestBlocking(params));
+  }
+
+  @Test
+  void makePersistentGlobalRequestBlocking_whenJobThrowsIOException_expectPropagated()
+      throws Exception {
+    // Arrange
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    FcpServerPersistentOps ops = spy(newOps(root));
+    ClientContext context = clientContextWithJobRunner(new ImmediateJobRunner());
+    when(core.getClientContext()).thenReturn(context);
+    PersistentGlobalRequestParams params =
+        new PersistentGlobalRequestParams(
+            mock(FreenetURI.class), false, "text/plain", "reboot", "none", false, new File("/tmp"));
+    doThrow(new IOException("boom")).when(ops).makePersistentGlobalRequest(params);
+
+    // Act & Assert
+    assertThrows(IOException.class, () -> ops.makePersistentGlobalRequestBlocking(params));
+  }
+
+  @Test
+  void makePersistentGlobalRequestBlocking_whenOverloadInvoked_expectParamsForwarded()
+      throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = spy(newOps(new PersistentRequestRoot()));
+    FreenetURI uri = mock(FreenetURI.class);
+    AtomicReference<PersistentGlobalRequestParams> captured = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              captured.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(ops)
+        .makePersistentGlobalRequestBlocking(any(PersistentGlobalRequestParams.class));
+
+    // Act
+    ops.makePersistentGlobalRequestBlocking(
+        uri, true, "text/plain", "reboot", "none", true, new File("/tmp"));
+
+    // Assert
+    PersistentGlobalRequestParams params = captured.get();
+    assertNotNull(params);
+    assertSame(uri, params.fetchURI());
+    assertEquals("text/plain", params.expectedMimeType());
+    assertEquals("reboot", params.persistenceType());
+    assertEquals("none", params.returnType());
+  }
+
+  @Test
+  void makePersistentGlobalRequest_whenInvalidReturnType_expectIllegalArgumentException() {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentGlobalRequestParams params =
+        new PersistentGlobalRequestParams(
+            mock(FreenetURI.class),
+            false,
+            "text/plain",
+            "reboot",
+            "bogus",
+            false,
+            new File("/tmp"));
+
+    // Act & Assert
+    assertThrows(IllegalArgumentException.class, () -> ops.makePersistentGlobalRequest(params));
+  }
+
+  @Test
+  void makePersistentGlobalRequest_whenOverloadUsesDownloadsDir_expectForwarded() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = spy(newOps(new PersistentRequestRoot()));
+    FreenetURI uri = mock(FreenetURI.class);
+    File downloads = new File("/tmp/downloads");
+    when(core.getDownloadsDir()).thenReturn(downloads);
+    AtomicReference<PersistentGlobalRequestParams> captured = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              captured.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(ops)
+        .makePersistentGlobalRequest(any(PersistentGlobalRequestParams.class));
+
+    // Act
+    ops.makePersistentGlobalRequest(uri, false, "text/plain", "reboot", "none", false);
+
+    // Assert
+    PersistentGlobalRequestParams params = captured.get();
+    assertNotNull(params);
+    assertSame(downloads, params.downloadsDir());
+  }
+
+  @Test
+  void makePersistentGlobalRequest_whenOverloadWithDir_expectForwarded() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = spy(newOps(new PersistentRequestRoot()));
+    FreenetURI uri = mock(FreenetURI.class);
+    File downloads = new File("/tmp/custom");
+    AtomicReference<PersistentGlobalRequestParams> captured = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              captured.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(ops)
+        .makePersistentGlobalRequest(any(PersistentGlobalRequestParams.class));
+
+    // Act
+    ops.makePersistentGlobalRequest(uri, true, "text/plain", "reboot", "none", true, downloads);
+
+    // Assert
+    assertSame(downloads, captured.get().downloadsDir());
+  }
+
+  @Test
+  void getGlobalForeverClient_whenInvoked_expectInstance() {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+
+    // Act
+    PersistentRequestClient client = ops.getGlobalForeverClient();
+
+    // Assert
+    assertNotNull(client);
+  }
+
+  @Test
+  void getGlobalRequest_whenRebootPresent_expectRebootRequestReturned() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
+    ClientRequest request = mock(ClientRequest.class);
+    when(rebootClient.getRequest("id")).thenReturn(request);
+    setField(ops, "globalRebootClient", rebootClient);
+    setField(ops, "globalForeverClient", foreverClient);
+
+    // Act
+    ClientRequest result = ops.getGlobalRequest("id");
+
+    // Assert
+    assertSame(request, result);
+    verify(foreverClient, times(0)).getRequest("id");
+  }
+
+  @Test
+  void setCompletionCallback_whenInvoked_expectAddedToQueues() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
+    RequestCompletionCallback callback = mock(RequestCompletionCallback.class);
+    setField(ops, "globalRebootClient", rebootClient);
+    setField(ops, "globalForeverClient", foreverClient);
+
+    // Act
+    ops.setCompletionCallback(callback);
+
+    // Assert
+    verify(rebootClient).addRequestCompletionCallback(callback);
+    verify(foreverClient).addRequestCompletionCallback(callback);
+  }
+
+  @Test
+  void startBlocking_whenRebootRequest_expectStartInvoked() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    ClientRequest request = mock(ClientRequest.class);
+    ClientContext context = mock(ClientContext.class);
+    when(core.getClientContext()).thenReturn(context);
+    setClientRequestPersistence(request, Persistence.REBOOT);
+
+    // Act
+    ops.startBlocking(request);
+
+    // Assert
+    verify(request).start(any(ClientContext.class));
+  }
+
+  @Test
+  void startBlocking_whenForeverRequest_expectQueuedAndStarted() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    ClientRequest request = mock(ClientRequest.class);
+    ClientContext context = clientContextWithJobRunner(new ImmediateJobRunner());
+    when(core.getClientContext()).thenReturn(context);
+    setClientRequestPersistence(request, Persistence.FOREVER);
+
+    // Act
+    ops.startBlocking(request);
+
+    // Assert
+    verify(request).register(false);
+    verify(request).start(any(ClientContext.class));
+  }
+
+  @Test
+  void restartBlocking_whenRebootRequest_expectRestarted() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    ClientRequest request = mock(ClientRequest.class);
+    ClientContext context = mock(ClientContext.class);
+    when(core.getClientContext()).thenReturn(context);
+    when(rebootClient.getRequest("id")).thenReturn(request);
+    setField(ops, "globalRebootClient", rebootClient);
+
+    // Act
+    boolean result = ops.restartBlocking("id", true);
+
+    // Assert
+    assertTrue(result);
+    verify(request).restart(context, true);
+  }
+
+  @Test
+  void restartBlocking_whenRebootMissing_expectForeverRestarted() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
+    ClientRequest request = mock(ClientRequest.class);
+    ClientContext context = clientContextWithJobRunner(new ImmediateJobRunner());
+    when(core.getClientContext()).thenReturn(context);
+    when(rebootClient.getRequest("id")).thenReturn(null);
+    when(foreverClient.getRequest("id")).thenReturn(request);
+    setField(ops, "globalRebootClient", rebootClient);
+    setField(ops, "globalForeverClient", foreverClient);
+
+    // Act
+    boolean result = ops.restartBlocking("id", false);
+
+    // Assert
+    assertTrue(result);
+    verify(request).restart(any(ClientContext.class), eq(false));
+  }
+
+  @Test
+  void getCompletedRequestBlocking_whenRebootCompleted_expectFetchResult() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    ClientGet get = mock(ClientGet.class);
+    Bucket bucket = mock(Bucket.class);
+    when(get.getMIMEType()).thenReturn("text/plain");
+    when(get.getBucket()).thenReturn(bucket);
+    when(rebootClient.getCompletedRequest(any(FreenetURI.class))).thenReturn(get);
+    setField(ops, "globalRebootClient", rebootClient);
+
+    // Act
+    FetchResult result = ops.getCompletedRequestBlocking(mock(FreenetURI.class));
+
+    // Assert
+    assertEquals("text/plain", result.getMimeType());
+    assertNotNull(result.getMetadata());
+  }
+
+  @Test
+  void lookupInstant_whenCompletedRequestNoCopy_expectCacheResult() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
+    ClientGet get = mock(ClientGet.class);
+    Bucket bucket = mock(Bucket.class);
+    when(get.filterData()).thenReturn(true);
+    when(get.getMIMEType()).thenReturn("text/plain");
+    when(get.getBucket()).thenReturn(bucket);
+    when(rebootClient.getCompletedRequest(any(FreenetURI.class))).thenReturn(get);
+    setField(ops, "globalRebootClient", rebootClient);
+
+    // Act
+    CacheFetchResult result = ops.lookupInstant(mock(FreenetURI.class), false, false, null);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals("text/plain", result.getMimeType());
+    assertTrue(result.alreadyFiltered);
+  }
+
+  @Test
+  void lookup_whenCompletedRequestNoCopy_expectShadowBucketReturned() throws Exception {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+    PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
+    ClientGet get = mock(ClientGet.class);
+    Bucket bucket = mock(Bucket.class);
+    Bucket shadow = mock(Bucket.class);
+    when(get.filterData()).thenReturn(false);
+    when(get.getBucket()).thenReturn(bucket);
+    when(get.getMIMEType()).thenReturn("text/plain");
+    when(bucket.createShadow()).thenReturn(shadow);
+    when(foreverClient.getCompletedRequest(any(FreenetURI.class))).thenReturn(get);
+    setField(ops, "globalForeverClient", foreverClient);
+
+    // Act
+    CacheFetchResult result =
+        ops.lookup(mock(FreenetURI.class), false, mock(ClientContext.class), false, null);
+
+    // Assert
+    assertNotNull(result);
+    assertSame(shadow, result.asBucket());
+    assertEquals("text/plain", result.getMimeType());
+  }
+
+  @Test
+  void getGlobalRebootClient_whenInvoked_expectInstance() {
+    // Arrange
+    FcpServerPersistentOps ops = newOps(new PersistentRequestRoot());
+
+    // Act
+    PersistentRequestClient client = ops.getGlobalRebootClient();
+
+    // Assert
+    assertNotNull(client);
+  }
+
+  private FcpServerPersistentOps newOps(PersistentRequestRoot root) {
+    return new FcpServerPersistentOps(server, core, root);
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private ClientContext clientContextWithJobRunner(PersistentJobRunner runner) throws Exception {
+    ClientContext context = mock(ClientContext.class);
+    Field field = ClientContext.class.getDeclaredField("jobRunner");
+    field.setAccessible(true);
+    field.set(context, runner);
+    return context;
+  }
+
+  private void setClientRequestPersistence(ClientRequest request, Persistence persistence)
+      throws Exception {
+    Field field = ClientRequest.class.getDeclaredField("persistence");
+    field.setAccessible(true);
+    field.set(request, persistence);
+  }
+
+  private static final class ImmediateJobRunner implements PersistentJobRunner {
+    @Override
+    public void queue(PersistentJob persistentJob, int threadPriority) {
+      persistentJob.run(mock(ClientContext.class));
+    }
+
+    @Override
+    public void queueNormalOrDrop(PersistentJob persistentJob) {
+      persistentJob.run(mock(ClientContext.class));
+    }
+
+    @Override
+    public void queueInternal(PersistentJob job, int threadPriority) {
+      job.run(mock(ClientContext.class));
+    }
+
+    @Override
+    public void queueInternal(PersistentJob job) {
+      job.run(mock(ClientContext.class));
+    }
+
+    @Override
+    public void setCheckpointASAP() {
+      // This test runner executes jobs synchronously and does not model checkpoints.
+      throw new UnsupportedOperationException("Checkpoint scheduling is not supported in tests");
+    }
+
+    @Override
+    public boolean hasLoaded() {
+      return true;
+    }
+
+    @Override
+    public CheckpointLock lock() {
+      return (_, _) -> {};
+    }
+
+    @Override
+    public boolean newSalt() {
+      return false;
+    }
+
+    @Override
+    public boolean shuttingDown() {
+      return false;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FcpServerPluginConnectionsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerPluginConnectionsTest.java
@@ -1,0 +1,170 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.UUID;
+import network.crypta.clients.fcp.FCPPluginConnection.SendDirection;
+import network.crypta.node.Node;
+import network.crypta.pluginmanager.FredPluginFCPMessageHandler.ClientSideFCPMessageHandler;
+import network.crypta.pluginmanager.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FcpServerPluginConnectionsTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Test
+  void startTrackerIfEnabled_whenEnabled_expectTrackerStarted() throws Exception {
+    // Arrange
+    FcpServerPluginConnections connections = new FcpServerPluginConnections(node);
+    FCPPluginConnectionTracker tracker = mock(FCPPluginConnectionTracker.class);
+    setTracker(connections, tracker);
+    when(node.services().pluginManager().isEnabled()).thenReturn(true);
+
+    // Act
+    connections.startTrackerIfEnabled();
+
+    // Assert
+    verify(tracker).start();
+  }
+
+  @Test
+  void startTrackerIfEnabled_whenDisabled_expectNoStart() throws Exception {
+    // Arrange
+    FcpServerPluginConnections connections = new FcpServerPluginConnections(node);
+    FCPPluginConnectionTracker tracker = mock(FCPPluginConnectionTracker.class);
+    setTracker(connections, tracker);
+    when(node.services().pluginManager().isEnabled()).thenReturn(false);
+
+    // Act
+    connections.startTrackerIfEnabled();
+
+    // Assert
+    verify(tracker, never()).start();
+  }
+
+  @Test
+  void createFCPPluginConnectionForNetworkedFCP_whenInvoked_expectStaticFactoryUsed()
+      throws Exception {
+    // Arrange
+    FcpServerPluginConnections connections = new FcpServerPluginConnections(node);
+    FCPPluginConnectionTracker tracker = getTracker(connections);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    FCPPluginConnectionImpl expected = mock(FCPPluginConnectionImpl.class);
+    PluginManager pluginManager = node.services().pluginManager();
+
+    try (MockedStatic<FCPPluginConnectionImpl> mocked = mockStatic(FCPPluginConnectionImpl.class)) {
+      mocked
+          .when(
+              () ->
+                  FCPPluginConnectionImpl.constructForNetworkedFCP(
+                      tracker, node.network().executor(), pluginManager, "plugin", handler))
+          .thenReturn(expected);
+
+      // Act
+      FCPPluginConnectionImpl result =
+          connections.createFCPPluginConnectionForNetworkedFCP("plugin", handler);
+
+      // Assert
+      assertSame(expected, result);
+    }
+  }
+
+  @Test
+  void createFCPPluginConnectionForIntraNodeFCP_whenInvoked_expectAdapterReturned()
+      throws Exception {
+    // Arrange
+    FcpServerPluginConnections connections = new FcpServerPluginConnections(node);
+    FCPPluginConnectionTracker tracker = getTracker(connections);
+    ClientSideFCPMessageHandler handler = mock(ClientSideFCPMessageHandler.class);
+    FCPPluginConnectionImpl connection = mock(FCPPluginConnectionImpl.class);
+    FCPPluginConnection adapter = mock(FCPPluginConnection.class);
+    PluginManager pluginManager = node.services().pluginManager();
+    when(connection.getDefaultSendDirectionAdapter(SendDirection.TO_SERVER)).thenReturn(adapter);
+
+    try (MockedStatic<FCPPluginConnectionImpl> mocked = mockStatic(FCPPluginConnectionImpl.class)) {
+      mocked
+          .when(
+              () ->
+                  FCPPluginConnectionImpl.constructForIntraNodeFCP(
+                      tracker, node.network().executor(), pluginManager, "plugin", handler))
+          .thenReturn(connection);
+
+      // Act
+      FCPPluginConnection result =
+          connections.createFCPPluginConnectionForIntraNodeFCP("plugin", handler);
+
+      // Assert
+      assertSame(adapter, result);
+      verify(connection).getDefaultSendDirectionAdapter(SendDirection.TO_SERVER);
+    }
+  }
+
+  @Test
+  void getPluginConnectionByID_whenInvoked_expectAdapterReturned() throws Exception {
+    // Arrange
+    FcpServerPluginConnections connections = new FcpServerPluginConnections(node);
+    FCPPluginConnectionTracker tracker = mock(FCPPluginConnectionTracker.class);
+    FCPPluginConnectionImpl connection = mock(FCPPluginConnectionImpl.class);
+    FCPPluginConnection adapter = mock(FCPPluginConnection.class);
+    UUID id = UUID.randomUUID();
+    when(tracker.getConnection(id)).thenReturn(connection);
+    when(connection.getDefaultSendDirectionAdapter(SendDirection.TO_CLIENT)).thenReturn(adapter);
+    setTracker(connections, tracker);
+
+    // Act
+    FCPPluginConnection result = connections.getPluginConnectionByID(id);
+
+    // Assert
+    assertSame(adapter, result);
+    verify(tracker).getConnection(id);
+  }
+
+  @Test
+  void getPluginConnectionByID_whenTrackerThrows_expectIOException() throws Exception {
+    // Arrange
+    FcpServerPluginConnections connections = new FcpServerPluginConnections(node);
+    FCPPluginConnectionTracker tracker = mock(FCPPluginConnectionTracker.class);
+    UUID id = UUID.randomUUID();
+    IOException failure = new IOException("boom");
+    when(tracker.getConnection(id)).thenThrow(failure);
+    setTracker(connections, tracker);
+
+    // Act
+    IOException result =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            IOException.class, () -> connections.getPluginConnectionByID(id));
+
+    // Assert
+    assertSame(failure, result);
+  }
+
+  private static FCPPluginConnectionTracker getTracker(FcpServerPluginConnections connections)
+      throws Exception {
+    Field field = FcpServerPluginConnections.class.getDeclaredField("pluginConnectionTracker");
+    field.setAccessible(true);
+    return (FCPPluginConnectionTracker) field.get(connections);
+  }
+
+  private static void setTracker(FcpServerPluginConnections connections, Object tracker)
+      throws Exception {
+    Field field = FcpServerPluginConnections.class.getDeclaredField("pluginConnectionTracker");
+    field.setAccessible(true);
+    field.set(connections, tracker);
+  }
+}


### PR DESCRIPTION
## Summary
- refactor FCPServer into listener, persistence, plugin connection, and config registrar helpers
- update FCP server Javadocs to reflect new responsibilities and delegation
- add unit tests covering the new helper classes and config registration