### PR TITLE
Fix async get timeout status handling

### DIFF
--- a/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
@@ -181,7 +181,7 @@ public final class NodeClientCoreTransfers {
             synchronized (this) {
               rejectedOverloadLocal = this.rejectedOverload;
             }
-            handleAsyncGetFinished(context, realTimeFlag, rs, rejectedOverloadLocal);
+            handleAsyncGetFinished(context, realTimeFlag, rs, rejectedOverloadLocal, status);
           }
 
           @Override
@@ -217,12 +217,15 @@ public final class NodeClientCoreTransfers {
   }
 
   private void handleAsyncGetFinished(
-      AsyncGetContext context, boolean realTimeFlag, RequestSender rs, boolean rejectedOverload) {
+      AsyncGetContext context,
+      boolean realTimeFlag,
+      RequestSender rs,
+      boolean rejectedOverload,
+      int status) {
     boolean isSSK = context.isSSK();
     RequestCompletionListener listener = context.listener();
     long startTime = context.startTime();
     Key key = context.key();
-    int status = rs.getStatus();
     if (status == RequestSender.NOT_FINISHED) {
       LOG.error("Bogus status in onRequestSenderFinished for {}", rs, new Exception("error"));
       listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));

--- a/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTransfersTest.java
@@ -169,7 +169,7 @@ class NodeClientCoreTransfersTest {
     RequestSender sender = mock(RequestSender.class);
     when(node.routing().makeRequestSender(any(), anyShort(), anyLong(), any(), any(), any()))
         .thenReturn(sender);
-    when(sender.getStatus()).thenReturn(RequestSender.TIMED_OUT);
+    when(sender.getStatus()).thenReturn(RequestSender.NOT_FINISHED);
     when(sender.hasForwarded()).thenReturn(false);
 
     AtomicReference<RequestSenderListener> listenerRef = new AtomicReference<>();


### PR DESCRIPTION
## Summary
- honor RequestSender callback status for async get completion to avoid bogus NOT_FINISHED handling on timeout reassigns
- keep timeout test exercising NOT_FINISHED sender state while expecting rejected-overload path

## Testing
- ./gradlew test