### PR TITLE
refactor: remove deprecated read paths

### DIFF
--- a/src/main/java/network/crypta/io/comm/Message.java
+++ b/src/main/java/network/crypta/io/comm/Message.java
@@ -1,6 +1,7 @@
 package network.crypta.io.comm;
 
 import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -26,8 +27,8 @@ import org.slf4j.LoggerFactory;
  * top‑level types.
  *
  * <p>Security note: Prefer constructing a fresh {@code Message} when forwarding rather than passing
- * an incoming instance verbatim. Forwarding as‑is preserves any embedded sub‑messages, and can
- * inadvertently leak metadata (e.g., labelling, collusion signals along a route) and waste
+ * an incoming instance verbatim. Forwarding as‑is preserves any embedded submessages and can
+ * inadvertently leak metadata (e.g., labeling, collusion signals along a route) and waste
  * bandwidth. Sub‑messages exist primarily for historical compatibility and should be used
  * judiciously.
  *
@@ -173,13 +174,16 @@ public class Message {
 
   private static void readMessageFields(MessageType mspec, Message m, ByteBufferInputStream bb)
       throws IOException {
+    DataInput dataInput = bb.asDataInput();
     for (String name : mspec.getOrderedFields()) {
       Class<?> type = mspec.getFields().get(name);
       if (type.equals(LinkedList.class)) {
         m.set(
-            name, Serializer.readListFromDataInputStream(mspec.getLinkedListTypes().get(name), bb));
+            name,
+            Serializer.readListFromDataInputStream(
+                mspec.getLinkedListTypes().get(name), dataInput));
       } else {
-        m.set(name, Serializer.readFromDataInputStream(type, bb));
+        m.set(name, Serializer.readFromDataInputStream(type, dataInput));
       }
     }
   }
@@ -224,7 +228,7 @@ public class Message {
   }
 
   /**
-   * Constructs a new, locally originated message with default priority.
+   * Constructs a new, locally originated message with a default priority.
    *
    * @param spec message type descriptor; must not be {@code null}
    */
