### PR TITLE
Polish config/compress APIs and docs

### DIFF
--- a/src/main/java/network/crypta/client/filter/HTMLFilter.java
+++ b/src/main/java/network/crypta/client/filter/HTMLFilter.java
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Streams and sanitizes HTML emitted by the node so the FProxy surface only exposes vetted,
+ * Streams and sanitizes HTML emitted by the node, so the FProxy surface only exposes vetted,
  * policy-compliant markup. The filter rewrites tags, normalizes attributes, and optionally injects
  * helper snippets while preserving the original document structure as closely as possible.
  *
@@ -237,7 +237,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * Streams untrusted HTML from {@code input}, sanitizes it according to the current policy, and
    * writes the resulting markup to {@code output}. The method configures buffered character
    * streams, enforces the negotiated {@code charset}, and drives an {@link HTMLParseContext} that
-   * emits callbacks for visible text or URIs while blocking unsafe constructs. All state lives
+   * emits callbacks for visible text or URIs while blocking unsafe constructs. All states live
    * inside the parse context, so callers may safely reuse {@link HTMLFilter} instances only when
    * they have completed a previous invocation.
    *
@@ -256,7 +256,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * @param otherParams mutable metadata map passed through unchanged for downstream handlers
    * @param schemeHostAndPort absolute origin string used when rewriting relative resource links
    * @param cb callback receiving sanitized text and URIs; a {@link NullFilterCallback} is allowed
