### PR TITLE
refactor(client-filter): clarify filter logs

### DIFF
--- a/src/main/java/network/crypta/client/filter/CSSTokenizerFilter.java
+++ b/src/main/java/network/crypta/client/filter/CSSTokenizerFilter.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * pipeline.
  *
  * <p>This component reads CSS from a {@link Reader}, tokenizes it with a small state machine, and
- * applies a conservative allowlist of properties, values, selectors and at-rules. The primary goal
+ * applies a conservative allowlist of properties, values, selectors, and at-rules. The primary goal
  * is to preserve a wide subset of legitimate stylesheet constructs while reliably rejecting or
  * neutralizing values and selectors that could break layout assumptions or enable content
  * exfiltration when rendered by a browser. The implementation predates a formal grammar; it focuses
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Typical usage is to construct a filter with an input {@code Reader}, an output {@code Writer},
  * and a {@link FilterCallback} that validates and possibly rewrites URIs. Call {@link #parse()}
- * once to filter the input stream into the output writer. The filter keeps a small amount of state
- * around quotes, comments, braces and current property context. It does not attempt to preserve
+ * once to filter the input stream into the output writer. The filter keeps a small number of states
+ * around quotes, comments, braces, and current property context. It does not attempt to preserve
  * unreachable or structurally invalid content.
  *
  * <ul>
@@ -107,15 +107,35 @@ class CSSTokenizerFilter {
   private static final String WS_T_R_N = " \t\r\n";
   private static final String WS_T_R_N_F = " \t\r\n\f";
 
-  private static final String MSG_HTML_COMMENT_WS = "<!-- not followed by whitespace!";
-  private static final String MSG_SPLIT = "Split: {}";
-  private static final String MSG_OPEN_BRACES_S3 =
-      "openBraces now {} not moving on because openBracesStartingS3={} in S3";
-  private static final String MSG_PROPERTY_VALUE = "Property value: {}";
-  private static final String MSG_NO_SUCH_PROPERTY_NAME = "No such property name \"{}\"";
-  private static final String MSG_APPEND_WS_AFTER_COLON =
-      "Appending whitespace after colon (}): {}";
-  private static final String MSG_APPEND_WS_STATE2 = "Appending whitespace in state2: \"{}\"";
+  private static final String MSG_HTML_COMMENT_WS_LEADING =
+      "HTML comment marker invalid in leading scan: <!-- not followed by whitespace!";
+  private static final String MSG_HTML_COMMENT_WS_PREFIX =
+      "HTML comment marker invalid in prefix scan: <!-- not followed by whitespace!";
+  private static final String MSG_SPLIT_STATE1_OPEN_BRACE =
+      "Split tokens for STATE1 '{' processing: {}";
+  private static final String MSG_SPLIT_STATE3_SEMI =
+      "Split property value tokens at ';' in STATE3: {}";
+  private static final String MSG_SPLIT_STATE3_RBRACE =
+      "Split property value tokens before '}' in STATE3: {}";
+  private static final String MSG_OPEN_BRACES_S3_COLON =
+      "STATE3 ':' inside nested braces: openBraces={} start={}";
+  private static final String MSG_OPEN_BRACES_S3_SEMI =
+      "STATE3 ';' inside nested braces: openBraces={} start={}";
+  private static final String MSG_OPEN_BRACES_S3_RBRACE =
+      "STATE3 '}' inside nested braces: openBraces={} start={}";
+  private static final String MSG_PROPERTY_VALUE_SEMI =
+      "Parsed property value at ';' in STATE3: {}";
+  private static final String MSG_PROPERTY_VALUE_RBRACE =
+      "Parsed property value before '}' in STATE3: {}";
+  private static final String MSG_NO_SUCH_PROPERTY_NAME_SEMI =
+      "Unknown property name at ';' in STATE3: \"{}\"";
+  private static final String MSG_NO_SUCH_PROPERTY_NAME_RBRACE =
+      "Unknown property name before '}' in STATE3: \"{}\"";
+  private static final String MSG_APPEND_WS_AFTER_COLON_RBRACE =
+      "Captured whitespace after colon before '}' in STATE3: {}";
+  private static final String MSG_APPEND_WS_PREFIX_RBRACE =
+      "Captured prefix whitespace before '}' in STATE3: {}";
+  private static final String MSG_APPEND_WS_STATE2 = "Appending whitespace in STATE2: \"{}\"";
   private static final String TOK_COUNTERS = "counters(";
   private static final String TOK_COUNTER = "counter(";
   private static final Logger LOG = LoggerFactory.getLogger(CSSTokenizerFilter.class);
@@ -141,7 +161,7 @@ class CSSTokenizerFilter {
   // no static init required
 
   /**
-   * Creates a filter with default configuration suitable for basic uses in tests. The input and
+   * Creates a filter with a default configuration suitable for basic uses in tests. The input and
    * callback must be supplied before calling {@link #parse()}.
    */
   CSSTokenizerFilter() {
@@ -151,7 +171,7 @@ class CSSTokenizerFilter {
   }
 
   /**
-   * Creates a filter bound to the given input, output and URI processing callback.
+   * Creates a filter bound to the given input, output, and URI processing callback.
    *
    * <p>The filter reads from {@code r}, emits sanitized CSS to {@code w}, and consults {@code cb}
    * for URI validation and rewriting. The declared charset influences how {@code @charset} handling
@@ -188,7 +208,7 @@ class CSSTokenizerFilter {
    *
    * <p>The method forwards the URI to {@link FilterCallback#processURI(String, String)} with a
    * {@code null} override type. If the callback throws or returns a different value, the URI is
-   * considered invalid for the purpose of acceptance in CSS.
+   * considered invalid for acceptance in CSS.
    *
    * @param uri absolute or relative URI to validate; must be a non-null, non-empty string.
    * @return {@code true} when the callback returns the same value; {@code false} on rewrite,
@@ -205,11 +225,11 @@ class CSSTokenizerFilter {
   // Removed: unused generic array concat helper.
 
   /* To save the memory, only those Verifier objects would be created which are actually present in the CSS document.
-   * allelementVerifiers contains all the CSS property tags as String. All loaded Verifier objects are stored in elementVerifier.
+   * allelementVerifiers contain all the CSS property tags as String. All loaded Verifier objects are stored in elementVerifier.
    * When retrieving a Verifier object, first it is searched in elementVerifiers to see if it is already loaded.
-   * If it is not loaded then allelementVerifiers is checked to see if the property name is valid. If it is valid, then the desired Verifier object is loaded in allelemntVerifiers.
+   * If it is not loaded, then allelementVerifiers are checked to see if the property name is valid. If it is valid, then the desired Verifier object is loaded in allelemntVerifiers.
    */
-  // Note: this is probably overkill, initialising all of them on startup would probably be cleaner
+  // Note: this is probably overkill, initializing all of them on startup would probably be cleaner
   // code, less synchronization, at very little memory cost.
   // Note: check how many bytes we save by lazy init here.
   private static final Map<String, CSSPropertyVerifier> elementVerifiers = new HashMap<>();
@@ -535,7 +555,8 @@ class CSSTokenizerFilter {
   private static final CSSPropertyVerifier[] auxilaryVerifiers = new CSSPropertyVerifier[149];
 
   static {
-    /*CSSPropertyVerifier(String[] allowedValues,String[] possibleValues,String expression,boolean onlyValueVerifier)*/
+    // CSSPropertyVerifier(String[] allowedValues,String[] possibleValues, String expression,
+    // boolean onlyValueVerifier)
     // for background-position
     auxilaryVerifiers[2] =
         new CSSPropertyVerifier(
@@ -823,7 +844,7 @@ class CSSTokenizerFilter {
   private static Map<String, PropertyRule> buildRules() {
     Map<String, PropertyRule> m = new HashMap<>();
 
-    // Example ports to the registry. Remaining properties fall back to legacy handler.
+    // Example ports to the registry. Remaining properties fall back to the legacy handler.
 
     // accent-color
     register(
@@ -3181,7 +3202,7 @@ class CSSTokenizerFilter {
   }
 
   /* This function loads a verifier object in elementVerifiers.
-   * After the object has been loaded, property name is removed from allelementVerifier.
+   * After the object has been loaded, the property name is removed from allelementVerifier.
    */
   private static void addVerifier(String element) {
     PropertyRule rule = RULES.get(element.toLowerCase());
@@ -3227,7 +3248,7 @@ class CSSTokenizerFilter {
     // 3) Class or ID
     if (!extractClassOrId(parts, isIDSelector)) return null;
     if (isIDSelector && parts.id.isEmpty()) return null; // require an ID
-    // 4) Validate element and names
+    // 4) Validate the element and names
     if (!isElementValid(parts)) return null;
     if (!validateNames(parts)) return null;
     // 5) Validate pseudo class semantics
@@ -3414,9 +3435,9 @@ class CSSTokenizerFilter {
 
   /*
    * This function works with different operators, +, >, " " and verifies each HTML element with htmlElementVerifier(String elementString)
-   * e.g. div > p:first-child
+   * e.g., div > p:first-child
    * This would call HTMLelementVerifier with div and p:first-child
-   * Returns null on failure (selector invalid), empty string on banned but otherwise valid selector.
+   * Returns null on failure (selectors invalid), empty string on banned but otherwise valid selector.
    */
   /**
    * Parses and validates a full selector list or a single selector and returns a sanitized form.
@@ -3751,7 +3772,7 @@ class CSSTokenizerFilter {
       return false;
     }
 
-    /** Handles BOM at current character; returns true if the caller should continue loop. */
+    /** Handles BOM at the current character; returns true if the caller should continue loop. */
     private boolean handlePossibleBom() throws IOException {
       if (x != (char) 0xFEFF) return false;
       if (bomPossible) {
@@ -3805,7 +3826,7 @@ class CSSTokenizerFilter {
       }
     }
 
-    // Extracted handlers to reduce complexity/LOC of handleCurrentStateChar()
+    // Extracted handlers to reduce the complexity/LOC of handleCurrentStateChar()
     /**
      * Handle characters in STATE1 by delegating complex branches to focused helpers. This keeps the
      * top-level switch small, reducing cyclomatic and cognitive complexity while preserving
@@ -3893,7 +3914,8 @@ class CSSTokenizerFilter {
       String postSpace = extractTrailingWhitespaceAndTrim();
       String orig = buffer.toString().trim();
       ParsedWord[] parts = split(orig, false);
-      if (LOG.isTraceEnabled()) LOG.trace(MSG_SPLIT, CSSPropertyVerifier.toString(parts));
+      if (LOG.isTraceEnabled())
+        LOG.trace(MSG_SPLIT_STATE1_OPEN_BRACE, CSSPropertyVerifier.toString(parts));
       buffer.setLength(0);
       boolean valid = processState1OpenBraceParts(parts, braceSpace, postSpace, orig);
 
@@ -3969,11 +3991,11 @@ class CSSTokenizerFilter {
       if (buffer.length() > 4 && buffer.substring(0, 4).equals("<!--")) {
         w.write(buffer.substring(0, 4));
         if (WS_T_R_N.indexOf(buffer.charAt(4)) == -1) {
-          LOG.error(MSG_HTML_COMMENT_WS);
+          LOG.error(MSG_HTML_COMMENT_WS_LEADING);
           return;
         }
         buffer.delete(0, 4);
-        // Restart whitespace scan after the comment from the new buffer start.
+        // Restart the whitespace scan after the comment from the new buffer start.
         i = 0;
         while (i < buffer.length() && WS_T_R_N_F.indexOf(buffer.charAt(i)) != -1) {
           i++;
@@ -4013,7 +4035,9 @@ class CSSTokenizerFilter {
       w.write("@charset \"" + detectedCharset + "\";");
     }
 
-    /** Returns prefix whitespace plus an optional HTML comment marker; null on invalid pattern. */
+    /**
+     * Returns prefix whitespace plus an optional HTML comment marker; null on an invalid pattern.
+     */
     private String extractLeadingWhitespaceAndOptionalHtmlComment() {
       int i = 0;
       while (i < buffer.length() && WS_T_R_N_F.indexOf(buffer.charAt(i)) != -1) {
@@ -4024,11 +4048,11 @@ class CSSTokenizerFilter {
       if (buffer.length() > 4 && buffer.substring(0, 4).equals("<!--")) {
         prefix += buffer.substring(0, 4);
         if (WS_T_R_N.indexOf(buffer.charAt(4)) == -1) {
-          LOG.error(MSG_HTML_COMMENT_WS);
+          LOG.error(MSG_HTML_COMMENT_WS_PREFIX);
           return null;
         }
         buffer.delete(0, 4);
-        // Restart whitespace scan after the comment from the new buffer start.
+        // Restart the whitespace scan after the comment from the new buffer start.
         i = 0;
         while (i < buffer.length() && WS_T_R_N_F.indexOf(buffer.charAt(i)) != -1) {
           i++;
@@ -4142,7 +4166,7 @@ class CSSTokenizerFilter {
 
     private String extractImportUri(ParsedWord head) {
       if (head instanceof ParsedURL url) return url.getDecoded();
-      // Fallback: head must be a ParsedString per isValidImportHead()
+      // Fallback: the head must be a ParsedString per isValidImportHead()
       if (head instanceof ParsedString string) return string.getDecoded();
       // Defensive: should not happen; return original encoding
       return head == null ? null : head.original;
@@ -4413,7 +4437,8 @@ class CSSTokenizerFilter {
       }
       if (openBraces > openBracesStartingS3) {
         buffer.append(c);
-        if (LOG.isDebugEnabled()) LOG.debug(MSG_OPEN_BRACES_S3, openBraces, openBracesStartingS3);
+        if (LOG.isDebugEnabled())
+          LOG.debug(MSG_OPEN_BRACES_S3_COLON, openBraces, openBracesStartingS3);
         return;
       }
       int i = 0;
@@ -4435,17 +4460,19 @@ class CSSTokenizerFilter {
       }
       if (openBraces > openBracesStartingS3) {
         buffer.append(c);
-        if (LOG.isDebugEnabled()) LOG.debug(MSG_OPEN_BRACES_S3, openBraces, openBracesStartingS3);
+        if (LOG.isDebugEnabled())
+          LOG.debug(MSG_OPEN_BRACES_S3_SEMI, openBraces, openBracesStartingS3);
         return;
       }
       preparePropertyValueFromBuffer();
       CSSPropertyVerifier obj = getVerifier(propertyName);
       if (obj != null) {
         ParsedWord[] words = split(propertyValue, obj.allowCommaDelimiters);
-        if (LOG.isTraceEnabled()) LOG.trace(MSG_SPLIT, CSSPropertyVerifier.toString(words));
+        if (LOG.isTraceEnabled())
+          LOG.trace(MSG_SPLIT_STATE3_SEMI, CSSPropertyVerifier.toString(words));
         appendPropertyIfValid(words, obj, true);
       } else if (LOG.isTraceEnabled()) {
-        LOG.trace(MSG_NO_SUCH_PROPERTY_NAME, propertyName);
+        LOG.trace(MSG_NO_SUCH_PROPERTY_NAME_SEMI, propertyName);
       }
       ignoreElementsS3 = false;
       propertyName = "";
@@ -4458,10 +4485,10 @@ class CSSTokenizerFilter {
         i++;
       }
       if (LOG.isDebugEnabled())
-        LOG.debug("Appending whitespace after colon: \"{}\"", buffer.substring(0, i));
+        LOG.debug("STATE3 after-colon whitespace before ';': \"{}\"", buffer.substring(0, i));
       whitespaceAfterColon = buffer.substring(0, i);
       propertyValue = buffer.delete(0, i).toString().trim();
-      if (LOG.isTraceEnabled()) LOG.trace(MSG_PROPERTY_VALUE, propertyValue);
+      if (LOG.isTraceEnabled()) LOG.trace(MSG_PROPERTY_VALUE_SEMI, propertyValue);
       buffer.setLength(0);
     }
 
@@ -4536,7 +4563,8 @@ class CSSTokenizerFilter {
       openBraces--;
       if (openBraces > openBracesStartingS3 - 1) {
         buffer.append(c);
-        if (LOG.isDebugEnabled()) LOG.debug(MSG_OPEN_BRACES_S3, openBraces, openBracesStartingS3);
+        if (LOG.isDebugEnabled())
+          LOG.debug(MSG_OPEN_BRACES_S3_RBRACE, openBraces, openBracesStartingS3);
         if (openBraces < 0) openBraces = 0;
         return;
       }
@@ -4552,21 +4580,22 @@ class CSSTokenizerFilter {
       while (i < buffer.length() && WS_T_R_N_F.indexOf(buffer.charAt(i)) != -1) {
         i++;
       }
-      if (LOG.isDebugEnabled()) LOG.debug(MSG_APPEND_WS_AFTER_COLON, buffer.substring(0, i));
+      if (LOG.isDebugEnabled()) LOG.debug(MSG_APPEND_WS_AFTER_COLON_RBRACE, buffer.substring(0, i));
       whitespaceAfterColon = buffer.substring(0, i);
       buffer.delete(0, i);
       propertyValue = buffer.toString().trim();
-      if (LOG.isTraceEnabled()) LOG.trace(MSG_PROPERTY_VALUE, propertyValue);
+      if (LOG.isTraceEnabled()) LOG.trace(MSG_PROPERTY_VALUE_RBRACE, propertyValue);
       buffer.setLength(0);
       CSSPropertyVerifier obj = getVerifier(propertyName);
       if (LOG.isDebugEnabled())
         LOG.debug("Found PropertyName:{} propertyValue:{}", propertyName, propertyValue);
       if (obj != null) {
         ParsedWord[] words = split(propertyValue, obj.allowCommaDelimiters);
-        if (LOG.isTraceEnabled()) LOG.trace(MSG_SPLIT, CSSPropertyVerifier.toString(words));
+        if (LOG.isTraceEnabled())
+          LOG.trace(MSG_SPLIT_STATE3_RBRACE, CSSPropertyVerifier.toString(words));
         appendPropertyIfValid(words, obj, false);
       } else {
-        if (LOG.isTraceEnabled()) LOG.trace(MSG_NO_SUCH_PROPERTY_NAME, propertyName);
+        if (LOG.isTraceEnabled()) LOG.trace(MSG_NO_SUCH_PROPERTY_NAME_RBRACE, propertyName);
       }
       propertyName = "";
     }
@@ -4576,7 +4605,7 @@ class CSSTokenizerFilter {
       while (i < buffer.length() && WS_T_R_N_F.indexOf(buffer.charAt(i)) != -1) {
         i++;
       }
-      if (LOG.isDebugEnabled()) LOG.debug(MSG_APPEND_WS_AFTER_COLON, buffer.substring(0, i));
+      if (LOG.isDebugEnabled()) LOG.debug(MSG_APPEND_WS_PREFIX_RBRACE, buffer.substring(0, i));
       filteredTokens.append(buffer, 0, i);
       buffer.delete(0, i);
     }
@@ -4784,7 +4813,7 @@ class CSSTokenizerFilter {
     /** Original source lexeme preserved for re-encoding when unchanged. */
     final String original;
 
-    /** Has decoded changed? If not we can use the original. */
+    /** Has decoded changed? If not, we can use the original. */
     protected boolean changed;
 
     /** Whether this token immediately follows a comma in the source (affects list parsing). */
@@ -4843,8 +4872,8 @@ class CSSTokenizerFilter {
     /**
      * Creates a token with both the original lexeme and its decoded form.
      *
-     * @param original original source lexeme as it appeared in the stylesheet; retained for reuse
-     *     when no transformation is necessary.
+     * @param original the original source lexeme as it appeared in the stylesheet; retained for
+     *     reuse when no transformation is necessary.
      * @param decoded normalized value used for validation and re-encoding decisions.
      * @param changed set {@code true} when the original encoding was unsuitable and the decoded
      *     value should be used when re-serializing.
@@ -4955,7 +4984,7 @@ class CSSTokenizerFilter {
 
     /**
      * Is the word quoted? If true, the word is completely enclosed by the given string character
-     * (either ' or "), which are not included in the decoded string.
+     * (either ' or "), which is not included in the decoded string.
      */
     final char stringChar;
 
@@ -4966,7 +4995,7 @@ class CSSTokenizerFilter {
       if (c == '\r' || c == '\n' || c == '\f')
         // Except newlines.
         return true;
-      else // And control chars, and anything outside Basic Latin (unless we know the output charset
+      else // And control chars and anything outside Basic Latin (unless we know the output charset
       // is unicode-complete).
       if (c == stringChar)
         // And the quote itself.
@@ -5109,7 +5138,7 @@ class CSSTokenizerFilter {
   }
 
   /**
-   * Stateful splitter to keep the public split(...) method small and focused. Encapsulates
+   * Stateful splitter to keep the public split(...) method small and focused. Encapsulates the
    * tokenization state and mirrors the prior behavior exactly.
    */
   private static final class SplitRunner {
@@ -5123,7 +5152,7 @@ class CSSTokenizerFilter {
     boolean eatLF = false; // eat the next linefeed due to an escape closing
     final StringBuilder origToken;
     final StringBuilder decodedToken;
-    boolean dontLikeOrigToken = false; // original token bends the spec in unacceptable ways
+    boolean dontLikeOrigToken = false; // the original token bends the spec in unacceptable ways
     final StringBuilder escape = new StringBuilder(6);
     boolean couldBeIdentifier = true;
     boolean addComma = false;
@@ -5846,7 +5875,7 @@ class CSSTokenizerFilter {
     }
 
     /**
-     * Full constructor exposing all verifier knobs including expression patterns and value-only
+     * Full constructor exposing all verifier knobs, including expression patterns and value-only
      * mode.
      *
      * @param allowedValues accepted literal keywords; may be {@code null}.
@@ -5914,7 +5943,7 @@ class CSSTokenizerFilter {
       this.isIDSelector = flags.idSelector;
       this.isShape = flags.shape;
       this.isString = flags.string;
-      this.isCounter = flags.counter; // not set by tokens currently, reserved
+      this.isCounter = flags.counter; // not set by tokens currently reserved
       this.isIdentifier = flags.identifier;
       this.isTime = flags.time;
       this.isFrequency = flags.frequency;
@@ -6063,7 +6092,7 @@ class CSSTokenizerFilter {
     /**
      * Convenience overload that validates a single token value.
      *
-     * @param word token to validate according to this property’s rules.
+     * @param word token to validate, according to this property’s rules.
      * @param cb auxiliary callback for URI checks when {@code word} is a URL.
      * @return {@code true} when the token is accepted.
      */
@@ -6091,7 +6120,7 @@ class CSSTokenizerFilter {
       if (!onlyValueVerifier && allowedMedia != null && !isAnyMediaAllowed(media)) {
         if (LOG.isDebugEnabled())
           LOG.debug(
-              "checkValidity Media of the element is not allowed.Media={} allowed Media={}",
+              "checkValidity rejected: media not allowed for element. media={} allowedMedia={}",
               Fields.commaList(media),
               allowedMedia);
         return false;
@@ -6264,7 +6293,7 @@ class CSSTokenizerFilter {
       return false;
     }
 
-    /** Returns the index where the initial 1a2a3... chain ends (position of last digit). */
+    /** Returns the index where the initial 1a2a3... chain ends (position of the last digit). */
     private int findEndOfOrChain(String expression) {
       int endIndex = expression.length();
       for (int j = 0; j < expression.length(); j++) {
@@ -6395,7 +6424,7 @@ class CSSTokenizerFilter {
     /**
      * Takes b-expressions and evaluates them.
      *
-     * <p>{@literal &&} means all of the expressions must occur in any order.<br>
+     * <p>{@literal &&} means all the expressions must occur in any order.<br>
      * CSS Grammar {@code list-item &amp;&amp; [ block | nonsense ] &amp;&amp; [ more ]?}<br>
      * Will accept the following inputs as valid:<br>
      * {@code list-item block}<br>
@@ -6477,9 +6506,6 @@ class CSSTokenizerFilter {
       return false;
     }
 
-    /*
-     * This function takes an array of string and concatenates everything in a " " seperated string.
-     */
     /**
      * Joins a contiguous slice of {@code parts} into a single space-separated string.
      *
@@ -6513,7 +6539,7 @@ class CSSTokenizerFilter {
     }
 
     /**
-     * Creates a new sub-array from {@code array} spanning {@code [lowerIndex, upperIndex)}.
+     * Creates a new subarray from {@code array} spanning {@code [lowerIndex, upperIndex)}.
      *
      * @param array source array; {@code null} yields an empty array.
      * @param lowerIndex inclusive lower bound index into {@code array}.
@@ -6847,7 +6873,7 @@ class CSSTokenizerFilter {
      * Checks whether the supplied {@code content} value is acceptable.
      *
      * <p>Accepts a single keyword from {@code allowedValues}, any string, or a counter/counters
-     * construct with optional list style type.
+     * construct with an optional list style type.
      *
      * @param media unused for {@code content}; may be {@code null}.
      * @param elements unused for {@code content}; may be {@code null}.
@@ -6936,9 +6962,9 @@ class CSSTokenizerFilter {
     }
   }
 
-  // For verifying ’font-size’[ / ’line-height’]? of Font property
   /**
-   * Verifier for font-related shorthand parts such as style, variant, weight, size and line-height.
+   * Verifier for font-related shorthand parts such as style, variant, weight, size, and
+   * line-height.
    */
   static class FontPartPropertyVerifier extends CSSPropertyVerifier {
     /** Creates a verifier for parts used by the {@code font} shorthand. */
@@ -7013,8 +7039,8 @@ class CSSTokenizerFilter {
 
     // We do not change the tokens.
     // We probably should put in quotes around unquoted font family names, put spaces after commas
-    // etc, but
-    // this may be a bit tricky: we'd have to put spaces etc inside some words, and delete some
+    // etc., but this may be a bit tricky: we'd have to put spaces etc. inside some words, and
+    // delete some
     // words...
     // Quite possible, but not a high priority, "verdana,arial,times new roman,sans-serif" is not
     // dangerous, it's just hard to parse.
@@ -7048,7 +7074,7 @@ class CSSTokenizerFilter {
         ProcessResult pr = consumeUnquotedFont(value, i, fontWords);
         if (pr.shouldReturn) return pr.returnValue;
 
-        // Continue outer loop from the consumed index
+        // Continue the outer loop from the consumed index
         i = pr.nextIndex + 1;
       }
       if (LOG.isTraceEnabled()) LOG.trace("font: reached end, valid");
@@ -7072,7 +7098,7 @@ class CSSTokenizerFilter {
       }
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "checkValidity Media of the element is not allowed.Media={} allowed Media={}",
+            "FontPartPropertyVerifier media not allowed. media={} allowedMedia={}",
             Fields.commaList(media),
             allowedMedia);
       return false;

--- a/src/main/java/network/crypta/client/filter/ContentFilter.java
+++ b/src/main/java/network/crypta/client/filter/ContentFilter.java
@@ -600,7 +600,7 @@ public class ContentFilter {
     if (bom == null || bom.charset == null) return null;
     String v = tryGetCharset(extractor, input, length, bom.charset);
     if (v != null) {
-      if (LOG.isDebugEnabled()) LOG.debug("Returning charset: {}", v);
+      if (LOG.isDebugEnabled()) LOG.debug("Detected charset from BOM: {}", v);
       return v;
     }
     if (bom.mustHaveCharset) throw new UndetectableCharsetException(bom.charset);
@@ -612,7 +612,7 @@ public class ContentFilter {
       throws IOException {
     if (defaultCharset == null) return null;
     String v = tryGetCharset(extractor, input, length, defaultCharset);
-    if (v != null && LOG.isDebugEnabled()) LOG.debug("Returning charset: {}", v);
+    if (v != null && LOG.isDebugEnabled()) LOG.debug("Detected charset from default: {}", v);
     return v;
   }
 
@@ -748,9 +748,9 @@ public class ContentFilter {
     return null;
   }
 
-  // Byte Order Mark's - from Wikipedia. We keep all of them because a rare encoding might
-  // be deliberately used by an attacker to confuse the filter, because at present a charset
-  // is not mandatory, and because some browsers may pick these up anyway even if one is present.
+  // Byte Order Mark's - from Wikipedia. We keep all of them because an attacker might
+  // deliberately use a rare encoding to confuse the filter. At present a charset is not
+  // mandatory, and some browsers may pick these up anyway even if one is present.
 
   static byte[] bomUtf8 = new byte[] {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
   static byte[] bomUtf16Be = new byte[] {(byte) 0xFE, (byte) 0xFF};

--- a/src/main/java/network/crypta/client/filter/GenericReadFilterCallback.java
+++ b/src/main/java/network/crypta/client/filter/GenericReadFilterCallback.java
@@ -54,7 +54,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
   private static final Set<String> allowedProtocols;
 
   // RFC3986
-  //  unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+  //  unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
   /**
    * Pattern for an RFC 3986 "unreserved" character. The value matches ASCII letters, digits and the
    * characters {@code - . _ ~}. It is used as a building block for more complete expressions that
@@ -172,9 +172,9 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
    * URI} suitable for use as a base for resolution.
    *
    * @param uri Base key represented as a {@code FreenetURI}. Must parse into a valid relative
-   *     {@code URI} for subsequent resolution operations.
-   * @param cb Callback notified when URIs are found. May be {@code null} if notifications are not
-   *     required by the caller.
+   *     {@code URI} for later resolution operations.
+   * @param cb Callback notified when URIs are found. May be {@code null} if the caller does not
+   *     require notifications.
    * @param trc Tag replacement callback invoked for each parsed tag. May be {@code null} to disable
    *     tag-level rewrites.
    * @param linkFilterExceptionProvider Provider consulted to decide whether a given link should be
@@ -225,8 +225,8 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
    * protocol and path rules. Relative references are resolved against the current base URI. Use the
    * multi-argument overloads to control base-href handling or inline context.
    *
-   * @param u Raw URI string taken from markup or attribute content. May be absolute or relative,
-   *     and may contain percent-encoded sequences.
+   * @param u Raw URI string taken from markup or attribute content. Maybe absolute or relative, and
+   *     may contain percent-encoded sequences.
    * @param overrideType Optional media-type override used when building internal links. When {@code
    *     null}, no override is applied.
    * @return A sanitized, ASCII-safe URI string suitable for emission back into the filtered
@@ -282,7 +282,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
 
     URI origURI = uri;
 
-    // Convert localhost uri's to relative internal ones.
+    // Convert localhost uri to relative internal ones.
     uri = normalizeLocalhost(uri);
 
     String host = uri.getHost();
@@ -349,7 +349,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       uri = URIPreEncoder.encodeURI(filtered).normalize();
     } catch (URISyntaxException e1) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Failed to parse URI: {}", String.valueOf(e1));
+        LOG.debug("URI parse failed while forcing absolute: {}", String.valueOf(e1));
       }
       throw new CommentException(l10n("couldNotParseURIWithError", ERROR_KEY, e1.getMessage()));
     }
@@ -379,7 +379,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
    * Handles a {@code <base href>} declaration and updates the current base URI when valid.
    *
    * <p>The supplied value is sanitized through the general URI processing routine in {@code
-   * forBaseHref} mode. When accepted, the internal base used for subsequent relative resolution is
+   * forBaseHref} mode. When accepted, the internal base used for later relative resolution is
    * updated and the ASCII representation of the new base is returned.
    *
    * @param baseHref The candidate base-href value from markup.
@@ -414,9 +414,9 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
    *
    * <p>When a {@code FoundURICallback} is configured, this method forwards the text and its type
    * together with the current base URI so callers can perform additional analysis or analytics. The
-   * method does not modify state and performs no rewriting.
+   * method does not modify the state and performs no rewriting.
    *
-   * @param s The text content as extracted from the document. May be empty.
+   * @param s The text content as extracted from the document. Maybe empty.
    * @param type A short classifier supplied by the caller describing the context of the text (for
    *     example, attribute kind or element name). May be {@code null} if unspecified.
    */
@@ -455,7 +455,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       return null; // no irregular form sending methods
     }
     // Note: Access to other internal paths (e.g., /downloads/, /friends/) is not permitted here.
-    // Allow access to Library for searching, form passwords are used for actions such as adding
+    // Allow access to Library for searching; form passwords are used for actions such as adding
     // bookmarks
     if (action.equals("/library/")) {
       return action;
@@ -615,11 +615,11 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
   private ParsedUris parseAndResolve(String u, boolean noRelative) throws CommentException {
     try {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Processing {}", u);
+        LOG.debug("URI input raw: {}", u);
       }
       URI uri = URIPreEncoder.encodeURI(u).normalize();
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Processing {}", uri);
+        LOG.debug("URI normalized: {}", uri);
       }
       if (u.startsWith("/") || u.startsWith("%2f")) {
         // Don't bother with relative URIs if it's obviously absolute.
@@ -629,12 +629,12 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       }
       URI resolved = noRelative ? uri : baseURI.resolve(uri);
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Resolved: {}", resolved);
+        LOG.debug("URI resolved against base: {}", resolved);
       }
       return new ParsedUris(uri, resolved, noRelative);
     } catch (URISyntaxException e1) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Failed to parse URI: {}", String.valueOf(e1));
+        LOG.debug("URI parse failed in parseAndResolve: {}", String.valueOf(e1));
       }
       throw new CommentException(l10n("couldNotParseURIWithError", ERROR_KEY, e1.getMessage()));
     }
@@ -676,18 +676,18 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       String rpath, URI uri, String overrideType, boolean inline) {
     if (rpath == null) return null;
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Resolved URI (rpath absolute): \"{}\"", rpath);
+      LOG.debug("Resolved absolute path candidate: \"{}\"", rpath);
     }
     try {
       String p = stripLeadingSlashes(rpath);
       FreenetURI furi = new FreenetURI(p, true);
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Parsed: {}", furi);
+        LOG.debug("Parsed Freenet URI from absolute path: {}", furi);
       }
       return processURI(furi, uri, overrideType, true, inline);
     } catch (MalformedURLException e) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Malformed URL (a): {}", e, e);
+        LOG.debug("Freenet URI parse failed for absolute path: {}", e, e);
       }
       return null;
     }
@@ -706,18 +706,18 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       throw new CommentException("No URI");
     }
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Resolved URI (rpath relative): {}", rpath);
+      LOG.debug("Resolved relative path candidate: {}", rpath);
     }
     try {
       String p = stripLeadingSlashes(rpath);
       FreenetURI furi = new FreenetURI(p, true);
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Parsed: {}", furi);
+        LOG.debug("Parsed Freenet URI from relative path: {}", furi);
       }
       return processURI(furi, uri, overrideType, false, inline);
     } catch (MalformedURLException e) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Malformed URL (b): {}", e, e);
+        LOG.debug("Freenet URI parse failed for relative path: {}", e, e);
       }
       return null;
     }

--- a/src/main/java/network/crypta/client/filter/HTMLFilter.java
+++ b/src/main/java/network/crypta/client/filter/HTMLFilter.java
@@ -113,7 +113,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
     static final String STR_COMMENT_PREFIX = "<!-- ";
     static final String STR_DELETING_XML_DECLARATION_INVALID_ENCODING =
-        "Deleting xml declaration, invalid encoding";
+        "XML declaration dropped: reason=invalid_encoding";
     static final String STR_ACCENT = "accent";
     static final String STR_ACCENTUNDER = "accentunder";
     static final String STR_ACCESSKEY = "accesskey";
@@ -3133,7 +3133,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       }
       if ("xml:lang".equals(name) || "lang".equals(name)) {
         if (LOG.isTraceEnabled()) {
-          LOG.trace("HTML Filter is putting attribute: {} = {}", name, value);
+          LOG.trace("HTML Filter accepted language attribute: {} = {}", name, value);
         }
         output.put(name, value);
         return true;
@@ -3143,7 +3143,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
             || stringValue.equalsIgnoreCase("rtl")
             || stringValue.equalsIgnoreCase("auto")) {
           if (LOG.isTraceEnabled()) {
-            LOG.trace("HTML Filter is putting attribute: {} = {}", name, value);
+            LOG.trace("HTML Filter accepted direction attribute: {} = {}", name, value);
           }
           output.put(name, value);
         }
@@ -4238,14 +4238,14 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     @Override
     ParsedTag sanitize(ParsedTag t, HTMLParseContext pc) throws DataFilterException {
       if (!hasValidAttributeLength(t)) {
-        logXmlDebug("Deleting xml declaration, invalid length");
+        logXmlDebug("XML declaration dropped: reason=invalid_attribute_length");
         return null;
       }
       if (!hasValidEndingToken(t)) {
         return null;
       }
       if (!hasValidVersionToken(t)) {
-        logXmlDebug("Deleting xml declaration, invalid version");
+        logXmlDebug("XML declaration dropped: reason=invalid_version");
         return null;
       }
       String charset = extractCharset(t);
@@ -4256,11 +4256,9 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       if (!charset.equalsIgnoreCase(pc.charset)) {
         if (pc.charset != null) {
           logXmlDebug(
-              "Deleting xml declaration (invalid charset "
-                  + charset
-                  + " should be "
-                  + pc.charset
-                  + ")");
+              "XML declaration dropped: reason=charset_mismatch declared={} expected={}",
+              charset,
+              pc.charset);
           return null;
         }
         if (pc.detectedCharset != null) {
@@ -4277,11 +4275,11 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
     private boolean hasValidEndingToken(ParsedTag tag) {
       if (tag.unparsedAttrs.length == 3 && !"?".equals(tag.unparsedAttrs[2])) {
-        logXmlDebug("Deleting xml declaration, invalid ending (length 2)");
+        logXmlDebug("XML declaration dropped: reason=invalid_ending_token length=2");
         return false;
       }
       if (tag.unparsedAttrs.length == 2 && !tag.unparsedAttrs[1].endsWith("?")) {
-        logXmlDebug("Deleting xml declaration, invalid ending (length 3)");
+        logXmlDebug("XML declaration dropped: reason=invalid_ending_token length=3");
         return false;
       }
       return true;
@@ -4309,9 +4307,9 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       return null;
     }
 
-    private void logXmlDebug(String message) {
+    private void logXmlDebug(String template, Object... args) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug(message);
+        LOG.debug(template, args);
       }
     }
   }

--- a/src/main/java/network/crypta/client/filter/MP3Filter.java
+++ b/src/main/java/network/crypta/client/filter/MP3Filter.java
@@ -18,8 +18,8 @@ import org.slf4j.LoggerFactory;
  * frames unchanged to the provided output. It recognizes and skips both ID3v2 headers at the
  * beginning of a stream and ID3v1 tags typically found at the end. While scanning, the filter
  * searches for a valid frame sync, validates header fields (MPEG version, layer, sample rate,
- * emphasis), and computes the length of each frame in order to copy it verbatim. Frames marked as
- * protected include a two-byte CRC which is preserved but not recalculated.
+ * emphasis), and computes the length of each frame to copy it verbatim. Frames marked as protected
+ * include a two-byte CRC which is preserved but not recalculated.
  *
  * <p>The implementation rejects uncommon or hard-to-handle cases to remain safe by default. In
  * particular, so-called “free format” bitstreams (non-standard bitrates) are considered invalid for
@@ -252,20 +252,20 @@ public class MP3Filter implements ContentDataFilter {
     size |= (encodedSize[2] & 0x7F) << 7;
     size |= (encodedSize[3] & 0x7F);
     skipFully(in, size);
-    LOG.info("Skipped {} bytes of ID3v2 data", size);
+    LOG.info("ID3v2 header skipped: {} bytes", size);
     st.frameHeader = in.readInt();
     st.foundStream = hasFrameSync(st.frameHeader);
   }
 
   private static void skipID3v1(DataInputStream in, State st) throws IOException {
-    skipFully(in, 124); // fixed length is 128 bytes; 4 already read
-    LOG.info("Skipped an ID3v1 TAG");
+    skipFully(in, 124); // the fixed length is 128 bytes; 4 already read
+    LOG.info("ID3v1 tag skipped");
     st.frameHeader = in.readInt();
     st.foundStream = hasFrameSync(st.frameHeader);
   }
 
   private static void handleOutOfSync(DataInputStream in, State st) throws IOException {
-    if (st.foundFrames != 0) LOG.info("Series of frames: {}", st.foundFrames);
+    if (st.foundFrames != 0) LOG.info("Frame run ended before resync: {} frames", st.foundFrames);
     if (st.foundFrames > st.maxFoundFrames) st.maxFoundFrames = st.foundFrames;
     st.foundFrames = 0;
     st.frameHeader = st.frameHeader << 8;
@@ -321,14 +321,14 @@ public class MP3Filter implements ContentDataFilter {
     final int granularity = bitsPerSlot[layer];
     int frameLength = samples / granularity * bitrate / samplerate;
     frameLength += paddingBit ? 1 : 0;
-    // Avoid integer-division-before-multiplication; multiply first then divide
+    // Avoid integer-division-before-multiplication; multiply first, then divide
     frameLength = (frameLength * granularity) / 8;
 
     short crc = 0;
     if (hasCRC) {
       st.totalCRCs++;
       crc = in.readShort();
-      LOG.info("Found a CRC");
+      LOG.info("Frame CRC present");
       // CRC calculation is not implemented; the value is preserved.
     }
 
@@ -339,14 +339,16 @@ public class MP3Filter implements ContentDataFilter {
     out.write(frame);
     st.totalFrames++;
     st.foundFrames++;
-    if (st.countLostSyncBytes != 0) LOG.info("Lost sync for {} bytes", st.countLostSyncBytes);
+    if (st.countLostSyncBytes != 0)
+      LOG.info("Recovered frame sync after {} bytes", st.countLostSyncBytes);
     st.countLostSyncBytes = 0;
     st.frameHeader = in.readInt();
   }
 
   private void handleEOF(DataOutputStream out, State st) throws IOException {
-    if (st.foundFrames != 0) LOG.info("Series of frames: {}", st.foundFrames);
-    if (st.countLostSyncBytes != 0) LOG.info("Lost sync for {} bytes", st.countLostSyncBytes);
+    if (st.foundFrames != 0) LOG.info("EOF after final frame run: {} frames", st.foundFrames);
+    if (st.countLostSyncBytes != 0)
+      LOG.info("EOF with trailing out-of-sync bytes: {}", st.countLostSyncBytes);
     if (st.totalFrames == 0 || st.maxFoundFrames < 10) {
       if (st.countFreeBitrate > 100)
         throw new DataFilterException(
@@ -361,6 +363,6 @@ public class MP3Filter implements ContentDataFilter {
     }
 
     out.flush();
-    LOG.info("{} frames, of which {} had a CRC", st.totalFrames, st.totalCRCs);
+    LOG.info("MP3 filter completed: {} frames ({} with CRC)", st.totalFrames, st.totalCRCs);
   }
 }

--- a/src/main/java/network/crypta/client/filter/RIFFFilter.java
+++ b/src/main/java/network/crypta/client/filter/RIFFFilter.java
@@ -151,7 +151,7 @@ public abstract class RIFFFilter implements ContentDataFilter {
           l10n(KEY_INVALID_TITLE),
           NodeL10n.getBase().getString(KEY_EOF_MESSAGE));
     }
-    // Testing if there is any unprocessed bytes left
+    // Testing if there are any unprocessed bytes left
     if (input.read() != -1) {
       // A byte is after expected EOF
       throw new DataFilterException(
@@ -315,7 +315,7 @@ public abstract class RIFFFilter implements ContentDataFilter {
       throws IOException {
     if (size < 0) {
       if (LOG.isWarnEnabled()) {
-        LOG.warn("RIFF block size {} is less than 0", size);
+        LOG.warn("RIFF passthrough chunk size {} is less than 0", size);
       }
       throw new DataFilterException(
           l10n(KEY_INVALID_TITLE), l10n(KEY_INVALID_TITLE), l10n(KEY_DATA_TOO_BIG));
@@ -340,7 +340,7 @@ public abstract class RIFFFilter implements ContentDataFilter {
    *
    * <p>The method skips the incoming payload (rounded up to an even size per RIFF rules), then
    * writes a matching {@code JUNK} header and zero‑filled body to {@code out}. This is useful for
-   * discarding unsupported or unsafe chunks while preserving container structure.
+   * discarding unsupported or unsafe chunks while preserving the container structure.
    *
    * @param in input stream supplying the bytes to discard; must contain at least {@code size}
    *     bytes, rounded up to an even length
@@ -352,14 +352,14 @@ public abstract class RIFFFilter implements ContentDataFilter {
    */
   protected void writeJunkChunk(DataInputStream in, DataOutputStream out, int size)
       throws IOException {
-    size += size % 2; // Add a padding if necessary
+    size += size % 2; // Add padding if necessary
     if (in.skip(size) < size) {
       // EOFException?
       throw new EOFException();
     }
     if (size < 0) {
       if (LOG.isWarnEnabled()) {
-        LOG.warn("RIFF block size {} is less than 0", size);
+        LOG.warn("RIFF JUNK chunk size {} is less than 0", size);
       }
       throw new DataFilterException(
           l10n(KEY_INVALID_TITLE), l10n(KEY_INVALID_TITLE), l10n(KEY_DATA_TOO_BIG));
@@ -390,8 +390,8 @@ public abstract class RIFFFilter implements ContentDataFilter {
    * the byte order of {@code readInt()} to match RIFF semantics.
    *
    * @param stream data input to read from; the method consumes exactly four bytes
-   * @return the 32‑bit value interpreted as little‑endian; note that RIFF fields may be used as
-   *     unsigned values by callers
+   * @return the 32‑bit value interpreted as little‑endian; note that callers may use RIFF fields as
+   *     unsigned values
    * @throws IOException if the stream ends before four bytes are available or another I/O error
    *     occurs
    */


### PR DESCRIPTION
## Summary
- clarify filter log messages to capture state and context during parsing
- tighten inline documentation for CSS/HTML/MP3/RIFF filtering flows
- keep behavior unchanged while improving diagnostics

## Testing
- ./gradlew spotlessApply