### PR TITLE
chore(ci): bump action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,21 +33,21 @@ jobs:
       artifact-id: ${{ steps.upload-artifact.outputs.artifact-id}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: crypta-network/cryptad
           ref: ${{ inputs.git-ref }}
           fetch-depth: 0 # Required for Sonar analysis accuracy
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ inputs.jdk-version }}
           distribution: 'temurin'
 
       # Cache SonarQube packages to speed up analysis
       - name: Cache SonarQube packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -56,7 +56,7 @@ jobs:
       # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
       # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build and analyze (Gradle)
         if: ${{ env.SONAR_TOKEN != '' }}
@@ -73,13 +73,13 @@ jobs:
 
       - name: Upload cryptad.jar
         id: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cryptad
           path: build/libs/cryptad.jar
 
       - name: Upload jlink tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cryptad-jlink
           path: build/distributions/cryptad-jlink-v*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -35,4 +35,4 @@ jobs:
       # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
       # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
       - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v4
+        uses: gradle/actions/dependency-submission@v5

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: '${{ matrix.os }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Wrapper validation
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v5
 
       - name: Speedup dpkg
         run: sudo sh -c "echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/force-unsafe-io"
@@ -32,7 +32,7 @@ jobs:
           sudo chmod o+rwx ~/.gradle
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           cache: 'gradle'
           distribution: '${{ matrix.distribution }}'
@@ -59,7 +59,7 @@ jobs:
           cp ../freenet*.deb ./
 
       - name: Provide Debian Package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: debian-package
           path: freenet_*.deb


### PR DESCRIPTION
## Summary
- Bump GitHub Actions to current major releases across CI/build/package workflows.
- Update Gradle actions for setup, dependency submission, and wrapper validation.
- Keep workflow tooling aligned with supported versions.

## Testing
- Not run (workflow changes only)