### PR TITLE
refactor: tidy build logic and config placeholders

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -10,31 +10,46 @@ val wrapperDeltaPack = "wrapper-delta-pack-$wrapperVersion.tar.gz"
 val wrapperBaseUrl =
   "https://sourceforge.net/projects/wrapper/files/wrapper/Wrapper_3.6.2_20250605/$wrapperDeltaPack/download"
 
-val wrapperWorkDir = layout.buildDirectory.dir("wrapper")
-val wrapperExtractDir = layout.buildDirectory.dir("wrapper/extracted")
-val wrapperDistDir = layout.buildDirectory.dir("cryptad-dist")
+val wrapperWorkDir: Provider<Directory> = layout.buildDirectory.dir("wrapper")
+val wrapperExtractDir: Provider<Directory> = layout.buildDirectory.dir("wrapper/extracted")
+val wrapperDistDir: Provider<Directory> = layout.buildDirectory.dir("cryptad-dist")
 
 // Windows wrapper binaries are not present in the delta pack. We fetch them from the latest
 // release of crypta-network/wrapper-windows-build.
 val wrapperWindowsRepo = "crypta-network/wrapper-windows-build"
-val wrapperWindowsApiLatest =
+val wrapperWindowsApiLatest: Provider<String> =
   providers
     .gradleProperty("wrapperWinApiUrl")
     .orElse("https://api.github.com/repos/$wrapperWindowsRepo/releases/latest")
-val wrapperWindowsWorkDir = layout.buildDirectory.dir("wrapper/windows")
+val wrapperWindowsWorkDir: Provider<Directory> = layout.buildDirectory.dir("wrapper/windows")
 // We don't assume a specific archive extension from GitHub assets (.zip or .tar.gz).
-// Download to a neutral extension; extraction tasks will auto-detect type by magic bytes.
-val wrapperWindowsAmd64Archive = wrapperWindowsWorkDir.map { it.file("windows-amd64.bin") }
-val wrapperWindowsArm64Archive = wrapperWindowsWorkDir.map { it.file("windows-arm64.bin") }
-val wrapperWindowsAmd64Extract = wrapperWindowsWorkDir.map { it.dir("extracted-amd64") }
-val wrapperWindowsArm64Extract = wrapperWindowsWorkDir.map { it.dir("extracted-arm64") }
+// Download to a neutral extension; extraction tasks will auto-detect the type by magic bytes.
+val wrapperWindowsAmd64Archive: Provider<RegularFile> =
+  wrapperWindowsWorkDir.map { it.file("windows-amd64.bin") }
+val wrapperWindowsArm64Archive: Provider<RegularFile> =
+  wrapperWindowsWorkDir.map { it.file("windows-arm64.bin") }
+val wrapperWindowsAmd64Extract: Provider<Directory> =
+  wrapperWindowsWorkDir.map { it.dir("extracted-amd64") }
+val wrapperWindowsArm64Extract: Provider<Directory> =
+  wrapperWindowsWorkDir.map { it.dir("extracted-arm64") }
 
 // Seednodes generation settings
 val seedrefsZipUrl = "https://codeload.github.com/hyphanet/seedrefs/zip/refs/heads/master"
-val seedrefsWorkDir = layout.buildDirectory.dir("seedrefs")
-val seedrefsZip = seedrefsWorkDir.map { it.file("seedrefs.zip") }
-val seedrefsExtracted = seedrefsWorkDir.map { it.dir("extracted") }
-val seednodesOut = layout.buildDirectory.file("generated/seednodes/seednodes.fref")
+val seedrefsWorkDir: Provider<Directory> = layout.buildDirectory.dir("seedrefs")
+val seedrefsZip: Provider<RegularFile> = seedrefsWorkDir.map { it.file("seedrefs.zip") }
+val seedrefsExtracted: Provider<Directory> = seedrefsWorkDir.map { it.dir("extracted") }
+val seednodesOut: Provider<RegularFile> =
+  layout.buildDirectory.file("generated/seednodes/seednodes.fref")
+
+fun downloadTo(url: String, targetFile: Provider<RegularFile>) {
+  val target = targetFile.get().asFile
+  target.parentFile.mkdirs()
+  val resolvedUrl = URI(url).toURL()
+  println("Downloading $url -> " + target.absolutePath)
+  resolvedUrl.openStream().use { input ->
+    Files.copy(input, target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+  }
+}
 
 // Download the Wrapper delta pack
 val downloadWrapper by
@@ -43,15 +58,7 @@ val downloadWrapper by
     description = "Downloads Tanuki Java Service Wrapper delta pack"
     val outFile = wrapperWorkDir.map { it.file(wrapperDeltaPack) }
     outputs.file(outFile)
-    doLast {
-      val target = outFile.get().asFile
-      target.parentFile.mkdirs()
-      val url = URI(wrapperBaseUrl).toURL()
-      println("Downloading $wrapperBaseUrl -> " + target.absolutePath)
-      url.openStream().use { input ->
-        Files.copy(input, target.toPath(), StandardCopyOption.REPLACE_EXISTING)
-      }
-    }
+    doLast { downloadTo(wrapperBaseUrl, outFile) }
   }
 
 // Extract the delta pack