-   * @throws IOException if the input cannot be decoded or the output stream rejects the write
+   * @throws IOException if the input cannot be decoded or the output stream rejects the writing
    */
   @Override
   public void readFilter(
@@ -289,7 +289,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
   /**
    * Detects the declared character set within an HTML byte buffer by running the tokenizer in a
-   * special "detection only" mode. The method reads at most {@link #getCharsetBufferSize()} bytes
+   * special "detection-only" mode. The method reads at most {@link #getCharsetBufferSize()} bytes
    * through a {@link java.io.BufferedReader}, stops after the head section is conclusively parsed,
    * and returns the first {@code <meta charset>} encountered. Mixed encodings or malformed markup
    * cause the detector to bail out early so downstream consumers can fall back to defaults.
@@ -354,8 +354,8 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     boolean firstChar = true;
 
     /**
-     * If <head> is found, then it is true. It is needed that if <title> or <meta> is found outside
-     * <head> or if a <body> is found first, then insert a <head> too
+     * If <head> is found, then it is true. It is necessary that if <title> or <meta> is found
+     * outside <head> or if a <body> is found first, then insert a <head> too
      */
     boolean wasHeadElementFound = false;
 
@@ -843,7 +843,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * Reports whether the sanitizer should inject the lightweight M3U JavaScript player when media
    * tags are encountered. Toggling this value lets administrators balance user convenience against
    * strict content policies without recompiling the node. The flag is read on every HTML parse, so
-   * changes take effect immediately for subsequent requests.
+   * changes take effect immediately for later requests.
    *
    * @return {@code true} when eligible media tags cause the player snippet to be inlined
    */
@@ -875,7 +875,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
   }
 
   /**
-   * Updates the interval guarding same-page meta refresh operations. Negative values disable the
+   * Updates the interval guarding same-page meta-refresh operations. Negative values disable the
    * tag entirely, while zero preserves only single-refresh pages. Higher numbers give users more
    * time to react when viewing large forms or threaded discussions.
    *
@@ -886,7 +886,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
   }
 
   /**
-   * Returns the policy-controlled delay required before a meta refresh pointing to another location
+   * Returns the policy-controlled delay required before a meta-refresh pointing to another location
    * is allowed to survive filtering. Redirects that fire too quickly are frequently used for
    * phishing and annoyance attacks, so this value determines how aggressively the node trims such
    * tags.
@@ -898,7 +898,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
   }
 
   /**
-   * Sets the minimum delay enforced for meta refreshes that redirect the browser to a new URL.
+   * Sets the minimum delay enforced for meta-refreshes that redirect the browser to a new URL.
    * Values less than zero reject all redirect refresh tags; large values effectively disable the
    * feature unless the document explicitly opts in with a long timeout. Update this setting only
    * during configuration reloads to avoid surprising concurrent sanitization tasks.
@@ -1163,11 +1163,11 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * <p>The structure is purposely forgiving: {@code startSlash} and {@code endSlash} are recorded
    * even when the tokenizer encountered mismatched syntax, allowing downstream verifiers to insert
    * recovery comments or drop the offending tag entirely. String casing is normalized during
-   * parsing so comparisons can be performed cheaply.
+   * parsing, so comparisons can be performed cheaply.
    */
   public static class ParsedTag {
     /**
-     * Element name captured from the tokenizer, normalized to lower-case ASCII so case-insensitive
+     * Element name captured from the tokenizer, normalized to lower-case ASCII, so case-insensitive
      * comparisons and hash lookups remain cheap even when reserializing the tag later.
      */
     public final String element;
@@ -1293,7 +1293,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
     /**
      * Serializes this token back into an HTML tag, honoring whether it was originally a closing or
-     * self-closing construct. Attribute ordering and quoting are preserved exactly as captured so
+     * self-closing construct. Attribute ordering and quoting are preserved exactly as captured, so
      * higher layers can re-emit familiar markup for trusted clients. The string is primarily used
      * by {@link #htmlwrite(Writer, HTMLParseContext)} when committing sanitized tags to the output.
      *
@@ -1343,25 +1343,25 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       for (String rawAttribute : unparsedAttrs) {
         // Skip empty or whitespace-only fragments that can appear due to trailing spaces
         // before '>' or multiple consecutive spaces between attributes.
-        if (rawAttribute == null) {
-          continue;
+        String trimmedAttribute = rawAttribute;
+        if (trimmedAttribute != null) {
+          trimmedAttribute = trimmedAttribute.trim();
         }
-        rawAttribute = rawAttribute.trim();
-        if (rawAttribute.isEmpty()) {
+        if (trimmedAttribute == null || trimmedAttribute.isEmpty()) {
           continue;
         }
         if (waitingForValue) {
           waitingForValue = false;
-          previousKey = applyDeferredValue(attributes, previousKey, rawAttribute);
-          continue;
-        }
-        AttributeToken token = parseAttributeToken(rawAttribute, previousKey);
-        waitingForValue = token.expectingValue;
-        previousKey = token.key;
-        if (token.value != null) {
-          attributes.put(token.key, token.value);
-        } else if (!waitingForValue) {
-          attributes.put(token.key, new Object());
+          previousKey = applyDeferredValue(attributes, previousKey, trimmedAttribute);
+        } else {
+          AttributeToken token = parseAttributeToken(trimmedAttribute, previousKey);
+          waitingForValue = token.expectingValue;
+          previousKey = token.key;
+          if (token.value != null) {
+            attributes.put(token.key, token.value);
+          } else if (!waitingForValue) {
+            attributes.put(token.key, new Object());
+          }
         }
       }
       return attributes;
@@ -2141,7 +2141,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
      * not included so don't try using them. xref not supported as it is
      * mainly used to link presentation and content in parallel markup.
      *
-     * Content markup not supported as it is larger and presumably not
+     * Content markup isn't supported as it is larger and presumably not
      * used that much, and **HAS SECURITY ISSUES**: Content markup uses
      * Content Dictionaries, which by default are loaded from a default
      * URL on the web.
@@ -2817,7 +2817,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
             emptyStringArray,
             emptyStringArray,
             emptyStringArray));
-    // <maction> would go here though it seems a bit pointless and may require extra filtering
+    // <maction> would go here, though it seems a bit pointless and may require extra filtering
     // MathML content tags would go here if anyone used them
 
     return allowedTagsVerifiers;
@@ -2842,7 +2842,6 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     // Attributes which need no sanitation
     private final HashSet<String> allowedAttrs;
 
-    // Attributes which will be sanitized by child classes
     /**
      * Set of attribute names that require special handling (event handlers, core attrs, etc.) and
      * therefore must be copied into {@link ParsedTag} instances even if they are removed from the
@@ -3707,8 +3706,8 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
   /**
    * Verify media tags (audio and video). This needs its own verifier, because different from
    * images, browsers use content sniffing to find out whether to display it as media content. Using
-   * text/plain as content type would allow exploiting this to run unfiltered files as media files.
-   * We fix this by encoding the mime type into the uri.
+   * text/plain as a content type would allow exploiting this to run unfiltered files as media
+   * files. We fix this by encoding the mime type into the uri.
    */
   static class MediaTagVerifier extends CoreTagVerifier {
     private static final String[] locallyVerifiedAttrs = new String[] {"src"};
@@ -3821,7 +3820,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
         throws DataFilterException {
       Map<String, Object> hn = super.sanitizeHash(h, p, pc);
 
-      // We drop the whole <input> if type isn't allowed (case-insensitive)
+      // We drop the whole <input> if the type isn't allowed (case-insensitive)
       if (hn.get("type") != null
           && !allowedTypes.contains(hn.get("type").toString().toLowerCase())) {
         return dropTag();
@@ -4058,7 +4057,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
         // Same-page refreshes are disabled: drop the tag.
         return false;
       } else if (getMetaRefreshRedirectMinInterval() >= 0) {
-        // Redirect refresh: separator present and redirect filtering enabled.
+        // Redirect refresh: separator presents and redirect filtering enabled.
         return handleRedirectRefresh(content, idx, output, pc);
       }
       // Redirect refreshes are disabled: drop the tag.
@@ -4552,7 +4551,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    *
    * @param input byte buffer containing the beginning of the document
    * @param length number of bytes provided for inspection
-   * @return always {@code null}, indicating BOM checks should be handled by the caller
+   * @return always {@code null}, indicating the caller should handle BOM checks
    */
   @Override
   public BOMDetection getCharsetByBOM(byte[] input, int length) {
@@ -4561,7 +4560,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
   /**
    * Indicates how many bytes callers should supply when asking {@link #getCharset(byte[], int,
-   * String)} to detect a charset. The value balances accuracy (meta tags can appear deep inside a
+   * String)} to detect a charset. The value balances accuracy (meta-tags can appear deep inside a
    * head section) with memory consumption. Override this only if the upstream buffering strategy is
    * known to surface unusually large {@code <head>} sections.
    *

--- a/src/main/java/network/crypta/clients/fcp/ConfigData.java
+++ b/src/main/java/network/crypta/clients/fcp/ConfigData.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.util.EnumSet;
+import java.util.Set;
 import network.crypta.config.Config;
 import network.crypta.config.PersistentConfig;
 import network.crypta.node.Node;
@@ -64,9 +65,9 @@ public class ConfigData extends FCPMessage {
    * @param identifier identifier echoed into the payload via {@link FCPMessage#IDENTIFIER}; may be
    *     {@code null} when the caller does not need correlation.
    */
-  public ConfigData(Node node, EnumSet<Section> sections, String identifier) {
+  public ConfigData(Node node, Set<Section> sections, String identifier) {
     this.node = node;
-    this.sections = EnumSet.copyOf(sections);
+    this.sections = sections.isEmpty() ? EnumSet.noneOf(Section.class) : EnumSet.copyOf(sections);
     this.requestIdentifier = identifier;
   }
 
@@ -157,9 +158,9 @@ public class ConfigData extends FCPMessage {
   /**
    * Returns a snapshot of the enabled configuration sections.
    *
-   * @return a new {@link EnumSet} containing the enabled {@link Section} values.
+   * @return a new {@link Set} containing the enabled {@link Section} values.
    */
-  public EnumSet<Section> getSections() {
+  public Set<Section> getSections() {
     return EnumSet.copyOf(sections);
   }
 

--- a/src/main/java/network/crypta/io/comm/RetrievalException.java
+++ b/src/main/java/network/crypta/io/comm/RetrievalException.java
@@ -35,7 +35,7 @@ public class RetrievalException extends LightweightException {
   /** Operation exceeded the allowed time. */
   public static final int TIMED_OUT = 4;
 
-  /** Requested block already exists locally; retrieval not performed. */
+  /** The requested block already exists locally; retrieval not performed. */
   public static final int ALREADY_CACHED = 6;
 
   /** Sender disconnected before completion. */
@@ -44,7 +44,7 @@ public class RetrievalException extends LightweightException {
   /** Data insert is unavailable or not permitted for this operation. */
   public static final int NO_DATAINSERT = 8;
 
-  /** Transfer was cancelled by the receiver. */
+  /** Transfer was canceled by the receiver. */
   public static final int CANCELLED_BY_RECEIVER = 9;
 
   /** Receiver terminated unexpectedly during the transfer. */
@@ -60,9 +60,9 @@ public class RetrievalException extends LightweightException {
   public static final int TURTLE_KILLED = 14;
 
   // Numeric reason code; one of the public constants above.
-  int reason;
+  final int reason;
   // Optional human-readable detail for diagnostics (may be empty).
-  String cause;
+  final String cause;
 
   /**
    * Creates an instance with the given reason code.
@@ -85,8 +85,8 @@ public class RetrievalException extends LightweightException {
    */
   public RetrievalException(int reason, String cause) {
     this.reason = reason;
-    this.cause = cause;
-    if (cause == null || cause.isEmpty() || cause.equals("null")) this.cause = getErrString(reason);
+    this.cause =
+        cause == null || cause.isEmpty() || cause.equals("null") ? getErrString(reason) : cause;
   }
 
   /**

--- a/src/main/java/network/crypta/node/FailureTableEntry.java
+++ b/src/main/java/network/crypta/node/FailureTableEntry.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  * <p>This entry maintains two weakly referenced peer sets for the tracked key:
  *
  * <ul>
- *   <li>Requestors — peers that asked us for the key. When the data becomes available we offer it
+ *   <li>Requestors — peers that asked us for the key. When the data becomes available, we offer it
  *       to them to reduce latency for polling clients.
  *   <li>Requested-from — peers we routed a request to. Failures on this path set timeouts so we do
  *       not retry the same peer too soon. Timeouts are tracked per-HTL (hops-to-live).
@@ -111,7 +111,7 @@ class FailureTableEntry implements TimedOutNodesList {
   private static PeerNodeUnlocked asPeerNodeUnlocked(WeakReference<PeerContext> ref) {
     if (ref == null) return null;
     PeerContext ctx = ref.get();
-    return (ctx instanceof PeerNodeUnlocked) ? (PeerNodeUnlocked) ctx : null;
+    return ctx instanceof PeerNodeUnlocked peerNodeUnlocked ? peerNodeUnlocked : null;
   }
 
   FailureTableEntry(Key key) {
@@ -145,7 +145,7 @@ class FailureTableEntry implements TimedOutNodesList {
    * @param ftTimeout duration in milliseconds for the per-node failure-table timeout; {@code <= 0}
    *     means no update.
    * @param now current time in milliseconds since epoch.
-   * @param htl HTL used when the failure occurred; determines applicability of the timeout.
+   * @param htl HTL used when the failure occurred; determines the applicability of the timeout.
    */
   public synchronized void failedTo(
       PeerNodeUnlocked routedTo, long rfTimeout, long ftTimeout, long now, short htl) {
@@ -437,7 +437,7 @@ class FailureTableEntry implements TimedOutNodesList {
   /**
    * Offers the key to peers that previously asked for it and to peers we previously queried.
    *
-   * <p>Intended to be called after the data is stored and this entry is removed from the failure
+   * <p>Intended to be called after the data is stored, and this entry is removed from the failure
    * table. Offers are deduplicated across both lists and sent outside this entry's monitor.
    */
   public void offer() {
@@ -625,8 +625,8 @@ class FailureTableEntry implements TimedOutNodesList {
    * Returns the timeout time for the given peer, taking HTL into account.
    *
    * <p>If a timeout was recorded at HTL {@code 1} and we now send at HTL {@code 2}, the timeout is
-   * ignored. The result is an absolute time in milliseconds since epoch, or {@code -1} if there is
-   * no applicable timeout.
+   * ignored. The result has been an absolute time in milliseconds since epoch, or {@code -1} if
+   * there is no applicable timeout.
    *
    * @param peer peer to query.
    * @param htl HTL for the pending request.

--- a/src/main/java/network/crypta/node/IPDetectorPluginManager.java
+++ b/src/main/java/network/crypta/node/IPDetectorPluginManager.java
@@ -20,8 +20,6 @@ import network.crypta.io.comm.FreenetInetAddress;
 import network.crypta.io.comm.Peer;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.useralerts.AbstractUserAlert;
-import network.crypta.node.useralerts.AbstractUserAlert.Body;
-import network.crypta.node.useralerts.AbstractUserAlert.DismissOptions;
 import network.crypta.node.useralerts.ProxyUserAlert;
 import network.crypta.node.useralerts.SimpleUserAlert;
 import network.crypta.node.useralerts.UserAlert;
@@ -42,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * Coordinates IP-detection and port-forwarding plugins and decides when to run them.
  *
  * <p>The manager aggregates {@link FredPluginIPDetector} implementations (typically one, but
- * multiple are allowed) and applies lightweight heuristics to determine when a detection should be
+ * multiple are allowed) and applies lightweight heuristics to determine when detection should be
  * executed. It also receives callbacks from {@link FredPluginPortForward} plugins and updates user
  * alerts accordingly. Long-running work executes on the node's executor; this class keeps only the
  * scheduling and aggregation logic.
@@ -473,7 +471,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
    * Starts the manager and registers user alerts.
    *
    * <p>After this call, the manager performs an immediate detection attempt (subject to heuristics)
-   * and schedules subsequent checks at one-minute intervals.
+   * and schedules later checks at one-minute intervals.
    */
   void start() {
     // Cannot be initialized until UserAlertManager has been created.
@@ -546,7 +544,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
    *   30 minutes or (b) we have connected to at least two distinct real-IP peers since
    *   startup, skip detection (we might still be firewalled, so this is not a hard ban).
    * - With zero peers: run at most once every 6 hours (time not persisted across restarts).
-   * - With peers present: skip if a detection ran within the last hour.
+   * - With peers present: skip if detection ran within the last hour.
    * - Guard against bogus peer reports:
    *   If one or two connected peers report the same IP, other nodes have been connected
    *   recently, and this state has persisted for 2 minutes, run detection.
@@ -560,7 +558,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
   private long firstTimeUrgent;
 
   /**
-   * Evaluates current state and runs detection plugins when heuristics allow.
+   * Evaluates the current state and runs detection plugins when heuristics allow.
    *
    * <p>Fast, non-blocking: schedules work to the executor when a run is needed. Safe to call
    * frequently.
@@ -611,7 +609,8 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
         return GateDecision.RETURN;
       }
       if (failedRunners.size() == plugins.length) {
-        // If detect attempt failed to produce an IP in the last 5 minutes, don't try again yet.
+        // If a detection attempt failed to produce an IP in the last 5 minutes, don't try again
+        // yet.
         if (now - lastDetectAttemptEndedTime < MINUTES.toMillis(5)) {
           if (LOG.isDebugEnabled()) LOG.debug("Skip detect; last failure < 5 minutes ago");
           return GateDecision.RETURN;
@@ -629,7 +628,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
    * once every 6 hours.
    *
    * @param now The time at the start of the calling method.
-   * @return True if we should run a detection.
+   * @return True if we should run detection.
    */
   private boolean shouldDetectNoPeers(long now) {
     boolean tooSoon = now - lastDetectAttemptEndedTime < HOURS.toMillis(6);
@@ -647,7 +646,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
    * @param now The time at the beginning of the calling method.
    * @param peers The node's peers.
    * @param conns The node's connected peers.
-   * @return True if we should run a detection.
+   * @return True if we should run detection.
    */
   private boolean shouldDetectWithPeers(
       long now, PeerNode[] peers, PeerNode[] conns, FreenetInetAddress[] nodeAddrs) {
@@ -722,7 +721,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
   private Decision decideWithOldIP(long now) {
     if (LOG.isTraceEnabled()) LOG.trace("Schedule detect in 2 minutes (oldIPAddress present)");
     if (now - firstTimeUrgent > MINUTES.toMillis(2)) {
-      firstTimeUrgent = now; // Reset now rather than on next round.
+      firstTimeUrgent = now; // Reset now rather than on the next round.
       if (LOG.isDebugEnabled()) LOG.debug("Detect now; 2 minutes elapsed (oldIPAddress present)");
       return checkHourlyThrottleDecision(now);
     }
@@ -779,8 +778,9 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 
   private static boolean isAddrUsable(InetAddress addr) {
     // Only treat peers with a concrete, validated InetAddress as usable.
-    // Peers often report null addresses transiently (e.g., on connect or IP-less transports).
-    // Counting those as usable inflates real connection counts and can suppress needed detection.
+    // Peers often report null addresses transiently (e.g., on connection or IP-less transports).
+    // Counting those as usable inflates real connection counts and can suppress necessary
+    // detection.
     return (addr != null) && IPUtil.isValidAddress(addr, false);
   }
 
@@ -801,7 +801,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
    * @param now The time at the beginning of the calling method.
    * @param peers The node's peers.
    * @param nodeAddrs Our peers' addresses.
-   * @return True if we should run a detection.
+   * @return True if we should run detection.
    */
   private boolean shouldDetectDespiteRealIP(
       long now, PeerNode[] peers, FreenetInetAddress[] nodeAddrs) {

--- a/src/main/java/network/crypta/node/subsystem/NodeNetworkSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeNetworkSubsystem.java
@@ -166,7 +166,7 @@ public final class NodeNetworkSubsystem {
    *
    * @param config persistent configuration root used to build the node load sub-config; non-null
    * @param sortOrder current configuration sort order, returned unchanged for chaining
-   * @return the next sort order for subsequent configuration registration calls
+   * @return the next sort order for later configuration registration calls
    * @throws NodeInitException if node statistics fail to initialize with the provided config
    */
   public int initNodeStats(PersistentConfig config, int sortOrder) throws NodeInitException {
@@ -204,7 +204,7 @@ public final class NodeNetworkSubsystem {
    *
    * <p>This method assumes the packet sender has been constructed during crypto/transport
    * initialization. It supplies stats for bandwidth and throughput tracking. Callers typically
-   * invoke this before networking begins so outgoing traffic is accounted for from the start.
+   * invoke this before networking begins, so outgoing traffic is accounted for from the start.
    */
   public void startPacketSender() {
     packetSender.start(nodeStats);
@@ -424,10 +424,10 @@ public final class NodeNetworkSubsystem {
    * should invoke {@link #startNetworking()} after other subsystems are ready.
    *
    * @param params bundled initialization inputs including config, executor, shutdown hook, and
-   *     security levels; must be non-null and contain non-null fields
+   *     security levels, must be non-null and contain non-null fields
    * @param sortOrder current configuration sort order for subsequent registration
    * @return updated sort order after registering crypto configuration options
-   * @throws NodeInitException if configuration is invalid or crypto cannot be initialized
+   * @throws NodeInitException if the configuration is invalid or crypto cannot be initialized
    */
   public int initCryptoAndTransport(CryptoAndTransportParams params, int sortOrder)
       throws NodeInitException {
@@ -985,7 +985,7 @@ public final class NodeNetworkSubsystem {
   }
 
   /**
-   * Attempts to read persisted peer references from disk.
+   * Attempts to read persisted peer references from the disk.
    *
    * <p>This method builds the expected peers filename from the current darknet port and delegates
    * loading to the {@link PeerManager}. It does not throw on missing files and does not start any
@@ -1484,7 +1484,7 @@ public final class NodeNetworkSubsystem {
   /**
    * Returns the array of currently connected peer nodes.
    *
-   * <p>The peer manager determines connected state based on its internal connection tracking. The
+   * <p>The peer manager determines a connected state based on its internal connection tracking. The
    * returned array reflects a snapshot at the time of the call and may change immediately
    * afterward. Callers should treat the array as read-only.
    *
@@ -1535,7 +1535,7 @@ public final class NodeNetworkSubsystem {
    * <p>This method constructs a routed ping message using a random UID and counter, dispatches it
    * via the node dispatcher, and waits up to five seconds for a matching routed pong. If the wait
    * fails, disconnects, or a rejection is received, it returns {@code -1}. On success, it returns
-   * the counter delta reported by the responder.
+   * the counter-delta reported by the responder.
    *
    * @param loc2 target location for the ping, expressed as a routing location
    * @param pubKeyHash public key hash of the target, used for routing and verification; non-null
@@ -1589,7 +1589,7 @@ public final class NodeNetworkSubsystem {
     dispatcher().handleRouted(m, null);
     try {
       if (!latch.await(5, SECONDS)) return -1;
-    } catch (InterruptedException e) {
+    } catch (InterruptedException _) {
       Thread.currentThread().interrupt();
       return -1;
     }
@@ -1845,7 +1845,7 @@ public final class NodeNetworkSubsystem {
   /**
    * Returns the count of swaps rejected due to rate limiting.
    *
-   * <p>This static counter reflects how often swap attempts were suppressed by rate limits. It is
+   * <p>This static counter reflects how often rate limits suppressed swap attempts. It is
    * maintained by {@link LocationManager} and is provided for diagnostics and tuning.
    *
    * @return count of swaps rejected due to rate limiting
@@ -1857,8 +1857,8 @@ public final class NodeNetworkSubsystem {
   /**
    * Returns the count of swaps rejected because the peer was already recognized.
    *
-   * <p>This static counter from {@link LocationManager} indicates swap attempts that were rejected
-   * because the peer ID was already known or did not meet uniqueness constraints.
+   * <p>This static counter from {@link LocationManager} indicates swap attempts rejected because
+   * the peer ID was already known or did not meet uniqueness constraints.
    *
    * @return count of swaps rejected due to recognized peer IDs
    */
@@ -1917,7 +1917,7 @@ public final class NodeNetworkSubsystem {
    * Adds a peer connection and writes the peers file urgently.
    *
    * <p>This method delegates to {@link PeerManager#addPeer(PeerNode)} and then requests an urgent
-   * peers file write to persist the new peer. The result indicates whether the peer was accepted.
+   * peers file writing to persist the new peer. The result indicates whether the peer was accepted.
    * The peer's opennet status determines which file or policy applies.
    *
    * @param pn peer node to add; must be non-null
@@ -1957,8 +1957,8 @@ public final class NodeNetworkSubsystem {
    * Reports whether the node is considered outdated.
    *
    * <p>This method delegates to the peer manager, which may evaluate protocol compatibility or
-   * update status based on peer feedback. The returned value is a snapshot and may change as peer
-   * state changes.
+   * update status based on peer feedback. The returned value is a snapshot and may change as the
+   * peer state changes.
    *
    * @return {@code true} if the node is considered outdated, {@code false} otherwise
    */
@@ -2254,9 +2254,9 @@ public final class NodeNetworkSubsystem {
    *
    * <p>The returned set always includes the darknet UDP port and additionally includes the opennet
    * UDP port when opennet is enabled. The set is newly constructed on each call and can be modified
-   * by the caller without affecting internal state.
+   * by the caller without affecting the internal state.
    *
-   * @return set of forwardable port descriptors for current network configuration
+   * @return set of forwardable port descriptors for the current network configuration
    */
   public Set<ForwardPort> publicInterfacePorts() {
     HashSet<ForwardPort> set = new HashSet<>();
@@ -2292,7 +2292,7 @@ public final class NodeNetworkSubsystem {
    *
    * <p>The returned array includes the darknet socket and, when opennet is enabled, the opennet
    * socket. The array is newly allocated on each call and can be modified by the caller without
-   * affecting internal state. The sockets are owned by their respective crypto components.
+   * affecting the internal state. The sockets are owned by their respective crypto components.
    *
    * @return array of UDP socket handlers in use by the node
    */
@@ -2308,7 +2308,7 @@ public final class NodeNetworkSubsystem {
    *
    * <p>If opennet and its announcer are present, this method requests that the announcer evaluate
    * whether a new announcement should be sent. The call is asynchronous and intended for use after
-   * IP discovery events. No action is taken when opennet is disabled.
+   * IP discovery events. No action is taken when the opennet is disabled.
    */
   public void onAddedValidIP() {
     OpennetManager om = opennet();
@@ -2325,7 +2325,7 @@ public final class NodeNetworkSubsystem {
    *
    * <p>This reflects the {@code acceptSeedConnections} configuration and indicates whether the node
    * should act as a seed for other peers. It is a simple boolean flag and does not validate other
-   * opennet state.
+   * opennet states.
    *
    * @return {@code true} if seed connections are accepted, {@code false} otherwise
    */

--- a/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
+++ b/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
@@ -60,7 +60,6 @@ import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.Version;
 import network.crypta.node.useralerts.AbstractUserAlert;
-import network.crypta.node.useralerts.AbstractUserAlert.DismissOptions;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.HexUtil;
@@ -91,7 +90,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Behavior differs depending on the update mode. In the current package‑based updater flow
  * (where {@link NodeUpdateManager#supportsJarUOM()} returns {@code false}), UoM is only used for
- * revocation handling; main‑jar exchange is disabled and any received main‑jar offers are ignored
+ * revocation handling; main‑jar exchange is disabled, and any received main‑jar offers are ignored
  * after being logged for diagnostics. In legacy jar‑based mode, this manager may fetch a new jar
  * directly from peers after a configurable grace period.
  *
@@ -136,10 +135,10 @@ public class UpdateOverMandatoryManager implements RequestClient {
    */
   private final HashSet<PeerNode> nodesSayKeyRevokedTransferring;
 
-  /** PeerNode's which have offered the main jar which we are not fetching it from right now */
+  /** PeerNode's, which have offered the main jar which we are not fetching it from right now */
   private final HashSet<PeerNode> nodesOfferedMainJar;
 
-  /** PeerNode's which have offered the ext jar which we are not fetching it from right now */
+  /** PeerNode's, which have offered the ext jar which we are not fetching it from right now */
   private final HashSet<PeerNode> nodesAskedSendMainJar;
 
   /** PeerNode's sending us the main jar */
@@ -162,7 +161,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
    *
    * <p>When a peer offers a newer main jar, the normal updater is given this much time before UoM
    * initiates a peer‑to‑peer fetch. The value is expressed in milliseconds and currently equals
-   * three hours. Implementations should treat this as read‑only configuration; callers must not
+   * three hours. Implementations should treat this as a read ‑only configuration; callers must not
    * modify it.
    */
   public static final long GRACE_TIME = HOURS.toMillis(3);
@@ -182,7 +181,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
   private static final Pattern revocationTempBuildNumberPattern =
       Pattern.compile("^revocation(?:-jar)?-(\\d+-)?(\\d+)\\.fblob\\.tmp*$");
 
-  // Main jar insert policy via UOM is handled elsewhere; no random insert here.
+  // The main jar insert policy via UOM is handled elsewhere; no random insert here.
 
   private boolean fetchingUOM;
 
@@ -193,7 +192,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
   private final HashMap<ShortBuffer, UOMDependencyFetcher> dependencyFetchers;
 
   /**
-   * Creates a new manager bound to the given updater.
+   * Creates a new manager bound to the given-updater.
    *
    * <p>The instance observes and updates UoM‑related state through the provided {@link
    * NodeUpdateManager}. The manager is ready for use immediately after construction and maintains
@@ -226,9 +225,9 @@ public class UpdateOverMandatoryManager implements RequestClient {
    * either fetches immediately (when outdated or past the grace time) or remembers the offer for a
    * later takeover.
    *
-   * @param m UOM announce message to handle. Expected to contain keys such as {@code MAIN_JAR_KEY},
-   *     {@code MAIN_JAR_VERSION}, and revocation fields; the map must be well‑formed for correct
-   *     processing.
+   * @param m UOM announcement message to handle. Expected to contain keys such as {@code
+   *     MAIN_JAR_KEY}, {@code MAIN_JAR_VERSION}, and revocation fields; the map must be well‑formed
+   *     for correct processing.
    * @param source The peer that sent the announcement. Must be a currently known {@link PeerNode};
    *     its connection status influences later scheduling.
    * @return Always {@code true}. Returning a value allows symmetry with other handlers and aids
@@ -347,7 +346,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
 
         tryFetchRevocation(source);
       } else {
-        // Should probably also be an useralert?
+        // Should probably also be a useralert?
         LOG.info(
             """
             Node {} sent us a UOM claiming that the auto-update key was blown, but it used a different key to us:
@@ -359,7 +358,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
             revocationURI);
       }
     } catch (MalformedURLException e) {
-      // Should maybe be an useralert?
+      // Should maybe be a useralert?
       LOG.error(
           "Node {} sent us a UOMAnnouncement claiming that the auto-update key was blown, but it"
               + " had an invalid revocation URI: {}",
@@ -457,7 +456,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
             SECONDS.toMillis(60));
 
     // The reply message will start the transfer. It includes the revocation URI
-    // so we can tell if anything wierd is happening.
+    // so we can tell if anything weird is happening.
 
   }
 
@@ -468,7 +467,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
     long whenToTakeOverTheNormalUpdater =
         (started > 0) ? started + GRACE_TIME : System.currentTimeMillis() + GRACE_TIME;
     boolean isOutdated = updateManager.getNode().isOutdated();
-    // if the new build is self-mandatory or if the "normal" updater has been trying to update for
+    // if the new build is self-mandatory, or if the "normal" updater has been trying to update for
     // more than one hour
     if (LOG.isInfoEnabled()) {
       String takeoverDelay = TimeUtil.formatTime(whenToTakeOverTheNormalUpdater - now);
@@ -524,7 +523,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
       int mainJarVersion,
       PeerNode source,
       String jarKey) {
-    // Take up the offer, subject to limits on number of simultaneous downloads.
+    // Take up the offer, subject to limits on the number of simultaneous downloads.
     // If we have fetches running already, then sendUOMRequestMainJar() will add the offer to
     // nodesOfferedMainJar, so that if all our fetches fail, we can fetch from this node.
     if (!isOutdated) {
@@ -553,7 +552,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
         }
       }
     } catch (MalformedURLException e) {
-      // Should maybe be an useralert?
+      // Should maybe be a useralert?
       LOG.error(
           "Node {} sent us a UOMAnnouncement claiming to have a new ext jar, but it had an invalid"
               + " URI: {}",
@@ -568,7 +567,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
 
   private void scheduleMainJarTakeover(
       long whenToTakeOverTheNormalUpdater, long now, final PeerNode source) {
-    // Don't take up the offer. Add to nodesOfferedMainJar, so that we know where to fetch it
+    // Don't take up the offer. Add to nodesOfferedMainJar so that we know where to fetch it
     // from when we need it.
     synchronized (this) {
       nodesOfferedMainJar.add(source);
@@ -1003,7 +1002,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
       LOG.info(
           "Peer {} asked us for the blob file for the revocation key but we don't have it!",
           source);
-      // Probably a race condition on reconnect, hopefully we'll be asked again
+      // Probably a race condition on reconnection, hopefully we'll be asked again
     }
 
     return true;
@@ -1136,8 +1135,8 @@ public class UpdateOverMandatoryManager implements RequestClient {
    * Handles a peer announcement that it is sending the revocation certificate to us.
    *
    * <p>Validates the advertised {@code URI} and length, checks acceptance rules and size limits,
-   * and, if acceptable, schedules a bulk receive to a temporary file followed by verification and
-   * processing. If the offer is rejected or malformed, the transfer is cancelled.
+   * and, if acceptable, schedules a bulk receiving to a temporary file followed by verification and
+   * processing. If the offer is rejected or malformed, the transfer is canceled.
    *
    * @param m Message describing the transfer, including {@code UID}, {@code FILE_LENGTH}, and
    *     {@code REVOCATION_KEY} fields.
@@ -1645,8 +1644,8 @@ public class UpdateOverMandatoryManager implements RequestClient {
   /**
    * Unregisters and clears the current “peers say key blown” alert, if any.
    *
-   * <p>This is a best‑effort cleanup used when conditions rendering the alert obsolete are met. It
-   * is safe to call even when no alert is registered.
+   * <p>This is the best‑effort cleanup used when conditions rendering the alert obsolete are met.
+   * It is safe to call even when no alert is registered.
    */
   public void killAlert() {
     updateManager.getNode().services().clientCore().getAlerts().unregister(alert);
@@ -1679,7 +1678,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
     File data;
     int version;
     FreenetURI uri;
-    // Legacy support removed - only serve current version
+    // Legacy support removed - only serve the current version
     if (!Version.isBuildAtLeast(
         source.getNodeName(), source.getBuildNumber(), NodeUpdateManager.TRANSITION_VERSION)) {
       // Don't serve updates to very old nodes
@@ -1695,7 +1694,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
 
     if (data == null) {
       LOG.info(PEER_ASKED_BLOB_PREFIX + "{} jar but we don't have it!", source, name);
-      // Probably a race condition on reconnect, hopefully we'll be asked again
+      // Probably a race condition on reconnection, hopefully we'll be asked again
       return;
     }
 
@@ -1827,7 +1826,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
    * Handles a peer announcement that it is sending the main jar to us.
    *
    * <p>Validates the advertised {@code URI}, version, and length, checks local acceptance rules,
-   * and, if acceptable, schedules a bulk receive to a temporary file followed by verification and
+   * and, if acceptable, schedules a bulk receiving to a temporary file followed by verification and
    * cleanup. If the offer is rejected, the method cancels the transfer.
    *
    * @param m Message describing the transfer, including {@code UID}, {@code FILE_LENGTH}, {@code
@@ -2007,7 +2006,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
    * Verifies and processes a received main‑jar binary blob.
    *
    * <p>Reads the blob, reconstructs a temporary fetch context using its blocks, and fetches the jar
-   * via the local store using the supplied {@code uri}. On success, the cleaned blob is freed and
+   * via the local store using the supplied {@code uri}. On success, the cleaned blob is freed, and
    * the temporary file is deleted; failures are logged and the temp file is removed.
    *
    * @param temp Temporary file containing the binary blob as received over UoM; must exist.
@@ -2147,7 +2146,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
     if (cleanedBlob != null) cleanedBlob.free();
   }
 
-  // Removed unused method maybeInsertMainJar: insertion is coordinated via updater flows.
+  // Removed an unused method maybeInsertMainJar: insertion is coordinated via updater flows.
 
   /**
    * Deletes obsolete persistent temporary files related to UoM transfers.
@@ -2190,7 +2189,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
       }
     }
 
-    // Result not used by caller; nothing to return.
+    // Caller doesn't use the result; nothing to return.
   }
 
   private boolean shouldDeleteTempFile(String fileName) {
@@ -2522,7 +2521,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
    * Fetches a single dependency by hash via UoM, retrying across peers.
    *
    * <p>Instances track their own progress and avoid duplicate concurrent requests to the same peer.
-   * Completion is signalled through a callback.
+   * Completion is signaled through a callback.
    */
   class UOMDependencyFetcher {
 

--- a/src/main/java/network/crypta/support/PrioritizedTicker.java
+++ b/src/main/java/network/crypta/support/PrioritizedTicker.java
@@ -23,12 +23,12 @@ import org.slf4j.LoggerFactory;
  * on {@code timedJobsByTime}. The ticker sleeps by calling {@link #sleep(long)}, which uses a timed
  * {@code wait} on {@code this}; wake‑ups use {@link #wakeUp()}.
  *
- * <p>Time base and units: Delays and times are in milliseconds. Absolute times are interpreted as
- * milliseconds since the epoch as returned by {@link System#currentTimeMillis()}.
+ * <p>Time base and units: Delays and times are in milliseconds. Absolute times have been
+ * interpreted as milliseconds since the epoch as returned by {@link System#currentTimeMillis()}.
  *
- * <p>Fairness and guarantees: Execution is best‑effort. Tasks run at or after their scheduled time;
- * no real‑time guarantees are made. When {@code noDupes} is enabled, duplicate tasks already queued
- * for the same or an earlier time are not added again.
+ * <p>Fairness and guarantees: Execution is the best‑effort. Tasks run at or after their scheduled
+ * time; no real‑time guarantees are made. When {@code noDupes} is enabled, duplicate tasks already
+ * queued for the same or an earlier time are not added again.
  *
  * @see Ticker
  * @see PriorityAwareExecutor
@@ -46,7 +46,7 @@ public class PrioritizedTicker implements Ticker, Runnable {
       if (!(o instanceof Job)) {
         return false;
       }
-      // Ignore the name, we are only interested in the job, needed for noDupes.
+      // Ignore the name; we are only interested in the job, needed for noDupes.
       return ((Job) o).task == task;
     }
 
@@ -124,7 +124,7 @@ public class PrioritizedTicker implements Ticker, Runnable {
         LOG.error(ERR_PREFIX + "{}", fatal, fatal);
         throw fatal;
       } catch (Throwable t) {
-        // Keep ticker alive even on Errors (e.g., AssertionError, LinkageError).
+        // Keep the ticker alive even on Errors (e.g., AssertionError, LinkageError).
         LOG.error(ERR_PREFIX + "{}", t, t);
       }
     }
@@ -225,9 +225,9 @@ public class PrioritizedTicker implements Ticker, Runnable {
    * Sleeps up to {@code sleepTime} milliseconds or until {@link #wakeUp()} notifies this monitor.
    *
    * <p>Design notes: - This uses a single timed {@code wait(sleepTime)} (no {@code while} loop) on
-   * purpose to maximize wake-up responsiveness. When notified, we return promptly so the ticker can
-   * re-check the timed-job queue outside the monitor and run any newly scheduled work without
-   * waiting out the remainder of the original sleep window. - Spurious wakeups are acceptable for
+   * purpose to maximize wake-up responsiveness. When notified, we return promptly, so the ticker
+   * can re-check the timed-job queue outside the monitor and run any newly scheduled work without
+   * waiting out the remainder of the original sleep window. - Spurious wakeup is acceptable for
    * this method: an early return only causes an early re-drain of the queue, which is safe and
    * desirable for latency. The queue/predicate is not tied to this monitor; it lives in {@code
    * timedJobsByTime} and is checked immediately after this method returns.
@@ -315,7 +315,7 @@ public class PrioritizedTicker implements Ticker, Runnable {
    * Queue a job at a specific absolute time.
    *
    * @param runJobAt The absolute time at which the job should run.
-   * @param offset The offset in milliseconds from "now" (i.e. some recent call to
+   * @param offset The offset in milliseconds from "now" (i.e., some recent call to
    *     System.currentTimeMillis()).
    */
   private void queueTimedJobInner(
@@ -401,8 +401,8 @@ public class PrioritizedTicker implements Ticker, Runnable {
   /**
    * Attempts to remove a previously queued task that has not yet started.
    *
-   * <p>This is the best‑effort cancellation. If the task is not queued, or has already started,
-   * this method does nothing.
+   * <p>This is the best‑effort cancellation. If the task is not queued or has already started, this
+   * method does nothing.
    *
    * @param runnable the task instance to remove; must be the same {@link Runnable} instance that
    *     was queued
@@ -424,7 +424,7 @@ public class PrioritizedTicker implements Ticker, Runnable {
    * all inside the timedJobsByTime lock.
    *
    * @param job The job to remove.
-   * @param t The time at which is it scheduled.
+   * @param t The time at which it is scheduled.
    */
   private void removeQueuedJobInner(Job job, Long t) {
     Object o = timedJobsByTime.get(t);

--- a/src/main/java/network/crypta/support/compress/Compressor.java
+++ b/src/main/java/network/crypta/support/compress/Compressor.java
@@ -325,7 +325,7 @@ public interface Compressor {
    * @since 1
    */
   Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength)
-      throws IOException, CompressionOutputSizeException;
+      throws IOException;
 
   /**
    * Compress data from an input stream to an output stream.
@@ -342,7 +342,7 @@ public interface Compressor {
    * @since 1
    */
   long compress(InputStream input, OutputStream output, long maxReadLength, long maxWriteLength)
-      throws IOException, CompressionOutputSizeException;
+      throws IOException;
 
   /**
    * Compress data with an optional minimum compression effectiveness check.
@@ -386,7 +386,7 @@ public interface Compressor {
    */
   long decompress(
       InputStream input, OutputStream output, long maxLength, long maxEstimateSizeLength)
-      throws IOException, CompressionOutputSizeException;
+      throws IOException;
 
   /**
    * Decompress from a byte array into another byte array.

--- a/src/main/java/network/crypta/support/plugins/helpers1/InvisibleWebInterfaceToadlet.java
+++ b/src/main/java/network/crypta/support/plugins/helpers1/InvisibleWebInterfaceToadlet.java
@@ -8,23 +8,89 @@ import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.ToadletContextClosedException;
 import network.crypta.support.api.HTTPRequest;
 
+/**
+ * Web UI toadlet wrapper that exposes another toadlet without adding visible UI elements.
+ *
+ * <p>This implementation is used by plugins that need to register a {@link Toadlet} in the node's
+ * HTTP stack but do not want the toadlet to appear as a standalone web interface. It delegates
+ * visibility decisions to {@link #showAsToadlet(ToadletContext)} while retaining the core behavior
+ * from {@link WebInterfaceToadlet}. Typical usage is to construct an instance during plugin setup,
+ * register it with the hosting {@link PluginContext}, and then override {@link
+ * #handleMethodGET(URI, HTTPRequest, ToadletContext)} in a subclass to provide actual content.
+ *
+ * <p>State is immutable after construction. The instance is thread-safe under the same assumptions
+ * as {@link WebInterfaceToadlet}; it holds only a reference to the delegate toadlet and otherwise
+ * relies on the HTTP framework for concurrency guarantees. The trade-off is that unimplemented
+ * request handlers return an error response, so callers must override the GET handler for real
+ * output.
+ *
+ * <ul>
+ *   <li>Delegates UI exposure to a provided toadlet instance.
+ *   <li>Provides a safe default GET handler that returns an error page.
+ *   <li>Designed for plugin helpers where UI visibility is controlled elsewhere.
+ * </ul>
+ *
+ * @see WebInterfaceToadlet
+ * @see PluginContext
+ */
+@SuppressWarnings("unused")
 public class InvisibleWebInterfaceToadlet extends WebInterfaceToadlet {
 
-  private final Toadlet _showAsToadlet;
+  private final Toadlet showAsToadlet;
 
+  /**
+   * Creates an invisible web interface wrapper for plugin routing.
+   *
+   * <p>The constructed toadlet is registered like any other {@link WebInterfaceToadlet} but will
+   * report the supplied delegate when the HTTP layer asks which UI to show. This lets plugins reuse
+   * an existing {@link Toadlet} for display decisions while keeping the handler class itself
+   * invisible in menus or listings. The provided fields are stored directly and are not mutated
+   * later, so callers should supply stable objects that remain valid for the lifetime of the
+   * toadlet.
+   *
+   * @param pluginContext2 plugin context that owns the registration and lifecycle coordination
+   * @param pluginURL2 base URL segment under which the toadlet is mounted in HTTP paths
+   * @param pageName2 human-readable page name used for diagnostics and registration metadata
+   * @param showAsToadlet delegate used to decide UI exposure; may be {@code null}
+   */
   protected InvisibleWebInterfaceToadlet(
       PluginContext pluginContext2, String pluginURL2, String pageName2, Toadlet showAsToadlet) {
     super(pluginContext2, pluginURL2, pageName2);
-    _showAsToadlet = showAsToadlet;
+    this.showAsToadlet = showAsToadlet;
   }
 
+  /**
+   * Returns the toadlet that should be treated as the visible UI representative.
+   *
+   * <p>The HTTP layer calls this method when determining whether the current toadlet should appear
+   * in UI listings. The returned object is not modified; it is simply forwarded as-is. If {@code
+   * null} is returned, callers should treat this toadlet as having no visible UI representation.
+   *
+   * @param context active request context used for visibility decisions, typically non-null
+   * @return the delegate toadlet to show instead, or {@code null} for no UI surface
+   */
   @Override
   public Toadlet showAsToadlet(ToadletContext context) {
-    return _showAsToadlet;
+    return showAsToadlet;
   }
 
+  /**
+   * Handles HTTP GET requests with a default error response.
+   *
+   * <p>This base implementation exists solely to avoid silent failures when subclasses do not
+   * provide a handler. It responds with an internal error page indicating that the handler is not
+   * implemented. Subclasses are expected to override this method and generate the desired content
+   * while preserving the same exception contract. The method does not alter the state beyond
+   * emitting the response.
+   *
+   * @param uri requested URI including path and query components for the incoming request
+   * @param request parsed HTTP request wrapper supplying parameters and body data
+   * @param ctx request context used to write the response and manage connection state
+   * @throws ToadletContextClosedException if the client disconnects while writing the response
+   * @throws IOException if the response cannot be written to the underlying stream
+   * @throws RedirectException if a subclass chooses to perform a redirect instead
+   */
   @Override
-  /** Override this! */
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     this.sendErrorPage(ctx, 500, "Internal Server Error", "Not implemented");

--- a/src/main/java/network/crypta/support/plugins/helpers1/WebInterfaceToadlet.java
+++ b/src/main/java/network/crypta/support/plugins/helpers1/WebInterfaceToadlet.java
@@ -11,37 +11,107 @@ import network.crypta.pluginmanager.PluginRespirator;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 
+/**
+ * Base toadlet for plugin web interfaces with shared helpers for path handling and error
+ * presentation.
+ *
+ * <p>This class centralizes small utilities that most plugin toadlets need: it preserves the
+ * resolved path prefix, provides a consistent path normalization routine for dispatching subpaths,
+ * validates form-password submissions for state-changing requests, and builds a simple error
+ * infobox for HTML responses. Subclasses typically register the toadlet with a plugin URL prefix
+ * and then implement their own GET/POST handlers using these helpers to reduce boilerplate.
+ *
+ * <p>The class is effectively immutable after construction, but it exposes the shared {@link
+ * PluginContext} which is mutable and owned by the plugin runtime. Thread-safety therefore depends
+ * on the underlying toadlet lifecycle and the services exposed by {@link PluginContext}; this class
+ * does not add synchronization.
+ *
+ * <ul>
+ *   <li>Stores the resolved toadlet path and exposes it via {@link #path()}.
+ *   <li>Normalizes request paths to stable, comparable suffixes.
+ *   <li>Builds standard error infoboxes with optional retry links.
+ * </ul>
+ *
+ * @see PluginContext
+ * @see PluginRespirator
+ */
 public abstract class WebInterfaceToadlet extends Toadlet implements LinkEnabledCallback {
 
+  /**
+   * Shared plugin services used by the toadlet for page building and security checks.
+   *
+   * <p>The reference is immutable, but the services it exposes may be mutable and are owned by the
+   * plugin runtime. Callers should not assume thread-safety beyond what those services provide.
+   */
   protected final PluginContext pluginContext;
 
-  private final String _path;
+  private static final char PATH_SEPARATOR = '/';
 
+  private final String toadletPath;
+
+  /**
+   * Constructs a new web-interface toadlet with a resolved path prefix.
+   *
+   * <p>The resulting path is built from the plugin URL prefix and the page name. The value is
+   * computed once and reused for all requests, so callers should ensure the inputs are stable and
+   * already normalized to the desired base path.
+   *
+   * @param pluginContext2 plugin runtime services used for page and security helpers; must be
+   *     non-null and valid for the toadlet lifetime
+   * @param pluginURL plugin base URL prefix that anchors this toadlet; non-null and typically
+   *     already rooted at the plugin mount point
+   * @param pageName page path segment appended to the plugin URL; non-null and not expected to
+   *     contain trailing separators
+   */
   protected WebInterfaceToadlet(PluginContext pluginContext2, String pluginURL, String pageName) {
     super(pluginContext2.hlsc);
     pluginContext = pluginContext2;
-    _path = pluginURL + "/" + pageName;
+    toadletPath = pluginURL + PATH_SEPARATOR + pageName;
   }
 
+  /**
+   * Returns the full, resolved path prefix for this toadlet.
+   *
+   * <p>The returned value is stable for the lifetime of the instance and includes the plugin URL
+   * prefix plus the page name supplied to the constructor. The method has no side effects and never
+   * returns {@code null}.
+   *
+   * @return resolved toadlet path used for request routing and link construction
+   */
   @Override
   public String path() {
-    return _path;
+    return toadletPath;
   }
 
+  /**
+   * Reports whether this toadlet is enabled for the supplied context.
+   *
+   * <p>This implementation always returns {@code true} and ignores the context. Subclasses may
+   * override when they need dynamic enablement based on context, permissions, or configuration.
+   *
+   * @param ctx request context associated with the current HTTP handling; may be ignored
+   * @return {@code true} to indicate the toadlet should be available for handling requests
+   */
   @Override
   public boolean isEnabled(ToadletContext ctx) {
     return true;
   }
 
   /**
-   * returns allways at min a "/", but "/path" is allways without trailing '/' so
-   * "/path/to/toadlet/blah" and "/path/to/toadlet/blah/" cant be distinguished
+   * Normalizes a request path to a stable suffix relative to this toadlet.
    *
-   * @param path
-   * @return the path without "/path/to/toadlet"
+   * <p>The input is expected to start with {@link #path()} and represent a request URI path. The
+   * returned value omits the toadlet prefix and trims exactly one trailing {@code '/'} character,
+   * so {@code "/foo"} and {@code "/foo/"} are normalized to the same suffix. If the suffix is
+   * empty, this method returns {@code "/"} to provide a consistent root marker.
+   *
+   * @param path full request path starting with this toadlet prefix; must be at least the prefix
+   *     length
+   * @return normalized suffix without the toadlet prefix, or {@code "/"} for the root
    */
+  @SuppressWarnings("unused")
   protected String normalizePath(String path) {
-    String result = path.substring(_path.length());
+    String result = path.substring(toadletPath.length());
     if (result.isEmpty()) {
       return "/";
     }
@@ -52,30 +122,61 @@ public abstract class WebInterfaceToadlet extends Toadlet implements LinkEnabled
   }
 
   /**
-   * Validates whether the request contains a formPassword which matches {@link
-   * NodeClientCore#getFormPassword() formPassword}. See the JavaDoc there for an explanation of the
-   * purpose of this mechanism.
+   * Validates that the request carries the current form password.
    *
-   * <p><b>ATTENTION</b>: It is critically important to use this function when processing requests
-   * which "change the server state". Other words for this would be requests which change your
-   * database or "write" requests. Requests which only read values from the server don't have to
-   * validate the form password.
+   * <p>The password is read from either a standard parameter or a multipart field named {@code
+   * "formPassword"} and then compared with {@link NodeClientCore#getFormPassword()}. The check is
+   * intended for requests that mutate server state such as writes or configuration updates;
+   * read-only requests typically do not require this validation.
    *
-   * <p>To produce a form which already contains the password, use {@link
-   * PluginRespirator#addFormChild(HTMLNode, String, String)}.
+   * <p>To create forms that already embed the password, use {@link
+   * PluginRespirator#addFormChild(HTMLNode, String, String)}. This method does not mutate the
+   * request and has no side effects.
    *
-   * @return true if the form password is valid
+   * @param req request whose parameters or parts may contain the form password; may be a multipart
+   *     request
+   * @return {@code true} when a password is present and matches the current node form password
    */
+  @SuppressWarnings("unused")
   protected boolean isFormPassword(HTTPRequest req) {
     String passwd = req.getParam("formPassword", null);
     if (passwd == null) passwd = req.getPartAsStringFailsafe("formPassword", 32);
     return (passwd != null) && passwd.equals(pluginContext.clientCore.getFormPassword());
   }
 
+  /**
+   * Builds an error infobox containing the provided messages.
+   *
+   * <p>This convenience overload creates a standard error infobox without a retry link. Each error
+   * string is rendered as a text node followed by a {@code <br>} for visual separation. The list is
+   * not modified, and any ordering supplied by the caller is preserved.
+   *
+   * @param errors ordered, user-visible error messages to include in the infobox; entries should be
+   *     non-null and already localized
+   * @return the outer HTML node representing the error infobox container
+   */
+  @SuppressWarnings("unused")
   public HTMLNode createErrorBox(List<String> errors) {
     return createErrorBox(errors, null, null, null);
   }
 
+  /**
+   * Builds an error infobox with optional retry link parameters.
+   *
+   * <p>Each error message is rendered as a text node followed by a line break. When a retry URI is
+   * provided, the method appends a link with the supplied path and a {@code key} parameter derived
+   * from the retry URI. The {@code extraParams} string is concatenated directly to the retry URI
+   * string, so callers are responsible for any separators or encoding they require.
+   *
+   * @param errors ordered, user-visible error messages to include in the infobox; entries should be
+   *     non-null and already localized
+   * @param path base path used for the retry link href; should be non-null when retry is enabled
+   * @param retryUri URI to serialize as the retry {@code key} parameter; {@code null} disables the
+   *     retry link
+   * @param extraParams optional string appended to the retry URI serialization; may be {@code null}
+   *     when no extra parameters are needed
+   * @return the outer HTML node representing the error infobox container
+   */
   public HTMLNode createErrorBox(
       List<String> errors, String path, FreenetURI retryUri, String extraParams) {
     InfoboxNode box = pluginContext.pageMaker.getInfobox("infobox-alert", "ERROR");

--- a/src/test/java/com/onionnetworks/io/JournalingRAFTest.java
+++ b/src/test/java/com/onionnetworks/io/JournalingRAFTest.java
@@ -139,7 +139,7 @@ class JournalingRAFTest {
     }
   }
 
-  private JournalingRAF newJournalingRaf(File initialFile) throws Exception {
+  private JournalingRAF newJournalingRaf(File initialFile) {
     when(delegateRaf.getMode()).thenReturn("rw");
     when(delegateRaf.getFile()).thenReturn(initialFile);
     return new JournalingRAF(delegateRaf, journal);

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginMessageEncodeDecodeTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginMessageEncodeDecodeTest.java
@@ -1,28 +1,28 @@
 package network.crypta.clients.fcp;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import network.crypta.node.FSParseException;
 import network.crypta.support.SimpleFieldSet;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests encoding and decoding of {@link FCPPluginMessage}s into the on-network format: - Encodes
- * them via {@link FCPPluginServerMessage}, which is the encoder for sending messages from a FCP
+ * them via {@link FCPPluginServerMessage}, which is the encoder for sending messages from an FCP
  * server plugin to a client which is attached by network.<br>
  * - Decodes them via {@link FCPPluginClientMessage}, which is the decoder for decoding messages
- * which we have received from a client which is attached by network.<br>
+ * which we have received from a client which network attaches.<br>
  * - Compares whether the decoded version matches the original {@link FCPPluginMessage}.<br>
  * <br>
  * Notice that this test is sort of an abuse: {@link FCPPluginClientMessage} is not meant to decode
  * {@link FCPPluginServerMessage}s as they are from the server, not from the client.<br>
- * It works because their format is very similar though.<br>
- * And it is the only way we have for testing encoding and decoding: There is no decoder for server
- * messages and no encoder for client messages because the current architecture of plugin FCP is to
- * always have the server plugin run locally in the same node as the FCP code and only allow clients
- * to be attached by network, not server plugins.<br>
+ * It works because their format is very similar, though.<br>
+ * And it is the only way we have for testing, encoding, and decoding: There is no decoder for
+ * server messages and no encoder for client messages because the current architecture of plugin FCP
+ * is to always have the server plugin run locally in the same node as the FCP code and only allow
+ * clients to be attached by network, not server plugins.<br>
  * See {@link FCPPluginConnectionImpl} for an overview of the architecture.
  */
 final class FCPPluginMessageEncodeDecodeTest {
@@ -32,7 +32,7 @@ final class FCPPluginMessageEncodeDecodeTest {
    * decoding is then tested using {@link #testEncodeDecode(FCPPluginMessage)}.
    */
   @Test
-  void testEncodeDecode() throws MessageInvalidException, IOException, FSParseException {
+  void testEncodeDecode() throws MessageInvalidException {
     ArrayList<FCPPluginMessage> messages = new ArrayList<>();
 
     // Non-reply messages. Can either have a SimpleFieldSet, or a Bucket, or both. We don't use
@@ -52,7 +52,7 @@ final class FCPPluginMessageEncodeDecodeTest {
     messages.add(FCPPluginMessage.constructSuccessReply(FCPPluginMessage.construct()));
 
     // Now the messages are created, but their SimpleFieldSet are empty. We test the
-    // encode-decode cycle with various amount of data in the SFS.
+    // encode-decode cycle with various amounts of data in the SFS.
 
     for (FCPPluginMessage message : messages) {
       // Non-reply messages cannot have an empty SFS and a null Bucket because then they have
@@ -80,21 +80,11 @@ final class FCPPluginMessageEncodeDecodeTest {
   }
 
   /**
-   * @see FCPPluginMessageEncodeDecodeTest Explained at class-level JavaDoc of this class.
+   * @see FCPPluginMessageEncodeDecodeTest Explained at class-level Javadoc of this class.
    */
-  private void testEncodeDecode(FCPPluginMessage message)
-      throws MessageInvalidException, IOException, FSParseException {
+  private void testEncodeDecode(FCPPluginMessage message) throws MessageInvalidException {
 
-    SimpleFieldSet encodedMessage = new FCPPluginServerMessage("testPlugin", message).getFieldSet();
-
-    // The params have a different prefix in FCPPluginServerMessage and FCPPluginClientMessage.
-    // So we have to rename them by removing the sub-SimpleFieldSet with the old prefix and
-    // re-adding it with the new one.
-    SimpleFieldSet params = encodedMessage.subset(FCPPluginServerMessage.PARAM_PREFIX);
-    if (params != null) {
-      encodedMessage.removeSubset(FCPPluginServerMessage.PARAM_PREFIX);
-      encodedMessage.put(FCPPluginClientMessage.PARAM_PREFIX, params);
-    }
+    SimpleFieldSet encodedMessage = getSimpleFieldSet(message);
 
     FCPPluginMessage decodedMessage =
         new FCPPluginClientMessage(encodedMessage).constructFCPPluginMessage();
@@ -104,7 +94,7 @@ final class FCPPluginMessageEncodeDecodeTest {
 
     assertEquals(message.identifier, decodedMessage.identifier);
 
-    // SimpleFieldSet offers no equals(). But its designed to be human readable, so we can
+    // SimpleFieldSet offers no equals(). But its designed to be human-readable, so we can
     // just encode them into Strings and compare those.
     if (message.params == null) {
       assertNull(decodedMessage.params);
@@ -115,7 +105,7 @@ final class FCPPluginMessageEncodeDecodeTest {
     if (message.data == null) {
       assertNull(decodedMessage.data);
     } else {
-      // Not implemented yet because the parsing of the data is higher level FCP code; i.e.
+      // Not implemented yet because the parsing of the data is higher level FCP code; i.e.,
       // it is not implemented in FCPPluginClientMessage, but one of its parent classes.
       throw new UnsupportedOperationException("Data parsing is not implemented here.");
     }
@@ -125,5 +115,19 @@ final class FCPPluginMessageEncodeDecodeTest {
     assertEquals(message.errorCode, decodedMessage.errorCode);
 
     assertEquals(message.errorMessage, decodedMessage.errorMessage);
+  }
+
+  private static @NonNull SimpleFieldSet getSimpleFieldSet(FCPPluginMessage message) {
+    SimpleFieldSet encodedMessage = new FCPPluginServerMessage("testPlugin", message).getFieldSet();
+
+    // The params have a different prefix in FCPPluginServerMessage and FCPPluginClientMessage.
+    // So we have to rename them by removing the sub-SimpleFieldSet with the old prefix and
+    // re-adding it with the new one.
+    SimpleFieldSet params = encodedMessage.subset(FCPPluginServerMessage.PARAM_PREFIX);
+    if (params != null) {
+      encodedMessage.removeSubset(FCPPluginServerMessage.PARAM_PREFIX);
+      encodedMessage.put(FCPPluginClientMessage.PARAM_PREFIX, params);
+    }
+    return encodedMessage;
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.EnumSet;
+import java.util.Set;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
@@ -109,7 +109,7 @@ class GetConfigTest {
     ConfigData sent = captor.getValue();
 
     assertEquals(node, sent.node);
-    EnumSet<ConfigData.Section> sections = sent.getSections();
+    Set<ConfigData.Section> sections = sent.getSections();
     assertTrue(sections.contains(ConfigData.Section.CURRENT));
     assertTrue(sections.contains(ConfigData.Section.DEFAULTS));
     assertFalse(sections.contains(ConfigData.Section.SORT_ORDER));

--- a/src/test/java/network/crypta/clients/http/N2NTMToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/N2NTMToadletTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -52,7 +51,7 @@ class N2NTMToadletTest {
 
   @BeforeAll
   static void initL10n() {
-    // Ensure localization bundle is initialised once for predictable strings.
+    // Ensure the localization bundle is initialized once for predictable strings.
     new NodeL10n();
   }
 
@@ -216,8 +215,7 @@ class N2NTMToadletTest {
   }
 
   @Test
-  void createN2NTMSendForm_whenAdvanced_addsFileControls()
-      throws ToadletContextClosedException, IOException {
+  void createN2NTMSendForm_whenAdvanced_addsFileControls() {
     HTMLNode contentNode = new HTMLNode("div");
     HashMap<String, String> peers = new HashMap<>();
     peers.put("7", "Bob");

--- a/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
@@ -53,7 +53,8 @@ class SymlinkerToadletTest {
 
   @Test
   void handleMethodGET_whenAliasMatches_redirectsWithOriginalQueryAndFragment() throws Exception {
-    SymlinkerToadlet toadlet = createToadletWithConfigLinks("/cfg/#/target/");
+    when(subConfig.getStringArr("symlinks")).thenReturn(new String[] {"/cfg/#/target/"});
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
 
     URI incoming = new URI("http://localhost/cfg/path?foo=bar#frag");
 
@@ -139,7 +140,7 @@ class SymlinkerToadletTest {
   }
 
   @Test
-  void handleMethodGET_whenTargetContainsSpaces_redirectsWithEncodedPath() throws Exception {
+  void handleMethodGET_whenTargetContainsSpaces_redirectsWithEncodedPath() {
     when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
     SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
     toadlet.addLink("/bad/", "/target with space/", false);
@@ -151,10 +152,5 @@ class SymlinkerToadletTest {
 
     assertEquals("/target with space/here", redirect.getTarget().getPath());
     assertEquals("/target%20with%20space/here", redirect.getTarget().getRawPath());
-  }
-
-  private SymlinkerToadlet createToadletWithConfigLinks(String... links) {
-    when(subConfig.getStringArr("symlinks")).thenReturn(links);
-    return new SymlinkerToadlet(client, node);
   }
 }

--- a/src/test/java/network/crypta/config/CryptadConfigSecurityTest.java
+++ b/src/test/java/network/crypta/config/CryptadConfigSecurityTest.java
@@ -42,7 +42,7 @@ class CryptadConfigSecurityTest {
   }
 
   @Test
-  void allowsNormalization_withinBase() throws IOException {
+  void allowsNormalization_withinBase() {
     Map<String, String> b = base();
     String expanded = CryptadConfig.expandValue("dataDir/foo/../bar", b);
     assertEquals(expanded, Path.of(b.get("dataDir"), "bar").toString());

--- a/src/test/java/network/crypta/config/FilePersistentConfigTest.java
+++ b/src/test/java/network/crypta/config/FilePersistentConfigTest.java
@@ -38,7 +38,7 @@ class FilePersistentConfigTest {
     FilePersistentConfig cfgObj =
         FilePersistentConfig.constructFilePersistentConfig(cfg, HEADER_UNIT);
 
-    // Register subconfig and option; should read initial value from the file
+    // Register subconfig and option; should read the initial value from the file
     SubConfig sc = cfgObj.createSubConfig("test.prefix");
     sc.register(
         "key",
@@ -101,7 +101,7 @@ class FilePersistentConfigTest {
     assertFalse(cfg.exists(), "config file must not be created before finishedInit");
     assertFalse(tmpFile.exists(), "temp file must not exist before finishedInit");
 
-    // Act: now finish init — should trigger a write
+    // Act: now finish init — should trigger a writing
     cfgObj.finishedInit();
 
     // Assert: config written with header and our value
@@ -195,13 +195,13 @@ class FilePersistentConfigTest {
           }
         });
 
-    // Assert: initial value taken from temp file
+    // Assert: initial value taken from the temp file
     assertEquals("v", sc.getString("k"));
   }
 
   @Test
   @DisplayName("innerStore_whenNotFinished_throwsIllegalStateException")
-  void innerStore_whenNotFinished_throwsIllegalStateException(@TempDir File tmp) throws Exception {
+  void innerStore_whenNotFinished_throwsIllegalStateException(@TempDir File tmp) {
     // Arrange: use a test subclass to expose innerStore()
     File cfg = new File(tmp, "guard.ini");
     File tmpFile = new File(cfg.getPath() + ".tmp");
@@ -223,7 +223,7 @@ class FilePersistentConfigTest {
 
   /** Test subclass exposing {@code innerStore()} for precondition testing. */
   static final class TestableConfig extends FilePersistentConfig {
-    TestableConfig(SimpleFieldSet fs, File fnam, File tmp, String header) throws IOException {
+    TestableConfig(SimpleFieldSet fs, File fnam, File tmp, String header) {
       super(fs, fnam, tmp, header);
     }
 

--- a/src/test/java/network/crypta/node/NodeAndClientLayerTestBase.java
+++ b/src/test/java/network/crypta/node/NodeAndClientLayerTestBase.java
@@ -1,6 +1,5 @@
 package network.crypta.node;
 
-import java.net.MalformedURLException;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertBlock;
 import network.crypta.crypt.DummyRandomSource;
@@ -11,7 +10,6 @@ import network.crypta.support.api.RandomAccessBucket;
 
 class NodeAndClientLayerTestBase {
 
-  static final int PORT = 2048;
   static final int FILE_SIZE = 1024 * 1024;
 
   static RequestClient rc =
@@ -28,8 +26,7 @@ class NodeAndClientLayerTestBase {
         }
       };
 
-  protected InsertBlock generateBlock(DummyRandomSource random, boolean createUsk)
-      throws MalformedURLException {
+  protected InsertBlock generateBlock(DummyRandomSource random, boolean createUsk) {
     byte[] data = new byte[FILE_SIZE];
     random.nextBytes(data);
     RandomAccessBucket bucket = new SimpleReadOnlyArrayBucket(data);

--- a/src/test/java/network/crypta/node/NodeIPDetectorTest.java
+++ b/src/test/java/network/crypta/node/NodeIPDetectorTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -99,7 +100,7 @@ class NodeIPDetectorTest {
     InetAddress a = ip("203.0.113.10");
     primeIpDetector(det, a);
 
-    // First detection writes file
+    // First detection writes a file
     det.redetectAddress();
     verify(node).writeNodeFile();
 
@@ -122,7 +123,7 @@ class NodeIPDetectorTest {
     when(network.peers()).thenReturn(null);
     when(network.dontDetect()).thenReturn(false);
 
-    // No directly detected addresses; plugin IPs should be considered
+    // No direct-detected addresses; plugin IPs should be considered
     primeIpDetector(det /* none */);
 
     DetectedIP v4 = new DetectedIP(ip("203.0.113.7"), DetectedIP.FULL_INTERNET);
@@ -152,7 +153,7 @@ class NodeIPDetectorTest {
     assertEquals(Integer.MAX_VALUE, det.getMinimumDetectedMTU(true));
     assertEquals(Integer.MAX_VALUE, det.getMinimumDetectedMTU());
 
-    // First valid report lowers the minima and triggers node.network().updateMTU()
+    // The first valid report lowers the minima and triggers node.network().updateMTU()
     det.reportMTU(1400, false);
     verify(network).updateMTU();
     assertEquals(1400, det.getMinimumDetectedMTU(false));
@@ -181,7 +182,7 @@ class NodeIPDetectorTest {
     // Complete IPAddressDetector path by redetecting once
     primeIpDetector(det, ip("203.0.113.20"));
     det.redetectAddress();
-    assertTrue(det.isDetecting()); // PM not yet signaled
+    assertTrue(det.isDetecting()); // PM isn't yet signaled
 
     // Signal plugin manager completion
     det.hasDetectedPM();
@@ -208,7 +209,7 @@ class NodeIPDetectorTest {
     Option<?> override = nodeCfg.getOption("ipAddressOverride");
     assertThrows(InvalidConfigValueException.class, () -> override.setValue("bad host$"));
 
-    // ipAddressOverride: valid hostname triggers redetect and keeps hostname-only entry
+    // ipAddressOverride: a valid hostname triggers redetect and keeps hostname-only entry
     // Force detector to avoid direct detection so only the override is considered
     when(network.dontDetect()).thenReturn(true);
     when(node.services().clientCore()).thenReturn(null);
@@ -249,8 +250,7 @@ class NodeIPDetectorTest {
     assertTrue(det.hasValidAddressOverride());
     verify(alerts)
         .unregister(
-            org.mockito.ArgumentMatchers.argThat(
-                (UserAlert ua) -> ua instanceof InvalidAddressOverrideUserAlert));
+            ArgumentMatchers.<UserAlert>argThat(InvalidAddressOverrideUserAlert.class::isInstance));
   }
 
   @Test

--- a/src/test/java/network/crypta/pluginmanager/PluginRespiratorTest.java
+++ b/src/test/java/network/crypta/pluginmanager/PluginRespiratorTest.java
@@ -67,7 +67,6 @@ class PluginRespiratorTest {
   @Mock private HighLevelSimpleClient highLevelSimpleClient;
   @Mock private PluginStores pluginStores;
   @Mock private PluginInfoWrapper pluginInfoWrapper;
-  @Mock private FilterCallback filterCallback;
   @Mock private SimpleToadletServer toadletContainer;
   @Mock private ClientEndpoints endpoints;
   @Mock private PageMaker pageMaker;
@@ -114,7 +113,7 @@ class PluginRespiratorTest {
   }
 
   @Test
-  void makeFilterCallback_whenPathRequiresEncoding_passesEncodedUriToCore() throws Exception {
+  void makeFilterCallback_whenPathRequiresEncoding_passesEncodedUriToCore() {
     // Arrange
     PluginRespirator respirator = new PluginRespirator(node, pluginInfoWrapper);
     String rawPath = "http://example.invalid/a b?q=c d";

--- a/src/test/java/network/crypta/support/compress/Bzip2CompressorTest.java
+++ b/src/test/java/network/crypta/support/compress/Bzip2CompressorTest.java
@@ -1,11 +1,24 @@
 package network.crypta.support.compress;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Random;
 import java.util.stream.Stream;
 import network.crypta.support.api.Bucket;
@@ -30,7 +43,7 @@ class Bzip2CompressorTest {
 
   private static byte[] repeat(byte value, int n) {
     byte[] arr = new byte[n];
-    for (int i = 0; i < n; i++) arr[i] = value;
+    Arrays.fill(arr, value);
     return arr;
   }
 
@@ -49,19 +62,19 @@ class Bzip2CompressorTest {
 
   private static Stream<Arguments> roundTripInputs() {
     return Stream.of(
-        Arguments.of(new byte[0], "empty"),
-        Arguments.of("hello world".getBytes(StandardCharsets.UTF_8), "small-text"),
-        Arguments.of(repeat((byte) 'A', 10_000), "repeated-10k"),
-        Arguments.of(randomBytes(1_000, 42L), "random-1k-seed42"),
-        Arguments.of(repeat((byte) 'Z', 32_768), "boundary-32k"),
-        Arguments.of(repeat((byte) 'Y', 32_769), "boundary-32k+1"));
+        Arguments.of((Object) new byte[0]),
+        Arguments.of((Object) "hello world".getBytes(StandardCharsets.UTF_8)),
+        Arguments.of((Object) repeat((byte) 'A', 10_000)),
+        Arguments.of((Object) randomBytes(1_000, 42L)),
+        Arguments.of((Object) repeat((byte) 'Z', 32_768)),
+        Arguments.of((Object) repeat((byte) 'Y', 32_769)));
   }
 
   // ------------------ Round-trip ------------------
 
-  @ParameterizedTest(name = "roundTrip: {1}")
+  @ParameterizedTest(name = "roundTrip[{index}]")
   @MethodSource("roundTripInputs")
-  void compressAndDecompress_roundTrip_success(byte[] original, String label) throws Exception {
+  void compressAndDecompress_roundTrip_success(byte[] original) throws Exception {
     // Arrange
     ByteArrayOutputStream compressed = new ByteArrayOutputStream();
 
@@ -104,8 +117,7 @@ class Bzip2CompressorTest {
 
     // Act + Assert
     assertThrows(
-        NullPointerException.class,
-        () -> compressor.compress((InputStream) null, out, 16, Long.MAX_VALUE, 0, 0));
+        NullPointerException.class, () -> compressor.compress(null, out, 16, Long.MAX_VALUE, 0, 0));
   }
 
   @Test
@@ -123,6 +135,7 @@ class Bzip2CompressorTest {
   @Test
   void compress_whenInputReadReturnsZero_expectIOException() throws IOException {
     // Arrange
+    //noinspection resource
     InputStream in = mock(InputStream.class);
     when(in.read(any(byte[].class), anyInt(), anyInt())).thenReturn(0); // force zero-length read
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -229,11 +242,11 @@ class Bzip2CompressorTest {
 
     RandomAccessBucket outputBucket = mock(RandomAccessBucket.class);
     ByteArrayOutputStream capturedOut = new ByteArrayOutputStream();
-    // Provide an OutputStream to collect compressed bytes
+    // Provide a OutputStream to collect compressed bytes
     when(outputBucket.getOutputStream()).thenReturn(capturedOut);
     // Allow test to later read what was written
     when(outputBucket.getInputStream())
-        .thenAnswer(inv -> new ByteArrayInputStream(capturedOut.toByteArray()));
+        .thenAnswer(_ -> new ByteArrayInputStream(capturedOut.toByteArray()));
 
     BucketFactory bf = mock(BucketFactory.class);
     when(bf.makeBucket(anyLong())).thenReturn(outputBucket);
@@ -244,7 +257,8 @@ class Bzip2CompressorTest {
     // Assert
     assertSame(outputBucket, result, "Should return the bucket created by the factory");
     // Verify factory interaction
-    verify(bf).makeBucket(eq(Long.MAX_VALUE));
+    //noinspection resource
+    verify(bf).makeBucket(Long.MAX_VALUE);
     verify(dataBucket).getInputStream();
     verify(outputBucket).getOutputStream();
 


### PR DESCRIPTION
## Summary
- apply Spotless-driven style and Javadoc cleanup across core classes
- make ConfigData accept empty section sets and update FCP tests accordingly
- tighten HTMLFilter attribute parsing, compressor exception signatures, and related tests

## Testing
- Not run (not requested)