### PR TITLE
fix(client): reduce key listener deadlocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /generator/js/gwt-unitCache/
 /run
 .classpath
+.factorypath
 *.swp
 *.iml
 *.ipr

--- a/src/main/java/network/crypta/client/async/KeyListenerTracker.java
+++ b/src/main/java/network/crypta/client/async/KeyListenerTracker.java
@@ -274,16 +274,14 @@ class KeyListenerTracker implements KeySalter {
   }
 
   private ArrayList<KeyListener> probablyMatches(Key key, byte[] saltedKey) {
-    Object singleMatch;
-    List<KeyListener> listMatches;
     final ByteArrayWrapper wrapper = new ByteArrayWrapper(saltedKey);
     synchronized (this) {
-      singleMatch = singleKeyListeners.get(wrapper);
-      listMatches =
-          keyListeners.isEmpty() ? Collections.emptyList() : new ArrayList<>(keyListeners);
+      Object singleMatch = singleKeyListeners.get(wrapper);
+      ArrayList<KeyListener> matches = appendSingleMatches(singleMatch, key, saltedKey);
+      if (keyListeners.isEmpty()) return matches;
+      List<KeyListener> listMatches = new ArrayList<>(keyListeners);
+      return appendListMatches(matches, listMatches, key, saltedKey);
     }
-    ArrayList<KeyListener> matches = appendSingleMatches(singleMatch, key, saltedKey);
-    return appendListMatches(matches, listMatches, key, saltedKey);
   }
 
   /**
@@ -401,16 +399,14 @@ class KeyListenerTracker implements KeySalter {
       return false;
     }
     byte[] saltedKey = saltKey(key);
-    Object singleMatch;
-    List<KeyListener> listMatches;
     final ByteArrayWrapper wrapper = new ByteArrayWrapper(saltedKey);
     synchronized (this) {
-      singleMatch = singleKeyListeners.get(wrapper);
-      listMatches =
-          keyListeners.isEmpty() ? Collections.emptyList() : new ArrayList<>(keyListeners);
+      Object singleMatch = singleKeyListeners.get(wrapper);
+      if (anySingleProbablyWant(singleMatch, key, saltedKey)) return true;
+      if (keyListeners.isEmpty()) return false;
+      List<KeyListener> listMatches = new ArrayList<>(keyListeners);
+      return anyListProbablyWant(listMatches, key, saltedKey);
     }
-    if (anySingleProbablyWant(singleMatch, key, saltedKey)) return true;
-    return anyListProbablyWant(listMatches, key, saltedKey);
   }
 
   /**
@@ -509,23 +505,23 @@ class KeyListenerTracker implements KeySalter {
 
   /** Returns all KeyListeners that return true on probablyWantKey(key, saltedKey) */
   private List<KeyListener> probablyWantKey(Key key, byte[] saltedKey) {
-    List<KeyListener> listSnapshot;
+    ArrayList<KeyListener> matches = null;
     synchronized (this) {
       if (keyListeners.isEmpty()) return Collections.emptyList();
-      listSnapshot = new ArrayList<>(keyListeners);
-    }
-    ArrayList<KeyListener> matches = new ArrayList<>();
-    for (KeyListener listener : listSnapshot) {
-      try {
-        if (listener.probablyWantKey(key, saltedKey)) {
-          matches.add(listener);
+      List<KeyListener> listSnapshot = new ArrayList<>(keyListeners);
+      for (KeyListener listener : listSnapshot) {
+        try {
+          if (listener.probablyWantKey(key, saltedKey)) {
+            if (matches == null) matches = new ArrayList<>();
+            matches.add(listener);
+          }
+        } catch (Exception t) {
+          LOG.error(
+              "Error in probablyWantKey callback during probablyWantKey scan for {}", listener, t);
         }
-      } catch (Exception t) {
-        LOG.error(
-            "Error in probablyWantKey callback during probablyWantKey scan for {}", listener, t);
       }
     }
-    return matches;
+    return matches == null ? Collections.emptyList() : matches;
   }
 
   private void registerListener(byte[] wantedKey, ByteArrayWrapper wrapper, KeyListener listener) {

--- a/src/main/java/network/crypta/client/async/KeyListenerTracker.java
+++ b/src/main/java/network/crypta/client/async/KeyListenerTracker.java
@@ -273,12 +273,17 @@ class KeyListenerTracker implements KeySalter {
     return ret;
   }
 
-  private synchronized ArrayList<KeyListener> probablyMatches(Key key, byte[] saltedKey) {
-    ArrayList<KeyListener> matches;
+  private ArrayList<KeyListener> probablyMatches(Key key, byte[] saltedKey) {
+    Object singleMatch;
+    List<KeyListener> listMatches;
     final ByteArrayWrapper wrapper = new ByteArrayWrapper(saltedKey);
-    matches = appendSingleMatches(wrapper, key, saltedKey);
-    matches = appendListMatches(matches, key, saltedKey);
-    return matches;
+    synchronized (this) {
+      singleMatch = singleKeyListeners.get(wrapper);
+      listMatches =
+          keyListeners.isEmpty() ? Collections.emptyList() : new ArrayList<>(keyListeners);
+    }
+    ArrayList<KeyListener> matches = appendSingleMatches(singleMatch, key, saltedKey);
+    return appendListMatches(matches, listMatches, key, saltedKey);
   }
 
   /**
@@ -321,16 +326,24 @@ class KeyListenerTracker implements KeySalter {
    *
    * @return the sum of {@code countKeys()} across all listeners; never negative.
    */
-  public synchronized long countWaitingKeys() {
+  public long countWaitingKeys() {
+    List<Object> singleSnapshot;
+    List<KeyListener> listSnapshot;
+    synchronized (this) {
+      if (singleKeyListeners.isEmpty() && keyListeners.isEmpty()) return 0;
+      singleSnapshot = new ArrayList<>(singleKeyListeners.values());
+      listSnapshot =
+          keyListeners.isEmpty() ? Collections.emptyList() : new ArrayList<>(keyListeners);
+    }
     long count = 0;
-    for (Object o : singleKeyListeners.values()) {
+    for (Object o : singleSnapshot) {
       if (o instanceof KeyListener listener1) {
         count += listener1.countKeys();
       } else if (o instanceof KeyListener[] listeners) {
         for (KeyListener listener : listeners) count += listener.countKeys();
       }
     }
-    for (KeyListener listener : keyListeners) {
+    for (KeyListener listener : listSnapshot) {
       try {
         count += listener.countKeys();
       } catch (Exception t) {
@@ -382,14 +395,22 @@ class KeyListenerTracker implements KeySalter {
    * @param context execution context used for validation only; must not be {@code null}.
    * @return {@code true} if any listener indicates probable interest; {@code false} otherwise.
    */
-  public synchronized boolean anyProbablyWantKey(Key key, ClientContext context) {
+  public boolean anyProbablyWantKey(Key key, ClientContext context) {
     java.util.Objects.requireNonNull(context, "context");
     if ((key instanceof NodeSSK) != isSSKScheduler) {
       return false;
     }
     byte[] saltedKey = saltKey(key);
-    if (anySingleProbablyWant(key, saltedKey)) return true;
-    return anyListProbablyWant(key, saltedKey);
+    Object singleMatch;
+    List<KeyListener> listMatches;
+    final ByteArrayWrapper wrapper = new ByteArrayWrapper(saltedKey);
+    synchronized (this) {
+      singleMatch = singleKeyListeners.get(wrapper);
+      listMatches =
+          keyListeners.isEmpty() ? Collections.emptyList() : new ArrayList<>(keyListeners);
+    }
+    if (anySingleProbablyWant(singleMatch, key, saltedKey)) return true;
+    return anyListProbablyWant(listMatches, key, saltedKey);
   }
 
   /**
@@ -488,17 +509,20 @@ class KeyListenerTracker implements KeySalter {
 
   /** Returns all KeyListeners that return true on probablyWantKey(key, saltedKey) */
   private List<KeyListener> probablyWantKey(Key key, byte[] saltedKey) {
-    ArrayList<KeyListener> matches = new ArrayList<>();
+    List<KeyListener> listSnapshot;
     synchronized (this) {
-      for (KeyListener listener : keyListeners) {
-        try {
-          if (listener.probablyWantKey(key, saltedKey)) {
-            matches.add(listener);
-          }
-        } catch (Exception t) {
-          LOG.error(
-              "Error in probablyWantKey callback during probablyWantKey scan for {}", listener, t);
+      if (keyListeners.isEmpty()) return Collections.emptyList();
+      listSnapshot = new ArrayList<>(keyListeners);
+    }
+    ArrayList<KeyListener> matches = new ArrayList<>();
+    for (KeyListener listener : listSnapshot) {
+      try {
+        if (listener.probablyWantKey(key, saltedKey)) {
+          matches.add(listener);
         }
+      } catch (Exception t) {
+        LOG.error(
+            "Error in probablyWantKey callback during probablyWantKey scan for {}", listener, t);
       }
     }
     return matches;
@@ -582,20 +606,19 @@ class KeyListenerTracker implements KeySalter {
   }
 
   private ArrayList<KeyListener> appendSingleMatches(
-      ByteArrayWrapper wrapper, Key key, byte[] saltedKey) {
+      Object singleMatch, Key key, byte[] saltedKey) {
     ArrayList<KeyListener> matches = null;
-    Object o = singleKeyListeners.get(wrapper);
-    if (o instanceof KeyListener single) {
+    if (singleMatch instanceof KeyListener single) {
       matches = appendMatchIfSingle(single, key, saltedKey);
-    } else if (o instanceof KeyListener[] listeners) {
+    } else if (singleMatch instanceof KeyListener[] listeners) {
       matches = appendMatchesIfArray(listeners, key, saltedKey);
     }
     return matches;
   }
 
   private ArrayList<KeyListener> appendListMatches(
-      ArrayList<KeyListener> matches, Key key, byte[] saltedKey) {
-    for (KeyListener listener : keyListeners) {
+      ArrayList<KeyListener> matches, List<KeyListener> listMatches, Key key, byte[] saltedKey) {
+    for (KeyListener listener : listMatches) {
       if (listener.probablyWantKey(key, saltedKey)) {
         if (matches == null) matches = new ArrayList<>();
         matches.add(listener);
@@ -706,13 +729,11 @@ class KeyListenerTracker implements KeySalter {
     return accum;
   }
 
-  private boolean anySingleProbablyWant(Key key, byte[] saltedKey) {
-    final ByteArrayWrapper wrapper = new ByteArrayWrapper(saltedKey);
-    Object o = singleKeyListeners.get(wrapper);
-    if (o instanceof KeyListener listener) {
+  private boolean anySingleProbablyWant(Object singleMatch, Key key, byte[] saltedKey) {
+    if (singleMatch instanceof KeyListener listener) {
       return listener.probablyWantKey(key, saltedKey);
     }
-    if (o instanceof KeyListener[] listeners) {
+    if (singleMatch instanceof KeyListener[] listeners) {
       for (KeyListener listener : listeners) {
         if (listener.probablyWantKey(key, saltedKey)) return true;
       }
@@ -720,8 +741,8 @@ class KeyListenerTracker implements KeySalter {
     return false;
   }
 
-  private boolean anyListProbablyWant(Key key, byte[] saltedKey) {
-    for (KeyListener listener : keyListeners) {
+  private boolean anyListProbablyWant(List<KeyListener> listMatches, Key key, byte[] saltedKey) {
+    for (KeyListener listener : listMatches) {
       try {
         if (listener.probablyWantKey(key, saltedKey)) {
           return true;

--- a/src/main/java/network/crypta/client/async/USKFetcher.java
+++ b/src/main/java/network/crypta/client/async/USKFetcher.java
@@ -559,7 +559,10 @@ public class USKFetcher
       shouldFillKeysWatching =
           (!schedulingCoordinator.scheduleAfterDBRsDone()) || !dbrHintFetches.hasOutstanding();
     }
-    boolean registerNow = shouldFillKeysWatching && !fillKeysWatching(effectiveLatest, context);
+    boolean registerNow = false;
+    if (shouldFillKeysWatching && !isCancelled()) {
+      registerNow = !fillKeysWatching(effectiveLatest, context);
+    }
     return successPlanner.createSuccessPlan(decode, effectiveLatest, registerNow, killAttempts);
   }
 
@@ -1025,7 +1028,10 @@ public class USKFetcher
       shouldFillKeysWatching =
           (!schedulingCoordinator.scheduleAfterDBRsDone()) || !dbrHintFetches.hasOutstanding();
     }
-    boolean registerNow = shouldFillKeysWatching && !fillKeysWatching(effectiveEd, context);
+    boolean registerNow = false;
+    if (shouldFillKeysWatching && !isCancelled()) {
+      registerNow = !fillKeysWatching(effectiveEd, context);
+    }
     return successPlanner.createFoundPlan(decode, registerNow, killAttempts);
   }
 

--- a/src/main/java/network/crypta/client/async/USKFetcher.java
+++ b/src/main/java/network/crypta/client/async/USKFetcher.java
@@ -540,7 +540,8 @@ public class USKFetcher
       long lastEd) {
     boolean decode;
     List<USKAttempt> killAttempts = null;
-    boolean registerNow;
+    boolean shouldFillKeysWatching;
+    long effectiveLatest = curLatest;
     synchronized (this) {
       if (att != null) attempts.removeRunningAttempt(att.number);
       if (completed || cancelled) {
@@ -549,17 +550,17 @@ public class USKFetcher
         return null;
       }
       decode = USKSuccessPlanner.shouldDecode(curLatest, lastEd, dontUpdate, block);
-      curLatest = Math.max(lastEd, curLatest);
-      if (LOG.isDebugEnabled()) LOG.debug("Latest: {} in onSuccess", curLatest);
+      effectiveLatest = Math.max(lastEd, curLatest);
+      if (LOG.isDebugEnabled()) LOG.debug("Latest: {} in onSuccess", effectiveLatest);
       if (!checkStoreOnly) {
-        killAttempts = attempts.cancelBefore(curLatest);
-        attempts.addNewAttempts(curLatest, context, pollingRound.firstLoop());
+        killAttempts = attempts.cancelBefore(effectiveLatest);
+        attempts.addNewAttempts(effectiveLatest, context, pollingRound.firstLoop());
       }
-      if ((!schedulingCoordinator.scheduleAfterDBRsDone()) || !dbrHintFetches.hasOutstanding())
-        registerNow = !fillKeysWatching(curLatest, context);
-      else registerNow = false;
+      shouldFillKeysWatching =
+          (!schedulingCoordinator.scheduleAfterDBRsDone()) || !dbrHintFetches.hasOutstanding();
     }
-    return successPlanner.createSuccessPlan(decode, curLatest, registerNow, killAttempts);
+    boolean registerNow = shouldFillKeysWatching && !fillKeysWatching(effectiveLatest, context);
+    return successPlanner.createSuccessPlan(decode, effectiveLatest, registerNow, killAttempts);
   }
 
   /**
@@ -1009,21 +1010,22 @@ public class USKFetcher
     final long lastEd = uskManager.lookupLatestSlot(origUSK);
     boolean decode;
     List<USKAttempt> killAttempts = null;
-    boolean registerNow;
+    boolean shouldFillKeysWatching;
+    long effectiveEd = ed;
     synchronized (this) {
       if (completed || cancelled) return null;
       decode = lastEd == ed && data != null;
-      ed = Math.max(lastEd, ed);
-      if (LOG.isDebugEnabled()) LOG.debug("Latest: {} in onFoundEdition", ed);
+      effectiveEd = Math.max(lastEd, ed);
+      if (LOG.isDebugEnabled()) LOG.debug("Latest: {} in onFoundEdition", effectiveEd);
 
       if (!checkStoreOnly) {
-        killAttempts = attempts.cancelBefore(ed);
-        attempts.addNewAttempts(ed, context, pollingRound.firstLoop());
+        killAttempts = attempts.cancelBefore(effectiveEd);
+        attempts.addNewAttempts(effectiveEd, context, pollingRound.firstLoop());
       }
-      if ((!schedulingCoordinator.scheduleAfterDBRsDone()) || !dbrHintFetches.hasOutstanding())
-        registerNow = !fillKeysWatching(ed, context);
-      else registerNow = false;
+      shouldFillKeysWatching =
+          (!schedulingCoordinator.scheduleAfterDBRsDone()) || !dbrHintFetches.hasOutstanding();
     }
+    boolean registerNow = shouldFillKeysWatching && !fillKeysWatching(effectiveEd, context);
     return successPlanner.createFoundPlan(decode, registerNow, killAttempts);
   }
 


### PR DESCRIPTION
## Summary
- move key listener scanning to snapshot-based access to reduce lock contention
- avoid holding locks during USK success handling while still updating latest editions
- include .factorypath in gitignore to keep IDE artifacts out of the repo
- guard store-check scheduling against cancellation races

## Tests
- ./gradlew test --tests network.crypta.client.async.USKSchedulingCoordinatorTest