@@ -71,15 +78,7 @@ val downloadSeedrefs by
     group = "distribution"
     description = "Downloads hyphanet/seedrefs repository as a zip"
     outputs.file(seedrefsZip)
-    doLast {
-      val out = seedrefsZip.get().asFile
-      out.parentFile.mkdirs()
-      val url = URI(seedrefsZipUrl).toURL()
-      println("Downloading $seedrefsZipUrl -> " + out.absolutePath)
-      url.openStream().use { input ->
-        Files.copy(input, out.toPath(), StandardCopyOption.REPLACE_EXISTING)
-      }
-    }
+    doLast { downloadTo(seedrefsZipUrl, seedrefsZip) }
   }
 
 // Extract seedrefs
@@ -140,9 +139,13 @@ val copyWrapperBinaries by
 
 abstract class DownloadWindowsWrapper @Inject constructor() : DefaultTask() {
   @get:Input abstract val apiUrl: Property<String>
+
   @get:Input @get:Optional abstract val amd64UrlOverride: Property<String>
+
   @get:Input @get:Optional abstract val arm64UrlOverride: Property<String>
+
   @get:OutputFile abstract val amd64Archive: RegularFileProperty
+
   @get:OutputFile abstract val arm64Archive: RegularFileProperty
 
   @TaskAction
@@ -187,8 +190,9 @@ abstract class DownloadWindowsWrapper @Inject constructor() : DefaultTask() {
           l.contains("win") &&
           archHints.any { hint -> l.contains(hint) }
       }
-    if (candidate == null)
+    if (candidate == null) {
       throw GradleException("Could not find Windows asset for $archHints in $apiUrl")
+    }
     return candidate
   }
 
@@ -237,12 +241,19 @@ fun detectArchiveType(file: File): ArchiveType {
   val isZip = magic[0] == 0x50.toByte() && magic[1] == 0x4B.toByte()
   val isGzip = magic[0] == 0x1F.toByte() && magic[1] == 0x8B.toByte()
   return when {
-    isZip -> ArchiveType.ZIP
-    isGzip -> ArchiveType.TAR_GZ
-    else ->
+    isZip -> {
+      ArchiveType.ZIP
+    }
+
+    isGzip -> {
+      ArchiveType.TAR_GZ
+    }
+
+    else -> {
       throw GradleException(
         "Unsupported or unrecognized archive format for Windows wrapper: ${file.name}"
       )
+    }
   }
 }
 
@@ -252,7 +263,7 @@ fun fileTreeFromArchive(file: File): FileTree =
     ArchiveType.TAR_GZ -> tarTree(resources.gzip(file))
   }
 
