### PR TITLE
fix(errorprone): clean warning patterns

### DIFF
--- a/src/main/java/network/crypta/client/ArchiveManager.java
+++ b/src/main/java/network/crypta/client/ArchiveManager.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringTokenizer;
 import java.util.zip.GZIPInputStream;
 import network.crypta.client.async.ClientContext;
 import network.crypta.keys.FreenetURI;
@@ -74,16 +75,16 @@ public class ArchiveManager {
     /** ZIP archives; common MIME aliases are supported. */
     ZIP(
         (short) 0,
-        new String[] {
-          "application/zip", "application/x-zip"
-        }), /* eventually get rid of ZIP support at some point */
+        mimeTypes(
+            "application/zip",
+            "application/x-zip")), /* eventually get rid of ZIP support at some point */
     /** TAR archives; a standard TAR MIME type is supported. */
-    TAR((short) 1, new String[] {"application/x-tar"});
+    TAR((short) 1, mimeTypes("application/x-tar"));
 
     /** Stable numeric identifier for this type used in serialized metadata and messages. */
     public final short metadataID;
 
-    private final String[] mimeTypes;
+    private final String mimeTypes;
 
     /** Cached values(). Never modify or pass this array to outside code! */
     private static final ARCHIVE_TYPE[] values = values();
