### PR TITLE
fix(errorprone): migrate Date to Instant

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientRequester.java
+++ b/src/main/java/network/crypta/client/async/ClientRequester.java
@@ -5,7 +5,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 import java.util.WeakHashMap;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.FreenetURI;
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
  *
  * @see SendableRequest
  */
-@SuppressWarnings("JavaUtilDate")
 public abstract class ClientRequester implements Serializable, ClientRequestSchedulerGroup {
   private static final Logger LOG = LoggerFactory.getLogger(ClientRequester.class);
 
@@ -222,7 +221,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
    * #getLatestSuccess()} for the precise semantics and defaulting behavior that keeps the user
    * interface sortable even before any blocks complete.
    */
-  protected Date latestSuccess = new Date();
+  protected Instant latestSuccess = Instant.now();
 
   /** Number of blocks which have failed. */
   protected int failedBlocks;
@@ -231,7 +230,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
   protected int fatallyFailedBlocks;
 
   /** Timestamp of the most recent failed or fatally failed block, if any. */
-  protected Date latestFailure = null;
+  protected Instant latestFailure = null;
 
   /** Minimum number of blocks required to succeed for success. */
   protected int minSuccessBlocks;
@@ -265,28 +264,25 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
    * newly created requests. For very old serialized data that lacks this field the method returns
    * the epoch start.
    *
-   * @return a defensive copy of the last-success timestamp; never {@code null}
+   * @return the last-success timestamp; never {@code null}
    */
-  public Date getLatestSuccess() {
-    // clone() because Date is mutable.
+  public Instant getLatestSuccess() {
     // Null-check for backwards compatibility: Old serialized versions of objects of this
     // class might not have this field yet.
-    return latestSuccess != null ? (Date) latestSuccess.clone() : new Date(0);
+    return latestSuccess != null ? latestSuccess : Instant.EPOCH;
   }
 
   /**
    * Returns the UTC timestamp of the most recent block failure or fatal failure.
    *
-   * <p>When no failure has occurred the value is {@code null}. The returned {@link Date} instance
-   * is a defensive copy because {@code Date} is mutable.
+   * <p>When no failure has occurred the value is {@code null}.
    *
-   * @return a defensive copy of the last-failure timestamp, or {@code null} when no failures
+   * @return the last-failure timestamp, or {@code null} when no failures
    */
-  public Date getLatestFailure() {
-    // clone() because Date is mutable.
+  public Instant getLatestFailure() {
     // Null-check for backwards compatibility: Old serialized versions of objects of this
     // class might not have this field yet.
-    return latestFailure != null ? (Date) latestFailure.clone() : null;
+    return latestFailure;
   }
 
   /**
@@ -299,7 +295,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
     totalBlocks = 0;
     successfulBlocks = 0;
     // See ClientRequester.getLatestSuccess() for why this defaults to current time.
-    latestSuccess = new Date();
+    latestSuccess = Instant.now();
     failedBlocks = 0;
     fatallyFailedBlocks = 0;
     latestFailure = null;
@@ -405,7 +401,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
     synchronized (this) {
       if (cancelled) return;
       successfulBlocks++;
-      latestSuccess = new Date();
+      latestSuccess = Instant.now();
     }
     if (dontNotify) return;
     notifyClients(context);
@@ -420,7 +416,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
   public void failedBlock(boolean dontNotify, ClientContext context) {
     synchronized (this) {
       failedBlocks++;
-      latestFailure = new Date();
+      latestFailure = Instant.now();
     }
     if (!dontNotify) notifyClients(context);
   }
@@ -442,7 +438,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
   public void fatallyFailedBlock(ClientContext context) {
     synchronized (this) {
       fatallyFailedBlocks++;
-      latestFailure = new Date();
+      latestFailure = Instant.now();
     }
     notifyClients(context);
   }
@@ -543,7 +539,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
     this.sentToNetwork = false;
     this.successfulBlocks = 0;
     // See ClientRequester.getLatestSuccess() for why this defaults to current time.
-    this.latestSuccess = new Date();
+    this.latestSuccess = Instant.now();
     this.totalBlocks = 0;
   }
 

--- a/src/main/java/network/crypta/client/events/SplitfileProgressEvent.java
+++ b/src/main/java/network/crypta/client/events/SplitfileProgressEvent.java
@@ -1,6 +1,6 @@
 package network.crypta.client.events;
 
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.async.ClientRequester;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +21,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Thread-safety: event instances are safely published and read-only. Consumers may freely access
  * the fields without additional synchronization, but should avoid mutating referenced values such
- * as {@link #latestSuccess} and {@link #latestFailure} (defensive copies are used on construction).
+ * as {@link #latestSuccess} and {@link #latestFailure} (immutable instants are stored on
+ * construction).
  *
  * <ul>
  *   <li>Progress accounting: {@link #succeedBlocks}, {@link #failedBlocks}, and {@link
@@ -34,7 +35,6 @@ import org.slf4j.LoggerFactory;
  * @see network.crypta.client.async.ClientGetter
  * @see network.crypta.client.async.ClientPutter
  */
-@SuppressWarnings("JavaUtilDate")
 public class SplitfileProgressEvent implements ClientEvent {
   private static final Logger LOG = LoggerFactory.getLogger(SplitfileProgressEvent.class);
 
@@ -56,11 +56,11 @@ public class SplitfileProgressEvent implements ClientEvent {
 
   /**
    * Timestamp of the latest successful block completion. When unavailable, this value is {@code
-   * null}. A defensive copy is stored to prevent external mutation.
+   * null}.
    *
    * @see ClientRequester#getLatestSuccess()
    */
-  public final Date latestSuccess;
+  public final Instant latestSuccess;
 
   /**
    * Number of blocks that have failed but may still be retried by the scheduler. Retries can
@@ -75,12 +75,11 @@ public class SplitfileProgressEvent implements ClientEvent {
   public final int fatallyFailedBlocks;
 
   /**
-   * Timestamp of the latest block failure. When unavailable, this value is {@code null}. A
-   * defensive copy is stored to prevent external mutation.
+   * Timestamp of the latest block failure. When unavailable, this value is {@code null}.
    *
    * @see ClientRequester#getLatestFailure()
    */
-  public final Date latestFailure;
+  public final Instant latestFailure;
 
   /**
    * Minimum number of fetchable blocks for the current split context. This value reflects the
@@ -101,8 +100,7 @@ public class SplitfileProgressEvent implements ClientEvent {
    * Creates a new snapshot of splitfile progress.
    *
    * <p>All counts are non-negative. Timestamp values may be {@code null} when no corresponding
-   * event has occurred. Timestamps are defensively copied to preserve immutability of the event
-   * instance.
+   * event has occurred. Instants are stored directly because they are immutable.
    *
    * @param counts numeric progress counters for the splitfile operation
    * @param timestamps latest success and failure timestamps, or {@code null} values when unknown
@@ -111,14 +109,12 @@ public class SplitfileProgressEvent implements ClientEvent {
       SplitfileProgressCounts counts, SplitfileProgressTimestamps timestamps) {
     this.totalBlocks = counts.totalBlocks();
     this.succeedBlocks = counts.succeedBlocks();
-    Date latestSuccessTimestamp = timestamps.latestSuccess();
-    this.latestSuccess =
-        latestSuccessTimestamp != null ? new Date(latestSuccessTimestamp.getTime()) : null;
+    Instant latestSuccessTimestamp = timestamps.latestSuccess();
+    this.latestSuccess = latestSuccessTimestamp;
     this.failedBlocks = counts.failedBlocks();
     this.fatallyFailedBlocks = counts.fatallyFailedBlocks();
-    Date latestFailureTimestamp = timestamps.latestFailure();
-    this.latestFailure =
-        latestFailureTimestamp != null ? new Date(latestFailureTimestamp.getTime()) : null;
+    Instant latestFailureTimestamp = timestamps.latestFailure();
+    this.latestFailure = latestFailureTimestamp;
     this.minSuccessfulBlocks = counts.minSuccessfulBlocks();
     this.finalizedTotal = counts.finalizedTotal();
     this.minSuccessFetchBlocks = counts.minSuccessFetchBlocks();
@@ -144,7 +140,7 @@ public class SplitfileProgressEvent implements ClientEvent {
     totalBlocks = 0;
     succeedBlocks = 0;
     // See ClientRequester.getLatestSuccess() for why this defaults to current time.
-    latestSuccess = new Date();
+    latestSuccess = Instant.now();
     failedBlocks = 0;
     fatallyFailedBlocks = 0;
     latestFailure = null;

--- a/src/main/java/network/crypta/client/events/SplitfileProgressTimestamps.java
+++ b/src/main/java/network/crypta/client/events/SplitfileProgressTimestamps.java
@@ -1,45 +1,40 @@
 package network.crypta.client.events;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * Captures the latest success and failure timestamps for a splitfile operation snapshot.
  *
- * <p>This record holds the most recent success and failure {@link Date} values associated with a
+ * <p>This record holds the most recent success and failure {@link Instant} values associated with a
  * splitfile fetch or insert. It is typically created alongside the splitfile progress counters and
  * passed to the corresponding progress event so consumers can display timing hints without
  * maintaining direct references to mutable timestamps. The record is immutable and therefore safe
  * to share across threads as a read-only snapshot.
  *
- * <p>The canonical constructor defensively copies the incoming {@link Date} instances. Callers may
- * pass {@code null} for either timestamp to indicate that no success or failure has occurred yet. A
+ * <p>The canonical constructor stores the incoming {@link Instant} instances. Callers may pass
+ * {@code null} for either timestamp to indicate that no success or failure has occurred yet. A
  * {@code null} value remains {@code null} in the stored snapshot, while non-null dates are copied
  * to prevent external mutation after construction.
  *
  * <ul>
  *   <li>Represents timestamps only; it does not contain counters or totals.
- *   <li>Uses {@link Date} values in milliseconds since the epoch.
+ *   <li>Uses {@link Instant} values in milliseconds since the epoch.
  *   <li>Provides a stable, read-only view of the latest known activity.
  * </ul>
  *
  * @param latestSuccess time of the most recent successful block, or {@code null} if none yet
  * @param latestFailure time of the most recent failure, or {@code null} if none yet
  */
-@SuppressWarnings("JavaUtilDate")
-public record SplitfileProgressTimestamps(Date latestSuccess, Date latestFailure) {
+public record SplitfileProgressTimestamps(Instant latestSuccess, Instant latestFailure) {
   /**
    * Creates a snapshot of the latest success and failure timestamps.
    *
-   * <p>This constructor copies the supplied {@link Date} instances to preserve immutability. It
-   * performs no validation beyond null handling and is idempotent with respect to already-copied
-   * values. Passing {@code null} for either argument leaves that component unset in the snapshot,
-   * which callers can interpret as “no event yet.”
+   * <p>This constructor stores the supplied {@link Instant} instances directly. It performs no
+   * validation beyond null handling. Passing {@code null} for either argument leaves that component
+   * unset in the snapshot, which callers can interpret as “no event yet.”
    *
    * @param latestSuccess time of the most recent successful block, or {@code null} if absent
    * @param latestFailure time of the most recent failure, or {@code null} if absent
    */
-  public SplitfileProgressTimestamps {
-    latestSuccess = latestSuccess != null ? new Date(latestSuccess.getTime()) : null;
-    latestFailure = latestFailure != null ? new Date(latestFailure.getTime()) : null;
-  }
+  public SplitfileProgressTimestamps {}
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -6,7 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Objects;
 import network.crypta.client.FetchContext;
@@ -196,8 +196,8 @@ final class ClientGetGetterFactory {
     int fatal = 0;
     int failed = 0;
     // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
-    Date latestSuccess = new Date();
-    Date latestFailure = null;
+    Instant latestSuccess = Instant.now();
+    Instant latestFailure = null;
     String identifier = snapshot.identifier();
     Persistence persistence = snapshot.persistence();
     boolean started = snapshot.started();

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -7,7 +7,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.net.MalformedURLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.DefaultMIMETypes;
@@ -723,7 +723,6 @@ public class ClientPutDir extends ClientPutBase {
   }
 
   @Override
-  @SuppressWarnings("JavaUtilDate")
   RequestStatus getStatus() {
     FreenetURI finalURI = getFinalURI();
     InsertExceptionMode failureCode = null;
@@ -739,8 +738,8 @@ public class ClientPutDir extends ClientPutBase {
     int fatal = 0;
     int failed = 0;
     // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
-    Date latestSuccess = new Date();
-    Date latestFailure = null;
+    Instant latestSuccess = Instant.now();
+    Instant latestFailure = null;
     boolean totalFinalized = false;
 
     if (progressMessage instanceof SimpleProgressMessage msg) {

--- a/src/main/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilder.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilder.java
@@ -1,7 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.io.File;
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.keys.FreenetURI;
 
@@ -17,8 +17,8 @@ import network.crypta.keys.FreenetURI;
  *
  * <p>The builder does not mutate the request. It reads the current fields, captures counts and
  * timestamps, and returns a new {@link UploadFileRequestStatus} instance that safely encapsulates
- * the snapshot. Any mutable values such as {@link Date} are either cloned by downstream types or
- * copied into immutable records, so callers can keep the result without additional synchronization.
+ * the snapshot. Timestamps are captured as {@link Instant} values so callers can keep the result
+ * without additional synchronization.
  *
  * <ul>
  *   <li>Preserves failure metadata reported by {@link PutFailedMessage} when available.
@@ -99,8 +99,8 @@ final class ClientPutStatusSnapshotBuilder {
     int fatal = 0;
     int failed = 0;
     // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
-    Date latestSuccess = new Date();
-    Date latestFailure = null;
+    Instant latestSuccess = Instant.now();
+    Instant latestFailure = null;
     boolean totalFinalized = false;
 
     if (request.progressMessage instanceof SimpleProgressMessage msg) {

--- a/src/main/java/network/crypta/clients/fcp/RequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestStatus.java
@@ -1,6 +1,6 @@
 package network.crypta.clients.fcp;
 
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
@@ -45,12 +45,12 @@ public abstract class RequestStatus {
   private int fetchedBlocks;
 
   /** Timestamp of the most recent successful block or completion event. */
-  private Date latestSuccess;
+  private Instant latestSuccess;
 
   private int fatallyFailedBlocks;
   private int failedBlocks;
   /* @see ClientRequester#latestFailure */
-  private Date latestFailure;
+  private Instant latestFailure;
   private boolean isTotalFinalized;
   private final Persistence persistence;
 
@@ -60,7 +60,7 @@ public abstract class RequestStatus {
    * @param success Did it succeed?
    */
   synchronized void setFinished(boolean success) {
-    this.latestSuccess = new Date();
+    this.latestSuccess = Instant.now();
     this.hasFinished = true;
     this.hasSucceeded = success;
     this.hasStarted = true;
@@ -70,7 +70,7 @@ public abstract class RequestStatus {
   @SuppressWarnings("SameParameterValue")
   synchronized void restart(boolean started) {
     // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
-    this.latestSuccess = new Date();
+    this.latestSuccess = Instant.now();
     this.hasFinished = false;
     this.hasSucceeded = false;
     this.hasStarted = started;
@@ -98,14 +98,10 @@ public abstract class RequestStatus {
     this.totalBlocks = snapshot.total();
     this.minBlocks = snapshot.min();
     this.fetchedBlocks = snapshot.fetched();
-    // clone() because Date is mutable
-    this.latestSuccess =
-        snapshot.latestSuccess() != null ? (Date) snapshot.latestSuccess().clone() : null;
+    this.latestSuccess = snapshot.latestSuccess();
     this.fatallyFailedBlocks = snapshot.fatal();
     this.failedBlocks = snapshot.failed();
-    // clone() because Date is mutable
-    this.latestFailure =
-        snapshot.latestFailure() != null ? (Date) snapshot.latestFailure().clone() : null;
+    this.latestFailure = snapshot.latestFailure();
     this.isTotalFinalized = snapshot.totalFinalized();
   }
 
@@ -130,10 +126,10 @@ public abstract class RequestStatus {
     this.totalBlocks = source.totalBlocks;
     this.minBlocks = source.minBlocks;
     this.fetchedBlocks = source.fetchedBlocks;
-    this.latestSuccess = source.latestSuccess != null ? (Date) source.latestSuccess.clone() : null;
+    this.latestSuccess = source.latestSuccess;
     this.fatallyFailedBlocks = source.fatallyFailedBlocks;
     this.failedBlocks = source.failedBlocks;
-    this.latestFailure = source.latestFailure != null ? (Date) source.latestFailure.clone() : null;
+    this.latestFailure = source.latestFailure;
     this.isTotalFinalized = source.isTotalFinalized;
   }
 
@@ -256,30 +252,24 @@ public abstract class RequestStatus {
    * Returns a defensive copy of the last success timestamp.
    *
    * <p>The timestamp records the moment when the most recent block, or the whole request,
-   * succeeded. A {@code null} value indicates that no successes have occurred yet. Callers receive
-   * a clone to avoid mutating internal state and may safely retain the returned {@link Date} for
-   * formatting or auditing purposes.
+   * succeeded. A {@code null} value indicates that no successes have occurred yet.
    *
-   * @return cloned {@link Date} of the last success, or {@code null} if none occurred.
+   * @return last success timestamp, or {@code null} if none occurred.
    */
-  public Date getLastSuccess() {
-    // clone() because Date is mutable.
-    return latestSuccess != null ? (Date) latestSuccess.clone() : null;
+  public Instant getLastSuccess() {
+    return latestSuccess;
   }
 
   /**
    * Returns a defensive copy of the most recent failure timestamp.
    *
    * <p>The value is updated whenever {@link #updateStatus(SplitfileProgressEvent)} records a fatal
-   * or transient failure. A {@code null} timestamp indicates a failure-free run so far. The clone
-   * is safe to retain beyond the lifespan of the status object and is suitable for logging or
-   * alerting without additional synchronization.
+   * or transient failure. A {@code null} timestamp indicates a failure-free run so far.
    *
-   * @return cloned {@link Date} representing the last failure, or {@code null} if nothing failed.
+   * @return timestamp representing the last failure, or {@code null} if nothing failed.
    */
-  public Date getLastFailure() {
-    // clone() because Date is mutable.
-    return latestFailure != null ? (Date) latestFailure.clone() : null;
+  public Instant getLastFailure() {
+    return latestFailure;
   }
 
   /**
@@ -403,11 +393,9 @@ public abstract class RequestStatus {
   public synchronized void updateStatus(SplitfileProgressEvent event) {
     this.failedBlocks = event.failedBlocks;
     this.fatallyFailedBlocks = event.fatallyFailedBlocks;
-    // clone() because Date is mutable
-    this.latestFailure = event.latestFailure != null ? (Date) event.latestFailure.clone() : null;
+    this.latestFailure = event.latestFailure;
     this.fetchedBlocks = event.succeedBlocks;
-    // clone() because Date is mutable
-    this.latestSuccess = event.latestSuccess != null ? (Date) event.latestSuccess.clone() : null;
+    this.latestSuccess = event.latestSuccess;
     this.isTotalFinalized = event.finalizedTotal;
     this.minBlocks = event.getMinSuccessfulBlocks();
     this.totalBlocks = event.totalBlocks;

--- a/src/main/java/network/crypta/clients/fcp/RequestStatusSnapshot.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestStatusSnapshot.java
@@ -1,6 +1,6 @@
 package network.crypta.clients.fcp;
 
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 
 /**
@@ -34,9 +34,9 @@ public record RequestStatusSnapshot(
     int total,
     int min,
     int fetched,
-    Date latestSuccess,
+    Instant latestSuccess,
     int fatal,
     int failed,
-    Date latestFailure,
+    Instant latestFailure,
     boolean totalFinalized,
     short priority) {}

--- a/src/main/java/network/crypta/clients/fcp/SimpleProgressMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SimpleProgressMessage.java
@@ -1,6 +1,6 @@
 package network.crypta.clients.fcp;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Objects;
 import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.node.Node;
@@ -27,7 +27,7 @@ import network.crypta.support.SimpleFieldSet;
  * <ul>
  *   <li>Identifier mapping ensures clients can correlate updates with the originating request.
  *   <li>Global flag communicates whether the request resides in the shared queue.
- *   <li>Date fields are defensively cloned to prevent callers from mutating internal state.
+ *   <li>Timestamps use {@link java.time.Instant} for immutable time snapshots.
  * </ul>
  *
  * @see SplitfileProgressEvent
@@ -107,7 +107,8 @@ public class SimpleProgressMessage extends FCPMessage {
      * limitation is addressed. */
     fs.put("Succeeded", localEvent.succeedBlocks);
     fs.put(
-        "LastProgress", localEvent.latestSuccess != null ? localEvent.latestSuccess.getTime() : 0);
+        "LastProgress",
+        localEvent.latestSuccess != null ? localEvent.latestSuccess.toEpochMilli() : 0);
     fs.put("FinalizedTotal", localEvent.finalizedTotal);
     if (localEvent.minSuccessFetchBlocks != 0)
       fs.put("MinSuccessFetchBlocks", localEvent.minSuccessFetchBlocks);
@@ -225,19 +226,14 @@ public class SimpleProgressMessage extends FCPMessage {
   /**
    * Retrieves the timestamp of the most recent successful block transfer, if any.
    *
-   * <p>The returned {@link Date} is a defensive clone of the event's {@code latestSuccess} field to
-   * prevent accidental mutation of internal state. A {@code null} value indicates that no
-   * successful completion has been recorded yet. Consumers should treat the timestamp as wall-clock
-   * time in the default timezone of the node that generated the event; no normalization is
-   * performed here.
+   * <p>A {@code null} value indicates that no successful completion has been recorded yet.
    *
-   * @return clone of the latest success timestamp, or {@code null} when no successes have occurred
-   *     for this request.
+   * @return latest success timestamp, or {@code null} when no successes have occurred for this
+   *     request.
    */
-  public Date getLatestSuccess() {
-    // clone() because Date is mutable
+  public Instant getLatestSuccess() {
     SplitfileProgressEvent localEvent = requireEvent();
-    return localEvent.latestSuccess != null ? (Date) localEvent.latestSuccess.clone() : null;
+    return localEvent.latestSuccess;
   }
 
   /**
@@ -273,18 +269,15 @@ public class SimpleProgressMessage extends FCPMessage {
   /**
    * Returns the timestamp of the most recent failure event, whether recoverable or fatal.
    *
-   * <p>The value is cloned from the underlying {@code latestFailure} field to preserve
-   * encapsulation while allowing callers to modify the returned {@link Date} safely. When no
-   * failures have occurred, {@code null} is returned. Consumers should consider pairing this value
-   * with {@link #getFailedBlocks()} or {@link #getFatalyFailedBlocks()} when diagnosing recent
-   * instability.
+   * <p>When no failures have occurred, {@code null} is returned. Consumers should consider pairing
+   * this value with {@link #getFailedBlocks()} or {@link #getFatalyFailedBlocks()} when diagnosing
+   * recent instability.
    *
-   * @return cloned timestamp of the last recorded failure, or {@code null} if none are available.
+   * @return timestamp of the last recorded failure, or {@code null} if none are available.
    */
-  public Date getLatestFailure() {
-    // clone() because Date is mutable
+  public Instant getLatestFailure() {
     SplitfileProgressEvent localEvent = requireEvent();
-    return localEvent.latestFailure != null ? (Date) localEvent.latestFailure.clone() : null;
+    return localEvent.latestFailure;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/Cookie.java
+++ b/src/main/java/network/crypta/clients/http/Cookie.java
@@ -2,7 +2,7 @@ package network.crypta.clients.http;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Set;
 import network.crypta.support.TimeUtil;
@@ -13,14 +13,14 @@ import network.crypta.support.TimeUtil;
  *
  * <p>This class encapsulates the state required to emit standards-compliant {@code Set-Cookie2}
  * headers for the web interface. Callers typically construct an instance with {@link #Cookie(URI,
- * String, String, Date)} and pass it to {@link ToadletContext#setCookie(Cookie)} to attach it to a
- * response. Validation routines enforce a conservative subset of RFC2965/RFC2616 so malformed or
+ * String, String, Instant)} and pass it to {@link ToadletContext#setCookie(Cookie)} to attach it to
+ * a response. Validation routines enforce a conservative subset of RFC2965/RFC2616 so malformed or
  * potentially dangerous values are rejected early. Instances are mutable only by subclasses (all
  * fields are {@code protected}); typical callers treat them as single-use values assembled on a
  * per-response basis.
  *
  * <p>Cookies produced here use version {@code 1}, default to discard-on-close, and expect absolute
- * paths with optional domains limited to HTTP(S) schemes. Date handling uses {@link
+ * paths with optional domains limited to HTTP(S) schemes. Timestamp handling uses {@link
  * TimeUtil#makeHTTPDate(long)} to format expiration timestamps in HTTP-date format. This class is
  * not thread-safe; create and use instances on the request-handling thread. It deliberately avoids
  * client-side storage concerns and focuses solely on producing outbound header strings suitable for
@@ -37,7 +37,6 @@ import network.crypta.support.TimeUtil;
  *
  * @author xor (xor@freenetproject.org)
  */
-@SuppressWarnings("JavaUtilDate")
 public class Cookie {
   /** Characters that must not appear unquoted in cookie values (based on RFC2616 separators). */
   private static final Set<Character> INVALID_VALUE_CHARACTERS =
@@ -88,9 +87,9 @@ public class Cookie {
 
   /**
    * Expiration timestamp interpreted in the GMT HTTP-date format during header serialization;
-   * callers provide an absolute {@link Date} in the future.
+   * callers provide an absolute {@link Instant} in the future.
    */
-  protected Date expirationDate;
+  protected Instant expirationDate;
 
   /**
    * Indicates whether the cookie should be discarded when the user agent session ends; defaults to
@@ -115,12 +114,12 @@ public class Cookie {
    *     names such as {@code domain} or {@code secure}.
    * @param myValue Payload to send to the client; may be {@code null} to request an empty cookie
    *     value and must avoid control characters and separator tokens.
-   * @param myExpirationDate Absolute expiration moment in the future; dates in the past cause an
+   * @param myExpirationDate Absolute expiration moment in the future; instants in the past cause an
    *     {@link IllegalArgumentException} during validation.
    * @throws IllegalArgumentException If any attribute violates RFC-inspired validation rules or the
    *     expiration time is not in the future.
    */
-  public Cookie(URI myPath, String myName, String myValue, Date myExpirationDate) {
+  public Cookie(URI myPath, String myName, String myValue, Instant myExpirationDate) {
     version = 1;
 
     domain = null;
@@ -368,14 +367,13 @@ public class Cookie {
    * {@link IllegalArgumentException}. Callers should compute the desired lifetime before invoking
    * this method to avoid partially constructed cookies.
    *
-   * @param expirationDate Absolute expiration {@link Date}; must represent a time after the current
-   *     system clock value.
-   * @return The same {@link Date} instance when valid; callers retain ownership of the mutable
-   *     object.
+   * @param expirationDate Absolute expiration {@link Instant}; must represent a time after the
+   *     current system clock value.
+   * @return The same {@link Instant} instance when valid; callers retain ownership of the value.
    * @throws IllegalArgumentException If the supplied date is in the past or exactly now.
    */
-  public static Date validateExpirationDate(Date expirationDate) {
-    if (new Date().after(expirationDate))
+  public static Instant validateExpirationDate(Instant expirationDate) {
+    if (Instant.now().isAfter(expirationDate))
       throw new IllegalArgumentException("Illegal expiration date, is in past: " + expirationDate);
 
     return expirationDate;
@@ -461,7 +459,7 @@ public class Cookie {
     sb.append(';');
 
     sb.append("expires=");
-    sb.append(TimeUtil.makeHTTPDate(expirationDate.getTime()));
+    sb.append(TimeUtil.makeHTTPDate(expirationDate.toEpochMilli()));
     sb.append(';');
 
     if (discard) {

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -13,9 +13,9 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -1217,7 +1217,6 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       context.writeData(data);
     }
 
-    @SuppressWarnings("JavaUtilDate")
     private void sendRangeOrFullResponse(
         ToadletContext context,
         BucketFactory bucketFactory,
@@ -1266,7 +1265,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
       retHdr.put(HEADER_X_CONTENT_TYPE_OPTIONS, NOSNIFF);
       if (container.enableCachingForChkAndSskKeys() && (key.isCHK() || key.isSSK())) {
-        context.sendReplyHeadersStatic(200, "OK", retHdr, mimeType, size, new Date());
+        context.sendReplyHeadersStatic(200, "OK", retHdr, mimeType, size, Instant.now());
       } else {
         context.sendReplyHeadersFProxy(200, "OK", retHdr, mimeType, size);
       }

--- a/src/main/java/network/crypta/clients/http/ImageCreatorToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ImageCreatorToadlet.java
@@ -9,8 +9,8 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
-import java.sql.Date;
 import java.text.ParseException;
+import java.time.Instant;
 import javax.imageio.ImageIO;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.support.MultiValueTable;
@@ -71,7 +71,7 @@ public class ImageCreatorToadlet extends Toadlet {
    * <p>Update this value whenever the rendering behavior or resource output changes so browsers can
    * correctly invalidate cached responses and fetch a fresh image.
    */
-  protected static final Date LAST_MODIFIED = new Date(1593361729000L);
+  protected static final Instant LAST_MODIFIED = Instant.ofEpochMilli(1593361729000L);
 
   private static final String WIDTH_PARAM = "width";
   private static final String HEIGHT_PARAM = "height";
@@ -194,9 +194,10 @@ public class ImageCreatorToadlet extends Toadlet {
       throws ToadletContextClosedException, IOException {
     if (ctx.getHeaders().containsKey("if-modified-since")) {
       try {
-        if (ToadletContextImpl.parseHTTPDate(ctx.getHeaders().getFirst("if-modified-since"))
-                .compareTo(LAST_MODIFIED)
-            == 0) {
+        Instant ifModifiedSince =
+            ToadletContextImpl.parseHTTPDate(ctx.getHeaders().getFirst("if-modified-since"))
+                .toInstant();
+        if (ifModifiedSince.equals(LAST_MODIFIED)) {
           ctx.sendReplyHeadersStatic(304, "Not Modified", null, "image/png", 0, LAST_MODIFIED);
           return true;
         }

--- a/src/main/java/network/crypta/clients/http/PproxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/PproxyToadlet.java
@@ -6,10 +6,13 @@ import java.io.File;
 import java.io.IOException;
 import java.net.SocketException;
 import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -55,6 +58,9 @@ import org.slf4j.LoggerFactory;
  * HTTPRequest, ToadletContext)} for each request.
  */
 public class PproxyToadlet extends Toadlet {
+  private static final DateTimeFormatter PLUGIN_STARTED_FORMATTER =
+      DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US)
+          .withZone(ZoneId.systemDefault());
   private static final Logger LOG = LoggerFactory.getLogger(PproxyToadlet.class);
   private static final String KEY_PLUGINS = "plugins";
   private static final String PATH_SEPARATOR = "/";
@@ -704,7 +710,8 @@ public class PproxyToadlet extends Toadlet {
     pluginRow.addChild("td", formatPluginVersion(pluginInfo));
     if (advancedMode) {
       pluginRow.addChild("td", pluginInfo.getThreadName());
-      pluginRow.addChild("td", new Date(pluginInfo.getStarted()).toString());
+      pluginRow.addChild(
+          "td", PLUGIN_STARTED_FORMATTER.format(Instant.ofEpochMilli(pluginInfo.getStarted())));
     }
     if (pluginInfo.isStopping()) {
       addStoppingCells(pluginRow);

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -16,10 +16,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -4092,30 +4092,29 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
    * @param lastActivity The last activity of the request
    * @return The created table cell HTML node
    */
-  @SuppressWarnings("JavaUtilDate")
-  private HTMLNode createLastActivityCell(long now, Date lastActivity) {
+  private HTMLNode createLastActivityCell(long now, Instant lastActivity) {
     HTMLNode lastActivityCell = new HTMLNode("td", ATTR_CLASS, "request-last-activity");
     if (lastActivity == null) {
       // During normal operation, the lastActivity will never be null even if there was no
-      // activity yet. It will default to the Date when the request was added. (See
+      // activity yet. It will default to the timestamp when the request was added. (See
       // ClientRequester.getLatestSuccess() for the usability motivation behind that.)
       // lastActivity can, however, be null if the user had been using a pre-release of
-      // purge-db4o which did not store the lastActivity Date to the database yet.
+      // purge-db4o which did not store the lastActivity timestamp to the database yet.
       // Thus, we initialize to "unknown" instead of "never" to stress that there was possibly
-      // activity, but we cannot know because the Date was not stored yet.
+      // activity, but we cannot know because the timestamp was not stored yet.
       lastActivityCell.addChild("i", l10n("lastActivity.unknown"));
     } else {
       lastActivityCell.addChild(
-          "#", l10n("lastActivity.ago", "time", TimeUtil.formatTime(now - lastActivity.getTime())));
+          "#",
+          l10n("lastActivity.ago", "time", TimeUtil.formatTime(now - lastActivity.toEpochMilli())));
     }
     return lastActivityCell;
   }
 
   /**
-   * @see #createLastActivityCell(long, Date)
+   * @see #createLastActivityCell(long, Instant)
    */
-  @SuppressWarnings("JavaUtilDate")
-  private HTMLNode createLastFailureCell(long now, Date lastFailure) {
+  private HTMLNode createLastFailureCell(long now, Instant lastFailure) {
     HTMLNode lastFailureCell = new HTMLNode("td", ATTR_CLASS, "request-last-failure");
     if (lastFailure == null) {
       // This is "never" instead of "unknown" because the backend of RequestStatus uses null
@@ -4123,7 +4122,8 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       lastFailureCell.addChild("i", l10n("lastFailure.never"));
     } else {
       lastFailureCell.addChild(
-          "#", l10n("lastFailure.ago", "time", TimeUtil.formatTime(now - lastFailure.getTime())));
+          "#",
+          l10n("lastFailure.ago", "time", TimeUtil.formatTime(now - lastFailure.toEpochMilli())));
     }
     return lastFailureCell;
   }

--- a/src/main/java/network/crypta/clients/http/SessionManager.java
+++ b/src/main/java/network/crypta/clients/http/SessionManager.java
@@ -5,7 +5,7 @@ import static java.util.concurrent.TimeUnit.HOURS;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -454,7 +454,7 @@ public final class SessionManager {
             mCookiePath,
             mCookieName,
             session.getID().toString(),
-            new Date(session.getExpirationTime())));
+            Instant.ofEpochMilli(session.getExpirationTime())));
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/StaticToadlet.java
+++ b/src/main/java/network/crypta/clients/http/StaticToadlet.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.DefaultMIMETypes;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.api.Bucket;
@@ -132,17 +132,16 @@ public class StaticToadlet extends Toadlet {
    * resources from the JAR, or possibly from a file in some setups, so we check the modification
    * time of the JAR for resources in a jar and the mtime for files.
    */
-  @SuppressWarnings("JavaUtilDate")
-  private Date getUrlMTime(URL url) {
+  private Instant getUrlMTime(URL url) {
     if (url == null) {
       return null;
     }
     if (url.getProtocol().equals("jar")) {
       File f = new File(url.getPath().substring(0, url.getPath().indexOf('!')));
-      return new Date(f.lastModified());
+      return Instant.ofEpochMilli(f.lastModified());
     } else if (url.getProtocol().equals("file")) {
       File f = new File(url.getPath());
-      return new Date(f.lastModified());
+      return Instant.ofEpochMilli(f.lastModified());
     } else {
       return null;
     }
@@ -199,7 +198,7 @@ public class StaticToadlet extends Toadlet {
     return !path.matches("^[A-Za-z0-9._/\\-]*$") || path.contains("..");
   }
 
-  @SuppressWarnings({"java:S2095", "JavaUtilDate"})
+  @SuppressWarnings("java:S2095")
   private void serveOverride(String path, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     File overrideFile = this.container.getOverrideFile();
@@ -238,7 +237,7 @@ public class StaticToadlet extends Toadlet {
           null,
           DefaultMIMETypes.guessMIMEType(path, false),
           fb.size(),
-          new Date(System.currentTimeMillis() - 1000)); // Already expired, we want it to reload it.
+          Instant.now().minusMillis(1000)); // Already expired, we want it to reload it.
       handedOff = true;
       ctx.writeData(fb);
     } catch (IOException _) {
@@ -270,7 +269,7 @@ public class StaticToadlet extends Toadlet {
     }
 
     URL url = getClass().getResource(ROOT_PATH + path);
-    Date mTime = getUrlMTime(url);
+    Instant mTime = getUrlMTime(url);
 
     ctx.sendReplyHeadersStatic(
         200, "OK", null, DefaultMIMETypes.guessMIMEType(path, false), data.size(), mTime);

--- a/src/main/java/network/crypta/clients/http/ToadletContext.java
+++ b/src/main/java/network/crypta/clients/http/ToadletContext.java
@@ -3,7 +3,7 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.net.URI;
 import java.text.ParseException;
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.node.useralerts.UserAlertManager;
@@ -103,7 +103,7 @@ public interface ToadletContext {
       MultiValueTable<String, String> mvt,
       String mimeType,
       long length,
-      Date mTime)
+      Instant mTime)
       throws ToadletContextClosedException, IOException;
 
   /**

--- a/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -348,7 +349,7 @@ public class ToadletContextImpl implements ToadletContext {
       MultiValueTable<String, String> mvt,
       String mimeType,
       long contentLength,
-      Date mTime)
+      Instant mTime)
       throws ToadletContextClosedException, IOException {
     if (mTime == null) throw new IllegalArgumentException();
     ReplyHeaders replyHeaders = ReplyHeaders.of(replyCode, replyDescription, mimeType, mvt);
@@ -683,7 +684,7 @@ public class ToadletContextImpl implements ToadletContext {
     String lastModString =
         options.modifiedTime() == null
             ? nowString
-            : TimeUtil.makeHTTPDate(options.modifiedTime().getTime());
+            : TimeUtil.makeHTTPDate(options.modifiedTime().toEpochMilli());
 
     mvt.put("last-modified", lastModString);
     mvt.put("date", nowString);
@@ -719,7 +720,7 @@ public class ToadletContextImpl implements ToadletContext {
     sockOutputStream.write(buf.toString().getBytes(StandardCharsets.US_ASCII));
   }
 
-  private static void addCachingHeaders(MultiValueTable<String, String> mvt, Date mTime) {
+  private static void addCachingHeaders(MultiValueTable<String, String> mvt, Instant mTime) {
     boolean allowCaching = mTime != null;
     String expiresTime;
     String cacheControl;
@@ -1468,7 +1469,7 @@ public class ToadletContextImpl implements ToadletContext {
  */
 record ReplyHeaderOptions(
     long contentLength,
-    Date modifiedTime,
+    Instant modifiedTime,
     boolean disconnect,
     boolean allowScripts,
     boolean allowFrames) {}

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -7,9 +7,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import network.crypta.client.async.USKCallback;
 import network.crypta.client.async.USKFoundEdition;
 import network.crypta.clients.http.FProxyToadlet;
@@ -186,9 +189,12 @@ public class BookmarkManager implements RequestClient {
    *
    * <p>This operation is additive: it does not remove or overwrite existing user bookmarks.
    */
-  @SuppressWarnings("JavaUtilDate")
   public void reAddDefaultBookmarks() {
-    BookmarkCategory bc = new BookmarkCategory(l10n("defaultBookmarks") + " - " + new Date());
+    DateTimeFormatter formatter =
+        DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US)
+            .withZone(ZoneId.systemDefault());
+    BookmarkCategory bc =
+        new BookmarkCategory(l10n("defaultBookmarks") + " - " + formatter.format(Instant.now()));
     addBookmark("/", bc);
     innerReadBookmarks("/", bc, DEFAULT_BOOKMARKS);
   }

--- a/src/main/java/network/crypta/crypt/SSL.java
+++ b/src/main/java/network/crypta/crypt/SSL.java
@@ -19,7 +19,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.Date;
+import java.time.Instant;
 import javax.net.ServerSocketFactory;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -386,11 +386,16 @@ public class SSL {
     // Build a certificate.
     X500Name issuer = new X500Name("CN=" + CERTIFICATE_CN + ", OU=" + CERTIFICATE_OU);
     BigInteger serial = BigInteger.valueOf(System.currentTimeMillis());
-    Date notBefore = new Date(System.currentTimeMillis());
-    Date notAfter = new Date(System.currentTimeMillis() + CERTIFICATE_LIFETIME * 1000);
+    Instant notBefore = Instant.now();
+    Instant notAfter = notBefore.plusSeconds(CERTIFICATE_LIFETIME);
     JcaX509v3CertificateBuilder certBuilder =
         new JcaX509v3CertificateBuilder(
-            issuer, serial, notBefore, notAfter, issuer, keyPair.getPublic());
+            issuer,
+            serial,
+            java.util.Date.from(notBefore),
+            java.util.Date.from(notAfter),
+            issuer,
+            keyPair.getPublic());
     certBuilder.addExtension(
         Extension.extendedKeyUsage, true, new ExtendedKeyUsage(KeyPurposeId.id_kp_timeStamping));
 

--- a/src/main/java/network/crypta/node/LocationManager.java
+++ b/src/main/java/network/crypta/node/LocationManager.java
@@ -15,25 +15,25 @@ import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.MessageDigest;
-import java.text.DateFormat;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TimeZone;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClient;
@@ -1169,7 +1169,6 @@ public class LocationManager implements ByteCounter {
     if (log) recordLocChange(randomReset, fromDupLocation);
   }
 
-  @SuppressWarnings("JavaUtilDate")
   private void recordLocChange(final boolean randomReset, final boolean fromDupLocation) {
     node.network()
         .executor()
@@ -1186,14 +1185,21 @@ public class LocationManager implements ByteCounter {
               try (FileOutputStream os = new FileOutputStream(locationLog, true);
                   BufferedWriter bw =
                       new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.ISO_8859_1))) {
-                DateFormat df = DateFormat.getDateTimeInstance();
-                df.setTimeZone(TimeZone.getTimeZone("GMT"));
+                DateTimeFormatter formatter =
+                    DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
+                        .withLocale(Locale.getDefault())
+                        .withZone(ZoneOffset.UTC);
                 String suffix = "";
                 if (randomReset) {
                   suffix =
                       " (random reset" + (fromDupLocation ? " from duplicated location" : "") + ")";
                 }
-                bw.write(df.format(new Date()) + " : " + getLocation() + suffix + '\n');
+                bw.write(
+                    formatter.format(Instant.now(systemClockUTC))
+                        + " : "
+                        + getLocation()
+                        + suffix
+                        + '\n');
               } catch (IOException e) {
                 LOG.error("Unable to write changed location to {} : {}", locationLog, e, e);
               }

--- a/src/main/java/network/crypta/node/PeerNodeReferenceSupport.java
+++ b/src/main/java/network/crypta/node/PeerNodeReferenceSupport.java
@@ -120,7 +120,7 @@ final class PeerNodeReferenceSupport {
     if (sfs == null) {
       GregorianCalendar gc = new GregorianCalendar(2013, Calendar.JULY, 20);
       gc.setTimeZone(TimeZone.getTimeZone("GMT"));
-      throw new PeerTooOldException("No ECC support", 1449, gc.getTime());
+      throw new PeerTooOldException("No ECC support", 1449, gc.toInstant());
     }
     byte[] pub;
     try {

--- a/src/main/java/network/crypta/node/PeerTooOldException.java
+++ b/src/main/java/network/crypta/node/PeerTooOldException.java
@@ -1,7 +1,7 @@
 package network.crypta.node;
 
 import java.io.Serial;
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * Exception indicating that a remote peer was rejected because its software build is older than the
@@ -26,7 +26,7 @@ public class PeerTooOldException extends Exception {
    * Peer-reported build date. May be {@code null} when the date is unknown or not provided by the
    * remote peer.
    */
-  public final Date buildDate;
+  public final Instant buildDate;
 
   /**
    * Constructs a new exception with contextual details about the outdated remote peer.
@@ -35,7 +35,7 @@ public class PeerTooOldException extends Exception {
    * @param build peer-reported build number
    * @param d peer-reported build date; may be {@code null} if unavailable
    */
-  public PeerTooOldException(final String reason, final int build, final Date d) {
+  public PeerTooOldException(final String reason, final int build, final Instant d) {
     super("Peer too old: " + reason + " from " + build + " at " + d);
     this.buildDate = d;
     this.buildNumber = build;

--- a/src/main/java/network/crypta/node/useralerts/DroppedOldPeersUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/DroppedOldPeersUserAlert.java
@@ -1,9 +1,12 @@
 package network.crypta.node.useralerts;
 
 import java.io.File;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.FeedMessage;
 import network.crypta.l10n.NodeL10n;
@@ -39,9 +42,13 @@ public class DroppedOldPeersUserAlert implements UserAlert {
   private static final String KEY_BUILD_NUMBER = "buildNumber";
   private static final String KEY_BUILD_DATE = "buildDate";
 
+  private static final DateTimeFormatter BUILD_DATE_FORMATTER =
+      DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US)
+          .withZone(ZoneId.systemDefault());
+
   private final List<String> droppedOldPeers;
   private int droppedOldPeersBuild;
-  private Date droppedOldPeersDate;
+  private Instant droppedOldPeersDate;
   private final File peersBrokenFile;
   private final long creationTime;
 
@@ -60,7 +67,7 @@ public class DroppedOldPeersUserAlert implements UserAlert {
     this.peersBrokenFile = droppedPeersFile;
     creationTime = System.currentTimeMillis();
     this.droppedOldPeersBuild = 0;
-    this.droppedOldPeersDate = new Date();
+    this.droppedOldPeersDate = Instant.now();
   }
 
   /**
@@ -120,7 +127,7 @@ public class DroppedOldPeersUserAlert implements UserAlert {
         new String[] {
           "" + droppedOldPeers.size(),
           "" + droppedOldPeersBuild,
-          droppedOldPeersDate.toString(),
+          formatBuildDate(droppedOldPeersDate),
           peersBrokenFile.toString()
         };
     return l10n("droppingOldFriendFull", keys, values);
@@ -141,7 +148,7 @@ public class DroppedOldPeersUserAlert implements UserAlert {
         new String[] {
           "" + droppedOldPeers.size(),
           "" + droppedOldPeersBuild,
-          droppedOldPeersDate.toString(),
+          formatBuildDate(droppedOldPeersDate),
           peersBrokenFile.toString()
         };
     return l10n("droppingOldFriendTitle", keys, values);
@@ -306,9 +313,13 @@ public class DroppedOldPeersUserAlert implements UserAlert {
         new String[] {
           Integer.toString(droppedOldPeers.size()),
           Integer.toString(e.buildNumber),
-          e.buildDate.toString(),
+          formatBuildDate(e.buildDate),
           peersBrokenFile.getPath()
         };
     return l10n("droppingOldFriendTitle", keys, values);
+  }
+
+  private static String formatBuildDate(Instant buildDate) {
+    return BUILD_DATE_FORMATTER.format(buildDate);
   }
 }

--- a/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
@@ -1,8 +1,11 @@
 package network.crypta.node.useralerts;
 
 import java.lang.ref.WeakReference;
-import java.text.DateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Locale;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.N2NFeedMessageParams;
 import network.crypta.clients.fcp.TextFeedMessage;
@@ -43,6 +46,10 @@ import network.crypta.support.HTMLNode;
  */
 public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessageUserAlert {
   private static final String L10N_PREFIX = "N2NTMUserAlert.";
+  private static final DateTimeFormatter MESSAGE_TIME_FORMATTER =
+      DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
+          .withLocale(Locale.getDefault())
+          .withZone(ZoneId.systemDefault());
   private final WeakReference<PeerContext> peerRef;
   private final String messageText;
   private final int fileNumber;
@@ -120,8 +127,8 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
    * Returns a localized text body that includes metadata (from/sent/received times) followed by the
    * raw message text.
    *
-   * <p>Date values are formatted with the environment {@link DateFormat} in the current locale.
-   * Newlines embedded in the original message are preserved in the returned string.
+   * <p>Date values are formatted with the environment locale in the current timezone. Newlines
+   * embedded in the original message are preserved in the returned string.
    *
    * @return the full plain-text message body including a localized header; never {@code null}
    */
@@ -132,9 +139,9 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
             new String[] {"from", "composed", "sent", "received"},
             new String[] {
               sourceNodeName,
-              DateFormat.getInstance().format(new Date(composedTime)),
-              DateFormat.getInstance().format(new Date(sentTime)),
-              DateFormat.getInstance().format(new Date(receivedTime))
+              formatTimestamp(composedTime),
+              formatTimestamp(sentTime),
+              formatTimestamp(receivedTime)
             })
         + ": "
         + messageText;
@@ -169,9 +176,9 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
             new String[] {"from", "composed", "sent", "received"},
             new String[] {
               sourceNodeName,
-              DateFormat.getInstance().format(new Date(composedTime)),
-              DateFormat.getInstance().format(new Date(sentTime)),
-              DateFormat.getInstance().format(new Date(receivedTime))
+              formatTimestamp(composedTime),
+              formatTimestamp(sentTime),
+              formatTimestamp(receivedTime)
             }));
     String[] lines = messageText.split("\n");
     for (int i = 0, c = lines.length; i < c; i++) {
@@ -203,6 +210,10 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
 
   private String l10n(String key, String[] patterns, String[] values) {
     return NodeL10n.getBase().getString(L10N_PREFIX + key, patterns, values);
+  }
+
+  private static String formatTimestamp(long epochMillis) {
+    return MESSAGE_TIME_FORMATTER.format(Instant.ofEpochMilli(epochMillis));
   }
 
   /**

--- a/src/main/java/network/crypta/pluginmanager/PluginInfoWrapper.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginInfoWrapper.java
@@ -2,8 +2,11 @@ package network.crypta.pluginmanager;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
+import java.util.Locale;
 import network.crypta.clients.http.ConfigToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.FilePersistentConfig;
@@ -42,6 +45,9 @@ import org.slf4j.LoggerFactory;
  */
 public class PluginInfoWrapper implements Comparable<PluginInfoWrapper> {
   private static final Logger LOG = LoggerFactory.getLogger(PluginInfoWrapper.class);
+  private static final DateTimeFormatter STARTED_FORMATTER =
+      DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US)
+          .withZone(ZoneId.systemDefault());
 
   private final String className;
   private Thread thread;
@@ -159,7 +165,12 @@ public class PluginInfoWrapper implements Comparable<PluginInfoWrapper> {
    */
   @Override
   public String toString() {
-    return "ID: \"" + threadName + "\", Name: " + className + ", Started: " + new Date(start);
+    return "ID: \""
+        + threadName
+        + "\", Name: "
+        + className
+        + ", Started: "
+        + STARTED_FORMATTER.format(Instant.ofEpochMilli(start));
   }
 
   /**

--- a/src/main/java/network/crypta/support/Fields.java
+++ b/src/main/java/network/crypta/support/Fields.java
@@ -1,15 +1,14 @@
 package network.crypta.support;
 
 import java.nio.ByteBuffer;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.StringTokenizer;
-import java.util.TimeZone;
 import network.crypta.config.Dimension;
 import network.crypta.l10n.NodeL10n;
 import org.slf4j.Logger;
@@ -71,6 +70,9 @@ public abstract class Fields {
   private static final String[] MULTIPLES_2 = {
     "k", "K", "m", "M", "g", "G", "t", "T", "p", "P", "e", "E"
   };
+
+  private static final DateTimeFormatter SEC_TO_DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyyMMdd-HH:mm:ss").withZone(ZoneOffset.UTC);
 
   // IEC size suffix helpers are implemented without a regex to avoid ReDoS risks.
 
@@ -421,11 +423,8 @@ public abstract class Fields {
    * @param time seconds since 1970-01-01T00:00:00Z.
    * @return formatted timestamp in GMT.
    */
-  @SuppressWarnings("JavaUtilDate")
   public static String secToDateTime(long time) {
-    DateFormat f = new SimpleDateFormat("yyyyMMdd-HH:mm:ss");
-    f.setTimeZone(TimeZone.getTimeZone("GMT"));
-    String dateString = f.format(new Date(time * 1000));
+    String dateString = SEC_TO_DATE_TIME_FORMATTER.format(Instant.ofEpochSecond(time));
 
     if (dateString.endsWith("-00:00:00")) {
       dateString = dateString.substring(0, 8);
@@ -1406,13 +1405,12 @@ public abstract class Fields {
    *
    * @param a first date or {@code null}.
    * @param b second date or {@code null}.
-   * @return the result of {@link Date#compareTo(Date)} on normalized values.
+   * @return the result of {@link Instant#compareTo(Instant)} on normalized values.
    */
-  @SuppressWarnings("JavaUtilDate")
-  public static int compare(Date a, Date b) {
-    // Normalize nulls to epoch so Date#compareTo can be used safely.
-    a = (a != null ? a : new Date(0));
-    b = (b != null ? b : new Date(0));
+  public static int compare(Instant a, Instant b) {
+    // Normalize nulls to epoch so Instant#compareTo can be used safely.
+    a = (a != null ? a : Instant.EPOCH);
+    b = (b != null ? b : Instant.EPOCH);
     return a.compareTo(b);
   }
 

--- a/src/main/java/network/crypta/support/TimeUtil.java
+++ b/src/main/java/network/crypta/support/TimeUtil.java
@@ -11,7 +11,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -27,7 +26,7 @@ import java.util.regex.Pattern;
  *   <li>Parse a human-friendly interval string (e.g., {@code 2h30m15.250s}) into milliseconds with
  *       overflow saturation.
  *   <li>Create RFC&nbsp;1123 timestamps suitable for HTTP headers.
- *   <li>Truncate a {@link java.util.Date} to the start of its UTC day.
+ *   <li>Truncate an {@link Instant} to the start of its UTC day.
  * </ul>
  *
  * <p>The class is stateless and thread-safe.
@@ -283,14 +282,14 @@ public class TimeUtil {
   /**
    * Truncates a date to the start of its UTC day.
    *
-   * <p>Returns a new {@link Date} representing the same instant rounded down to {@code
+   * <p>Returns a new {@link Instant} representing the same instant rounded down to {@code
    * 00:00:00.000} in UTC for that day.
    *
-   * @param date the input date, not {@code null}
-   * @return a new {@link Date} aligned to the UTC day boundary
-   * @throws NullPointerException if {@code date} is {@code null}
+   * @param instant the input instant, not {@code null}
+   * @return a new {@link Instant} aligned to the UTC day boundary
+   * @throws NullPointerException if {@code instant} is {@code null}
    */
-  public static Date setTimeToZero(final Date date) {
-    return Date.from(date.toInstant().truncatedTo(ChronoUnit.DAYS));
+  public static Instant setTimeToZero(final Instant instant) {
+    return instant.truncatedTo(ChronoUnit.DAYS);
   }
 }

--- a/src/test/java/network/crypta/client/events/SplitfileProgressEventTest.java
+++ b/src/test/java/network/crypta/client/events/SplitfileProgressEventTest.java
@@ -7,13 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Date;
+import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 class SplitfileProgressEventTest {
 
   @Test
@@ -29,27 +29,23 @@ class SplitfileProgressEventTest {
   }
 
   @Test
-  void constructor_whenDatesProvided_makesDefensiveCopies() {
-    Date success = new Date(1_000_000L);
-    Date failure = new Date(2_000_000L);
+  void constructor_whenInstantsProvided_storesValues() {
+    Instant success = Instant.ofEpochMilli(1_000_000L);
+    Instant failure = Instant.ofEpochMilli(2_000_000L);
 
     SplitfileProgressEvent event =
         new SplitfileProgressEvent(
             new SplitfileProgressCounts(1, 0, 0, 0, 1, 0, false),
             new SplitfileProgressTimestamps(success, failure));
 
-    // Mutate the original inputs after construction
-    success.setTime(9_999_999L);
-    failure.setTime(8_888_888L);
-
     assertNotNull(event.latestSuccess);
     assertNotNull(event.latestFailure);
-    assertEquals(1_000_000L, event.latestSuccess.getTime(), "latestSuccess must be copied");
-    assertEquals(2_000_000L, event.latestFailure.getTime(), "latestFailure must be copied");
+    assertEquals(success, event.latestSuccess, "latestSuccess must match input");
+    assertEquals(failure, event.latestFailure, "latestFailure must match input");
   }
 
   @Test
-  void constructor_whenNullDatesProvided_storesNulls() {
+  void constructor_whenNullTimestampsProvided_storesNulls() {
     SplitfileProgressEvent event =
         new SplitfileProgressEvent(
             new SplitfileProgressCounts(0, 0, 0, 0, 1, 0, false),

--- a/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
@@ -40,7 +40,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class ClientGetEventHandlingTest {
   private static final String CLIENT_FIELD = "client";
@@ -386,7 +386,7 @@ class ClientGetEventHandlingTest {
   private static SplitfileProgressEvent newProgressEvent() {
     return new SplitfileProgressEvent(
         new SplitfileProgressCounts(10, 2, 1, 0, 10, 10, true),
-        new SplitfileProgressTimestamps(new Date(0L), new Date(0L)));
+        new SplitfileProgressTimestamps(Instant.EPOCH, Instant.EPOCH));
   }
 
   private static HashResult newSha256Hash() {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetMessageReplayTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetMessageReplayTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
@@ -32,7 +32,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class ClientGetMessageReplayTest {
 
@@ -49,7 +49,7 @@ class ClientGetMessageReplayTest {
     PersistentRequestClient client = root.getGlobalForeverClient();
     FreenetURI uri = new FreenetURI("SSK@");
     SplitfileProgressCounts counts = new SplitfileProgressCounts(10, 5, 1, 0, 5, 5, true);
-    SplitfileProgressTimestamps timestamps = new SplitfileProgressTimestamps(new Date(0), null);
+    SplitfileProgressTimestamps timestamps = new SplitfileProgressTimestamps(Instant.EPOCH, null);
     SimpleProgressMessage progressMessage =
         new SimpleProgressMessage("req-1", true, new SplitfileProgressEvent(counts, timestamps));
     HashResult[] hashes = {new HashResult(HashType.SHA256, new byte[32])};

--- a/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class ClientGetTest {
 
@@ -77,7 +77,8 @@ class ClientGetTest {
     SplitfileProgressEvent event =
         new SplitfileProgressEvent(
             new SplitfileProgressCounts(10, 7, 2, 1, 8, 5, true),
-            new SplitfileProgressTimestamps(new Date(1_000L), new Date(2_000L)));
+            new SplitfileProgressTimestamps(
+                Instant.ofEpochMilli(1_000L), Instant.ofEpochMilli(2_000L)));
     SimpleProgressMessage progress = new SimpleProgressMessage("req", false, event);
     setField(clientGet, "progressPending", progress);
 

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Field;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.InsertException;
@@ -33,7 +33,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 class ClientPutDirTest {
 
   @Mock private PersistentRequestClient persistentRequestClient;
@@ -104,7 +104,8 @@ class ClientPutDirTest {
     SplitfileProgressEvent event =
         new SplitfileProgressEvent(
             new SplitfileProgressCounts(50, 10, 4, 2, 20, 5, true),
-            new SplitfileProgressTimestamps(new Date(1000), new Date(2000)));
+            new SplitfileProgressTimestamps(
+                Instant.ofEpochMilli(1000), Instant.ofEpochMilli(2000)));
     setField(
         ClientPutBase.class,
         putDir,

--- a/src/test/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilderTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilderTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContextOptions;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings({"java:S100", "java:S3011", "JavaUtilDate"})
+@SuppressWarnings({"java:S100", "java:S3011"})
 class ClientPutStatusSnapshotBuilderTest {
   private static final String VALID_CHK =
       "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,"
@@ -85,8 +85,8 @@ class ClientPutStatusSnapshotBuilderTest {
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     when(bucket.size()).thenReturn(42L);
     InsertContext context = new InsertContext(InsertContextOptions.builder().build());
-    Date success = new Date(1000L);
-    Date failure = new Date(2000L);
+    Instant success = Instant.ofEpochMilli(1000L);
+    Instant failure = Instant.ofEpochMilli(2000L);
     SplitfileProgressCounts counts = new SplitfileProgressCounts(10, 3, 2, 1, 5, 0, true);
     SplitfileProgressTimestamps timestamps = new SplitfileProgressTimestamps(success, failure);
     SplitfileProgressEvent event = new SplitfileProgressEvent(counts, timestamps);

--- a/src/test/java/network/crypta/clients/fcp/DownloadRequestStatusTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DownloadRequestStatusTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class DownloadRequestStatusTest {
 
@@ -216,7 +216,7 @@ class DownloadRequestStatusTest {
             10,
             5,
             3,
-            new Date(0L),
+            Instant.EPOCH,
             0,
             0,
             null,

--- a/src/test/java/network/crypta/clients/fcp/SimpleProgressMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SimpleProgressMessageTest.java
@@ -1,24 +1,23 @@
 package network.crypta.clients.fcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 class SimpleProgressMessageTest {
 
   private static final String IDENTIFIER = "req-123";
-  private static final Date SUCCESS_TIME = new Date(1_700_000_000_000L);
-  private static final Date FAILURE_TIME = new Date(1_700_000_100_000L);
+  private static final Instant SUCCESS_TIME = Instant.ofEpochMilli(1_700_000_000_000L);
+  private static final Instant FAILURE_TIME = Instant.ofEpochMilli(1_700_000_100_000L);
 
   @Test
   void getFieldSet_whenMinSuccessFetchZero_excludesOptionalField() {
@@ -35,7 +34,7 @@ class SimpleProgressMessageTest {
     assertEquals("2", fieldSet.get("Failed"));
     assertEquals("1", fieldSet.get("FatallyFailed"));
     assertEquals("4", fieldSet.get("Succeeded"));
-    assertEquals(Long.toString(SUCCESS_TIME.getTime()), fieldSet.get("LastProgress"));
+    assertEquals(Long.toString(SUCCESS_TIME.toEpochMilli()), fieldSet.get("LastProgress"));
     assertEquals("true", fieldSet.get("FinalizedTotal"));
     assertEquals(IDENTIFIER, fieldSet.get("Identifier"));
     assertEquals("true", fieldSet.get("Global"));
@@ -87,33 +86,25 @@ class SimpleProgressMessageTest {
   }
 
   @Test
-  void getLatestSuccess_whenModified_doesNotAffectStoredValue() {
+  void getLatestSuccess_whenRead_matchesEventValue() {
     SplitfileProgressEvent event =
         new SplitfileProgressEvent(
             new SplitfileProgressCounts(5, 3, 0, 0, 4, 0, false),
             new SplitfileProgressTimestamps(SUCCESS_TIME, null));
     SimpleProgressMessage message = new SimpleProgressMessage(IDENTIFIER, false, event);
 
-    Date returned = message.getLatestSuccess();
-    returned.setTime(42L);
-
-    assertNotSame(event.latestSuccess, returned);
-    assertEquals(SUCCESS_TIME.getTime(), message.getLatestSuccess().getTime());
+    assertEquals(SUCCESS_TIME, message.getLatestSuccess());
   }
 
   @Test
-  void getLatestFailure_whenModified_doesNotAffectStoredValue() {
+  void getLatestFailure_whenRead_matchesEventValue() {
     SplitfileProgressEvent event =
         new SplitfileProgressEvent(
             new SplitfileProgressCounts(5, 3, 0, 1, 4, 0, false),
             new SplitfileProgressTimestamps(SUCCESS_TIME, FAILURE_TIME));
     SimpleProgressMessage message = new SimpleProgressMessage(IDENTIFIER, false, event);
 
-    Date returned = message.getLatestFailure();
-    returned.setTime(84L);
-
-    assertNotSame(event.latestFailure, returned);
-    assertEquals(FAILURE_TIME.getTime(), message.getLatestFailure().getTime());
+    assertEquals(FAILURE_TIME, message.getLatestFailure());
   }
 
   @Test
@@ -130,8 +121,8 @@ class SimpleProgressMessageTest {
     assertEquals(9, message.getFetchedBlocks());
     assertEquals(2, message.getFailedBlocks());
     assertEquals(1, message.getFatalyFailedBlocks());
-    assertEquals(FAILURE_TIME.getTime(), message.getLatestFailure().getTime());
-    assertEquals(SUCCESS_TIME.getTime(), message.getLatestSuccess().getTime());
+    assertEquals(FAILURE_TIME, message.getLatestFailure());
+    assertEquals(SUCCESS_TIME, message.getLatestSuccess());
     assertTrue(message.isTotalFinalized());
     assertEquals("SimpleProgress", message.getName());
   }

--- a/src/test/java/network/crypta/clients/fcp/UploadDirRequestStatusTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UploadDirRequestStatusTest.java
@@ -3,17 +3,17 @@ package network.crypta.clients.fcp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 class UploadDirRequestStatusTest {
 
-  private static final Date SUCCESS_DATE = new Date(5_000L);
-  private static final Date FAILURE_DATE = new Date(10_000L);
+  private static final Instant SUCCESS_DATE = Instant.ofEpochMilli(5_000L);
+  private static final Instant FAILURE_DATE = Instant.ofEpochMilli(10_000L);
 
   @Test
   void constructor_whenInitialized_preservesDirectoryMetadata() {

--- a/src/test/java/network/crypta/clients/fcp/UploadFileRequestStatusTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UploadFileRequestStatusTest.java
@@ -6,18 +6,18 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.File;
-import java.util.Date;
+import java.time.Instant;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 class UploadFileRequestStatusTest {
 
-  private static final Date SUCCESS_DATE = new Date(1_000L);
-  private static final Date FAILURE_DATE = new Date(2_000L);
+  private static final Instant SUCCESS_DATE = Instant.ofEpochMilli(1_000L);
+  private static final Instant FAILURE_DATE = Instant.ofEpochMilli(2_000L);
 
   @Test
   void constructor_whenInitialized_preservesProvidedMetadata() {

--- a/src/test/java/network/crypta/clients/http/CookieTest.java
+++ b/src/test/java/network/crypta/clients/http/CookieTest.java
@@ -8,18 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.time.Instant;
-import java.util.Date;
 import network.crypta.support.TimeUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings({"java:S100", "JavaUtilDate"})
+@SuppressWarnings("java:S100")
 class CookieTest {
 
   private static final URI VALID_PATH = URI.create("/Freetalk");
   private static final String VALID_NAME = "SessionID";
   private static final String VALID_VALUE = "abCd12345";
-  private static final Date FUTURE_DATE = Date.from(Instant.parse("2099-01-01T00:00:00Z"));
+  private static final Instant FUTURE_DATE = Instant.parse("2099-01-01T00:00:00Z");
 
   private Cookie cookie;
 
@@ -118,14 +117,14 @@ class CookieTest {
 
   @Test
   void validateExpirationDate_withFutureDate_expectSameInstance() {
-    Date validated = Cookie.validateExpirationDate(FUTURE_DATE);
+    Instant validated = Cookie.validateExpirationDate(FUTURE_DATE);
 
     assertEquals(FUTURE_DATE, validated);
   }
 
   @Test
   void validateExpirationDate_withPastDate_expectException() {
-    Date past = Date.from(Instant.parse("2020-01-01T00:00:00Z"));
+    Instant past = Instant.parse("2020-01-01T00:00:00Z");
 
     assertThrows(IllegalArgumentException.class, () -> Cookie.validateExpirationDate(past));
   }
@@ -195,7 +194,7 @@ class CookieTest {
   @Test
   void encodeToHeaderValue_includesAllAttributesInOrder() {
     String encoded = cookie.encodeToHeaderValue();
-    String expectedExpires = TimeUtil.makeHTTPDate(FUTURE_DATE.getTime());
+    String expectedExpires = TimeUtil.makeHTTPDate(FUTURE_DATE.toEpochMilli());
 
     assertTrue(encoded.startsWith("sessionid=" + VALID_VALUE + ";version=1;"));
     assertTrue(encoded.contains("path=" + VALID_PATH + ";"));

--- a/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.time.Instant;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
@@ -246,7 +247,7 @@ class FileInsertWizardToadletTest {
         MultiValueTable<String, String> mvt,
         String mimeType,
         long length,
-        java.util.Date mTime) {
+        Instant mTime) {
       this.statusCode = code;
     }
 

--- a/src/test/java/network/crypta/clients/http/HTTPRequestImplTest.java
+++ b/src/test/java/network/crypta/clients/http/HTTPRequestImplTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -217,7 +218,7 @@ class HTTPRequestImplTest {
           MultiValueTable<String, String> mvt,
           String mimeType,
           long length,
-          java.util.Date mTime) {
+          Instant mTime) {
         throw new UnsupportedOperationException();
       }
 

--- a/src/test/java/network/crypta/clients/http/ImageCreatorToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ImageCreatorToadletTest.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import java.util.TimeZone;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
@@ -94,9 +94,10 @@ class ImageCreatorToadletTest {
   @Test
   void handleMethodGET_whenIfModifiedSinceMatches_sendsNotModified() throws Exception {
     MultiValueTable<String, String> headers = new MultiValueTable<>();
-    SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US);
-    sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-    headers.put("if-modified-since", sdf.format(ImageCreatorToadlet.LAST_MODIFIED));
+    DateTimeFormatter formatter =
+        DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US)
+            .withZone(ZoneOffset.UTC);
+    headers.put("if-modified-since", formatter.format(ImageCreatorToadlet.LAST_MODIFIED));
     when(ctx.getHeaders()).thenReturn(headers);
 
     toadlet.handleMethodGET(new URI("/imagecreator/"), request, ctx);

--- a/src/test/java/network/crypta/clients/http/StaticToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/StaticToadletTest.java
@@ -25,7 +25,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Objects;
 import network.crypta.client.DefaultMIMETypes;
 import network.crypta.l10n.NodeL10n;
@@ -102,14 +102,13 @@ class StaticToadletTest {
   }
 
   @Test
-  @SuppressWarnings("JavaUtilDate")
   void handleMethodGET_whenResourceExists_streamsFromClasspath() throws Exception {
     URL resourceUrl =
         Objects.requireNonNull(
             StaticToadlet.class.getResource(StaticToadlet.ROOT_PATH + "base.css"));
     Path resourcePath = Path.of(resourceUrl.toURI());
     byte[] expectedBytes = Files.readAllBytes(resourcePath);
-    Date expectedMtime = new Date(resourcePath.toFile().lastModified());
+    Instant expectedMtime = Instant.ofEpochMilli(resourcePath.toFile().lastModified());
 
     InMemoryBucketFactory bucketFactory = new InMemoryBucketFactory();
     when(ctx.getBucketFactory()).thenReturn(bucketFactory);
@@ -126,7 +125,7 @@ class StaticToadletTest {
     RandomAccessBucket writtenBucket = bucketFactory.lastCreated;
     assertEquals(expectedBytes.length, writtenBucket.size());
 
-    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+    ArgumentCaptor<Instant> dateCaptor = ArgumentCaptor.forClass(Instant.class);
     ArgumentCaptor<Long> lengthCaptor = ArgumentCaptor.forClass(Long.class);
     ArgumentCaptor<String> mimeCaptor = ArgumentCaptor.forClass(String.class);
 
@@ -177,7 +176,7 @@ class StaticToadletTest {
             isNull(),
             eq(DefaultMIMETypes.guessMIMEType("custom.txt", false)),
             eq(overrideFile.toFile().length()),
-            any(Date.class));
+            any(Instant.class));
     verify(ctx).writeData(any(Bucket.class));
     assertNull(toadlet.lastError());
   }

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -11,8 +11,8 @@ import java.net.Socket;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -68,10 +68,9 @@ class ToadletContextImplTest {
   }
 
   @Test
-  @SuppressWarnings("JavaUtilDate")
   void parseHTTPDate_whenValidString_parsesEpoch() throws Exception {
-    Date parsed = ToadletContextImpl.parseHTTPDate("Thu, 01 Jan 1970 00:00:00 GMT");
-    assertEquals(0L, parsed.getTime());
+    Instant parsed = ToadletContextImpl.parseHTTPDate("Thu, 01 Jan 1970 00:00:00 GMT").toInstant();
+    assertEquals(Instant.EPOCH, parsed);
   }
 
   @Test
@@ -154,10 +153,9 @@ class ToadletContextImplTest {
   }
 
   @Test
-  @SuppressWarnings("JavaUtilDate")
   void sendReplyHeaders_withModifiedTime_allowsCachingAndScripts() throws Exception {
     MultiValueTable<String, String> headers = new MultiValueTable<>();
-    Date modified = new Date(0L);
+    Instant modified = Instant.EPOCH;
 
     ReplyHeaders replyHeaders = ReplyHeaders.of(200, "OK", "text/html", headers);
     ReplyHeaderOptions options = new ReplyHeaderOptions(5, modified, false, true, true);
@@ -168,9 +166,9 @@ class ToadletContextImplTest {
     assertEquals("keep-alive", parsed.get("connection").getFirst());
     assertEquals("text/html; charset=UTF-8", parsed.get("content-type").getFirst());
     assertTrue(parsed.get("cache-control").getFirst().startsWith("public"));
-    assertEquals(
-        ToadletContextImpl.parseHTTPDate(parsed.get("last-modified").getFirst()).getTime(),
-        modified.getTime());
+    Instant lastModified =
+        ToadletContextImpl.parseHTTPDate(parsed.get("last-modified").getFirst()).toInstant();
+    assertEquals(modified, lastModified);
     String csp = parsed.get("content-security-policy").getFirst();
     assertTrue(csp.contains("frame-src 'self'"));
     assertTrue(csp.contains("unsafe-inline"));

--- a/src/test/java/network/crypta/node/useralerts/DroppedOldPeersUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/DroppedOldPeersUserAlertTest.java
@@ -8,8 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.time.Instant;
-import java.util.Date;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.PeerTooOldException;
@@ -22,7 +24,6 @@ import org.junit.jupiter.api.io.TempDir;
 class DroppedOldPeersUserAlertTest {
 
   @Test
-  @SuppressWarnings("JavaUtilDate")
   void isEmpty_whenNoAdds_expectTrueAndAfterAddFalse(@TempDir java.nio.file.Path tmp) {
     // Arrange
     DroppedOldPeersUserAlert alert =
@@ -32,7 +33,7 @@ class DroppedOldPeersUserAlertTest {
     assertTrue(alert.isEmpty());
 
     // Act
-    alert.add(new PeerTooOldException("old", 1, new Date(0)), "Alice");
+    alert.add(new PeerTooOldException("old", 1, Instant.EPOCH), "Alice");
 
     // Assert
     assertFalse(alert.isEmpty());
@@ -43,8 +44,8 @@ class DroppedOldPeersUserAlertTest {
     // Arrange
     File peersFile = tmp.resolve("dropped-peers.lst").toFile();
     DroppedOldPeersUserAlert alert = new DroppedOldPeersUserAlert(peersFile);
-    Date d1 = Date.from(Instant.ofEpochSecond(1_000));
-    Date d2 = Date.from(Instant.ofEpochSecond(2_000));
+    Instant d1 = Instant.ofEpochSecond(1_000);
+    Instant d2 = Instant.ofEpochSecond(2_000);
 
     // Act: add a named and an unnamed (null) peer
     alert.add(new PeerTooOldException("too old", 5, d1), "Alice");
@@ -88,13 +89,12 @@ class DroppedOldPeersUserAlertTest {
   }
 
   @Test
-  @SuppressWarnings("JavaUtilDate")
   void getTitle_whenMultipleBuilds_expectBuildDateFromMaxBuild(@TempDir java.nio.file.Path tmp) {
     // Arrange
     DroppedOldPeersUserAlert alert =
         new DroppedOldPeersUserAlert(tmp.resolve("peers.txt").toFile());
-    Date older = new Date(1_000L);
-    Date newer = new Date(2_000L);
+    Instant older = Instant.ofEpochMilli(1_000L);
+    Instant newer = Instant.ofEpochMilli(2_000L);
 
     // Act: first smaller build (should not win), then larger build (should win)
     alert.add(new PeerTooOldException("x", 1, newer), "P1");
@@ -102,27 +102,29 @@ class DroppedOldPeersUserAlertTest {
 
     // Assert: title includes the date string of the max buildNumber entry (older)
     String title = alert.getTitle();
-    assertTrue(title.contains(older.toString()));
+    String expectedDate =
+        DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US)
+            .withZone(ZoneId.systemDefault())
+            .format(older);
+    assertTrue(title.contains(expectedDate));
   }
 
   @Test
-  @SuppressWarnings("JavaUtilDate")
   void getShortText_whenCalled_expectSameAsTitle(@TempDir java.nio.file.Path tmp) {
     // Arrange
     DroppedOldPeersUserAlert alert = new DroppedOldPeersUserAlert(tmp.resolve("p.txt").toFile());
-    alert.add(new PeerTooOldException("r", 7, new Date(0)), "N");
+    alert.add(new PeerTooOldException("r", 7, Instant.EPOCH), "N");
 
     // Act + Assert
     assertEquals(alert.getTitle(), alert.getShortText());
   }
 
   @Test
-  @SuppressWarnings("JavaUtilDate")
   void getFCPMessage_whenBuilt_expectFieldsMatchAlert(@TempDir java.nio.file.Path tmp) {
     // Arrange
     DroppedOldPeersUserAlert alert =
         new DroppedOldPeersUserAlert(tmp.resolve("peers.bin").toFile());
-    alert.add(new PeerTooOldException("r", 42, new Date(1234)), "Zed");
+    alert.add(new PeerTooOldException("r", 42, Instant.ofEpochMilli(1234)), "Zed");
 
     // Act
     FCPMessage msg = alert.getFCPMessage();

--- a/src/test/java/network/crypta/support/FieldsTest.java
+++ b/src/test/java/network/crypta/support/FieldsTest.java
@@ -9,10 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Locale;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -622,9 +622,8 @@ class FieldsTest {
   }
 
   @Test
-  @SuppressWarnings("JavaUtilDate")
-  void compareDate_whenNulls_expectZeroAndOrdering() {
-    Date now = new Date();
+  void compareInstant_whenNulls_expectZeroAndOrdering() {
+    Instant now = Instant.now();
     assertEquals(0, Fields.compare(null, null));
     assertEquals(-1, Fields.compare(null, now));
     assertEquals(1, Fields.compare(now, null));

--- a/src/test/java/network/crypta/support/TimeUtilTest.java
+++ b/src/test/java/network/crypta/support/TimeUtilTest.java
@@ -2,12 +2,10 @@ package network.crypta.support;
 
 import static java.util.Calendar.MILLISECOND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -131,9 +129,8 @@ class TimeUtilTest {
     assertThrows(IllegalArgumentException.class, () -> TimeUtil.formatTime(oneForTermLong, 7));
   }
 
-  /** Tests {@link TimeUtil#setTimeToZero(Date)} */
+  /** Tests {@link TimeUtil#setTimeToZero(Instant)} */
   @Test
-  @SuppressWarnings("JavaUtilDate")
   void testSetTimeToZero() {
     // Test whether zeroing doesn't happen when it needs not to.
 
@@ -141,30 +138,23 @@ class TimeUtilTest {
     c.set(2015, Calendar.JANUARY, 1, 0, 0, 0);
     c.set(MILLISECOND, 0);
 
-    Date original = c.getTime();
-    Date zeroed = TimeUtil.setTimeToZero(original);
+    Instant original = c.toInstant();
+    Instant zeroed = TimeUtil.setTimeToZero(original);
 
     assertEquals(original, zeroed);
-    // Date objects are mutable so their recycling is discouraged, check for it
-    assertNotSame(original, zeroed);
-
     // Test whether zeroing happens when it should.
 
     c.set(2014, Calendar.DECEMBER, 31, 23, 59, 59);
     c.set(MILLISECOND, 999);
-    original = c.getTime();
-    Date originalBackup = (Date) original.clone();
+    original = c.toInstant();
 
     c.set(2014, Calendar.DECEMBER, 31, 0, 0, 0);
     c.set(MILLISECOND, 0);
-    Date expected = c.getTime();
+    Instant expected = c.toInstant();
 
     zeroed = TimeUtil.setTimeToZero(original);
 
     assertEquals(expected, zeroed);
-    assertNotSame(original, zeroed);
-    // Check for bogus tampering with original object
-    assertEquals(originalBackup, original);
   }
 
   @Test
@@ -284,7 +274,6 @@ class TimeUtilTest {
   }
 
   @Test
-  @SuppressWarnings("JavaUtilDate")
   void setTimeToZero_whenDefaultTzNotUtc_truncatesByUtcDay() {
     // Arrange
     TimeZone originalTz = TimeZone.getDefault();
@@ -293,18 +282,17 @@ class TimeUtilTest {
       GregorianCalendar c = new GregorianCalendar(TimeZone.getTimeZone("America/Los_Angeles"));
       c.set(2021, Calendar.JULY, 10, 8, 15, 30);
       c.set(MILLISECOND, 123);
-      Date original = c.getTime();
+      Instant original = c.toInstant();
 
       // Compute expected UTC midnight by flooring epoch millis to day length
-      long expectedMs = (original.getTime() / 86_400_000L) * 86_400_000L;
-      Date expected = new Date(expectedMs);
+      long expectedMs = (original.toEpochMilli() / 86_400_000L) * 86_400_000L;
+      Instant expected = Instant.ofEpochMilli(expectedMs);
 
       // Act
-      Date zeroed = TimeUtil.setTimeToZero(original);
+      Instant zeroed = TimeUtil.setTimeToZero(original);
 
       // Assert
       assertEquals(expected, zeroed);
-      assertNotSame(original, zeroed);
     } finally {
       TimeZone.setDefault(originalTz);
     }


### PR DESCRIPTION
## Summary
- replace java.util.Date timestamps with java.time.Instant across request progress/status and HTTP caching paths to clear JavaUtilDate warnings
- update time formatting for alerts, bookmarks, plugin listings, and SSL certificate validity where Date is still required
- align tests and toadlet context stubs with the Instant-based APIs

## Testing
- `./gradlew test`