### PR TITLE
chore(tooling): add Error Prone reports

### DIFF
--- a/.opencode/skills/cryptad-build-tooling/SKILL.md
+++ b/.opencode/skills/cryptad-build-tooling/SKILL.md
@@ -86,6 +86,35 @@ If strict verification blocks resolution:
 Gradle daemon heap was increased to reduce OOM during SonarLint indexing:
 - `gradle.properties`: `org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8`
 
+## Error Prone
+### Key behaviors
+- Enabled via `net.ltgt.errorprone` in the Java/Kotlin convention plugin.
+- Errors are downgraded to warnings by default (`options.errorprone.allErrorsAsWarnings = true`).
+
+### Report task
+- Generate XML reports:
+  - `./gradlew errorproneReport`
+- Output:
+  - `build/reports/errorprone/<task>/<task>.xml` (e.g., `compileJava/compileJava.xml`, `compileTestJava/compileTestJava.xml`)
+
+### Report schema (custom)
+- Root element: `<errorproneReport>`
+- Per warning: `<diagnostic>` with attributes `severity`, `check`, `file`, `line`, plus `<message>` and optional `<details>`.
+
+### Enforcing errors
+- To fail the build on Error Prone errors, set `allErrorsAsWarnings` to `false` in:
+  - `build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts`
+
+### Verification refresh on Error Prone bumps
+If strict verification blocks resolution:
+1) Set `org.gradle.dependency.verification=lenient`
+2) Run:
+```bash
+./gradlew --write-verification-metadata sha256,pgp :build-logic:compileKotlin
+```
+3) Restore `org.gradle.dependency.verification=strict`
+4) Optionally `./gradlew --export-keys`
+
 ## JaCoCo + SonarCloud coverage
 - JaCoCo toolVersion: `0.8.14`
 - XML/HTML reports are enabled:

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -24,6 +24,9 @@ dependencies {
   // Allow precompiled plugins to apply these without specifying versions in their scripts
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")
   implementation("com.diffplug.spotless:spotless-plugin-gradle:${libs.versions.spotless.get()}")
+  implementation(
+    "net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin:${libs.versions.errorpronePlugin.get()}"
+  )
   // SonarQube plugin marker for precompiled convention plugin usage
   implementation("org.sonarqube:org.sonarqube.gradle.plugin:${libs.versions.sonarqube.get()}")
   // name.remal.sonarlint plugin marker so our convention plugin can apply it without a version

--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -130,11 +130,11 @@ tasks.withType<JavaCompile>().configureEach {
 
   val taskPathLabel = path.removePrefix(":").replace(':', '_').ifBlank { "root" }
   val reportFileProvider = layout.buildDirectory.file("reports/errorprone/$taskPathLabel/$name.xml")
-  outputs.file(reportFileProvider)
-
-  outputs.upToDateWhen { !errorproneReportEnabled.get() }
-
-  usesService(errorproneReportService)
+  if (errorproneReportEnabled.get()) {
+    outputs.file(reportFileProvider)
+    outputs.upToDateWhen { false }
+    usesService(errorproneReportService)
+  }
 
   val capturedOutput = StringBuilder()
   val standardOutListener = StandardOutputListener { capturedOutput.append(it) }

--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -1,10 +1,87 @@
+import java.time.Instant
+import javax.xml.stream.XMLOutputFactory
+import net.ltgt.gradle.errorprone.errorprone
+import org.gradle.api.logging.StandardOutputListener
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   java
   kotlin("jvm")
   jacoco
+  id("net.ltgt.errorprone")
 }
+
+abstract class ErrorProneReportService : BuildService<BuildServiceParameters.None>
+
+data class ErrorProneDiagnostic(
+  val file: String,
+  val line: Int,
+  val severity: String,
+  val check: String,
+  val message: String,
+  val details: String,
+)
+
+fun parseErrorProneDiagnostics(output: String): List<ErrorProneDiagnostic> {
+  val pattern = Regex("^(.+):(\\d+): (warning|error): \\[(.+)] (.+)$")
+  val diagnostics = mutableListOf<ErrorProneDiagnostic>()
+  var current: ErrorProneDiagnostic? = null
+  val detailsBuffer = StringBuilder()
+
+  fun flush() {
+    val diag = current ?: return
+    diagnostics.add(diag.copy(details = detailsBuffer.toString().trimEnd()))
+    current = null
+    detailsBuffer.setLength(0)
+  }
+
+  output.lineSequence().forEach { line ->
+    val match = pattern.matchEntire(line)
+    if (match != null) {
+      flush()
+      val file = match.groupValues[1]
+      val lineNumber = match.groupValues[2].toInt()
+      val severity = match.groupValues[3]
+      val check = match.groupValues[4]
+      val message = match.groupValues[5]
+      current = ErrorProneDiagnostic(file, lineNumber, severity, check, message, "")
+    } else if (current != null) {
+      if (line.isNotBlank()) {
+        detailsBuffer.append(line).append('\n')
+      }
+    }
+  }
+  flush()
+  return diagnostics
+}
+
+val libs: VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+val errorproneReportService =
+  gradle.sharedServices.registerIfAbsent(
+    "errorproneReportService",
+    ErrorProneReportService::class,
+  ) {
+    maxParallelUsages.set(1)
+  }
+
+val errorproneReportTask =
+  tasks.register("errorproneReport") {
+    group = "verification"
+    description = "Generates Error Prone XML reports for Java compile tasks."
+  }
+
+errorproneReportTask.configure { dependsOn(tasks.withType<JavaCompile>()) }
+
+val errorproneReportEnabled =
+  providers.provider {
+    gradle.startParameter.taskNames.any { taskName ->
+      taskName == "errorproneReport" || taskName.endsWith(":errorproneReport")
+    }
+  }
 
 java {
   toolchain { languageVersion.set(JavaLanguageVersion.of(25)) }
@@ -43,10 +120,71 @@ sourceSets.named("main") {
   java.exclude("network/crypta/node/Version.kt")
 }
 
+dependencies { add("errorprone", libs.findLibrary("errorproneCore").get()) }
+
 tasks.withType<JavaCompile>().configureEach {
   options.encoding = "UTF-8"
   // Surface deprecation/unchecked sites explicitly during compilation.
   options.compilerArgs.addAll(listOf("-Xlint:deprecation", "-Xlint:unchecked"))
+  options.errorprone.allErrorsAsWarnings.set(true)
+
+  val taskPathLabel = path.removePrefix(":").replace(':', '_').ifBlank { "root" }
+  val reportFileProvider = layout.buildDirectory.file("reports/errorprone/$taskPathLabel/$name.xml")
+  outputs.file(reportFileProvider)
+
+  outputs.upToDateWhen { !errorproneReportEnabled.get() }
+
+  usesService(errorproneReportService)
+
+  val capturedOutput = StringBuilder()
+  val standardOutListener = StandardOutputListener { capturedOutput.append(it) }
+  val standardErrListener = StandardOutputListener { capturedOutput.append(it) }
+
+  doFirst {
+    if (!errorproneReportEnabled.get()) return@doFirst
+    logging.addStandardOutputListener(standardOutListener)
+    logging.addStandardErrorListener(standardErrListener)
+  }
+
+  doLast {
+    if (!errorproneReportEnabled.get()) return@doLast
+    logging.removeStandardOutputListener(standardOutListener)
+    logging.removeStandardErrorListener(standardErrListener)
+
+    val diagnostics = parseErrorProneDiagnostics(capturedOutput.toString())
+    val reportFile = reportFileProvider.get().asFile
+    reportFile.parentFile.mkdirs()
+
+    val writer =
+      XMLOutputFactory.newInstance().createXMLStreamWriter(reportFile.writer(Charsets.UTF_8))
+    writer.writeStartDocument("UTF-8", "1.0")
+    writer.writeStartElement("errorproneReport")
+    writer.writeAttribute("project", project.path)
+    writer.writeAttribute("task", name)
+    writer.writeAttribute("generatedAt", Instant.now().toString())
+    diagnostics.forEach { diagnostic ->
+      writer.writeStartElement("diagnostic")
+      writer.writeAttribute("severity", diagnostic.severity)
+      writer.writeAttribute("check", diagnostic.check)
+      writer.writeAttribute("file", diagnostic.file)
+      writer.writeAttribute("line", diagnostic.line.toString())
+
+      writer.writeStartElement("message")
+      writer.writeCharacters(diagnostic.message)
+      writer.writeEndElement()
+
+      if (diagnostic.details.isNotBlank()) {
+        writer.writeStartElement("details")
+        writer.writeCharacters(diagnostic.details)
+        writer.writeEndElement()
+      }
+      writer.writeEndElement()
+    }
+    writer.writeEndElement()
+    writer.writeEndDocument()
+    writer.flush()
+    writer.close()
+  }
 }
 
 tasks.withType<Javadoc>().configureEach {
@@ -99,9 +237,6 @@ tasks.withType<Test>().configureEach {
 tasks.withType<Test>().configureEach { enableAssertions = false }
 
 // JaCoCo setup: use a recent agent and produce XML for Sonar
-// Version is sourced from the version catalog (gradle/libs.versions.toml: [versions].jacoco)
-val libs: VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
-
 extensions.configure<JacocoPluginExtension>("jacoco") {
   toolVersion = libs.findVersion("jacoco").get().requiredVersion
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ sonarqube = "7.2.2.6593"
 remalSonarlint = "7.0.1"
 #noinspection UnusedVersionCatalogEntry
 jacoco = "0.8.14"
+errorpronePlugin = "4.4.0"
+errorproneCore = "2.38.0"
 
 [libraries]
 bcprov = { group = "org.bouncycastle", name = "bcprov-lts8on", version.ref = "bcprov" }
@@ -52,6 +54,7 @@ junitJupiterParams = { group = "org.junit.jupiter", name = "junit-jupiter-params
 junitJupiterEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitJupiter" }
 junitPlatformLauncher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junitPlatform" }
 junitPlatformSuite = { group = "org.junit.platform", name = "junit-platform-suite", version.ref = "junitPlatform" }
+errorproneCore = { group = "com.google.errorprone", name = "error_prone_core", version.ref = "errorproneCore" }
 
 [plugins]
 #noinspection UnusedVersionCatalogEntry
@@ -60,3 +63,4 @@ kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 #noinspection UnusedVersionCatalogEntry
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
+errorprone = { id = "net.ltgt.errorprone", version.ref = "errorpronePlugin" }

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -35,9 +35,11 @@
             <trusting group="org.mockito" name="mockito-junit-jupiter" version="5.19.0"/>
          </trusted-key>
          <trusted-key id="19BEAB2D799C020F17C69126B16698A4ADF4D638">
+            <trusting group="org.checkerframework" name="checker-qual" version="3.19.0"/>
             <trusting group="org.checkerframework" name="checker-qual" version="3.37.0"/>
             <trusting group="org.checkerframework" name="checker-qual" version="3.43.0"/>
          </trusted-key>
+         <trusted-key id="1A55F091AD28C07F831FA44D7905DE25C78AD456" group="com.google.protobuf"/>
          <trusted-key id="1BD97A6A154E7810EE0BC832E2F38302C8075E3D">
             <trusting group="org.gradle.kotlin" name="gradle-kotlin-dsl-plugins" version="6.2.0"/>
             <trusting group="org.gradle.kotlin" name="gradle-kotlin-dsl-plugins" version="6.4.1"/>
@@ -82,11 +84,15 @@
             <trusting group="ch.qos.logback"/>
             <trusting group="org.slf4j"/>
          </trusted-key>
-         <trusted-key id="635EE627345F3C1DD422B2E207D3516820BCF6B1" group="com.github.ben-manes.caffeine" name="caffeine" version="2.9.3"/>
+         <trusted-key id="635EE627345F3C1DD422B2E207D3516820BCF6B1">
+            <trusting group="com.github.ben-manes.caffeine" name="caffeine" version="2.9.3"/>
+            <trusting group="com.github.ben-manes.caffeine" name="caffeine" version="3.0.5"/>
+         </trusted-key>
          <trusted-key id="648190996EC0930A6D7D49A978178478013521D0" group="com.facebook"/>
          <trusted-key id="6658DD7F76FCDF7812114F85DC032628E927D006" group="com.android.tools.external.lombok" name="lombok-ast" version="0.2.2"/>
          <trusted-key id="694621A7227D8D5289699830ABE9F3126BB741C1" group="com.google.guava"/>
          <trusted-key id="6F538074CCEBF35F28AF9B066A0975F8B1127B83" group="^org[.]jetbrains[.]kotlin($|([.].*))" regex="true"/>
+         <trusted-key id="7186BBF993566D8C2F4F7ED7D945E643368FEF62" group="io.github.eisop" name="dataflow-errorprone" version="3.41.0-eisop1"/>
          <trusted-key id="7616EB882DAF57A11477AAF559A252FB1199D873" group="com.google.code.findbugs" name="jsr305" version="3.0.2"/>
          <trusted-key id="7744B88EDD98A7402C0C341D9291F17036AEE155" group="com.github.hypfvieh"/>
          <trusted-key id="78DA3333F653B1C54A938BE24DB7BC57DFDBCEA4" group="net.java.dev.jna" name="jna" version="4.2.2"/>
@@ -111,6 +117,7 @@
          <trusted-key id="A33A0B49A4C1AB590B0A4DDC1364C5E2DF3E99C5" group="org.reactivestreams" name="reactive-streams" version="1.0.3"/>
          <trusted-key id="A413F67D71BEEC23ADD0CE0ACB43338E060CF9FA" group="org.jacoco"/>
          <trusted-key id="A4FACCFE5AFA1EB5FA3F4155A41774F54142A24C" group="de.jangassen" name="jfa" version="1.2.0"/>
+         <trusted-key id="A4FD709CC4B0515F2E6AF04E218FA0F6A941A037" group="com.github.kevinstern" name="software-and-algorithms" version="1.0"/>
          <trusted-key id="A58D5AF54809A8A63F458BBD56CD8D5D24452160" group="org.codehaus.sonar"/>
          <trusted-key id="A5BD02B93E7A40482EB1D66A5F69AD087600B22C" group="org.ow2.asm"/>
          <trusted-key id="A7892505CF1A58076453E52D7999BEFBA1039E8B" group="net.bytebuddy"/>
@@ -118,8 +125,14 @@
          <trusted-key id="AA417737BD805456DB3CBDDE6601E5C08DCCBB96" group="info.picocli" name="picocli" version="4.7.7"/>
          <trusted-key id="B0255B26003EF6F82491ACD7254E9C64C264C176" group="com.github.weisj"/>
          <trusted-key id="B920D295BF0E61CB4CF0896C33CD6733AF5EC452" group="commons-logging"/>
-         <trusted-key id="BDB5FA4FE719D787FB3D3197F6D4A1D411E9D1AE" group="com.google.guava"/>
-         <trusted-key id="C7BE5BCC9FEC15518CFDA882B0F3710FA64900E7" group="com.google.code.gson"/>
+         <trusted-key id="BDB5FA4FE719D787FB3D3197F6D4A1D411E9D1AE">
+            <trusting group="com.google.guava"/>
+            <trusting group="com.google.j2objc" name="j2objc-annotations" version="3.0.0"/>
+         </trusted-key>
+         <trusted-key id="C7BE5BCC9FEC15518CFDA882B0F3710FA64900E7">
+            <trusting group="com.google.code.gson"/>
+            <trusting group="^com[.]google[.]auto($|([.].*))" regex="true"/>
+         </trusted-key>
          <trusted-key id="CACFBD4755A2FC78709BDD92BE096E29EDB8D141" group="net.sf.proguard"/>
          <trusted-key id="CB9A3ECF68EFC2235510789F88C36BE872C7E1B0" group="io.sentry" name="sentry" version="8.20.0"/>
          <trusted-key id="CC4483CD6A3EB2939B948667A1B4460D8BA7B9AF" group="org.mockito" name="mockito-core" version="1.9.5"/>
@@ -130,12 +143,14 @@
          <trusted-key id="D84B2A55CBE37E731816F18138DC6A61B99534FF" group="io.github.g00fy2" name="versioncompare" version="1.4.1"/>
          <trusted-key id="D9E6E4CC8F66B2034995C7192189CA6247F3DEE5" group="^com[.]android[.]tools($|([.].*))" regex="true"/>
          <trusted-key id="DBD744ACE7ADE6AA50DD591F66B50994442D2D40" group="^com[.]squareup($|([.].*))" regex="true"/>
+         <trusted-key id="E0D98C5FD55A8AF232290E58DEE12B9896F97E34" group="org.pcollections" name="pcollections" version="4.0.1"/>
          <trusted-key id="E3A9F95079E84CE201F7CF60BEDE11EAF1164480">
             <trusting group="org.hamcrest"/>
             <trusting group="org.hamcrest" name="hamcrest" version="3.0"/>
          </trusted-key>
          <trusted-key id="E46653B20B6E2D5F61D040BB55E69DA20203C59E" group="^name[.]remal[.]gradle-plugins($|([.].*))" regex="true"/>
          <trusted-key id="E5138A8E9F2E7E42D38B14D99AEE152CDCCEBFCB" group="io.github.hakky54"/>
+         <trusted-key id="E77417AC194160A3FABD04969A259C7EE636C5ED" group="com.google.errorprone" name="javac" version="9+181-r4173-1"/>
          <trusted-key id="E7DC75FC24FB3C8DFE8086AD3D5839A2262CBBFB" group="org.jetbrains.kotlinx"/>
          <trusted-key id="E85AED155021AF8A6C6B7A4A7C7D8456294423BA" group="org.objenesis"/>
          <trusted-key id="EB1B3DE71713C9EC2E87CC26EE92349AD86DE446" group="com.google.j2objc" name="j2objc-annotations" version="2.8"/>
@@ -649,6 +664,11 @@
             <sha256 value="fa81829d049559df6927f9c9a6fd6bbd09f8b50e6d4736ae72c8300b6c3d7654" origin="Generated by Gradle" reason="A key couldn't be downloaded"/>
          </artifact>
       </component>
+      <component group="com.google.errorprone" name="error_prone_parent" version="2.38.0">
+         <artifact name="error_prone_parent-2.38.0.pom">
+            <sha256 value="e62458a6a3e63081bc7c57b3c0fac9f04f76ce32f606532db69fe2b3d47b934c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
       <component group="com.google.googlejavaformat" name="google-java-format" version="1.19.2">
          <artifact name="google-java-format-1.19.2.jar">
             <sha256 value="bac84458eb12499585f2fabb1ac13bbe5b455c120bf3d19db21597814a27c863" origin="Generated by Gradle"/>
@@ -1026,6 +1046,14 @@
             <sha256 value="e7fd7232e96307a575b2494c9367d68cf43ec98244aace3ccc23e1773ffa6fda" origin="Generated by Gradle"/>
          </artifact>
       </component>
+      <component group="javax.inject" name="javax.inject" version="1">
+         <artifact name="javax.inject-1.jar">
+            <sha256 value="91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff" origin="Generated by Gradle" reason="Artifact is not signed"/>
+         </artifact>
+         <artifact name="javax.inject-1.pom">
+            <sha256 value="943e12b100627804638fa285805a0ab788a680266531e650921ebfe4621a8bfa" origin="Generated by Gradle" reason="Artifact is not signed"/>
+         </artifact>
+      </component>
       <component group="junit" name="junit" version="4.13">
          <artifact name="junit-4.13.jar">
             <sha256 value="4b8532f63bdc0e0661507f947eb324a954d1dbac631ad19c8aa9a00feed1d863" origin="Generated by Gradle"/>
@@ -1160,6 +1188,32 @@
          </artifact>
          <artifact name="jna-platform-5.18.1.pom">
             <sha256 value="39d538a9599a4474770838865ed42cfa3e6b3d13086cb1e577b8bb43148d1a65" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="net.ltgt.errorprone" name="net.ltgt.errorprone.gradle.plugin" version="4.3.0">
+         <artifact name="net.ltgt.errorprone.gradle.plugin-4.3.0.pom">
+            <sha256 value="3370e20ef3213ffce47f7fda31266c33e9cca3b1b7f4d54169b482277042654b" origin="Generated by Gradle" reason="Artifact is not signed"/>
+         </artifact>
+      </component>
+      <component group="net.ltgt.errorprone" name="net.ltgt.errorprone.gradle.plugin" version="4.4.0">
+         <artifact name="net.ltgt.errorprone.gradle.plugin-4.4.0.pom">
+            <sha256 value="31585b3845a8aa0bee8d554306bf12508a253be535930204a89c3b5a842102c4" origin="Generated by Gradle" reason="Artifact is not signed"/>
+         </artifact>
+      </component>
+      <component group="net.ltgt.gradle" name="gradle-errorprone-plugin" version="4.3.0">
+         <artifact name="gradle-errorprone-plugin-4.3.0.jar">
+            <sha256 value="42f89c1f582ecd09459586d3d19c0fa92a332035e4a70b5699a8ec6a81aec32c" origin="Generated by Gradle" reason="Artifact is not signed"/>
+         </artifact>
+         <artifact name="gradle-errorprone-plugin-4.3.0.module">
+            <sha256 value="6d2b0a7809ffde227ec15a4cf28e68929be22a1a12a0f56ad5e795d5058f2f6e" origin="Generated by Gradle" reason="Artifact is not signed"/>
+         </artifact>
+      </component>
+      <component group="net.ltgt.gradle" name="gradle-errorprone-plugin" version="4.4.0">
+         <artifact name="gradle-errorprone-plugin-4.4.0.jar">
+            <sha256 value="e418ed0338b13fe7026d90b96c60e407f27d349076b33d36962d9c0a829a7a6f" origin="Generated by Gradle" reason="Artifact is not signed"/>
+         </artifact>
+         <artifact name="gradle-errorprone-plugin-4.4.0.module">
+            <sha256 value="b35b0829b52a1588abb7846808aa53d10faa1ad76a2320adc1457f32175ffa3d" origin="Generated by Gradle" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="net.sf.kxml" name="kxml2" version="2.3.0">


### PR DESCRIPTION
## Summary
- Wire Error Prone into the Java/Kotlin conventions and add XML report generation for JavaCompile tasks.
- Add version catalog entries and verification metadata for Error Prone artifacts.
- Document Error Prone reporting usage in build tooling skill.

## Testing
- ./gradlew spotlessApply