-// Helper to detect archive type and configure extraction dynamically at execution time.
+// Helper to detect the archive type and configure extraction dynamically at execution time.
 fun Copy.fromAutoArchive(file: File) {
   when (detectArchiveType(file)) {
     ArchiveType.ZIP -> from(zipTree(file))
@@ -315,6 +326,7 @@ val copyWindowsWrapperBinaries by
       val arm64Archive = wrapperWindowsArm64Archive.get().asFile
 
       println("[dist] copyWindowsWrapperBinaries: starting")
+
       fun humanSize(bytes: Long): String {
         val units = arrayOf("B", "KB", "MB", "GB")
         var b = bytes.toDouble()
@@ -466,7 +478,7 @@ val prepareWrapperLibs by
     }
   }
 
-// Generate conf/wrapper.conf from template
+// Generate conf/wrapper.conf from a template
 val generateWrapperConf by
   tasks.registering {
     group = "distribution"
@@ -474,7 +486,7 @@ val generateWrapperConf by
     dependsOn(prepareWrapperLibs)
     val confDir = wrapperDistDir.map { it.dir("conf") }
     outputs.file(confDir.map { it.file("wrapper.conf") })
-    // Capture template file at configuration time to avoid Task.project access at execution
+    // Capture the template file at configuration time to avoid Task.project access at execution
     val confTemplate = layout.projectDirectory.file("src/main/templates/wrapper.conf.tpl")
     doLast {
       val confDirFile = confDir.get().asFile
@@ -494,7 +506,7 @@ val generateWrapperLaunchers by
     dependsOn(copyWrapperBinaries)
     val binDir = wrapperDistDir.map { it.dir("bin") }
     outputs.files(binDir.map { it.file("cryptad") }, binDir.map { it.file("cryptad.bat") })
-    // Resolve inputs up front (configuration time) to be config-cache friendly
+    // Resolve inputs up front (configuration time) to be config-cache-friendly
     val launcherTemplateUnix =
       layout.projectDirectory.file("src/main/templates/cryptad-launcher.sh.tpl")
     val launcherTemplateBat =
@@ -636,7 +648,7 @@ val dist by
     dependsOn("distTarCryptad", "distZipCryptad")
   }
 
-// Ensure standard build also produces the distribution archives
+// Ensure the standard build also produces the distribution archives
 tasks.named("build") { dependsOn(dist) }
 
 // Make sure jpackage resources exist even if only installer/image is requested later

--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -1,9 +1,3 @@
-import java.math.BigDecimal
-import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.kotlin.dsl.getByType
-import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
-import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
-import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -106,7 +100,7 @@ tasks.withType<Test>().configureEach { enableAssertions = false }
 
 // JaCoCo setup: use a recent agent and produce XML for Sonar
 // Version is sourced from the version catalog (gradle/libs.versions.toml: [versions].jacoco)
-val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+val libs: VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
 extensions.configure<JacocoPluginExtension>("jacoco") {
   toolVersion = libs.findVersion("jacoco").get().requiredVersion
@@ -122,7 +116,7 @@ tasks.withType<JacocoReport>().configureEach {
   }
 }
 
-// Enforce coverage threshold (80% minimum)
+// Enforce a coverage threshold (80% minimum)
 tasks.withType<JacocoCoverageVerification>().configureEach {
   dependsOn(tasks.withType<Test>())
   violationRules {

--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -9,17 +9,17 @@ plugins { java }
  * - Creates an app image via `jpackage --type app-image`
  * - Optionally builds native installers via `jpackage --type <os-default>`
  * - Copies the portable node layout (build/cryptad-dist) into the app image under app/cryptad-dist
- * - Prepares standard resources (LICENSE.txt, EULA.txt, README.txt) from project root
+ * - Prepares standard resources (LICENSE.txt, EULA.txt, README.txt) from the project root
  *
  * This file intentionally avoids duplicating jars under the jpackage image; instead a tiny
  * bootstrap jar is created so we can later rewrite `Crypta.cfg` to reference the jars under
  * `app/cryptad-dist/lib/` + `*.jar` as the runtime classpath.
  */
-val jreDir = layout.buildDirectory.dir("jre")
-val cryptadDistDir = layout.buildDirectory.dir("cryptad-dist")
-val jpackageOutDir = layout.buildDirectory.dir("jpackage")
-val jpackageResourcesDir = layout.buildDirectory.dir("jpackage/resources")
-val jpackageInputDir = layout.buildDirectory.dir("jpackage/input")
+val jreDir: Provider<Directory> = layout.buildDirectory.dir("jre")
+val cryptadDistDir: Provider<Directory> = layout.buildDirectory.dir("cryptad-dist")
+val jpackageOutDir: Provider<Directory> = layout.buildDirectory.dir("jpackage")
+val jpackageResourcesDir: Provider<Directory> = layout.buildDirectory.dir("jpackage/resources")
+val jpackageInputDir: Provider<Directory> = layout.buildDirectory.dir("jpackage/input")
 
 // Compute version string: v<project.version>+<gitRevShort>
 fun gitRevShort(): String =
@@ -35,6 +35,18 @@ fun gitRevShort(): String =
     "unknown"
   }
 
+fun clearXattrsQuiet(target: File, timeoutSeconds: Long) {
+  try {
+    val xattr = File("/usr/bin/xattr")
+    if (xattr.canExecute()) {
+      ProcessBuilder(xattr.absolutePath, "-cr", target.absolutePath)
+        .redirectErrorStream(true)
+        .start()
+        .waitFor(timeoutSeconds, TimeUnit.SECONDS)
+    }
+  } catch (_: Exception) {}
+}
+
 val appName = "Crypta"
 val vendor = "crypta.network"
 val appId = "network.crypta.cryptad"
@@ -43,6 +55,7 @@ val appId = "network.crypta.cryptad"
 
 // jpackage --app-version is strict (e.g., macOS CFBundleVersion must be 1..3 integers separated by
 // dots).
+
 /** Returns a numeric app version accepted by jpackage (platform compliant). */
 fun numericAppVersion(): String {
   val raw = project.version.toString()
@@ -80,7 +93,7 @@ val prepareJpackageResources by
     }
     // For RPM: jpackage supports overriding its spec via a file named
     // "<package-name>.spec" in the resource dir (package-name defaults to the application
-    // name lowercased; here it is "crypta"). Include our customized spec. We also copy
+    // name lowercased; here it is "crypta"). Include our customized specs. We also copy
     // template.spec for completeness, but the concrete package spec takes precedence.
     from(layout.projectDirectory.dir("src/jpackage/linux")) {
       include("crypta.spec", "template.spec")
@@ -136,7 +149,8 @@ val prepareJpackageResources by
     }
   }
 
-// Helper resolving OS and icon path
+// Helper resolving the OS and icon path
+
 /** Detects the current OS as a stable token: mac|win|linux. */
 fun currentOs(): String {
   val os = org.gradle.internal.os.OperatingSystem.current()
@@ -147,13 +161,16 @@ fun currentOs(): String {
   }
 }
 
-/** Checks if an executable exists on PATH using platform-appropriate command. */
+/** Checks if an executable exists on PATH using the platform-appropriate command. */
 fun hasExe(name: String): Boolean =
   try {
     val pb =
       ProcessBuilder(
-        if (org.gradle.internal.os.OperatingSystem.current().isWindows) listOf("where", name)
-        else listOf("which", name)
+        if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
+          listOf("where", name)
+        } else {
+          listOf("which", name)
+        }
       )
     pb.redirectErrorStream(true)
     val p = pb.start()
@@ -164,13 +181,16 @@ fun hasExe(name: String): Boolean =
   }
 
 /**
- * Picks installer type for the current OS; Windows intentionally unsupported. On Linux, supports
- * override via `-PlinuxInstaller=<deb|rpm>` or env `CRYPTA_LINUX_INSTALLER`. Defaults to preferring
- * rpm when both tools are present.
+ * Picks the installer type for the current OS; Windows intentionally unsupported. On Linux,
+ * supports override via `-PlinuxInstaller=<deb|rpm>` or env `CRYPTA_LINUX_INSTALLER`. Defaults to
+ * preferring rpm when both tools are present.
  */
 fun resolveInstallerType(os: String): String =
   when (os) {
-    "mac" -> "dmg"
+    "mac" -> {
+      "dmg"
+    }
+
     else -> {
       val override =
         (providers.gradleProperty("linuxInstaller").orNull
@@ -178,14 +198,21 @@ fun resolveInstallerType(os: String): String =
           ?.trim()
           ?.lowercase()
       when (override) {
-        "deb" -> "deb"
-        "rpm" -> "rpm"
-        else ->
+        "deb" -> {
+          "deb"
+        }
+
+        "rpm" -> {
+          "rpm"
+        }
+
+        else -> {
           when {
             hasExe("rpmbuild") -> "rpm"
             hasExe("dpkg-deb") -> "deb"
             else -> "deb"
           }
+        }
       }
     }
   }
@@ -206,7 +233,11 @@ fun resolveJpackageExecutable(): File {
   val exe =
     javaHome.resolve(
       "bin/jpackage" +
-        if (org.gradle.internal.os.OperatingSystem.current().isWindows) ".exe" else ""
+        if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
+          ".exe"
+        } else {
+          ""
+        }
     )
   if (!exe.isFile) throw GradleException("jpackage not found in toolchain: $exe")
   return exe
@@ -270,7 +301,7 @@ val jpackageImageCryptad by
       val inputDir = jpackageInputDir.get().asFile
       val stagedMain = createBootstrapJar(inputDir)
 
-      // Ensure we start from a clean target (jpackage fails if image exists)
+      // Ensure we start from a clean target (jpackage fails if the image exists)
       cleanExistingImage(outDir, os)
 
       // On macOS, stage the app image under the system temp directory to avoid iCloud/
@@ -282,7 +313,9 @@ val jpackageImageCryptad by
             System.getProperty("java.io.tmpdir"),
             "crypta-jpackage-${System.currentTimeMillis()}",
           )
-        } else outDir
+        } else {
+          outDir
+        }
       destDir.mkdirs()
 
       val args =
