### PR TITLE
Polish Javadocs and narrow demo entry points

### DIFF
--- a/src/main/java/com/onionnetworks/util/FilteringIterator.java
+++ b/src/main/java/com/onionnetworks/util/FilteringIterator.java
@@ -118,7 +118,7 @@ public abstract class FilteringIterator<T> implements Iterator<T> {
    * <p>If no such element exists, the method throws {@link NoSuchElementException} in accordance
    * with the iterator contract. When a buffered element is present from a prior {@link #hasNext()}
    * call, it is returned immediately; otherwise the method advances the parent until it finds a
-   * match or exhausts the source. Each successful call clears the buffer so the next invocation
+   * match or exhausts the source. Each successful call clears the buffer, so the next invocation
    * will re-evaluate availability.
    *
    * @return the next acceptable element; never {@code null} unless the parent produces nulls and
@@ -140,12 +140,10 @@ public abstract class FilteringIterator<T> implements Iterator<T> {
    *
    * <p>The example logs both the unfiltered list and the filtered output to illustrate iteration
    * order preservation. It intentionally uses explicit {@link #hasNext()} / {@link #next()} calls
-   * to mirror typical consumer code. Any unexpected state during the walk triggers a logged warning
-   * so the example remains simple to debug.
-   *
-   * @param args ignored command-line arguments; present for standard Java entry-point compatibility
+   * to mirror typical consumer code. Any unexpected state during the walk triggers a logged
+   * warning, so the example remains simple to debug.
    */
-  public static void main(String[] args) {
+  static void main() {
     List<String> l = new LinkedList<>(Arrays.asList("a", null, "was", null));
     Iterator<String> i = l.iterator();
     FilteringIterator<String> f =

--- a/src/main/java/com/onionnetworks/util/NetUtil.java
+++ b/src/main/java/com/onionnetworks/util/NetUtil.java
@@ -36,15 +36,7 @@ public class NetUtil {
 
   private static final Logger LOGGER = Logger.getLogger(NetUtil.class.getName());
 
-  /**
-   * Creates a new NetUtil instance. The class is stateless, so constructing it is rarely necessary;
-   * callers typically access the static utilities directly. The constructor exists only to satisfy
-   * environments that prefer instance-based access patterns or dependency injection frameworks and
-   * performs no initialization work.
-   */
-  public NetUtil() {
-    // Intentional no-op: class is stateless and intended for static access patterns only.
-  }
+  private NetUtil() {}
 
   /**
    * Returns IP-literal variants of the provided URL for each DNS address.
@@ -53,8 +45,8 @@ public class NetUtil {
    * supplied URL, substitutes each textual address into the host field, and preserves protocol,
    * user info, port, path, query, and fragment components. When the host is null or empty, the
    * original URL is returned in a single-element array to avoid resolver failures. The order of the
-   * returned URLs mirrors the resolver output so callers can respect the system's preferred address
-   * ordering.
+   * returned URLs mirrors the resolver output, so callers can respect the system's preferred
+   * address ordering.
    *
    * @param url non-null URL whose hostname should be expanded into concrete IP addresses; other
    *     components remain unchanged.
@@ -111,10 +103,8 @@ public class NetUtil {
    *
    * @param args optional URL strings to resolve; when empty, built-in examples are used to showcase
    *     common edge cases.
-   * @throws Exception if parsing inputs, resolving DNS records, or constructing URL objects fails
-   *     at any stage.
    */
-  public static void main(String[] args) throws Exception {
+  static void main(String[] args) throws IOException {
 
     if (args.length == 0) {
       args =

--- a/src/main/java/com/onionnetworks/util/RangeSet.java
+++ b/src/main/java/com/onionnetworks/util/RangeSet.java
@@ -56,7 +56,7 @@ public class RangeSet {
   /**
    * Creates an empty {@code RangeSet} with capacity for {@link #DEFAULT_CAPACITY} range pairs.
    *
-   * <p>No ranges are present after construction and both infinity flags are clear. Callers
+   * <p>No ranges are present after construction, and both infinity flags are clear. Callers
    * typically add values or ranges immediately using {@link #add(long)} or {@link #add(Range)}. The
    * instance is mutable and may expand its internal storage automatically as additional ranges are
    * merged.
@@ -82,9 +82,9 @@ public class RangeSet {
   /**
    * Copy constructor that duplicates another {@code RangeSet} including infinity markers.
    *
-   * <p>All endpoints are copied into a fresh backing array and the source set remains unchanged.
-   * The resulting instance is a shallow structural clone: subsequent modifications to either set do
-   * not affect the other, but {@link Range} objects returned by iterators are newly allocated each
+   * <p>All endpoints are copied into a fresh backing array, and the source set remains unchanged.
+   * The resulting instance is a shallow structural clone: later modifications to either set do not
+   * affect the other, but {@link Range} objects returned by iterators are newly allocated each
    * time.
    *
    * @param source the {@code RangeSet} to replicate, including its current ranges and flags.
@@ -110,7 +110,7 @@ public class RangeSet {
    */
   public RangeSet union(RangeSet rs) {
     // This should be rewritten to interleave the additions so that there
-    // is fewer midlist insertions.
+    // are fewer midlist insertions.
     RangeSet result = new RangeSet();
     result.add(this);
     result.add(rs);
@@ -120,7 +120,7 @@ public class RangeSet {
   /**
    * Produces the intersection of this set and the provided set.
    *
-   * <p>The returned {@code RangeSet} contains only values present in both operands. Internally the
+   * <p>The returned {@code RangeSet} contains only values present in both operands. Internally, the
    * method leverages complement logic, so infinite bounds are handled consistently with other set
    * operations. Neither input set is modified. When the operands do not overlap, an empty set is
    * returned.
@@ -166,7 +166,7 @@ public class RangeSet {
   /**
    * Determines whether the specified value is a member of this set.
    *
-   * <p>The lookup uses a binary search across stored endpoints and completes in O(log n) time where
+   * <p>The lookup uses a binary search across stored endpoints and completes in O(log n) time when
    * {@code n} is the number of disjoint ranges. Negative and positive infinity markers are honored,
    * so values beyond the finite endpoints are considered present when the corresponding flag is
    * set.
@@ -268,8 +268,8 @@ public class RangeSet {
       return;
     }
 
-    // This case should be the most common (insert at the end) so we will
-    // specifically check for it.  Its +1 so that we make sure it's not
+    // This case should be the most common (insert at the end), so we will
+    // specifically check for it.  It's +1 so that we make sure it's not
     // adjacent.  Do the MIN_VALUE check to make sure we don't overflow
     // the long.
     if (min != Long.MIN_VALUE && min - 1 > ranges[(rangeCount - 1) * 2 + 1]) {
@@ -361,8 +361,8 @@ public class RangeSet {
    * Returns an iterator over normalized {@link Range} instances contained in this set.
    *
    * <p>The iterator produces ranges in ascending order and expands infinity markers into explicit
-   * {@link Range} objects. The returned iterator is fail-safe with respect to subsequent mutations
-   * of this set because it iterates over a snapshot list created at invocation time.
+   * {@link Range} objects. The returned iterator is fail-safe with respect to later mutations of
+   * this set because it iterates over a snapshot list created at invocation time.
    *
    * @return an iterator that traverses each stored range exactly once in ascending order.
    */
@@ -513,12 +513,8 @@ public class RangeSet {
    * when enabled, and then processes user commands to add ranges, intersect with another set, or
    * invert the current set. Input of {@code q} ends the loop. This method is intended as a quick
    * manual exploration aid rather than a production interface.
-   *
-   * @param args command-line arguments, currently unused but accepted for conventional entry
-   *     points.
-   * @throws Exception if parsing or I/O fails while processing input.
    */
-  public static void main(String[] args) throws Exception {
+  static void main() throws IOException, ParseException {
     RangeSet rs = RangeSet.parse("5-10,15-20,25-30");
     try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
       boolean exit = false;

--- a/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
+++ b/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
@@ -542,7 +542,7 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
       }
     }
 
-    // last round is special
+    // the last round is special
     ker = ke[rounds];
     int tt = ker[0];
     result[0] = (byte) (S[t0 >>> 24 & 0xFF] ^ tt >>> 24 & 0xFF);
@@ -718,7 +718,7 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
       }
     }
 
-    // last round is special
+    // the last round is special
     ker = ke[rounds];
     int tt = ker[0];
     result[0] = (byte) (S[t0 >>> 24 & 0xFF] ^ tt >>> 24 & 0xFF);
@@ -861,7 +861,7 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
       }
     }
 
-    // last round is special
+    // the last round is special
     kdr = kd[rounds];
     int tt = kdr[0];
     result[0] = (byte) (Si[t0 >>> 24 & 0xFF] ^ tt >>> 24 & 0xFF);
@@ -1042,7 +1042,7 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
       }
     }
 
-    // last round is special
+    // the last round is special
     kdr = kd[rounds];
     int tt = kdr[0];
     result[0] = (byte) (Si[t0 >>> 24 & 0xFF] ^ tt >>> 24 & 0xFF);
@@ -1145,7 +1145,7 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
     KeyScheduleCtx ctx = new KeyScheduleCtx(ke, kd, rounds, bcShift, bc, kc, roundKeyCount);
     // copy initial round keys
     int t = copyRoundKeysFromTk(ctx, tk, 0);
-    // evolve key schedule and continue copying until filled
+    // evolve a key schedule and continue copying until filled
     evolveKeySchedule(ctx, tk, t);
     // inverse MixColumn where needed for decryption keys
     inverseMixColumnsOnKd(ctx.kd, ctx.rounds, ctx.bc);
@@ -1477,7 +1477,7 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
       ok = encryptDecryptAndCompare(kb, pt);
       if (!ok) throw new IllegalStateException("Symmetric operation failed");
     } catch (Exception x) {
-      // Always log unexpected runtime exceptions at error level.
+      // Always log unexpected runtime exceptions at the error level.
       LOG.error("Self-test failed for keysize {}", keysize, x);
       ok = false;
     }
@@ -1568,8 +1568,8 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
   }
 
   /**
-   * Returns a string of 2 hexadecimal digits (most significant digit first) corresponding to the
-   * lowest 8 bits of <i>n</i>.
+   * Returns a string of 2 hexadecimal digits (the most significant digit first) corresponding to
+   * the lowest 8 bits of <i>n</i>.
    */
   private static String byteToString(int n) {
     char[] buf = {HEX_DIGITS[n >>> 4 & 0x0F], HEX_DIGITS[n & 0x0F]};
@@ -1577,8 +1577,8 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
   }
 
   /**
-   * Returns a string of 8 hexadecimal digits (most significant digit first) corresponding to the
-   * integer <i>n</i>, which is treated as unsigned.
+   * Returns a string of 8 hexadecimal digits (the most significant digit first) corresponding to
+   * the integer <i>n</i>, which is treated as unsigned.
    */
   private static String intToString(int n) {
     char[] buf = new char[8];
@@ -1633,10 +1633,8 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
    *
    * <p>Runs internal self‑tests for 128‑, 192‑, and 256‑bit keys using the default 128‑bit block
    * size. Intended for developers; production code does not invoke this method.
-   *
-   * @param args Unused.
    */
-  public static void main(String[] args) {
+  static void main() {
     selfTest(16);
     selfTest(24);
     selfTest(32);

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -98,7 +98,7 @@ public class Node implements TimeSkewDetectorCallback {
   /** Config key name used to control datastore preallocation. */
   private static final String STORE_PREALLOCATE_KEY = "storePreallocate";
 
-  /** SimpleFieldSet key for Node-to-Node message type. */
+  /** SimpleFieldSet key for a Node-to-Node message type. */
   public static final String N2N_TYPE_KEY = "n2nType";
 
   /** System property to override the hardware RNG device path. */
@@ -106,8 +106,6 @@ public class Node implements TimeSkewDetectorCallback {
 
   /** Default hardware RNG device path for Unix-like systems. */
   public static final String DEFAULT_HWRNG_PATH = "/dev/hwrng";
-
-  // Static initializer not required
 
   /** Config object for the whole node. */
   private final PersistentConfig config;
@@ -128,16 +126,16 @@ public class Node implements TimeSkewDetectorCallback {
   /** Probability of decrementing at the maximum HTL boundary. */
   public static final double DECREMENT_AT_MAX_PROB = 0.5;
 
-  // Send keepalives every 7-14 seconds. Will be acked and if necessary resent.
+  // Send keepalives every 7-14 seconds. Will be acked and if necessary, resent.
   // Old behavior was keepalives every 14-28. Even that was adequate for a 30-second
   // timeout. Most nodes don't need to send keepalives because they are constantly busy,
-  // this is only an issue for disabled darknet connections, very quiet private networks
+  // this is only an issue for disabled darknet connections, very quiet private networks,
   // etc.
   /** Interval for sending keep‑alive packets on idle connections (milliseconds). */
   public static final long KEEPALIVE_INTERVAL = SECONDS.toMillis(7);
 
-  // If no activity for 30 seconds, node is dead
-  // 35 seconds allows plenty of time for resends etc. even if above is 14 sec as it is on older
+  // If no activity for 30 seconds, the node is dead
+  // 35 seconds allows plenty of time for resends etc. even if the above is 14 sec as it is on older
   // nodes.
   /** Inactivity timeout after which a peer is considered dead (milliseconds). */
   public static final long MAX_PEER_INACTIVITY = SECONDS.toMillis(35);
@@ -222,8 +220,6 @@ public class Node implements TimeSkewDetectorCallback {
 
   private String myName;
 
-  // location manager and peers live in network subsystem
-
   /** Node-reference directory (node identity, peers, etc.) */
   private final ProgramDirectory nodeDir;
 
@@ -276,7 +272,7 @@ public class Node implements TimeSkewDetectorCallback {
   /** Threshold in milliseconds defining a "low" backoff period for inserts. */
   public static final long LOW_BACKOFF = SECONDS.toMillis(30);
 
-  /** Default policy for prioritizing inserts on accept. */
+  /** Default policy for prioritizing inserts on acceptance. */
   public static final boolean PREFER_INSERT_DEFAULT = false;
 
   /** Default policy for forking insert when an item becomes cacheable. */
@@ -326,9 +322,9 @@ public class Node implements TimeSkewDetectorCallback {
 
   /**
    * The bootID of the last time the node booted up. Or -1 if we don't know due to permissions
-   * problems, or we suspect that the node has been booted and not written the file e.g. if we can't
-   * write it. So if we want to compare data gathered in the last session and only recorded to disk
-   * on a clean shutdown to data we have now, we just include the lastBootID.
+   * problems, or we suspect that the node has been booted and not written the file e.g., if we
+   * can't write it. So if we want to compare data gathered in the last session and only recorded to
+   * disk on a clean shutdown to data we have now, we just include the lastBootID.
    */
   private final long lastBootID;
 
@@ -357,7 +353,7 @@ public class Node implements TimeSkewDetectorCallback {
   /**
    * Minimum uptime for us to consider a node an acceptable place to store a key. We store a key to
    * the datastore only if it's from an insert, and we are a sink, but when calculating whether we
-   * are a sink we ignore nodes which have less uptime (percentage) than this parameter.
+   * are a sink, we ignore nodes which have less uptime (percentage) than this parameter.
    */
   static final int MIN_UPTIME_STORE_KEY = 40;
 
@@ -370,7 +366,7 @@ public class Node implements TimeSkewDetectorCallback {
   /**
    * Minimum bandwidth limit in bytes considered usable: 10 KiB. If there is an attempt to set a
    * limit below this - excluding the reserved -1 for input bandwidth - the callback will throw. See
-   * the callbacks for outputBandwidthLimit and inputBandwidthLimit. 10 KiB are equivalent to 50 GiB
+   * the callbacks for outputBandwidthLimit and inputBandwidthLimit. 10 KiB is equivalent to 50 GiB
    * traffic per month.
    */
   private static final int MINIMUM_BANDWIDTH = 10 * 1024;
@@ -381,7 +377,7 @@ public class Node implements TimeSkewDetectorCallback {
    * <p>This accessor exposes the hard floor enforced by bandwidth configuration callbacks. Values
    * below this threshold are treated as invalid because they would effectively stall node traffic.
    * The threshold does not apply to the reserved input-bandwidth sentinel value {@code -1}, which
-   * is handled separately by the configuration logic. The method is pure and side-effect free.
+   * is handled separately by the configuration logic. The method is pure and side-effect-free.
    *
    * @return minimum acceptable bandwidth limit, expressed in bytes per second.
    * @see #MINIMUM_BANDWIDTH
@@ -506,7 +502,7 @@ public class Node implements TimeSkewDetectorCallback {
    *
    * @param args command-line arguments forwarded to the wrapper-managed launcher; may be empty.
    */
-  public static void main(String[] args) {
+  static void main(String[] args) {
     NodeStarter.main(args);
   }
 
@@ -542,9 +538,9 @@ public class Node implements TimeSkewDetectorCallback {
    *
    * @param config The Config object for this node.
    * @param r The random number generator for this node. Passed in because we may want to use a
-   *     non-secure RNG for e.g. one-JVM live-code simulations. Should be a Yarrow in a production
+   *     non-secure RNG for e.g., one-JVM live-code simulations. Should be a Yarrow in a production
    *     node. Yarrow will be used if that parameter is null
-   * @param weakRandom The fast random number generator the node will use. If null an MT instance
+   * @param weakRandom The fast random number generator the node will use. If null, an MT instance
    *     will be used, seeded from the secure PRNG.
    * @param ns NodeStarter
    * @param executor Executor
@@ -839,11 +835,11 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
 
     /*
      * On Windows, setting the file length normally involves writing lots of zeros.
-     * So it's an uninterruptible system call that takes a loooong time. On OS/X,
+     * So it's an uninterruptible system call that takes a long time. On OS/X,
      * presumably the same is true. If the RNG is fast enough, this means that
      * setting the length and writing random data take exactly the same amount
-     * of time. On most versions of Unix, holes can be created. However on all
-     * systems, predictable disk usage is a good thing. So lets turn it on by
+     * of time. On most versions of Unix, holes can be created. However, on all
+     * systems, predictable disk usage is a good thing. So let's turn it on by
      * default for now, on all systems. The datastore can be read but mostly not
      * written while the random data is being written.
      */
@@ -1099,9 +1095,9 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     // Short timeouts and JVM timeouts with nothing more said than the above have been seen...
     // I don't know why... need a stack dump...
     // For now just give it an extra 2 minutes. If it doesn't start in that time,
-    // it's likely (on reports so far) that a restart will fix it.
+    // it's likely (from reports so far) that a restart will fix it.
     // And we have to get a build out because ALL plugins are now failing to load,
-    // including the absolutely essential (for most nodes) JSTUN and UPnP.
+    // including the essential (for most nodes) JSTUN and UPnP.
     WrapperManager.signalStarting((int) MINUTES.toMillis(2));
 
     FetchContext ctx = services.clientCore().makeClient((short) 0, true, false).getFetchContext();
@@ -1124,7 +1120,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
 
     // Note: this is a hack
     // toadlet server should start after all initialized
-    // see NodeClientCore line 437
+    // to see NodeClientCore line 437
     finishToadletsIfEnabled();
 
     LOG.info("Node constructor completed");
@@ -1148,7 +1144,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
 
   private int registerMasterKeyFileConfig(SubConfig nodeConfig, int sortOrder)
       throws NodeInitException {
-    // Location of master key
+    // Location of the master key
     nodeConfig.register(
         "masterKeyFile",
         "master.keys",
@@ -1163,8 +1159,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
 
           @Override
           public void set(String val) throws InvalidConfigValueException {
-            // Localization may be needed
-            // Wipe the old one and move
+            // Localization may be needed to Wipe the old one and move
             throw new InvalidConfigValueException(
                 "Node.masterKeyFile cannot be changed on the fly, you must shutdown, wipe the old"
                     + " file and reconfigure");
@@ -1762,9 +1757,11 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
   private BootIdState initializeBootId() {
     // Boot ID
     long bootId = bootstrap.random().nextLong();
-    // Fixed length file containing boot ID. Accessed with random access file. So hopefully it will
-    // always be written. Note that we set lastBootID to -1 if we can't _write_ our ID as well as if
-    // we can't read it, because if we can't write it then we probably couldn't write it on the
+    // Fixed the length file containing boot ID. Accessed with a random access file. So hopefully it
+    // will
+    // always be written. Note that we set the lastBootID to -1 if we can't _write_ our ID as well
+    // as if
+    // we can't read it, because if we can't write it, then we probably couldn't write it on the
     // last bootup either.
     File bootIDFile = runDir.file("bootID");
     int bootFileLength = 64 / 4; // A long in padded hex bytes
@@ -1792,9 +1789,9 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
   }
 
   private void loadOrInitNodeFile(File nodeFile, File nodeFileBackup) {
-    // After we have set up testnet and IP address, load the node file
+    // After we have set up the testnet and IP address, load the node file
     try {
-      // May take file directly in the future.
+      // May take the file directly in the future.
       readNodeFile(nodeFile.getPath());
     } catch (IOException e) {
       try {
@@ -1969,7 +1966,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
   private void finishToadletsIfEnabled() {
     // Note: this is a hack
     // toadlet server should start after all initialized
-    // see NodeClientCore line 437
+    // to see NodeClientCore line 437
     if (services.toadlets().isEnabled()) {
       services.toadlets().finishStart();
       services.toadlets().createFproxy();
@@ -1987,7 +1984,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     else if (memoryLimit <= 128 * 1024 * 1024)
       defaultCacheSize = 0; // Turn off completely for very small memory.
     else {
-      // 9 stores, total should be 5% of memory, up to maximum of 1MB per store at 308MB+
+      // 9 stores, total should be 5% of memory, up to a maximum of 1MB per store at 308MB+
       defaultCacheSize = Math.min(1024L * 1024, (memoryLimit - 128L * 1024 * 1024) / (20 * 9));
     }
     return defaultCacheSize;
@@ -2040,7 +2037,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    *
    * @param installConfig configuration section to register and read the directory option from.
    * @param cfgKey option key under which the directory path is stored.
-   * @param defaultValue default path used when the option is unset; may be absolute or relative.
+   * @param defaultValue the default path used when the option is unset; may be absolute or
+   *     relative.
    * @param shortdesc i18n key for a short description shown to users.
    * @param longdesc i18n key for a longer description shown to users.
    * @param moveErrMsg message used when emitting errors during directory creation/move; may be
@@ -2085,7 +2083,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    *
    * @param installConfig configuration section to register and read the directory option from.
    * @param cfgKey option key under which the directory path is stored.
-   * @param defaultValue default path used when the option is unset; may be absolute or relative.
+   * @param defaultValue the default path used when the option is unset; may be absolute or
+   *     relative.
    * @param shortdesc i18n key for a short description shown to users.
    * @param longdesc i18n key for a longer description shown to users.
    * @return a {@link ProgramDirectory} bound to the resolved path and callbacks.
@@ -2106,10 +2105,10 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    *
    * <p>This method transitions the node from initialized to running by starting network
    * dispatchers, peers, routing maintenance, and service layers. It also starts the updater,
-   * applies startup logging, and persists configuration state. The call is not idempotent; callers
-   * should invoke it exactly once after construction. Startup ordering is significant, particularly
-   * for peer loading and dispatcher setup, so the method should not be interrupted or run
-   * concurrently.
+   * applies startup logging, and persists the configuration state. The call is not idempotent;
+   * callers should invoke it exactly once after construction. Startup ordering is significant,
+   * particularly for peer loading and dispatcher setup, so the method should not be interrupted or
+   * run concurrently.
    *
    * @param noSwaps when {@code true}, suppresses swap activity even if configured otherwise.
    * @throws NodeInitException if a required subsystem fails to initialize or start.
@@ -2189,7 +2188,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
   }
 
   /**
-   * Returns a human‑readable summary of current node status.
+   * Returns a human‑readable summary of the current node status.
    *
    * <p>The summary includes peer connectivity information and the current number of transferring
    * request senders. The exact formatting is intended for diagnostics or operator output rather
@@ -2277,9 +2276,9 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    * Quiesces the node so it can be stopped safely.
    *
    * <p>The method is idempotent and may be called multiple times, including during wrapper-driven
-   * shutdown sequences. It broadcasts disconnects to peers, persists configuration, and flushes any
-   * persistent random seed data. It does not block for full subsystem shutdown and should be used
-   * as a best-effort transition into a safe-to-exit state rather than a full stop barrier.
+   * shutdown sequences. It broadcasts, disconnects to peers, persists configuration, and flushes
+   * any persistent random seed data. It does not block for full subsystem shutdown and should be
+   * used as a best-effort transition into a safe-to-exit state rather than a full stop barrier.
    */
   public void park() {
     synchronized (this) {
@@ -2339,7 +2338,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    * Returns whether advanced mode is enabled in the client UI.
    *
    * <p>Advanced mode controls the visibility of expert settings and diagnostics. If the client core
-   * is not yet initialized, this method returns {@code false}. The value reflects current UI
+   * is not yet initialized, this method returns {@code false}. The value reflects the current UI
    * configuration and does not affect underlying networking behavior directly.
    *
    * @return {@code true} when advanced mode is enabled; {@code false} otherwise.
@@ -2381,9 +2380,9 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    * Accumulates payload bytes sent by the node.
    *
    * <p>Callers should supply the number of payload bytes (not including protocol overhead) for a
-   * completed send. The method performs a synchronized increment and does not validate the value,
-   * so callers must ensure the length is non-negative. It has no return value and is safe for
-   * concurrent use.
+   * completed sending. The method performs a synchronized increment and does not validate the
+   * value, so callers must ensure the length is non-negative. It has no return value and is safe
+   * for concurrent use.
    *
    * @param len number of payload bytes sent; must be non-negative.
    */
@@ -2428,8 +2427,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    * Returns the current maximum hop-to-live (HTL) value.
    *
    * <p>The value is derived from configuration and applies to routed requests that do not specify
-   * an explicit HTL. It is read-only from callers' perspective and does not perform synchronization
-   * because updates are serialized through configuration callbacks.
+   * an explicit HTL. It is read-only from the callers' perspective and does not perform
+   * synchronization because updates are serialized through configuration callbacks.
    *
    * @return maximum HTL value used by default for routing decisions.
    */
@@ -2462,10 +2461,10 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
   /**
    * Returns the node directory root (identity and peer files).
    *
-   * <p>This directory holds the node identity file, peer references, and other core state that is
-   * tied to the node's network identity. The value is derived from startup configuration and is
-   * stable for the lifetime of the process. Callers should not mutate the directory structure while
-   * the node is running.
+   * <p>This directory holds the node identity file, peer references, and other core states tied to
+   * the node's network identity. The value is derived from startup configuration and is stable for
+   * the lifetime of the process. Callers should not mutate the directory structure while the node
+   * is running.
    *
    * @return node directory path.
    */
@@ -2628,7 +2627,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    * Indicates whether opennet references are allowed to pass through darknet peers.
    *
    * <p>This setting affects how peer references are forwarded between networks. The method returns
-   * a snapshot of current configuration and is synchronized to align with updates from config
+   * a snapshot of the current configuration and is synchronized to align with updates from config
    * callbacks.
    *
    * @return {@code true} if opennet references may pass through darknet; {@code false} otherwise.
@@ -2673,7 +2672,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    *
    * <p>The decision depends on both the configuration flag and the provided hop-to-live value. The
    * method returns {@code false} for {@code htl <= 1} to avoid unnecessary routing heuristics on
-   * near-terminal hops. It is a pure check and does not modify state.
+   * near-terminal hops. It is a pure check and does not modify the state.
    *
    * @param htl hop-to-live value for the current request; must be non-negative.
    * @return {@code true} if peer-location routing should be applied; {@code false} otherwise.
@@ -2817,7 +2816,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
   /**
    * Returns whether the Slashdot cache is enabled.
    *
-   * <p>The Slashdot cache is a transient cache layer for frequently accessed blocks. When disabled
+   * <p>The Slashdot cache is a transient cache layer for frequently accessed blocks. When disabled,
    * the node still operates normally but may serve less effectively under load. This method is a
    * configuration snapshot with no side effects.
    *
@@ -2978,7 +2977,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    *
    * <p>The network subsystem owns peer managers, packet dispatchers, and transport configuration.
    * It is initialized during construction and started via {@link #start(boolean)}. Callers should
-   * treat the returned instance as node-owned shared state.
+   * treat the returned instance as a node-owned shared state.
    *
    * @return network subsystem instance.
    */
@@ -3108,8 +3107,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    * Returns the active {@link SecurityLevels} configuration.
    *
    * <p>The returned instance is owned by the node and may be mutated by configuration callbacks.
-   * Callers should treat it as shared mutable state and avoid storing long-lived references unless
-   * they can tolerate updates.
+   * Callers should treat it as a shared mutable state and avoid storing long-lived references
+   * unless they can tolerate updates.
    *
    * @return current security levels configuration instance.
    */
@@ -3165,8 +3164,8 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
    * Returns the non-persistent real-time request client.
    *
    * <p>This client issues real-time priority requests and does not persist state. It is suited for
-   * interactive operations where latency matters. The client is owned by the node; callers should
-   * treat it as shared and not attempt to close it directly.
+   * interactive operations where latency matters. The node owns the client; callers should treat it
+   * as shared and not attempt to close it directly.
    *
    * @return non-persistent real-time request client instance.
    */

--- a/src/main/java/network/crypta/node/simulator/RealNodeRequestInsertTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeRequestInsertTest.java
@@ -111,12 +111,11 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
    * The method is not idempotent because it deletes and recreates the working directory on each
    * run. It is intended to be executed from the command line in a controlled environment.
    *
-   * @throws CHKEncodeException if CHK key generation fails for the test payload
    * @throws NodeInitException if node initialization fails during test setup
    * @throws InterruptedException if the test thread is interrupted while waiting
    */
   @SuppressWarnings("unused")
-  static void main() throws CHKEncodeException, NodeInitException, InterruptedException {
+  static void main() throws NodeInitException, InterruptedException {
     String name = "realNodeRequestInsertTest";
     File wd = new File(name);
     if (!FileUtil.removeAll(wd)) {

--- a/src/main/java/network/crypta/node/simulator/RealNodeRoutingTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeRoutingTest.java
@@ -5,6 +5,7 @@ import network.crypta.crypt.DummyRandomSource;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.LocationManager;
 import network.crypta.node.Node;
+import network.crypta.node.NodeInitException;
 import network.crypta.node.NodeStarter;
 import network.crypta.support.PooledExecutor;
 import network.crypta.support.PriorityAwareExecutor;
@@ -20,8 +21,8 @@ import org.slf4j.event.Level;
  * Runs a deterministic routing simulation across a small in-process darknet mesh.
  *
  * <p>This class creates a fixed-size set of real nodes, wires them into a Kleinberg-style topology,
- * and repeatedly issues routed pings until the observed success rate reaches a target accuracy. It
- * is intended for manual, long-running experiments that compare routing behavior under different
+ * and repeatedly issues routed pings until the observed success rate reaches target accuracy. It is
+ * intended for manual, long-running experiments that compare routing behavior under different
  * configuration knobs, rather than for unit-test execution. The harness keeps the random seed
  * stable so that routing changes can be compared across runs, while still allowing natural timing
  * variance from the threaded node runtime.
@@ -58,7 +59,7 @@ public class RealNodeRoutingTest extends RealNodeTest {
    * Last darknet port reserved for the simulated node range, inclusive.
    *
    * <p>This value is derived from the base port and {@link #NUMBER_OF_NODES} so that the simulator
-   * can allocate a contiguous range without scanning. It is constant for a given run and is
+   * can allocate a contiguous range without scanning. It is constant for a given run and is a
    * read-only configuration used when setting up external tooling or log filters.
    */
   public static final int DARKNET_PORT_END = DARKNET_PORT_BASE + NUMBER_OF_NODES;
@@ -74,17 +75,17 @@ public class RealNodeRoutingTest extends RealNodeTest {
    * the network to connect and performs routed pings in cycles, logging location swaps and hop
    * statistics. The process exits with a non-zero status if it cannot prepare the working directory
    * or if the accuracy target is not reached within the configured maximum tests. This entry point
-   * is not intended to be idempotent because it wipes prior state on each run.
+   * is not intended to be idempotent because it wipes the prior state on each run.
    *
    * <pre>{@code
    * // Example: run the routing simulator from the command line.
    * RealNodeRoutingTest.main(new String[0]);
    * }</pre>
    *
-   * @param args ignored command-line arguments, typically an empty array for manual runs
-   * @throws Exception if node initialization or startup throws an unexpected checked failure
+   * @throws NodeInitException if node initialization fails while creating the test nodes
+   * @throws InterruptedException if the thread is interrupted while waiting for connectivity
    */
-  public static void main(String[] args) throws Exception {
+  static void main() throws NodeInitException, InterruptedException {
     LOG.info("Routing test using real nodes:");
     LOG.info("");
     String dir = "realNodeRequestInsertTest";
@@ -97,7 +98,7 @@ public class RealNodeRoutingTest extends RealNodeTest {
       LOG.error("Working directory could not be created: {}", wd.getAbsolutePath());
       System.exit(EXIT_CANNOT_DELETE_OLD_DATA);
     }
-    // NOTE: globalTestInit returns in ignored random source
+    // NOTE: globalTestInit returns in an ignored random source
     NodeStarter.globalTestInit(wd, false, Level.ERROR, "", true, null);
     // Make the network reproducible so we can easily compare different routing options by
     // specifying a seed.

--- a/src/main/java/network/crypta/support/PooledExecutor.java
+++ b/src/main/java/network/crypta/support/PooledExecutor.java
@@ -34,7 +34,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
   private static final Logger LOG = LoggerFactory.getLogger(PooledExecutor.class);
 
   /**
-   * Counts of workers that exist per priority (running + waiting). Subtract the corresponding
+   * Counts of workers that exist per priority (running and waiting). Subtract the corresponding
    * waiting count to estimate actively running workers.
    */
   private final int[] runningThreads = new int[NativeThread.JAVA_PRIORITY_RANGE + 1];
@@ -77,7 +77,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
   /**
    * No-op lifecycle hook kept for API compatibility.
    *
-   * <p>PooledExecutor creates worker threads lazily on first task submission and allows them to
+   * <p>PooledExecutor creates worker threads lazily on the first task submission and allows them to
    * expire after inactivity; there is no global start/shutdown state to initialize here.
    */
   public void start() {
@@ -279,7 +279,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
   }
 
   /** Immutable diagnostic sample for a worker thread. */
-  public static record DiagSample(int jobId, String name, long cpuTime) {}
+  public record DiagSample(int jobId, String name, long cpuTime) {}
 
   /**
    * Worker that executes tasks and returns to an idle state when finished.
@@ -428,7 +428,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
           // We observed an interrupt while idle: clear the status unconditionally so that user
           // code never starts with an unexpected interrupted flag, regardless of whether a job is
           // already assigned now or will be assigned just after we release this monitor.
-          // Capture the return value to satisfy static analysis (don’t ignore result).
+          // Capture the return value to satisfy static analysis (don’t ignore the result).
           boolean cleared = Thread.interrupted();
           if (LOG.isDebugEnabled()) {
             LOG.debug("Cleared interrupt status after idle interrupt (cleared={})", cleared);

--- a/src/main/java/network/crypta/tools/AddRef.java
+++ b/src/main/java/network/crypta/tools/AddRef.java
@@ -52,7 +52,7 @@ public class AddRef {
   private AddRef() {}
 
   /**
-   * Runs the AddRef command-line entry point, validating arguments and executing the add flow.
+   * Runs the AddRef command-line entry point, validating arguments and executing the adding flow.
    *
    * <p>This method configures console logging suitable for standalone execution, validates that a
    * reference file path is provided and readable, and then attempts to connect to the local FCP
@@ -64,7 +64,7 @@ public class AddRef {
    * @param args command-line arguments where {@code args[0]} is a readable reference file path
    *     suitable for {@link SimpleFieldSet#readFrom(File, boolean, boolean)}.
    */
-  public static void main(String[] args) {
+  static void main(String[] args) {
     configureStandaloneConsoleLogging();
     if (args.length < 1) {
       LOG.error("Please provide a file name as the first argument.");

--- a/src/main/java/org/bitpedia/collider/core/Bitprint.java
+++ b/src/main/java/org/bitpedia/collider/core/Bitprint.java
@@ -16,10 +16,10 @@ import org.bitpedia.util.TigerTree;
  *
  * <p>The class encapsulates the lifecycle needed to derive the combined binary digest used by the
  * Bitzi submission format: call {@link #analyzeInit()} to seed internal hashers, feed data chunks
- * through {@link #analyzeUpdate(byte[], int, int)}, then call {@link #analyzeFinal()} to obtain the
+ * through {@link #analyzeUpdate(byte[], int, int)}, then call {@link #analyzeFinal()} to get the
  * concatenated digest (SHA-1 bytes followed by Tiger Tree bytes). Clients are expected to encode
  * the result with {@link Base32} and split it at {@link #SHA_BASE32SIZE} characters when producing
- * the canonical dotted bitprint string. Instances maintain mutable state and are not thread-safe.
+ * the canonical dotted bitprint string. Instances maintain a mutable state and are not thread-safe.
  *
  * <p>Hashing is strictly forward-only: once {@link #analyzeFinal()} is called, the internal state
  * is consumed and the instance should be discarded or reinitialized before reuse. Built-in
@@ -79,7 +79,7 @@ public class Bitprint {
    * synchronization.
    */
   public Bitprint() {
-    // Constructor intentionally empty: lifecycle begins when analyzeInit() allocates hash state.
+    // Constructor intentionally empties: lifecycle begins when analyzeInit() allocates hash state.
   }
 
   /* NOTE: This function returns true if it failed the check! */
@@ -189,10 +189,8 @@ public class Bitprint {
    * Command-line entry point that runs the internal hash sanity check and logs the outcome. This
    * helper is intended for quick verification that the embedded SHA-1 and Tiger Tree
    * implementations produce the expected vectors on the current platform.
-   *
-   * @param args command-line arguments; ignored because the self-test uses built-in sample data.
    */
-  public static void main(String[] args) {
+  static void main() {
 
     if (hashSanityCheck()) {
       LOGGER.info("Hash test FAILED");

--- a/src/main/java/org/bitpedia/util/Base32.java
+++ b/src/main/java/org/bitpedia/util/Base32.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
  *   <li>Optimizes shifts to avoid temporary byte arrays while preserving deterministic output.
  * </ul>
  *
- * <p>Typical flow: supply a byte array to {@link #encode(byte[])} to obtain its textual form, then
+ * <p>Typical flow: supply a byte array to {@link #encode(byte[])} to get its textual form, then
  * later feed that string to {@link #decode(String)} to restore the original bytes. Because padding
  * is omitted, consumers must rely on external framing to detect truncation. Input arguments must be
  * non-null; callers retain ownership of provided buffers.
@@ -58,7 +58,7 @@ public class Base32 {
    * Callers should prefer the static utility methods unless dependency injection or reflective
    * creation requires an instance.
    */
-  public Base32() {
+  private Base32() {
     // Constructor intentionally empty because the utility holds no instance state or resources.
   }
 
@@ -113,7 +113,7 @@ public class Base32 {
   /**
    * Decodes an unpadded Base32 string into its original byte sequence.
    *
-   * <p>The decoder tolerates and skips characters outside the Base32 alphabet so callers may pass
+   * <p>The decoder tolerates and skips characters outside the Base32 alphabet, so callers may pass
    * strings containing whitespace or incidental punctuation. Bits are reassembled in order; when
    * the input length is not a multiple of eight characters, the final byte may be partially filled,
    * mirroring the behavior of the original Bitzi implementation. The returned array has a
@@ -128,7 +128,7 @@ public class Base32 {
    *
    * @param base32 text to decode; characters outside {@code A-Z2-7} are ignored rather than failing
    *     the operation
-   * @return newly allocated byte array containing the decoded data in original order
+   * @return newly allocated byte array containing the decoded data in the original order
    */
   public static byte[] decode(final String base32) {
     byte[] bytes = new byte[base32.length() * 5 / 8];
@@ -174,7 +174,7 @@ public class Base32 {
    * @param args command-line arguments where {@code args[0]} should hold a Base32-encoded payload;
    *     additional elements are ignored
    */
-  public static void main(String[] args) {
+  static void main(String[] args) {
     if (args.length == 0) {
       LOGGER.info("Supply a Base32-encoded argument.");
       return;

--- a/src/main/java/org/spaceroots/mantissa/ode/FixedStepHandler.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/FixedStepHandler.java
@@ -3,11 +3,11 @@ package org.spaceroots.mantissa.ode;
 /**
  * This interface represents a handler that should be called after each successful fixed step.
  *
- * <p>This interface should be implemented by anyone who is interested in getting the solution of an
+ * <p>This interface should be implemented by anyone interested in getting the solution of an
  * ordinary differential equation at fixed time steps. Objects implementing this interface should be
  * wrapped within an instance of {@link StepNormalizer} that itself is used as the general {@link
  * StepHandler} by the integrator. The {@link StepNormalizer} object is called according to the
- * integrator internal algorithms and it calls objects implementing this interface as necessary at
+ * integrator internal algorithms, and it calls objects implementing this interface as necessary at
  * fixed time steps.
  *
  * @see StepHandler
@@ -22,10 +22,10 @@ public interface FixedStepHandler {
    *
    * @param t time of the current step
    * @param y state vector at t. For efficiency purposes, the {@link StepNormalizer} class reuse the
-   *     same array on each call, so if the instance wants to keep it across all calls (for example
+   *     same array on each call, so if the instance wants to keep it across all calls (for example,
    *     to provide at the end of the integration a complete array of all steps), it should build a
    *     local copy store this copy.
    * @param isLast true if the step is the last one
    */
-  public void handleStep(double t, double[] y, boolean isLast);
+  void handleStep(double t, double[] y, boolean isLast);
 }

--- a/src/main/java/org/spaceroots/mantissa/quadrature/vectorial/ComputableFunctionIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/quadrature/vectorial/ComputableFunctionIntegrator.java
@@ -15,8 +15,8 @@ import org.spaceroots.mantissa.functions.vectorial.ComputableFunction;
  * reuse scratch buffers, or allocate per call, but they all guarantee that the returned vector
  * corresponds to the definite integral from {@code a} to {@code b}, preserving sign when the bounds
  * are reversed. Unless stated otherwise by a concrete class, instances are not guaranteed to be
- * thread-safe; prefer one integrator per concurrent integration task to avoid shared mutable state.
- * Callers remain responsible for ensuring that the supplied function is side-effect free or
+ * thread-safe; prefer one integrator per concurrent integration task to avoid a shared mutable
+ * state. Callers remain responsible for ensuring that the supplied function is side-effect free or
  * otherwise safe to sample repeatedly.
  *
  * <ul>
@@ -56,5 +56,5 @@ public interface ComputableFunctionIntegrator {
    * @throws FunctionException if evaluating the supplied function fails or signals an unrecoverable
    *     condition during integration
    */
-  public double[] integrate(ComputableFunction f, double a, double b) throws FunctionException;
+  double[] integrate(ComputableFunction f, double a, double b) throws FunctionException;
 }


### PR DESCRIPTION
## Summary
- refine Javadoc wording and punctuation across utility, node, and simulator sources
- narrow demo/main entry points and constructor visibility for internal helpers
- align interface methods with implicit public visibility