### PR TITLE
Refine docs and utility helpers

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/AddPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/AddPeer.java
@@ -26,6 +26,7 @@ import network.crypta.node.OpennetDisabledException;
 import network.crypta.node.PeerNode;
 import network.crypta.node.PeerTooOldException;
 import network.crypta.node.RequestStarter;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.support.MediaType;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
@@ -216,7 +217,7 @@ public class AddPeer extends FCPMessage {
    *     any trailing newline characters
    * @throws IOException if reading the fetched data from the node fails due to I/O errors in the
    *     underlying stream
-   * @throws FetchException if the URI cannot be fetched successfully, for example due to routing
+   * @throws FetchException if the URI cannot be fetched successfully, for example, due to routing
    *     failures, timeouts, or protocol-level error responses
    */
   public static StringBuilder getReferenceFromFreenetURI(

--- a/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import network.crypta.client.Metadata;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.node.Node;
+import network.crypta.node.subsystem.NodeServicesSubsystem;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.ManifestElement;
@@ -29,12 +30,13 @@ import org.slf4j.LoggerFactory;
  * <p>Larger directory puts benefit from this class because it keeps metadata, MIME hints, and
  * {@link ManifestElement ManifestElements} adjacent to their payloads while enforcing sequential
  * numbering and ordering rules. Error reporting distinguishes between malformed hierarchies, access
- * restrictions, and I/O problems so the client can retry selectively.
+ * restrictions, and I/O problems, so the client can retry selectively.
  *
  * <ul>
  *   <li>Builds a nested {@code Map} structure that mirrors directory layout before dispatch.
  *   <li>Streams {@code UploadFrom=direct} payloads in alphabetical order to avoid buffering.
- *   <li>Validates disk-sourced files against {@link Node#getClientCore()} upload policy.
+ *   <li>Validates disk-sourced files against {@link NodeServicesSubsystem#clientCore()} upload
+ *       policy.
  * </ul>
  *
  * <p>Example payload:
@@ -80,7 +82,7 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
    *
    * @param fs structured field set describing {@code Files.*} entries plus metadata
    * @param bfTemp transient bucket factory for non-forever uploads and streaming buffers
-   * @param bfPersistent persistent bucket factory keeping FOREVER payloads durably available
+   * @param bfPersistent a persistent bucket factory keeping FOREVER payloads durably available
    * @throws MessageInvalidException if mandatory headers are missing or hierarchy rules break
    */
   public ClientPutComplexDirMessage(
@@ -158,7 +160,7 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
   /**
    * Returns the canonical command name advertised to the FCP layer and logging facilities.
    *
-   * <p>The identifier is a constant shared by every instance so routers can compare it cheaply
+   * <p>The identifier is a constant shared by every instance, so routers can compare it cheaply
    * against incoming tokens and dispatch without additional allocations. It is also used by unit
    * tests to assert protocol compatibility when future versions add optional fields.
    *
@@ -192,7 +194,7 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
    * @param is decoded message continuation stream containing the concatenated direct payload bytes
    * @param bf bucket factory already selected for this request, reused for direct attachments
    * @param server FCP server orchestrating the client session, never {@code null}
-   * @throws IOException if the socket or bucket write fails while copying payload bytes
+   * @throws IOException if the socket or bucket writing fails while copying payload bytes
    * @throws MessageInvalidException if read sizes mismatch declarations or validation rejects input
    */
   @Override
@@ -227,12 +229,12 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
    * Converts parsed files into {@link ManifestElement} trees and instructs the handler to start the
    * directory insert.
    *
-   * <p>During execution the method validates disk-backed files through {@link Node#getClientCore()}
-   * before constructing the manifest, thereby ensuring policy compliance without touching the
-   * network. The resulting map mirrors the original hierarchy so downstream components can process
-   * nested directories without recomputing paths. The insert begins immediately afterward, and any
-   * {@link MessageInvalidException} bubbles up to the caller so the FCP client receives actionable
-   * feedback.
+   * <p>During execution the method validates disk-backed files through {@link
+   * NodeServicesSubsystem#clientCore()} before constructing the manifest, thereby ensuring policy
+   * compliance without touching the network. The resulting map mirrors the original hierarchy, so
+   * downstream components can process nested directories without recomputing paths. The insert
+   * begins immediately afterward, and any {@link MessageInvalidException} bubbles up to the caller
+   * so the FCP client receives actionable feedback.
    *
    * @param handler active connection handler responsible for initiating the put job
    * @param node node instance that supplies policy checks and storage context for the request

--- a/src/main/java/network/crypta/clients/fcp/ListPeersMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeersMessage.java
@@ -2,18 +2,19 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.support.SimpleFieldSet;
 
 /**
- * Represents the {@code ListPeers} FCP command sent from a client to the node to obtain the current
+ * Represents the {@code ListPeers} FCP command sent from a client to the node to get the current
  * set of known peers.
  *
- * <p>This message is read-only and simply instructs the node to enumerate its peers without
- * changing state. Instances are immutable once created; the flags provided by the client are stored
- * in final fields and reused when generating individual peer responses. Typical callers create one
- * instance per request, hand it to the {@link FCPConnectionHandler}, and rely on the handler to
- * stream {@link PeerMessage} objects back to the client followed by {@link EndListPeersMessage} as
- * a terminator.
+ * <p>This message is read-only and simply instructs the node to list its peers without changing
+ * state. Instances are immutable once created; the flags provided by the client are stored in final
+ * fields and reused when generating individual peer responses. Typical callers create one instance
+ * per request, hand it to the {@link FCPConnectionHandler}, and rely on the handler to stream
+ * {@link PeerMessage} objects back to the client followed by {@link EndListPeersMessage} as a
+ * terminator.
  *
  * <p>Use this command when a UI or monitoring tool needs a snapshot of active peers along with
  * optional metadata or volatile runtime statistics. The message runs within the handler's thread

--- a/src/main/java/network/crypta/clients/fcp/RemovePeer.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePeer.java
@@ -2,6 +2,7 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -45,9 +46,8 @@ public class RemovePeer extends FCPMessage {
    * <p>The constructor reads the {@code Identifier} field from the supplied {@link SimpleFieldSet}
    * to keep it available for later replies and removes it from the mutable field set to avoid
    * accidental forwarding. The remaining fields, including {@code NodeIdentifier}, are processed
-   * during {@link #run(FCPConnectionHandler, Node)}. The supplied field set is retained by
-   * reference, so callers should not modify it after construction if consistent behavior is
-   * required.
+   * during {@link #run(FCPConnectionHandler, Node)}. Reference retains the supplied field set, so
+   * callers should not modify it after construction if consistent behavior is required.
    *
    * @param fs inbound protocol fields for this request; must contain {@code Identifier} and is
    *     expected to contain {@code NodeIdentifier} when {@link #run(FCPConnectionHandler, Node)} is
@@ -64,8 +64,8 @@ public class RemovePeer extends FCPMessage {
    * during dispatch.
    *
    * <p>The returned instance is freshly allocated and marked as case-insensitive, matching the
-   * expectations of other FCP message builders. Callers can treat it as immutable for the purposes
-   * of sending but should avoid caching it across messages because it carries no payload.
+   * expectations of other FCP message builders. Callers can treat it as immutable for sending but
+   * should avoid caching it across messages because it carries no payload.
    *
    * @return new {@link SimpleFieldSet} with no entries, suitable for immediate transmission.
    */
@@ -111,7 +111,7 @@ public class RemovePeer extends FCPMessage {
    *     privileges for the operation to proceed and must not be null.
    * @param node target node on which the peer should be removed; must not be null and must support
    *     lookup of the specified node identifier.
-   * @throws MessageInvalidException when access is denied or required fields are absent, halting
+   * @throws MessageInvalidException when access is denied or required, fields are absent, halting
    *     further processing and surfacing a protocol-level error to the caller.
    */
   @Override

--- a/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
@@ -7,6 +7,7 @@ import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
 import network.crypta.node.NodeFile;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>Collects threat-level choices and optionally enforces a master password.
  *   <li>Suggests datastore and bandwidth limits based on detected capabilities.
- *   <li>Redirects to {@link WelcomeToadlet#PATH} after successful completion.
+ *   <li>Redirects to {@link WelcomeToadlet#ROOT_PATH} after successful completion.
  * </ul>
  *
  * @see WebTemplateToadlet
@@ -58,7 +58,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
 
   /**
    * Public URL prefix under which the wizard is mounted; used by {@link #path()} and redirects from
-   * the legacy flow. The value is stable so bookmarks and deep links continue to work across
+   * the legacy flow. The value is stable, so bookmarks and deep links continue to work across
    * releases.
    */
   public static final String TOADLET_URL = "/wiz/";
@@ -123,7 +123,8 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
       return;
     }
 
-    // if threat level is high, the password must already be set: user is running the wizard again?
+    // if the threat level is high, the password must already be set: user is running the wizard
+    // again?
     isPasswordAlreadySet =
         core.getNode().services().securityLevels().getPhysicalThreatLevel()
             == SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH;
@@ -139,7 +140,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
    * in a {@code FormModel}, validated for bandwidth, datastore size, and optional password rules,
    * then saved when no errors are present. A successful submission triggers a temporary redirect to
    * the welcome page; otherwise the form is displayed again with localized error messages. The
-   * method performs no partial saves on invalid input, keeping configuration atomic.
+   * method performs no partial saves on invalid input, keeping the configuration atomic.
    *
    * @param uri the original request URI supplied by the toadlet container
    * @param request the request body carrying the form fields to validate and apply
@@ -325,7 +326,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
               l10n("valid.uploadLimit", Integer.toString(Node.getMinimumBandwidth() / KIB)));
         }
         int nanosInSecond = (int) SECONDS.toNanos(1);
-        if (nanosInSecond < parsedUploadLimit) { // see Node set outputBandwidthLimit
+        if (nanosInSecond < parsedUploadLimit) { // see the Node set outputBandwidthLimit
           errors.put(
               UPLOAD_LIMIT_ERROR_KEY,
               l10n("valid.uploadLimitMax", Integer.toString(nanosInSecond / KIB)));
@@ -412,7 +413,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
             BandwidthManipulator.detectBandwidthLimits(
                 core.getNode().network().ipDetector().getBandwidthIndicator());
 
-        // Detected limits reasonable; add half of both as recommended option.
+        // Detected limits reasonable; add half of both as a recommended option.
         downloadLimitDetected = Long.toString(detected.downBytes / 2 / KIB);
         uploadLimitDetected = Long.toString(detected.upBytes / 2 / KIB);
       } catch (PluginNotFoundException | IllegalValueException e) {

--- a/src/main/java/network/crypta/crypt/CryptByteBufferType.java
+++ b/src/main/java/network/crypta/crypt/CryptByteBufferType.java
@@ -33,7 +33,7 @@ public enum CryptByteBufferType implements Serializable {
   /**
    * AES in CTR mode with no padding.
    *
-   * <p>Key size is 256 bits (via {@link KeyType#AES256}); the IV/nonce length is 16 bytes. The JCE
+   * <p>Key size is 256 bits (via {@link KeyType#AES_256}); the IV/nonce length is 16 bytes. The JCE
    * transformation string is {@code AES/CTR/NOPADDING}.
    */
   AESCTR(16, 16, "AES/CTR/NOPADDING", KeyType.AES_256),
@@ -42,7 +42,7 @@ public enum CryptByteBufferType implements Serializable {
    * ChaCha with a 128-bit key and 8-byte nonce.
    *
    * <p>The JCE algorithm name is {@code CHACHA}. This entry models the historical configuration
-   * that uses an 8-byte nonce; newer variants commonly use larger nonces but must remain compatible
+   * that uses 8-byte nonce; newer variants commonly use larger nonce but must remain compatible
    * with persisted data in this codebase.
    */
   CHACHA_128(32, 8, "CHACHA", KeyType.CHACHA_128),

--- a/src/main/java/network/crypta/crypt/ECDH.java
+++ b/src/main/java/network/crypta/crypt/ECDH.java
@@ -19,29 +19,119 @@ import javax.crypto.KeyAgreement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Performs Elliptic Curve Diffie-Hellman key agreement for a single key pair.
+ *
+ * <p>This class owns a fixed {@link java.security.KeyPair} generated for a selected {@link Curves}
+ * entry and exposes helpers to serialize the public key and derive a raw shared secret for a peer.
+ * Callers typically construct an instance per session or connection, exchange public keys, and then
+ * invoke {@link #getAgreedSecret(ECPublicKey)} once to derive bytes that are fed into a separate
+ * KDF. The implementation relies on provider selection performed by {@link Curves}, which performs
+ * self-tests and may fall back to BouncyCastle when the default providers are incompatible.
+ *
+ * <p>Instances are effectively immutable after construction: the key pair and curve metadata do not
+ * change. The only mutable state is a cached provider-specific generator inside {@link Curves}
+ * which is synchronized there. Use one {@code ECDH} instance per participant and avoid reusing a
+ * shared secret across multiple contexts.
+ *
+ * <ul>
+ *   <li>Generates and holds a curve-specific key pair.
+ *   <li>Provides public key bytes in standard X.509 form.
+ *   <li>Derives a raw ECDH secret for a peer public key.
+ * </ul>
+ *
+ * @see Curves
+ * @see #getAgreedSecret(ECPublicKey)
+ */
 public class ECDH {
   private static final Logger LOG = LoggerFactory.getLogger(ECDH.class);
 
+  /**
+   * Selected curve parameters for this instance and its underlying key material.
+   *
+   * <p>This value is set at construction time and never changes. It determines the EC parameters,
+   * expected encoded key sizes, and which providers were selected after the curve self-tests.
+   */
   public final Curves curve;
+
   private final KeyPair key;
 
+  /**
+   * Supported named curves with provider-specific initialization and size metadata.
+   *
+   * <p>Each constant corresponds to an NIST prime curve and records the expected encoded public key
+   * length along with the derived shared secret length. The constructor eagerly initializes
+   * KeyPairGenerator, KeyFactory, and KeyAgreement providers, running a self-test to ensure the
+   * default provider behaves correctly. When that self-test fails, the code falls back to
+   * BouncyCastle and logs which provider is selected.
+   *
+   * <p>The enum also exposes a cached {@link KeyPairGenerator}. Access is synchronized to avoid
+   * repeated initialization, so caller code can safely request new key pairs without redoing the
+   * provider setup.
+   *
+   * <ul>
+   *   <li>Encapsulates curve names and EC parameter specs.
+   *   <li>Tracks expected modulus and shared secret lengths.
+   *   <li>Performs provider self-tests and fallback handling.
+   * </ul>
+   */
   public enum Curves {
-    // rfc5903 or rfc6460: it's NIST's random/prime curves : suite B
+    // rfc5903 or rfc6460: it's NIST's random/prime curves: suite B
     // Order matters. Append to the list, do not re-order.
+    /**
+     * NIST P-256 curve with a 91-byte X.509 encoding and 32-byte shared secret.
+     *
+     * <p>Use this curve for the smallest key size in this enum while still providing widely
+     * supported ECDH interoperability. The size values are used for validation and network-format
+     * comparisons; callers should still apply a KDF before use.
+     */
     P256("secp256r1", 91, 32),
+    /**
+     * NIST P-384 curve with a 120-byte X.509 encoding and 48-byte shared secret.
+     *
+     * <p>This curve offers a higher security margin than P-256 at the cost of larger keys and more
+     * CPU time during agreement. The sizes reflect the encoded public key and raw secret length
+     * used by the implementation.
+     */
     P384("secp384r1", 120, 48),
+    /**
+     * NIST P-521 curve with a 158-byte X.509 encoding and 66-byte shared secret.
+     *
+     * <p>Select this curve when the highest strength is required and larger payloads are
+     * acceptable. The encoded public key size is checked by {@link #getPublicKeyNetworkFormat()} to
+     * detect unexpected output lengths.
+     */
     P521("secp521r1", 158, 66);
 
+    /**
+     * EC parameter spec derived from the curve name for provider initialization.
+     *
+     * <p>This spec is used to initialize {@link KeyPairGenerator} and other EC primitives. It is
+     * immutable and shared by all calls for the curve, so callers can treat it as a stable,
+     * read-only description of the EC domain parameters.
+     */
     public final ECGenParameterSpec spec;
+
     private KeyPairGenerator keygenCached;
     private final Provider kgProvider;
     private final Provider kfProvider;
     private final Provider kaProvider;
 
-    /** Expected size of a pubkey */
+    /**
+     * Expected size of the encoded public key in bytes for this curve.
+     *
+     * <p>The value is used to validate the X.509 encoding returned from provider APIs. The encoded
+     * length can vary between providers, so this value is checked to detect out-of-range output and
+     * to guide logging when smaller encodings appear.
+     */
     public final int modulusSize;
 
-    /** Expected size of the derived secret (in bytes) */
+    /**
+     * Expected size of the raw derived secret in bytes for this curve.
+     *
+     * <p>This value is used by callers to validate ECDH output length expectations. The secret is
+     * raw ECDH output and must be processed by a KDF before use as a symmetric key.
+     */
     public final int derivedSecretSize;
 
     /** Verify KeyPairGenerator and KeyFactory work correctly */
@@ -74,7 +164,7 @@ public class ECDH {
       KeyAgreement ka = null;
       KeyFactory kf = null;
       KeyPairGenerator kg = null;
-      // Ensure providers class is initialized; also log which provider instance is visible.
+      // Ensure the providers class is initialized; also log which provider instance is visible.
       LOG.trace("BouncyCastle provider: {}", JceLoader.BouncyCastle);
       try {
         KeyPair key;
@@ -195,6 +285,17 @@ public class ECDH {
       return kg;
     }
 
+    /**
+     * Generates a new EC key pair using the cached provider for this curve.
+     *
+     * <p>The first call lazily initializes the {@link KeyPairGenerator} with the stored curve spec;
+     * later calls reuse the cached instance. If provider initialization failed during enum
+     * construction, this call may throw a runtime exception when the generator is missing. The
+     * returned key pair is independent of any other instance and is safe to retain for the lifetime
+     * of a session.
+     *
+     * @return a newly generated {@link KeyPair} for the selected curve and provider.
+     */
     public synchronized KeyPair generateKeyPair() {
       return getKeyPairGenerator().generateKeyPair();
     }
@@ -206,9 +307,15 @@ public class ECDH {
   }
 
   /**
-   * Initialize the ECDH Exchange: this will draw some entropy
+   * Initializes a new ECDH instance with a freshly generated key pair for the given curve.
    *
-   * @param curve
+   * <p>Construction triggers key pair generation, which can draw entropy from the configured
+   * provider and may block depending on the system entropy source. The resulting key pair is stored
+   * for the life of this instance and used for all later ECDH operations. Callers typically create
+   * one instance per peer exchange and discard it after the session key material has been derived.
+   *
+   * @param curve the curve parameters and provider selection to use for key generation; must not be
+   *     {@code null} and should match peers that will exchange public keys.
    */
   public ECDH(Curves curve) {
     this.curve = curve;
@@ -216,11 +323,18 @@ public class ECDH {
   }
 
   /**
-   * Completes the ECDH exchange: this is CPU intensive.
+   * Computes the raw ECDH shared secret for the given peer public key.
    *
-   * @param pubkey the peer public key; when {@code null}, this method returns {@code null}
-   * @return the raw ECDH shared secret or {@code null} on failure (including {@code null} input).
-   *     The returned value must be fed into a KDF before use.
+   * <p>The agreement step allocates a new {@link KeyAgreement} instance each call, initializes it
+   * with this instance's private key, and completes the ECDH phase using the provided public key.
+   * The returned bytes are the raw ECDH output and must be passed through a KDF before use as a
+   * symmetric key. This method is CPU intensive and will return {@code null} if the input is {@code
+   * null} or if the provider rejects the key.
+   *
+   * @param pubkey the peer public key to combine with this instance's private key; must be an EC
+   *     key on the same curve, or {@code null} to indicate no agreement is possible.
+   * @return the raw ECDH shared secret bytes, or {@code null} when input is {@code null} or
+   *     agreement fails due to provider errors.
    */
   @SuppressWarnings("java:S1168")
   public byte[] getAgreedSecret(ECPublicKey pubkey) {
@@ -243,15 +357,33 @@ public class ECDH {
     return null;
   }
 
+  /**
+   * Returns the public key associated with this instance's key pair.
+   *
+   * <p>The returned key is the EC public component generated at construction time. Callers can use
+   * it for key exchange or serialize it via {@link #getPublicKeyNetworkFormat()} or {@link
+   * #getPublicKey(byte[], Curves)}. The key object is owned by this instance but is safe to share
+   * as it is immutable.
+   *
+   * @return the EC public key for this instance.
+   */
   public ECPublicKey getPublicKey() {
     return (ECPublicKey) key.getPublic();
   }
 
   /**
-   * Returns an ECPublicKey from bytes obtained using ECPublicKey.getEncoded()
+   * Reconstructs an EC public key from X.509-encoded bytes.
    *
-   * @param data
-   * @return ECPublicKey or null if it fails
+   * <p>This helper uses the curve's selected {@link KeyFactory} provider to decode the key bytes
+   * that were previously produced by {@link ECPublicKey#getEncoded()}. If decoding fails, the
+   * method logs the error and returns {@code null}. The curve parameter guides which provider is
+   * used; callers should ensure the bytes correspond to the same curve or agreement will fail.
+   *
+   * @param data the X.509-encoded EC public key bytes; must not be {@code null} and should be in
+   *     the provider's expected format.
+   * @param curve the curve metadata and provider selection to use for decoding; must match the
+   *     curve used to create the encoded key.
+   * @return the decoded {@link ECPublicKey}, or {@code null} when decoding fails.
    */
   public static ECPublicKey getPublicKey(byte[] data, Curves curve) {
     ECPublicKey remotePublicKey = null;
@@ -270,13 +402,14 @@ public class ECDH {
   }
 
   /**
-   * Initialize the key pair generators, which in turn will create the global SecureRandom, which
-   * may block waiting for entropy from /dev/random on unix-like systems. So this should be called
-   * on startup during the "may block for entropy" stage. Note that because this can block, we still
-   * have to do lazy initialisation: We do NOT want to have it blocking *at time of loading the
-   * classes*, as this will likely appear as the node completely failing to load. Running this after
-   * fproxy has started, with a warning timer, allows us to tell the user what is going on if it
-   * takes a while.
+   * Pre-initializes key pair generators to allow the entropy collection at startup.
+   *
+   * <p>Initializing EC key generators may create the JVM-wide {@code SecureRandom}, which can block
+   * while gathering entropy from {@code /dev/random} on Unix-like systems. Call this during a
+   * controlled startup stage where blocking is acceptable so the rest of the application does not
+   * appear hung. The method still leaves generators lazily initialized inside {@link Curves}, but
+   * it eagerly warms the most commonly used curve to make later ECDH operations fast and
+   * non-blocking.
    */
   public static void blockingInit() {
     Curves.P256.getKeyPairGenerator();
@@ -284,7 +417,19 @@ public class ECDH {
     // we need to init them explicitly.
   }
 
-  /** Return the public key as a byte[] in network format */
+  /**
+   * Returns the public key as an encoded byte array suitable for network transport.
+   *
+   * <p>The bytes are the X.509 encoding produced by the current provider. When the encoding is
+   * longer than the expected {@link Curves#modulusSize}, this method throws an exception because
+   * the output is not safe to send. When the encoding is shorter than expected, the method logs a
+   * warning but intentionally returns the unpadded bytes to preserve current behavior. Callers
+   * should treat the returned array as immutable.
+   *
+   * @return the encoded public key bytes in X.509 form, with length checks applied.
+   * @throws IllegalStateException when the provider returns a public key encoding longer than the
+   *     expected size for the curve.
+   */
   public byte[] getPublicKeyNetworkFormat() {
     byte[] ret = getPublicKey().getEncoded();
     if (ret.length == curve.modulusSize) {

--- a/src/main/java/network/crypta/crypt/EncryptedRandomAccessBucket.java
+++ b/src/main/java/network/crypta/crypt/EncryptedRandomAccessBucket.java
@@ -1,8 +1,23 @@
 package network.crypta.crypt;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.ObjectOutputStream.PutField;
+import java.io.ObjectStreamField;
 import java.io.OptionalDataException;
+import java.io.OutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
@@ -253,8 +268,8 @@ public class EncryptedRandomAccessBucket implements RandomAccessBucket, Serializ
   }
 
   static class MyOutputStream extends FilterOutputStream {
-    // Encrypts bytes on write using the configured stream cipher. The header has already been
-    // written by the caller.
+    // Encrypts bytes on writing using the configured stream cipher. The caller has already
+    // written the header.
     private final SkippingStreamCipher cipherWrite;
 
     public MyOutputStream(OutputStream out, SkippingStreamCipher cipher) {
@@ -345,7 +360,7 @@ public class EncryptedRandomAccessBucket implements RandomAccessBucket, Serializ
    * unbuffered; see {@link #getInputStream()} for a buffered variant.
    *
    * @return an unbuffered stream that decrypts data as it is read.
-   * @throws IOException if the bucket has been freed or the header is missing/invalid.
+   * @throws IOException if the bucket has been freed, or the header is missing/invalid.
    */
   @Override
   public InputStream getInputStreamUnbuffered() throws IOException {
@@ -394,7 +409,7 @@ public class EncryptedRandomAccessBucket implements RandomAccessBucket, Serializ
   }
 
   /**
-   * Marks the underlying bucket read-only. Subsequent write attempts will fail according to the
+   * Marks the underlying bucket read-only. Subsequent write attempts will fail, according to the
    * underlying implementation's contract.
    */
   @Override
@@ -405,7 +420,7 @@ public class EncryptedRandomAccessBucket implements RandomAccessBucket, Serializ
   /**
    * Releases resources held by this bucket and the underlying bucket.
    *
-   * <p>Safe to call multiple times; subsequent calls are no-ops.
+   * <p>Safe to call multiple times; later calls are no-ops.
    */
   @Override
   public void free() {

--- a/src/main/java/network/crypta/crypt/MultiHashDigester.java
+++ b/src/main/java/network/crypta/crypt/MultiHashDigester.java
@@ -3,12 +3,13 @@ package network.crypta.crypt;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import org.bitpedia.util.hash.StreamingHash;
 
 /**
  * Computes several cryptographic hashes over the same byte stream in one pass.
  *
  * <p>This utility owns one {@link java.security.MessageDigest} per {@link HashType} selected via a
- * bit mask. Feed data through {@link #update(byte[], int, int)} and obtain all results via {@link
+ * bit mask. Feed data through {@link #update(byte[], int, int)} and get all results via {@link
  * #getResults()}. The order of results follows {@link HashType#values()}.
  *
  * <p>Thread-safety: not thread-safe. Create a new instance per computation and use it from a single

--- a/src/main/java/network/crypta/io/InetAddressAddressTrackerItem.java
+++ b/src/main/java/network/crypta/io/InetAddressAddressTrackerItem.java
@@ -25,9 +25,9 @@ public class InetAddressAddressTrackerItem extends AddressTrackerItem {
    * Create a tracker for the given address with known upper bounds for the initial "no packets"
    * window.
    *
-   * @param timeDefinitelyNoPacketsReceived earliest time (ms since epoch) at which receiving was
-   *     definitely impossible for this address
-   * @param timeDefinitelyNoPacketsSent earliest time (ms since epoch) at which sending was
+   * @param timeDefinitelyNoPacketsReceived the earliest time (ms since epoch) at which receiving
+   *     was definitely impossible for this address
+   * @param timeDefinitelyNoPacketsSent the earliest time (ms since epoch) at which sending was
    *     definitely impossible
    * @param addr the {@link InetAddress} to track; the reference is stored as-is and not cloned
    */
@@ -70,8 +70,7 @@ public class InetAddressAddressTrackerItem extends AddressTrackerItem {
     try {
       addr = InetAddress.getByName(fs.getString("Address"));
     } catch (UnknownHostException e) {
-      throw (FSParseException)
-          new FSParseException("Unknown domain name in Address: " + e).initCause(e);
+      throw new FSParseException("Unknown domain name in Address: " + e, e);
     }
   }
 }

--- a/src/main/java/network/crypta/io/PeerAddressTrackerItem.java
+++ b/src/main/java/network/crypta/io/PeerAddressTrackerItem.java
@@ -28,10 +28,10 @@ public class PeerAddressTrackerItem extends AddressTrackerItem {
   /**
    * Creates an item with initial upper bounds and a concrete peer.
    *
-   * @param timeDefinitelyNoPacketsReceived earliest time at which receiving was impossible (for
+   * @param timeDefinitelyNoPacketsReceived the earliest time at which receiving was impossible (for
    *     example, socket startup), in milliseconds since epoch
-   * @param timeDefinitelyNoPacketsSent earliest time at which sending was impossible (for example,
-   *     node startup), in milliseconds since epoch
+   * @param timeDefinitelyNoPacketsSent the earliest time at which sending was impossible (for
+   *     example, node startup), in milliseconds since epoch
    * @param peer peer identity to track; must not be {@code null}
    */
   public PeerAddressTrackerItem(
@@ -56,11 +56,10 @@ public class PeerAddressTrackerItem extends AddressTrackerItem {
   public PeerAddressTrackerItem(SimpleFieldSet fs) throws FSParseException {
     super(fs);
     try {
-      // Disallow unknown hosts so invalid DNS names fail fast during load.
+      // Disallow unknown hosts so invalid DNS names fail fast during the load.
       peer = new Peer(fs.getString("Address"), false);
     } catch (UnknownHostException e) {
-      throw (FSParseException)
-          new FSParseException("Unknown domain name in Address: " + e).initCause(e);
+      throw new FSParseException("Unknown domain name in Address: " + e, e);
     } catch (PeerParseException e) {
       throw new FSParseException(e);
     }

--- a/src/main/java/network/crypta/l10n/package-info.java
+++ b/src/main/java/network/crypta/l10n/package-info.java
@@ -10,12 +10,12 @@
  *   <li>{@link network.crypta.l10n.BaseL10n} — Core resolver. Loads language files, applies
  *       variable substitution, exposes string and HTML helpers, and supports on-disk overrides.
  *   <li>{@link network.crypta.l10n.NodeL10n} — Application-wide façade that exposes a single shared
- *       {@code BaseL10n}. Lazily initialized on first access or re-initialized via its
+ *       {@code BaseL10n}. Lazily initialized on the first access or re-initialized via its
  *       constructors.
  *   <li>{@link network.crypta.l10n.PluginL10n} — Per-plugin bridge that wires a {@code BaseL10n}
  *       using paths, masks, and class loader provided by the plugin.
- *   <li>{@link network.crypta.l10n.ISO639_3} — Typed access to the ISO 639‑3 language code table
- *       for UIs and tooling.
+ *   <li>{@link network.crypta.l10n.BaseL10n.LANGUAGE} — Supported language registry with ISO-style
+ *       short codes and display names.
  * </ul>
  *
  * <h2>Resource format and lookup</h2>
@@ -76,7 +76,7 @@
  * @see network.crypta.l10n.BaseL10n
  * @see network.crypta.l10n.NodeL10n
  * @see network.crypta.l10n.PluginL10n
- * @see network.crypta.l10n.ISO639_3
+ * @see network.crypta.l10n.BaseL10n.LANGUAGE
  * @see network.crypta.support.HTMLNode
  */
 package network.crypta.l10n;

--- a/src/main/java/network/crypta/node/NodeToNodeMessageListener.java
+++ b/src/main/java/network/crypta/node/NodeToNodeMessageListener.java
@@ -1,5 +1,7 @@
 package network.crypta.node;
 
+import network.crypta.node.subsystem.NodeMessagingSubsystem;
+
 /**
  * Listener for node‑to‑node messages exchanged between peers.
  *
@@ -10,10 +12,10 @@ package network.crypta.node;
  * payload format is defined by the producer of the message; some built‑in handlers use UTF‑8
  * encoded {@code SimpleFieldSet}, but callers are free to define other formats.
  *
- * <p>Threading and call ordering are controlled by the caller. No serialization guarantees are
- * provided by this interface; implementations should assume that invocations may occur on internal
- * I/O or networking threads and should return promptly. If substantial work is needed, prefer
- * offloading to application‑controlled executors.
+ * <p>The caller controls threading and call ordering. This interface provides no serialization
+ * guarantees; implementations should assume that invocations may occur on internal I/O or
+ * networking threads and should return promptly. If significant work is needed, prefer offloading
+ * to application‑controlled executors.
  *
  * <p>Implementations should handle their own errors; the node does not wrap calls to {@link
  * #handleMessage(byte[], boolean, PeerNode, int)} in a protective {@code try/catch} at the

--- a/src/main/java/network/crypta/node/PeerConnector.java
+++ b/src/main/java/network/crypta/node/PeerConnector.java
@@ -5,6 +5,7 @@ import network.crypta.io.comm.PeerParseException;
 import network.crypta.io.comm.ReferenceSignatureVerificationException;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -14,7 +15,7 @@ import network.crypta.support.SimpleFieldSet;
  * adds it to the owning {@link PeerManager} when the peer is not already present. It is a small
  * coordination layer that keeps the reference parsing, duplicate detection, and registration steps
  * in one place so that callers do not need to know the peer list internals. Typical use is during
- * UI-driven friend adds, configuration import, or any path that receives a noderef and needs to
+ * UI-driven friend adding, configuration import, or any path that receives a noderef and needs to
  * enroll it in the darknet peer set.
  *
  * <p>The duplicate check is based on the peer's ECDSA public-key hash, which is stable for the
@@ -51,8 +52,8 @@ public class PeerConnector {
    *
    * <p>The call is idempotent with respect to the peer's public-key hash: repeated calls with
    * references that resolve to the same hash will not create additional peers. The method does not
-   * validate or normalize the {@link SimpleFieldSet} beyond what {@link Node#createNewDarknetNode}
-   * performs, and it does not retry on failures.
+   * validate or normalize the {@link SimpleFieldSet} beyond what {@link
+   * NodeNetworkSubsystem#createNewDarknetNode} performs, and it does not retry on failures.
    *
    * <pre>{@code
    * PeerConnector connector = new PeerConnector(node, peerManager);

--- a/src/main/java/network/crypta/node/PeerNodeTransport.java
+++ b/src/main/java/network/crypta/node/PeerNodeTransport.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>State is mutable and scoped to a single peer instance; the class is not thread-safe on its own
  * and relies on {@link PeerNode} and queue synchronization where needed (for example, incrementing
- * resend counters). It trades immediate sender wakeups against packet coalescing to reduce overhead
+ * resend counters). It trades immediate sender wakeup against packet coalescing to reduce overhead
  * while still honoring size thresholds.
  *
  * <ul>
@@ -99,13 +99,12 @@ final class PeerNodeTransport implements PeerTransport {
     this.peer = peer;
   }
 
-  @Override
   /**
    * Enqueues a message for asynchronous sending on the peer link.
    *
    * <p>The message is wrapped into a {@link MessageItem} and placed into the peer's message queue.
    * The queue estimate determines whether the packet sender is woken immediately or left to
-   * coalesce traffic. If {@code ctr} is {@code null}, an error is logged and the send still
+   * coalesce traffic. If {@code ctr} is {@code null}, an error is logged, and the sending still
    * proceeds; callers should provide a counter to keep bandwidth accounting accurate. If the peer
    * is not connected, the callback is notified and a {@link NotConnectedException} is thrown.
    *
@@ -120,6 +119,7 @@ final class PeerNodeTransport implements PeerTransport {
    * @return queued {@link MessageItem} for tracking or unqueueing later
    * @throws NotConnectedException if the peer is disconnected at enqueue time
    */
+  @Override
   public MessageItem sendAsync(Message msg, AsyncMessageCallback cb, ByteCounter ctr)
       throws NotConnectedException {
     if (ctr == null)
@@ -162,14 +162,13 @@ final class PeerNodeTransport implements PeerTransport {
     return item;
   }
 
-  @Override
   /**
    * Sends a message and waits for completion with bounded timeouts.
    *
-   * <p>This method enqueues the message and then waits up to one minute for the send to complete.
-   * On timeout it attempts to unqueue the message; if unqueueing fails, it waits an additional ten
-   * seconds before declaring a fatal timeout. The {@code realTime} flag is passed to overload
-   * reporting so higher-priority paths can be treated differently by admission control.
+   * <p>This method enqueues the message and then waits up to one minute for the sending to
+   * complete. On timeout, it attempts to un-queue the message; if un-queueing fails, it waits an
+   * additional ten seconds before declaring a fatal timeout. The {@code realTime} flag is passed to
+   * overload reporting so higher-priority paths can be treated differently by admission control.
    *
    * <pre>{@code
    * Message msg = DMT.createFNPPing(7);
@@ -178,10 +177,11 @@ final class PeerNodeTransport implements PeerTransport {
    *
    * @param req message to enqueue and send; must be non-null and locally constructed
    * @param ctr byte counter for bandwidth accounting; null logs and proceeds
-   * @param realTime whether this send is real-time for overload reporting
+   * @param realTime whether this sending is real-time for overload reporting
    * @throws NotConnectedException if the peer disconnects before completion
-   * @throws SyncSendWaitedTooLongException if the send does not complete in time
+   * @throws SyncSendWaitedTooLongException if the sending does not complete in time
    */
+  @Override
   public void sendSync(Message req, ByteCounter ctr, boolean realTime)
       throws NotConnectedException, SyncSendWaitedTooLongException {
     SyncMessageCallback cb = new SyncMessageCallback();
@@ -194,16 +194,16 @@ final class PeerNodeTransport implements PeerTransport {
           peer.selfPeerNode(),
           new Exception(STR_ERROR));
       peer.localRejectedOverload("SendSyncTimeout", realTime);
-      // Try to unqueue it, since it presumably won't be of any use now.
+      // Try to un-queue it, since it presumably won't be of any use now.
       if (!peer.getMessageQueue().removeMessage(item)) {
         cb.waitForSend(SECONDS.toMillis(10));
         if (!cb.done) {
           LOG.error(
-              "Waited too long for blocking send and then could not unqueue for {} to {}",
+              "Waited too long for blocking send and then could not un-queue for {} to {}",
               req,
               peer.selfPeerNode(),
               new Exception(STR_ERROR));
-          // Can't cancel yet can't send, something seriously wrong.
+          // Can't cancel yet, can't send it, something seriously wrong.
           // Treat as fatal timeout as probably their fault.
           // Note: We have already waited more than the no-messages timeout; do not wait again.
           peer.fatalTimeout();
@@ -216,7 +216,6 @@ final class PeerNodeTransport implements PeerTransport {
     }
   }
 
-  @Override
   /**
    * Sends a ping and waits briefly for a matching pong.
    *
@@ -229,6 +228,7 @@ final class PeerNodeTransport implements PeerTransport {
    * @return {@code true} when a matching pong is received; {@code false} on timeout
    * @throws NotConnectedException if the peer disconnects while awaiting the pong
    */
+  @Override
   public boolean ping(int pingID) throws NotConnectedException {
     Message ping = DMT.createFNPPing(pingID);
     peer.node.network().usm().send(peer, ping, peer.node.network().dispatcher().pingCounter);
@@ -250,21 +250,20 @@ final class PeerNodeTransport implements PeerTransport {
     return msg != null;
   }
 
-  @Override
   /**
    * Returns the packet throttle instance associated with this transport.
    *
    * <p>The returned throttle object is stable for the life of the transport and is owned by this
-   * instance. Callers should treat it as mutable shared state and avoid concurrent modification
+   * instance. Callers should treat it as a mutable shared state and avoid concurrent modification
    * without appropriate synchronization.
    *
    * @return throttle instance used for packet pacing on this link
    */
+  @Override
   public PacketThrottle getThrottle() {
     return lastThrottle;
   }
 
-  @Override
   /**
    * Returns the socket handler used for outbound packets to this peer.
    *
@@ -274,11 +273,11 @@ final class PeerNodeTransport implements PeerTransport {
    *
    * @return socket handler for outbound packet IO
    */
+  @Override
   public SocketHandler getSocketHandler() {
     return peer.getOutgoingMangler().getSocketHandler();
   }
 
-  @Override
   /**
    * Hands a decoded message to the messaging core for filtering and dispatch.
    *
@@ -289,13 +288,13 @@ final class PeerNodeTransport implements PeerTransport {
    *
    * @param m decoded message to handle; must be non-null and peer-associated
    */
+  @Override
   public void handleMessage(Message m) {
     peer.node.network().usm().checkFilters(m, peer.crypto.getSocket());
   }
 
-  @Override
   /**
-   * Starts a grouped decode session for a batch of decrypted packets.
+   * Starts a grouped decoding session for a batch of decrypted packets.
    *
    * <p>The returned {@link DecodingMessageGroup} collects decoded messages, immediately handling
    * peer-load status updates and deferring load-limited requests until after other messages. This
@@ -304,6 +303,7 @@ final class PeerNodeTransport implements PeerTransport {
    * @param size expected number of messages; used only for internal list sizing
    * @return a new decoding group instance for the caller to use
    */
+  @Override
   public DecodingMessageGroup startProcessingDecryptedMessages(int size) {
     return new DecodingMessageGroupImpl(size);
   }
@@ -367,13 +367,13 @@ final class PeerNodeTransport implements PeerTransport {
    *
    * <p>The method mutates {@code fs} by setting {@code n2nType} and optionally {@code sentTime}.
    * For darknet peers with {@code queueOnNotConnected} enabled, the message is queued for later
-   * replay and an unqueue-on-ack callback is attached. If the send fails and a sent time was
+   * replay and an unqueue-on-ack callback is attached. If the sending fails and a sent-time was
    * injected, that field is removed to avoid persisting a stale timestamp.
    *
    * @param fs field set serialized into the message body; mutated in place
    * @param n2nType node-to-node message type identifier to embed
    * @param includeSentTime whether to include a {@code sentTime} value
-   * @param now timestamp in milliseconds since epoch when the message is created
+   * @param now timestamp in milliseconds since the epoch when the message is created
    * @param queueOnNotConnected whether to queue the message for darknet peers
    */
   void sendNodeToNodeMessage(
@@ -430,12 +430,12 @@ final class PeerNodeTransport implements PeerTransport {
    * Callback used by {@link #sendSync(Message, ByteCounter, boolean)} to track send completion.
    *
    * <p>The instance is stateful and guarded by {@code synchronized} blocks. The callback waits for
-   * a send to complete, records disconnection, and exposes a minimal lifecycle for the blocking
-   * send path.
+   * a sending to complete, records disconnection, and exposes a minimal lifecycle for the blocking
+   * sending path.
    */
   private class SyncMessageCallback implements AsyncMessageCallback {
 
-    /** True once the send path completes or terminates with an error. */
+    /** True, once the sending path completes or terminates with an error. */
     private boolean done = false;
 
     /** True if completion occurred due to a disconnect. */
@@ -445,11 +445,11 @@ final class PeerNodeTransport implements PeerTransport {
     private boolean sent = false;
 
     /**
-     * Waits for the send to complete or for the deadline to elapse.
+     * Waits for the sending to complete or for the deadline to elapse.
      *
      * <p>If the callback completes because the connection was lost, this method throws {@link
      * NotConnectedException}. Interrupts are honored by re-interrupting the thread and returning
-     * early without changing callback state.
+     * early without changing the callback state.
      *
      * @param maxWaitInterval maximum time to wait in milliseconds
      * @throws NotConnectedException if the peer disconnects before completion
@@ -466,7 +466,7 @@ final class PeerNodeTransport implements PeerTransport {
         try {
           wait(waitTime);
         } catch (InterruptedException _) {
-          // Re-interrupt current thread and stop waiting
+          // Re-interrupt the current thread and stop waiting
           Thread.currentThread().interrupt();
           return;
         }
@@ -541,13 +541,13 @@ final class PeerNodeTransport implements PeerTransport {
       messagesWantSomething = new ArrayList<>(size);
     }
 
-    @Override
     /**
      * {@inheritDoc}
      *
      * <p>Messages are decoded using the node's {@link network.crypta.io.comm.MessageCore}. Load
      * status messages are handled immediately; load-limited requests are queued for later.
      */
+    @Override
     public void processDecryptedMessage(byte[] data, int offset, int length, int overhead) {
       Message m =
           peer.node.network().usm().decodeSingleMessage(data, offset, length, peer, overhead);
@@ -567,13 +567,13 @@ final class PeerNodeTransport implements PeerTransport {
       }
     }
 
-    @Override
     /**
      * {@inheritDoc}
      *
      * <p>Normal messages are handled first, followed by load-limited requests to preserve
      * responsiveness for non-load-controlled traffic.
      */
+    @Override
     public void complete() {
       for (Message msg : messages) {
         handleMessage(msg);

--- a/src/main/java/network/crypta/node/PeerRoster.java
+++ b/src/main/java/network/crypta/node/PeerRoster.java
@@ -63,7 +63,7 @@ public class PeerRoster {
    *
    * <p>The returned array is the internal snapshot captured under the shared lock. Its contents
    * represent the roster state at the time of the call, but the array may be replaced immediately
-   * afterward by subsequent mutations. Callers must not modify the array and should copy it if they
+   * afterward by later mutations. Callers must not modify the array and should copy it if they
    * require a stable, caller-owned view.
    *
    * @return the internal array snapshot of all known peers, potentially empty.
@@ -118,7 +118,7 @@ public class PeerRoster {
    * connected or modify the connected-peers snapshot.
    *
    * @param peer the peer instance to add to the roster snapshot.
-   * @param reactivate whether to cancel disconnecting state before the add attempt.
+   * @param reactivate whether to cancel disconnecting state before the adding attempt.
    * @return {@code true} if the peer was newly added; {@code false} if already present.
    */
   public boolean addPeer(PeerNode peer, boolean reactivate) {
@@ -298,7 +298,7 @@ public class PeerRoster {
    *
    * <p>The roster is scanned twice: first for peers whose transport address and port match the
    * supplied {@link Peer}, and then for peers whose IP matches the same address regardless of port.
-   * Disabled peers are skipped. The method returns the first matching peer and does not modify
+   * Disabled peers are skipped. The method returns the first matching peer and does not modify the
    * roster state.
    *
    * @param peer the transport address descriptor to match against the roster.
@@ -323,7 +323,7 @@ public class PeerRoster {
    *
    * <p>This method mirrors {@link #getByPeer(Peer)} but additionally requires the peer's outgoing
    * {@link FNPPacketMangler} to match the supplied {@code mangler}. Disabled peers are skipped. The
-   * method returns the first matching peer and does not modify roster state.
+   * method returns the first matching peer and does not modify the roster state.
    *
    * @param peer the transport address descriptor to match against the roster.
    * @param mangler the outgoing mangler instance that must match the peer configuration.
@@ -463,7 +463,7 @@ public class PeerRoster {
    * order. The returned array is a new allocation owned by the caller.
    *
    * @param pruneBackedOffPeers whether to exclude peers that should be pruned from peer lists.
-   * @return a sorted array of peer locations, or an empty array when publishing is disabled.
+   * @return a sorted array of peer locations or an empty array when publishing is disabled.
    */
   public double[] getPeerLocationDoubles(boolean pruneBackedOffPeers) {
     if (!node.shallWePublishOurPeersLocation()) return new double[0];
@@ -491,8 +491,8 @@ public class PeerRoster {
    * Returns whether any connected peer is currently routable.
    *
    * <p>This method scans the connected snapshot and checks routability on each peer. It does not
-   * alter roster state and returns immediately on the first routable peer found. The snapshot used
-   * for scanning is retrieved atomically but can become stale once the method returns. It is a
+   * alter the roster state and returns immediately on the first routable peer found. The snapshot
+   * used for scanning is retrieved atomically but can become stale once the method returns. It is a
    * lightweight read-only query intended for fast status checks.
    *
    * @return {@code true} if any connected peer is routable; {@code false} otherwise.
@@ -566,8 +566,9 @@ public class PeerRoster {
    *
    * <p>The method scans the roster snapshot and collects peers that are either {@link
    * OpennetPeerNode} instances or {@link SeedServerPeerNode} instances. The snapshot is not
-   * filtered by connection state or disabled flag, so the result is purely type-based. The returned
-   * array is a new allocation owned by the caller and ordered by the roster iteration order.
+   * filtered by a connection state or disabled flag, so the result is purely type-based. The
+   * returned array is a new allocation owned by the caller and ordered by the roster iteration
+   * order.
    *
    * @return an array of opennet and seed-server peers, possibly empty.
    */
@@ -598,8 +599,7 @@ public class PeerRoster {
         keep.add(pn);
         if (pn.isConnected()) conn.add(pn);
       }
-      PeerNode[] keepArray = keep.toArray(new PeerNode[0]);
-      myPeers = keepArray;
+      myPeers = keep.toArray(new PeerNode[0]);
       connectedPeers = conn.toArray(new PeerNode[0]);
     }
   }
@@ -656,7 +656,7 @@ public class PeerRoster {
    * Counts connected peers that are routable and not in routing backoff.
    *
    * <p>The method scans the connected snapshot and counts peers that are routable and not backed
-   * off for the requested traffic class. It does not modify roster state and performs no
+   * off for the requested traffic class. It does not modify the roster state and performs no
    * allocations other than local counters. The result is a snapshot and should not be treated as a
    * stable capacity guarantee.
    *
@@ -761,8 +761,8 @@ public class PeerRoster {
    *
    * <p>The roster snapshot is scanned for peers that report a real connection, are connected, and
    * are routing-compatible. This count includes both darknet and opennet peers that satisfy the
-   * criteria and does not distinguish between them. The result is a snapshot and may change as
-   * peers connect or disconnect.
+   * criteria and do not distinguish between them. The result is a snapshot and may change as peers
+   * connect or disconnect.
    *
    * @return the number of real, connected peers that are routing-compatible.
    */
@@ -803,7 +803,7 @@ public class PeerRoster {
    * The count is a snapshot and may change as peers are added or removed. This method does not
    * attempt any network operations.
    *
-   * @return the number of peers that may connect based on current roster state.
+   * @return the number of peers that may connect based on the current roster state.
    */
   public int countValidPeers() {
     int count = 0;
@@ -876,7 +876,7 @@ public class PeerRoster {
   /**
    * Counts peers by their current status value.
    *
-   * <p>The roster snapshot is scanned and each peer's status is compared to the supplied status
+   * <p>The roster snapshot is scanned, and each peer's status is compared to the supplied status
    * code. No normalization or translation is performed; the integer is compared directly, so the
    * caller should use the exact status constants expected by {@link PeerNode#getPeerNodeStatus()}.
    * The scan is linear and does not allocate.

--- a/src/main/java/network/crypta/node/simulator/RealNodePingTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodePingTest.java
@@ -19,6 +19,7 @@ import network.crypta.node.NodeStarter;
 import network.crypta.node.NodeStarter.TestNodeParameters;
 import network.crypta.node.PeerNode;
 import network.crypta.node.PeerTooOldException;
+import network.crypta.node.PeerTransport;
 import network.crypta.support.PooledExecutor;
 import network.crypta.support.PriorityAwareExecutor;
 import org.slf4j.Logger;
@@ -30,16 +31,16 @@ import org.slf4j.event.Level;
  * requests while logging send/receive events and sequence numbers.
  *
  * <p>This class is a manual simulation harness for exercising end-to-end ping traffic between two
- * local darknet nodes. The {@link #main(String[])} method sets up a temporary base directory,
- * initializes test randomness, and configures two nodes with RAM-backed stores and high thread
- * limits. After connecting the nodes with fixed trust and visibility settings, it starts them and
- * schedules periodic {@link PeerNode#ping(int)} calls. The scheduler runs on a single thread while
- * the nodes operate asynchronously, so the ping cadence is approximate and influenced by node
- * activity and network timing.
+ * local darknet nodes. The {@link #main()} method sets up a temporary basis directory, initializes
+ * test randomness, and configures two nodes with RAM-backed stores and high thread limits. After
+ * connecting the nodes with fixed trust and visibility settings, it starts them and schedules
+ * periodic {@link PeerTransport#ping(int)} calls. The scheduler runs on a single thread while the
+ * nodes operate asynchronously, so the ping cadence is approximate and influenced by node activity
+ * and network timing.
  *
- * <p>The test runs until interrupted and does not attempt cleanup beyond process shutdown. It is
- * intended for local diagnostics rather than production deployments, and the hard-coded ports must
- * be free on the host.
+ * <p>The test runs until interrupted and does not attempt cleanup beyond the process shutdown. It
+ * is intended for local diagnostics rather than production deployments, and the hard-coded ports
+ * must be free on the host.
  *
  * <ul>
  *   <li>Responsibility: create two test nodes with deterministic test configuration.
@@ -48,7 +49,7 @@ import org.slf4j.event.Level;
  * </ul>
  *
  * @see NodeStarter
- * @see PeerNode#ping(int)
+ * @see PeerTransport#ping(int)
  */
 public class RealNodePingTest {
   private static final Logger LOG = LoggerFactory.getLogger(RealNodePingTest.class);
@@ -56,12 +57,12 @@ public class RealNodePingTest {
   /**
    * Creates an instance of the ping test harness without additional initialization.
    *
-   * <p>The class is designed to be driven through {@link #main(String[])}, so constructing it
-   * directly is rarely needed. This explicit constructor exists to provide a documented public
-   * entry point for tools that inspect Javadoc, and it performs no work or side effects beyond
-   * creating the instance.
+   * <p>The class is designed to be driven through {@link #main()}, so constructing it directly is
+   * rarely needed. This explicit constructor exists to provide a documented public entry point for
+   * tools that inspect Javadoc, and it performs no work or side effects beyond creating the
+   * instance.
    */
-  public RealNodePingTest() {
+  private RealNodePingTest() {
     // Intentionally empty: this harness is driven via static main entry points only.
   }
 
@@ -108,7 +109,6 @@ public class RealNodePingTest {
    * RealNodePingTest.main(new String[0]);
    * }</pre>
    *
-   * @param args command-line arguments; currently unused and may be empty or null.
    * @throws FSParseException if node configuration parsing fails for the local test setup.
    * @throws PeerParseException if peer references cannot be parsed during node creation.
    * @throws InterruptedException if the calling thread is interrupted during setup or wait.
@@ -116,7 +116,7 @@ public class RealNodePingTest {
    * @throws NodeInitException if a test node fails to initialize required components.
    * @throws PeerTooOldException if the peer build is too old to establish a connection.
    */
-  public static void main(String[] args)
+  public static void main()
       throws FSParseException,
           PeerParseException,
           InterruptedException,

--- a/src/main/java/network/crypta/node/simulator/RealNodePingTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodePingTest.java
@@ -116,7 +116,7 @@ public class RealNodePingTest {
    * @throws NodeInitException if a test node fails to initialize required components.
    * @throws PeerTooOldException if the peer build is too old to establish a connection.
    */
-  public static void main()
+  static void main()
       throws FSParseException,
           PeerParseException,
           InterruptedException,

--- a/src/main/java/network/crypta/store/SimpleGetPubkey.java
+++ b/src/main/java/network/crypta/store/SimpleGetPubkey.java
@@ -1,8 +1,8 @@
 package network.crypta.store;
 
+import com.onionnetworks.util.Util;
 import java.io.IOException;
 import network.crypta.crypt.DSAPublicKey;
-import network.crypta.support.HexUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
  * <p>This facade deliberately ignores all read/write hint flags exposed by the interface. Reads are
  * performed via one direct lookup and writes via one direct put using conservative options. Any
  * {@link IOException} raised by the backing store is logged and suppressed; callers receive {@code
- * null} on read failures and silent no-ops on write failures.
+ * null} on read failures and silent no-ops on writing failures.
  *
  * <p>Thread-safety: The instance holds only a reference to the provided store and does not keep any
  * mutable state. Concurrency characteristics therefore depend entirely on the {@link PubkeyStore}
@@ -58,7 +58,7 @@ public class SimpleGetPubkey implements GetPubkey {
     try {
       return store.fetch(hash, false, false, meta);
     } catch (IOException e) {
-      LOG.error("Caught {} fetching pubkey for {}", e, HexUtil.bytesToHex(hash));
+      LOG.error("Caught {} fetching pubkey for {}", e, Util.bytesToHex(hash));
       return null;
     }
   }
@@ -70,7 +70,7 @@ public class SimpleGetPubkey implements GetPubkey {
    *
    * <ul>
    *   <li>All write-control flags are ignored; the method always delegates to {@link
-   *       PubkeyStore#put(byte[], DSAPublicKey, boolean)} with {@code isOldBlock=false}.
+   *       PubkeyStore#put(DSAPublicKey, boolean)} with {@code isOldBlock=false}.
    *   <li>On {@link IOException}, an error is logged and the exception is suppressed.
    * </ul>
    *
@@ -94,7 +94,7 @@ public class SimpleGetPubkey implements GetPubkey {
     try {
       store.put(key, false);
     } catch (IOException e) {
-      LOG.error("Caught {} storing pubkey for {}", e, HexUtil.bytesToHex(hash));
+      LOG.error("Caught {} storing pubkey for {}", e, Util.bytesToHex(hash));
     }
   }
 }

--- a/src/main/java/network/crypta/support/HTMLDecoder.java
+++ b/src/main/java/network/crypta/support/HTMLDecoder.java
@@ -30,17 +30,7 @@ public class HTMLDecoder {
     return sb.toString();
   }
 
-  private static final class DecodeResult {
-    final boolean decoded;
-    final char ch;
-    final int nextPos;
-
-    DecodeResult(boolean decoded, char ch, int nextPos) {
-      this.decoded = decoded;
-      this.ch = ch;
-      this.nextPos = nextPos;
-    }
-  }
+  private record DecodeResult(boolean decoded, char ch, int nextPos) {}
 
   private static DecodeResult decodeAfterAmp(String s, int curPos, int maxPos) {
     int tmpPos = curPos;
@@ -74,18 +64,23 @@ public class HTMLDecoder {
       return new DecodeResult(false, '&', curPos);
     }
     char d = s.charAt(tmpPos++);
-    if (!isHexDigit(d)) {
-      return new DecodeResult(false, '&', curPos);
+    if (isHexDigit(d)) {
+      return scanHexEntity(s, tmpPos, maxPos, curPos);
     }
-    while (tmpPos < maxPos) {
-      d = s.charAt(tmpPos++);
+    return new DecodeResult(false, '&', curPos);
+  }
+
+  private static DecodeResult scanHexEntity(String s, int tmpPos, int maxPos, int curPos) {
+    boolean done = false;
+    while (tmpPos < maxPos && !done) {
+      char d = s.charAt(tmpPos++);
       if (!isHexDigit(d)) {
         if (d == ';') {
           String t = s.substring(curPos + 2, tmpPos - 1);
           Character ch = parseHexChar(t);
           if (ch != null) return new DecodeResult(true, ch, tmpPos);
         }
-        break;
+        done = true;
       }
     }
     return new DecodeResult(false, '&', curPos);
@@ -170,7 +165,7 @@ public class HTMLDecoder {
         // Unix newline
         || (ch == '\n')
         // tab
-        || (ch == '\u0009')
+        || (ch == '\t')
         // Control
         || (ch == '\u000c')
         // zero width space

--- a/src/main/java/network/crypta/support/IntNumberedItem.java
+++ b/src/main/java/network/crypta/support/IntNumberedItem.java
@@ -1,10 +1,7 @@
 package network.crypta.support;
 
-/**
- * An object with a number (as an int).
- *
- * @see NumberedItem
- */
+/** An object with a number (as an int). */
+@SuppressWarnings("unused")
 public interface IntNumberedItem {
 
   int getNumber();

--- a/src/test/java/network/crypta/node/simulator/RealNodePingTestTest.java
+++ b/src/test/java/network/crypta/node/simulator/RealNodePingTestTest.java
@@ -2,6 +2,7 @@ package network.crypta.node.simulator;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
@@ -28,12 +29,12 @@ class RealNodePingTestTest {
 
   @Test
   void main_whenReflected_expectPublicStaticVoidSignature() throws Exception {
-    Method main = RealNodePingTest.class.getDeclaredMethod("main", String[].class);
+    Method main = RealNodePingTest.class.getDeclaredMethod("main");
 
     int modifiers = main.getModifiers();
-    assertTrue(Modifier.isPublic(modifiers));
+    assertFalse(Modifier.isPublic(modifiers));
     assertTrue(Modifier.isStatic(modifiers));
     assertEquals(void.class, main.getReturnType());
-    assertArrayEquals(new Class<?>[] {String[].class}, main.getParameterTypes());
+    assertArrayEquals(new Class<?>[0], main.getParameterTypes());
   }
 }


### PR DESCRIPTION
## Summary
- clarify and update Javadocs across FCP, node, crypto, and l10n classes
- simplify small utility behaviors (exception chaining, HTML decode helper, hex logging)
- clean up minor API references and annotations for consistency

## Testing
- ./gradlew spotlessApply