### PR TITLE
fix(client): map unknown charset to unsafe content

### DIFF
--- a/src/main/java/network/crypta/client/FetchException.java
+++ b/src/main/java/network/crypta/client/FetchException.java
@@ -3,6 +3,7 @@ package network.crypta.client;
 import java.io.Serial;
 import java.util.HashMap;
 import network.crypta.client.filter.DataFilterException;
+import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import org.slf4j.Logger;
@@ -22,7 +23,7 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Network code constructs a {@code FetchException} when a request cannot progress or should
- *       stop, optionally attaching the underlying {@linkplain #getCause() cause} (for example a
+ *       stop, optionally attaching the underlying {@linkplain #getCause() cause} (for example, a
  *       content‑filter exception).
  *   <li>Higher layers inspect {@link #mode}, {@link #getCause()}, and helpers such as {@link
  *       #isFatal()} to decide between retry, redirect, or user‑visible error.
@@ -95,7 +96,7 @@ public class FetchException extends Exception {
   /**
    * Returns the expected size of the content, or {@code -1} if unknown.
    *
-   * <p>This value may be a best‑effort estimate provided by the network and is not always final
+   * <p>This value may be the best‑effort estimate provided by the network and is not always final
    * unless {@link #finalizedSize()} returns {@code true}.
    *
    * @return content length in bytes or {@code -1} when the size is unknown
@@ -109,7 +110,7 @@ public class FetchException extends Exception {
    *
    * <p>The returned instance preserves the original {@linkplain #mode error mode}, message, new
    * URI, error codes, and the direct {@linkplain #getCause() cause}. Only size/finalization/MIME
-   * fields may differ according to the arguments supplied.
+   * fields may differ, according to the arguments supplied.
    *
    * @param newExpectedSize the size in bytes to record for this failure; use {@code -1} when
    *     unknown
@@ -121,7 +122,7 @@ public class FetchException extends Exception {
   }
 
   /**
-   * If there are many failures, usually in a splitfile fetch, tracks the number of failures of each
+   * If there are many failures, usually in a splitfile fetch tracks the number of failures of each
    * type.
    */
   public final FailureCodeTracker errorCodes;
@@ -367,7 +368,33 @@ public class FetchException extends Exception {
   }
 
   /**
-   * Creates a failure with expected size, cause, and MIME type.
+   * Creates a failure for content that failed validation in the content filter.
+   *
+   * @param expectedSize estimated or final size in bytes, or {@code -1} when unknown
+   * @param t the filter-level exception describing why the content is unsafe; becomes the direct
+   *     cause
+   * @param expectedMimeType MIME type inferred or declared for the content; may be {@code null}
+   */
+  public FetchException(long expectedSize, UnsafeContentTypeException t, String expectedMimeType) {
+    super(
+        getMessage(FetchExceptionMode.CONTENT_VALIDATION_FAILED)
+            + " "
+            + NodeL10n.getBase().getString("FetchException.unsafeContentDetails")
+            + " "
+            + t.getMessage());
+    extraMessage = t.getMessage();
+    this.mode = FetchExceptionMode.CONTENT_VALIDATION_FAILED;
+    this.expectedSize = expectedSize;
+    this.expectedMimeType = expectedMimeType;
+    this.finalizedSizeAndMimeType = false;
+    errorCodes = null;
+    initCause(t);
+    newURI = null;
+    if (LOG.isDebugEnabled()) LOG.debug(LOG_DEBUG_PATTERN, getMessage(mode), this);
+  }
+
+  /**
+   * Creates a failure with the expected size, cause, and MIME type.
    *
    * @param mode the error mode; must not be {@code null}
    * @param expectedSize estimated or final size in bytes, or {@code -1} when unknown
@@ -661,7 +688,7 @@ public class FetchException extends Exception {
     /** Too many levels of recursion into archives */
     @Deprecated // not used
     TOO_DEEP_ARCHIVE_RECURSION(1),
-    /** Don't know what to do with splitfile */
+    /** Don't know what to do with a splitfile */
     @Deprecated // not used
     UNKNOWN_SPLITFILE_METADATA(2),
     /** Don't know what to do with metadata */
@@ -670,7 +697,7 @@ public class FetchException extends Exception {
     INVALID_METADATA(4),
     /** Got an ArchiveFailureException */
     ARCHIVE_FAILURE(5),
-    /** Failed to decode a block. But we found it i.e. it is valid on the network level. */
+    /** Failed to decode a block. But we found it i.e., it is valid on the network level. */
     BLOCK_DECODE_ERROR(6),
     /** Too many split metadata levels */
     @Deprecated // not used
@@ -711,7 +738,7 @@ public class FetchException extends Exception {
     TOO_BIG_METADATA(22),
     /** Splitfile has too big segments */
     TOO_MANY_BLOCKS_PER_SEGMENT(23),
-    /** Not enough meta strings in URI given and no default document */
+    /** Not enough meta-strings in URI given and no default document */
     NOT_ENOUGH_PATH_COMPONENTS(24),
     /** Explicitly canceled */
     CANCELLED(25),
@@ -731,15 +758,15 @@ public class FetchException extends Exception {
     CONTENT_VALIDATION_UNKNOWN_MIME(32),
     /** The content filter knows this data type is dangerous */
     CONTENT_VALIDATION_BAD_MIME(33),
-    /** The metadata specified a hash but the data didn't match it. */
+    /** The metadata specified a hash, but the data didn't match it. */
     CONTENT_HASH_FAILED(34),
     /** FEC decode produced a block that doesn't match the data in the original splitfile. */
     SPLITFILE_DECODE_ERROR(35),
     /**
      * For a filtered download to disk, the MIME type is incompatible with the extension,
-     * potentially resulting in data on disk filtered with one MIME type but accessed by the
+     * potentially resulting in data on the disk filtered with one MIME type but accessed by the
      * operating system with another MIME type. This is equivalent to it not being filtered at all
-     * i.e. potentially dangerous.
+     * i.e., potentially dangerous.
      */
     MIME_INCOMPATIBLE_WITH_EXTENSION(36),
     /** Not enough disk space to start a download or the next stage of a download. */
@@ -820,7 +847,7 @@ public class FetchException extends Exception {
           SPLITFILE_DECODE_ERROR ->
           true;
 
-      // Low level errors, can be retried. Not usually fatal.
+      // Low-level errors can be retried. Not usually fatal.
       case DATA_NOT_FOUND,
           ROUTE_NOT_FOUND,
           REJECTED_OVERLOAD,
@@ -893,7 +920,7 @@ public class FetchException extends Exception {
           SPLITFILE_DECODE_ERROR ->
           true;
 
-      // Low level errors, can be retried. Not usually fatal.
+      // Low-level errors can be retried. Not usually fatal.
       case DATA_NOT_FOUND,
           ROUTE_NOT_FOUND,
           REJECTED_OVERLOAD,
@@ -904,7 +931,7 @@ public class FetchException extends Exception {
           false;
       case BUCKET_ERROR, INTERNAL_ERROR, NOT_ENOUGH_DISK_SPACE ->
           // No point retrying.
-          // But it's not really fatal. I.e. it's not necessarily a problem with the inserted data.
+          // But it's not really fatal. I.e., it's not necessarily a problem with the inserted data.
           false;
 
       // The ContentFilter failed to validate the data. Retrying won't fix this.
@@ -914,8 +941,7 @@ public class FetchException extends Exception {
           MIME_INCOMPATIBLE_WITH_EXTENSION ->
           true;
 
-      // Wierd ones
-      // Not necessarily a problem with the inserted data.
+      // Weird ones are Not necessarily a problem with the inserted data.
       case CANCELLED -> false;
       case ARCHIVE_RESTART, PERMANENT_REDIRECT, WRONG_MIME_TYPE ->
           // Fatal

--- a/src/main/java/network/crypta/client/filter/ContentFilter.java
+++ b/src/main/java/network/crypta/client/filter/ContentFilter.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * <p>Typical usage is to call one of the {@code filter(...)} overloads with an input stream, an
  * output stream, the declared MIME type, and the request context. The method returns a small {@link
  * FilterStatus} value describing the effective MIME/charset so that callers can persist or surface
- * that information. All methods are static and the internal registry is shared; the class is
+ * that information. All methods are static, and the internal registry is shared; the class is
  * thread-safe for concurrent use. Registration occurs at class initialization and may be extended
  * via {@link #register(FilterMIMEType)} at startup.
  *
@@ -53,10 +53,10 @@ public class ContentFilter {
   private static final String CHARSET_UTF16 = "UTF-16";
   private static final String CHARSET_UTF32 = "UTF-32";
 
-  // Use a concurrent map to avoid legacy synchronized Hashtable
+  // Use a concurrent map to avoid a legacy synchronized Hashtable
   static final ConcurrentMap<String, FilterMIMEType> mimeTypesByName = new ConcurrentHashMap<>();
 
-  /** The HTML mime types are defined here, to allow other modules to identify it */
+  /** The HTML mime types are defined here to allow other modules to identify it */
   protected static final String[] HTML_MIME_TYPES =
       new String[] {
         "text/html", "application/xhtml+xml", "text/xml+xhtml", "text/xhtml", "application/xhtml"
@@ -169,9 +169,9 @@ public class ContentFilter {
 
     /* FLAC - has a filter
      * Lossless audio format. This data is sometimes encapsulated inside
-     * ogg containers. It is, however, not currently supported, and
+     * ogg containers. It is, however, not currently supported and
      * is very dangerous, as it may specify URLs from which album art
-     * will be dwonloaded from
+     * will be downloaded from
      */
     register(
         new FilterMIMEType(
@@ -281,7 +281,7 @@ public class ContentFilter {
    * Register a {@link FilterMIMEType} under its primary and alternate names.
    *
    * <p>This associates the supplied handler with its {@code primaryMimeType} and any alternate
-   * types so that subsequent lookups via {@link #getMIMEType(String)} resolve to the same object.
+   * types so that later lookups via {@link #getMIMEType(String)} resolve to the same object.
    * Registration is idempotent with respect to keys; an existing mapping will be replaced.
    *
    * @param mimeType the handler describing capabilities, defaults, and filters for a MIME type; may
@@ -633,7 +633,7 @@ public class ContentFilter {
     } catch (UnsupportedEncodingException _) {
       if (LOG.isDebugEnabled()) LOG.debug("{} not supported", candidate);
       return null;
-    } catch (DataFilterException _) {
+    } catch (UnknownCharsetException | DataFilterException _) {
       return null;
     }
   }
@@ -768,7 +768,7 @@ public class ContentFilter {
   static byte[] bomBocu1 = new byte[] {(byte) 0xFB, (byte) 0xEE, (byte) 0x28};
 
   // These BOMs are invalid. That is, we do not support them, they will produce an unrecoverable
-  // error, since we cannot decode them, but the browser might be able to, as e.g. the CSS spec
+  // error, since we cannot decode them, but the browser might be able to, as e.g., the CSS spec
   // refers to them.
   static byte[] bomUtf322143 = new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0xff, (byte) 0xfe};
   static byte[] bomUtf323412 = new byte[] {(byte) 0xfe, (byte) 0xff, (byte) 0x00, (byte) 0x00};
@@ -856,7 +856,7 @@ public class ContentFilter {
   }
 
   /**
-   * Validate whether a specific MIME type can be handled safely by this filter system.
+   * Validate whether this filter system can handle a specific MIME type safely.
    *
    * <p>Intended for preflight checks before downloading content. If the type is unknown or marked
    * unsafe (for example, formats that cannot be sanitized reliably), the method returns an

--- a/src/main/java/network/crypta/client/filter/UnknownCharsetException.java
+++ b/src/main/java/network/crypta/client/filter/UnknownCharsetException.java
@@ -1,6 +1,7 @@
 package network.crypta.client.filter;
 
 import java.io.Serial;
+import network.crypta.client.FetchException;
 import network.crypta.l10n.NodeL10n;
 
 /**
@@ -10,15 +11,15 @@ import network.crypta.l10n.NodeL10n;
  * higher-level code (for example, HTTP responses or UI alerts).
  *
  * <p>This type is typically thrown by content data filters when they attempt to construct
- * character-oriented readers or writers for a specific charset and the runtime cannot provide a
+ * character-oriented readers or writers for a specific charset, and the runtime cannot provide a
  * corresponding codec. The {@link #charset} field preserves the name that was originally requested,
  * allowing callers to include it in diagnostics or logs. Values are not normalized; the original
  * input is retained to avoid losing context.
  *
  * <p>Exception instances are immutable and therefore safe to share across threads if needed;
  * however, in normal usage they are created and immediately thrown in the same thread where the
- * failure occurs. No automatic recovery is performed by this class. Callers should select and retry
- * with an alternative charset when appropriate or propagate the exception to abort processing.
+ * failure occurs. This class performs no automatic recovery. Callers should select and retry with
+ * an alternative charset when appropriate or propagate the exception to abort processing.
  *
  * <ul>
  *   <li>Purpose: report charset lookup or initialization failures encountered in filters.
@@ -26,11 +27,15 @@ import network.crypta.l10n.NodeL10n;
  *   <li>Localization: message text is sourced from the node localization bundle.
  * </ul>
  */
-public class UnknownCharsetException extends DataFilterException {
+public class UnknownCharsetException extends UnsafeContentTypeException {
   @Serial private static final long serialVersionUID = 1L;
 
+  private final String rawTitle;
+  private final String encodedTitle;
+  private final String explanation;
+
   /**
-   * The character set name that was requested when the failure occurred.
+   * The character set the name that was requested when the failure occurred.
    *
    * <p>The value is preserved exactly as supplied by the caller to facilitate accurate diagnostics
    * and end-user feedback. It may be {@code null} or an empty string if the originating code did
@@ -39,8 +44,11 @@ public class UnknownCharsetException extends DataFilterException {
    */
   public final String charset;
 
-  private UnknownCharsetException(String warning, String warning2, String string, String charset) {
-    super(warning, warning2, string);
+  private UnknownCharsetException(
+      String rawTitle, String encodedTitle, String explanation, String charset) {
+    this.rawTitle = rawTitle;
+    this.encodedTitle = encodedTitle;
+    this.explanation = explanation;
     this.charset = charset;
   }
 
@@ -67,6 +75,31 @@ public class UnknownCharsetException extends DataFilterException {
         NodeL10n.getBase()
             .getString("ContentDataFilter.warningUnknownCharsetTitle", "charset", charset);
     return new UnknownCharsetException(warning, warning, explTitle + " " + expl, charset);
+  }
+
+  @Override
+  public String getMessage() {
+    return explanation;
+  }
+
+  @Override
+  public String getHTMLEncodedTitle() {
+    return encodedTitle;
+  }
+
+  @Override
+  public String getRawTitle() {
+    return rawTitle;
+  }
+
+  @Override
+  public FetchException recreateFetchException(FetchException e, String mime) {
+    return new FetchException(e.getExpectedSize(), this, mime);
+  }
+
+  @Override
+  public FetchException createFetchException(String mime, long expectedSize) {
+    return new FetchException(expectedSize, this, mime);
   }
 
   private static String l10nDF(String key) {


### PR DESCRIPTION
## Summary
- map UnknownCharsetException to unsafe content validation failures
- allow fetch failures to carry unsafe-content details with expected size/MIME
- refine content filter charset handling and related documentation