### PR TITLE
style(comments): refine test wording

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
@@ -18,7 +18,7 @@ import network.crypta.node.NodeClientCore;
  * #unsubscribe()} when the client disconnects or no longer requires updates.
  *
  * <p>Typical usage is driven by the FCP protocol flow: the handler constructs this class when a
- * client issues a subscribe request, lets the node push progress callbacks, and eventually calls
+ * client issues a subscription request, lets the node push progress callbacks, and eventually calls
  * {@link #unsubscribe()} during teardown. The object does not perform retries itself; it relies on
  * the underlying USK manager for polling cadence, sparse polling decisions, and cache ownership.
  * All callbacks are expected to be invoked on the node's internal threads, so callers should avoid
@@ -107,7 +107,6 @@ public class SubscribeUSK implements USKProgressCallback {
       core.getUskManager().unsubscribe(key, toUnsub);
       return;
     }
-    // if(newKnownGood && !newSlotToo) return;
     FCPMessage msg =
         new SubscribedUSKUpdate(
             clientIdentifier,
@@ -121,7 +120,7 @@ public class SubscribeUSK implements USKProgressCallback {
   /**
    * Returns the client-requested priority for regular polling cycles.
    *
-   * <p>The value originates from the FCP subscribe message and is passed through unchanged so the
+   * <p>The value originates from the FCP subscribe message and is passed through unchanged, so the
    * USK manager can schedule this subscription relative to others. Lower values typically denote
    * higher priority depending on the underlying scheduler configuration.
    *
@@ -150,9 +149,9 @@ public class SubscribeUSK implements USKProgressCallback {
    * Cancels the active subscription with the USK manager.
    *
    * <p>Callers should invoke this when the FCP connection closes or when the client issues an
-   * unsubscribe request. The method forwards the removal to the node's USK manager using the key
-   * captured at construction. It is safe to call multiple times; redundant calls are ignored by the
-   * manager.
+   * unsubscribed request. The method forwards the removal to the node's USK manager using the key
+   * captured at construction. It is safe to call multiple times; the manager ignores redundant
+   * calls.
    */
   public void unsubscribe() {
     core.getUskManager().unsubscribe(usk, toUnsub);

--- a/src/test/java/network/crypta/client/OnionFECCodecTest.java
+++ b/src/test/java/network/crypta/client/OnionFECCodecTest.java
@@ -1,6 +1,8 @@
 package network.crypta.client;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
@@ -24,7 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-/** Test the new (post db4o) high level FEC API */
+/** Test the new (post db4o) high-level FEC API */
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class OnionFECCodecTest {
@@ -275,10 +277,10 @@ class OnionFECCodecTest {
     int r = 3;
     byte[][] d = new byte[k][BLOCK_SIZE];
     byte[][] c = new byte[r][BLOCK_SIZE];
-    // Mark only 1st and last as missing → encode indices {k+0, k+2}
+    // Mark the first and last checks as missing so only those parity blocks are encoded.
     boolean[] present = new boolean[] {false, true, false};
 
-    try (MockedConstruction<PureCode> cons = mockConstruction(PureCode.class, (mock, ctx) -> {})) {
+    try (MockedConstruction<PureCode> cons = mockConstruction(PureCode.class, (_, _) -> {})) {
       codec.encode(d, c, present, BLOCK_SIZE);
       PureCode mock = cons.constructed().getFirst();
 
@@ -401,7 +403,7 @@ class OnionFECCodecTest {
   void getCheckBlocks_whenCompat1250Small_expectAtMostData() {
     int data = 5;
     int checks = codec.getCheckBlocks(data, CompatibilityMode.COMPAT_1250);
-    assertEquals(5, checks); // data+1 would be 6, but capped to data for 1250
+    assertEquals(5, checks); // data+1 would be 6 but capped to data for 1250
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/SimpleBlockChooserTest.java
+++ b/src/test/java/network/crypta/client/async/SimpleBlockChooserTest.java
@@ -73,7 +73,7 @@ class SimpleBlockChooserTest {
   @Test
   void chooseKey_whenMultipleCandidates_selectsUsingRandomAmongMinRetry() {
     SimpleBlockChooser chooser = new SimpleBlockChooser(5, new FixedRandom(0), 2);
-    // Set higher retry count for some blocks so min-retry candidates are {0,2,4}
+    // Increase retries on some blocks so the lowest-retry candidates are 0, 2, and 4.
     chooser.onNonFatalFailure(1);
     chooser.onNonFatalFailure(3);
 

--- a/src/test/java/network/crypta/client/filter/TheoraPacketFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/TheoraPacketFilterTest.java
@@ -141,7 +141,7 @@ class TheoraPacketFilterTest {
     w.u24(0);
     w.u24(0);
 
-    // CS ∈ {0,1,2}
+    // Use CS value 1 within the allowed 0-2 range.
     w.u8(1);
 
     // NOMBR + QUAL + KFGSHIFT: 35 bits (zeros)
@@ -162,7 +162,7 @@ class TheoraPacketFilterTest {
     BitWriter w = new BitWriter();
     w.u8(0x81);
     w.magic();
-    // Remaining bytes (vendor and user comments) are ignored by the parser; include a small filler.
+    // The parser ignores remaining bytes (vendor and user comments); include a small filler.
     w.u32(1); // vendor length (dummy)
     w.u8('x');
     w.u32(0); // userCommentsNumber
@@ -216,7 +216,7 @@ class TheoraPacketFilterTest {
       }
     }
 
-    // 80 Huffman tables: use single-leaf with TOKEN=0 (ISLEAF=1, then 5 bits token)
+    // 80 Huffman tables: use single-leaf with TOKEN=0 (ISLEAF=1, then 5-bit token)
     for (int i = 0; i < 80; i++) {
       w.bits(1, 1);
       w.bits(0, 5);
@@ -249,7 +249,9 @@ class TheoraPacketFilterTest {
     // (qti=0, pli=0): no NEWQR read here
     w.bits(0, 1); // QRBMIS with 1 bit (ilog(1) = 1)
     w.bits(63, 6); // QRSIZES -> 63 + 1 => 64 -> triggers exception
-    w.bits(0, 1); // second QRBMIS read (not reached logically, but consumed by reader before throw)
+    w.bits(
+        0, 1); // the second QRBMIS read (not reached logically, but consumed by the reader before
+    // throw)
 
     // The rest of the stream is irrelevant; parser will throw when qi > 63
     return w.toByteArray();

--- a/src/test/java/network/crypta/keys/NodeCHKTest.java
+++ b/src/test/java/network/crypta/keys/NodeCHKTest.java
@@ -132,7 +132,7 @@ class NodeCHKTest {
 
   @Test
   void routingKeyFromFullKey_whenUnknownHeader_returnsFirst32BytesCopy() {
-    // Arrange: first two bytes are not {BASE_TYPE, known algo}
+    // Arrange a header that does not match the expected type or algorithm bytes.
     byte[] full = new byte[NodeCHK.FULL_KEY_LENGTH];
     // Header deliberately invalid: type=9, algo=77
     full[0] = 9;
@@ -142,7 +142,7 @@ class NodeCHKTest {
     // Act
     byte[] rk = NodeCHK.routingKeyFromFullKey(full);
 
-    // Assert: equals first 32 bytes; not the same reference as input
+    // Assert: equals the first 32 bytes; different reference as input
     assertArrayEquals(Arrays.copyOf(full, NodeCHK.KEY_LENGTH), rk);
     assertNotSame(full, rk);
   }

--- a/src/test/java/network/crypta/support/StringCounterTest.java
+++ b/src/test/java/network/crypta/support/StringCounterTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("java:S100") // Allow method names in given_when_then style
+@SuppressWarnings("java:S100") // Allow method names in the given_when_then style
 class StringCounterTest {
 
   @Test
@@ -161,7 +161,7 @@ class StringCounterTest {
     assertEquals("td", c0.getName());
     assertEquals("td", c1.getName());
 
-    // First cell ends with NBSP; HTML encoding converts it to &nbsp;
+    // Expect the first cell text to end with a non-breaking space entity.
     assertEquals(count + "&nbsp;", c0.generateChildren());
     assertEquals(text, c1.generateChildren());
   }


### PR DESCRIPTION
## Summary
- clarify SubscribeUSK subscription javadoc and remove stale comment
- improve test comment phrasing for readability
- normalize assertions/comments in FEC and codec tests