### PR TITLE
test(sonarlint): isolate exception assertions

### DIFF
--- a/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
@@ -69,20 +69,19 @@ class DefaultManifestPutterTest {
     InsertContext ctx = newInsertContextCurrent();
 
     // Act + Assert
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new DefaultManifestPutter(
-                new ManifestPutterParams(
-                    cb,
-                    root,
-                    /*prioClass*/ (short) 0,
-                    FreenetURI.EMPTY_CHK_URI,
-                    /*defaultName*/ "index.html",
-                    ctx,
-                    /*forceCryptoKey*/ null,
-                    /*context*/ mock(ClientContext.class)),
-                /*persistent*/ false));
+    ClientContext context = mock(ClientContext.class);
+    ManifestPutterParams params =
+        new ManifestPutterParams(
+            cb,
+            root,
+            /*prioClass*/ (short) 0,
+            FreenetURI.EMPTY_CHK_URI,
+            /*defaultName*/ "index.html",
+            ctx,
+            /*forceCryptoKey*/ null,
+            context);
+
+    assertThrows(IllegalArgumentException.class, () -> new DefaultManifestPutter(params, false));
   }
 
   // A subclass that lets us spy on the builders created during packing
@@ -172,7 +171,7 @@ class DefaultManifestPutterTest {
     assertEquals(ManifestElement.class, idx.getClass());
     assertEquals(ManifestElement.class, sty.getClass());
     assertEquals(Metadata.class, def.getClass());
-    // Access private field via reflection to verify shortlink type
+    // Access the private field via reflection to verify the shortlink type
     DocumentType dt1 = (DocumentType) readField(def, "documentType");
     assertEquals(DocumentType.SYMBOLIC_SHORTLINK, dt1);
   }
@@ -205,7 +204,7 @@ class DefaultManifestPutterTest {
             /*forceKey*/ null,
             /*context*/ mock(ClientContext.class));
 
-    // Assert: small file added in-container, big file added as external
+    // Assert: the small file added in-container, the big file added as external
     verify(putter.rootSpy, atLeastOnce())
         .addItem(eq("index.html"), eq("index.html"), any(ManifestElement.class), eq(true));
     verify(putter.rootSpy, atLeastOnce())
@@ -259,11 +258,11 @@ class DefaultManifestPutterTest {
             /*forceKey*/ null,
             /*context*/ mock(ClientContext.class));
 
-    // A is added as item, B and C are added to some archive (single or filled)
+    // A is added as an item, B and C are added to some archive (single or filled)
     verify(putter.rootSpy, atLeastOnce())
         .addItem(eq("A.bin"), eq("A.bin"), any(ManifestElement.class), eq(true));
 
-    // Capture the archive add calls and assert names
+    // Capture the archive, add calls and assert names
     org.mockito.ArgumentCaptor<BaseManifestPutter.ContainerBuilder> arcCap =
         org.mockito.ArgumentCaptor.forClass(BaseManifestPutter.ContainerBuilder.class);
     org.mockito.ArgumentCaptor<String> nameCap = org.mockito.ArgumentCaptor.forClass(String.class);

--- a/src/test/java/network/crypta/clients/fcp/ExpectedHashesTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ExpectedHashesTest.java
@@ -12,6 +12,7 @@ import network.crypta.crypt.HashType;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 @SuppressWarnings("java:S100")
@@ -91,13 +92,10 @@ class ExpectedHashesTest {
   @Test
   void run_whenInvoked_expectUnsupportedOperationException() {
     ExpectedHashes expectedHashes = new ExpectedHashes(new HashResult[0], "run", false);
+    FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
+    Node node = Mockito.mock(Node.class, Answers.RETURNS_DEEP_STUBS);
 
-    assertThrows(
-        UnsupportedOperationException.class,
-        () ->
-            expectedHashes.run(
-                Mockito.mock(FCPConnectionHandler.class),
-                Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS)));
+    assertThrows(UnsupportedOperationException.class, () -> expectedHashes.run(handler, node));
   }
 
   private static HashResult createHash(HashType type, byte fillValue) {

--- a/src/test/java/network/crypta/clients/fcp/ExpectedHashesTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ExpectedHashesTest.java
@@ -92,6 +92,7 @@ class ExpectedHashesTest {
   @Test
   void run_whenInvoked_expectUnsupportedOperationException() {
     ExpectedHashes expectedHashes = new ExpectedHashes(new HashResult[0], "run", false);
+    //noinspection resource
     FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
     Node node = Mockito.mock(Node.class, Answers.RETURNS_DEEP_STUBS);
 

--- a/src/test/java/network/crypta/config/PersistentConfigTest.java
+++ b/src/test/java/network/crypta/config/PersistentConfigTest.java
@@ -198,11 +198,10 @@ class PersistentConfigTest {
     cfg.finishedInit();
     SubConfig sub = cfg.createSubConfig("s");
     NullIntCallback cb = new NullIntCallback();
+    Option.Meta meta = new Option.Meta(0, false, false, "sd", "ld");
 
     // Act + Assert
-    assertThrows(
-        IllegalStateException.class,
-        () -> sub.register("o", 1, new Option.Meta(0, false, false, "sd", "ld"), cb, false));
+    assertThrows(IllegalStateException.class, () -> sub.register("o", 1, meta, cb, false));
   }
 
   @Test

--- a/src/test/java/network/crypta/node/PeerNodeRoutingReporterTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeRoutingReporterTest.java
@@ -161,15 +161,13 @@ class PeerNodeRoutingReporterTest {
     RunningAverage bulk = mock(RunningAverage.class);
     Set<PeerNode> routedTo = Set.of();
     double target = 0.1;
+    PeerNodeRoutingReportParams params =
+        new PeerNodeRoutingReportParams(target, true, true, null, routedTo, 5);
     when(peerNode.getLocation()).thenReturn(-0.5);
 
     assertThrows(
         IllegalArgumentException.class,
-        () ->
-            PeerNodeRoutingReporter.reportRoutedTo(
-                node,
-                peerNode,
-                new PeerNodeRoutingReportParams(target, true, true, null, routedTo, 5)));
+        () -> PeerNodeRoutingReporter.reportRoutedTo(node, peerNode, params));
 
     verifyNoInteractions(overall, local, remote, rt, bulk);
   }


### PR DESCRIPTION
## Summary
- isolate assertThrows lambdas to satisfy SonarLint S5778 in test cases
- keep test setup unchanged while extracting inputs for clarity

## Testing
- ./gradlew test --tests \"network.crypta.client.async.DefaultManifestPutterTest\"
- ./gradlew test --tests \"network.crypta.clients.fcp.ExpectedHashesTest\"
- ./gradlew test --tests \"network.crypta.config.PersistentConfigTest\"
- ./gradlew test --tests \"network.crypta.node.PeerNodeRoutingReporterTest\"
- ./gradlew test
- ./gradlew sonarlintFile -Psonarlint.file=\"src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java\"
- ./gradlew sonarlintFile -Psonarlint.file=\"src/test/java/network/crypta/clients/fcp/ExpectedHashesTest.java\"
- ./gradlew sonarlintFile -Psonarlint.file=\"src/test/java/network/crypta/config/PersistentConfigTest.java\"
- ./gradlew sonarlintFile -Psonarlint.file=\"src/test/java/network/crypta/node/PeerNodeRoutingReporterTest.java\"