### PR TITLE
test(fcp): remove helper @Test

### DIFF
--- a/src/test/java/network/crypta/clients/fcp/FCPPluginClientMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginClientMessageTest.java
@@ -220,7 +220,6 @@ class FCPPluginClientMessageTest {
     }
   }
 
-  @Test
   private FCPPluginClientMessage createMessage(Consumer<SimpleFieldSet> customizer)
       throws MessageInvalidException {
     SimpleFieldSet fs = minimalFieldSet();


### PR DESCRIPTION
## Summary
- remove the accidental @Test annotation from the createMessage helper in FCPPluginClientMessageTest
- keep the helper as a non-test method to satisfy SonarLint and JUnit visibility expectations

## Testing
- ./gradlew test --tests \"network.crypta.clients.fcp.FCPPluginClientMessageTest\"
- ./gradlew sonarlintFile -Psonarlint.file=src/test/java/network/crypta/clients/fcp/FCPPluginClientMessageTest.java
- ./gradlew test