@@ -738,7 +742,7 @@ public class Message {
   /**
    * Creates a shallow copy without sub‑messages and with a local origin.
    *
-   * <p>Payload entries and priority are copied; sub‑messages are dropped and the source reference
+   * <p>Payload entries and priority are copied; sub‑messages are dropped, and the source reference
    * is cleared.
    *
    * @return a new {@code Message} with no sub‑messages

--- a/src/main/java/network/crypta/support/ByteBufferInputStream.java
+++ b/src/main/java/network/crypta/support/ByteBufferInputStream.java
@@ -10,24 +10,102 @@ import java.nio.ByteBuffer;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An {@link InputStream} and {@link DataInput} implementation backed by a {@link ByteBuffer}.
+ * An {@link InputStream} implementation backed by a {@link ByteBuffer}.
  *
  * <p>This stream exposes sequential read access over the remaining region of a provided {@code
- * ByteBuffer} (or over a wrapped byte array). All {@code DataInput} primitive reads delegate to the
- * underlying buffer (e.g., {@link ByteBuffer#getInt()}), therefore they use the buffer's current
- * byte order (default is big-endian unless the buffer was created/modified with a different order).
+ * ByteBuffer} (or over a wrapped byte array). Primitive reads delegate to the underlying buffer
+ * (e.g., {@link ByteBuffer#getInt()}), therefore, they use the buffer's current byte order (default
+ * is big-endian unless the buffer was created/modified with a different order).
  *
  * <p>Instances are not thread-safe. The buffer position advances as data is read. No copying is
  * performed by the constructors; the stream reflects the provided buffer's state.
  *
  * @author sdiz
  */
-public class ByteBufferInputStream extends InputStream implements DataInput {
+public class ByteBufferInputStream extends InputStream {
   /**
    * The backing buffer. Reads advance its position. The buffer's byte order controls the semantics
    * of multibyte reads.
    */
   protected ByteBuffer buf;
+
+  private final DataInput dataInputView =
+      new DataInput() {
+        @Override
+        public void readFully(byte @NotNull [] b) throws IOException {
+          ByteBufferInputStream.this.readFully(b);
+        }
+
+        @Override
+        public void readFully(byte @NotNull [] b, int off, int len) throws IOException {
+          ByteBufferInputStream.this.readFully(b, off, len);
+        }
+
+        @Override
+        public int skipBytes(int n) {
+          return ByteBufferInputStream.this.skipBytes(n);
+        }
+
+        @Override
+        public boolean readBoolean() throws IOException {
+          return ByteBufferInputStream.this.readBoolean();
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+          return ByteBufferInputStream.this.readByte();
+        }
+
+        @Override
+        public int readUnsignedByte() throws IOException {
+          return ByteBufferInputStream.this.readUnsignedByte();
+        }
+
+        @Override
+        public short readShort() throws IOException {
+          return ByteBufferInputStream.this.readShort();
+        }
+
+        @Override
+        public int readUnsignedShort() throws IOException {
+          return ByteBufferInputStream.this.readUnsignedShort();
+        }
+
+        @Override
+        public char readChar() throws IOException {
+          return ByteBufferInputStream.this.readChar();
+        }
+
+        @Override
+        public int readInt() throws IOException {
+          return ByteBufferInputStream.this.readInt();
+        }
+
+        @Override
+        public long readLong() throws IOException {
+          return ByteBufferInputStream.this.readLong();
+        }
+
+        @Override
+        public float readFloat() throws IOException {
+          return ByteBufferInputStream.this.readFloat();
+        }
+
+        @Override
+        public double readDouble() throws IOException {
+          return ByteBufferInputStream.this.readDouble();
+        }
+
+        @Override
+        public String readLine() {
+          throw new UnsupportedOperationException("readLine is deprecated");
+        }
+
+        @Override
+        public @NotNull String readUTF() throws IOException {
+          return DataInputStream.readUTF(this);
+        }
+      };
 
   /**
    * Creates a stream over the entire {@code array}.
@@ -113,7 +191,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 1 byte remains
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public boolean readBoolean() throws IOException {
     try {
       return buf.get() != 0;
@@ -129,7 +206,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 1 byte remains
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public byte readByte() throws IOException {
     try {
       return buf.get();
@@ -145,7 +221,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 2 bytes remain
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public char readChar() throws IOException {
     try {
       return buf.getChar();
@@ -161,7 +236,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 8 bytes remain
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public double readDouble() throws IOException {
     try {
       return buf.getDouble();
@@ -177,7 +251,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 4 bytes remain
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public float readFloat() throws IOException {
     try {
       return buf.getFloat();
@@ -193,7 +266,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer bytes remain than {@code b.length}
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public void readFully(byte @NotNull [] b) throws IOException {
     try {
       buf.get(b);
@@ -212,7 +284,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws IndexOutOfBoundsException if {@code off} or {@code len} are invalid
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public void readFully(byte @NotNull [] b, int off, int len) throws IOException {
     try {
       buf.get(b, off, len);
@@ -228,7 +299,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 4 bytes remain
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public int readInt() throws IOException {
     try {
       return buf.getInt();
@@ -244,7 +314,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 8 bytes remain
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public long readLong() throws IOException {
     try {
       return buf.getLong();
@@ -260,7 +329,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 2 bytes remain
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public short readShort() throws IOException {
     try {
       return buf.getShort();
@@ -276,7 +344,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 1 byte remains
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public int readUnsignedByte() throws IOException {
     try {
       return buf.get() & 0xFF;
@@ -292,7 +359,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if fewer than 2 bytes remain
    * @throws IOException if an I/O error occurs
    */
-  @Override
   public int readUnsignedShort() throws IOException {
     try {
       return buf.getShort() & 0xFFFF;
@@ -307,7 +373,6 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @param n the requested number of bytes to skip (non-negative)
    * @return the actual number of bytes skipped (may be less than {@code n})
    */
-  @Override
   public int skipBytes(int n) {
     int skip = Math.min(n, buf.remaining());
     buf.position(buf.position() + skip);
@@ -324,28 +389,19 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    * @throws EOFException if the stream ends prematurely
    * @throws IOException if an I/O error occurs or the UTF data is malformed
    */
-  @Override
   public @NotNull String readUTF() throws IOException {
-    return DataInputStream.readUTF(this);
+    return DataInputStream.readUTF(dataInputView);
   }
 
   /**
-   * Reads a line of text as defined by the deprecated {@link DataInputStream#readLine()} contract.
+   * Returns a {@link DataInput} view over this stream.
    *
-   * <p>This method exists only for compatibility with {@link DataInput}. It delegates to the
-   * deprecated API in {@link DataInputStream}. For new code, prefer well-defined text encodings
-   * (for example, {@code readUTF()}) and avoid this method.
+   * <p>The returned view shares this stream's position and byte order.
    *
-   * @return the line without any line-termination characters, or {@code null} at end of stream
-   * @throws IOException if an I/O error occurs
-   * @deprecated This method is deprecated along with {@link DataInputStream#readLine()}. See that
-   *     method's documentation for details.
+   * @return a {@link DataInput} that reads from this stream
    */
-  @Override
-  @Deprecated(since = "2")
-  public String readLine() throws IOException {
-    // Delegate to the legacy implementation for compatibility with DataInput.
-    return new DataInputStream(this).readLine();
+  public DataInput asDataInput() {
+    return dataInputView;
   }
 
   /**
@@ -353,7 +409,7 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
    *
    * <p>The returned stream is backed by a {@link ByteBuffer#slice()} of the remaining region and
    * reflects the same byte order. On success, this stream's position advances by {@code size} so
-   * subsequent reads continue after the slice.
+   * later reads continue after the slice.
    *
    * @param size number of bytes to expose in the slice
    * @return a new {@code ByteBufferInputStream} reading exactly {@code size} bytes

--- a/src/main/java/network/crypta/support/compress/OldLZMACompressor.java
+++ b/src/main/java/network/crypta/support/compress/OldLZMACompressor.java
@@ -27,17 +27,17 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Compression uses a fixed dictionary size of {@code 1 << 20} (approximately 1 MiB), which
- *       corresponds to the legacy “lzma -4” setting. Coder properties are not written to the output
- *       stream by this class.
+ *       corresponds to the legacy “lzma -4” setting. This class does not write Coder properties to
+ *       the output stream.
  *   <li>The {@code maxReadLength} parameter of the stream-based {@code compress} overload is not
- *       enforced; input is read until end of stream.
- *   <li>{@code maxWriteLength} is enforced only after compression completes (a post-write check).
+ *       enforced; input is read until the end of stream.
+ *   <li>{@code maxWriteLength} is enforced only after compression completes (a post-writing check).
  *       If it is exceeded, a {@link CompressionOutputSizeException} is thrown and the output stream
  *       may already contain more data than the configured limit.
  *   <li>Decompression uses a fixed property array equivalent to the legacy encoder properties bytes
  *       {@code 5d 00 00 10 00}. The reader does not expect coder properties in the stream itself.
- *   <li>Instances are stateless and safe to use from multiple threads as long as the provided
- *       streams/buckets are not shared unsafely by the caller.
+ *   <li>Instances are stateless and safe to use from multiple threads as long as the caller does
+ *       not share the provided streams/buckets unsafely.
  *   <li>Unless otherwise documented, these methods do not close the caller-provided streams.
  *       Bucket-based methods manage their own bucket I/O streams via try-with-resources.
  * </ul>
@@ -52,7 +52,7 @@ public class OldLZMACompressor implements Compressor {
    * Compresses a bucket using the legacy LZMA settings.
    *
    * <p>This overload creates an output bucket via the supplied {@link BucketFactory} and writes the
-   * compressed data into it. It logs a deprecation warning on each call.
+   * compressed data into it. It logs a compatibility warning on each call.
    *
    * @param data input bucket; must not be {@code null}
    * @param bf factory used to construct the output bucket; must not be {@code null}
@@ -64,10 +64,7 @@ public class OldLZMACompressor implements Compressor {
    * @return a bucket containing the compressed output
    * @throws IOException if reading or writing fails
    * @throws CompressionOutputSizeException if the post-write size check detects an overflow
-   * @deprecated since 2019‑11‑17. OldLZMA compression is buggy and unsupported; retained only to
-   *     allow reinserting existing keys.
    */
-  @Deprecated(since = "2019-11-17", forRemoval = true)
   @Override
   public Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength)
       throws IOException {
@@ -87,8 +84,8 @@ public class OldLZMACompressor implements Compressor {
   /**
    * Compresses data from an input stream to an output stream using the legacy LZMA settings.
    *
-   * <p>Dictionary size is fixed to {@code 1 << 20}. Encoder properties are not written to the
-   * output by this class. The caller remains responsible for closing the provided streams.
+   * <p>Dictionary size is fixed to {@code 1 << 20}. This class does not write encoder properties to
+   * the output. The caller remains responsible for closing the provided streams.
    *
    * @param is input stream; must not be {@code null}
    * @param os output stream; must not be {@code null}
@@ -99,10 +96,7 @@ public class OldLZMACompressor implements Compressor {
    * @return number of bytes written to {@code os}
    * @throws IOException if I/O fails
    * @throws CompressionOutputSizeException if the post-write size check detects an overflow
-   * @deprecated since 2019‑11‑17. OldLZMA compression is buggy and unsupported; retained only to
-   *     allow reinserting existing keys.
    */
-  @Deprecated(since = "2019-11-17", forRemoval = true)
   @Override
   public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength)
       throws IOException {
@@ -174,7 +168,7 @@ public class OldLZMACompressor implements Compressor {
   }
 
   // Copied from the historical DecoderThread.
-  // LICENSING NOTE: DecoderThread was distributed under LGPL 2.1 / CPL according to its header.
+  // LICENSING NOTE: DecoderThread was distributed under LGPL 2.1 / CPL, according to its header.
 
   private static final int PROP_SIZE = 5;
 

--- a/src/main/java/network/crypta/support/io/Fallocate.java
+++ b/src/main/java/network/crypta/support/io/Fallocate.java
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
  *   <li>Instances are not thread-safe. Use a separate instance per file/channel.
  *   <li>{@link FileChannel} must be open and writable. Behavior is undefined if the channel is
  *       closed during execution.
- *   <li>The implementation uses reflection to obtain the underlying file descriptor. If the
- *       descriptor cannot be accessed, the code silently falls back to the legacy fill path.
+ *   <li>The implementation uses reflection to get the underlying file descriptor. If the descriptor
+ *       cannot be accessed, the code silently falls back to the legacy fill path.
  *   <li>Native calls are made via JNA to the platform C library.
  * </ul>
  *
@@ -50,10 +50,7 @@ public final class Fallocate {
       !Platform.isWindows() && !Platform.isMac() && !Platform.isOpenBSD();
   private static final boolean IS_ANDROID = Platform.isAndroid();
 
-  private static final int FALLOC_FL_KEEP_SIZE = 0x01;
-
   private final int fd;
-  private int mode;
   private long offset;
   private final long finalFilesize;
   private final FileChannel channel;
@@ -75,8 +72,8 @@ public final class Fallocate {
    * Creates an instance for the given channel and desired final size.
    *
    * <p>Attempts to discover the native file descriptor behind the channel via reflection. If this
-   * discovery fails due to platform or security restrictions, subsequent execution falls back to
-   * the legacy writer.
+   * discovery fails due to platform or security restrictions, later execution falls back to the
+   * legacy writer.
    *
    * @param channel target channel; must be open and writable
    * @param finalFilesize desired file size in bytes after allocation completes
@@ -117,29 +114,6 @@ public final class Fallocate {
   }
 
   /**
-   * Requests Linux {@code FALLOC_FL_KEEP_SIZE} mode.
-   *
-   * <p>This flag preallocates blocks without extending the apparent file length. The mode is only
-   * supported on Linux; calling it on other platforms throws an exception.
-   *
-   * @deprecated Linux-only; on non-Linux systems this method throws {@link
-   *     UnsupportedOperationException}. Prefer the default behavior or simply call {@link
-   *     #execute()} without keep-size mode.
-   * @since 2
-   * @return this instance for fluent chaining
-   * @throws UnsupportedOperationException when invoked on non-Linux platforms
-   */
-  @Deprecated(since = "2")
-  public Fallocate keepSize() {
-    if (!IS_LINUX) {
-      throw new UnsupportedOperationException(
-          "fallocate keep size is not supported on this file system");
-    }
-    mode |= FALLOC_FL_KEEP_SIZE;
-    return this;
-  }
-
-  /**
    * Performs the allocation using the best available strategy on the current platform.
    *
    * <p>Behavior by platform:
@@ -165,7 +139,7 @@ public final class Fallocate {
     boolean isUnsupported = false;
     if (fd > 2) {
       if (IS_LINUX) {
-        final int result = FallocateHolder.fallocate(fd, mode, offset, finalFilesize - offset);
+        final int result = FallocateHolder.fallocate(fd, 0, offset, finalFilesize - offset);
         errno = result == 0 ? 0 : Native.getLastError();
       } else if (IS_POSIX) {
         errno = FallocateHolderPOSIX.posix_fallocate(fd, offset, finalFilesize - offset);
@@ -205,7 +179,7 @@ public final class Fallocate {
   }
 
   /**
-   * Best-effort extraction of a channel's {@link FileDescriptor} to obtain its native fd value.
+   * Best-effort extraction of a channel's {@link FileDescriptor} to get its native fd value.
    *
    * <p>Returns {@code 0} when the descriptor is inaccessible (e.g., different JDK implementation or
    * insufficient permissions) which forces legacy behavior for allocation.
@@ -242,7 +216,7 @@ public final class Fallocate {
       }
       return (int) field.get(descriptor);
     } catch (final Exception _) {
-      // Intentionally fall back: descriptor is unavailable or null; return 0 for legacy path.
+      // Intentionally fall back: descriptor is unavailable or null; return 0 for the legacy path.
       return 0;
     }
   }
@@ -257,7 +231,7 @@ public final class Fallocate {
    * @param fc target channel
    * @param newLength desired file size in bytes after the operation
    * @param offset starting position (inclusive)
-   * @throws IOException if any channel write fails
+   * @throws IOException if any channel writing fails
    */
   private static void legacyFill(FileChannel fc, long newLength, long offset) throws IOException {
     if (IS_WINDOWS) {

--- a/src/test/java/network/crypta/support/io/FallocateTest.java
+++ b/src/test/java/network/crypta/support/io/FallocateTest.java
@@ -1,11 +1,18 @@
 package network.crypta.support.io;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.sun.jna.Platform;
 import java.io.IOException;
@@ -117,7 +124,7 @@ class FallocateTest {
     when(channel.write(any(ByteBuffer.class), anyLong())).thenReturn(1);
 
     long finalSize = 10L;
-    long offset = 7L; // ignored on Windows path
+    long offset = 7L; // ignored on a Windows path
     Fallocate f = Fallocate.forChannel(channel, finalSize).fromOffset(offset);
 
     // Act
@@ -151,37 +158,6 @@ class FallocateTest {
       // On non-Windows, zero remaining => no writes
       verify(channel, never()).write(any(ByteBuffer.class), anyLong());
     }
-  }
-
-  // endregion
-
-  // region keepSize()
-
-  @Test
-  @SuppressWarnings("deprecation")
-  void keepSize_whenNotLinux_expectUnsupportedOperationException() {
-    // Arrange
-    assumeFalse(Platform.isLinux(), "Skip when Linux; covered by the Linux test.");
-    FileChannel channel = mock(FileChannel.class);
-    Fallocate f = Fallocate.forChannel(channel, 10L);
-
-    // Act + Assert
-    assertThrows(UnsupportedOperationException.class, f::keepSize);
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  void keepSize_whenLinux_doesNotThrowAndReturnsSame() {
-    // Arrange
-    assumeTrue(Platform.isLinux(), "Linux-only behavior under test.");
-    FileChannel channel = mock(FileChannel.class);
-    Fallocate f = Fallocate.forChannel(channel, 10L);
-
-    // Act
-    Fallocate result = f.keepSize();
-
-    // Assert
-    assertSame(f, result);
   }
 
   // endregion


### PR DESCRIPTION
## Summary
- drop deprecated DataInput usage by exposing a DataInput view from ByteBufferInputStream
- remove deprecated keep-size support in Fallocate and update related tests/docs
- clean up legacy deprecation markers and wording for OldLZMA compressor and message docs