@@ -326,21 +359,13 @@ val jpackageImageCryptad by
             logger.lifecycle("Relocating app image from staging -> {}", target.absolutePath)
             staged.copyRecursively(target, overwrite = true)
             // Best-effort: remove any staging attributes after copy
-            try {
-              val xattr = File("/usr/bin/xattr")
-              if (xattr.canExecute()) {
-                ProcessBuilder(xattr.absolutePath, "-cr", target.absolutePath)
-                  .redirectErrorStream(true)
-                  .start()
-                  .waitFor(5, TimeUnit.SECONDS)
-              }
-            } catch (_: Exception) {}
+            clearXattrsQuiet(target, 5)
             destDir.deleteRecursively()
           }
         }
       } catch (e: Exception) {
         // Workaround for macOS codesign failing with FinderInfo xattr on the app bundle root.
-        // On some macOS versions, jpackage ad-hoc signs the bundle and codesign rejects
+        // On some macOS versions, jpackage ad-hoc signs the bundle, and codesign rejects
         // com.apple.FinderInfo on the freshly created <App>.app, yielding:
         //   resource fork, Finder information, or similar detritus not allowed
         // If we see a failure and the output image exists, clear xattrs and ad-hoc sign the
@@ -386,15 +411,7 @@ val jpackageImageCryptad by
                 if (finalApp.exists()) finalApp.deleteRecursively()
                 stagedApp.copyRecursively(finalApp, overwrite = true)
                 // Remove any staged attrs again just in case
-                try {
-                  val x = File("/usr/bin/xattr")
-                  if (x.canExecute()) {
-                    ProcessBuilder(x.absolutePath, "-cr", finalApp.absolutePath)
-                      .redirectErrorStream(true)
-                      .start()
-                      .waitFor(5, TimeUnit.SECONDS)
-                  }
-                } catch (_: Exception) {}
+                clearXattrsQuiet(finalApp, 5)
                 // Clean up staging directory
                 destDir.deleteRecursively()
                 logger.lifecycle("Relocated fixed app image -> {}", finalApp.absolutePath)
@@ -458,7 +475,7 @@ val enrichAppImageWithDist by
             dstIcon.length(),
           )
 
