### PR TITLE
Exclude doc-files assets from Sonar analysis

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -27,6 +27,7 @@ sonar {
     property("sonar.testExecutionReportPaths", "build/sonar-test-results/test-execution.xml")
     property("sonar.tests", "src/test/java,src/test/kotlin")
     property("sonar.test.inclusions", "src/test/java/**,src/test/kotlin/**")
+    property("sonar.exclusions", "**/doc-files/**")
 
     // Read token from environment if provided to avoid passing on CLI (modern scanners read
     // sonar.token)
@@ -51,6 +52,8 @@ extensions.configure<SonarLintSettings>("sonarLint") {
     // Use Sonar's standard inclusions property so the engine narrows the scope
     sonarProperty("sonar.inclusions", value)
   }
+
+  sonarProperty("sonar.exclusions", "**/doc-files/**")
 
   val fileProp = providers.gradleProperty("sonarlint.file").orElse(providers.gradleProperty("file"))
   fileProp.orNull?.let { value ->


### PR DESCRIPTION
## Summary
- exclude Javadoc doc-files assets from Sonar analysis to prevent UTF-8 warnings
- align SonarLint with SonarQube exclusions

## Testing
- `./gradlew sonarlintMain` (reports existing issues unrelated to this change; UTF-8 warning is gone)