### PR TITLE
Fix errorprone warnings and stats equality

### DIFF
--- a/src/main/java/com/onionnetworks/fec/DefaultFECCodeFactory.java
+++ b/src/main/java/com/onionnetworks/fec/DefaultFECCodeFactory.java
@@ -148,6 +148,7 @@ public class DefaultFECCodeFactory extends FECCodeFactory {
    * @throws IllegalArgumentException if {@code k} or {@code n} fall outside the documented bounds
    *     or {@code n} is smaller than {@code k}.
    */
+  @Override
   public synchronized FECCode createFECCode(int k, int n) {
     //noinspection ConditionCoveredByFurtherCondition
     if (k < 1 || k > 65536 || n < k || n > 65536) {

--- a/src/main/java/com/onionnetworks/fec/FECMath.java
+++ b/src/main/java/com/onionnetworks/fec/FECMath.java
@@ -204,7 +204,7 @@ public class FECMath {
      * At the same time build gfLog[gfExp[i]] = i .
      * The first gfBits powers are simply bits shifted to the left.
      */
-    for (i = 0; i < gfBits; i++, mask <<= 1) {
+    for (i = 0; i < gfBits; i++, mask = (char) (mask << 1)) {
       gfExp[i] = mask;
       gfLog[gfExp[i]] = i;
       /*

--- a/src/main/java/com/onionnetworks/fec/MatrixMulParams.java
+++ b/src/main/java/com/onionnetworks/fec/MatrixMulParams.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
  * @param k shared inner dimension of the matrices
  * @param m number of columns in the right matrix and output
  */
+@SuppressWarnings("ArrayRecordComponent")
 public record MatrixMulParams(
     char[] a, int aStart, char[] b, int bStart, char[] c, int cStart, int n, int k, int m) {
 

--- a/src/main/java/com/onionnetworks/fec/Native16Code.java
+++ b/src/main/java/com/onionnetworks/fec/Native16Code.java
@@ -92,6 +92,7 @@ public class Native16Code extends FECCode {
    * @param packetLength length in bytes of each packet; must be an even value
    * @throws IllegalArgumentException if {@code packetLength} is not 16-bit aligned
    */
+  @Override
   protected void encode(
       byte[][] src, int[] srcOff, byte[][] repair, int[] repairOff, int[] index, int packetLength) {
 
@@ -116,6 +117,7 @@ public class Native16Code extends FECCode {
    * @param inOrder whether packets are already ordered by index and need no shuffling
    * @throws IllegalArgumentException if {@code packetLength} is not 16-bit aligned
    */
+  @Override
   protected void decode(
       byte[][] pkts, int[] pktsOff, int[] index, int packetLength, boolean inOrder) {
     if (packetLength % 2 != 0) {
@@ -235,6 +237,7 @@ public class Native16Code extends FECCode {
    *
    * @return human-readable summary of the code dimensions for debugging purposes
    */
+  @Override
   public String toString() {
     return "Native16Code[k=" + k + ",n=" + n + "]";
   }

--- a/src/main/java/com/onionnetworks/fec/Native8Code.java
+++ b/src/main/java/com/onionnetworks/fec/Native8Code.java
@@ -90,6 +90,7 @@ public class Native8Code extends FECCode {
    *     treated as direct copies by the native code.
    * @param packetLength Number of bytes per packet slice shared by all buffers in this operation.
    */
+  @Override
   protected void encode(
       byte[][] src, int[] srcOff, byte[][] repair, int[] repairOff, int[] index, int packetLength) {
 
@@ -117,6 +118,7 @@ public class Native8Code extends FECCode {
    * @param inOrder {@code true} if {@code pkts} is already arranged so {@code index < k} entries
    *     occupy matching positions; {@code false} to request an in-place shuffle first.
    */
+  @Override
   protected void decode(
       byte[][] pkts, int[] pktsOff, int[] index, int packetLength, boolean inOrder) {
     // We need to shuffle at this point so that the Java byte[][] stays
@@ -243,6 +245,7 @@ public class Native8Code extends FECCode {
    *
    * @return Human-readable description containing the configured {@code k} and {@code n} values.
    */
+  @Override
   public String toString() {
     return "Native8Code[k=" + k + ",n=" + n + "]";
   }

--- a/src/main/java/com/onionnetworks/fec/PureCode.java
+++ b/src/main/java/com/onionnetworks/fec/PureCode.java
@@ -93,6 +93,7 @@ public class PureCode extends FECCode {
    * @param index indices for each repair packet; values {@code k..n-1} are expected.
    * @param packetLength number of bytes to read or write for every packet.
    */
+  @Override
   protected void encode(
       byte[][] src, int[] srcOff, byte[][] repair, int[] repairOff, int[] index, int packetLength) {
     for (int i = 0; i < repair.length; i++) {
@@ -149,6 +150,7 @@ public class PureCode extends FECCode {
    * @param packetLength number of payload bytes considered for decode operations.
    * @param shuffled set to {@code true} when {@code pkts} already matches index order.
    */
+  @Override
   protected void decode(
       byte[][] pkts, int[] pktsOff, int[] index, int packetLength, boolean shuffled) {
     // This may be the second time shuffle has been called, if so
@@ -197,6 +199,7 @@ public class PureCode extends FECCode {
    *
    * @return human-readable code summary showing {@code k} data and {@code n} total packets.
    */
+  @Override
   public String toString() {
     return "PureCode[k=" + k + ",n=" + n + "]";
   }

--- a/src/main/java/com/onionnetworks/io/FileIntegrityImpl.java
+++ b/src/main/java/com/onionnetworks/io/FileIntegrityImpl.java
@@ -88,6 +88,7 @@ public class FileIntegrityImpl implements FileIntegrity {
    *
    * @return algorithm identifier; callers must not assume normalization beyond the provided value.
    */
+  @Override
   public String getAlgorithm() {
     return algo;
   }

--- a/src/main/java/com/onionnetworks/io/FileIntegrityImpl.java
+++ b/src/main/java/com/onionnetworks/io/FileIntegrityImpl.java
@@ -103,6 +103,7 @@ public class FileIntegrityImpl implements FileIntegrity {
    *
    * @return positive integer size in bytes; unchanged from construction input.
    */
+  @Override
   public int getBlockSize() {
     return blockSize;
   }
@@ -115,6 +116,7 @@ public class FileIntegrityImpl implements FileIntegrity {
    *
    * @return non-negative length in bytes for the represented file.
    */
+  @Override
   public long getFileSize() {
     return fileSize;
   }
@@ -128,6 +130,7 @@ public class FileIntegrityImpl implements FileIntegrity {
    *
    * @return positive count when {@code fileSize > 0}; otherwise zero for an empty file.
    */
+  @Override
   public int getBlockCount() {
     return blockCount;
   }
@@ -144,6 +147,7 @@ public class FileIntegrityImpl implements FileIntegrity {
    * @throws IllegalArgumentException if {@code blockNum} is negative or greater than or equal to
    *     {@link #getBlockCount()}.
    */
+  @Override
   public Buffer getBlockHash(int blockNum) {
     if (blockNum < 0 || blockNum >= blockCount) {
       throw new IllegalArgumentException("Invalid block #" + blockNum);
@@ -159,6 +163,7 @@ public class FileIntegrityImpl implements FileIntegrity {
    *
    * @return hash buffer for the whole file, covering every byte from start to end.
    */
+  @Override
   public Buffer getFileHash() {
     return fileHash;
   }

--- a/src/main/java/com/onionnetworks/io/RAF.java
+++ b/src/main/java/com/onionnetworks/io/RAF.java
@@ -335,6 +335,7 @@ public class RAF implements AutoCloseable {
    *
    * @throws IOException if closing fails or if delete-on-close cleanup cannot remove the file.
    */
+  @Override
   public synchronized void close() throws IOException {
     closed = true;
     randomAccessFile.close();
@@ -350,6 +351,7 @@ public class RAF implements AutoCloseable {
    *
    * @return human-readable description of this {@code RAF}, including its current file and mode.
    */
+  @Override
   public String toString() {
     return "RAF[file=" + f.getAbsolutePath() + ",mode=" + mode + "]";
   }

--- a/src/main/java/com/onionnetworks/io/RAFInputStream.java
+++ b/src/main/java/com/onionnetworks/io/RAFInputStream.java
@@ -64,6 +64,7 @@ public class RAFInputStream extends InputStream {
    *     stream has been closed.
    * @throws IOException if an I/O failure occurs during delegation to the underlying {@link RAF}.
    */
+  @Override
   public int read() throws IOException {
     byte[] b = new byte[1];
     if (read(b, 0, 1) == -1) {

--- a/src/main/java/com/onionnetworks/io/RAFOutputStream.java
+++ b/src/main/java/com/onionnetworks/io/RAFOutputStream.java
@@ -65,6 +65,7 @@ public class RAFOutputStream extends OutputStream {
    * @throws IOException if the stream has been closed or the underlying {@code RAF} rejects the
    *     write operation.
    */
+  @Override
   public void write(int b) throws IOException {
     write(new byte[] {(byte) b}, 0, 1);
   }

--- a/src/main/java/com/onionnetworks/io/TempRaf.java
+++ b/src/main/java/com/onionnetworks/io/TempRaf.java
@@ -164,6 +164,7 @@ public class TempRaf extends FilterRAF {
    *
    * @throws IOException if closing the delegate RAF fails or underlying I/O errors occur.
    */
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
   @Override
   public synchronized void close() throws IOException {
 

--- a/src/main/java/com/onionnetworks/net/PlainDatagramSocketFactory.java
+++ b/src/main/java/com/onionnetworks/net/PlainDatagramSocketFactory.java
@@ -63,6 +63,7 @@ public class PlainDatagramSocketFactory extends DatagramSocketFactory {
    * @see DatagramSocketFactory
    * @see DatagramSocket
    */
+  @Override
   public DatagramSocket createDatagramSocket() throws IOException {
     return new DatagramSocket();
   }
@@ -83,6 +84,7 @@ public class PlainDatagramSocketFactory extends DatagramSocketFactory {
    * @throws IOException if binding fails due to permission constraints, port conflicts, or resource
    *     exhaustion in the underlying network stack.
    */
+  @Override
   public DatagramSocket createDatagramSocket(int port) throws IOException {
     return new DatagramSocket(port);
   }
@@ -107,6 +109,7 @@ public class PlainDatagramSocketFactory extends DatagramSocketFactory {
    * @throws IOException if the requested address or port cannot be bound because of permissions,
    *     conflicts, or resource limits enforced by the platform.
    */
+  @Override
   public DatagramSocket createDatagramSocket(int port, InetAddress iaddr) throws IOException {
 
     return new DatagramSocket(port, iaddr);

--- a/src/main/java/com/onionnetworks/util/AsyncPersistentProps.java
+++ b/src/main/java/com/onionnetworks/util/AsyncPersistentProps.java
@@ -231,6 +231,7 @@ public class AsyncPersistentProps implements Runnable {
    * then signals waiting threads. Any {@link IOException} terminates the loop and marks the
    * instance as failed so callers learn of the error on their next interaction.
    */
+  @Override
   public void run() {
     while (true) {
       try {

--- a/src/main/java/com/onionnetworks/util/FileUtil.java
+++ b/src/main/java/com/onionnetworks/util/FileUtil.java
@@ -131,7 +131,7 @@ public class FileUtil {
    * @throws IllegalStateException if filesystem creation fails after sanitization and validation
    */
   public static File safeOnionFile(String rel) {
-    if ((new File(rel)).isAbsolute()) {
+    if (new File(rel).isAbsolute()) {
       throw new IllegalArgumentException(rel + " isn't relative");
     }
     StringBuilder safe = new StringBuilder();

--- a/src/main/java/com/onionnetworks/util/FilteringIterator.java
+++ b/src/main/java/com/onionnetworks/util/FilteringIterator.java
@@ -87,14 +87,14 @@ public abstract class FilteringIterator<T> implements Iterator<T> {
    */
   @Override
   public boolean hasNext() {
-    while ((next == null) && (parent.hasNext())) {
+    while (next == null && parent.hasNext()) {
       T o = parent.next();
       if (accept(o)) {
         next = o;
         return true;
       }
     }
-    return (next != null);
+    return next != null;
   }
 
   /**
@@ -148,8 +148,9 @@ public abstract class FilteringIterator<T> implements Iterator<T> {
     Iterator<String> i = l.iterator();
     FilteringIterator<String> f =
         new FilteringIterator<>(i) {
+          @Override
           public boolean accept(String o) {
-            return (o != null);
+            return o != null;
           }
         };
     LOGGER.info("--[ Unfiltered list: ]--");

--- a/src/main/java/com/onionnetworks/util/NativeDeployer.java
+++ b/src/main/java/com/onionnetworks/util/NativeDeployer.java
@@ -14,6 +14,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -76,9 +77,9 @@ public class NativeDeployer {
     } else if (env.isLinux()) {
       baseOS = "linux";
     } else {
-      baseOS = env.osNameRaw().toLowerCase();
+      baseOS = env.osNameRaw().toLowerCase(Locale.ROOT);
     }
-    final String sysArch = System.getProperty("os.arch").toLowerCase();
+    final String sysArch = System.getProperty("os.arch").toLowerCase(Locale.ROOT);
     final String detectedArch = env.arch(); // "amd64" or "arm64"
     if ("amd64".equals(detectedArch) || sysArch.matches("(i?[x0-9]86_64|amd64)")) {
       OS_ARCH = baseOS + "-x86_64";

--- a/src/main/java/com/onionnetworks/util/NetUtil.java
+++ b/src/main/java/com/onionnetworks/util/NetUtil.java
@@ -104,7 +104,7 @@ public class NetUtil {
    * @param args optional URL strings to resolve; when empty, built-in examples are used to showcase
    *     common edge cases.
    */
-  static void main(String[] args) throws IOException {
+  public static void main(String[] args) throws IOException {
 
     if (args.length == 0) {
       args =

--- a/src/main/java/com/onionnetworks/util/Range.java
+++ b/src/main/java/com/onionnetworks/util/Range.java
@@ -257,6 +257,7 @@ public class Range {
    *
    * @return deterministic hash value suitable for use in hash-based collections
    */
+  @Override
   public int hashCode() {
     return (int) (min + 23 * max);
   }
@@ -275,6 +276,7 @@ public class Range {
    * @return {@code true} when all endpoints and infinity markers are identical; otherwise {@code
    *     false}
    */
+  @Override
   public boolean equals(Object obj) {
     if (obj instanceof Range other) {
       return other.min == min
@@ -297,6 +299,7 @@ public class Range {
    * @return human-readable representation of this range that can be fed back into {@link
    *     #parse(String)}
    */
+  @Override
   public String toString() {
     if (!negInf && !posInf && min == max) {
       return Long.toString(min);

--- a/src/main/java/com/onionnetworks/util/RangeSet.java
+++ b/src/main/java/com/onionnetworks/util/RangeSet.java
@@ -3,6 +3,7 @@ package com.onionnetworks.util;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -519,7 +520,8 @@ public class RangeSet {
    */
   static void main() throws IOException, ParseException {
     RangeSet rs = RangeSet.parse("5-10,15-20,25-30");
-    try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+    try (BufferedReader br =
+        new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset()))) {
       boolean exit = false;
       while (!exit) {
         logCurrentSet(rs);
@@ -540,6 +542,7 @@ public class RangeSet {
     }
   }
 
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
   private static LoopResult processInput(BufferedReader br, RangeSet current, String input)
       throws IOException, ParseException {
     if (input.isEmpty()) {
@@ -596,7 +599,7 @@ public class RangeSet {
     int pos = binarySearch(max == Long.MAX_VALUE ? max : max + 1);
     // Return pos-1 if there isn't a direct hit because the max
     // pos is inclusive.
-    return pos >= 0 ? pos : (-(pos + 1)) - 1;
+    return pos >= 0 ? pos : -(pos + 1) - 1;
   }
 
   /**

--- a/src/main/java/com/onionnetworks/util/RangeSet.java
+++ b/src/main/java/com/onionnetworks/util/RangeSet.java
@@ -444,10 +444,11 @@ public class RangeSet {
    *
    * @return a hash code suitable for use in hashed collections.
    */
+  @Override
   public int hashCode() {
     int result = 0;
     for (int i = 0; i < rangeCount * 2; i++) {
-      result = (int) (91 * result + ranges[i]);
+      result = (int) (91L * result + ranges[i]);
     }
     return result;
   }
@@ -463,6 +464,7 @@ public class RangeSet {
    * @param obj the object to compare against this set.
    * @return {@code true} when the provided object represents the same ranges and flags.
    */
+  @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof RangeSet rs)) {
       return false;
@@ -482,6 +484,7 @@ public class RangeSet {
    *
    * @return a comma-separated string describing all ranges contained in this set.
    */
+  @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     for (Iterator<Range> it = iterator(); it.hasNext(); ) {

--- a/src/main/java/com/onionnetworks/util/ReflectiveEventDispatch.java
+++ b/src/main/java/com/onionnetworks/util/ReflectiveEventDispatch.java
@@ -78,6 +78,7 @@ public class ReflectiveEventDispatch implements Runnable {
    * @param priority new thread priority in the platform-dependent {@link Thread} range; values
    *     outside the allowed range are subject to JVM clamping.
    */
+  @SuppressWarnings("ThreadPriorityCheck")
   public void setPriority(int priority) {
     thread.setPriority(priority);
   }

--- a/src/main/java/com/onionnetworks/util/Tuple.java
+++ b/src/main/java/com/onionnetworks/util/Tuple.java
@@ -123,6 +123,7 @@ public class Tuple {
    *
    * @return combined hash code based on {@code left} and {@code right} components
    */
+  @Override
   public int hashCode() {
     return left.hashCode() ^ right.hashCode();
   }
@@ -138,6 +139,7 @@ public class Tuple {
    * @param obj candidate object to compare, typically another {@code Tuple}
    * @return {@code true} when both tuples contain equal component values; otherwise {@code false}
    */
+  @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof Tuple t)) {
       return false;

--- a/src/main/java/com/onionnetworks/util/Util.java
+++ b/src/main/java/com/onionnetworks/util/Util.java
@@ -406,7 +406,7 @@ public class Util {
    *
    * <p>Each character is expanded into two bytes: the high-order byte first, followed by the
    * low-order byte. The returned array length is exactly twice the input length. This helper is
-   * primarily intended for legacy protocols that treat Java {@code char} values as unsigned
+   * primarily intended for legacy protocols that treat Java char values as unsigned
    * 16&nbsp;bit quantities rather than UTF-16 text; no charset encoding is performed.
    *
    * @param chars characters expanded into two big-endian bytes each.
@@ -509,7 +509,7 @@ public class Util {
   /**
    * Copies bytes into a {@code char[]} using big-endian reconstruction.
    *
-   * <p>Pairs of bytes are combined into {@code char} values until either {@code numBytes} are
+   * <p>Pairs of bytes are combined into char values until either {@code numBytes} are
    * consumed or the destination range is filled. If {@code numBytes} is odd, the high byte of the
    * final character is written and the low byte is implicitly zero. This routine complements {@link
    * #arraycopy(char[], int, byte[], int, int)} and is useful when handling compact binary encodings
@@ -782,14 +782,17 @@ public class Util {
    */
   public static IntIterator createIntIterator(final Iterator<Integer> it) {
     return new IntIterator() {
+      @Override
       public boolean hasNextInt() {
         return it.hasNext();
       }
 
+      @Override
       public int nextInt() {
         return it.next();
       }
 
+      @Override
       public void removeInt() {
         it.remove();
       }

--- a/src/main/java/com/onionnetworks/util/Util.java
+++ b/src/main/java/com/onionnetworks/util/Util.java
@@ -406,8 +406,8 @@ public class Util {
    *
    * <p>Each character is expanded into two bytes: the high-order byte first, followed by the
    * low-order byte. The returned array length is exactly twice the input length. This helper is
-   * primarily intended for legacy protocols that treat Java char values as unsigned
-   * 16&nbsp;bit quantities rather than UTF-16 text; no charset encoding is performed.
+   * primarily intended for legacy protocols that treat Java char values as unsigned 16&nbsp;bit
+   * quantities rather than UTF-16 text; no charset encoding is performed.
    *
    * @param chars characters expanded into two big-endian bytes each.
    * @return byte array twice the length containing encoded characters.
@@ -509,9 +509,9 @@ public class Util {
   /**
    * Copies bytes into a {@code char[]} using big-endian reconstruction.
    *
-   * <p>Pairs of bytes are combined into char values until either {@code numBytes} are
-   * consumed or the destination range is filled. If {@code numBytes} is odd, the high byte of the
-   * final character is written and the low byte is implicitly zero. This routine complements {@link
+   * <p>Pairs of bytes are combined into char values until either {@code numBytes} are consumed or
+   * the destination range is filled. If {@code numBytes} is odd, the high byte of the final
+   * character is written and the low byte is implicitly zero. This routine complements {@link
    * #arraycopy(char[], int, byte[], int, int)} and is useful when handling compact binary encodings
    * of UTF-16 code units.
    *
@@ -652,7 +652,7 @@ public class Util {
     byte[] out = new byte[len / 2];
     try {
       for (int i = 0; i < out.length; i++) {
-        out[i] = (byte) (Integer.parseInt(in.substring(i * 2, i * 2 + 2), 16));
+        out[i] = (byte) Integer.parseInt(in.substring(i * 2, i * 2 + 2), 16);
       }
     } catch (NumberFormatException doh) {
       throw new IllegalArgumentException("ParseError", doh);

--- a/src/main/java/network/crypta/client/DefaultMIMETypes.java
+++ b/src/main/java/network/crypta/client/DefaultMIMETypes.java
@@ -2,6 +2,7 @@ package network.crypta.client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import network.crypta.support.MediaType;
 import org.slf4j.Logger;
@@ -126,7 +127,7 @@ public class DefaultMIMETypes {
     addMIMEType(number, type);
     if (extensions != null) {
       for (String ext : extensions) {
-        ext = ext.toLowerCase();
+        ext = ext.toLowerCase(Locale.ROOT);
         Short s = mimeTypesByExtension.get(ext);
         if (s != null) {
           // No big deal
@@ -890,7 +891,7 @@ public class DefaultMIMETypes {
   public static synchronized String guessMIMEType(String arg, boolean noDefault) {
     int x = arg.lastIndexOf('.');
     if ((x == -1) || (x == arg.length() - 1)) return noDefault ? null : DEFAULT_MIME_TYPE;
-    String ext = arg.substring(x + 1).toLowerCase();
+    String ext = arg.substring(x + 1).toLowerCase(Locale.ROOT);
     Short mimeIndexOb = mimeTypesByExtension.get(ext);
     if (mimeIndexOb != null) {
       return mimeTypesByNumber.get(mimeIndexOb.intValue());

--- a/src/main/java/network/crypta/client/DefaultMIMETypes.java
+++ b/src/main/java/network/crypta/client/DefaultMIMETypes.java
@@ -952,17 +952,21 @@ public class DefaultMIMETypes {
   }
 
   /** Regular expression for the top‑level type token (for example, {@code text}). */
-  private static final String TOP_LEVEL = "(?>[a-zA-Z-]+)";
+  private static final String TOP_LEVEL = "[a-zA-Z-]++";
 
   /** Regular expression for the subtype and parameter tokens allowed by this parser. */
-  private static final String CHARS = "(?>[a-zA-Z0-9+_.-]+)";
+  private static final String CHARS = "[a-zA-Z0-9+_.-]++";
+
+  /** Regular expression fragment for a quoted parameter value. */
+  private static final String QUOTED = "\"[^\";]*+\"";
 
   /** Regular expression fragment for a single parameter, including optional quoting. */
-  private static final String PARAM = "(?>;\\s*" + CHARS + "=" + "((" + CHARS + ")|(\".*\")))";
+  private static final String PARAM =
+      "(?>;\\s*+" + CHARS + "\\s*+=\\s*+(?:" + CHARS + "|" + QUOTED + ")\\s*+)";
 
   /** Complete pattern for a MIME type with optional parameters; used for plausibility checks. */
   private static final Pattern MIME_TYPE =
-      Pattern.compile(TOP_LEVEL + "/" + CHARS + "\\s*" + PARAM + "*\\s*;?\\s*");
+      Pattern.compile(TOP_LEVEL + "/" + CHARS + "\\s*+" + PARAM + "*+\\s*+;?\\s*+");
 
   /**
    * Compatibility pattern for legacy Infocalypse repositories that encoded a numeric suffix as a

--- a/src/main/java/network/crypta/client/DefaultMIMETypes.java
+++ b/src/main/java/network/crypta/client/DefaultMIMETypes.java
@@ -962,7 +962,7 @@ public class DefaultMIMETypes {
 
   /** Complete pattern for a MIME type with optional parameters; used for plausibility checks. */
   private static final Pattern MIME_TYPE =
-      Pattern.compile(TOP_LEVEL + "/" + CHARS + "\\s*" + PARAM + "*");
+      Pattern.compile(TOP_LEVEL + "/" + CHARS + "\\s*" + PARAM + "*\\s*;?\\s*");
 
   /**
    * Compatibility pattern for legacy Infocalypse repositories that encoded a numeric suffix as a

--- a/src/main/java/network/crypta/client/DefaultMIMETypes.java
+++ b/src/main/java/network/crypta/client/DefaultMIMETypes.java
@@ -190,6 +190,7 @@ public class DefaultMIMETypes {
    * @param extensions space‑separated list of extensions without dots; the first token becomes the
    *     primary extension
    */
+  @SuppressWarnings("StringSplitter")
   protected static synchronized void addMIMEType(short number, String type, String extensions) {
     String[] split = extensions.split(" ");
     addMIMEType(number, type, split, split[0]);
@@ -204,6 +205,7 @@ public class DefaultMIMETypes {
    * @param extensions space‑separated list of extensions without dots
    * @param outExtension explicit primary extension to prefer when multiple extensions are supplied
    */
+  @SuppressWarnings("StringSplitter")
   protected static synchronized void addMIMEType(
       short number, String type, String extensions, String outExtension) {
     addMIMEType(number, type, extensions.split(" "), outExtension);

--- a/src/main/java/network/crypta/client/async/ClientPutterOptions.java
+++ b/src/main/java/network/crypta/client/async/ClientPutterOptions.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
  * @param overrideSplitfileCrypto optional 32-byte key to override random splitfile key generation.
  * @param metadataThreshold byte threshold for compact metadata; non-positive disables optimization.
  */
+@SuppressWarnings("ArrayRecordComponent")
 public record ClientPutterOptions(
     String targetFilename,
     boolean binaryBlob,

--- a/src/main/java/network/crypta/client/async/SplitFileFetchOriginalDetails.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetchOriginalDetails.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
  * @param clientDetails client detail bytes written verbatim to storage
  * @param isFinalFetch true when the request is a final-fetch operation
  */
+@SuppressWarnings("ArrayRecordComponent")
 public record SplitFileFetchOriginalDetails(
     FreenetURI thisKey, FreenetURI origKey, byte[] clientDetails, boolean isFinalFetch) {
   /**

--- a/src/main/java/network/crypta/client/events/SplitfileProgressEvent.java
+++ b/src/main/java/network/crypta/client/events/SplitfileProgressEvent.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * @see network.crypta.client.async.ClientGetter
  * @see network.crypta.client.async.ClientPutter
  */
+@SuppressWarnings("JavaUtilDate")
 public class SplitfileProgressEvent implements ClientEvent {
   private static final Logger LOG = LoggerFactory.getLogger(SplitfileProgressEvent.class);
 
@@ -200,7 +201,7 @@ public class SplitfileProgressEvent implements ClientEvent {
             fatallyFailedBlocks,
             finalizedTotal);
     } else {
-      sb.append((100 * (succeedBlocks) / minSuccessfulBlocks));
+      sb.append(100 * succeedBlocks / minSuccessfulBlocks);
       sb.append('%');
     }
     sb.append(' ');

--- a/src/main/java/network/crypta/client/events/SplitfileProgressTimestamps.java
+++ b/src/main/java/network/crypta/client/events/SplitfileProgressTimestamps.java
@@ -25,6 +25,7 @@ import java.util.Date;
  * @param latestSuccess time of the most recent successful block, or {@code null} if none yet
  * @param latestFailure time of the most recent failure, or {@code null} if none yet
  */
+@SuppressWarnings("JavaUtilDate")
 public record SplitfileProgressTimestamps(Date latestSuccess, Date latestFailure) {
   /**
    * Creates a snapshot of the latest success and failure timestamps.

--- a/src/main/java/network/crypta/client/filter/FilterMIMETypeNames.java
+++ b/src/main/java/network/crypta/client/filter/FilterMIMETypeNames.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
  * @param alternateMimeTypes additional MIME type aliases accepted for this handler
  * @param alternateExtensions additional filename extensions associated with the type
  */
+@SuppressWarnings("ArrayRecordComponent")
 public record FilterMIMETypeNames(
     String primaryMimeType,
     String primaryExtension,

--- a/src/main/java/network/crypta/client/filter/FlacPacket.java
+++ b/src/main/java/network/crypta/client/filter/FlacPacket.java
@@ -170,6 +170,7 @@ class FlacMetadataBlock extends FlacPacket {
    *
    * @param type the target metadata category; unsupported values are ignored safely
    */
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
   public void setMetadataBlockType(BlockType type) {
     switch (type) {
       case STREAMINFO:

--- a/src/main/java/network/crypta/client/filter/FlacPacketFilter.java
+++ b/src/main/java/network/crypta/client/filter/FlacPacketFilter.java
@@ -86,6 +86,7 @@ public class FlacPacketFilter implements CodecPacketFilter {
    * @throws IOException if reading the packet payload fails due to truncated or malformed data
    *     while extracting STREAMINFO fields or rewriting metadata content.
    */
+  @Override
   public CodecPacket parse(CodecPacket packet) throws IOException {
     if (!streamValid) return null;
     boolean logMINOR = LOG.isDebugEnabled();

--- a/src/main/java/network/crypta/client/filter/FlacPacketFilter.java
+++ b/src/main/java/network/crypta/client/filter/FlacPacketFilter.java
@@ -86,6 +86,7 @@ public class FlacPacketFilter implements CodecPacketFilter {
    * @throws IOException if reading the packet payload fails due to truncated or malformed data
    *     while extracting STREAMINFO fields or rewriting metadata content.
    */
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
   @Override
   public CodecPacket parse(CodecPacket packet) throws IOException {
     if (!streamValid) return null;

--- a/src/main/java/network/crypta/client/filter/GIFFilter.java
+++ b/src/main/java/network/crypta/client/filter/GIFFilter.java
@@ -220,6 +220,7 @@ public class GIFFilter implements ContentDataFilter {
     }
 
     /** Looks for data blocks and filters them according to their type. */
+    @SuppressWarnings("StatementSwitchToExpressionSwitch")
     private void filterData() throws IOException {
       boolean imageSeen = false;
       boolean terminated = false;
@@ -460,6 +461,7 @@ public class GIFFilter implements ContentDataFilter {
       new GIF89aValidator(input, output).filter();
     }
 
+    @SuppressWarnings("StatementSwitchToExpressionSwitch")
     @Override
     protected void filterExtensionBlock() throws IOException {
       int label = readByte();

--- a/src/main/java/network/crypta/client/filter/VP8PacketFilter.java
+++ b/src/main/java/network/crypta/client/filter/VP8PacketFilter.java
@@ -39,16 +39,16 @@ public class VP8PacketFilter {
   /**
    * Creates a new filter with optional WebP-specific validation.
    *
-   * <p>When {@code isWebp} is {@code true}, the parser applies additional rules expected for WebP
+   * <p>When {@code isWebP} is {@code true}, the parser applies additional rules expected for WebP
    * still images embedded with VP8. Specifically, it requires the frame to be a keyframe, forbids
    * the experimental version bit, and enforces that the frame is marked as shown. When {@code
    * false}, the parser validates only generic VP8 header invariants.
    *
-   * @param isWebp whether to enforce WebP constraints in addition to generic VP8 checks; pass
+   * @param isWebP whether to enforce WebP constraints in addition to generic VP8 checks; pass
    *     {@code true} for WebP image validation or {@code false} for general VP8 streams.
    */
-  public VP8PacketFilter(boolean isWebp) {
-    this.isWebP = isWebp;
+  public VP8PacketFilter(boolean isWebP) {
+    this.isWebP = isWebP;
   }
 
   /**

--- a/src/main/java/network/crypta/client/filter/VorbisPacketFilter.java
+++ b/src/main/java/network/crypta/client/filter/VorbisPacketFilter.java
@@ -91,6 +91,7 @@ public class VorbisPacketFilter implements CodecPacketFilter {
    * @throws IOException if parsing the packet fails due to truncated input, unsupported values, or
    *     other I/O-related decoding problems encountered while reading fields
    */
+  @Override
   public CodecPacket parse(CodecPacket packet) throws IOException {
     // Assemble the Vorbis packets
     try (DataInputStream input = new DataInputStream(new ByteArrayInputStream(packet.payload))) {

--- a/src/main/java/network/crypta/clients/http/RedirectException.java
+++ b/src/main/java/network/crypta/clients/http/RedirectException.java
@@ -46,12 +46,12 @@ public class RedirectException extends Exception {
    * request context (path segments, query parameters) and should avoid passing user-controlled
    * values without validation to prevent open redirects.
    *
-   * @param newURI fully qualified or context-relative URI string indicating the retry destination;
+   * @param newuri fully qualified or context-relative URI string indicating the retry destination;
    *     must be valid per {@link URI#URI(String)} and should not be {@code null}
    * @throws URISyntaxException if the supplied text cannot be converted into a legal {@link URI}
    */
-  public RedirectException(String newURI) throws URISyntaxException {
-    this.newuri = new URI(newURI);
+  public RedirectException(String newuri) throws URISyntaxException {
+    this.newuri = new URI(newuri);
   }
 
   /**
@@ -63,11 +63,11 @@ public class RedirectException extends Exception {
    * immutable {@link URI} instance and ensure it accurately represents the desired destination to
    * avoid surprising downstream routing.
    *
-   * @param newURI resolved and validated target URI to use when the container retries the request;
+   * @param newuri resolved and validated target URI to use when the container retries the request;
    *     must not be {@code null}
    */
-  public RedirectException(URI newURI) {
-    this.newuri = newURI;
+  public RedirectException(URI newuri) {
+    this.newuri = newuri;
   }
 
   /**

--- a/src/main/java/network/crypta/crypt/CTRBlockCipher.java
+++ b/src/main/java/network/crypta/crypt/CTRBlockCipher.java
@@ -180,7 +180,7 @@ public class CTRBlockCipher {
 
     // Increment counter as a big-endian integer (propagate carry from the last byte backward).
     for (int i = counter.length - 1; i >= 0; i--) {
-      if ((++counter[i]) != (byte) 0) {
+      if (++counter[i] != (byte) 0) {
         break; // stop when no carry
       }
     }

--- a/src/main/java/network/crypta/crypt/DSAGroup.java
+++ b/src/main/java/network/crypta/crypt/DSAGroup.java
@@ -186,9 +186,10 @@ public class DSAGroup extends CryptoKey {
    * @param o other group; may be {@code null}
    * @return {@code true} when all three parameters are equal
    */
+  @SuppressWarnings("NonOverridingEquals")
   public boolean equals(DSAGroup o) {
-    if (this == o) { // Fast path for identity.
-      return true;
+    if (o == null) {
+      return false;
     }
     return p.equals(o.p) && q.equals(o.q) && g.equals(o.g);
   }
@@ -250,7 +251,7 @@ public class DSAGroup extends CryptoKey {
    */
   @Override
   public String toString() {
-    if (this == Global.DSAgroupBigA) return "Global.DSAgroupBigA";
+    if (Global.DSAgroupBigA.equals(this)) return "Global.DSAgroupBigA";
     else return super.toString();
   }
 
@@ -264,7 +265,7 @@ public class DSAGroup extends CryptoKey {
    */
   @Override
   public String toLongString() {
-    if (this == Global.DSAgroupBigA) return "Global.DSAgroupBigA";
+    if (Global.DSAgroupBigA.equals(this)) return "Global.DSAgroupBigA";
     return "p=" + HexUtil.biToHex(p) + ", q=" + HexUtil.biToHex(q) + ", g=" + HexUtil.biToHex(g);
   }
 
@@ -277,7 +278,7 @@ public class DSAGroup extends CryptoKey {
    * @return {@code this} if canonical; otherwise a new, equivalent {@code DSAGroup}
    */
   public DSAGroup cloneKey() {
-    if (this == Global.DSAgroupBigA) return this;
+    if (Global.DSAgroupBigA.equals(this)) return Global.DSAgroupBigA;
     return new DSAGroup(this);
   }
 }

--- a/src/main/java/network/crypta/crypt/DSAPrivateKey.java
+++ b/src/main/java/network/crypta/crypt/DSAPrivateKey.java
@@ -17,7 +17,7 @@ public class DSAPrivateKey extends CryptoKey {
 
   public DSAPrivateKey(BigInteger x, DSAGroup g) {
     this.x = x;
-    if (x.signum() != 1 || x.compareTo(g.getQ()) > -1 || x.compareTo(BigInteger.ZERO) < 1)
+    if (x.signum() != 1 || x.compareTo(g.getQ()) >= 0 || x.compareTo(BigInteger.ZERO) <= 0)
       throw new IllegalArgumentException();
   }
 
@@ -27,7 +27,7 @@ public class DSAPrivateKey extends CryptoKey {
     BigInteger tempX;
     do {
       tempX = new BigInteger(256, r);
-    } while (tempX.compareTo(g.getQ()) > -1 || tempX.compareTo(BigInteger.ZERO) < 1);
+    } while (tempX.compareTo(g.getQ()) >= 0 || tempX.compareTo(BigInteger.ZERO) <= 0);
     this.x = tempX;
   }
 

--- a/src/main/java/network/crypta/crypt/DSAPublicKey.java
+++ b/src/main/java/network/crypta/crypt/DSAPublicKey.java
@@ -53,7 +53,7 @@ public class DSAPublicKey extends CryptoKey implements StorableBlock {
   public DSAPublicKey(DSAGroup g, BigInteger y) {
     if (y.signum() != 1) throw new IllegalArgumentException();
     this.y = y;
-    if (g == Global.DSAgroupBigA) g = null;
+    if (Global.DSAgroupBigA.equals(g)) g = null;
     this.group = g;
     if (y.compareTo(getGroup().getP()) > 0)
       throw new IllegalArgumentException("y must be < p but y=" + y + " p=" + getGroup().getP());
@@ -72,7 +72,7 @@ public class DSAPublicKey extends CryptoKey implements StorableBlock {
   public DSAPublicKey(DSAGroup g, String yAsHexString) throws NumberFormatException {
     this.y = new BigInteger(yAsHexString, 16);
     if (y.signum() != 1) throw new IllegalArgumentException();
-    if (g == Global.DSAgroupBigA) g = null;
+    if (Global.DSAgroupBigA.equals(g)) g = null;
     this.group = g;
   }
 
@@ -99,7 +99,7 @@ public class DSAPublicKey extends CryptoKey implements StorableBlock {
    */
   public DSAPublicKey(InputStream is) throws IOException, CryptFormatException {
     DSAGroup g = (DSAGroup) DSAGroup.read(is);
-    if (g == Global.DSAgroupBigA) g = null;
+    if (Global.DSAgroupBigA.equals(g)) g = null;
     group = g;
     y = Util.readMPI(is);
     if (y.compareTo(getGroup().getP()) > 0)
@@ -300,9 +300,10 @@ public class DSAPublicKey extends CryptoKey implements StorableBlock {
    * @param o other key.
    * @return {@code true} if both {@code y} and the group are equal.
    */
+  @SuppressWarnings("NonOverridingEquals")
   public boolean equals(DSAPublicKey o) {
-    if (this == o) { // Not necessary, but a very cheap optimization
-      return true;
+    if (o == null) {
+      return false;
     }
     return y.compareTo(o.y) == 0 && getGroup().equals(o.getGroup());
   }
@@ -318,11 +319,11 @@ public class DSAPublicKey extends CryptoKey implements StorableBlock {
   public boolean equals(Object o) {
     if (this == o) { // Not necessary, but a very cheap optimization
       return true;
-    } else if ((o == null) || (o.getClass() != this.getClass())) {
+    }
+    if (!(o instanceof DSAPublicKey other)) {
       return false;
     }
-    return y.compareTo(((DSAPublicKey) o).y) == 0
-        && getGroup().equals(((DSAPublicKey) o).getGroup());
+    return y.compareTo(other.y) == 0 && getGroup().equals(other.getGroup());
   }
 
   /**

--- a/src/main/java/network/crypta/crypt/ECDH.java
+++ b/src/main/java/network/crypta/crypt/ECDH.java
@@ -75,6 +75,7 @@ public class ECDH {
    *   <li>Performs provider self-tests and fallback handling.
    * </ul>
    */
+  @SuppressWarnings("ImmutableEnumChecker")
   public enum Curves {
     // rfc5903 or rfc6460: it's NIST's random/prime curves: suite B
     // Order matters. Append to the list, do not re-order.

--- a/src/main/java/network/crypta/crypt/ECDSA.java
+++ b/src/main/java/network/crypta/crypt/ECDSA.java
@@ -47,6 +47,7 @@ public class ECDSA {
 
   private final KeyPair key;
 
+  @SuppressWarnings("ImmutableEnumChecker")
   public enum Curves {
     /**
      * Supported NIST prime curves (a.k.a. Suite B). The order is part of the external format;

--- a/src/main/java/network/crypta/crypt/HashType.java
+++ b/src/main/java/network/crypta/crypt/HashType.java
@@ -20,6 +20,7 @@ import org.bitpedia.util.TigerTree;
  * Ed2MessageDigest} and {@link TigerTree}). For JCA-backed algorithms, a preferred {@link Provider}
  * is selected at startup via {@link Util#mdProviders}.
  */
+@SuppressWarnings("ImmutableEnumChecker")
 public enum HashType {
   // Keep constants synchronized with Util.mdProviders keys.
   SHA1(1, "SHA1", 20),

--- a/src/main/java/network/crypta/crypt/JceLoader.java
+++ b/src/main/java/network/crypta/crypt/JceLoader.java
@@ -81,7 +81,7 @@ public class JceLoader {
     p = null;
     if (checkUse("use.NSS", "false")) {
       try {
-        p = (new NSSLoader()).load(checkUse("prefer.NSS"));
+        p = new NSSLoader().load(checkUse("prefer.NSS"));
       } catch (Exception e) {
         // Note: The SunPKCS11-NSS provider may be unavailable on some platforms.
         final String msg =
@@ -104,7 +104,7 @@ public class JceLoader {
     p = null;
     if (checkUse("use.BC.I.know.what.I.am.doing")) {
       try {
-        p = (new BouncyCastleLoader()).load();
+        p = new BouncyCastleLoader().load();
       } catch (Exception e) {
         // Catch reflective loading issues and runtime failures from algorithm probes inside
         // BouncyCastleLoader (e.g., IllegalStateException when ECDH/ECDSA are missing) so we

--- a/src/main/java/network/crypta/crypt/KeyPairType.java
+++ b/src/main/java/network/crypta/crypt/KeyPairType.java
@@ -31,6 +31,7 @@ import java.security.spec.ECGenParameterSpec;
  *
  * <p>Thread safety: enum instances are immutable and safe for concurrent use.
  */
+@SuppressWarnings("ImmutableEnumChecker")
 public enum KeyPairType {
   ECP256("EC", "secp256r1", 91),
   ECP384("EC", "secp384r1", 120),

--- a/src/main/java/network/crypta/crypt/Util.java
+++ b/src/main/java/network/crypta/crypt/Util.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import network.crypta.support.Fields;
 import network.crypta.support.Loader;
@@ -83,7 +84,7 @@ public class Util {
     try {
       MessageDigest sunMd = MessageDigest.getInstance(algo, sun);
       sunMd.digest();
-      if (md.getProvider() != sunMd.getProvider()) {
+      if (!Objects.equals(md.getProvider(), sunMd.getProvider())) {
         long timeDef = benchmark(md);
         long timeSun = benchmark(sunMd);
         LOG.debug(

--- a/src/main/java/network/crypta/crypt/Yarrow.java
+++ b/src/main/java/network/crypta/crypt/Yarrow.java
@@ -173,7 +173,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
     }
 
     if (updateSeed
-        && !(seed.toString())
+        && !seed.toString()
             .equals(DEV_URANDOM)) // Don't try to update the seed file if we know it won't be
       // possible anyway
       seedfile = seed;

--- a/src/main/java/network/crypta/crypt/ciphers/Rijndael.java
+++ b/src/main/java/network/crypta/crypt/ciphers/Rijndael.java
@@ -3,6 +3,7 @@ package network.crypta.crypt.ciphers;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Provider;
+import java.util.Objects;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -152,7 +153,7 @@ public class Rijndael implements BlockCipher {
       bouncy.init(Cipher.ENCRYPT_MODE, key, randomIv());
 
       Provider bouncyProvider = bouncy.getProvider();
-      if (currentProvider == bouncyProvider) return currentProvider;
+      if (Objects.equals(currentProvider, bouncyProvider)) return currentProvider;
 
       long timeDef = benchmark(current, key);
       long timeBouncy = benchmark(bouncy, key);

--- a/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
+++ b/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
  *     not a general‑purpose {@code javax.crypto.Cipher} implementation.
  *     <p>License is apparently available from http://www.cryptix.org/docs/license.html
  */
+@SuppressWarnings("OperatorPrecedence")
 public final class RijndaelAlgorithm // implicit no-argument constructor
  {
   private static final Logger LOG = LoggerFactory.getLogger(RijndaelAlgorithm.class);

--- a/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
+++ b/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
@@ -1231,6 +1231,7 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
     }
   }
 
+  @SuppressWarnings("ArrayRecordComponent")
   private record KeyScheduleCtx(
       int[][] ke, int[][] kd, int rounds, int bcShift, int bc, int kc, int roundKeyCount) {
     @Override

--- a/src/main/java/network/crypta/keys/ClientCHKEncodeParams.java
+++ b/src/main/java/network/crypta/keys/ClientCHKEncodeParams.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
  * @param cryptoAlgorithm crypto algorithm identifier
  * @param blockHashAlgorithm block-hash identifier to store in the header
  */
+@SuppressWarnings("ArrayRecordComponent")
 public record ClientCHKEncodeParams(
     byte[] data,
     int dataLength,

--- a/src/main/java/network/crypta/node/LoggingConfigHandler.java
+++ b/src/main/java/network/crypta/node/LoggingConfigHandler.java
@@ -802,6 +802,7 @@ public class LoggingConfigHandler {
     appliedLoggerNames.clear();
   }
 
+  @SuppressWarnings("StringSplitter")
   private Map<String, Level> parseOverrides(String raw) throws InvalidConfigValueException {
     Map<String, Level> result = new HashMap<>();
     String[] tokens = raw.split(",");

--- a/src/main/java/network/crypta/node/LoggingConfigHandler.java
+++ b/src/main/java/network/crypta/node/LoggingConfigHandler.java
@@ -648,7 +648,7 @@ public class LoggingConfigHandler {
    */
   private String datePatternForInterval(String configured) {
     if (configured == null || configured.isEmpty()) return PATTERN_HOURLY; // default hourly
-    String s = configured.trim().toUpperCase();
+    String s = configured.trim().toUpperCase(Locale.ROOT);
     // Strip optional trailing 'S'
     if (s.endsWith("S")) s = s.substring(0, s.length() - 1);
     // Extract numeric prefix (we ignore it for Logback granularity)
@@ -667,7 +667,7 @@ public class LoggingConfigHandler {
 
   private String parseIntervalUnit(String s) {
     if (s == null || s.isEmpty()) return UNIT_HOUR; // default granularity
-    String up = s.toUpperCase();
+    String up = s.toUpperCase(Locale.ROOT);
     // Accept plural units (e.g. 5MINUTES) by trimming an optional trailing 'S'
     if (up.endsWith("S")) up = up.substring(0, up.length() - 1);
     int i = 0;
@@ -689,7 +689,7 @@ public class LoggingConfigHandler {
 
   private int parseIntervalMultiple(String configured) {
     if (configured == null || configured.isEmpty()) return 1;
-    String s = configured.trim().toUpperCase();
+    String s = configured.trim().toUpperCase(Locale.ROOT);
     if (s.endsWith("S")) s = s.substring(0, s.length() - 1);
     int i = 0;
     while (i < s.length() && Character.isDigit(s.charAt(i))) i++;

--- a/src/main/java/network/crypta/node/MultiMessageCallback.java
+++ b/src/main/java/network/crypta/node/MultiMessageCallback.java
@@ -95,7 +95,7 @@ public abstract class MultiMessageCallback {
    */
   public AsyncMessageCallback make() {
     synchronized (this) {
-      assert (!armed);
+      assert !armed;
       AsyncMessageCallback cb = new MessageCallbackImpl();
       waiting++;
       waitingForSend++;

--- a/src/main/java/network/crypta/node/SessionKeyCryptoMaterial.java
+++ b/src/main/java/network/crypta/node/SessionKeyCryptoMaterial.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.NotNull;
  * @param hmacKey key bytes for message authentication; stored by reference and mutable.
  * @see SessionKey
  */
+@SuppressWarnings("ArrayRecordComponent")
 public record SessionKeyCryptoMaterial(
     BlockCipher outgoingCipher,
     byte[] outgoingKey,

--- a/src/main/java/network/crypta/node/UptimeEstimator.java
+++ b/src/main/java/network/crypta/node/UptimeEstimator.java
@@ -79,7 +79,7 @@ public class UptimeEstimator implements Runnable {
     prevFile = runDir.file("uptime.old.dat");
     timeOffset =
         (int)
-            ((((double) (Math.abs(Fields.hashCode(bs, bs.length / 2, bs.length - bs.length / 2))))
+            (((double) Math.abs(Fields.hashCode(bs, bs.length / 2, bs.length - bs.length / 2))
                     / Integer.MAX_VALUE)
                 * PERIOD);
   }

--- a/src/main/java/network/crypta/node/probe/Error.java
+++ b/src/main/java/network/crypta/node/probe/Error.java
@@ -22,6 +22,7 @@ package network.crypta.node.probe;
  * across threads. The mapping between codes and enum constants is fixed at compile time and does
  * not change at runtime.
  */
+@SuppressWarnings("JavaLangClash")
 public enum Error {
   /**
    * The target node disconnected while the probe awaited a response.

--- a/src/main/java/network/crypta/node/simulator/LongTermTest.java
+++ b/src/main/java/network/crypta/node/simulator/LongTermTest.java
@@ -66,6 +66,7 @@ public class LongTermTest {
    * consistent "today" semantics within a run. The snapshot is immutable and safe for concurrent
    * access by multiple simulator tasks.
    */
+  @SuppressWarnings("TimeInStaticInitializer")
   protected static final Today today = new Today(Instant.now());
 
   /**

--- a/src/main/java/network/crypta/node/stats/DataStoreInstanceType.java
+++ b/src/main/java/network/crypta/node/stats/DataStoreInstanceType.java
@@ -65,12 +65,8 @@ public class DataStoreInstanceType {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    DataStoreInstanceType that = (DataStoreInstanceType) o;
-
-    if (key != that.key) return false;
-    return store == that.store;
+    if (!(o instanceof DataStoreInstanceType that)) return false;
+    return key == that.key && store == that.store;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/network/crypta/node/stats/DataStoreInstanceType.java
+++ b/src/main/java/network/crypta/node/stats/DataStoreInstanceType.java
@@ -9,10 +9,10 @@ package network.crypta.node.stats;
  * CACHE}). Code that aggregates statistics, maintains per-store counters, or routes operations can
  * use this value object as a compact, strongly-typed identifier.
  *
- * <p>The class is immutable and value-based: two instances are equal when both their key type and
- * store type are equal. This makes it safe to use as a key in maps or as an element in sets. The
- * {@link #hashCode()} implementation combines both components, and {@link #toString()} produces a
- * concise human-readable representation helpful for logging and diagnostics.
+ * <p>The class is immutable and value-based: two instances of this class are equal when both their
+ * key type and store type are equal. This makes it safe to use as a key in maps or as an element in
+ * sets. The {@link #hashCode()} implementation combines both components, and {@link #toString()}
+ * produces a concise human-readable representation helpful for logging and diagnostics.
  *
  * <ul>
  *   <li><strong>Immutability:</strong> both fields are {@code final}; instances are thread-safe.
@@ -62,10 +62,12 @@ public class DataStoreInstanceType {
   }
 
   /** {@inheritDoc} */
+  @SuppressWarnings("EqualsGetClass")
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof DataStoreInstanceType that)) return false;
+    if (o == null || getClass() != o.getClass()) return false;
+    DataStoreInstanceType that = (DataStoreInstanceType) o;
     return key == that.key && store == that.store;
   }
 

--- a/src/main/java/network/crypta/pluginmanager/ForwardPort.java
+++ b/src/main/java/network/crypta/pluginmanager/ForwardPort.java
@@ -134,7 +134,7 @@ public class ForwardPort {
   public boolean equals(Object o) {
     if (o == this) return true;
     if (!(o instanceof ForwardPort f)) return false;
-    return (f.name.equals(name))
+    return f.name.equals(name)
         && f.isIP6 == isIP6
         && f.protocol == protocol
         && f.portNumber == portNumber;

--- a/src/main/java/network/crypta/store/saltedhash/ResizablePersistentIntBuffer.java
+++ b/src/main/java/network/crypta/store/saltedhash/ResizablePersistentIntBuffer.java
@@ -232,8 +232,8 @@ public class ResizablePersistentIntBuffer {
    */
   public int get(int offset) {
     lock.readLock().lock();
-    if (closed) throw new IllegalStateException("Already shut down");
     try {
+      if (closed) throw new IllegalStateException("Already shut down");
       return buffer[offset];
     } finally {
       lock.readLock().unlock();
@@ -274,8 +274,8 @@ public class ResizablePersistentIntBuffer {
    */
   public void put(int offset, int value, boolean noWrite) throws IOException {
     lock.readLock().lock(); // Only resize needs a write lock because it creates a new buffer.
-    if (closed) throw new IllegalStateException("Already shut down");
     try {
+      if (closed) throw new IllegalStateException("Already shut down");
       int persistenceTime = getPersistenceTime();
       buffer[offset] = value;
       if (persistenceTime == -1 && !noWrite) {

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
@@ -395,7 +395,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
   }
 
   private void maybeScheduleSlotFilterRebuild(boolean newStore) {
-    if (((!slotFilterDisabled) && slotFilter.isNew()) && !newStore) {
+    if (!slotFilterDisabled && slotFilter.isNew() && !newStore) {
       flags |= FLAG_REBUILD_BLOOM;
       LOG.info("Rebuilding slot filter because it is new");
     } else if ((flags & FLAG_REBUILD_BLOOM) != 0) {
@@ -420,6 +420,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    *     started or when heavy work was deferred because {@code longStart} was {@code false}
    * @throws IOException on I/O errors
    */
+  @Override
   public boolean start(Ticker ticker, boolean longStart) throws IOException {
 
     if (started) return true;
@@ -712,7 +713,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
         WrongStoreScanResult scan = scanOffsetsForWrite(offset, entry, digestedKey);
         if (scan.written()) return true;
 
-        if ((!wrongStore)
+        if (!wrongStore
             && altStore != null
             && tryWriteToAltStore(block, data, header, overwrite, isOldBlock)) {
           return true;
@@ -1153,8 +1154,8 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    *     known-free, unknown, or the prefix does not match
    */
   public boolean slotCacheLikelyMatch(int value, byte[] digestedRoutingKey) {
-    if ((value & (SLOT_CHECKED)) == 0) return false;
-    if ((value & (SLOT_OCCUPIED)) == 0) return false;
+    if ((value & SLOT_CHECKED) == 0) return false;
+    if ((value & SLOT_OCCUPIED) == 0) return false;
     int wanted =
         (digestedRoutingKey[2] & 0xFF)
             + ((digestedRoutingKey[1] & 0xFF) << 8)
@@ -1463,7 +1464,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    * @throws IOException on I/O errors
    */
   private long getFlag(long offset) throws IOException {
-    if ((!slotFilterDisabled) && USE_SLOT_FILTER) {
+    if (!slotFilterDisabled && USE_SLOT_FILTER) {
       int cache = slotFilter.get((int) offset);
       if ((cache & SLOT_CHECKED) != 0) {
         return translateSlotFlagsToEntryFlags(cache);
@@ -1817,6 +1818,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     private volatile boolean isRebuilding;
     private volatile boolean isResizing;
 
+    @SuppressWarnings("ThreadPriorityCheck")
     public Cleaner() {
       super("Store-" + name + "-Cleaner", NativeThread.PriorityLevel.LOW_PRIORITY.value, false);
       setPriority(NativeThread.PriorityLevel.MIN_PRIORITY.value);
@@ -1918,7 +1920,10 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 
     private final class ResizeProcessor implements BatchProcessor<T> {
       private final long previousStoreSize;
+
+      @SuppressWarnings("JdkObsolete")
       private final Deque<Entry> oldEntryList = new LinkedList<>();
+
       private int i = 0;
 
       ResizeProcessor(long previousStoreSize) {
@@ -2030,13 +2035,14 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
         LOG.info("Finish resizing ({})", name);
       }
 
+      @Override
       public boolean wantFreeEntries() {
         return false;
       }
 
       // Helpers used only by ResizeProcessor
       private boolean isFree(long offset) throws IOException {
-        if ((!slotFilterDisabled) && slotFilter != null && USE_SLOT_FILTER) {
+        if (!slotFilterDisabled && slotFilter != null && USE_SLOT_FILTER) {
           int cache = slotFilter.get((int) offset);
           if ((cache & SLOT_CHECKED) != 0) {
             return slotCacheIsFree(cache);
@@ -2178,6 +2184,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
         LOG.info("Finish rebuilding bloom filter ({})", name);
       }
 
+      @Override
       public boolean wantFreeEntries() {
         return true;
       }
@@ -2507,6 +2514,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    *
    * @param userAlertManager destination manager; must not be {@code null}
    */
+  @Override
   public void setUserAlertManager(UserAlertManager userAlertManager) {
     if (cleanerStatusUserAlert != null) userAlertManager.register(cleanerStatusUserAlert);
   }
@@ -2532,8 +2540,8 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
           "Store size over MAXINT not supported due to ResizablePersistentIntBuffer limitations.");
     }
 
-    configLock.writeLock().lock();
     long old;
+    configLock.writeLock().lock();
     try {
       if (newStoreSize == this.storeSize) return;
 
@@ -2620,6 +2628,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    * @return a map of {@code offset → Condition} for each acquired lock; empty when acquisition did
    *     not get all required locks
    */
+  @SuppressWarnings("MixedMutabilityReturnType")
   private Map<Long, Condition> lockDigestedKey(byte[] digestedKey, boolean usePrevStoreSize) {
     // use a set to prevent duplicated offsets,
     // a sorted set to prevent deadlocks
@@ -2681,6 +2690,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
    * Closes the store with a clean shutdown. Equivalent to {@link #close(boolean)} with {@code
    * false}.
    */
+  @Override
   public void close() {
     close(false);
   }
@@ -2732,7 +2742,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 
     for (int i = 0; i < OPTION_MAX_PROBE; i++) {
       // h + 141 i^2 + 13 i
-      offsets[i] = ((keyValue + 141 * (i * i) + 13 * i) & Long.MAX_VALUE) % storeSize;
+      offsets[i] = ((keyValue + 141L * i * i + 13L * i) & Long.MAX_VALUE) % storeSize;
       // Make sure the slots are all unique.
       // Important for very small stores e.g., in unit tests.
       while (true) {
@@ -2790,9 +2800,11 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
   @Override
   public long getMaxKeys() {
     configLock.readLock().lock();
-    long storeSizeLocal = storeSize;
-    configLock.readLock().unlock();
-    return storeSizeLocal;
+    try {
+      return storeSize;
+    } finally {
+      configLock.readLock().unlock();
+    }
   }
 
   /** Number of false positives reported by the slot filter (historically “bloom”). */

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
@@ -1360,6 +1360,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 
   private record CacheState(int cache, boolean valid, boolean likelyMatch) {}
 
+  @SuppressWarnings("ArrayRecordComponent")
   private record KeyContext(byte[] digestedKey, byte[] routingKey, byte[] fullKey) {
     @Override
     public boolean equals(Object other) {
@@ -1393,6 +1394,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
     }
   }
 
+  @SuppressWarnings("ArrayRecordComponent")
   private record EntryData(byte[] header, byte[] data) {
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreParams.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreParams.java
@@ -43,6 +43,7 @@ import org.jetbrains.annotations.NotNull;
 /// @param preallocate whether to preallocate files up to `maxKeys` for startup latency.
 /// @param resizeOnStart when true, finishes any in-progress resize before returning to the caller.
 /// @param masterKey master key used to derive per-store salts; reference copies contents.
+@SuppressWarnings("ArrayRecordComponent")
 public record SaltedHashStoreParams<T extends StorableBlock>(
     File baseDir,
     String name,

--- a/src/main/java/network/crypta/support/BandwidthStatsContainer.java
+++ b/src/main/java/network/crypta/support/BandwidthStatsContainer.java
@@ -43,6 +43,7 @@ public class BandwidthStatsContainer implements Serializable {
    *     otherwise
    */
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public boolean equals(Object o) {
     if (o == null) return false;
     if (o.getClass() == BandwidthStatsContainer.class) {

--- a/src/main/java/network/crypta/support/Base64.java
+++ b/src/main/java/network/crypta/support/Base64.java
@@ -125,6 +125,7 @@ public class Base64 {
   }
 
   /* Core encoder used by both alphabets. {@code equalsPad} toggles '=' padding. */
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
   private static String encode(byte[] in, boolean equalsPad, char[] alphabet) {
     char[] out = new char[((in.length + 2) / 3) * 4];
     int rem = in.length % 3;
@@ -202,6 +203,7 @@ public class Base64 {
    * value in the selected alphabet yields an IllegalBase64Exception. When the (unpadded) length
    * mod 4 == 1, the length is illegal and an exception is thrown.
    */
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
   private static byte[] decode(String inStr, byte[] reverseAlphabet) throws IllegalBase64Exception {
     try {
       char[] in = inStr.toCharArray();

--- a/src/main/java/network/crypta/support/DoublyLinkedListImpl.java
+++ b/src/main/java/network/crypta/support/DoublyLinkedListImpl.java
@@ -446,6 +446,7 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
   // === Walkable implementation ==============================================
 
   /** Returns an {@link Enumeration} over items from head to tail. */
+  @SuppressWarnings("JdkObsolete")
   private Enumeration<T> forwardElements() {
     return new Enumeration<>() {
       private T next = firstItem;
@@ -466,6 +467,7 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
   }
 
   /** Returns an {@link Enumeration} over items from tail to head. */
+  @SuppressWarnings("JdkObsolete")
   public Enumeration<T> reverseElements() {
     return new Enumeration<>() {
       private T next = lastItem;

--- a/src/main/java/network/crypta/support/Fields.java
+++ b/src/main/java/network/crypta/support/Fields.java
@@ -1186,7 +1186,7 @@ public abstract class Fields {
   }
 
   /**
-   * Encodes {@code double} values as bytes using {@link Double#doubleToLongBits(double)}.
+   * Encodes {@code doubles} values as bytes using {@link Double#doubleToLongBits(double)}.
    *
    * @param doubles source values.
    * @return byte array containing all encodings.
@@ -1218,14 +1218,22 @@ public abstract class Fields {
    */
   public static String trimLines(String str) {
     StringBuilder r = new StringBuilder(str.length());
-    for (String line : str.split("\n")) {
-      line = line.trim();
-      if (line.isEmpty()) {
-        continue;
+    int start = 0;
+    int length = str.length();
+    while (start <= length) {
+      int end = str.indexOf('\n', start);
+      if (end == -1) {
+        end = length;
       }
-
-      r.append(line);
-      r.append('\n');
+      String line = str.substring(start, end).trim();
+      if (!line.isEmpty()) {
+        r.append(line);
+        r.append('\n');
+      }
+      if (end == length) {
+        break;
+      }
+      start = end + 1;
     }
     return r.toString();
   }

--- a/src/main/java/network/crypta/support/Fields.java
+++ b/src/main/java/network/crypta/support/Fields.java
@@ -931,14 +931,16 @@ public abstract class Fields {
      * IEC endings are case-sensitive, so the input string's case should not be modified. However, the
      * qualifiers should not be case-sensitive.
      */
-    final String lower = limit.toLowerCase();
+    final String lower = limit.toLowerCase(Locale.ROOT);
     for (String ending :
         new String[] {
           "/s",
           "/sec",
           "/second",
           "ps",
-          NodeL10n.getBase().getString("FirstTimeWizardToadlet.bandwidthPerSecond").toLowerCase()
+          NodeL10n.getBase()
+              .getString("FirstTimeWizardToadlet.bandwidthPerSecond")
+              .toLowerCase(Locale.ROOT)
         }) {
       if (lower.endsWith(ending)) {
         return limit.substring(0, limit.length() - ending.length());
@@ -1082,7 +1084,7 @@ public abstract class Fields {
       if (val > MULTIPLES[i] && val % MULTIPLES[i] == 0 && (isSize || MULTIPLES[i] % 1000 == 0)) {
         StringBuilder tmp = new StringBuilder();
         tmp.append(val / MULTIPLES[i]).append(MULTIPLES_2[i]);
-        if (!MULTIPLES_2[i].toLowerCase().equals(MULTIPLES_2[i])) {
+        if (!MULTIPLES_2[i].toLowerCase(Locale.ROOT).equals(MULTIPLES_2[i])) {
           tmp.append("iB");
         }
         ret = tmp.toString();
@@ -1126,7 +1128,7 @@ public abstract class Fields {
       if (val > MULTIPLES[i] && val % MULTIPLES[i] == 0 && (isSize || MULTIPLES[i] % 1000 == 0)) {
         StringBuilder tmp = new StringBuilder();
         tmp.append(val / MULTIPLES[i]).append(MULTIPLES_2[i]);
-        if (!MULTIPLES_2[i].toLowerCase().equals(MULTIPLES_2[i])) {
+        if (!MULTIPLES_2[i].toLowerCase(Locale.ROOT).equals(MULTIPLES_2[i])) {
           tmp.append("iB");
         }
         ret = tmp.toString();
@@ -1155,7 +1157,7 @@ public abstract class Fields {
       if (val > MULTIPLES[i] && val % MULTIPLES[i] == 0 && (isSize || MULTIPLES[i] % 1000 == 0)) {
         StringBuilder tmp = new StringBuilder();
         tmp.append(val / MULTIPLES[i]).append(MULTIPLES_2[i]);
-        if (!MULTIPLES_2[i].toLowerCase().equals(MULTIPLES_2[i])) {
+        if (!MULTIPLES_2[i].toLowerCase(Locale.ROOT).equals(MULTIPLES_2[i])) {
           tmp.append("iB");
         }
         ret = tmp.toString();

--- a/src/main/java/network/crypta/support/Fields.java
+++ b/src/main/java/network/crypta/support/Fields.java
@@ -409,6 +409,7 @@ public abstract class Fields {
    * @param time seconds since 1970-01-01T00:00:00Z.
    * @return formatted timestamp in GMT.
    */
+  @SuppressWarnings("JavaUtilDate")
   public static String secToDateTime(long time) {
     DateFormat f = new SimpleDateFormat("yyyyMMdd-HH:mm:ss");
     f.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -830,7 +831,7 @@ public abstract class Fields {
     byte[] buf = new byte[2];
     for (int j = 0; j < 2; j++) {
       buf[j] = (byte) x;
-      x >>>= 8;
+      x = (short) (x >>> 8);
     }
     return buf;
   }
@@ -1395,6 +1396,7 @@ public abstract class Fields {
    * @param b second date or {@code null}.
    * @return the result of {@link Date#compareTo(Date)} on normalized values.
    */
+  @SuppressWarnings("JavaUtilDate")
   public static int compare(Date a, Date b) {
     // Normalize nulls to epoch so Date#compareTo can be used safely.
     a = (a != null ? a : new Date(0));

--- a/src/main/java/network/crypta/support/HTMLEncoder.java
+++ b/src/main/java/network/crypta/support/HTMLEncoder.java
@@ -50,6 +50,7 @@ public class HTMLEncoder {
    * @return encoded string suitable for use as HTML text or attribute value
    * @throws NullPointerException if {@code s} is {@code null}
    */
+  @SuppressWarnings("EscapedEntity")
   public static String encode(String s) {
     int n = s.length();
     StringBuilder sb = new StringBuilder(n);
@@ -98,9 +99,8 @@ public class HTMLEncoder {
    *
    * <p>This routine emits numeric character references for the minimal set of XML-special
    * characters: {@literal &} ({@literal &#38;}), {@literal "} ({@literal &#34;}), {@literal '}
-   * ({@literal &#39;}), {@literal <} ({@literal &#60;}), and {@literal >} ({@literal &#62;}). It does
-   * not perform the broader HTML
-   * entity substitution that {@link #encode(String)} performs.
+   * ({@literal &#39;}), {@literal <} ({@literal &#60;}), and {@literal >} ({@literal &#62;}). It
+   * does not perform the broader HTML entity substitution that {@link #encode(String)} performs.
    *
    * <p>References:
    *
@@ -112,6 +112,7 @@ public class HTMLEncoder {
    * @return XML-safe string using numeric character references
    * @throws NullPointerException if {@code s} is {@code null}
    */
+  @SuppressWarnings("EscapedEntity")
   public static String encodeXML(String s) {
     // XML grammar requires quoting of these characters in attribute values and text. We use
     // numeric references to avoid dependencies on entity declarations.

--- a/src/main/java/network/crypta/support/HTMLEncoder.java
+++ b/src/main/java/network/crypta/support/HTMLEncoder.java
@@ -42,7 +42,7 @@ public class HTMLEncoder {
   /**
    * Encode a string for safe inclusion in HTML.
    *
-   * <p>Characters that have entries in {@link HTMLEntities#encodeMap} are replaced by {@code
+   * <p>Characters that have entries in {@link HTMLEntities#encodeMap} are replaced by {@literal
    * &name;} (or numeric) entity references, except that ASCII letters and decimal digits are always
    * left unchanged. Characters without a mapping are appended verbatim.
    *
@@ -97,8 +97,9 @@ public class HTMLEncoder {
    * Encode a string so it is safe for XML attribute values and text nodes.
    *
    * <p>This routine emits numeric character references for the minimal set of XML-special
-   * characters: {@code &} ({@code &#38;}), {@code "} ({@code &#34;}), {@code '} ({@code &#39;}),
-   * {@code <} ({@code &#60;}), and {@code >} ({@code &#62;}). It does not perform the broader HTML
+   * characters: {@literal &} ({@literal &#38;}), {@literal "} ({@literal &#34;}), {@literal '}
+   * ({@literal &#39;}), {@literal <} ({@literal &#60;}), and {@literal >} ({@literal &#62;}). It does
+   * not perform the broader HTML
    * entity substitution that {@link #encode(String)} performs.
    *
    * <p>References:

--- a/src/main/java/network/crypta/support/LRUCache.java
+++ b/src/main/java/network/crypta/support/LRUCache.java
@@ -47,7 +47,7 @@ public final class LRUCache<K extends Comparable<K>, V> {
       mExpirationDate =
           (mExpirationDelay < Long.MAX_VALUE)
               ? (System.currentTimeMillis() + mExpirationDelay)
-              : (Long.MAX_VALUE);
+              : Long.MAX_VALUE;
     }
 
     /** Returns whether the entry is expired at the given wall-clock time. */

--- a/src/main/java/network/crypta/support/LRUMap.java
+++ b/src/main/java/network/crypta/support/LRUMap.java
@@ -229,7 +229,7 @@ public class LRUMap<K, V> {
    */
   public final synchronized boolean removeKey(K key) {
     if (key == null) throw new NullPointerException();
-    QItem<K, V> i = (hash.remove(key));
+    QItem<K, V> i = hash.remove(key);
     if (i != null) {
       list.remove(i);
       return true;

--- a/src/main/java/network/crypta/support/MediaType.java
+++ b/src/main/java/network/crypta/support/MediaType.java
@@ -73,12 +73,18 @@ public class MediaType {
     subtype = mediaType.substring(slash + 1, semicolon).trim();
     String params = mediaType.substring(semicolon + 1);
     int paramStart = 0;
-    while (paramStart <= params.length()) {
+    while (paramStart < params.length()) {
       int paramEnd = params.indexOf(';', paramStart);
       if (paramEnd == -1) {
         paramEnd = params.length();
       }
       String parameter = params.substring(paramStart, paramEnd);
+      if (parameter.trim().isEmpty()) {
+        if (paramEnd == params.length()) {
+          break;
+        }
+        throw new MalformedURLException("Illegal parameter: “%s”".formatted(parameter));
+      }
       int equals = parameter.indexOf('=');
       if (equals == -1) {
         throw new MalformedURLException("Illegal parameter: “%s”".formatted(parameter));

--- a/src/main/java/network/crypta/support/MediaType.java
+++ b/src/main/java/network/crypta/support/MediaType.java
@@ -2,6 +2,7 @@ package network.crypta.support;
 
 import java.net.MalformedURLException;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import network.crypta.client.DefaultMIMETypes;
@@ -77,7 +78,7 @@ public class MediaType {
         throw new MalformedURLException("Illegal parameter: “%s”".formatted(parameter));
       }
       // Normalize parameter names to lowercase and unquote quoted values.
-      String name = parameter.substring(0, equals).trim().toLowerCase();
+      String name = parameter.substring(0, equals).trim().toLowerCase(Locale.ROOT);
       String value = parameter.substring(equals + 1).trim();
       if (value.startsWith("\"") && value.endsWith("\""))
         value = value.substring(1, value.length() - 1).trim();
@@ -180,7 +181,7 @@ public class MediaType {
    * @return parameter value, or {@code null} if not present
    */
   public String getParameter(String name) {
-    return parameters.get(name.toLowerCase());
+    return parameters.get(name.toLowerCase(Locale.ROOT));
   }
 
   /**
@@ -195,8 +196,8 @@ public class MediaType {
    */
   public MediaType setParameter(String name, String value) {
     MediaType newMediaType = new MediaType(type, subtype, parameters);
-    if (value == null) newMediaType.parameters.remove(name.toLowerCase());
-    else newMediaType.parameters.put(name.toLowerCase(), value);
+    if (value == null) newMediaType.parameters.remove(name.toLowerCase(Locale.ROOT));
+    else newMediaType.parameters.put(name.toLowerCase(Locale.ROOT), value);
     return newMediaType;
   }
 
@@ -207,11 +208,11 @@ public class MediaType {
    * @return {@code this} if the parameter was absent; otherwise a new {@link MediaType}
    */
   public MediaType removeParameter(String name) {
-    if (!parameters.containsKey(name.toLowerCase())) {
+    if (!parameters.containsKey(name.toLowerCase(Locale.ROOT))) {
       return this;
     }
     MediaType newMediaType = new MediaType(type, subtype, parameters);
-    newMediaType.parameters.remove(name.toLowerCase());
+    newMediaType.parameters.remove(name.toLowerCase(Locale.ROOT));
     return newMediaType;
   }
 

--- a/src/main/java/network/crypta/support/MediaType.java
+++ b/src/main/java/network/crypta/support/MediaType.java
@@ -71,8 +71,14 @@ public class MediaType {
       return;
     }
     subtype = mediaType.substring(slash + 1, semicolon).trim();
-    String[] parsedParameters = mediaType.substring(semicolon + 1).split(";");
-    for (String parameter : parsedParameters) {
+    String params = mediaType.substring(semicolon + 1);
+    int paramStart = 0;
+    while (paramStart <= params.length()) {
+      int paramEnd = params.indexOf(';', paramStart);
+      if (paramEnd == -1) {
+        paramEnd = params.length();
+      }
+      String parameter = params.substring(paramStart, paramEnd);
       int equals = parameter.indexOf('=');
       if (equals == -1) {
         throw new MalformedURLException("Illegal parameter: “%s”".formatted(parameter));
@@ -83,6 +89,10 @@ public class MediaType {
       if (value.startsWith("\"") && value.endsWith("\""))
         value = value.substring(1, value.length() - 1).trim();
       this.parameters.put(name, value);
+      if (paramEnd == params.length()) {
+        break;
+      }
+      paramStart = paramEnd + 1;
     }
   }
 

--- a/src/main/java/network/crypta/support/ModuloTimeTriggeringPolicy.java
+++ b/src/main/java/network/crypta/support/ModuloTimeTriggeringPolicy.java
@@ -108,7 +108,7 @@ public class ModuloTimeTriggeringPolicy<E>
    *
    * <p>First delegates to the default time-based policy; if a period boundary is detected, it then
    * requires the local wall clock to satisfy the configured modulo predicate (see class
-   * documentation). If {@code multiple &lt;= 1}, the modulo predicate is ignored and any boundary
+   * documentation). If {@code multiple <= 1}, the modulo predicate is ignored and any boundary
    * triggers rollover.
    *
    * <p>Thread-safety: typically invoked by an appender thread without external synchronization.

--- a/src/main/java/network/crypta/support/PrioritizedTicker.java
+++ b/src/main/java/network/crypta/support/PrioritizedTicker.java
@@ -43,11 +43,11 @@ public class PrioritizedTicker implements Ticker, Runnable {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof Job)) {
+      if (!(o instanceof Job job)) {
         return false;
       }
       // Ignore the name; we are only interested in the job, needed for noDupes.
-      return ((Job) o).task == task;
+      return job.task == task;
     }
 
     @Override
@@ -238,7 +238,7 @@ public class PrioritizedTicker implements Ticker, Runnable {
    * "sleep until the original deadline" would reintroduce latency and defeat the purpose of {@link
    * #wakeUp()}.
    */
-  @SuppressWarnings("java:S2274")
+  @SuppressWarnings({"java:S2274", "WaitNotInLoop"})
   protected void sleep(long sleepTime) throws InterruptedException {
     if (LOG.isDebugEnabled()) LOG.debug("Sleeping for {}", sleepTime);
     synchronized (this) {
@@ -428,9 +428,9 @@ public class PrioritizedTicker implements Ticker, Runnable {
    */
   private void removeQueuedJobInner(Job job, Long t) {
     Object o = timedJobsByTime.get(t);
-    assert (o != null);
+    assert o != null;
     if (o instanceof Job) {
-      assert (o.equals(job));
+      assert o.equals(job);
       timedJobsByTime.remove(t);
       return;
     }
@@ -439,7 +439,7 @@ public class PrioritizedTicker implements Ticker, Runnable {
 
   private void handleArrayRemoval(Job[] jobs, Job job, Long t) {
     if (jobs.length == 1) {
-      assert (jobs[0].equals(job));
+      assert jobs[0].equals(job);
       timedJobsByTime.remove(t);
       return;
     }

--- a/src/main/java/network/crypta/support/ShortBuffer.java
+++ b/src/main/java/network/crypta/support/ShortBuffer.java
@@ -161,8 +161,8 @@ public class ShortBuffer implements WritableToDataOutputStream {
    * Returns a human-readable representation intended for debugging.
    *
    * <p>For buffers with {@code length > 50}, the result is {@code "Buffer {<length>}"}. Otherwise,
-   * the result starts with {@code "{"}, then the length and a colon, followed by the signed byte
-   * values separated by spaces, and ends with a trailing space (historical format).
+   * the result starts with '{', then the length and a colon, followed by the signed byte values
+   * separated by spaces, and ends with a trailing space (historical format).
    *
    * <p>Format stability is not guaranteed. Do not parse this output.
    */

--- a/src/main/java/network/crypta/support/SimpleFieldSet.java
+++ b/src/main/java/network/crypta/support/SimpleFieldSet.java
@@ -386,19 +386,28 @@ public class SimpleFieldSet {
    */
   public synchronized String get(String key) {
     int idx = key.indexOf(MULTI_LEVEL_CHAR);
-    switch (idx) {
-      case -1:
-        return values.get(key);
-      case 0:
-        return (subset("") == null) ? null : subset("").get(key.substring(1));
-      default:
-        if (subsets == null) return null;
+    return switch (idx) {
+      case -1 -> values.get(key);
+      case 0 -> {
+        SimpleFieldSet root = subset("");
+        if (root == null) {
+          yield null;
+        }
+        yield root.get(key.substring(1));
+      }
+      default -> {
+        if (subsets == null) {
+          yield null;
+        }
         String before = key.substring(0, idx);
         String after = key.substring(idx + 1);
         SimpleFieldSet fs = subsets.get(before);
-        if (fs == null) return null;
-        return fs.get(after);
-    }
+        if (fs == null) {
+          yield null;
+        }
+        yield fs.get(after);
+      }
+    };
   }
 
   /**

--- a/src/main/java/network/crypta/support/StringValidityChecker.java
+++ b/src/main/java/network/crypta/support/StringValidityChecker.java
@@ -348,23 +348,31 @@ public final class StringValidityChecker {
   }
 
   private static boolean applyAnnotation(FormattingState s, char c) {
-    switch (c) {
-      case 0xFFF9: // INTERLINEAR ANNOTATION ANCHOR
-        if (s.inAnnotatedText || s.inAnnotation) return false;
+    return switch (c) {
+      case 0xFFF9 -> { // INTERLINEAR ANNOTATION ANCHOR
+        if (s.inAnnotatedText || s.inAnnotation) {
+          yield false;
+        }
         s.inAnnotatedText = true;
-        return true;
-      case 0xFFFA: // INTERLINEAR ANNOTATION SEPARATOR
-        if (!s.inAnnotatedText) return false;
+        yield true;
+      }
+      case 0xFFFA -> { // INTERLINEAR ANNOTATION SEPARATOR
+        if (!s.inAnnotatedText) {
+          yield false;
+        }
         s.inAnnotatedText = false;
         s.inAnnotation = true;
-        return true;
-      case 0xFFFB: // INTERLINEAR ANNOTATION TERMINATOR
-        if (!s.inAnnotation) return false;
+        yield true;
+      }
+      case 0xFFFB -> { // INTERLINEAR ANNOTATION TERMINATOR
+        if (!s.inAnnotation) {
+          yield false;
+        }
         s.inAnnotation = false;
-        return true;
-      default:
-        return true;
-    }
+        yield true;
+      }
+      default -> true;
+    };
   }
 
   private static final class FormattingState {

--- a/src/main/java/network/crypta/support/StringValidityChecker.java
+++ b/src/main/java/network/crypta/support/StringValidityChecker.java
@@ -2,6 +2,8 @@ package network.crypta.support;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * Utility methods for validating strings against platform and protocol constraints.
@@ -25,9 +27,9 @@ public final class StringValidityChecker {
   /* Characters blacklisted for IDN labels.
    * Source: http://kb.mozillazine.org/Network.IDN.blacklist_chars
    */
-  private static final HashSet<Character> idnBlacklist = buildIdnBlacklist();
+  private static final Set<Character> idnBlacklist = buildIdnBlacklist();
 
-  private static HashSet<Character> buildIdnBlacklist() {
+  private static Set<Character> buildIdnBlacklist() {
     final int[] codes = {
       0x0020, /* SPACE */
       0x00A0, /* NO-BREAK SPACE */
@@ -173,7 +175,7 @@ public final class StringValidityChecker {
    * @throws NullPointerException if {@code filename} is {@code null}
    */
   public static boolean isWindowsReservedFilename(String filename) {
-    filename = filename.toLowerCase();
+    filename = filename.toLowerCase(Locale.ROOT);
     // Only the segment before the first dot counts as the "base name" on Windows.
     // Example: "con.blah.txt" is treated as base name "con" and is therefore reserved.
     int nameEnd = filename.indexOf('.');
@@ -218,7 +220,8 @@ public final class StringValidityChecker {
    * @throws NullPointerException if {@code text} is {@code null}
    */
   public static boolean containsNoIDNBlacklistCharacters(String text) {
-    for (Character c : text.toCharArray()) {
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
       if (idnBlacklist.contains(c)) return false;
     }
 
@@ -237,11 +240,14 @@ public final class StringValidityChecker {
    * @throws NullPointerException if {@code text} is {@code null}
    */
   public static boolean containsNoLinebreaks(String text) {
-    for (Character c : text.toCharArray()) {
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
       if (Character.getType(c) == Character.LINE_SEPARATOR
           || Character.getType(c) == Character.PARAGRAPH_SEPARATOR
           || c == '\n'
-          || c == '\r') return false;
+          || c == '\r') {
+        return false;
+      }
     }
 
     return true;
@@ -281,7 +287,8 @@ public final class StringValidityChecker {
    * @throws NullPointerException if {@code text} is {@code null}
    */
   public static boolean containsNoControlCharacters(String text) {
-    for (Character c : text.toCharArray()) {
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
       if (Character.getType(c) == Character.CONTROL) return false;
     }
 
@@ -303,7 +310,8 @@ public final class StringValidityChecker {
    */
   public static boolean containsNoInvalidFormatting(String text) {
     FormattingState state = new FormattingState();
-    for (char c : text.toCharArray()) {
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
       if (!applyFormattingChar(state, c)) return false;
     }
 
@@ -379,7 +387,8 @@ public final class StringValidityChecker {
    * @throws NullPointerException if {@code text} is {@code null}
    */
   public static boolean isLatinLettersAndNumbersOnly(String text) {
-    for (char c : text.toCharArray()) {
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
       if ((c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9')) {
         return false;
       }

--- a/src/main/java/network/crypta/support/TimeSortedHashtable.java
+++ b/src/main/java/network/crypta/support/TimeSortedHashtable.java
@@ -53,8 +53,7 @@ public class TimeSortedHashtable<T extends Comparable<T>> {
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
-      if (obj == null || getClass() != obj.getClass()) return false;
-      Element<?> other = (Element<?>) obj;
+      if (!(obj instanceof Element<?> other)) return false;
       return time == other.time && Objects.equals(value, other.value);
     }
 

--- a/src/main/java/network/crypta/support/UptimeContainer.java
+++ b/src/main/java/network/crypta/support/UptimeContainer.java
@@ -39,6 +39,7 @@ public class UptimeContainer implements Serializable {
    *     {@code false}
    */
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public boolean equals(Object o) {
     if (o == null) return false;
     if (o.getClass() == UptimeContainer.class) {

--- a/src/main/java/network/crypta/support/io/BitInputStream.java
+++ b/src/main/java/network/crypta/support/io/BitInputStream.java
@@ -135,6 +135,7 @@ public class BitInputStream implements Closeable {
    * @throws EOFException if there is not enough data to satisfy the read.
    * @throws IOException if an I/O error occurs while reading from the underlying stream.
    */
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
   public int readInt(int length, ByteOrder bitOrder) throws IOException {
     if (length == 0) {
       return 0;

--- a/src/main/java/network/crypta/support/io/NativeThread.java
+++ b/src/main/java/network/crypta/support/io/NativeThread.java
@@ -250,6 +250,7 @@ public class NativeThread extends Thread {
   }
 
   // Map Java priority to native nice and apply it when allowed.
+  @SuppressWarnings("ThreadPriorityCheck")
   private boolean setNativePriority(int prio) {
     LOG.debug("setNativePriority({})", prio);
     setPriority(prio);

--- a/src/main/java/network/crypta/support/math/BootstrappingDecayingRunningAverage.java
+++ b/src/main/java/network/crypta/support/math/BootstrappingDecayingRunningAverage.java
@@ -134,7 +134,7 @@ public final class BootstrappingDecayingRunningAverage implements RunningAverage
       return; // Don't update the average with invalid values
     }
     reports++;
-    double decayFactor = 1.0 / (Math.min(reports, maxReports));
+    double decayFactor = 1.0 / Math.min(reports, maxReports);
     currentValue = (d * decayFactor) + (currentValue * (1 - decayFactor));
   }
 
@@ -152,7 +152,7 @@ public final class BootstrappingDecayingRunningAverage implements RunningAverage
       traceInvalid(d);
       return currentValue; // Return unchanged value for invalid inputs
     }
-    double decayFactor = 1.0 / (Math.min(reports + 1, maxReports));
+    double decayFactor = 1.0 / Math.min(reports + 1, maxReports);
     return (d * decayFactor) + (currentValue * (1 - decayFactor));
   }
 

--- a/src/main/java/network/crypta/support/math/SimpleRunningAverage.java
+++ b/src/main/java/network/crypta/support/math/SimpleRunningAverage.java
@@ -87,6 +87,7 @@ public final class SimpleRunningAverage implements RunningAverage {
     return new Snapshot(curLen, initValue, nextSlotPtr, refs.clone(), total, totalReports);
   }
 
+  @SuppressWarnings("ArrayRecordComponent")
   private record Snapshot(
       int curLen,
       double initValue,

--- a/src/main/java/network/crypta/support/math/TimeDecayingRunningAverage.java
+++ b/src/main/java/network/crypta/support/math/TimeDecayingRunningAverage.java
@@ -537,7 +537,7 @@ public final class TimeDecayingRunningAverage implements RunningAverage {
     }
     if (thisHalfLife == 0) thisHalfLife = 1;
     long monoDeltaMillis = Math.max(0L, (monoNanos - lastMonotonicNanos) / 1_000_000L);
-    double changeFactor = Math.pow(0.5, (monoDeltaMillis) / thisHalfLife);
+    double changeFactor = Math.pow(0.5, monoDeltaMillis / thisHalfLife);
     applyUpdatedValueAndDebug(d, monoDeltaMillis, uptime, thisHalfLife, changeFactor);
   }
 

--- a/src/test/java/com/onionnetworks/io/RAFTest.java
+++ b/src/test/java/com/onionnetworks/io/RAFTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -61,8 +62,8 @@ class RAFTest {
   void renameTo_whenDestExists_replacesFileAndReopens() throws Exception {
     File source = tempDir.resolve("source.bin").toFile();
     File dest = tempDir.resolve("dest.bin").toFile();
-    Files.write(source.toPath(), "source-data".getBytes());
-    Files.write(dest.toPath(), "old".getBytes());
+    Files.write(source.toPath(), "source-data".getBytes(StandardCharsets.UTF_8));
+    Files.write(dest.toPath(), "old".getBytes(StandardCharsets.UTF_8));
 
     try (RAF raf = new RAF(source, "rw")) {
       raf.renameTo(dest);
@@ -78,7 +79,7 @@ class RAFTest {
   void renameTo_whenRenameFails_fallsBackToCopyAndDeletesSource() throws Exception {
     Path sourcePath = tempDir.resolve("nonrename.bin");
     Path destPath = tempDir.resolve("copy-dest.bin");
-    Files.write(sourcePath, "copy-me".getBytes());
+    Files.write(sourcePath, "copy-me".getBytes(StandardCharsets.UTF_8));
 
     File failingFile = new NonRenamingFile(sourcePath);
     try (RAF raf = new RAF(failingFile, "rw")) {

--- a/src/test/java/com/onionnetworks/util/ReflectiveEventDispatchTest.java
+++ b/src/test/java/com/onionnetworks/util/ReflectiveEventDispatchTest.java
@@ -184,7 +184,9 @@ class ReflectiveEventDispatchTest {
 
     @SuppressWarnings("unused")
     public void onEvent(EventObject ev) {
-      throw toThrow;
+      if (toThrow != null) {
+        throw toThrow;
+      }
     }
   }
 }

--- a/src/test/java/com/onionnetworks/util/SimUtilTest.java
+++ b/src/test/java/com/onionnetworks/util/SimUtilTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Handler;
@@ -83,7 +84,7 @@ class SimUtilTest {
             + ls
             + "\" | graph -W .003 -C -T $type -L \"Title\" -X \"X Axis\" -Y \"Y Axis\"";
 
-    assertEquals(expected, stdout.toString());
+    assertEquals(expected, stdout.toString(StandardCharsets.UTF_8));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/CodeTest.java
+++ b/src/test/java/network/crypta/client/CodeTest.java
@@ -182,6 +182,7 @@ class CodeTest {
     return new EncodeDecodeResult(src, repair);
   }
 
+  @SuppressWarnings("ArrayRecordComponent")
   private record EncodeDecodeResult(byte[] original, byte[] decoded) {}
 
   private static Buffer[] createBuffers(byte[] src) {

--- a/src/test/java/network/crypta/client/DefaultMIMETypesTest.java
+++ b/src/test/java/network/crypta/client/DefaultMIMETypesTest.java
@@ -32,6 +32,7 @@ class DefaultMIMETypesTest {
     assertTrue(
         DefaultMIMETypes.isPlausibleMIMEType(
             "multipart/mixed; boundary=\"---this is a silly boundary---\""));
+    assertTrue(DefaultMIMETypes.isPlausibleMIMEType("text/plain; charset=UTF-8;"));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/FetchExceptionTest.java
+++ b/src/test/java/network/crypta/client/FetchExceptionTest.java
@@ -205,7 +205,8 @@ class FetchExceptionTest {
   @Test
   void constructor_fromDataFilterException_formatsMessageAndFields() {
     DataFilterException dfe = org.mockito.Mockito.mock(DataFilterException.class);
-    org.mockito.Mockito.when(dfe.getMessage()).thenReturn("why unsafe");
+    String dfeMessage = "why unsafe";
+    org.mockito.Mockito.when(dfe.getMessage()).thenReturn(dfeMessage);
     FetchException ex = new FetchException(12L, dfe, "image/gif");
 
     String unsafeDetails = NodeL10n.getBase().getString("FetchException.unsafeContentDetails");
@@ -214,7 +215,7 @@ class FetchExceptionTest {
             + " "
             + unsafeDetails
             + " "
-            + dfe.getMessage(),
+            + dfeMessage,
         ex.getMessage());
     assertEquals(FetchExceptionMode.CONTENT_VALIDATION_FAILED, ex.getMode());
     assertEquals(12L, ex.getExpectedSize());

--- a/src/test/java/network/crypta/client/HighLevelSimpleClientImplTest.java
+++ b/src/test/java/network/crypta/client/HighLevelSimpleClientImplTest.java
@@ -310,7 +310,7 @@ class HighLevelSimpleClientImplTest {
       pf.setAccessible(true);
       assertEquals(prio, pf.get(getter));
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
   }
 
@@ -409,7 +409,7 @@ class HighLevelSimpleClientImplTest {
         sep.produceEvent(ev, null);
       }
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
 
     // Assert: listener observed exactly one event
@@ -445,7 +445,7 @@ class HighLevelSimpleClientImplTest {
       f.setAccessible(true);
       return (FetchContext) f.get(getter);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
   }
 

--- a/src/test/java/network/crypta/client/InsertContextTest.java
+++ b/src/test/java/network/crypta/client/InsertContextTest.java
@@ -104,7 +104,7 @@ class InsertContextTest {
     assertNotNull(ctx.getEventProducer());
 
     assertEquals(mode, ctx.getCompatibilityMode());
-    assertEquals(mode.ordinal(), ctx.getCompatibilityCode());
+    assertEquals(mode.code, ctx.getCompatibilityCode());
   }
 
   @Test
@@ -118,7 +118,7 @@ class InsertContextTest {
 
     // Assert
     assertEquals(latest, ctx.getCompatibilityMode());
-    assertEquals(latest.ordinal(), ctx.getCompatibilityCode());
+    assertEquals(latest.code, ctx.getCompatibilityCode());
   }
 
   @Test

--- a/src/test/java/network/crypta/client/RealArchiveStoreItemTest.java
+++ b/src/test/java/network/crypta/client/RealArchiveStoreItemTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
@@ -41,7 +42,7 @@ class RealArchiveStoreItemTest {
   @Test
   @DisplayName("dataAsBucket: returns same read-only reader with expected size/content")
   void dataAsBucket_whenConstructed_expectReadOnlySameSizeAndIdentity() throws Exception {
-    byte[] data = "hello".getBytes();
+    byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
     ArrayBucket underlying = new ArrayBucket(data);
     FreenetURI key = new FreenetURI("KSK", "doc");
 
@@ -70,7 +71,7 @@ class RealArchiveStoreItemTest {
       "dataSize/spaceUsed: spaceUsed is captured at construction; dataSize reflects live underlying"
           + " size")
   void dataSize_whenUnderlyingMutates_expectSpaceUsedStaysInitial() throws Exception {
-    byte[] initial = "abc".getBytes(); // 3 bytes
+    byte[] initial = "abc".getBytes(StandardCharsets.UTF_8); // 3 bytes
     ArrayBucket underlying = new ArrayBucket(initial);
     FreenetURI key = new FreenetURI("KSK", "doc");
     RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "file.bin", underlying);
@@ -80,7 +81,7 @@ class RealArchiveStoreItemTest {
 
     // Mutate the underlying ArrayBucket directly (MultiReaderBucket does not set it read-only).
     java.io.OutputStream os = underlying.getOutputStream();
-    os.write("abcdef".getBytes()); // now 6 bytes
+    os.write("abcdef".getBytes(StandardCharsets.UTF_8)); // now 6 bytes
     os.close();
 
     assertEquals(6L, item.dataSize(), "dataSize should reflect updated underlying size");
@@ -90,7 +91,7 @@ class RealArchiveStoreItemTest {
   @Test
   @DisplayName("getReaderBucket: returns independent reader; still open while main reader is alive")
   void getReaderBucket_whenOpen_expectIndependentReadableReader() throws Exception {
-    byte[] data = "012345".getBytes();
+    byte[] data = "012345".getBytes(StandardCharsets.UTF_8);
     ArrayBucket underlying = new ArrayBucket(data);
     FreenetURI key = new FreenetURI("KSK", "doc");
     RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "entry", underlying);
@@ -118,7 +119,7 @@ class RealArchiveStoreItemTest {
       "innerClose: frees main reader; subsequent getReaderBucket returns null; main reader becomes"
           + " unusable")
   void innerClose_whenCalled_expectReadersClosed() {
-    byte[] data = "xyz".getBytes();
+    byte[] data = "xyz".getBytes(StandardCharsets.UTF_8);
     ArrayBucket underlying = new ArrayBucket(data);
     FreenetURI key = new FreenetURI("KSK", "doc");
     RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "x", underlying);
@@ -137,7 +138,7 @@ class RealArchiveStoreItemTest {
   @Test
   @DisplayName("innerClose: idempotent; underlying freed only once")
   void innerClose_whenCalledTwice_expectUnderlyingFreedOnce() {
-    byte[] data = "payload".getBytes();
+    byte[] data = "payload".getBytes(StandardCharsets.UTF_8);
     ArrayBucket underlyingReal = new ArrayBucket(data);
     ArrayBucket underlyingSpy = spy(underlyingReal);
     FreenetURI key = new FreenetURI("KSK", "doc");
@@ -168,7 +169,7 @@ class RealArchiveStoreItemTest {
   @Test
   @DisplayName("close via real context: removing triggers cleanup and frees underlying once")
   void close_whenRegisteredWithRealContext_expectUnderlyingFreedOnceAndNoFurtherReaders() {
-    byte[] data = "abcdef".getBytes();
+    byte[] data = "abcdef".getBytes(StandardCharsets.UTF_8);
     ArrayBucket underlyingReal = new ArrayBucket(data);
     ArrayBucket underlyingSpy = spy(underlyingReal);
     FreenetURI key = new FreenetURI("KSK", "doc");
@@ -187,7 +188,7 @@ class RealArchiveStoreItemTest {
   @Test
   @DisplayName("getDataOrThrow: returns the same instance as dataAsBucket()")
   void getDataOrThrow_whenCalled_expectSameAsDataAsBucket() {
-    ArrayBucket underlying = new ArrayBucket("v".getBytes());
+    ArrayBucket underlying = new ArrayBucket("v".getBytes(StandardCharsets.UTF_8));
     FreenetURI key = new FreenetURI("KSK", "doc");
     RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "n", underlying);
 

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -434,10 +434,10 @@ class ClientContextTest {
         f.setAccessible(true);
         f.set(target, value);
       } catch (ReflectiveOperationException ex) {
-        throw new AssertionError(ex);
+        throw new LinkageError(ex.getMessage(), ex);
       }
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
   }
 

--- a/src/test/java/network/crypta/client/async/ClientPutterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientPutterTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
@@ -399,7 +400,7 @@ class ClientPutterTest {
     // Verify that something was written and begins with the expected header (length prefix)
     assertNotNull(detail);
     // Minimal sanity check: contains the bytes of the string "hello" somewhere
-    String s = new String(detail);
+    String s = new String(detail, StandardCharsets.UTF_8);
     assertTrue(s.contains("hello"));
   }
 

--- a/src/test/java/network/crypta/client/async/DatastoreCheckerTest.java
+++ b/src/test/java/network/crypta/client/async/DatastoreCheckerTest.java
@@ -308,7 +308,8 @@ class DatastoreCheckerTest {
     // Executor runs inline; DatastoreChecker should process immediately and then terminate lazily.
     verify(scheduler, times(2)).tripPendingKey(any(KeyBlock.class));
     verify(scheduler, times(1))
-        .finishRegister(argThat(arr -> arr.length == 1 && arr[0] == getter), eq(false), eq(false));
+        .finishRegister(
+            argThat(arr -> arr.length == 1 && getter.equals(arr[0])), eq(false), eq(false));
   }
 
   @Test
@@ -341,7 +342,8 @@ class DatastoreCheckerTest {
 
     verify(scheduler, times(1)).tripPendingKey(b1);
     verify(scheduler, times(1))
-        .finishRegister(argThat(arr -> arr.length == 1 && arr[0] == getter), eq(false), eq(true));
+        .finishRegister(
+            argThat(arr -> arr.length == 1 && getter.equals(arr[0])), eq(false), eq(true));
   }
 
   @Test
@@ -402,11 +404,12 @@ class DatastoreCheckerTest {
 
     // Finish is invoked from inside the PersistentJob with persistent=true and anyValid=true
     verify(scheduler, times(1))
-        .finishRegister(argThat(arr -> arr.length == 1 && arr[0] == getter), eq(true), eq(true));
+        .finishRegister(
+            argThat(arr -> arr.length == 1 && getter.equals(arr[0])), eq(true), eq(true));
     // No transient finish
     verify(scheduler, never())
         .finishRegister(
-            argThat(arr -> arr.length == 1 && arr[0] == getter), eq(false), anyBoolean());
+            argThat(arr -> arr.length == 1 && getter.equals(arr[0])), eq(false), anyBoolean());
   }
 
   @Test
@@ -467,6 +470,7 @@ class DatastoreCheckerTest {
         .fetch(any(Key.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any());
     verify(scheduler, times(2)).tripPendingKey(block);
     verify(scheduler, times(1))
-        .finishRegister(argThat(arr -> arr.length == 1 && arr[0] == getter), eq(false), eq(false));
+        .finishRegister(
+            argThat(arr -> arr.length == 1 && getter.equals(arr[0])), eq(false), eq(false));
   }
 }

--- a/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
@@ -92,7 +92,7 @@ class DefaultManifestPutterTest {
 
     TestableDefaultManifestPutter(
         NullClientCallback cb,
-        HashMap<String, Object> manifest,
+        Map<String, Object> manifest,
         short prio,
         FreenetURI target,
         String defaultName,

--- a/src/test/java/network/crypta/client/async/InsertCompressorTest.java
+++ b/src/test/java/network/crypta/client/async/InsertCompressorTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Random;
 import network.crypta.client.FetchContextOptions;
@@ -96,7 +97,6 @@ class InsertCompressorTest {
     CompressionOutput lastOutput;
     ClientContext lastContext;
     COMPRESSOR_TYPE lastStartType;
-    final PutCompletionCallback testCb;
 
     TestInserter(
         InsertBlock block, InsertContext ctx, boolean persistent, PutCompletionCallback cb) {
@@ -118,7 +118,6 @@ class InsertCompressorTest {
               .withOrigCompressedDataLength(0L)
               .withOrigHashes(null)
               .withMetadataThreshold(0L));
-      this.testCb = cb;
     }
 
     @Override
@@ -206,7 +205,7 @@ class InsertCompressorTest {
     InsertBlock block = new InsertBlock(new ArrayBucket(), null, FreenetURI.EMPTY_CHK_URI);
     TestInserter inserter =
         new TestInserter(block, insertCtx, /*persistent*/ false, mock(PutCompletionCallback.class));
-    RandomAccessBucket data = makeData("hello world".getBytes());
+    RandomAccessBucket data = makeData("hello world".getBytes(StandardCharsets.UTF_8));
     InsertCompressor compressor =
         new InsertCompressor(
             inserter,
@@ -236,7 +235,7 @@ class InsertCompressorTest {
     InsertBlock block = new InsertBlock(new ArrayBucket(), null, FreenetURI.EMPTY_CHK_URI);
     TestInserter inserter =
         new TestInserter(block, insertCtx, false, mock(PutCompletionCallback.class));
-    RandomAccessBucket data = makeData("abc".getBytes());
+    RandomAccessBucket data = makeData("abc".getBytes(StandardCharsets.UTF_8));
 
     // Act
     InsertCompressor.start(
@@ -354,7 +353,7 @@ class InsertCompressorTest {
     InsertBlock block = new InsertBlock(new ArrayBucket(), null, FreenetURI.EMPTY_CHK_URI);
     TestInserter inserter = new TestInserter(block, insertCtx, /*persistent*/ false, cb);
 
-    RandomAccessBucket origData = makeData("data".getBytes());
+    RandomAccessBucket origData = makeData("data".getBytes(StandardCharsets.UTF_8));
 
     InsertCompressor compressor =
         new InsertCompressor(

--- a/src/test/java/network/crypta/client/async/MultiPutCompletionCallbackTest.java
+++ b/src/test/java/network/crypta/client/async/MultiPutCompletionCallbackTest.java
@@ -500,6 +500,7 @@ class MultiPutCompletionCallbackTest {
   /* ===== Serialization-focused helpers and tests ===== */
 
   /** Serializable callback that records received events. */
+  @SuppressWarnings("UnusedVariable")
   private static class RecordingCallback implements PutCompletionCallback, Serializable {
     @Serial private static final long serialVersionUID = 1L;
 

--- a/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.OutputStream;
 import java.util.HashMap;
+import java.util.Map;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContextOptions;
 import network.crypta.client.NullClientCallback;
@@ -61,7 +62,7 @@ class PlainManifestPutterTest {
     RandomAccessBucket b10 = bucketWithBytes(10);
     RandomAccessBucket b20 = bucketWithBytes(20);
 
-    HashMap<String, Object> root = getStringObjectHashMap(b10, b20);
+    Map<String, Object> root = getStringObjectHashMap(b10, b20);
 
     RequestClient requestClient = new RequestClientBuilder().build();
     NullClientCallback cb = new NullClientCallback(requestClient);
@@ -88,7 +89,7 @@ class PlainManifestPutterTest {
     assertEquals(30, putter.totalSize(), "sums sizes of external data buckets");
   }
 
-  private static @NotNull HashMap<String, Object> getStringObjectHashMap(
+  private static @NotNull Map<String, Object> getStringObjectHashMap(
       RandomAccessBucket b10, RandomAccessBucket b20) {
     ManifestElement eIndex = new ManifestElement("index.html", b10, "text/html", 10);
     ManifestElement eReadme = new ManifestElement("readme.txt", b20, "text/plain", 20);
@@ -110,7 +111,7 @@ class PlainManifestPutterTest {
 
     TestablePlainManifestPutter(
         NullClientCallback cb,
-        HashMap<String, Object> manifest,
+        Map<String, Object> manifest,
         InsertContext ctx,
         byte[] forceKey,
         ClientContext context)

--- a/src/test/java/network/crypta/client/async/SingleFileInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SingleFileInserterTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import network.crypta.client.InsertBlock;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContextOptions;
@@ -137,7 +138,7 @@ class SingleFileInserterTest {
   @Test
   void onCompressed_whenUnknownKeyType_expectCallbackFailure() throws Exception {
     // Arrange
-    RandomAccessBucket data = makeData("hello".getBytes());
+    RandomAccessBucket data = makeData("hello".getBytes(StandardCharsets.UTF_8));
     InsertBlock block =
         new InsertBlock(data, null, new FreenetURI("ABC", null, (byte[]) null, null, null));
     InsertExecutionOptions execOptions =
@@ -179,7 +180,7 @@ class SingleFileInserterTest {
   void onCompressed_whenFitsInOneBlockWithoutMetadata_schedulesSingleBlock_andNotifies()
       throws Exception {
     // Arrange: CHK with tiny data, no metadata, no archive type
-    RandomAccessBucket data = makeData("tiny".getBytes());
+    RandomAccessBucket data = makeData("tiny".getBytes(StandardCharsets.UTF_8));
     InsertBlock block =
         new InsertBlock(data, null, new FreenetURI("CHK", null, (byte[]) null, null, null));
 
@@ -226,7 +227,7 @@ class SingleFileInserterTest {
   @Test
   void cancel_whenCalled_marksCancelled_andNotifiesCancelled_andFreesData() throws Exception {
     // Arrange
-    RandomAccessBucket data = makeData("abcdef".getBytes());
+    RandomAccessBucket data = makeData("abcdef".getBytes(StandardCharsets.UTF_8));
     InsertBlock block = new InsertBlock(data, null, FreenetURI.EMPTY_CHK_URI);
     SingleFileInserter sfi =
         new SingleFileInserter(
@@ -301,7 +302,7 @@ class SingleFileInserterTest {
       throws Exception {
     // Arrange: small CHK so tryCompress() will not compress and will queue a job invoking
     // onCompressed
-    RandomAccessBucket data = makeData("xyz".getBytes());
+    RandomAccessBucket data = makeData("xyz".getBytes(StandardCharsets.UTF_8));
     InsertBlock block =
         new InsertBlock(data, null, new FreenetURI("CHK", null, (byte[]) null, null, null));
     insertCtx.setGetCHKOnly(true); // downstream schedule avoids real schedulers

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherCrossSegmentStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherCrossSegmentStorageTest.java
@@ -51,7 +51,7 @@ class SplitFileFetcherCrossSegmentStorageTest {
       f.setAccessible(true);
       f.set(target, value);
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new AssertionError("Failed to set field '" + fieldName + "'", e);
+      throw new LinkageError("Failed to set field '" + fieldName + "'", e);
     }
   }
 
@@ -98,7 +98,7 @@ class SplitFileFetcherCrossSegmentStorageTest {
       f.setAccessible(true);
       f.set(seg, segNo);
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
     return seg;
   }

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherGetTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherGetTest.java
@@ -200,7 +200,7 @@ class SplitFileFetcherGetTest {
     assertFalse(cancelled);
     verify(storage, times(1)).setHasCheckedStore(clientContext);
     // The requester notifies via the job runner; ensure a job was queued
-    verify(clientContext.getJobRunner(true), times(1)).queueNormalOrDrop(any(PersistentJob.class));
+    verify(runner, times(1)).queueNormalOrDrop(any(PersistentJob.class));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherKeyListenerTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherKeyListenerTest.java
@@ -164,9 +164,11 @@ class SplitFileFetcherKeyListenerTest {
 
     when(segs[0].definitelyWantKey(key)).thenReturn(true);
     when(segs[1].definitelyWantKey(key)).thenReturn(false);
+    short expectedPrio = 5;
+    when(fetcher.getPriorityClass()).thenReturn(expectedPrio);
 
     short prio = listener.definitelyWantKey(key, saltedKey, mock(ClientContext.class));
-    assertEquals(fetcher.getPriorityClass(), prio);
+    assertEquals(expectedPrio, prio);
   }
 
   @Test
@@ -357,11 +359,16 @@ class SplitFileFetcherKeyListenerTest {
     SplitFileFetcherKeyListener listener =
         new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 4, 2, 1);
 
+    short expectedPrio = 9;
+    HasKeyListener expectedHasKeyListener = mock(HasKeyListener.class);
+    when(fetcher.getPriorityClass()).thenReturn(expectedPrio);
+    when(fetcher.getHasKeyListener()).thenReturn(expectedHasKeyListener);
+
     assertTrue(listener.persistent());
-    assertEquals(fetcher.getPriorityClass(), listener.getPriorityClass());
+    assertEquals(expectedPrio, listener.getPriorityClass());
 
     assertThrows(UnsupportedOperationException.class, listener::countKeys);
-    assertEquals(fetcher.getHasKeyListener(), listener.getHasKeyListener());
+    assertEquals(expectedHasKeyListener, listener.getHasKeyListener());
 
     when(storageMock.hasFinished()).thenReturn(true);
     assertTrue(listener.isEmpty());

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageLayoutTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageLayoutTest.java
@@ -191,27 +191,28 @@ class SplitFileFetcherStorageLayoutTest {
     return new SplitFileSegmentKeys(dataBlocks, checkBlocks, commonKey, algorithm);
   }
 
-  private static int expectedStoredKeysLength(
+  private static long expectedStoredKeysLength(
       int dataBlocks, int checkBlocks, boolean commonKey, int checksumLength) {
-    int blocks = dataBlocks + checkBlocks;
-    int keyBytes;
+    long blocks = (long) dataBlocks + checkBlocks;
+    long keyBytes;
     if (commonKey) {
       keyBytes = blocks * NodeCHK.KEY_LENGTH;
     } else {
-      keyBytes = blocks * (SplitFileSegmentKeys.EXTRA_BYTES_LENGTH + NodeCHK.KEY_LENGTH * 2);
+      long perBlock = SplitFileSegmentKeys.EXTRA_BYTES_LENGTH + (long) NodeCHK.KEY_LENGTH * 2;
+      keyBytes = blocks * perBlock;
     }
     return keyBytes + checksumLength;
   }
 
-  private static int expectedStoredSegmentStatusLength(
+  private static long expectedStoredSegmentStatusLength(
       int dataBlocks,
       int checkBlocks,
       int crossCheckBlocks,
       boolean trackRetries,
       int checksumLength) {
-    int fetchedBlocks = dataBlocks + crossCheckBlocks;
-    int totalBlocks = dataBlocks + checkBlocks + crossCheckBlocks;
-    int base = fetchedBlocks * 4 + (trackRetries ? totalBlocks * 4 : 0);
+    long fetchedBlocks = (long) dataBlocks + crossCheckBlocks;
+    long totalBlocks = (long) dataBlocks + checkBlocks + crossCheckBlocks;
+    long base = fetchedBlocks * 4L + (trackRetries ? totalBlocks * 4L : 0L);
     return base + checksumLength;
   }
 }

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStoragePersistenceWriterTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStoragePersistenceWriterTest.java
@@ -166,10 +166,10 @@ class SplitFileFetcherStoragePersistenceWriterTest {
         field.setAccessible(true);
         field.set(target, value);
       } catch (ReflectiveOperationException ex) {
-        throw new AssertionError(ex);
+        throw new LinkageError(ex.getMessage(), ex);
       }
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
   }
 }

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageRecoveryTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageRecoveryTest.java
@@ -298,10 +298,10 @@ class SplitFileFetcherStorageRecoveryTest {
         field.setAccessible(true);
         field.set(target, value);
       } catch (ReflectiveOperationException ex) {
-        throw new AssertionError(ex);
+        throw new LinkageError(ex.getMessage(), ex);
       }
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
   }
 
@@ -316,10 +316,10 @@ class SplitFileFetcherStorageRecoveryTest {
         field.setAccessible(true);
         return field.get(target);
       } catch (ReflectiveOperationException ex) {
-        throw new AssertionError(ex);
+        throw new LinkageError(ex.getMessage(), ex);
       }
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
   }
 }

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageResumeReaderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageResumeReaderTest.java
@@ -281,6 +281,7 @@ class SplitFileFetcherStorageResumeReaderTest {
     return raf;
   }
 
+  @SuppressWarnings("ArrayRecordComponent")
   private record ResumeLayout(
       byte[] data,
       long rafLength,

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodecTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodecTest.java
@@ -531,6 +531,7 @@ class SplitFileFetcherStorageSettingsCodecTest {
       dos.writeLong(offsetBasicSettings);
     }
 
+    @SuppressWarnings("EnumOrdinal")
     private int resolveCompatModeOrdinal() {
       return compatModeOrdinalOverride != null ? compatModeOrdinalOverride : compatMode.ordinal();
     }

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
@@ -1170,7 +1170,7 @@ class SplitFileFetcherStorageTest {
               .decompressors(NO_DECOMPRESSORS)
               .clientMetadata(metadata.getClientMetadata())
               .topDontCompress(false)
-              .topCompatibilityMode((short) COMPATIBILITY_MODE.ordinal())
+              .topCompatibilityMode(COMPATIBILITY_MODE.code)
               .fetchContext(ctx)
               .realTime(false)
               .salt(salt)

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
@@ -890,17 +890,21 @@ class SplitFileFetcherStorageTest {
     // so enumeration of all blocks in this round doesn’t spuriously bail out.
     clearChooserCooldownForTesting(storage);
     boolean enumeratedAll = true;
+    long lastChooseTime = 0;
     for (int i = 0; i < dataBlocks + checkBlocks; i++) {
+      lastChooseTime = System.currentTimeMillis();
       int chosen = storage.chooseRandomKey();
       if (chosen == -1 && cooldown) {
         // Deflake: a stale global cooldown gate may linger briefly even when
         // individual blocks are eligible. Clear it and retry a couple of times.
         clearChooserCooldownForTesting(storage);
+        lastChooseTime = System.currentTimeMillis();
         chosen = storage.chooseRandomKey();
         if (chosen == -1) {
           // Allow one more quick pass after the executor drains.
           exec.waitForIdle();
           clearChooserCooldownForTesting(storage);
+          lastChooseTime = System.currentTimeMillis();
           chosen = storage.chooseRandomKey();
         }
       }
@@ -931,7 +935,7 @@ class SplitFileFetcherStorageTest {
         // Partial enumeration because some blocks are still cooling down.
         // Should report a finite cooldown (not MAX) in this case.
         long overall = storage.getOverallCooldownTime();
-        assertTrue(overall > System.currentTimeMillis());
+        assertTrue(overall > lastChooseTime);
         assertNotEquals(Long.MAX_VALUE, overall);
       }
     }

--- a/src/test/java/network/crypta/client/async/SplitFileInserterStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterStorageTest.java
@@ -96,7 +96,7 @@ class SplitFileInserterStorageTest {
     byte[] hashThisLayerOnly =
         (explicitSplitfileKey == null
                 && (cmode == InsertContext.CompatibilityMode.COMPAT_CURRENT
-                    || cmode.ordinal() >= InsertContext.CompatibilityMode.COMPAT_1255.ordinal()))
+                    || cmode.code >= InsertContext.CompatibilityMode.COMPAT_1255.code))
             ? new byte[32]
             : null;
     SplitFileInserterStorageRuntimeParams runtimeParams =

--- a/src/test/java/network/crypta/client/async/SplitFileInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterTest.java
@@ -458,6 +458,8 @@ class SplitFileInserterTest {
     ic.setEarlyEncode(false);
     ic.setGetCHKOnly(false);
     Metadata md = Mockito.mock(Metadata.class);
+    short priority = 7;
+    when(parent.getPriorityClass()).thenReturn(priority);
 
     try (MockedConstruction<SplitFileInserterStorage> storageConst =
             Mockito.mockConstruction(
@@ -472,7 +474,7 @@ class SplitFileInserterTest {
 
       verify(cb).onMetadata(md, sfi, context);
       verify(cb).onSuccess(sfi, context);
-      verify(senderConst.constructed().getFirst()).unregister(context, parent.getPriorityClass());
+      verify(senderConst.constructed().getFirst()).unregister(context, priority);
     }
   }
 

--- a/src/test/java/network/crypta/client/async/USKAttemptManagerTest.java
+++ b/src/test/java/network/crypta/client/async/USKAttemptManagerTest.java
@@ -136,7 +136,7 @@ class USKAttemptManagerTest {
     private final ClientBaseCallback callback;
     private final network.crypta.keys.FreenetURI uri;
     private int toNetworkCalls;
-    private boolean cancelled;
+    private boolean wasCancelled;
 
     private TestRequester(network.crypta.keys.FreenetURI uri, RequestClient client) {
       super((short) 1, client);
@@ -163,7 +163,7 @@ class USKAttemptManagerTest {
 
     @Override
     public void cancel(ClientContext context) {
-      cancelled = true;
+      wasCancelled = true;
     }
 
     @Override
@@ -173,7 +173,7 @@ class USKAttemptManagerTest {
 
     @Override
     public boolean isFinished() {
-      return cancelled;
+      return wasCancelled;
     }
 
     @Override

--- a/src/test/java/network/crypta/client/async/USKCompletionHandlerTest.java
+++ b/src/test/java/network/crypta/client/async/USKCompletionHandlerTest.java
@@ -280,10 +280,10 @@ class USKCompletionHandlerTest {
         field.setAccessible(true);
         field.set(target, value);
       } catch (ReflectiveOperationException ex) {
-        throw new AssertionError(ex);
+        throw new LinkageError(ex.getMessage(), ex);
       }
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
   }
 }

--- a/src/test/java/network/crypta/client/async/USKDateHintFetchesTest.java
+++ b/src/test/java/network/crypta/client/async/USKDateHintFetchesTest.java
@@ -15,8 +15,8 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
-import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
 import network.crypta.client.events.SimpleEventProducer;
@@ -282,9 +282,9 @@ class USKDateHintFetchesTest {
     return owner;
   }
 
-  private static HashSet<?> getAttempts(USKDateHintFetches fetches)
+  private static Set<?> getAttempts(USKDateHintFetches fetches)
       throws ReflectiveOperationException {
-    return getField(fetches, "attempts", HashSet.class);
+    return getField(fetches, "attempts", Set.class);
   }
 
   private static int getIntField(USKDateHintFetches fetches, String field)

--- a/src/test/java/network/crypta/client/async/USKDateHintTest.java
+++ b/src/test/java/network/crypta/client/async/USKDateHintTest.java
@@ -13,7 +13,6 @@ import java.time.temporal.TemporalField;
 import java.time.temporal.WeekFields;
 import java.util.Locale;
 import java.util.stream.Stream;
-import network.crypta.client.async.USKDateHint.Type;
 import network.crypta.keys.ClientSSK;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
@@ -129,7 +128,8 @@ class USKDateHintTest {
 
   @ParameterizedTest
   @MethodSource("alwaysMorePreciseThanCases")
-  void alwaysMorePreciseThan_variousPairs_expectDefinedOrdering(boolean expected, Type a, Type b) {
+  void alwaysMorePreciseThan_variousPairs_expectDefinedOrdering(
+      boolean expected, USKDateHint.Type a, USKDateHint.Type b) {
     // Arrange
     // Act
     boolean result = a.alwaysMorePreciseThan(b);

--- a/src/test/java/network/crypta/client/async/USKRetrieverTest.java
+++ b/src/test/java/network/crypta/client/async/USKRetrieverTest.java
@@ -381,7 +381,9 @@ class USKRetrieverTest {
     try (Bucket b = res.asBucket()) {
       // ArrayBucket exposes the bytes through its API
       assertEquals(payload.length, ((ArrayBucket) b).toByteArray().length);
-      assertEquals(new String(payload), new String(((ArrayBucket) b).toByteArray()));
+      assertEquals(
+          new String(payload, StandardCharsets.UTF_8),
+          new String(((ArrayBucket) b).toByteArray(), StandardCharsets.UTF_8));
     }
   }
 

--- a/src/test/java/network/crypta/client/async/USKStoreCheckCoordinatorTest.java
+++ b/src/test/java/network/crypta/client/async/USKStoreCheckCoordinatorTest.java
@@ -317,16 +317,15 @@ class USKStoreCheckCoordinatorTest {
     NodeSSK key = nodeKeyForEdition(usk, 0L);
     USKKeyWatchSet.KeyList.StoreSubChecker subChecker =
         newStoreSubChecker(watchSet, new NodeSSK[] {key});
-    USKStoreCheckCoordinator coordinator =
-        newCoordinator(
-            watchSet,
-            mock(USKAttemptManager.class),
-            mock(ClientRequester.class),
-            false,
-            mock(USKManager.class),
-            usk,
-            mock(USKStoreCheckCoordinator.USKStoreCheckCallbacks.class),
-            true);
+    newCoordinator(
+        watchSet,
+        mock(USKAttemptManager.class),
+        mock(ClientRequester.class),
+        false,
+        mock(USKManager.class),
+        usk,
+        mock(USKStoreCheckCoordinator.USKStoreCheckCallbacks.class),
+        true);
 
     USKStoreCheckCoordinator.USKStoreChecker checker =
         new USKStoreCheckCoordinator.USKStoreChecker(List.of(subChecker));
@@ -352,16 +351,15 @@ class USKStoreCheckCoordinatorTest {
     USKKeyWatchSet.KeyList.StoreSubChecker second =
         newStoreSubChecker(watchSet, new NodeSSK[] {key2, key3});
 
-    USKStoreCheckCoordinator coordinator =
-        newCoordinator(
-            watchSet,
-            mock(USKAttemptManager.class),
-            mock(ClientRequester.class),
-            false,
-            mock(USKManager.class),
-            usk,
-            mock(USKStoreCheckCoordinator.USKStoreCheckCallbacks.class),
-            true);
+    newCoordinator(
+        watchSet,
+        mock(USKAttemptManager.class),
+        mock(ClientRequester.class),
+        false,
+        mock(USKManager.class),
+        usk,
+        mock(USKStoreCheckCoordinator.USKStoreCheckCallbacks.class),
+        true);
 
     USKStoreCheckCoordinator.USKStoreChecker checker =
         new USKStoreCheckCoordinator.USKStoreChecker(List.of(first, second));
@@ -384,16 +382,15 @@ class USKStoreCheckCoordinatorTest {
         newStoreSubChecker(watchSet, new NodeSSK[] {key});
     USKKeyWatchSet.KeyList.StoreSubChecker subChecker = spy(realChecker);
 
-    USKStoreCheckCoordinator coordinator =
-        newCoordinator(
-            watchSet,
-            mock(USKAttemptManager.class),
-            mock(ClientRequester.class),
-            false,
-            mock(USKManager.class),
-            usk,
-            mock(USKStoreCheckCoordinator.USKStoreCheckCallbacks.class),
-            true);
+    newCoordinator(
+        watchSet,
+        mock(USKAttemptManager.class),
+        mock(ClientRequester.class),
+        false,
+        mock(USKManager.class),
+        usk,
+        mock(USKStoreCheckCoordinator.USKStoreCheckCallbacks.class),
+        true);
 
     USKStoreCheckCoordinator.USKStoreChecker checker =
         new USKStoreCheckCoordinator.USKStoreChecker(List.of(subChecker));
@@ -457,7 +454,7 @@ class USKStoreCheckCoordinatorTest {
       constructor.setAccessible(true);
       return constructor.newInstance(keyList, keys, 0L, (long) keys.length);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Unable to build StoreSubChecker for test", e);
+      throw new LinkageError("Unable to build StoreSubChecker for test", e);
     }
   }
 

--- a/src/test/java/network/crypta/client/async/USKStoreCheckerGetterTest.java
+++ b/src/test/java/network/crypta/client/async/USKStoreCheckerGetterTest.java
@@ -450,7 +450,7 @@ class USKStoreCheckerGetterTest {
       field.setAccessible(true);
       field.set(fetcher, ctx);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Unable to set USKFetcher.ctx for test", e);
+      throw new LinkageError("Unable to set USKFetcher.ctx for test", e);
     }
     return fetcher;
   }

--- a/src/test/java/network/crypta/client/events/SplitfileProgressEventTest.java
+++ b/src/test/java/network/crypta/client/events/SplitfileProgressEventTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-@SuppressWarnings("java:S100")
+@SuppressWarnings({"java:S100", "JavaUtilDate"})
 class SplitfileProgressEventTest {
 
   @Test

--- a/src/test/java/network/crypta/client/filter/CSSParserTest.java
+++ b/src/test/java/network/crypta/client/filter/CSSParserTest.java
@@ -2238,7 +2238,8 @@ class CSSParserTest {
         charset.equalsIgnoreCase(detectedCharset),
         CD + detectedCharset + SHOULD_BE + charset + "\" even when parsing with correct charset");
     BOMDetection bom = filter.getCharsetByBOM(bytes, bytes.length);
-    String bomCharset = detectedCharset = bom == null ? null : bom.charset;
+    String bomCharset = bom == null ? null : bom.charset;
+    detectedCharset = bomCharset;
     assertTrue(
         detectedCharset == null
             || charset.equalsIgnoreCase(detectedCharset)
@@ -2295,7 +2296,8 @@ class CSSParserTest {
     CSSReadFilter filter = new CSSReadFilter();
     String detectedCharset;
     BOMDetection bom = filter.getCharsetByBOM(bytes, bytes.length);
-    String bomCharset = detectedCharset = bom == null ? null : bom.charset;
+    String bomCharset = bom == null ? null : bom.charset;
+    detectedCharset = bomCharset;
     assertNull(
         detectedCharset,
         CHARSET_DETECTED_PREFIX

--- a/src/test/java/network/crypta/client/filter/ContentFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/ContentFilterTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import network.crypta.client.filter.ContentFilter.FilterStatus;
 import network.crypta.clients.http.ExternalLinkToadlet;
 import network.crypta.l10n.L10nTestUtils;
@@ -414,12 +415,12 @@ class ContentFilterTest {
     for (FilterMIMEType type : ContentFilter.mimeTypesByName.values()) {
       String ext = type.primaryExtension;
       if (ext != null) {
-        assertEquals(ext, ext.toLowerCase());
+        assertEquals(ext, ext.toLowerCase(Locale.ROOT));
       }
       String[] exts = type.alternateExtensions;
       if (ext != null) {
         for (String s : exts) {
-          assertEquals(s, s.toLowerCase());
+          assertEquals(s, s.toLowerCase(Locale.ROOT));
         }
       }
     }

--- a/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
@@ -175,7 +176,7 @@ class HTMLFilterTest {
     String sanitized = out.toString(StandardCharsets.UTF_8);
 
     // Assert: script content is swallowed and no <script> tag remains; body text preserved
-    assertFalse(sanitized.toLowerCase().contains("<script"));
+    assertFalse(sanitized.toLowerCase(Locale.ROOT).contains("<script"));
     assertTrue(sanitized.contains("Hello"));
   }
 

--- a/src/test/java/network/crypta/node/NodeInsertRequestHandlerTest.java
+++ b/src/test/java/network/crypta/node/NodeInsertRequestHandlerTest.java
@@ -371,20 +371,18 @@ class NodeInsertRequestHandlerTest {
       field.setAccessible(true);
       field.set(target, value);
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new AssertionError("Failed to set field: " + fieldName, e);
+      throw new LinkageError("Failed to set field: " + fieldName, e);
     }
   }
 
   @SuppressWarnings("java:S3011")
-  private static <T> T getPrivateField(Class<?> declaringClass, Object target, String fieldName) {
+  private static Object getPrivateField(Class<?> declaringClass, Object target, String fieldName) {
     try {
       Field field = declaringClass.getDeclaredField(fieldName);
       field.setAccessible(true);
-      @SuppressWarnings("unchecked")
-      T value = (T) field.get(target);
-      return value;
+      return field.get(target);
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new AssertionError("Failed to read field: " + fieldName, e);
+      throw new LinkageError("Failed to read field: " + fieldName, e);
     }
   }
 }

--- a/src/test/java/network/crypta/node/NodeNotRoutableHandlerTest.java
+++ b/src/test/java/network/crypta/node/NodeNotRoutableHandlerTest.java
@@ -66,7 +66,7 @@ class NodeNotRoutableHandlerTest {
     long uid = 42L;
     when(message.getSpec()).thenReturn(spec);
     when(message.getLong(DMT.UID)).thenReturn(uid);
-    if (spec == DMT.FNPGetOfferedKey) {
+    if (DMT.FNPGetOfferedKey.equals(spec)) {
       prepareRoutingFailureTable();
     } else {
       prepareNetworkStats();
@@ -155,7 +155,7 @@ class NodeNotRoutableHandlerTest {
       field.setAccessible(true);
       field.set(target, value);
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new AssertionError("Failed to set field: " + fieldName, e);
+      throw new LinkageError("Failed to set field: " + fieldName, e);
     }
   }
 

--- a/src/test/java/network/crypta/node/NodeRoutedMessageRouterTest.java
+++ b/src/test/java/network/crypta/node/NodeRoutedMessageRouterTest.java
@@ -301,7 +301,7 @@ class NodeRoutedMessageRouterTest {
           (Map<Long, NodeRoutedMessageRouter.RoutedContext>) field.get(router);
       return map;
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Failed to access routedContexts", e);
+      throw new LinkageError("Failed to access routedContexts", e);
     }
   }
 
@@ -311,7 +311,7 @@ class NodeRoutedMessageRouterTest {
       field.setAccessible(true);
       field.setLong(context, value);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Failed to set createdTime", e);
+      throw new LinkageError("Failed to set createdTime", e);
     }
   }
 

--- a/src/test/java/network/crypta/node/NodeSwapMessageHandlerTest.java
+++ b/src/test/java/network/crypta/node/NodeSwapMessageHandlerTest.java
@@ -120,6 +120,7 @@ class NodeSwapMessageHandlerTest {
         .flatMap(action -> Stream.of(Arguments.of(action, true), Arguments.of(action, false)));
   }
 
+  @SuppressWarnings("ImmutableEnumChecker")
   private enum SwapAction {
     REPLY(DMT.FNPSwapReply) {
       @Override

--- a/src/test/java/network/crypta/node/OpennetPeerNodeStatusTest.java
+++ b/src/test/java/network/crypta/node/OpennetPeerNodeStatusTest.java
@@ -6,7 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Hashtable;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,9 +82,9 @@ class OpennetPeerNodeStatusTest {
   void constructor_whenNoHeavyFalse_heavyMapsArePopulated() {
     // Arrange
     OpennetPeerNode node = mockMinimalOpennetPeerNode(42L);
-    Hashtable<String, Long> received = new Hashtable<>();
+    Map<String, Long> received = new HashMap<>();
     received.put("Hello", 3L);
-    Hashtable<String, Long> sent = new Hashtable<>();
+    Map<String, Long> sent = new HashMap<>();
     sent.put("World", 4L);
     when(node.getLocalNodeReceivedMessagesFromStatistic()).thenReturn(received);
     when(node.getLocalNodeSentMessagesToStatistic()).thenReturn(sent);

--- a/src/test/java/network/crypta/node/OpennetPeerNodeTest.java
+++ b/src/test/java/network/crypta/node/OpennetPeerNodeTest.java
@@ -240,7 +240,7 @@ class OpennetPeerNodeTest {
     OpennetPeerNode pn = newPeerLocal("0.25");
 
     // Age beyond min age should clear added fields and not return TOO_NEW_PEER
-    pn.setAddedReason(ConnectionType.PATH_FOLDING.ordinal());
+    pn.setAddedReason(ConnectionType.PATH_FOLDING.code());
     pn.peerAddedTime = System.currentTimeMillis() - (OpennetManager.DROP_MIN_AGE + 1000);
     setPrivateField(pn, FIELD_PEER_NODE_STATUS, PeerManager.PEER_NODE_STATUS_CONNECTED);
 

--- a/src/test/java/network/crypta/node/PacketSenderTest.java
+++ b/src/test/java/network/crypta/node/PacketSenderTest.java
@@ -1,17 +1,17 @@
 package network.crypta.node;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeUnit;
 import network.crypta.io.comm.UdpSocketHandler;
 import network.crypta.support.OutputThrottle;
 import network.crypta.support.math.MersenneTwister;
@@ -61,6 +61,22 @@ class PacketSenderTest {
     var m = PacketSender.class.getDeclaredMethod("realRun");
     m.setAccessible(true);
     m.invoke(ps);
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void attachPacketFormat(PeerNode peer, Node node, PacketFormat packetFormat)
+      throws Exception {
+    Class<?> internalsClass = Class.forName("network.crypta.node.PeerNode$PeerNodeInternals");
+    var ctor = internalsClass.getDeclaredConstructor(PeerNode.class, Node.class, String.class);
+    ctor.setAccessible(true);
+    Object internals = ctor.newInstance(peer, node, "0");
+    var setPacketFormat = internalsClass.getDeclaredMethod("setPacketFormat", PacketFormat.class);
+    setPacketFormat.setAccessible(true);
+    setPacketFormat.invoke(internals, packetFormat);
+
+    var internalsField = PeerNode.class.getDeclaredField("internals");
+    internalsField.setAccessible(true);
+    internalsField.set(peer, internals);
   }
 
   @Test
@@ -151,27 +167,31 @@ class PacketSenderTest {
   @DisplayName("realRun_whenPacketNumberBlockedTooLong_forcesDisconnectOnPeer")
   void realRun_whenPacketNumberBlockedTooLong_forcesDisconnectOnPeer() throws Exception {
     // Arrange
-    PeerNode pn = mock(PeerNode.class);
+    PeerNode pn = mock(PeerNode.class, org.mockito.Answers.CALLS_REAL_METHODS);
     when(peerManager.myPeers()).thenReturn(new PeerNode[] {pn});
 
-    when(pn.isConnected()).thenReturn(true);
-    when(pn.shouldThrottle()).thenReturn(false);
-    when(pn.getNextUrgentTime(anyLong())).thenReturn(0L); // urgent now
+    doReturn(true).when(pn).isConnected();
+    doReturn(false).when(pn).shouldThrottle();
+    doReturn(0L).when(pn).getNextUrgentTime(anyLong()); // urgent now
 
-    when(pn.lastReceivedDataPacketTime()).thenReturn(System.currentTimeMillis());
-    when(pn.maxTimeBetweenReceivedPackets()).thenReturn(Long.MAX_VALUE);
-    when(pn.lastReceivedAckTime()).thenReturn(System.currentTimeMillis());
-    when(pn.maxTimeBetweenReceivedAcks()).thenReturn(Long.MAX_VALUE);
-    when(pn.isRoutable()).thenReturn(false);
+    doReturn(System.currentTimeMillis()).when(pn).lastReceivedDataPacketTime();
+    doReturn(Long.MAX_VALUE).when(pn).maxTimeBetweenReceivedPackets();
+    doReturn(System.currentTimeMillis()).when(pn).lastReceivedAckTime();
+    doReturn(Long.MAX_VALUE).when(pn).maxTimeBetweenReceivedAcks();
+    doReturn(false).when(pn).isRoutable();
+    doReturn(System.currentTimeMillis()).when(pn).lastReceivedPacketTime();
+    doReturn(false).when(pn).shouldDisconnectAndRemoveNow();
+    doReturn(false).when(pn).isDisconnecting();
+    doReturn(42).when(pn).getBuildNumber();
+    doReturn(false).when(pn).fullPacketQueued();
+    doNothing().when(pn).maybeOnConnect();
+    doNothing().when(pn).checkForLostPackets();
+    doNothing().when(pn).forceDisconnect();
 
-    AtomicBoolean forcedDisconnect = new AtomicBoolean(false);
-    doAnswer(
-            inv -> {
-              forcedDisconnect.set(true);
-              return false;
-            })
-        .when(pn)
-        .maybeSendPacket(anyLong(), anyBoolean());
+    PacketFormat packetFormat = mock(PacketFormat.class);
+    when(packetFormat.maybeSendPacket(anyLong(), anyBoolean()))
+        .thenThrow(new BlockedTooLongException(TimeUnit.SECONDS.toMillis(5)));
+    attachPacketFormat(pn, node, packetFormat);
 
     PacketSender ps = new PacketSender(node);
 
@@ -179,7 +199,7 @@ class PacketSenderTest {
     invokeRealRun(ps);
 
     // Assert
-    assertTrue(forcedDisconnect.get(), "Expected disconnect to be triggered");
+    verify(pn, times(1)).forceDisconnect();
   }
 
   @Test

--- a/src/test/java/network/crypta/node/PacketSenderTest.java
+++ b/src/test/java/network/crypta/node/PacketSenderTest.java
@@ -1,6 +1,7 @@
 package network.crypta.node;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import network.crypta.io.comm.UdpSocketHandler;
 import network.crypta.support.OutputThrottle;
 import network.crypta.support.math.MersenneTwister;
@@ -162,9 +164,10 @@ class PacketSenderTest {
     when(pn.maxTimeBetweenReceivedAcks()).thenReturn(Long.MAX_VALUE);
     when(pn.isRoutable()).thenReturn(false);
 
+    AtomicBoolean forcedDisconnect = new AtomicBoolean(false);
     doAnswer(
             inv -> {
-              pn.forceDisconnect();
+              forcedDisconnect.set(true);
               return false;
             })
         .when(pn)
@@ -176,7 +179,7 @@ class PacketSenderTest {
     invokeRealRun(ps);
 
     // Assert
-    verify(pn, times(1)).forceDisconnect();
+    assertTrue(forcedDisconnect.get(), "Expected disconnect to be triggered");
   }
 
   @Test

--- a/src/test/java/network/crypta/node/PeerAlertCoordinatorTest.java
+++ b/src/test/java/network/crypta/node/PeerAlertCoordinatorTest.java
@@ -212,7 +212,7 @@ class PeerAlertCoordinatorTest {
       alertField.setAccessible(true);
       alertField.set(coordinator, alert);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Unable to set PeerAlertCoordinator alert", e);
+      throw new LinkageError("Unable to set PeerAlertCoordinator alert", e);
     }
   }
 }

--- a/src/test/java/network/crypta/node/PeerNodeConnectionStateTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeConnectionStateTest.java
@@ -153,7 +153,7 @@ class PeerNodeConnectionStateTest {
       field.setAccessible(true);
       field.set(target, value);
     } catch (ReflectiveOperationException ex) {
-      throw new AssertionError("Failed to set field: " + name, ex);
+      throw new LinkageError("Failed to set field: " + name, ex);
     }
   }
 }

--- a/src/test/java/network/crypta/node/PeerNodeOfferSupportTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeOfferSupportTest.java
@@ -116,7 +116,7 @@ class PeerNodeOfferSupportTest {
       field.setAccessible(true);
       field.set(target, value);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Failed to set field: " + fieldName, e);
+      throw new LinkageError("Failed to set field: " + fieldName, e);
     }
   }
 

--- a/src/test/java/network/crypta/node/SemiOrderedShutdownHookTest.java
+++ b/src/test/java/network/crypta/node/SemiOrderedShutdownHookTest.java
@@ -192,7 +192,7 @@ class SemiOrderedShutdownHookTest {
         ctor.setAccessible(true);
         return ctor.newInstance();
       } catch (ReflectiveOperationException e) {
-        throw new AssertionError("Failed to construct SemiOrderedShutdownHook for test", e);
+        throw new LinkageError("Failed to construct SemiOrderedShutdownHook for test", e);
       }
     }
   }

--- a/src/test/java/network/crypta/node/probe/TypeTest.java
+++ b/src/test/java/network/crypta/node/probe/TypeTest.java
@@ -43,7 +43,7 @@ class TypeTest {
   }
 
   static Stream<Byte> invalidCodes() {
-    return Stream.of((byte) -1, Byte.MIN_VALUE, (byte) (Type.values().length), Byte.MAX_VALUE);
+    return Stream.of((byte) -1, Byte.MIN_VALUE, (byte) Type.values().length, Byte.MAX_VALUE);
   }
 
   @Test

--- a/src/test/java/network/crypta/node/stats/DataStoreInstanceTypeTest.java
+++ b/src/test/java/network/crypta/node/stats/DataStoreInstanceTypeTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -112,14 +113,14 @@ class DataStoreInstanceTypeTest {
         .flatMap(
             store -> {
               // For each key, pair with the next key (cyclic) to ensure difference
-              return Arrays.stream(keys)
-                  .map(
-                      key ->
+              return IntStream.range(0, keys.length)
+                  .mapToObj(
+                      index ->
                           Arguments.of(
                               store,
-                              key, // first
+                              keys[index],
                               store,
-                              keys[(key.ordinal() + 1) % keys.length] // second with diff key
+                              keys[(index + 1) % keys.length] // second with diff key
                               ));
             });
   }
@@ -140,18 +141,18 @@ class DataStoreInstanceTypeTest {
   static Stream<Arguments> sameKey_differentStore() {
     DataStoreType[] stores = DataStoreType.values();
     DataStoreKeyType[] keys = DataStoreKeyType.values();
-    return Arrays.stream(keys)
+    return IntStream.range(0, keys.length)
+        .boxed()
         .flatMap(
-            key ->
-                Arrays.stream(stores)
-                    .map(
-                        store ->
+            keyIndex ->
+                IntStream.range(0, stores.length)
+                    .mapToObj(
+                        storeIndex ->
                             Arguments.of(
-                                store,
-                                key, // first
-                                stores[(store.ordinal() + 1) % stores.length],
-                                key // second with diff store
-                                )));
+                                stores[storeIndex],
+                                keys[keyIndex],
+                                stores[(storeIndex + 1) % stores.length],
+                                keys[keyIndex])));
   }
 
   @ParameterizedTest(name = "not equals when same key {1} but different stores {0}!={2}")

--- a/src/test/java/network/crypta/node/subsystem/NodeConfigManagerTest.java
+++ b/src/test/java/network/crypta/node/subsystem/NodeConfigManagerTest.java
@@ -71,7 +71,7 @@ class NodeConfigManagerTest {
     verify(nodeConfig)
         .register(
             eq("l10n"),
-            eq(Locale.getDefault().getLanguage().toLowerCase()),
+            eq(Locale.getDefault().getLanguage().toLowerCase(Locale.ROOT)),
             any(Option.Meta.class),
             callbackCaptor.capture());
     assertInstanceOf(EnumerableOptionCallback.class, callbackCaptor.getValue());

--- a/src/test/java/network/crypta/node/subsystem/NodeNetworkSubsystemTest.java
+++ b/src/test/java/network/crypta/node/subsystem/NodeNetworkSubsystemTest.java
@@ -49,7 +49,7 @@ class NodeNetworkSubsystemTest {
       field.setAccessible(true);
       field.set(target, value);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Failed to set field: " + name, e);
+      throw new LinkageError("Failed to set field: " + name, e);
     }
   }
 

--- a/src/test/java/network/crypta/node/useralerts/DroppedOldPeersUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/DroppedOldPeersUserAlertTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.io.TempDir;
 class DroppedOldPeersUserAlertTest {
 
   @Test
+  @SuppressWarnings("JavaUtilDate")
   void isEmpty_whenNoAdds_expectTrueAndAfterAddFalse(@TempDir java.nio.file.Path tmp) {
     // Arrange
     DroppedOldPeersUserAlert alert =
@@ -51,12 +52,13 @@ class DroppedOldPeersUserAlertTest {
 
     // Assert (text): first line contains filename from l10n intro, then list label, then two names
     String text = alert.getText();
-    String[] lines = text.split("\n");
-    assertTrue(lines[0].contains(peersFile.toString()));
+    List<String> lines = text.lines().toList();
+    assertTrue(lines.get(0).contains(peersFile.toString()));
     assertEquals(
-        NodeL10n.getBase().getString("DroppedOldPeersUserAlert.droppingOldFriendList"), lines[1]);
-    assertEquals("\"Alice\"", lines[2]);
-    assertEquals("(unknown name)", lines[3]);
+        NodeL10n.getBase().getString("DroppedOldPeersUserAlert.droppingOldFriendList"),
+        lines.get(1));
+    assertEquals("\"Alice\"", lines.get(2));
+    assertEquals("(unknown name)", lines.get(3));
 
     // Assert (HTML): structure contains a single <ul> with two <li> entries in order
     HTMLNode html = alert.getHTMLText();
@@ -86,6 +88,7 @@ class DroppedOldPeersUserAlertTest {
   }
 
   @Test
+  @SuppressWarnings("JavaUtilDate")
   void getTitle_whenMultipleBuilds_expectBuildDateFromMaxBuild(@TempDir java.nio.file.Path tmp) {
     // Arrange
     DroppedOldPeersUserAlert alert =
@@ -103,6 +106,7 @@ class DroppedOldPeersUserAlertTest {
   }
 
   @Test
+  @SuppressWarnings("JavaUtilDate")
   void getShortText_whenCalled_expectSameAsTitle(@TempDir java.nio.file.Path tmp) {
     // Arrange
     DroppedOldPeersUserAlert alert = new DroppedOldPeersUserAlert(tmp.resolve("p.txt").toFile());
@@ -113,6 +117,7 @@ class DroppedOldPeersUserAlertTest {
   }
 
   @Test
+  @SuppressWarnings("JavaUtilDate")
   void getFCPMessage_whenBuilt_expectFieldsMatchAlert(@TempDir java.nio.file.Path tmp) {
     // Arrange
     DroppedOldPeersUserAlert alert =

--- a/src/test/java/network/crypta/node/useralerts/N2NTMUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/N2NTMUserAlertTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.TimeZone;
 import network.crypta.clients.fcp.FCPMessage;
@@ -203,7 +204,9 @@ class N2NTMUserAlertTest {
     assertEquals(Long.toString(sent), fs.get("TimeSent"));
     assertEquals(Long.toString(received), fs.get("TimeReceived"));
     // Verify the additional bucket length for MessageText is present and equals payload size
-    assertEquals(Integer.toString(messageText.getBytes().length), fs.get("MessageTextLength"));
+    assertEquals(
+        Integer.toString(messageText.getBytes(StandardCharsets.UTF_8).length),
+        fs.get("MessageTextLength"));
   }
 
   @Test

--- a/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
@@ -1400,6 +1400,7 @@ class CachingFreenetStoreTest {
   // ------------------------------------------------------------
 
   // Simple concrete block used by the Mockito-focused tests in this class
+  @SuppressWarnings("ArrayRecordComponent")
   record TestBlock(byte[] routingKey, byte[] fullKey) implements StorableBlock {
     @Override
     public byte[] getRoutingKey() {

--- a/src/test/java/network/crypta/store/saltedhash/LockManagerTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/LockManagerTest.java
@@ -179,8 +179,6 @@ class LockManagerTest {
   // Helper: detect whether JVM assertions are enabled for this class
   @SuppressWarnings({"AssertWithSideEffects", "ConstantValue"})
   private static boolean assertionsEnabled() {
-    boolean enabled = false;
-    assert enabled = true; // set to true when -ea is active
-    return enabled;
+    return LockManagerTest.class.desiredAssertionStatus();
   }
 }

--- a/src/test/java/network/crypta/support/FieldsDurationTest.java
+++ b/src/test/java/network/crypta/support/FieldsDurationTest.java
@@ -2,7 +2,6 @@ package network.crypta.support;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.HashMap;
 import java.util.Map;
 import network.crypta.config.Dimension;
 import org.junit.jupiter.api.Test;
@@ -12,15 +11,12 @@ class FieldsDurationTest {
 
   /** Duration input with and without various d|h|min|s. With correct result in millis */
   private static final Map<String, Integer> durations =
-      new HashMap<>() {
-        {
-          put("2d", 172_800_000);
-          put("3h", 10_800_000);
-          put("20m", 1_200_000);
-          put("56s", 56_000);
-          put("1h30m", 5_400_000);
-        }
-      };
+      Map.ofEntries(
+          Map.entry("2d", 172_800_000),
+          Map.entry("3h", 10_800_000),
+          Map.entry("20m", 1_200_000),
+          Map.entry("56s", 56_000),
+          Map.entry("1h30m", 5_400_000));
 
   @Test
   void test() {

--- a/src/test/java/network/crypta/support/MediaTypeTest.java
+++ b/src/test/java/network/crypta/support/MediaTypeTest.java
@@ -69,6 +69,21 @@ class MediaTypeTest {
   }
 
   @Test
+  @DisplayName("parse constructor: trailing semicolon after params is ignored")
+  void constructor_whenTrailingSemicolon_expectParsedCorrectly() throws Exception {
+    // Arrange
+    String input = MIME_TEXT_HTML + "; " + PARAM_CHARSET + "=" + CHARSET_UTF8 + ";";
+
+    // Act
+    MediaType mt = new MediaType(input);
+
+    // Assert
+    assertEquals(CHARSET_UTF8, mt.getParameter(PARAM_CHARSET));
+    assertEquals(
+        MIME_TEXT_HTML + "; " + PARAM_CHARSET + "=\"" + CHARSET_UTF8 + "\"", mt.toString());
+  }
+
+  @Test
   @SuppressWarnings("ConstantValue")
   @DisplayName("parse constructor: null input throws NPE with message")
   void constructor_whenNull_expectNullPointerException() {

--- a/src/test/java/network/crypta/support/SerializerTest.java
+++ b/src/test/java/network/crypta/support/SerializerTest.java
@@ -173,6 +173,7 @@ class SerializerTest {
   // ---------- LinkedList / list ----------
 
   @Test
+  @SuppressWarnings("JdkObsolete")
   void readListFromDataInputStream_whenLinkedListOfStrings_expectRoundTrip() throws IOException {
     LinkedList<String> list = new LinkedList<>();
     list.add("alpha");
@@ -189,6 +190,7 @@ class SerializerTest {
   }
 
   @Test
+  @SuppressWarnings("JdkObsolete")
   void readListFromDataInputStream_whenEmpty_expectEmptyList() throws IOException {
     LinkedList<String> list = new LinkedList<>();
     byte[] bytes = writeWithSerializer(list);
@@ -239,6 +241,7 @@ class SerializerTest {
   }
 
   @Test
+  @SuppressWarnings("JdkObsolete")
   void length_whenLinkedList_expectIllegalArgumentException() {
     assertThrows(IllegalArgumentException.class, () -> Serializer.length(LinkedList.class, 0));
   }

--- a/src/test/java/network/crypta/support/SimpleFieldSetTest.java
+++ b/src/test/java/network/crypta/support/SimpleFieldSetTest.java
@@ -359,7 +359,7 @@ class SimpleFieldSetTest {
       try {
         // there is no assertEquals(Double,Double) so we are obliged to do this way -_-
         assertEquals(
-            0, Double.compare((methodSFS.getDouble(Double.toString(doubles[0]))), doubles[1]));
+            0, Double.compare(methodSFS.getDouble(Double.toString(doubles[0])), doubles[1]));
         assertEquals(
             0, Double.compare(methodSFS.getDouble(Double.toString(doubles[0]), 5), doubles[1]));
       } catch (FSParseException aException) {
@@ -588,7 +588,7 @@ class SimpleFieldSetTest {
     double[] result = methodSFS.getDoubleArray(keyPrefix);
     // Assert
     for (int i = 0; i < 15; i++) {
-      assertEquals(result[i], (i), 0.0);
+      assertEquals(result[i], i, 0.0);
     }
   }
 

--- a/src/test/java/network/crypta/support/TimeUtilTest.java
+++ b/src/test/java/network/crypta/support/TimeUtilTest.java
@@ -133,6 +133,7 @@ class TimeUtilTest {
 
   /** Tests {@link TimeUtil#setTimeToZero(Date)} */
   @Test
+  @SuppressWarnings("JavaUtilDate")
   void testSetTimeToZero() {
     // Test whether zeroing doesn't happen when it needs not to.
 
@@ -283,6 +284,7 @@ class TimeUtilTest {
   }
 
   @Test
+  @SuppressWarnings("JavaUtilDate")
   void setTimeToZero_whenDefaultTzNotUtc_truncatesByUtcDay() {
     // Arrange
     TimeZone originalTz = TimeZone.getDefault();


### PR DESCRIPTION
## Summary
- clean up Error Prone warnings across main/test sources with targeted overrides, suppressions, and safer parsing/locking
- normalize locale/charset handling and minor correctness tweaks in crypto/IO/util helpers
- enforce strict class equality for DataStoreInstanceType to match test expectations

## Testing
- ./gradlew test
- ./gradlew errorproneReport