### PR TITLE
refactor(client): add fetcher hook providers

### DIFF
--- a/src/main/java/network/crypta/client/async/SimpleSingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SimpleSingleFileFetcher.java
@@ -10,6 +10,7 @@ import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchResult;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.ClientKeyBlock;
+import network.crypta.keys.Key;
 import network.crypta.keys.KeyDecodeException;
 import network.crypta.keys.TooBigException;
 import network.crypta.node.LowLevelGetException;
@@ -22,34 +23,83 @@ import org.slf4j.LoggerFactory;
 /**
  * Fetches exactly one client-level block and reports the outcome to a completion callback.
  *
- * <p>This type is used directly for trivial single-block GETs and also serves as the base for
- * higher-level helpers such as {@link SingleFileFetcher}. It wires common mechanics implemented by
- * {@link BaseSingleFileFetcher} — request registration, cooldown/retry handling, and delegation to
- * subclass hooks — with a compact surface area focused on the final delivery of a decoded {@link
- * FetchResult}. Typical usage is to construct an instance with a {@link Cfg} and then call {@link
- * #schedule(ClientContext)} (inherited) to participate in the client request schedulers.
+ * <p>This class is the minimal building block for a single-block GET operation. It composes the
+ * request registration, cooldown/retry policy, and scheduler integration provided by {@link
+ * BaseSingleFileFetcher} with a narrow API focused on producing a decoded {@link FetchResult}. Use
+ * it when a caller already has a {@link ClientKey} that resolves to exactly one block or when a
+ * higher-level helper can short-circuit into a direct block fetch. Typical usage is to build a
+ * {@link Cfg}, construct the fetcher, and invoke {@link #schedule(ClientContext)} (inherited) so
+ * the request participates in the client schedulers.
  *
- * <p>Lifecycle and invariants:
+ * <p>Instances are stateful and progress through a simple lifecycle: created, scheduled, retried
+ * (optional), and then terminal success or failure. The instance tracks cancellation and completion
+ * flags, and for persistent requests the callback and state are serialized, so work can resume
+ * after restart. Callers should treat the fetcher as mutable and rely on its internal
+ * synchronization for state transitions rather than accessing fields directly.
  *
  * <ul>
- *   <li>Each instance represents one logical block fetch. It becomes <em>finished</em> after a
- *       terminal success or failure and will not emit further callbacks.
- *   <li>Cancellation ends scheduling and results in a failure callback with mode {@link
- *       FetchException.FetchExceptionMode#CANCELLED}.
- *   <li>When the owning request is persistent, this object is serialized and later resumed; the
- *       completion callback is part of the serialized state.
+ *   <li><strong>Responsibilities</strong>: register a single key, decode the resulting block, and
+ *       notify a {@link GetCompletionCallback}.
+ *   <li><strong>Notable behaviors</strong>: cancellation reports {@link
+ *       FetchException.FetchExceptionMode#CANCELLED} and prevents further callbacks.
+ *   <li><strong>Threading</strong>: methods may be called on scheduler threads; the implementation
+ *       synchronizes narrowly on {@code this} to protect flags.
  * </ul>
- *
- * <p>Thread-safety: instances are mutable and synchronize narrowly on {@code this} for state flags
- * such as {@code finished} and {@code cancelled}. Callers should not assume broader thread-safety.
  *
  * @see BaseSingleFileFetcher
  * @see ClientRequester
  * @see ClientContext
  * @see FetchContext
+ * @see SingleFileFetcher
  */
 public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     implements ClientGetState, Serializable {
+
+  /**
+   * Supplies a custom priority class for scheduling operations.
+   *
+   * <p>Implementations provide a stable priority value for use by schedulers. The provider should
+   * avoid expensive computation because it may be invoked from scheduling hot paths. Implementers
+   * must be {@link Serializable} when the owning request is persistent.
+   */
+  public interface PriorityClassProvider extends Serializable {
+    /**
+     * Returns the priority class used to schedule this fetcher.
+     *
+     * <p>Callers expect a value compatible with the request scheduler priority bands. The return
+     * value should remain consistent for the lifetime of the fetcher unless the caller explicitly
+     * wants priority to change between scheduling cycles. Providers should avoid blocking work or
+     * expensive computation because this method may be invoked from scheduling hot paths.
+     *
+     * @return priority class for scheduler registration and wakeup decisions
+     */
+    short getPriorityClass();
+  }
+
+  /**
+   * Builds a key listener for this fetcher when scheduling.
+   *
+   * <p>The factory allows callers to customize listener creation while preserving the fetcher's
+   * internal bookkeeping. Implementations should be {@link Serializable} if the parent request is
+   * persistent so the listener logic survives restarts.
+   */
+  public interface KeyListenerFactory extends Serializable {
+    /**
+     * Creates the key listener used by schedulers to match and handle keys.
+     *
+     * <p>The implementation may return {@code null} to indicate that no listener should be created
+     * for the current state (for example, when canceled). Factories should avoid mutating external
+     * state and should return quickly to keep scheduler threads responsive. The {@code onStartup}
+     * flag can be used to decide whether to suppress listener creation during initialization.
+     *
+     * @param fetcher fetcher requesting the listener, never {@code null}
+     * @param context client context for scheduler access, never {@code null}
+     * @param onStartup {@code true} when invoked during node startup initialization
+     * @return a listener instance, or {@code null} to skip listener creation
+     */
+    KeyListener makeKeyListener(
+        SimpleSingleFileFetcher fetcher, ClientContext context, boolean onStartup);
+  }
 
   private static final Logger LOG = LoggerFactory.getLogger(SimpleSingleFileFetcher.class);
 
@@ -59,6 +109,8 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     super(cfg.key, cfg.maxRetries, cfg.ctx, cfg.parent, cfg.deleteFetchContext, cfg.realTimeFlag);
     this.rcb = cfg.rcb;
     this.token = cfg.token;
+    this.priorityClassProvider = cfg.priorityClassProvider;
+    this.keyListenerFactory = cfg.keyListenerFactory;
     if (!cfg.dontAdd) {
       if (cfg.isEssential) cfg.parent.addMustSucceedBlocks(1);
       else cfg.parent.addBlock();
@@ -85,9 +137,86 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
    */
   final long token;
 
+  /** Optional provider that supplies the scheduling priority for this fetcher. */
+  private final PriorityClassProvider priorityClassProvider;
+
+  /** Optional factory that customizes key listener creation for this fetcher. */
+  private final KeyListenerFactory keyListenerFactory;
+
+  /**
+   * Returns the priority class used by schedulers to order this fetcher.
+   *
+   * <p>If a {@link PriorityClassProvider} is configured, the value is delegated to that provider;
+   * otherwise the priority of the parent requester is used. The method performs no side effects and
+   * may be called frequently while scheduling is active. Callers should not assume the value is
+   * cached between invocations, so providers should keep the computation lightweight.
+   *
+   * @return scheduler priority class, consistent with the current request configuration
+   */
+  @Override
+  public short getPriorityClass() {
+    if (priorityClassProvider != null) return priorityClassProvider.getPriorityClass();
+    return super.getPriorityClass();
+  }
+
+  /**
+   * Creates the key listener used to match the fetcher's key in schedulers and stores.
+   *
+   * <p>The default implementation delegates to {@link BaseSingleFileFetcher} to create a listener
+   * that tracks a single node key. When a {@link KeyListenerFactory} is supplied, this method
+   * delegates to the factory instead, enabling custom cancellation checks or priority adjustments.
+   * The method may return {@code null} when the request is already finished or canceled, and it
+   * should not be used to perform long-running setup work.
+   *
+   * @param context client context used for scheduler access and node state
+   * @param onStartup {@code true} when invoked during node startup initialization
+   * @return a key listener for scheduling, or {@code null} if none should be registered
+   */
+  @Override
+  public KeyListener makeKeyListener(ClientContext context, boolean onStartup) {
+    if (keyListenerFactory != null)
+      return keyListenerFactory.makeKeyListener(this, context, onStartup);
+    return super.makeKeyListener(context, onStartup);
+  }
+
+  KeyListener createKeyListener(short priorityClass) {
+    synchronized (this) {
+      if (finished) return null;
+      if (cancelled) return null;
+    }
+    if (key == null) {
+      if (LOG.isErrorEnabled()) {
+        LOG.error(
+            "Key is null - left over BSSF? on {} in makeKeyListener()",
+            this,
+            new Exception("error"));
+      }
+      return null;
+    }
+    if (parent == null) {
+      LOG.error("Parent is null on {} persistent={} key={} ctx={}", this, persistent, key, ctx);
+      return null;
+    }
+    Key newKey = key.getNodeKey(true);
+    return new SingleKeyListener(newKey, this, priorityClass, persistent);
+  }
+
   // No static initialization required.
 
-  // Translate it, then call the real onFailure
+  /**
+   * Translates a low-level failure into a client-level failure and forwards it.
+   *
+   * <p>This method maps a {@link LowLevelGetException} into a {@link FetchException} and then
+   * delegates to {@link #onFailure(FetchException, boolean, ClientContext)} for retry and
+   * notification handling. It does not attempt additional recovery on its own and does not inspect
+   * the scheduler token beyond accepting the callback signature. The call is idempotent with
+   * respect to an already finished or canceled fetch; any such state is handled in the delegated
+   * method.
+   *
+   * @param e low-level failure reported by the scheduler, never {@code null}
+   * @param reqTokenIgnored scheduling token for the failed request, ignored by this implementation
+   * @param context client runtime context used for scheduler and callback access
+   */
   @Override
   public void onFailure(
       LowLevelGetException e, SendableRequestItem reqTokenIgnored, ClientContext context) {
@@ -97,15 +226,15 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
   /**
    * Handles a mapped client-level failure for this fetch.
    *
-   * <p>The method translates cancellation state, applies retry/cooldown policy when the failure is
-   * non-fatal, and emits the appropriate callback. When the outcome is terminal, the request is
-   * unregistered and the parent counters are updated. This method is idempotent with respect to a
-   * finished or cancelled fetch.
+   * <p>The method checks cancellation state, applies retry and cooldown policy when the failure is
+   * non-fatal, and emits the appropriate completion callback. When a terminal outcome is reached,
+   * the request is unregistered and the parent counters are updated to reflect failure. This method
+   * is safe to call multiple times; once the fetch is finished or canceled, further calls only
+   * observe that state and return without scheduling additional work.
    *
-   * @param e client-level failure describing the reason for the error; never {@code null}
-   * @param forceFatal when {@code true}, treats the error as terminal regardless of retry policy
-   * @param context client runtime context used to access schedulers and factories; never {@code
-   *     null}
+   * @param e client-level failure describing the reason and details, never {@code null}
+   * @param forceFatal when {@code true}, treat the error as terminal regardless of retry policy
+   * @param context client runtime context used for schedulers and resource management
    */
   protected void onFailure(FetchException e, boolean forceFatal, ClientContext context) {
     if (LOG.isDebugEnabled()) LOG.debug("onFailure( {} , {})", e, forceFatal, e);
@@ -129,14 +258,16 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
   }
 
   /**
-   * Delivers a successful decode to the completion callback.
+   * Delivers a successful decoding to the completion callback.
    *
-   * <p>If the owning request has been cancelled meanwhile, the provided data is released and a
-   * cancellation failure is reported instead. On success, the method wraps the bucket inside a
-   * {@link SingleFileStreamGenerator} for streaming to the client.
+   * <p>The method guards against late cancellation: if the parent request is already canceled, the
+   * decoded data is released and a cancellation failure is reported instead of success. Otherwise,
+   * the data bucket is wrapped in a {@link SingleFileStreamGenerator} and forwarded to the
+   * callback. This method performs no retries and is expected to be called at most once per
+   * instance.
    *
-   * @param data decoded result including metadata and data bucket; never {@code null}
-   * @param context client runtime context used for resource management; never {@code null}
+   * @param data decoded result containing metadata and a data bucket, never {@code null}
+   * @param context client runtime context used for resource cleanup and callbacks
    */
   protected void onSuccess(FetchResult data, ClientContext context) {
     if (parent.isCancelled()) {
@@ -155,6 +286,19 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
         context);
   }
 
+  /**
+   * Handles a verified client-level block and completes the fetch if it contains data.
+   *
+   * <p>The method extracts a data bucket from the provided block and, when successful, forwards the
+   * result to {@link #onSuccess(FetchResult, ClientContext)}. Metadata blocks are treated as an
+   * error because this fetcher expects a single data block. Callers should pass the block as
+   * verified; this method does not re-validate signatures beyond the decoding step.
+   *
+   * @param block verified client key block holding the fetched payload, never {@code null}
+   * @param fromStore {@code true} when the block originated from local storage
+   * @param reqTokenIgnored scheduler token for the request, ignored by this implementation
+   * @param context client runtime context used for bucket factories and callbacks
+   */
   @Override
   public void onSuccess(
       ClientKeyBlock block, boolean fromStore, Object reqTokenIgnored, ClientContext context) {
@@ -173,16 +317,16 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
   }
 
   /**
-   * Extracts the data bucket from a verified {@link ClientKeyBlock}.
+   * Extracts a decoded data bucket from a verified {@link ClientKeyBlock}.
    *
-   * <p>On decode errors or I/O conditions, this method reports the appropriate failure via {@link
-   * #onFailure(FetchException, boolean, ClientContext)} and returns {@code null}. The caller should
-   * treat a {@code null} return as a terminal path for this attempt.
+   * <p>The block is decoded using the current fetch context limits. Any decoding failure or I/O
+   * error is reported through {@link #onFailure(FetchException, boolean, ClientContext)}, and this
+   * method returns {@code null} to signal a terminal path. A non-null return indicates ownership of
+   * the bucket has been transferred to the caller, who is responsible for closing or freeing it.
    *
-   * @param block verified client key block obtained from the network or a local store; never {@code
-   *     null}
-   * @param context client runtime context providing factories and schedulers; never {@code null}
-   * @return the decoded {@link Bucket} when successful; {@code null} when a failure was reported
+   * @param block verified client key block obtained from network or local storage
+   * @param context client runtime context providing bucket factories and scheduler access
+   * @return a decoded data bucket, or {@code null} after a reported failure
    */
   protected Bucket extract(ClientKeyBlock block, ClientContext context) {
     Bucket data;
@@ -216,30 +360,60 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
   /**
    * Returns the opaque token associated with this fetcher.
    *
-   * <p>The value originates from the {@link Cfg} used at construction time and can be used by
-   * callers to correlate callbacks with external bookkeeping.
+   * <p>The value originates from the {@link Cfg} used at construction time. It is propagated
+   * unchanged through callbacks so higher-level code can correlate scheduler events with external
+   * state. The token is not interpreted by this class and may be any 64-bit value chosen by the
+   * caller.
    *
-   * @return the creator-supplied token value; no semantics are attached by this class
+   * @return the creator-supplied token used for external correlation and logging
    */
   @Override
   public long getToken() {
     return token;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Cancels the fetch and reports cancellation to the completion callback.
+   *
+   * <p>The fetcher is removed from scheduling via the superclass cancellation logic and then emits
+   * a {@link FetchException.FetchExceptionMode#CANCELLED} failure to the callback. Repeated calls
+   * are safe: once canceled, later invocations will simply re-emit the cancellation failure and
+   * leave the instance in its terminal state.
+   *
+   * @param context client runtime context used to unregister from schedulers
+   */
   @Override
   public void cancel(ClientContext context) {
     super.cancel(context);
     rcb.onFailure(new FetchException(FetchExceptionMode.CANCELLED), this, context);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Reports a missing block when the local store did not contain the key.
+   *
+   * <p>This method converts the absence into a terminal failure with mode {@link
+   * FetchException.FetchExceptionMode#DATA_NOT_FOUND}. It is invoked by the base fetcher when the
+   * request is configured for local-only behavior and no matching data is found. The method does
+   * not attempt retries because the local store has already been checked.
+   *
+   * @param context client runtime context used for failure reporting and scheduling
+   */
   @Override
   protected void notFoundInStore(ClientContext context) {
     this.onFailure(new FetchException(FetchExceptionMode.DATA_NOT_FOUND), true, context);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Reports a terminal failure when a block cannot be decoded or verified.
+   *
+   * <p>The failure is treated as fatal because the requested block does not match the expected
+   * content. The callback receives a {@link FetchException.FetchExceptionMode#BLOCK_DECODE_ERROR}
+   * to signal a non-retryable error for this logical fetch. The token is accepted for completeness
+   * but is not used to change the failure handling.
+   *
+   * @param token scheduling token for the failed request, unused in this implementation
+   * @param context client runtime context used for failure reporting and scheduling
+   */
   @Override
   protected void onBlockDecodeError(SendableRequestItem token, ClientContext context) {
     onFailure(
@@ -251,13 +425,29 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
         context);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Handles scheduler shutdown for this fetcher.
+   *
+   * <p>This implementation has no shutdown-specific behavior. The method exists to satisfy the
+   * {@link ClientGetState} contract and may be overridden by subclasses that need to release
+   * resources on shutdown. It does not attempt to cancel or reschedule work on its own.
+   *
+   * @param context client runtime context provided during shutdown
+   */
   @Override
   public void onShutdown(ClientContext context) {
     // Do nothing.
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Returns the active {@link ClientGetState} for callbacks and scheduling.
+   *
+   * <p>This fetcher represents the current state itself, so the method simply returns {@code this}.
+   * Subclasses that wrap or delegate to other states should override this method accordingly. The
+   * return value is used by callbacks that need a stable handle to the active request state.
+   *
+   * @return this instance as the active client get state
+   */
   @Override
   protected ClientGetState getClientGetState() {
     return this;
@@ -266,10 +456,16 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
   /**
    * Builder-style configuration used to construct a {@link SimpleSingleFileFetcher}.
    *
-   * <p>The configuration collects all constructor inputs to avoid long parameter lists. Instances
-   * are created via {@link #create(ClientKey, int, FetchContext, ClientRequester,
-   * GetCompletionCallback, long, ClientContext)} and can be refined through fluent setters before
-   * being passed to the constructor.
+   * <p>This configuration aggregates the required constructor parameters and exposes fluent setters
+   * for optional behavior such as essential accounting and real-time scheduling. Callers create an
+   * instance using {@link #create(ClientKey, int, FetchContext, ClientRequester,
+   * GetCompletionCallback, long, ClientContext)}, then refine the instance using the available
+   * setters before passing it to the {@link SimpleSingleFileFetcher} constructor. The configuration
+   * is immutable with respect to required fields and mutable for optional flags.
+   *
+   * <p>The intent is to keep call sites readable and to preserve a stable parameter ordering. The
+   * configuration object itself does not validate inputs beyond nullness expectations; callers
+   * should ensure the provided values align with the fetch context limits and scheduling policy.
    */
   public static final class Cfg {
     final ClientKey key;
@@ -283,6 +479,8 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     boolean dontAdd;
     boolean deleteFetchContext;
     boolean realTimeFlag;
+    PriorityClassProvider priorityClassProvider;
+    KeyListenerFactory keyListenerFactory;
 
     private Cfg(
         ClientKey key,
@@ -304,18 +502,19 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     /**
      * Creates a configuration instance with the required parameters.
      *
-     * @param key client key identifying the block to fetch; must not be {@code null}
-     * @param maxRetries maximum number of retry attempts; use {@code -1} for unlimited retries
-     * @param ctx fetch context carrying limits, cooldown policy, and preferences; must not be
-     *     {@code null}
-     * @param parent owning requester used for accounting and notifications; must not be {@code
-     *     null}
-     * @param rcb completion callback to receive results and progress; for persistent requests the
-     *     implementation must be {@link Serializable}
-     * @param token opaque token associated with this fetch; returned by {@link #getToken()}
-     * @param context client runtime context used for scheduling and factories; must not be {@code
-     *     null}
-     * @return a new configuration instance ready to be refined via fluent setters
+     * <p>The returned configuration captures the mandatory inputs needed to build a fetcher and
+     * leaves optional behavior at its defaults. Callers should set any optional flags on the
+     * returned instance before passing it to the fetcher constructor. The method performs no side
+     * effects beyond storing the provided references and does not allocate network resources.
+     *
+     * @param key client key identifying the single block to fetch, never {@code null}
+     * @param maxRetries maximum retry attempts; use {@code -1} to allow unlimited retries
+     * @param ctx fetch context with limits, cooldown policy, and scheduling preferences
+     * @param parent owning requester used for accounting, cancellation, and notifications
+     * @param rcb completion callback receiving results and progress, must be serializable
+     * @param token opaque token carried through callbacks for correlation and logging
+     * @param context client runtime context used for schedulers and bucket factories
+     * @return a new configuration instance ready for fluent option refinement
      */
     public static Cfg create(
         ClientKey key,
@@ -331,9 +530,14 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     /**
      * Marks the fetch as essential for the parent’s success accounting.
      *
-     * @param value when {@code true}, the parent increments “must succeed” counters; otherwise a
-     *     regular block is added
-     * @return this configuration instance for chaining
+     * <p>When set to {@code true}, the parent request increments the “must succeed” counters rather
+     * than the standard block counters, which can affect higher-level success criteria. Leave this
+     * flag {@code false} for ordinary single-block fetches that should not gate overall success.
+     * The change is local to the configuration and takes effect when the fetcher is constructed. It
+     * does not alter retry limits or other fetch context settings.
+     *
+     * @param value {@code true} to treat the block as essential for completion criteria
+     * @return this configuration instance so callers can continue fluent updates
      */
     public Cfg essential(boolean value) {
       this.isEssential = value;
@@ -341,10 +545,16 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     }
 
     /**
-     * Controls whether the constructor updates the parent’s block counters and notifies clients.
+     * Controls whether the constructor updates parent counters and notifies clients.
      *
-     * @param value when {@code true}, suppresses the add/notify side effects during construction
-     * @return this configuration instance for chaining
+     * <p>When set to {@code true}, the constructor does not increment block counters and does not
+     * notify listeners, allowing the caller to integrate the fetcher into existing accounting
+     * flows. When {@code false}, the constructor performs the usual add/notify side effects. The
+     * setting only affects construction-time bookkeeping and does not change retry handling or
+     * decoding.
+     *
+     * @param value {@code true} to suppress parent add/notify side effects on construction
+     * @return this configuration instance so additional options can be chained
      */
     public Cfg dontAdd(boolean value) {
       this.dontAdd = value;
@@ -352,10 +562,15 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     }
 
     /**
-     * Requests deletion of the associated fetch context after the request completes.
+     * Requests deletion of the associated fetch context after completion.
      *
-     * @param value when {@code true}, the fetch context is deleted on terminal completion
-     * @return this configuration instance for chaining
+     * <p>When enabled, the parent request may delete the fetch context once the fetch reaches a
+     * terminal state, reducing retained state for short-lived requests. Disable this option if the
+     * context must remain available for later operations that share the same settings. The flag
+     * only affects cleanup after completion and does not change fetch behavior while active.
+     *
+     * @param value {@code true} to delete the fetch context after terminal completion
+     * @return this configuration instance so additional options can be chained
      */
     public Cfg deleteFetchContext(boolean value) {
       this.deleteFetchContext = value;
@@ -365,11 +580,49 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     /**
      * Sets whether the fetch should use the real-time scheduling lane.
      *
-     * @param value {@code true} to use the real-time schedulers; {@code false} for the bulk lane
-     * @return this configuration instance for chaining
+     * <p>Real-time scheduling prioritizes latency-sensitive requests at the cost of throughput. Use
+     * {@code true} for interactive user requests and {@code false} for background or bulk work. The
+     * value is captured on construction and supplied to the base scheduler registration. It does
+     * not modify fetch context limits or key decoding behavior.
+     *
+     * @param value {@code true} for real-time schedulers; {@code false} for bulk scheduling
+     * @return this configuration instance so additional options can be chained
      */
     public Cfg realTime(boolean value) {
       this.realTimeFlag = value;
+      return this;
+    }
+
+    /**
+     * Overrides the priority class used by this fetcher.
+     *
+     * <p>Supplying a provider allows the caller to supply a priority class that may differ from the
+     * parent requester, while still deferring computation to a lightweight callback. If {@code
+     * null} is provided, the fetcher falls back to the parent’s priority value. The provider is
+     * consulted whenever the fetcher reports its current scheduling priority.
+     *
+     * @param provider priority provider used for scheduling decisions, or {@code null}
+     * @return this configuration instance so additional options can be chained
+     */
+    public Cfg priorityClassProvider(PriorityClassProvider provider) {
+      this.priorityClassProvider = provider;
+      return this;
+    }
+
+    /**
+     * Overrides key listener creation for this fetcher.
+     *
+     * <p>When supplied, the factory is invoked to create the key listener used by schedulers to
+     * match and dispatch keys. This enables callers to inject cancellation checks or custom
+     * listener selection without subclassing. Passing {@code null} restores the default listener
+     * behavior from {@link BaseSingleFileFetcher}. The factory is called on demand when schedulers
+     * request a listener, not during configuration.
+     *
+     * @param factory key listener factory to use, or {@code null} for default behavior
+     * @return this configuration instance so additional options can be chained
+     */
+    public Cfg keyListenerFactory(KeyListenerFactory factory) {
+      this.keyListenerFactory = factory;
       return this;
     }
   }

--- a/src/main/java/network/crypta/client/async/USKDateHintFetches.java
+++ b/src/main/java/network/crypta/client/async/USKDateHintFetches.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.io.Serial;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -21,7 +22,6 @@ import network.crypta.crypt.HashResult;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.ClientSSK;
 import network.crypta.keys.FreenetURI;
-import network.crypta.keys.Key;
 import network.crypta.keys.USK;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.compress.Compressor;
@@ -40,29 +40,34 @@ import org.slf4j.LoggerFactory;
  * alongside the fetcher and call {@link #maybeStart(ClientContext)} once per polling cycle,
  * followed by {@link #cancelAll(ClientContext)} when the fetcher shuts down.
  *
- * <p>Instances are mutable and synchronize on {@code this} for state such as scheduled flags and
- * active attempts. The set of in-flight attempts is small (one per {@link USKDateHint.Type}) and is
- * pruned when a more precise hint succeeds. The helper is intentionally conservative: if hints are
- * disabled or already scheduled, it performs no work and leaves the fetcher to continue its normal
- * probing.
+ * <p>The helper is intentionally conservative about work. It schedules at most one attempt per
+ * {@link USKDateHint.Type} in a cycle, and it will skip scheduling entirely when hints are disabled
+ * or already attempted. Successful hint parses prune less precise siblings, keeping I/O minimal.
+ * The helper is mutable and tracks per-cycle counters for hints started and found to guide later
+ * probing decisions. Callers should treat the instance as tied to a single fetcher lifecycle and
+ * reuse it across polling rounds.
  *
  * <ul>
  *   <li><strong>Responsibilities</strong>: schedule DBR hint fetches, parse hint payloads, and
  *       forward valid editions to {@link USKManager}.
  *   <li><strong>State model</strong>: scheduled once per cycle; attempts cleared on completion or
- *       cancellation.
- *   <li><strong>Threading</strong>: internal collections are guarded by synchronization; callbacks
- *       may run on scheduler threads.
+ *       cancellation; hint counters reset per cycle.
+ *   <li><strong>Threading</strong>: synchronization guards internal collections and counters;
+ *       callbacks may run on scheduler threads.
  * </ul>
+ *
+ * @see USKFetcher
+ * @see USKManager
+ * @see USKDateHint
  */
 final class USKDateHintFetches {
   /** Logger for hint scheduling, parsing, and failure diagnostics. */
   private static final Logger LOG = LoggerFactory.getLogger(USKDateHintFetches.class);
 
-  /** Owning fetcher that supplies priority class and completion hooks for DBR work. */
+  /** The owning fetcher that supplies priority class and completion hooks for DBR work. */
   private final USKFetcher owner;
 
-  /** Manager that consumes DBR hint updates and schedules follow-up probes. */
+  /** Manager that consumes DBR hints updates and schedules follow-up probes. */
   private final USKManager uskManager;
 
   /** Original USK used to derive hint request URIs and to copy with hinted editions. */
@@ -77,7 +82,7 @@ final class USKDateHintFetches {
   /** Parent requester that defines persistence and real-time scheduling policies. */
   private final ClientRequester parent;
 
-  /** Cached real-time flag from the parent to avoid repeated lookups. */
+  /** Cached the real-time flag from the parent to avoid repeated lookups. */
   private final boolean realTimeFlag;
 
   /** Active DBR attempts, guarded by {@code this} for thread-safe access. */
@@ -93,13 +98,79 @@ final class USKDateHintFetches {
   private int hintsStarted;
 
   /**
+   * Supplies a priority class for DBR hint fetchers with a safe fallback.
+   *
+   * <p>The provider captures the owner's priority at construction time so that serialized attempts
+   * still have a sensible priority even if the owning fetcher is not available after restart.
+   */
+  private static final class DBRPriorityProvider
+      implements SimpleSingleFileFetcher.PriorityClassProvider {
+    /** Serialization version for the priority provider. */
+    @Serial private static final long serialVersionUID = 1L;
+
+    /** Owning fetcher reference, transient for persistence safety. */
+    private final transient USKFetcher owner;
+
+    /** Priority to use when the owner reference is unavailable. */
+    private final short fallbackPriority;
+
+    /**
+     * Creates a provider bound to the owning fetcher.
+     *
+     * @param owner owning fetcher that supplies priority information never {@code null}
+     */
+    private DBRPriorityProvider(USKFetcher owner) {
+      this.owner = owner;
+      this.fallbackPriority = owner.getPriorityClass();
+    }
+
+    @Override
+    public short getPriorityClass() {
+      if (owner == null) return fallbackPriority;
+      return owner.getPriorityClass();
+    }
+  }
+
+  /**
+   * Creates key listeners for DBR attempts while honoring owner cancellation.
+   *
+   * <p>The factory delegates to the fetcher's listener creation helper while short-circuiting when
+   * the owning fetcher is already canceled.
+   */
+  private static final class DBRKeyListenerFactory
+      implements SimpleSingleFileFetcher.KeyListenerFactory {
+    /** Serialization version for the key listener factory. */
+    @Serial private static final long serialVersionUID = 1L;
+
+    /** Owning fetcher reference, transient for persistence safety. */
+    private final transient USKFetcher owner;
+
+    /**
+     * Creates a factory bound to the owning fetcher.
+     *
+     * @param owner owning fetcher used for cancellation checks, never {@code null}
+     */
+    private DBRKeyListenerFactory(USKFetcher owner) {
+      this.owner = owner;
+    }
+
+    @Override
+    public KeyListener makeKeyListener(
+        SimpleSingleFileFetcher fetcher, ClientContext context, boolean onStartup) {
+      if (owner != null && owner.isCancelled()) return null;
+      return fetcher.createKeyListener(fetcher.getPriorityClass());
+    }
+  }
+
+  /**
    * Creates a coordinator for DBR hint fetches associated with a single USK fetcher.
    *
    * <p>The instance is bound to the provided contexts and parent requester. It does not schedule
    * work until {@link #maybeStart(ClientContext)} is invoked, and it does not mutate the contexts.
    * Callers should reuse the instance for the lifetime of the owning {@link USKFetcher}.
    *
-   * @param owner owning fetcher that provides priority and lifecycle callbacks; must not be null
+   * @param owner the owning fetcher that provides priority and lifecycle callbacks; must not be
+   *     null
    * @param uskManager manager to receive parsed hint updates; must not be null
    * @param origUSK base USK used to derive hint URIs and to copy editions; must not be null
    * @param ctx main fetch context used for limits and parsing decisions; must not be null
@@ -183,9 +254,9 @@ final class USKDateHintFetches {
   /**
    * Cancels all in-flight DBR attempts and clears internal tracking.
    *
-   * <p>This method is idempotent and may be called multiple times; subsequent calls will simply
-   * observe an empty attempt set. It is typically invoked when the owning request is canceled or
-   * shut down, ensuring that no more hint callbacks will fire.
+   * <p>This method is idempotent and may be called multiple times; later calls will simply observe
+   * an empty attempt set. It is typically invoked when the owning request is canceled or shut down,
+   * ensuring that no more hint callbacks will fire.
    *
    * @param context client context used to propagate cancellation to schedulers; must not be null
    */
@@ -201,7 +272,7 @@ final class USKDateHintFetches {
   /**
    * Decides whether to add random edition probes based on prior hint outcomes.
    *
-   * <p>The decision is stochastic to spread load: the method samples a random value in a range
+   * <p>The decision is stochastic to the spread load: the method samples a random value in a range
    * based on how many hints were started and compares it to how many were successfully parsed. On
    * the first loop, the method always returns {@code false} to avoid extra work before hints have
    * had a chance to complete.
@@ -254,32 +325,9 @@ final class USKDateHintFetches {
                   .essential(false)
                   .dontAdd(true)
                   .deleteFetchContext(false)
-                  .realTime(realTimeFlag)) {
-            @Override
-            public short getPriorityClass() {
-              return owner.getPriorityClass();
-            }
-
-            @Override
-            public KeyListener makeKeyListener(ClientContext context, boolean onStartup) {
-              synchronized (this) {
-                if (finished) return null;
-              }
-              if (owner.isCancelled()) return null;
-              if (key == null) {
-                if (LOG.isErrorEnabled()) {
-                  LOG.error(
-                      "Key is null - left over BSSF? on {} in makeKeyListener()",
-                      this,
-                      new Exception("error"));
-                }
-                return null;
-              }
-              Key newKey = key.getNodeKey(true);
-              short prio = owner.getPriorityClass();
-              return new SingleKeyListener(newKey, this, prio, persistent);
-            }
-          };
+                  .realTime(realTimeFlag)
+                  .priorityClassProvider(new DBRPriorityProvider(owner))
+                  .keyListenerFactory(new DBRKeyListenerFactory(owner)));
       this.type = type;
       if (LOG.isTraceEnabled()) LOG.trace("Created {} with {}", this, fetcher);
     }


### PR DESCRIPTION
## Summary
- add priority and key listener provider hooks on single-block fetchers
- reuse hooks for USK DBR hint attempts with safe fallback priorities
- expand fetcher Javadoc to clarify lifecycle and callback behavior

## Testing
- ./gradlew spotlessApply