-          // Also place a stable copy and our own .desktop file referencing it, so the desktop
+          // Also, place a stable copy and our own .desktop file referencing it, so the desktop
           // entry uses the exact provided icon even if jpackage generates a 32x32 fallback.
           val stableIcon = imageRoot.resolve("lib/cryptad.png")
           srcIcon.copyTo(stableIcon, overwrite = true)
@@ -483,7 +500,7 @@ val enrichAppImageWithDist by
           logger.warn("Failed to finalize Linux icon/desktop: {}", e.message)
         }
 
-        // Also stage systemd units and helper artifacts under lib/ so installers and
+        // Also, stage systemd units and helper artifacts under lib/ so installers and
         // post-install scripts can find them inside the app image.
         try {
           val serviceSrc = project.file("src/jpackage/linux/cryptad.service")
@@ -547,7 +564,8 @@ val enrichAppImageWithDist by
         }
       }
 
-      // Patch the jpackage launcher config to point classpath to cryptad-dist/lib and correct main
+      // Patch the jpackage launcher config to point the classpath to cryptad-dist/lib and correct
+      // the main
       // class.
       val cfg =
         when (os) {
@@ -568,7 +586,7 @@ val enrichAppImageWithDist by
         val jars =
           jarDir.listFiles { f -> f.isFile && f.name.endsWith(".jar") }?.sortedBy { it.name }
         val cpPrefix =
-          if (os == "linux") "\$APPDIR/cryptad-dist/lib/" else "\$APPDIR/cryptad-dist/lib/"
+          if (os == "linux") $$"$APPDIR/cryptad-dist/lib/" else $$"$APPDIR/cryptad-dist/lib/"
         out += "app.classpath=${cpPrefix}cryptad.jar"
         jars
           ?.filter { it.name != "cryptad.jar" }
@@ -584,7 +602,7 @@ val enrichAppImageWithDist by
     }
   }
 
