### PR TITLE
test(crypt): mark close override

### DIFF
--- a/src/test/java/network/crypta/crypt/CorruptingOutputStream.java
+++ b/src/test/java/network/crypta/crypt/CorruptingOutputStream.java
@@ -41,6 +41,7 @@ class CorruptingOutputStream extends OutputStream {
     os.write(b);
   }
 
+  @Override
   public void close() throws IOException {
     os.close();
   }


### PR DESCRIPTION
## Summary
- annotate the test helper close method as an override to make intent explicit