### PR TITLE
refactor(node): clean up test helpers

### DIFF
--- a/src/main/java/network/crypta/node/NodeStarter.java
+++ b/src/main/java/network/crypta/node/NodeStarter.java
@@ -60,7 +60,7 @@ public class NodeStarter implements WrapperListener {
    * Constructors
    *-------------------------------------------------------------*/
   private NodeStarter() {
-    // Force it to load right now, and log what exactly is loaded.
+    // Force it to load right now and log what exactly is loaded.
     JceLoader.dumpLoaded();
   }
 
@@ -68,7 +68,7 @@ public class NodeStarter implements WrapperListener {
    * Returns whether this JVM was initialized for testing via {@link #globalTestInit}.
    *
    * <p>When {@code true}, the process is in a test/simulator VM. When {@code false}, it is a
-   * regular node process. This method is valid only after startup has begun.
+   * regular node process. This method is valid only after the startup has begun.
    *
    * @return {@code true} when running in a testing VM; otherwise {@code false}
    * @throws IllegalStateException if called before startup initializes the flag
@@ -99,7 +99,7 @@ public class NodeStarter implements WrapperListener {
   }
 
   /**
-   * Initializes a testing VM. This is VM-scoped state; multiple nodes may be created afterward.
+   * Initializes a testing VM. This is a VM-scoped state; multiple nodes may be created afterward.
    *
    * @param baseDirectory directory for test data; created if missing (caller cleans up)
    * @param enablePlug when {@code true}, starts a background keep-alive thread
@@ -374,7 +374,7 @@ public class NodeStarter implements WrapperListener {
   }
 
   /**
-   * Returns a lazily-initialized process-wide {@link SecureRandom} and ensures it seeds eagerly.
+   * Returns a lazily initialized process-wide {@link SecureRandom} and ensures it seeds eagerly.
    *
    * @return shared {@link SecureRandom} instance
    */
@@ -382,7 +382,7 @@ public class NodeStarter implements WrapperListener {
     if (globalSecureRandom == null) {
       globalSecureRandom = new SecureRandom();
       globalSecureRandom.nextBytes(
-          new byte[16]); // Force it to seed itself so it blocks now not later.
+          new byte[16]); // Force it to seed itself so it blocks now, not later.
     }
     return globalSecureRandom;
   }
@@ -399,7 +399,7 @@ public class NodeStarter implements WrapperListener {
   /**
    * Print resolved directories to stdout to help users understand where files are stored. Includes
    * the configuration file path and the resolved config, data, cache, run, and logs directories.
-   * Reflects environment detection (service vs user) and CLI overrides.
+   * Reflects environment detection (service vs. user) and CLI overrides.
    */
   private static void printResolvedDirectories(Resolved r, File configFile, boolean serviceMode) {
     try {
@@ -420,8 +420,8 @@ public class NodeStarter implements WrapperListener {
           r.getCacheDir(),
           r.getRunDir(),
           r.getLogsDir());
-    } catch (Throwable _) {
-      // Do not fail startup due to logging
+    } catch (Exception _) {
+      // Do not fail to start up due to logging
     }
   }
 
@@ -447,7 +447,7 @@ public class NodeStarter implements WrapperListener {
    *
    * @param args List of arguments used to initialize the application.
    * @return Any error code if the application should exit on completion of the start method. If
-   *     there were no problems then this method should return null.
+   *     there were no problems, then this method should return null.
    */
   @Override
   public Integer start(String[] args) {
@@ -505,7 +505,7 @@ public class NodeStarter implements WrapperListener {
 
     PooledExecutor executor = startExecutor();
 
-    // Extend wrapper startup timeout to 500000 ms. Diffie-Hellman init can be slow on some hosts.
+    // Extend wrapper startup timeout to 500,000 ms. Diffie-Hellman init can be slow on some hosts.
     WrapperManager.signalStarting(500000);
 
     startKeepAliveNativePlugThread();
@@ -687,19 +687,19 @@ public class NodeStarter implements WrapperListener {
    * Called when the application is shutting down. The Wrapper assumes that this method will return
    * fairly quickly. If the shutdown code could take a long time, then
    * WrapperManager.signalStopping() should be called to extend the timeout period. If for some
-   * reason, the stop method can not return, then it must call WrapperManager.stopped() to avoid
+   * reason, the stop method cannot return, then it must call WrapperManager.stopped() to avoid
    * warning messages from the Wrapper.
    *
    * @param exitCode The suggested exit code that will be returned to the OS when the JVM exits.
    * @return The exit code to actually return to the OS. In most cases, this should just be the
-   *     value of exitCode, however the user code has the option of changing the exit code if there
+   *     value of exitCode. However, the user code has the option of changing the exit code if there
    *     are any problems during shutdown.
    */
   @Override
   public int stop(int exitCode) {
     LOG.info("Shutting down with exit code {}", exitCode);
     node.park();
-    // Extend wrapper shutdown timeout to 120000 ms (see #354).
+    // Extend the wrapper shutdown timeout to 120,000 ms (see #354).
     WrapperManager.signalStopping(120000);
 
     return exitCode;

--- a/src/main/java/network/crypta/node/PacketSender.java
+++ b/src/main/java/network/crypta/node/PacketSender.java
@@ -32,8 +32,8 @@ import org.slf4j.LoggerFactory;
  * send/handshake methods. - Emits structured logs for diagnostics; does not expose public
  * callbacks.
  */
-// Historical note: This component once doubled as an ad‑hoc scheduler. Today, recurring work is
-// delegated to the Ticker; PacketSender focuses on send decisions and timing.
+// Historical note: This component once doubled as an ad‑hoc scheduler. Today recurring work is
+// delegated to the Ticker; PacketSender focuses on sending decisions and timing.
 public class PacketSender implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(PacketSender.class);
 
@@ -44,7 +44,7 @@ public class PacketSender implements Runnable {
    * Maximum time to queue bulk data before sending (milliseconds).
    *
    * <p>Bulk payloads typically fill a packet and are sent immediately; this value still influences
-   * realtime vs bulk selection (see {@code PeerMessageQueue.addMessages()}).
+   * realtime vs. bulk selection (see {@code PeerMessageQueue.addMessages()}).
    */
   static final long MAX_COALESCING_DELAY_BULK = SECONDS.toMillis(5);
 
@@ -69,11 +69,6 @@ public class PacketSender implements Runnable {
     localRandom = node.bootstrap().createRandom();
   }
 
-  /**
-   * Starts the sender thread and records the {@link NodeStats} sink.
-   *
-   * @param stats destination for periodic statistics updates; must be non‑{@code null}
-   */
   /**
    * Starts the packet sender thread using the provided stats counters.
    *
@@ -115,7 +110,7 @@ public class PacketSender implements Runnable {
   }
 
   /**
-   * Runs the main send loop.
+   * Runs the main sending loop.
    *
    * <p>Behavior: - Schedules periodic maintenance via the node ticker. - Iterates indefinitely,
    * selecting and sending work for peers, then sleeping until the next action time. - Logs and
@@ -127,7 +122,7 @@ public class PacketSender implements Runnable {
     if (LOG.isDebugEnabled()) LOG.debug("In PacketSender.run()");
 
     schedulePeriodicJob();
-    // Process peers, perform the selected action, then sleep until the next action time.
+    // Process peers perform the selected action, then sleep until the next action time.
     while (true) {
       lastReceivedPacketFromAnyNode = lastReportedNoPackets;
       try {
@@ -146,9 +141,9 @@ public class PacketSender implements Runnable {
    * the peer with the oldest data. - If there are peers with overdue ack's, send to the peer whose
    * acks are oldest.
    *
-   * <p>It does not attempt to ensure fairness, it attempts to minimise latency. Fairness is best
-   * dealt with at a higher level e.g. requests, although some transfers are not part of requests,
-   * e.g. bulk f2f transfers, so we may need to reconsider this eventually...
+   * <p>It does not attempt to ensure fairness, it attempts to minimize latency. Fairness is best
+   * dealt with at a higher level e.g., requests, although some transfers are not part of requests,
+   * e.g., bulk f2f transfers, so we may need to reconsider this eventually...
    */
   private void realRun() {
     long now = System.currentTimeMillis();
@@ -389,10 +384,8 @@ public class PacketSender implements Runnable {
       if (sel.toSendPacket.maybeSendPacket(now, false)) {
         agg.nextActionTime = now;
       }
-    } else if (sel.toSendAckOnly != null) {
-      if (sel.toSendAckOnly.maybeSendPacket(now, true)) {
-        agg.nextActionTime = now;
-      }
+    } else if (sel.toSendAckOnly != null && sel.toSendAckOnly.maybeSendPacket(now, true)) {
+      agg.nextActionTime = now;
     }
 
     if (sel.toSendHandshake != null) {
@@ -415,8 +408,8 @@ public class PacketSender implements Runnable {
   }
 
   private void processOldOpennetPeers(long now) {
-    // If we send something we will have to go around the loop again.
-    // Optimisation possibility: Track the second best, and check how many are in the array.
+    // If we send something, we will have to go around the loop again.
+    // Optimization possibility: Track the second best and check how many are in the array.
     OpennetManager om = node.network().opennet();
     if (om == null || node.network().uptime() <= SECONDS.toMillis(30)) return;
 

--- a/src/main/java/network/crypta/node/PeerManager.java
+++ b/src/main/java/network/crypta/node/PeerManager.java
@@ -1,6 +1,7 @@
 package network.crypta.node;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,10 +9,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates darknet and opennet peers for the local node.
  *
- * <p>Responsibilities include maintaining the desired peer set (configured + discovered), tracking
- * currently connected peers, recording per-peer status, selecting routing targets, and persisting
- * peer references to disk. The manager also exposes helper queries for counts, lookups, and status
- * summaries, and emits user alerts summarizing connectivity.
+ * <p>Responsibilities include maintaining the desired peer set (configured and discovered),
+ * tracking currently connected peers, recording per-peer status, selecting routing targets, and
+ * persisting peer references to disk. The manager also exposes helper queries for counts, lookups,
+ * and status summaries, and emits user alerts summarizing connectivity.
  *
  * <p>Threading: most public methods briefly synchronize on the manager when reading/writing the
  * peer arrays. Callers should avoid holding unrelated locks when invoking selection or mutation
@@ -25,7 +26,7 @@ public class PeerManager {
   /** Our Node */
   final Node node;
 
-  /** First time we got any connections since startup. */
+  /** First time we've got any connections since startup. */
   long timeFirstAnyConnections = 0;
 
   /** Handles peer reference persistence and scheduling. */
@@ -84,8 +85,8 @@ public class PeerManager {
    * <p>The manager starts empty; peers are added by higher-level components or by reading persisted
    * files during startup. The supplied shutdown hook flushes peer lists on early shutdown.
    *
-   * @param node Owning node instance. Must be fully constructed before invoking methods that call
-   *     back into {@code node}.
+   * @param node The owning node instance. Must be fully constructed before invoking methods that
+   *     call back into {@code node}.
    * @param shutdownHook Hook used to register an early job that writes peers to disk on shutdown.
    */
   public PeerManager(Node node, SemiOrderedShutdownHook shutdownHook) {
@@ -134,7 +135,7 @@ public class PeerManager {
     return routingSelector;
   }
 
-  /** Reads peers from disk using the configured persistence helper. */
+  /** Reads peers from the disk using the configured persistence helper. */
   public void tryReadPeers(
       String filename,
       NodeCrypto crypto,
@@ -152,15 +153,15 @@ public class PeerManager {
    * Add a peer.
    *
    * @param pn The node to add to the routing table.
-   * @param ignoreOpennet If true, don't check for opennet peers. If false, check for opennet peers
-   *     and if so, if opennet is enabled auto-add them to the opennet LRU, otherwise fail.
+   * @param ignoreOpennet If true, don't check for opennet peers. If false, check for opennet peers,
+   *     and if so, if opennet is enabled, auto-add them to the opennet LRU, otherwise fail.
    * @param reactivate If true, re-enable the peer if it is in state DISCONNECTING before re-adding
    *     it.
    * @return True if the node was successfully added. False if it was already present, or if we
    *     tried to add an opennet peer when opennet was disabled.
    */
   public boolean addPeer(PeerNode pn, boolean ignoreOpennet, boolean reactivate) {
-    assert (pn != null);
+    Objects.requireNonNull(pn, "pn");
     boolean added = roster.addPeer(pn, reactivate);
     if (!added) return false;
     statusBook.onPeerAdded(pn);
@@ -225,7 +226,7 @@ public class PeerManager {
   /**
    * Returns the timestamp of the first successful connection since startup.
    *
-   * @return Epoch milliseconds of first connection, or 0 if none yet.
+   * @return Epoch milliseconds of the first connection, or 0 if none yet.
    */
   public long getTimeFirstAnyConnections() {
     return timeFirstAnyConnections;
@@ -259,7 +260,7 @@ public class PeerManager {
    * Returns the current locations of connected peers as doubles in [0.0, 1.0).
    *
    * @param pruneBackedOffPeers When true, omit peers excluded from lists due to backoff.
-   * @return A sorted array of peer locations, or an empty array when publishing is disabled.
+   * @return A sorted array of peer locations or an empty array when publishing is disabled.
    */
   public double[] getPeerLocationDoubles(boolean pruneBackedOffPeers) {
     return roster.getPeerLocationDoubles(pruneBackedOffPeers);
@@ -313,7 +314,7 @@ public class PeerManager {
   }
 
   /**
-   * Update the numbers needed by our PeerManagerUserAlert on the UAM. Also run the node's
+   * Update the numbers needed by our PeerManagerUserAlert on the UAM. Also, run the node's
    * onConnectedPeers() method if applicable. LOCKING: Do not call inside PeerNode lock.
    */
   public void updatePMUserAlert() {
@@ -343,7 +344,7 @@ public class PeerManager {
     roster.readExtraPeerData();
   }
 
-  /** Initializes user alerts and schedules the first peer persistence write. */
+  /** Initializes user alerts and schedules the first peer persistence writing. */
   public void start() {
     alertCoordinator.start();
     peerPersistence.scheduleInitialWrite();
@@ -544,7 +545,7 @@ public class PeerManager {
     roster.incrementSelectionSamples(pn);
   }
 
-  /** Notifies the listeners about status change */
+  /** Notifies the listeners about the status change */
   private void notifyPeerStatusChangeListeners() {
     for (PeerStatusChangeListener l : listeners) {
       l.onPeerStatusChange();
@@ -555,7 +556,7 @@ public class PeerManager {
   }
 
   /**
-   * Registers a listener to be notified when peers' statuses changes
+   * Registers a listener to be notified when peers' statuses change
    *
    * @param listener - the listener to be registered
    */
@@ -578,7 +579,7 @@ public class PeerManager {
 
   /** A listener interface that can be used to be notified about peer status change events */
   public interface PeerStatusChangeListener {
-    /** Peers status have changed */
+    /** Peers status has changed */
     void onPeerStatusChange();
   }
 
@@ -586,9 +587,6 @@ public class PeerManager {
    * Get a non-copied snapshot of the peers list. NOTE: LOW LEVEL: Should be up to date (but not
    * guaranteed when exit lock), DO NOT MODIFY THE RETURNED DATA! Package-local - stuff outside
    * node/ should use the copying getters (which are a little more expensive).
-   */
-  /**
-   * Returns a snapshot of all configured peers.
    *
    * @return peer array snapshot
    */
@@ -602,9 +600,6 @@ public class PeerManager {
    *
    * <p>Note: Check all callers. Should they use myPeers and check for connectedness, and/or should
    * they use a copying method? I'm not sure how reliable updating of connectedPeers is ...
-   */
-  /**
-   * Returns a snapshot of currently connected peers.
    *
    * @return connected peer array snapshot
    */
@@ -642,9 +637,9 @@ public class PeerManager {
 
     int tooNewOpennet = getPeerNodeStatusSize(PEER_NODE_STATUS_TOO_NEW, false);
 
-    // Note: constants below are heuristics and may require tuning.
+    // Note: the constants below are heuristics and may require tuning.
     // We cannot count on the version announcements.
-    // Until we actually get a validated update jar it's all potentially bogus.
+    // Until we actually get a validated update jar, it's all potentially bogus.
 
     int connections =
         getPeerNodeStatusSize(PEER_NODE_STATUS_CONNECTED, false)

--- a/src/main/java/network/crypta/node/SeedServerTestPeerNode.java
+++ b/src/main/java/network/crypta/node/SeedServerTestPeerNode.java
@@ -124,14 +124,13 @@ public class SeedServerTestPeerNode extends SeedServerPeerNode {
   }
 
   /**
-   * Mirrors the removal reason to both stderr and the structured logger.
+   * Mirrors the removal reason to the structured logger.
    *
-   * <p>This class is used exclusively by seed-server tests. Tests capture {@code System.err} to
-   * assert on the textual classification, so we emit to both the console and the logger.
+   * <p>This class is used exclusively by seed-server tests. Tests assert on the logger output to
+   * validate the textual classification.
    */
   private void printRemovalReason(String reason) {
     String msg = this.getIdentityString() + " : REMOVED: " + reason;
-    System.err.println(msg);
     LOG.warn(msg);
   }
 

--- a/src/main/java/network/crypta/support/math/MersenneTwister.java
+++ b/src/main/java/network/crypta/support/math/MersenneTwister.java
@@ -21,7 +21,7 @@ import network.crypta.support.Fields;
  ** As of fred commit e89a2f63e819e8c088a14eaa3c809770db822956, this class, and
  ** its associated test, re-implements the diff between X-A, by extending
  ** o.s.m.r.MersenneTwister. Above that, it is also runtime-compatible with any
- ** version (O,A,X) of it.
+ ** version (O, A, X) of it.
  **
  ** This should provide a smooth upgrade path:
  **
@@ -76,18 +76,18 @@ public class MersenneTwister extends MersenneTwisterBase {
 
   /** {@inheritDoc} */
   @Override
-  public void setSeed(long seed) {
-    synchronized (this) {
-      super.setSeed(seed);
-    }
+  public synchronized void setSeed(long seed) {
+    super.setSeed(seed);
   }
 
   /**
    * * Reinitialize the generator as if just built with the given byte array seed. *
    *
    * <p>The state of the generator is exactly the same as a new * generator built with the same
-   * seed. * @param seed the initial seed (8 bits byte array), if null * the seed of the generator
-   * will be related to the current time
+   * seed.
+   *
+   * @param seed the initial seed (8-bit byte array), if null * the seed of the generator will be
+   *     related to the current time
    */
   public void setSeed(byte[] seed) {
     synchronized (this) {
@@ -141,7 +141,7 @@ public class MersenneTwister extends MersenneTwisterBase {
     }
 
     @Override
-    public void setSeed(long seed) {
+    public synchronized void setSeed(long seed) {
       unsynchronizedSetSeed(seed);
     }
 

--- a/src/main/kotlin/com/jthemedetecor/PortalThemeDetector.kt
+++ b/src/main/kotlin/com/jthemedetecor/PortalThemeDetector.kt
@@ -9,7 +9,9 @@ import network.crypta.launcher.PortalThemeDetectorImpl
  * OsThemeDetector (its constructor is package‑private). The implementation lives in
  * network.crypta.launcher.PortalThemeDetectorImpl to avoid split ownership.
  */
-class PortalThemeDetector(private val impl: PortalThemeDetectorImpl = PortalThemeDetectorImpl()) :
+class PortalThemeDetector
+@JvmOverloads
+constructor(private val impl: PortalThemeDetectorImpl = PortalThemeDetectorImpl()) :
   OsThemeDetector(), Closeable by impl {
   override fun isDark(): Boolean = impl.isDark()
 

--- a/src/main/kotlin/com/jthemedetecor/PortalThemeDetector.kt
+++ b/src/main/kotlin/com/jthemedetecor/PortalThemeDetector.kt
@@ -2,15 +2,15 @@ package com.jthemedetecor
 
 import java.io.Closeable
 import java.util.function.Consumer
+import network.crypta.launcher.PortalThemeDetectorImpl
 
 /**
  * Thin compatibility stub that keeps the subclass inside the original package so it can extend
  * OsThemeDetector (its constructor is package‑private). The implementation lives in
  * network.crypta.launcher.PortalThemeDetectorImpl to avoid split ownership.
  */
-class PortalThemeDetector : OsThemeDetector(), Closeable {
-  private val impl = network.crypta.launcher.PortalThemeDetectorImpl()
-
+class PortalThemeDetector(private val impl: PortalThemeDetectorImpl = PortalThemeDetectorImpl()) :
+  OsThemeDetector(), Closeable by impl {
   override fun isDark(): Boolean = impl.isDark()
 
   override fun registerListener(darkThemeListener: Consumer<Boolean>) {
@@ -19,9 +19,5 @@ class PortalThemeDetector : OsThemeDetector(), Closeable {
 
   override fun removeListener(darkThemeListener: Consumer<Boolean>?) {
     impl.removeListener(darkThemeListener)
-  }
-
-  override fun close() {
-    impl.close()
   }
 }

--- a/src/main/kotlin/network/crypta/launcher/PortalThemeDetectorImpl.kt
+++ b/src/main/kotlin/network/crypta/launcher/PortalThemeDetectorImpl.kt
@@ -127,22 +127,6 @@ class PortalThemeDetectorImpl : Closeable {
     // Keep handler registered; connection is closed on process exit.
   }
 
-  /**
-   * Closes the underlying D-Bus connection used by this detector.
-   *
-   * Closing is best-effort and ignores shutdown failures, which mirrors the non-fatal behavior used
-   * elsewhere in the detector. After closing, further reads or listener registration may fail
-   * depending on the connection state, so callers should discard the instance and create a new one
-   * if they need to resume portal access.
-   */
-  override fun close() {
-    try {
-      if (conn.isConnected) conn.close()
-    } catch (_: Exception) {
-      // Ignore shutdown failures; connection is best-effort.
-    }
-  }
-
   private fun mapVariantToDark(v: Variant<*>): Boolean {
     val code =
       when (val raw = unwrap(v)) {
@@ -153,6 +137,14 @@ class PortalThemeDetectorImpl : Closeable {
       }
     val dark = code == 1 // 1 = prefer-dark, 2 = prefer-light, 0 = no preference
     return dark
+  }
+
+  override fun close() {
+    try {
+      if (conn.isConnected) conn.close()
+    } catch (_: Exception) {
+      // Ignore shutdown failures; connection is best-effort.
+    }
   }
 
   private tailrec fun unwrap(any: Any?): Any? =

--- a/src/main/kotlin/network/crypta/tools/PrintDirs.kt
+++ b/src/main/kotlin/network/crypta/tools/PrintDirs.kt
@@ -2,27 +2,27 @@ package network.crypta.tools
 
 import network.crypta.fs.AppDirs
 import network.crypta.fs.AppEnv
+import network.crypta.fs.Resolved
 import network.crypta.fs.ServiceDirs
 
 fun main() {
-  val env = System.getenv()
-  val appEnv = AppEnv(env)
+  val appEnv = AppEnv(System.getenv())
   println("cryptad.service.mode=${System.getProperty("cryptad.service.mode")}")
   if (appEnv.isServiceMode()) {
     val r = ServiceDirs().resolve()
     println("mode=service")
-    println("configDir=${r.configDir}")
-    println("dataDir=${r.dataDir}")
-    println("cacheDir=${r.cacheDir}")
-    println("runDir=${r.runDir}")
-    println("logsDir=${r.logsDir}")
+    printDirs(r)
   } else {
     val r = AppDirs().resolve()
     println("mode=user")
-    println("configDir=${r.configDir}")
-    println("dataDir=${r.dataDir}")
-    println("cacheDir=${r.cacheDir}")
-    println("runDir=${r.runDir}")
-    println("logsDir=${r.logsDir}")
+    printDirs(r)
   }
+}
+
+private fun printDirs(resolved: Resolved) {
+  println("configDir=${resolved.configDir}")
+  println("dataDir=${resolved.dataDir}")
+  println("cacheDir=${resolved.cacheDir}")
+  println("runDir=${resolved.runDir}")
+  println("logsDir=${resolved.logsDir}")
 }

--- a/src/test/java/network/crypta/config/CryptadConfigExpandEdgeCasesTest.java
+++ b/src/test/java/network/crypta/config/CryptadConfigExpandEdgeCasesTest.java
@@ -7,8 +7,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class CryptadConfigExpandEdgeCasesTest {
 
@@ -59,25 +62,26 @@ class CryptadConfigExpandEdgeCasesTest {
   }
 
   @Test
-  void placeholder_windowsTraversal_rejectedWhenAnchored() {
-    Map<String, String> b = base();
-    assertThrows(
-        IOException.class, () -> CryptadConfig.expandValue("${dataDir}\\..\\..\\etc\\passwd", b));
-  }
-
-  @Test
   void placeholder_inMiddle_isReplaced() {
     Map<String, String> b = base();
     String out = CryptadConfig.expandValue("prefix-${cacheDir}-suffix", b);
     assertEquals(out, "prefix-" + b.get("cacheDir") + "-suffix");
   }
 
-  @Test
-  void placeholder_inMiddle_withTraversal_rejected() {
+  static Stream<String> traversalInputs() {
+    return Stream.of(
+        "${dataDir}\\..\\..\\etc\\passwd",
+        "prefix-${dataDir}/../../etc/passwd",
+        "dataDir/..\\..\\evil");
+  }
+
+  // Mixed traversal using interleaved separators must be rejected when it would
+  // escape the base directory after normalization.
+  @ParameterizedTest
+  @MethodSource("traversalInputs")
+  void traversal_rejected(String input) {
     Map<String, String> b = base();
-    assertThrows(
-        IOException.class,
-        () -> CryptadConfig.expandValue("prefix-${dataDir}/../../etc/passwd", b));
+    assertThrows(IOException.class, () -> CryptadConfig.expandValue(input, b));
   }
 
   @Test
@@ -106,13 +110,5 @@ class CryptadConfigExpandEdgeCasesTest {
     Map<String, String> b = base();
     String out = CryptadConfig.expandValue(b.get("dataDir") + "\\x\\y", b);
     assertEquals(out, Path.of(b.get("dataDir"), "x", "y").toString());
-  }
-
-  // Mixed traversal using interleaved separators must be rejected when it would
-  // escape the base directory after normalization.
-  @Test
-  void leadingToken_mixedTraversal_rejected() {
-    Map<String, String> b = base();
-    assertThrows(IOException.class, () -> CryptadConfig.expandValue("dataDir/..\\..\\evil", b));
   }
 }

--- a/src/test/java/network/crypta/node/NodeAndClientLayerTest.java
+++ b/src/test/java/network/crypta/node/NodeAndClientLayerTest.java
@@ -1,6 +1,7 @@
 package network.crypta.node;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,7 +66,8 @@ class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
       throws NodeInitException, InsertException, FetchException {
     final PriorityAwareExecutor executor = new PooledExecutor();
     FileUtil.removeAll(dir);
-    dir.mkdir();
+    boolean created = dir.mkdir();
+    assertTrue(created || dir.isDirectory(), "Failed to create test directory: " + dir);
     NodeStarter.globalTestInit(dir, false, Level.ERROR, "", true, random);
     TestNodeParameters params = new TestNodeParameters();
     params.setRandom(new DummyRandomSource(253121));
@@ -79,7 +81,7 @@ class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
     InsertContext ictx = client.getInsertContext(true);
     ictx.setLocalRequestOnly(true);
     FreenetURI uri = client.insert(block, "", (short) 0, ictx);
-    assertEquals(uri.getKeyType(), "SSK");
+    assertEquals("SSK", uri.getKeyType());
     FetchContext ctx = client.getFetchContext(FILE_SIZE * 2);
     ctx.setLocalRequestOnly(true);
     FetchWaiter fw = new FetchWaiter(rc);

--- a/src/test/java/network/crypta/node/NullBasePeerNode.java
+++ b/src/test/java/network/crypta/node/NullBasePeerNode.java
@@ -7,14 +7,12 @@ import java.util.Random;
 import network.crypta.io.comm.AsyncMessageCallback;
 import network.crypta.io.comm.ByteCounter;
 import network.crypta.io.comm.Message;
-import network.crypta.io.comm.NotConnectedException;
 import network.crypta.io.comm.Peer;
-import network.crypta.io.comm.Peer.LocalAddressException;
 import network.crypta.io.comm.PeerContext;
 import network.crypta.io.comm.SocketHandler;
 import network.crypta.io.xfer.PacketThrottle;
 
-/** Tests can override this to record specific events e.g. rekey */
+/** Tests can override this to record specific events e.g., rekey */
 public class NullBasePeerNode implements BasePeerNode {
   private final PeerTransport transport = new NullTransport();
 
@@ -130,7 +128,14 @@ public class NullBasePeerNode implements BasePeerNode {
 
   protected ArrayList<byte[]> decryptedMessages;
 
-  protected void processDecryptedMessage(byte[] data, int offset, int length, int overhead) {
+  /**
+   * Records a decrypted message for tests that opt in to capturing data.
+   *
+   * @param data packet buffer containing the decrypted payload
+   * @param offset start offset into {@code data}
+   * @param length number of bytes to record
+   */
+  protected void processDecryptedMessage(byte[] data, int offset, int length) {
     if (decryptedMessages == null) {
       throw new UnsupportedOperationException();
     } else {
@@ -173,7 +178,7 @@ public class NullBasePeerNode implements BasePeerNode {
   byte[] sentEncryptedPacket;
 
   @Override
-  public void sendEncryptedPacket(byte[] data) throws LocalAddressException {
+  public void sendEncryptedPacket(byte[] data) {
     sentEncryptedPacket = data;
   }
 
@@ -237,19 +242,17 @@ public class NullBasePeerNode implements BasePeerNode {
   private final class NullTransport implements PeerTransport {
 
     @Override
-    public MessageItem sendAsync(Message msg, AsyncMessageCallback cb, ByteCounter ctr)
-        throws NotConnectedException {
+    public MessageItem sendAsync(Message msg, AsyncMessageCallback cb, ByteCounter ctr) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public void sendSync(Message req, ByteCounter ctr, boolean realTime)
-        throws NotConnectedException, SyncSendWaitedTooLongException {
+    public void sendSync(Message req, ByteCounter ctr, boolean realTime) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean ping(int pingID) throws NotConnectedException {
+    public boolean ping(int pingID) {
       throw new UnsupportedOperationException();
     }
 
@@ -274,7 +277,7 @@ public class NullBasePeerNode implements BasePeerNode {
 
         @Override
         public void processDecryptedMessage(byte[] data, int offset, int length, int overhead) {
-          NullBasePeerNode.this.processDecryptedMessage(data, offset, length, overhead);
+          NullBasePeerNode.this.processDecryptedMessage(data, offset, length);
         }
 
         @Override

--- a/src/test/java/network/crypta/node/SeedServerTestPeerNodeTest.java
+++ b/src/test/java/network/crypta/node/SeedServerTestPeerNodeTest.java
@@ -11,9 +11,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import java.lang.reflect.Field;
+import java.util.stream.Collectors;
 import network.crypta.node.SeedServerTestPeerNode.FATE;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.support.Ticker;
@@ -23,24 +25,29 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({"java:S100", "java:S106", "java:S112", "java:S3011"})
+@SuppressWarnings({"java:S100", "java:S112", "java:S3011"})
 @ExtendWith(MockitoExtension.class)
 class SeedServerTestPeerNodeTest {
 
-  private PrintStream originalErr;
-  private ByteArrayOutputStream errBuffer;
+  private Logger seedLogger;
+  private ListAppender<ILoggingEvent> logAppender;
 
   @BeforeEach
-  void setUpStreams() {
-    originalErr = System.err;
-    errBuffer = new ByteArrayOutputStream(256);
-    System.setErr(new PrintStream(errBuffer));
+  void setUpLogger() {
+    seedLogger = (Logger) LoggerFactory.getLogger(SeedServerTestPeerNode.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    seedLogger.addAppender(logAppender);
   }
 
   @AfterEach
-  void restoreStreams() {
-    System.setErr(originalErr);
+  void tearDownLogger() {
+    if (seedLogger != null && logAppender != null) {
+      seedLogger.detachAppender(logAppender);
+      logAppender.stop();
+    }
   }
 
   // -------- getFate() --------
@@ -158,7 +165,7 @@ class SeedServerTestPeerNodeTest {
 
     sut.onRemove();
 
-    String err = errBuffer.toString();
+    String err = getLoggedMessages();
     verify(sut, times(1)).disconnected(true, true);
     verify(ticker, times(1)).removeQueuedJob(any());
     // Expect the NEVER CONNECTED classification
@@ -189,7 +196,7 @@ class SeedServerTestPeerNodeTest {
 
     sut.onRemove();
 
-    String err = errBuffer.toString();
+    String err = getLoggedMessages();
     org.hamcrest.MatcherAssert.assertThat(
         err,
         org.hamcrest.Matchers.containsString(
@@ -218,7 +225,7 @@ class SeedServerTestPeerNodeTest {
 
     sut.onRemove();
 
-    String err = errBuffer.toString();
+    String err = getLoggedMessages();
     org.hamcrest.MatcherAssert.assertThat(
         err, org.hamcrest.Matchers.containsString("ID-UNK : REMOVED: UNKNOWN CAUSE"));
   }
@@ -229,5 +236,11 @@ class SeedServerTestPeerNodeTest {
     Field f = PeerNode.class.getDeclaredField("node");
     f.setAccessible(true);
     f.set(target, node);
+  }
+
+  private String getLoggedMessages() {
+    return logAppender.list.stream()
+        .map(ILoggingEvent::getFormattedMessage)
+        .collect(Collectors.joining(System.lineSeparator()));
   }
 }


### PR DESCRIPTION
## Summary
- keep PortalThemeDetector Java no-arg constructor for compatibility callers
- switch seed server tests to capture structured logger output instead of stderr
- consolidate small utility and null-check tweaks in node helpers
- tighten docs and small readability adjustments across node and config tests