-// Build OS-native installer (dmg/msi/deb) using the image created above.
+// Build an OS-native installer (dmg/msi/deb) using the image created above.
 val jpackageInstallerCryptad by
   tasks.registering {
     group = "jpackage"
@@ -593,7 +611,10 @@ val jpackageInstallerCryptad by
     onlyIf {
       when (currentOs()) {
         "linux" -> hasExe("dpkg-deb") || hasExe("rpmbuild")
-        "win" -> false // Windows installers removed
+
+        "win" -> false
+
+        // Windows installers removed
         else -> true
       }
     }

--- a/build-logic/src/main/kotlin/cryptad.runtime.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.runtime.gradle.kts
@@ -6,10 +6,10 @@ plugins { java }
 // We keep our existing custom distribution (assembleCryptadDist) intact.
 // This plugin builds a jlink image directly (no external runtime plugin).
 
-val cryptadDistDir = layout.buildDirectory.dir("cryptad-dist")
-val jlinkImageDir = layout.buildDirectory.dir("cryptad-jlink-image")
+val cryptadDistDir: Provider<Directory> = layout.buildDirectory.dir("cryptad-dist")
+val jlinkImageDir: Provider<Directory> = layout.buildDirectory.dir("cryptad-jlink-image")
 
-// No application plugin: launchers below invoke the main class directly
+// No application plugin: the launchers below invoke the main class directly
 
 // jdeps prefers a versioned jar; copy our custom jar to that name
 val syncRuntimeJar by
@@ -31,7 +31,7 @@ val syncRuntimeJar by
 
 // No external runtime plugin configuration; jlink is invoked below
 
-// Our existing bin/cryptad script (Tanuki Wrapper) isn't patched by the plugin.
+// The plugin doesn't patch our existing bin/cryptad script (Tanuki Wrapper).
 // No separate jlink-specific launchers; we reuse dist/bin scripts and wrapper binaries
 
 // Discover Java modules with jdeps for the assembled app classpath
@@ -45,6 +45,7 @@ abstract class ComputeJlinkModules @Inject constructor(private val execOps: Exec
   @get:InputFiles @get:Classpath abstract val classpath: ConfigurableFileCollection
 
   @get:Input abstract val javaLanguageVersion: Property<Int>
+
   // Provide JDK home explicitly to avoid accessing Project services during execution
   @get:Input abstract val javaHomePath: Property<String>
 
@@ -61,8 +62,8 @@ abstract class ComputeJlinkModules @Inject constructor(private val execOps: Exec
     val jdeps =
       javaHome.resolve(
         "bin/jdeps${
-              if (System.getProperty("os.name").lowercase().contains("win")) ".exe" else ""
-          }"
+                        if (System.getProperty("os.name").lowercase().contains("win")) ".exe" else ""
+                    }"
       )
 
     val classpathArg =
@@ -89,9 +90,9 @@ abstract class ComputeJlinkModules @Inject constructor(private val execOps: Exec
 
     val baseline = baselineModules.get().toSet()
     val modules: Set<String> =
-      if (exit == 0 && detected.isNotBlank())
+      if (exit == 0 && detected.isNotBlank()) {
         detected.split(',').map { it.trim() }.filter { it.isNotEmpty() }.toSet() + baseline
-      else
+      } else {
         baseline +
           setOf(
             "java.base",
@@ -106,6 +107,7 @@ abstract class ComputeJlinkModules @Inject constructor(private val execOps: Exec
             "java.sql",
             "java.xml",
           )
+      }
 
     val outFile = modulesFile.get().asFile
     outFile.parentFile.mkdirs()
@@ -135,7 +137,7 @@ val computeJlinkModules by
 
     // Toolchain + baseline
     javaLanguageVersion.set(25)
-    // Resolve toolchain at configuration time and pass JDK home path as input
+    // Resolve the toolchain at configuration time and pass JDK home path as input
     val toolchains = project.serviceOf<JavaToolchainService>()
     val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
     javaHomePath.set(launcher.map { it.metadata.installationPath.asFile.absolutePath })
@@ -237,7 +239,7 @@ val prepareJlinkImage by
     }
   }
 
-// Zip the jlink image with predictable name
+// Zip the jlink image with a predictable name
 val distZipCryptadJlink by
   tasks.registering(Zip::class) {
     group = "distribution"

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -1,9 +1,5 @@
 import name.remal.gradle_plugins.sonarlint.SonarLint
 import name.remal.gradle_plugins.sonarlint.SonarLintSettings
-import org.gradle.api.JavaVersion
-import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 plugins {
   // Apply SonarQube/SonarCloud and SonarLint centrally via convention plugin
@@ -75,21 +71,20 @@ extensions.configure<SonarLintSettings>("sonarLint") {
 // Usage:
 //   ./gradlew sonarlintFile -Psonarlint.file=src/main/java/SevenZip/LzmaAlone.java
 //   (aliases: -Pfile=..., -Psonarlint.sources=...)
-val sourceSets = extensions.getByType(SourceSetContainer::class.java)
+val sourceSets: SourceSetContainer = extensions.getByType(SourceSetContainer::class.java)
 
 tasks.register("sonarlintFile", SonarLint::class.java) {
   group = "verification"
   description = "Run SonarLint on a single file (-Psonarlint.file=<path>)."
   // Analyze against main sources by default
   setSource(sourceSets.named("main").get().allSource)
-  // Propagate Java language level explicitly for single-file analysis
+  // Propagate the Java language level explicitly for single-file analysis
   val javaExt = project.extensions.findByType(JavaPluginExtension::class.java)
-  val sourceVersion = (javaExt?.sourceCompatibility ?: JavaVersion.current()).majorVersion
   val targetVersion = (javaExt?.targetCompatibility ?: JavaVersion.current()).majorVersion
-  // Configure task-scoped Java release for the SonarLint engine
-  java { release.set(JavaLanguageVersion.of(sourceVersion.toInt())) }
+  // Configure a task-scoped Java release for the SonarLint engine
+  java { release.set(JavaLanguageVersion.of(targetVersion.toInt())) }
 
-  // Provide classpath and output directories so Java rules that require
+  // Provide classpath and output directories, so Java rules that require
   // semantic information are enabled even for single-file analysis.
   val mainSourceSet = sourceSets.named("main").get()
   java {
@@ -105,8 +100,8 @@ tasks.register("sonarlintFile", SonarLint::class.java) {
       .orElse(providers.gradleProperty("sonar.inclusions"))
 
   val pattern = fileProp.orNull
-  if (pattern != null && pattern.isNotBlank()) {
-    // Normalize to project-relative path and set it as the only source
+  if (!pattern.isNullOrBlank()) {
+    // Normalize to a project-relative path and set it as the only source
     val f = project.layout.projectDirectory.file(pattern).asFile
     val rel = project.relativePath(f)
     if (f.isFile) {

--- a/build-logic/src/main/kotlin/cryptad.versioning.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.versioning.gradle.kts
@@ -19,7 +19,7 @@ val gitrev: String =
     "@unknown@"
   }
 
-val sourceSetsContainer = extensions.getByType(SourceSetContainer::class.java)
+val sourceSetsContainer: SourceSetContainer = extensions.getByType(SourceSetContainer::class.java)
 // Also consider Kotlin source roots so the Version.kt template may live under src/*/kotlin/
 val kotlinExt =
   extensions.findByType(org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension::class.java)

--- a/src/main/kotlin/network/crypta/config/ConfigMigrator.kt
+++ b/src/main/kotlin/network/crypta/config/ConfigMigrator.kt
@@ -55,7 +55,7 @@ private fun moveIfPresent(src: Path, dst: Path) {
     if (!Files.exists(dst.parent)) Files.createDirectories(dst.parent)
     Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE)
     LOG.info("Moved {} -> {} (atomic)", src, dst)
-  } catch (e: AtomicMoveNotSupportedException) {
+  } catch (_: AtomicMoveNotSupportedException) {
     // Fallback to non-atomic move and log
     try {
       Files.move(src, dst)
@@ -83,21 +83,21 @@ private fun rewriteLegacyPaths(configFile: Path) {
       val v = sfs[key] ?: return
       if (v == rel || v == "./$rel") sfs.putOverwrite(key, placeholder)
     }
-    rewrite("node.install.cfgDir", ".", "\${configDir}")
-    rewrite("node.install.userDir", ".", "\${configDir}")
-    rewrite("node.install.nodeDir", ".", "\${dataDir}/node")
-    rewrite("node.install.storeDir", "./datastore", "\${dataDir}/datastore")
-    rewrite("node.install.pluginDir", "./plugins", "\${dataDir}/plugins")
-    rewrite("node.install.pluginStoresDir", "plugin-data", "\${dataDir}/plugins")
-    rewrite("node.install.tempDir", "./temp", "\${cacheDir}/tmp")
-    rewrite("node.install.persistentTempDir", "./persistent-temp", "\${cacheDir}/persistent-temp")
-    rewrite("node.downloadsDir", "./downloads", "\${dataDir}/downloads")
-    rewrite("logger.dirname", "./logs", "\${logsDir}")
+    rewrite("node.install.cfgDir", ".", $$"${configDir}")
+    rewrite("node.install.userDir", ".", $$"${configDir}")
+    rewrite("node.install.nodeDir", ".", $$"${dataDir}/node")
+    rewrite("node.install.storeDir", "./datastore", $$"${dataDir}/datastore")
+    rewrite("node.install.pluginDir", "./plugins", $$"${dataDir}/plugins")
+    rewrite("node.install.pluginStoresDir", "plugin-data", $$"${dataDir}/plugins")
+    rewrite("node.install.tempDir", "./temp", $$"${cacheDir}/tmp")
+    rewrite("node.install.persistentTempDir", "./persistent-temp", $$"${cacheDir}/persistent-temp")
+    rewrite("node.downloadsDir", "./downloads", $$"${dataDir}/downloads")
+    rewrite("logger.dirname", "./logs", $$"${logsDir}")
 
     Files.newOutputStream(configFile).use { os -> sfs.writeToBigBuffer(os) }
     LOG.info("Rewrote legacy paths in {}", configFile)
   } catch (e: Exception) {
-    // Tolerate parse errors; continue without rewrite, but log for visibility
+    // Tolerate parse errors; continue without a rewrite, but log for visibility
     LOG.warn("Failed to rewrite legacy paths in {}: {}", configFile, e.message, e)
   }
 }

--- a/src/main/kotlin/network/crypta/config/CryptadConfig.kt
+++ b/src/main/kotlin/network/crypta/config/CryptadConfig.kt
@@ -113,7 +113,7 @@ private fun replacePlaceholders(input: String, base: Map<String, String>): Pair<
   var out = input
   var replacedAny = false
   base.forEach { (k, v) ->
-    val placeholder = "\${$k}"
+    val placeholder = $$"${$$k}"
     if (out.contains(placeholder)) replacedAny = true
     out = out.replace(placeholder, v)
   }

--- a/src/main/kotlin/network/crypta/support/compress/LzmaInputStream.kt
+++ b/src/main/kotlin/network/crypta/support/compress/LzmaInputStream.kt
@@ -1,10 +1,6 @@
 package network.crypta.support.compress
 
-import java.io.BufferedInputStream
-import java.io.IOException
-import java.io.InputStream
-import java.io.PipedInputStream
-import java.io.PipedOutputStream
+import java.io.*
 import java.util.concurrent.CountDownLatch
 import org.sevenzip.compression.lzma.Decoder
 
@@ -129,7 +125,7 @@ class LzmaInputStream(private val source: InputStream) : InputStream() {
   /**
    * Reads up to `len` decoded bytes into `b` starting at `off`.
    *
-   * This method may block until data becomes available from the decoder or end of stream is
+   * This method may block until data becomes available from the decoder or the end of the stream is
    * reached.
    *
    * @return number of bytes read, or `-1` if the end of stream has been reached.
@@ -152,10 +148,6 @@ class LzmaInputStream(private val source: InputStream) : InputStream() {
    * @throws IOException if closing the underlying streams fails.
    */
   override fun close() {
-    try {
-      pipeIn.close()
-    } finally {
-      source.close()
-    }
+    source.use { _ -> pipeIn.close() }
   }
 }


### PR DESCRIPTION
## Summary
- normalize provider typing and helper reuse in build logic tasks
- centralize wrapper/seed download and macOS xattr cleanup paths
- tighten config placeholder escaping and SonarLint Java release selection

## Testing
- ./gradlew spotlessApply