### PR TITLE
style(javadoc): tidy comments and test helpers

### DIFF
--- a/src/main/java/network/crypta/client/async/PersistentJobRunner.java
+++ b/src/main/java/network/crypta/client/async/PersistentJobRunner.java
@@ -51,12 +51,12 @@ public interface PersistentJobRunner {
    * @param threadPriority the platform-specific priority to apply when running the job; higher
    *     numbers indicate higher priority as defined by the executor.
    * @throws PersistenceDisabledException if persistence is not available or the runner is shutting
-   *     down so jobs cannot be accepted.
+   *     down, so jobs cannot be accepted.
    */
   void queue(PersistentJob persistentJob, int threadPriority) throws PersistenceDisabledException;
 
   /**
-   * Queue a job at the normal priority, or silently drop it when persistence is disabled.
+   * Queue a job at the normal priority or silently drop it when persistence is disabled.
    *
    * <p>This is a convenience for callers that can safely ignore the work when persistence is not
    * active, avoiding checked exception handling. The job is not persisted and may be delayed until
@@ -68,13 +68,13 @@ public interface PersistentJobRunner {
   void queueNormalOrDrop(PersistentJob persistentJob);
 
   /**
-   * Start an "internal" job. We will not checkpoint until all the internal jobs have finished; we
+   * Start an "internal" job. We will not check point until all the internal jobs have finished; we
    * do not queue them at all. Hence, a series of internal jobs is atomic. This should be used for
    * stuff like creating the next stage of a request, where storing the half-way state would lead to
    * it potentially not restarting properly after shutdown. It MUST NOT be used for events from
-   * outside the client layer, including finding blocks in the datastore, on the network etc.
+   * outside the client layer, including finding blocks in the datastore, on the network, etc.
    *
-   * <p>FIXME this doesn't queue at all. Come up with a better name! :)
+   * <p>Note: this doesn't queue at all; the name reflects legacy usage.
    *
    * <p>Internal jobs often continue an in-progress workflow on a different thread to minimize lock
    * contention or increase throughput while preserving atomicity with respect to checkpointing
@@ -90,17 +90,17 @@ public interface PersistentJobRunner {
   void queueInternal(PersistentJob job, int threadPriority) throws PersistenceDisabledException;
 
   /**
-   * Start an "internal" job. We will not checkpoint until all the internal jobs have finished; we
+   * Start an "internal" job. We will not check point until all the internal jobs have finished; we
    * do not queue them at all. Hence, a series of internal jobs is atomic. This should be used for
    * stuff like creating the next stage of a request, where storing the half-way state would lead to
    * it potentially not restarting properly after shutdown. It MUST NOT be used for events from
-   * outside the client layer, including finding blocks in the datastore, on the network etc.
+   * outside the client layer, including finding blocks in the datastore, on the network, etc.
    *
-   * <p>Often when we call this we could have continued the job on the same thread. That's not
-   * always the best thing to do however; we frequently move work to another job to minimize lock
+   * <p>Often when we call this, we could have continued the job on the same thread. That's not
+   * always the best thing to do, however; we frequently move work to another job to minimize lock
    * contention or increase throughput.
    *
-   * <p>FIXME this doesn't queue at all. Come up with a better name! :)
+   * <p>Note: this doesn't queue at all; the name reflects legacy usage.
    *
    * @param job the internal job to execute immediately at the default priority; must participate in
    *     a short atomic sequence that should not be checkpointed midway.
@@ -112,7 +112,7 @@ public interface PersistentJobRunner {
    *
    * <p>Jobs may also request a checkpoint by returning {@code true} from {@link
    * PersistentJob#run(ClientContext)}. This method allows callers to request an early checkpoint
-   * inline, outside of job execution, for example when several related updates have just been
+   * inline, outside of job execution, for example, when several related updates have just been
    * enqueued.
    */
   void setCheckpointASAP();
@@ -139,26 +139,26 @@ public interface PersistentJobRunner {
      * Release the lock, optionally requesting an immediate checkpoint.
      *
      * <p>Callers should keep the protected section as small as possible to minimize checkpoint
-     * delay. Unlocking may trigger a write immediately when there are no running jobs and the
+     * delay. Unlocking may trigger a writing immediately when there are no running jobs and the
      * caller priority permits off-thread checkpointing.
      *
-     * @param forceWrite set to {@code true} to request a checkpoint as soon as feasible after the
+     * @param forceWrite set to {@code true} to request a checkpoint as soon as possible after the
      *     lock is released; {@code false} to leave scheduling unchanged.
-     * @param threadPriority the priority to use when scheduling any work resulting from the unlock;
-     *     higher values map to higher executor priority.
+     * @param threadPriority the priority to use when scheduling any work resulting from the
+     *     unlocking; higher values map to higher executor priority.
      */
     void unlock(boolean forceWrite, int threadPriority);
   }
 
   /**
-   * Obtain a lock which will prevent checkpointing until it is unlocked. This counts as a thread,
-   * and can be used for e.g. MemoryLimitedJob's that can change persistent data. Like any lock, you
+   * Get a lock which will prevent checkpointing until it is unlocked. This counts as a thread and
+   * can be used for e.g., MemoryLimitedJob's that can change persistent data. Like any lock, you
    * MUST use a try/finally block. lock() may block if a checkpoint is in progress or is scheduled.
    *
    * @return a {@link CheckpointLock} that defers checkpointing while held and must be released to
    *     allow the next checkpoint to proceed.
-   * @throws PersistenceDisabledException if unable to obtain the lock because the system is
-   *     shutting down or persistence is disabled.
+   * @throws PersistenceDisabledException if unable to get the lock because the system is shutting
+   *     down or persistence is disabled.
    */
   CheckpointLock lock() throws PersistenceDisabledException;
 
@@ -166,15 +166,15 @@ public interface PersistentJobRunner {
    * For persistent requests, return true if the bloom filter salt has changed when loading the
    * requests. In which case all the Bloom filters will be invalid and will need to be recomputed.
    *
-   * @return {@code true} when a new salt was detected during load and dependent Bloom filters must
-   *     be rebuilt; {@code false} when existing filters remain valid.
+   * @return {@code true} when a new salt was detected during the load and dependent Bloom filters
+   *     must be rebuilt; {@code false} when existing filters remain valid.
    */
   boolean newSalt();
 
   /**
    * Indicate whether the node is in the process of shutting down and no longer accepts new work.
    *
-   * @return {@code true} if shutdown has been requested and new submissions may be rejected;
+   * @return {@code true} if shutdown has been requested, and new submissions may be rejected;
    *     otherwise {@code false}.
    */
   boolean shuttingDown();

--- a/src/main/java/network/crypta/client/async/RequestSelectionTreeNode.java
+++ b/src/main/java/network/crypta/client/async/RequestSelectionTreeNode.java
@@ -15,7 +15,7 @@ package network.crypta.client.async;
  *
  * <p><strong>Threading:</strong> unless otherwise documented by an implementation, instances are
  * not inherently thread-safe. Access should be serialized by the request scheduler or owning
- * subsystem. Methods do not guarantee idempotency: reducing or clearing wakeups mutates state and
+ * subsystem. Methods do not guarantee idempotency: reducing or clearing wakeup mutates state and
  * can propagate upward to parent nodes.
  *
  * <ul>
@@ -24,8 +24,8 @@ package network.crypta.client.async;
  *   <li>Propagates changes upward so parent nodes reflect earlier eligibility.
  * </ul>
  *
- * (but ClientRequestSelector isn't actually a RequestSelectionTreeNode at the moment, the root is
- * the priorities in the array on ClientRequestSelector; FIXME consistency with RGA.root etc)
+ * (but ClientRequestSelector isn't a RequestSelectionTreeNode at the moment, the root is the
+ * priorities in the array on ClientRequestSelector; consistency with RGA.root etc.)
  */
 public interface RequestSelectionTreeNode {
 
@@ -46,7 +46,7 @@ public interface RequestSelectionTreeNode {
    * Returns the next wakeup time for this node.
    *
    * <p>For aggregation nodes this is the wakeup time for the entire subtree rooted at this node.
-   * For a leaf (for example a {@code RandomGrabArrayItem}), this is the wakeup time for the single
+   * For a leaf (for example, a {@code RandomGrabArrayItem}), this is the wakeup time for the single
    * request represented by the leaf. The time base and units are implementation-defined; callers
    * should pass a {@code now} value from the same source they use to interpret the return value.
    *
@@ -64,8 +64,8 @@ public interface RequestSelectionTreeNode {
    * toward the root.
    *
    * <p>This method is used when an earlier eligibility is discovered within the subtree. If the
-   * change reaches the root and causes it to become earlier than previously recorded, the owning
-   * scheduler should be notified by the implementation. The operation is stateful and may alter the
+   * change reaches the root and causes it to become earlier than previously recorded, the
+   * implementation should notify the owning scheduler. The operation is stateful and may alter the
    * effective scheduling of ancestor nodes.
    *
    * @param wakeupTime a candidate earlier wakeup time, expressed in the time base used by the

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageCallback.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageCallback.java
@@ -30,11 +30,11 @@ import network.crypta.node.BaseSendableGet;
  * </ul>
  *
  * <p>Implementations should be thread-safe where noted, because some callbacks are invoked on a
- * decode thread. State is typically owned by the fetcher; callbacks should avoid long blocking
+ * decoding thread. State is typically owned by the fetcher; callbacks should avoid long blocking
  * operations and heavy locking. The interface itself is intentionally narrow to streamline unit
  * testing and to allow storage strategies to evolve independently.
  *
- * <p>FIXME reconsider.
+ * <p>Note: reviewed for current fetcher/storage responsibilities.
  *
  * @author toad
  * @see SplitFileFetcher
@@ -85,7 +85,7 @@ public interface SplitFileFetcherStorageCallback {
    *
    * <p>Unlike I/O failures, corruption indicates that on-disk data failed integrity verification
    * (e.g., checksum mismatch). Implementations should abort the request and surface a clear error
-   * to clients. This callback may be invoked on a decode thread.
+   * to clients. This callback may be invoked on a decoding thread.
    *
    * @param e the checksum failure that explains the corruption; non-null and specific to the
    *     detected condition.
@@ -100,7 +100,7 @@ public interface SplitFileFetcherStorageCallback {
    * correction. Values are non-negative and typically remain constant for the duration of the
    * request.
    *
-   * @param requiredBlocks the number of blocks that must be fetched for a successful decode; zero
+   * @param requiredBlocks the number of blocks that must be fetched for a successful decoding; zero
    *     is valid for empty content but unusual in practice.
    * @param remainingBlocks the number of non-required blocks (total minus required); used for
    *     progress reporting and scheduling decisions across segments.
@@ -115,12 +115,12 @@ public interface SplitFileFetcherStorageCallback {
    * @param max The highest CompatibilityMode that appears to be valid based on what we've fetched
    *     so far.
    * @param customSplitfileKey The fixed byte[] encryption key used on insert. On anything recent,
-   *     we generate a single key, randomly for an SSK, or based on the content for a CHK, and use
-   *     it for everything. This saves metadata space and improves security for SSKs.
+   *     we generate a single key, randomly for an SSK, or base on the content for a CHK, and use it
+   *     for everything. This saves metadata space and improves security for SSKs.
    * @param compressed Whether the content is compressed. If false, the dontCompress option was
    *     used.
    * @param bottomLayer Whether this report originates at the bottom layer of the splitfile pyramid.
-   *     I.e. the actual file, not the file containing the metadata to fetch the file (this can
+   *     I.e., the actual file, not the file containing the metadata to fetch the file (this can
    *     recurse for several levels!)
    * @param definitiveAnyway Whether this report is definitive even though it's not from the bottom
    *     layer. This is true of recent splitfiles, where we store all the data in the top key.
@@ -137,8 +137,8 @@ public interface SplitFileFetcherStorageCallback {
    * Queue a block for healing by the storage layer.
    *
    * <p>Healing requests are typically issued when decoding reveals an otherwise fixable defect or
-   * when parity information needs to be regenerated. The method is called from a decode thread, so
-   * implementations must avoid heavy locking and long-running operations.
+   * when parity information needs to be regenerated. The method is called from a decoding thread,
+   * so implementations must avoid heavy locking and long-running operations.
    *
    * @param data the raw block payload bytes to be considered for healing; must not be modified
    *     after the call returns by the implementation.
@@ -163,7 +163,7 @@ public interface SplitFileFetcherStorageCallback {
    *
    * <p>Callers invoke this for every successful block retrieval/verification. Implementations may
    * update progress indicators, adjust scheduling, or trigger downstream notifications. The call is
-   * side effect only and does not carry block content.
+   * a side effect only and does not carry block content.
    */
   void onFetchedBlock();
 
@@ -192,7 +192,7 @@ public interface SplitFileFetcherStorageCallback {
   void onResume(int succeededBlocks, int failedBlocks, ClientMetadata mimeType, long finalSize);
 
   /**
-   * Called when the fetch failed, for example after exhausting retry attempts.
+   * Called when the fetch failed, for example, after exhausting retry attempts.
    *
    * @param fetchException a structured description of the failure condition; contains user-facing
    *     details and internal causes that can be logged or surfaced to clients.
@@ -201,7 +201,7 @@ public interface SplitFileFetcherStorageCallback {
 
   /**
    * Called whenever we successfully download, decode or encode a block, and it matches the expected
-   * key. LOCKING: Called on the decode thread so should avoid taking any dangerous locks.
+   * key. LOCKING: Called on the decoding thread so should avoid taking any dangerous locks.
    *
    * @param decodedBlock the verified block that matched its expected key; implementations must not
    *     mutate the instance and should treat it as read-only input for aggregation logic.
@@ -232,9 +232,9 @@ public interface SplitFileFetcherStorageCallback {
   BaseSendableGet getSendableGet();
 
   /**
-   * Called when we recover from disk corruption, and have to re-download some blocks that we had
-   * already downloaded but which were corrupted on disk. E.g. when a segment attempts to decode but
-   * discovers that a block doesn't match the key given.
+   * Called when we recover from disk corruption and have to re-download some blocks that we had
+   * already downloaded but which were corrupted on disk. E.g., when a segment attempts to decode
+   * but discovers that a block doesn't match the key given.
    */
   void restartedAfterDataCorruption();
 
@@ -242,13 +242,13 @@ public interface SplitFileFetcherStorageCallback {
   void clearCooldown();
 
   /**
-   * Indicate that the cooldown wake-up time was reduced but the request remains non-fetchable.
+   * Indicate that the cooldown wake-up time was reduced, but the request remains non-fetchable.
    *
    * <p>Implementations may update internal timers or user-visible schedules. This is a hint rather
    * than a guarantee and does not by itself make the request immediately eligible for fetch.
    *
    * @param wakeupTime the next suggested wake-up time in milliseconds since the epoch; callers do
-   *     not assume strict adherence and may send subsequent updates.
+   *     not assume strict adherence and may send later updates.
    */
   void reduceCooldown(long wakeupTime);
 

--- a/src/main/java/network/crypta/client/filter/FoundURICallback.java
+++ b/src/main/java/network/crypta/client/filter/FoundURICallback.java
@@ -15,7 +15,7 @@ import network.crypta.keys.FreenetURI;
  * stream of events rather than a random-access model.
  *
  * <p>Thread-safety is implementation defined. Unless otherwise documented by the caller, you should
- * not assume that invocations are serialized; if shared state is mutated, synchronize or use
+ * not assume that invocations are serialized; if a shared state is mutated, synchronize or use
  * concurrent collections. Implementations are generally expected to be stateless or to scope state
  * to the current page between the first event and {@code onFinishedPage()}.
  *
@@ -38,9 +38,8 @@ public interface FoundURICallback {
    * once. The method is idempotent with respect to side effects only if the implementation makes it
    * so; callers may not perform duplicate suppression.
    *
-   * @param uri The URI. FIXME: Indicate the type of the link e.g. inline image, hyperlink, etc?
-   *     Consider clarifying how the caller communicates link semantics when richer metadata is
-   *     available.
+   * @param uri The URI. Consider clarifying how the caller communicates link semantics when richer
+   *     metadata is available.
    */
   void foundURI(FreenetURI uri);
 
@@ -50,12 +49,11 @@ public interface FoundURICallback {
    *
    * <p>This variant carries an {@code inline} flag to help distinguish embedded resources from
    * navigational links in simple pipelines. The flag is advisory only. Implementations may ignore
-   * it, or use it to prioritize fetching, indexing, or display decisions. Callers may repeat the
+   * it or use it to prioritize fetching, indexing, or display decisions. Callers may repeat the
    * same URI with different flags as they encounter it in multiple contexts.
    *
-   * @param uri The URI. FIXME: Indicate the type of the link e.g. inline image, hyperlink, etc?
-   *     Consider clarifying how the caller communicates link semantics when richer metadata is
-   *     available.
+   * @param uri The URI. Consider clarifying how the caller communicates link semantics when richer
+   *     metadata is available.
    * @param inline {@code true} when the URI appears as an inline/embedded resource in the current
    *     context (such as an image, stylesheet, or script); {@code false} when it is a navigational
    *     link or otherwise not rendered inline. Callers may pass either value; implementations
@@ -64,21 +62,21 @@ public interface FoundURICallback {
   void foundURI(FreenetURI uri, boolean inline);
 
   /**
-   * Called when some plain text is processed. This is used typically by spiders to index pages by
-   * their content.
+   * Called when some plain text is processed. Spiders use this typically to index pages by their
+   * content.
    *
    * <p>The supplied text has already been decoded according to the source format (for example, HTML
    * entity decoding if extracted from HTML). Implementations that forward text to a consumer which
    * expects display-ready data should re-encode as appropriate for that consumer.
    *
    * @param text The text. Will already have been fed through whatever decoding is necessary
-   *     depending on the type of the source document e.g. HTMLDecoder. Will need to be re-encoded
-   *     before being sent to e.g. a browser.
-   * @param type Can be null, or may be for example the name of the HTML tag directly surrounding
+   *     depending on the type of the source document e.g., HTMLDecoder. Will need to be re-encoded
+   *     before being sent to e.g., a browser.
+   * @param type Can be null, or may be, for example, the name of the HTML tag directly surrounding
    *     the text. E.g. "title" lets you find page titles.
    * @param baseURI The current base URI for this page. The base URI is not necessarily the URI of
    *     the page. It's the URI against which URIs on the page are resolved. It defaults to the URI
-   *     of the page but can be overridden by base href in html, for example.
+   *     of the page but can be overridden by base href in HTML, for example.
    */
   void onText(String text, String type, URI baseURI);
 

--- a/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
@@ -65,8 +65,8 @@ public class ModifyPeerNote extends FCPMessage {
    * Returns the field template for this message type.
    *
    * <p>The current implementation returns a new, empty {@link SimpleFieldSet} instance. This is
-   * sufficient because {@code ModifyPeerNote} is handled primarily as an inbound message parsed
-   * from the client, and the node does not need to advertise additional fields when constructing
+   * enough because {@code ModifyPeerNote} is handled primarily as an inbound message parsed from
+   * the client, and the node does not need to advertise additional fields when constructing
    * responses. Callers should not rely on the returned instance being reused.
    *
    * @return a new, empty field set instance representing the message fields for this type
@@ -101,10 +101,10 @@ public class ModifyPeerNote extends FCPMessage {
    * client reflecting the new state. Invalid or missing fields cause {@link
    * MessageInvalidException} to be thrown or a specific error response to be sent.
    *
-   * <p>The method is not idempotent with respect to note contents: subsequent calls with the same
-   * peer and note type overwrite the existing note. The call relies on the caller to provide a
-   * valid, running {@link Node} instance; behaviour is undefined if the node is stopping or the
-   * referenced peer disappears concurrently.
+   * <p>The method is not idempotent with respect to note contents: later calls with the same peer
+   * and note type overwrite the existing note. The call relies on the caller to provide a valid,
+   * running {@link Node} instance; behavior is undefined if the node is stopping or the referenced
+   * peer disappears concurrently.
    *
    * @param handler the connection handler that received the request and is used to send any reply
    *     or error messages back to the client; must have full access for the operation to proceed
@@ -162,8 +162,7 @@ public class ModifyPeerNote extends FCPMessage {
           false);
     }
     String noteText;
-    // **FIXME** this should be generalized for multiple peer notes per peer, after PeerNode is
-    // similarly generalized
+    // Note: this supports the single private note type until PeerNode supports multiple notes.
     try {
       noteText = Base64.decodeUTF8(encodedNoteText);
     } catch (IllegalBase64Exception e) {

--- a/src/main/java/network/crypta/node/KeysFetchingLocally.java
+++ b/src/main/java/network/crypta/node/KeysFetchingLocally.java
@@ -52,8 +52,8 @@ public interface KeysFetchingLocally {
    *
    * <p>Used to avoid duplicate inserts originating from the same scheduler context.
    *
-   * <p>FIXME: Track the request:token association in the inserter implementation and retire this
-   * interface-level query.
+   * <p>Note: this could move into the inserter implementation when "request:token" association is
+   * tracked there.
    *
    * @param token identifier for the in-flight insert
    * @return {@code true} if the token is executing locally; otherwise {@code false}

--- a/src/main/java/network/crypta/node/OutgoingPacketMangler.java
+++ b/src/main/java/network/crypta/node/OutgoingPacketMangler.java
@@ -8,7 +8,7 @@ import network.crypta.io.comm.PeerContext;
 import network.crypta.io.comm.SocketHandler;
 
 /**
- * Abstraction for composing and sending outgoing packets for a transport.
+ * Abstraction for composing and sending outgoing packets for transport.
  *
  * <p>Implementations provide the mechanics to initiate handshakes, assess connectivity constraints,
  * and emit wire-ready datagrams/frames to a {@link SocketHandler}. A UDP-based transport typically
@@ -92,14 +92,14 @@ public interface OutgoingPacketMangler {
   /**
    * Port forwarding status.
    *
-   * @return a status code from {@link network.crypta.io.AddressTracker}. FIXME: Consider
-   *     abstracting the return type away from {@code AddressTracker.Status} to a transport-agnostic
-   *     connectivity indicator when multiple transports require it.
+   * @return a status code from {@link network.crypta.io.AddressTracker}. Consider abstracting the
+   *     return type away from {@code AddressTracker.Status} to a transport-agnostic connectivity
+   *     indicator when multiple transports require it.
    */
   Status getConnectivityStatus();
 
   /**
-   * Is there any reason not to allow this connection? E.g. limits on the number of nodes on a
+   * Is there any reason not to allow this connection? E.g., limits on the number of nodes on a
    * specific IP address?
    *
    * @param node the peer node we intend to connect to.

--- a/src/main/java/network/crypta/node/RequestScheduler.java
+++ b/src/main/java/network/crypta/node/RequestScheduler.java
@@ -169,7 +169,7 @@ public interface RequestScheduler {
    * @param key the key to evaluate
    * @return {@code true} if the key should be requested
    */
-  /* FIXME SECURITY Clarify trust and authorization boundaries if a future tunneling
+  /* Security note: Clarify trust and authorization boundaries if a future tunneling
    * mechanism allows starting requests remotely. Revisit the caller-side logic noted in
    * RequestHandler (onAbort() handler) to ensure this check remains valid. */
   boolean wantKey(Key key);

--- a/src/test/java/network/crypta/crypt/PCFBModeTest.java
+++ b/src/test/java/network/crypta/crypt/PCFBModeTest.java
@@ -14,7 +14,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Random;
 import network.crypta.crypt.ciphers.Rijndael;
-import network.crypta.support.HexUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,9 +21,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-// 256,256 PCFB is the same as 256,256 CFB, however JCA does not support 256-bit block size, so we
+// 256,256 PCFB is the same as 256,256 CFB, however, JCA does not support 256-bit block size, so we
 // can't
-// test against JCA. We will move to the standard block size, and stop using PCFB, eventually, but
+// test against JCA. We will move to the standard block size and stop using PCFB, eventually, but
 // we'll
 // need PCFB for a while if only for old keys, so we need to test it.
 @SuppressWarnings("java:S100")
@@ -34,21 +33,21 @@ class PCFBModeTest {
   private final Random mt = new Random(1634L);
   private static final int RIJNDAEL_BLOCK_BITS = 256;
 
-  // FIXME I don't think there are any standard test vectors?
+  // Note: no standard test vectors are available for this configuration.
   private static final byte[] PCFB_256_ENCRYPT_KEY =
-      HexUtil.hexToBytes("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4");
-  // FIXME This IV was tailored for CTR mode and 128-bit block, maybe needs adjustment
+      hexToBytes("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4");
+  // Note: this IV was tailored for CTR mode and a 128-bit block.
   private static final byte[] PCFB_256_ENCRYPT_IV =
-      HexUtil.hexToBytes("f0f1f2f3f4f5f6f7f8f9fafbfcfdfefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
-  // FIXME This plaintext was tailored for 128-bit block, maybe needs adjustment
+      hexToBytes("f0f1f2f3f4f5f6f7f8f9fafbfcfdfefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
+  // Note: this plaintext was tailored for a 128-bit block.
   private static final byte[] PCFB_256_ENCRYPT_PLAINTEXT =
-      HexUtil.hexToBytes(
+      hexToBytes(
           "6bc1bee22e409f96e93d7e117393172a"
               + "ae2d8a571e03ac9c9eb76fac45af8e51"
               + "30c81c46a35ce411e5fbc1191a0a52ef"
               + "f69f2445df4f9b17ad2b417be66c3710");
   private static final byte[] PCFB_256_ENCRYPT_CIPHERTEXT =
-      HexUtil.hexToBytes(
+      hexToBytes(
           "c964b00326e216214f1a68f5b0872608"
               + "1b403c92fe02898664a81f5bbbbf8341"
               + "fc1d04b2c1addfb826cca1eab6813127"
@@ -148,7 +147,7 @@ class PCFBModeTest {
       mt.nextBytes(plaintext);
       mt.nextBytes(key);
       mt.nextBytes(iv);
-      // First encrypt as a block.
+      // First, encrypt as a block.
       Rijndael cipher = new Rijndael(RIJNDAEL_BLOCK_BITS, RIJNDAEL_BLOCK_BITS);
       cipher.initialize(key);
       PCFBMode pcfb = PCFBMode.create(cipher, iv);
@@ -447,5 +446,22 @@ class PCFBModeTest {
 
   private static PCFBMode createZeroIv(BlockCipher c) {
     return PCFBMode.create(c, new byte[PCFBMode.lengthIV(c)]);
+  }
+
+  private static byte[] hexToBytes(String hex) {
+    int length = hex.length();
+    int size = (length + 1) / 2;
+    byte[] out = new byte[size];
+    int offset = (length % 2 == 0) ? 0 : 1;
+    int index = 0;
+    if (offset == 1) {
+      out[index++] = (byte) Character.digit(hex.charAt(0), 16);
+    }
+    for (int i = offset; i < length; i += 2) {
+      int high = Character.digit(hex.charAt(i), 16);
+      int low = Character.digit(hex.charAt(i + 1), 16);
+      out[index++] = (byte) ((high << 4) | low);
+    }
+    return out;
   }
 }

--- a/src/test/java/network/crypta/node/NodeClientCoreTransferPolicyTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTransferPolicyTest.java
@@ -41,10 +41,6 @@ class NodeClientCoreTransferPolicyTest {
   private static final String OUTSIDE_FILE_NAME = "outside.bin";
   private static final String DOWNLOAD_ALLOWED_DIRS_KEY = "downloadAllowedDirs";
   private static final String UPLOAD_ALLOWED_DIRS_KEY = "uploadAllowedDirs";
-  private static final String DOWNLOAD_ALLOWED_DIRS_SHORT = "NodeClientCore.downloadAllowedDirs";
-  private static final String DOWNLOAD_ALLOWED_DIRS_LONG = "NodeClientCore.downloadAllowedDirsLong";
-  private static final String UPLOAD_ALLOWED_DIRS_SHORT = "NodeClientCore.uploadAllowedDirs";
-  private static final String UPLOAD_ALLOWED_DIRS_LONG = "NodeClientCore.uploadAllowedDirsLong";
 
   @TempDir Path tempDir;
 

--- a/src/test/java/network/crypta/node/subsystem/NodeServicesSubsystemTest.java
+++ b/src/test/java/network/crypta/node/subsystem/NodeServicesSubsystemTest.java
@@ -52,8 +52,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @SuppressWarnings("java:S100")
 class NodeServicesSubsystemTest {
   private static final String PEERS_OFFERS_DISMISSED = "peersOffersDismissed";
-  private static final String PEERS_OFFERS_DISMISSED_SHORT = "Node.peersOffersDismissed";
-  private static final String PEERS_OFFERS_DISMISSED_LONG = "Node.peersOffersDismissedLong";
 
   @Mock private Node node;
   @Mock private NodeClientCore clientCore;


### PR DESCRIPTION
## Summary
- polish interface and callback documentation wording
- replace lingering FIXME notes with current guidance
- simplify tests by removing unused constants and inlining hex parsing

## Testing
- not run (comment-only changes)