@@ -94,9 +95,16 @@ public class ArchiveManager {
      * @param metadataID stable, persisted identifier for this archive type
      * @param mimeTypes recognized MIME aliases, compared case-insensitively
      */
-    ARCHIVE_TYPE(short metadataID, String[] mimeTypes) {
+    ARCHIVE_TYPE(short metadataID, String mimeTypes) {
       this.metadataID = metadataID;
       this.mimeTypes = mimeTypes;
+    }
+
+    private static String mimeTypes(String... values) {
+      if (values.length == 0) {
+        return "";
+      }
+      return String.join(",", values);
     }
 
     /**
@@ -118,8 +126,7 @@ public class ArchiveManager {
      * @return {@code true} if the MIME maps to one of the supported types; else {@code false}
      */
     public static boolean isUsableArchiveType(String type) {
-      for (ARCHIVE_TYPE current : values)
-        for (String ctype : current.mimeTypes) if (ctype.equalsIgnoreCase(type)) return true;
+      for (ARCHIVE_TYPE current : values) if (current.matchesMimeType(type)) return true;
       return false;
     }
 
@@ -130,8 +137,7 @@ public class ArchiveManager {
      * @return matching {@link ARCHIVE_TYPE}, or {@code null} if unsupported
      */
     public static ARCHIVE_TYPE getArchiveType(String type) {
-      for (ARCHIVE_TYPE current : values)
-        for (String ctype : current.mimeTypes) if (ctype.equalsIgnoreCase(type)) return current;
+      for (ARCHIVE_TYPE current : values) if (current.matchesMimeType(type)) return current;
       return null;
     }
 
@@ -161,7 +167,19 @@ public class ArchiveManager {
      * @return non-null MIME string suitable for labelling responses
      */
     public String defaultMimeType() {
-      return mimeTypes[0];
+      int commaIndex = mimeTypes.indexOf(',');
+      return commaIndex == -1 ? mimeTypes : mimeTypes.substring(0, commaIndex);
+    }
+
+    private boolean matchesMimeType(String type) {
+      if (type == null) return false;
+      StringTokenizer tokenizer = new StringTokenizer(mimeTypes, ",");
+      while (tokenizer.hasMoreTokens()) {
+        if (tokenizer.nextToken().equalsIgnoreCase(type)) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 

--- a/src/main/java/network/crypta/client/FetchContext.java
+++ b/src/main/java/network/crypta/client/FetchContext.java
@@ -1116,9 +1116,7 @@ public class FetchContext implements Serializable {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    FetchContext other = (FetchContext) obj;
+    if (!(obj instanceof FetchContext other)) return false;
     // eventProducer is ignored.
     if (allowSplitfiles != other.allowSplitfiles) return false;
     if (allowedMIMETypes == null) {

--- a/src/main/java/network/crypta/client/InsertContext.java
+++ b/src/main/java/network/crypta/client/InsertContext.java
@@ -483,9 +483,7 @@ public class InsertContext implements Serializable {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    InsertContext other = (InsertContext) obj;
+    if (!(obj instanceof InsertContext other)) return false;
     if (canWriteClientCache != other.canWriteClientCache) return false;
     if (compatibilityMode != other.compatibilityMode) return false;
     if (compressorDescriptor == null) {

--- a/src/main/java/network/crypta/client/async/BinaryBlob.java
+++ b/src/main/java/network/crypta/client/async/BinaryBlob.java
@@ -191,19 +191,21 @@ public final class BinaryBlob {
       short blobVer = dis.readShort();
 
       switch (blobType) {
-        case BLOB_END:
+        case BLOB_END -> {
           dis.close();
           return;
-        case BLOB_BLOCK:
+        }
+        case BLOB_BLOCK -> {
           KeyBlock block = readBlock(dis, blobLength, blobVer);
           blocks.add(block);
-          break;
-        default:
+        }
+        default -> {
           if (tolerant) {
             FileUtil.skipFully(dis, blobLength);
           } else {
             throw new BinaryBlobFormatException("Unknown blob type: " + blobType);
           }
+        }
       }
     }
   }

--- a/src/main/java/network/crypta/client/async/BinaryBlobInserter.java
+++ b/src/main/java/network/crypta/client/async/BinaryBlobInserter.java
@@ -222,24 +222,18 @@ public class BinaryBlobInserter implements ClientPutState {
         return;
       }
       switch (e.code) {
-        case LowLevelPutException.COLLISION:
-          fail(false, context);
-          break;
-        case LowLevelPutException.INTERNAL_ERROR:
-          errors.inc(InsertExceptionMode.INTERNAL_ERROR);
-          break;
-        case LowLevelPutException.REJECTED_OVERLOAD:
-          errors.inc(InsertExceptionMode.REJECTED_OVERLOAD);
-          break;
-        case LowLevelPutException.ROUTE_NOT_FOUND:
-          errors.inc(InsertExceptionMode.ROUTE_NOT_FOUND);
-          break;
-        case LowLevelPutException.ROUTE_REALLY_NOT_FOUND:
-          errors.inc(InsertExceptionMode.ROUTE_REALLY_NOT_FOUND);
-          break;
-        default:
+        case LowLevelPutException.COLLISION -> fail(false, context);
+        case LowLevelPutException.INTERNAL_ERROR -> errors.inc(InsertExceptionMode.INTERNAL_ERROR);
+        case LowLevelPutException.REJECTED_OVERLOAD ->
+            errors.inc(InsertExceptionMode.REJECTED_OVERLOAD);
+        case LowLevelPutException.ROUTE_NOT_FOUND ->
+            errors.inc(InsertExceptionMode.ROUTE_NOT_FOUND);
+        case LowLevelPutException.ROUTE_REALLY_NOT_FOUND ->
+            errors.inc(InsertExceptionMode.ROUTE_REALLY_NOT_FOUND);
+        default -> {
           LOG.error("Unknown LowLevelPutException code: {}", e.code);
           errors.inc(InsertExceptionMode.INTERNAL_ERROR);
+        }
       }
       if (e.code == LowLevelPutException.ROUTE_NOT_FOUND) {
         consecutiveRNFs++;

--- a/src/main/java/network/crypta/client/async/BlockInsertPayload.java
+++ b/src/main/java/network/crypta/client/async/BlockInsertPayload.java
@@ -16,23 +16,71 @@ import org.jetbrains.annotations.NotNull;
  *
  * <p>The {@code cryptoKey} array is stored by reference and compared by content for equality. Avoid
  * mutating it after construction if you rely on stable equality or hash semantics.
- *
- * @param data source bucket containing the bytes to insert; must remain readable during encoding
- * @param uri target URI that determines the key type (e.g., CHK/SSK/USK)
- * @param compressionCodec compression codec identifier; {@code -1} lets the encoder decide
- * @param isMetadata whether the content should be encoded as metadata
- * @param sourceLength uncompressed source length in bytes, or {@code -1} if unknown
- * @param cryptoAlgorithm identifier for optional per-block cryptography; {@code 0} for none
- * @param cryptoKey raw key material for {@code cryptoAlgorithm}; may be {@code null} when unused
  */
-public record BlockInsertPayload(
-    Bucket data,
-    FreenetURI uri,
-    short compressionCodec,
-    boolean isMetadata,
-    int sourceLength,
-    byte cryptoAlgorithm,
-    byte[] cryptoKey) {
+public final class BlockInsertPayload {
+  private final Bucket data;
+  private final FreenetURI uri;
+  private final short compressionCodec;
+  private final boolean isMetadata;
+  private final int sourceLength;
+  private final byte cryptoAlgorithm;
+  private final byte[] cryptoKey;
+
+  /**
+   * Creates a bundle describing a single block insert payload.
+   *
+   * @param data source bucket containing the bytes to insert; must remain readable during encoding
+   * @param uri target URI that determines the key type (e.g., CHK/SSK/USK)
+   * @param compressionCodec compression codec identifier; {@code -1} lets the encoder decide
+   * @param isMetadata whether the content should be encoded as metadata
+   * @param sourceLength uncompressed source length in bytes, or {@code -1} if unknown
+   * @param cryptoAlgorithm identifier for optional per-block cryptography; {@code 0} for none
+   * @param cryptoKey raw key material for {@code cryptoAlgorithm}; may be {@code null} when unused
+   */
+  public BlockInsertPayload(
+      Bucket data,
+      FreenetURI uri,
+      short compressionCodec,
+      boolean isMetadata,
+      int sourceLength,
+      byte cryptoAlgorithm,
+      byte[] cryptoKey) {
+    this.data = data;
+    this.uri = uri;
+    this.compressionCodec = compressionCodec;
+    this.isMetadata = isMetadata;
+    this.sourceLength = sourceLength;
+    this.cryptoAlgorithm = cryptoAlgorithm;
+    this.cryptoKey = cryptoKey;
+  }
+
+  public Bucket data() {
+    return data;
+  }
+
+  public FreenetURI uri() {
+    return uri;
+  }
+
+  public short compressionCodec() {
+    return compressionCodec;
+  }
+
+  public boolean isMetadata() {
+    return isMetadata;
+  }
+
+  public int sourceLength() {
+    return sourceLength;
+  }
+
+  public byte cryptoAlgorithm() {
+    return cryptoAlgorithm;
+  }
+
+  public byte[] cryptoKey() {
+    return cryptoKey;
+  }
 
   /**
    * Compares this payload to another for structural equality, including array contents.
@@ -43,23 +91,14 @@ public record BlockInsertPayload(
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o
-        instanceof
-        BlockInsertPayload(
-            Bucket otherData,
-            FreenetURI otherUri,
-            short otherCompressionCodec,
-            boolean otherIsMetadata,
-            int otherSourceLength,
-            byte otherCryptoAlgorithm,
-            byte[] otherCryptoKey))) return false;
-    return compressionCodec == otherCompressionCodec
-        && isMetadata == otherIsMetadata
-        && sourceLength == otherSourceLength
-        && cryptoAlgorithm == otherCryptoAlgorithm
-        && Objects.equals(data, otherData)
-        && Objects.equals(uri, otherUri)
-        && Arrays.equals(cryptoKey, otherCryptoKey);
+    if (!(o instanceof BlockInsertPayload other)) return false;
+    return compressionCodec == other.compressionCodec
+        && isMetadata == other.isMetadata
+        && sourceLength == other.sourceLength
+        && cryptoAlgorithm == other.cryptoAlgorithm
+        && Objects.equals(data, other.data)
+        && Objects.equals(uri, other.uri)
+        && Arrays.equals(cryptoKey, other.cryptoKey);
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/ChosenBlockImpl.java
+++ b/src/main/java/network/crypta/client/async/ChosenBlockImpl.java
@@ -139,7 +139,7 @@ public class ChosenBlockImpl extends ChosenBlock {
               try {
                 ((SendableInsert) request).onFailure(e, token, context1);
               } finally {
-                sched.removeRunningInsert((SendableInsert) (request), token.getKey());
+                sched.removeRunningInsert((SendableInsert) request, token.getKey());
                 // Something might be waiting for a request to complete (e.g. if we have two
                 // requests for the same key),
                 // so wake the starter thread.
@@ -168,7 +168,7 @@ public class ChosenBlockImpl extends ChosenBlock {
               try {
                 ((SendableInsert) request).onSuccess(token, key, context1);
               } finally {
-                sched.removeRunningInsert((SendableInsert) (request), token.getKey());
+                sched.removeRunningInsert((SendableInsert) request, token.getKey());
               }
               // Something might be waiting for a request to complete (e.g. if we have two
               // requests for the same key),

--- a/src/main/java/network/crypta/client/async/CompatibilityAnalyser.java
+++ b/src/main/java/network/crypta/client/async/CompatibilityAnalyser.java
@@ -125,9 +125,8 @@ public class CompatibilityAnalyser implements Serializable {
     }
     if (definitive) this.definitive = true;
     if (!dontCompress) this.dontCompress = false;
-    if (min.ordinal() > this.min.ordinal()) this.min = min;
-    if (max.ordinal() < this.max.ordinal() || this.max == CompatibilityMode.COMPAT_UNKNOWN)
-      this.max = max;
+    if (min.code > this.min.code) this.min = min;
+    if (max.code < this.max.code || this.max == CompatibilityMode.COMPAT_UNKNOWN) this.max = max;
     if (this.cryptoKey == null) {
       this.cryptoKey = cryptoKey;
     } else if (cryptoKey != null && !Arrays.equals(this.cryptoKey, cryptoKey)) {

--- a/src/main/java/network/crypta/client/async/CompressionOutput.java
+++ b/src/main/java/network/crypta/client/async/CompressionOutput.java
@@ -37,25 +37,48 @@ import org.jetbrains.annotations.NotNull;
  * var out = new CompressionOutput(bucket, codec, hashes);
  * writer.write(out.data());
  * }</pre>
- *
- * @param data the {@link RandomAccessBucket} containing the bytes produced by compression; never
- *     wrapped or copied, and may reference uncompressed data when no codec is selected
- * @param bestCodec the {@link network.crypta.support.compress.Compressor.COMPRESSOR_TYPE} selected
- *     as most effective for this content, or {@code null} when compression was not applied
- * @param hashes an optional array of {@link HashResult} values describing computed content digests;
- *     may be {@code null} or empty, and is stored without defensive copying
  */
-record CompressionOutput(RandomAccessBucket data, COMPRESSOR_TYPE bestCodec, HashResult[] hashes) {
+final class CompressionOutput {
+  private final RandomAccessBucket data;
+  private final COMPRESSOR_TYPE bestCodec;
+  private final HashResult[] hashes;
+
+  /**
+   * Creates a compression output bundle.
+   *
+   * @param data the {@link RandomAccessBucket} containing the bytes produced by compression; never
+   *     wrapped or copied, and may reference uncompressed data when no codec is selected
+   * @param bestCodec the {@link network.crypta.support.compress.Compressor.COMPRESSOR_TYPE}
+   *     selected as most effective for this content, or {@code null} when compression was not
+   *     applied
+   * @param hashes an optional array of {@link HashResult} values describing computed content
+   *     digests; may be {@code null} or empty, and is stored without defensive copying
+   */
+  CompressionOutput(RandomAccessBucket data, COMPRESSOR_TYPE bestCodec, HashResult[] hashes) {
+    this.data = data;
+    this.bestCodec = bestCodec;
+    this.hashes = hashes;
+  }
+
+  RandomAccessBucket data() {
+    return data;
+  }
+
+  COMPRESSOR_TYPE bestCodec() {
+    return bestCodec;
+  }
+
+  HashResult[] hashes() {
+    return hashes;
+  }
 
   @Override
   public boolean equals(Object o) {
     if (o == this) return true;
-    return (o
-            instanceof
-            CompressionOutput(RandomAccessBucket od, COMPRESSOR_TYPE oc, HashResult[] oh))
-        && Objects.equals(this.data, od)
-        && this.bestCodec == oc
-        && Arrays.equals(this.hashes, oh);
+    if (!(o instanceof CompressionOutput other)) return false;
+    return Objects.equals(this.data, other.data)
+        && this.bestCodec == other.bestCodec
+        && Arrays.equals(this.hashes, other.hashes);
   }
 
   @Override

--- a/src/main/java/network/crypta/client/async/ContainerInserter.java
+++ b/src/main/java/network/crypta/client/async/ContainerInserter.java
@@ -321,7 +321,7 @@ public class ContainerInserter implements ClientPutState, Serializable {
     for (Metadata m : metas) {
       try {
         Bucket bucket = m.toBucket(context.getBucketFactory(persistent));
-        String nameInArchive = ".metadata-" + (x++);
+        String nameInArchive = ".metadata-" + x++;
         containerItems.add(new ContainerElement(bucket, nameInArchive));
         m.resolve(nameInArchive);
       } catch (MetadataUnresolvedException _) {

--- a/src/main/java/network/crypta/client/async/DefaultManifestPutter.java
+++ b/src/main/java/network/crypta/client/async/DefaultManifestPutter.java
@@ -498,7 +498,7 @@ public class DefaultManifestPutter extends BaseManifestPutter {
 
   private long groupRemainingIntoArchives(
       ContainerBuilder containerBuilder,
-      HashMap<String, Object> itemsLeft,
+      Map<String, Object> itemsLeft,
       String defaultName,
       long tmpSize) {
     while (!itemsLeft.isEmpty()) {
@@ -528,7 +528,7 @@ public class DefaultManifestPutter extends BaseManifestPutter {
   }
 
   private void handleSingleItemLeft(
-      ContainerBuilder containerBuilder, HashMap<String, Object> itemsLeft, String defaultName) {
+      ContainerBuilder containerBuilder, Map<String, Object> itemsLeft, String defaultName) {
     for (Map.Entry<String, Object> entry : itemsLeft.entrySet()) {
       String lname = entry.getKey();
       ManifestElement me = (ManifestElement) entry.getValue();
@@ -548,7 +548,7 @@ public class DefaultManifestPutter extends BaseManifestPutter {
   }
 
   private void addAllToSingleArchive(
-      ContainerBuilder containerBuilder, HashMap<String, Object> itemsLeft, String defaultName) {
+      ContainerBuilder containerBuilder, Map<String, Object> itemsLeft, String defaultName) {
     ContainerBuilder archive = makeArchive();
     for (Map.Entry<String, Object> entry : itemsLeft.entrySet()) {
       String lname = entry.getKey();
@@ -558,7 +558,7 @@ public class DefaultManifestPutter extends BaseManifestPutter {
   }
 
   private void addAllAsExternalElements(
-      ContainerBuilder containerBuilder, HashMap<String, Object> itemsLeft, String defaultName) {
+      ContainerBuilder containerBuilder, Map<String, Object> itemsLeft, String defaultName) {
     for (Map.Entry<String, Object> entry : itemsLeft.entrySet()) {
       String lname = entry.getKey();
       ManifestElement me = (ManifestElement) entry.getValue();
@@ -568,7 +568,7 @@ public class DefaultManifestPutter extends BaseManifestPutter {
 
   private long fillPartialArchive(
       ContainerBuilder containerBuilder,
-      HashMap<String, Object> itemsLeft,
+      Map<String, Object> itemsLeft,
       String defaultName,
       long tmpSize) {
     long archiveLimit = DEFAULT_CONTAINERSIZE_SPARE;

--- a/src/main/java/network/crypta/client/async/InsertExecutionOptions.java
+++ b/src/main/java/network/crypta/client/async/InsertExecutionOptions.java
@@ -15,21 +15,64 @@ import org.jetbrains.annotations.NotNull;
  * <p>The {@code forceCryptoKey} array is stored by reference and compared by content for equality.
  * Callers should avoid mutating it after construction if they rely on stable equality or hash
  * semantics.
- *
- * @param dontCompress whether compression is disabled for the insert
- * @param reportMetadataOnly whether to stop after preparing metadata and report it directly
- * @param archiveType optional archive type used when building metadata for redirects or manifests
- * @param forceCryptoKey optional explicit crypto key material; {@code null} to derive or randomize
- * @param cryptoAlgorithm crypto algorithm identifier understood by downstream inserters
- * @param realTimeFlag whether to request real-time scheduling behavior
  */
-public record InsertExecutionOptions(
-    boolean dontCompress,
-    boolean reportMetadataOnly,
-    ARCHIVE_TYPE archiveType,
-    byte[] forceCryptoKey,
-    byte cryptoAlgorithm,
-    boolean realTimeFlag) {
+public final class InsertExecutionOptions {
+  private final boolean dontCompress;
+  private final boolean reportMetadataOnly;
+  private final ARCHIVE_TYPE archiveType;
+  private final byte[] forceCryptoKey;
+  private final byte cryptoAlgorithm;
+  private final boolean realTimeFlag;
+
+  /**
+   * Creates an immutable execution options bundle for inserts.
+   *
+   * @param dontCompress whether compression is disabled for the insert
+   * @param reportMetadataOnly whether to stop after preparing metadata and report it directly
+   * @param archiveType optional archive type used when building metadata for redirects or manifests
+   * @param forceCryptoKey optional explicit crypto key material; {@code null} to derive or
+   *     randomize
+   * @param cryptoAlgorithm crypto algorithm identifier understood by downstream inserters
+   * @param realTimeFlag whether to request real-time scheduling behavior
+   */
+  public InsertExecutionOptions(
+      boolean dontCompress,
+      boolean reportMetadataOnly,
+      ARCHIVE_TYPE archiveType,
+      byte[] forceCryptoKey,
+      byte cryptoAlgorithm,
+      boolean realTimeFlag) {
+    this.dontCompress = dontCompress;
+    this.reportMetadataOnly = reportMetadataOnly;
+    this.archiveType = archiveType;
+    this.forceCryptoKey = forceCryptoKey;
+    this.cryptoAlgorithm = cryptoAlgorithm;
+    this.realTimeFlag = realTimeFlag;
+  }
+
+  public boolean dontCompress() {
+    return dontCompress;
+  }
+
+  public boolean reportMetadataOnly() {
+    return reportMetadataOnly;
+  }
+
+  public ARCHIVE_TYPE archiveType() {
+    return archiveType;
+  }
+
+  public byte[] forceCryptoKey() {
+    return forceCryptoKey;
+  }
+
+  public byte cryptoAlgorithm() {
+    return cryptoAlgorithm;
+  }
+
+  public boolean realTimeFlag() {
+    return realTimeFlag;
+  }
 
   /**
    * Compares two option bundles by value, including array contents.
@@ -40,21 +83,13 @@ public record InsertExecutionOptions(
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o
-        instanceof
-        InsertExecutionOptions(
-            boolean otherDontCompress,
-            boolean otherReportMetadataOnly,
-            ARCHIVE_TYPE otherArchiveType,
-            byte[] otherForceCryptoKey,
-            byte otherCryptoAlgorithm,
-            boolean otherRealTimeFlag))) return false;
-    return dontCompress == otherDontCompress
-        && reportMetadataOnly == otherReportMetadataOnly
-        && cryptoAlgorithm == otherCryptoAlgorithm
-        && realTimeFlag == otherRealTimeFlag
-        && archiveType == otherArchiveType
-        && Arrays.equals(forceCryptoKey, otherForceCryptoKey);
+    if (!(o instanceof InsertExecutionOptions other)) return false;
+    return dontCompress == other.dontCompress
+        && reportMetadataOnly == other.reportMetadataOnly
+        && cryptoAlgorithm == other.cryptoAlgorithm
+        && realTimeFlag == other.realTimeFlag
+        && archiveType == other.archiveType
+        && Arrays.equals(forceCryptoKey, other.forceCryptoKey);
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/ManifestPutterParams.java
+++ b/src/main/java/network/crypta/client/async/ManifestPutterParams.java
@@ -28,32 +28,88 @@ import org.jetbrains.annotations.NotNull;
  *   <li>Preserves existing semantics by avoiding validation or copying.
  *   <li>Supports content-based equality for the optional crypto key.
  * </ul>
- *
- * @param clientCallback callback receiver for progress and completion events; must remain valid for
- *     the putter lifetime and may be {@code null} if callers allow it.
- * @param manifestElements manifest tree of entry names to elements or sub-maps; contents are
- *     interpreted by the target putter without additional normalization here.
- * @param prioClass scheduler priority class for the request; valid values depend on scheduler
- *     configuration and must match the caller’s intent.
- * @param target target URI for the root manifest; typically an SSK or CHK-like {@link FreenetURI}.
- * @param defaultName default document name for directory levels; may be {@code null} when no
- *     default document should be inferred.
- * @param ctx insert context providing retry, chunking, and compatibility settings; must align with
- *     the caller’s overall insertion policy.
- * @param forceCryptoKey optional explicit splitfile key material; {@code null} means the putter may
- *     derive or randomize keys as needed.
- * @param context client context providing randomness and scheduling services; expected to be
- *     non-{@code null} during putter execution.
  */
-public record ManifestPutterParams(
-    ClientPutCallback clientCallback,
-    Map<String, Object> manifestElements,
-    short prioClass,
-    FreenetURI target,
-    String defaultName,
-    InsertContext ctx,
-    byte[] forceCryptoKey,
-    ClientContext context) {
+public final class ManifestPutterParams {
+  private final ClientPutCallback clientCallback;
+  private final Map<String, Object> manifestElements;
+  private final short prioClass;
+  private final FreenetURI target;
+  private final String defaultName;
+  private final InsertContext ctx;
+  private final byte[] forceCryptoKey;
+  private final ClientContext context;
+
+  /**
+   * Creates a parameter bundle for manifest putter construction.
+   *
+   * @param clientCallback callback receiver for progress and completion events; must remain valid
+   *     for the putter lifetime and may be {@code null} if callers allow it.
+   * @param manifestElements manifest tree of entry names to elements or sub-maps; contents are
+   *     interpreted by the target putter without additional normalization here.
+   * @param prioClass scheduler priority class for the request; valid values depend on scheduler
+   *     configuration and must match the caller’s intent.
+   * @param target target URI for the root manifest; typically an SSK or CHK-like {@link
+   *     FreenetURI}.
+   * @param defaultName default document name for directory levels; may be {@code null} when no
+   *     default document should be inferred.
+   * @param ctx insert context providing retry, chunking, and compatibility settings; must align
+   *     with the caller’s overall insertion policy.
+   * @param forceCryptoKey optional explicit splitfile key material; {@code null} means the putter
+   *     may derive or randomize keys as needed.
+   * @param context client context providing randomness and scheduling services; expected to be
+   *     non-{@code null} during putter execution.
+   */
+  public ManifestPutterParams(
+      ClientPutCallback clientCallback,
+      Map<String, Object> manifestElements,
+      short prioClass,
+      FreenetURI target,
+      String defaultName,
+      InsertContext ctx,
+      byte[] forceCryptoKey,
+      ClientContext context) {
+    this.clientCallback = clientCallback;
+    this.manifestElements = manifestElements;
+    this.prioClass = prioClass;
+    this.target = target;
+    this.defaultName = defaultName;
+    this.ctx = ctx;
+    this.forceCryptoKey = forceCryptoKey;
+    this.context = context;
+  }
+
+  public ClientPutCallback clientCallback() {
+    return clientCallback;
+  }
+
+  public Map<String, Object> manifestElements() {
+    return manifestElements;
+  }
+
+  public short prioClass() {
+    return prioClass;
+  }
+
+  public FreenetURI target() {
+    return target;
+  }
+
+  public String defaultName() {
+    return defaultName;
+  }
+
+  public InsertContext ctx() {
+    return ctx;
+  }
+
+  public byte[] forceCryptoKey() {
+    return forceCryptoKey;
+  }
+
+  public ClientContext context() {
+    return context;
+  }
+
   /**
    * Compares this parameter bundle to another for structural equality.
    *
@@ -69,25 +125,15 @@ public record ManifestPutterParams(
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o
-        instanceof
-        ManifestPutterParams(
-            ClientPutCallback otherClientCallback,
-            Map<String, Object> otherManifestElements,
-            short otherPrioClass,
-            FreenetURI otherTarget,
-            String otherDefaultName,
-            InsertContext otherCtx,
-            byte[] otherForceCryptoKey,
-            ClientContext otherContext))) return false;
-    return prioClass == otherPrioClass
-        && Objects.equals(clientCallback, otherClientCallback)
-        && Objects.equals(manifestElements, otherManifestElements)
-        && Objects.equals(target, otherTarget)
-        && Objects.equals(defaultName, otherDefaultName)
-        && Objects.equals(ctx, otherCtx)
-        && Arrays.equals(forceCryptoKey, otherForceCryptoKey)
-        && Objects.equals(context, otherContext);
+    if (!(o instanceof ManifestPutterParams other)) return false;
+    return prioClass == other.prioClass
+        && Objects.equals(clientCallback, other.clientCallback)
+        && Objects.equals(manifestElements, other.manifestElements)
+        && Objects.equals(target, other.target)
+        && Objects.equals(defaultName, other.defaultName)
+        && Objects.equals(ctx, other.ctx)
+        && Arrays.equals(forceCryptoKey, other.forceCryptoKey)
+        && Objects.equals(context, other.context);
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/SingleBlockInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleBlockInserter.java
@@ -929,7 +929,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     @Override
     public boolean equals(Object o) {
       if (o instanceof BlockItemKey key) {
-        return key.parent == parent;
+        return Objects.equals(key.parent, parent);
       }
       return false;
     }

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -6,6 +6,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.util.HashMap;
+import java.util.Locale;
 import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertBlock;
@@ -150,7 +151,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
    * @param params parameter bundle describing the insert inputs and execution options
    */
   SingleFileInserter(SingleFileInserterParams params) {
-    hashCode = super.hashCode();
+    hashCode = System.identityHashCode(this);
     InsertExecutionOptions execOptions = params.executionOptions;
     this.reportMetadataOnly = execOptions.reportMetadataOnly();
     this.token = params.token;
@@ -641,7 +642,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       CompatibilityMode cmode = ctx.getCompatibilityMode();
       boolean allowSizes =
           (cmode == CompatibilityMode.COMPAT_CURRENT
-              || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal());
+              || cmode.code >= CompatibilityMode.COMPAT_1255.code);
       if (metadata) allowSizes = false;
       SplitHandler sh = new SplitHandler(origSize, data.size(), allowSizes);
       SplitFileInserter.Options opts =
@@ -700,7 +701,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
     if (block.desiredURI == null) {
       throw new InsertException(InsertExceptionMode.INVALID_URI, "Null key type", null);
     }
-    BlockSizes sizes = determineBlockSizes(block.desiredURI.getKeyType().toUpperCase());
+    BlockSizes sizes = determineBlockSizes(block.desiredURI.getKeyType().toUpperCase(Locale.ROOT));
     long origSize = origData.size();
     long wantHashes = computeWantedHashes(origData.size());
     boolean tryCompress =
@@ -757,7 +758,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
     CompatibilityMode cmode = ctx.getCompatibilityMode();
     boolean atLeast1254 =
         (cmode == CompatibilityMode.COMPAT_CURRENT
-            || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal());
+            || cmode.code >= CompatibilityMode.COMPAT_1255.code);
     if (atLeast1254) {
       // We verify this. We want it for *all* files.
       wantHashes |= HashType.SHA256.bitmask;
@@ -958,7 +959,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
     public SplitHandler(long origDataLength, long origCompressedDataLength, boolean allowSizes) {
       // Default constructor
       this.persistent = SingleFileInserter.this.persistent;
-      this.hashCode = super.hashCode();
+      this.hashCode = System.identityHashCode(this);
       this.origDataLength = allowSizes ? origDataLength : 0;
       this.origCompressedDataLength = allowSizes ? origCompressedDataLength : 0;
     }
@@ -1157,7 +1158,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       ClientMetadata m = meta.getClientMetadata();
       CompatibilityMode cmode = ctx.getCompatibilityMode();
       if (!(cmode == CompatibilityMode.COMPAT_CURRENT
-          || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal())) m = null;
+          || cmode.code >= CompatibilityMode.COMPAT_1255.code)) m = null;
       return m;
     }
 
@@ -1176,14 +1177,36 @@ class SingleFileInserter implements ClientPutState, Serializable {
       return false;
     }
 
-    private record RedirectResult(Metadata meta, byte[] bytes, String target) {
+    private static final class RedirectResult {
+      private final Metadata meta;
+      private final byte[] bytes;
+      private final String target;
+
+      private RedirectResult(Metadata meta, byte[] bytes, String target) {
+        this.meta = meta;
+        this.bytes = bytes;
+        this.target = target;
+      }
+
+      private Metadata meta() {
+        return meta;
+      }
+
+      private byte[] bytes() {
+        return bytes;
+      }
+
+      private String target() {
+        return target;
+      }
+
       @Override
       public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof RedirectResult(var m, var b, var t))) return false;
-        if (!java.util.Objects.equals(meta, m)) return false;
-        if (!java.util.Arrays.equals(bytes, b)) return false;
-        return java.util.Objects.equals(target, t);
+        if (!(o instanceof RedirectResult other)) return false;
+        if (!java.util.Objects.equals(meta, other.meta)) return false;
+        if (!java.util.Arrays.equals(bytes, other.bytes)) return false;
+        return java.util.Objects.equals(target, other.target);
       }
 
       @Override

--- a/src/main/java/network/crypta/client/async/SplitFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcher.java
@@ -343,6 +343,7 @@ public class SplitFileFetcher
    *
    * @param e reason for failure to report to the client; must not be {@code null}
    */
+  @Override
   public void fail(FetchException e) {
     synchronized (this) {
       if (succeeded || failed) return;
@@ -432,6 +433,7 @@ public class SplitFileFetcher
    *
    * @return a priority identifier; higher values may imply lower scheduling priority
    */
+  @Override
   public short getPriorityClass() {
     return this.parent.getPriorityClass();
   }

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentStorage.java
@@ -9,6 +9,7 @@ import java.lang.ref.SoftReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
@@ -324,7 +325,7 @@ public class SplitFileFetcherSegmentStorage {
     this.segmentBlockDataOffset = p.segmentDataOffset;
     long sccdo = p.segmentCrossCheckDataOffset;
     if (sccdo == -1) {
-      sccdo = segmentBlockDataOffset + dataBlocks * CHKBlock.DATA_LENGTH;
+      sccdo = segmentBlockDataOffset + dataBlocks * ((long) CHKBlock.DATA_LENGTH);
     }
     this.segmentCrossCheckBlockDataOffset = sccdo;
     this.segmentKeyListOffset = p.segmentKeysOffset;
@@ -553,8 +554,7 @@ public class SplitFileFetcherSegmentStorage {
     }
   }
 
-  private record BlocksBuildResult(
-      ArrayList<SplitFileFetcherBlock> maybeBlocks, int fetchedCount) {}
+  private record BlocksBuildResult(List<SplitFileFetcherBlock> maybeBlocks, int fetchedCount) {}
 
   private BlocksBuildResult buildBlockCandidates(int totalBlocks, byte[][] allBlocks) {
     ArrayList<SplitFileFetcherBlock> maybeBlocks = new ArrayList<>();
@@ -629,7 +629,7 @@ public class SplitFileFetcherSegmentStorage {
   }
 
   private DecodePrep prepareDecodeArrays(
-      ArrayList<SplitFileFetcherBlock> maybeBlocks, SplitFileSegmentKeys keys) {
+      List<SplitFileFetcherBlock> maybeBlocks, SplitFileSegmentKeys keys) {
     int validBlocks = 0;
     int validDataBlocks = 0;
     byte[][] dataBlocksArr = new byte[blocksForDecode()][];
@@ -1429,7 +1429,7 @@ public class SplitFileFetcherSegmentStorage {
    * trigger a read of the keys before they have been persisted.
    */
   void writeKeysWithChecksum(SplitFileSegmentKeys keys) throws IOException {
-    assert (keysCache.get() == keys);
+    assert Objects.equals(keysCache.get(), keys);
     assert (this.dataBlocks + this.crossSegmentCheckBlocks == keys.dataBlocks);
     assert (this.checkBlocks == keys.checkBlocks);
     OutputStream cos = parent.writeChecksummedTo(segmentKeyListOffset, segmentKeyListLength);
@@ -1682,7 +1682,7 @@ public class SplitFileFetcherSegmentStorage {
           ClientCHKBlock block =
               ClientCHKBlock.encodeSplitfileBlock(
                   buf, key.getCryptoKey(), key.getCryptoAlgorithm());
-          if (!(block.getClientKey().equals(key))) {
+          if (!block.getClientKey().equals(key)) {
             LOG.error("Block {} in blocksFound[{}] is not valid!", blockNum, i);
             blockChooser.onUnSuccess(blockNum);
             succeeded = false;

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentsLoadParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentsLoadParams.java
@@ -25,36 +25,122 @@ import org.jetbrains.annotations.NotNull;
  *   <li>Holds the stream and segment array that will be mutated during reconstruction.
  * </ul>
  *
- * @param parent owning storage that supplies layout constants and retry behavior.
- * @param totalDataBlocks total number of data blocks across all segments; non-negative count.
- * @param totalCheckBlocks total number of check blocks across all segments; non-negative count.
- * @param totalCrossCheckBlocks total number of cross-check blocks across all segments; non-negative
- *     count.
- * @param dis input stream positioned at the start of segment metadata; read in-order.
- * @param completeViaTruncation whether completion is recorded via file truncation semantics.
- * @param keysFetching optional helper for tracking locally fetched keys; may be {@code null}.
- * @param segments mutable segment array to populate with reconstructed storage objects.
- * @param checksumLength checksum length in bytes used for persisted checksummed blocks.
- * @param hasSplitfileSingleCryptoKey whether a single splitfile crypto key is present.
- * @param offsetKeyList byte offset of the persisted key list section in the storage layout.
- * @param offsetSegmentStatus byte offset of the persisted segment status section.
- * @param rafLength total length of the backing storage buffer in bytes.
  * @see SplitFileFetcherSegmentsBuilder#initSegmentsFromStream(SplitFileFetcherSegmentsLoadParams)
  */
-record SplitFileFetcherSegmentsLoadParams(
-    SplitFileFetcherStorage parent,
-    int totalDataBlocks,
-    int totalCheckBlocks,
-    int totalCrossCheckBlocks,
-    DataInputStream dis,
-    boolean completeViaTruncation,
-    KeysFetchingLocally keysFetching,
-    SplitFileFetcherSegmentStorage[] segments,
-    int checksumLength,
-    boolean hasSplitfileSingleCryptoKey,
-    long offsetKeyList,
-    long offsetSegmentStatus,
-    long rafLength) {
+final class SplitFileFetcherSegmentsLoadParams {
+  private final SplitFileFetcherStorage parent;
+  private final int totalDataBlocks;
+  private final int totalCheckBlocks;
+  private final int totalCrossCheckBlocks;
+  private final DataInputStream dis;
+  private final boolean completeViaTruncation;
+  private final KeysFetchingLocally keysFetching;
+  private final SplitFileFetcherSegmentStorage[] segments;
+  private final int checksumLength;
+  private final boolean hasSplitfileSingleCryptoKey;
+  private final long offsetKeyList;
+  private final long offsetSegmentStatus;
+  private final long rafLength;
+
+  /**
+   * Creates a bundle of parameters for rebuilding segments from persisted storage.
+   *
+   * @param parent owning storage that supplies layout constants and retry behavior.
+   * @param totalDataBlocks total number of data blocks across all segments; non-negative count.
+   * @param totalCheckBlocks total number of check blocks across all segments; non-negative count.
+   * @param totalCrossCheckBlocks total number of cross-check blocks across all segments;
+   *     non-negative count.
+   * @param dis input stream positioned at the start of segment metadata; read in-order.
+   * @param completeViaTruncation whether completion is recorded via file truncation semantics.
+   * @param keysFetching optional helper for tracking locally fetched keys; may be {@code null}.
+   * @param segments mutable segment array to populate with reconstructed storage objects.
+   * @param checksumLength checksum length in bytes used for persisted checksummed blocks.
+   * @param hasSplitfileSingleCryptoKey whether a single splitfile crypto key is present.
+   * @param offsetKeyList byte offset of the persisted key list section in the storage layout.
+   * @param offsetSegmentStatus byte offset of the persisted segment status section.
+   * @param rafLength total length of the backing storage buffer in bytes.
+   */
+  SplitFileFetcherSegmentsLoadParams(
+      SplitFileFetcherStorage parent,
+      int totalDataBlocks,
+      int totalCheckBlocks,
+      int totalCrossCheckBlocks,
+      DataInputStream dis,
+      boolean completeViaTruncation,
+      KeysFetchingLocally keysFetching,
+      SplitFileFetcherSegmentStorage[] segments,
+      int checksumLength,
+      boolean hasSplitfileSingleCryptoKey,
+      long offsetKeyList,
+      long offsetSegmentStatus,
+      long rafLength) {
+    this.parent = parent;
+    this.totalDataBlocks = totalDataBlocks;
+    this.totalCheckBlocks = totalCheckBlocks;
+    this.totalCrossCheckBlocks = totalCrossCheckBlocks;
+    this.dis = dis;
+    this.completeViaTruncation = completeViaTruncation;
+    this.keysFetching = keysFetching;
+    this.segments = segments;
+    this.checksumLength = checksumLength;
+    this.hasSplitfileSingleCryptoKey = hasSplitfileSingleCryptoKey;
+    this.offsetKeyList = offsetKeyList;
+    this.offsetSegmentStatus = offsetSegmentStatus;
+    this.rafLength = rafLength;
+  }
+
+  SplitFileFetcherStorage parent() {
+    return parent;
+  }
+
+  int totalDataBlocks() {
+    return totalDataBlocks;
+  }
+
+  int totalCheckBlocks() {
+    return totalCheckBlocks;
+  }
+
+  int totalCrossCheckBlocks() {
+    return totalCrossCheckBlocks;
+  }
+
+  DataInputStream dis() {
+    return dis;
+  }
+
+  boolean completeViaTruncation() {
+    return completeViaTruncation;
+  }
+
+  KeysFetchingLocally keysFetching() {
+    return keysFetching;
+  }
+
+  SplitFileFetcherSegmentStorage[] segments() {
+    return segments;
+  }
+
+  int checksumLength() {
+    return checksumLength;
+  }
+
+  boolean hasSplitfileSingleCryptoKey() {
+    return hasSplitfileSingleCryptoKey;
+  }
+
+  long offsetKeyList() {
+    return offsetKeyList;
+  }
+
+  long offsetSegmentStatus() {
+    return offsetSegmentStatus;
+  }
+
+  long rafLength() {
+    return rafLength;
+  }
+
   /**
    * Compares this bundle to another, including array contents for segments.
    *
@@ -70,37 +156,22 @@ record SplitFileFetcherSegmentsLoadParams(
     if (this == other) {
       return true;
     }
-    if (!(other
-        instanceof
-        SplitFileFetcherSegmentsLoadParams(
-            var otherParent,
-            var otherTotalDataBlocks,
-            var otherTotalCheckBlocks,
-            var otherTotalCrossCheckBlocks,
-            var otherDis,
-            var otherCompleteViaTruncation,
-            var otherKeysFetching,
-            var otherSegments,
-            var otherChecksumLength,
-            var otherHasSplitfileSingleCryptoKey,
-            var otherOffsetKeyList,
-            var otherOffsetSegmentStatus,
-            var otherRafLength))) {
+    if (!(other instanceof SplitFileFetcherSegmentsLoadParams otherParams)) {
       return false;
     }
-    return completeViaTruncation == otherCompleteViaTruncation
-        && totalDataBlocks == otherTotalDataBlocks
-        && totalCheckBlocks == otherTotalCheckBlocks
-        && totalCrossCheckBlocks == otherTotalCrossCheckBlocks
-        && checksumLength == otherChecksumLength
-        && hasSplitfileSingleCryptoKey == otherHasSplitfileSingleCryptoKey
-        && offsetKeyList == otherOffsetKeyList
-        && offsetSegmentStatus == otherOffsetSegmentStatus
-        && rafLength == otherRafLength
-        && parent == otherParent
-        && dis == otherDis
-        && keysFetching == otherKeysFetching
-        && Arrays.equals(segments, otherSegments);
+    return completeViaTruncation == otherParams.completeViaTruncation
+        && totalDataBlocks == otherParams.totalDataBlocks
+        && totalCheckBlocks == otherParams.totalCheckBlocks
+        && totalCrossCheckBlocks == otherParams.totalCrossCheckBlocks
+        && checksumLength == otherParams.checksumLength
+        && hasSplitfileSingleCryptoKey == otherParams.hasSplitfileSingleCryptoKey
+        && offsetKeyList == otherParams.offsetKeyList
+        && offsetSegmentStatus == otherParams.offsetSegmentStatus
+        && rafLength == otherParams.rafLength
+        && parent == otherParams.parent
+        && dis == otherParams.dis
+        && keysFetching == otherParams.keysFetching
+        && Arrays.equals(segments, otherParams.segments);
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
@@ -620,9 +620,14 @@ public class SplitFileFetcherStorage {
         boolean dontCompress = decompressors.isEmpty();
         if (topCompatibilityMode != 0) {
           if (minCompatMode == CompatibilityMode.COMPAT_UNKNOWN
-              || !(minCompatMode.ordinal() > topCompatibilityMode
-                  || maxCompatMode.ordinal() < topCompatibilityMode)) {
-            minCompatMode = maxCompatMode = CompatibilityMode.values()[topCompatibilityMode];
+              || !(minCompatMode.code > topCompatibilityMode
+                  || maxCompatMode.code < topCompatibilityMode)) {
+            if (!CompatibilityMode.hasCode(topCompatibilityMode)) {
+              throw new FetchException(
+                  FetchExceptionMode.INVALID_METADATA,
+                  "Top compatibility mode is incompatible with detected compatibility mode");
+            }
+            minCompatMode = maxCompatMode = CompatibilityMode.byCode(topCompatibilityMode);
             dontCompress = topDontCompress;
           } else {
             throw new FetchException(
@@ -1183,6 +1188,7 @@ public class SplitFileFetcherStorage {
      *
      * @return a stable hash suitable for hash-based collections and caches.
      */
+    @Override
     public int hashCode() {
       return hashCode;
     }
@@ -1206,6 +1212,7 @@ public class SplitFileFetcherStorage {
      *
      * @return a concise string containing the segment and block numbers.
      */
+    @Override
     public String toString() {
       return "SplitFileFetcherStorageKey:" + segmentNumber + ":" + blockNumber;
     }
@@ -1366,7 +1373,7 @@ public class SplitFileFetcherStorage {
    */
   public boolean lastBlockMightNotBePadded() {
     return (finalMinCompatMode == CompatibilityMode.COMPAT_UNKNOWN
-        || finalMinCompatMode.ordinal() < CompatibilityMode.COMPAT_1416.ordinal());
+        || finalMinCompatMode.code < CompatibilityMode.COMPAT_1416.code);
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageInitParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageInitParams.java
@@ -40,7 +40,6 @@ import network.crypta.support.io.FileRandomAccessBufferFactory;
  *
  * @see SplitFileFetcherStorage
  * @see SplitFileFetcherStorageInitParams.Builder
- * @hidden
  */
 public final class SplitFileFetcherStorageInitParams {
   Metadata metadata;
@@ -83,8 +82,6 @@ public final class SplitFileFetcherStorageInitParams {
    *   <li>Provide runtime helpers such as tickers, RNGs, and job runners.
    *   <li>Create repeatable snapshots by reusing the same builder.
    * </ul>
-   *
-   * @hidden
    */
   public static class Builder {
     private Metadata metadata;

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStoragePersistence.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStoragePersistence.java
@@ -55,35 +55,60 @@ final class SplitFileFetcherStoragePersistence {
    * coordinates. The {@link Bucket} is intentionally left open so it can be copied later; callers
    * should either close it directly or pass the record to {@link #writePersistentMetadata}, which
    * closes it after copying.
-   *
-   * @param metadataTemp temporary bucket containing encoded metadata and appended hash
-   * @param encodedURI encoded original details plus checksum for persistent layout
-   * @param offsetOriginalDetails byte offset of encoded original details within storage layout
-   * @param offsetBasicSettings byte offset of basic settings block within storage layout
    */
-  record PreparedMetadata(
-      Bucket metadataTemp,
-      byte[] encodedURI,
-      long offsetOriginalDetails,
-      long offsetBasicSettings) {
+  static final class PreparedMetadata {
+    private final Bucket metadataTemp;
+    private final byte[] encodedURI;
+    private final long offsetOriginalDetails;
+    private final long offsetBasicSettings;
+
+    /**
+     * Creates a prepared metadata bundle for the persistent layout.
+     *
+     * @param metadataTemp temporary bucket containing encoded metadata and appended hash
+     * @param encodedURI encoded original details plus checksum for persistent layout
+     * @param offsetOriginalDetails byte offset of encoded original details within storage layout
+     * @param offsetBasicSettings byte offset of basic settings block within storage layout
+     */
+    PreparedMetadata(
+        Bucket metadataTemp,
+        byte[] encodedURI,
+        long offsetOriginalDetails,
+        long offsetBasicSettings) {
+      this.metadataTemp = metadataTemp;
+      this.encodedURI = encodedURI;
+      this.offsetOriginalDetails = offsetOriginalDetails;
+      this.offsetBasicSettings = offsetBasicSettings;
+    }
+
+    Bucket metadataTemp() {
+      return metadataTemp;
+    }
+
+    byte[] encodedURI() {
+      return encodedURI;
+    }
+
+    long offsetOriginalDetails() {
+      return offsetOriginalDetails;
+    }
+
+    long offsetBasicSettings() {
+      return offsetBasicSettings;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;
       }
-      if (!(o
-          instanceof
-          PreparedMetadata(
-              Bucket otherMetadataTemp,
-              byte[] otherEncodedURI,
-              long otherOffsetOriginalDetails,
-              long otherOffsetBasicSettings))) {
+      if (!(o instanceof PreparedMetadata other)) {
         return false;
       }
-      return offsetOriginalDetails == otherOffsetOriginalDetails
-          && offsetBasicSettings == otherOffsetBasicSettings
-          && Objects.equals(metadataTemp, otherMetadataTemp)
-          && Arrays.equals(encodedURI, otherEncodedURI);
+      return offsetOriginalDetails == other.offsetOriginalDetails
+          && offsetBasicSettings == other.offsetBasicSettings
+          && Objects.equals(metadataTemp, other.metadataTemp)
+          && Arrays.equals(encodedURI, other.encodedURI);
     }
 
     @Override

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageResumeParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageResumeParams.java
@@ -33,7 +33,6 @@ import network.crypta.support.api.LockableRandomAccessBuffer;
  * @see SplitFileFetcherStorageResumeParams.Builder
  * @see SplitFileFetcherStorageInitParams
  * @see SplitFileFetcherStorage
- * @hidden
  */
 public final class SplitFileFetcherStorageResumeParams {
   LockableRandomAccessBuffer raf;
@@ -74,8 +73,6 @@ public final class SplitFileFetcherStorageResumeParams {
    *         .ticker(ticker)
    *         .build();
    * }</pre>
-   *
-   * @hidden
    */
   public static class Builder {
     private LockableRandomAccessBuffer raf;

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodec.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodec.java
@@ -224,9 +224,12 @@ public final class SplitFileFetcherStorageSettingsCodec {
   private static CompatAndCounts readCompatAndCounts(DataInputStream dis)
       throws IOException, StorageFormatException {
     int compatMode = dis.readInt();
-    if (compatMode < 0 || compatMode > CompatibilityMode.values().length)
+    if (compatMode < 0 || compatMode > Short.MAX_VALUE)
       throw new StorageFormatException("Invalid compatibility mode " + compatMode);
-    CompatibilityMode finalMode = CompatibilityMode.values()[compatMode];
+    short compatCode = (short) compatMode;
+    if (!CompatibilityMode.hasCode(compatCode))
+      throw new StorageFormatException("Invalid compatibility mode " + compatMode);
+    CompatibilityMode finalMode = CompatibilityMode.byCode(compatCode);
     int segmentCount = dis.readInt();
     if (segmentCount <= 0)
       throw new StorageFormatException("Invalid segment count " + segmentCount);
@@ -277,7 +280,7 @@ public final class SplitFileFetcherStorageSettingsCodec {
       dos.writeLong(storage.offsetOriginalDetails);
       dos.writeLong(storage.offsetBasicSettings);
       dos.writeBoolean(storage.completeViaTruncation);
-      dos.writeInt(storage.finalMinCompatMode.ordinal());
+      dos.writeInt(storage.finalMinCompatMode.code);
       dos.writeInt(storage.segments.length);
       dos.writeInt(totalDataBlocks);
       dos.writeInt(totalCheckBlocks);
@@ -382,80 +385,103 @@ public final class SplitFileFetcherStorageSettingsCodec {
  * <p>The {@code settingsStream} remains open and positioned at the first byte after the parsed
  * fields so callers can continue reading segment metadata without reparsing the buffer.
  */
-record ParsedBasicSettings(
-    SplitfileAlgorithm splitfileType,
-    byte splitfileSingleCryptoAlgorithm,
-    byte[] splitfileSingleCryptoKey,
-    long finalLength,
-    long decompressedLength,
-    ClientMetadata clientMetadata,
-    List<COMPRESSOR_TYPE> decompressors,
-    long offsetKeyList,
-    long offsetSegmentStatus,
-    long offsetGeneralProgress,
-    long offsetMainBloomFilter,
-    long offsetSegmentBloomFilters,
-    long offsetOriginalMetadata,
-    long offsetOriginalDetails,
-    long offsetBasicSettings,
-    CompatibilityMode finalMinCompatMode,
-    int segmentCount,
-    int totalDataBlocks,
-    int totalCheckBlocks,
-    int totalCrossCheckBlocks,
-    DataInputStream settingsStream) {
+final class ParsedBasicSettings {
+  private final SplitfileAlgorithm splitfileType;
+  private final byte splitfileSingleCryptoAlgorithm;
+  private final byte[] splitfileSingleCryptoKey;
+  private final long finalLength;
+  private final long decompressedLength;
+  private final ClientMetadata clientMetadata;
+  private final List<COMPRESSOR_TYPE> decompressors;
+  private final long offsetKeyList;
+  private final long offsetSegmentStatus;
+  private final long offsetGeneralProgress;
+  private final long offsetMainBloomFilter;
+  private final long offsetSegmentBloomFilters;
+  private final long offsetOriginalMetadata;
+  private final long offsetOriginalDetails;
+  private final long offsetBasicSettings;
+  private final CompatibilityMode finalMinCompatMode;
+  private final int segmentCount;
+  private final int totalDataBlocks;
+  private final int totalCheckBlocks;
+  private final int totalCrossCheckBlocks;
+  private final DataInputStream settingsStream;
+
+  ParsedBasicSettings(
+      SplitfileAlgorithm splitfileType,
+      byte splitfileSingleCryptoAlgorithm,
+      byte[] splitfileSingleCryptoKey,
+      long finalLength,
+      long decompressedLength,
+      ClientMetadata clientMetadata,
+      List<COMPRESSOR_TYPE> decompressors,
+      long offsetKeyList,
+      long offsetSegmentStatus,
+      long offsetGeneralProgress,
+      long offsetMainBloomFilter,
+      long offsetSegmentBloomFilters,
+      long offsetOriginalMetadata,
+      long offsetOriginalDetails,
+      long offsetBasicSettings,
+      CompatibilityMode finalMinCompatMode,
+      int segmentCount,
+      int totalDataBlocks,
+      int totalCheckBlocks,
+      int totalCrossCheckBlocks,
+      DataInputStream settingsStream) {
+    this.splitfileType = splitfileType;
+    this.splitfileSingleCryptoAlgorithm = splitfileSingleCryptoAlgorithm;
+    this.splitfileSingleCryptoKey = splitfileSingleCryptoKey;
+    this.finalLength = finalLength;
+    this.decompressedLength = decompressedLength;
+    this.clientMetadata = clientMetadata;
+    this.decompressors = decompressors;
+    this.offsetKeyList = offsetKeyList;
+    this.offsetSegmentStatus = offsetSegmentStatus;
+    this.offsetGeneralProgress = offsetGeneralProgress;
+    this.offsetMainBloomFilter = offsetMainBloomFilter;
+    this.offsetSegmentBloomFilters = offsetSegmentBloomFilters;
+    this.offsetOriginalMetadata = offsetOriginalMetadata;
+    this.offsetOriginalDetails = offsetOriginalDetails;
+    this.offsetBasicSettings = offsetBasicSettings;
+    this.finalMinCompatMode = finalMinCompatMode;
+    this.segmentCount = segmentCount;
+    this.totalDataBlocks = totalDataBlocks;
+    this.totalCheckBlocks = totalCheckBlocks;
+    this.totalCrossCheckBlocks = totalCrossCheckBlocks;
+    this.settingsStream = settingsStream;
+  }
+
   @Override
   public boolean equals(Object other) {
     if (this == other) {
       return true;
     }
-    if (!(other
-        instanceof
-        ParsedBasicSettings(
-            var otherSplitfileType,
-            var otherSplitfileSingleCryptoAlgorithm,
-            var otherSplitfileSingleCryptoKey,
-            var otherFinalLength,
-            var otherDecompressedLength,
-            var otherClientMetadata,
-            var otherDecompressors,
-            var otherOffsetKeyList,
-            var otherOffsetSegmentStatus,
-            var otherOffsetGeneralProgress,
-            var otherOffsetMainBloomFilter,
-            var otherOffsetSegmentBloomFilters,
-            var otherOffsetOriginalMetadata,
-            var otherOffsetOriginalDetails,
-            var otherOffsetBasicSettings,
-            var otherFinalMinCompatMode,
-            var otherSegmentCount,
-            var otherTotalDataBlocks,
-            var otherTotalCheckBlocks,
-            var otherTotalCrossCheckBlocks,
-            var otherSettingsStream))) {
+    if (!(other instanceof ParsedBasicSettings otherSettings)) {
       return false;
     }
-    return splitfileSingleCryptoAlgorithm == otherSplitfileSingleCryptoAlgorithm
-        && finalLength == otherFinalLength
-        && decompressedLength == otherDecompressedLength
-        && offsetKeyList == otherOffsetKeyList
-        && offsetSegmentStatus == otherOffsetSegmentStatus
-        && offsetGeneralProgress == otherOffsetGeneralProgress
-        && offsetMainBloomFilter == otherOffsetMainBloomFilter
-        && offsetSegmentBloomFilters == otherOffsetSegmentBloomFilters
-        && offsetOriginalMetadata == otherOffsetOriginalMetadata
-        && offsetOriginalDetails == otherOffsetOriginalDetails
-        && offsetBasicSettings == otherOffsetBasicSettings
-        && segmentCount == otherSegmentCount
-        && totalDataBlocks == otherTotalDataBlocks
-        && totalCheckBlocks == otherTotalCheckBlocks
-        && totalCrossCheckBlocks == otherTotalCrossCheckBlocks
-        && Objects.equals(splitfileType, otherSplitfileType)
-        && Arrays.equals(splitfileSingleCryptoKey, otherSplitfileSingleCryptoKey)
-        && Objects.equals(clientMetadata, otherClientMetadata)
-        && Objects.equals(decompressors, otherDecompressors)
-        && Objects.equals(finalMinCompatMode, otherFinalMinCompatMode)
-        && Objects.equals(settingsStream, otherSettingsStream);
+    return splitfileSingleCryptoAlgorithm == otherSettings.splitfileSingleCryptoAlgorithm
+        && finalLength == otherSettings.finalLength
+        && decompressedLength == otherSettings.decompressedLength
+        && offsetKeyList == otherSettings.offsetKeyList
+        && offsetSegmentStatus == otherSettings.offsetSegmentStatus
+        && offsetGeneralProgress == otherSettings.offsetGeneralProgress
+        && offsetMainBloomFilter == otherSettings.offsetMainBloomFilter
+        && offsetSegmentBloomFilters == otherSettings.offsetSegmentBloomFilters
+        && offsetOriginalMetadata == otherSettings.offsetOriginalMetadata
+        && offsetOriginalDetails == otherSettings.offsetOriginalDetails
+        && offsetBasicSettings == otherSettings.offsetBasicSettings
+        && segmentCount == otherSettings.segmentCount
+        && totalDataBlocks == otherSettings.totalDataBlocks
+        && totalCheckBlocks == otherSettings.totalCheckBlocks
+        && totalCrossCheckBlocks == otherSettings.totalCrossCheckBlocks
+        && Objects.equals(splitfileType, otherSettings.splitfileType)
+        && Arrays.equals(splitfileSingleCryptoKey, otherSettings.splitfileSingleCryptoKey)
+        && Objects.equals(clientMetadata, otherSettings.clientMetadata)
+        && Objects.equals(decompressors, otherSettings.decompressors)
+        && Objects.equals(finalMinCompatMode, otherSettings.finalMinCompatMode)
+        && Objects.equals(settingsStream, otherSettings.settingsStream);
   }
 
   @Override

--- a/src/main/java/network/crypta/client/async/SplitFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserter.java
@@ -581,7 +581,7 @@ public class SplitFileInserter
    */
   @Override
   public void onResume(ClientContext context) throws InsertException, ResumeFailedException {
-    assert (persistent);
+    assert persistent;
     synchronized (this) {
       if (resumed) return;
       resumed = true;

--- a/src/main/java/network/crypta/client/async/SplitFileInserterSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterSegmentStorage.java
@@ -1095,8 +1095,14 @@ public class SplitFileInserterSegmentStorage {
       return this;
     }
 
+    @Override
     public String toString() {
-      return "BlockInsert:" + segment + ":" + blockNumber + "@memory:" + super.hashCode();
+      return "BlockInsert:"
+          + segment
+          + ":"
+          + blockNumber
+          + "@memory:"
+          + System.identityHashCode(this);
     }
   }
 
@@ -1127,6 +1133,7 @@ public class SplitFileInserterSegmentStorage {
     return blockChooser.countFetchable();
   }
 
+  @Override
   public String toString() {
     return super.toString() + ":" + parent;
   }

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
@@ -299,7 +299,7 @@ public class SplitFileInserterStorage {
     InsertContext ctx = params.ctx;
     byte[] providedSplitfileCryptoKey = params.splitfileCryptoKey;
     cmode = ctx.getCompatibilityMode();
-    if (cmode.ordinal() < CompatibilityMode.COMPAT_1255.ordinal()) {
+    if (cmode.code < CompatibilityMode.COMPAT_1255.code) {
       this.hashes = null;
       providedSplitfileCryptoKey = null;
     } else {
@@ -661,7 +661,7 @@ public class SplitFileInserterStorage {
   private int calculateDeductBlocks(
       int totalDataBlocks, int segmentSize, int segs, CompatibilityMode cmode) {
     if (cmode == CompatibilityMode.COMPAT_CURRENT
-        || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal()) {
+        || cmode.code >= CompatibilityMode.COMPAT_1255.code) {
       int lastSegmentSize = totalDataBlocks - (segmentSize * (segs - 1));
       return segmentSize - lastSegmentSize;
     }
@@ -672,7 +672,7 @@ public class SplitFileInserterStorage {
     // Cross-segment splitfile redundancy becomes useful at 20 segments.
     if (segs >= 20
         && (cmode == CompatibilityMode.COMPAT_CURRENT
-            || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal())) {
+            || cmode.code >= CompatibilityMode.COMPAT_1255.code)) {
       return 3; // Optimal number of cross-check blocks per segment
     }
     return 0;
@@ -766,7 +766,7 @@ public class SplitFileInserterStorage {
         dos.write(splitfileCryptoKey);
       }
       dos.writeInt(keyLength);
-      dos.writeInt(cmode.ordinal());
+      dos.writeInt(cmode.code);
       // hasPaddedLastBlock will be recomputed.
       dos.writeInt(deductBlocksFromSegments);
       dos.writeInt(maxRetries);
@@ -866,9 +866,10 @@ public class SplitFileInserterStorage {
   private CompatibilityMode readCompatibilityModeChecked(DataInputStream dis)
       throws IOException, StorageFormatException {
     int compatMode = dis.readInt();
-    if (compatMode < 0 || compatMode > CompatibilityMode.values().length)
+    short compatCode = (short) compatMode;
+    if (!CompatibilityMode.hasCode(compatCode))
       throw new StorageFormatException("Invalid compatibility mode " + compatMode);
-    return CompatibilityMode.values()[compatMode];
+    return CompatibilityMode.byCode(compatCode);
   }
 
   @SuppressWarnings("java:S1168")
@@ -1129,7 +1130,7 @@ public class SplitFileInserterStorage {
     if (providedKey != null) {
       return new CryptoInit(providedKey, true);
     } else if (cmode == CompatibilityMode.COMPAT_CURRENT
-        || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal()) {
+        || cmode.code >= CompatibilityMode.COMPAT_1255.code) {
       byte[] key =
           (hashThisLayerOnly != null)
               ? Metadata.getCryptoKey(hashThisLayerOnly)

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorageInitParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorageInitParams.java
@@ -20,7 +20,6 @@ import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
  *
  * @see SplitFileInserterStorage
  * @see SplitFileInserterStorageRuntimeParams
- * @hidden
  */
 public final class SplitFileInserterStorageInitParams {
   LockableRandomAccessBuffer originalData;
@@ -51,8 +50,6 @@ public final class SplitFileInserterStorageInitParams {
    * Fluent builder for {@link SplitFileInserterStorageInitParams}.
    *
    * <p>The builder stores references as-is and performs no validation.
-   *
-   * @hidden
    */
   public static final class Builder {
     private LockableRandomAccessBuffer originalData;

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorageResumeParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorageResumeParams.java
@@ -14,7 +14,6 @@ import network.crypta.support.io.PersistentFileTracker;
  *
  * @see SplitFileInserterStorage
  * @see SplitFileInserterStorageRuntimeParams
- * @hidden
  */
 public final class SplitFileInserterStorageResumeParams {
   LockableRandomAccessBuffer raf;
@@ -30,8 +29,6 @@ public final class SplitFileInserterStorageResumeParams {
    * Fluent builder for {@link SplitFileInserterStorageResumeParams}.
    *
    * <p>The builder stores references as-is and performs no validation.
-   *
-   * @hidden
    */
   public static final class Builder {
     private LockableRandomAccessBuffer raf;

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorageRuntimeParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorageRuntimeParams.java
@@ -14,7 +14,6 @@ import network.crypta.support.Ticker;
  *
  * @see SplitFileInserterStorageInitParams
  * @see SplitFileInserterStorageResumeParams
- * @hidden
  */
 public final class SplitFileInserterStorageRuntimeParams {
   SplitFileInserterStorageCallback callback;
@@ -30,8 +29,6 @@ public final class SplitFileInserterStorageRuntimeParams {
    * Fluent builder for {@link SplitFileInserterStorageRuntimeParams}.
    *
    * <p>The builder stores references as-is and performs no validation.
-   *
-   * @hidden
    */
   public static final class Builder {
     private SplitFileInserterStorageCallback callback;

--- a/src/main/java/network/crypta/client/async/SplitFileSegmentKeys.java
+++ b/src/main/java/network/crypta/client/async/SplitFileSegmentKeys.java
@@ -553,9 +553,7 @@ public class SplitFileSegmentKeys implements Serializable {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    SplitFileSegmentKeys other = (SplitFileSegmentKeys) obj;
+    if (!(obj instanceof SplitFileSegmentKeys other)) return false;
     if (checkBlocks != other.checkBlocks) return false;
     if (!Arrays.equals(commonDecryptKey, other.commonDecryptKey)) return false;
     if (!Arrays.equals(commonExtraBytes, other.commonExtraBytes)) return false;

--- a/src/main/java/network/crypta/client/async/USKDateHint.java
+++ b/src/main/java/network/crypta/client/async/USKDateHint.java
@@ -5,7 +5,9 @@ import java.time.ZoneOffset;
 import java.time.temporal.TemporalField;
 import java.time.temporal.WeekFields;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.Locale;
+import java.util.Map;
 import network.crypta.keys.ClientSSK;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableUSK;
@@ -194,6 +196,23 @@ public class USKDateHint {
     return Arrays.stream(Type.values())
         .map(type -> key.getSSK(getDocName(key, type)))
         .toArray(ClientSSK[]::new);
+  }
+
+  /**
+   * Compute request-capable SSK URIs for each precision variant keyed by {@link Type}.
+   *
+   * <p>The returned map preserves {@link Type#values()} order via {@link EnumMap} and provides a
+   * direct association between precision levels and their corresponding request URIs.
+   *
+   * @param key the USK used to derive per-precision SSK request URIs; must not be {@code null}.
+   * @return a map of precision types to request URIs, never {@code null}.
+   */
+  public Map<Type, ClientSSK> getRequestURIsByType(USK key) {
+    EnumMap<Type, ClientSSK> result = new EnumMap<>(Type.class);
+    for (Type type : Type.values()) {
+      result.put(type, key.getSSK(getDocName(key, type)));
+    }
+    return result;
   }
 
   private String getDocName(USK key, Type type) {

--- a/src/main/java/network/crypta/client/async/USKDateHintFetches.java
+++ b/src/main/java/network/crypta/client/async/USKDateHintFetches.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchContext;
@@ -231,17 +232,18 @@ final class USKDateHintFetches {
     }
 
     USKDateHint date = USKDateHint.now();
-    ClientSSK[] ssks = date.getRequestURIs(origUSK);
-    if (ssks.length == 0) return false;
+    Map<USKDateHint.Type, ClientSSK> ssksByType = date.getRequestURIsByType(origUSK);
+    if (ssksByType.isEmpty()) return false;
 
-    DBRAttempt[] created = new DBRAttempt[ssks.length];
-    for (int i = 0; i < ssks.length; i++) {
-      ClientKey key = ssks[i];
-      DBRAttempt attempt = new DBRAttempt(key, context, USKDateHint.Type.values()[i]);
+    DBRAttempt[] created = new DBRAttempt[ssksByType.size()];
+    int index = 0;
+    for (Map.Entry<USKDateHint.Type, ClientSSK> entry : ssksByType.entrySet()) {
+      ClientKey key = entry.getValue();
+      DBRAttempt attempt = new DBRAttempt(key, context, entry.getKey());
       synchronized (this) {
         attempts.add(attempt);
       }
-      created[i] = attempt;
+      created[index++] = attempt;
     }
     synchronized (this) {
       hintsStarted = created.length;

--- a/src/main/java/network/crypta/client/async/USKStoreCheckCoordinator.java
+++ b/src/main/java/network/crypta/client/async/USKStoreCheckCoordinator.java
@@ -441,7 +441,7 @@ final class USKStoreCheckCoordinator {
    * <p>This helper merges keys from multiple sources and forwards completion notifications back to
    * the underlying sub-checkers.
    */
-  final class USKStoreChecker {
+  static final class USKStoreChecker {
 
     /** Sub-checkers contributing keys to a query in the datastore. */
     final USKKeyWatchSet.KeyList.StoreSubChecker[] checkers;

--- a/src/main/java/network/crypta/client/filter/BMPFilter.java
+++ b/src/main/java/network/crypta/client/filter/BMPFilter.java
@@ -297,12 +297,12 @@ public class BMPFilter implements ContentDataFilter {
   }
 
   private void validateStartWord(byte[] startWord) throws DataFilterException {
-    if ((!Arrays.equals(startWord, bmpHeaderwindows))
-        && (!Arrays.equals(startWord, bmpHeaderos2bArray))
-        && (!Arrays.equals(startWord, bmpHeaderos2cIcon))
-        && (!Arrays.equals(startWord, bmpHeaderos2cPointer))
-        && (!Arrays.equals(startWord, bmpHeaderos2Icon))
-        && (!Arrays.equals(startWord, bmpHeaderos2Pointer))) { // Checking the first word
+    if (!Arrays.equals(startWord, bmpHeaderwindows)
+        && !Arrays.equals(startWord, bmpHeaderos2bArray)
+        && !Arrays.equals(startWord, bmpHeaderos2cIcon)
+        && !Arrays.equals(startWord, bmpHeaderos2cPointer)
+        && !Arrays.equals(startWord, bmpHeaderos2Icon)
+        && !Arrays.equals(startWord, bmpHeaderos2Pointer)) { // Checking the first word
       throwHeaderError(l10n("InvalidStartWordT"), l10n("InvalidStartWordD"));
     }
   }

--- a/src/main/java/network/crypta/client/filter/CSSReadFilter.java
+++ b/src/main/java/network/crypta/client/filter/CSSReadFilter.java
@@ -270,7 +270,7 @@ public class CSSReadFilter implements ContentDataFilter, CharsetExtractor {
    *     valid entries are present after filtering.
    */
   public static String filterMediaList(String media) {
-    String[] split = media.split(",");
+    String[] split = FilterUtils.splitOnChar(media, ',');
     boolean first = true;
     StringBuilder sb = new StringBuilder();
     for (String m : split) {

--- a/src/main/java/network/crypta/client/filter/CSSTokenizerFilter.java
+++ b/src/main/java/network/crypta/client/filter/CSSTokenizerFilter.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -836,7 +837,7 @@ class CSSTokenizerFilter {
   }
 
   private static void register(Map<String, PropertyRule> m, PropertyRule rule, String... names) {
-    for (String n : names) m.put(n.toLowerCase(), rule);
+    for (String n : names) m.put(n.toLowerCase(Locale.ROOT), rule);
   }
 
   private static final Map<String, PropertyRule> RULES = buildRules();
@@ -3205,7 +3206,7 @@ class CSSTokenizerFilter {
    * After the object has been loaded, the property name is removed from allelementVerifier.
    */
   private static void addVerifier(String element) {
-    PropertyRule rule = RULES.get(element.toLowerCase());
+    PropertyRule rule = RULES.get(element.toLowerCase(Locale.ROOT));
     if (rule != null) {
       rule.apply(element);
     }
@@ -3216,7 +3217,7 @@ class CSSTokenizerFilter {
    * Note: Lazy init probably doesn't make sense, but while we are initting lazily, we need to hold a lock here.
    */
   private static synchronized CSSPropertyVerifier getVerifier(String element) {
-    element = element.toLowerCase();
+    element = element.toLowerCase(Locale.ROOT);
     if (elementVerifiers.get(element) != null) return elementVerifiers.get(element);
     else if (allelementVerifiers.contains(element)) {
       addVerifier(element);
@@ -3351,17 +3352,17 @@ class CSSTokenizerFilter {
   private static boolean isElementValid(SelectorParts p) {
     return "*".equals(p.element)
         || "~".equals(p.element)
-        || ElementInfo.isValidHTMLTag(p.element.toLowerCase())
-        || p.element.trim().isEmpty()
+        || ElementInfo.isValidHTMLTag(p.element.toLowerCase(Locale.ROOT))
+        || (p.element.trim().isEmpty()
             && (!p.className.isEmpty()
                 || !p.id.isEmpty()
                 || p.attSelections != null
-                || !p.pseudoClass.isEmpty());
+                || !p.pseudoClass.isEmpty()));
   }
 
   private static boolean validateNames(SelectorParts p) {
-    return !(!p.className.isEmpty() && !ElementInfo.isValidName(p.className)
-        || p.className.isEmpty() && !p.id.isEmpty() && !ElementInfo.isValidName(p.id));
+    return !((!p.className.isEmpty() && !ElementInfo.isValidName(p.className))
+        || (p.className.isEmpty() && !p.id.isEmpty() && !ElementInfo.isValidName(p.id)));
   }
 
   // returns -1 invalid, 0 ok, 1 banned
@@ -3372,7 +3373,7 @@ class CSSTokenizerFilter {
     return 0;
   }
 
-  private static boolean validateAttributeSelections(ArrayList<String> atts) {
+  private static boolean validateAttributeSelections(List<String> atts) {
     if (atts == null) return true;
     for (String attSelection : atts) {
       String[] parts = splitAttributeSelection(attSelection);
@@ -3406,10 +3407,10 @@ class CSSTokenizerFilter {
   private static boolean isValidAttributeName(String name) {
     if (name == null || name.isEmpty()) return false;
     char c = name.charAt(0);
-    if (!(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z')) return false;
+    if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))) return false;
     for (int i = 1; i < name.length(); i++) {
       c = name.charAt(i);
-      if (!(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_' || c == '-')) return false;
+      if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == '-')) return false;
     }
     return true;
   }
@@ -3528,7 +3529,7 @@ class CSSTokenizerFilter {
     }
 
     private boolean shouldSetSelector(int i) {
-      return index == -1 || index == i - 1 && selector == ' ';
+      return index == -1 || (index == i - 1 && selector == ' ');
     }
 
     private boolean tryHandleParentheses(char c) {
@@ -3592,7 +3593,7 @@ class CSSTokenizerFilter {
     }
 
     private boolean isHexDigit(char c) {
-      return c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F';
+      return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
     }
 
     private boolean tryHandleHexEscapeDigit(char c) {
@@ -3800,29 +3801,14 @@ class CSSTokenizerFilter {
 
     void handleCurrentStateChar() throws IOException {
       switch (currentState) {
-        case STATE1:
-          handleState1();
-          break;
-        case STATE1INQUOTE:
-          handleState1InQuote();
-          break;
-        case STATE2:
-          handleState2();
-          break;
-        case STATE2INQUOTE:
-          handleState2InQuote();
-          break;
-        case STATE3:
-          handleState3();
-          break;
-        case STATE3INQUOTE:
-          handleState3InQuote();
-          break;
-        case STATECOMMENT:
-          handleStateComment();
-          break;
-        default:
-          break;
+        case STATE1 -> handleState1();
+        case STATE1INQUOTE -> handleState1InQuote();
+        case STATE2 -> handleState2();
+        case STATE2INQUOTE -> handleState2InQuote();
+        case STATE3 -> handleState3();
+        case STATE3INQUOTE -> handleState3InQuote();
+        case STATECOMMENT -> handleStateComment();
+        default -> {}
       }
     }
 
@@ -4136,7 +4122,7 @@ class CSSTokenizerFilter {
     private void writeFilteredImportIfValid() throws IOException {
       if (LOG.isTraceEnabled()) LOG.trace("STATE1 CASE ;statement={}", buffer);
       String strbuffer = buffer.toString().trim();
-      int importIndex = strbuffer.toLowerCase().indexOf("@import");
+      int importIndex = strbuffer.toLowerCase(Locale.ROOT).indexOf("@import");
       if (!isImportAtStart(strbuffer, importIndex)) return;
       ParsedWord[] strparts = split(strbuffer.substring(importIndex + 7), false);
       if (!isValidImportHead(strparts)) return;
@@ -4198,17 +4184,17 @@ class CSSTokenizerFilter {
     void handleState1InQuote() {
       if (LOG.isTraceEnabled()) LOG.trace("STATE1INQUOTE: {}", c);
       switch (c) {
-        case '"':
+        case '"' -> {
           if (currentQuote == '"' && prevc != '\\') currentState = STATE1;
           buffer.append(c);
-          break;
-        case '\'':
+        }
+        case '\'' -> {
           if (currentQuote == '\'' && prevc != '\\') currentState = STATE1;
           buffer.append(c);
-          break;
-        case '\n', '\f', '\r':
+        }
+        case '\n', '\f', '\r' -> {
           if (c == '\n' && prevc == '\r') {
-            break;
+            return;
           }
           if (prevc != '\\') {
             ignoreElementsS1 = true;
@@ -4217,10 +4203,8 @@ class CSSTokenizerFilter {
             // Wipe out the \\ as well.
             buffer.setLength(buffer.length() - 1);
           }
-          break;
-        default:
-          buffer.append(c);
-          break;
+        }
+        default -> buffer.append(c);
       }
     }
 
@@ -4384,17 +4368,17 @@ class CSSTokenizerFilter {
       if (LOG.isTraceEnabled()) LOG.trace("STATE2INQUOTE: {}", c);
       charsetPossible = false;
       switch (c) {
-        case '"':
+        case '"' -> {
           if (currentQuote == '"' && prevc != '\\') currentState = STATE2;
           buffer.append(c);
-          break;
-        case '\'':
+        }
+        case '\'' -> {
           if (currentQuote == '\'' && prevc != '\\') currentState = STATE2;
           buffer.append(c);
-          break;
-        case '\n', '\f', '\r':
+        }
+        case '\n', '\f', '\r' -> {
           if (c == '\n' && prevc == '\r') {
-            break;
+            return;
           }
           if (prevc != '\\') {
             ignoreElementsS2 = true;
@@ -4403,10 +4387,8 @@ class CSSTokenizerFilter {
           } else {
             buffer.setLength(buffer.length() - 1);
           }
-          break;
-        default:
-          buffer.append(c);
-          break;
+        }
+        default -> buffer.append(c);
       }
     }
 
@@ -4663,17 +4645,17 @@ class CSSTokenizerFilter {
       }
       if (LOG.isTraceEnabled()) LOG.trace("STATE3INQUOTE: {}", c);
       switch (c) {
-        case '"':
+        case '"' -> {
           if (currentQuote == '"' && prevc != '\\') currentState = STATE3;
           buffer.append(c);
-          break;
-        case '\'':
+        }
+        case '\'' -> {
           if (currentQuote == '\'' && prevc != '\\') currentState = STATE3;
           buffer.append(c);
-          break;
-        case '\n', '\r', '\f':
+        }
+        case '\n', '\r', '\f' -> {
           if (c == '\n' && prevc == '\r') {
-            break;
+            return;
           }
           if (prevc != '\\') {
             ignoreElementsS3 = true;
@@ -4681,10 +4663,8 @@ class CSSTokenizerFilter {
           } else {
             buffer.setLength(buffer.length() - 1);
           }
-          break;
-        default:
-          buffer.append(c);
-          break;
+        }
+        default -> buffer.append(c);
       }
     }
 
@@ -4784,7 +4764,7 @@ class CSSTokenizerFilter {
           first = false;
           continue;
         }
-        if (!appendFromWord(out, word)) return Collections.emptyList(); // broken: signal to caller
+        if (!appendFromWord(out, word)) return new ArrayList<>(); // broken: signal to caller
       }
       return out;
     }
@@ -4797,7 +4777,7 @@ class CSSTokenizerFilter {
       }
       if (word instanceof SimpleParsedWord) {
         String data = word.original;
-        String[] split = FilterUtils.removeWhiteSpace(data.split(","), false);
+        String[] split = FilterUtils.removeWhiteSpace(FilterUtils.splitOnChar(data, ','), false);
         out.addAll(Arrays.asList(split));
         return true;
       }
@@ -4954,14 +4934,14 @@ class CSSTokenizerFilter {
     @Override
     protected boolean mustEncode(char c, int i, char prevc, boolean unicode) {
       // It is an identifier.
-      if (c >= 'a' && c <= 'z'
-          || c >= 'A' && c <= 'Z'
-          || c >= '0' && c <= '9'
+      if ((c >= 'a' && c <= 'z')
+          || (c >= 'A' && c <= 'Z')
+          || (c >= '0' && c <= '9')
           || c == '-'
           || c == '_'
-          || c >= (char) 0x00A1 && unicode) {
+          || (c >= (char) 0x00A1 && unicode)) {
         // Cannot start with a digit or a hyphen followed by a digit.
-        return i == 0 && c >= '0' && c <= '9' || i == 1 && prevc == '-' && c >= '0' && c <= '9';
+        return (i == 0 && c >= '0' && c <= '9') || (i == 1 && prevc == '-' && c >= '0' && c <= '9');
       }
       return true;
     }
@@ -5000,7 +4980,7 @@ class CSSTokenizerFilter {
       if (c == stringChar)
         // And the quote itself.
         return true;
-      else return c < 32 || c >= (char) 0x0080 && !unicode;
+      else return c < 32 || (c >= (char) 0x0080 && !unicode);
     }
 
     @Override
@@ -5247,7 +5227,8 @@ class CSSTokenizerFilter {
     }
 
     private boolean isDelimiterOutsideBrackets() {
-      return (WS_T_R_N_F.indexOf(c) != -1 || allowCommaDelimiters && c == ',') && bracketCount == 0;
+      return (WS_T_R_N_F.indexOf(c) != -1 || (allowCommaDelimiters && c == ','))
+          && bracketCount == 0;
     }
 
     private void handleDelimiter(int index) {
@@ -5318,7 +5299,7 @@ class CSSTokenizerFilter {
       boolean isAlphaLower = c >= 'a' && c <= 'z';
       boolean isAlphaUpper = c >= 'A' && c <= 'Z';
       boolean allowed =
-          isDigit && !origToken.isEmpty()
+          (isDigit && !origToken.isEmpty())
               || isAlphaLower
               || isAlphaUpper
               || c == '-'
@@ -5334,7 +5315,7 @@ class CSSTokenizerFilter {
     }
 
     private static boolean isHexDigit(char ch) {
-      return ch >= '0' && ch <= '9' || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F';
+      return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
     }
 
     private static boolean isLineBreak(char ch) {
@@ -5424,7 +5405,7 @@ class CSSTokenizerFilter {
         decodedToken.append(c);
         return;
       }
-      if (c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F') {
+      if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
         escape.append(c);
         return;
       }
@@ -5438,7 +5419,7 @@ class CSSTokenizerFilter {
     }
 
     private void handleStringEscapingContinue() {
-      if (c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F') {
+      if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
         escape.append(c);
         if (escape.length() == 6) {
           origToken.append(escape);
@@ -5582,7 +5563,7 @@ class CSSTokenizerFilter {
       String s = origToken.toString();
       if (couldBeIdentifier)
         return new ParsedIdentifier(s, decodedToken.toString(), dontLikeOrigToken);
-      String sl = s.toLowerCase();
+      String sl = s.toLowerCase(Locale.ROOT);
       if (sl.startsWith("url("))
         return parseUrlToken(s, origToken, decodedToken, dontLikeOrigToken);
       if (sl.startsWith("attr("))
@@ -5704,7 +5685,8 @@ class CSSTokenizerFilter {
       strippedOrig = strippedOrig.substring(0, strippedOrig.length() - trailing);
       if (strippedOrig.isEmpty()) return null;
 
-      String[] split = FilterUtils.removeWhiteSpace(strippedOrig.split(","), false);
+      String[] split =
+          FilterUtils.removeWhiteSpace(FilterUtils.splitOnChar(strippedOrig, ','), false);
       if (!isValidCounterPartsCount(split.length, plural)) return null;
 
       ParsedIdentifier ident = makeParsedIdentifier(split[0]);
@@ -5714,7 +5696,7 @@ class CSSTokenizerFilter {
       if (plural && separator == null) return null;
 
       ParsedIdentifier listType = parseCounterListType(plural, split);
-      if ((plural && split.length == 3 || !plural && split.length == 2) && listType == null)
+      if (((plural && split.length == 3) || (!plural && split.length == 2)) && listType == null)
         return null;
       return new ParsedCounter(origToken.toString(), ident, listType, separator);
     }
@@ -5732,7 +5714,7 @@ class CSSTokenizerFilter {
 
     private static ParsedIdentifier parseCounterListType(boolean plural, String[] split) {
       int idx = plural ? 2 : 1;
-      if (plural && split.length == 3 || !plural && split.length == 2) {
+      if ((plural && split.length == 3) || (!plural && split.length == 2)) {
         return makeParsedIdentifier(split[idx]);
       }
       return null;
@@ -5977,50 +5959,21 @@ class CSSTokenizerFilter {
         if (possibleValues == null) return f;
         for (String p : possibleValues) {
           switch (p) {
-            case "in":
-              f.integer = true;
-              break;
-            case "re":
-              f.real = true;
-              break;
-            case "pe":
-              f.percentage = true;
-              break;
-            case "le":
-              f.length = true;
-              break;
-            case "an":
-              f.angle = true;
-              break;
-            case "co":
-              f.color = true;
-              break;
-            case "ur":
-              f.uri = true;
-              break;
-            case "se":
-              f.idSelector = true;
-              break;
-            case "sh":
-              f.shape = true;
-              break;
-            case "st":
-              f.string = true;
-              break;
-            case "id":
-              f.identifier = true;
-              break;
-            case "ti":
-              f.time = true;
-              break;
-            case "fr":
-              f.frequency = true;
-              break;
-            case "tr":
-              f.transform = true;
-              break;
-            default:
-              break;
+            case "in" -> f.integer = true;
+            case "re" -> f.real = true;
+            case "pe" -> f.percentage = true;
+            case "le" -> f.length = true;
+            case "an" -> f.angle = true;
+            case "co" -> f.color = true;
+            case "ur" -> f.uri = true;
+            case "se" -> f.idSelector = true;
+            case "sh" -> f.shape = true;
+            case "st" -> f.string = true;
+            case "id" -> f.identifier = true;
+            case "ti" -> f.time = true;
+            case "fr" -> f.frequency = true;
+            case "tr" -> f.transform = true;
+            default -> {}
           }
         }
         return f;
@@ -6156,7 +6109,7 @@ class CSSTokenizerFilter {
     }
 
     private boolean validateIdentifierDefaults(ParsedIdentifier word) {
-      String lower = word.original.toLowerCase();
+      String lower = word.original.toLowerCase(Locale.ROOT);
       if (allowedValues != null && allowedValues.contains(lower)) return true;
       return isDefaultingKeyword(lower);
     }
@@ -6173,19 +6126,19 @@ class CSSTokenizerFilter {
     }
 
     private boolean matchesNumericTypes(String w) {
-      return isInteger && isIntegerChecker(w)
-          || isReal && isRealChecker(w)
-          || isPercentage && FilterUtils.isPercentage(w)
-          || isLength && FilterUtils.isLength(w, false)
-          || isAngle && FilterUtils.isAngle(w);
+      return (isInteger && isIntegerChecker(w))
+          || (isReal && isRealChecker(w))
+          || (isPercentage && FilterUtils.isPercentage(w))
+          || (isLength && FilterUtils.isLength(w, false))
+          || (isAngle && FilterUtils.isAngle(w));
     }
 
     private boolean matchesOtherTypes(String w) {
-      return isColor && FilterUtils.isColor(w)
-          || isShape && FilterUtils.isValidCSSShape(w)
-          || isFrequency && FilterUtils.isFrequency(w)
-          || isTime && FilterUtils.isTime(w)
-          || isTransform && FilterUtils.isCSSTransform(w);
+      return (isColor && FilterUtils.isColor(w))
+          || (isShape && FilterUtils.isValidCSSShape(w))
+          || (isFrequency && FilterUtils.isFrequency(w))
+          || (isTime && FilterUtils.isTime(w))
+          || (isTransform && FilterUtils.isCSSTransform(w));
     }
 
     private boolean validateIdentifierSpecials(ParsedIdentifier word) {
@@ -6298,7 +6251,7 @@ class CSSTokenizerFilter {
       int endIndex = expression.length();
       for (int j = 0; j < expression.length(); j++) {
         char ch = expression.charAt(j);
-        if (!(ch == 'a' || '0' <= ch && '9' >= ch)) {
+        if (!(ch == 'a' || ('0' <= ch && '9' >= ch))) {
           endIndex = j;
           break;
         }
@@ -6326,7 +6279,7 @@ class CSSTokenizerFilter {
       int endIndex = expression.length();
       for (int j = 0; j < expression.length(); j++) {
         char ch = expression.charAt(j);
-        if (!(ch == 'b' || '0' <= ch && '9' >= ch)) {
+        if (!(ch == 'b' || ('0' <= ch && '9' >= ch))) {
           endIndex = j;
           break;
         }
@@ -6385,7 +6338,7 @@ class CSSTokenizerFilter {
             tokensUpper);
 
       int index = Integer.parseInt(firstPart);
-      String[] strLimits = expression.substring(ltIndex + 1, tindex).split(",");
+      String[] strLimits = FilterUtils.splitOnChar(expression.substring(ltIndex + 1, tindex), ',');
       if (strLimits.length != 2) return false;
       int lowerLimit = Integer.parseInt(strLimits[0]);
       int upperLimit = Integer.parseInt(strLimits[1]);
@@ -6405,7 +6358,7 @@ class CSSTokenizerFilter {
       if (tindex != expression.length() - 1 && expression.charAt(tindex + 1) == '[') {
         int end = expression.indexOf(']');
         if (end > tindex + 1) {
-          String[] limits = expression.substring(tindex + 2, end).split(",");
+          String[] limits = FilterUtils.splitOnChar(expression.substring(tindex + 2, end), ',');
           tokensLower = Integer.parseInt(limits[0]);
           tokensUpper = Integer.parseInt(limits[1]);
           firstIndex = end + 1;
@@ -6425,7 +6378,7 @@ class CSSTokenizerFilter {
      * Takes b-expressions and evaluates them.
      *
      * <p>{@literal &&} means all the expressions must occur in any order.<br>
-     * CSS Grammar {@code list-item &amp;&amp; [ block | nonsense ] &amp;&amp; [ more ]?}<br>
+     * CSS Grammar {@code list-item && [ block | nonsense ] && [ more ]?}<br>
      * Will accept the following inputs as valid:<br>
      * {@code list-item block}<br>
      * {@code block list-item more}<br>
@@ -6572,37 +6525,63 @@ class CSSTokenizerFilter {
       }
     }
 
-    /**
-     * Parameters for verifying parse expressions that use the {@code []} repetition operator.
-     *
-     * @param verifierIndex index into {@code auxilaryVerifiers} for the repeated sub-expression.
-     * @param valueParts token sequence to validate.
-     * @param limits repetition bounds and token consumption limits.
-     * @param secondPart expression to validate after the repeated part.
-     * @param cb callback consulted by nested verifiers when URLs are encountered.
-     */
-    private record VariableOccurrenceParams(
-        int verifierIndex,
-        ParsedWord[] valueParts,
-        VariableOccurrenceLimits limits,
-        String secondPart,
-        FilterCallback cb) {
+    /** Parameters for verifying parse expressions that use the {@code []} repetition operator. */
+    private static final class VariableOccurrenceParams {
+      private final int verifierIndex;
+      private final ParsedWord[] valueParts;
+      private final VariableOccurrenceLimits limits;
+      private final String secondPart;
+      private final FilterCallback cb;
+
+      /**
+       * @param verifierIndex index into {@code auxilaryVerifiers} for the repeated sub-expression.
+       * @param valueParts token sequence to validate.
+       * @param limits repetition bounds and token consumption limits.
+       * @param secondPart expression to validate after the repeated part.
+       * @param cb callback consulted by nested verifiers when URLs are encountered.
+       */
+      private VariableOccurrenceParams(
+          int verifierIndex,
+          ParsedWord[] valueParts,
+          VariableOccurrenceLimits limits,
+          String secondPart,
+          FilterCallback cb) {
+        this.verifierIndex = verifierIndex;
+        this.valueParts = valueParts;
+        this.limits = limits;
+        this.secondPart = secondPart;
+        this.cb = cb;
+      }
+
+      private int verifierIndex() {
+        return verifierIndex;
+      }
+
+      private ParsedWord[] valueParts() {
+        return valueParts;
+      }
+
+      private VariableOccurrenceLimits limits() {
+        return limits;
+      }
+
+      private String secondPart() {
+        return secondPart;
+      }
+
+      private FilterCallback cb() {
+        return cb;
+      }
+
       @Override
       public boolean equals(Object obj) {
         if (this == obj) return true;
-        if (!(obj
-            instanceof
-            VariableOccurrenceParams(
-                int otherVerifierIndex,
-                ParsedWord[] otherValueParts,
-                VariableOccurrenceLimits otherLimits,
-                String otherSecondPart,
-                FilterCallback otherCb))) return false;
-        return verifierIndex == otherVerifierIndex
-            && Arrays.equals(valueParts, otherValueParts)
-            && Objects.equals(limits, otherLimits)
-            && Objects.equals(secondPart, otherSecondPart)
-            && Objects.equals(cb, otherCb);
+        if (!(obj instanceof VariableOccurrenceParams other)) return false;
+        return verifierIndex == other.verifierIndex
+            && Arrays.equals(valueParts, other.valueParts)
+            && Objects.equals(limits, other.limits)
+            && Objects.equals(secondPart, other.secondPart)
+            && Objects.equals(cb, other.cb);
       }
 
       @Override
@@ -7113,7 +7092,7 @@ class CSSTokenizerFilter {
     private StartDecision analyzeStartFromString(ParsedString string) {
       String decoded = string.getDecoded();
       if (LOG.isTraceEnabled()) LOG.trace("decoded: \"{}\"", decoded);
-      String lower = decoded.toLowerCase();
+      String lower = decoded.toLowerCase(Locale.ROOT);
       if (isSpecificFamily(lower) || isGenericFamily(lower)) return StartDecision.continueNext();
       return StartDecision.startWith(decoded);
     }
@@ -7132,7 +7111,7 @@ class CSSTokenizerFilter {
     }
 
     private ProcessResult consumeUnquotedFont(
-        ParsedWord[] value, int startIndex, ArrayList<String> fontWords) {
+        ParsedWord[] value, int startIndex, List<String> fontWords) {
       if (atLastWord(startIndex, value)) return finalizeLastWord(fontWords);
       if (!possiblyValidFontWords(fontWords)) return ProcessResult.returning(false);
       return consumeFollowingFontWords(value, startIndex, fontWords);
@@ -7142,7 +7121,7 @@ class CSSTokenizerFilter {
       return startIndex == value.length - 1;
     }
 
-    private ProcessResult finalizeLastWord(ArrayList<String> fontWords) {
+    private ProcessResult finalizeLastWord(List<String> fontWords) {
       boolean ok = validFontWords(fontWords);
       if (LOG.isDebugEnabled())
         LOG.debug(
@@ -7153,7 +7132,7 @@ class CSSTokenizerFilter {
     }
 
     private ProcessResult consumeFollowingFontWords(
-        ParsedWord[] value, int startIndex, ArrayList<String> fontWords) {
+        ParsedWord[] value, int startIndex, List<String> fontWords) {
       for (int j = startIndex + 1; j < value.length; j++) {
         ParsedWord newWord = value[j];
         if (!isIdentifier(newWord)) return ProcessResult.returning(false);
@@ -7170,7 +7149,7 @@ class CSSTokenizerFilter {
     }
 
     private ProcessResult maybeReturnAtLastIndex(
-        ParsedWord newWord, int j, ParsedWord[] value, ArrayList<String> fontWords) {
+        ParsedWord newWord, int j, ParsedWord[] value, List<String> fontWords) {
       if (!isLastIndex(j, value)) return null;
       if (newWord.postComma && LOG.isTraceEnabled()) LOG.trace("not valid: trailing comma at end");
       if (validFontWords(fontWords)) return ProcessResult.returning(true);
@@ -7187,7 +7166,7 @@ class CSSTokenizerFilter {
       return j == value.length - 1;
     }
 
-    private ProcessResult handleCommaInFontList(ArrayList<String> fontWords, int j) {
+    private ProcessResult handleCommaInFontList(List<String> fontWords, int j) {
       if (validFontWords(fontWords)) {
         fontWords.clear();
         return ProcessResult.continuingFrom(j);
@@ -7238,7 +7217,7 @@ class CSSTokenizerFilter {
       }
     }
 
-    private boolean possiblyValidFontWords(ArrayList<String> fontWords) {
+    private boolean possiblyValidFontWords(List<String> fontWords) {
       if (ElementInfo.DISALLOW_UNKNOWN_SPECIFIC_FONTS) {
         StringBuilder sb = new StringBuilder();
         boolean first = true;
@@ -7247,7 +7226,7 @@ class CSSTokenizerFilter {
           first = false;
           sb.append(s);
         }
-        String s = sb.toString().toLowerCase();
+        String s = sb.toString().toLowerCase(Locale.ROOT);
         return ElementInfo.isWordPrefixOrMatchOfSpecificFontFamily(s);
       } else {
         for (String s : fontWords) if (!isSpecificFamily(s)) return false;
@@ -7255,11 +7234,12 @@ class CSSTokenizerFilter {
       }
     }
 
-    private boolean validFontWords(ArrayList<String> fontWords) {
+    private boolean validFontWords(List<String> fontWords) {
       for (String s : fontWords) {
         if (s == null) throw new NullPointerException();
       }
-      if (fontWords.size() == 1 && isGenericFamily(fontWords.getFirst().toLowerCase())) return true;
+      if (fontWords.size() == 1 && isGenericFamily(fontWords.getFirst().toLowerCase(Locale.ROOT)))
+        return true;
       StringBuilder sb = new StringBuilder();
       boolean first = true;
       for (String s : fontWords) {
@@ -7267,7 +7247,7 @@ class CSSTokenizerFilter {
         first = false;
         sb.append(s);
       }
-      return isSpecificFamily(sb.toString().toLowerCase());
+      return isSpecificFamily(sb.toString().toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/src/main/java/network/crypta/client/filter/ElementInfo.java
+++ b/src/main/java/network/crypta/client/filter/ElementInfo.java
@@ -1,5 +1,6 @@
 package network.crypta.client.filter;
 
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -490,7 +491,8 @@ public class ElementInfo {
    * @return {@code true} when the normalized name is in the allow list; {@code false} otherwise.
    */
   public static boolean isValidHTMLTag(String tag) {
-    return (HTML_ELEMENTS.contains(tag.toLowerCase()) || VOID_ELEMENTS.contains(tag.toLowerCase()));
+    String lowered = tag.toLowerCase(Locale.ROOT);
+    return HTML_ELEMENTS.contains(lowered) || VOID_ELEMENTS.contains(lowered);
   }
 
   /**
@@ -698,7 +700,7 @@ public class ElementInfo {
   public static boolean isBannedPseudoClass(String cname) {
     if (cname.indexOf(':') != -1) {
       // Pseudo-classes can be chained, at least dynamic ones can, see CSS2.1 section 5.11.3
-      String[] split = cname.split(":");
+      String[] split = FilterUtils.splitOnChar(cname, ':');
       for (String s : split) if (isBannedPseudoClass2(s)) return true;
       return false;
     } else {
@@ -707,7 +709,7 @@ public class ElementInfo {
   }
 
   private static boolean isBannedPseudoClass2(String cname) {
-    return BANNED_PSEUDOCLASS.contains(cname.toLowerCase());
+    return BANNED_PSEUDOCLASS.contains(cname.toLowerCase(Locale.ROOT));
   }
 
   /**
@@ -723,7 +725,7 @@ public class ElementInfo {
   public static boolean isValidPseudoClass(String cname) {
     if (cname.indexOf(':') != -1) {
       // Pseudo-classes can be chained, at least dynamic ones can, see CSS2.1 section 5.11.3
-      String[] split = cname.split(":");
+      String[] split = FilterUtils.splitOnChar(cname, ':');
       for (String s : split) if (!isValidPseudoClass2(s)) return false;
       return true;
     } else {
@@ -732,7 +734,7 @@ public class ElementInfo {
   }
 
   private static boolean isValidPseudoClass2(String cname) {
-    cname = cname.toLowerCase();
+    cname = cname.toLowerCase(Locale.ROOT);
     if (PSEUDOCLASS.contains(cname)) return true;
     else if (cname.startsWith(PC_LANG)
         && Pattern.matches("[\\w\\-*]{1,30}", getPseudoClassArg(cname, PC_LANG))) {

--- a/src/main/java/network/crypta/client/filter/FilterUtils.java
+++ b/src/main/java/network/crypta/client/filter/FilterUtils.java
@@ -3,6 +3,7 @@ package network.crypta.client.filter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -227,17 +228,17 @@ public class FilterUtils {
     if (value.contains("deg")) {
       index = value.indexOf("deg");
       String secondpart = value.substring(index).trim();
-      if (!("deg".equals(secondpart))) isValid = false;
+      if (!"deg".equals(secondpart)) isValid = false;
     } else if (value.contains("grad")) {
       index = value.indexOf("grad");
       String secondpart = value.substring(index).trim();
 
-      if (!("grad".equals(secondpart))) isValid = false;
+      if (!"grad".equals(secondpart)) isValid = false;
     } else if (value.contains("rad")) {
       index = value.indexOf("rad");
       String secondpart = value.substring(index).trim();
 
-      if (!("rad".equals(secondpart))) isValid = false;
+      if (!"rad".equals(secondpart)) isValid = false;
     }
     if (index != -1 && isValid) {
       String firstPart = value.substring(0, index);
@@ -426,7 +427,7 @@ public class FilterUtils {
    */
   public static boolean isValidCSSShape(String value) {
     if (value.indexOf("rect(") == 0 && value.indexOf(')') == value.length() - 1) {
-      String[] shapeParts = value.substring(5, value.length() - 1).split(",");
+      String[] shapeParts = splitOnChar(value.substring(5, value.length() - 1), ',');
       if (shapeParts.length == 4) {
         for (String s : shapeParts) {
           s = s.trim();
@@ -492,7 +493,7 @@ public class FilterUtils {
    * @return {@code true} if the value matches any supported color notation; otherwise {@code false}
    */
   public static boolean isColor(String value) {
-    String v = value.trim().toLowerCase();
+    String v = value.trim().toLowerCase(Locale.ROOT);
 
     if (CSScolorKeywords.contains(v)
         || CSSsystemColorKeywords.contains(v)
@@ -511,14 +512,14 @@ public class FilterUtils {
 
   private static boolean isColorHsl(String v) {
     if (v.indexOf("hsl(") != 0 || v.indexOf(')') != v.length() - 1) return false;
-    String[] colorParts = v.substring(4, v.length() - 1).split(",");
+    String[] colorParts = splitOnChar(v.substring(4, v.length() - 1), ',');
     if (colorParts.length != 3) return false;
     return isNumber(colorParts[0]) && isPercentage(colorParts[1]) && isPercentage(colorParts[2]);
   }
 
   private static boolean isColorHsla(String v) {
     if (v.indexOf("hsla(") != 0 || v.indexOf(')') != v.length() - 1) return false;
-    String[] colorParts = v.substring(5, v.length() - 1).split(",");
+    String[] colorParts = splitOnChar(v.substring(5, v.length() - 1), ',');
     if (colorParts.length != 4) return false;
     return isNumber(colorParts[0])
         && isPercentage(colorParts[1])
@@ -531,7 +532,7 @@ public class FilterUtils {
   }
 
   private static boolean isColorRgbLegacy(String v) {
-    String[] colorParts = v.substring(v.indexOf("(") + 1, v.length() - 1).split(",");
+    String[] colorParts = splitOnChar(v.substring(v.indexOf("(") + 1, v.length() - 1), ',');
     if (colorParts.length != 3 && colorParts.length != 4) return false;
     for (int i = 0; i < 3; i++) {
       if (!(isPercentage(colorParts[i].trim()) || isInteger(colorParts[i].trim()))) return false;
@@ -551,7 +552,7 @@ public class FilterUtils {
       v = v.substring(0, v.indexOf("/")) + ")"; // Strip alpha value
     }
     // Modern format rgba(r g b)
-    String[] colorParts = v.substring(v.indexOf("(") + 1, v.length() - 1).split(" ");
+    String[] colorParts = splitOnChar(v.substring(v.indexOf("(") + 1, v.length() - 1), ' ');
     if (colorParts.length != 3) return false;
     for (int i = 0; i < 3; i++) {
       String trimmed = colorParts[i].trim();
@@ -592,7 +593,7 @@ public class FilterUtils {
 
   private static boolean isTransformMatrix(String v) {
     if (v.indexOf("matrix(") == 0 && v.indexOf(')') == v.length() - 1) {
-      String[] parts = v.substring(7, v.length() - 1).split(",");
+      String[] parts = splitOnChar(v.substring(7, v.length() - 1), ',');
       if (parts.length != 6) return false;
       for (String part : parts) if (!isNumber(part.trim())) return false;
       if (LOG.isTraceEnabled()) LOG.trace("isCSSTransform found a matrix()");
@@ -625,7 +626,7 @@ public class FilterUtils {
 
   private static boolean isTransformTranslate(String v) {
     if (v.indexOf("translate(") == 0 && v.indexOf(')') == v.length() - 1) {
-      String[] parts = v.substring(10, v.length() - 1).split(",");
+      String[] parts = splitOnChar(v.substring(10, v.length() - 1), ',');
       boolean valid =
           (parts.length == 1 && (isPercentage(parts[0].trim()) || isLength(parts[0].trim(), false)))
               || (parts.length == 2
@@ -641,7 +642,7 @@ public class FilterUtils {
 
   private static boolean isTransformScale(String v) {
     if (v.indexOf("scale(") == 0 && v.indexOf(')') == v.length() - 1) {
-      String[] parts = v.substring(6, v.length() - 1).split(",");
+      String[] parts = splitOnChar(v.substring(6, v.length() - 1), ',');
       boolean valid =
           (parts.length == 1 && isNumber(parts[0].trim()))
               || (parts.length == 2 && isNumber(parts[0].trim()) && isNumber(parts[1].trim()));
@@ -710,7 +711,7 @@ public class FilterUtils {
 
   private static boolean isTransformSkew(String v) {
     if (v.indexOf("skew(") == 0 && v.indexOf(')') == v.length() - 1) {
-      String[] parts = v.substring(5, v.length() - 1).split(",");
+      String[] parts = splitOnChar(v.substring(5, v.length() - 1), ',');
       boolean valid =
           (parts.length == 1 && (isNumber(parts[0].trim()) || isAngle(parts[0].trim())))
               || (parts.length == 2
@@ -737,19 +738,19 @@ public class FilterUtils {
    */
   public static boolean isFrequency(String value) {
     String firstPart;
-    value = value.trim().toLowerCase();
+    value = value.trim().toLowerCase(Locale.ROOT);
     boolean isValidFrequency = true;
     if (value.contains("khz")) {
       int index = value.indexOf("khz");
       firstPart = value.substring(0, index).trim();
-      if (!("khz".equals(value.substring(index).trim()))) {
+      if (!"khz".equals(value.substring(index).trim())) {
         isValidFrequency = false;
       }
 
     } else if (value.contains("hz")) {
       int index = value.indexOf("hz");
       firstPart = value.substring(0, index).trim();
-      if (!("hz".equals(value.substring(index).trim()))) {
+      if (!"hz".equals(value.substring(index).trim())) {
         isValidFrequency = false;
       }
 
@@ -776,7 +777,7 @@ public class FilterUtils {
    * @return {@code true} if a numeric value followed by a supported unit is present
    */
   public static boolean isTime(String value) {
-    value = value.toLowerCase();
+    value = value.toLowerCase(Locale.ROOT);
     String intValue;
     if (value.contains("ms") && value.length() > 2)
       intValue = value.substring(0, value.length() - 2);
@@ -784,6 +785,24 @@ public class FilterUtils {
       intValue = value.substring(0, value.length() - 1);
     else return false;
     return isNumber(intValue);
+  }
+
+  /** Splits on a delimiter char and drops trailing empty segments. */
+  static String[] splitOnChar(String value, char delimiter) {
+    ArrayList<String> parts = new ArrayList<>();
+    int start = 0;
+    for (int i = 0; i < value.length(); i++) {
+      if (value.charAt(i) == delimiter) {
+        parts.add(value.substring(start, i));
+        start = i + 1;
+      }
+    }
+    parts.add(value.substring(start));
+    for (int i = parts.size() - 1; i >= 0; i--) {
+      if (!parts.get(i).isEmpty()) break;
+      parts.remove(i);
+    }
+    return parts.toArray(new String[0]);
   }
 
   /**
@@ -894,7 +913,7 @@ public class FilterUtils {
   public static boolean isPointPair(String value) {
     String[] pointPairs = splitOnCharArray(value, " \n\t");
     for (String pointPair : pointPairs) {
-      String[] strParts = pointPair.split(",");
+      String[] strParts = splitOnChar(pointPair, ',');
       if (strParts.length != 2) return false;
       try {
         Float.parseFloat(strParts[0]);

--- a/src/main/java/network/crypta/client/filter/FlacFilter.java
+++ b/src/main/java/network/crypta/client/filter/FlacFilter.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import network.crypta.l10n.NodeL10n;
@@ -56,12 +57,33 @@ public class FlacFilter implements ContentDataFilter {
     STREAM_FINISHED
   }
 
-  private record AudioReadResult(byte[] payload, short nextFrameHeader, boolean streamFinished) {
+  private static final class AudioReadResult {
+    private final byte[] payload;
+    private final short nextFrameHeader;
+    private final boolean streamFinished;
+
+    private AudioReadResult(byte[] payload, short nextFrameHeader, boolean streamFinished) {
+      this.payload = payload;
+      this.nextFrameHeader = nextFrameHeader;
+      this.streamFinished = streamFinished;
+    }
+
+    private byte[] payload() {
+      return payload;
+    }
+
+    private short nextFrameHeader() {
+      return nextFrameHeader;
+    }
+
+    private boolean streamFinished() {
+      return streamFinished;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      AudioReadResult that = (AudioReadResult) o;
+      if (!(o instanceof AudioReadResult that)) return false;
       return nextFrameHeader == that.nextFrameHeader
           && streamFinished == that.streamFinished
           && Arrays.equals(payload, that.payload);
@@ -111,12 +133,12 @@ public class FlacFilter implements ContentDataFilter {
     return block;
   }
 
-  private static void addFrameHeaderBytes(ArrayList<Byte> buffer, short frameHeader) {
+  private static void addFrameHeaderBytes(List<Byte> buffer, short frameHeader) {
     buffer.add((byte) ((frameHeader & 0xFF00) >>> 8));
     buffer.add((byte) (frameHeader & 0x00FF));
   }
 
-  private static byte[] toByteArray(ArrayList<Byte> buffer) {
+  private static byte[] toByteArray(List<Byte> buffer) {
     byte[] payload = new byte[buffer.size()];
     for (int i = 0; i < buffer.size(); i++) {
       payload[i] = buffer.get(i);
@@ -224,6 +246,7 @@ public class FlacFilter implements ContentDataFilter {
    * @throws IOException if an I/O error occurs while reading from {@code input} or writing to
    *     {@code output}; partial output may already be written when the exception is thrown
    */
+  @Override
   public void readFilter(
       InputStream input,
       OutputStream output,

--- a/src/main/java/network/crypta/client/filter/GenericReadFilterCallback.java
+++ b/src/main/java/network/crypta/client/filter/GenericReadFilterCallback.java
@@ -6,6 +6,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
@@ -450,7 +451,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
     if (method == null) {
       method = "GET";
     }
-    method = method.toUpperCase();
+    method = method.toUpperCase(Locale.ROOT);
     if (!(method.equals("POST") || method.equals("GET"))) {
       return null; // no irregular form sending methods
     }
@@ -776,7 +777,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       sb.append(strippedBaseURI.getScheme());
       sb.append("://");
       sb.append(strippedBaseURI.getAuthority());
-      assert (path.startsWith("/"));
+      assert path.startsWith("/");
     }
     sb.append(path);
     if (typeOverride != null) {

--- a/src/main/java/network/crypta/client/filter/HTMLFilter.java
+++ b/src/main/java/network/crypta/client/filter/HTMLFilter.java
@@ -17,6 +17,7 @@ import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.MalformedInputException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.AbstractMap;
 import java.util.ArrayDeque;
@@ -28,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -446,29 +448,18 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
     private void handleEndOfStream() throws IOException {
       switch (mode) {
-        case INTEXT:
-          flushPendingText();
-          break;
-        case INTAG:
-          w.write("<!-- truncated page: last tag not unfinished -->");
-          break;
-        case INTAGQUOTES:
-          w.write("<!-- truncated page: deleted unfinished tag: still in quotes -->");
-          break;
-        case INTAGSQUOTES:
-          w.write("<!-- truncated page: deleted unfinished tag: still in single quotes -->");
-          break;
-        case INTAGWHITESPACE:
-          w.write("<!-- truncated page: deleted unfinished tag: still in whitespace -->");
-          break;
-        case INTAGCOMMENT:
-          w.write("<!-- truncated page: deleted unfinished comment -->");
-          break;
-        case INTAGCOMMENTCLOSING:
-          w.write("<!-- truncated page: deleted unfinished comment, might be closing -->");
-          break;
-        default:
-          break;
+        case INTEXT -> flushPendingText();
+        case INTAG -> w.write("<!-- truncated page: last tag not unfinished -->");
+        case INTAGQUOTES ->
+            w.write("<!-- truncated page: deleted unfinished tag: still in quotes -->");
+        case INTAGSQUOTES ->
+            w.write("<!-- truncated page: deleted unfinished tag: still in single quotes -->");
+        case INTAGWHITESPACE ->
+            w.write("<!-- truncated page: deleted unfinished tag: still in whitespace -->");
+        case INTAGCOMMENT -> w.write("<!-- truncated page: deleted unfinished comment -->");
+        case INTAGCOMMENTCLOSING ->
+            w.write("<!-- truncated page: deleted unfinished comment, might be closing -->");
+        default -> {}
       }
     }
 
@@ -496,29 +487,14 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
     private void dispatchTokenizerMode() throws IOException {
       switch (mode) {
-        case INTEXT:
-          handleTextMode();
-          break;
-        case INTAG:
-          handleTagMode();
-          break;
-        case INTAGQUOTES:
-          handleDoubleQuoteMode();
-          break;
-        case INTAGSQUOTES:
-          handleSingleQuoteMode();
-          break;
-        case INTAGCOMMENT:
-          handleCommentMode();
-          break;
-        case INTAGCOMMENTCLOSING:
-          handleCommentClosingMode();
-          break;
-        case INTAGWHITESPACE:
-          handleWhitespaceMode();
-          break;
-        default:
-          break;
+        case INTEXT -> handleTextMode();
+        case INTAG -> handleTagMode();
+        case INTAGQUOTES -> handleDoubleQuoteMode();
+        case INTAGSQUOTES -> handleSingleQuoteMode();
+        case INTAGCOMMENT -> handleCommentMode();
+        case INTAGCOMMENTCLOSING -> handleCommentClosingMode();
+        case INTAGWHITESPACE -> handleWhitespaceMode();
+        default -> {}
       }
     }
 
@@ -823,7 +799,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     }
     String tagContent;
     try (BufferedReader bufferedReader =
-        new BufferedReader(new InputStreamReader(m3uPlayerTagStream))) {
+        new BufferedReader(new InputStreamReader(m3uPlayerTagStream, StandardCharsets.UTF_8))) {
       StringBuilder stringBuilder = new StringBuilder("<script>");
       String line;
       while ((line = bufferedReader.readLine()) != null) {
@@ -837,6 +813,22 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       return errorTag;
     }
     return tagContent;
+  }
+
+  private static String[] splitOnComma(String input) {
+    ArrayList<String> parts = new ArrayList<>();
+    int start = 0;
+    for (int i = 0; i < input.length(); i++) {
+      if (input.charAt(i) == ',') {
+        parts.add(input.substring(start, i));
+        start = i + 1;
+      }
+    }
+    parts.add(input.substring(start));
+    for (int i = parts.size() - 1; i >= 0 && parts.get(i).isEmpty(); i--) {
+      parts.remove(i);
+    }
+    return parts.toArray(new String[0]);
   }
 
   /**
@@ -1276,7 +1268,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     }
 
     ParsedTag sanitize(HTMLParseContext pc) throws DataFilterException {
-      TagVerifier tv = allowedTagsVerifiers.get(element.toLowerCase());
+      TagVerifier tv = allowedTagsVerifiers.get(element.toLowerCase(Locale.ROOT));
       if (LOG.isTraceEnabled()) LOG.trace("Got verifier: {} for {}", tv, element);
       if (tv == null) {
         if (!DELETE_WIERD_STUFF) {
@@ -1375,7 +1367,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       if (separatorIndex >= 0 && separatorIndex == rawAttribute.length() - 1) {
         token.expectingValue = true;
         token.key = separatorIndex == 0 ? previousKey : rawAttribute.substring(0, separatorIndex);
-        token.key = token.key.toLowerCase();
+        token.key = token.key.toLowerCase(Locale.ROOT);
         return token;
       }
       if (separatorIndex > -1) {
@@ -1383,7 +1375,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
         if (key.isEmpty()) {
           key = previousKey;
         }
-        token.key = key.toLowerCase();
+        token.key = key.toLowerCase(Locale.ROOT);
         String rawValue = rawAttribute.substring(separatorIndex + 1);
         token.value = stripQuotes(rawValue);
         return token;
@@ -3005,7 +2997,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     private void removeBlankEntries(Map<String, Object> attributes, boolean isXhtml) {
       attributes
           .entrySet()
-          .removeIf(entry -> entry.getValue() == null || entry.getValue().equals("") && isXhtml);
+          .removeIf(entry -> entry.getValue() == null || (entry.getValue().equals("") && isXhtml));
     }
 
     static String getHashString(Map<String, Object> h, String key) {
@@ -3553,7 +3545,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       if (rel == null) {
         return new RelParseResult(null, "", false, false);
       }
-      String lowercase = rel.toLowerCase();
+      String lowercase = rel.toLowerCase(Locale.ROOT);
       StringTokenizer tok = new StringTokenizer(lowercase, " ");
       int index = 0;
       String previousToken = null;
@@ -3598,7 +3590,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       if (rev == null) {
         return "";
       }
-      String lowercase = rev.toLowerCase();
+      String lowercase = rev.toLowerCase(Locale.ROOT);
       StringTokenizer tok = new StringTokenizer(lowercase, " ");
       StringBuilder builder = new StringBuilder(lowercase.length());
       while (tok.hasMoreTokens()) {
@@ -3699,7 +3691,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private boolean isStandardLinkType(String token) {
-      return standardRelTypes.contains(token.toLowerCase());
+      return standardRelTypes.contains(token.toLowerCase(Locale.ROOT));
     }
   }
 
@@ -3822,7 +3814,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
       // We drop the whole <input> if the type isn't allowed (case-insensitive)
       if (hn.get("type") != null
-          && !allowedTypes.contains(hn.get("type").toString().toLowerCase())) {
+          && !allowedTypes.contains(hn.get("type").toString().toLowerCase(Locale.ROOT))) {
         return dropTag();
       }
 
@@ -3898,7 +3890,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     }
 
     private void handleNamedMetaTag(String name, String content, Map<String, Object> output) {
-      String lowered = name.toLowerCase();
+      String lowered = name.toLowerCase(Locale.ROOT);
       if (SUPPORTED_NAME_FIELDS.contains(lowered)) {
         output.put("name", name);
         output.put(HtmlStrings.STR_CONTENT, content);
@@ -3911,8 +3903,8 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 
     private void handleRobotsMeta(String name, String content, Map<String, Object> output) {
       StringBuilder normalized = new StringBuilder(content.length());
-      for (String token : content.split(",")) {
-        String trimmed = token.trim().toLowerCase();
+      for (String token : splitOnComma(content)) {
+        String trimmed = token.trim().toLowerCase(Locale.ROOT);
         if (!validRobotsValues.contains(trimmed)) {
           continue;
         }
@@ -3930,7 +3922,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     private boolean handleHttpEquivMeta(
         String httpEquiv, String content, Map<String, Object> output, HTMLParseContext pc)
         throws DataFilterException {
-      String lowered = httpEquiv.toLowerCase();
+      String lowered = httpEquiv.toLowerCase(Locale.ROOT);
       return switch (lowered) {
         case "expires" -> handleExpiresMeta(content, output);
         case "content-style-type" -> handleStyleTypeMeta(content, output);
@@ -4013,7 +4005,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       if (trimmed.isEmpty()) {
         return false;
       }
-      for (String token : trimmed.split(",")) {
+      for (String token : splitOnComma(trimmed)) {
         String cleaned = token.trim();
         if (!isValidLanguageToken(cleaned)) {
           return false;
@@ -4094,7 +4086,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
           seconds = getMetaRefreshRedirectMinInterval();
         }
         String after = content.substring(separatorIndex + 1).trim();
-        if (!after.toLowerCase().startsWith("url=")) {
+        if (!after.toLowerCase(Locale.ROOT).startsWith("url=")) {
           pc.writeAfterTag.append("<!-- no url but doesn't parse as number in meta refresh -->");
           return false;
         }

--- a/src/main/java/network/crypta/client/filter/JPEGFilter.java
+++ b/src/main/java/network/crypta/client/filter/JPEGFilter.java
@@ -195,7 +195,7 @@ public class JPEGFilter implements ContentDataFilter {
 
   private int readBlockLength(int markerType, DataInputStream dis, DataOutputStream dos)
       throws IOException {
-    if (markerType == MARKER_EOI || markerType >= MARKER_RST0 && markerType <= MARKER_RST7) {
+    if (markerType == MARKER_EOI || (markerType >= MARKER_RST0 && markerType <= MARKER_RST7)) {
       return 0;
     }
     int blockLength = dis.readUnsignedShort();

--- a/src/main/java/network/crypta/client/filter/M3UFilter.java
+++ b/src/main/java/network/crypta/client/filter/M3UFilter.java
@@ -31,8 +31,8 @@ import network.crypta.clients.http.ExternalLinkToadlet;
  * URI line; dedicated directive/comment lines are intentionally removed. The canonical extended
  * header is {@code #EXTM3U}. A typical entry line that accompanies metadata looks like {@code
  * #EXTINF:233,Title 1} followed by a path, for example {@code Somewhere\\title1.mp3}. In prose the
- * rule is often described as: {@code #EXTINF:&lt;length in seconds&gt;,&lt;title&gt;} followed by
- * {@code &lt;path&gt;}.
+ * rule is often described as: {@code #EXTINF:<length in seconds>,<title>} followed by {@code
+ * <path>}.
  *
  * <ul>
  *   <li>Comments beginning with {@code #} are dropped.

--- a/src/main/java/network/crypta/client/filter/OggFilter.java
+++ b/src/main/java/network/crypta/client/filter/OggFilter.java
@@ -93,6 +93,7 @@ public class OggFilter implements ContentDataFilter {
    * @throws IOException if reading from {@code input} or writing to {@code output} fails; includes
    *     validation failures signaled via {@link DataFilterException}.
    */
+  @Override
   public void readFilter(
       InputStream input,
       OutputStream output,

--- a/src/main/java/network/crypta/client/filter/PNGFilter.java
+++ b/src/main/java/network/crypta/client/filter/PNGFilter.java
@@ -7,6 +7,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.zip.CRC32;
@@ -374,7 +375,7 @@ public class PNGFilter implements ContentDataFilter {
     if (readCRC != computedCRC && LOG.isDebugEnabled()) {
       LOG.debug(
           "CRC of the chunk {} doesn't match ({} but should be {})!",
-          new String(type),
+          new String(type, StandardCharsets.US_ASCII),
           Long.toHexString(readCRC),
           Long.toHexString(computedCRC));
     }
@@ -484,21 +485,17 @@ public class PNGFilter implements ContentDataFilter {
 
   private void throwOnInvalidColour(int bitDepth, int colourType) throws DataFilterException {
     switch (bitDepth) {
-      case 1, 2, 4:
+      case 1, 2, 4 -> {
         if (colourType != 0 && colourType != 3) invalidColourCombo(colourType, bitDepth);
-        break;
-      case 16:
+      }
+      case 16 -> {
         if (colourType == 3) invalidColourCombo(colourType, bitDepth);
-        if (isValidColourType8(colourType)) break;
-        invalidColourCombo(colourType, bitDepth);
-        break;
-      case 8:
-        if (isValidColourType8(colourType)) break;
-        invalidColourCombo(colourType, bitDepth);
-        break;
-      default:
-        invalidColourCombo(colourType, bitDepth);
-        break;
+        if (!isValidColourType8(colourType)) invalidColourCombo(colourType, bitDepth);
+      }
+      case 8 -> {
+        if (!isValidColourType8(colourType)) invalidColourCombo(colourType, bitDepth);
+      }
+      default -> invalidColourCombo(colourType, bitDepth);
     }
   }
 

--- a/src/main/java/network/crypta/client/filter/TheoraPacketFilter.java
+++ b/src/main/java/network/crypta/client/filter/TheoraPacketFilter.java
@@ -93,35 +93,35 @@ public class TheoraPacketFilter implements CodecPacketFilter {
    * @throws IOException if reading the bitstream fails or the packet cannot be fully consumed due
    *     to I/O problems; malformed content may trigger unchecked exceptions as appropriate.
    */
+  @Override
   public CodecPacket parse(CodecPacket packet) throws IOException {
     // Assemble the Theora packets https://www.theora.org/doc/Theora.pdf
     // https://github.com/xiph/theora/blob/master/doc/spec/spec.tex
     BitInputStream input = new BitInputStream(new ByteArrayInputStream(packet.payload));
-    switch (expectedPacket) {
-      case IDENTIFICATION_HEADER: // must be first
+    return switch (expectedPacket) {
+      case IDENTIFICATION_HEADER -> {
+        // must be first
         LOG.debug("IDENTIFICATION_HEADER");
         verifyIdentificationHeader(input);
         expectedPacket = Packet.COMMENT_HEADER;
-        break;
-
-      case COMMENT_HEADER: // must be second
+        yield packet;
+      }
+      case COMMENT_HEADER -> {
+        // must be second
         LOG.debug("COMMENT_HEADER");
         verifyTypeAndHeader("Comment", input, 0x81); // expected -127
         expectedPacket = Packet.SETUP_HEADER;
-        return constructCommentHeaderWithEmptyVendorStringAndComments();
-
-      case SETUP_HEADER: // must be third
+        yield constructCommentHeaderWithEmptyVendorStringAndComments();
+      }
+      case SETUP_HEADER -> {
+        // must be third
         LOG.debug("SETUP_HEADER");
         verifySetupHeader(input);
         expectedPacket = Packet.FRAME;
-        break;
-
-      case FRAME:
-        // fall-through: frames are passed through unchanged
-        break;
-    }
-
-    return packet;
+        yield packet;
+      }
+      case FRAME -> packet;
+    };
   }
 
   private void verifyIdentificationHeader(BitInputStream input) throws IOException {

--- a/src/main/java/network/crypta/client/filter/WebPFilter.java
+++ b/src/main/java/network/crypta/client/filter/WebPFilter.java
@@ -270,7 +270,7 @@ public class WebPFilter extends RIFFFilter {
     if (ctx.hasVP8L
         || ctx.hasANIM
         || ctx.hasALPH
-        || (!ctx.hasVP8X)
+        || !ctx.hasVP8X
         || ((ctx.vp8xFlags & ALPHA_FLAG) == 0)) {
       throw new DataFilterException(
           l10n(L10N_INVALID_TITLE),

--- a/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshot.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshot.java
@@ -14,88 +14,177 @@ import org.jetbrains.annotations.NotNull;
  * <p>This record mirrors the inputs required to construct a {@link DownloadRequestStatus} from the
  * current state of a {@link ClientGet} request. It is intentionally immutable and performs no
  * validation, so callers can reuse it across status refreshes without altering behavior.
- *
- * @param identifier request identifier to report.
- * @param persistence persistence mode for the request.
- * @param started whether the request has started.
- * @param finished whether the request has finished.
- * @param succeeded whether the request has succeeded.
- * @param progressPending last recorded progress snapshot, if any.
- * @param failedMessage cached failure message, if any.
- * @param foundDataMimeType MIME type discovered for the data.
- * @param foundDataLength data length recorded for the request.
- * @param destinationFile destination file for disk requests.
- * @param dataBucket bucket containing result data.
- * @param fetchContext fetch context providing filter and MIME overrides.
- * @param priorityClass scheduler priority class.
- * @param compatModes compatibility modes observed for the request.
- * @param splitfileKey splitfile crypto key override, if any.
- * @param uri request URI to report.
- * @param dontCompress whether reinsertion should skip compression.
  */
-public record ClientGetStatusSnapshot(
-    String identifier,
-    ClientRequest.Persistence persistence,
-    boolean started,
-    boolean finished,
-    boolean succeeded,
-    SimpleProgressMessage progressPending,
-    GetFailedMessage failedMessage,
-    String foundDataMimeType,
-    long foundDataLength,
-    File destinationFile,
-    Bucket dataBucket,
-    FetchContext fetchContext,
-    short priorityClass,
-    CompatibilityMode[] compatModes,
-    byte[] splitfileKey,
-    FreenetURI uri,
-    boolean dontCompress) {
+public final class ClientGetStatusSnapshot {
+  private final String identifier;
+  private final ClientRequest.Persistence persistence;
+  private final boolean started;
+  private final boolean finished;
+  private final boolean succeeded;
+  private final SimpleProgressMessage progressPending;
+  private final GetFailedMessage failedMessage;
+  private final String foundDataMimeType;
+  private final long foundDataLength;
+  private final File destinationFile;
+  private final Bucket dataBucket;
+  private final FetchContext fetchContext;
+  private final short priorityClass;
+  private final CompatibilityMode[] compatModes;
+  private final byte[] splitfileKey;
+  private final FreenetURI uri;
+  private final boolean dontCompress;
+
+  /**
+   * Creates a snapshot containing the current request metadata.
+   *
+   * @param identifier request identifier to report.
+   * @param persistence persistence mode for the request.
+   * @param started whether the request has started.
+   * @param finished whether the request has finished.
+   * @param succeeded whether the request has succeeded.
+   * @param progressPending last recorded progress snapshot, if any.
+   * @param failedMessage cached failure message, if any.
+   * @param foundDataMimeType MIME type discovered for the data.
+   * @param foundDataLength data length recorded for the request.
+   * @param destinationFile destination file for disk requests.
+   * @param dataBucket bucket containing result data.
+   * @param fetchContext fetch context providing filter and MIME overrides.
+   * @param priorityClass scheduler priority class.
+   * @param compatModes compatibility modes observed for the request.
+   * @param splitfileKey splitfile crypto key override, if any.
+   * @param uri request URI to report.
+   * @param dontCompress whether reinsertion should skip compression.
+   */
+  public ClientGetStatusSnapshot(
+      String identifier,
+      ClientRequest.Persistence persistence,
+      boolean started,
+      boolean finished,
+      boolean succeeded,
+      SimpleProgressMessage progressPending,
+      GetFailedMessage failedMessage,
+      String foundDataMimeType,
+      long foundDataLength,
+      File destinationFile,
+      Bucket dataBucket,
+      FetchContext fetchContext,
+      short priorityClass,
+      CompatibilityMode[] compatModes,
+      byte[] splitfileKey,
+      FreenetURI uri,
+      boolean dontCompress) {
+    this.identifier = identifier;
+    this.persistence = persistence;
+    this.started = started;
+    this.finished = finished;
+    this.succeeded = succeeded;
+    this.progressPending = progressPending;
+    this.failedMessage = failedMessage;
+    this.foundDataMimeType = foundDataMimeType;
+    this.foundDataLength = foundDataLength;
+    this.destinationFile = destinationFile;
+    this.dataBucket = dataBucket;
+    this.fetchContext = fetchContext;
+    this.priorityClass = priorityClass;
+    this.compatModes = compatModes;
+    this.splitfileKey = splitfileKey;
+    this.uri = uri;
+    this.dontCompress = dontCompress;
+  }
+
+  public String identifier() {
+    return identifier;
+  }
+
+  public ClientRequest.Persistence persistence() {
+    return persistence;
+  }
+
+  public boolean started() {
+    return started;
+  }
+
+  public boolean finished() {
+    return finished;
+  }
+
+  public boolean succeeded() {
+    return succeeded;
+  }
+
+  public SimpleProgressMessage progressPending() {
+    return progressPending;
+  }
+
+  public GetFailedMessage failedMessage() {
+    return failedMessage;
+  }
+
+  public String foundDataMimeType() {
+    return foundDataMimeType;
+  }
+
+  public long foundDataLength() {
+    return foundDataLength;
+  }
+
+  public File destinationFile() {
+    return destinationFile;
+  }
+
+  public Bucket dataBucket() {
+    return dataBucket;
+  }
+
+  public FetchContext fetchContext() {
+    return fetchContext;
+  }
+
+  public short priorityClass() {
+    return priorityClass;
+  }
+
+  public CompatibilityMode[] compatModes() {
+    return compatModes;
+  }
+
+  public byte[] splitfileKey() {
+    return splitfileKey;
+  }
+
+  public FreenetURI uri() {
+    return uri;
+  }
+
+  public boolean dontCompress() {
+    return dontCompress;
+  }
 
   @Override
   public boolean equals(Object other) {
     if (this == other) {
       return true;
     }
-    if (!(other
-        instanceof
-        ClientGetStatusSnapshot(
-            String otherIdentifier,
-            ClientRequest.Persistence otherPersistence,
-            boolean otherStarted,
-            boolean otherFinished,
-            boolean otherSucceeded,
-            SimpleProgressMessage otherProgressPending,
-            GetFailedMessage otherFailedMessage,
-            String otherFoundDataMimeType,
-            long otherFoundDataLength,
-            File otherDestinationFile,
-            Bucket otherDataBucket,
-            FetchContext otherFetchContext,
-            short otherPriorityClass,
-            CompatibilityMode[] otherCompatModes,
-            byte[] otherSplitfileKey,
-            FreenetURI otherUri,
-            boolean otherDontCompress))) {
+    if (!(other instanceof ClientGetStatusSnapshot otherSnapshot)) {
       return false;
     }
-    return started == otherStarted
-        && finished == otherFinished
-        && succeeded == otherSucceeded
-        && foundDataLength == otherFoundDataLength
-        && priorityClass == otherPriorityClass
-        && dontCompress == otherDontCompress
-        && java.util.Objects.equals(identifier, otherIdentifier)
-        && persistence == otherPersistence
-        && java.util.Objects.equals(progressPending, otherProgressPending)
-        && java.util.Objects.equals(failedMessage, otherFailedMessage)
-        && java.util.Objects.equals(foundDataMimeType, otherFoundDataMimeType)
-        && java.util.Objects.equals(destinationFile, otherDestinationFile)
-        && java.util.Objects.equals(dataBucket, otherDataBucket)
-        && java.util.Objects.equals(fetchContext, otherFetchContext)
-        && Arrays.equals(compatModes, otherCompatModes)
-        && Arrays.equals(splitfileKey, otherSplitfileKey)
-        && java.util.Objects.equals(uri, otherUri);
+    return started == otherSnapshot.started
+        && finished == otherSnapshot.finished
+        && succeeded == otherSnapshot.succeeded
+        && foundDataLength == otherSnapshot.foundDataLength
+        && priorityClass == otherSnapshot.priorityClass
+        && dontCompress == otherSnapshot.dontCompress
+        && java.util.Objects.equals(identifier, otherSnapshot.identifier)
+        && persistence == otherSnapshot.persistence
+        && java.util.Objects.equals(progressPending, otherSnapshot.progressPending)
+        && java.util.Objects.equals(failedMessage, otherSnapshot.failedMessage)
+        && java.util.Objects.equals(foundDataMimeType, otherSnapshot.foundDataMimeType)
+        && java.util.Objects.equals(destinationFile, otherSnapshot.destinationFile)
+        && java.util.Objects.equals(dataBucket, otherSnapshot.dataBucket)
+        && java.util.Objects.equals(fetchContext, otherSnapshot.fetchContext)
+        && Arrays.equals(compatModes, otherSnapshot.compatModes)
+        && Arrays.equals(splitfileKey, otherSnapshot.splitfileKey)
+        && java.util.Objects.equals(uri, otherSnapshot.uri);
   }
 
   @Override

--- a/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
@@ -256,7 +256,7 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
    * containing ManifestElement's.
    */
   private void convertFilesByNameToManifestElements(
-      Map<String, Object> filesByName, HashMap<String, Object> manifestElements, Node node)
+      Map<String, Object> filesByName, Map<String, Object> manifestElements, Node node)
       throws MessageInvalidException {
 
     for (Map.Entry<String, Object> entry : filesByName.entrySet()) {

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDirMessage.java
@@ -171,15 +171,15 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
       return InsertContext.CompatibilityMode.valueOf(modeValue).intern();
     } catch (IllegalArgumentException _) {
       try {
-        int ordinal = Integer.parseInt(modeValue);
-        return InsertContext.CompatibilityMode.values()[ordinal].intern();
+        int code = Integer.parseInt(modeValue);
+        return InsertContext.CompatibilityMode.byCode((short) code).intern();
       } catch (NumberFormatException _) {
         throw new MessageInvalidException(
             ProtocolErrorMessage.INVALID_FIELD,
             "Invalid CompatibilityMode (not a name and not a number)",
             identifier,
             global);
-      } catch (ArrayIndexOutOfBoundsException _) {
+      } catch (IllegalArgumentException _) {
         throw new MessageInvalidException(
             ProtocolErrorMessage.INVALID_FIELD,
             "Invalid CompatibilityMode (not a valid number)",

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
@@ -206,13 +206,33 @@ final class ClientPutDiskUploadValidator {
  * <p>When no hash was supplied, callers use {@link #empty()} to get a shared instance with {@code
  * null} components. Downstream checks can call {@link #hasSalt()} to determine whether verification
  * should occur.
- *
- * @param salt per-request salt string used when computing the digest, or {@code null} when absent.
- * @param saltedHash hash bytes computed by the client, or {@code null} when not provided.
  */
-record DiskUploadContext(String salt, byte[] saltedHash) {
+final class DiskUploadContext {
+  private final String salt;
+  private final byte[] saltedHash;
+
+  /**
+   * Creates a new disk-upload context with optional salted hash data.
+   *
+   * @param salt per-request salt string used when computing the digest, or {@code null} when
+   *     absent.
+   * @param saltedHash hash bytes computed by the client, or {@code null} when not provided.
+   */
+  DiskUploadContext(String salt, byte[] saltedHash) {
+    this.salt = salt;
+    this.saltedHash = saltedHash;
+  }
+
   /** Shared empty context used when no salted hash was supplied. */
   private static final DiskUploadContext EMPTY = new DiskUploadContext(null, null);
+
+  String salt() {
+    return salt;
+  }
+
+  byte[] saltedHash() {
+    return saltedHash;
+  }
 
   /**
    * Returns a shared empty context that indicates no salted hash is available.
@@ -236,8 +256,8 @@ record DiskUploadContext(String salt, byte[] saltedHash) {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof DiskUploadContext(String otherSalt, byte[] otherHash))) return false;
-    return Objects.equals(salt, otherSalt) && Arrays.equals(saltedHash, otherHash);
+    if (!(o instanceof DiskUploadContext other)) return false;
+    return Objects.equals(salt, other.salt) && Arrays.equals(saltedHash, other.saltedHash);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
@@ -184,14 +184,14 @@ public class ClientPutMessage extends DataCarryingMessage {
         cmode = InsertContext.CompatibilityMode.valueOf(s);
       } catch (IllegalArgumentException _) {
         try {
-          cmode = InsertContext.CompatibilityMode.values()[Integer.parseInt(s)];
+          cmode = InsertContext.CompatibilityMode.byCode((short) Integer.parseInt(s));
         } catch (NumberFormatException _) {
           throw new MessageInvalidException(
               ProtocolErrorMessage.INVALID_FIELD,
               "Invalid CompatibilityMode (not a name and not a number)",
               identifier,
               global);
-        } catch (ArrayIndexOutOfBoundsException _) {
+        } catch (IllegalArgumentException _) {
           throw new MessageInvalidException(
               ProtocolErrorMessage.INVALID_FIELD,
               "Invalid CompatibilityMode (not a valid number)",

--- a/src/main/java/network/crypta/clients/fcp/CompatibilityMode.java
+++ b/src/main/java/network/crypta/clients/fcp/CompatibilityMode.java
@@ -87,8 +87,8 @@ public class CompatibilityMode extends FCPMessage {
     SimpleFieldSet fs = new SimpleFieldSet(false);
     fs.putOverwrite("Min", compat.min().name());
     fs.putOverwrite("Max", compat.max().name());
-    fs.put("Min.Number", compat.min().ordinal());
-    fs.put("Max.Number", compat.max().ordinal());
+    fs.put("Min.Number", compat.min().code);
+    fs.put("Max.Number", compat.max().code);
     fs.putOverwrite("Identifier", messageIdentifier);
     fs.put("Global", global);
     byte[] cryptoKey = compat.getCryptoKey();

--- a/src/main/java/network/crypta/clients/fcp/LoadPlugin.java
+++ b/src/main/java/network/crypta/clients/fcp/LoadPlugin.java
@@ -2,6 +2,7 @@ package network.crypta.clients.fcp;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.util.Locale;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.pluginmanager.PluginInfoWrapper;
@@ -190,7 +191,7 @@ public class LoadPlugin extends FCPMessage {
 
   private String resolveUrlType(Node node) {
     if (urlType != null) {
-      return urlType.toLowerCase();
+      return urlType.toLowerCase(Locale.ROOT);
     }
     if (node.services().pluginManager().isOfficialPlugin(pluginURL) != null) {
       return TYPENAME_OFFICIAL;
@@ -208,16 +209,13 @@ public class LoadPlugin extends FCPMessage {
   }
 
   private PluginInfoWrapper startPlugin(Node node, String type, FCPConnectionHandler handler) {
-    switch (type) {
-      case TYPENAME_OFFICIAL:
-        return node.services().pluginManager().startPluginOfficial(pluginURL, store);
-      case TYPENAME_FILE:
-        return node.services().pluginManager().startPluginFile(pluginURL, store);
-      case TYPENAME_FREENET:
-        return node.services().pluginManager().startPluginFreenet(pluginURL, store);
-      case TYPENAME_URL:
-        return node.services().pluginManager().startPluginURL(pluginURL, store);
-      default:
+    return switch (type) {
+      case TYPENAME_OFFICIAL ->
+          node.services().pluginManager().startPluginOfficial(pluginURL, store);
+      case TYPENAME_FILE -> node.services().pluginManager().startPluginFile(pluginURL, store);
+      case TYPENAME_FREENET -> node.services().pluginManager().startPluginFreenet(pluginURL, store);
+      case TYPENAME_URL -> node.services().pluginManager().startPluginURL(pluginURL, store);
+      default -> {
         LOG.error("This should really not happen!");
         handler.send(
             new ProtocolErrorMessage(
@@ -226,7 +224,8 @@ public class LoadPlugin extends FCPMessage {
                 "This should really not happen! See logs for details.",
                 messageIdentifier,
                 false));
-        return null;
-    }
+        yield null;
+      }
+    };
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/PersistentGet.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentGet.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.io.File;
+import java.util.Locale;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
@@ -102,8 +103,8 @@ public class PersistentGet extends FCPMessage {
     fs.putSingle("Identifier", messageIdentifier);
     fs.putSingle("URI", uri.toString(false, false));
     fs.put("Verbosity", verbosity);
-    fs.putSingle("ReturnType", returnType.toString().toLowerCase());
-    fs.putSingle("Persistence", persistence.toString().toLowerCase());
+    fs.putSingle("ReturnType", returnType.toString().toLowerCase(Locale.ROOT));
+    fs.putSingle("Persistence", persistence.toString().toLowerCase(Locale.ROOT));
     if (returnType == ReturnType.DISK) {
       fs.putSingle("Filename", targetFile.getAbsolutePath());
     }

--- a/src/main/java/network/crypta/clients/fcp/PersistentPut.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentPut.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.io.File;
+import java.util.Locale;
 import network.crypta.client.InsertContext;
 import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
@@ -122,8 +123,8 @@ public class PersistentPut extends FCPMessage {
     if (privateURI != null) fs.putSingle("PrivateURI", privateURI.toString(false, false));
     fs.put("Verbosity", verbosity);
     fs.put("PriorityClass", priorityClass);
-    fs.putSingle("UploadFrom", uploadFrom.toString().toLowerCase());
-    fs.putSingle("Persistence", persistence.toString().toLowerCase());
+    fs.putSingle("UploadFrom", uploadFrom.toString().toLowerCase(Locale.ROOT));
+    fs.putSingle("Persistence", persistence.toString().toLowerCase(Locale.ROOT));
     if (origFilename != null) fs.putSingle("Filename", origFilename.getAbsolutePath());
     if (targetURI != null) fs.putSingle("TargetURI", targetURI.toString());
     if (mimeType != null) fs.putSingle("Metadata.ContentType", mimeType);

--- a/src/main/java/network/crypta/clients/fcp/PersistentPutRequestMetadata.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentPutRequestMetadata.java
@@ -11,43 +11,83 @@ import org.jetbrains.annotations.NotNull;
  *
  * <p>This record groups the optional private URI alongside retry and compression settings that are
  * reused by both single-file and directory persistent put messages.
- *
- * @param privateURI optional private insert URI for resume or cancellation
- * @param started whether the request has already begun processing
- * @param maxRetries maximum retry attempts configured for the insert
- * @param compatMode insert compatibility mode requested by the client
- * @param dontCompress whether compression should be avoided for this insert
- * @param compressorDescriptor optional codec pipeline description
- * @param splitfileCryptoKey encryption key for splitfile segments, if known
  */
-public record PersistentPutRequestMetadata(
-    FreenetURI privateURI,
-    boolean started,
-    int maxRetries,
-    InsertContext.CompatibilityMode compatMode,
-    boolean dontCompress,
-    String compressorDescriptor,
-    byte[] splitfileCryptoKey) {
+public final class PersistentPutRequestMetadata {
+  private final FreenetURI privateURI;
+  private final boolean started;
+  private final int maxRetries;
+  private final InsertContext.CompatibilityMode compatMode;
+  private final boolean dontCompress;
+  private final String compressorDescriptor;
+  private final byte[] splitfileCryptoKey;
+
+  /**
+   * Creates a metadata bundle describing a persistent insert request.
+   *
+   * @param privateURI optional private insert URI for resume or cancellation
+   * @param started whether the request has already begun processing
+   * @param maxRetries maximum retry attempts configured for the insert
+   * @param compatMode insert compatibility mode requested by the client
+   * @param dontCompress whether compression should be avoided for this insert
+   * @param compressorDescriptor optional codec pipeline description
+   * @param splitfileCryptoKey encryption key for splitfile segments, if known
+   */
+  public PersistentPutRequestMetadata(
+      FreenetURI privateURI,
+      boolean started,
+      int maxRetries,
+      InsertContext.CompatibilityMode compatMode,
+      boolean dontCompress,
+      String compressorDescriptor,
+      byte[] splitfileCryptoKey) {
+    this.privateURI = privateURI;
+    this.started = started;
+    this.maxRetries = maxRetries;
+    this.compatMode = compatMode;
+    this.dontCompress = dontCompress;
+    this.compressorDescriptor = compressorDescriptor;
+    this.splitfileCryptoKey = splitfileCryptoKey;
+  }
+
+  public FreenetURI privateURI() {
+    return privateURI;
+  }
+
+  public boolean started() {
+    return started;
+  }
+
+  public int maxRetries() {
+    return maxRetries;
+  }
+
+  public InsertContext.CompatibilityMode compatMode() {
+    return compatMode;
+  }
+
+  public boolean dontCompress() {
+    return dontCompress;
+  }
+
+  public String compressorDescriptor() {
+    return compressorDescriptor;
+  }
+
+  public byte[] splitfileCryptoKey() {
+    return splitfileCryptoKey;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o
-        instanceof
-        PersistentPutRequestMetadata(
-            FreenetURI otherPrivateUri,
-            boolean otherStarted,
-            int otherMaxRetries,
-            InsertContext.CompatibilityMode otherCompatMode,
-            boolean otherDontCompress,
-            String otherCompressorDescriptor,
-            byte[] otherSplitfileCryptoKey))) return false;
-    return started == otherStarted
-        && maxRetries == otherMaxRetries
-        && dontCompress == otherDontCompress
-        && Objects.equals(privateURI, otherPrivateUri)
-        && compatMode == otherCompatMode
-        && Objects.equals(compressorDescriptor, otherCompressorDescriptor)
-        && Arrays.equals(splitfileCryptoKey, otherSplitfileCryptoKey);
+    if (!(o instanceof PersistentPutRequestMetadata other)) return false;
+    return started == other.started
+        && maxRetries == other.maxRetries
+        && dontCompress == other.dontCompress
+        && Objects.equals(privateURI, other.privateURI)
+        && compatMode == other.compatMode
+        && Objects.equals(compressorDescriptor, other.compressorDescriptor)
+        && Arrays.equals(splitfileCryptoKey, other.splitfileCryptoKey);
   }
 
   @Override

--- a/src/main/java/network/crypta/clients/fcp/ProbeUptime.java
+++ b/src/main/java/network/crypta/clients/fcp/ProbeUptime.java
@@ -61,6 +61,7 @@ public class ProbeUptime extends FCPResponse {
    *
    * @return immutable literal {@code "ProbeUptime"} understood by the FCP framing layer.
    */
+  @Override
   public String getName() {
     return "ProbeUptime";
   }

--- a/src/main/java/network/crypta/clients/fcp/SendingToNetworkMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SendingToNetworkMessage.java
@@ -53,11 +53,11 @@ public class SendingToNetworkMessage extends FCPMessage {
    * reused across threads that merely serialize the fields.
    *
    * @param id Request identifier echoed back to the FCP client for correlation.
-   * @param global2 True when the request should be visible on the global client queue.
+   * @param global True when the request should be visible on the global client queue.
    */
-  public SendingToNetworkMessage(String id, boolean global2) {
+  public SendingToNetworkMessage(String id, boolean global) {
     this.messageIdentifier = id;
-    this.global = global2;
+    this.global = global;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/TestDdaCompleteMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaCompleteMessage.java
@@ -110,7 +110,7 @@ public class TestDdaCompleteMessage extends FCPMessage {
     boolean isWriteAllowed = false;
 
     if (checkJob.readFilename != null) {
-      isReadAllowed = (checkJob.readContent.equals(readContentFromClient));
+      isReadAllowed = checkJob.readContent.equals(readContentFromClient);
       // cleanup in any case : we created it!... let's hope the client will do the same on its side.
       try {
         Files.deleteIfExists(checkJob.readFilename.toPath());

--- a/src/main/java/network/crypta/clients/fcp/TestDdaRequestMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaRequestMessage.java
@@ -90,7 +90,7 @@ public class TestDdaRequestMessage extends FCPMessage {
 
     wantRead = fs.getBoolean(WANT_READ, false);
     wantWrite = fs.getBoolean(WANT_WRITE, false);
-    if ((!wantRead) && (!wantWrite))
+    if (!wantRead && !wantWrite)
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_MESSAGE,
           "Both "

--- a/src/main/java/network/crypta/clients/http/DecodeToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DecodeToadlet.java
@@ -56,6 +56,7 @@ public class DecodeToadlet extends Toadlet {
    *     written
    * @throws IOException if generating or sending the redirect page encounters an I/O failure
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
 

--- a/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
@@ -117,6 +117,7 @@ public class ExternalLinkToadlet extends Toadlet {
    *     written.
    * @throws IOException if rendering or sending the response fails.
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     Objects.requireNonNull(uri, "uri");

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
@@ -524,11 +524,13 @@ public class FirstTimeWizardToadlet extends Toadlet {
 
     // First pages for the presets
     if (preset == WIZARD_PRESET.HIGH) {
-      switch (currentStep) {
-        case SECURITY_NETWORK, SECURITY_PHYSICAL:
-          return WIZARD_STEP.WELCOME;
-        default:
-          // do nothing
+      WIZARD_STEP previous =
+          switch (currentStep) {
+            case SECURITY_NETWORK, SECURITY_PHYSICAL -> WIZARD_STEP.WELCOME;
+            default -> null;
+          };
+      if (previous != null) {
+        return previous;
       }
     } else if (preset == WIZARD_PRESET.LOW
         && Objects.requireNonNull(currentStep) == WIZARD_STEP.DATASTORE_SIZE) {

--- a/src/main/java/network/crypta/clients/http/HTTPRequestImpl.java
+++ b/src/main/java/network/crypta/clients/http/HTTPRequestImpl.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
-import java.util.regex.Pattern;
 import javax.naming.SizeLimitExceededException;
 import network.crypta.support.Fields;
 import network.crypta.support.MultiValueTable;
@@ -55,8 +54,6 @@ import org.slf4j.LoggerFactory;
  */
 public class HTTPRequestImpl implements HTTPRequest {
   private static final Logger LOG = LoggerFactory.getLogger(HTTPRequestImpl.class);
-  private static final Pattern SEMICOLON_SPLITTER = Pattern.compile(";");
-  private static final Pattern EQUALS_SPLITTER = Pattern.compile("=");
 
   /**
    * This map is used to store all parameter values.
@@ -349,6 +346,21 @@ public class HTTPRequestImpl implements HTTPRequest {
     return new ParameterNameValue(name, value);
   }
 
+  private static String[] splitOnChar(String input, char delimiter) {
+    ArrayList<String> parts = new ArrayList<>();
+    int start = 0;
+    for (int i = 0; i <= input.length(); i++) {
+      if (i == input.length() || input.charAt(i) == delimiter) {
+        parts.add(input.substring(start, i));
+        start = i + 1;
+      }
+    }
+    for (int i = parts.size() - 1; i >= 0 && parts.get(i).isEmpty(); i--) {
+      parts.remove(i);
+    }
+    return parts.toArray(new String[0]);
+  }
+
   private record ParameterNameValue(String name, String value) {}
 
   /**
@@ -574,7 +586,7 @@ public class HTTPRequestImpl implements HTTPRequest {
 
     if (LOG.isDebugEnabled()) LOG.debug("Uploaded content-type header: {}", contentTypeHeader);
 
-    String[] contentTypeParts = SEMICOLON_SPLITTER.split(contentTypeHeader);
+    String[] contentTypeParts = splitOnChar(contentTypeHeader, ';');
     if (isUrlEncoded(contentTypeParts)) {
       parseUrlEncodedBody();
       return;
@@ -612,7 +624,7 @@ public class HTTPRequestImpl implements HTTPRequest {
   private String extractBoundary(String[] contentTypeParts) {
     String boundary = null;
     for (String contentTypePart : contentTypeParts) {
-      String[] subparts = EQUALS_SPLITTER.split(contentTypePart);
+      String[] subparts = splitOnChar(contentTypePart, '=');
       if ((subparts.length == 2) && subparts[0].trim().equalsIgnoreCase("boundary")) {
         boundary = subparts[1];
       }
@@ -722,7 +734,7 @@ public class HTTPRequestImpl implements HTTPRequest {
   }
 
   private void parseContentDisposition(String headerValue, MutablePartMetadata metadata) {
-    String[] valueparts = SEMICOLON_SPLITTER.split(headerValue);
+    String[] valueparts = splitOnChar(headerValue, ';');
     for (String valuepart : valueparts) {
       String[] subparts = valuepart.split("=", 2);
       if (subparts.length != 2) {

--- a/src/main/java/network/crypta/clients/http/HTTPRequestImpl.java
+++ b/src/main/java/network/crypta/clients/http/HTTPRequestImpl.java
@@ -12,10 +12,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
+import java.util.regex.Pattern;
 import javax.naming.SizeLimitExceededException;
 import network.crypta.support.Fields;
 import network.crypta.support.MultiValueTable;
@@ -53,6 +55,8 @@ import org.slf4j.LoggerFactory;
  */
 public class HTTPRequestImpl implements HTTPRequest {
   private static final Logger LOG = LoggerFactory.getLogger(HTTPRequestImpl.class);
+  private static final Pattern SEMICOLON_SPLITTER = Pattern.compile(";");
+  private static final Pattern EQUALS_SPLITTER = Pattern.compile("=");
 
   /**
    * This map is used to store all parameter values.
@@ -570,7 +574,7 @@ public class HTTPRequestImpl implements HTTPRequest {
 
     if (LOG.isDebugEnabled()) LOG.debug("Uploaded content-type header: {}", contentTypeHeader);
 
-    String[] contentTypeParts = contentTypeHeader.split(";");
+    String[] contentTypeParts = SEMICOLON_SPLITTER.split(contentTypeHeader);
     if (isUrlEncoded(contentTypeParts)) {
       parseUrlEncodedBody();
       return;
@@ -608,7 +612,7 @@ public class HTTPRequestImpl implements HTTPRequest {
   private String extractBoundary(String[] contentTypeParts) {
     String boundary = null;
     for (String contentTypePart : contentTypeParts) {
-      String[] subparts = contentTypePart.split("=");
+      String[] subparts = EQUALS_SPLITTER.split(contentTypePart);
       if ((subparts.length == 2) && subparts[0].trim().equalsIgnoreCase("boundary")) {
         boundary = subparts[1];
       }
@@ -718,7 +722,7 @@ public class HTTPRequestImpl implements HTTPRequest {
   }
 
   private void parseContentDisposition(String headerValue, MutablePartMetadata metadata) {
-    String[] valueparts = headerValue.split(";");
+    String[] valueparts = SEMICOLON_SPLITTER.split(headerValue);
     for (String valuepart : valueparts) {
       String[] subparts = valuepart.split("=", 2);
       if (subparts.length != 2) {
@@ -1090,10 +1094,10 @@ public class HTTPRequestImpl implements HTTPRequest {
    */
   @Override
   public String getHeader(String name) {
-    if (!name.equals(name.toLowerCase())) {
+    if (!name.equals(name.toLowerCase(Locale.ROOT))) {
       throw new IllegalArgumentException("Header name must be lower-case");
     }
-    return this.headers.getFirst(name.toLowerCase());
+    return this.headers.getFirst(name.toLowerCase(Locale.ROOT));
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/InsertFreesiteToadlet.java
+++ b/src/main/java/network/crypta/clients/http/InsertFreesiteToadlet.java
@@ -58,6 +58,7 @@ public class InsertFreesiteToadlet extends Toadlet {
    *     written
    * @throws IOException if header emission or HTML streaming fails while writing the reply
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     PageNode page = ctx.getPageMaker().getPageNode(l10n("title"), ctx);

--- a/src/main/java/network/crypta/clients/http/N2NTMToadlet.java
+++ b/src/main/java/network/crypta/clients/http/N2NTMToadlet.java
@@ -112,6 +112,7 @@ public class N2NTMToadlet extends Toadlet {
    * @throws IOException if response writing fails due to I/O issues.
    * @throws RedirectException if a redirect is required for the request flow.
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
 

--- a/src/main/java/network/crypta/clients/http/PproxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/PproxyToadlet.java
@@ -497,6 +497,7 @@ public class PproxyToadlet extends Toadlet {
    * @throws ToadletContextClosedException if the client disconnects before the response completes
    * @throws IOException if the handler encounters an I/O problem while reading or writing data
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     String path = normalizePluginPath(request.getPath());

--- a/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
+++ b/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
@@ -86,8 +86,10 @@ public class SymlinkerToadlet extends Toadlet {
     String[] fns = tslconfig.getStringArr("symlinks");
     if (fns != null) {
       for (String fn : fns) {
-        String[] tuple = fn.split("#");
-        if (tuple.length == 2) addLink(tuple[0], tuple[1], false);
+        int hashIndex = fn.indexOf('#');
+        if (hashIndex > 0 && hashIndex == fn.lastIndexOf('#') && hashIndex < fn.length() - 1) {
+          addLink(fn.substring(0, hashIndex), fn.substring(hashIndex + 1), false);
+        }
       }
     }
 
@@ -175,6 +177,7 @@ public class SymlinkerToadlet extends Toadlet {
    * @throws IOException if writing a response fails due to I/O problems in the context.
    * @throws RedirectException when a matching alias is found and the client should be redirected.
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String path = uri.getPath();

--- a/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Pattern;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.crypt.SSL;
@@ -93,7 +92,6 @@ public class ToadletContextImpl implements ToadletContext {
   private static final String METHODS_MUST_HAVE_DATA = "POST";
   private static final String METHODS_CANNOT_HAVE_DATA = "GET";
   private static final String METHODS_RESTRICTED_MODE = "GET POST";
-  private static final Pattern REQUEST_LINE_SPLITTER = Pattern.compile(" ");
 
   private final MultiValueTable<String, String> headers;
   private ArrayList<ReceivedCookie>
@@ -945,18 +943,24 @@ public class ToadletContextImpl implements ToadletContext {
       throws IOException, ParseException {
     if (LOG.isDebugEnabled()) LOG.debug("first line: {}", firstLine);
 
-    String[] split = REQUEST_LINE_SPLITTER.split(firstLine);
-
-    if (split.length != 3) {
-      throw new ParseException(
-          "Could not parse request line (split.length=" + split.length + "): " + firstLine, -1);
+    int firstSpace = firstLine.indexOf(' ');
+    int secondSpace = firstLine.indexOf(' ', firstSpace + 1);
+    if (firstSpace <= 0 || secondSpace <= firstSpace || secondSpace == firstLine.length() - 1) {
+      throw new ParseException("Could not parse request line: " + firstLine, -1);
+    }
+    if (firstLine.indexOf(' ', secondSpace + 1) != -1) {
+      throw new ParseException("Could not parse request line (too many parts): " + firstLine, -1);
     }
 
-    if (!split[2].startsWith("HTTP/1."))
-      throw new ParseException("Unrecognized protocol " + split[2], -1);
+    String method = firstLine.substring(0, firstSpace);
+    String rawUri = firstLine.substring(firstSpace + 1, secondSpace);
+    String protocol = firstLine.substring(secondSpace + 1);
+
+    if (!protocol.startsWith("HTTP/1."))
+      throw new ParseException("Unrecognized protocol " + protocol, -1);
 
     try {
-      URI uri = URIPreEncoder.encodeURI(split[1]).normalize();
+      URI uri = URIPreEncoder.encodeURI(rawUri).normalize();
       if (LOG.isDebugEnabled())
         LOG.debug(
             "URI: {} path {} host {} frag {} port {} query {} scheme {}",
@@ -967,7 +971,7 @@ public class ToadletContextImpl implements ToadletContext {
             uri.getPort(),
             uri.getQuery(),
             uri.getScheme());
-      return new RequestLine(split[0], uri, split[2]);
+      return new RequestLine(method, uri, protocol);
     } catch (URISyntaxException e) {
       sendURIParseError(sock.getOutputStream(), e);
       return null;

--- a/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.crypt.SSL;
@@ -92,6 +93,7 @@ public class ToadletContextImpl implements ToadletContext {
   private static final String METHODS_MUST_HAVE_DATA = "POST";
   private static final String METHODS_CANNOT_HAVE_DATA = "GET";
   private static final String METHODS_RESTRICTED_MODE = "GET POST";
+  private static final Pattern REQUEST_LINE_SPLITTER = Pattern.compile(" ");
 
   private final MultiValueTable<String, String> headers;
   private ArrayList<ReceivedCookie>
@@ -139,7 +141,7 @@ public class ToadletContextImpl implements ToadletContext {
    * @param services Shared request-handling services bundled by the HTTP listener.
    * @param uri Fully parsed and normalized request URI associated with the incoming HTTP request
    *     line.
-   * @param uniqueID Monotonic identifier supplied by the container to correlate logs and responses
+   * @param uniqueId Monotonic identifier supplied by the container to correlate logs and responses
    *     across asynchronous callbacks.
    * @throws IOException If the socket output stream cannot be obtained for later replies.
    */
@@ -149,7 +151,7 @@ public class ToadletContextImpl implements ToadletContext {
       BucketFactory bf,
       ToadletRequestServices services,
       URI uri,
-      long uniqueID)
+      long uniqueId)
       throws IOException {
     this.headers = headers;
     this.cookies = null;
@@ -165,7 +167,7 @@ public class ToadletContextImpl implements ToadletContext {
     this.userAlertManager = services.userAlertManager();
     this.bookmarkManager = services.bookmarkManager();
     // Generate a unique id
-    uniqueId = String.valueOf(uniqueID);
+    this.uniqueId = String.valueOf(uniqueId);
   }
 
   private void close() {
@@ -286,6 +288,7 @@ public class ToadletContextImpl implements ToadletContext {
    *     output.
    * @throws IOException If writing to the underlying socket output stream fails.
    */
+  @Override
   public void sendReplyHeaders(
       int code, String desc, MultiValueTable<String, String> mvt, String mimeType, long length)
       throws ToadletContextClosedException, IOException {
@@ -313,6 +316,7 @@ public class ToadletContextImpl implements ToadletContext {
    *     output.
    * @throws IOException If writing to the underlying socket output stream fails.
    */
+  @Override
   public void sendReplyHeaders(
       int code,
       String desc,
@@ -322,7 +326,7 @@ public class ToadletContextImpl implements ToadletContext {
       boolean forceDisableJavascript)
       throws ToadletContextClosedException, IOException {
     ReplyHeaders replyHeaders = ReplyHeaders.of(code, desc, mimeType, mvt, forceDisableJavascript);
-    boolean enableJavascript = (!forceDisableJavascript) && container.isFProxyJavascriptEnabled();
+    boolean enableJavascript = !forceDisableJavascript && container.isFProxyJavascriptEnabled();
     ReplyHeaderOptions options =
         new ReplyHeaderOptions(length, null, shouldDisconnect, enableJavascript, false);
     sendReplyHeaders(replyHeaders, options);
@@ -343,6 +347,7 @@ public class ToadletContextImpl implements ToadletContext {
    * @throws ToadletContextClosedException If the context is already closed and cannot send data.
    * @throws IOException If the socket output stream rejects the header bytes.
    */
+  @Override
   public void sendReplyHeadersStatic(
       int replyCode,
       String replyDescription,
@@ -632,7 +637,7 @@ public class ToadletContextImpl implements ToadletContext {
       return null;
     }
 
-    name = name.toLowerCase();
+    name = name.toLowerCase(Locale.ROOT);
 
     for (ReceivedCookie cookie : cookies) {
       try {
@@ -940,7 +945,7 @@ public class ToadletContextImpl implements ToadletContext {
       throws IOException, ParseException {
     if (LOG.isDebugEnabled()) LOG.debug("first line: {}", firstLine);
 
-    String[] split = firstLine.split(" ");
+    String[] split = REQUEST_LINE_SPLITTER.split(firstLine);
 
     if (split.length != 3) {
       throw new ParseException(
@@ -985,7 +990,7 @@ public class ToadletContextImpl implements ToadletContext {
       if (index < 0) {
         throw new ParseException("Missing ':' in request header field", -1);
       }
-      String before = line.substring(0, index).toLowerCase();
+      String before = line.substring(0, index).toLowerCase(Locale.ROOT);
       String after = line.substring(index + 1).trim();
       headers.put(before, after);
     }
@@ -1024,7 +1029,7 @@ public class ToadletContextImpl implements ToadletContext {
       return DataReadResult.stop();
     }
 
-    if (allowPost && ((!container.publicGatewayMode()) || ctx.isAllowedFullAccess())) {
+    if (allowPost && (!container.publicGatewayMode() || ctx.isAllowedFullAccess())) {
       Bucket data = bf.makeBucket(length);
       BucketTools.copyFrom(data, is, length);
       return DataReadResult.success(data);

--- a/src/main/java/network/crypta/clients/http/UserAlertsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/UserAlertsToadlet.java
@@ -68,6 +68,7 @@ public class UserAlertsToadlet extends Toadlet {
    *     completes writing.
    * @throws IOException if the response cannot be generated or sent to the client successfully.
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     if (!ctx.checkFullAccess(this)) return;

--- a/src/main/java/network/crypta/clients/http/ajaxpush/DismissAlertToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/DismissAlertToadlet.java
@@ -76,6 +76,7 @@ public class DismissAlertToadlet extends Toadlet {
    * @throws IOException If writing the response fails due to I/O problems.
    * @throws RedirectException Never thrown by this implementation, but declared by contract.
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     // The anchor is used to identify the alert

--- a/src/main/java/network/crypta/clients/http/ajaxpush/LogWritebackToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/LogWritebackToadlet.java
@@ -80,6 +80,7 @@ public class LogWritebackToadlet extends Toadlet {
    * @throws RedirectException declared for the base dispatch contract; this implementation does not
    *     initiate redirects
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     if (LOG.isDebugEnabled()) {

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushDataToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushDataToadlet.java
@@ -90,6 +90,7 @@ public class PushDataToadlet extends Toadlet {
    * @throws IOException If writing the response fails due to an I/O error.
    * @throws RedirectException If the container requests a redirect while processing this request.
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushFailoverToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushFailoverToadlet.java
@@ -87,6 +87,7 @@ public class PushFailoverToadlet extends Toadlet {
    * @throws IOException If writing the response fails due to an I/O error.
    * @throws RedirectException If the container requests a redirect while processing this request.
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushKeepaliveToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushKeepaliveToadlet.java
@@ -76,6 +76,7 @@ public class PushKeepaliveToadlet extends Toadlet {
    * @throws IOException if writing the response fails due to an underlying I/O problem
    * @throws RedirectException if the request must be redirected by the surrounding toadlet logic
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushLeavingToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushLeavingToadlet.java
@@ -71,6 +71,7 @@ public class PushLeavingToadlet extends Toadlet {
    * @throws RedirectException if the framework requires redirecting this request to another
    *     location
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushNotificationToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushNotificationToadlet.java
@@ -81,6 +81,7 @@ public class PushNotificationToadlet extends Toadlet {
    * @throws IOException if writing the HTTP response fails due to an underlying I/O error
    * @throws RedirectException if the framework requires a redirect response for this request
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");

--- a/src/main/java/network/crypta/clients/http/ajaxpush/PushTesterToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ajaxpush/PushTesterToadlet.java
@@ -76,6 +76,7 @@ public class PushTesterToadlet extends Toadlet {
    * @throws RedirectException if the framework requests a redirect instead of sending a direct
    *     reply
    */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     PageNode pageNode =

--- a/src/main/java/network/crypta/clients/http/bookmark/Bookmark.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/Bookmark.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.http.bookmark;
 
+import java.util.Locale;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.SimpleFieldSet;
 
@@ -80,7 +81,7 @@ public abstract class Bookmark {
    * @return the localized name when {@code l10n:} is used, otherwise the raw name.
    */
   public String getVisibleName() {
-    if (name.toLowerCase().startsWith("l10n:"))
+    if (name.toLowerCase(Locale.ROOT).startsWith("l10n:"))
       return NodeL10n.getBase()
           .getString("Bookmarks.Defaults.Name." + name.substring("l10n:".length()));
     return name;

--- a/src/main/java/network/crypta/clients/http/geoip/Cache.java
+++ b/src/main/java/network/crypta/clients/http/geoip/Cache.java
@@ -5,9 +5,9 @@ package network.crypta.clients.http.geoip;
  *
  * <p>This class is a lightweight container for two parallel primitive arrays used during IPv4
  * lookups: an {@code int[]} of table entries (often interpreted as unsigned 32-bit values) and a
- * {@code short[]} of country identifiers stored as {@link IPConverter.Country} ordinals. The data
- * is typically produced by parsing a downloaded database file once and then re-used for many
- * lookups without allocating per-query objects.
+ * {@code short[]} of country identifiers stored as encoded two-character codes. The data is
+ * typically produced by parsing a downloaded database file once and then re-used for many lookups
+ * without allocating per-query objects.
  *
  * <p>The constructor stores references to the provided arrays directly, and the getters return the
  * same live backing arrays. This avoids copies, but it also means callers must maintain the
@@ -25,7 +25,7 @@ package network.crypta.clients.http.geoip;
  *
  * <pre>{@code
  * Cache table = new Cache(codes, ips);
- * short[] countryOrdinals = table.getCodes();
+ * short[] countryCodes = table.getCodes();
  * int[] ipTable = table.getIps();
  * }</pre>
  *
@@ -43,8 +43,8 @@ public class Cache {
    * #getIps()}. Mutating either array after construction will therefore be observed through this
    * instance, which is convenient for tests but usually undesirable in production usage.
    *
-   * @param codes array of country ordinals aligned by index with {@code ips}; may be {@code null}
-   *     to represent an intentionally absent table.
+   * @param codes array of encoded country codes aligned by index with {@code ips}; may be {@code
+   *     null} to represent an intentionally absent table.
    * @param ips array of IPv4 table entries aligned by index with {@code codes}; may be {@code null}
    *     to represent an intentionally absent table.
    */
@@ -57,11 +57,12 @@ public class Cache {
    * Returns the country code table associated with this cache.
    *
    * <p>The returned array is the live backing {@code short[]} provided to the constructor; it is
-   * not a defensive copy. Each element is typically an {@link IPConverter.Country} ordinal, with
+   * not a defensive copy. Each element is typically an encoded two-character country code, with
    * negative values sometimes used by callers to indicate "unknown". Treat the array as read-only
    * once the cache is in use, especially if it may be accessed concurrently.
    *
-   * @return the live backing {@code short[]} of country ordinals, or {@code null} if none exists.
+   * @return the live backing {@code short[]} of encoded country codes, or {@code null} if none
+   *     exists.
    */
   public short[] getCodes() {
     return codes;

--- a/src/main/java/network/crypta/clients/http/geoip/IPConverter.java
+++ b/src/main/java/network/crypta/clients/http/geoip/IPConverter.java
@@ -803,15 +803,22 @@ public class IPConverter {
    * @throws NumberFormatException If the string is not an IP address.
    */
   public long ip2num(String ip) {
-    String[] split = IPV4_SPLITTER.split(ip);
-    if (split.length != 4) throw new NumberFormatException();
     long num = 0;
     long coef = (256 << 16);
-    for (String s : split) {
-      long modulo = Integer.parseInt(s) % 256;
-      num += (modulo * coef);
-      coef >>= 8;
+    int start = 0;
+    int segment = 0;
+    int length = ip.length();
+    for (int i = 0; i <= length; i++) {
+      if (i == length || ip.charAt(i) == '.') {
+        if (i == start || segment >= 4) throw new NumberFormatException();
+        long modulo = Integer.parseInt(ip.substring(start, i)) % 256;
+        num += (modulo * coef);
+        coef >>= 8;
+        segment++;
+        start = i + 1;
+      }
     }
+    if (segment != 4) throw new NumberFormatException();
     return num;
   }
 

--- a/src/main/java/network/crypta/clients/http/geoip/IPConverter.java
+++ b/src/main/java/network/crypta/clients/http/geoip/IPConverter.java
@@ -9,7 +9,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import network.crypta.clients.http.StaticToadlet;
 import network.crypta.support.HTMLNode;
 import org.slf4j.Logger;
@@ -588,8 +590,7 @@ public class IPConverter {
     /** GeoIP code {@code EU} ({@code European Union}). */
     EU("European Union");
     private final String name;
-    private boolean hasFlag;
-    private boolean checkedHasFlag;
+    private static final ConcurrentHashMap<Country, Boolean> FLAG_CACHE = new ConcurrentHashMap<>();
 
     Country(String name) {
       this.name = name;
@@ -640,7 +641,7 @@ public class IPConverter {
 
     /** Does not check whether it exists. Relative to the top of static files. */
     private String flagIconPath() {
-      return "icon/flags/" + toString().toLowerCase() + ".png";
+      return "icon/flags/" + toString().toLowerCase(Locale.ROOT) + ".png";
     }
 
     /**
@@ -653,17 +654,23 @@ public class IPConverter {
      */
     public String getFlagIconPath() {
       String flagPath = flagIconPath();
-      synchronized (this) {
-        if (!checkedHasFlag) {
-          hasFlag = StaticToadlet.haveFile(flagPath);
-          checkedHasFlag = true;
-        }
-        return hasFlag ? flagPath : null;
+      boolean hasFlag =
+          FLAG_CACHE.computeIfAbsent(this, country -> StaticToadlet.haveFile(flagPath));
+      return hasFlag ? flagPath : null;
+    }
+  }
+
+  private static final Map<Short, Country> COUNTRIES_BY_CODE;
+
+  static {
+    Map<Short, Country> byCode = new HashMap<>();
+    for (Country country : Country.values()) {
+      short encoded = encodeCountryCode(country.name());
+      if (byCode.put(encoded, country) != null) {
+        throw new IllegalStateException("Duplicate country code: " + country.name());
       }
     }
-
-    /** cached values(). Never modify or pass this array to outside code! */
-    private static final Country[] values = values();
+    COUNTRIES_BY_CODE = Map.copyOf(byCode);
   }
 
   // Base85 Decoding table
@@ -717,14 +724,25 @@ public class IPConverter {
     return instance;
   }
 
-  private static short countryOrdinalOrUnknown(String code) {
+  private static short countryCodeOrUnknown(String code) {
     try {
-      return (short) Country.valueOf(code).ordinal();
+      short encoded = encodeCountryCode(code);
+      if (COUNTRIES_BY_CODE.containsKey(encoded)) {
+        return encoded;
+      }
     } catch (IllegalArgumentException _) {
-      // Does not invalidate the whole file, just means the country list is out of date.
-      LOG.error("Country not in list: {}", code);
-      return (short) -1;
+      // fall through to log and return unknown
     }
+    // Does not invalidate the whole file, just means the country list is out of date.
+    LOG.error("Country not in list: {}", code);
+    return (short) -1;
+  }
+
+  private static short encodeCountryCode(String code) {
+    if (code == null || code.length() != 2) {
+      throw new IllegalArgumentException("Invalid country code: " + code);
+    }
+    return (short) ((code.charAt(0) << 8) | code.charAt(1));
   }
 
   /**
@@ -756,7 +774,7 @@ public class IPConverter {
         // Ip
         String ipcode = line.substring(offset + 2, offset + 7);
         long ip = decodeBase85(ipcode.getBytes(StandardCharsets.ISO_8859_1));
-        codes[i] = countryOrdinalOrUnknown(code);
+        codes[i] = countryCodeOrUnknown(code);
         ips[i] = (int) ip;
       }
       return new Cache(codes, ips);
@@ -785,7 +803,7 @@ public class IPConverter {
    * @throws NumberFormatException If the string is not an IP address.
    */
   public long ip2num(String ip) {
-    String[] split = ip.split("\\.");
+    String[] split = IPV4_SPLITTER.split(ip);
     if (split.length != 4) throw new NumberFormatException();
     long num = 0;
     long coef = (256 << 16);
@@ -902,9 +920,10 @@ public class IPConverter {
         start = midpos;
       }
     }
-    short countryOrdinal = codes[last];
-    if (countryOrdinal < 0) return null;
-    Country country = Country.values[countryOrdinal];
+    short countryCode = codes[last];
+    if (countryCode < 0) return null;
+    Country country = COUNTRIES_BY_CODE.get(countryCode);
+    if (country == null) return null;
     cache.put((int) longip, country);
     return country;
   }

--- a/src/main/java/network/crypta/clients/http/utils/UriFilterProxyHeaderParser.java
+++ b/src/main/java/network/crypta/clients/http/utils/UriFilterProxyHeaderParser.java
@@ -131,6 +131,7 @@ public class UriFilterProxyHeaderParser {
      *
      * @return a URI-like string consisting of the scheme, {@code ://}, and the stored host.
      */
+    @Override
     public String toString() {
       return scheme + "://" + host;
     }

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -523,33 +523,15 @@ public class SubConfig implements Comparable<SubConfig> {
         continue;
       }
       switch (configRequestType) {
-        case CURRENT_SETTINGS:
-          fs.putSingle(key, o.getValueString());
-          break;
-        case DEFAULT_SETTINGS:
-          fs.putSingle(key, o.getDefault());
-          break;
-        case SORT_ORDER:
-          fs.put(key, o.getSortOrder());
-          break;
-        case EXPERT_FLAG:
-          fs.put(key, o.isExpert());
-          break;
-        case FORCE_WRITE_FLAG:
-          fs.put(key, o.isForcedWrite());
-          break;
-        case SHORT_DESCRIPTION:
-          fs.putSingle(key, o.getLocalisedShortDesc());
-          break;
-        case LONG_DESCRIPTION:
-          fs.putSingle(key, o.getLocalisedLongDesc());
-          break;
-        case DATA_TYPE:
-          fs.putSingle(key, o.getDataTypeStr());
-          break;
-        default:
-          LOG.error("Unknown config request type value: {}", configRequestType);
-          break;
+        case CURRENT_SETTINGS -> fs.putSingle(key, o.getValueString());
+        case DEFAULT_SETTINGS -> fs.putSingle(key, o.getDefault());
+        case SORT_ORDER -> fs.put(key, o.getSortOrder());
+        case EXPERT_FLAG -> fs.put(key, o.isExpert());
+        case FORCE_WRITE_FLAG -> fs.put(key, o.isForcedWrite());
+        case SHORT_DESCRIPTION -> fs.putSingle(key, o.getLocalisedShortDesc());
+        case LONG_DESCRIPTION -> fs.putSingle(key, o.getLocalisedLongDesc());
+        case DATA_TYPE -> fs.putSingle(key, o.getDataTypeStr());
+        default -> LOG.error("Unknown config request type value: {}", configRequestType);
       }
       if (LOG.isDebugEnabled()) LOG.debug("Key={}.{} value={}", prefix, key, o.getValueString());
     }

--- a/src/main/java/network/crypta/config/WrapperConfig.java
+++ b/src/main/java/network/crypta/config/WrapperConfig.java
@@ -9,6 +9,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import network.crypta.node.NodeInitException;
 import network.crypta.support.io.FileUtil;
@@ -114,10 +115,10 @@ public class WrapperConfig {
       throws IOException {
     try (FileInputStream fis = new FileInputStream(oldConfig);
         BufferedInputStream bis = new BufferedInputStream(fis);
-        InputStreamReader isr = new InputStreamReader(bis);
+        InputStreamReader isr = new InputStreamReader(bis, StandardCharsets.UTF_8);
         BufferedReader br = new BufferedReader(isr);
         FileOutputStream fos = new FileOutputStream(newConfig);
-        OutputStreamWriter osw = new OutputStreamWriter(fos);
+        OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
         BufferedWriter bw = new BufferedWriter(osw)) {
 
       String line;

--- a/src/main/java/network/crypta/crypt/AEADCryptBucket.java
+++ b/src/main/java/network/crypta/crypt/AEADCryptBucket.java
@@ -283,6 +283,7 @@ public class AEADCryptBucket implements Bucket, Serializable {
 
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
+    assert serialPersistentFields.length > 0;
     // Write fields using the default field block. Include the underlying only when it is
     // Serializable; otherwise fail fast to avoid silently dropping data.
     ObjectOutputStream.PutField fields = out.putFields();

--- a/src/main/java/network/crypta/crypt/EncryptedRandomAccessBucket.java
+++ b/src/main/java/network/crypta/crypt/EncryptedRandomAccessBucket.java
@@ -555,13 +555,9 @@ public class EncryptedRandomAccessBucket implements RandomAccessBucket, Serializ
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
+    if (!(obj instanceof EncryptedRandomAccessBucket other)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    EncryptedRandomAccessBucket other = (EncryptedRandomAccessBucket) obj;
     if (type != other.type) {
       return false;
     }
@@ -594,6 +590,7 @@ public class EncryptedRandomAccessBucket implements RandomAccessBucket, Serializ
 
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
+    assert serialPersistentFields.length > 0;
     // Persist core fields via the default field block. Include the underlying only when it is
     // Serializable; otherwise fail fast to avoid silently dropping data on checkpoint.
     PutField fields = out.putFields();

--- a/src/main/java/network/crypta/crypt/EncryptedRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/crypt/EncryptedRandomAccessBuffer.java
@@ -507,6 +507,7 @@ public final class EncryptedRandomAccessBuffer implements LockableRandomAccessBu
 
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
+    assert serialPersistentFields.length > 0;
     PutField fields = out.putFields();
     fields.put(FIELD_TYPE, type);
     fields.put(FIELD_VERSION, version);

--- a/src/main/java/network/crypta/io/comm/DMT.java
+++ b/src/main/java/network/crypta/io/comm/DMT.java
@@ -1854,15 +1854,14 @@ public class DMT {
    * Creates a probe response to a query for identifier.
    *
    * @param uid Probe UID.
-   * @param probeIdentifier Endpoint identifier.
+   * @param probeId Endpoint identifier.
    * @param uptimePercentage 7-day uptime percentage.
    * @return Message with requested attributes.
    */
-  public static Message createProbeIdentifier(
-      long uid, long probeIdentifier, byte uptimePercentage) {
+  public static Message createProbeIdentifier(long uid, long probeId, byte uptimePercentage) {
     Message msg = new Message(ProbeIdentifier);
     msg.set(UID, uid);
-    msg.set(PROBE_IDENTIFIER, probeIdentifier);
+    msg.set(PROBE_IDENTIFIER, probeId);
     msg.set(UPTIME_PERCENT, uptimePercentage);
     return msg;
   }

--- a/src/main/java/network/crypta/io/comm/IncomingPacketFilter.java
+++ b/src/main/java/network/crypta/io/comm/IncomingPacketFilter.java
@@ -22,7 +22,7 @@ public interface IncomingPacketFilter {
    */
   enum DECODED {
     /** The packet was recognized and decoded; messages may have been dispatched to USM/filters. */
-    DECODED,
+    SUCCESS,
     /** No matching context was found; the packet was not decoded. */
     NOT_DECODED,
     /**

--- a/src/main/java/network/crypta/io/comm/IncomingPacketFilterImpl.java
+++ b/src/main/java/network/crypta/io/comm/IncomingPacketFilterImpl.java
@@ -1,5 +1,6 @@
 package network.crypta.io.comm;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import network.crypta.crypt.EntropySource;
 import network.crypta.node.FNPPacketMangler;
@@ -177,7 +178,7 @@ public class IncomingPacketFilterImpl implements IncomingPacketFilter {
   private boolean tryFallbackPeers(
       byte[] buf, int offset, int length, Peer peer, long now, PeerNode opn) {
     for (PeerNode pn : crypto.getPeerNodes()) {
-      if (pn == opn) {
+      if (Objects.equals(pn, opn)) {
         continue;
       }
       if (pn.handleReceivedPacket(buf, offset, length, now, peer)) {

--- a/src/main/java/network/crypta/io/comm/IncomingPacketFilterImpl.java
+++ b/src/main/java/network/crypta/io/comm/IncomingPacketFilterImpl.java
@@ -129,20 +129,20 @@ public class IncomingPacketFilterImpl implements IncomingPacketFilter {
       LOG.info("Got packet from unknown address");
     } else if (opn.handleReceivedPacket(buf, offset, length, now, peer)) {
       incrementDecoded();
-      return DECODED.DECODED;
+      return DECODED.SUCCESS;
     }
 
     DECODED decoded = mangler.process(buf, offset, length, peer, opn);
-    if (decoded == DECODED.DECODED) {
+    if (decoded == DECODED.SUCCESS) {
       incrementDecoded();
-      return DECODED.DECODED;
+      return DECODED.SUCCESS;
     }
     if (decoded == DECODED.NOT_DECODED) {
       // Probe other known peers (excluding the owning peer) as a last resort. This is O(n) in the
       // number of peers but triggers only for undecoded packets.
       if (tryFallbackPeers(buf, offset, length, peer, now, opn)) {
         incrementDecoded();
-        return DECODED.DECODED;
+        return DECODED.SUCCESS;
       }
       incrementFailed();
     }

--- a/src/main/java/network/crypta/io/comm/MessageCore.java
+++ b/src/main/java/network/crypta/io/comm/MessageCore.java
@@ -202,7 +202,7 @@ public class MessageCore {
   private void logIfUnclaimedWouldMatch(MessageFilter f, long tStart) {
     for (Message m : unclaimed) {
       MATCHED status = f.match(m, true, tStart);
-      if (status == MATCHED.MATCHED) {
+      if (status == MATCHED.FOUND) {
         // Don't match it, we timed out; two-level timeouts etc. may want it for the next filter.
         LOG.error("Timed out but should have matched in _unclaimed: {} for {}", m, f);
         break;
@@ -350,7 +350,7 @@ public class MessageCore {
         i.remove();
         return null;
       }
-      case MATCHED -> {
+      case FOUND -> {
         i.remove();
         // Set the message while holding the monitor so a concurrent waitFor() that is about to
         // time out can still observe the match.
@@ -390,7 +390,7 @@ public class MessageCore {
     for (ListIterator<MessageFilter> i = filters.listIterator(); i.hasNext(); ) {
       MessageFilter f = i.next();
       MATCHED status = f.match(m, false, tStart);
-      if (status == MATCHED.MATCHED) {
+      if (status == MATCHED.FOUND) {
         matched = true;
         match = f;
         i.remove();
@@ -547,7 +547,7 @@ public class MessageCore {
       Message m = i.next();
       // These messages have already arrived, so we can match against them even if we are timed out.
       MATCHED status = filter.match(m, true, now);
-      if (status == MATCHED.MATCHED) {
+      if (status == MATCHED.FOUND) {
         i.remove();
         if (LOG.isDebugEnabled()) LOG.debug("addAsyncFilter: matched in unclaimed queue");
         return m;
@@ -676,7 +676,7 @@ public class MessageCore {
       Iterator<Message> iterator,
       Message message) {
     MATCHED status = filter.match(message, true, startTime);
-    if (status == MATCHED.MATCHED) {
+    if (status == MATCHED.FOUND) {
       iterator.remove();
       if (LOG.isDebugEnabled()) LOG.debug("waitFor: matched in unclaimed queue");
       return message;

--- a/src/main/java/network/crypta/io/comm/MessageFilter.java
+++ b/src/main/java/network/crypta/io/comm/MessageFilter.java
@@ -263,7 +263,7 @@ public final class MessageFilter {
   /** Outcome of {@link #match(Message, long)}. */
   public enum MATCHED {
     /** The message matches all constraints and is within the timeout window. */
-    MATCHED,
+    FOUND,
     /** The filter has expired without a match. */
     TIMED_OUT,
     /** The message matches but the filter expired by the time it was checked. */
@@ -288,7 +288,7 @@ public final class MessageFilter {
    *
    * <p>When {@code noTimeout} is {@code false}, a message that matches after the filter has expired
    * yields {@link MATCHED#TIMED_OUT_AND_MATCHED}. When {@code true}, the method reports only {@link
-   * MATCHED#MATCHED} or a non-match/timeout result from the preliminary checks.
+   * MATCHED#FOUND} or a non-match/timeout result from the preliminary checks.
    *
    * @param m message to evaluate
    * @param noTimeout if {@code true}, skip the "matched but expired" check
@@ -316,7 +316,7 @@ public final class MessageFilter {
       if (LOG.isDebugEnabled()) LOG.debug("Matched but timed out: {}", this);
       return MATCHED.TIMED_OUT_AND_MATCHED;
     }
-    return MATCHED.MATCHED;
+    return MATCHED.FOUND;
   }
 
   private boolean isTypeOrSourceMismatch(Message m) {

--- a/src/main/java/network/crypta/keys/ClientCHKBlock.java
+++ b/src/main/java/network/crypta/keys/ClientCHKBlock.java
@@ -54,7 +54,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
     final String algo = base.getAlgorithm();
     Mac sunHmac = Mac.getInstance(algo, sun);
     sunHmac.init(dummyKey);
-    if (base.getProvider() == sunHmac.getProvider()) return base;
+    if (base.getProvider().equals(sunHmac.getProvider())) return base;
     long timeDef = benchmark(base);
     long timeSun = benchmark(sunHmac);
     LOG.debug("{}/{}: {}ns", algo, base.getProvider(), timeDef);
@@ -752,7 +752,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
     byte[] plainIV = md256.digest(encKey);
     header = new byte[plainIV.length + 2 + 2];
     header[0] = 0;
-    header[1] = (byte) (KeyBlock.HASH_SHA256);
+    header[1] = (byte) KeyBlock.HASH_SHA256;
     System.arraycopy(plainIV, 0, header, 2, plainIV.length);
     header[plainIV.length + 2] = (byte) (dataLength >> 8);
     header[plainIV.length + 3] = (byte) (dataLength & 0xff);

--- a/src/main/java/network/crypta/keys/FreenetURI.java
+++ b/src/main/java/network/crypta/keys/FreenetURI.java
@@ -449,7 +449,7 @@ public class FreenetURI implements Comparable<FreenetURI>, Serializable {
     return new MetaParse(de.docName(), meta, de.edition(), segs.base());
   }
 
-  private record Segments(ArrayList<String> list, String base) {}
+  private record Segments(List<String> list, String base) {}
 
   private static Segments decodeSegments(String remainder, boolean isKSK)
       throws MalformedURLException {
@@ -472,7 +472,7 @@ public class FreenetURI implements Comparable<FreenetURI>, Serializable {
   private record DocEdition(String docName, long edition) {}
 
   private static DocEdition deriveDocAndEdition(
-      ArrayList<String> segments, String keyType, boolean isUSK, boolean isSSK, boolean isKSK)
+      List<String> segments, String keyType, boolean isUSK, boolean isSSK, boolean isKSK)
       throws MalformedURLException {
     if (segments.isEmpty() && (isUSK || isKSK))
       throw new MalformedURLException("No docname for " + keyType);
@@ -489,8 +489,7 @@ public class FreenetURI implements Comparable<FreenetURI>, Serializable {
     return new DocEdition(docName, edition);
   }
 
-  private static long parseUskEditionOrThrow(ArrayList<String> segments)
-      throws MalformedURLException {
+  private static long parseUskEditionOrThrow(List<String> segments) throws MalformedURLException {
     if (segments.isEmpty()) throw new MalformedURLException("No suggested edition number for USK");
     try {
       return Long.parseLong(segments.removeLast());
@@ -500,7 +499,7 @@ public class FreenetURI implements Comparable<FreenetURI>, Serializable {
     }
   }
 
-  private static String[] toMetaArray(ArrayList<String> segments) {
+  private static String[] toMetaArray(List<String> segments) {
     if (segments.isEmpty()) return new String[0];
     String[] meta = new String[segments.size()];
     for (int i = 0; i < meta.length; i++) {

--- a/src/main/java/network/crypta/keys/FreenetURI.java
+++ b/src/main/java/network/crypta/keys/FreenetURI.java
@@ -1006,7 +1006,7 @@ public class FreenetURI implements Comparable<FreenetURI>, Serializable {
    * @throws IOException On I/O errors.
    */
   @SuppressWarnings("unused")
-  public static void writeFullBinaryKeyWithLength(FreenetURI uri, DataOutputStream dos)
+  public static void writeNullableFullBinaryKeyWithLength(FreenetURI uri, DataOutputStream dos)
       throws IOException {
     if (uri == null) dos.writeShort((short) 0);
     else uri.writeFullBinaryKeyWithLength(dos);
@@ -1189,7 +1189,7 @@ public class FreenetURI implements Comparable<FreenetURI>, Serializable {
    * you must insert a directory to create a directory structure.
    */
   @SuppressWarnings("unused")
-  public static void checkInsertURI(FreenetURI uri) throws InsertException {
+  public static void checkInsertURIOrThrow(FreenetURI uri) throws InsertException {
     uri.checkInsertURI();
   }
 

--- a/src/main/java/network/crypta/keys/NodeSSK.java
+++ b/src/main/java/network/crypta/keys/NodeSSK.java
@@ -294,22 +294,20 @@ public class NodeSSK extends Key {
    *     collision is detected with an existing different key.
    */
   public void setPubKey(DSAPublicKey pubKey2) throws SSKVerifyException {
-    if (pubKey == pubKey2) return;
     if (pubKey2 == null) return;
-    if ((pubKey == null) || !pubKey2.equals(pubKey)) {
-      byte[] newPubKeyHash = SHA256.digest(pubKey2.asBytes());
-      if (Arrays.equals(pubKeyHash, newPubKeyHash)) {
-        if (pubKey != null) {
-          // Same hash yet a different key instance: treat as a collision.
-          LOG.error("Found SHA-256 collision or something... WTF?");
-          throw new SSKVerifyException("Invalid new pubkey: " + pubKey2 + " old pubkey: " + pubKey);
-        }
-        // Hash matches and no previous key: accept.
-      } else {
-        throw new SSKVerifyException("New pubkey has invalid hash");
+    if (pubKey2.equals(pubKey)) return;
+    byte[] newPubKeyHash = SHA256.digest(pubKey2.asBytes());
+    if (Arrays.equals(pubKeyHash, newPubKeyHash)) {
+      if (pubKey != null) {
+        // Same hash yet a different key instance: treat as a collision.
+        LOG.error("Found SHA-256 collision or something... WTF?");
+        throw new SSKVerifyException("Invalid new pubkey: " + pubKey2 + " old pubkey: " + pubKey);
       }
-      pubKey = pubKey2;
+      // Hash matches and no previous key: accept.
+    } else {
+      throw new SSKVerifyException("New pubkey has invalid hash");
     }
+    pubKey = pubKey2;
   }
 
   @Override

--- a/src/main/java/network/crypta/l10n/BaseL10n.java
+++ b/src/main/java/network/crypta/l10n/BaseL10n.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.NoSuchElementException;
+import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 import network.crypta.clients.http.TranslationToadlet;
 import network.crypta.support.HTMLNode;
@@ -68,98 +69,99 @@ public class BaseL10n {
     // Windows language codes must be preceded with WINDOWS and be in upper case hex, 4 digits.
     // See http://www.autohotkey.com/docs/misc/Languages.htm
 
-    CROATIAN("hr", "Hrvatski", "hrv", new String[] {"WINDOWS041A"}),
+    CROATIAN("hr", "Hrvatski", "hrv", aliases("WINDOWS041A")),
     ENGLISH(
         "en",
         "English",
         "eng",
-        new String[] {
-          "WINDOWS0409",
-          "WINDOWS0809",
-          "WINDOWS0C09",
-          "WINDOWS1009",
-          "WINDOWS1409",
-          "WINDOWS1809",
-          "WINDOWS1C09",
-          "WINDOWS2009",
-          "WINDOWS2409",
-          "WINDOWS2809",
-          "WINDOWS2C09",
-          "WINDOWS3009",
-          "WINDOWS3409"
-        }),
-    HUNGARIAN("hu", "magyar", "hun", new String[] {"WINDOWS040E"}),
+        aliases(
+            "WINDOWS0409",
+            "WINDOWS0809",
+            "WINDOWS0C09",
+            "WINDOWS1009",
+            "WINDOWS1409",
+            "WINDOWS1809",
+            "WINDOWS1C09",
+            "WINDOWS2009",
+            "WINDOWS2409",
+            "WINDOWS2809",
+            "WINDOWS2C09",
+            "WINDOWS3009",
+            "WINDOWS3409")),
+    HUNGARIAN("hu", "magyar", "hun", aliases("WINDOWS040E")),
     SPANISH(
         "es",
         "Español",
         "spa",
-        new String[] {
-          "WINDOWS040A",
-          "WINDOWS080A",
-          "WINDOWS0C0A",
-          "WINDOWS100A",
-          "WINDOWS140A",
-          "WINDOWS180A",
-          "WINDOWS1C0A",
-          "WINDOWS200A",
-          "WINDOWS240A",
-          "WINDOWS280A",
-          "WINDOWS2C0A",
-          "WINDOWS300A",
-          "WINDOWS340A",
-          "WINDOWS380A",
-          "WINDOWS3C0A",
-          "WINDOWS400A",
-          "WINDOWS440A",
-          "WINDOWS480A",
-          "WINDOWS4C0A",
-          "WINDOWS500A"
-        }),
-    DANISH("da", "Dansk", "dan", new String[] {"WINDOWS0406"}),
-    DUTCH("nl", "Nederlands", "nld", new String[] {"WINDOWS0413", "WINDOWS0813"}),
+        aliases(
+            "WINDOWS040A",
+            "WINDOWS080A",
+            "WINDOWS0C0A",
+            "WINDOWS100A",
+            "WINDOWS140A",
+            "WINDOWS180A",
+            "WINDOWS1C0A",
+            "WINDOWS200A",
+            "WINDOWS240A",
+            "WINDOWS280A",
+            "WINDOWS2C0A",
+            "WINDOWS300A",
+            "WINDOWS340A",
+            "WINDOWS380A",
+            "WINDOWS3C0A",
+            "WINDOWS400A",
+            "WINDOWS440A",
+            "WINDOWS480A",
+            "WINDOWS4C0A",
+            "WINDOWS500A")),
+    DANISH("da", "Dansk", "dan", aliases("WINDOWS0406")),
+    DUTCH("nl", "Nederlands", "nld", aliases("WINDOWS0413", "WINDOWS0813")),
     GERMAN(
         "de",
         "Deutsch",
         "deu",
-        new String[] {"WINDOWS0407", "WINDOWS0807", "WINDOWS0C07", "WINDOWS1007", "WINDOWS1407"}),
-    FINNISH("fi", "Suomi", "fin", new String[] {"WINDOWS040B"}),
+        aliases("WINDOWS0407", "WINDOWS0807", "WINDOWS0C07", "WINDOWS1007", "WINDOWS1407")),
+    FINNISH("fi", "Suomi", "fin", aliases("WINDOWS040B")),
     FRENCH(
         "fr",
         "Français",
         "fra",
-        new String[] {
-          "WINDOWS040C", "WINDOWS080C", "WINDOWS0C0C", "WINDOWS100C", "WINDOWS140C", "WINDOWS180C"
-        }),
-    ITALIAN("it", "Italiano", "ita", new String[] {"WINDOWS0410", "WINDOWS0810"}),
+        aliases(
+            "WINDOWS040C",
+            "WINDOWS080C",
+            "WINDOWS0C0C",
+            "WINDOWS100C",
+            "WINDOWS140C",
+            "WINDOWS180C")),
+    ITALIAN("it", "Italiano", "ita", aliases("WINDOWS0410", "WINDOWS0810")),
     // RFC 5646 non-compliant. Rename when converting the entire list to RFC 5646; provide a
     // migration path to avoid breaking plugin identifiers.
-    NORWEGIAN("nb-no", "Bokmål", "nob", new String[] {"WINDOWS0414", "WINDOWS0814"}),
-    POLISH("pl", "Polski", "pol", new String[] {"WINDOWS0415"}),
-    SWEDISH("sv", "Svenska", "swe", new String[] {"WINDOWS041D", "WINDOWS081D"}),
+    NORWEGIAN("nb-no", "Bokmål", "nob", aliases("WINDOWS0414", "WINDOWS0814")),
+    POLISH("pl", "Polski", "pol", aliases("WINDOWS0415")),
+    SWEDISH("sv", "Svenska", "swe", aliases("WINDOWS041D", "WINDOWS081D")),
     // RFC 5646 non-compliant. Rename when converting the entire list to RFC 5646; provide a
     // migration path to avoid breaking plugin identifiers.
-    CHINESE("zh-cn", "中文(简体)", "chn", new String[] {"WINDOWS0804", "WINDOWS1004"}),
+    CHINESE("zh-cn", "中文(简体)", "chn", aliases("WINDOWS0804", "WINDOWS1004")),
     // simplified chinese, used on mainland, Singapore and Malaysia
     // RFC 5646 non-compliant. Rename when converting the entire list to RFC 5646; provide a
     // migration path to avoid breaking plugin identifiers.
     CHINESE_TAIWAN(
-        "zh-tw", "中文(繁體)", "zh-tw", new String[] {"WINDOWS0404", "WINDOWS0C04", "WINDOWS1404"}),
+        "zh-tw", "中文(繁體)", "zh-tw", aliases("WINDOWS0404", "WINDOWS0C04", "WINDOWS1404")),
     // traditional chinese, used in Taiwan, Hong Kong and Macau
     RUSSIAN(
         "ru",
         "Русский",
         "rus",
-        new String[] {
-          "WINDOWS0419"
-        }), // Just one variant for russian. Belorussian is separate, code page 423, speakers may or
+        aliases("WINDOWS0419")), // Just one variant for russian. Belorussian is separate, code page
+    // 423, speakers may or
     // may not speak russian, I'm not including it.
-    JAPANESE("ja", "日本語", "jpn", new String[] {"WINDOWS0411"}),
-    PORTUGUESE("pt-PT", "Português do Portugal", "pt", new String[] {"WINDOWS0816"}),
+    JAPANESE("ja", "日本語", "jpn", aliases("WINDOWS0411")),
+    PORTUGUESE("pt-PT", "Português do Portugal", "pt", aliases("WINDOWS0816")),
     // RFC 5646 non-compliant. Rename when converting the entire list to RFC 5646; provide a
     // migration path to avoid breaking plugin identifiers.
-    BRAZILIAN_PORTUGUESE("pt-br", "Português do Brasil", "pt-br", new String[] {"WINDOWS0416"}),
-    GREEK("el", "Ελληνικά", "ell", new String[] {"WINDOWS0408"}),
-    UNLISTED(UNLISTED_LITERAL, UNLISTED_LITERAL, UNLISTED_LITERAL, new String[] {});
+    BRAZILIAN_PORTUGUESE("pt-br", "Português do Brasil", "pt-br", aliases("WINDOWS0416")),
+    GREEK("el", "Ελληνικά", "ell", aliases("WINDOWS0408")),
+    UNLISTED(UNLISTED_LITERAL, UNLISTED_LITERAL, UNLISTED_LITERAL, "");
 
     /** Internal identifier; must be unique. */
     public final String shortCode;
@@ -170,13 +172,20 @@ public class BaseL10n {
     /** Installer-facing language identifier; must be unique (see bug #2424). */
     public final String isoCode;
 
-    private final String[] aliases;
+    private final String aliases;
 
-    LANGUAGE(String shortCode, String fullName, String isoCode, String[] aliases) {
+    LANGUAGE(String shortCode, String fullName, String isoCode, String aliases) {
       this.shortCode = shortCode;
       this.fullName = fullName;
       this.isoCode = isoCode;
       this.aliases = aliases;
+    }
+
+    private static String aliases(String... values) {
+      if (values.length == 0) {
+        return "";
+      }
+      return String.join(",", values);
     }
 
     // No copy-constructor; enum constants are fixed.
@@ -196,9 +205,12 @@ public class BaseL10n {
             || currentLanguage.toString().equalsIgnoreCase(whatever)) {
           return currentLanguage;
         }
-        if (currentLanguage.aliases != null) {
-          for (String s : currentLanguage.aliases)
+        if (!currentLanguage.aliases.isEmpty()) {
+          StringTokenizer tokenizer = new StringTokenizer(currentLanguage.aliases, ",");
+          while (tokenizer.hasMoreTokens()) {
+            String s = tokenizer.nextToken();
             if (whatever.equalsIgnoreCase(s)) return currentLanguage;
+          }
         }
       }
       return null;

--- a/src/main/java/network/crypta/node/AnnounceSender.java
+++ b/src/main/java/network/crypta/node/AnnounceSender.java
@@ -1,6 +1,8 @@
 package network.crypta.node;
 
 import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import network.crypta.io.comm.ByteCounter;
 import network.crypta.io.comm.DMT;
 import network.crypta.io.comm.DisconnectedException;
@@ -161,18 +163,16 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
       }
 
       NodeProcessResult result = routeOnce(nodesRoutedTo, next);
-      switch (result) {
-        case TERMINATE:
-          return;
-        case CONTINUE_FORWARDED:
-          hasForwarded = true;
-          last = next;
-          break;
-        case CONTINUE_NO_FORWARD:
-          // Track the attempted peer even if we failed to send/forward.
-          // This keeps HTL decrement attribution consistent with the peer we just tried.
-          last = next;
-          break;
+      if (result == NodeProcessResult.TERMINATE) {
+        return;
+      }
+      if (result == NodeProcessResult.CONTINUE_FORWARDED) {
+        hasForwarded = true;
+        last = next;
+      } else if (result == NodeProcessResult.CONTINUE_NO_FORWARD) {
+        // Track the attempted peer even if we failed to send/forward.
+        // This keeps HTL decrement attribution consistent with the peer we just tried.
+        last = next;
       }
       // else: no forward this iteration, keep the previous 'last' and hasForwarded
     }
@@ -184,7 +184,7 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
     CONTINUE_FORWARDED
   }
 
-  private NodeProcessResult routeOnce(HashSet<PeerNode> nodesRoutedTo, PeerNode next) {
+  private NodeProcessResult routeOnce(Set<PeerNode> nodesRoutedTo, PeerNode next) {
     if (LOG.isDebugEnabled()) LOG.debug("Routing request to {}", next);
     if (onlyNode == null)
       PeerNodeRoutingReporter.reportRoutedTo(
@@ -228,7 +228,7 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
     }
   }
 
-  private PeerNode chooseNextNode(HashSet<PeerNode> routed) {
+  private PeerNode chooseNextNode(Set<PeerNode> routed) {
     if (onlyNode == null) {
       return node.network()
           .peers()
@@ -334,16 +334,17 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
       if (LOG.isDebugEnabled()) LOG.debug("Accepted wait timed out");
       return AcceptWaitOutcome.TRY_ANOTHER;
     }
-    if (msg.getSpec() == DMT.FNPRejectedLoop) {
+    MessageType spec = msg.getSpec();
+    if (DMT.FNPRejectedLoop.equals(spec)) {
       if (LOG.isDebugEnabled()) LOG.debug("Accepted rejected: loop");
       return AcceptWaitOutcome.TRY_ANOTHER;
-    } else if (msg.getSpec() == DMT.FNPRejectedOverload) {
+    } else if (DMT.FNPRejectedOverload.equals(spec)) {
       if (LOG.isDebugEnabled()) LOG.debug("Accepted rejected: overload");
       return AcceptWaitOutcome.TRY_ANOTHER;
-    } else if (msg.getSpec() == DMT.FNPOpennetDisabled) {
+    } else if (DMT.FNPOpennetDisabled.equals(spec)) {
       if (LOG.isDebugEnabled()) LOG.debug("Accepted rejected: opennet disabled");
       return AcceptWaitOutcome.TRY_ANOTHER;
-    } else if (msg.getSpec() == DMT.FNPAccepted) {
+    } else if (DMT.FNPAccepted.equals(spec)) {
       return AcceptWaitOutcome.ACCEPTED;
     }
     LOG.error("Unrecognized accepted-wait message: {}", msg);
@@ -373,19 +374,18 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
       if (LOG.isDebugEnabled()) LOG.debug("Final response received {}", msg);
 
       FinalOutcome outcome = evaluateFinalMessage(msg, next);
-      switch (outcome) {
-        case TERMINATE:
-          return Flow.TERMINATE;
-        case CONTINUE:
-          // Exit the final-response wait loop and try another peer.
-          return Flow.CONTINUE;
-        case COMPLETED:
-          handleCompletedSequence(next);
-          return Flow.TERMINATE;
-        case KEEP_WAITING:
-          // Keep waiting on this peer for more replies or completion.
-          break;
+      if (outcome == FinalOutcome.TERMINATE) {
+        return Flow.TERMINATE;
       }
+      if (outcome == FinalOutcome.CONTINUE) {
+        // Exit the final-response wait loop and try another peer.
+        return Flow.CONTINUE;
+      }
+      if (outcome == FinalOutcome.COMPLETED) {
+        handleCompletedSequence(next);
+        return Flow.TERMINATE;
+      }
+      // KEEP_WAITING: loop again
     }
   }
 
@@ -464,13 +464,15 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
 
   private java.util.function.BiFunction<Message, PeerNode, FinalOutcome> handlerFor(
       MessageType spec) {
-    if (spec == DMT.FNPOpennetNoderefRejected) return this::handleNoderefRejected;
-    if (spec == DMT.FNPOpennetAnnounceCompleted) return (_, _) -> FinalOutcome.COMPLETED;
-    if (spec == DMT.FNPRouteNotFound) return this::handleRouteNotFound;
-    if (spec == DMT.FNPRejectedOverload) return this::handleRejectedOverload;
-    if (spec == DMT.FNPOpennetDisabled) return this::handleOpennetDisabled;
-    if (spec == DMT.FNPOpennetAnnounceReply) return this::handleAnnounceReply;
-    if (spec == DMT.FNPOpennetAnnounceNodeNotWanted) return (_, _) -> handleNodeNotWanted();
+    if (Objects.equals(spec, DMT.FNPOpennetNoderefRejected)) return this::handleNoderefRejected;
+    if (Objects.equals(spec, DMT.FNPOpennetAnnounceCompleted))
+      return (_, _) -> FinalOutcome.COMPLETED;
+    if (Objects.equals(spec, DMT.FNPRouteNotFound)) return this::handleRouteNotFound;
+    if (Objects.equals(spec, DMT.FNPRejectedOverload)) return this::handleRejectedOverload;
+    if (Objects.equals(spec, DMT.FNPOpennetDisabled)) return this::handleOpennetDisabled;
+    if (Objects.equals(spec, DMT.FNPOpennetAnnounceReply)) return this::handleAnnounceReply;
+    if (Objects.equals(spec, DMT.FNPOpennetAnnounceNodeNotWanted))
+      return (_, _) -> handleNodeNotWanted();
     return null;
   }
 
@@ -567,11 +569,12 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
 
   private boolean processCompletionFollowup(Message msg, PeerNode next) {
     if (msg == null) return false;
-    if (msg.getSpec() == DMT.FNPOpennetAnnounceReply) {
+    MessageType spec = msg.getSpec();
+    if (DMT.FNPOpennetAnnounceReply.equals(spec)) {
       validateForwardReply(msg, next);
       return true; // keep waiting; there may be more
     }
-    if (msg.getSpec() == DMT.FNPOpennetAnnounceNodeNotWanted) {
+    if (DMT.FNPOpennetAnnounceNodeNotWanted.equals(spec)) {
       if (cb != null) cb.nodeNotWanted();
       if (source != null) {
         try {

--- a/src/main/java/network/crypta/node/Announcer.java
+++ b/src/main/java/network/crypta/node/Announcer.java
@@ -595,38 +595,36 @@ public class Announcer {
 
   private boolean started = false;
 
-  private Runnable checker() {
-    return () -> {
-      int running;
-      synchronized (Announcer.this) {
-        running = runningAnnouncements;
+  private void checker() {
+    int running;
+    synchronized (Announcer.this) {
+      running = runningAnnouncements;
+    }
+    if (enoughPeers()) {
+      for (SeedServerPeerNode pn :
+          node.network().peers().seedPeers().getConnectedSeedServerPeersVector(null)) {
+        node.network().peers().messenger().disconnectAndRemove(pn, true, true, false);
       }
-      if (enoughPeers()) {
-        for (SeedServerPeerNode pn :
-            node.network().peers().seedPeers().getConnectedSeedServerPeersVector(null)) {
-          node.network().peers().messenger().disconnectAndRemove(pn, true, true, false);
-        }
-        // Re-check every minute. Adverse conditions (e.g., CPU starvation) might require reseeding.
-        node.network()
-            .ticker()
-            .queueTimedJob(
-                this::maybeSendAnnouncement,
-                "Check whether we need to announce",
-                RETRY_DELAY,
-                false,
-                true);
-      } else {
-        node.network()
-            .ticker()
-            .queueTimedJob(
-                this::maybeSendAnnouncement,
-                "Check whether we need to announce",
-                RETRY_DELAY,
-                false,
-                true);
-        if (running != 0) maybeSendAnnouncement();
-      }
-    };
+      // Re-check every minute. Adverse conditions (e.g., CPU starvation) might require reseeding.
+      node.network()
+          .ticker()
+          .queueTimedJob(
+              this::maybeSendAnnouncement,
+              "Check whether we need to announce",
+              RETRY_DELAY,
+              false,
+              true);
+    } else {
+      node.network()
+          .ticker()
+          .queueTimedJob(
+              this::maybeSendAnnouncement,
+              "Check whether we need to announce",
+              RETRY_DELAY,
+              false,
+              true);
+      if (running != 0) maybeSendAnnouncement();
+    }
   }
 
   /**
@@ -672,7 +670,7 @@ public class Announcer {
     if (enoughPeers()) {
       node.network()
           .ticker()
-          .queueTimedJob(checker(), "Announcement checker", FINAL_DELAY, false, true);
+          .queueTimedJob(this::checker, "Announcement checker", FINAL_DELAY, false, true);
       return true;
     }
     return false;
@@ -683,7 +681,7 @@ public class Announcer {
     if (enoughPeers()) {
       node.network()
           .ticker()
-          .queueTimedJob(checker(), "Announcement checker", FINAL_DELAY, false, true);
+          .queueTimedJob(this::checker, "Announcement checker", FINAL_DELAY, false, true);
       return true;
     }
     if (runningAnnouncements > WANT_ANNOUNCEMENTS) {

--- a/src/main/java/network/crypta/node/BandwidthManager.java
+++ b/src/main/java/network/crypta/node/BandwidthManager.java
@@ -87,10 +87,10 @@ public class BandwidthManager {
                       node.getConfig().get("node").getInt("outputBandwidthLimit");
 
                   // Trigger only on a large step-up (≥3×) vs current and last offer.
-                  if (detectedInputBandwidth > currentInputBandwidth * 3
-                          && detectedInputBandwidth > lastOfferedInputBandwidth * 3
-                      || detectedOutputBandwidth > currentOutputBandwidth * 3
-                          && detectedOutputBandwidth > lastOfferedOutputBandwidth * 3) {
+                  if ((detectedInputBandwidth > currentInputBandwidth * 3
+                          && detectedInputBandwidth > lastOfferedInputBandwidth * 3)
+                      || (detectedOutputBandwidth > currentOutputBandwidth * 3
+                          && detectedOutputBandwidth > lastOfferedOutputBandwidth * 3)) {
                     // Offer half of the detected rate but never below current limits.
                     lastOfferedInputBandwidth =
                         Math.max(detectedInputBandwidth / 2, currentInputBandwidth);

--- a/src/main/java/network/crypta/node/CHKInsertHandler.java
+++ b/src/main/java/network/crypta/node/CHKInsertHandler.java
@@ -153,7 +153,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
       return;
     }
 
-    if (msg.getSpec() == DMT.FNPDataInsertRejected) {
+    if (DMT.FNPDataInsertRejected.equals(msg.getSpec())) {
       forwardDataInsertRejected(msg);
       return;
     }
@@ -293,23 +293,19 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
   }
 
   private void handleTerminalStatus(int status) {
-    switch (status) {
-      case CHKInsertSender.TIMED_OUT,
-      CHKInsertSender.GENERATED_REJECTED_OVERLOAD,
-      CHKInsertSender.INTERNAL_ERROR:
-        handleFatalOverload(status);
-        break;
-      case CHKInsertSender.ROUTE_NOT_FOUND, CHKInsertSender.ROUTE_REALLY_NOT_FOUND:
-        handleRouteNotFound(status);
-        break;
-      case CHKInsertSender.RECEIVE_FAILED:
-        handleReceiveFailed();
-        break;
-      case CHKInsertSender.SUCCESS:
-        handleSuccess(status);
-        break;
-      default:
-        handleUnknownStatus();
+    if (status == CHKInsertSender.TIMED_OUT
+        || status == CHKInsertSender.GENERATED_REJECTED_OVERLOAD
+        || status == CHKInsertSender.INTERNAL_ERROR) {
+      handleFatalOverload(status);
+    } else if (status == CHKInsertSender.ROUTE_NOT_FOUND
+        || status == CHKInsertSender.ROUTE_REALLY_NOT_FOUND) {
+      handleRouteNotFound(status);
+    } else if (status == CHKInsertSender.RECEIVE_FAILED) {
+      handleReceiveFailed();
+    } else if (status == CHKInsertSender.SUCCESS) {
+      handleSuccess(status);
+    } else {
+      handleUnknownStatus();
     }
   }
 
@@ -533,7 +529,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
 
     Message m = awaitDownstreamAndBuildCompletionMsg(sentCompletionWasSet, transferTimeout);
 
-    if ((sender == null) && (!sentCompletionWasSet) && (canCommit)) {
+    if (sender == null && !sentCompletionWasSet && canCommit) {
       // There are no downstream senders, but we stored the data locally, report successful
       // transfer. Note that this is done even if the verifying fails.
       m = DMT.createFNPInsertTransfersCompleted(uid, false /* no timeouts */);

--- a/src/main/java/network/crypta/node/DatabaseKey.java
+++ b/src/main/java/network/crypta/node/DatabaseKey.java
@@ -121,13 +121,9 @@ public class DatabaseKey {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
+    if (!(obj instanceof DatabaseKey other)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    DatabaseKey other = (DatabaseKey) obj;
     return Arrays.equals(key, other.key);
   }
 }

--- a/src/main/java/network/crypta/node/FNPPacketMangler.java
+++ b/src/main/java/network/crypta/node/FNPPacketMangler.java
@@ -189,18 +189,18 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       LOG.trace("AnonAuth change IP permitted");
     }
 
-    if (tryExactPeerMatch(buf, offset, length, peer, opn)) return DECODED.DECODED;
+    if (tryExactPeerMatch(buf, offset, length, peer, opn)) return DECODED.SUCCESS;
 
     if (node.isStopping()) return DECODED.SHUTTING_DOWN;
 
-    if (tryPeersAuthOrAnon(buf, offset, length, peer, opn, wantAnonAuth)) return DECODED.DECODED;
+    if (tryPeersAuthOrAnon(buf, offset, length, peer, opn, wantAnonAuth)) return DECODED.SUCCESS;
 
     if (maybeHandleAnonAuthChangeIPCombined(wantAnonAuth, opn, buf, offset, length, peer))
-      return DECODED.DECODED;
+      return DECODED.SUCCESS;
 
     // Try legacy/old opennet peers. If one succeeds, return DECODED immediately.
     OldOpennetTryResult oldOpennetResult = tryOldOpennetPeers(buf, offset, length, peer);
-    if (oldOpennetResult == OldOpennetTryResult.SUCCEEDED) return DECODED.DECODED;
+    if (oldOpennetResult == OldOpennetTryResult.SUCCEEDED) return DECODED.SUCCESS;
     boolean didntTryOldOpennetPeers = oldOpennetResult == OldOpennetTryResult.DIDNT_TRY;
 
     // peers/anon already tried; no additional anon-auth checks needed here

--- a/src/main/java/network/crypta/node/MessageFragmentPayload.java
+++ b/src/main/java/network/crypta/node/MessageFragmentPayload.java
@@ -21,12 +21,30 @@ import org.jetbrains.annotations.NotNull;
  *   <li>Leaves lifecycle and threading guarantees to the caller and referenced wrapper.
  * </ul>
  *
- * @param fragmentData payload bytes of this fragment; used for size and transmission
- * @param wrapper originating wrapper when sending; {@code null} when created by a receiver
  * @see MessageFragment
  * @see MessageWrapper
  */
-record MessageFragmentPayload(byte[] fragmentData, MessageWrapper wrapper) {
+final class MessageFragmentPayload {
+  private final byte[] fragmentData;
+  private final MessageWrapper wrapper;
+
+  /**
+   * @param fragmentData payload bytes of this fragment; used for size and transmission
+   * @param wrapper originating wrapper when sending; {@code null} when created by a receiver
+   */
+  MessageFragmentPayload(byte[] fragmentData, MessageWrapper wrapper) {
+    this.fragmentData = fragmentData;
+    this.wrapper = wrapper;
+  }
+
+  byte[] fragmentData() {
+    return fragmentData;
+  }
+
+  MessageWrapper wrapper() {
+    return wrapper;
+  }
+
   /**
    * Compares this payload to another object using buffer contents and wrapper identity.
    *
@@ -45,11 +63,10 @@ record MessageFragmentPayload(byte[] fragmentData, MessageWrapper wrapper) {
     if (this == obj) {
       return true;
     }
-    if (!(obj
-        instanceof MessageFragmentPayload(byte[] otherFragmentData, MessageWrapper otherWrapper))) {
+    if (!(obj instanceof MessageFragmentPayload other)) {
       return false;
     }
-    return Arrays.equals(fragmentData, otherFragmentData) && wrapper == otherWrapper;
+    return Arrays.equals(fragmentData, other.fragmentData) && wrapper == other.wrapper;
   }
 
   /**

--- a/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
+++ b/src/main/java/network/crypta/node/NodeClientCoreTransfers.java
@@ -316,41 +316,50 @@ public final class NodeClientCoreTransfers {
   private void handleStatusResult(
       boolean isSSK, RequestCompletionListener listener, RequestSender rs, int status) {
     switch (status) {
-      case RequestSender.NOT_FINISHED:
+      case RequestSender.NOT_FINISHED -> {
         LOG.error(
             "Async get handler saw RequestSender still running for {}: {}",
             isSSK ? "SSK" : "CHK",
             rs);
         listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
         return;
-      case RequestSender.DATA_NOT_FOUND:
+      }
+      case RequestSender.DATA_NOT_FOUND -> {
         listener.onFailed(new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND));
         return;
-      case RequestSender.RECENTLY_FAILED:
+      }
+      case RequestSender.RECENTLY_FAILED -> {
         listener.onFailed(new LowLevelGetException(LowLevelGetException.RECENTLY_FAILED));
         return;
-      case RequestSender.ROUTE_NOT_FOUND:
+      }
+      case RequestSender.ROUTE_NOT_FOUND -> {
         listener.onFailed(new LowLevelGetException(LowLevelGetException.ROUTE_NOT_FOUND));
         return;
-      case RequestSender.TRANSFER_FAILED, RequestSender.GET_OFFER_TRANSFER_FAILED:
+      }
+      case RequestSender.TRANSFER_FAILED, RequestSender.GET_OFFER_TRANSFER_FAILED -> {
         listener.onFailed(new LowLevelGetException(LowLevelGetException.TRANSFER_FAILED));
         return;
-      case RequestSender.VERIFY_FAILURE, RequestSender.GET_OFFER_VERIFY_FAILURE:
+      }
+      case RequestSender.VERIFY_FAILURE, RequestSender.GET_OFFER_VERIFY_FAILURE -> {
         listener.onFailed(new LowLevelGetException(LowLevelGetException.VERIFY_FAILED));
         return;
-      case RequestSender.GENERATED_REJECTED_OVERLOAD, RequestSender.TIMED_OUT:
+      }
+      case RequestSender.GENERATED_REJECTED_OVERLOAD, RequestSender.TIMED_OUT -> {
         listener.onFailed(new LowLevelGetException(LowLevelGetException.REJECTED_OVERLOAD));
         return;
-      case RequestSender.INTERNAL_ERROR:
+      }
+      case RequestSender.INTERNAL_ERROR -> {
         listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
         return;
-      default:
+      }
+      default -> {
         LOG.error(
             "Async get received unknown RequestSender status for {}: {} on {}",
             isSSK ? "SSK" : "CHK",
             status,
             rs);
         listener.onFailed(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR));
+      }
     }
   }
 

--- a/src/main/java/network/crypta/node/NodeCryptoConfig.java
+++ b/src/main/java/network/crypta/node/NodeCryptoConfig.java
@@ -122,7 +122,7 @@ public class NodeCryptoConfig {
         new IntCallback() {
           @Override
           public Integer get() {
-            synchronized (NodeCryptoConfig.class) {
+            synchronized (NodeCryptoConfig.this) {
               if (crypto != null) portNumber = crypto.getPortNumber();
               return portNumber;
             }
@@ -134,7 +134,7 @@ public class NodeCryptoConfig {
               throw new InvalidConfigValueException("Invalid port number");
             }
 
-            synchronized (NodeCryptoConfig.class) {
+            synchronized (NodeCryptoConfig.this) {
               if (portNumber == val) return;
               // On-the-fly listenPort changes are not supported.
               // Note that this sort of thing should be the exception rather than the rule!

--- a/src/main/java/network/crypta/node/NodeStatsFieldSetExporter.java
+++ b/src/main/java/network/crypta/node/NodeStatsFieldSetExporter.java
@@ -307,8 +307,8 @@ final class NodeStatsFieldSetExporter {
   private static void putTotalAndRecentIOMetrics(
       NodeStats stats, SimpleFieldSet fs, long nodeUptimeSecondsLocal) {
     long[] total = stats.node.network().collector().getTotalIO();
-    long totalOutputRate = (total[0]) / nodeUptimeSecondsLocal;
-    long totalInputRate = (total[1]) / nodeUptimeSecondsLocal;
+    long totalOutputRate = total[0] / nodeUptimeSecondsLocal;
+    long totalInputRate = total[1] / nodeUptimeSecondsLocal;
     long totalPayloadOutput = stats.node.getTotalPayloadSent();
     long totalPayloadOutputRate = totalPayloadOutput / nodeUptimeSecondsLocal;
     int totalPayloadOutputPercent =

--- a/src/main/java/network/crypta/node/PeerNodeReferenceSupport.java
+++ b/src/main/java/network/crypta/node/PeerNodeReferenceSupport.java
@@ -320,6 +320,22 @@ final class PeerNodeReferenceSupport {
     }
   }
 
+  private static String[] splitOnComma(String input) {
+    ArrayList<String> parts = new ArrayList<>();
+    int start = 0;
+    for (int i = 0; i < input.length(); i++) {
+      if (input.charAt(i) == ',') {
+        parts.add(input.substring(start, i));
+        start = i + 1;
+      }
+    }
+    parts.add(input.substring(start));
+    for (int i = parts.size() - 1; i >= 0 && parts.get(i).isEmpty(); i--) {
+      parts.remove(i);
+    }
+    return parts.toArray(new String[0]);
+  }
+
   /**
    * Parses a comma-separated host list with a shared port suffix.
    *
@@ -330,7 +346,7 @@ final class PeerNodeReferenceSupport {
    * @param phys raw physical entry string that may contain {@code A,B,C:port}
    * @param out destination list to append parsed peers to
    */
-  private static void addPeersWithSharedPortSuffix(String phys, ArrayList<Peer> out) {
+  private static void addPeersWithSharedPortSuffix(String phys, List<Peer> out) {
     int lastColon = phys.lastIndexOf(':');
     if (lastColon <= 0 || lastColon >= phys.length() - 1) {
       return;
@@ -342,7 +358,7 @@ final class PeerNodeReferenceSupport {
     }
 
     String hostList = phys.substring(0, lastColon);
-    for (String host : hostList.split(",")) {
+    for (String host : splitOnComma(hostList)) {
       addPeerIfParsable(host.trim() + ":" + portStr, out);
     }
   }
@@ -356,8 +372,8 @@ final class PeerNodeReferenceSupport {
    * @param phys raw physical entry string that may contain {@code A:port,B:port}
    * @param out destination list to append parsed peers to
    */
-  private static void addPeersFromCommaSeparatedTokens(String phys, ArrayList<Peer> out) {
-    for (String token : phys.split(",")) {
+  private static void addPeersFromCommaSeparatedTokens(String phys, List<Peer> out) {
+    for (String token : splitOnComma(phys)) {
       String cand = token.trim();
       if (cand.isEmpty()) {
         continue;
@@ -393,7 +409,7 @@ final class PeerNodeReferenceSupport {
    * @param cand candidate {@code host:port} string to parse
    * @param out destination list to append a parsed peer to
    */
-  private static void addPeerIfParsable(String cand, ArrayList<Peer> out) {
+  private static void addPeerIfParsable(String cand, List<Peer> out) {
     try {
       out.add(new Peer(cand, true, true));
     } catch (Exception _) {
@@ -410,7 +426,7 @@ final class PeerNodeReferenceSupport {
    * @param cand candidate {@code host:port} string to parse
    * @param out destination list to append a parsed peer to if unique
    */
-  private static void addPeerIfParsableAndNotDuplicate(String cand, ArrayList<Peer> out) {
+  private static void addPeerIfParsableAndNotDuplicate(String cand, List<Peer> out) {
     try {
       Peer parsed = new Peer(cand, true, true);
       if (!out.contains(parsed)) {
@@ -483,7 +499,7 @@ final class PeerNodeReferenceSupport {
    */
   void checkTestnetAndOpennet(SimpleFieldSet fs, boolean forDiffNodeRef, boolean forFullNodeRef)
       throws FSParseException {
-    if (!forDiffNodeRef && (fs.getBoolean(PeerNode.SFS_KEY_TESTNET, false))) {
+    if (!forDiffNodeRef && fs.getBoolean(PeerNode.SFS_KEY_TESTNET, false)) {
       String err = "Preventing connection to node " + peer.getPeer() + " - testnet is enabled!";
       LOG.error(err);
       throw new FSParseException(err);
@@ -630,7 +646,7 @@ final class PeerNodeReferenceSupport {
 
       // If there is no signature, FAIL
       // If there is an ECDSA signature, and it doesn't verify, FAIL
-      boolean hasNoSignature = (!isECDSAsigPresent);
+      boolean hasNoSignature = !isECDSAsigPresent;
       boolean isECDSAsigInvalid = (isECDSAsigPresent && !verifyECDSA);
       failed = hasNoSignature || isECDSAsigInvalid;
       if (failed) {
@@ -761,7 +777,7 @@ final class PeerNodeReferenceSupport {
     if (versionStr == null) {
       return new String[0];
     }
-    String[] raw = versionStr.split(",");
+    String[] raw = splitOnComma(versionStr);
     ArrayList<String> components = new ArrayList<>(raw.length);
     for (String token : raw) {
       String trimmed = token.trim();

--- a/src/main/java/network/crypta/node/PeerNodeTransport.java
+++ b/src/main/java/network/crypta/node/PeerNodeTransport.java
@@ -462,7 +462,7 @@ final class PeerNodeTransport implements PeerTransport {
           if (disconnected) throw new NotConnectedException();
           return;
         }
-        int waitTime = (int) (Math.min(end - now, Integer.MAX_VALUE));
+        int waitTime = (int) Math.min(end - now, Integer.MAX_VALUE);
         try {
           wait(waitTime);
         } catch (InterruptedException _) {

--- a/src/main/java/network/crypta/node/PeerPersistence.java
+++ b/src/main/java/network/crypta/node/PeerPersistence.java
@@ -99,14 +99,15 @@ class PeerPersistence {
   private String oldOpennetPeersStringCache = null;
 
   /** Periodic write runnable that writes peers and re-schedules itself. */
-  private final Runnable writePeersRunnable =
-      () -> {
-        try {
-          writePeersNow();
-        } finally {
-          scheduleWritePeersNextRun();
-        }
-      };
+  private final Runnable writePeersRunnable = this::writePeersAndReschedule;
+
+  private void writePeersAndReschedule() {
+    try {
+      writePeersNow();
+    } finally {
+      scheduleWritePeersNextRun();
+    }
+  }
 
   /**
    * Create a new persistence helper bound to a node and its peer manager.

--- a/src/main/java/network/crypta/node/RequestHandler.java
+++ b/src/main/java/network/crypta/node/RequestHandler.java
@@ -206,11 +206,13 @@ public class RequestHandler
         return;
       }
       appliedByteCounts = true;
-      if (!((!finalTransferFailed)
-          && rs != null
-          && status != RequestSender.TIMED_OUT
-          && status != RequestSender.GENERATED_REJECTED_OVERLOAD
-          && status != RequestSender.INTERNAL_ERROR)) return;
+      if (finalTransferFailed
+          || rs == null
+          || status == RequestSender.TIMED_OUT
+          || status == RequestSender.GENERATED_REJECTED_OVERLOAD
+          || status == RequestSender.INTERNAL_ERROR) {
+        return;
+      }
     }
     int sent;
     int rcvd;
@@ -543,39 +545,34 @@ public class RequestHandler
   }
 
   private boolean processStatusSimpleCases(int status, RequestSender rs) {
-    switch (status) {
-      case RequestSender.NOT_FINISHED, RequestSender.DATA_NOT_FOUND:
-        {
-          Message dnf = DMT.createFNPDataNotFound(uid);
-          sendTerminal(dnf);
-          return true;
-        }
-      case RequestSender.RECENTLY_FAILED:
-        {
-          Message rf = DMT.createFNPRecentlyFailed(uid, rs.getRecentlyFailedTimeLeft());
-          sendTerminal(rf);
-          return true;
-        }
+    return switch (status) {
+      case RequestSender.NOT_FINISHED, RequestSender.DATA_NOT_FOUND -> {
+        Message dnf = DMT.createFNPDataNotFound(uid);
+        sendTerminal(dnf);
+        yield true;
+      }
+      case RequestSender.RECENTLY_FAILED -> {
+        Message rf = DMT.createFNPRecentlyFailed(uid, rs.getRecentlyFailedTimeLeft());
+        sendTerminal(rf);
+        yield true;
+      }
       case RequestSender.GENERATED_REJECTED_OVERLOAD,
-      RequestSender.TIMED_OUT,
-      RequestSender.INTERNAL_ERROR:
-        {
-          // Locally generated. Propagate back to the source who needs to reduce send rate
-          // @bug: we may not want to translate fatal timeouts into non-fatal timeouts.
-          Message reject = DMT.createFNPRejectedOverload(uid, true);
-          sendTerminal(reject);
-          return true;
-        }
-      case RequestSender.ROUTE_NOT_FOUND:
-        {
-          // Tell source
-          Message rnf = DMT.createFNPRouteNotFound(uid, rs.getHTL());
-          sendTerminal(rnf);
-          return true;
-        }
-      default:
-        return false;
-    }
+          RequestSender.TIMED_OUT,
+          RequestSender.INTERNAL_ERROR -> {
+        // Locally generated. Propagate back to the source who needs to reduce send rate
+        // @bug: we may not want to translate fatal timeouts into non-fatal timeouts.
+        Message reject = DMT.createFNPRejectedOverload(uid, true);
+        sendTerminal(reject);
+        yield true;
+      }
+      case RequestSender.ROUTE_NOT_FOUND -> {
+        // Tell source
+        Message rnf = DMT.createFNPRouteNotFound(uid, rs.getHTL());
+        sendTerminal(rnf);
+        yield true;
+      }
+      default -> false;
+    };
   }
 
   private boolean processStatusSuccessOrFailures(int status, RequestSender rs)
@@ -588,7 +585,7 @@ public class RequestHandler
   private boolean handleSuccess(int status, RequestSender rs) throws NotConnectedException {
     if (status != RequestSender.SUCCESS) return false;
     if (key instanceof NodeSSK) {
-      sendSSK(rs.getHeaders(), rs.getSSKData(), (rs.getSSKBlock().getKey()).getPubKey());
+      sendSSK(rs.getHeaders(), rs.getSSKData(), rs.getSSKBlock().getKey().getPubKey());
     } else {
       maybeCompleteTransfer();
     }
@@ -1203,7 +1200,7 @@ public class RequestHandler
   @Override
   public void onNotStarted(boolean internalError) {
     // Impossible
-    assert (false);
+    assert false;
   }
 
   /**
@@ -1214,6 +1211,6 @@ public class RequestHandler
   @Override
   public void onDataFoundLocally() {
     // Can't happen.
-    assert (false);
+    assert false;
   }
 }

--- a/src/main/java/network/crypta/node/SSKInsertHandler.java
+++ b/src/main/java/network/crypta/node/SSKInsertHandler.java
@@ -209,18 +209,18 @@ public class SSKInsertHandler implements PrioRunnable, ByteCounter {
       }
       return false;
     }
-    if (msg.getSpec() == DMT.FNPSSKInsertRequestHeaders) {
+    if (DMT.FNPSSKInsertRequestHeaders.equals(msg.getSpec())) {
       headers = ((ShortBuffer) msg.getObject(DMT.BLOCK_HEADERS)).getData();
       return true;
     }
-    if (msg.getSpec() == DMT.FNPSSKInsertRequestData) {
+    if (DMT.FNPSSKInsertRequestData.equals(msg.getSpec())) {
       data = ((ShortBuffer) msg.getObject(DMT.DATA)).getData();
       return true;
     }
-    if (msg.getSpec() == DMT.FNPSSKPubKey) {
+    if (DMT.FNPSSKPubKey.equals(msg.getSpec())) {
       return handlePubKeyMessage(msg);
     }
-    if (msg.getSpec() == DMT.FNPDataInsertRejected) {
+    if (DMT.FNPDataInsertRejected.equals(msg.getSpec())) {
       try {
         source
             .transport()

--- a/src/main/java/network/crypta/node/SimpleSendableInsert.java
+++ b/src/main/java/network/crypta/node/SimpleSendableInsert.java
@@ -1,6 +1,7 @@
 package network.crypta.node;
 
 import java.io.Serial;
+import java.util.Objects;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.ChosenBlock;
 import network.crypta.client.async.ClientContext;
@@ -394,7 +395,7 @@ public class SimpleSendableInsert extends SendableInsert {
     @Override
     public boolean equals(Object o) {
       if (o instanceof MySendableRequestItem item) {
-        return item.parent == parent;
+        return Objects.equals(item.parent, parent);
       } else return false;
     }
 

--- a/src/main/java/network/crypta/node/probe/Probe.java
+++ b/src/main/java/network/crypta/node/probe/Probe.java
@@ -679,35 +679,17 @@ public class Probe implements ByteCounter {
     final MessageFilter filter = createFilter(candidate, uid, timeout);
 
     switch (type) {
-      case BANDWIDTH:
-        filter.setType(DMT.ProbeBandwidth);
-        break;
-      case BUILD:
-        filter.setType(DMT.ProbeBuild);
-        break;
-      case IDENTIFIER:
-        filter.setType(DMT.ProbeIdentifier);
-        break;
-      case LINK_LENGTHS:
-        filter.setType(DMT.ProbeLinkLengths);
-        break;
-      case LOCATION:
-        filter.setType(DMT.ProbeLocation);
-        break;
-      case STORE_SIZE:
-        filter.setType(DMT.ProbeStoreSize);
-        break;
-      case UPTIME_48H, UPTIME_7D:
-        filter.setType(DMT.ProbeUptime);
-        break;
-      case REJECT_STATS:
-        filter.setType(DMT.ProbeRejectStats);
-        break;
-      case OVERALL_BULK_OUTPUT_CAPACITY_USAGE:
-        filter.setType(DMT.ProbeOverallBulkOutputCapacityUsage);
-        break;
-      default:
-        throw new UnsupportedOperationException("Missing filter for " + type.name());
+      case BANDWIDTH -> filter.setType(DMT.ProbeBandwidth);
+      case BUILD -> filter.setType(DMT.ProbeBuild);
+      case IDENTIFIER -> filter.setType(DMT.ProbeIdentifier);
+      case LINK_LENGTHS -> filter.setType(DMT.ProbeLinkLengths);
+      case LOCATION -> filter.setType(DMT.ProbeLocation);
+      case STORE_SIZE -> filter.setType(DMT.ProbeStoreSize);
+      case UPTIME_48H, UPTIME_7D -> filter.setType(DMT.ProbeUptime);
+      case REJECT_STATS -> filter.setType(DMT.ProbeRejectStats);
+      case OVERALL_BULK_OUTPUT_CAPACITY_USAGE ->
+          filter.setType(DMT.ProbeOverallBulkOutputCapacityUsage);
+      default -> throw new UnsupportedOperationException("Missing filter for " + type.name());
     }
 
     // Refusal or an error should also be listened for so it can be relayed.
@@ -742,7 +724,7 @@ public class Probe implements ByteCounter {
      * reasonable values.
      */
     switch (type) {
-      case BANDWIDTH:
+      case BANDWIDTH -> {
         /*
          * 5% noise:
          * Reasonable output bandwidth limit is 20 KiB and people are likely to set limits in increments
@@ -751,11 +733,9 @@ public class Probe implements ByteCounter {
          */
         listener.onOutputBandwidth(
             (float) randomNoise((double) node.network().outputBandwidthLimit() / (1 << 10), 0.05));
-        break;
-      case BUILD:
-        listener.onBuild(node.services().nodeUpdater().getMainVersion());
-        break;
-      case IDENTIFIER:
+      }
+      case BUILD -> listener.onBuild(node.services().nodeUpdater().getMainVersion());
+      case IDENTIFIER -> {
         /*
          * 5% noise:
          * Reasonable uptime percentage is at least ~40 hours a week, or ~20%. This uptime is
@@ -773,8 +753,8 @@ public class Probe implements ByteCounter {
         if (percent > Byte.MAX_VALUE) percent = Byte.MAX_VALUE;
         else if (percent < Byte.MIN_VALUE) percent = Byte.MIN_VALUE;
         listener.onIdentifier(probeIdentifier, (byte) percent);
-        break;
-      case LINK_LENGTHS:
+      }
+      case LINK_LENGTHS -> {
         PeerNode[] peers = node.network().connectedPeers();
         float[] linkLengths = new float[peers.length];
         int i = 0;
@@ -795,11 +775,9 @@ public class Probe implements ByteCounter {
         linkLengths = Arrays.copyOf(linkLengths, i);
         Arrays.sort(linkLengths);
         listener.onLinkLengths(linkLengths);
-        break;
-      case LOCATION:
-        listener.onLocation((float) node.network().location());
-        break;
-      case STORE_SIZE:
+      }
+      case LOCATION -> listener.onLocation((float) node.network().location());
+      case STORE_SIZE -> {
         /*
          * 5% noise:
          * Reasonable datastore size is 20 GiB, and size is likely set in, at most, increments of 1 GiB.
@@ -807,8 +785,8 @@ public class Probe implements ByteCounter {
          * 1,073,741,824 bytes (2^30) per GiB.
          */
         listener.onStoreSize((float) randomNoise((double) node.getStoreSize() / (1 << 30), 0.05));
-        break;
-      case UPTIME_48H:
+      }
+      case UPTIME_48H -> {
         /*
          * 8% noise:
          * Continuing with the assumption that reasonable weekly uptime is around 40 hours, this allows
@@ -817,8 +795,8 @@ public class Probe implements ByteCounter {
          */
         listener.onUptime(
             (float) randomNoise(100 * node.network().uptimeEstimator().getUptime(), 0.04));
-        break;
-      case UPTIME_7D:
+      }
+      case UPTIME_7D -> {
         /*
          * 2.4% noise:
          * As a 168-hour uptime covers a longer period 1 hour of ambiguity seems sufficient.
@@ -826,20 +804,19 @@ public class Probe implements ByteCounter {
          */
         listener.onUptime(
             (float) randomNoise(100 * node.network().uptimeEstimator().getUptimeWeek(), 0.03));
-        break;
-      case REJECT_STATS:
+      }
+      case REJECT_STATS -> {
         byte[] stats = node.network().stats().getNoisyRejectStats();
         listener.onRejectStats(stats);
-        break;
-      case OVERALL_BULK_OUTPUT_CAPACITY_USAGE:
+      }
+      case OVERALL_BULK_OUTPUT_CAPACITY_USAGE -> {
         byte bandwidthClass =
             DMT.bandwidthClassForCapacityUsage(node.network().outputBandwidthLimit());
         listener.onOverallBulkOutputCapacity(
             bandwidthClass,
             (float) randomNoise(node.network().stats().getBandwidthLiabilityUsage(), 0.1));
-        break;
-      default:
-        throw new UnsupportedOperationException("Missing response for " + type.name());
+      }
+      default -> throw new UnsupportedOperationException("Missing response for " + type.name());
     }
   }
 

--- a/src/main/java/network/crypta/node/simulator/BootstrapPullTest.java
+++ b/src/main/java/network/crypta/node/simulator/BootstrapPullTest.java
@@ -332,7 +332,7 @@ public class BootstrapPullTest {
 
   private static FreenetURI insertData(File dataFile) throws IOException {
     long startInsertTime = System.currentTimeMillis();
-    InetAddress localhost = InetAddress.getByName("127.0.0.1");
+    InetAddress localhost = InetAddress.getLoopbackAddress();
     try (Socket sock = new Socket(localhost, 9481);
         OutputStream sockOS = sock.getOutputStream();
         InputStream sockIS = sock.getInputStream();

--- a/src/main/java/network/crypta/node/simulator/RealNodePingTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodePingTest.java
@@ -174,27 +174,28 @@ public class RealNodePingTest {
     PeerNode pn = node1.network().peerNodes()[0];
     AtomicInteger pingID = new AtomicInteger();
     try (ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor()) {
-      scheduler.scheduleWithFixedDelay(
-          () -> {
-            int ping = pingID.getAndIncrement();
-            LOG.error("Sending PING {}", ping);
-            boolean success;
-            boolean connected = true;
-            try {
-              success = pn.transport().ping(ping);
-            } catch (NotConnectedException _) {
-              LOG.error("Not connected");
-              connected = false;
-              success = false;
-            }
-            if (connected) {
-              if (success) LOG.error("PING {} successful", ping);
-              else LOG.error("PING FAILED: {}", ping);
-            }
-          },
-          20,
-          2,
-          TimeUnit.SECONDS);
+      java.util.Objects.requireNonNull(
+          scheduler.scheduleWithFixedDelay(
+              () -> {
+                int ping = pingID.getAndIncrement();
+                LOG.error("Sending PING {}", ping);
+                boolean success;
+                boolean connected = true;
+                try {
+                  success = pn.transport().ping(ping);
+                } catch (NotConnectedException _) {
+                  LOG.error("Not connected");
+                  connected = false;
+                  success = false;
+                }
+                if (connected) {
+                  if (success) LOG.error("PING {} successful", ping);
+                  else LOG.error("PING FAILED: {}", ping);
+                }
+              },
+              20,
+              2,
+              TimeUnit.SECONDS));
       CountDownLatch done = new CountDownLatch(1);
       try {
         done.await();

--- a/src/main/java/network/crypta/node/simulator/RealNodePitchBlackMitigationTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodePitchBlackMitigationTest.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import java.io.File;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import network.crypta.crypt.DummyRandomSource;
@@ -236,7 +237,7 @@ public class RealNodePitchBlackMitigationTest extends RealNodeTest {
 
     // set the time yesterday to have pitch black information
     LocationManager.setClockForTesting(
-        Clock.offset(Clock.systemDefaultZone(), Duration.ofDays(-1)));
+        Clock.offset(Clock.system(ZoneId.systemDefault()), Duration.ofDays(-1)));
     // shift forward one day per 5 minutes
     Runnable dayIncrementingJob =
         new Runnable() {

--- a/src/main/java/network/crypta/node/simulator/RealNodeProbeTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeProbeTest.java
@@ -1,10 +1,10 @@
 package network.crypta.node.simulator;
 
 import java.io.BufferedReader;
-import java.io.Console;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
@@ -339,12 +339,7 @@ public class RealNodeProbeTest extends RealNodeRoutingTest {
   }
 
   private static BufferedReader createReader() {
-    Console console = System.console();
-    if (console != null) {
-      return new BufferedReader(console.reader());
-    }
-    // Use the system locale here.
-    return new BufferedReader(new InputStreamReader(System.in));
+    return new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
   }
 
   private static void logMenu(int index, byte htl) {

--- a/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
@@ -2,6 +2,7 @@ package network.crypta.node.simulator;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 import network.crypta.crypt.DummyRandomSource;
 import network.crypta.io.comm.DMT;
 import network.crypta.io.comm.PeerParseException;
@@ -315,8 +316,8 @@ public class RealNodeULPRTest extends RealNodeTest {
     boolean[] visited = new boolean[nodes.length];
     NodeDispatcherCallback cb =
         (m, n) -> {
-          if (((!isSSK) && m.getSpec() == DMT.FNPCHKDataRequest)
-              || (isSSK && m.getSpec() == DMT.FNPSSKDataRequest)) {
+          if ((!isSSK && Objects.equals(m.getSpec(), DMT.FNPCHKDataRequest))
+              || (isSSK && Objects.equals(m.getSpec(), DMT.FNPSSKDataRequest))) {
             Key key = (Key) m.getObject(DMT.FREENET_ROUTING_KEY);
             if (key.equals(nodeKey)) {
               visited[n.network().darknetPortNumber() - DARKNET_PORT_BASE] = true;

--- a/src/main/java/network/crypta/node/simulator/SeednodePingTest.java
+++ b/src/main/java/network/crypta/node/simulator/SeednodePingTest.java
@@ -391,7 +391,7 @@ public class SeednodePingTest extends RealNodeTest {
             new InputStreamReader(new FileInputStream(logFile), StandardCharsets.UTF_8))) {
       String line;
       while ((line = br.readLine()) != null) {
-        String[] results = line.split(" : ");
+        String[] results = splitStatusLine(line);
         if (results.length != 3) {
           LOG.error(
               "Unable to parse line in {} : wrong number of fields : {} : {}",
@@ -416,6 +416,21 @@ public class SeednodePingTest extends RealNodeTest {
       }
     }
     return new SeednodeHistory(firstSample, lastSuccess, successes, failures);
+  }
+
+  private static String[] splitStatusLine(String line) {
+    ArrayList<String> parts = new ArrayList<>();
+    int start = 0;
+    int idx;
+    while ((idx = line.indexOf(" : ", start)) >= 0) {
+      parts.add(line.substring(start, idx));
+      start = idx + 3;
+    }
+    parts.add(line.substring(start));
+    while (!parts.isEmpty() && parts.get(parts.size() - 1).isEmpty()) {
+      parts.remove(parts.size() - 1);
+    }
+    return parts.toArray(new String[0]);
   }
 
   private static void logHistory(

--- a/src/main/java/network/crypta/node/subsystem/NodeConfigManager.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeConfigManager.java
@@ -75,7 +75,7 @@ public final class NodeConfigManager {
   public int configureLocalization(SubConfig nodeConfig, ProgramDirectory cfgDir, int sortOrder) {
     nodeConfig.register(
         "l10n",
-        Locale.getDefault().getLanguage().toLowerCase(),
+        Locale.getDefault().getLanguage().toLowerCase(Locale.ROOT),
         new Option.Meta(sortOrder++, false, true, "Node.l10nLanguage", "Node.l10nLanguageLong"),
         new L10nCallback());
 

--- a/src/main/java/network/crypta/node/useralerts/BookmarkFeedUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/BookmarkFeedUserAlert.java
@@ -1,6 +1,7 @@
 package network.crypta.node.useralerts;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import network.crypta.clients.fcp.BookmarkFeed;
 import network.crypta.clients.fcp.N2NFeedMessageParams;
 import network.crypta.io.comm.PeerContext;
@@ -176,7 +177,7 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
             });
     alertNode.addChild("a", "href", "/freenet:" + uri.toString()).addChild("#", name);
     if (description != null && !description.isEmpty()) {
-      String[] lines = description.split("\n");
+      String[] lines = splitLines(description);
       alertNode.addChild("br");
       alertNode.addChild("br");
       alertNode.addChild("#", l10n("bookmarkDescription"));
@@ -204,6 +205,21 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
 
   private String l10n(String key) {
     return NodeL10n.getBase().getString("BookmarkFeedUserAlert." + key);
+  }
+
+  private static String[] splitLines(String text) {
+    ArrayList<String> lines = new ArrayList<>();
+    int start = 0;
+    int idx;
+    while ((idx = text.indexOf('\n', start)) >= 0) {
+      lines.add(text.substring(start, idx));
+      start = idx + 1;
+    }
+    lines.add(text.substring(start));
+    while (!lines.isEmpty() && lines.get(lines.size() - 1).isEmpty()) {
+      lines.remove(lines.size() - 1);
+    }
+    return lines.toArray(new String[0]);
   }
 
   /** Resolve the localized title using the {@code ${from}} placeholder for the source node name. */

--- a/src/main/java/network/crypta/node/useralerts/DownloadFeedUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/DownloadFeedUserAlert.java
@@ -1,6 +1,7 @@
 package network.crypta.node.useralerts;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.N2NFeedMessageParams;
 import network.crypta.clients.fcp.URIFeedMessage;
@@ -142,7 +143,7 @@ public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNo
     HTMLNode alertNode = new HTMLNode("div");
     alertNode.addChild("a", "href", "/" + uri).addChild("#", uri.toShortString());
     if (description != null && !description.isEmpty()) {
-      String[] lines = description.split("\n");
+      String[] lines = splitLines(description);
       alertNode.addChild("br");
       alertNode.addChild("br");
       alertNode.addChild("#", l10n("fileDescription"));
@@ -170,6 +171,21 @@ public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNo
 
   private String l10n(String key) {
     return NodeL10n.getBase().getString("DownloadFeedUserAlert." + key);
+  }
+
+  private static String[] splitLines(String text) {
+    ArrayList<String> lines = new ArrayList<>();
+    int start = 0;
+    int idx;
+    while ((idx = text.indexOf('\n', start)) >= 0) {
+      lines.add(text.substring(start, idx));
+      start = idx + 1;
+    }
+    lines.add(text.substring(start));
+    while (!lines.isEmpty() && lines.get(lines.size() - 1).isEmpty()) {
+      lines.remove(lines.size() - 1);
+    }
+    return lines.toArray(new String[0]);
   }
 
   /**

--- a/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/N2NTMUserAlert.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.ArrayList;
 import java.util.Locale;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.N2NFeedMessageParams;
@@ -180,7 +181,7 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
               formatTimestamp(sentTime),
               formatTimestamp(receivedTime)
             }));
-    String[] lines = messageText.split("\n");
+    String[] lines = splitLines(messageText);
     for (int i = 0, c = lines.length; i < c; i++) {
       alertNode.addChild("#", lines[i]);
       if (i != lines.length - 1) alertNode.addChild("br");
@@ -214,6 +215,21 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
 
   private static String formatTimestamp(long epochMillis) {
     return MESSAGE_TIME_FORMATTER.format(Instant.ofEpochMilli(epochMillis));
+  }
+
+  private static String[] splitLines(String text) {
+    ArrayList<String> lines = new ArrayList<>();
+    int start = 0;
+    int idx;
+    while ((idx = text.indexOf('\n', start)) >= 0) {
+      lines.add(text.substring(start, idx));
+      start = idx + 1;
+    }
+    lines.add(text.substring(start));
+    while (!lines.isEmpty() && lines.get(lines.size() - 1).isEmpty()) {
+      lines.remove(lines.size() - 1);
+    }
+    return lines.toArray(new String[0]);
   }
 
   /**

--- a/src/main/java/network/crypta/support/Buffer.java
+++ b/src/main/java/network/crypta/support/Buffer.java
@@ -155,8 +155,8 @@ public class Buffer implements WritableToDataOutputStream {
    * Return a human-readable representation.
    *
    * <p>If the length is greater than 50, returns {@code "Buffer {<length>}"}. Otherwise, returns a
-   * string in the form {@code "{<length>:<byte0> <byte1> ... "} with a trailing space after the
-   * last value. This method is intended for debugging only; do not parse its output.
+   * string in the form {@code "{length:byte0 byte1 ... }"} with a trailing space after the last
+   * value. This method is intended for debugging only; do not parse its output.
    */
   @Override
   public String toString() {

--- a/src/main/java/network/crypta/support/Fields.java
+++ b/src/main/java/network/crypta/support/Fields.java
@@ -325,10 +325,10 @@ public abstract class Fields {
       // Preserve historical behavior: default to days when the unit is omitted.
       gc.add(Calendar.DAY_OF_YEAR, amount);
     } else {
-      String deltaTypeString = date.substring(chop).toLowerCase();
+      String deltaTypeString = date.substring(chop).toLowerCase(Locale.ROOT);
       addDelta(gc, deltaTypeString, amount);
     }
-    return gc.getTime().getTime();
+    return gc.getTimeInMillis();
   }
 
   private static void addDelta(GregorianCalendar gc, String deltaTypeString, int amount) {
@@ -371,46 +371,34 @@ public abstract class Fields {
     return switch (month) {
       case 1 ->
           new GregorianCalendar(year, Calendar.JANUARY, day, hour, minute, second)
-              .getTime()
-              .getTime();
+              .getTimeInMillis();
       case 2 ->
           new GregorianCalendar(year, Calendar.FEBRUARY, day, hour, minute, second)
-              .getTime()
-              .getTime();
+              .getTimeInMillis();
       case 3 ->
-          new GregorianCalendar(year, Calendar.MARCH, day, hour, minute, second)
-              .getTime()
-              .getTime();
+          new GregorianCalendar(year, Calendar.MARCH, day, hour, minute, second).getTimeInMillis();
       case 4 ->
-          new GregorianCalendar(year, Calendar.APRIL, day, hour, minute, second)
-              .getTime()
-              .getTime();
+          new GregorianCalendar(year, Calendar.APRIL, day, hour, minute, second).getTimeInMillis();
       case 5 ->
-          new GregorianCalendar(year, Calendar.MAY, day, hour, minute, second).getTime().getTime();
+          new GregorianCalendar(year, Calendar.MAY, day, hour, minute, second).getTimeInMillis();
       case 6 ->
-          new GregorianCalendar(year, Calendar.JUNE, day, hour, minute, second).getTime().getTime();
+          new GregorianCalendar(year, Calendar.JUNE, day, hour, minute, second).getTimeInMillis();
       case 7 ->
-          new GregorianCalendar(year, Calendar.JULY, day, hour, minute, second).getTime().getTime();
+          new GregorianCalendar(year, Calendar.JULY, day, hour, minute, second).getTimeInMillis();
       case 8 ->
-          new GregorianCalendar(year, Calendar.AUGUST, day, hour, minute, second)
-              .getTime()
-              .getTime();
+          new GregorianCalendar(year, Calendar.AUGUST, day, hour, minute, second).getTimeInMillis();
       case 9 ->
           new GregorianCalendar(year, Calendar.SEPTEMBER, day, hour, minute, second)
-              .getTime()
-              .getTime();
+              .getTimeInMillis();
       case 10 ->
           new GregorianCalendar(year, Calendar.OCTOBER, day, hour, minute, second)
-              .getTime()
-              .getTime();
+              .getTimeInMillis();
       case 11 ->
           new GregorianCalendar(year, Calendar.NOVEMBER, day, hour, minute, second)
-              .getTime()
-              .getTime();
+              .getTimeInMillis();
       case 12 ->
           new GregorianCalendar(year, Calendar.DECEMBER, day, hour, minute, second)
-              .getTime()
-              .getTime();
+              .getTimeInMillis();
       default -> throw new NumberFormatException("Invalid month: " + month);
     };
   }

--- a/src/main/java/network/crypta/support/Serializer.java
+++ b/src/main/java/network/crypta/support/Serializer.java
@@ -3,6 +3,7 @@ package network.crypta.support;
 import java.io.DataInput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import network.crypta.io.WritableToDataOutputStream;
@@ -67,7 +68,7 @@ public class Serializer {
    * @param elementType the expected element type. Must be one of the types recognized by {@link
    *     #readFromDataInputStream(Class, DataInput)}.
    * @param dis the input to read from; not closed by this method.
-   * @return a new {@link LinkedList} containing the decoded elements in order.
+   * @return a new {@link List} containing the decoded elements in order.
    * @throws IOException if an I/O error occurs or an element payload is invalid for the declared
    *     type.
    * @throws IllegalArgumentException if {@code elementType} is unsupported.
@@ -76,8 +77,8 @@ public class Serializer {
    */
   public static List<Object> readListFromDataInputStream(Class<?> elementType, DataInput dis)
       throws IOException {
-    LinkedList<Object> ret = new LinkedList<>();
     int length = dis.readInt();
+    List<Object> ret = new ArrayList<>(Math.max(0, length));
     for (int x = 0; x < length; x++) {
       ret.add(readFromDataInputStream(elementType, dis));
     }
@@ -241,7 +242,7 @@ public class Serializer {
    * {@link #readFromDataInputStream(Class, DataInput)}.
    *
    * <p>The {@code object} must be non-{@code null} and of a supported type. For lists, only {@link
-   * LinkedList} is supported here; see {@link #writeLinkedList(LinkedList, DataOutputStream)} for
+   * LinkedList} is supported here; see {@link #writeLinkedList(List, DataOutputStream)} for
    * details. Strings are written as a 32-bit length followed by UTF-16 {@code char}s via {@link
    * DataOutputStream#writeChar(int)}.
    *
@@ -336,8 +337,8 @@ public class Serializer {
   }
 
   /**
-   * Serializes a {@link LinkedList} using a snapshot-and-write strategy to avoid concurrent
-   * modification races.
+   * Serializes a {@link List} using a snapshot-and-write strategy to avoid concurrent modification
+   * races.
    *
    * <p>First, the method takes a stable snapshot of the list under synchronization on the list
    * instance itself; then it releases the lock and writes the snapshot to the stream. Synchronizing
@@ -351,8 +352,7 @@ public class Serializer {
    * @throws IOException if an I/O error occurs while writing an element.
    */
   @SuppressWarnings({"java:S2445", "SynchronizationOnLocalVariableOrMethodParameter"})
-  private static void writeLinkedList(final LinkedList<?> ll, DataOutputStream dos)
-      throws IOException {
+  private static void writeLinkedList(final List<?> ll, DataOutputStream dos) throws IOException {
     // Intentionally lock on the list instance so external synchronization on the same
     // object also applies. Snapshot under lock; perform I/O after releasing it to
     // minimize contention.

--- a/src/main/java/network/crypta/support/compress/AbstractCompressor.java
+++ b/src/main/java/network/crypta/support/compress/AbstractCompressor.java
@@ -38,6 +38,7 @@ abstract class AbstractCompressor implements Compressor {
    * @throws IOException on I/O errors; the specific subclass {@link CompressionOutputSizeException}
    *     may be thrown if {@code maxWriteLength} is exceeded
    */
+  @Override
   public long compress(
       InputStream input, OutputStream output, long maxReadLength, long maxWriteLength)
       throws IOException {

--- a/src/main/java/network/crypta/support/compress/Compressor.java
+++ b/src/main/java/network/crypta/support/compress/Compressor.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
@@ -47,19 +48,16 @@ public interface Compressor {
    */
   enum COMPRESSOR_TYPE implements Compressor {
     // Codecs will be tried in order; put the less resource-consuming first
-    GZIP("GZIP", new GzipCompressor(), (short) 0),
-    BZIP2("BZIP2", new Bzip2Compressor(), (short) 1),
-    LZMA("LZMA", new OldLZMACompressor(), (short) 2),
-    LZMA_NEW("LZMA_NEW", new NewLZMACompressor(), (short) 3);
+    GZIP("GZIP", (short) 0),
+    BZIP2("BZIP2", (short) 1),
+    LZMA("LZMA", (short) 2),
+    LZMA_NEW("LZMA_NEW", (short) 3);
 
     /**
      * Human-readable codec name used in descriptors. Distinct from {@link #name()}, the Java enum
      * identifier.
      */
     public final String codecName;
-
-    /** Underlying implementation that performs the actual compression/decompression. */
-    public final Compressor compressor;
 
     /** Short, stable identifier written to metadata and used on the wire. */
     public final short metadataID;
@@ -68,11 +66,23 @@ public interface Compressor {
     private static final COMPRESSOR_TYPE[] values = values();
 
     private static final Logger LOG = LoggerFactory.getLogger(COMPRESSOR_TYPE.class);
+    private static final EnumMap<COMPRESSOR_TYPE, Compressor> compressors =
+        new EnumMap<>(COMPRESSOR_TYPE.class);
 
-    COMPRESSOR_TYPE(String name, Compressor c, short metadataID) {
+    static {
+      compressors.put(GZIP, new GzipCompressor());
+      compressors.put(BZIP2, new Bzip2Compressor());
+      compressors.put(LZMA, new OldLZMACompressor());
+      compressors.put(LZMA_NEW, new NewLZMACompressor());
+    }
+
+    COMPRESSOR_TYPE(String name, short metadataID) {
       this.codecName = name;
-      this.compressor = c;
       this.metadataID = metadataID;
+    }
+
+    private Compressor compressor() {
+      return compressors.get(this);
     }
 
     /**
@@ -278,14 +288,14 @@ public interface Compressor {
     @Override
     public Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength)
         throws IOException {
-      return compressor.compress(data, bf, maxReadLength, maxWriteLength);
+      return compressor().compress(data, bf, maxReadLength, maxWriteLength);
     }
 
     /** {@inheritDoc} */
     @Override
     public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength)
         throws IOException {
-      return compressor.compress(is, os, maxReadLength, maxWriteLength);
+      return compressor().compress(is, os, maxReadLength, maxWriteLength);
     }
 
     /** {@inheritDoc} */
@@ -298,13 +308,14 @@ public interface Compressor {
         long amountOfDataToCheckCompressionRatio,
         int minimumCompressionPercentage)
         throws IOException, CompressionRatioException {
-      return compressor.compress(
-          is,
-          os,
-          maxReadLength,
-          maxWriteLength,
-          amountOfDataToCheckCompressionRatio,
-          minimumCompressionPercentage);
+      return compressor()
+          .compress(
+              is,
+              os,
+              maxReadLength,
+              maxWriteLength,
+              amountOfDataToCheckCompressionRatio,
+              minimumCompressionPercentage);
     }
 
     /** {@inheritDoc} */
@@ -312,14 +323,14 @@ public interface Compressor {
     public long decompress(
         InputStream input, OutputStream output, long maxLength, long maxEstimateSizeLength)
         throws IOException {
-      return compressor.decompress(input, output, maxLength, maxEstimateSizeLength);
+      return compressor().decompress(input, output, maxLength, maxEstimateSizeLength);
     }
 
     /** {@inheritDoc} */
     @Override
     public int decompress(byte[] dbuf, int i, int j, byte[] output)
         throws CompressionOutputSizeException {
-      return compressor.decompress(dbuf, i, j, output);
+      return compressor().decompress(dbuf, i, j, output);
     }
   }
 

--- a/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
+++ b/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
@@ -327,7 +327,7 @@ public class NewLZMACompressor extends AbstractCompressor {
     CountedOutputStream cos = new CountedOutputStream(os);
 
     int dictionarySize = 0;
-    for (int i = 0; i < 4; i++) dictionarySize += ((props[1 + i]) & 0xFF) << (i * 8);
+    for (int i = 0; i < 4; i++) dictionarySize += (props[1 + i] & 0xFF) << (i * 8);
 
     if (dictionarySize < 0) throw new InvalidCompressedDataException("Invalid dictionary size");
     if (dictionarySize > MAX_DICTIONARY_SIZE) throw new TooBigDictionaryException();

--- a/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
+++ b/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
@@ -74,6 +74,7 @@ public class NewLZMACompressor extends AbstractCompressor {
    * @throws IOException on I/O errors
    * @throws CompressionRatioException if the compression ratio check fails
    */
+  @Override
   public long compress(
       InputStream is,
       OutputStream os,
@@ -317,6 +318,7 @@ public class NewLZMACompressor extends AbstractCompressor {
    *     negative
    * @throws TooBigDictionaryException if the dictionary exceeds {@link #MAX_DICTIONARY_SIZE}
    */
+  @Override
   public long decompress(InputStream is, OutputStream os, long maxLength, long maxCheckSizeBytes)
       throws IOException {
     byte[] props = new byte[5];
@@ -350,6 +352,7 @@ public class NewLZMACompressor extends AbstractCompressor {
    * @return number of bytes written into {@code output}
    * @throws CompressionOutputSizeException if the decompressed size would exceed {@code output}
    */
+  @Override
   public int decompress(byte[] dbuf, int i, int j, byte[] output)
       throws CompressionOutputSizeException {
     // Note: java.util.zip.Inflater does not apply to LZMA bitstream format.

--- a/src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBuffer.java
@@ -265,13 +265,9 @@ public class DelayedFreeRandomAccessBuffer
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
+    if (!(obj instanceof DelayedFreeRandomAccessBuffer other)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    DelayedFreeRandomAccessBuffer other = (DelayedFreeRandomAccessBuffer) obj;
     return underlying.equals(other.underlying);
   }
 

--- a/src/main/java/network/crypta/support/io/FileRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/FileRandomAccessBuffer.java
@@ -348,13 +348,9 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
+    if (!(obj instanceof FileRandomAccessBuffer other)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    FileRandomAccessBuffer other = (FileRandomAccessBuffer) obj;
     if (!file.equals(other.file)) {
       return false;
     }

--- a/src/main/java/network/crypta/support/io/FileUtil.java
+++ b/src/main/java/network/crypta/support/io/FileUtil.java
@@ -812,7 +812,7 @@ public final class FileUtil {
    */
   public static boolean equals(File a, File b) {
     if (Objects.equals(a, b)) return true;
-    if (a.equals(b)) return true;
+    if (a == null || b == null) return false;
     a = getCanonicalFile(a);
     b = getCanonicalFile(b);
     return a.equals(b);

--- a/src/main/java/network/crypta/support/io/FileUtil.java
+++ b/src/main/java/network/crypta/support/io/FileUtil.java
@@ -20,6 +20,8 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Random;
 import network.crypta.client.DefaultMIMETypes;
 import network.crypta.node.NodeStarter;
@@ -232,33 +234,35 @@ public final class FileUtil {
   private static OperatingSystem detectOperatingSystem() { // Now delegates to AppEnv first
     try {
       network.crypta.fs.AppEnv env = new network.crypta.fs.AppEnv();
-      switch (env.osKind()) {
-        case WINDOWS:
-          return OperatingSystem.WINDOWS;
-        case MAC:
-          return OperatingSystem.MAC_OS;
-        case LINUX:
-          // AppEnv groups all non-Windows/non-macOS here, which includes FreeBSD and other Unix.
-          // Only return LINUX when the JVM reports actual Linux; otherwise fall through, so
-          // FreeBSD keeps its legacy mapping.
-          // Keep the legacy os.name fallback until AppEnv distinguishes BSD variants to avoid
-          // misclassifying FreeBSD as Linux.
-          {
-            final String n = String.valueOf(System.getProperty("os.name")).toLowerCase();
-            if (n.contains("linux")) return OperatingSystem.LINUX;
-            // fall through to legacy fallback for FreeBSD/Generic Unix
-            break;
-          }
-        default:
-          // fall through to legacy fallback for other/unrecognized variants
-          break;
+      OperatingSystem detected =
+          switch (env.osKind()) {
+            case WINDOWS -> OperatingSystem.WINDOWS;
+            case MAC -> OperatingSystem.MAC_OS;
+            case LINUX -> {
+              // AppEnv groups all non-Windows/non-macOS here, which includes FreeBSD and other
+              // Unix.
+              // Only return LINUX when the JVM reports actual Linux; otherwise fall through, so
+              // FreeBSD keeps its legacy mapping.
+              // Keep the legacy os.name fallback until AppEnv distinguishes BSD variants to avoid
+              // misclassifying FreeBSD as Linux.
+              final String n =
+                  String.valueOf(System.getProperty("os.name")).toLowerCase(Locale.ROOT);
+              if (n.contains("linux")) {
+                yield OperatingSystem.LINUX;
+              }
+              yield null;
+            }
+            default -> null;
+          };
+      if (detected != null) {
+        return detected;
       }
     } catch (Exception e) {
       // If AppEnv is unavailable (e.g., restricted env), fall back to legacy detection below
       LOG.error("Operating system detection via AppEnv failed", e);
     }
     // Legacy fallback to preserve FreeBSD/GenericUnix behavior and work in restricted envs
-    final String name = String.valueOf(System.getProperty("os.name")).toLowerCase();
+    final String name = String.valueOf(System.getProperty("os.name")).toLowerCase(Locale.ROOT);
     if (name.contains("freebsd")) return OperatingSystem.FREE_BSD;
     if (name.contains("linux")) return OperatingSystem.LINUX;
     if (name.contains("unix")) return OperatingSystem.GENERIC_UNIX;
@@ -278,7 +282,7 @@ public final class FileUtil {
       LOG.error("CPU architecture detection via AppEnv failed", e);
     }
     try {
-      final String name = System.getProperty("os.arch").toLowerCase();
+      final String name = System.getProperty("os.arch").toLowerCase(Locale.ROOT);
       if (name.equals("x86") || name.equals("i386") || name.matches("i[3-9]86"))
         return CPUArchitecture.X86;
       if (name.equals("amd64")
@@ -348,7 +352,7 @@ public final class FileUtil {
     // issues observed with some persistence layers.
     String name = file.getPath();
     if (File.pathSeparatorChar == '\\') {
-      name = name.toLowerCase();
+      name = name.toLowerCase(Locale.ROOT);
     }
     file = new File(name);
     File result;
@@ -807,7 +811,7 @@ public final class FileUtil {
    * @return {@code true} if both refer to the same canonical path
    */
   public static boolean equals(File a, File b) {
-    if (a == b) return true;
+    if (Objects.equals(a, b)) return true;
     if (a.equals(b)) return true;
     a = getCanonicalFile(a);
     b = getCanonicalFile(b);

--- a/src/main/java/network/crypta/support/io/NoFreeBucket.java
+++ b/src/main/java/network/crypta/support/io/NoFreeBucket.java
@@ -260,6 +260,7 @@ public class NoFreeBucket implements Bucket, Serializable {
    */
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
+    assert serialPersistentFields.length > 0;
     // Preserve compatibility with older releases that rely on default Java serialization
     // (no readObject) and expect the legacy 'proxy' field to carry the wrapped bucket when it is
     // serializable. Only when the wrapped bucket is not serializable do we throw, matching legacy

--- a/src/main/java/network/crypta/support/io/NullRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/NullRandomAccessBuffer.java
@@ -32,7 +32,7 @@ import network.crypta.support.api.LockableRandomAccessBuffer;
  * <p>Thread-safety: Methods contain no shared mutable state beyond the immutable size; they do not
  * block or perform I/O.
  */
-public class NullRandomAccessBuffer implements LockableRandomAccessBuffer {
+public final class NullRandomAccessBuffer implements LockableRandomAccessBuffer {
 
   private final long length;
 
@@ -170,7 +170,6 @@ public class NullRandomAccessBuffer implements LockableRandomAccessBuffer {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null) return false;
-    return o.getClass() == getClass();
+    return o instanceof NullRandomAccessBuffer;
   }
 }

--- a/src/main/java/network/crypta/support/io/PaddedBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedBucket.java
@@ -428,6 +428,7 @@ public class PaddedBucket implements Bucket, Serializable {
    */
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
+    assert serialPersistentFields.length > 0;
     ObjectOutputStream.PutField fields = out.putFields();
     fields.put(FIELD_SIZE, size);
     fields.put(FIELD_READ_ONLY, readOnly);

--- a/src/main/java/network/crypta/support/io/PaddedBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedBucket.java
@@ -166,6 +166,7 @@ public class PaddedBucket implements Bucket, Serializable {
       }
     }
 
+    @Override
     public String toString() {
       return "TrivialPaddedBucketOutputStream:" + out + "(" + PaddedBucket.this + ")";
     }

--- a/src/main/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
@@ -165,6 +165,7 @@ public class PaddedEphemerallyEncryptedBucket implements Bucket, Serializable {
    * @return an unbuffered stream for encrypted writes
    * @throws IOException if the wrapper is read-only or the underlying bucket rejects the request
    */
+  @Override
   public OutputStream getOutputStreamUnbuffered() throws IOException {
     if (readOnly) throw new IOException("Read only");
     OutputStream os = bucket.getOutputStreamUnbuffered();

--- a/src/main/java/network/crypta/support/io/PaddedRandomAccessBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedRandomAccessBucket.java
@@ -469,6 +469,7 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
 
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
+    assert serialPersistentFields.length > 0;
     ObjectOutputStream.PutField fields = out.putFields();
     fields.put(FIELD_SIZE, size);
     fields.put(FIELD_READ_ONLY, readOnly);

--- a/src/main/java/network/crypta/support/io/PaddedRandomAccessBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedRandomAccessBucket.java
@@ -182,6 +182,7 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
       }
     }
 
+    @Override
     public String toString() {
       return "TrivialPaddedBucketOutputStream:" + out + "(" + PaddedRandomAccessBucket.this + ")";
     }

--- a/src/main/java/network/crypta/support/io/PaddedRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/PaddedRandomAccessBuffer.java
@@ -230,13 +230,9 @@ public class PaddedRandomAccessBuffer implements LockableRandomAccessBuffer, Ser
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
+    if (!(obj instanceof PaddedRandomAccessBuffer other)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    PaddedRandomAccessBuffer other = (PaddedRandomAccessBuffer) obj;
     if (!raf.equals(other.raf)) {
       return false;
     }
@@ -263,6 +259,7 @@ public class PaddedRandomAccessBuffer implements LockableRandomAccessBuffer, Ser
   /** Writes the declared fields using the standard {@link ObjectOutputStream} protocol. */
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
+    assert serialPersistentFields.length > 0;
     ObjectOutputStream.PutField fields = out.putFields();
     if (!(raf instanceof Serializable)) {
       throw new NotSerializableException(raf == null ? "nullRaf" : raf.getClass().getName());

--- a/src/main/java/network/crypta/support/io/PooledFileRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/PooledFileRandomAccessBuffer.java
@@ -671,13 +671,9 @@ public class PooledFileRandomAccessBuffer implements LockableRandomAccessBuffer,
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
+    if (!(obj instanceof PooledFileRandomAccessBuffer other)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    PooledFileRandomAccessBuffer other = (PooledFileRandomAccessBuffer) obj;
     if (deleteOnFree != other.deleteOnFree) {
       return false;
     }

--- a/src/main/java/network/crypta/support/io/ReadOnlyRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/ReadOnlyRandomAccessBuffer.java
@@ -190,13 +190,9 @@ public class ReadOnlyRandomAccessBuffer implements LockableRandomAccessBuffer {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
+    if (!(obj instanceof ReadOnlyRandomAccessBuffer other)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    ReadOnlyRandomAccessBuffer other = (ReadOnlyRandomAccessBuffer) obj;
     return underlying.equals(other.underlying);
   }
 }

--- a/src/main/java/network/crypta/support/io/SwitchableProxyRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/SwitchableProxyRandomAccessBuffer.java
@@ -55,8 +55,8 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
   public void pread(long fileOffset, byte[] buf, int bufOffset, int length) throws IOException {
     if (fileOffset < 0) throw new IllegalArgumentException();
     if (fileOffset + length > size) throw new IOException("Tried to read past end of file");
+    lock.readLock().lock();
     try {
-      lock.readLock().lock();
       if (underlying == null || closed) throw new IOException("Already closed");
       underlying.pread(fileOffset, buf, bufOffset, length);
     } finally {
@@ -68,8 +68,8 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
   public void pwrite(long fileOffset, byte[] buf, int bufOffset, int length) throws IOException {
     if (fileOffset < 0) throw new IllegalArgumentException();
     if (fileOffset + length > size) throw new IOException("Tried to write past end of file");
+    lock.readLock().lock();
     try {
-      lock.readLock().lock();
       if (underlying == null || closed) throw new IOException("Already closed");
       underlying.pwrite(fileOffset, buf, bufOffset, length);
     } finally {
@@ -79,8 +79,8 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
 
   @Override
   public void close() {
+    lock.writeLock().lock();
     try {
-      lock.writeLock().lock();
       if (underlying == null) return;
       if (closed) return;
       closed = true;
@@ -96,12 +96,14 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
   }
 
   /**
+   * Returns true unless the buffer has already been freed.
+   *
    * @return True unless the buffer has already been freed.
    */
   protected boolean innerFree() {
+    // Write lock as we're going to change the underlying pointer.
+    lock.writeLock().lock();
     try {
-      // Write lock as we're going to change the underlying pointer.
-      lock.writeLock().lock();
       closed = true; // Effectively ...
       if (underlying == null) return false;
       underlying.free();
@@ -115,8 +117,8 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
 
   @SuppressWarnings("unused")
   public boolean hasBeenFreed() {
+    lock.readLock().lock();
     try {
-      lock.readLock().lock();
       return underlying == null;
     } finally {
       lock.readLock().unlock();
@@ -133,8 +135,8 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
 
   @Override
   public RAFLock lockOpen() throws IOException {
+    lock.writeLock().lock();
     try {
-      lock.writeLock().lock();
       if (closed || underlying == null) throw new IOException("Already closed");
       RAFLock rafLock =
           new RAFLock() {
@@ -157,8 +159,8 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
 
   /** Called when an external lock-open RAFLock is closed. */
   protected void externalUnlock() {
+    lock.writeLock().lock();
     try {
-      lock.writeLock().lock();
       lockOpenCount--;
       if (lockOpenCount == 0) {
         underlyingLock.unlock();
@@ -171,8 +173,8 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
 
   /** Migrate from one underlying LockableRandomAccessBuffer to another. */
   protected final void migrate() throws IOException {
+    lock.writeLock().lock();
     try {
-      lock.writeLock().lock();
       if (closed) return;
       if (underlying == null) throw new IOException("Already freed");
       LockableRandomAccessBuffer successor = innerMigrate(underlying);

--- a/src/main/java/network/crypta/tools/AddRef.java
+++ b/src/main/java/network/crypta/tools/AddRef.java
@@ -9,6 +9,7 @@ import ch.qos.logback.core.spi.FilterReply;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketException;
 import network.crypta.clients.fcp.AddPeer;
@@ -64,7 +65,7 @@ public class AddRef {
    * @param args command-line arguments where {@code args[0]} is a readable reference file path
    *     suitable for {@link SimpleFieldSet#readFrom(File, boolean, boolean)}.
    */
-  static void main(String[] args) {
+  public static void main(String[] args) {
     configureStandaloneConsoleLogging();
     if (args.length < 1) {
       LOG.error("Please provide a file name as the first argument.");
@@ -82,7 +83,8 @@ public class AddRef {
 
   private static void addRef(File reference) {
     try {
-      try (Socket fcpSocket = new Socket("127.0.0.1", FCPServer.DEFAULT_FCP_PORT);
+      try (Socket fcpSocket =
+              new Socket(InetAddress.getLoopbackAddress(), FCPServer.DEFAULT_FCP_PORT);
           LineReadingInputStream lis = new LineReadingInputStream(fcpSocket.getInputStream());
           OutputStream os = fcpSocket.getOutputStream()) {
         fcpSocket.setSoTimeout(2000);

--- a/src/main/java/network/crypta/tools/AddRef.java
+++ b/src/main/java/network/crypta/tools/AddRef.java
@@ -83,8 +83,7 @@ public class AddRef {
 
   private static void addRef(File reference) {
     try {
-      try (Socket fcpSocket =
-              new Socket(InetAddress.getLoopbackAddress(), FCPServer.DEFAULT_FCP_PORT);
+      try (Socket fcpSocket = openFcpSocket();
           LineReadingInputStream lis = new LineReadingInputStream(fcpSocket.getInputStream());
           OutputStream os = fcpSocket.getOutputStream()) {
         fcpSocket.setSoTimeout(2000);
@@ -101,6 +100,21 @@ public class AddRef {
     } finally {
       sleepAtShutdown();
     }
+  }
+
+  private static Socket openFcpSocket() throws IOException {
+    IOException lastException = null;
+    for (String host : new String[] {"127.0.0.1", "::1"}) {
+      try {
+        return new Socket(InetAddress.getByName(host), FCPServer.DEFAULT_FCP_PORT);
+      } catch (IOException e) {
+        lastException = e;
+      }
+    }
+    if (lastException != null) {
+      throw lastException;
+    }
+    throw new SocketException("No loopback addresses available");
   }
 
   private static void sendClientHelloAndValidateNode(LineReadingInputStream lis, OutputStream os)

--- a/src/test/java/network/crypta/client/async/USKStoreCheckCoordinatorTest.java
+++ b/src/test/java/network/crypta/client/async/USKStoreCheckCoordinatorTest.java
@@ -317,19 +317,8 @@ class USKStoreCheckCoordinatorTest {
     NodeSSK key = nodeKeyForEdition(usk, 0L);
     USKKeyWatchSet.KeyList.StoreSubChecker subChecker =
         newStoreSubChecker(watchSet, new NodeSSK[] {key});
-    USKStoreCheckCoordinator coordinator =
-        newCoordinator(
-            watchSet,
-            mock(USKAttemptManager.class),
-            mock(ClientRequester.class),
-            false,
-            mock(USKManager.class),
-            usk,
-            mock(USKStoreCheckCoordinator.USKStoreCheckCallbacks.class),
-            true);
-
     USKStoreCheckCoordinator.USKStoreChecker checker =
-        coordinator.new USKStoreChecker(List.of(subChecker));
+        new USKStoreCheckCoordinator.USKStoreChecker(List.of(subChecker));
 
     // Act
     Key[] keys = checker.getKeys();
@@ -352,19 +341,8 @@ class USKStoreCheckCoordinatorTest {
     USKKeyWatchSet.KeyList.StoreSubChecker second =
         newStoreSubChecker(watchSet, new NodeSSK[] {key2, key3});
 
-    USKStoreCheckCoordinator coordinator =
-        newCoordinator(
-            watchSet,
-            mock(USKAttemptManager.class),
-            mock(ClientRequester.class),
-            false,
-            mock(USKManager.class),
-            usk,
-            mock(USKStoreCheckCoordinator.USKStoreCheckCallbacks.class),
-            true);
-
     USKStoreCheckCoordinator.USKStoreChecker checker =
-        coordinator.new USKStoreChecker(List.of(first, second));
+        new USKStoreCheckCoordinator.USKStoreChecker(List.of(first, second));
 
     // Act
     Key[] keys = checker.getKeys();
@@ -384,19 +362,8 @@ class USKStoreCheckCoordinatorTest {
         newStoreSubChecker(watchSet, new NodeSSK[] {key});
     USKKeyWatchSet.KeyList.StoreSubChecker subChecker = spy(realChecker);
 
-    USKStoreCheckCoordinator coordinator =
-        newCoordinator(
-            watchSet,
-            mock(USKAttemptManager.class),
-            mock(ClientRequester.class),
-            false,
-            mock(USKManager.class),
-            usk,
-            mock(USKStoreCheckCoordinator.USKStoreCheckCallbacks.class),
-            true);
-
     USKStoreCheckCoordinator.USKStoreChecker checker =
-        coordinator.new USKStoreChecker(List.of(subChecker));
+        new USKStoreCheckCoordinator.USKStoreChecker(List.of(subChecker));
 
     // Act
     checker.checked();

--- a/src/test/java/network/crypta/io/comm/IncomingPacketFilterImplTest.java
+++ b/src/test/java/network/crypta/io/comm/IncomingPacketFilterImplTest.java
@@ -96,7 +96,7 @@ class IncomingPacketFilterImplTest {
 
     DECODED result = filter.process(buf, 0, buf.length, peer, now);
 
-    assertSame(DECODED.DECODED, result);
+    assertSame(DECODED.SUCCESS, result);
     // Should gather timer entropy with the expected bias
     verify(randomSource, times(1)).acceptTimerEntropy(any(), eq(0.25d));
     // Mangler should not be invoked if the owning PeerNode handled the packet
@@ -109,11 +109,11 @@ class IncomingPacketFilterImplTest {
     when(node.network().peers()).thenReturn(peerManager);
     when(peerManager.roster()).thenReturn(roster);
     when(roster.getByPeer(peer, mangler)).thenReturn(null);
-    when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.DECODED);
+    when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.SUCCESS);
 
     DECODED result = filter.process(buf, 0, buf.length, peer, now);
 
-    assertSame(DECODED.DECODED, result);
+    assertSame(DECODED.SUCCESS, result);
     verify(randomSource, times(1)).acceptTimerEntropy(any(), eq(0.25d));
     verify(mangler, times(1)).process(buf, 0, buf.length, peer, null);
   }
@@ -137,7 +137,7 @@ class IncomingPacketFilterImplTest {
 
     DECODED result = filter.process(buf, 0, buf.length, peer, now);
 
-    assertSame(DECODED.DECODED, result);
+    assertSame(DECODED.SUCCESS, result);
     verify(pn1, times(1)).handleReceivedPacket(buf, 0, buf.length, now, peer);
     verify(pn2, times(1)).handleReceivedPacket(buf, 0, buf.length, now, peer);
   }

--- a/src/test/java/network/crypta/io/comm/MessageFilterTest.java
+++ b/src/test/java/network/crypta/io/comm/MessageFilterTest.java
@@ -80,7 +80,7 @@ class MessageFilterTest {
     m.set("i", 3);
     m.set("l", 4L);
 
-    assertEquals(MessageFilter.MATCHED.MATCHED, f.match(m, System.currentTimeMillis()));
+    assertEquals(MessageFilter.MATCHED.FOUND, f.match(m, System.currentTimeMillis()));
   }
 
   @Test
@@ -118,7 +118,7 @@ class MessageFilterTest {
     msg.set("id", 1L);
 
     MessageFilter.MATCHED res = left.match(msg, System.currentTimeMillis());
-    assertEquals(MessageFilter.MATCHED.MATCHED, res);
+    assertEquals(MessageFilter.MATCHED.FOUND, res);
   }
 
   @Test
@@ -193,7 +193,7 @@ class MessageFilterTest {
 
     // Because noTimeout=true, shouldTimeout() must not be consulted.
     MessageFilter.MATCHED res = f.match(m, /* noTimeout= */ true, System.currentTimeMillis());
-    assertEquals(MessageFilter.MATCHED.MATCHED, res);
+    assertEquals(MessageFilter.MATCHED.FOUND, res);
     verifyNoInteractions(cb);
 
     // Without noTimeout and with an immediate-timeout signal, we should see TIMED_OUT_AND_MATCHED.

--- a/src/test/java/network/crypta/io/comm/UdpSocketHandlerTest.java
+++ b/src/test/java/network/crypta/io/comm/UdpSocketHandlerTest.java
@@ -156,7 +156,7 @@ class UdpSocketHandlerTest {
     // Prepare filter and wire it into the handler before starting the thread.
     IncomingPacketFilter filter = Mockito.mock(IncomingPacketFilter.class);
     when(filter.process(any(byte[].class), anyInt(), anyInt(), any(Peer.class), anyLong()))
-        .thenReturn(IncomingPacketFilter.DECODED.DECODED);
+        .thenReturn(IncomingPacketFilter.DECODED.SUCCESS);
     // Build a fresh handler bound to a specific free UDP port to avoid reflection.
     if (handler != null) handler.close();
     int freePort = findFreeUdpPort();

--- a/src/test/java/network/crypta/keys/NodeSSKTest.java
+++ b/src/test/java/network/crypta/keys/NodeSSKTest.java
@@ -20,10 +20,12 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import network.crypta.crypt.DSAPublicKey;
+import network.crypta.crypt.Global;
 import network.crypta.crypt.SHA256;
 import network.crypta.store.BlockMetadata;
 import network.crypta.store.GetPubkey;
@@ -209,10 +211,9 @@ class NodeSSKTest {
   @Test
   void hasPubKey_getPubKey_and_setPubKey_happyPath() throws SSKVerifyException {
     byte[] eh = bytes(NodeSSK.E_H_DOCNAME_SIZE, 0x70);
-    byte[] pubBytes = "pub-for-hash".getBytes(StandardCharsets.US_ASCII);
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, BigInteger.valueOf(7L));
+    byte[] pubBytes = pub.asBytes();
     byte[] pkh = sha256(pubBytes);
-    DSAPublicKey pub = org.mockito.Mockito.mock(DSAPublicKey.class);
-    doReturn(pubBytes).when(pub).asBytes();
 
     NodeSSK key = new NodeSSK(pkh, eh, Key.ALGO_AES_PCFB_256_SHA256);
     assertFalse(key.hasPubKey());

--- a/src/test/java/network/crypta/node/FNPPacketManglerTest.java
+++ b/src/test/java/network/crypta/node/FNPPacketManglerTest.java
@@ -132,7 +132,7 @@ class FNPPacketManglerTest {
     DECODED result = mangler.process(packet, 0, packet.length, loopbackPeer, null);
 
     // Assert
-    assertSame(DECODED.DECODED, result);
+    assertSame(DECODED.SUCCESS, result);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Replace record-based payload and param holders with final classes and explicit accessors to resolve error-prone warnings.
- Standardize warning cleanups across client/filter/http/comm paths (switch/instanceof patterns, generic types, Locale.ROOT, parsing tweaks).
- Use CompatibilityMode `code` values and stricter validation instead of ordinal comparisons.

## Testing
- Not run (not requested)