### PR TITLE
fix(sonar): avoid Task.project access

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
-        run: ./gradlew build sonar
+        run: ./gradlew build sonar --warning-mode all
 
       - name: Build (no Sonar token)
         if: ${{ env.SONAR_TOKEN == '' }}

--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -446,6 +446,18 @@ val enrichAppImageWithDist by
     group = "jpackage"
     description = "Copies cryptad-dist into the jpackage image (mac: Contents/app; linux: lib/app)"
     dependsOn(jpackageImageCryptad)
+    val serviceSrc =
+      project.layout.projectDirectory.file("src/jpackage/linux/cryptad.service").asFile
+    val helperUnitSrc =
+      project.layout.projectDirectory
+        .file("src/jpackage/linux/cryptad-core-install@.service")
+        .asFile
+    val helperScriptSrc =
+      project.layout.projectDirectory.file("src/jpackage/linux/cryptad-core-install.sh").asFile
+    val polkitSrc =
+      project.layout.projectDirectory
+        .file("src/jpackage/linux/polkit-1/60-cryptad-core-install.rules")
+        .asFile
     doLast {
       val os = currentOs()
       val root = jpackageOutDir.get().asFile
@@ -513,7 +525,6 @@ val enrichAppImageWithDist by
         // Also, stage systemd units and helper artifacts under lib/ so installers and
         // post-install scripts can find them inside the app image.
         try {
-          val serviceSrc = project.file("src/jpackage/linux/cryptad.service")
           if (serviceSrc.isFile) {
             val serviceDst = imageRoot.resolve("lib/systemd/system/cryptad.service")
             serviceDst.parentFile.mkdirs()
@@ -528,7 +539,6 @@ val enrichAppImageWithDist by
 
         // Stage headless core installer template unit
         try {
-          val helperUnitSrc = project.file("src/jpackage/linux/cryptad-core-install@.service")
           if (helperUnitSrc.isFile) {
             val helperUnitDst =
               imageRoot.resolve("lib/systemd/system/cryptad-core-install@.service")
@@ -544,7 +554,6 @@ val enrichAppImageWithDist by
 
         // Stage headless core installer script
         try {
-          val helperScriptSrc = project.file("src/jpackage/linux/cryptad-core-install.sh")
           if (helperScriptSrc.isFile) {
             val helperScriptDst = imageRoot.resolve("lib/cryptad-core-install.sh")
             helperScriptDst.parentFile.mkdirs()
@@ -560,7 +569,6 @@ val enrichAppImageWithDist by
 
         // Stage polkit rule to allow controlled start of the oneshot helper
         try {
-          val polkitSrc = project.file("src/jpackage/linux/polkit-1/60-cryptad-core-install.rules")
           if (polkitSrc.isFile) {
             val polkitDst = imageRoot.resolve("lib/polkit-1/60-cryptad-core-install.rules")
             polkitDst.parentFile.mkdirs()

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -117,7 +117,9 @@ tasks.register("prepareKotlinTestReports") {
 
     val reportDir = testResultsDir.get().asFile
     val outputDir = kotlinTestReportDir.get().asFile
-    project.delete(outputDir)
+    if (outputDir.exists()) {
+      outputDir.deleteRecursively()
+    }
     outputDir.mkdirs()
 
     val reportNames =
@@ -140,6 +142,8 @@ tasks.register("prepareTestExecutionReport") {
   dependsOn(tasks.withType<Test>())
   inputs.dir(testResultsDir)
   outputs.file(testExecutionReportFile)
+
+  val projectPath = project.projectDir.toPath()
 
   doLast {
     data class TestCase(
@@ -232,7 +236,13 @@ tasks.register("prepareTestExecutionReport") {
                           .firstOrNull { srcDir -> File(srcDir, relativePath).isFile }
                           ?.let { srcDir -> File(srcDir, relativePath) }
                       } ?: continue
-                    val sonarPath = project.relativePath(sourceFile)
+                    val sourcePath = sourceFile.toPath()
+                    val sonarPath =
+                      if (sourcePath.startsWith(projectPath)) {
+                        projectPath.relativize(sourcePath).toString()
+                      } else {
+                        sourceFile.absolutePath
+                      }
                     byFile
                       .getOrPut(sonarPath) { mutableListOf() }
                       .add(TestCase(name, durationMs, status, messageText))


### PR DESCRIPTION
## Summary
- remove Task.project usage from Sonar report tasks to avoid Gradle 10 deprecation warnings
- compute report paths via project root path with safe fallback

## Testing
- ./gradlew spotlessApply