### PR TITLE
fix(build): avoid Gradle internal APIs

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -151,22 +151,26 @@ val prepareJpackageResources by
 
 // Helper resolving the OS and icon path
 
+private val osNameLower = (System.getProperty("os.name") ?: "").lowercase()
+
+fun isWindowsOs(): Boolean = osNameLower.contains("win")
+
+fun isMacOs(): Boolean = osNameLower.contains("mac") || osNameLower.contains("darwin")
+
 /** Detects the current OS as a stable token: mac|win|linux. */
-fun currentOs(): String {
-  val os = org.gradle.internal.os.OperatingSystem.current()
-  return when {
-    os.isMacOsX -> "mac"
-    os.isWindows -> "win"
+fun currentOs(): String =
+  when {
+    isMacOs() -> "mac"
+    isWindowsOs() -> "win"
     else -> "linux"
   }
-}
 
 /** Checks if an executable exists on PATH using the platform-appropriate command. */
 fun hasExe(name: String): Boolean =
   try {
     val pb =
       ProcessBuilder(
-        if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
+        if (isWindowsOs()) {
           listOf("where", name)
         } else {
           listOf("which", name)
@@ -233,7 +237,7 @@ fun resolveJpackageExecutable(): File {
   val exe =
     javaHome.resolve(
       "bin/jpackage" +
-        if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
+        if (isWindowsOs()) {
           ".exe"
         } else {
           ""
@@ -571,8 +575,10 @@ val enrichAppImageWithDist by
         when (os) {
           // macOS: cfg lives under Contents/app
           "mac" -> appDir.resolve("$appName.cfg")
+
           // Windows: cfg lives under app/
           "win" -> appDir.resolve("$appName.cfg")
+
           // Linux: cfg lives under lib/app
           else -> imageRoot.resolve("lib/app/$appName.cfg")
         }

--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -1,3 +1,4 @@
+import java.util.Locale
 import java.util.jar.JarOutputStream as JJarOutputStream
 import java.util.jar.Manifest as JManifest
 
@@ -151,7 +152,7 @@ val prepareJpackageResources by
 
 // Helper resolving the OS and icon path
 
-private val osNameLower = (System.getProperty("os.name") ?: "").lowercase().trim()
+private val osNameLower = (System.getProperty("os.name") ?: "").lowercase(Locale.ROOT).trim()
 
 fun isWindowsOs(): Boolean =
   osNameLower.startsWith("windows") ||

--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -151,9 +151,14 @@ val prepareJpackageResources by
 
 // Helper resolving the OS and icon path
 
-private val osNameLower = (System.getProperty("os.name") ?: "").lowercase()
+private val osNameLower = (System.getProperty("os.name") ?: "").lowercase().trim()
 
-fun isWindowsOs(): Boolean = osNameLower.contains("win")
+fun isWindowsOs(): Boolean =
+  osNameLower.startsWith("windows") ||
+    osNameLower.startsWith("cygwin") ||
+    osNameLower.startsWith("mingw") ||
+    osNameLower.startsWith("msys") ||
+    osNameLower == "win"
 
 fun isMacOs(): Boolean = osNameLower.contains("mac") || osNameLower.contains("darwin")
 

--- a/build-logic/src/main/kotlin/cryptad.runtime.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.runtime.gradle.kts
@@ -1,5 +1,4 @@
 import java.io.ByteArrayOutputStream
-import org.gradle.kotlin.dsl.support.serviceOf
 
 plugins { java }
 
@@ -138,8 +137,7 @@ val computeJlinkModules by
     // Toolchain + baseline
     javaLanguageVersion.set(25)
     // Resolve the toolchain at configuration time and pass JDK home path as input
-    val toolchains = project.serviceOf<JavaToolchainService>()
-    val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
+    val launcher = javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
     javaHomePath.set(launcher.map { it.metadata.installationPath.asFile.absolutePath })
     baselineModules.set(
       listOf(
@@ -164,12 +162,10 @@ val createJreImage by
     description = "Creates a minimal JRE with jlink into build/jre"
     dependsOn(computeJlinkModules)
     // Resolve toolchain and static inputs at configuration time to avoid Task.project access
-    val toolchains = project.serviceOf<JavaToolchainService>()
-    val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
+    val launcher = javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
     val javaHomePath = launcher.map { it.metadata.installationPath.asFile.absolutePath }
     val jreDirProvider = layout.buildDirectory.dir("jre")
     val modulesFileProvider = layout.buildDirectory.dir("jlink").map { it.file("modules.list") }
-    val execOps = project.serviceOf<ExecOperations>()
     doLast {
       val javaHome = File(javaHomePath.get())
       val jlink =
@@ -203,7 +199,11 @@ val createJreImage by
         )
 
       println("Executing jlink: ${args.joinToString(" ")}")
-      execOps.exec { commandLine(args) }
+      val process = ProcessBuilder(args).inheritIO().start()
+      val exit = process.waitFor()
+      if (exit != 0) {
+        throw GradleException("jlink failed with exit code $exit")
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- replace internal OperatingSystem usage in jpackage build logic with lightweight OS helpers
- use javaToolchains and a direct jlink process to avoid internal Gradle APIs

## Testing
- ./gradlew help --warning-mode all