### PR TITLE
test(assertions): clarify equality checks

### DIFF
--- a/src/test/java/network/crypta/support/PooledExecutorTest.java
+++ b/src/test/java/network/crypta/support/PooledExecutorTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.node.PrioRunnable;
 import network.crypta.support.io.NativeThread;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -200,11 +201,11 @@ class PooledExecutorTest {
           ran2.countDown();
         };
 
-    // Run first job and wait until it completed.
+    // Run the first job and wait until it completed.
     exec.execute(first, "first");
     assertTrue(uninterruptiblyAwait(ran1, 2), "first job did not run");
 
-    // Wait until worker has entered the waiting list before submitting the next job.
+    // Wait until a worker has entered the waiting list before submitting the next job.
     assertTimeout(
         Duration.ofSeconds(2),
         () -> {
@@ -214,7 +215,7 @@ class PooledExecutorTest {
           }
         });
 
-    // Submit second job and ensure it runs.
+    // Submit a second job and ensure it runs.
     exec.execute(second, "second");
     assertTrue(uninterruptiblyAwait(ran2, 2), "second job did not run");
 
@@ -288,8 +289,7 @@ class PooledExecutorTest {
     String id1 = extractWorkerIdSuffix(firstName.get());
     String id2 = extractWorkerIdSuffix(secondName.get());
     // If the interrupted worker retired, the thread id suffix must differ.
-    org.junit.jupiter.api.Assertions.assertFalse(
-        id1.equals(id2), "expected a new worker thread after interrupt");
+    Assertions.assertNotEquals(id1, id2, "expected a new worker thread after interrupt");
   }
 
   // --- Helpers ---

--- a/src/test/java/org/spaceroots/mantissa/optimization/PointCostPairTest.java
+++ b/src/test/java/org/spaceroots/mantissa/optimization/PointCostPairTest.java
@@ -2,10 +2,9 @@ package org.spaceroots.mantissa.optimization;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,6 @@ class PointCostPairTest {
   void constructor_whenPointIsNull_throwsNullPointerException() {
     // Arrange
     // Act / Assert
-    //noinspection DataFlowIssue
     assertThrows(NullPointerException.class, () -> new PointCostPair(null, 1.0));
   }
 
@@ -61,7 +59,7 @@ class PointCostPairTest {
     PointCostPair second = new PointCostPair(new double[] {1.0, 2.0}, 3.0);
 
     // Act + Assert
-    assertTrue(first.equals(second));
+    assertEquals(first, second);
     assertEquals(first.hashCode(), second.hashCode());
   }
 
@@ -73,7 +71,7 @@ class PointCostPairTest {
     PointCostPair second = new PointCostPair(new double[] {1.0, 2.0}, 4.0);
 
     // Act + Assert
-    assertFalse(first.equals(second));
+    assertNotEquals(first, second);
   }
 
   @Test
@@ -84,7 +82,7 @@ class PointCostPairTest {
     PointCostPair second = new PointCostPair(new double[] {1.0, 2.1}, 3.0);
 
     // Act + Assert
-    assertFalse(first.equals(second));
+    assertNotEquals(first, second);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- replace manual equals checks with JUnit equality assertions in tests
- tidy test comments and remove redundant annotations

## Testing
- ./gradlew spotlessApply