### PR TITLE
refactor: reduce S107 parameter fanout

### DIFF
--- a/.opencode/command/fix-sonarlint-S107-too-many-parameters.md
+++ b/.opencode/command/fix-sonarlint-S107-too-many-parameters.md
@@ -19,7 +19,7 @@ Refactor **`$1`** to eliminate **SonarLint `java:S107`** issues by reducing exce
 ## Do this
 
 ### 0) Repo conventions
-1. Read and follow `AGENTS.md` (and any formatting/linting conventions) if present.
+1. Read and follow `AGENTS.md` (and any formatting/linting conventions) if present. Use $cryptad-build-tooling skill.
 2. Keep changes minimal and localized unless call sites require updates.
 3. Prefer consistent naming/location patterns already used in the repo (e.g., `*Params`, `*Request`, `*Options`, `Context`, `Paging`, etc.).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Load only what you need. It’s normal to load multiple skills for one task.
 
 ## Quick commands (high-level)
 
-Prefer the Gradle wrapper and follow the project’s build/test/tooling guidance in the skills:
+Prefer the Gradle wrapper and follow the project’s build/test/tooling guidance in the skills (always load `$cryptad-build-test` skill):
 
 - `./gradlew build`
 - `./gradlew test` (Always give enough running time (more than 15 minutes) for Gradle to complete tests.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **$cryptad-appenv** — Use AppEnv as the single source of truth for OS/arch/sandbox/service detection; refactor legacy checks safely.
 - **$cryptad-architecture** — Navigate Cryptad’s module/package architecture, key subsystems, design patterns, security model, and versioning scheme.
 - **$cryptad-build-test** — Build, test, and run Cryptad safely using the Gradle wrapper (Java 25+, JUnit 6).
-- **$cryptad-build-tooling** — Maintain formatting and code-quality tooling: Spotless, Gradle dependency verification (verification-metadata), SonarLint, JaCoCo coverage, and SonarCloud uploads.
+- **$cryptad-build-tooling** — Maintain formatting and code-quality tooling: Spotless, Gradle dependency verification (verification-metadata), SonarLint, Error Prone, JaCoCo coverage, and SonarCloud uploads.
 - **$cryptad-core-updater** — Understand and modify the package-based CoreUpdater update system: /core-update/ endpoints, descriptor format, UI wiring, and platform behaviors.
 - **$cryptad-crypto-aead** — Work safely on AEAD streams and persistent formats (AES-GCM migration + legacy OCB compatibility notes).
 - **$cryptad-git-workflow** — Follow repository etiquette: branch naming, GitFlow merges, conventional commits, PR rules, and strict git identity policy.

--- a/src/main/java/com/onionnetworks/fec/FECMath.java
+++ b/src/main/java/com/onionnetworks/fec/FECMath.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
  *
  * <ul>
  *   <li>Create an instance with the desired field width.
- *   <li>Call {@link #createEncodeMatrix(int, int)} to obtain a systematic generator matrix.
+ *   <li>Call {@link #createEncodeMatrix(int, int)} to get a systematic generator matrix.
  *   <li>Use {@link #createDecodeMatrix(char[], int[], int, int)} with available symbol indexes to
  *       reconstruct a decoding matrix.
  *   <li>Apply {@link #addMul(char[], int, char[], int, char, int)} or the byte overload to combine
@@ -36,7 +36,7 @@ public class FECMath {
 
   /**
    * The following parameter defines how many bits are used for field elements. This probably only
-   * supports 8 and 16 bit codes at this time because Java lacks a typedef construct. This code
+   * supports 8 and 16-bit codes at this time because Java lacks a typedef construct. This code
    * should perhaps be redone with some sort of template language/ precompiler for Java.
    */
 
@@ -50,7 +50,7 @@ public class FECMath {
    * The first part of the file implements linear algebra in GF.
    *
    * gf is the type used to store an element of the Galois Field.
-   * Must constain at least gfBits bits.
+   * Must contain at least gfBits bits.
    */
   // 2^n-1 = the number of elements in this extension field
   private final int gfSize; // powers of alpha
@@ -101,7 +101,7 @@ public class FECMath {
    * <p>USE_GF_MULC, GF_MULC0(c) and GF_ADDMULC(x) can be used when multiplying many numbers by the
    * same constant. In this case the first call sets the constant, and others perform the
    * multiplications. A value related to the multiplication is held in a local variable declared
-   * with USE_GF_MULC . See usage in addMul1().
+   * with USE_GF_MULC. See usage in addMul1().
    */
   private char[][] gfMulTable;
 
@@ -142,7 +142,7 @@ public class FECMath {
   /**
    * Returns the number of bits that define this Galois field, e.g., {@code 8} for GF(256).
    *
-   * @return bit width used to derive field size and primitive polynomial
+   * @return the bit width used to derive field size and primitive polynomial
    */
   @SuppressWarnings("unused")
   public int getGfBits() {
@@ -182,7 +182,7 @@ public class FECMath {
 
   /**
    * Generates logarithm, exponent, and inverse lookup tables for the configured field. The routine
-   * walks the primitive polynomial bits to enumerate powers of the generator and derives inverse
+   * walks the primitive polynomial bits to list powers of the generator and derives inverse
    * elements for every non-zero value. It is invoked during construction and should not be called
    * concurrently with mutation of the same instance.
    *
@@ -200,8 +200,8 @@ public class FECMath {
     gfExp[gfBits] = 0; // will be updated at the end of the 1st loop
     /*
      * first, generate the (polynomial representation of) powers of \alpha,
-     * which are stored in gfExp[i] = \alpha ** i .
-     * At the same time build gfLog[gfExp[i]] = i .
+     * which are stored in gfExp[i] = \alpha ** i
+     * At the same time, build gfLog[gfExp[i]] = i
      * The first gfBits powers are simply bits shifted to the left.
      */
     for (i = 0; i < gfBits; i++, mask = (char) (mask << 1)) {
@@ -239,7 +239,7 @@ public class FECMath {
      * log(0) is not defined, so use a special value
      */
     gfLog[0] = gfSize;
-    // set the extended gfExp values for fast multiply
+    // set the extended gfExp values for fast multiplying
     for (i = 0; i < gfSize; i++) {
       gfExp[i + gfSize] = gfExp[i];
     }
@@ -280,7 +280,7 @@ public class FECMath {
   }
 
   /**
-   * Computes {@code x mod gfSize} using bit folding instead of division. This helper keeps loop
+   * Computes {@code x mod gfSize} using a bit folding instead of division. This helper keeps loop
    * indices within the field order when accumulating exponents during multiplication.
    *
    * @param x value to be reduced; negative values are not supported and produce unspecified results
@@ -361,7 +361,7 @@ public class FECMath {
     int lim = dstPos + len;
 
     if (gfBits <= 8) { // use our multiplication table.
-      // Instead of doing gfMulTable[c,x] for multiply, we'll save
+      // Instead of doing gfMulTable[c,x] for multiplying, we'll save
       // the gfMulTable[c] to a local variable since it is going to
       // be used many times.
       char[] gfMulc = gfMulTable[c];
@@ -418,7 +418,7 @@ public class FECMath {
   /**
    * Byte-array variant of {@link #addMul(char[], int, char[], int, char, int)} that operates on
    * unsigned byte values encoded in two's complement. The multiplication constant and inputs are
-   * widened to {@code char} during arithmetic and narrowed back on write.
+   * widened to {@code char} during arithmetic and narrowed back on writing.
    *
    * @param dst destination byte buffer mutated in place; must accommodate {@code len} updates from
    *     {@code dstPos}
@@ -440,7 +440,7 @@ public class FECMath {
     int lim = dstPos + len;
 
     // use our multiplication table.
-    // Instead of doing gfMulTable[c,x] for multiply, we'll save
+    // Instead of doing gfMulTable[c,x] for multiplying, we'll save
     // the gfMulTable[c] to a local variable since it is going to
     // be used many times.
     char[] gfMulc = gfMulTable[c & 0xff];
@@ -493,7 +493,12 @@ public class FECMath {
    * @param m number of columns in {@code b} and {@code c}
    */
   public final void matMul(char[] a, char[] b, char[] c, int n, int k, int m) {
-    matMul(new MatrixMulParams(a, 0, b, 0, c, 0, n, k, m));
+    matMul(
+        new MatrixMulParams(
+            new MatrixSlice(a, 0),
+            new MatrixSlice(b, 0),
+            new MatrixSlice(c, 0),
+            new MatrixMulDimensions(n, k, m)));
   }
 
   /*
@@ -634,9 +639,9 @@ public class FECMath {
       throw new IllegalArgumentException("singular matrix 2");
     }
     if (pivotValue != 1) {
-      /* otherwhise this is a NOP */
+      /* otherwise this is a NOP */
       /*
-       * this is done often , but optimizing is not so
+       * this is often done, but optimizing is not so
        * fruitful, at least in the obvious ways (unrolling)
        */
       char scaledPivot = inverse[pivotValue];
@@ -715,7 +720,7 @@ public class FECMath {
      */
     c[k - 1] = p[0]; /* really -p(0), but x = -x in GF(2^m) */
     for (int i = 1; i < k; i++) {
-      char pElement = p[i]; /* see above comment */
+      char pElement = p[i]; /* see the above comment */
       for (int j = k - 1 - (i - 1); j < k - 1; j++) {
         c[j] ^= mul(pElement, c[j + 1]);
       }
@@ -745,7 +750,7 @@ public class FECMath {
    * enabling direct use with {@link #addMul(char[], int, char[], int, char, int)} during encoding.
    *
    * @param k number of data symbols; must be {@code <= n} and not exceed {@code gfSize + 1}
-   * @param n total symbols (data + parity) to generate; must be {@code <= gfSize + 1}
+   * @param n total symbols (data and parity) to generate; must be {@code <= gfSize + 1}
    * @return newly allocated encoding matrix in row-major order
    * @throws IllegalArgumentException if the requested dimensions exceed the field capacity or
    *     {@code k > n}
@@ -759,7 +764,7 @@ public class FECMath {
     char[] encMatrix = createGFMatrix(n, k);
 
     /*
-     * The encoding matrix is computed starting with a Vandermonde matrix,
+     * The encoding matrix is computed starting with a Vandermonde matrix
      * and then transforming it into a systematic matrix.
      *
      * fill the matrix with powers of field elements, starting from 0.
@@ -768,7 +773,7 @@ public class FECMath {
     char[] tmpMatrix = createGFMatrix(n, k);
 
     tmpMatrix[0] = 1;
-    // first row should be 0's, fill in the rest.
+    // the first row should be 0's, fill in the rest.
     for (int pos = k, row = 0; row < n - 1; row++, pos += k) {
       for (int col = 0; col < k; col++) {
         tmpMatrix[pos + col] = gfExp[modnn(row * col)];
@@ -782,10 +787,15 @@ public class FECMath {
      */
     // much faster than invertMatrix
     invertVandermonde(tmpMatrix, k);
-    matMul(new MatrixMulParams(tmpMatrix, k * k, tmpMatrix, 0, encMatrix, k * k, n - k, k, k));
+    matMul(
+        new MatrixMulParams(
+            new MatrixSlice(tmpMatrix, k * k),
+            new MatrixSlice(tmpMatrix, 0),
+            new MatrixSlice(encMatrix, k * k),
+            new MatrixMulDimensions(n - k, k, k)));
 
     /*
-     * the upper matrix is I so do not bother with a slow multiply
+     * the upper matrix is I so do not bother with a slow multiplying
      */
     Util.bzero(encMatrix, 0, k * k);
     for (int i = 0, col = 0; col < k; col++, i += k + 1) {

--- a/src/main/java/com/onionnetworks/fec/MatrixMulDimensions.java
+++ b/src/main/java/com/onionnetworks/fec/MatrixMulDimensions.java
@@ -1,0 +1,44 @@
+package com.onionnetworks.fec;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Encapsulates the dimensions for multiplying an {@code n x k} matrix by a {@code k x m} matrix.
+ *
+ * <p>This record is a lightweight carrier for the three integer dimensions that describe a
+ * row-major matrix multiplication. It is useful when callers want to pass the dimensions as a
+ * single value alongside matrix buffers or slices. The values are stored verbatim, with no
+ * validation, normalization, or derived computations performed by this type.
+ *
+ * <p>The record is immutable and thread-safe as a value object. It carries no lifecycle beyond
+ * construction and has no side effects. Consumers should interpret the dimensions consistently with
+ * their matrix storage conventions, typically row-major arrays where {@code n} is the number of
+ * rows, {@code k} is the shared inner dimension, and {@code m} is the number of columns on the
+ * right-hand matrix.
+ *
+ * <ul>
+ *   <li>Groups the three dimensions for a single multiplication operation.
+ *   <li>Expresses shape only; it does not validate or allocate storage.
+ *   <li>Composes naturally with {@link MatrixMulParams} when building parameter bundles.
+ * </ul>
+ *
+ * @param n number of rows in the left matrix and the resulting output matrix
+ * @param k shared inner dimension; columns of the left, rows of the right matrix
+ * @param m number of columns in the right matrix and the resulting output matrix
+ * @see MatrixMulParams
+ */
+public record MatrixMulDimensions(int n, int k, int m) {
+  /**
+   * Returns a compact string representation of the dimensions.
+   *
+   * <p>The output includes the three integer values labeled by name, in the order {@code n}, {@code
+   * k}, and {@code m}. This method is intended for diagnostics and debugging and makes no
+   * assumptions about whether the dimensions are valid or consistent with any particular buffers.
+   *
+   * @return a string describing {@code n}, {@code k}, and {@code m}
+   */
+  @Override
+  public @NotNull String toString() {
+    return "MatrixMulDimensions{" + "n=" + n + ", k=" + k + ", m=" + m + '}';
+  }
+}

--- a/src/main/java/com/onionnetworks/fec/MatrixMulParams.java
+++ b/src/main/java/com/onionnetworks/fec/MatrixMulParams.java
@@ -2,8 +2,26 @@ package com.onionnetworks.fec;
 
 import org.jetbrains.annotations.NotNull;
 
-/** Parameter carrier for finite-field matrix multiplication slices. */
-@SuppressWarnings("java:S6206")
+/**
+ * Holds the inputs for a finite-field matrix multiplication over sliced buffers.
+ *
+ * <p>This class packages three row-major matrix buffers and their starting offsets together with
+ * the {@code n x k} by {@code k x m} dimensions that define the multiplication. It is intended for
+ * callers that want to pass a single object into matrix multiplication routines instead of a long
+ * list of parameters. The instance stores the caller-provided arrays and offsets directly and does
+ * not perform any copying or validation.
+ *
+ * <p>Instances are immutable in terms of reference identity, but the referenced arrays are mutable
+ * and are not defensively copied. If the arrays are changed concurrently, all derived behavior (for
+ * example, equality, hash codes, and debug output) can change as well. When arrays are treated as
+ * stable inputs for the duration of the call, the object is safe to share across threads.
+ *
+ * <ul>
+ *   <li>Groups three matrix slices and their multiplication dimensions.
+ *   <li>Represents buffers as-is without bounds checking or normalization.
+ *   <li>Compares array contents in {@link #equals(Object)} and {@link #hashCode()}.
+ * </ul>
+ */
 public final class MatrixMulParams {
   private final char[] a;
   private final int aStart;
@@ -18,65 +36,159 @@ public final class MatrixMulParams {
   /**
    * Creates a parameter bundle for matrix multiplication slices.
    *
-   * @param a backing array for the left matrix
-   * @param aStart offset into {@code a} where the {@code n x k} block starts
-   * @param b backing array for the right matrix
-   * @param bStart offset into {@code b} where the {@code k x m} block starts
-   * @param c destination array for the {@code n x m} product
-   * @param cStart offset into {@code c} where results are written
-   * @param n number of rows in the left matrix and output
-   * @param k shared inner dimension of the matrices
-   * @param m number of columns in the right matrix and output
+   * <p>The provided slices are stored by reference and are assumed to point at row-major blocks of
+   * matrices sized according to the supplied dimensions. This constructor does not validate array
+   * bounds, nullability, or dimensional consistency. It is the caller's responsibility to ensure
+   * that each slice has enough backing capacity for the multiplication and that the dimensions
+   * represent the intended {@code n x k} by {@code k x m} operation.
+   *
+   * @param a slice for the left matrix; must reference a row-major {@code n x k} block
+   * @param b slice for the right matrix; must reference a row-major {@code k x m} block
+   * @param c slice for the destination; must reference a row-major {@code n x m} block
+   * @param dimensions multiplication dimensions describing {@code n}, {@code k}, and {@code m}
    */
   public MatrixMulParams(
-      char[] a, int aStart, char[] b, int bStart, char[] c, int cStart, int n, int k, int m) {
-    this.a = a;
-    this.aStart = aStart;
-    this.b = b;
-    this.bStart = bStart;
-    this.c = c;
-    this.cStart = cStart;
-    this.n = n;
-    this.k = k;
-    this.m = m;
+      MatrixSlice a, MatrixSlice b, MatrixSlice c, MatrixMulDimensions dimensions) {
+    this.a = a.data();
+    this.aStart = a.start();
+    this.b = b.data();
+    this.bStart = b.start();
+    this.c = c.data();
+    this.cStart = c.start();
+    this.n = dimensions.n();
+    this.k = dimensions.k();
+    this.m = dimensions.m();
   }
 
+  /**
+   * Returns the backing array for the left matrix slice.
+   *
+   * <p>The returned array reference is the same object provided by the caller when this instance
+   * was created. It is not copied or wrapped, so further mutations to the array will be observed by
+   * any consumer of this object. Treat the returned buffer as read-only for predictable equality
+   * and to avoid altering matrix multiplication results in flight.
+   *
+   * @return the left matrix buffer reference, not copied or normalized
+   */
   public char[] a() {
     return a;
   }
 
+  /**
+   * Returns the starting offset within {@link #a()} for the left matrix slice.
+   *
+   * <p>The offset is expressed as a zero-based index into the backing array and is applied to the
+   * row-major {@code n x k} block. No bounds checking is performed when using this value, so it is
+   * the caller's responsibility to ensure it points at a valid location with sufficient capacity.
+   *
+   * @return zero-based offset into the left matrix buffer
+   */
   public int aStart() {
     return aStart;
   }
 
+  /**
+   * Returns the backing array for the right matrix slice.
+   *
+   * <p>The returned array reference is the same object supplied during construction and is not
+   * cloned. Changes to the array contents will be reflected in any computation that uses this
+   * instance. For stable behavior, callers should avoid mutating the array while it is in use.
+   *
+   * @return the right matrix buffer reference, not copied or transformed
+   */
   public char[] b() {
     return b;
   }
 
+  /**
+   * Returns the starting offset within {@link #b()} for the right matrix slice.
+   *
+   * <p>The offset is a zero-based index into the buffer representing the {@code k x m} block. It is
+   * used by matrix multiplication routines to locate the first element of the slice in row-major
+   * order. No validation is performed, so callers must ensure the offset and buffer are valid.
+   *
+   * @return zero-based offset into the right matrix buffer
+   */
   public int bStart() {
     return bStart;
   }
 
+  /**
+   * Returns the backing array for the destination matrix slice.
+   *
+   * <p>The returned array reference is the caller-provided destination buffer where multiplication
+   * results are written. The array is not copied or cleared by this class. If the buffer is shared
+   * with other operations, ensure appropriate coordination to avoid unintended overwrites.
+   *
+   * @return the destination matrix buffer reference, not copied or initialized
+   */
   public char[] c() {
     return c;
   }
 
+  /**
+   * Returns the starting offset within {@link #c()} for the destination matrix slice.
+   *
+   * <p>The offset is a zero-based index into the destination buffer and points at the first element
+   * of the {@code n x m} output block in row-major order. The value is used as-is without bounds
+   * checks or normalization, so it must be consistent with the destination buffer's length.
+   *
+   * @return zero-based offset into the destination matrix buffer
+   */
   public int cStart() {
     return cStart;
   }
 
+  /**
+   * Returns the number of rows in the left matrix and the output matrix.
+   *
+   * <p>This dimension corresponds to the {@code n} in the {@code n x k} by {@code k x m}
+   * multiplication. The value is stored verbatim without validation and is used to determine the
+   * row count for traversal of the left slice and the output slice in row-major order.
+   *
+   * @return row count for the left matrix and output matrix
+   */
   public int n() {
     return n;
   }
 
+  /**
+   * Returns the shared inner dimension for the multiplication.
+   *
+   * <p>This dimension corresponds to the {@code k} in the {@code n x k} by {@code k x m}
+   * multiplication and represents the number of columns in the left matrix and the number of rows
+   * in the right matrix. The value is stored as provided and is not validated against buffer sizes.
+   *
+   * @return shared inner dimension of the multiplication
+   */
   public int k() {
     return k;
   }
 
+  /**
+   * Returns the number of columns in the right matrix and the output matrix.
+   *
+   * <p>This dimension corresponds to the {@code m} in the {@code n x k} by {@code k x m}
+   * multiplication. It controls the column count for the right-hand slice and the output slice in
+   * row-major order. The value is used as-is without range checks or normalization.
+   *
+   * @return column count for the right matrix and output matrix
+   */
   public int m() {
     return m;
   }
 
+  /**
+   * Compares this parameter bundle to another object for structural equality.
+   *
+   * <p>Equality is defined by comparing the contents of the three backing arrays, the three start
+   * offsets, and the three-dimension values. Because arrays are compared by contents rather than
+   * identity, this operation can be relatively expensive for large buffers. If any of the arrays
+   * are mutated after construction, the equality relation can change over time.
+   *
+   * @param obj candidate object to compare against; may be {@code null}
+   * @return {@code true} when the other object represents the same parameter set
+   */
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -96,6 +208,16 @@ public final class MatrixMulParams {
         && m == other.m;
   }
 
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash code is derived from the contents of the three backing arrays, the start offsets,
+   * and the dimension values. Because array contents participate in the hash, computing the value
+   * can be relatively expensive and is sensitive to mutations of the arrays after construction. For
+   * predictable hashing behavior, avoid modifying the buffers once shared in hashed collections.
+   *
+   * @return hash code representing the current parameter values
+   */
   @Override
   public int hashCode() {
     int result = java.util.Arrays.hashCode(a);
@@ -110,6 +232,16 @@ public final class MatrixMulParams {
     return result;
   }
 
+  /**
+   * Returns a debug-oriented string representation of this parameter bundle.
+   *
+   * <p>The string includes {@link java.util.Arrays#toString(char[])} output for each backing array
+   * along with the stored offsets and dimensions. This makes the output potentially large and
+   * sensitive to changes if the arrays are mutated after construction. Use this representation for
+   * diagnostics rather than for stable identifiers or logging of very large buffers.
+   *
+   * @return a string describing arrays, offsets, and dimensions
+   */
   @Override
   public @NotNull String toString() {
     return "MatrixMulParams{"

--- a/src/main/java/com/onionnetworks/fec/MatrixSlice.java
+++ b/src/main/java/com/onionnetworks/fec/MatrixSlice.java
@@ -1,0 +1,126 @@
+package com.onionnetworks.fec;
+
+import java.util.Arrays;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a view into a row-major matrix buffer with a starting offset.
+ *
+ * <p>This class groups a backing {@code char[]} buffer with a zero-based start index that marks
+ * where a matrix block begins. It is typically used to reference submatrices that live inside
+ * larger buffers without allocating or copying. The instance stores the array reference as-is and
+ * does not validate bounds, dimensions, or content.
+ *
+ * <p>The slice is immutable with respect to its fields, but the referenced array remains mutable
+ * and is not defensively copied. Any concurrent modifications to the buffer can change observable
+ * behavior, including equality, hash codes, and string output. When the underlying array is treated
+ * as stable for the duration of use, the object is safe to share between threads.
+ *
+ * <ul>
+ *   <li>Packages a backing buffer and a start offset for row-major data.
+ *   <li>Avoids allocations by reusing caller-provided arrays.
+ *   <li>Defers all bounds and size validation to the caller.
+ * </ul>
+ *
+ * @see MatrixMulParams
+ */
+@SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+public final class MatrixSlice {
+  private final char[] data;
+  private final int start;
+
+  /**
+   * Creates a slice into a matrix buffer.
+   *
+   * <p>The provided array is stored by reference, and the start offset is treated as a zero-based
+   * index into that array. This constructor does not check for {@code null}, negative offsets, or
+   * sufficient remaining capacity for any particular matrix dimensions. Callers are responsible for
+   * ensuring the slice is meaningful and consistent with the expected row-major layout.
+   *
+   * @param data backing array for the matrix buffer; stored by reference and not copied
+   * @param start zero-based offset where the matrix block begins in {@code data}
+   */
+  public MatrixSlice(char[] data, int start) {
+    this.data = data;
+    this.start = start;
+  }
+
+  /**
+   * Returns the backing array for this slice.
+   *
+   * <p>The returned array is the exact reference supplied at construction time. It is not cloned or
+   * wrapped, so any modifications are visible to all users of this slice. For predictable behavior
+   * in equality and hashing, treat the buffer as read-only while the slice is in use.
+   *
+   * @return the backing buffer reference for the slice, not copied or normalized
+   */
+  public char[] data() {
+    return data;
+  }
+
+  /**
+   * Returns the zero-based start offset into {@link #data()}.
+   *
+   * <p>The offset indicates where the matrix block begins in the row-major buffer. It is
+   * interpreted as a simple index and is not validated for bounds or consistency with any implied
+   * dimensions. Use the value in combination with the caller's matrix size information to locate
+   * elements.
+   *
+   * @return zero-based offset into the backing buffer
+   */
+  public int start() {
+    return start;
+  }
+
+  /**
+   * Compares this slice with another object for structural equality.
+   *
+   * <p>Equality is defined by comparing the contents of the backing array and the start offset.
+   * This comparison can be expensive for large arrays because it examines all elements. If the
+   * buffer is mutated after construction, the equality relationship may change over time.
+   *
+   * @param obj candidate object to compare against; may be {@code null}
+   * @return {@code true} when the other object represents the same slice contents and offset
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof MatrixSlice other)) {
+      return false;
+    }
+    return Arrays.equals(data, other.data) && start == other.start;
+  }
+
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash code is derived from the contents of the backing array and the start offset.
+   * Because array contents are included, this method may be relatively expensive and is sensitive
+   * to buffer mutations. For stable hashing, avoid modifying the underlying array while it is used
+   * as a key.
+   *
+   * @return hash code for the current slice contents and offset
+   */
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(data);
+    result = 31 * result + Integer.hashCode(start);
+    return result;
+  }
+
+  /**
+   * Returns a debug-oriented string representation of this slice.
+   *
+   * <p>The string includes a {@link Arrays#toString(char[])} representation of the entire backing
+   * array and the start offset. This can be large for big buffers and should be used primarily for
+   * diagnostics rather than for stable identifiers or high-volume logging.
+   *
+   * @return a string describing the buffer contents and start offset
+   */
+  @Override
+  public @NotNull String toString() {
+    return "MatrixSlice{" + "data=" + Arrays.toString(data) + ", start=" + start + '}';
+  }
+}

--- a/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
+++ b/src/main/java/network/crypta/client/HighLevelSimpleClientImpl.java
@@ -13,6 +13,7 @@ import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientPutterOptions;
 import network.crypta.client.async.ClientPutterRequest;
 import network.crypta.client.async.DefaultManifestPutter;
+import network.crypta.client.async.InsertRequestParams;
 import network.crypta.client.async.ManifestPutterParams;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.TooManyFilesInsertException;
@@ -477,12 +478,9 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
     ClientPutter put =
         new ClientPutter(
             new ClientPutterRequest(
-                pw,
+                new InsertRequestParams(pw, insert.desiredURI, ctx, priority),
                 insert.getData(),
-                insert.desiredURI,
                 insert.clientMetadata,
-                ctx,
-                priority,
                 isMetadata),
             new ClientPutterOptions(filenameHint, false, forceCryptoKey, -1));
     try {
@@ -516,12 +514,9 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
     ClientPutter put =
         new ClientPutter(
             new ClientPutterRequest(
-                cb,
+                new InsertRequestParams(cb, insert.desiredURI, ctx, priority),
                 insert.getData(),
-                insert.desiredURI,
                 insert.clientMetadata,
-                ctx,
-                priority,
                 isMetadata),
             new ClientPutterOptions(filenameHint, false, null, -1));
     try {
@@ -607,12 +602,9 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
       putter =
           new DefaultManifestPutter(
               new ManifestPutterParams(
-                  pw,
+                  new InsertRequestParams(pw, insertURI, getInsertContext(true), priorityClass),
                   BaseManifestPutter.bucketsByNameToManifestEntries(bucketsByName),
-                  priorityClass,
-                  insertURI,
                   defaultName,
-                  getInsertContext(true),
                   forceCryptoKey,
                   core.getClientContext()),
               false);

--- a/src/main/java/network/crypta/client/Metadata.java
+++ b/src/main/java/network/crypta/client/Metadata.java
@@ -47,11 +47,11 @@ import org.slf4j.LoggerFactory;
  * <p>Typical usage follows a parse → inspect → act pattern during fetches, and a build → serialize
  * → insert pattern during inserts. The class exposes helpers to read the header, manifest entries,
  * and splitfile layout, while keeping low‑level binary details encapsulated. After parsing, some
- * derived fields (for example segment counts) are computed from the serialized parameters to match
+ * derived fields (for example, segment counts) are computed from the serialized parameters to match
  * the historical format expected by fetchers.
  *
  * <p>Thread-safety and mutability: a {@code Metadata} instance is mutable during construction and
- * parsing. Once populated it is commonly treated as effectively immutable by callers. No internal
+ * parsing. Once populated, it is commonly treated as effectively immutable by callers. No internal
  * synchronization is provided; publish safely if sharing across threads or prefer per‑thread
  * instances. Larger structures (such as segment keys) may be shared read‑most after construction.
  *
@@ -73,7 +73,7 @@ public class Metadata implements Serializable {
   static final long FREENET_METADATA_MAGIC = 0xf053b2842d91482bL;
   static final int MAX_SPLITFILE_PARAMS_LENGTH = 32768;
 
-  /** Soft limit, to avoid memory DoS */
+  /** Soft limit to avoid memory DoS */
   static final int MAX_SPLITFILE_BLOCKS = 1000 * 1000;
 
   /** Splitfile parameters: segmenting without any special deductions. */
@@ -179,14 +179,6 @@ public class Metadata implements Serializable {
     return new HeaderState(compressed, hasTopBlocks);
   }
 
-  private record TopInfo(
-      long size,
-      long compressedSize,
-      int blocksRequired,
-      int blocksTotal,
-      boolean dontCompress,
-      CompatibilityMode compatMode) {}
-
   /** Holder for initializing final top-layer fields inside constructors. */
   private record TopLayerInit(
       long size,
@@ -197,7 +189,7 @@ public class Metadata implements Serializable {
       CompatibilityMode compatMode,
       short parsedVersion) {}
 
-  private TopInfo readTopBlocksInfo(DataInputStream dis, boolean hasTopBlocks)
+  private TopLayerBlockInfo readTopBlocksInfo(DataInputStream dis, boolean hasTopBlocks)
       throws IOException, MetadataParseException {
     if (hasTopBlocks) {
       long size = dis.readLong();
@@ -207,9 +199,10 @@ public class Metadata implements Serializable {
       boolean dont = dis.readBoolean();
       short code = dis.readShort();
       CompatibilityMode compat = parseTopCompatibility(code, size);
-      return new TopInfo(size, comp, req, tot, dont, compat);
+      return new TopLayerBlockInfo(size, comp, req, tot, dont, compat);
     } else {
-      return new TopInfo(0, 0, 0, 0, false, InsertContext.CompatibilityMode.COMPAT_UNKNOWN);
+      return new TopLayerBlockInfo(
+          0, 0, 0, 0, false, InsertContext.CompatibilityMode.COMPAT_UNKNOWN);
     }
   }
 
@@ -578,7 +571,7 @@ public class Metadata implements Serializable {
   short parsedVersion;
 
   // 2 bytes of flags
-  /** Is a splitfile */
+  /** Is a splitfile? */
   boolean splitfile;
 
   /** Is a DBR */
@@ -607,7 +600,8 @@ public class Metadata implements Serializable {
   static final short FLAGS_COMPRESSED = 128;
   static final short FLAGS_TOP_SIZE = 256;
   static final short FLAGS_HASHES = 512;
-  // If parsed version = 1 and splitfile is set and hashes exist, we create the splitfile key from
+  // If the parsed version = 1 and splitfile is set and hashes exist, we create the splitfile key
+  // from
   // the hashes.
   // This flag overrides this behavior and reads a key anyway.
   static final short FLAGS_SPECIFY_SPLITFILE_KEY = 1024;
@@ -642,7 +636,7 @@ public class Metadata implements Serializable {
   String mimeType;
 
   /**
-   * The compressed MIME type - lookup index for the MIME types table. Must be between 0 and 32767.
+   * The compressed MIME type - lookup index for the MIME types table. Must be between 0 and 32,767.
    */
   short compressedMIMEValue;
 
@@ -714,7 +708,9 @@ public class Metadata implements Serializable {
   /** Used if splitfile single crypto key is enabled */
   byte splitfileSingleCryptoAlgorithm;
 
-  /** Common crypto key applied to all blocks when parsed version ≥ 1; otherwise {@code null}. */
+  /**
+   * Common crypto key applied to all blocks when the parsed version ≥ 1; otherwise {@code null}.
+   */
   byte[] splitfileSingleCryptoKey;
 
   /** If false, the splitfile key can be computed from hashes; if true, it must be specified. */
@@ -732,7 +728,7 @@ public class Metadata implements Serializable {
   /** Number of segments computed from the layout parameters. */
   int segmentCount;
 
-  /** How many trailing segments lose one data block for balancing. */
+  /** How many trailing segments lose one data block for balancing? */
   int deductBlocksFromSegments;
 
   /** Number of cross‑segment parity blocks per segment (0 when not used). */
@@ -751,7 +747,7 @@ public class Metadata implements Serializable {
   /** Manifest entries by name */
   HashMap<String, Metadata> manifestEntries;
 
-  /** Archive internal redirect: name of file in archive SympolicShortLink: Target name */
+  /** Archive internal redirect: name of the file in archive SympolicShortLink: Target name */
   String targetName;
 
   /** Client metadata such as MIME type; may be {@code null}. */
@@ -956,7 +952,7 @@ public class Metadata implements Serializable {
    *     closed by this method; must not be {@code null}.
    * @param length total number of bytes available for the metadata payload from {@code dis}; used
    *     for bounds checking and manifest parsing decisions.
-   * @throws IOException if an I/O error occurs or the stream cannot supply the required bytes.
+   * @throws IOException if an I/O error occurs, or the stream cannot supply the required bytes.
    * @throws MetadataParseException if the payload is structurally invalid or uses an unsupported
    *     version or document type.
    */
@@ -965,13 +961,13 @@ public class Metadata implements Serializable {
     readMagicVersionAndDocType(dis);
 
     HeaderState header = readFlagsAndHashes(dis);
-    TopInfo top = readTopBlocksInfo(dis, header.hasTopBlocks);
-    this.topSize = top.size;
-    this.topCompressedSize = top.compressedSize;
-    this.topBlocksRequired = top.blocksRequired;
-    this.topBlocksTotal = top.blocksTotal;
-    this.topDontCompress = top.dontCompress;
-    this.topCompatibilityMode = top.compatMode;
+    TopLayerBlockInfo top = readTopBlocksInfo(dis, header.hasTopBlocks);
+    this.topSize = top.size();
+    this.topCompressedSize = top.compressedSize();
+    this.topBlocksRequired = top.blocksRequired();
+    this.topBlocksTotal = top.blocksTotal();
+    this.topDontCompress = top.dontCompress();
+    this.topCompatibilityMode = top.compatMode();
 
     readArchiveTypeIfNeeded(dis);
 
@@ -1019,9 +1015,10 @@ public class Metadata implements Serializable {
    * @return a 32‑byte key bytes array suitable for splitfile encryption.
    */
   public static byte[] getCryptoKey(byte[] hash) {
-    // This is exactly the same algorithm used by e.g. JFK for generating multiple session keys from
+    // This is exactly the same algorithm used by e.g., JFK for generating multiple session keys
+    // from
     // a single generated value.
-    // The only difference is we use a constant of more than one byte's length here, to avoid having
+    // The only difference is we use a constant of more than one byte's length here to avoid having
     // to keep a registry.
     MessageDigest md = SHA256.getMessageDigest();
     md.update(hash);
@@ -1057,9 +1054,10 @@ public class Metadata implements Serializable {
    * @return seed bytes for cross‑segment parity; never {@code null}.
    */
   public static byte[] getCrossSegmentSeed(byte[] hash) {
-    // This is exactly the same algorithm used by e.g. JFK for generating multiple session keys from
+    // This is exactly the same algorithm used by e.g., JFK for generating multiple session keys
+    // from
     // a single generated value.
-    // The only difference is we use a constant of more than one byte's length here, to avoid having
+    // The only difference is we use a constant of more than one byte's length here to avoid having
     // to keep a registry.
     MessageDigest md = SHA256.getMessageDigest();
     md.update(hash);
@@ -1085,7 +1083,7 @@ public class Metadata implements Serializable {
    *
    * @param dir A map of names (string) to either files (same string) or directories (more
    *     HashMap's)
-   * @throws MalformedURLException One of the URI:s were malformed
+   * @throws MalformedURLException One of the URI:s was malformed
    */
   private void addRedirectionManifest(Map<String, Object> dir) throws MalformedURLException {
     // Simple manifest - contains actual redirects.
@@ -1128,7 +1126,7 @@ public class Metadata implements Serializable {
 
   /**
    * Create a Metadata object and add manifest entries from the given map. The map can contain
-   * either string -> Metadata, or string -> map, the latter indicating subdirs.
+   * either string -> Metadata or string -> map, the latter indicating subdirs.
    *
    * @param dir a map from entry names to either {@link Metadata} (files/redirects) or nested maps
    *     (sub‑directories). Names must not contain {@code '/'}.
@@ -1270,10 +1268,10 @@ public class Metadata implements Serializable {
   }
 
   /**
-   * Create a Metadata redircet object that points to resolved metadata inside container. docType =
-   * ARCHIVE_METADATA_REDIRECT
+   * Create a Metadata redirect object that points to resolved metadata inside the container.
+   * docType = ARCHIVE_METADATA_REDIRECT
    *
-   * @param name the filename in the archive to read from, must be ".metadata-N" scheme.
+   * @param name the filename in the archive to read from must be a ".metadata-N" scheme.
    */
   private Metadata(DocumentType docType, String name) {
     hashCode = System.identityHashCode(this);
@@ -1466,7 +1464,7 @@ public class Metadata implements Serializable {
     }
   }
 
-  // Top fields are final; compute values then assign once in constructors.
+  // Top fields are final; compute values, then assign once in constructors.
 
   private void buildSplitfileParamsBytes(SplitfileParams params) {
     int segmentSize = params.segmentSize();
@@ -1577,7 +1575,7 @@ public class Metadata implements Serializable {
   /**
    * Read a key using the current settings.
    *
-   * @throws IOException if the stream cannot supply enough bytes for a full key or an I/O error
+   * @throws IOException if the stream cannot supply enough bytes for a full key, or an I/O error
    *     occurs while reading.
    * @throws MalformedURLException If the key could not be read due to an error in parsing the key.
    *     REDFLAG: May want to recover from these in the future, hence the short length.
@@ -1654,7 +1652,7 @@ public class Metadata implements Serializable {
   }
 
   /**
-   * The default document is the one which has an empty name.
+   * The default document is the one that has an empty name.
    *
    * @return the {@code Metadata} document mapped to the empty name within this manifest, or {@code
    *     null} when no default is set.
@@ -2050,12 +2048,12 @@ public class Metadata implements Serializable {
     int dataIdx = 0;
     int checkIdx = 0;
     for (int s = 0; s < segmentCount; s++) {
-      // Base data blocks for this segment, accounting for "deduct last N segments by 1" rule.
+      // Base data blocks for this segment, accounting for the "deduct last N segments by 1" rule.
       int baseDataPerSeg =
           blocksPerSegment - (s >= (segmentCount - Math.max(0, deductBlocksFromSegments)) ? 1 : 0);
       // In cross-segment mode, each segment also carries crossCheckBlocks additional data-like
       // blocks
-      // that participate in segment-level decode. Include them in the data-per-segment target.
+      // that participate in segment-level decoding. Include them in the data-per-segment target.
       int nominalDps = baseDataPerSeg + Math.max(0, crossCheckBlocks);
       int remainingData = splitfileDataKeys != null ? (splitfileDataKeys.length - dataIdx) : 0;
       int dps = Math.clamp(remainingData, 0, nominalDps);
@@ -2098,6 +2096,7 @@ public class Metadata implements Serializable {
     }
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class ManifestEntryData {
     final byte[] data;
 
@@ -2350,7 +2349,7 @@ public class Metadata implements Serializable {
 
     private Metadata m;
 
-    /** Create a new compose helper (an empty dir) */
+    /** Create a new composition helper (an empty dir) */
     public SimpleManifestComposer() {
       m = new Metadata();
       m.documentType = DocumentType.SIMPLE_MANIFEST;
@@ -2378,7 +2377,7 @@ public class Metadata implements Serializable {
      * @return the composed metadata object
      */
     public Metadata getMetadata() {
-      // after handing off the metadata object it is read only.
+      // after handing off the metadata object, it is read-only.
       Metadata result = m;
       m = null;
       return result;
@@ -2599,7 +2598,7 @@ public class Metadata implements Serializable {
   }
 
   /**
-   * Returns number of cross‑segment parity blocks per segment (0 when not used).
+   * Returns the number of cross‑segment parity blocks per segment (0 when not used).
    *
    * @return count of cross‑segment parity blocks.
    */
@@ -2608,7 +2607,7 @@ public class Metadata implements Serializable {
   }
 
   /**
-   * Returns number of check/parity blocks per segment.
+   * Returns the number of check/parity blocks per segment.
    *
    * @return parity/check blocks per segment.
    */
@@ -2617,7 +2616,7 @@ public class Metadata implements Serializable {
   }
 
   /**
-   * Returns number of data blocks per segment (not including cross‑segment blocks).
+   * Returns the number of data blocks per segment (not including cross‑segment blocks).
    *
    * @return data blocks per segment.
    */
@@ -2684,7 +2683,7 @@ public class Metadata implements Serializable {
   }
 
   /**
-   * Return a best‑guess compatibility mode, guaranteed not to be {@code COMPAT_UNKNOWN} or {@code
+   * Return the best‑guess compatibility mode, guaranteed not to be {@code COMPAT_UNKNOWN} or {@code
    * COMPAT_CURRENT}.
    *
    * @return the most appropriate {@link CompatibilityMode} for this metadata when an exact top mode

--- a/src/main/java/network/crypta/client/MetadataTopLayerInfo.java
+++ b/src/main/java/network/crypta/client/MetadataTopLayerInfo.java
@@ -9,19 +9,20 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Carries top-layer sizing, compatibility, and hash details for {@link Metadata}.
  *
- * <p>This value object groups the fields that describe how the outermost metadata layer should be
- * interpreted: the original and compressed byte lengths, the number of required and total blocks,
- * the top-layer compression preference, and any hashes that apply to the final data or just the
- * current layer. It is typically constructed alongside {@link MetadataRedirectTarget} or {@link
- * SplitfilePayload} and then supplied to {@link Metadata} constructors that need to serialize or
- * validate top-layer information. The instance preserves inputs exactly as provided, allowing the
- * metadata encoder to remain focused on formatting and validation rather than value synthesis.
+ * <p>This value object packages the metadata fields that describe how the outermost layer should be
+ * interpreted during serialization and parsing. It is typically constructed in tandem with {@link
+ * MetadataRedirectTarget} or {@link SplitfilePayload} and then supplied to {@link Metadata}
+ * constructors so that encoding logic can treat these values as already established. It does not
+ * compute, validate, or normalize values; it simply preserves the inputs and exposes them for
+ * downstream use. This makes the type suitable for call sites that already know the sizes, block
+ * counts, compression intent, and hash inputs for the top layer.
  *
- * <p>Instances are immutable, but array components are not copied. Callers should treat the
- * referenced arrays as stable for the duration of metadata construction and avoid mutating them
- * after passing this instance to any encoder. All numeric values represent byte counts or block
- * counts and are expected to be non-negative; consistency between sizes and block totals is the
- * caller's responsibility.
+ * <p>Instances are immutable, but array components are not copied. Callers should treat the arrays
+ * as stable for the lifetime of metadata construction and avoid mutating them after passing this
+ * instance to any encoder or serializer. All numeric values represent byte counts or block counts
+ * and are expected to be non-negative; consistency between sizes and block totals remains the
+ * caller's responsibility. The type is safe to share across threads as long as referenced arrays
+ * are not mutated.
  *
  * <ul>
  *   <li>Captures original and compressed lengths in bytes for the top layer.
@@ -33,7 +34,6 @@ import org.jetbrains.annotations.NotNull;
  * @see MetadataRedirectTarget
  * @see SplitfilePayload
  */
-@SuppressWarnings("java:S6206")
 public final class MetadataTopLayerInfo {
   private final long origDataLength;
   private final long origCompressedDataLength;
@@ -45,64 +45,143 @@ public final class MetadataTopLayerInfo {
   private final byte[] hashThisLayerOnly;
 
   /**
-   * Creates a top-layer metadata info bundle.
+   * Creates a top-layer metadata info bundle from the supplied groups.
    *
-   * @param origDataLength original uncompressed byte length for the top layer; zero when unknown.
-   * @param origCompressedDataLength original compressed byte length; zero when unknown or unused.
-   * @param requiredBlocks minimum blocks required to reconstruct the final data; non-negative.
-   * @param totalBlocks total blocks inserted for the final data; non-negative and >= required.
-   * @param topDontCompress whether top-layer compression was intentionally disabled by the caller.
-   * @param topCompatibilityMode declared compatibility mode for the insert; never {@code null}.
-   * @param hashes hashes of the final/original data; may be {@code null} or empty.
-   * @param hashThisLayerOnly hash of only this metadata layer; may be {@code null}.
+   * <p>This constructor copies the scalar values out of {@code blockInfo} and assigns the hash
+   * arrays from {@code hashInfo} directly, without cloning. It performs no range checks or
+   * cross-field validation, so callers must ensure that byte counts, block counts, and
+   * compatibility mode are coherent for the metadata they are about to serialize. Construction is
+   * idempotent and side-effect free, making it suitable for repeated use at call sites that
+   * precompute sizes and hashes. The referenced arrays should be treated as immutable for the
+   * lifetime of the resulting instance.
+   *
+   * @param blockInfo sizing and block-count details for the top layer; must not be {@code null} and
+   *     should contain non-negative sizes and block counts.
+   * @param hashInfo hash details for the final data and/or this layer; must not be {@code null} and
+   *     may contain {@code null} arrays when hashes are unavailable.
    */
-  public MetadataTopLayerInfo(
-      long origDataLength,
-      long origCompressedDataLength,
-      int requiredBlocks,
-      int totalBlocks,
-      boolean topDontCompress,
-      CompatibilityMode topCompatibilityMode,
-      HashResult[] hashes,
-      byte[] hashThisLayerOnly) {
-    this.origDataLength = origDataLength;
-    this.origCompressedDataLength = origCompressedDataLength;
-    this.requiredBlocks = requiredBlocks;
-    this.totalBlocks = totalBlocks;
-    this.topDontCompress = topDontCompress;
-    this.topCompatibilityMode = topCompatibilityMode;
-    this.hashes = hashes;
-    this.hashThisLayerOnly = hashThisLayerOnly;
+  public MetadataTopLayerInfo(TopLayerBlockInfo blockInfo, TopLayerHashInfo hashInfo) {
+    this.origDataLength = blockInfo.size();
+    this.origCompressedDataLength = blockInfo.compressedSize();
+    this.requiredBlocks = blockInfo.blocksRequired();
+    this.totalBlocks = blockInfo.blocksTotal();
+    this.topDontCompress = blockInfo.dontCompress();
+    this.topCompatibilityMode = blockInfo.compatMode();
+    this.hashes = hashInfo.hashes();
+    this.hashThisLayerOnly = hashInfo.hashThisLayerOnly();
   }
 
+  /**
+   * Returns the original uncompressed size of the top layer, in bytes.
+   *
+   * <p>The value is returned exactly as provided at construction time and is not validated or
+   * normalized. Callers commonly use {@code 0} to indicate that the size is unknown or not provided
+   * for this metadata instance. The value is a byte count and is expected to be non-negative. This
+   * getter is a simple accessor and has no side effects.
+   *
+   * @return the uncompressed top-layer byte length, or {@code 0} when unspecified by the caller.
+   */
   public long origDataLength() {
     return origDataLength;
   }
 
+  /**
+   * Returns the original compressed size of the top layer, in bytes.
+   *
+   * <p>The value is returned exactly as provided at construction time and may be {@code 0} when the
+   * compressed size is unknown, not applicable, or intentionally omitted. The value represents a
+   * byte count and is expected to be non-negative. This getter does not compute compression or
+   * perform any validation; it simply exposes the stored value for serialization.
+   *
+   * @return the compressed top-layer byte length, or {@code 0} when unspecified by the caller.
+   */
   public long origCompressedDataLength() {
     return origCompressedDataLength;
   }
 
+  /**
+   * Returns the minimum number of blocks required to reconstruct the top-layer data.
+   *
+   * <p>This value is returned exactly as provided at construction time and is not validated against
+   * {@link #totalBlocks()}. It is expected to be a non-negative block count, with {@code 0}
+   * commonly used to indicate that no block data is provided. The value is used by metadata
+   * serializers and progress reporting to reflect recovery requirements, but it carries no
+   * enforcement here.
+   *
+   * @return the required top-layer block count, or {@code 0} when not supplied by the caller.
+   */
   public int requiredBlocks() {
     return requiredBlocks;
   }
 
+  /**
+   * Returns the total number of blocks inserted for the top-layer data.
+   *
+   * <p>The value is returned as stored and is expected to be a non-negative block count, typically
+   * greater than or equal to {@link #requiredBlocks()}. A value of {@code 0} is commonly used when
+   * block counts are unknown or absent. This accessor does not validate any relationships or apply
+   * defaults; it simply exposes the stored total for serialization and diagnostics.
+   *
+   * @return the total top-layer block count, or {@code 0} when not supplied by the caller.
+   */
   public int totalBlocks() {
     return totalBlocks;
   }
 
+  /**
+   * Returns whether compression was intentionally disabled for the top layer.
+   *
+   * <p>This flag is stored exactly as provided and does not imply whether the data is actually
+   * compressed; it only communicates the caller's intent for top-layer compression handling. When
+   * {@code true}, metadata serializers typically record that compression was skipped. When {@code
+   * false}, this type makes no additional assumptions. The value is immutable and has no side
+   * effects on access.
+   *
+   * @return {@code true} if top-layer compression was disabled, otherwise {@code false}.
+   */
   public boolean topDontCompress() {
     return topDontCompress;
   }
 
+  /**
+   * Returns the declared compatibility mode for the top layer.
+   *
+   * <p>The value is returned exactly as provided at construction time and is not adjusted or
+   * normalized. {@link CompatibilityMode#COMPAT_UNKNOWN} is often used when the compatibility mode
+   * is unknown or not specified. Callers are responsible for selecting a mode that matches the
+   * metadata they intend to serialize. This accessor is a simple, side-effect-free getter.
+   *
+   * @return the top-layer compatibility mode supplied by the caller, possibly {@code
+   *     COMPAT_UNKNOWN}.
+   */
   public CompatibilityMode topCompatibilityMode() {
     return topCompatibilityMode;
   }
 
+  /**
+   * Returns the hashes of the final/original data, if provided.
+   *
+   * <p>The returned array reference is the same one supplied at construction time; it is not copied
+   * or validated. The array may be {@code null} or empty when no hashes are available. Because the
+   * array is shared, callers must treat it as immutable after construction to keep {@link #equals}
+   * and {@link #hashCode} stable. This accessor does not allocate or transform the array contents.
+   *
+   * @return the final-data hash array, or {@code null} when no hashes were supplied.
+   */
   public HashResult[] hashes() {
     return hashes;
   }
 
+  /**
+   * Returns the optional hash of only this metadata layer, if provided.
+   *
+   * <p>The returned array reference is the same one supplied at construction time and is not copied
+   * or validated. The array may be {@code null} when a layer-local hash is unavailable or not
+   * needed. Because the array is shared, callers should not mutate it after construction to avoid
+   * destabilizing {@link #equals}, {@link #hashCode}, or diagnostic output.
+   *
+   * @return the layer-local hash bytes, or {@code null} when not supplied by the caller.
+   */
   public byte[] hashThisLayerOnly() {
     return hashThisLayerOnly;
   }
@@ -114,13 +193,15 @@ public final class MetadataTopLayerInfo {
    * CompatibilityMode#COMPAT_UNKNOWN} for compatibility, and {@code null} for both hash arrays. It
    * is intended for call sites that do not have top-layer information or that want to indicate that
    * no top-layer fields should be serialized. The returned instance is immutable and safe to share
-   * across threads as long as callers treat it as a constant.
+   * across threads as long as callers treat it as a constant. Callers must still avoid mutating the
+   * returned arrays (which are {@code null} here) if they replace them later.
    *
    * @return a canonical "empty" top-layer info instance with no sizes or hashes.
    */
   public static MetadataTopLayerInfo none() {
     return new MetadataTopLayerInfo(
-        0, 0, 0, 0, false, CompatibilityMode.COMPAT_UNKNOWN, null, null);
+        new TopLayerBlockInfo(0, 0, 0, 0, false, CompatibilityMode.COMPAT_UNKNOWN),
+        new TopLayerHashInfo(null, null));
   }
 
   /**
@@ -131,7 +212,7 @@ public final class MetadataTopLayerInfo {
    * {@code null} arrays. This method performs a shallow comparison of array elements and does not
    * clone or normalize inputs. It is appropriate when the arrays supplied to the instance are
    * stable for the duration of comparison and should not be used if callers mutate arrays after
-   * construction.
+   * construction, because that would make equality time-dependent.
    *
    * @param o object to compare against; may be {@code null} or of another type.
    * @return {@code true} when all components, including array contents, are equal.
@@ -158,7 +239,8 @@ public final class MetadataTopLayerInfo {
    * <p>The hash combines scalar components with {@link Arrays#hashCode(Object[])} for array fields,
    * producing a shallow hash that depends on the current contents of the arrays. This makes the
    * hash code suitable for use as a map key only when callers do not mutate the arrays after
-   * construction. The method performs no copying and assumes the instance's fields are stable.
+   * construction. The method performs no copying and assumes the instance's fields are stable. If
+   * array contents are mutated later, the hash code will change and map lookups may fail.
    *
    * @return a hash code derived from all components, including array contents.
    */
@@ -183,7 +265,8 @@ public final class MetadataTopLayerInfo {
    * <p>The string lists each component in order and uses {@link Arrays#toString(Object[])} for the
    * array fields. It is intended for diagnostics and logging, not for stable serialization or
    * parsing. The output will reflect the current contents of any arrays at the time of the call, so
-   * callers should avoid mutating arrays if a stable representation is required.
+   * callers should avoid mutating arrays if a stable representation is required. The returned value
+   * is non-null and computed without allocating defensive copies.
    *
    * @return a non-null diagnostic string containing all component values and array contents.
    */

--- a/src/main/java/network/crypta/client/SplitfileBlockKeys.java
+++ b/src/main/java/network/crypta/client/SplitfileBlockKeys.java
@@ -1,0 +1,49 @@
+package network.crypta.client;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.keys.ClientCHK;
+
+/** Data and check block keys used by a splitfile. */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+public final class SplitfileBlockKeys {
+  private final ClientCHK[] dataURIs;
+  private final ClientCHK[] checkURIs;
+
+  public SplitfileBlockKeys(ClientCHK[] dataURIs, ClientCHK[] checkURIs) {
+    this.dataURIs = dataURIs;
+    this.checkURIs = checkURIs;
+  }
+
+  public ClientCHK[] dataURIs() {
+    return dataURIs;
+  }
+
+  public ClientCHK[] checkURIs() {
+    return checkURIs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof SplitfileBlockKeys other)) {
+      return false;
+    }
+    return Arrays.equals(dataURIs, other.dataURIs) && Arrays.equals(checkURIs, other.checkURIs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(Arrays.hashCode(dataURIs), Arrays.hashCode(checkURIs));
+  }
+
+  @Override
+  public String toString() {
+    return "SplitfileBlockKeys["
+        + "dataURIs="
+        + Arrays.toString(dataURIs)
+        + ", checkURIs="
+        + Arrays.toString(checkURIs)
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/client/SplitfileCryptoParams.java
+++ b/src/main/java/network/crypta/client/SplitfileCryptoParams.java
@@ -1,0 +1,61 @@
+package network.crypta.client;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/** Splitfile crypto parameters and key specification flags. */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+public final class SplitfileCryptoParams {
+  private final byte splitfileCryptoAlgorithm;
+  private final byte[] splitfileCryptoKey;
+  private final boolean specifySplitfileKey;
+
+  public SplitfileCryptoParams(
+      byte splitfileCryptoAlgorithm, byte[] splitfileCryptoKey, boolean specifySplitfileKey) {
+    this.splitfileCryptoAlgorithm = splitfileCryptoAlgorithm;
+    this.splitfileCryptoKey = splitfileCryptoKey;
+    this.specifySplitfileKey = specifySplitfileKey;
+  }
+
+  public byte splitfileCryptoAlgorithm() {
+    return splitfileCryptoAlgorithm;
+  }
+
+  public byte[] splitfileCryptoKey() {
+    return splitfileCryptoKey;
+  }
+
+  public boolean specifySplitfileKey() {
+    return specifySplitfileKey;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof SplitfileCryptoParams other)) {
+      return false;
+    }
+    return splitfileCryptoAlgorithm == other.splitfileCryptoAlgorithm
+        && specifySplitfileKey == other.specifySplitfileKey
+        && Arrays.equals(splitfileCryptoKey, other.splitfileCryptoKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        splitfileCryptoAlgorithm, Arrays.hashCode(splitfileCryptoKey), specifySplitfileKey);
+  }
+
+  @Override
+  public String toString() {
+    String keyString = (splitfileCryptoKey == null) ? "null" : Arrays.toString(splitfileCryptoKey);
+    return "SplitfileCryptoParams["
+        + "splitfileCryptoAlgorithm="
+        + splitfileCryptoAlgorithm
+        + ", splitfileCryptoKey="
+        + keyString
+        + ", specifySplitfileKey="
+        + specifySplitfileKey
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/client/SplitfileParams.java
+++ b/src/main/java/network/crypta/client/SplitfileParams.java
@@ -32,7 +32,6 @@ import org.jetbrains.annotations.NotNull;
  * @see SplitfilePayload
  * @see MetadataTopLayerInfo
  */
-@SuppressWarnings("java:S6206")
 public final class SplitfileParams {
   private final SplitfileAlgorithm splitfileAlgorithm;
   private final ClientCHK[] dataURIs;
@@ -50,41 +49,25 @@ public final class SplitfileParams {
    *
    * @param splitfileAlgorithm splitfile algorithm identifier; must match the intended encoding
    *     path.
-   * @param dataURIs data block keys in block order; may be empty but not {@code null}.
-   * @param checkURIs check block keys in block order; may be empty but not {@code null}.
-   * @param segmentSize data blocks per typical segment, excluding cross-segment blocks;
-   *     non-negative.
-   * @param checkSegmentSize check blocks per typical segment, excluding cross-segment blocks.
-   * @param deductBlocksFromSegments count of trailing segments with one fewer data block;
-   *     non-negative.
-   * @param crossSegmentBlocks cross-segment parity blocks per segment; zero when not used.
-   * @param splitfileCryptoAlgorithm algorithm code applied to splitfile block encryption or
-   *     routing.
-   * @param splitfileCryptoKey splitfile-wide crypto key bytes; may be {@code null} for legacy
-   *     modes.
-   * @param specifySplitfileKey whether the crypto key is explicitly specified rather than derived.
+   * @param blockKeys data and check block keys in block order; may be empty but not {@code null}.
+   * @param layout splitfile layout sizing and redundancy counts.
+   * @param crypto crypto parameters applied to splitfile block encryption or routing.
    */
   public SplitfileParams(
       SplitfileAlgorithm splitfileAlgorithm,
-      ClientCHK[] dataURIs,
-      ClientCHK[] checkURIs,
-      int segmentSize,
-      int checkSegmentSize,
-      int deductBlocksFromSegments,
-      int crossSegmentBlocks,
-      byte splitfileCryptoAlgorithm,
-      byte[] splitfileCryptoKey,
-      boolean specifySplitfileKey) {
+      SplitfileBlockKeys blockKeys,
+      SplitfileSegmentLayout layout,
+      SplitfileCryptoParams crypto) {
     this.splitfileAlgorithm = splitfileAlgorithm;
-    this.dataURIs = dataURIs;
-    this.checkURIs = checkURIs;
-    this.segmentSize = segmentSize;
-    this.checkSegmentSize = checkSegmentSize;
-    this.deductBlocksFromSegments = deductBlocksFromSegments;
-    this.crossSegmentBlocks = crossSegmentBlocks;
-    this.splitfileCryptoAlgorithm = splitfileCryptoAlgorithm;
-    this.splitfileCryptoKey = splitfileCryptoKey;
-    this.specifySplitfileKey = specifySplitfileKey;
+    this.dataURIs = blockKeys.dataURIs();
+    this.checkURIs = blockKeys.checkURIs();
+    this.segmentSize = layout.segmentSize();
+    this.checkSegmentSize = layout.checkSegmentSize();
+    this.deductBlocksFromSegments = layout.deductBlocksFromSegments();
+    this.crossSegmentBlocks = layout.crossSegmentBlocks();
+    this.splitfileCryptoAlgorithm = crypto.splitfileCryptoAlgorithm();
+    this.splitfileCryptoKey = crypto.splitfileCryptoKey();
+    this.specifySplitfileKey = crypto.specifySplitfileKey();
   }
 
   public SplitfileAlgorithm splitfileAlgorithm() {

--- a/src/main/java/network/crypta/client/SplitfileSegmentLayout.java
+++ b/src/main/java/network/crypta/client/SplitfileSegmentLayout.java
@@ -1,0 +1,5 @@
+package network.crypta.client;
+
+/** Layout sizing and redundancy counts for a splitfile. */
+public record SplitfileSegmentLayout(
+    int segmentSize, int checkSegmentSize, int deductBlocksFromSegments, int crossSegmentBlocks) {}

--- a/src/main/java/network/crypta/client/TopLayerBlockInfo.java
+++ b/src/main/java/network/crypta/client/TopLayerBlockInfo.java
@@ -1,0 +1,47 @@
+package network.crypta.client;
+
+import network.crypta.client.InsertContext.CompatibilityMode;
+
+/**
+ * Groups sizing, block-count, compression, and compatibility details for a metadata top layer.
+ *
+ * <p>This record is a compact carrier for the values that describe how the outermost metadata layer
+ * is sized and how it should be interpreted during serialization. It is typically constructed by
+ * callers that already know the top-layer byte sizes, the required and total block counts, and the
+ * intended compatibility mode. The record does not validate or normalize values; it preserves them
+ * as provided so that upstream code can decide on coherent ranges and relationships. It is often
+ * paired with {@link TopLayerHashInfo} when building {@link MetadataTopLayerInfo} instances.
+ *
+ * <p>All numeric fields represent byte counts or block counts and are expected to be non-negative.
+ * The record is immutable and safe to share across threads. The only trade-off is that no defensive
+ * checks are performed, which keeps construction lightweight but places responsibility for
+ * correctness on the caller.
+ *
+ * <ul>
+ *   <li>Captures byte lengths for original and compressed top-layer data.
+ *   <li>Stores required and total block counts used by serializers and progress reporting.
+ *   <li>Records compression intent and compatibility mode without inference.
+ * </ul>
+ *
+ * @param size original uncompressed size in bytes for the top layer; non-negative, {@code 0} when
+ *     unknown.
+ * @param compressedSize original compressed size in bytes; non-negative, {@code 0} when unknown or
+ *     not applicable.
+ * @param blocksRequired minimum number of blocks required to reconstruct the data; non-negative,
+ *     {@code 0} when not supplied.
+ * @param blocksTotal total number of blocks inserted for the data; non-negative and typically
+ *     greater than or equal to {@code blocksRequired}.
+ * @param dontCompress whether compression was intentionally disabled for the top layer; {@code
+ *     true} records intent, not actual compression state.
+ * @param compatMode declared compatibility mode for the top layer; never {@code null}, often {@link
+ *     CompatibilityMode#COMPAT_UNKNOWN} when unspecified.
+ * @see MetadataTopLayerInfo
+ * @see TopLayerHashInfo
+ */
+public record TopLayerBlockInfo(
+    long size,
+    long compressedSize,
+    int blocksRequired,
+    int blocksTotal,
+    boolean dontCompress,
+    CompatibilityMode compatMode) {}

--- a/src/main/java/network/crypta/client/TopLayerHashInfo.java
+++ b/src/main/java/network/crypta/client/TopLayerHashInfo.java
@@ -1,0 +1,108 @@
+package network.crypta.client;
+
+import java.util.Arrays;
+import network.crypta.crypt.HashResult;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Groups hash data for the final content and optional layer-local hash.
+ *
+ * <p>This value object captures hash material used when serializing or interpreting the top layer
+ * of metadata. It is typically assembled by callers that already computed hashes and want to pass
+ * them through as-is alongside size and block-count information. The class does not validate hash
+ * contents, compute digests, or enforce particular hash algorithms; it only preserves the arrays
+ * supplied at construction time. This keeps construction lightweight and makes the type a simple
+ * carrier for downstream serialization or diagnostics.
+ *
+ * <p>Instances are immutable, but the underlying arrays are not copied. Callers should treat the
+ * arrays as stable for the lifetime of metadata construction and avoid mutating them after passing
+ * this instance to {@link MetadataTopLayerInfo}. The class is thread-safe if the referenced arrays
+ * are treated as immutable.
+ *
+ * <ul>
+ *   <li>Stores hashes for final/original data when provided.
+ *   <li>Optionally stores a layer-local hash for the current metadata layer.
+ *   <li>Does not infer or validate hash algorithms or array lengths.
+ * </ul>
+ *
+ * @see MetadataTopLayerInfo
+ * @see TopLayerBlockInfo
+ */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+public final class TopLayerHashInfo {
+  private final HashResult[] hashes;
+  private final byte[] hashThisLayerOnly;
+
+  /**
+   * Creates a hash bundle for top-layer metadata.
+   *
+   * <p>This constructor stores the provided arrays directly without cloning or validation. It is
+   * intended for callers that already computed hash values and want to provide them to metadata
+   * serialization. Either array may be {@code null} to indicate absence of that hash material. The
+   * constructor has no side effects and can be used repeatedly with the same inputs. Callers must
+   * avoid mutating the arrays after construction if stable equality and hashing are required.
+   *
+   * @param hashes hashes of the final or original data; may be {@code null} or empty when hashes
+   *     are not available.
+   * @param hashThisLayerOnly hash of only this metadata layer; may be {@code null} when not
+   *     provided or not required.
+   */
+  public TopLayerHashInfo(HashResult[] hashes, byte[] hashThisLayerOnly) {
+    this.hashes = hashes;
+    this.hashThisLayerOnly = hashThisLayerOnly;
+  }
+
+  /**
+   * Returns the hashes of the final or original data, if provided.
+   *
+   * <p>The returned array is the same reference supplied at construction time and is not copied or
+   * normalized. It may be {@code null} or empty, depending on whether hashes were available at the
+   * call site. Because the array is shared, callers should treat it as immutable to keep {@link
+   * #equals(Object)} and {@link #hashCode()} stable over time.
+   *
+   * @return the final-data hash array, or {@code null} when no hashes were supplied.
+   */
+  public HashResult[] hashes() {
+    return hashes;
+  }
+
+  /**
+   * Returns the optional hash for only this metadata layer, if provided.
+   *
+   * <p>The returned array is the same reference supplied at construction time and is not copied or
+   * validated. It may be {@code null} when a layer-local hash is not available. Callers should not
+   * mutate the array after construction if they depend on stable equality, hashing, or diagnostic
+   * output. This accessor performs no allocation and has no side effects.
+   *
+   * @return the layer-local hash bytes, or {@code null} when not supplied.
+   */
+  public byte[] hashThisLayerOnly() {
+    return hashThisLayerOnly;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TopLayerHashInfo other)) {
+      return false;
+    }
+    return Arrays.equals(hashes, other.hashes)
+        && Arrays.equals(hashThisLayerOnly, other.hashThisLayerOnly);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(hashes);
+    result = 31 * result + Arrays.hashCode(hashThisLayerOnly);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "TopLayerHashInfo[hashes="
+        + Arrays.toString(hashes)
+        + ", hashThisLayerOnly="
+        + Arrays.toString(hashThisLayerOnly)
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/client/async/ClientPutter.java
+++ b/src/main/java/network/crypta/client/async/ClientPutter.java
@@ -165,13 +165,15 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
    *     standard behavior.
    */
   public ClientPutter(ClientPutterRequest request, ClientPutterOptions options) {
-    super(request.priorityClass(), request.callback().getRequestClient());
+    super(
+        request.requestParams().priorityClass(),
+        request.requestParams().callback().getRequestClient());
     this.cm = request.clientMetadata();
     this.isMetadata = request.isMetadata();
-    this.callback = request.callback();
+    this.callback = request.requestParams().callback();
     this.data = request.data();
-    this.targetURI = request.targetURI();
-    this.ctx = request.insertContext();
+    this.targetURI = request.requestParams().targetURI();
+    this.ctx = request.requestParams().insertContext();
     this.finished = false;
     this.cancelled = false;
     this.targetFilename = options.targetFilename();

--- a/src/main/java/network/crypta/client/async/ClientPutterRequest.java
+++ b/src/main/java/network/crypta/client/async/ClientPutterRequest.java
@@ -1,14 +1,12 @@
 package network.crypta.client.async;
 
 import network.crypta.client.ClientMetadata;
-import network.crypta.client.InsertContext;
-import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.RandomAccessBucket;
 
 /**
  * Immutable bundle of inputs for a single-file {@link ClientPutter} request.
  *
- * <p>This record captures the callback, payload source, destination URI, metadata, and scheduling
+ * <p>This record captures the request context, payload source, destination metadata, and scheduling
  * configuration needed to construct a putter. Callers typically create one instance per insert,
  * populate it with the desired references, and hand it to the relevant {@link ClientPutter} entry
  * point. The record performs no validation and stores references verbatim, which preserves legacy
@@ -25,21 +23,15 @@ import network.crypta.support.api.RandomAccessBucket;
  *   <li>Provides a stable, reusable container for scheduling parameters.
  * </ul>
  *
- * @param callback callback receiving progress and completion events; may be {@code null}.
+ * @param requestParams shared request context including callback, target URI, and priority.
  * @param data payload bucket to insert; must remain readable for insert lifetime.
- * @param targetURI destination URI for the insert; should be insert-capable.
  * @param clientMetadata optional client-visible metadata such as MIME type; may be {@code null}.
- * @param insertContext insert configuration controlling splitfile strategy and scheduling.
- * @param priorityClass scheduling priority class; smaller values represent higher priority.
  * @param isMetadata whether the payload represents metadata rather than user content.
  * @see ClientPutter
  * @see ClientPutterOptions
  */
 public record ClientPutterRequest(
-    ClientPutCallback callback,
+    InsertRequestParams requestParams,
     RandomAccessBucket data,
-    FreenetURI targetURI,
     ClientMetadata clientMetadata,
-    InsertContext insertContext,
-    short priorityClass,
     boolean isMetadata) {}

--- a/src/main/java/network/crypta/client/async/InsertRequestParams.java
+++ b/src/main/java/network/crypta/client/async/InsertRequestParams.java
@@ -1,0 +1,22 @@
+package network.crypta.client.async;
+
+import network.crypta.client.InsertContext;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Shared request metadata for client-side insert operations.
+ *
+ * <p>This record groups the callback, target URI, insert context, and scheduling priority required
+ * by multiple inserters. It intentionally performs no validation or defensive copying to preserve
+ * legacy behavior and caller control over input preparation.
+ *
+ * @param callback callback receiving progress and completion events; may be {@code null}.
+ * @param targetURI destination URI for the insert; should be insert-capable.
+ * @param insertContext insert configuration controlling splitfile strategy and scheduling.
+ * @param priorityClass scheduling priority class; smaller values represent higher priority.
+ */
+public record InsertRequestParams(
+    ClientPutCallback callback,
+    FreenetURI targetURI,
+    InsertContext insertContext,
+    short priorityClass) {}

--- a/src/main/java/network/crypta/client/async/ManifestPutterParams.java
+++ b/src/main/java/network/crypta/client/async/ManifestPutterParams.java
@@ -8,105 +8,186 @@ import network.crypta.keys.FreenetURI;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Bundles the shared construction arguments for manifest putters.
+ * Bundles shared construction arguments for manifest putters.
  *
- * <p>This record collects the common inputs required to construct manifest putters such as {@link
- * DefaultManifestPutter} and {@link PlainManifestPutter}. Typical call sites assemble the manifest
- * tree, select a priority class and target {@link FreenetURI}, then pass this bundle to a putter
- * constructor alongside any mode-specific flags (for example, persistence). It is intentionally
- * lightweight: it performs no validation, transformation, or defensive copying, so callers and the
- * receiving putter determine how and when values are checked or copied.
+ * <p>This class is a small, immutable container that groups the inputs repeatedly required when
+ * constructing manifest putters such as {@link DefaultManifestPutter} and {@link
+ * PlainManifestPutter}. Callers typically build a manifest tree, choose a scheduler priority, and
+ * select a target {@link FreenetURI}; those values are captured alongside a {@link InsertContext},
+ * an optional crypto key override, and the runtime {@link ClientContext}. The bundle is
+ * intentionally lightweight and does not validate, normalize, or copy any of its inputs, so callers
+ * and downstream putters remain responsible for enforcing invariants and making defensive copies
+ * when needed.
  *
- * <p>Because the record carries references, its thread-safety depends on the referenced objects.
- * The record instance itself is immutable, but mutable inputs such as the manifest map or the
- * crypto key byte array can be modified by external code. If shared across threads, callers should
- * provide appropriately safe, stable inputs. Equality and hashing compare array contents for the
- * crypto key to avoid reference-only comparisons.
+ * <p>Thread-safety is entirely determined by the referenced objects. The instance itself is
+ * immutable, but values like the manifest map or the crypto key array can be mutated externally; if
+ * the same instance is shared across threads, supply stable, thread-safe references. Equality and
+ * hashing are structural and compare the crypto key by content to avoid reference-only comparisons.
  *
  * <ul>
- *   <li>Groups parameters that are repeated across manifest putter constructors.
- *   <li>Preserves existing semantics by avoiding validation or copying.
- *   <li>Supports content-based equality for the optional crypto key.
+ *   <li>Collects shared inputs for manifest putter construction and reuse.
+ *   <li>Preserves legacy behavior by storing references without validation or copying.
+ *   <li>Defines equality and hashing that include byte-array contents.
  * </ul>
  */
-@SuppressWarnings("java:S6206")
 public final class ManifestPutterParams {
-  private final ClientPutCallback clientCallback;
+  private final InsertRequestParams requestParams;
   private final Map<String, Object> manifestElements;
-  private final short prioClass;
-  private final FreenetURI target;
   private final String defaultName;
-  private final InsertContext ctx;
   private final byte[] forceCryptoKey;
   private final ClientContext context;
 
   /**
    * Creates a parameter bundle for manifest putter construction.
    *
-   * @param clientCallback callback receiver for progress and completion events; must remain valid
-   *     for the putter lifetime and may be {@code null} if callers allow it.
-   * @param manifestElements manifest tree of entry names to elements or sub-maps; contents are
-   *     interpreted by the target putter without additional normalization here.
-   * @param prioClass scheduler priority class for the request; valid values depend on scheduler
-   *     configuration and must match the caller’s intent.
-   * @param target target URI for the root manifest; typically an SSK or CHK-like {@link
-   *     FreenetURI}.
-   * @param defaultName default document name for directory levels; may be {@code null} when no
-   *     default document should be inferred.
-   * @param ctx insert context providing retry, chunking, and compatibility settings; must align
-   *     with the caller’s overall insertion policy.
-   * @param forceCryptoKey optional explicit splitfile key material; {@code null} means the putter
-   *     may derive or randomize keys as needed.
+   * <p>This constructor simply stores the provided references and does not validate them. Callers
+   * should ensure that required references are non-null and remain valid for the lifetime of the
+   * putter. Any mutable inputs (for example, the manifest map or crypto key bytes) should not be
+   * modified in ways that could affect downstream behavior. The bundle is designed for reuse across
+   * constructors. The core configuration is assembled once and passed unchanged.
+   *
+   * <pre>{@code
+   * var params = new ManifestPutterParams(
+   *     new InsertRequestParams(cb, target, ctx, prio),
+   *     manifest,
+   *     defaultName,
+   *     forceKey,
+   *     context);
+   * }</pre>
+   *
+   * @param requestParams shared insert request parameters including callback, target URI, and
+   *     scheduling priority; may be {@code null} only if callers tolerate downstream failures.
+   * @param manifestElements manifest tree of entry names to elements or sub-maps; stored by
+   *     reference and interpreted by the target putter without normalization.
+   * @param defaultName default document name for directory levels; may be {@code null} to disable
+   *     default document inference by the putter.
+   * @param forceCryptoKey optional explicit splitfile key material; may be {@code null} to allow
+   *     derivation or randomization by downstream putters.
    * @param context client context providing randomness and scheduling services; expected to be
    *     non-{@code null} during putter execution.
    */
   public ManifestPutterParams(
-      ClientPutCallback clientCallback,
+      InsertRequestParams requestParams,
       Map<String, Object> manifestElements,
-      short prioClass,
-      FreenetURI target,
       String defaultName,
-      InsertContext ctx,
       byte[] forceCryptoKey,
       ClientContext context) {
-    this.clientCallback = clientCallback;
+    this.requestParams = requestParams;
     this.manifestElements = manifestElements;
-    this.prioClass = prioClass;
-    this.target = target;
     this.defaultName = defaultName;
-    this.ctx = ctx;
     this.forceCryptoKey = forceCryptoKey;
     this.context = context;
   }
 
+  /**
+   * Returns the callback used for progress and completion notifications.
+   *
+   * <p>The callback reference is sourced from {@link InsertRequestParams} and is returned as-is
+   * without any validation or wrapping. Callers should treat the returned reference as a mutable
+   * external state and avoid assuming thread-safety beyond what the callback implementation
+   * guarantees. The value may be {@code null} if a caller supplied a null callback and the
+   * downstream putter tolerates that configuration.
+   *
+   * @return the callback reference for insert lifecycle events, possibly {@code null}.
+   */
   public ClientPutCallback clientCallback() {
-    return clientCallback;
+    return requestParams.callback();
   }
 
+  /**
+   * Returns the manifest tree that maps entry names to elements or nested maps.
+   *
+   * <p>The returned map is the exact reference passed at construction time. No defensive copy is
+   * created and no normalization is applied here, so callers should avoid mutating the map after
+   * construction unless they explicitly intend to affect the downstream putter. If the map is
+   * shared across threads, it must be safe for concurrent access or external synchronization should
+   * be applied.
+   *
+   * @return the manifest element map reference; may be {@code null} if constructed that way.
+   */
   public Map<String, Object> manifestElements() {
     return manifestElements;
   }
 
+  /**
+   * Returns the scheduler priority class for the insert request.
+   *
+   * <p>The priority value is forwarded directly from {@link InsertRequestParams}. This class does
+   * not validate the value or enforce any ranges; it is interpreted by the scheduler in the
+   * surrounding client context. Callers should supply a priority consistent with local policy and
+   * should not expect this class to clamp or normalize the value.
+   *
+   * @return the priority class for scheduling, as originally provided by the caller.
+   */
   public short prioClass() {
-    return prioClass;
+    return requestParams.priorityClass();
   }
 
+  /**
+   * Returns the target URI for the root manifest insert.
+   *
+   * <p>The URI is returned by reference and should be suitable for insertion (for example, a CHK or
+   * SSK-like key). No validation is performed here, so any parsing or key-type checks are the
+   * responsibility of the caller or the downstream putter. If the URI instance is mutable or
+   * shared, callers must ensure it remains stable during use.
+   *
+   * @return the target {@link FreenetURI} used for the manifest insert, possibly {@code null}.
+   */
   public FreenetURI target() {
-    return target;
+    return requestParams.targetURI();
   }
 
+  /**
+   * Returns the default document name used for directory entries.
+   *
+   * <p>This value indicates which file name should be treated as the default document within each
+   * directory level when a manifest is constructed. The value is stored without normalization and
+   * may be {@code null} to indicate that no default document inference should occur. Consumers
+   * should apply any required checks before relying on this value.
+   *
+   * @return the default document name, or {@code null} if no default is configured.
+   */
   public String defaultName() {
     return defaultName;
   }
 
+  /**
+   * Returns the insert context that controls retry, compression, and compatibility policies.
+   *
+   * <p>The context reference is passed through from {@link InsertRequestParams} and is not copied.
+   * It should remain valid and consistent for the lifetime of the insert operation that consumes
+   * this bundle. If the context is mutable, callers must avoid changing settings in ways that could
+   * invalidate the assumptions of a running putter.
+   *
+   * @return the insert context reference used by the manifest putter, possibly {@code null}.
+   */
   public InsertContext ctx() {
-    return ctx;
+    return requestParams.insertContext();
   }
 
+  /**
+   * Returns the explicit splitfile crypto key override, if any.
+   *
+   * <p>The returned array is the original reference supplied at construction time; it is not copied
+   * or validated. When provided, downstream putters may use these bytes as deterministic key
+   * material; when {@code null}, they may derive or randomize a key as needed. Callers should treat
+   * the returned array as immutable to avoid subtle behavior changes.
+   *
+   * @return the crypto key byte array reference, or {@code null} if no override is set.
+   */
   public byte[] forceCryptoKey() {
     return forceCryptoKey;
   }
 
+  /**
+   * Returns the runtime client context used for randomness and scheduling services.
+   *
+   * <p>The context reference is stored without validation and is expected to remain non-null and
+   * operational when the putter uses it. This bundle does not synchronize access to the context, so
+   * callers should ensure the instance is safe for concurrent use according to its contract.
+   *
+   * @return the client context reference for execution services, possibly {@code null}.
+   */
   public ClientContext context() {
     return context;
   }
@@ -115,10 +196,11 @@ public final class ManifestPutterParams {
    * Compares this parameter bundle to another for structural equality.
    *
    * <p>All reference fields are compared using their {@link Object#equals(Object)} implementations,
-   * while the {@code forceCryptoKey} array is compared by content. The method does not treat any
-   * field as optional beyond normal {@code null} handling, and it does not attempt to validate or
-   * normalize values. As a result, two bundles created from distinct but equal maps or URIs will be
-   * considered equal, while identity-different arrays with the same bytes will also be equal.
+   * while the {@code forceCryptoKey} array is compared by content rather than reference. This
+   * method does not validate or normalize inputs and does not treat any field as optional beyond
+   * normal {@code null} handling. Two bundles created from distinct but equal maps, URIs, or
+   * contexts are therefore considered equal, and different byte arrays with identical contents are
+   * considered equal as well.
    *
    * @param o candidate object to compare with this bundle; may be {@code null}.
    * @return {@code true} when all fields are equal by the rules above, otherwise {@code false}.
@@ -127,12 +209,9 @@ public final class ManifestPutterParams {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (!(o instanceof ManifestPutterParams other)) return false;
-    return prioClass == other.prioClass
-        && Objects.equals(clientCallback, other.clientCallback)
+    return Objects.equals(requestParams, other.requestParams)
         && Objects.equals(manifestElements, other.manifestElements)
-        && Objects.equals(target, other.target)
         && Objects.equals(defaultName, other.defaultName)
-        && Objects.equals(ctx, other.ctx)
         && Arrays.equals(forceCryptoKey, other.forceCryptoKey)
         && Objects.equals(context, other.context);
   }
@@ -140,18 +219,17 @@ public final class ManifestPutterParams {
   /**
    * Computes a hash code consistent with {@link #equals(Object)}.
    *
-   * <p>The hash uses {@link Objects#hash(Object...)} for reference fields and {@link
-   * Arrays#hashCode(byte[])} for the crypto key array to preserve content-based semantics. This is
-   * suitable for use in hash-based collections as long as callers do not mutate referenced objects
-   * that participate in equality.
+   * <p>The hash incorporates all fields, using {@link Objects#hash(Object...)} for reference
+   * components and {@link Arrays#hashCode(byte[])} for the crypto key array so that byte contents
+   * participate in the hash. This makes the object suitable for hash-based collections as long as
+   * callers avoid mutating referenced objects or the crypto key array after the bundle is used as a
+   * key, because such mutations would violate the hash/equals contract.
    *
-   * @return hash code derived from all record components, including the array contents.
+   * @return hash code derived from all components, including the crypto key contents.
    */
   @Override
   public int hashCode() {
-    int result =
-        Objects.hash(
-            clientCallback, manifestElements, prioClass, target, defaultName, ctx, context);
+    int result = Objects.hash(requestParams, manifestElements, defaultName, context);
     result = 31 * result + Arrays.hashCode(forceCryptoKey);
     return result;
   }
@@ -159,9 +237,11 @@ public final class ManifestPutterParams {
   /**
    * Returns a human-readable representation of the bundle for diagnostics.
    *
-   * <p>The string includes all record components in declaration order and renders the crypto key
-   * using {@link Arrays#toString(byte[])} for byte-content visibility. It is intended for logging
-   * and debugging and should not be parsed or used for security-sensitive output.
+   * <p>The string includes all components in declaration order and renders the crypto key using
+   * {@link Arrays#toString(byte[])} so byte contents are visible. The output is intended for
+   * logging and debugging and should not be parsed or used for security-sensitive decisions.
+   * Because the result includes potentially sensitive values, callers should take care when
+   * emitting it to untrusted logs or user-visible channels.
    *
    * @return descriptive string including component values and the crypto key contents.
    */
@@ -169,17 +249,17 @@ public final class ManifestPutterParams {
   public @NotNull String toString() {
     return "ManifestPutterParams{"
         + "clientCallback="
-        + clientCallback
+        + requestParams.callback()
         + ", manifestElements="
         + manifestElements
         + ", prioClass="
-        + prioClass
+        + requestParams.priorityClass()
         + ", target="
-        + target
+        + requestParams.targetURI()
         + ", defaultName="
         + defaultName
         + ", ctx="
-        + ctx
+        + requestParams.insertContext()
         + ", forceCryptoKey="
         + Arrays.toString(forceCryptoKey)
         + ", context="

--- a/src/main/java/network/crypta/client/async/PlainManifestPutter.java
+++ b/src/main/java/network/crypta/client/async/PlainManifestPutter.java
@@ -62,7 +62,9 @@ public class PlainManifestPutter extends BaseManifestPutter {
    * Map<String, Object> root = new HashMap<>();
    * root.put("dir", sub);
    * root.put("readme.txt", elementReadme);
-   * var params = new ManifestPutterParams(cb, root, prio, target, "index.html", ctx, key, context);
+   * var params =
+   *     new ManifestPutterParams(
+   *         new InsertRequestParams(cb, target, ctx, prio), root, "index.html", key, context);
    * var putter = new PlainManifestPutter(params);
    * }</pre>
    *

--- a/src/main/java/network/crypta/client/async/SingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SingleFileFetcher.java
@@ -2241,7 +2241,9 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
         try {
           onFoundEdition(
               new USKFoundEdition(
-                  usk.suggestedEdition, usk, context, false, (short) -1, null, false, false));
+                  new USKFoundEditionPayload(usk.suggestedEdition, usk, false, (short) -1, null),
+                  context,
+                  new USKFoundEditionProgress(false, false)));
           return;
         } catch (Exception t) {
           e = new FetchException(FetchExceptionMode.INTERNAL_ERROR, t);

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -19,6 +19,8 @@ import network.crypta.client.Metadata.DocumentType;
 import network.crypta.client.MetadataRedirectTarget;
 import network.crypta.client.MetadataTopLayerInfo;
 import network.crypta.client.MetadataUnresolvedException;
+import network.crypta.client.TopLayerBlockInfo;
+import network.crypta.client.TopLayerHashInfo;
 import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.client.events.FinishedCompressionEvent;
 import network.crypta.client.events.StartedCompressionEvent;
@@ -48,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * selecting and applying a compression codec when beneficial, and then delegating to either a
  * {@code SingleBlockInserter} (for small payloads) or a {@code SplitFileInserter} (for larger
  * payloads). Compression may be performed off the calling thread; after compression, this instance
- * coordinates subsequent steps and emits progress via a {@link PutCompletionCallback}.
+ * coordinates further steps and emits progress via a {@link PutCompletionCallback}.
  *
  * <p>Typical usage is: construct an instance with the desired {@link InsertContext} and {@link
  * InsertBlock}, call {@link #start(ClientContext)} to begin preprocessing, and allow it to drive
@@ -85,7 +87,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
   final ARCHIVE_TYPE archiveType;
 
   /**
-   * If true, we are not the top level request, and should not update our parent to point to us as
+   * If true, we are not the top level request and should not update our parent to point to us as
    * current put-stage.
    */
   private final boolean reportMetadataOnly;
@@ -121,11 +123,11 @@ class SingleFileInserter implements ClientPutState, Serializable {
 
   /**
    * When positive, means we will return metadata rather than a URI, once the metadata is under this
-   * length. If it is too short it is still possible to return a URI, but we won't return both.
+   * length. If it is too short, it is still possible to return a URI, but we won't return both.
    */
   private final long metadataThreshold;
 
-  // A persistent hashCode is helpful in debugging, and also means we can put
+  // A persistent hashCode is helpful in debugging and also means we can put
   // these objects into sets etc. when we need to.
 
   private final int hashCode;
@@ -238,7 +240,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
     boolean isCHK = key.isCHK;
     boolean isUSK = key.isUSK;
 
-    // Compressed data ; now insert it
+    // Compressed data; now insert it
     // We do NOT need to switch threads here: the actual compression is done by InsertCompressor on
     // the RealCompressor thread,
     // which then switches either to the database thread or to a new executable to run this method.
@@ -272,6 +274,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
     handleSplitfile(data, origSize, bestCodec, hashThisLayerOnly, hashes, shouldFreeData, context);
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static class HashProcess {
     final HashResult[] hashes;
     final byte[] hashThisLayerOnly;
@@ -322,7 +325,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
    * provided {@link CompressionOutput} is intentionally not closed in this method. Ownership of the
    * bucket is transferred to downstream inserters, which will free/close it according to the {@code
    * shouldFreeData} flag and insertion flow. Closing it here would prematurely release the
-   * underlying storage and break subsequent processing.
+   * underlying storage and break later processing.
    */
   @SuppressWarnings({"resource"})
   private DataPrep prepareData(CompressionOutput output, long origSize) {
@@ -594,7 +597,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       ClientContext context)
       throws InsertException {
 
-    // Otherwise the file is too big to fit into one block
+    // Otherwise the file is too big to fit into one block.
     // We therefore must make a splitfile
     // Job of SplitHandler: when the splitinserter has the metadata,
     // insert it. Then when the splitinserter has finished, and the
@@ -765,7 +768,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       // If the user requests it, calculate the others for small files.
       // The thresholds could be made configurable in the future.
       if (size >= 1024 * 1024 && !metadata) {
-        // SHA1 is common and MD5 is cheap.
+        // SHA1 is common and MD5 is inexpensive.
         wantHashes |= HashType.SHA1.bitmask;
         wantHashes |= HashType.MD5.bitmask;
       }
@@ -838,8 +841,10 @@ class SingleFileInserter implements ClientPutState, Serializable {
       data = origDataLength;
       compressed = origCompressedDataLength;
     }
-    return new MetadataTopLayerInfo(
-        data, compressed, req, total, topDontCompress, topCompatibilityMode, hashes, null);
+    TopLayerBlockInfo blockInfo =
+        new TopLayerBlockInfo(data, compressed, req, total, topDontCompress, topCompatibilityMode);
+    TopLayerHashInfo hashInfo = new TopLayerHashInfo(hashes, null);
+    return new MetadataTopLayerInfo(blockInfo, hashInfo);
   }
 
   /**
@@ -931,7 +936,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
     final long origCompressedDataLength;
     private transient boolean resumed;
 
-    // A persistent hashCode is helpful in debugging, and also means we can put
+    // A persistent hashCode is helpful in debugging and also means we can put
     // these objects into sets etc. when we need to.
 
     private final int hashCode;
@@ -974,7 +979,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
     @Serial
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
       in.defaultReadObject();
-      // Only fix when callback is absent or points to the parent putter (unsafe fallback).
+      // Only fix when the callback is absent or points to the parent putter (unsafe fallback).
       if (metadataPutter instanceof SingleFileInserter childSfi
           && (childSfi.cb == null || childSfi.cb == parent)) {
         childSfi.cb = this;
@@ -1098,7 +1103,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
     /**
      * Handles metadata production and decides whether to inline or insert separately.
      *
-     * <p>Small metadata (under threshold) is returned directly to the caller. Otherwise, a new
+     * <p>Small metadata (under the threshold) is returned directly to the caller. Otherwise, a new
      * metadata inserter is created and started when policy permits. Duplicate notifications from
      * the splitfile are ignored once metadata handling has begun.
      *
@@ -1177,7 +1182,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       return false;
     }
 
-    @SuppressWarnings("java:S6206")
+    @SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
     private static final class RedirectResult {
       private final Metadata meta;
       private final byte[] bytes;
@@ -1421,7 +1426,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       if (oldMetadataPutter != null) oldMetadataPutter.cancel(context);
 
       // In other cases (fail() and onSuccess()), we only free when we set finished.
-      // Here we free defensively to avoid leaking, even if callbacks also free.
+      // Here we free defensively to avoid leaking, even if callbacks are also free.
       if (freeData) {
         block.free();
       } else {
@@ -1702,7 +1707,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
               @Override
               public void onFailure(
                   InsertException e, ClientPutState state, ClientContext context) {
-                // Intentionally no-op: see rationale above. Failures are observed upstream when
+                // Intentionally no-op: see the rationale above. Failures are observed upstream when
                 // a real callback exists; this stub avoids crashing on legacy resumes.
               }
 

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherBasicSettingsHeader.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherBasicSettingsHeader.java
@@ -1,0 +1,149 @@
+package network.crypta.client.async;
+
+import java.util.List;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.Metadata.SplitfileAlgorithm;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+
+/**
+ * Holds the decoded basic header fields for splitfile fetcher persistence.
+ *
+ * <p>This package-private carrier groups the fixed header values that are read from or written to
+ * the splitfile storage footer. It is typically constructed by the settings codec during parsing
+ * and then passed into {@link ParsedBasicSettings}, which combines these values with offsets and
+ * block counts. The holder keeps the values as provided by the caller and does not validate them,
+ * leaving structural checks to the parser that produced the data.
+ *
+ * <p>The instance is immutable but may reference mutable collaborators such as the metadata object
+ * and decompressor list. Callers should treat those references as read-only within the resume path
+ * and avoid sharing across threads without external coordination.
+ *
+ * <ul>
+ *   <li>Captures algorithm identifiers and per-file crypto settings.
+ *   <li>Records final and decompressed lengths as stored in the footer.
+ *   <li>Preserves client metadata and decompressor ordering for later use.
+ * </ul>
+ *
+ * @see SplitFileFetcherStorageSettingsCodec
+ * @see ParsedBasicSettings
+ */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+final class SplitFileFetcherBasicSettingsHeader {
+  /** Algorithm identifier persisted in the splitfile header. */
+  private final SplitfileAlgorithm splitfileType;
+
+  /** Crypto algorithm code stored as a single header byte. */
+  private final byte splitfileSingleCryptoAlgorithm;
+
+  /** Optional shared crypto key bytes associated with the header. */
+  private final byte[] splitfileSingleCryptoKey;
+
+  /** Final length value in bytes as stored in the header. */
+  private final long finalLength;
+
+  /** Decompressed length value in bytes as stored in the header. */
+  private final long decompressedLength;
+
+  /** Client metadata decoded from the header, or {@code null} if absent. */
+  private final ClientMetadata clientMetadata;
+
+  /** Ordered decompressor identifiers recorded in the header, or {@code null}. */
+  private final List<COMPRESSOR_TYPE> decompressors;
+
+  /**
+   * Creates a header holder from already-parsed settings values.
+   *
+   * <p>The constructor copies the provided references and scalar values without validation. It is
+   * intended for use by parsing code that has already validated lengths, offsets, and identifiers.
+   * The resulting instance is a simple data carrier that preserves the order and identity of the
+   * supplied metadata and decompressor list for later consumption.
+   *
+   * @param splitfileType algorithm identifier for the splitfile storage format; may be {@code
+   *     null}.
+   * @param splitfileSingleCryptoAlgorithm crypto algorithm code stored in the header byte field.
+   * @param splitfileSingleCryptoKey optional shared crypto key bytes; may be {@code null}.
+   * @param finalLength the final persisted length in bytes as stored in the header.
+   * @param decompressedLength expected decompressed length in bytes; non-negative in valid data.
+   * @param clientMetadata client metadata as decoded from the header; may be {@code null}.
+   * @param decompressors ordered list of decompressor identifiers; may be {@code null}.
+   */
+  SplitFileFetcherBasicSettingsHeader(
+      SplitfileAlgorithm splitfileType,
+      byte splitfileSingleCryptoAlgorithm,
+      byte[] splitfileSingleCryptoKey,
+      long finalLength,
+      long decompressedLength,
+      ClientMetadata clientMetadata,
+      List<COMPRESSOR_TYPE> decompressors) {
+    this.splitfileType = splitfileType;
+    this.splitfileSingleCryptoAlgorithm = splitfileSingleCryptoAlgorithm;
+    this.splitfileSingleCryptoKey = splitfileSingleCryptoKey;
+    this.finalLength = finalLength;
+    this.decompressedLength = decompressedLength;
+    this.clientMetadata = clientMetadata;
+    this.decompressors = decompressors;
+  }
+
+  /**
+   * Returns the splitfile algorithm identifier stored in the header.
+   *
+   * @return algorithm identifier as decoded from the persisted header fields.
+   */
+  SplitfileAlgorithm splitfileType() {
+    return splitfileType;
+  }
+
+  /**
+   * Returns the crypto algorithm code stored in the header.
+   *
+   * @return raw algorithm code byte persisted in the storage header.
+   */
+  byte splitfileSingleCryptoAlgorithm() {
+    return splitfileSingleCryptoAlgorithm;
+  }
+
+  /**
+   * Returns the shared crypto key bytes or {@code null} when absent.
+   *
+   * @return key byte array reference, or {@code null} if the header had no key.
+   */
+  byte[] splitfileSingleCryptoKey() {
+    return splitfileSingleCryptoKey;
+  }
+
+  /**
+   * Returns the final length value recorded in the header, in bytes.
+   *
+   * @return the final length in bytes as decoded from the header.
+   */
+  long finalLength() {
+    return finalLength;
+  }
+
+  /**
+   * Returns the decompressed length value recorded in the header, in bytes.
+   *
+   * @return decompressed length in bytes as decoded from the header.
+   */
+  long decompressedLength() {
+    return decompressedLength;
+  }
+
+  /**
+   * Returns the client metadata decoded from the header, or {@code null} if unavailable.
+   *
+   * @return client metadata reference, or {@code null} when the header had none.
+   */
+  ClientMetadata clientMetadata() {
+    return clientMetadata;
+  }
+
+  /**
+   * Returns the ordered list of decompressor identifiers, or {@code null} if absent.
+   *
+   * @return ordered decompressor list reference, or {@code null} when not present.
+   */
+  List<COMPRESSOR_TYPE> decompressors() {
+    return decompressors;
+  }
+}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherCompatCounts.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherCompatCounts.java
@@ -1,0 +1,39 @@
+package network.crypta.client.async;
+
+import network.crypta.client.InsertContext.CompatibilityMode;
+
+/**
+ * Groups compatibility mode and block count totals parsed from splitfile settings.
+ *
+ * <p>This record is a lightweight carrier used when decoding the fixed header of the splitfile
+ * fetcher storage footer. The settings codec extracts the compatibility mode, segment count, and
+ * aggregated block totals from the persisted header and bundles them into this value object before
+ * assembling a {@link ParsedBasicSettings}. The record does not validate ranges or enforce
+ * invariants; callers are expected to construct it only after the parser has verified basic
+ * constraints, such as non-negative totals and a valid compatibility code.
+ *
+ * <p>Instances are immutable and safe to share, but the record reflects the raw persisted values
+ * rather than recomputed counts. This helps keep resume-time parsing deterministic and avoids
+ * expensive recalculation before segment metadata is read.
+ *
+ * <ul>
+ *   <li>Captures the minimum compatibility mode stored in the header.
+ *   <li>Records the persisted segment count for later validation.
+ *   <li>Aggregates data, check, and cross-check block totals across all segments.
+ * </ul>
+ *
+ * @param finalMinCompatMode compatibility mode value stored in the header; not validated here.
+ * @param segmentCount segment count value stored in the header; expected to be positive.
+ * @param totalDataBlocks total data block count across segments; non-negative in valid headers.
+ * @param totalCheckBlocks total check block count across segments; non-negative in valid headers.
+ * @param totalCrossCheckBlocks total cross-check block count across segments; non-negative in valid
+ *     headers.
+ * @see SplitFileFetcherStorageSettingsCodec
+ * @see ParsedBasicSettings
+ */
+record SplitFileFetcherCompatCounts(
+    CompatibilityMode finalMinCompatMode,
+    int segmentCount,
+    int totalDataBlocks,
+    int totalCheckBlocks,
+    int totalCrossCheckBlocks) {}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentsLoadParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentsLoadParams.java
@@ -7,137 +7,160 @@ import network.crypta.node.KeysFetchingLocally;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Bundles parameters needed to load splitfile segments from persisted storage.
+ * Bundles resume-time parameters used to load splitfile segments from persisted storage.
  *
- * <p>This record captures the resume-time inputs that {@link SplitFileFetcherSegmentsBuilder} needs
- * when rehydrating segment storage from a settings stream. Callers populate the full set of
- * metadata, offsets, and sizing information once, then pass the record to the builder, which
- * consumes the {@link DataInputStream} in-order and reconstructs per-segment offsets.
+ * <p>This class captures the inputs that {@link SplitFileFetcherSegmentsBuilder} expects when
+ * rehydrating segment storage from a settings stream. Callers supply parsed settings, offsets, and
+ * totals once, then pass the instance to the builder, which consumes the {@link DataInputStream} in
+ * order and reconstructs per-segment offsets. The bundle itself is a simple carrier; it does not
+ * validate values or normalize units, and it assumes the supplied data describes a coherent layout
+ * consistent with the persisted footer.
  *
- * <p>The record is immutable but refers to mutable collaborators such as the backing buffer and
- * segment array. It does not perform validation and assumes the supplied values describe a coherent
- * layout consistent with the persisted footer. Construct a fresh instance for each resume attempt
- * and avoid reusing it across threads because the stream is stateful.
+ * <p>Instances are immutable but hold references to mutable collaborators such as the backing
+ * stream and the segment array that will be populated. Use a fresh instance per resume attempt and
+ * avoid sharing across threads, because the stream position is stateful and the segment array is
+ * mutated during reconstruction.
  *
  * <ul>
- *   <li>Stores the expected block totals and checksum sizing used for validation.
- *   <li>Captures the offsets into the storage layout for key lists and segment status blocks.
- *   <li>Holds the stream and segment array that will be mutated during reconstruction.
+ *   <li>Holds expected block totals used later to validate reconstructed segments.
+ *   <li>Captures storage offsets for key lists and segment status sections.
+ *   <li>Provides the settings stream and segment array to be consumed and filled.
  * </ul>
  *
  * @see SplitFileFetcherSegmentsBuilder#initSegmentsFromStream(SplitFileFetcherSegmentsLoadParams)
  */
-@SuppressWarnings("java:S6206")
 final class SplitFileFetcherSegmentsLoadParams {
+  /** Owning storage that provides layout constants and derived values. */
   private final SplitFileFetcherStorage parent;
+
+  /** Total number of data blocks across all segments; non-negative count. */
   private final int totalDataBlocks;
+
+  /** Total number of check blocks across all segments; non-negative count. */
   private final int totalCheckBlocks;
+
+  /** Total number of cross-check blocks across all segments; non-negative count. */
   private final int totalCrossCheckBlocks;
+
+  /** Settings stream positioned at the start of segment metadata; read in order. */
   private final DataInputStream dis;
+
+  /** Whether completion is recorded by truncating the backing storage file. */
   private final boolean completeViaTruncation;
+
+  /** Optional helper for tracking locally fetched keys; may be {@code null}. */
   private final KeysFetchingLocally keysFetching;
+
+  /** Mutable segment array that will be populated with reconstructed storage objects. */
   private final SplitFileFetcherSegmentStorage[] segments;
-  private final int checksumLength;
-  private final boolean hasSplitfileSingleCryptoKey;
+
+  /** Byte offset of the persisted key list section in the storage layout. */
   private final long offsetKeyList;
+
+  /** Byte offset of the persisted segment status section in the storage layout. */
   private final long offsetSegmentStatus;
+
+  /** Total length of the backing storage buffer in bytes. */
   private final long rafLength;
 
   /**
    * Creates a bundle of parameters for rebuilding segments from persisted storage.
    *
-   * @param parent owning storage that supplies layout constants and retry behavior.
-   * @param totalDataBlocks total number of data blocks across all segments; non-negative count.
-   * @param totalCheckBlocks total number of check blocks across all segments; non-negative count.
-   * @param totalCrossCheckBlocks total number of cross-check blocks across all segments;
-   *     non-negative count.
-   * @param dis input stream positioned at the start of segment metadata; read in-order.
+   * <p>This constructor copies totals, offsets, and the settings stream reference out of {@code
+   * settings}, and retains references to runtime collaborators such as {@code parent} and {@code
+   * segments}. It performs no validation and does not advance the stream. Callers are responsible
+   * for ensuring the stream is positioned at the start of segment metadata, and that the supplied
+   * offsets and totals match the persisted layout. The segment array is filled later by the builder
+   * and must be mutable for the duration of reconstruction.
+   *
+   * @param parent owning storage that supplies layout constants and derived values.
+   * @param settings parsed settings with totals, offsets, and settings stream.
    * @param completeViaTruncation whether completion is recorded via file truncation semantics.
    * @param keysFetching optional helper for tracking locally fetched keys; may be {@code null}.
    * @param segments mutable segment array to populate with reconstructed storage objects.
-   * @param checksumLength checksum length in bytes used for persisted checksummed blocks.
-   * @param hasSplitfileSingleCryptoKey whether a single splitfile crypto key is present.
-   * @param offsetKeyList byte offset of the persisted key list section in the storage layout.
-   * @param offsetSegmentStatus byte offset of the persisted segment status section.
    * @param rafLength total length of the backing storage buffer in bytes.
    */
   SplitFileFetcherSegmentsLoadParams(
       SplitFileFetcherStorage parent,
-      int totalDataBlocks,
-      int totalCheckBlocks,
-      int totalCrossCheckBlocks,
-      DataInputStream dis,
+      ParsedBasicSettings settings,
       boolean completeViaTruncation,
       KeysFetchingLocally keysFetching,
       SplitFileFetcherSegmentStorage[] segments,
-      int checksumLength,
-      boolean hasSplitfileSingleCryptoKey,
-      long offsetKeyList,
-      long offsetSegmentStatus,
       long rafLength) {
     this.parent = parent;
-    this.totalDataBlocks = totalDataBlocks;
-    this.totalCheckBlocks = totalCheckBlocks;
-    this.totalCrossCheckBlocks = totalCrossCheckBlocks;
-    this.dis = dis;
+    this.totalDataBlocks = settings.getTotalDataBlocks();
+    this.totalCheckBlocks = settings.getTotalCheckBlocks();
+    this.totalCrossCheckBlocks = settings.getTotalCrossCheckBlocks();
+    this.dis = settings.getSettingsStream();
     this.completeViaTruncation = completeViaTruncation;
     this.keysFetching = keysFetching;
     this.segments = segments;
-    this.checksumLength = checksumLength;
-    this.hasSplitfileSingleCryptoKey = hasSplitfileSingleCryptoKey;
-    this.offsetKeyList = offsetKeyList;
-    this.offsetSegmentStatus = offsetSegmentStatus;
+    this.offsetKeyList = settings.getOffsetKeyList();
+    this.offsetSegmentStatus = settings.getOffsetSegmentStatus();
     this.rafLength = rafLength;
   }
 
+  /** Returns the owning storage that provides layout constants and derived values. */
   SplitFileFetcherStorage parent() {
     return parent;
   }
 
+  /** Returns the expected total number of data blocks across all segments. */
   int totalDataBlocks() {
     return totalDataBlocks;
   }
 
+  /** Returns the expected total number of check blocks across all segments. */
   int totalCheckBlocks() {
     return totalCheckBlocks;
   }
 
+  /** Returns the expected total number of cross-check blocks across all segments. */
   int totalCrossCheckBlocks() {
     return totalCrossCheckBlocks;
   }
 
+  /** Returns the settings stream positioned at the start of segment metadata. */
   DataInputStream dis() {
     return dis;
   }
 
+  /** Returns {@code true} when completion is recorded by truncating the backing storage file. */
   boolean completeViaTruncation() {
     return completeViaTruncation;
   }
 
+  /** Returns the optional helper used to track locally fetched keys, or {@code null}. */
   KeysFetchingLocally keysFetching() {
     return keysFetching;
   }
 
+  /** Returns the mutable segment array to be populated by the builder. */
   SplitFileFetcherSegmentStorage[] segments() {
     return segments;
   }
 
+  /** Returns the checksum length in bytes as provided by the owning storage. */
   int checksumLength() {
-    return checksumLength;
+    return parent.checksumLength;
   }
 
+  /** Returns {@code true} if the splitfile has a single shared crypto key. */
   boolean hasSplitfileSingleCryptoKey() {
-    return hasSplitfileSingleCryptoKey;
+    return parent.splitfileSingleCryptoKey != null;
   }
 
+  /** Returns the byte offset of the persisted key list section. */
   long offsetKeyList() {
     return offsetKeyList;
   }
 
+  /** Returns the byte offset of the persisted segment status section. */
   long offsetSegmentStatus() {
     return offsetSegmentStatus;
   }
 
+  /** Returns the total length of the backing storage buffer in bytes. */
   long rafLength() {
     return rafLength;
   }
@@ -147,7 +170,9 @@ final class SplitFileFetcherSegmentsLoadParams {
    *
    * <p>The comparison uses reference equality for collaborators such as {@code parent} and {@code
    * dis}, because they represent runtime services, while {@code segments} is compared by content to
-   * reflect the array's elements rather than its identity.
+   * reflect the array's elements rather than its identity. The comparison does not attempt to
+   * compare stream positions or external storage state; it only compares the values stored in this
+   * instance and the references it holds.
    *
    * @param other object to compare against; may be {@code null}.
    * @return {@code true} when all scalar fields match and segment arrays contain equal entries.
@@ -164,8 +189,8 @@ final class SplitFileFetcherSegmentsLoadParams {
         && totalDataBlocks == otherParams.totalDataBlocks
         && totalCheckBlocks == otherParams.totalCheckBlocks
         && totalCrossCheckBlocks == otherParams.totalCrossCheckBlocks
-        && checksumLength == otherParams.checksumLength
-        && hasSplitfileSingleCryptoKey == otherParams.hasSplitfileSingleCryptoKey
+        && checksumLength() == otherParams.checksumLength()
+        && hasSplitfileSingleCryptoKey() == otherParams.hasSplitfileSingleCryptoKey()
         && offsetKeyList == otherParams.offsetKeyList
         && offsetSegmentStatus == otherParams.offsetSegmentStatus
         && rafLength == otherParams.rafLength
@@ -179,7 +204,9 @@ final class SplitFileFetcherSegmentsLoadParams {
    * Computes a hash code that reflects scalar fields and the segment array contents.
    *
    * <p>The segment array is hashed with {@link Arrays#hashCode(Object[])}, while the remaining
-   * components use {@link Objects#hash(Object...)} to preserve the record's usual behavior.
+   * components use {@link Objects#hash(Object...)}. This matches the equality contract used by
+   * {@link #equals(Object)} and ensures that instances used as keys in hash-based collections
+   * remain consistent with their contained values and references.
    *
    * @return hash code suitable for hash-based collections.
    */
@@ -194,8 +221,8 @@ final class SplitFileFetcherSegmentsLoadParams {
             dis,
             completeViaTruncation,
             keysFetching,
-            checksumLength,
-            hasSplitfileSingleCryptoKey,
+            checksumLength(),
+            hasSplitfileSingleCryptoKey(),
             offsetKeyList,
             offsetSegmentStatus,
             rafLength);
@@ -206,8 +233,10 @@ final class SplitFileFetcherSegmentsLoadParams {
   /**
    * Returns a human-readable string that includes the segment array contents.
    *
-   * <p>The output mirrors the record component order, formatting the {@code segments} array with
-   * {@link Arrays#toString(Object[])} so that its elements are visible in logs and diagnostics.
+   * <p>The output mirrors the component order of this bundle, formatting the {@code segments} array
+   * with {@link Arrays#toString(Object[])} so that its elements are visible in logs and
+   * diagnostics. The resulting string is intended for debugging and should not be parsed or relied
+   * upon for stable serialization.
    *
    * @return non-null textual representation of the parameter bundle.
    */
@@ -231,9 +260,9 @@ final class SplitFileFetcherSegmentsLoadParams {
         + ", segments="
         + Arrays.toString(segments)
         + ", checksumLength="
-        + checksumLength
+        + checksumLength()
         + ", hasSplitfileSingleCryptoKey="
-        + hasSplitfileSingleCryptoKey
+        + hasSplitfileSingleCryptoKey()
         + ", offsetKeyList="
         + offsetKeyList
         + ", offsetSegmentStatus="

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorage.java
@@ -501,19 +501,7 @@ public class SplitFileFetcherStorage {
     SplitFileFetcherSegmentsInit segmentsInit =
         SplitFileFetcherSegmentsBuilder.initSegmentsFromStream(
             new SplitFileFetcherSegmentsLoadParams(
-                this,
-                parsed.getTotalDataBlocks(),
-                parsed.getTotalCheckBlocks(),
-                parsed.getTotalCrossCheckBlocks(),
-                parsed.getSettingsStream(),
-                p.completeViaTruncation,
-                p.keysFetching,
-                this.segments,
-                checksumLength,
-                splitfileSingleCryptoKey != null,
-                offsetKeyList,
-                offsetSegmentStatus,
-                rafLength));
+                this, parsed, p.completeViaTruncation, p.keysFetching, this.segments, rafLength));
     this.crossSegments = segmentsInit.crossSegments;
     this.keyListener =
         new SplitFileFetcherKeyListener(

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageOffsets.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageOffsets.java
@@ -1,0 +1,42 @@
+package network.crypta.client.async;
+
+/**
+ * Groups byte offsets for sections within the splitfile fetcher storage layout.
+ *
+ * <p>This record captures the offsets that point to each fixed section in the persisted storage
+ * footer. It is typically created by the settings codec when parsing the basic settings block and
+ * then passed into {@link ParsedBasicSettings}, which exposes the values to resume-time builders.
+ * The offsets are expressed in bytes relative to the start of the storage file and are expected to
+ * refer to positions within the backing buffer. This record does not validate or normalize the
+ * values; it relies on the parser to enforce invariants before construction.
+ *
+ * <p>Instances are immutable and safe to share. The record represents the persisted layout as-is
+ * and does not recompute offsets from other metadata, which keeps parsing deterministic and avoids
+ * extra dependencies during recovery.
+ *
+ * <ul>
+ *   <li>Captures offsets for key lists, segment status, and progress tracking sections.
+ *   <li>Records bloom filter locations and original metadata/detail boundaries.
+ *   <li>Preserves the basic settings offset used to validate layout integrity.
+ * </ul>
+ *
+ * @param offsetKeyList byte offset of the persisted key list section in the storage file.
+ * @param offsetSegmentStatus byte offset of the persisted segment status section.
+ * @param offsetGeneralProgress byte offset of the general progress section, in bytes.
+ * @param offsetMainBloomFilter byte offset of the main bloom filter section, in bytes.
+ * @param offsetSegmentBloomFilters byte offset of the segment bloom filters section, in bytes.
+ * @param offsetOriginalMetadata byte offset of the original metadata section, in bytes.
+ * @param offsetOriginalDetails byte offset of the original details section, in bytes.
+ * @param offsetBasicSettings byte offset of the basic settings block, in bytes.
+ * @see SplitFileFetcherStorageSettingsCodec
+ * @see ParsedBasicSettings
+ */
+record SplitFileFetcherStorageOffsets(
+    long offsetKeyList,
+    long offsetSegmentStatus,
+    long offsetGeneralProgress,
+    long offsetMainBloomFilter,
+    long offsetSegmentBloomFilters,
+    long offsetOriginalMetadata,
+    long offsetOriginalDetails,
+    long offsetBasicSettings) {}

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodec.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodec.java
@@ -19,25 +19,26 @@ import network.crypta.support.io.StorageFormatException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Encodes and decodes the basic settings section of splitfile fetcher persistence.
+ * Encodes and decodes the basic settings block for splitfile fetcher persistence.
  *
- * <p>This utility reads and writes the fixed header portion that precedes per-segment metadata in
- * the splitfile fetcher storage footer. Encoding gathers immutable settings and offsets from a
- * fully initialized {@link SplitFileFetcherStorage} and produces a single byte array, including the
- * checksum, that can be written to the storage file. Decoding consumes the corresponding byte
- * block, validates structural invariants such as lengths, offsets, and compatibility modes, and
- * exposes the parsed values for follow-on parsing.
+ * <p>This utility handles the fixed header that precedes per-segment metadata in the splitfile
+ * storage footer. Callers use {@link #encodeBasicSettings(SplitFileFetcherStorage, int, int, int)}
+ * once the {@link SplitFileFetcherStorage} instance has computed offsets and lengths, and the
+ * method returns a single byte array that already includes the checksum. Callers use {@link
+ * #parseBasicSettings(byte[], long, boolean, long)} when resuming from disk to validate the stored
+ * layout, decode compatibility and block counts, and obtain a {@link ParsedBasicSettings} that
+ * exposes both values and a stream positioned after the fixed fields.
  *
- * <p>The class is stateless and does not cache or retain input buffers; callers are responsible for
- * synchronization around shared {@link SplitFileFetcherStorage} instances and for ensuring that the
- * buffer represents the on-disk basic settings block they intend to parse. Parsing returns a {@link
- * ParsedBasicSettings} that keeps the {@link DataInputStream} open and positioned after the fixed
- * fields so callers can read segment metadata sequentially.
+ * <p>The codec is stateless and does not retain buffers, so it is safe for concurrent use as long
+ * as callers synchronize access to shared storage instances and shared file buffers. It performs
+ * structural validation (lengths, offsets, and compatibility mode) but intentionally does not
+ * recompute totals; it trusts the provided counts and writes them verbatim. The returned settings
+ * stream remains open, and callers must advance it in order when reading segment metadata.
  *
  * <ul>
- *   <li>Serializes splitfile algorithm, crypto parameters, lengths, and client metadata.
- *   <li>Writes and validates offsets for subsequent storage sections.
- *   <li>Records compatibility mode and block counts used for segment construction.
+ *   <li>Serializes crypto settings, lengths, offsets, and client metadata into a fixed header.
+ *   <li>Validates decoded offsets against the known backing buffer length.
+ *   <li>Captures compatibility and block counts needed for later segment parsing.
  * </ul>
  *
  * @see SplitFileFetcherStorage
@@ -46,7 +47,23 @@ import org.jetbrains.annotations.NotNull;
 public final class SplitFileFetcherStorageSettingsCodec {
   private SplitFileFetcherStorageSettingsCodec() {}
 
-  /** Parse the basic settings block from the persisted splitfile storage format. */
+  /**
+   * Parses the basic settings block from persisted splitfile storage bytes.
+   *
+   * <p>The method reads the fixed header fields from the supplied buffer, validates offsets and
+   * lengths against {@code rafLength}, and verifies that the persisted truncation flag matches the
+   * supplied {@code completeViaTruncation} value. On success, it returns a {@link
+   * ParsedBasicSettings} that wraps a {@link DataInputStream} positioned immediately after the
+   * fixed fields so callers can continue reading per-segment metadata in order. The stream remains
+   * open; callers are responsible for closing it when the buffer is no longer needed.
+   *
+   * @param basicSettingsBuffer byte array holding the serialized settings header and trailer.
+   * @param basicSettingsOffset expected byte offset recorded in the persisted header.
+   * @param completeViaTruncation expected truncation flag that must match persisted value.
+   * @param rafLength total length of the backing storage buffer in bytes.
+   * @return parsed settings with an open stream positioned after fixed fields.
+   * @throws StorageFormatException when offsets, lengths, or flags are inconsistent or invalid.
+   */
   static ParsedBasicSettings parseBasicSettings(
       byte[] basicSettingsBuffer,
       long basicSettingsOffset,
@@ -58,33 +75,21 @@ public final class SplitFileFetcherStorageSettingsCodec {
       SplitfileAlgorithm splitfileAlgorithm = readSplitfileAlgorithm(dis);
       CryptoInfo crypto = readCryptoInfo(dis, splitfileAlgorithm);
       LengthsInfo lengths = readLengths(dis);
-      HeaderInfo header = new HeaderInfo(splitfileAlgorithm, crypto, lengths);
       ClientMetadata cm = readClientMetadataSafe(dis);
       List<COMPRESSOR_TYPE> decomps = readDecompressors(dis);
-      OffsetsInfo offsets = readOffsets(dis, basicSettingsOffset, completeViaTruncation, rafLength);
-      CompatAndCounts compat = readCompatAndCounts(dis);
-      return new ParsedBasicSettings(
-          header.splitfileType,
-          header.crypto.algorithm,
-          header.crypto.key,
-          header.lengths.finalLength,
-          header.lengths.decompressedLength,
-          cm,
-          decomps,
-          offsets.offsetKeyList,
-          offsets.offsetSegmentStatus,
-          offsets.offsetGeneralProgress,
-          offsets.offsetMainBloomFilter,
-          offsets.offsetSegmentBloomFilters,
-          offsets.offsetOriginalMetadata,
-          offsets.offsetOriginalDetails,
-          offsets.offsetBasicSettings,
-          compat.mode,
-          compat.segmentCount,
-          compat.totalDataBlocks,
-          compat.totalCheckBlocks,
-          compat.totalCrossCheckBlocks,
-          dis);
+      SplitFileFetcherBasicSettingsHeader header =
+          new SplitFileFetcherBasicSettingsHeader(
+              splitfileAlgorithm,
+              crypto.algorithm,
+              crypto.key,
+              lengths.finalLength,
+              lengths.decompressedLength,
+              cm,
+              decomps);
+      SplitFileFetcherStorageOffsets offsets =
+          readOffsets(dis, basicSettingsOffset, completeViaTruncation, rafLength);
+      SplitFileFetcherCompatCounts compat = readCompatAndCounts(dis);
+      return new ParsedBasicSettings(header, offsets, compat, dis);
     } catch (IOException e) {
       throw new StorageFormatException(
           "Cannot read basic settings even though passed checksum: " + e, e);
@@ -98,8 +103,9 @@ public final class SplitFileFetcherStorageSettingsCodec {
    * parameters, lengths, client metadata, offsets, compatibility mode, and the supplied block
    * totals. It then writes fixed metadata for each segment, any cross-segment metadata, and the key
    * listener's static settings before appending the checksum with the storage checker. The method
-   * does not perform additional validation of the block totals and assumes the offsets and lengths
-   * in {@code storage} are already computed.
+   * is deterministic for a stable {@code storage} state and does not validate the supplied totals
+   * beyond writing them as provided; callers must ensure the counts match the segments that will be
+   * encoded. The returned array is suitable for direct persistence to the storage file.
    *
    * <pre>{@code
    * byte[] settings =
@@ -107,14 +113,13 @@ public final class SplitFileFetcherStorageSettingsCodec {
    *         storage, dataBlocks, checkBlocks, crossBlocks);
    * }</pre>
    *
-   * @param storage storage instance providing offsets, metadata, and checksum checker; initialized
-   *     for serialization
-   * @param totalDataBlocks total count of data blocks across all segments; non-negative
-   * @param totalCheckBlocks total count of check blocks across all segments; non-negative
+   * @param storage storage instance with computed offsets and metadata ready to serialize.
+   * @param totalDataBlocks total count of data blocks across all segments; non-negative.
+   * @param totalCheckBlocks total count of check blocks across all segments; non-negative.
    * @param totalCrossCheckBlocks total count of cross-check blocks across all segments;
-   *     non-negative
-   * @return byte array containing the encoded settings block with appended checksum
-   * @throws IllegalStateException if an unexpected I/O error occurs while encoding
+   *     non-negative.
+   * @return byte array holding the encoded settings block plus checksum trailer.
+   * @throws IllegalStateException when an unexpected I/O error occurs while encoding.
    */
   public static byte[] encodeBasicSettings(
       SplitFileFetcherStorage storage,
@@ -187,7 +192,7 @@ public final class SplitFileFetcherStorageSettingsCodec {
     return decomps;
   }
 
-  private static OffsetsInfo readOffsets(
+  private static SplitFileFetcherStorageOffsets readOffsets(
       DataInputStream dis, long basicSettingsOffset, boolean completeViaTruncation, long rafLength)
       throws IOException, StorageFormatException {
     long keyListOffset = readValidatedOffset(dis, "key list", rafLength);
@@ -202,7 +207,7 @@ public final class SplitFileFetcherStorageSettingsCodec {
       throw new StorageFormatException("Invalid basic settings offset (not the same as computed)");
     if (completeViaTruncation != dis.readBoolean())
       throw new StorageFormatException("Complete via truncation flag is wrong");
-    return new OffsetsInfo(
+    return new SplitFileFetcherStorageOffsets(
         keyListOffset,
         segmentStatusOffset,
         generalProgressOffset,
@@ -221,7 +226,7 @@ public final class SplitFileFetcherStorageSettingsCodec {
     return value;
   }
 
-  private static CompatAndCounts readCompatAndCounts(DataInputStream dis)
+  private static SplitFileFetcherCompatCounts readCompatAndCounts(DataInputStream dis)
       throws IOException, StorageFormatException {
     int compatMode = dis.readInt();
     if (compatMode < 0 || compatMode > Short.MAX_VALUE)
@@ -245,7 +250,7 @@ public final class SplitFileFetcherStorageSettingsCodec {
     if (totalDataBlocks + totalCheckBlocks + totalCrossCheckBlocks <= 0) {
       throw new StorageFormatException("Total number of blocks in splitfile is non-positive");
     }
-    return new CompatAndCounts(
+    return new SplitFileFetcherCompatCounts(
         finalMode, segmentCount, totalDataBlocks, totalCheckBlocks, totalCrossCheckBlocks);
   }
 
@@ -303,6 +308,7 @@ public final class SplitFileFetcherStorageSettingsCodec {
     return baos.toByteArray();
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class CryptoInfo {
     private final byte algorithm;
     private final byte[] key;
@@ -313,70 +319,7 @@ public final class SplitFileFetcherStorageSettingsCodec {
     }
   }
 
-  private static final class LengthsInfo {
-    private final long finalLength;
-    private final long decompressedLength;
-
-    private LengthsInfo(long finalLength, long decompressedLength) {
-      this.finalLength = finalLength;
-      this.decompressedLength = decompressedLength;
-    }
-  }
-
-  private static final class HeaderInfo {
-    private final SplitfileAlgorithm splitfileType;
-    private final CryptoInfo crypto;
-    private final LengthsInfo lengths;
-
-    private HeaderInfo(SplitfileAlgorithm splitfileType, CryptoInfo crypto, LengthsInfo lengths) {
-      this.splitfileType = splitfileType;
-      this.crypto = crypto;
-      this.lengths = lengths;
-    }
-  }
-
-  private static final class OffsetsInfo {
-    private final long offsetKeyList;
-    private final long offsetSegmentStatus;
-    private final long offsetGeneralProgress;
-    private final long offsetMainBloomFilter;
-    private final long offsetSegmentBloomFilters;
-    private final long offsetOriginalMetadata;
-    private final long offsetOriginalDetails;
-    private final long offsetBasicSettings;
-
-    private OffsetsInfo(long... offsets) {
-      this.offsetKeyList = offsets[0];
-      this.offsetSegmentStatus = offsets[1];
-      this.offsetGeneralProgress = offsets[2];
-      this.offsetMainBloomFilter = offsets[3];
-      this.offsetSegmentBloomFilters = offsets[4];
-      this.offsetOriginalMetadata = offsets[5];
-      this.offsetOriginalDetails = offsets[6];
-      this.offsetBasicSettings = offsets[7];
-    }
-  }
-
-  private static final class CompatAndCounts {
-    private final CompatibilityMode mode;
-    private final int segmentCount;
-    private final int totalDataBlocks;
-    private final int totalCheckBlocks;
-    private final int totalCrossCheckBlocks;
-
-    private CompatAndCounts(
-        CompatibilityMode mode,
-        int segmentCount,
-        int totalDataBlocks,
-        int totalCheckBlocks,
-        int totalCrossCheckBlocks) {
-      this.mode = mode;
-      this.segmentCount = segmentCount;
-      this.totalDataBlocks = totalDataBlocks;
-      this.totalCheckBlocks = totalCheckBlocks;
-      this.totalCrossCheckBlocks = totalCrossCheckBlocks;
-    }
-  }
+  private record LengthsInfo(long finalLength, long decompressedLength) {}
 }
 
 /**
@@ -410,47 +353,30 @@ final class ParsedBasicSettings {
   private final DataInputStream settingsStream;
 
   ParsedBasicSettings(
-      SplitfileAlgorithm splitfileType,
-      byte splitfileSingleCryptoAlgorithm,
-      byte[] splitfileSingleCryptoKey,
-      long finalLength,
-      long decompressedLength,
-      ClientMetadata clientMetadata,
-      List<COMPRESSOR_TYPE> decompressors,
-      long offsetKeyList,
-      long offsetSegmentStatus,
-      long offsetGeneralProgress,
-      long offsetMainBloomFilter,
-      long offsetSegmentBloomFilters,
-      long offsetOriginalMetadata,
-      long offsetOriginalDetails,
-      long offsetBasicSettings,
-      CompatibilityMode finalMinCompatMode,
-      int segmentCount,
-      int totalDataBlocks,
-      int totalCheckBlocks,
-      int totalCrossCheckBlocks,
+      SplitFileFetcherBasicSettingsHeader header,
+      SplitFileFetcherStorageOffsets offsets,
+      SplitFileFetcherCompatCounts compatCounts,
       DataInputStream settingsStream) {
-    this.splitfileType = splitfileType;
-    this.splitfileSingleCryptoAlgorithm = splitfileSingleCryptoAlgorithm;
-    this.splitfileSingleCryptoKey = splitfileSingleCryptoKey;
-    this.finalLength = finalLength;
-    this.decompressedLength = decompressedLength;
-    this.clientMetadata = clientMetadata;
-    this.decompressors = decompressors;
-    this.offsetKeyList = offsetKeyList;
-    this.offsetSegmentStatus = offsetSegmentStatus;
-    this.offsetGeneralProgress = offsetGeneralProgress;
-    this.offsetMainBloomFilter = offsetMainBloomFilter;
-    this.offsetSegmentBloomFilters = offsetSegmentBloomFilters;
-    this.offsetOriginalMetadata = offsetOriginalMetadata;
-    this.offsetOriginalDetails = offsetOriginalDetails;
-    this.offsetBasicSettings = offsetBasicSettings;
-    this.finalMinCompatMode = finalMinCompatMode;
-    this.segmentCount = segmentCount;
-    this.totalDataBlocks = totalDataBlocks;
-    this.totalCheckBlocks = totalCheckBlocks;
-    this.totalCrossCheckBlocks = totalCrossCheckBlocks;
+    this.splitfileType = header.splitfileType();
+    this.splitfileSingleCryptoAlgorithm = header.splitfileSingleCryptoAlgorithm();
+    this.splitfileSingleCryptoKey = header.splitfileSingleCryptoKey();
+    this.finalLength = header.finalLength();
+    this.decompressedLength = header.decompressedLength();
+    this.clientMetadata = header.clientMetadata();
+    this.decompressors = header.decompressors();
+    this.offsetKeyList = offsets.offsetKeyList();
+    this.offsetSegmentStatus = offsets.offsetSegmentStatus();
+    this.offsetGeneralProgress = offsets.offsetGeneralProgress();
+    this.offsetMainBloomFilter = offsets.offsetMainBloomFilter();
+    this.offsetSegmentBloomFilters = offsets.offsetSegmentBloomFilters();
+    this.offsetOriginalMetadata = offsets.offsetOriginalMetadata();
+    this.offsetOriginalDetails = offsets.offsetOriginalDetails();
+    this.offsetBasicSettings = offsets.offsetBasicSettings();
+    this.finalMinCompatMode = compatCounts.finalMinCompatMode();
+    this.segmentCount = compatCounts.segmentCount();
+    this.totalDataBlocks = compatCounts.totalDataBlocks();
+    this.totalCheckBlocks = compatCounts.totalCheckBlocks();
+    this.totalCrossCheckBlocks = compatCounts.totalCrossCheckBlocks();
     this.settingsStream = settingsStream;
   }
 

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
@@ -24,8 +24,11 @@ import network.crypta.client.Metadata;
 import network.crypta.client.Metadata.SplitfileAlgorithm;
 import network.crypta.client.MetadataParseException;
 import network.crypta.client.MetadataTopLayerInfo;
+import network.crypta.client.SplitfileBlockKeys;
+import network.crypta.client.SplitfileCryptoParams;
 import network.crypta.client.SplitfileParams;
 import network.crypta.client.SplitfilePayload;
+import network.crypta.client.SplitfileSegmentLayout;
 import network.crypta.client.TopLayerBlockInfo;
 import network.crypta.client.TopLayerHashInfo;
 import network.crypta.client.async.SplitFileInserterSegmentStorage.BlockInsert;
@@ -1874,15 +1877,11 @@ public class SplitFileInserterStorage {
     SplitfileParams params =
         new SplitfileParams(
             splitfileType,
-            dataKeys,
-            checkKeys,
-            segmentSize,
-            checkSegmentSize,
-            deductBlocksFromSegments,
-            crossCheckBlocks,
-            splitfileCryptoAlgorithm,
-            splitfileCryptoKey,
-            specifySplitfileKeyInMetadata);
+            new SplitfileBlockKeys(dataKeys, checkKeys),
+            new SplitfileSegmentLayout(
+                segmentSize, checkSegmentSize, deductBlocksFromSegments, crossCheckBlocks),
+            new SplitfileCryptoParams(
+                splitfileCryptoAlgorithm, splitfileCryptoKey, specifySplitfileKeyInMetadata));
     SplitfilePayload payload =
         new SplitfilePayload(
             clientMetadata,

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
@@ -26,6 +26,8 @@ import network.crypta.client.MetadataParseException;
 import network.crypta.client.MetadataTopLayerInfo;
 import network.crypta.client.SplitfileParams;
 import network.crypta.client.SplitfilePayload;
+import network.crypta.client.TopLayerBlockInfo;
+import network.crypta.client.TopLayerHashInfo;
 import network.crypta.client.async.SplitFileInserterSegmentStorage.BlockInsert;
 import network.crypta.client.async.SplitFileInserterSegmentStorage.MissingKeyException;
 import network.crypta.crypt.ChecksumChecker;
@@ -1115,6 +1117,7 @@ public class SplitFileInserterStorage {
     return passed;
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class CryptoInit {
     final byte[] key;
     final boolean specifyInMetadata;
@@ -1154,6 +1157,7 @@ public class SplitFileInserterStorage {
         + (crossSegmentSettings == null ? 0 : crossSegmentSettings.size());
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class OffsetArrays {
     final long[] offsetCrossSegmentBlocks;
     final long[] offsetSegmentCheckBlocks;
@@ -1184,6 +1188,7 @@ public class SplitFileInserterStorage {
     return new OffsetArrays(ocb, osc, oss, ocs, osk);
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class PersistenceInit {
     final byte[] header;
     final int offsetsLength;
@@ -1886,16 +1891,16 @@ public class SplitFileInserterStorage {
             compressionCodec,
             decompressedLength,
             isMetadata);
-    MetadataTopLayerInfo topLayer =
-        new MetadataTopLayerInfo(
+    TopLayerBlockInfo blockInfo =
+        new TopLayerBlockInfo(
             origDataSize,
             origCompressedDataSize,
             topRequiredBlocks,
             topTotalBlocks,
             topDontCompress,
-            cmode,
-            hashes,
-            hashThisLayerOnly);
+            cmode);
+    TopLayerHashInfo hashInfo = new TopLayerHashInfo(hashes, hashThisLayerOnly);
+    MetadataTopLayerInfo topLayer = new MetadataTopLayerInfo(blockInfo, hashInfo);
     return new Metadata(params, payload, topLayer);
   }
 

--- a/src/main/java/network/crypta/client/async/USKCompletionCoordinator.java
+++ b/src/main/java/network/crypta/client/async/USKCompletionCoordinator.java
@@ -178,7 +178,9 @@ final class USKCompletionCoordinator {
         else
           c.onFoundEdition(
               new USKFoundEdition(
-                  ed, origUSK.copy(ed), context, metadata, codec, data, false, false));
+                  new USKFoundEditionPayload(ed, origUSK.copy(ed), metadata, codec, data),
+                  context,
+                  new USKFoundEditionProgress(false, false)));
       } catch (Exception e) {
         LOG.error(
             "An exception occurred while dealing with a callback:{}\n{}", c, e.getMessage(), e);

--- a/src/main/java/network/crypta/client/async/USKFetcherCallback.java
+++ b/src/main/java/network/crypta/client/async/USKFetcherCallback.java
@@ -5,20 +5,20 @@ package network.crypta.client.async;
  *
  * <p>This interface is notified by a fetcher created for a specific Updateable Subspace Key (USK)
  * request when progress reaches a terminal state for that one-off fetch operation. Typical usage is
- * to obtain a fetcher from a manager, register an instance of this callback, and then react to one
- * of the lifecycle events defined here. Unlike long-lived USK subscriptions that continue to
- * receive updates, a {@code USKFetcherCallback} is expected to be invoked at most once per fetch
- * attempt and then considered complete by the caller.
+ * to get a fetcher from a manager, register an instance of this callback, and then react to one of
+ * the lifecycle events defined here. Unlike long-lived USK subscriptions that continue to receive
+ * updates, a {@code USKFetcherCallback} is expected to be invoked at most once per fetch attempt
+ * and then considered complete by the caller.
  *
  * <p>Implementations should be lightweight and non-blocking. Callbacks are generally invoked from
  * the client framework’s worker threads; heavy work should be dispatched elsewhere to avoid
- * starving the scheduler. Implementations must also tolerate re-entrancy and cancellation, because
+ * starving the scheduler. Implementations must also tolerate reentrancy and cancellation, because
  * fetches may be abandoned due to shut down or superseded by newer attempts when higher editions
  * are discovered.
  *
  * <ul>
  *   <li>Failure: no suitable edition found at or above a given hint.
- *   <li>Cancelled: fetch aborted before a definitive result could be produced.
+ *   <li>Canceled: fetch aborted before a definitive result could be produced.
  *   <li>Found: the latest known-good edition has been retrieved for this fetch.
  * </ul>
  */
@@ -38,7 +38,7 @@ public interface USKFetcherCallback extends USKCallback {
   void onFailure(ClientContext context);
 
   /**
-   * Signals that the fetch was cancelled before it completed.
+   * Signals that the fetch was canceled before it completed.
    *
    * <p>Cancellation can be explicit (requested by the caller) or implicit (triggered by shutdown,
    * superseding operations, or time budgeting). No guarantees are made about partial progress: the
@@ -58,11 +58,15 @@ public interface USKFetcherCallback extends USKCallback {
    * long-lived {@code USKCallback} subscription. The provided data represents the content for the
    * resolved edition along with metadata flags describing the payload. Implementations typically
    * persist or forward the result, update any local caches, and record the "known good" status for
-   * subsequent resolution and validation decisions.
+   * later resolution and validation decisions.
    *
    * <pre>{@code
    * // Example: record the resolved edition then hand off for processing
-   * callback.onFoundEdition(new USKFoundEdition(edition, usk, ctx, false, codec, bytes, true, false));
+   * callback.onFoundEdition(
+   *     new USKFoundEdition(
+   *         new USKFoundEditionPayload(edition, usk, false, codec, bytes),
+   *         ctx,
+   *         new USKFoundEditionProgress(true, false)));
    * }</pre>
    *
    * @param foundEdition The payload describing the discovered edition and its metadata.

--- a/src/main/java/network/crypta/client/async/USKFoundEdition.java
+++ b/src/main/java/network/crypta/client/async/USKFoundEdition.java
@@ -6,13 +6,31 @@ import network.crypta.keys.USK;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Immutable notification payload describing a discovered USK edition.
+ * Describes a discovered USK edition for client callback delivery.
  *
- * <p>This value object bundles the edition metadata, payload, and progress flags emitted by USK
- * fetchers and subscriptions. It is shared across callbacks to avoid long parameter lists and to
- * keep related data coherent during async handoff.
+ * <p>This immutable value object bundles edition identity, payload metadata, bytes, and progress
+ * flags emitted by USK fetchers and subscriptions. It is created at the point where a fetcher has
+ * enough information to notify observers and is typically passed through callbacks such as {@link
+ * USKCallback#onFoundEdition(USKFoundEdition)} or {@link
+ * USKFetcherCallback#onFoundEdition(USKFoundEdition)}. The class performs no validation or
+ * defensive copying, preserving the historical behavior where callers control allocation and
+ * ownership of the {@code byte[]} payload.
+ *
+ * <p>The instance is thread-safe only if the referenced {@link USK} and {@code data} array are
+ * treated as effectively immutable. Equality and hashing compare the array contents rather than the
+ * array identity, which makes the object suitable for caches or deduplication when data is stable.
+ *
+ * <p>Notable behaviors include:
+ *
+ * <ul>
+ *   <li>Fields are stored as provided, including {@code null} payload bytes.
+ *   <li>The {@code context} is carried for follow-up scheduling or resource access.
+ *   <li>Progress flags indicate whether known-good or slot boundaries advanced.
+ * </ul>
+ *
+ * @see USKFoundEditionPayload
+ * @see USKFoundEditionProgress
  */
-@SuppressWarnings("java:S6206")
 public final class USKFoundEdition {
   private final long edition;
   private final USK key;
@@ -26,64 +44,119 @@ public final class USKFoundEdition {
   /**
    * Creates a notification payload for a discovered USK edition.
    *
-   * @param edition The discovered logical edition number.
-   * @param key A copy of the key with the discovered edition set for this notification.
-   * @param context Execution context with client-layer services and schedulers for follow-up work.
-   * @param metadata True when the bytes correspond to metadata for the edition rather than content.
-   * @param codec Short identifier of the content codec associated with the returned byte payload.
-   * @param data Raw byte payload for the discovered edition or its metadata, as provided by
-   *     fetcher.
-   * @param newKnownGood True when the highest known-good, successfully fetched edition has
-   *     advanced.
-   * @param newSlotToo True when the highest known SSK slot has also advanced alongside known-good.
+   * <p>The constructor copies values from the provided payload and progress objects without
+   * validation or defensive copying. This preserves historical behavior and allows callers to share
+   * buffers or reuse key instances. The resulting object represents a point-in-time snapshot that
+   * can be handed across async boundaries.
+   *
+   * @param payload edition identity and bytes, possibly containing a {@code null} payload.
+   * @param context execution context used for follow-up scheduling or service access.
+   * @param progress progress flags describing known-good and slot transitions.
    */
   public USKFoundEdition(
-      long edition,
-      USK key,
-      ClientContext context,
-      boolean metadata,
-      short codec,
-      byte[] data,
-      boolean newKnownGood,
-      boolean newSlotToo) {
-    this.edition = edition;
-    this.key = key;
+      USKFoundEditionPayload payload, ClientContext context, USKFoundEditionProgress progress) {
+    this.edition = payload.edition();
+    this.key = payload.key();
     this.context = context;
-    this.metadata = metadata;
-    this.codec = codec;
-    this.data = data;
-    this.newKnownGood = newKnownGood;
-    this.newSlotToo = newSlotToo;
+    this.metadata = payload.metadata();
+    this.codec = payload.codec();
+    this.data = payload.data();
+    this.newKnownGood = progress.newKnownGood();
+    this.newSlotToo = progress.newSlotToo();
   }
 
+  /**
+   * Returns the discovered logical edition number for this notification.
+   *
+   * <p>The value is the same as provided by {@link USKFoundEditionPayload} and is not normalized or
+   * validated by this class.
+   *
+   * @return the logical edition number carried by this event snapshot.
+   */
   public long edition() {
     return edition;
   }
 
+  /**
+   * Returns the edition-specific {@link USK} associated with this notification.
+   *
+   * <p>The returned reference is the same object supplied in the payload. Callers should treat it
+   * as immutable when sharing across threads.
+   *
+   * @return the key reference for the discovered edition, possibly {@code null} if provided as
+   *     such.
+   */
   public USK key() {
     return key;
   }
 
+  /**
+   * Returns the execution context carried with this notification.
+   *
+   * <p>The context is used by clients to access schedulers and services for follow-up work. This
+   * class stores the reference as-is and does not enforce non-nullability.
+   *
+   * @return the client execution context associated with this event.
+   */
   public ClientContext context() {
     return context;
   }
 
+  /**
+   * Indicates whether the payload bytes represent metadata rather than content.
+   *
+   * <p>This flag originates from the fetcher and is preserved without interpretation. Callers use
+   * it to decide how to parse or store the byte payload.
+   *
+   * @return {@code true} when the payload represents metadata, {@code false} otherwise.
+   */
   public boolean metadata() {
     return metadata;
   }
 
+  /**
+   * Returns the codec identifier associated with the payload bytes.
+   *
+   * <p>The fetcher supplies the codec value. It may be {@code -1} or another sentinel when the
+   * codec is unknown or not applicable.
+   *
+   * @return the codec identifier for the payload, or a sentinel when absent.
+   */
   public short codec() {
     return codec;
   }
 
+  /**
+   * Returns the raw payload bytes for the discovered edition.
+   *
+   * <p>The returned array reference is shared with the caller and may be {@code null}. Callers that
+   * need immutability should copy the array before mutation.
+   *
+   * @return the payload byte array, or {@code null} when no bytes are available.
+   */
   public byte[] data() {
     return data;
   }
 
+  /**
+   * Indicates whether the highest known-good edition advanced for this notification.
+   *
+   * <p>This flag allows callers to distinguish between slot discoveries and verified, fetchable
+   * editions.
+   *
+   * @return {@code true} when the known-good marker advanced, {@code false} otherwise.
+   */
   public boolean newKnownGood() {
     return newKnownGood;
   }
 
+  /**
+   * Indicates whether the highest known slot advanced alongside a known-good update.
+   *
+   * <p>When {@code true}, both slot and known-good indices moved forward together for this event.
+   *
+   * @return {@code true} when the slot index advanced with known-good, {@code false} otherwise.
+   */
   public boolean newSlotToo() {
     return newSlotToo;
   }
@@ -91,17 +164,30 @@ public final class USKFoundEdition {
   /**
    * Returns a copy of this payload with a different execution context.
    *
-   * <p>This is useful when dispatching the same event through an alternate context, such as a
+   * <p>The returned instance shares the same payload bytes and flags while carrying the supplied
+   * context. This is useful when dispatching the same event through an alternate context, such as a
    * persistent job runner, without mutating the original instance.
    *
-   * @param context The execution context to carry.
-   * @return A copy of this event with the supplied context.
+   * @param context execution context to carry with the copied notification.
+   * @return a new {@link USKFoundEdition} instance with the updated context.
    */
   public USKFoundEdition withContext(ClientContext context) {
     return new USKFoundEdition(
-        edition, key, context, metadata, codec, data, newKnownGood, newSlotToo);
+        new USKFoundEditionPayload(edition, key, metadata, codec, data),
+        context,
+        new USKFoundEditionProgress(newKnownGood, newSlotToo));
   }
 
+  /**
+   * Compares this notification to another object for structural equality.
+   *
+   * <p>Equality compares primitive fields directly, the {@link USK} and {@link ClientContext} using
+   * {@link Object#equals}, and the payload bytes using {@link Arrays#equals(byte[], byte[])}. This
+   * makes equality sensitive to the contents of the {@code data} array rather than its identity.
+   *
+   * @param obj the candidate object to compare against, possibly {@code null}.
+   * @return {@code true} when all fields match by value, {@code false} otherwise.
+   */
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
@@ -118,6 +204,14 @@ public final class USKFoundEdition {
         && Arrays.equals(data, other.data);
   }
 
+  /**
+   * Returns a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash incorporates the payload byte contents using {@link Arrays#hashCode(byte[])} along
+   * with the remaining fields via {@link Objects#hash}.
+   *
+   * @return a hash code derived from the notification fields and payload bytes.
+   */
   @Override
   public int hashCode() {
     int result = Objects.hash(edition, key, context, metadata, codec, newKnownGood, newSlotToo);
@@ -125,6 +219,14 @@ public final class USKFoundEdition {
     return result;
   }
 
+  /**
+   * Returns a diagnostic string describing the notification fields.
+   *
+   * <p>The representation includes the edition, key, context, metadata flag, codec identifier, raw
+   * data, and progress flags. It is intended for logging and debugging rather than stable parsing.
+   *
+   * @return a human-readable string representation of this notification.
+   */
   @Override
   public @NotNull String toString() {
     return "USKFoundEdition["

--- a/src/main/java/network/crypta/client/async/USKFoundEditionPayload.java
+++ b/src/main/java/network/crypta/client/async/USKFoundEditionPayload.java
@@ -1,0 +1,181 @@
+package network.crypta.client.async;
+
+import java.util.Arrays;
+import java.util.Objects;
+import network.crypta.keys.USK;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Captures the payload metadata and bytes for a discovered USK edition.
+ *
+ * <p>This immutable carrier bundles the edition number, the edition-specific {@link USK}, and
+ * payload details produced by a fetch. It is typically created when an edition becomes available
+ * and then handed through callbacks such as {@link USKFoundEdition} to keep related data together.
+ * The class performs no validation or defensive copying so that callers preserve legacy behavior
+ * and retain control over allocation and ownership of the byte array. As a result, the instance is
+ * thread-safe only if callers treat the referenced key and byte array as effectively immutable.
+ *
+ * <p>Notable behaviors include:
+ *
+ * <ul>
+ *   <li>All fields are stored as-is, including a {@code null} payload.
+ *   <li>The {@code data} array reference is shared and may be reused by callers.
+ *   <li>Equality and hashing compare the array contents, not the reference.
+ * </ul>
+ *
+ * @see USKFoundEdition
+ */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+public final class USKFoundEditionPayload {
+  private final long edition;
+  private final USK key;
+  private final boolean metadata;
+  private final short codec;
+  private final byte[] data;
+
+  /**
+   * Creates a payload snapshot for a discovered edition.
+   *
+   * <p>The constructor stores references exactly as provided and performs no copying or validation.
+   * This matches historical behavior and lets the caller control memory usage. Callers may pass
+   * {@code null} for {@code data} to represent a metadata-only update or a discovery without bytes.
+   *
+   * @param edition logical edition number for the notification, expected non-negative.
+   * @param key key instance already updated to the discovered edition.
+   * @param metadata true when the payload represents metadata rather than content bytes.
+   * @param codec short codec identifier associated with the payload, or {@code -1} when unknown.
+   * @param data raw payload bytes, possibly {@code null} or shared by the caller.
+   */
+  public USKFoundEditionPayload(long edition, USK key, boolean metadata, short codec, byte[] data) {
+    this.edition = edition;
+    this.key = key;
+    this.metadata = metadata;
+    this.codec = codec;
+    this.data = data;
+  }
+
+  /**
+   * Returns the discovered logical edition number for this payload.
+   *
+   * <p>The value is stored exactly as supplied at construction time. It is typically non-negative
+   * and corresponds to the edition embedded in the {@link USK} instance, but this class does not
+   * enforce that relationship.
+   *
+   * @return the logical edition number carried by this payload snapshot.
+   */
+  public long edition() {
+    return edition;
+  }
+
+  /**
+   * Returns the {@link USK} instance associated with the discovered edition.
+   *
+   * <p>The returned reference is the same object passed to the constructor. Callers should treat it
+   * as immutable for the lifetime of this payload, especially when sharing across threads.
+   *
+   * @return the edition-specific key reference, possibly {@code null} if provided as such.
+   */
+  public USK key() {
+    return key;
+  }
+
+  /**
+   * Indicates whether the payload bytes represent metadata rather than content.
+   *
+   * <p>This flag is provided by the fetcher and preserved without interpretation. A {@code true}
+   * value usually implies a metadata payload, but the caller determines how the bytes are consumed.
+   *
+   * @return {@code true} when the payload corresponds to metadata, {@code false} otherwise.
+   */
+  public boolean metadata() {
+    return metadata;
+  }
+
+  /**
+   * Returns the codec identifier associated with the payload bytes.
+   *
+   * <p>The codec value is a short identifier supplied by the fetcher. It may be {@code -1} or
+   * another sentinel when no codec applies or the content is unknown.
+   *
+   * @return the codec identifier for the payload, or a sentinel when absent.
+   */
+  public short codec() {
+    return codec;
+  }
+
+  /**
+   * Returns the raw payload bytes for the discovered edition.
+   *
+   * <p>The returned array reference is the same object provided at construction time. It may be
+   * {@code null} to indicate the absence of bytes, and it may be shared across callbacks, so
+   * callers should not mutate it unless they fully own the reference.
+   *
+   * @return the raw payload bytes, or {@code null} when no data was provided.
+   */
+  public byte[] data() {
+    return data;
+  }
+
+  /**
+   * Compares this payload to another object for structural equality.
+   *
+   * <p>Equality compares primitive fields directly, the {@link USK} using {@link Object#equals},
+   * and the payload bytes using {@link Arrays#equals(byte[], byte[])}. This makes equality
+   * sensitive to the contents of the {@code data} array rather than its identity.
+   *
+   * @param obj the candidate object to compare against, possibly {@code null}.
+   * @return {@code true} when all fields match by value, {@code false} otherwise.
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj instanceof USKFoundEditionPayload other)) {
+      return false;
+    }
+    return edition == other.edition
+        && metadata == other.metadata
+        && codec == other.codec
+        && Objects.equals(key, other.key)
+        && Arrays.equals(data, other.data);
+  }
+
+  /**
+   * Returns a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash incorporates the array contents using {@link Arrays#hashCode(byte[])} and the
+   * remaining fields via {@link Objects#hash}. This allows equal payloads to hash identically.
+   *
+   * @return a hash code derived from the payload fields and byte contents.
+   */
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(edition, key, metadata, codec);
+    result = 31 * result + Arrays.hashCode(data);
+    return result;
+  }
+
+  /**
+   * Returns a diagnostic string describing the payload fields.
+   *
+   * <p>The representation includes the edition, key, metadata flag, codec identifier, and a
+   * rendered view of the byte array. A {@code null} array is represented as {@code "null"} so that
+   * logging does not throw when bytes are absent.
+   *
+   * @return a human-readable string for debugging and logging purposes.
+   */
+  @Override
+  public @NotNull String toString() {
+    return "USKFoundEditionPayload["
+        + "edition="
+        + edition
+        + ", key="
+        + key
+        + ", metadata="
+        + metadata
+        + ", codec="
+        + codec
+        + ", data="
+        + (data == null ? "null" : Arrays.toString(data))
+        + "]";
+  }
+}

--- a/src/main/java/network/crypta/client/async/USKFoundEditionProgress.java
+++ b/src/main/java/network/crypta/client/async/USKFoundEditionProgress.java
@@ -1,0 +1,26 @@
+package network.crypta.client.async;
+
+/**
+ * Captures progress flags for a discovered USK edition notification.
+ *
+ * <p>This record represents the two boolean signals emitted alongside a USK discovery: whether the
+ * highest known-good edition advanced and whether the highest known slot advanced at the same time.
+ * It is typically created by fetchers or managers when they have enough context to explain the
+ * significance of a found edition and then passed to {@link USKFoundEdition} as part of the
+ * notification payload. The record is immutable and thread-safe as long as callers treat it as a
+ * simple value object with no external side effects.
+ *
+ * <p>Notable behaviors include:
+ *
+ * <ul>
+ *   <li>Flags are stored exactly as supplied, with no inference or validation.
+ *   <li>{@code newSlotToo} may be {@code true} only when {@code newKnownGood} is also true.
+ * </ul>
+ *
+ * @param newKnownGood true when the highest known-good edition advances for this event, even if the
+ *     slot index did not change.
+ * @param newSlotToo true when the highest known slot advances alongside a known-good update,
+ *     indicating both signals moved forward together.
+ * @see USKFoundEdition
+ */
+public record USKFoundEditionProgress(boolean newKnownGood, boolean newSlotToo) {}

--- a/src/main/java/network/crypta/client/async/USKManager.java
+++ b/src/main/java/network/crypta/client/async/USKManager.java
@@ -711,14 +711,9 @@ public class USKManager {
                 () ->
                     callback.onFoundEdition(
                         new USKFoundEdition(
-                            number,
-                            usk, // non-persistent
+                            new USKFoundEditionPayload(number, usk, false, (short) -1, null),
                             context,
-                            false,
-                            (short) -1,
-                            null,
-                            true,
-                            newSlotToo)),
+                            new USKFoundEditionProgress(true, newSlotToo))),
                 "USKManager callback executor for " + callback);
     }
   }
@@ -754,14 +749,9 @@ public class USKManager {
                 () ->
                     callback.onFoundEdition(
                         new USKFoundEdition(
-                            number,
-                            usk, // non-persistent
+                            new USKFoundEditionPayload(number, usk, false, (short) -1, null),
                             context,
-                            false,
-                            (short) -1,
-                            null,
-                            false,
-                            false)),
+                            new USKFoundEditionProgress(false, false))),
                 "USKManager callback executor for " + callback);
     }
   }
@@ -838,11 +828,15 @@ public class USKManager {
     if (goodEd > ed)
       cb.onFoundEdition(
           new USKFoundEdition(
-              goodEd, origUSK.copy(curEd), context, false, (short) -1, null, true, curEd > ed));
+              new USKFoundEditionPayload(goodEd, origUSK.copy(curEd), false, (short) -1, null),
+              context,
+              new USKFoundEditionProgress(true, curEd > ed)));
     else if (curEd > ed)
       cb.onFoundEdition(
           new USKFoundEdition(
-              curEd, origUSK.copy(curEd), context, false, (short) -1, null, false, false));
+              new USKFoundEditionPayload(curEd, origUSK.copy(curEd), false, (short) -1, null),
+              context,
+              new USKFoundEditionProgress(false, false)));
 
     final USKFetcher fetcher = plan.toSchedule;
     if (fetcher != null) {

--- a/src/main/java/network/crypta/client/async/USKSparseProxyCallback.java
+++ b/src/main/java/network/crypta/client/async/USKSparseProxyCallback.java
@@ -80,7 +80,7 @@ public class USKSparseProxyCallback implements USKProgressCallback {
    * <p>Within a polling round the proxy remembers only the newest observed edition and whether it
    * also advanced the highest known-good value. Updates for older editions are dropped unless they
    * contribute a known-good advance. The wrapped callback is invoked immediately only after a phase
-   * boundary has been signalled; otherwise the information is retained and may be forwarded later
+   * boundary has been signaled; otherwise the information is retained and may be forwarded later
    * from {@link #onSendingToNetwork(ClientContext)} or {@link #onRoundFinished(ClientContext)}.
    *
    * @param foundEdition The payload describing the discovered edition and its metadata.
@@ -185,6 +185,9 @@ public class USKSparseProxyCallback implements USKProgressCallback {
     }
     // At this point, either we returned above or ed is guaranteed != -1
     target.onFoundEdition(
-        new USKFoundEdition(ed, key, context, meta, codec, data, wasKnownGood, wasKnownGood));
+        new USKFoundEdition(
+            new USKFoundEditionPayload(ed, key, meta, codec, data),
+            context,
+            new USKFoundEditionProgress(wasKnownGood, wasKnownGood)));
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -1430,25 +1430,24 @@ public class ClientGet extends ClientRequest {
 
   @Override
   synchronized RequestStatus getStatus() {
-    return ClientGetGetterFactory.buildStatus(
-        new ClientGetStatusSnapshot(
-            identifier,
-            persistence,
-            started,
-            finished,
-            succeeded,
-            progressPending,
-            getFailedMessage,
-            foundDataMimeType,
-            foundDataLength,
-            getDestFilename(),
-            getBucket(),
+    RequestStatusSnapshot statusSnapshot =
+        ClientGetStatusSnapshot.buildRequestStatusSnapshot(
+            identifier, persistence, started, finished, succeeded, progressPending, priorityClass);
+    DownloadProgressSnapshot progressSnapshot =
+        new DownloadProgressSnapshot(progressPending, getFailedMessage);
+    DownloadDataSnapshot dataSnapshot =
+        new DownloadDataSnapshot(
+            foundDataMimeType, foundDataLength, getDestFilename(), getBucket());
+    DownloadContextSnapshot contextSnapshot =
+        new DownloadContextSnapshot(
             fctx,
-            priorityClass,
             getCompatibilityMode(),
             getOverriddenSplitfileCryptoKey(),
             getURI(),
-            getDontCompress()));
+            getDontCompress());
+    return ClientGetGetterFactory.buildStatus(
+        new ClientGetStatusSnapshot(
+            statusSnapshot, progressSnapshot, dataSnapshot, contextSnapshot));
   }
 
   private static final long CLIENT_DETAIL_MAGIC = 0x67145b675d2e22f4L;

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.Objects;
 import network.crypta.client.FetchContext;
@@ -22,7 +21,6 @@ import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientGetterOptions;
 import network.crypta.client.async.ClientGetterRequest;
 import network.crypta.client.async.PersistentClientCallback;
-import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
 import network.crypta.keys.FreenetURI;
@@ -98,6 +96,7 @@ final class ClientGetGetterFactory {
    * so persistent requests can resume and serialize details through a single delegate. The only
    * state retained is the request instance provided at construction time.
    */
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class CallbackAdapter
       implements ClientGetCallback, PersistentClientCallback, Serializable {
     /** Serialization identifier for the adapter; no evolving state is persisted. */
@@ -189,45 +188,19 @@ final class ClientGetGetterFactory {
    */
   @SuppressWarnings("resource")
   static RequestStatus buildStatus(ClientGetStatusSnapshot snapshot) {
-    boolean totalFinalized = false;
-    int total = 0;
-    int min = 0;
-    int fetched = 0;
-    int fatal = 0;
-    int failed = 0;
-    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
-    Instant latestSuccess = Instant.now();
-    Instant latestFailure = null;
-    String identifier = snapshot.identifier();
-    Persistence persistence = snapshot.persistence();
-    boolean started = snapshot.started();
-    boolean finished = snapshot.finished();
-    boolean succeeded = snapshot.succeeded();
-    SimpleProgressMessage progressPending = snapshot.progressPending();
+    RequestStatusSnapshot statusSnapshot = snapshot.statusSnapshot();
+    boolean finished = statusSnapshot.finished();
+    boolean succeeded = statusSnapshot.success();
     GetFailedMessage failedMessage = snapshot.failedMessage();
     String foundDataMimeType = snapshot.foundDataMimeType();
     long foundDataLength = snapshot.foundDataLength();
     File destinationFile = snapshot.destinationFile();
     Bucket dataBucket = snapshot.dataBucket();
     FetchContext fetchContext = snapshot.fetchContext();
-    short priorityClass = snapshot.priorityClass();
     InsertContext.CompatibilityMode[] compatModes = snapshot.compatModes();
     byte[] splitfileKey = snapshot.splitfileKey();
     FreenetURI uri = snapshot.uri();
     boolean dontCompress = snapshot.dontCompress();
-
-    if (progressPending != null) {
-      totalFinalized = progressPending.isTotalFinalized();
-      // The progress API reports doubles to preserve partial block counts from the splitter.
-      total = (int) progressPending.getTotalBlocks();
-      min = (int) progressPending.getMinBlocks();
-      fetched = (int) progressPending.getFetchedBlocks();
-      latestSuccess = progressPending.getLatestSuccess();
-      fatal = (int) progressPending.getFatalyFailedBlocks();
-      failed = (int) progressPending.getFailedBlocks();
-      latestFailure = progressPending.getLatestFailure();
-    }
-    if (finished && succeeded) totalFinalized = true;
     FetchExceptionMode failureCode = null;
     String failureReasonShort = null;
     String failureReasonLong = null;
@@ -257,22 +230,6 @@ final class ClientGetGetterFactory {
     boolean overriddenDataType =
         fetchContext.getOverrideMIME() != null || fetchContext.getCharset() != null;
 
-    RequestStatusSnapshot statusSnapshot =
-        new RequestStatusSnapshot(
-            identifier,
-            persistence,
-            started,
-            finished,
-            succeeded,
-            total,
-            min,
-            fetched,
-            latestSuccess,
-            fatal,
-            failed,
-            latestFailure,
-            totalFinalized,
-            priorityClass);
     DownloadOutcomeInfo outcome =
         new DownloadOutcomeInfo(
             foundDataLength,
@@ -438,7 +395,7 @@ final class ClientGetGetterFactory {
   /**
    * Creates a disk-backed bucket intended to receive the final download output.
    *
-   * <p>The bucket is configured so the file must not pre-exist on first write, helping prevent
+   * <p>The bucket is configured so the file must not pre-exist on first writing, helping prevent
    * accidental overwrites. The bucket is writable by default and does not register for
    * delete-on-exit or delete-on-free behavior.
    *

--- a/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshot.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshot.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.Arrays;
 import network.crypta.client.FetchContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
@@ -9,328 +10,363 @@ import network.crypta.support.api.Bucket;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Parameter bundle describing a {@link ClientGet} request status snapshot.
+ * Represents an immutable status snapshot for a {@link ClientGet} request.
  *
- * <p>This type captures the data required to construct a {@link DownloadRequestStatus} from the
- * current state of a {@link ClientGet} request. It is intentionally immutable and performs no
- * validation, so callers can reuse it across status refreshes without altering behavior. Typical
- * usage is to assemble one instance when a status reply is being generated, then pass it through
- * the formatting layer that emits the FCP response.
+ * <p>This class aggregates the values needed to build a {@link DownloadRequestStatus} at a single
+ * point in time. Callers typically construct one instance while preparing an FCP status reply, then
+ * pass it to the formatter or status builder that emits the response. The snapshot does not
+ * validate or normalize any inputs; it is a thin, immutable carrier that preserves whatever values
+ * the request has recorded at that moment.
  *
- * <p>All fields are stored verbatim, including arrays and buckets; no defensive copies are made.
- * Callers should therefore treat contained arrays and referenced objects as read-only for the
- * lifetime of the snapshot. Equality and hash code calculations include array contents, so mutating
- * arrays after construction can destabilize hashing and comparisons. The instance is thread-safe
- * only if all referenced objects are used in a thread-safe manner by the caller.
+ * <p>All fields are stored verbatim, including arrays and buckets, and no defensive copies are
+ * created. As a result, callers must treat any referenced objects and arrays as read-only for the
+ * lifetime of the snapshot. Equality and hash code computations include array contents, so mutating
+ * arrays after construction can change equality and hash semantics. Thread-safety is therefore tied
+ * to the referenced objects and their usage by the caller.
  *
  * <ul>
- *   <li>Aggregates request identifiers, progress, and failure details.
- *   <li>Captures data destination, length, and MIME type hints.
- *   <li>Includes fetch context and compatibility metadata used for status output.
+ *   <li>Aggregates identifiers, lifecycle state, and progress counters from the request.
+ *   <li>Captures data destination, length, and MIME type hints for download reporting.
+ *   <li>Preserves fetch context and compatibility metadata needed by status encoders.
  * </ul>
  *
  * @see ClientGet
  * @see DownloadRequestStatus
  */
-@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
 public final class ClientGetStatusSnapshot {
-  private final String identifier;
-  private final ClientRequest.Persistence persistence;
-  private final boolean started;
-  private final boolean finished;
-  private final boolean succeeded;
-  private final SimpleProgressMessage progressPending;
-  private final GetFailedMessage failedMessage;
-  private final String foundDataMimeType;
-  private final long foundDataLength;
-  private final File destinationFile;
-  private final Bucket dataBucket;
-  private final FetchContext fetchContext;
-  private final short priorityClass;
-  private final CompatibilityMode[] compatModes;
-  private final byte[] splitfileKey;
-  private final FreenetURI uri;
-  private final boolean dontCompress;
+  private final RequestStatusSnapshot statusSnapshot;
+  private final DownloadProgressSnapshot progressSnapshot;
+  private final DownloadDataSnapshot dataSnapshot;
+  private final DownloadContextSnapshot contextSnapshot;
 
   /**
    * Creates a snapshot containing the current request metadata.
    *
-   * <p>This constructor stores the supplied values without validation or copying. It is intended to
-   * be called at the moment a status response is prepared so the snapshot reflects a coherent view
-   * of the request. All parameters are optional in the sense that {@code null} values are accepted
-   * for reference types; callers should pass {@code null} only when the data is unknown or not
-   * applicable to the request type.
+   * <p>This constructor stores the supplied values without validation or copying, so the snapshot
+   * reflects a coherent view of the request at the moment a status response is prepared. Reference
+   * parameters may be {@code null} when the corresponding data is unknown or not applicable; the
+   * snapshot forwards those {@code null} values to downstream status encoders without
+   * interpretation. The instance is immutable, but the referenced objects may still be mutable and
+   * should be treated as read-only once the snapshot is shared.
    *
-   * @param identifier request identifier to report, typically unique per client session
-   * @param persistence persistence mode for the request, reflecting its configured lifetime
-   * @param started whether the request has started executing or queued work
-   * @param finished whether the request has completed, regardless of success
-   * @param succeeded whether the request has completed successfully, when finished is true
-   * @param progressPending last recorded progress snapshot, or {@code null} if none
-   * @param failedMessage cached failure message, or {@code null} when no failure is known
-   * @param foundDataMimeType MIME type discovered for the data, or {@code null} if unknown
-   * @param foundDataLength data length recorded for the request, in bytes when known
-   * @param destinationFile destination file for disk requests, or {@code null} for in-memory data
-   * @param dataBucket bucket containing result data, or {@code null} when not yet available
-   * @param fetchContext fetch context providing filter and MIME overrides, or {@code null}
-   * @param priorityClass scheduler priority class used by the request queue
-   * @param compatModes compatibility modes observed for the request, possibly empty or null
-   * @param splitfileKey splitfile crypto key override, or {@code null} if not applicable
-   * @param uri request URI to report, or {@code null} when not yet resolved
-   * @param dontCompress whether reinsertion should skip compression when producing output
+   * <pre>{@code
+   * ClientGetStatusSnapshot snapshot =
+   *     new ClientGetStatusSnapshot(statusSnapshot, progressSnapshot, dataSnapshot, contextSnapshot);
+   * }</pre>
+   *
+   * @param statusSnapshot core lifecycle and progress counters for the request, stored as-is
+   * @param progressSnapshot cached progress and failure details, possibly {@code null}
+   * @param dataSnapshot discovered data MIME, length, and storage destinations, possibly {@code
+   *     null}
+   * @param contextSnapshot fetch context and compatibility metadata used for status output
    */
   public ClientGetStatusSnapshot(
+      RequestStatusSnapshot statusSnapshot,
+      DownloadProgressSnapshot progressSnapshot,
+      DownloadDataSnapshot dataSnapshot,
+      DownloadContextSnapshot contextSnapshot) {
+    this.statusSnapshot = statusSnapshot;
+    this.progressSnapshot = progressSnapshot;
+    this.dataSnapshot = dataSnapshot;
+    this.contextSnapshot = contextSnapshot;
+  }
+
+  static RequestStatusSnapshot buildRequestStatusSnapshot(
       String identifier,
       ClientRequest.Persistence persistence,
       boolean started,
       boolean finished,
       boolean succeeded,
       SimpleProgressMessage progressPending,
-      GetFailedMessage failedMessage,
-      String foundDataMimeType,
-      long foundDataLength,
-      File destinationFile,
-      Bucket dataBucket,
-      FetchContext fetchContext,
-      short priorityClass,
-      CompatibilityMode[] compatModes,
-      byte[] splitfileKey,
-      FreenetURI uri,
-      boolean dontCompress) {
-    this.identifier = identifier;
-    this.persistence = persistence;
-    this.started = started;
-    this.finished = finished;
-    this.succeeded = succeeded;
-    this.progressPending = progressPending;
-    this.failedMessage = failedMessage;
-    this.foundDataMimeType = foundDataMimeType;
-    this.foundDataLength = foundDataLength;
-    this.destinationFile = destinationFile;
-    this.dataBucket = dataBucket;
-    this.fetchContext = fetchContext;
-    this.priorityClass = priorityClass;
-    this.compatModes = compatModes;
-    this.splitfileKey = splitfileKey;
-    this.uri = uri;
-    this.dontCompress = dontCompress;
+      short priorityClass) {
+    boolean totalFinalized = false;
+    int total = 0;
+    int min = 0;
+    int fetched = 0;
+    int fatal = 0;
+    int failed = 0;
+    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
+    Instant latestSuccess = Instant.now();
+    Instant latestFailure = null;
+
+    if (progressPending != null) {
+      totalFinalized = progressPending.isTotalFinalized();
+      // The progress API reports doubles to preserve partial block counts from the splitter.
+      total = (int) progressPending.getTotalBlocks();
+      min = (int) progressPending.getMinBlocks();
+      fetched = (int) progressPending.getFetchedBlocks();
+      latestSuccess = progressPending.getLatestSuccess();
+      fatal = (int) progressPending.getFatalyFailedBlocks();
+      failed = (int) progressPending.getFailedBlocks();
+      latestFailure = progressPending.getLatestFailure();
+    }
+    if (finished && succeeded) totalFinalized = true;
+    return new RequestStatusSnapshot(
+        identifier,
+        persistence,
+        started,
+        finished,
+        succeeded,
+        total,
+        min,
+        fetched,
+        latestSuccess,
+        fatal,
+        failed,
+        latestFailure,
+        totalFinalized,
+        priorityClass);
   }
 
   /**
    * Returns the request identifier reported to the client.
    *
    * <p>The identifier is typically client-provided and used to correlate status responses with the
-   * initiating request. It is stored verbatim and may be {@code null} when not available.
+   * initiating request. The snapshot stores the value verbatim and does not normalize or validate
+   * it in any way. A {@code null} identifier is permitted when the request has not yet recorded or
+   * exposed its identifier, and that {@code null} will be propagated to downstream encoders.
    *
-   * @return the request identifier, or {@code null} if not set
+   * @return the request identifier, or {@code null} when the request has not set one
    */
   public String identifier() {
-    return identifier;
+    return statusSnapshot.identifier();
   }
 
   /**
    * Returns the persistence mode for the request.
    *
-   * <p>The persistence value indicates how the request survives restarts or disconnects. This
-   * snapshot does not interpret the value and merely reports it back to the status encoder.
+   * <p>The persistence value indicates how the request survives restarts or disconnects, and it is
+   * passed through without interpretation. A {@code null} value is allowed when persistence was not
+   * specified or is otherwise unavailable at snapshot creation time. The returned value is owned by
+   * the caller of the snapshot and should be treated as read-only metadata.
    *
-   * @return the persistence mode, or {@code null} if not specified
+   * @return the persistence mode, or {@code null} when no persistence policy is recorded
    */
   public ClientRequest.Persistence persistence() {
-    return persistence;
+    return statusSnapshot.persistence();
   }
 
   /**
    * Indicates whether the request has started.
    *
    * <p>This flag captures the most recent start state at snapshot creation time. It does not imply
-   * completion, and it may remain {@code true} throughout the entire request lifetime.
+   * completion and may remain {@code true} for the remainder of the request lifetime once execution
+   * begins. The snapshot does not compute or adjust this value; it simply reports what the request
+   * recorded at the moment the snapshot was built.
    *
-   * @return {@code true} if the request has started, {@code false} otherwise
+   * @return {@code true} when the request has started, {@code false} otherwise
    */
   public boolean started() {
-    return started;
+    return statusSnapshot.started();
   }
 
   /**
    * Indicates whether the request has finished.
    *
-   * <p>A finished request has reached a terminal state. When this value is {@code true}, the {@link
-   * #succeeded()} flag describes whether completion was successful.
+   * <p>A finished request has reached a terminal state and will not make further progress. When
+   * this value is {@code true}, the {@link #succeeded()} flag describes whether completion was
+   * successful or failed. This value is a snapshot of the request state and does not imply any
+   * future behavior beyond the recorded terminal state.
    *
-   * @return {@code true} if the request has finished, {@code false} otherwise
+   * @return {@code true} when the request has finished, {@code false} otherwise
    */
   public boolean finished() {
-    return finished;
+    return statusSnapshot.finished();
   }
 
   /**
    * Indicates whether the request has succeeded.
    *
-   * <p>This flag is meaningful primarily when {@link #finished()} is {@code true}. When the request
-   * fails, the failure details are usually reported through {@link #failedMessage()}.
+   * <p>This flag is primarily meaningful when {@link #finished()} is {@code true}; before
+   * completion it may represent an in-progress or default value. When a request fails, the failure
+   * details are typically available through {@link #failedMessage()}. The snapshot does not
+   * reconcile or infer success; it reports the value recorded by the request.
    *
-   * @return {@code true} if the request succeeded, {@code false} otherwise
+   * @return {@code true} when the request completed successfully, {@code false} otherwise
    */
   public boolean succeeded() {
-    return succeeded;
+    return statusSnapshot.success();
   }
 
   /**
    * Returns the most recently recorded progress message, if any.
    *
-   * <p>The progress snapshot is an optional view of in-flight work and may be {@code null} when no
-   * progress has been recorded or when the request has already completed.
+   * <p>The progress message provides a point-in-time view of in-flight work. It can be {@code null}
+   * when no progress has been recorded, when the request has already completed, or when the request
+   * does not emit incremental progress. The snapshot does not clone the message, so callers must
+   * not mutate it if it is shared across threads.
    *
-   * @return the last progress message, or {@code null} if none is available
+   * @return the last progress message, or {@code null} when no progress is available
    */
   public SimpleProgressMessage progressPending() {
-    return progressPending;
+    return progressSnapshot.progressPending();
   }
 
   /**
-   * Returns the cached failure message, if the request failed.
+   * Returns the cached failure message if the request failed.
    *
-   * <p>This value is {@code null} when no failure is known. The snapshot does not derive or
-   * validate failure details; it simply stores and returns the provided message object.
+   * <p>This value is {@code null} when no failure is known or when the request has not yet reached
+   * a terminal failure state. The snapshot does not derive or validate failure details; it simply
+   * stores and returns the provided message object. Callers should treat the returned message as
+   * read-only because it is not defensively copied.
    *
-   * @return the failure message, or {@code null} if the request has not failed
+   * @return the failure message, or {@code null} when no failure has been recorded
    */
   public GetFailedMessage failedMessage() {
-    return failedMessage;
+    return progressSnapshot.failedMessage();
   }
 
   /**
    * Returns the MIME type discovered for the data.
    *
    * <p>The MIME type is a hint derived from request processing and may be {@code null} when not yet
-   * known. The value is not normalized or validated by this snapshot.
+   * known or when no detection was performed. The snapshot does not normalize, validate, or
+   * canonicalize the value; it forwards exactly what was recorded. Consumers should therefore apply
+   * their own validation if they require a strict MIME format.
    *
-   * @return the discovered MIME type, or {@code null} if unknown
+   * @return the discovered MIME type, or {@code null} when it is not available
    */
   public String foundDataMimeType() {
-    return foundDataMimeType;
+    return dataSnapshot.foundDataMimeType();
   }
 
   /**
    * Returns the recorded data length for the request.
    *
    * <p>The length is expressed in bytes and reflects the latest known size at snapshot creation
-   * time. A value of {@code 0} may indicate unknown length or a zero-length payload depending on
-   * the calling context.
+   * time. A value of {@code 0} may indicate an unknown length or an empty payload, depending on the
+   * calling context and request type. The snapshot does not interpret or clamp this value; it
+   * simply returns the stored value for downstream status formatting.
    *
-   * @return the recorded data length in bytes
+   * @return the recorded data length in bytes, possibly zero when unknown or empty
    */
   public long foundDataLength() {
-    return foundDataLength;
+    return dataSnapshot.foundDataLength();
   }
 
   /**
    * Returns the destination file for disk-based requests.
    *
    * <p>The file reference is optional and may be {@code null} for in-memory requests or when the
-   * destination has not been assigned. The snapshot does not check file existence or permissions.
+   * destination has not been assigned. The snapshot does not check file existence, permissions, or
+   * path validity; it simply returns the stored reference. Callers should treat the returned value
+   * as read-only metadata rather than an authoritative file system guarantee.
    *
-   * @return the destination file, or {@code null} if not applicable
+   * @return the destination file, or {@code null} when no file target is applicable
    */
   public File destinationFile() {
-    return destinationFile;
+    return dataSnapshot.destinationFile();
   }
 
   /**
    * Returns the bucket containing result data.
    *
-   * <p>The bucket is optional and may be {@code null} when data is not yet available. No ownership
-   * transfer occurs; callers retain responsibility for bucket lifecycle management.
+   * <p>The bucket is optional and may be {@code null} when data is not yet available or when the
+   * request is configured to stream results elsewhere. No ownership transfer occurs; callers remain
+   * responsible for bucket lifecycle management and must not assume the bucket is immutable. The
+   * snapshot simply forwards the reference as recorded.
    *
-   * @return the result data bucket, or {@code null} if not available
+   * @return the result data bucket, or {@code null} when no data bucket is available
    */
   public Bucket dataBucket() {
-    return dataBucket;
+    return dataSnapshot.dataBucket();
   }
 
   /**
    * Returns the fetch context used for the request.
    *
    * <p>The context can include MIME overrides, filter settings, and other request-scoped options.
-   * The snapshot stores the reference as provided and does not copy or validate it.
+   * The snapshot stores the reference as provided and does not copy or validate it. A {@code null}
+   * value is permitted when a context is not available, and consumers should handle that case by
+   * falling back to their own defaults.
    *
-   * @return the fetch context, or {@code null} if not set
+   * @return the fetch context, or {@code null} when no context is available
    */
   public FetchContext fetchContext() {
-    return fetchContext;
+    return contextSnapshot.fetchContext();
   }
 
   /**
    * Returns the scheduler priority class for the request.
    *
    * <p>The value is stored verbatim and is interpreted by the request scheduler. This snapshot does
-   * not enforce any valid range or normalize the value.
+   * not enforce any valid range, clamp values, or normalize the priority; it simply reports what
+   * was recorded at snapshot creation time. Consumers should therefore avoid making assumptions
+   * beyond their scheduler's documented priority semantics.
    *
-   * @return the priority class as a short value
+   * @return the priority class as a short value, reported exactly as recorded
    */
   public short priorityClass() {
-    return priorityClass;
+    return statusSnapshot.priority();
   }
 
   /**
    * Returns the compatibility modes observed for the request.
    *
    * <p>The returned array is the original reference supplied to the constructor. It may be {@code
-   * null} or empty. Callers should treat it as read-only to avoid affecting equality or hash-based
-   * collections.
+   * null} or empty, and no defensive copy is made. Callers should therefore treat the array as
+   * read-only to avoid affecting equality or hash-based collections. The snapshot does not sort or
+   * deduplicate the modes.
    *
-   * @return the compatibility mode array, or {@code null} if not provided
+   * @return the compatibility mode array, or {@code null} when no modes were recorded
    */
   public CompatibilityMode[] compatModes() {
-    return compatModes;
+    return contextSnapshot.compatModes();
   }
 
   /**
    * Returns the splitfile crypto key override, if any.
    *
-   * <p>The returned array is not copied. It may be {@code null} when no override is configured.
-   * Callers should avoid mutating the array after snapshot construction.
+   * <p>The returned array is not copied. It may be {@code null} when no override is configured, and
+   * callers should avoid mutating the array after snapshot construction. Any mutation can change
+   * the snapshot's equality and hash semantics because array contents are included in comparisons.
    *
-   * @return the splitfile key bytes, or {@code null} if no override is set
+   * @return the splitfile key bytes, or {@code null} when no override is configured
    */
   public byte[] splitfileKey() {
-    return splitfileKey;
+    return contextSnapshot.splitfileKey();
   }
 
   /**
    * Returns the request URI associated with this snapshot.
    *
    * <p>The URI may be {@code null} when the request has not yet resolved a definitive URI or when
-   * the caller chooses not to expose it. The snapshot does not validate or normalize it.
+   * the caller chooses not to expose it. The snapshot does not validate or normalize the URI and
+   * does not resolve redirects; it simply returns the stored reference. Consumers should treat the
+   * value as a hint rather than a guaranteed canonical URI.
    *
-   * @return the request URI, or {@code null} if not available
+   * @return the request URI, or {@code null} when no URI is available
    */
   public FreenetURI uri() {
-    return uri;
+    return contextSnapshot.uri();
   }
 
   /**
    * Indicates whether reinsertion should skip compression.
    *
    * <p>This flag is reported to the status encoder to reflect the caller's reinsertion policy. It
-   * does not influence any other values held in this snapshot.
+   * does not influence any other values held in this snapshot and is not derived from other fields.
+   * The snapshot simply preserves the value set by the request at snapshot creation time.
    *
-   * @return {@code true} if reinsertion should skip compression, {@code false} otherwise
+   * @return {@code true} when reinsertion should skip compression, {@code false} otherwise
    */
   public boolean dontCompress() {
-    return dontCompress;
+    return contextSnapshot.dontCompress();
+  }
+
+  RequestStatusSnapshot statusSnapshot() {
+    return statusSnapshot;
   }
 
   /**
    * Compares this snapshot with another object for value equality.
    *
    * <p>Equality requires all scalar fields to match, as well as array contents for compatibility
-   * modes and splitfile key data. Mutable array contents can therefore affect equality over time.
-   * This method is deterministic provided the referenced arrays and objects are not mutated while
-   * comparison occurs.
+   * modes and splitfile key data. Because the arrays are not defensively copied, mutating their
+   * contents after construction can change equality results over time. The method is deterministic
+   * as long as the referenced arrays and objects are not mutated during comparison.
    *
-   * @param other the object to compare against, possibly {@code null}
+   * @param other object to compare against, possibly {@code null} and of another type
    * @return {@code true} when all fields and array contents are equal, otherwise {@code false}
    */
   @Override
@@ -341,55 +377,56 @@ public final class ClientGetStatusSnapshot {
     if (!(other instanceof ClientGetStatusSnapshot otherSnapshot)) {
       return false;
     }
-    return started == otherSnapshot.started
-        && finished == otherSnapshot.finished
-        && succeeded == otherSnapshot.succeeded
-        && foundDataLength == otherSnapshot.foundDataLength
-        && priorityClass == otherSnapshot.priorityClass
-        && dontCompress == otherSnapshot.dontCompress
-        && java.util.Objects.equals(identifier, otherSnapshot.identifier)
-        && persistence == otherSnapshot.persistence
-        && java.util.Objects.equals(progressPending, otherSnapshot.progressPending)
-        && java.util.Objects.equals(failedMessage, otherSnapshot.failedMessage)
-        && java.util.Objects.equals(foundDataMimeType, otherSnapshot.foundDataMimeType)
-        && java.util.Objects.equals(destinationFile, otherSnapshot.destinationFile)
-        && java.util.Objects.equals(dataBucket, otherSnapshot.dataBucket)
-        && java.util.Objects.equals(fetchContext, otherSnapshot.fetchContext)
-        && Arrays.equals(compatModes, otherSnapshot.compatModes)
-        && Arrays.equals(splitfileKey, otherSnapshot.splitfileKey)
-        && java.util.Objects.equals(uri, otherSnapshot.uri);
+    return started() == otherSnapshot.started()
+        && finished() == otherSnapshot.finished()
+        && succeeded() == otherSnapshot.succeeded()
+        && foundDataLength() == otherSnapshot.foundDataLength()
+        && priorityClass() == otherSnapshot.priorityClass()
+        && dontCompress() == otherSnapshot.dontCompress()
+        && java.util.Objects.equals(identifier(), otherSnapshot.identifier())
+        && persistence() == otherSnapshot.persistence()
+        && java.util.Objects.equals(progressPending(), otherSnapshot.progressPending())
+        && java.util.Objects.equals(failedMessage(), otherSnapshot.failedMessage())
+        && java.util.Objects.equals(foundDataMimeType(), otherSnapshot.foundDataMimeType())
+        && java.util.Objects.equals(destinationFile(), otherSnapshot.destinationFile())
+        && java.util.Objects.equals(dataBucket(), otherSnapshot.dataBucket())
+        && java.util.Objects.equals(fetchContext(), otherSnapshot.fetchContext())
+        && Arrays.equals(compatModes(), otherSnapshot.compatModes())
+        && Arrays.equals(splitfileKey(), otherSnapshot.splitfileKey())
+        && java.util.Objects.equals(uri(), otherSnapshot.uri());
   }
 
   /**
    * Computes a hash code from all stored snapshot fields.
    *
-   * <p>The hash includes the contents of the compatibility mode and splitfile key arrays, making it
-   * consistent with {@link #equals(Object)}. Mutating these arrays after construction can change
-   * the hash value and should be avoided when the instance is used as a map key.
+   * <p>The hash includes the contents of the compatibility mode and splitfile key arrays, keeping
+   * it consistent with {@link #equals(Object)}. Because those arrays are not copied, mutating their
+   * contents after construction can change the hash value. Avoid using this instance as a map key
+   * if the underlying arrays are expected to change.
    *
-   * @return a hash code derived from all snapshot fields
+   * @return a hash code derived from all snapshot fields and array contents
    */
   @Override
   public int hashCode() {
     int result =
         java.util.Objects.hash(
-            identifier,
-            persistence,
-            started,
-            finished,
-            succeeded,
-            progressPending,
-            failedMessage,
-            foundDataMimeType,
-            foundDataLength,
-            destinationFile,
-            dataBucket,
-            fetchContext,
-            priorityClass,
-            uri,
-            dontCompress);
-    result = 31 * result + Arrays.hashCode(compatModes);
-    result = 31 * result + Arrays.hashCode(splitfileKey);
+            identifier(),
+            persistence(),
+            started(),
+            finished(),
+            succeeded(),
+            progressPending(),
+            failedMessage(),
+            foundDataMimeType(),
+            foundDataLength(),
+            destinationFile(),
+            dataBucket(),
+            fetchContext(),
+            priorityClass(),
+            uri(),
+            dontCompress());
+    result = 31 * result + Arrays.hashCode(compatModes());
+    result = 31 * result + Arrays.hashCode(splitfileKey());
     return result;
   }
 
@@ -398,47 +435,49 @@ public final class ClientGetStatusSnapshot {
    *
    * <p>The string includes scalar values and full {@link Arrays#toString(byte[])} output for
    * arrays. Because it may include identifiers and key material, it should be used with care in
-   * production logs or user-visible output.
+   * production logs or user-visible output. The formatting is intended for debugging and should not
+   * be parsed or treated as a stable serialization format.
    *
-   * @return a human-readable representation of this snapshot
+   * @return a human-readable representation intended for diagnostic use only
    */
   @Override
   public @NotNull String toString() {
+    //noinspection resource
     return "ClientGetStatusSnapshot["
         + "identifier="
-        + identifier
+        + identifier()
         + ", persistence="
-        + persistence
+        + persistence()
         + ", started="
-        + started
+        + started()
         + ", finished="
-        + finished
+        + finished()
         + ", succeeded="
-        + succeeded
+        + succeeded()
         + ", progressPending="
-        + progressPending
+        + progressPending()
         + ", failedMessage="
-        + failedMessage
+        + failedMessage()
         + ", foundDataMimeType="
-        + foundDataMimeType
+        + foundDataMimeType()
         + ", foundDataLength="
-        + foundDataLength
+        + foundDataLength()
         + ", destinationFile="
-        + destinationFile
+        + destinationFile()
         + ", dataBucket="
-        + dataBucket
+        + dataBucket()
         + ", fetchContext="
-        + fetchContext
+        + fetchContext()
         + ", priorityClass="
-        + priorityClass
+        + priorityClass()
         + ", compatModes="
-        + Arrays.toString(compatModes)
+        + Arrays.toString(compatModes())
         + ", splitfileKey="
-        + Arrays.toString(splitfileKey)
+        + Arrays.toString(splitfileKey())
         + ", uri="
-        + uri
+        + uri()
         + ", dontCompress="
-        + dontCompress
+        + dontCompress()
         + ']';
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -15,6 +15,7 @@ import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientPutterOptions;
 import network.crypta.client.async.ClientPutterRequest;
 import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.InsertRequestParams;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
@@ -172,7 +173,10 @@ public class ClientPut extends ClientPutBase {
 
     ClientPutterRequest putterRequest =
         new ClientPutterRequest(
-            this, data, this.uri, cm, ctx, priorityClass, preparedData.isMetadata());
+            new InsertRequestParams(this, this.uri, ctx, priorityClass),
+            data,
+            cm,
+            preparedData.isMetadata());
     ClientPutterOptions putterOptions =
         new ClientPutterOptions(
             this.uri.getDocName() == null ? uploadTargetFilename : null,
@@ -267,7 +271,10 @@ public class ClientPut extends ClientPutBase {
     if (LOG.isDebugEnabled()) LOG.debug(MESSAGE_UPLOAD_LOG_TEMPLATE, data, uploadFrom);
     ClientPutterRequest putterRequest =
         new ClientPutterRequest(
-            this, data, this.uri, cm, ctx, priorityClass, preparedData.isMetadata());
+            new InsertRequestParams(this, this.uri, ctx, priorityClass),
+            data,
+            cm,
+            preparedData.isMetadata());
     ClientPutterOptions putterOptions =
         new ClientPutterOptions(
             this.uri.getDocName() == null ? targetFilename : null,

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -213,19 +213,21 @@ public class ClientPut extends ClientPutBase {
       throws IdentifierCollisionException, MessageInvalidException, IOException {
     FcpInsertOptions options =
         new FcpInsertOptions(
-            message.getCHKOnly,
-            message.dontCompress,
-            message.localRequestOnly,
-            message.maxRetries,
-            message.earlyEncode,
-            message.canWriteClientCache,
-            message.forkOnCacheable,
-            message.compressorDescriptor,
-            message.extraInsertsSingleBlock,
-            message.extraInsertsSplitfileHeaderBlock,
-            message.realTimeFlag,
-            message.compatibilityMode,
-            message.ignoreUSKDatehints,
+            new FcpInsertBehaviorOptions(
+                message.getCHKOnly,
+                message.dontCompress,
+                message.localRequestOnly,
+                message.maxRetries,
+                message.earlyEncode,
+                message.realTimeFlag,
+                message.ignoreUSKDatehints),
+            new FcpInsertTuningOptions(
+                message.canWriteClientCache,
+                message.forkOnCacheable,
+                message.compressorDescriptor,
+                message.extraInsertsSingleBlock,
+                message.extraInsertsSplitfileHeaderBlock,
+                message.compatibilityMode),
             message.overrideSplitfileCryptoKey);
     ClientRequestParams requestParams =
         new ClientRequestParams(

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -18,6 +18,7 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.ContainerInserter;
 import network.crypta.client.async.DefaultManifestPutter;
+import network.crypta.client.async.InsertRequestParams;
 import network.crypta.client.async.ManifestPutter;
 import network.crypta.client.async.ManifestPutterParams;
 import network.crypta.client.async.TooManyFilesInsertException;
@@ -402,12 +403,9 @@ public class ClientPutDir extends ClientPutBase {
     putter =
         new DefaultManifestPutter(
             new ManifestPutterParams(
-                this,
+                new InsertRequestParams(this, uri, ctx, priorityClass),
                 manifestElements,
-                priorityClass,
-                uri,
                 defaultName,
-                ctx,
                 overrideSplitfileCryptoKey,
                 context),
             persistence == Persistence.FOREVER);

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -121,19 +121,21 @@ public class ClientPutDir extends ClientPutBase {
       throws MalformedURLException, TooManyFilesInsertException {
     FcpInsertOptions options =
         new FcpInsertOptions(
-            message.getCHKOnly,
-            message.dontCompress,
-            message.localRequestOnly,
-            message.maxRetries,
-            message.earlyEncode,
-            message.canWriteClientCache,
-            message.forkOnCacheable,
-            message.compressorDescriptor,
-            message.extraInsertsSingleBlock,
-            message.extraInsertsSplitfileHeaderBlock,
-            message.realTimeFlag,
-            message.compatibilityMode,
-            message.ignoreUSKDatehints,
+            new FcpInsertBehaviorOptions(
+                message.getCHKOnly,
+                message.dontCompress,
+                message.localRequestOnly,
+                message.maxRetries,
+                message.earlyEncode,
+                message.realTimeFlag,
+                message.ignoreUSKDatehints),
+            new FcpInsertTuningOptions(
+                message.canWriteClientCache,
+                message.forkOnCacheable,
+                message.compressorDescriptor,
+                message.extraInsertsSingleBlock,
+                message.extraInsertsSplitfileHeaderBlock,
+                message.compatibilityMode),
             message.overrideSplitfileCryptoKey);
     ClientRequestParams requestParams =
         new ClientRequestParams(
@@ -190,19 +192,14 @@ public class ClientPutDir extends ClientPutBase {
    *         new FcpInsertRequest(
    *             client, uri, "upload", 1, null, priority, Persistence.CONNECTION, token, false),
    *         new FcpInsertOptions(
-   *             false,
-   *             false,
-   *             false,
-   *             3,
-   *             false,
-   *             true,
-   *             false,
-   *             null,
-   *             0,
-   *             0,
-   *             false,
-   *             InsertContext.CompatibilityMode.COMPAT_DEFAULT,
-   *             false,
+   *             new FcpInsertBehaviorOptions(false, false, false, 3, false, false, false),
+   *             new FcpInsertTuningOptions(
+   *                 true,
+   *                 false,
+   *                 null,
+   *                 0,
+   *                 0,
+   *                 InsertContext.CompatibilityMode.COMPAT_DEFAULT),
    *             null),
    *         new File("site"),
    *         "index.html",

--- a/src/main/java/network/crypta/clients/fcp/DownloadContextSnapshot.java
+++ b/src/main/java/network/crypta/clients/fcp/DownloadContextSnapshot.java
@@ -1,0 +1,138 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Represents fetch-context and compatibility metadata captured for a download request.
+ *
+ * <p>This value object aggregates the subset of download status data that is derived from the
+ * request's execution context rather than its progress counters or outcome. Callers typically build
+ * it alongside other snapshot bundles and pass it into a status formatter or encoder that produces
+ * an FCP reply. The snapshot stores all references as provided and does not perform validation,
+ * normalization, or defensive copying.
+ *
+ * <p>The instance is immutable, but the referenced {@link FetchContext} and any arrays may be
+ * mutable. As a result, thread-safety depends on how those objects are shared, and callers should
+ * treat the referenced values as read-only after the snapshot is created. The snapshot
+ * intentionally does not interpret compatibility mode ordering or URI normalization, leaving those
+ * concerns to downstream consumers.
+ *
+ * <ul>
+ *   <li>Preserves fetch-context settings that influence status output and filtering.
+ *   <li>Captures compatibility modes and splitfile key overrides, if any.
+ *   <li>Holds request URI and compression policy for reporting purposes.
+ * </ul>
+ *
+ * @see FetchContext
+ * @see DownloadRequestStatusDetails
+ */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+public final class DownloadContextSnapshot {
+  private final FetchContext fetchContext;
+  private final CompatibilityMode[] compatModes;
+  private final byte[] splitfileKey;
+  private final FreenetURI uri;
+  private final boolean dontCompress;
+
+  /**
+   * Creates a context snapshot for download status reporting.
+   *
+   * <p>The constructor stores each argument verbatim so the snapshot mirrors the request state at
+   * the time the status response is prepared. Reference parameters may be {@code null} when the
+   * associated data is unknown or not applicable, and those {@code null} values are forwarded
+   * unmodified to downstream encoders. The snapshot does not validate array lengths, URI schemes,
+   * or compatibility semantics; callers are responsible for ensuring the inputs are appropriate for
+   * their status reporting use case.
+   *
+   * <pre>{@code
+   * DownloadContextSnapshot context =
+   *     new DownloadContextSnapshot(fetchContext, compatModes, splitfileKey, uri, dontCompress);
+   * }</pre>
+   *
+   * @param fetchContext fetch context providing filter and MIME overrides, or {@code null}
+   * @param compatModes compatibility modes observed for the request, possibly empty or {@code null}
+   * @param splitfileKey splitfile crypto key override bytes, or {@code null} if not applicable
+   * @param uri request URI to report, or {@code null} when not yet resolved
+   * @param dontCompress whether reinsertion should skip compression when producing output
+   */
+  public DownloadContextSnapshot(
+      FetchContext fetchContext,
+      CompatibilityMode[] compatModes,
+      byte[] splitfileKey,
+      FreenetURI uri,
+      boolean dontCompress) {
+    this.fetchContext = fetchContext;
+    this.compatModes = compatModes;
+    this.splitfileKey = splitfileKey;
+    this.uri = uri;
+    this.dontCompress = dontCompress;
+  }
+
+  /**
+   * Returns the fetch context captured in this snapshot.
+   *
+   * <p>The context can include filtering settings, MIME overrides, and other request-scoped
+   * options. The returned reference is the original object supplied at construction time and is not
+   * copied. It may be {@code null} when no context was available, and callers should handle that
+   * case by applying their own defaults or by omitting context-derived fields in status output.
+   *
+   * @return the fetch context reference, or {@code null} when not available
+   */
+  public FetchContext fetchContext() {
+    return fetchContext;
+  }
+
+  /**
+   * Returns the compatibility modes observed for the request.
+   *
+   * <p>The returned array is the original reference supplied to the constructor. It may be {@code
+   * null} or empty, and no defensive copy is made. Callers should therefore treat the array as
+   * read-only and avoid mutation that could alter equality or hash-based behavior elsewhere.
+   *
+   * @return the compatibility mode array, or {@code null} if no modes were recorded
+   */
+  public CompatibilityMode[] compatModes() {
+    return compatModes;
+  }
+
+  /**
+   * Returns the splitfile crypto key override, if any.
+   *
+   * <p>The returned byte array is not copied. It may be {@code null} when no override is configured
+   * or when the request does not involve splitfiles. Callers should not mutate the array after
+   * construction to preserve stable equality and diagnostic output.
+   *
+   * @return the splitfile key bytes, or {@code null} when no override is set
+   */
+  public byte[] splitfileKey() {
+    return splitfileKey;
+  }
+
+  /**
+   * Returns the request URI associated with this snapshot.
+   *
+   * <p>The URI may be {@code null} when the request has not yet resolved a definitive URI or when
+   * the caller chooses not to expose it. The snapshot does not validate or normalize the URI; it
+   * simply returns the stored reference for status reporting.
+   *
+   * @return the request URI, or {@code null} when no URI is available
+   */
+  public FreenetURI uri() {
+    return uri;
+  }
+
+  /**
+   * Returns whether reinsertion should skip compression.
+   *
+   * <p>This flag is captured for status reporting and is not derived from other fields. It reflects
+   * the request's reinsertion policy at snapshot creation time and does not change after
+   * construction.
+   *
+   * @return {@code true} when reinsertion should skip compression, {@code false} otherwise
+   */
+  public boolean dontCompress() {
+    return dontCompress;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/DownloadDataSnapshot.java
+++ b/src/main/java/network/crypta/clients/fcp/DownloadDataSnapshot.java
@@ -1,0 +1,34 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Represents data-discovery and storage-target metadata captured for a download request.
+ *
+ * <p>This record bundles the request's data-related status values so they can be passed as a single
+ * object when building a {@link DownloadRequestStatus} or rendering an FCP status reply. Callers
+ * typically construct it alongside other snapshot bundles at the moment a status response is
+ * prepared. The record does not validate or normalize its inputs; it simply preserves whatever
+ * values the request has recorded at that point in time.
+ *
+ * <p>All components are stored verbatim. The {@link File} and {@link Bucket} references are not
+ * copied, and no existence or lifecycle checks are performed. Thread-safety therefore depends on
+ * how those referenced objects are shared, and callers should treat them as read-only while the
+ * snapshot is in use by downstream encoders.
+ *
+ * <ul>
+ *   <li>Captures discovered MIME type and data length in bytes.
+ *   <li>Records a destination file for disk-based returns, if applicable.
+ *   <li>Holds a bucket reference for in-memory or shadowed results.
+ * </ul>
+ *
+ * @param foundDataMimeType MIME type hint for the data, or {@code null} if unknown
+ * @param foundDataLength data length recorded for the request, in bytes when known
+ * @param destinationFile destination file for disk requests, or {@code null} for in-memory data
+ * @param dataBucket bucket containing result data, or {@code null} when not yet available
+ * @see DownloadRequestStatus
+ * @see DownloadRequestStatusDetails
+ */
+public record DownloadDataSnapshot(
+    String foundDataMimeType, long foundDataLength, File destinationFile, Bucket dataBucket) {}

--- a/src/main/java/network/crypta/clients/fcp/DownloadProgressSnapshot.java
+++ b/src/main/java/network/crypta/clients/fcp/DownloadProgressSnapshot.java
@@ -1,0 +1,10 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Parameter bundle describing cached progress and failure details for a download.
+ *
+ * @param progressPending last recorded progress message, or {@code null} if none
+ * @param failedMessage cached failure message, or {@code null} when no failure is known
+ */
+public record DownloadProgressSnapshot(
+    SimpleProgressMessage progressPending, GetFailedMessage failedMessage) {}

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertBehaviorOptions.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertBehaviorOptions.java
@@ -1,0 +1,43 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Bundles behavior flags and scheduling hints for FCP inserts.
+ *
+ * <p>This record captures a compact set of booleans and limits that describe how an insert request
+ * should behave when it is routed through the FCP pipeline. Callers typically create an instance
+ * alongside a tuning options record and pass both into {@link FcpInsertOptions} so the insert
+ * context can be initialized consistently for file and directory requests. The record is immutable
+ * and thread-safe because its components are final and have no mutable substructure. It performs no
+ * validation or normalization; the values are preserved exactly as supplied so protocol parsing and
+ * higher-level logic remain responsible for defaults and constraints.
+ *
+ * <ul>
+ *   <li>Captures request-local behavior such as early encoding and local-only constraints.
+ *   <li>Represents scheduling intent through the real-time flag.
+ *   <li>Records retry limits and USK datehint behavior without interpretation.
+ * </ul>
+ *
+ * @param getCHKOnly whether to compute the CHK without persisting blocks; {@code true} limits the
+ *     insert to key derivation only.
+ * @param dontCompress whether compression should be disabled for the insert; {@code true} bypasses
+ *     codec selection in downstream logic.
+ * @param localRequestOnly whether the insert should remain on the local node only; {@code true}
+ *     avoids network propagation by policy.
+ * @param maxRetries maximum retries before failing the insert; the value is stored as provided and
+ *     may follow sentinel conventions used elsewhere.
+ * @param earlyEncode whether encoding should begin before all data is received; {@code true} favors
+ *     lower latency for streaming inserts.
+ * @param realTimeFlag whether to schedule the insert in real-time queues; {@code true} requests low
+ *     latency queueing when supported.
+ * @param ignoreUSKDatehints whether USK datehints should be ignored during insert; {@code true}
+ *     bypasses datehint optimizations in the insert pipeline.
+ * @see FcpInsertOptions
+ */
+public record FcpInsertBehaviorOptions(
+    boolean getCHKOnly,
+    boolean dontCompress,
+    boolean localRequestOnly,
+    int maxRetries,
+    boolean earlyEncode,
+    boolean realTimeFlag,
+    boolean ignoreUSKDatehints) {}

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertOptions.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertOptions.java
@@ -8,9 +8,28 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Captures insert-specific tuning knobs supplied by FCP callers.
  *
- * <p>The options encapsulate retry limits, compression preferences, cache behaviors, redundancy
- * factors, real-time scheduling, and compatibility mode hints. They are shared between file and
- * directory put requests to ensure consistent configuration across insert flows.
+ * <p>This value object aggregates caller-selected flags and numeric limits that shape how insert
+ * requests are scheduled, encoded, and cached. Typical call sites assemble the two option group
+ * records for behavior and tuning, then pass this instance into a request constructor that
+ * initializes an {@link network.crypta.client.InsertContext}. The class is immutable in terms of
+ * its field references and does not validate or normalize any inputs, which preserves legacy
+ * behavior and keeps construction lightweight. Callers therefore remain responsible for providing
+ * coherent combinations such as compatible retry limits and compression settings.
+ *
+ * <p>Instances are safe to share between threads because all fields are final, but the optional
+ * {@code overrideSplitfileCryptoKey} array is stored by reference; if callers mutate the array
+ * after construction, observers will see those mutations. Prefer supplying a stable array or a
+ * defensive copy when sharing instances across components.
+ *
+ * <ul>
+ *   <li>Groups behavior flags like real-time scheduling and local-only inserts.
+ *   <li>Captures cache and redundancy tuning used by insert contexts.
+ *   <li>Retains optional compressor and splitfile key hints without modification.
+ * </ul>
+ *
+ * @see FcpInsertBehaviorOptions
+ * @see FcpInsertTuningOptions
+ * @see network.crypta.client.InsertContext
  */
 public final class FcpInsertOptions {
   private final boolean getCHKOnly;
@@ -29,110 +48,244 @@ public final class FcpInsertOptions {
   private final byte[] overrideSplitfileCryptoKey;
 
   /**
-   * Creates an insert options bundle.
+   * Creates an insert options bundle from the supplied option groups.
    *
-   * @param getCHKOnly whether to compute the CHK without persisting blocks
-   * @param dontCompress whether compression should be disabled for the insert
-   * @param localRequestOnly whether the insert should remain on the local node only
-   * @param maxRetries maximum retries before failing the insert
-   * @param earlyEncode whether encoding should begin before all data is received
-   * @param canWriteClientCache whether client cache writes are permitted
-   * @param forkOnCacheable whether to fork insert contexts when blocks become cacheable
-   * @param compressorDescriptor optional compressor descriptor string; may be {@code null}
-   * @param extraInsertsSingleBlock redundancy factor for single-block inserts
-   * @param extraInsertsSplitfileHeaderBlock redundancy factor for splitfile header blocks
-   * @param realTimeFlag whether to schedule the insert in real-time queues
-   * @param compatibilityMode compatibility mode guiding splitfile encoding parameters
-   * @param ignoreUSKDatehints whether USK datehints should be ignored during insert
+   * <p>The constructor copies the provided option values into fixed fields and retains the override
+   * key array reference as-is. It performs no validation, range checking, or normalization because
+   * the surrounding FCP request pipeline already enforces field syntax and defaults. For
+   * predictable behavior, callers should pass non-null option records and supply an override key
+   * only when the insert workflow expects a precomputed splitfile crypto key.
+   *
+   * @param behaviorOptions flags and scheduling hints for the insert; must be non-null and already
+   *     validated by the caller for consistency.
+   * @param tuningOptions cache and redundancy tuning parameters; must be non-null and represent the
+   *     desired compressor, redundancy, and compatibility choices.
    * @param overrideSplitfileCryptoKey optional splitfile crypto key override; may be {@code null}
+   *     and is stored by reference without defensive copying.
    */
   public FcpInsertOptions(
-      boolean getCHKOnly,
-      boolean dontCompress,
-      boolean localRequestOnly,
-      int maxRetries,
-      boolean earlyEncode,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      String compressorDescriptor,
-      int extraInsertsSingleBlock,
-      int extraInsertsSplitfileHeaderBlock,
-      boolean realTimeFlag,
-      InsertContext.CompatibilityMode compatibilityMode,
-      boolean ignoreUSKDatehints,
+      FcpInsertBehaviorOptions behaviorOptions,
+      FcpInsertTuningOptions tuningOptions,
       byte[] overrideSplitfileCryptoKey) {
-    this.getCHKOnly = getCHKOnly;
-    this.dontCompress = dontCompress;
-    this.localRequestOnly = localRequestOnly;
-    this.maxRetries = maxRetries;
-    this.earlyEncode = earlyEncode;
-    this.canWriteClientCache = canWriteClientCache;
-    this.forkOnCacheable = forkOnCacheable;
-    this.compressorDescriptor = compressorDescriptor;
-    this.extraInsertsSingleBlock = extraInsertsSingleBlock;
-    this.extraInsertsSplitfileHeaderBlock = extraInsertsSplitfileHeaderBlock;
-    this.realTimeFlag = realTimeFlag;
-    this.compatibilityMode = compatibilityMode;
-    this.ignoreUSKDatehints = ignoreUSKDatehints;
+    this.getCHKOnly = behaviorOptions.getCHKOnly();
+    this.dontCompress = behaviorOptions.dontCompress();
+    this.localRequestOnly = behaviorOptions.localRequestOnly();
+    this.maxRetries = behaviorOptions.maxRetries();
+    this.earlyEncode = behaviorOptions.earlyEncode();
+    this.realTimeFlag = behaviorOptions.realTimeFlag();
+    this.ignoreUSKDatehints = behaviorOptions.ignoreUSKDatehints();
+    this.canWriteClientCache = tuningOptions.canWriteClientCache();
+    this.forkOnCacheable = tuningOptions.forkOnCacheable();
+    this.compressorDescriptor = tuningOptions.compressorDescriptor();
+    this.extraInsertsSingleBlock = tuningOptions.extraInsertsSingleBlock();
+    this.extraInsertsSplitfileHeaderBlock = tuningOptions.extraInsertsSplitfileHeaderBlock();
+    this.compatibilityMode = tuningOptions.compatibilityMode();
     this.overrideSplitfileCryptoKey = overrideSplitfileCryptoKey;
   }
 
+  /**
+   * Returns whether the insert is limited to computing the CHK without persisting blocks.
+   *
+   * <p>When this flag is {@code true}, downstream insert contexts typically avoid writing data to
+   * the node stores and instead focus on deriving the final key. The value is a direct reflection
+   * of the caller's request and is not interpreted or normalized here. The method is a simple
+   * accessor and is idempotent; repeated calls return the same value.
+   *
+   * @return {@code true} when the insert should only compute the CHK and avoid persistence.
+   */
   public boolean getCHKOnly() {
     return getCHKOnly;
   }
 
+  /**
+   * Returns whether compression is disabled for this insert.
+   *
+   * <p>This flag is passed through to the underlying insert context to control whether compression
+   * codecs are considered. The value is stored exactly as provided and does not imply that data is
+   * already compressed; it simply signals that the insert pipeline should skip compression logic.
+   * The method is side-effect-free and always returns the stored value.
+   *
+   * @return {@code true} when compression should be bypassed for the insert payload.
+   */
   public boolean dontCompress() {
     return dontCompress;
   }
 
+  /**
+   * Returns whether the insert must remain local to the current node.
+   *
+   * <p>Local-only inserts typically avoid network propagation and are used for workflows that only
+   * need the key derivation or local storage side effects. This method exposes the stored flag
+   * without interpretation or additional validation, allowing higher-level logic to decide how
+   * strictly to enforce local-only behavior.
+   *
+   * @return {@code true} when the insert should not leave the local node.
+   */
   public boolean localRequestOnly() {
     return localRequestOnly;
   }
 
+  /**
+   * Returns the maximum retry limit configured for this insert.
+   *
+   * <p>The value is used by the insert context to cap the number of retry attempts per block. It is
+   * stored as provided and may follow sentinel conventions defined elsewhere (for example, negative
+   * values may mean unlimited retries). This method does not enforce any range constraints and is
+   * purely a value accessor.
+   *
+   * @return the maximum retry limit value supplied by the caller, unchanged.
+   */
   public int maxRetries() {
     return maxRetries;
   }
 
+  /**
+   * Returns whether the insert should start encoding before all data is received.
+   *
+   * <p>Early encoding can reduce latency for streaming workflows by allowing block generation to
+   * begin as soon as partial data is available. The flag is retained without modification; any
+   * constraints or safety checks are handled by the caller or the insert pipeline. The accessor is
+   * deterministic and has no side effects.
+   *
+   * @return {@code true} when early encoding is requested for this insert.
+   */
   public boolean earlyEncode() {
     return earlyEncode;
   }
 
+  /**
+   * Returns whether writing to the client cache is permitted.
+   *
+   * <p>This flag is passed to the insert context to decide whether successfully produced blocks may
+   * be stored in the client cache. It does not imply that caching will occur, only that it is
+   * allowed. The value is stored exactly as provided and returned unchanged on each invocation.
+   *
+   * @return {@code true} when client cache writes are allowed for this insert.
+   */
   public boolean canWriteClientCache() {
     return canWriteClientCache;
   }
 
+  /**
+   * Returns whether insert contexts may fork when blocks become cacheable.
+   *
+   * <p>Forking can allow insert scheduling to proceed with different cache-related assumptions once
+   * data is known to be cacheable. The flag is stored as a simple boolean and is not interpreted
+   * here. Consumers of this option decide how to use it in their scheduling and caching logic.
+   *
+   * @return {@code true} when insert contexts may fork on cacheable results.
+   */
   public boolean forkOnCacheable() {
     return forkOnCacheable;
   }
 
+  /**
+   * Returns the optional compressor descriptor string, if supplied.
+   *
+   * <p>The descriptor typically names compressors or codec preferences to be used by the insert
+   * pipeline. This class does not parse or validate the descriptor; it simply preserves the value
+   * from the caller. A {@code null} return value indicates that no explicit descriptor was
+   * specified and defaults should be applied by downstream logic.
+   *
+   * @return the compressor descriptor string, or {@code null} when no descriptor is provided.
+   */
   public String compressorDescriptor() {
     return compressorDescriptor;
   }
 
+  /**
+   * Returns the redundancy factor for single-block inserts.
+   *
+   * <p>This value influences how many extra insert attempts are scheduled for payloads that fit in
+   * a single block. It is preserved exactly as provided, including any sentinel values interpreted
+   * by downstream logic. The method is a direct accessor and does not enforce any bounds.
+   *
+   * @return the extra insert count configured for single-block payloads.
+   */
   public int extraInsertsSingleBlock() {
     return extraInsertsSingleBlock;
   }
 
+  /**
+   * Returns the redundancy factor for splitfile header blocks.
+   *
+   * <p>Splitfiles may have special header blocks that benefit from additional insert attempts. This
+   * value is used by the insert context to configure that redundancy, but this class does not
+   * interpret or validate the number. The accessor is deterministic and returns the stored value
+   * exactly.
+   *
+   * @return the extra insert count configured for splitfile header blocks.
+   */
   public int extraInsertsSplitfileHeaderBlock() {
     return extraInsertsSplitfileHeaderBlock;
   }
 
+  /**
+   * Returns whether the insert should be scheduled in real-time queues.
+   *
+   * <p>Real-time scheduling typically prioritizes lower latency over bulk throughput and is useful
+   * for interactive insert workflows. This flag is stored exactly as provided and does not imply
+   * any particular priority class; those decisions are made by higher-level scheduling logic. The
+   * accessor is side-effect-free.
+   *
+   * @return {@code true} when real-time queueing is requested.
+   */
   public boolean realTimeFlag() {
     return realTimeFlag;
   }
 
+  /**
+   * Returns the compatibility mode that guides splitfile encoding parameters.
+   *
+   * <p>The compatibility mode influences how metadata and block layouts are generated for insert
+   * payloads. This value is stored as provided and is expected to be non-null; this class does not
+   * perform any normalization or default selection. Downstream components should treat it as the
+   * authoritative compatibility hint for the insert.
+   *
+   * @return the compatibility mode selected by the caller for this insert.
+   */
   public InsertContext.CompatibilityMode compatibilityMode() {
     return compatibilityMode;
   }
 
+  /**
+   * Returns whether USK datehints should be ignored during insert.
+   *
+   * <p>When this flag is {@code true}, USK-specific date hints are bypassed so the insert proceeds
+   * without those optimizations or constraints. The value is stored directly from the caller and is
+   * exposed unchanged. No additional validation or normalization is performed.
+   *
+   * @return {@code true} when USK datehints should be ignored for this insert.
+   */
   public boolean ignoreUSKDatehints() {
     return ignoreUSKDatehints;
   }
 
+  /**
+   * Returns the optional override splitfile crypto key reference.
+   *
+   * <p>The returned value is the same array reference supplied at construction time and may be
+   * {@code null}. Because the array is not defensively copied, callers should treat the returned
+   * reference as read-only to avoid surprising mutations elsewhere in the insert pipeline. If no
+   * override key was supplied, downstream logic should fall back to generated keys.
+   *
+   * @return the override splitfile crypto key array reference, or {@code null} if none is set.
+   */
   public byte[] overrideSplitfileCryptoKey() {
     return overrideSplitfileCryptoKey;
   }
 
+  /**
+   * Compares this instance to another for value equality.
+   *
+   * <p>The comparison checks every stored field, including a deep array comparison for the override
+   * splitfile crypto key. Equality therefore reflects the content of the byte array at the time of
+   * comparison; if the array is mutated after construction, equality results may change. This
+   * method is symmetric, transitive, and consistent as long as inputs are not mutated.
+   *
+   * @param o object to compare against; may be {@code null}.
+   * @return {@code true} when all fields match and array contents are equal.
+   */
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -153,6 +306,16 @@ public final class FcpInsertOptions {
         && Arrays.equals(overrideSplitfileCryptoKey, other.overrideSplitfileCryptoKey);
   }
 
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash combines all scalar fields with a content-based hash of the override splitfile key
+   * array. If the array contents are mutated after construction, the hash code will change and may
+   * break usage in hashed collections. Callers should therefore treat the array as immutable once
+   * inserted into maps or sets.
+   *
+   * @return a hash code derived from all fields and array contents.
+   */
   @Override
   public int hashCode() {
     int result =
@@ -174,6 +337,16 @@ public final class FcpInsertOptions {
     return result;
   }
 
+  /**
+   * Returns a detailed string representation of this options bundle.
+   *
+   * <p>The output includes each field name and value, including the override splitfile key rendered
+   * via {@link Arrays#toString(byte[])} when present. The method does not redact or sanitize
+   * values, so callers should avoid logging the result if the raw key material is sensitive in
+   * their context. The returned string is non-null and reflects the current field values.
+   *
+   * @return a non-null string containing all option fields and their current values.
+   */
   @Override
   public @NotNull String toString() {
     return "FcpInsertOptions[getCHKOnly="

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertTuningOptions.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertTuningOptions.java
@@ -1,0 +1,41 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.InsertContext;
+
+/**
+ * Bundles cache, redundancy, and compatibility tuning parameters for FCP inserts.
+ *
+ * <p>This record groups the insert context settings that tune cache usage, redundancy behavior, and
+ * encoding compatibility. Callers typically build an instance alongside a behavior options record
+ * and pass both into {@code FcpInsertOptions} so a single request can initialize an {@link
+ * network.crypta.client.InsertContext} with consistent values. The record is immutable and
+ * thread-safe because its components are final and have no mutable substructure; it does not
+ * validate or normalize inputs, leaving default selection and range enforcement to higher layers.
+ * This preserves legacy behavior and makes construction inexpensive.
+ *
+ * <ul>
+ *   <li>Controls whether client cache writes and cacheable forks are permitted.
+ *   <li>Captures redundancy factors for single-block and splitfile header inserts.
+ *   <li>Records the compatibility mode used for splitfile encoding decisions.
+ * </ul>
+ *
+ * @param canWriteClientCache whether client cache writes are permitted; {@code true} allows
+ *     downstream logic to store insert results in the client cache.
+ * @param forkOnCacheable whether to fork insert contexts when blocks become cacheable; {@code true}
+ *     signals that cacheability may trigger a context fork.
+ * @param compressorDescriptor optional compressor descriptor string; may be {@code null} to use
+ *     default codec selection in downstream components.
+ * @param extraInsertsSingleBlock redundancy factor for single-block inserts; the value is stored as
+ *     provided and interpreted by downstream scheduling logic.
+ * @param extraInsertsSplitfileHeaderBlock redundancy factor for splitfile header blocks; stored as
+ *     provided and used to tune header reliability.
+ * @param compatibilityMode compatibility mode guiding splitfile encoding parameters; expected to be
+ *     non-null and preserved without normalization.
+ */
+public record FcpInsertTuningOptions(
+    boolean canWriteClientCache,
+    boolean forkOnCacheable,
+    String compressorDescriptor,
+    int extraInsertsSingleBlock,
+    int extraInsertsSplitfileHeaderBlock,
+    InsertContext.CompatibilityMode compatibilityMode) {}

--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -380,17 +380,14 @@ public abstract class ConnectionsToadlet extends Toadlet {
       contentNode.addChild(ctx.getAlertManager().createSummary());
     }
 
+    RenderMode renderMode = new RenderMode(advancedMode, drawMessageTypes);
+    RenderTiming renderTiming = new RenderTiming(now, percentageFormat);
     RenderContext renderContext =
         new RenderContext(
-            ctx,
-            path,
-            peerNodeStatuses,
-            drawMessageTypes,
-            percentageFormat,
-            advancedMode,
-            contentNode,
-            now,
-            counts);
+            new RenderPageContext(ctx, path, contentNode),
+            new RenderPeerSnapshot(peerNodeStatuses, counts),
+            renderMode,
+            renderTiming);
     renderContent(renderContext);
 
     if (peerNodeStatuses.length == 0) {
@@ -939,6 +936,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
       boolean advancedMode,
       long now) {
     double totalSelectionRate = 0.0;
+    RenderMode renderMode = new RenderMode(advancedMode, drawMessageTypes);
+    RenderTiming renderTiming = new RenderTiming(now, percentageFormat);
     PeerNodeStatus[] allPeerNodeStatuses =
         node.network().peers().statusBook().getPeerNodeStatuses(true);
     for (PeerNodeStatus status : allPeerNodeStatuses) {
@@ -947,16 +946,13 @@ public abstract class ConnectionsToadlet extends Toadlet {
     for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
       RowContext rowContext =
           new RowContext(
-              peerTableContext.peerTable(),
-              peerNodeStatus,
-              advancedMode,
-              node.isFProxyJavascriptEnabled(),
-              now,
-              peerTableContext.peerForm() != null,
-              peerTableContext.endCols(),
-              drawMessageTypes,
-              totalSelectionRate,
-              percentageFormat);
+              new PeerRowContext(
+                  peerTableContext.peerTable(), peerNodeStatus, peerTableContext.endCols()),
+              renderMode,
+              new PeerRowFlags(
+                  node.isFProxyJavascriptEnabled(), peerTableContext.peerForm() != null),
+              renderTiming,
+              new PeerSelectionStats(totalSelectionRate));
       drawRow(rowContext);
     }
 
@@ -1095,102 +1091,99 @@ public abstract class ConnectionsToadlet extends Toadlet {
       FRIEND_TRUST trust,
       FRIEND_VISIBILITY visibility) {}
 
-  @SuppressWarnings("java:S6206")
-  private static final class RenderContext {
-    private final ToadletContext ctx;
-    private final String path;
+  private record RenderPageContext(ToadletContext ctx, String path, HTMLNode contentNode) {}
+
+  @SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+  private static final class RenderPeerSnapshot {
     private final PeerNodeStatus[] peerNodeStatuses;
-    private final boolean drawMessageTypes;
-    private final DecimalFormat percentageFormat;
-    private final boolean advancedMode;
-    private final HTMLNode contentNode;
-    private final long now;
     private final PeerStatusCounts counts;
 
-    private RenderContext(
-        ToadletContext ctx,
-        String path,
-        PeerNodeStatus[] peerNodeStatuses,
-        boolean drawMessageTypes,
-        DecimalFormat percentageFormat,
-        boolean advancedMode,
-        HTMLNode contentNode,
-        long now,
-        PeerStatusCounts counts) {
-      this.ctx = ctx;
-      this.path = path;
+    private RenderPeerSnapshot(PeerNodeStatus[] peerNodeStatuses, PeerStatusCounts counts) {
       this.peerNodeStatuses = peerNodeStatuses;
-      this.drawMessageTypes = drawMessageTypes;
-      this.percentageFormat = percentageFormat;
-      this.advancedMode = advancedMode;
-      this.contentNode = contentNode;
-      this.now = now;
       this.counts = counts;
-    }
-
-    ToadletContext ctx() {
-      return ctx;
-    }
-
-    String path() {
-      return path;
     }
 
     PeerNodeStatus[] peerNodeStatuses() {
       return peerNodeStatuses;
     }
 
+    PeerStatusCounts counts() {
+      return counts;
+    }
+  }
+
+  private record RenderMode(boolean advancedModeEnabled, boolean drawMessageTypes) {}
+
+  private record RenderTiming(long now, DecimalFormat percentageFormat) {}
+
+  @SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+  private static final class RenderContext {
+    private final RenderPageContext pageContext;
+    private final RenderPeerSnapshot peerSnapshot;
+    private final RenderMode renderMode;
+    private final RenderTiming renderTiming;
+
+    private RenderContext(
+        RenderPageContext pageContext,
+        RenderPeerSnapshot peerSnapshot,
+        RenderMode renderMode,
+        RenderTiming renderTiming) {
+      this.pageContext = pageContext;
+      this.peerSnapshot = peerSnapshot;
+      this.renderMode = renderMode;
+      this.renderTiming = renderTiming;
+    }
+
+    ToadletContext ctx() {
+      return pageContext.ctx();
+    }
+
+    String path() {
+      return pageContext.path();
+    }
+
+    PeerNodeStatus[] peerNodeStatuses() {
+      return peerSnapshot.peerNodeStatuses();
+    }
+
     boolean drawMessageTypes() {
-      return drawMessageTypes;
+      return renderMode.drawMessageTypes();
     }
 
     DecimalFormat percentageFormat() {
-      return percentageFormat;
+      return renderTiming.percentageFormat();
     }
 
     boolean advancedMode() {
-      return advancedMode;
+      return renderMode.advancedModeEnabled();
     }
 
     HTMLNode contentNode() {
-      return contentNode;
+      return pageContext.contentNode();
     }
 
     long now() {
-      return now;
+      return renderTiming.now();
     }
 
     PeerStatusCounts counts() {
-      return counts;
+      return peerSnapshot.counts();
     }
 
     @Override
     public boolean equals(Object o) {
       if (!(o instanceof RenderContext that)) return false;
-      return drawMessageTypes == that.drawMessageTypes
-          && advancedMode == that.advancedMode
-          && now == that.now
-          && Objects.equals(ctx, that.ctx)
-          && Objects.equals(path, that.path)
-          && Arrays.equals(peerNodeStatuses, that.peerNodeStatuses)
-          && Objects.equals(percentageFormat, that.percentageFormat)
-          && Objects.equals(contentNode, that.contentNode)
-          && Objects.equals(counts, that.counts);
+      return Objects.equals(pageContext, that.pageContext)
+          && Objects.equals(renderMode, that.renderMode)
+          && Objects.equals(renderTiming, that.renderTiming)
+          && Objects.equals(peerSnapshot.counts(), that.peerSnapshot.counts())
+          && Arrays.equals(peerSnapshot.peerNodeStatuses(), that.peerSnapshot.peerNodeStatuses());
     }
 
     @Override
     public int hashCode() {
-      int result =
-          Objects.hash(
-              ctx,
-              path,
-              drawMessageTypes,
-              percentageFormat,
-              advancedMode,
-              contentNode,
-              now,
-              counts);
-      result = 31 * result + Arrays.hashCode(peerNodeStatuses);
+      int result = Objects.hash(pageContext, renderMode, renderTiming, peerSnapshot.counts());
+      result = 31 * result + Arrays.hashCode(peerSnapshot.peerNodeStatuses());
       return result;
     }
 
@@ -1198,39 +1191,41 @@ public abstract class ConnectionsToadlet extends Toadlet {
     public @NotNull String toString() {
       return "RenderContext{"
           + "ctx="
-          + ctx
+          + pageContext.ctx()
           + ", path='"
-          + path
+          + pageContext.path()
           + '\''
           + ", peerNodeStatuses="
-          + Arrays.toString(peerNodeStatuses)
+          + Arrays.toString(peerSnapshot.peerNodeStatuses())
           + ", drawMessageTypes="
-          + drawMessageTypes
+          + renderMode.drawMessageTypes()
           + ", percentageFormat="
-          + percentageFormat
+          + renderTiming.percentageFormat()
           + ", advancedMode="
-          + advancedMode
+          + renderMode.advancedModeEnabled()
           + ", contentNode="
-          + contentNode
+          + pageContext.contentNode()
           + ", now="
-          + now
+          + renderTiming.now()
           + ", counts="
-          + counts
+          + peerSnapshot.counts()
           + '}';
     }
   }
 
+  private record PeerRowContext(
+      HTMLNode peerTable, PeerNodeStatus peerNodeStatus, List<SimpleColumn> endCols) {}
+
+  private record PeerRowFlags(boolean fProxyJavascriptEnabled, boolean enablePeerActions) {}
+
+  private record PeerSelectionStats(double totalSelectionRate) {}
+
   private record RowContext(
-      HTMLNode peerTable,
-      PeerNodeStatus peerNodeStatus,
-      boolean advancedModeEnabled,
-      boolean fProxyJavascriptEnabled,
-      long now,
-      boolean enablePeerActions,
-      List<SimpleColumn> endCols,
-      boolean drawMessageTypes,
-      double totalSelectionRate,
-      DecimalFormat percentageFormat) {}
+      PeerRowContext peerRowContext,
+      RenderMode renderMode,
+      PeerRowFlags peerRowFlags,
+      RenderTiming renderTiming,
+      PeerSelectionStats selectionStats) {}
 
   /**
    * Indicates whether noderef POST submissions are accepted for this toadlet.
@@ -1855,12 +1850,12 @@ public abstract class ConnectionsToadlet extends Toadlet {
   protected abstract SimpleFieldSet getNoderef();
 
   private void drawRow(RowContext rowContext) {
-    PeerNodeStatus peerNodeStatus = rowContext.peerNodeStatus();
-    double totalSelectionRate = rowContext.totalSelectionRate();
-    DecimalFormat fix1 = rowContext.percentageFormat();
-    HTMLNode peerTable = rowContext.peerTable();
-    boolean advancedModeEnabled = rowContext.advancedModeEnabled();
-    boolean enablePeerActions = rowContext.enablePeerActions();
+    PeerNodeStatus peerNodeStatus = rowContext.peerRowContext().peerNodeStatus();
+    double totalSelectionRate = rowContext.selectionStats().totalSelectionRate();
+    DecimalFormat fix1 = rowContext.renderTiming().percentageFormat();
+    HTMLNode peerTable = rowContext.peerRowContext().peerTable();
+    boolean advancedModeEnabled = rowContext.renderMode().advancedModeEnabled();
+    boolean enablePeerActions = rowContext.peerRowFlags().enablePeerActions();
     int peerSelectionPercentage = calculateSelectionPercentage(totalSelectionRate, peerNodeStatus);
     HTMLNode peerRow =
         peerTable.addChild(
@@ -1885,14 +1880,15 @@ public abstract class ConnectionsToadlet extends Toadlet {
 
     if (advancedModeEnabled) {
       addLocationColumn(peerRow, peerNodeStatus);
-      addBackoffColumns(peerRow, peerNodeStatus, rowContext.now(), fix1);
+      addBackoffColumns(peerRow, peerNodeStatus, rowContext.renderTiming().now(), fix1);
       addPRejectColumn(peerRow, peerNodeStatus, fix1);
     }
 
-    addIdleColumn(peerRow, peerNodeStatus, rowContext.now());
+    addIdleColumn(peerRow, peerNodeStatus, rowContext.renderTiming().now());
 
     if (hasPrivateNoteColumn()) {
-      drawPrivateNoteColumn(peerRow, peerNodeStatus, rowContext.fProxyJavascriptEnabled());
+      drawPrivateNoteColumn(
+          peerRow, peerNodeStatus, rowContext.peerRowFlags().fProxyJavascriptEnabled());
     }
 
     if (advancedModeEnabled) {
@@ -1900,9 +1896,9 @@ public abstract class ConnectionsToadlet extends Toadlet {
           peerRow, peerNodeStatus, fix1, peerSelectionPercentage, totalSelectionRate);
     }
 
-    addEndColumns(peerRow, peerNodeStatus, rowContext.endCols());
+    addEndColumns(peerRow, peerNodeStatus, rowContext.peerRowContext().endCols());
 
-    if (rowContext.drawMessageTypes()) {
+    if (rowContext.renderMode().drawMessageTypes()) {
       drawMessageTypes(peerTable, peerNodeStatus);
     }
   }

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -52,8 +52,10 @@ import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.DownloadRequestStatus;
 import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpInsertBehaviorOptions;
 import network.crypta.clients.fcp.FcpInsertOptions;
 import network.crypta.clients.fcp.FcpInsertRequest;
+import network.crypta.clients.fcp.FcpInsertTuningOptions;
 import network.crypta.clients.fcp.IdentifierCollisionException;
 import network.crypta.clients.fcp.NotAllowedException;
 import network.crypta.clients.fcp.PersistentGlobalRequestParams;
@@ -1482,19 +1484,15 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
               null,
               true),
           new FcpInsertOptions(
-              false,
-              !params.compress(),
-              false,
-              -1,
-              false,
-              false,
-              Node.FORK_ON_CACHEABLE_DEFAULT,
-              null,
-              HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-              HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-              false,
-              params.cmode(),
-              false,
+              new FcpInsertBehaviorOptions(
+                  false, !params.compress(), false, -1, false, false, false),
+              new FcpInsertTuningOptions(
+                  false,
+                  Node.FORK_ON_CACHEABLE_DEFAULT,
+                  null,
+                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+                  params.cmode()),
               params.overrideSplitfileKey()),
           new ClientPutUpload(
               UploadFrom.DIRECT,
@@ -1687,19 +1685,15 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
               null,
               true),
           new FcpInsertOptions(
-              false,
-              !params.compress(),
-              false,
-              -1,
-              false,
-              false,
-              Node.FORK_ON_CACHEABLE_DEFAULT,
-              null,
-              HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-              HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-              false,
-              params.cmode(),
-              false,
+              new FcpInsertBehaviorOptions(
+                  false, !params.compress(), false, -1, false, false, false),
+              new FcpInsertTuningOptions(
+                  false,
+                  Node.FORK_ON_CACHEABLE_DEFAULT,
+                  null,
+                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+                  params.cmode()),
               params.overrideSplitfileKey()),
           new ClientPutUpload(
               UploadFrom.DISK,
@@ -1847,19 +1841,15 @@ public class QueueToadlet extends Toadlet implements LinkEnabledCallback {
               null,
               true),
           new FcpInsertOptions(
-              false,
-              !params.compress(),
-              false,
-              -1,
-              false,
-              false,
-              Node.FORK_ON_CACHEABLE_DEFAULT,
-              null,
-              HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-              HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-              false,
-              params.cmode(),
-              false,
+              new FcpInsertBehaviorOptions(
+                  false, !params.compress(), false, -1, false, false, false),
+              new FcpInsertTuningOptions(
+                  false,
+                  Node.FORK_ON_CACHEABLE_DEFAULT,
+                  null,
+                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+                  params.cmode()),
               params.overrideSplitfileKey()),
           params.file(),
           null,

--- a/src/main/java/network/crypta/node/AnnounceSender.java
+++ b/src/main/java/network/crypta/node/AnnounceSender.java
@@ -184,21 +184,20 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
   }
 
   private boolean applyRouteResult(RoutingState state, PeerNode next, NodeProcessResult result) {
-    switch (result) {
-      case TERMINATE:
-        return false;
-      case CONTINUE_FORWARDED:
+    return switch (result) {
+      case TERMINATE -> false;
+      case CONTINUE_FORWARDED -> {
         state.hasForwarded = true;
         state.last = next;
-        return true;
-      case CONTINUE_NO_FORWARD:
+        yield true;
+      }
+      case CONTINUE_NO_FORWARD -> {
         // Track the attempted peer even if we failed to send/forward.
         // This keeps HTL decrement attribution consistent with the peer we just tried.
         state.last = next;
-        return true;
-      default:
-        return true;
-    }
+        yield true;
+      }
+    };
   }
 
   private enum NodeProcessResult {

--- a/src/main/java/network/crypta/node/NodeARKInserter.java
+++ b/src/main/java/network/crypta/node/NodeARKInserter.java
@@ -14,6 +14,7 @@ import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientPutterOptions;
 import network.crypta.client.async.ClientPutterRequest;
+import network.crypta.client.async.InsertRequestParams;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.io.comm.Peer;
 import network.crypta.io.comm.PeerParseException;
@@ -192,13 +193,10 @@ public class NodeARKInserter implements ClientPutCallback, RequestClient {
     inserter =
         new ClientPutter(
             new ClientPutterRequest(
-                this,
+                new InsertRequestParams(this, uri, ctx, RequestStarter.INTERACTIVE_PRIORITY_CLASS),
                 b,
-                uri,
                 null, // Modern ARKs fit in ~1 KiB so use pure SSKs (no MIME type) to improve
                 // fetchability
-                ctx,
-                RequestStarter.INTERACTIVE_PRIORITY_CLASS,
                 false),
             ClientPutterOptions.defaults());
 

--- a/src/main/java/network/crypta/node/PeerRoutingSelector.java
+++ b/src/main/java/network/crypta/node/PeerRoutingSelector.java
@@ -11,24 +11,27 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Selects routing peers based on location closeness and peer status signals.
+ * Selects the most appropriate routing peer for a request.
  *
- * <p>This class centralizes the peer-selection policy that was previously spread across {@link
- * PeerManager}. Callers provide the candidate set and routing context, and the selector evaluates
- * peer distance, routing backoff state, timeouts, and optional recently failed handling to produce
+ * <p>This class centralizes peer-selection policy that was previously spread across {@link
+ * PeerManager}. Callers supply the current candidate set and routing context, and the selector
+ * evaluates peer distance, backoff state, timeout history, and load-management signals to choose
  * the single best peer. The selector does not mutate peer state directly; instead it reports
  * selection statistics and returns the chosen {@link PeerNode} for the caller to route to.
+ * Selection is deterministic for a given snapshot of inputs and is intended to be invoked once per
+ * routing decision.
  *
- * <p>Selection is stateful only within a single call and is safe for repeated use as long as
- * callers provide consistent inputs. The implementation assumes that the provided peer roster and
- * status book are kept up to date by the surrounding node lifecycle. Thread safety is delegated to
- * those collaborators; this class itself is immutable after construction.
+ * <p>State is scoped to a single call and derived entirely from input parameters and the current
+ * node services. Thread safety is delegated to {@link Node}, {@link PeerRoster}, and {@link
+ * PeerStatusBook}; this class itself is immutable after construction and safe to share. When
+ * recently failed handling is enabled, the selector may advise callers to delay invoking the
+ * provided callback instead of returning a peer.
  *
  * <p>Responsibilities include:
  *
  * <ul>
  *   <li>Filtering peers by eligibility (version, backoff, routing status).
- *   <li>Computing distance and load-based weighting.
+ *   <li>Computing distance and load-based weighting for viable candidates.
  *   <li>Optionally incorporating recently failed retry timing.
  * </ul>
  */
@@ -43,13 +46,14 @@ public class PeerRoutingSelector {
    * Creates a selector that draws candidates from the provided node services.
    *
    * <p>The selector keeps references to the node, roster, and status book so it can evaluate peer
-   * availability, distance, and routing backoff state during selection. The constructor does not
-   * validate these collaborators beyond storing them, so callers should ensure they are non-null
-   * and fully initialized before invoking selection methods.
+   * availability, distance, and routing backoff state during selection. The constructor performs no
+   * validation or defensive copying; it simply stores the provided collaborators for later queries.
+   * Callers should ensure the inputs are non-null and fully initialized before making selection
+   * calls. Instances are lightweight and can be reused across many routing decisions.
    *
-   * @param node owning node used for configuration and statistics reporting
-   * @param roster source of the currently connected peer set
-   * @param statusBook snapshot provider for peer routing status counts
+   * @param node the owning node providing configuration, stats, and routing services
+   * @param roster source of connected peers used during selection
+   * @param statusBook peer-status snapshot provider used for backoff reporting
    */
   public PeerRoutingSelector(Node node, PeerRoster roster, PeerStatusBook statusBook) {
     this.node = node;
@@ -62,12 +66,19 @@ public class PeerRoutingSelector {
    *
    * <p>This method evaluates all connected peers against distance, routing backoff, timeout, and
    * load-management constraints to produce the single best candidate. It can optionally integrate
-   * recently failed information to delay retries until an appropriate wake-up time. The selection
-   * is deterministic for the given inputs and does not mutate peers; callers remain responsible for
-   * updating per-request state and for respecting a {@code null} result.
+   * recently failed information to delay retries until an appropriate wake-up time, in which case
+   * it may call {@link RecentlyFailedReturn#fail(long)} and return {@code null}. The selection is
+   * deterministic for the given inputs, runs in time proportional to the number of connected peers,
+   * and does not mutate peers directly. Callers remain responsible for updating per-request state
+   * and for respecting a {@code null} result.
    *
-   * @param params routing selection parameters describing the request and policy
-   * @return the selected peer, or {@code null} if none qualifies
+   * <pre>{@code
+   * PeerRoutingSelectionParams params = ...;
+   * PeerNode nextHop = selector.closerPeer(params);
+   * </pre>
+   *
+   * @param params routing selection inputs and policy flags; must not be null
+   * @return best eligible peer, or null when no candidate qualifies
    */
   public PeerNode closerPeer(PeerRoutingSelectionParams params) {
     CloserPeerContext ctx = initCloserPeerContext(params);
@@ -96,6 +107,7 @@ public class PeerRoutingSelector {
     }
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class SelectionRates {
     private final double[] rates;
     private final double total;
@@ -112,7 +124,7 @@ public class PeerRoutingSelector {
   }
 
   @SuppressWarnings("java:S6206")
-  private static final class CloserPeerContextData {
+  private final class CloserPeerContextData {
     private final PeerNode[] peers;
     private final Key key;
     private final double myLoc;
@@ -123,25 +135,51 @@ public class PeerRoutingSelector {
     private final boolean enableFOAFMitigationHack;
     private final Set<Double> excludeLocations;
 
-    private CloserPeerContextData(
-        PeerNode[] peers,
-        Key key,
-        double myLoc,
-        double maxDiff,
-        double prevLoc,
-        TimedOutNodesList entry,
-        SelectionRates selection,
-        boolean enableFOAFMitigationHack,
-        Set<Double> excludeLocations) {
-      this.peers = peers;
-      this.key = key;
-      this.myLoc = myLoc;
-      this.maxDiff = maxDiff;
-      this.prevLoc = prevLoc;
-      this.entry = entry;
-      this.selection = selection;
-      this.enableFOAFMitigationHack = enableFOAFMitigationHack;
-      this.excludeLocations = excludeLocations;
+    private CloserPeerContextData(PeerRoutingSelectionParams params) {
+      PeerNode[] connectedPeers = roster.connectedPeers();
+      Key effectiveKey = node.isEnablePerNodeFailureTables() ? params.key() : null;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Choosing closest peer (connectedPeers={}, key={})",
+            connectedPeers.length,
+            effectiveKey);
+      }
+
+      double localLocation = node.network().location();
+      double maxDistanceFromSelf =
+          params.ignoreSelf()
+              ? Double.MAX_VALUE
+              : Location.distance(localLocation, params.target());
+      double previousLocation = params.origin() != null ? params.origin().getLocation() : -1.0;
+      TimedOutNodesList timedOutEntry =
+          effectiveKey != null
+              ? node.routing().failureTable().getTimedOutNodesList(effectiveKey)
+              : null;
+      SelectionRates selectionRates = computeSelectionRates(connectedPeers);
+      boolean enableFOAF =
+          connectedPeers.length >= PeerNode.SELECTION_MIN_PEERS && selectionRates.total > 0.0;
+      Set<Double> exclude =
+          buildExcludeLocations(localLocation, previousLocation, params.routedTo());
+
+      this.peers = connectedPeers;
+      this.key = effectiveKey;
+      this.myLoc = localLocation;
+      this.maxDiff = maxDistanceFromSelf;
+      this.prevLoc = previousLocation;
+      this.entry = timedOutEntry;
+      this.selection = selectionRates;
+      this.enableFOAFMitigationHack = enableFOAF;
+      this.excludeLocations = exclude;
+    }
+
+    private SelectionRates computeSelectionRates(PeerNode[] peers) {
+      double[] rates = new double[peers.length];
+      double total = 0.0;
+      for (int i = 0; i < peers.length; i++) {
+        rates[i] = peers[i].selectionRate();
+        total += rates[i];
+      }
+      return new SelectionRates(rates, total);
     }
 
     private PeerNode[] peers() {
@@ -289,37 +327,8 @@ public class PeerRoutingSelector {
   }
 
   private CloserPeerContext initCloserPeerContext(PeerRoutingSelectionParams params) {
-    PeerNode[] peers = roster.connectedPeers();
-    Key effectiveKey = node.isEnablePerNodeFailureTables() ? params.key() : null;
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Choosing closest peer (connectedPeers={}, key={})", peers.length, effectiveKey);
-    }
-
-    double myLoc = node.network().location();
-    double maxDiff =
-        params.ignoreSelf() ? Double.MAX_VALUE : Location.distance(myLoc, params.target());
-    double prevLoc = params.origin() != null ? params.origin().getLocation() : -1.0;
-    TimedOutNodesList entry =
-        effectiveKey != null
-            ? node.routing().failureTable().getTimedOutNodesList(effectiveKey)
-            : null;
-    SelectionRates selection = computeSelectionRates(peers);
-    boolean enableFOAF = peers.length >= PeerNode.SELECTION_MIN_PEERS && selection.total > 0.0;
-    Set<Double> exclude = buildExcludeLocations(myLoc, prevLoc, params.routedTo());
-    CloserPeerContextData data =
-        new CloserPeerContextData(
-            peers, effectiveKey, myLoc, maxDiff, prevLoc, entry, selection, enableFOAF, exclude);
+    CloserPeerContextData data = new CloserPeerContextData(params);
     return new CloserPeerContext(data);
-  }
-
-  private SelectionRates computeSelectionRates(PeerNode[] peers) {
-    double[] rates = new double[peers.length];
-    double total = 0.0;
-    for (int i = 0; i < peers.length; i++) {
-      rates[i] = peers[i].selectionRate();
-      total += rates[i];
-    }
-    return new SelectionRates(rates, total);
   }
 
   private void evaluateCandidatesInContext(
@@ -359,15 +368,7 @@ public class PeerRoutingSelector {
     private double leastRecentlyTimedOutBackedOffDistance = Double.MAX_VALUE;
   }
 
-  private static final class BestCandidate {
-    private final PeerNode best;
-    private final double bestDistance;
-
-    private BestCandidate(PeerNode best, double bestDistance) {
-      this.best = best;
-      this.bestDistance = bestDistance;
-    }
-  }
+  private record BestCandidate(PeerNode best, double bestDistance) {}
 
   private Set<Double> buildExcludeLocations(double myLoc, double prevLoc, Set<PeerNode> routedTo) {
     Set<Double> excludeLocations = new HashSet<>();
@@ -516,15 +517,7 @@ public class PeerRoutingSelector {
     return false;
   }
 
-  private static final class TimeoutInfo {
-    private final boolean timedOut;
-    private final long timeoutFT;
-
-    private TimeoutInfo(boolean timedOut, long timeoutFT) {
-      this.timedOut = timedOut;
-      this.timeoutFT = timeoutFT;
-    }
-  }
+  private record TimeoutInfo(boolean timedOut, long timeoutFT) {}
 
   private TimeoutInfo computeTimeoutInfo(CandidateEvaluationContext ctx, PeerNode p) {
     long timeoutRF;
@@ -541,19 +534,7 @@ public class PeerRoutingSelector {
     return new TimeoutInfo(timedOut, timeoutFT);
   }
 
-  private static final class DiffInfo {
-    private final double loc;
-    private final double diff;
-    private final double realDiff;
-    private final boolean direct;
-
-    private DiffInfo(double loc, double diff, double realDiff, boolean direct) {
-      this.loc = loc;
-      this.diff = diff;
-      this.realDiff = realDiff;
-      this.direct = direct;
-    }
-  }
+  private record DiffInfo(double loc, double diff, double realDiff, boolean direct) {}
 
   private DiffInfo computeDiffInfo(CandidateEvaluationContext ctx, PeerNode p) {
     return computeDiffInfo(p, ctx.params.target(), ctx.params.outgoingHTL(), ctx.excludeLocations);
@@ -760,15 +741,7 @@ public class PeerRoutingSelector {
     return key != null && node.routing().failureTable().hadAnyOffers(key) ? -1L : decidedUntil;
   }
 
-  private static final class FirstSecondChoice {
-    private final long firstTime;
-    private final long secondTime;
-
-    private FirstSecondChoice(long firstTime, long secondTime) {
-      this.firstTime = firstTime;
-      this.secondTime = secondTime;
-    }
-  }
+  private record FirstSecondChoice(long firstTime, long secondTime) {}
 
   private FirstSecondChoice computeFirstSecondChoice(
       PeerRoutingSelectionParams params, TimedOutNodesList entry) {

--- a/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
@@ -63,6 +63,10 @@ import network.crypta.store.caching.CachingFreenetStore;
 import network.crypta.store.caching.CachingFreenetStoreTracker;
 import network.crypta.store.saltedhash.ResizablePersistentIntBuffer;
 import network.crypta.store.saltedhash.SaltedHashFreenetStore;
+import network.crypta.store.saltedhash.SaltedHashStoreDependencies;
+import network.crypta.store.saltedhash.SaltedHashStoreLocation;
+import network.crypta.store.saltedhash.SaltedHashStoreParams;
+import network.crypta.store.saltedhash.SaltedHashStoreSizing;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.io.DatastoreUtil;
 import org.slf4j.Logger;
@@ -2006,18 +2010,17 @@ public final class NodeStorageSubsystem {
       throws IOException {
     LOG.info("Initializing {} Data{} ({} keys)", type, store, maxStoreKeys);
 
-    SaltedHashFreenetStore<T> fs =
-        SaltedHashFreenetStore.construct(
-            getStoreDir(),
-            type + "-" + store,
-            cb,
-            node.bootstrap().random(),
-            maxKeys,
-            storeUseSlotFilters,
-            SemiOrderedShutdownHook.get(),
-            storePreallocate,
-            storeSaltHashResizeOnStart && !lateStart,
-            clientCacheMasterKey);
+    SaltedHashStoreParams<T> params =
+        SaltedHashStoreParams.of(
+            new SaltedHashStoreLocation(getStoreDir(), type + "-" + store),
+            new SaltedHashStoreDependencies<>(
+                cb, node.bootstrap().random(), SemiOrderedShutdownHook.get(), clientCacheMasterKey),
+            new SaltedHashStoreSizing(
+                maxKeys,
+                storeUseSlotFilters,
+                storePreallocate,
+                storeSaltHashResizeOnStart && !lateStart));
+    SaltedHashFreenetStore<T> fs = SaltedHashFreenetStore.construct(params);
     if (cachingFreenetStoreMaxSize > 0) {
       new CachingFreenetStore<>(cb, fs, cachingFreenetStoreTracker);
       // CachingFreenetStore constructor calls cb.setStore(this)

--- a/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
+++ b/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
@@ -42,6 +42,7 @@ import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientPutterOptions;
 import network.crypta.client.async.ClientPutterRequest;
+import network.crypta.client.async.InsertRequestParams;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.SimpleBlockSet;
 import network.crypta.crypt.SHA256;
@@ -1599,7 +1600,10 @@ public class UpdateOverMandatoryManager implements RequestClient {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                callback, bucket, FreenetURI.EMPTY_CHK_URI, null, ctx, priority, false),
+                new InsertRequestParams(callback, FreenetURI.EMPTY_CHK_URI, ctx, priority),
+                bucket,
+                null,
+                false),
             new ClientPutterOptions(null, true, null, -1));
     try {
       updateManager.getNode().services().clientCore().getClientContext().start(putter);

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
@@ -226,16 +226,9 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
       throws IOException {
     return construct(
         SaltedHashStoreParams.of(
-            baseDir,
-            name,
-            callback,
-            random,
-            maxKeys,
-            useSlotFilter,
-            shutdownHook,
-            preallocate,
-            resizeOnStart,
-            masterKey));
+            new SaltedHashStoreLocation(baseDir, name),
+            new SaltedHashStoreDependencies<>(callback, random, shutdownHook, masterKey),
+            new SaltedHashStoreSizing(maxKeys, useSlotFilter, preallocate, resizeOnStart)));
   }
 
   private SaltedHashFreenetStore(SaltedHashStoreParams<T> params) throws IOException {

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreDependencies.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreDependencies.java
@@ -1,0 +1,116 @@
+package network.crypta.store.saltedhash;
+
+import java.util.Random;
+import network.crypta.node.SemiOrderedShutdownHook;
+import network.crypta.store.StorableBlock;
+import network.crypta.store.StoreCallback;
+
+/**
+ * Groups the runtime dependencies required to initialize a salted-hash store.
+ *
+ * <p>This value object packages the store's callback, randomness source, shutdown hook, and master
+ * key into a single unit for construction-time wiring. It is intended to be combined with {@link
+ * SaltedHashStoreLocation} and {@link SaltedHashStoreSizing} when creating {@link
+ * SaltedHashStoreParams}, keeping related runtime dependencies together and reducing call-site
+ * parameter noise. The instance holds references exactly as provided and does not validate or copy
+ * them.
+ *
+ * <p>The class does not perform any I/O or initialization. It simply stores dependencies for later
+ * consumption by store factories. Because the referenced objects may be mutable or stateful,
+ * callers must manage their lifetimes and thread-safety. Reference retains the master key array;
+ * its contents should be treated as sensitive and must be managed by the caller.
+ *
+ * <ul>
+ *   <li>Captures callback logic for sizing and (de-)serialization.
+ *   <li>Captures the randomness source used for cryptographic decisions.
+ *   <li>Captures lifecycle wiring such as shutdown hooks and master key material.
+ * </ul>
+ *
+ * @param <T> concrete {@link StorableBlock} type produced by the callback.
+ */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+public final class SaltedHashStoreDependencies<T extends StorableBlock> {
+  private final StoreCallback<T> callback;
+  private final Random random;
+  private final SemiOrderedShutdownHook shutdownHook;
+  private final byte[] masterKey;
+
+  /**
+   * Creates a dependency bundle for salted-hash store construction.
+   *
+   * <p>This constructor records the provided references without validation, copying, or defensive
+   * wrapping. It is suitable for dependency injection or configuration wiring where the same
+   * callback and randomness source are reused across multiple stores. The resulting bundle is a
+   * pure data carrier and does not interact with the callback, random instance, shutdown hook, or
+   * master key array.
+   *
+   * @param callback callback used to size and (de-)serialize store entries; not validated.
+   * @param random randomness source used for cryptographic decisions; stored by reference.
+   * @param shutdownHook hook used to register store close tasks during initialization.
+   * @param masterKey optional master key bytes used to derive per-store salts; not copied.
+   */
+  public SaltedHashStoreDependencies(
+      StoreCallback<T> callback,
+      Random random,
+      SemiOrderedShutdownHook shutdownHook,
+      byte[] masterKey) {
+    this.callback = callback;
+    this.random = random;
+    this.shutdownHook = shutdownHook;
+    this.masterKey = masterKey;
+  }
+
+  /**
+   * Returns the callback used to size and (de-)serialize store entries.
+   *
+   * <p>The returned reference is the same object supplied at construction time and is not wrapped
+   * or validated. Store implementations may rely on it to determine block sizes and to construct
+   * {@link StorableBlock} instances. This accessor is side-effect-free and always returns the
+   * stored reference.
+   *
+   * @return the callback reference associated with these dependencies.
+   */
+  public StoreCallback<T> callback() {
+    return callback;
+  }
+
+  /**
+   * Returns the randomness source used by the store.
+   *
+   * <p>The random instance is stored as provided and may be shared across stores. It is not
+   * reseeded or wrapped, so callers should supply an implementation appropriate for their threat
+   * model and thread-safety requirements. This method does not alter the random instance.
+   *
+   * @return the randomness source reference used by the store implementation.
+   */
+  public Random random() {
+    return random;
+  }
+
+  /**
+   * Returns the shutdown hook used to register store close tasks.
+   *
+   * <p>The hook reference is recorded without validation. Store initialization may register cleanup
+   * tasks on this hook, so callers should ensure the hook remains valid for the store's lifetime.
+   * This accessor does not interact with the hook and returns the stored reference directly.
+   *
+   * @return the shutdown hook reference associated with these dependencies.
+   */
+  public SemiOrderedShutdownHook shutdownHook() {
+    return shutdownHook;
+  }
+
+  /**
+   * Returns the master key bytes used to derive per-store salts.
+   *
+   * <p>The returned array is the original reference provided at construction time. It is not
+   * copied, cleared, or validated, so callers must manage its confidentiality and lifecycle. Store
+   * implementations may read this array during initialization; later modifications may influence
+   * behavior.
+   *
+   * @return the master key byte array reference, possibly {@code null}.
+   */
+  public byte[] masterKey() {
+    return masterKey;
+  }
+}

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreLocation.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreLocation.java
@@ -1,0 +1,26 @@
+package network.crypta.store.saltedhash;
+
+import java.io.File;
+
+/**
+ * Describes the filesystem location and logical name of a salted-hash store.
+ *
+ * <p>This record groups the base directory and store name used to derive on-disk file paths for a
+ * store instance. It is intended for configuration and dependency-injection layers where the
+ * location and naming details are passed around independently of other store options. The values
+ * are stored as provided and are not normalized, validated, or created on disk by this type.
+ *
+ * <p>Instances are immutable and thread-safe as long as the referenced {@link File} object is
+ * treated as immutable by callers. Use this record together with {@link
+ * SaltedHashStoreDependencies} and {@link SaltedHashStoreSizing} to build {@link
+ * SaltedHashStoreParams} for store construction.
+ *
+ * <ul>
+ *   <li>Captures the base directory where store files reside.
+ *   <li>Captures the logical name used as a filename prefix.
+ * </ul>
+ *
+ * @param baseDir directory reference used as the root for store files; not validated or created.
+ * @param name logical store name used as a filename prefix; stored verbatim.
+ */
+public record SaltedHashStoreLocation(File baseDir, String name) {}

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreParams.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreParams.java
@@ -9,31 +9,28 @@ import network.crypta.store.StorableBlock;
 import network.crypta.store.StoreCallback;
 import org.jetbrains.annotations.NotNull;
 
-/// Parameters required to construct a salted-hash store instance.
-///
-/// This value object bundles the full initialization surface used by [SaltedHashFreenetStore]
-/// factories, ensuring callers can pass around a single value object without losing
-/// configurability.
-/// It is intended for code that wires stores from configuration files or dependency injection,
-/// where
-/// keeping related arguments together avoids long parameter lists and makes auditing easier. The
-/// values are treated as immutable once created; callers should construct a new instance to change
-/// any option or to target a different store directory.
-///
-/// The instance is a pure data carrier: it does not validate the filesystem, does not read the
-/// store, and does not mutate the referenced [StoreCallback]. The caller
-/// manages the lifetime of the referenced objects. Use this object to keep the construction inputs
-/// in sync between
-/// primary and alternate stores, or to cache a template of initialization values for repeated store
-/// creation.
-///
-///     - Captures filesystem and naming details for the store files.
-///     - Captures crypto and sizing inputs that must be consistent across runs.
-///     - Captures lifecycle wiring such as shutdown hooks and preallocation policy.
-///
-///
-/// @param <T> concrete [StorableBlock] type produced by the callback.
-@SuppressWarnings("java:S6206")
+/**
+ * Bundles the initialization inputs required to construct a salted-hash store.
+ *
+ * <p>This type groups the full creation surface used by {@link SaltedHashFreenetStore} factories so
+ * callers can pass a single value object without losing configurability. It is intended for
+ * configuration-driven wiring, dependency injection, and repeatable store construction where large
+ * parameter lists are error-prone. The instance is immutable in the sense that its fields are
+ * assigned once; the referenced objects themselves may be mutable and remain owned by the caller.
+ *
+ * <p>The parameter bundle performs no validation, file I/O, or store initialization. It preserves
+ * object identity for references such as the {@link StoreCallback} and the master key array, so
+ * callers must manage lifetimes and contents carefully. Use a new instance to change any option or
+ * to target a different directory.
+ *
+ * <ul>
+ *   <li>Captures filesystem and naming details for store files.
+ *   <li>Captures crypto inputs and sizing policies that must remain consistent.
+ *   <li>Captures lifecycle wiring such as shutdown hooks and preallocation policy.
+ * </ul>
+ *
+ * @param <T> concrete {@link StorableBlock} type produced by the callback.
+ */
 public final class SaltedHashStoreParams<T extends StorableBlock> {
   private final File baseDir;
   private final String name;
@@ -47,82 +44,188 @@ public final class SaltedHashStoreParams<T extends StorableBlock> {
   private final byte[] masterKey;
 
   /**
-   * Creates a parameter bundle for a salted-hash store.
+   * Creates a parameter bundle for a salted-hash store from grouped inputs.
    *
-   * @param baseDir directory where the store files live; created if missing by the store
-   * @param name logical name; also used as a filename prefix for store files
-   * @param callback callback used to get header/data lengths and to (de-)serialize blocks
-   * @param random randomness source for encryption and placement tie-breakers
-   * @param maxKeys number of slots in the store (capacity), treated as a non-negative count
-   * @param useSlotFilter whether to enable the on-disk slot filter index for lookups
-   * @param shutdownHook hook on which the store registers a close task during initialization
-   * @param preallocate whether to preallocate files up to {@code maxKeys} for startup latency
-   * @param resizeOnStart when true, finishes any in-progress resize before returning to the caller
-   * @param masterKey master key used to derive per-store salts; reference copies contents
+   * <p>This constructor assembles the store parameters from three conceptual groups: location,
+   * dependencies, and sizing. It performs no validation or defensive copying and simply records the
+   * provided references for later consumption by store factories. Callers should ensure that
+   * referenced objects remain valid for the lifetime of any constructed store and that the caller
+   * manages the supplied master key array safely.
+   *
+   * <p>Construction is idempotent with respect to the supplied values: multiple calls with the same
+   * references yield distinct parameter objects that describe identical store inputs.
+   *
+   * @param location filesystem and naming details for store files and prefixes.
+   * @param dependencies callback, randomness, shutdown hook, and master key references.
+   * @param sizing capacity and lifecycle sizing policies for the target store.
    */
   public SaltedHashStoreParams(
-      File baseDir,
-      String name,
-      StoreCallback<T> callback,
-      Random random,
-      long maxKeys,
-      boolean useSlotFilter,
-      SemiOrderedShutdownHook shutdownHook,
-      boolean preallocate,
-      boolean resizeOnStart,
-      byte[] masterKey) {
-    this.baseDir = baseDir;
-    this.name = name;
-    this.callback = callback;
-    this.random = random;
-    this.maxKeys = maxKeys;
-    this.useSlotFilter = useSlotFilter;
-    this.shutdownHook = shutdownHook;
-    this.preallocate = preallocate;
-    this.resizeOnStart = resizeOnStart;
-    this.masterKey = masterKey;
+      SaltedHashStoreLocation location,
+      SaltedHashStoreDependencies<T> dependencies,
+      SaltedHashStoreSizing sizing) {
+    this.baseDir = location.baseDir();
+    this.name = location.name();
+    this.callback = dependencies.callback();
+    this.random = dependencies.random();
+    this.maxKeys = sizing.maxKeys();
+    this.useSlotFilter = sizing.useSlotFilter();
+    this.shutdownHook = dependencies.shutdownHook();
+    this.preallocate = sizing.preallocate();
+    this.resizeOnStart = sizing.resizeOnStart();
+    this.masterKey = dependencies.masterKey();
   }
 
+  /**
+   * Returns the base directory where the store files live.
+   *
+   * <p>The directory reference is the same object provided at construction time and is not
+   * validated or normalized. The store implementation may create the directory if it is missing, so
+   * callers should ensure the path is suitable for creation and has the expected permissions. This
+   * method is side-effect-free and always returns the stored reference.
+   *
+   * @return the base directory reference used for store file placement.
+   */
   public File baseDir() {
     return baseDir;
   }
 
+  /**
+   * Returns the logical store name used as a filename prefix.
+   *
+   * <p>The name is stored verbatim and is typically concatenated with file extensions to produce
+   * on-disk filenames. Callers should supply a stable value so that the following runs open the
+   * same store. This method does not sanitize or validate the string and always returns the stored
+   * reference.
+   *
+   * @return the logical store name used for file naming and identification.
+   */
   public String name() {
     return name;
   }
 
+  /**
+   * Returns the callback used to size and (de-)serialize store entries.
+   *
+   * <p>The callback reference is recorded without validation and is not invoked by this parameter
+   * object. It is expected to supply header/data lengths and block construction logic for the
+   * concrete {@link StorableBlock} type. The returned value is the original reference and should be
+   * treated as shared across any stores built from these parameters.
+   *
+   * @return the callback implementation associated with this store configuration.
+   */
   public StoreCallback<T> callback() {
     return callback;
   }
 
+  /**
+   * Returns the randomness source used by the store for cryptographic decisions.
+   *
+   * <p>The random instance is stored as provided, with no defensive copying or reseeding. Store
+   * construction and later operations may rely on it for encryption material or placement
+   * tie-breakers, so callers should provide a suitable implementation for their threat model. This
+   * method simply returns the stored reference.
+   *
+   * @return the randomness source used by the store implementation.
+   */
   public Random random() {
     return random;
   }
 
+  /**
+   * Returns the configured maximum number of keys for the store.
+   *
+   * <p>The value represents the logical capacity, typically interpreted as a non-negative count of
+   * slots. This parameter object does not enforce bounds or consistency; any validation is deferred
+   * to the store implementation. The returned value is the exact long supplied at construction
+   * time.
+   *
+   * @return the logical store capacity as a count of slots.
+   */
   public long maxKeys() {
     return maxKeys;
   }
 
+  /**
+   * Returns whether the on-disk slot filter index is enabled.
+   *
+   * <p>When enabled, the store maintains a slot filter structure to speed up lookups. This flag is
+   * stored verbatim and does not trigger any immediate initialization work in this parameter
+   * object. Callers should use a consistent value when reopening the same store to avoid unexpected
+   * behaviors during initialization.
+   *
+   * @return {@code true} to enable the slot filter index; {@code false} otherwise.
+   */
   public boolean useSlotFilter() {
     return useSlotFilter;
   }
 
+  /**
+   * Returns the shutdown hook used to register store close tasks.
+   *
+   * <p>The hook reference is stored without validation or wrapping. Store creation may register a
+   * close task on this hook during initialization, so callers should supply a suitable lifecycle
+   * manager for their environment. This parameter object does not interact with the hook directly
+   * and simply returns the stored reference.
+   *
+   * @return the shutdown hook reference associated with this configuration.
+   */
   public SemiOrderedShutdownHook shutdownHook() {
     return shutdownHook;
   }
 
+  /**
+   * Returns whether store files should be pre-allocated up to the configured capacity.
+   *
+   * <p>Preallocation can reduce runtime fragmentation or startup latency by reserving space up
+   * front, but may increase the time and disk I/O required for initial creation. This flag is
+   * stored verbatim and does not cause any immediate side effects in this parameter object.
+   *
+   * @return {@code true} if the store should preallocate to its capacity.
+   */
   public boolean preallocate() {
     return preallocate;
   }
 
+  /**
+   * Returns whether the store should finish any in-progress resize on startup.
+   *
+   * <p>When enabled, the store may complete a previous resize operation during initialization
+   * before returning control to the caller. This flag is stored without validation and is
+   * interpreted by the store implementation during construction and start-up. The parameter object
+   * itself performs no resizing work.
+   *
+   * @return {@code true} to finish any in-progress resize during startup.
+   */
   public boolean resizeOnStart() {
     return resizeOnStart;
   }
 
+  /**
+   * Returns the master key bytes used to derive per-store salts.
+   *
+   * <p>The returned array is the original reference provided at construction time; it is not copied
+   * or zeroed. Callers must manage the lifetime, mutability, and secrecy of the array themselves.
+   * Store implementations may read from this array during initialization or configuration loading,
+   * so modifications after construction can affect later store behavior.
+   *
+   * @return the master key byte array reference as provided by the caller.
+   */
   public byte[] masterKey() {
     return masterKey;
   }
 
+  /**
+   * Compares this parameter bundle to another object for equality.
+   *
+   * <p>Equality is defined by the stored configuration values: base directory, name, callback,
+   * randomness source, capacity and flags, shutdown hook, and the content of the master key array.
+   * The master key is compared using {@link Arrays#equals(byte[], byte[])} rather than reference
+   * identity. This method is deterministic, side-effect-free, and returns {@code true} when the
+   * other object is the same instance.
+   *
+   * @param other the candidate object to compare against, possibly {@code null}.
+   * @return {@code true} when all stored fields represent the same configuration.
+   */
   @Override
   public boolean equals(Object other) {
     if (this == other) return true;
@@ -139,6 +242,16 @@ public final class SaltedHashStoreParams<T extends StorableBlock> {
         && Arrays.equals(masterKey, params.masterKey);
   }
 
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash is derived from all stored configuration fields, including the contents of the
+   * master key array. This ensures that two equal parameter bundles produce the same hash code and
+   * can be used reliably in hash-based collections. The computation does not mutate any referenced
+   * objects and is safe to call repeatedly.
+   *
+   * @return a hash code representing the full store configuration.
+   */
   @Override
   public int hashCode() {
     int result =
@@ -156,6 +269,16 @@ public final class SaltedHashStoreParams<T extends StorableBlock> {
     return result;
   }
 
+  /**
+   * Returns a human-readable description of the stored configuration.
+   *
+   * <p>The string includes the base directory, name, callback, randomness source, capacity, flags,
+   * and shutdown hook values. The master key bytes are intentionally redacted to avoid accidental
+   * disclosure in logs or debugging output. The returned string is intended for diagnostics and
+   * does not imply that the referenced objects are safe to share or serialize.
+   *
+   * @return a descriptive string with sensitive key material redacted.
+   */
   @Override
   public @NotNull String toString() {
     return "SaltedHashStoreParams[baseDir="
@@ -181,63 +304,34 @@ public final class SaltedHashStoreParams<T extends StorableBlock> {
   }
 
   /**
-   * Creates a {@link SaltedHashStoreParams} instance from discrete inputs.
+   * Creates a {@link SaltedHashStoreParams} instance from grouped inputs.
    *
-   * <p>This factory mirrors the constructor parameters so callers can migrate from older
-   * constructor signatures without manually repeating the type name. It performs no validation and
-   * preserves object identity for inputs such as {@code callback} and {@code masterKey}; callers
-   * remain responsible for ensuring those values remain valid for the lifetime of the store. The
-   * returned instance is immutable and safe to reuse for repeated store creation when inputs are
-   * stable.
+   * <p>This factory mirrors the public constructor while emphasizing the three conceptual groups of
+   * parameters: location, dependencies, and sizing. It performs no validation and preserves object
+   * identity for inputs such as the {@code callback} and {@code masterKey} array; callers remain
+   * responsible for ensuring those values remain valid for the lifetime of the store. The returned
+   * instance is immutable and safe to reuse for repeated store creation when inputs are stable.
    *
    * <pre>{@code
    * SaltedHashStoreParams<CHKBlock> params = SaltedHashStoreParams.of(
-   *     baseDir,
-   *     "datastore",
-   *     callback,
-   *     random,
-   *     maxKeys,
-   *     true,
-   *     shutdownHook,
-   *     false,
-   *     true,
-   *     masterKey);
+   *     new SaltedHashStoreLocation(baseDir, "datastore"),
+   *     new SaltedHashStoreDependencies<>(callback, random, shutdownHook, masterKey),
+   *     new SaltedHashStoreSizing(maxKeys, true, false, true));
    * }</pre>
    *
+   * <p>The returned parameter bundle is a pure data carrier and does not open or validate the store
+   * directory; those responsibilities are handled by {@link SaltedHashFreenetStore}.
+   *
    * @param <T> concrete {@link StorableBlock} type produced by the callback.
-   * @param baseDir directory where the store files live; created if missing by the store.
-   * @param name logical name; also used as a filename prefix for store files.
-   * @param callback callback used to get header/data lengths and to (de-)serialize blocks.
-   * @param random randomness source for encryption and placement tie-breakers.
-   * @param maxKeys number of slots in the store (capacity), treated as a non-negative count.
-   * @param useSlotFilter whether to enable the on-disk slot filter index for lookups.
-   * @param shutdownHook hook on which the store registers a close task during initialization.
-   * @param preallocate whether to preallocate files up to {@code maxKeys} for startup latency.
-   * @param resizeOnStart when true, finishes any in-progress resize before returning to the caller.
-   * @param masterKey master key used to derive per-store salts; reference copies contents.
-   * @return immutable parameters object encapsulating the provided store configuration values.
+   * @param location filesystem and naming details for the store files and prefixes.
+   * @param dependencies callback, randomness source, shutdown hook, and master key references.
+   * @param sizing capacity and lifecycle sizing options for the store.
+   * @return immutable parameters object encapsulating the provided configuration values.
    */
   public static <T extends StorableBlock> SaltedHashStoreParams<T> of(
-      File baseDir,
-      String name,
-      StoreCallback<T> callback,
-      Random random,
-      long maxKeys,
-      boolean useSlotFilter,
-      SemiOrderedShutdownHook shutdownHook,
-      boolean preallocate,
-      boolean resizeOnStart,
-      byte[] masterKey) {
-    return new SaltedHashStoreParams<>(
-        baseDir,
-        name,
-        callback,
-        random,
-        maxKeys,
-        useSlotFilter,
-        shutdownHook,
-        preallocate,
-        resizeOnStart,
-        masterKey);
+      SaltedHashStoreLocation location,
+      SaltedHashStoreDependencies<T> dependencies,
+      SaltedHashStoreSizing sizing) {
+    return new SaltedHashStoreParams<>(location, dependencies, sizing);
   }
 }

--- a/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreSizing.java
+++ b/src/main/java/network/crypta/store/saltedhash/SaltedHashStoreSizing.java
@@ -1,0 +1,28 @@
+package network.crypta.store.saltedhash;
+
+/**
+ * Captures capacity and lifecycle sizing options for a salted-hash store.
+ *
+ * <p>This record groups the sizing-related inputs used during store initialization and startup. It
+ * is intended for configuration wiring where capacity, filter usage, preallocation, and
+ * resize-on-start policy are set together. The values are stored verbatim and are not validated or
+ * normalized by this type; any enforcement is handled by the store implementation.
+ *
+ * <p>The record is immutable and thread-safe for callers that treat its values as read-only.
+ * Typical usage is to combine it with {@link SaltedHashStoreLocation} and {@link
+ * SaltedHashStoreDependencies} when building {@link SaltedHashStoreParams} for store construction.
+ * Changes to sizing require constructing a new instance.
+ *
+ * <ul>
+ *   <li>Defines the logical capacity of the store in number of slots.
+ *   <li>Controls whether the on-disk slot filter structure is enabled.
+ *   <li>Controls preallocation and startup resizing behavior.
+ * </ul>
+ *
+ * @param maxKeys logical capacity expressed as a count of slots; stored verbatim.
+ * @param useSlotFilter whether to enable the on-disk slot filter index.
+ * @param preallocate whether to preallocate store files up to the configured capacity.
+ * @param resizeOnStart whether to finish any in-progress resize during startup.
+ */
+public record SaltedHashStoreSizing(
+    long maxKeys, boolean useSlotFilter, boolean preallocate, boolean resizeOnStart) {}

--- a/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegrator.java
@@ -5,21 +5,17 @@ import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Gragg–Bulirsch–Stoer integrator for non-stiff Ordinary Differential Equations with dense output
- * support.
+ * Adaptive Gragg-Bulirsch-Stoer integrator for non-stiff first-order ODEs with dense output.
  *
- * <p>This implementation follows the Richardson extrapolation scheme popularized by Hairer and
- * Wanner: it advances the solution with a modified midpoint method, refines the step through
- * polynomial extrapolation, and selects both the order and step size dynamically to minimize the
- * total number of derivative evaluations. It is aimed at smooth problems where very high accuracy
- * is desirable; in practice it surpasses embedded Runge–Kutta methods once the required tolerance
- * falls in the {@code 1e-6} to {@code 1e-11} range depending on problem sensitivity. Dense output
- * and switching functions are handled so callers can sample the solution or trigger events between
- * accepted steps. The integrator is not thread-safe; each instance manages mutable buffers that are
- * reused across calls to {@link #integrate(FirstOrderDifferentialEquations, double, double[],
- * double, double[])}. Typical usage creates one instance per ODE problem, configures optional
- * stability and interpolation controls, then integrates forward or backward in time while providing
- * a {@link StepHandler} for results.
+ * <p>This integrator advances the state with a modified midpoint scheme, then refines it using
+ * Richardson extrapolation and a polynomial tableau. It dynamically selects both step size and
+ * extrapolation to reduce total derivative evaluations while meeting accuracy goals. Typical usage
+ * creates a new instance per problem, configures stability and interpolation controls as needed,
+ * registers a {@link StepHandler} and any switching functions, then calls {@link
+ * #integrate(FirstOrderDifferentialEquations, double, double[], double, double[])}. The
+ * implementation stores working buffers across steps, so it is not thread-safe and should be reused
+ * only for sequential integrations. It is most effective on smooth problems requiring high
+ * accuracy; coarse steps on rough dynamics may trigger stability reductions.
  *
  * <ul>
  *   <li><strong>Responsibilities:</strong> adaptive order/step selection, error estimation, dense
@@ -32,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * <p><strong>License (Hairer/Wanner original odex code, summarized):</strong> redistribution and
  * use in source and binary forms, with or without modification, are permitted provided copyright
- * and disclaimer notices are preserved; the software is supplied “as is” without warranty and with
+ * and disclaimer notices are preserved; the software is supplied "as is" without warranty and with
  * no liability for damages.
  *
  * @author E. Hairer and G. Wanner (fortran version)
@@ -48,20 +44,18 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   /**
    * Create an integrator with scalar tolerances and default control settings.
    *
-   * <p>Use this constructor when a single absolute/relative tolerance pair applies to every state
-   * component. The integrator allocates internal work buffers sized for the problem dimension,
-   * enables dense output automatically when the configured {@link StepHandler} or any switching
-   * function requires it, and initializes stability, step-size, order, and interpolation control to
-   * values recommended in the Hairer–Wanner literature. Step handlers can be replaced later via
-   * {@link #setStepHandler(StepHandler)}; stability and order settings can be tuned after
-   * construction. The initial and maximum steps must be strictly positive; backward integration is
-   * handled by negating the direction internally.
+   * <p>Choose this constructor when a single absolute/relative tolerance pair applies to every
+   * state component. The integrator allocates internal work buffers sized for the problem dimension
+   * and enables dense output automatically when the configured {@link StepHandler} or any switching
+   * function requires it. Stability checks, step-size control, order control, and interpolation
+   * control are initialized to the recommended defaults, and you may adjust them later via the
+   * corresponding setters. Both step bounds must be strictly positive; backward integration is
+   * handled by internally negating the direction and step size as needed.
    *
-   * @param minStep minimal step size in integration variable; must be positive but the final step
-   *     may be smaller
-   * @param maxStep maximal step size allowed (positive even for backward runs)
-   * @param scalAbsoluteTolerance absolute tolerance applied uniformly to every state entry
-   * @param scalRelativeTolerance relative tolerance applied uniformly to every state entry
+   * @param minStep minimal step size in integration time units; must be positive
+   * @param maxStep maximal step size magnitude permitted; positive even for backward runs
+   * @param scalAbsoluteTolerance absolute tolerance applied uniformly to each state component
+   * @param scalRelativeTolerance relative tolerance applied uniformly to each state component
    */
   public GraggBulirschStoerIntegrator(
       double minStep, double maxStep, double scalAbsoluteTolerance, double scalRelativeTolerance) {
@@ -76,16 +70,18 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   /**
    * Create an integrator with per-component tolerances and default control settings.
    *
-   * <p>Choose this constructor when each state component requires its own absolute and relative
-   * tolerance. Vector tolerances must match the dimension returned by the supplied equations. All
-   * other defaults mirror the scalar constructor: stability checks are enabled, conservative
-   * step-size control, and dense output if any listener requires it. The integrator copies no user
-   * buffers, so callers retain ownership of the tolerance arrays.
+   * <p>Use this constructor when each state component needs its own absolute and relative tolerance
+   * values. The tolerance arrays must match the dimension returned by the supplied equations and be
+   * used directly, so callers retain ownership of the buffers. As with the scalar constructor,
+   * stability checks are enabled, conservative step-size control is selected, and dense output is
+   * automatically enabled when a handler or switching function requires it. Both step bounds must
+   * be strictly positive; backward integration is handled internally by negating the step
+   * direction.
    *
-   * @param minStep minimal step size in integration variable; must be strictly positive
-   * @param maxStep maximal step size allowed; must be strictly positive
-   * @param vecAbsoluteTolerance absolute tolerances per state entry; length equals state dimension
-   * @param vecRelativeTolerance relative tolerances per state entry; length equals state dimension
+   * @param minStep minimal step size in integration time units; must be positive
+   * @param maxStep maximal step size magnitude permitted; must be positive
+   * @param vecAbsoluteTolerance absolute tolerances per state entry; length equals dimension
+   * @param vecRelativeTolerance relative tolerances per state entry; length equals dimension
    */
   @SuppressWarnings("unused")
   public GraggBulirschStoerIntegrator(
@@ -107,16 +103,15 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
    * <p>For each candidate step the integrator compares the first derivative with later midpoint
    * derivatives to detect rapidly growing modes. If the check fails, the step is rejected, and the
    * trial step size is reduced by the supplied factor. Checks are limited to the first few
-   * extrapolation iterations to avoid excessive cost. Passing negative or zero limits restores the
-   * defaults ({@code maxIter=2}, {@code maxChecks=1}, {@code stabilityReduction=0.5}). This setting
+   * extrapolation iterations to avoid excessive cost. Passing non-positive limits restores defaults
+   * ({@code maxIter=2}, {@code maxChecks=1}, {@code stabilityReduction=0.5}). This setting
    * primarily guards against divergence on coarse steps or poorly scaled problems.
    *
-   * @param performTest {@code true} to enable stability checks, {@code false} to skip them entirely
-   * @param maxIter maximum extrapolation iterations to probe; non-positive values revert to default
-   * @param maxChecks maximum derivative comparisons per iteration; non-positive values revert to
-   *     default
-   * @param stabilityReduction multiplicative factor applied to the next trial step after a failure;
-   *     outside {@code [0.0001, 0.9999]} reverts to the default
+   * @param performTest {@code true} to enable checks; {@code false} disables all checks
+   * @param maxIter maximum extrapolation iterations to probe; non-positive restores default
+   * @param maxChecks maximum derivative comparisons per iteration; non-positive restores default
+   * @param stabilityReduction multiplicative factor for next trial step after failure; out of range
+   *     restores default
    */
   public void setStabilityCheck(
       boolean performTest, int maxIter, int maxChecks, double stabilityReduction) {
@@ -151,15 +146,15 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
    * }</pre>
    *
    * <p>Values outside the accepted ranges revert to defaults ({@code stepControl1=0.65}, {@code
-   * stepControl2=0.94}, {@code stepControl3=0.02}, {@code stepControl4=4.0}).
+   * stepControl2=0.94}, {@code stepControl3=0.02}, {@code stepControl4=4.0}). These coefficients
+   * influence how aggressively the method grows or shrinks step sizes after each accepted step.
    *
-   * @param stepControl1 numerator tolerance scale; outside {@code [0.0001, 0.9999]} resets to
+   * @param stepControl1 numerator tolerance scale; outside {@code [0.0001, 0.9999]} resets default
+   * @param stepControl2 multiplicative growth factor; outside {@code [0.0001, 0.9999]} resets
    *     default
-   * @param stepControl2 multiplicative growth factor; outside {@code [0.0001, 0.9999]} resets to
+   * @param stepControl3 clamp base for relative change; outside {@code [0.0001, 0.9999]} resets
    *     default
-   * @param stepControl3 clamp base for relative change; outside {@code [0.0001, 0.9999]} resets to
-   *     default
-   * @param stepControl4 clamp divisor limiting growth; outside {@code [1.0001, 999.9]} resets to
+   * @param stepControl4 clamp divisor limiting growth; outside {@code [1.0001, 999.9]} resets
    *     default
    */
   public void setStepsizeControl(
@@ -202,14 +197,13 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
    * increase order if w(k)     <= w(k - 1) * orderControl2
    * }</pre>
    *
-   * Orders below {@code 6} or odd values revert to the default maximum of {@code 18} (nine table
+   * <p>Orders below {@code 6} or odd values revert to the default maximum of {@code 18} (nine table
    * columns). Control factors outside {@code [0.0001, 0.9999]} revert to defaults of {@code 0.8}
-   * and {@code 0.9}.
+   * and {@code 0.9}. Use this method when tuning performance for a specific accuracy target.
    *
-   * @param maxOrder highest extrapolation order allowed; non-even or {@code <= 6} values reset to
-   *     the default maximum
-   * @param orderControl1 threshold to favor reducing order; outside range reverts to default
-   * @param orderControl2 threshold to favor increasing order; outside range reverts to default
+   * @param maxOrder highest extrapolation order allowed; non-even or {@code <= 6} resets default
+   * @param orderControl1 threshold favoring order reduction; outside range resets default
+   * @param orderControl2 threshold favoring order increase; outside range resets default
    */
   public void setOrderControl(int maxOrder, double orderControl1, double orderControl2) {
 
@@ -236,12 +230,14 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   /**
    * Install the step handler invoked after each accepted step.
    *
-   * <p>The handler receives dense interpolators when dense output is enabled, otherwise a dummy
+   * <p>The handler receives a dense interpolator when dense output is enabled, otherwise a dummy
    * interpolator exposing only end-of-step values. Replacing the handler triggers reallocation of
    * internal buffers because dense output requirements may change. Passing a handler that requests
-   * dense output increases memory and CPU usage but enables intermediate sampling.
+   * dense output increases memory and CPU usage but enables intermediate sampling and event
+   * processing between accepted steps. The supplied handler must be non-null and be used
+   * immediately for later integration calls.
    *
-   * @param handler recipient of accepted steps; must not be {@code null}
+   * @param handler recipient of accepted steps; must be non-null and retained by this instance
    */
   @Override
   public void setStepHandler(StepHandler handler) {
@@ -256,13 +252,14 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   /**
    * Register a switching function (event detector) evaluated during integration.
    *
-   * <p>The detector is polled at most every {@code maxCheckInterval} units to avoid missing sign
-   * changes; when a root is bracketed, a root-finding phase refines the event time using the given
-   * convergence threshold. Adding the first switching function enables dense output internally so
-   * the solver can sample the solution between steps.
+   * <p>The detector is polled at most every {@code maxCheckInterval} units of integration time to
+   * avoid missing sign changes; when a root is bracketed, a root-finding phase refines the event
+   * time using the given convergence threshold. Adding the first switching function enables dense
+   * output internally so the solver can sample the solution between steps. The function is retained
+   * until removed by the base class API or the integrator instance is discarded.
    *
-   * @param function function whose sign changes trigger events; must not be {@code null}
-   * @param maxCheckInterval maximum gap between event checks; large values risk missed events
+   * @param function function whose sign changes trigger events; must be non-null
+   * @param maxCheckInterval maximum time gap between event checks; large values risk missed events
    * @param convergence absolute time accuracy sought when locating the event instant
    */
   @Override
@@ -325,12 +322,12 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
    * k - mudif + 1}, where {@code k} is the last successful extrapolation column. When {@code
    * useInterpolationError} is {@code true}, the interpolator’s error estimate participates in
    * step-size control; otherwise only end-point errors drive adaptation. Values of {@code mudif}
-   * outside {@code [1, 6]} revert to the default of {@code 4}.
+   * outside {@code [1, 6]} revert to the default of {@code 4}. This setting affects the cost and
+   * accuracy of dense output without changing the accepted end-point solution.
    *
-   * @param useInterpolationError {@code true} to include interpolation error in step-size control;
-   *     {@code false} to ignore it
-   * @param mudif interpolation order control offset; values {@code <= 0} or {@code >= 7} reset to
-   *     the default of four
+   * @param useInterpolationError {@code true} to include interpolation error in step-size control
+   * @param mudif interpolation order control offset; values {@code <= 0} or {@code >= 7} reset
+   *     default
    */
   public void setInterpolationControl(boolean useInterpolationError, int mudif) {
 
@@ -346,7 +343,12 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   /**
    * Get the human-readable name of this integration method.
    *
-   * @return the constant string {@code "Gragg-Bulirsch-Stoer"}; callers must not mutate it
+   * <p>The returned value is a stable identifier for logging and reporting. It does not depend on
+   * runtime configuration and is safe to compare using string equality. Callers can use this value
+   * when presenting solver choices to users or when tagging diagnostic output for later analysis.
+   * The value never changes during the lifetime of the process.
+   *
+   * @return constant string {@code "Gragg-Bulirsch-Stoer"} identifying this integrator
    */
   @Override
   public String getName() {
@@ -500,14 +502,14 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
    * array {@code y} is used both as input (initial state) and output (final state); it may be the
    * same instance as {@code y0}. The method validates dimensional consistency and rejects
    * zero-length time spans. Step handlers and switching functions configured on the integrator are
-   * invoked during the process.
+   * invoked during the process, and dense output is used when required by those handlers.
    *
-   * @param equations system of differential equations; its dimension must match {@code y0}
-   * @param t0 initial integration time (independent variable value)
+   * @param equations system of differential equations; dimension must match {@code y0} length
+   * @param t0 initial integration time in problem units; may be any finite value
    * @param y0 initial state vector at {@code t0}; length must equal problem dimension
-   * @param t target time to reach; may be before {@code t0} for backward integration
+   * @param t target time to reach; may be before {@code t0} for backward runs
    * @param y array receiving the computed state at {@code t}; may alias {@code y0}
-   * @throws DerivativeException if user-supplied derivative computation fails
+   * @throws DerivativeException if the derivative computation fails during evaluation
    * @throws IntegratorException if dimensions mismatch or the step size becomes unusable
    */
   @Override
@@ -534,8 +536,10 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     handler.reset();
     costPerTimeUnit[0] = 0;
 
+    IntegrationState integrationState =
+        new IntegrationState(y, scale, interpolator, workingState, status);
     IntegrationContext integrationContext =
-        new IntegrationContext(equations, t, y, forward, scale, interpolator, workingState, status);
+        new IntegrationContext(equations, t, forward, integrationState);
     runIntegrationLoop(integrationContext);
   }
 
@@ -550,31 +554,26 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   private void performSingleStep(IntegrationContext context)
       throws DerivativeException, IntegratorException {
 
-    FirstOrderDifferentialEquations equations = context.equations;
     double targetTime = context.targetTime;
-    double[] y = context.y;
     boolean forward = context.forward;
-    double[] scale = context.scale;
-    AbstractStepInterpolator interpolator = context.interpolator;
-    WorkingState w = context.workingState;
     StepStatus status = context.status;
 
     status.reject = false;
     status.loopExit = false;
-    prepareNewStep(equations, y, forward, scale, interpolator, w, status);
+    prepareNewStep(context);
 
     stepSize = status.hNew;
     status.lastStep = adjustStepForTarget(targetTime, forward);
 
-    int k = runExtrapolationIterations(equations, y, scale, w, status);
+    int k = runExtrapolationIterations(context);
 
     double hInt = getMaxStep();
     if (denseOutput && !status.reject) {
-      hInt = handleDenseOutput(equations, y, scale, interpolator, w, k, status);
+      hInt = handleDenseOutput(context, k);
     }
 
     if (!status.reject) {
-      finalizeAcceptedStep(y, interpolator, w, k, status);
+      finalizeAcceptedStep(context, k);
     }
 
     status.hNew = Math.min(status.hNew, hInt);
@@ -584,6 +583,28 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
 
     status.firstTime = false;
     updateRejectionStatus(status, status.reject);
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class IntegrationState {
+    private final double[] y;
+    private final double[] scale;
+    private final AbstractStepInterpolator interpolator;
+    private final WorkingState workingState;
+    private final StepStatus status;
+
+    private IntegrationState(
+        double[] y,
+        double[] scale,
+        AbstractStepInterpolator interpolator,
+        WorkingState workingState,
+        StepStatus status) {
+      this.y = y;
+      this.scale = scale;
+      this.interpolator = interpolator;
+      this.workingState = workingState;
+      this.status = status;
+    }
   }
 
   private static final class IntegrationContext {
@@ -599,20 +620,16 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     private IntegrationContext(
         FirstOrderDifferentialEquations equations,
         double targetTime,
-        double[] y,
         boolean forward,
-        double[] scale,
-        AbstractStepInterpolator interpolator,
-        WorkingState workingState,
-        StepStatus status) {
+        IntegrationState state) {
       this.equations = equations;
       this.targetTime = targetTime;
-      this.y = y;
       this.forward = forward;
-      this.scale = scale;
-      this.interpolator = interpolator;
-      this.workingState = workingState;
-      this.status = status;
+      this.y = state.y;
+      this.scale = state.scale;
+      this.interpolator = state.interpolator;
+      this.workingState = state.workingState;
+      this.status = state.status;
     }
 
     @Override
@@ -664,6 +681,39 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     }
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class ModifiedMidpointState {
+    private final double t0;
+    private final double[] y0;
+    private final double step;
+    private final int k;
+
+    private ModifiedMidpointState(double t0, double[] y0, double step, int k) {
+      this.t0 = t0;
+      this.y0 = y0;
+      this.step = step;
+      this.k = k;
+    }
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class ModifiedMidpointBuffers {
+    private final double[] scale;
+    private final double[][] f;
+    private final double[] yMiddle;
+    private final double[] yEnd;
+    private final double[] yTmp;
+
+    private ModifiedMidpointBuffers(
+        double[] scale, double[][] f, double[] yMiddle, double[] yEnd, double[] yTmp) {
+      this.scale = scale;
+      this.f = f;
+      this.yMiddle = yMiddle;
+      this.yEnd = yEnd;
+      this.yTmp = yTmp;
+    }
+  }
+
   private static final class ModifiedMidpointContext {
     private final FirstOrderDifferentialEquations equations;
     private final double t0;
@@ -678,25 +728,18 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
 
     private ModifiedMidpointContext(
         FirstOrderDifferentialEquations equations,
-        double t0,
-        double[] y0,
-        double step,
-        int k,
-        double[] scale,
-        double[][] f,
-        double[] yMiddle,
-        double[] yEnd,
-        double[] yTmp) {
+        ModifiedMidpointState state,
+        ModifiedMidpointBuffers buffers) {
       this.equations = equations;
-      this.t0 = t0;
-      this.y0 = y0;
-      this.step = step;
-      this.k = k;
-      this.scale = scale;
-      this.f = f;
-      this.yMiddle = yMiddle;
-      this.yEnd = yEnd;
-      this.yTmp = yTmp;
+      this.t0 = state.t0;
+      this.y0 = state.y0;
+      this.step = state.step;
+      this.k = state.k;
+      this.scale = buffers.scale;
+      this.f = buffers.f;
+      this.yMiddle = buffers.yMiddle;
+      this.yEnd = buffers.yEnd;
+      this.yTmp = buffers.yTmp;
     }
 
     @Override
@@ -761,18 +804,19 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
   /**
    * Store results for an accepted step, notify handlers, and prepare the next trial size/order.
    *
-   * @param y caller-owned state array updated with the accepted end state
-   * @param interpolator step interpolator already primed with start state; will store end time here
-   * @param w working buffers holding extrapolated end state and derivatives
+   * @param context integration context carrying state, interpolator, and working buffers
    * @param k last successful extrapolation column
-   * @param status mutable step status tracking rejection history and next targets
    * @throws DerivativeException if switching functions require additional derivative evaluations
    * @throws IntegratorException if event processing or handler logic raises integration-level
    *     errors
    */
-  private void finalizeAcceptedStep(
-      double[] y, AbstractStepInterpolator interpolator, WorkingState w, int k, StepStatus status)
+  private void finalizeAcceptedStep(IntegrationContext context, int k)
       throws DerivativeException, IntegratorException {
+
+    double[] y = context.y;
+    AbstractStepInterpolator interpolator = context.interpolator;
+    WorkingState w = context.workingState;
+    StepStatus status = context.status;
 
     stepStart += stepSize;
     System.arraycopy(w.y1, 0, y, 0, y.length);
@@ -803,15 +847,15 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     }
   }
 
-  private void prepareNewStep(
-      FirstOrderDifferentialEquations equations,
-      double[] y,
-      boolean forward,
-      double[] scale,
-      AbstractStepInterpolator interpolator,
-      WorkingState w,
-      StepStatus status)
-      throws DerivativeException {
+  private void prepareNewStep(IntegrationContext context) throws DerivativeException {
+
+    FirstOrderDifferentialEquations equations = context.equations;
+    double[] y = context.y;
+    boolean forward = context.forward;
+    double[] scale = context.scale;
+    AbstractStepInterpolator interpolator = context.interpolator;
+    WorkingState w = context.workingState;
+    StepStatus status = context.status;
 
     status.reject = false;
     if (!status.newStep) {
@@ -853,26 +897,22 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     return forward ? (nextT >= targetTime) : (nextT <= targetTime);
   }
 
-  private int runExtrapolationIterations(
-      FirstOrderDifferentialEquations equations,
-      double[] y,
-      double[] scale,
-      WorkingState w,
-      StepStatus status)
+  private int runExtrapolationIterations(IntegrationContext context)
       throws DerivativeException, IntegratorException {
 
+    StepStatus status = context.status;
     int k = -1;
     boolean shouldContinue;
     do {
       status.loopExit = false;
       ++k;
-      if (!tryCurrentSubStep(equations, y, scale, w, k, status)) {
+      if (!tryCurrentSubStep(context, k)) {
         break;
       }
 
       shouldContinue = k == 0;
       if (!shouldContinue) {
-        computeExtrapolationAndError(y, scale, w, k, status);
+        computeExtrapolationAndError(context, k);
         shouldContinue = !(status.reject || status.loopExit);
       }
     } while (shouldContinue);
@@ -880,27 +920,24 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     return k;
   }
 
-  private boolean tryCurrentSubStep(
-      FirstOrderDifferentialEquations equations,
-      double[] y,
-      double[] scale,
-      WorkingState w,
-      int k,
-      StepStatus status)
+  private boolean tryCurrentSubStep(IntegrationContext context, int k)
       throws DerivativeException, IntegratorException {
 
-    if (tryStep(
-        new ModifiedMidpointContext(
-            equations,
-            stepStart,
-            y,
-            stepSize,
-            k,
+    FirstOrderDifferentialEquations equations = context.equations;
+    double[] y = context.y;
+    double[] scale = context.scale;
+    WorkingState w = context.workingState;
+    StepStatus status = context.status;
+
+    ModifiedMidpointState stepState = new ModifiedMidpointState(stepStart, y, stepSize, k);
+    ModifiedMidpointBuffers buffers =
+        new ModifiedMidpointBuffers(
             scale,
             w.fk[k],
             (k == 0) ? w.yMidDots[0] : w.diagonal[k - 1],
             (k == 0) ? w.y1 : w.y1Diag[k - 1],
-            w.yTmp))) {
+            w.yTmp);
+    if (tryStep(new ModifiedMidpointContext(equations, stepState, buffers))) {
       return true;
     }
 
@@ -910,9 +947,13 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     return false;
   }
 
-  private void computeExtrapolationAndError(
-      double[] y, double[] scale, WorkingState w, int k, StepStatus status)
+  private void computeExtrapolationAndError(IntegrationContext context, int k)
       throws IntegratorException {
+
+    double[] y = context.y;
+    double[] scale = context.scale;
+    WorkingState w = context.workingState;
+    StepStatus status = context.status;
 
     extrapolate(0, k, w.y1Diag, w.y1);
     rescale(y, w.y1, scale);
@@ -1022,15 +1063,13 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     status.reject = true;
   }
 
-  private double handleDenseOutput(
-      FirstOrderDifferentialEquations equations,
-      double[] y,
-      double[] scale,
-      AbstractStepInterpolator interpolator,
-      WorkingState w,
-      int k,
-      StepStatus status)
-      throws DerivativeException {
+  private double handleDenseOutput(IntegrationContext context, int k) throws DerivativeException {
+
+    FirstOrderDifferentialEquations equations = context.equations;
+    double[] y = context.y;
+    AbstractStepInterpolator interpolator = context.interpolator;
+    WorkingState w = context.workingState;
+    StepStatus status = context.status;
 
     for (int j = 1; j <= k; ++j) {
       extrapolate(0, j, w.diagonal, w.yMidDots[0]);
@@ -1042,7 +1081,7 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
 
     double hInt = getMaxStep();
     if (mu >= 0) {
-      hInt = applyInterpolationErrorControl(scale, interpolator, mu, hInt, status);
+      hInt = applyInterpolationErrorControl(context, mu, hInt);
       if (!status.reject) {
         handleSwitchingFunctions(interpolator, status);
       }
@@ -1107,12 +1146,11 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     }
   }
 
-  private double applyInterpolationErrorControl(
-      double[] scale,
-      AbstractStepInterpolator interpolator,
-      int mu,
-      double hInt,
-      StepStatus status) {
+  private double applyInterpolationErrorControl(IntegrationContext context, int mu, double hInt) {
+
+    double[] scale = context.scale;
+    AbstractStepInterpolator interpolator = context.interpolator;
+    StepStatus status = context.status;
 
     GraggBulirschStoerStepInterpolator gbsInterpolator =
         (GraggBulirschStoerStepInterpolator) interpolator;

--- a/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegrator.java
@@ -868,18 +868,11 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
     }
 
     if (status.firstTime) {
-      status.hNew =
-          initializeStep(
-              new StepInitializationContext(
-                  equations,
-                  forward,
-                  2 * status.targetIter + 1,
-                  scale,
-                  stepStart,
-                  y,
-                  w.yDot0,
-                  w.yTmp,
-                  w.yTmpDot));
+      StepInitializationInputs inputs =
+          new StepInitializationInputs(
+              equations, forward, 2 * status.targetIter + 1, scale, stepStart, y, w.yDot0);
+      StepInitializationWorkspace workspace = new StepInitializationWorkspace(w.yTmp, w.yTmpDot);
+      status.hNew = initializeStep(new StepInitializationContext(inputs, workspace));
       if (!forward) {
         status.hNew = -status.hNew;
       }

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaFehlbergIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaFehlbergIntegrator.java
@@ -280,18 +280,12 @@ public abstract class RungeKuttaFehlbergIntegrator extends AdaptiveStepsizeInteg
     }
 
     double[] scale = (vecAbsoluteTolerance != null) ? vecAbsoluteTolerance : buildScalarScale(y);
-    context.hNew =
-        initializeStep(
-            new StepInitializationContext(
-                equations,
-                forward,
-                getOrder(),
-                scale,
-                stepStart,
-                y,
-                context.yDotK[0],
-                context.yTmp,
-                context.yDotK[1]));
+    StepInitializationInputs inputs =
+        new StepInitializationInputs(
+            equations, forward, getOrder(), scale, stepStart, y, context.yDotK[0]);
+    StepInitializationWorkspace workspace =
+        new StepInitializationWorkspace(context.yTmp, context.yDotK[1]);
+    context.hNew = initializeStep(new StepInitializationContext(inputs, workspace));
     context.firstTime = false;
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/StepInitializationContext.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/StepInitializationContext.java
@@ -8,13 +8,18 @@ import org.jetbrains.annotations.NotNull;
  * Bundles inputs and work arrays used to estimate an initial step size.
  *
  * <p>This value object packages the values required by {@link
- * AdaptiveStepsizeIntegrator#initializeStep} so callers can pass a single object instead of a long
- * parameter list. It is typically created by adaptive integrators right before the first step is
- * chosen, using arrays that already exist in the integration workspace. The instance itself is
- * immutable, but it stores references to mutable arrays owned by the caller; no defensive copies
- * are made, and the arrays may be reused across attempts. Treat instances as short-lived,
- * single-thread use objects that describe one initialization attempt and provide access to the
- * shared scratch buffers.
+ * AdaptiveStepsizeIntegrator#initializeStep(StepInitializationContext)} so callers can pass a
+ * single object instead of a long parameter list. It is typically created by adaptive integrators
+ * right before the first step is chosen, using arrays that already exist in the integration
+ * workspace. The instance itself is immutable, but it stores references to mutable arrays owned by
+ * the caller; no defensive copies are made, and the arrays may be reused across attempts.
+ *
+ * <p>Use this context as a short-lived description of one initialization attempt. It captures a
+ * derivative provider, the integration direction, scaling information, and the working buffers for
+ * the Euler probe used by the step-size heuristic. The context does not validate array dimensions
+ * or contents; callers are responsible for supplying consistent array lengths and non-zero scaling
+ * values. Instances are not thread-safe because the arrays are shared and are expected to be
+ * mutated by the integrator during initialization.
  *
  * <p>Responsibilities include:
  *
@@ -26,7 +31,6 @@ import org.jetbrains.annotations.NotNull;
  *
  * @see AdaptiveStepsizeIntegrator#initializeStep(StepInitializationContext)
  */
-@SuppressWarnings("java:S6206")
 public final class StepInitializationContext {
   private final FirstOrderDifferentialEquations equations;
   private final boolean forward;
@@ -41,84 +45,178 @@ public final class StepInitializationContext {
   /**
    * Creates a bundle of inputs and work arrays for the initial step-size estimate.
    *
-   * @param equations the system that computes derivatives for the trial states; must not be null
-   * @param forward true to integrate toward increasing time, false for the backward direction
-   * @param order integration order used to scale the initial step estimate
-   * @param scale per-component scaling factors; length matches state and contains non-zero values
-   * @param t0 start time for the trial step; expressed in integration time units
-   * @param y0 state values at {@code t0}; array length matches the equations dimension
-   * @param yDot0 derivative values at {@code t0}; used as input and overwritten by callers
-   * @param y1 workspace holding the Euler-predicted trial state; same length as {@code y0}
-   * @param yDot1 workspace for derivatives at the trial state; same length as {@code y0}
+   * <p>The constructor simply stores references from the provided input and workspace containers.
+   * It does not clone or normalize any arrays, and it performs no consistency checks. Callers must
+   * ensure that all arrays have compatible lengths, that the scale entries are non-zero, and that
+   * the derivative buffer contains the derivative at {@code t0}. The resulting context is intended
+   * for immediate use during a single initialization pass and should not be shared across threads
+   * because the arrays are expected to be mutated during the Euler probe.
+   *
+   * @param inputs scalar values and state vectors used by the heuristic; must not be {@code null}
+   * @param workspace buffers reused during the Euler probe and derivative evaluation; must not be
+   *     {@code null}
    */
   public StepInitializationContext(
-      FirstOrderDifferentialEquations equations,
-      boolean forward,
-      int order,
-      double[] scale,
-      double t0,
-      double[] y0,
-      double[] yDot0,
-      double[] y1,
-      double[] yDot1) {
-    this.equations = equations;
-    this.forward = forward;
-    this.order = order;
-    this.scale = scale;
-    this.t0 = t0;
-    this.y0 = y0;
-    this.yDot0 = yDot0;
-    this.y1 = y1;
-    this.yDot1 = yDot1;
+      StepInitializationInputs inputs, StepInitializationWorkspace workspace) {
+    this.equations = inputs.equations();
+    this.forward = inputs.forward();
+    this.order = inputs.order();
+    this.scale = inputs.scale();
+    this.t0 = inputs.t0();
+    this.y0 = inputs.y0();
+    this.yDot0 = inputs.yDot0();
+    this.y1 = workspace.y1();
+    this.yDot1 = workspace.yDot1();
   }
 
+  /**
+   * Returns the derivative provider for the trial evaluations.
+   *
+   * <p>The returned instance is the same reference supplied by the caller and is used by the
+   * heuristic to compute derivatives during the Euler probe. The context does not wrap or cache the
+   * provider, so any side effects or state in the equations implementation are observed directly
+   * during initialization. Callers should ensure that the equations implementation is configured
+   * consistently with the supplied state arrays and that it can safely be invoked at {@code t0} and
+   * the trial time computed by the integrator.
+   *
+   * @return derivative provider used for trial derivative evaluations during initialization
+   */
   public FirstOrderDifferentialEquations equations() {
     return equations;
   }
 
+  /**
+   * Reports whether integration proceeds toward increasing time.
+   *
+   * <p>This flag mirrors the integrator direction used to sign the trial step size. It is not
+   * derived from the time values and remains constant for the lifetime of this context. The value
+   * is consulted by the initialization heuristic to orient the step toward the target time, and it
+   * is also used when clamping the initial step size to configured limits. Callers should provide a
+   * value consistent with the target time to avoid an initial step that points away from the goal.
+   *
+   * @return {@code true} for forward integration, {@code false} for backward integration
+   */
   public boolean forward() {
     return forward;
   }
 
+  /**
+   * Returns the integration order used by the step-size heuristic.
+   *
+   * <p>The order controls the power applied when scaling the error estimate. It should match the
+   * order of the method used by the integrator, and it is treated as an input parameter rather than
+   * recomputed. The context does not validate that the value is positive, so callers must supply a
+   * meaningful order and ensure consistency with the integrator implementation. An incorrect order
+   * can yield overly aggressive or overly conservative initial step sizes.
+   *
+   * @return integration order used when scaling the step-size estimate
+   */
   public int order() {
     return order;
   }
 
+  /**
+   * Returns the per-component scaling factors used to normalize errors.
+   *
+   * <p>The returned array reference is shared with the caller and is read multiple times during the
+   * heuristic. Each entry should be non-zero to avoid division by zero, and the array length must
+   * match the state dimension. The context does not enforce these invariants. If the array is
+   * modified while initialization is in progress, the computed step size may become inconsistent
+   * with the state and derivative values.
+   *
+   * @return scale array used to normalize state and derivative components
+   */
   public double[] scale() {
     return scale;
   }
 
+  /**
+   * Returns the start time used for the trial step.
+   *
+   * <p>This value is the integration time at which the initial state and derivative arrays are
+   * defined. The heuristic uses it when evaluating derivatives at the Euler trial point and when
+   * clamping the step size relative to the timescale. The value is stored verbatim and may be any
+   * finite or NaN value supported by the integrator. Callers should supply the same {@code t0} used
+   * to populate {@code y0} and {@code yDot0}.
+   *
+   * @return starting time for the initial step-size trial, in integrator time units
+   */
   public double t0() {
     return t0;
   }
 
+  /**
+   * Returns the state vector at the initial time.
+   *
+   * <p>The returned array is shared with the integrator and should contain the state at {@code t0}.
+   * The heuristic reads this array but does not modify it directly. Callers must ensure the array
+   * length matches the equation dimension used by the derivative provider and that the contents are
+   * consistent with {@code yDot0}. If the array is mutated during initialization, the estimated
+   * step size may be based on mixed state values.
+   *
+   * @return state vector at {@code t0}, shared with the integrator
+   */
   public double[] y0() {
     return y0;
   }
 
+  /**
+   * Returns the derivative vector at the initial time.
+   *
+   * <p>The returned array is both an input and a workspace: it initially holds the derivative at
+   * {@code t0}, and the integrator may overwrite it when recomputing derivatives. The heuristic
+   * reads this array when estimating the first step size, so it must be populated before use. The
+   * array length must match {@code y0}, and the values should be derived from the same equations
+   * instance returned by {@link #equations()}.
+   *
+   * @return derivative vector at {@code t0}, shared and mutable
+   */
   public double[] yDot0() {
     return yDot0;
   }
 
+  /**
+   * Returns the workspace array for the Euler-predicted trial state.
+   *
+   * <p>The heuristic writes the Euler trial state into this array and then uses it when requesting
+   * derivatives at the trial time. The contents are not preserved after initialization, and the
+   * array is owned by the caller. Its length must match the state dimension, and it should not
+   * alias {@code y0} or {@code yDot0} unless the caller can tolerate in-place overwrites. The
+   * initialization logic expects the array to be mutable.
+   *
+   * @return workspace holding the Euler trial state, reused across attempts
+   */
   public double[] y1() {
     return y1;
   }
 
+  /**
+   * Returns the workspace array for derivatives at the Euler trial state.
+   *
+   * <p>The derivative provider writes into this array when evaluating the Euler trial point. The
+   * values are used to estimate second derivatives and are not retained after initialization.
+   * Callers must ensure that the array length matches the state dimension and that it can be
+   * overwritten without affecting another integrator state. This buffer is read immediately after
+   * the trial evaluation and then discarded.
+   *
+   * @return workspace for derivatives at the trial state, reused across attempts
+   */
   public double[] yDot1() {
     return yDot1;
   }
 
   /**
-   * Compare this context with another for structural equality.
+   * Compares this context with another for structural equality.
    *
    * <p>The comparison uses the context fields as the semantic values but treats the array
    * components as ordered value sequences rather than reference identities. The time value is
    * compared using raw bit equality to keep {@code NaN} payloads distinct. This method is
    * deterministic and side-effect free, which makes it suitable for caching keys or assertions in
-   * tests.
+   * tests. Because content compares arrays, two contexts sharing different array instances can
+   * still be considered equal when their values match.
    *
-   * @param other candidate object to compare; may be null or any type.
-   * @return {@code true} when all scalar fields match and each array contains equal values.
+   * @param other candidate object to compare; may be {@code null} or any type instance
+   * @return {@code true} when all scalar fields match and each array contains equal values
    */
   @Override
   public boolean equals(Object other) {
@@ -140,14 +238,15 @@ public final class StepInitializationContext {
   }
 
   /**
-   * Compute a hash code consistent with the array-aware equality contract.
+   * Computes a hash code consistent with the array-aware equality contract.
    *
    * <p>The hash is composed of the scalar components and the contents of each array. This keeps the
    * result stable for identical value sequences even when the arrays are distinct instances.
    * Callers should remember that changing any referenced array will change the hash, so this
    * context should not be used as a key in mutable array scenarios unless the contents are stable.
+   * The method performs no caching and recomputes the hash on every call.
    *
-   * @return hash value derived from scalar components and array contents.
+   * @return hash value derived from scalar components and array contents
    */
   @Override
   public int hashCode() {
@@ -161,13 +260,15 @@ public final class StepInitializationContext {
   }
 
   /**
-   * Render a descriptive string that includes the contents of each array component.
+   * Renders a descriptive string that includes the contents of each array component.
    *
    * <p>The output mirrors the field order, formatting arrays with {@link Arrays#toString(double[])}
    * so the contents are visible for diagnostics. The returned string is non-null and intended for
-   * logging or debugging rather than parsing.
+   * logging or debugging rather than parsing. Because the arrays are mutable, the returned string
+   * reflects the state at the time of the call and may change if the arrays are later modified.
+   * This method has no side effects and does not allocate additional arrays beyond formatting.
    *
-   * @return human-readable representation containing scalar values and array contents.
+   * @return human-readable representation containing scalar values and array contents
    */
   @Override
   public @NotNull String toString() {

--- a/src/main/java/org/spaceroots/mantissa/ode/StepInitializationInputs.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/StepInitializationInputs.java
@@ -1,0 +1,170 @@
+package org.spaceroots.mantissa.ode;
+
+/**
+ * Bundles scalar and state inputs used to estimate an initial step size.
+ *
+ * <p>This value class collects the core inputs that remain stable during the initial step-size
+ * heuristic: the derivative provider, integration direction, scaling factors, the start time, and
+ * the state and derivative arrays at that time. Integrators typically assemble an instance right
+ * before invoking {@link AdaptiveStepsizeIntegrator#initializeStep(StepInitializationContext)} and
+ * pair it with a workspace that holds mutable trial buffers used during the Euler probe.
+ *
+ * <p>The instance is immutable, but it stores references to mutable arrays owned by the caller. No
+ * defensive copies are made, and callers are responsible for ensuring that array lengths match the
+ * equation dimension and that scaling factors are non-zero. The class does not validate inputs or
+ * enforce invariants, so it should be used as a short-lived carrier rather than a long-term cache.
+ * It is not thread-safe because its arrays are expected to be mutated by the integrator that uses
+ * them.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Providing the derivative provider and direction for the heuristic.
+ *   <li>Carrying the state, derivative, and scale arrays used in norm computations.
+ *   <li>Supplying the start time that anchors the trial evaluation.
+ * </ul>
+ *
+ * @see StepInitializationContext
+ */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+public final class StepInitializationInputs {
+  private final FirstOrderDifferentialEquations equations;
+  private final boolean forward;
+  private final int order;
+  private final double[] scale;
+  private final double t0;
+  private final double[] y0;
+  private final double[] yDot0;
+
+  /**
+   * Creates an input bundle for the initial step-size estimate.
+   *
+   * <p>This constructor stores references to the provided arrays without copying or validating
+   * them. Callers must ensure that {@code y0}, {@code yDot0}, and {@code scale} have identical
+   * lengths, that each scale entry is non-zero, and that {@code yDot0} reflects the derivative at
+   * {@code t0}. The resulting instance is intended for immediate use by a single integrator and
+   * should not be shared across threads because the arrays are mutable.
+   *
+   * @param equations derivative provider used by the initialization heuristic; must not be {@code
+   *     null}
+   * @param forward {@code true} for forward integration, {@code false} for backward direction
+   * @param order integration order used to scale the step estimate; must be positive
+   * @param scale per-component scaling factors used in norm calculations; entries must be non-zero
+   * @param t0 start time for the trial step, expressed in integrator time units
+   * @param y0 state vector at {@code t0}; length must match the equation dimension
+   * @param yDot0 derivative vector at {@code t0}; length must match {@code y0}
+   */
+  public StepInitializationInputs(
+      FirstOrderDifferentialEquations equations,
+      boolean forward,
+      int order,
+      double[] scale,
+      double t0,
+      double[] y0,
+      double[] yDot0) {
+    this.equations = equations;
+    this.forward = forward;
+    this.order = order;
+    this.scale = scale;
+    this.t0 = t0;
+    this.y0 = y0;
+    this.yDot0 = yDot0;
+  }
+
+  /**
+   * Returns the derivative provider used during the initial step-size heuristic.
+   *
+   * <p>The returned instance is the same reference supplied at construction time. It is invoked by
+   * the integrator to compute derivatives at {@code t0} and at the Euler trial point. The caller is
+   * responsible for ensuring that the provider is consistent with the supplied state arrays and
+   * that it can be called safely during initialization.
+   *
+   * @return derivative provider used for trial derivative evaluations
+   */
+  public FirstOrderDifferentialEquations equations() {
+    return equations;
+  }
+
+  /**
+   * Returns the integration direction flag.
+   *
+   * <p>The value determines whether the estimated step size is positive or negative relative to
+   * {@code t0}. It is not derived from time values and remains fixed for the lifetime of this
+   * instance. Callers should supply a direction consistent with the target time to avoid stepping
+   * away from the intended integration goal.
+   *
+   * @return {@code true} when integration advances toward increasing time, otherwise {@code false}
+   */
+  public boolean forward() {
+    return forward;
+  }
+
+  /**
+   * Returns the integration order used to scale the step-size estimate.
+   *
+   * <p>The order is used by the heuristic when converting normalized derivative estimates into a
+   * step size. This class does not validate the value, so callers must ensure it is positive and
+   * consistent with the integrator implementation. Incorrect values can lead to overly aggressive
+   * or overly conservative initial steps.
+   *
+   * @return integration order used when scaling the initial step-size estimate
+   */
+  public int order() {
+    return order;
+  }
+
+  /**
+   * Returns the per-component scaling factors used for normalization.
+   *
+   * <p>The array is shared with the caller and is read repeatedly during the heuristic. Each entry
+   * must be non-zero to avoid division by zero, and the array length must match the state vector
+   * dimension. The class does not validate these conditions and does not copy the array.
+   *
+   * @return scale array used to normalize state and derivative components
+   */
+  public double[] scale() {
+    return scale;
+  }
+
+  /**
+   * Returns the start time for the trial step.
+   *
+   * <p>This value anchors the state and derivative arrays and is used when evaluating derivatives
+   * at the Euler trial point. It is stored verbatim without validation and may be any finite value
+   * supported by the integrator. Callers should ensure it matches the time at which {@code y0} and
+   * {@code yDot0} were computed.
+   *
+   * @return start time for the trial step, expressed in integrator time units
+   */
+  public double t0() {
+    return t0;
+  }
+
+  /**
+   * Returns the state vector at the start time.
+   *
+   * <p>The returned array is shared with the caller and is read by the heuristic when estimating
+   * the initial step size. It must have the same length as the equation dimension and the scale
+   * array. The contents should represent the state at {@code t0} and remain stable during
+   * initialization.
+   *
+   * @return state vector at {@code t0}, shared with the integrator
+   */
+  public double[] y0() {
+    return y0;
+  }
+
+  /**
+   * Returns the derivative vector at the start time.
+   *
+   * <p>The returned array is shared with the caller and is read by the heuristic when computing
+   * normalized derivative norms. It should contain the derivative at {@code t0} and have the same
+   * length as {@code y0}. The integrator may overwrite the array during initialization, so callers
+   * should not rely on its contents after the step is estimated.
+   *
+   * @return derivative vector at {@code t0}, shared and mutable
+   */
+  public double[] yDot0() {
+    return yDot0;
+  }
+}

--- a/src/main/java/org/spaceroots/mantissa/ode/StepInitializationWorkspace.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/StepInitializationWorkspace.java
@@ -1,0 +1,72 @@
+package org.spaceroots.mantissa.ode;
+
+/**
+ * Holds reusable work arrays for the initial step-size estimate.
+ *
+ * <p>This class stores the mutable buffers used during the Euler probe that refines the initial
+ * step size. Integrators typically create a workspace alongside {@link StepInitializationInputs}
+ * and pass both into {@link StepInitializationContext}. The buffers are shared with the integrator
+ * and are written in-place when computing the Euler trial state and its derivative.
+ *
+ * <p>The instance is immutable, but it retains references to mutable arrays owned by the caller. No
+ * defensive copies are made. Callers must ensure that both arrays have the same length as the state
+ * vector and that they are safe to overwrite during initialization. The class is not thread-safe
+ * because it exposes mutable arrays that the integrator is expected to reuse.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Providing a buffer for the Euler-predicted trial state.
+ *   <li>Providing a buffer for derivatives at the trial state.
+ * </ul>
+ *
+ * @see StepInitializationContext
+ */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+public final class StepInitializationWorkspace {
+  private final double[] y1;
+  private final double[] yDot1;
+
+  /**
+   * Creates a workspace holding the mutable buffers used during initialization.
+   *
+   * <p>This constructor stores references to the supplied arrays without validation. Callers must
+   * ensure the arrays are non-null, have the correct length for the problem dimension, and can be
+   * overwritten during the Euler probe. The resulting instance is intended for immediate use by a
+   * single integrator and should not be shared across threads.
+   *
+   * @param y1 workspace for the Euler-predicted trial state; must be mutable and correctly sized
+   * @param yDot1 workspace for derivatives at the trial state; must be mutable and correctly sized
+   */
+  public StepInitializationWorkspace(double[] y1, double[] yDot1) {
+    this.y1 = y1;
+    this.yDot1 = yDot1;
+  }
+
+  /**
+   * Returns the workspace array for the Euler-predicted trial state.
+   *
+   * <p>The integrator writes the Euler trial state into this array and then uses it as input for
+   * derivative evaluation at the trial time. The contents are transient and may be overwritten on
+   * each initialization attempt. Callers should not assume the values persist beyond the step-size
+   * estimation.
+   *
+   * @return workspace array holding the Euler trial state, shared and mutable
+   */
+  public double[] y1() {
+    return y1;
+  }
+
+  /**
+   * Returns the workspace array for derivatives at the Euler trial state.
+   *
+   * <p>The derivative provider writes into this array when evaluating the Euler trial point. The
+   * values are consumed immediately by the heuristic to estimate curvature and are not retained.
+   * The array is shared with the caller and may be overwritten in further initialization steps.
+   *
+   * @return workspace array for derivatives at the trial state, shared and mutable
+   */
+  public double[] yDot1() {
+    return yDot1;
+  }
+}

--- a/src/test/java/network/crypta/client/MetadataTest.java
+++ b/src/test/java/network/crypta/client/MetadataTest.java
@@ -325,16 +325,13 @@ class MetadataTest {
     SplitfileParams params =
         new SplitfileParams(
             SplitfileAlgorithm.NONREDUNDANT,
-            data,
-            check,
-            1,
-            0,
-            0,
-            0,
-            Key.ALGO_AES_PCFB_256_SHA256,
-            // splitfileCryptoKey must be null for version 0; pass non-null to trigger exception
-            new byte[32],
-            false);
+            new SplitfileBlockKeys(data, check),
+            new SplitfileSegmentLayout(1, 0, 0, 0),
+            new SplitfileCryptoParams(
+                Key.ALGO_AES_PCFB_256_SHA256,
+                // splitfileCryptoKey must be null for version 0; pass non-null to trigger exception
+                new byte[32],
+                false));
     SplitfilePayload payload = new SplitfilePayload(cm, 1L, null, null, 1L, false);
     MetadataTopLayerInfo topLayer =
         new MetadataTopLayerInfo(
@@ -375,15 +372,16 @@ class MetadataTest {
     return new Metadata(
         new SplitfileParams(
             SplitfileAlgorithm.NONREDUNDANT,
-            dataURIs,
-            checkURIs,
-            /* segmentSize= */ 1,
-            /* checkSegmentSize= */ 0,
-            /* deductBlocksFromSegments= */ 0,
-            /* crossSegmentBlocks= */ 0,
-            /* splitfileCryptoAlgorithm= */ Key.ALGO_AES_CTR_256_SHA256,
-            /* splitfileCryptoKey= */ splitKey,
-            /* specifySplitfileKey= */ true),
+            new SplitfileBlockKeys(dataURIs, checkURIs),
+            new SplitfileSegmentLayout(
+                /* segmentSize= */ 1,
+                /* checkSegmentSize= */ 0,
+                /* deductBlocksFromSegments= */ 0,
+                /* crossSegmentBlocks= */ 0),
+            new SplitfileCryptoParams(
+                /* splitfileCryptoAlgorithm= */ Key.ALGO_AES_CTR_256_SHA256,
+                /* splitfileCryptoKey= */ splitKey,
+                /* specifySplitfileKey= */ true)),
         new SplitfilePayload(
             /* clientMetadata= */ null,
             /* dataLength= */ 1024L,

--- a/src/test/java/network/crypta/client/MetadataTest.java
+++ b/src/test/java/network/crypta/client/MetadataTest.java
@@ -161,7 +161,7 @@ class MetadataTest {
   @Test
   void mkRedirectionManifestWithMetadata_whenSlashInKey_throws() {
     HashMap<String, Object> bad = new HashMap<>();
-    // Value type here must be either Metadata or HashMap; provide a valid leaf Metadata
+    // The value type here must be either Metadata or HashMap; provide a valid leaf Metadata
     bad.put(
         "a/b",
         new Metadata(
@@ -255,7 +255,7 @@ class MetadataTest {
   void forceMap_behavior_copiesOrCasts_andRejectsBadKeysOrTypes() {
     HashMap<String, Object> original = new HashMap<>();
     original.put("x", "y");
-    // Returns same instance for HashMap
+    // Returns the same instance for HashMap
     Map<String, Object> same = Metadata.forceMap(original);
     assertSame(original, same);
 
@@ -274,7 +274,7 @@ class MetadataTest {
 
   @Test
   void guessCompatibilityMode_usesTopOrFallsBackToMax() throws Exception {
-    // Build a SIMPLE_REDIRECT with non-zero top fields but COMPAT_UNKNOWN in header.
+    // Build a SIMPLE_REDIRECT with non-zero top fields but COMPAT_UNKNOWN in the header.
     FreenetURI uri = FreenetURI.generateRandomCHK(new Random(0x0A141E28L));
     byte[] bytes = topHeaderUnknownBytes(uri);
 
@@ -302,15 +302,15 @@ class MetadataTest {
             new MetadataRedirectTarget(
                 DocumentType.SIMPLE_REDIRECT, null, null, uri, new ClientMetadata(MIME_TEXT)),
             new MetadataTopLayerInfo(
-                1234L, // topSize
-                1200L, // topCompressedSize
-                10, // topBlocksRequired
-                12, // topBlocksTotal
-                false,
-                CompatibilityMode
-                    .COMPAT_UNKNOWN, // write unknown into header alongside non-zero fields
-                null,
-                null));
+                new TopLayerBlockInfo(
+                    1234L, // topSize
+                    1200L, // topCompressedSize
+                    10, // topBlocksRequired
+                    12, // topBlocksTotal
+                    false,
+                    CompatibilityMode
+                        .COMPAT_UNKNOWN), // write unknown into the header alongside non-zero fields
+                new TopLayerHashInfo(null, null)));
     return writer.writeToByteArray();
   }
 
@@ -338,14 +338,9 @@ class MetadataTest {
     SplitfilePayload payload = new SplitfilePayload(cm, 1L, null, null, 1L, false);
     MetadataTopLayerInfo topLayer =
         new MetadataTopLayerInfo(
-            0L,
-            0L,
-            0,
-            0,
-            false,
-            CompatibilityMode.COMPAT_1250, // < 1255 → parsedVersion 0
-            null,
-            null);
+            new TopLayerBlockInfo(
+                0L, 0L, 0, 0, false, CompatibilityMode.COMPAT_1250), // < 1255 → parsedVersion 0
+            new TopLayerHashInfo(null, null));
 
     assertThrows(IllegalArgumentException.class, () -> new Metadata(params, payload, topLayer));
   }
@@ -362,7 +357,7 @@ class MetadataTest {
         new ClientCHK(routingKey, splitKey, false, Key.ALGO_AES_CTR_256_SHA256, (short) -1);
     Metadata meta = getMetadata(dataKey, splitKey);
 
-    // Assert: version remains 1 and crypto parameters are preserved.
+    // Assert: the version remains 1 and crypto parameters are preserved.
     assertEquals(1, meta.getParsedVersion(), "parsedVersion should be 1");
     assertEquals(
         Key.ALGO_AES_CTR_256_SHA256,
@@ -376,7 +371,7 @@ class MetadataTest {
     ClientCHK[] dataURIs = new ClientCHK[] {dataKey};
     ClientCHK[] checkURIs = new ClientCHK[] {};
 
-    // Act: build splitfile with compat >= 1255 (requires metadata v1) but no top section.
+    // Act: build a splitfile with compat >= 1255 (requires metadata v1) but no top section.
     return new Metadata(
         new SplitfileParams(
             SplitfileAlgorithm.NONREDUNDANT,
@@ -397,13 +392,13 @@ class MetadataTest {
             /* decompressedLength= */ 0L,
             /* isMetadata= */ false),
         new MetadataTopLayerInfo(
-            /* origDataLength= */ 0L,
-            /* origCompressedDataLength= */ 0L,
-            /* requiredBlocks= */ 0,
-            /* totalBlocks= */ 0,
-            /* topDontCompress= */ false,
-            /* topCompatibilityMode= */ CompatibilityMode.COMPAT_1255,
-            /* hashes= */ null,
-            /* hashThisLayerOnly= */ null));
+            new TopLayerBlockInfo(
+                /* size= */ 0L,
+                /* compressedSize= */ 0L,
+                /* blocksRequired= */ 0,
+                /* blocksTotal= */ 0,
+                /* dontCompress= */ false,
+                /* compatMode= */ CompatibilityMode.COMPAT_1255),
+            new TopLayerHashInfo(/* hashes= */ null, /* hashThisLayerOnly= */ null)));
   }
 }

--- a/src/test/java/network/crypta/client/async/ClientPutterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientPutterTest.java
@@ -74,12 +74,13 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback,
+                    FreenetURI.EMPTY_CHK_URI,
+                    insertContextCurrent,
+                    /*priorityClass*/ (short) 0),
                 /*data*/ null,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata("text/plain"),
-                insertContextCurrent,
-                /*priorityClass*/ (short) 0,
                 /*isMetadata*/ false),
             new ClientPutterOptions(
                 /*targetFilename*/ null,
@@ -105,12 +106,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback, FreenetURI.EMPTY_CHK_URI, insertContextCurrent, (short) 0),
                 data,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions(null, false, badOverride, 0L));
 
@@ -149,12 +148,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback, FreenetURI.EMPTY_CHK_URI, insertContextCurrent, (short) 0),
                 data,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions(null, false, null, 0L));
 
@@ -174,12 +171,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback, new FreenetURI("SSK", "doc"), insertContextCurrent, (short) 0),
                 data,
-                new FreenetURI("SSK", "doc"),
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions(null, false, override, 0L));
 
@@ -219,12 +214,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback, FreenetURI.EMPTY_CHK_URI, insertContextCurrent, (short) 0),
                 data,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions("file.txt", false, null, 0L));
 
@@ -252,12 +245,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback, FreenetURI.EMPTY_CHK_URI, insertContextCurrent, (short) 0),
                 data,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions(null, false, null, 0L));
 
@@ -279,12 +270,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback, FreenetURI.EMPTY_CHK_URI, insertContextCurrent, (short) 0),
                 data,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions(null, false, null, 0L));
 
@@ -308,12 +297,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback, FreenetURI.EMPTY_CHK_URI, insertContextCurrent, (short) 0),
                 data,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions(null, false, null, 0L));
 
@@ -337,12 +324,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback, FreenetURI.EMPTY_CHK_URI, insertContextCurrent, (short) 0),
                 data,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions(null, false, null, 0L));
 
@@ -359,12 +344,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                clientCallback,
+                new InsertRequestParams(
+                    clientCallback, FreenetURI.EMPTY_CHK_URI, insertContextCurrent, (short) 0),
                 data,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions(null, false, null, 0L));
 
@@ -408,12 +391,10 @@ class ClientPutterTest {
     ClientPutter putter =
         new ClientPutter(
             new ClientPutterRequest(
-                multiCb,
+                new InsertRequestParams(
+                    multiCb, FreenetURI.EMPTY_CHK_URI, insertContextCurrent, (short) 0),
                 data,
-                FreenetURI.EMPTY_CHK_URI,
                 new ClientMetadata(),
-                insertContextCurrent,
-                (short) 0,
                 false),
             new ClientPutterOptions(null, false, null, 0L));
 

--- a/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/DefaultManifestPutterTest.java
@@ -72,12 +72,9 @@ class DefaultManifestPutterTest {
     ClientContext context = mock(ClientContext.class);
     ManifestPutterParams params =
         new ManifestPutterParams(
-            cb,
+            new InsertRequestParams(cb, FreenetURI.EMPTY_CHK_URI, ctx, /*prioClass*/ (short) 0),
             root,
-            /*prioClass*/ (short) 0,
-            FreenetURI.EMPTY_CHK_URI,
             /*defaultName*/ "index.html",
-            ctx,
             /*forceCryptoKey*/ null,
             context);
 
@@ -102,7 +99,12 @@ class DefaultManifestPutterTest {
         ClientContext context)
         throws TooManyFilesInsertException {
       super(
-          new ManifestPutterParams(cb, manifest, prio, target, defaultName, ctx, forceKey, context),
+          new ManifestPutterParams(
+              new InsertRequestParams(cb, target, ctx, prio),
+              manifest,
+              defaultName,
+              forceKey,
+              context),
           persistent);
     }
 

--- a/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
@@ -75,12 +75,9 @@ class PlainManifestPutterTest {
     PlainManifestPutter putter =
         new PlainManifestPutter(
             new ManifestPutterParams(
-                cb,
+                new InsertRequestParams(cb, FreenetURI.EMPTY_CHK_URI, ctx, /*prioClass*/ (short) 0),
                 root,
-                /*prioClass*/ (short) 0,
-                FreenetURI.EMPTY_CHK_URI,
                 /*defaultName*/ "index.html",
-                ctx,
                 forceKey,
                 /*context*/ mock(ClientContext.class)));
 
@@ -118,12 +115,9 @@ class PlainManifestPutterTest {
         throws TooManyFilesInsertException {
       super(
           new ManifestPutterParams(
-              cb,
+              new InsertRequestParams(cb, FreenetURI.EMPTY_CHK_URI, ctx, /*prioClass*/ (short) 0),
               manifest,
-              /*prioClass*/ (short) 0,
-              FreenetURI.EMPTY_CHK_URI,
               /*defaultName*/ "index.html",
-              ctx,
               forceKey,
               context));
     }
@@ -271,12 +265,9 @@ class PlainManifestPutterTest {
     PlainManifestPutter putter =
         new PlainManifestPutter(
             new ManifestPutterParams(
-                cb,
+                new InsertRequestParams(cb, FreenetURI.EMPTY_CHK_URI, ctx, /*prioClass*/ (short) 0),
                 new HashMap<>(),
-                /*prioClass*/ (short) 0,
-                FreenetURI.EMPTY_CHK_URI,
                 /*defaultName*/ "index.html",
-                ctx,
                 forceKey,
                 mock(ClientContext.class)));
 

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherSegmentsBuilderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherSegmentsBuilderTest.java
@@ -281,28 +281,15 @@ class SplitFileFetcherSegmentsBuilderTest {
     int totalDataBlocks = 2;
     long offsetKeyList = 0L;
     long offsetSegmentStatus = 0L;
-    return new ParsedBasicSettings(
-        null,
-        (byte) 0,
-        null,
-        0L,
-        0L,
-        null,
-        null,
-        offsetKeyList,
-        offsetSegmentStatus,
-        0L,
-        0L,
-        0L,
-        0L,
-        0L,
-        0L,
-        null,
-        segmentCount,
-        totalDataBlocks,
-        totalCheckBlocks,
-        totalCrossCheckBlocks,
-        settingsStream);
+    SplitFileFetcherBasicSettingsHeader header =
+        new SplitFileFetcherBasicSettingsHeader(null, (byte) 0, null, 0L, 0L, null, null);
+    SplitFileFetcherStorageOffsets offsets =
+        new SplitFileFetcherStorageOffsets(
+            offsetKeyList, offsetSegmentStatus, 0L, 0L, 0L, 0L, 0L, 0L);
+    SplitFileFetcherCompatCounts compatCounts =
+        new SplitFileFetcherCompatCounts(
+            null, segmentCount, totalDataBlocks, totalCheckBlocks, totalCrossCheckBlocks);
+    return new ParsedBasicSettings(header, offsets, compatCounts, settingsStream);
   }
 
   private static SplitFileSegmentKeys newSegmentKeys(int dataBlocks, int checkBlocks)

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherSegmentsBuilderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherSegmentsBuilderTest.java
@@ -178,21 +178,15 @@ class SplitFileFetcherSegmentsBuilderTest {
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bos.toByteArray()));
     SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[1];
     SplitFileFetcherStorage parent = newMinimalParent(segments, 0L, 0L);
+    ParsedBasicSettings settings = newParsedSettings(1, 1, dis, segments.length);
 
     SplitFileFetcherSegmentsLoadParams params =
         new SplitFileFetcherSegmentsLoadParams(
             parent,
-            2,
-            1,
-            1,
-            dis,
+            settings,
             false,
             Mockito.mock(KeysFetchingLocally.class),
             segments,
-            4,
-            false,
-            0L,
-            0L,
             3L * CHKBlock.DATA_LENGTH + 1);
 
     SplitFileFetcherSegmentsInit init =
@@ -213,22 +207,11 @@ class SplitFileFetcherSegmentsBuilderTest {
 
     SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[1];
     SplitFileFetcherStorage parent = newMinimalParent(segments, 0L, 0L);
+    ParsedBasicSettings settings = newParsedSettings(0, 0, dis, segments.length);
 
     SplitFileFetcherSegmentsLoadParams params =
         new SplitFileFetcherSegmentsLoadParams(
-            parent,
-            2,
-            0,
-            0,
-            dis,
-            false,
-            null,
-            segments,
-            4,
-            false,
-            0L,
-            0L,
-            CHKBlock.DATA_LENGTH * 2L);
+            parent, settings, false, null, segments, CHKBlock.DATA_LENGTH * 2L);
 
     StorageFormatException ex =
         assertThrows(
@@ -243,10 +226,11 @@ class SplitFileFetcherSegmentsBuilderTest {
 
     SplitFileFetcherSegmentStorage[] segments = new SplitFileFetcherSegmentStorage[1];
     SplitFileFetcherStorage parent = newMinimalParent(segments, 0L, 0L);
+    ParsedBasicSettings settings = newParsedSettings(0, 1, dis, segments.length);
 
     SplitFileFetcherSegmentsLoadParams params =
         new SplitFileFetcherSegmentsLoadParams(
-            parent, 2, 0, 1, dis, false, null, segments, 4, false, 0L, 0L, CHKBlock.DATA_LENGTH);
+            parent, settings, false, null, segments, CHKBlock.DATA_LENGTH);
 
     StorageFormatException ex =
         assertThrows(
@@ -287,6 +271,38 @@ class SplitFileFetcherSegmentsBuilderTest {
     } catch (Exception e) {
       throw new AssertionError("Failed to set final field '" + fieldName + "'", e);
     }
+  }
+
+  private static ParsedBasicSettings newParsedSettings(
+      int totalCheckBlocks,
+      int totalCrossCheckBlocks,
+      DataInputStream settingsStream,
+      int segmentCount) {
+    int totalDataBlocks = 2;
+    long offsetKeyList = 0L;
+    long offsetSegmentStatus = 0L;
+    return new ParsedBasicSettings(
+        null,
+        (byte) 0,
+        null,
+        0L,
+        0L,
+        null,
+        null,
+        offsetKeyList,
+        offsetSegmentStatus,
+        0L,
+        0L,
+        0L,
+        0L,
+        0L,
+        0L,
+        null,
+        segmentCount,
+        totalDataBlocks,
+        totalCheckBlocks,
+        totalCrossCheckBlocks,
+        settingsStream);
   }
 
   private static SplitFileSegmentKeys newSegmentKeys(int dataBlocks, int checkBlocks)

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageResumeReaderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageResumeReaderTest.java
@@ -56,29 +56,7 @@ class SplitFileFetcherStorageResumeReaderTest {
     when(checksumChecker.checkChecksum(any(byte[].class), anyInt(), anyInt(), any(byte[].class)))
         .thenReturn(true);
 
-    ParsedBasicSettings expected =
-        new ParsedBasicSettings(
-            SplitfileAlgorithm.ONION_STANDARD,
-            (byte) 0,
-            null,
-            100L,
-            200L,
-            new ClientMetadata("text/plain"),
-            List.of(COMPRESSOR_TYPE.GZIP),
-            10L,
-            20L,
-            30L,
-            40L,
-            50L,
-            60L,
-            70L,
-            80L,
-            CompatibilityMode.COMPAT_1250,
-            2,
-            3,
-            4,
-            0,
-            new DataInputStream(new ByteArrayInputStream(new byte[0])));
+    ParsedBasicSettings expected = expectedParsedSettings();
 
     try (MockedStatic<SplitFileFetcherStorageSettingsCodec> mocked =
         mockStatic(SplitFileFetcherStorageSettingsCodec.class)) {
@@ -281,6 +259,25 @@ class SplitFileFetcherStorageResumeReaderTest {
     return raf;
   }
 
+  private static ParsedBasicSettings expectedParsedSettings() {
+    SplitFileFetcherBasicSettingsHeader header =
+        new SplitFileFetcherBasicSettingsHeader(
+            SplitfileAlgorithm.ONION_STANDARD,
+            (byte) 0,
+            null,
+            100L,
+            200L,
+            new ClientMetadata("text/plain"),
+            List.of(COMPRESSOR_TYPE.GZIP));
+    SplitFileFetcherStorageOffsets offsets =
+        new SplitFileFetcherStorageOffsets(10L, 20L, 30L, 40L, 50L, 60L, 70L, 80L);
+    SplitFileFetcherCompatCounts compatCounts =
+        new SplitFileFetcherCompatCounts(CompatibilityMode.COMPAT_1250, 2, 3, 4, 0);
+    return new ParsedBasicSettings(
+        header, offsets, compatCounts, new DataInputStream(new ByteArrayInputStream(new byte[0])));
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class ResumeLayout {
     private final byte[] data;
     private final long rafLength;

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
@@ -1,7 +1,13 @@
 package network.crypta.client.async;
 
 import static network.crypta.testsupport.TestRandomData.fillBucketWithRandom;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -26,6 +32,8 @@ import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.client.OnionFECCodec;
 import network.crypta.client.SplitfileParams;
 import network.crypta.client.SplitfilePayload;
+import network.crypta.client.TopLayerBlockInfo;
+import network.crypta.client.TopLayerHashInfo;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.crypt.CRCChecksumChecker;
 import network.crypta.crypt.ChecksumFailedException;
@@ -142,7 +150,7 @@ class SplitFileFetcherStorageTest {
     // Arrange
     // 2 data blocks.
     // We don't test this case because it just copies the data block to the check blocks.
-    // Which breaks some of the scripts here.
+    // Which breaks some scripts here.
     // Act + Assert
     testSingleSegment(2, 1, BLOCK_SIZE * 2L);
     testSingleSegment(2, 1, BLOCK_SIZE + 1L);
@@ -170,7 +178,7 @@ class SplitFileFetcherStorageTest {
     // to some degree.
 
     // Act + Assert
-    // Simplest case: Same number of blocks in each segment.
+    // the simplest case: Same number of blocks in each segment.
     // 2 blocks in each of 2 segments.
     testMultiSegment(32768L * 4, new int[] {2, 2}, new int[] {3, 3}, 2, 3, 0);
     testMultiSegment(32768L * 4 - 1, new int[] {2, 2}, new int[] {3, 3}, 2, 3, 0);
@@ -183,10 +191,10 @@ class SplitFileFetcherStorageTest {
 
     // Sharp truncation. This is how we used to handle non-divisible numbers...
     testMultiSegment(32768L * 9 - 1, new int[] {7, 2}, new int[] {7, 2}, 7, 7, 0);
-    // Still COMPAT_1416 because has crypto key etc.
+    // Still COMPAT_1416 because has a crypto key etc.
 
     // Note: legacy splitfiles are not covered here (tracked separately).
-    // Note: very old splitfiles where last data block is not padded are not covered.
+    // Note: very old splitfiles where the last data block is not padded are not covered.
     // Note: non-redundant legacy splitfile support is not covered.
   }
 
@@ -714,7 +722,7 @@ class SplitFileFetcherStorageTest {
     SplitFileFetcherStorage storage = test.createStorage(cb);
 
     try {
-      int blockIndex = 1; // within first (and only) segment
+      int blockIndex = 1; // within the first (and only) segment
       int segmentNumber = 0;
       SplitFileFetcherStorage.SplitFileFetcherStorageKey skey =
           new SplitFileFetcherStorage.SplitFileFetcherStorageKey(
@@ -723,7 +731,7 @@ class SplitFileFetcherStorageTest {
       // Act
       var clientKey = storage.getKey(skey);
 
-      // Assert: node key should match metadata
+      // Assert: the node key should match metadata
       assertNotNull(clientKey);
       assertEquals(test.getCHK(blockIndex), clientKey.getNodeKey(false));
     } finally {
@@ -733,7 +741,7 @@ class SplitFileFetcherStorageTest {
 
   @Test
   void setHasCheckedStore_whenCalled_marksFlagTrue() throws Exception {
-    // Arrange (persistent to exercise write path, though not asserted here)
+    // Arrange (persistent to exercise the writing path, though not asserted here)
     TestSplitfile test = TestSplitfile.constructSingleSegment(BLOCK_SIZE * 2L, 1, true);
     StorageCallback cb = test.createStorageCallback();
     SplitFileFetcherStorage storage = test.createStorage(cb);
@@ -1254,7 +1262,7 @@ class SplitFileFetcherStorageTest {
     public int segmentFor(int block) {
       int total = 0;
       // Must be consistent with the getCHK() counting etc.
-      // Count data blocks first then check blocks.
+      // Count data blocks first, then check blocks.
       for (int i = 0; i < segmentDataBlockCount.length; i++) {
         total += segmentDataBlockCount[i];
         if (block < total) {
@@ -1308,16 +1316,11 @@ class SplitFileFetcherStorageTest {
               cryptoKey,
               true);
       SplitfilePayload payload = new SplitfilePayload(cm, size, null, null, size, false);
-      MetadataTopLayerInfo topLayer =
-          new MetadataTopLayerInfo(
-              size,
-              size,
-              dataBlocks,
-              dataBlocks + checkBlocks,
-              false,
-              COMPATIBILITY_MODE,
-              null,
-              null);
+      TopLayerBlockInfo blockInfo =
+          new TopLayerBlockInfo(
+              size, size, dataBlocks, dataBlocks + checkBlocks, false, COMPATIBILITY_MODE);
+      TopLayerHashInfo hashInfo = new TopLayerHashInfo(null, null);
+      MetadataTopLayerInfo topLayer = new MetadataTopLayerInfo(blockInfo, hashInfo);
       Metadata m = new Metadata(params, payload, topLayer);
       // Make sure the metadata is reusable.
       // Note: ensures metadata is reusable; the above constructor doesn't set segments.
@@ -1346,7 +1349,7 @@ class SplitFileFetcherStorageTest {
     /**
      * Create a multi-segment test splitfile. The main complication with multi-segment is that we
      * can't choose the number of blocks in each segment arbitrarily; that depends on the metadata
-     * format; the caller must ensure that the number are consistent.
+     * format; the caller must ensure that the number is consistent.
      *
      * @param size Total size of the test data in bytes
      * @param segmentDataBlockCount The actual number of data blocks in each segment. Must be
@@ -1364,7 +1367,7 @@ class SplitFileFetcherStorageTest {
      * @throws IOException if random test data or buckets cannot be created
      * @throws CHKEncodeException if block keys cannot be encoded for the generated data
      * @throws MetadataUnresolvedException if test metadata cannot be fully resolved/constructed
-     * @throws MetadataParseException if constructed metadata cannot be serialized or parsed back
+     * @throws MetadataParseException if constructed, metadata cannot be serialized or parsed back
      */
     static TestSplitfile constructMultipleSegments(
         long size,
@@ -1423,16 +1426,16 @@ class SplitFileFetcherStorageTest {
               cryptoKey,
               true /* uses single-key splitfiles for tests */);
       SplitfilePayload payload = new SplitfilePayload(cm, size, null, null, size, false);
-      MetadataTopLayerInfo topLayer =
-          new MetadataTopLayerInfo(
+      TopLayerBlockInfo blockInfo =
+          new TopLayerBlockInfo(
               size,
               size,
               dataBlocks,
               dataBlocks + checkBlocks,
               false,
-              InsertContext.CompatibilityMode.COMPAT_1416,
-              null,
-              null);
+              InsertContext.CompatibilityMode.COMPAT_1416);
+      TopLayerHashInfo hashInfo = new TopLayerHashInfo(null, null);
+      MetadataTopLayerInfo topLayer = new MetadataTopLayerInfo(blockInfo, hashInfo);
       Metadata m = new Metadata(params, payload, topLayer);
       // Make sure the metadata is reusable.
       // Note: ensures metadata is reusable; the above constructor doesn't set segments.

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
@@ -30,8 +30,11 @@ import network.crypta.client.MetadataParseException;
 import network.crypta.client.MetadataTopLayerInfo;
 import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.client.OnionFECCodec;
+import network.crypta.client.SplitfileBlockKeys;
+import network.crypta.client.SplitfileCryptoParams;
 import network.crypta.client.SplitfileParams;
 import network.crypta.client.SplitfilePayload;
+import network.crypta.client.SplitfileSegmentLayout;
 import network.crypta.client.TopLayerBlockInfo;
 import network.crypta.client.TopLayerHashInfo;
 import network.crypta.client.events.SimpleEventProducer;
@@ -1306,15 +1309,9 @@ class SplitFileFetcherStorageTest {
       SplitfileParams params =
           new SplitfileParams(
               SplitfileAlgorithm.ONION_STANDARD,
-              dataKeys,
-              checkKeys,
-              dataBlocks,
-              checkBlocks,
-              0,
-              0,
-              cryptoAlgorithm,
-              cryptoKey,
-              true);
+              new SplitfileBlockKeys(dataKeys, checkKeys),
+              new SplitfileSegmentLayout(dataBlocks, checkBlocks, 0, 0),
+              new SplitfileCryptoParams(cryptoAlgorithm, cryptoKey, true));
       SplitfilePayload payload = new SplitfilePayload(cm, size, null, null, size, false);
       TopLayerBlockInfo blockInfo =
           new TopLayerBlockInfo(
@@ -1416,15 +1413,11 @@ class SplitFileFetcherStorageTest {
       SplitfileParams params =
           new SplitfileParams(
               SplitfileAlgorithm.ONION_STANDARD,
-              dataKeys,
-              checkKeys,
-              segmentSize,
-              checkSegmentSize,
-              deductBlocksFromSegments,
-              0,
-              cryptoAlgorithm,
-              cryptoKey,
-              true /* uses single-key splitfiles for tests */);
+              new SplitfileBlockKeys(dataKeys, checkKeys),
+              new SplitfileSegmentLayout(
+                  segmentSize, checkSegmentSize, deductBlocksFromSegments, 0),
+              new SplitfileCryptoParams(
+                  cryptoAlgorithm, cryptoKey, true /* uses single-key splitfiles for tests */));
       SplitfilePayload payload = new SplitfilePayload(cm, size, null, null, size, false);
       TopLayerBlockInfo blockInfo =
           new TopLayerBlockInfo(

--- a/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
+++ b/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
@@ -289,7 +289,7 @@ class USKFetcherTagTest {
 
     // Assert
     USK used = uskCap.getValue();
-    // For persistent=true, USK is copied even if edition is unchanged
+    // For persistent=true, USK is copied even if the edition is unchanged
     assertNotSame(used, usk, "Persistent start should pass a copy of the USK");
     assertEquals(used, usk, "Copied USK should be equal to the original");
     ClientRequester wrapper = reqCap.getValue();
@@ -397,7 +397,7 @@ class USKFetcherTagTest {
     when(cb.getPollingPriorityProgress()).thenReturn((short) 9);
     USKFetcherTag tag = newTag(cb, true, false, false, false, 2);
 
-    // jobRunner.queue should immediately run the job with provided context
+    // jobRunner.queue should immediately run the job with the provided context
     doAnswer(
             inv -> {
               PersistentJob job = inv.getArgument(0);
@@ -450,7 +450,9 @@ class USKFetcherTagTest {
     // Act
     tag.onFoundEdition(
         new USKFoundEdition(
-            edition, usk.copy(edition), mockContext, false, codec, data, true, true));
+            new USKFoundEditionPayload(edition, usk.copy(edition), false, codec, data),
+            mockContext,
+            new USKFoundEditionProgress(true, true)));
 
     // Assert
     verify(cb, times(1)).setTag(tag, mockContext);
@@ -469,7 +471,9 @@ class USKFetcherTagTest {
     // Calling again should be ignored because finished
     tag.onFoundEdition(
         new USKFoundEdition(
-            edition + 1, usk.copy(edition + 1), mockContext, false, codec, data, true, true));
+            new USKFoundEditionPayload(edition + 1, usk.copy(edition + 1), false, codec, data),
+            mockContext,
+            new USKFoundEditionProgress(true, true)));
     verify(cb, times(1)).onFoundEdition(any(USKFoundEdition.class));
   }
 
@@ -540,7 +544,7 @@ class USKFetcherTagTest {
     tag.onCancelled(mockContext); // mark finished
 
     tag.onResume(mockContext);
-    // No interactions expected since finished prevents restart
+    // No interactions expected since finished prevent restart
     verify(uskManager, times(0))
         .getFetcher(
             any(USK.class),

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -355,10 +355,13 @@ class USKInserterTest {
         newInserter(
             data, (short) 3, insertUri, ic, new InserterCfg(false, false, true, false, false));
 
-    // Act: Found matching edition with identical data
+    // Act: Found a matching edition with identical data
     long foundEdition = 7L;
     inserter.onFoundEdition(
-        new USKFoundEdition(foundEdition, publicUSK, context, false, (short) 3, bytes, true, true));
+        new USKFoundEdition(
+            new USKFoundEditionPayload(foundEdition, publicUSK, false, (short) 3, bytes),
+            context,
+            new USKFoundEditionProgress(true, true)));
 
     // Assert: parent and callback methods invoked; success path without date hints
     verify(parent, times(1)).completedBlock(true, context);
@@ -571,7 +574,7 @@ class USKInserterTest {
         .thenReturn(fetcherTag);
     inserter.schedule(context);
 
-    // Act: first call should notify; second call should be ignored
+    // Act: the first call should notify; the second call should be ignored
     inserter.onResume(context);
     inserter.onResume(context);
 

--- a/src/test/java/network/crypta/client/async/USKRetrieverTest.java
+++ b/src/test/java/network/crypta/client/async/USKRetrieverTest.java
@@ -335,7 +335,7 @@ class USKRetrieverTest {
   @Test
   void onSuccess_happyPath_writesToBucket_updatesKnownGood_andNotifiesCallback() throws Exception {
     // Arrange minimal context whose temp bucket factory produces ArrayBucket instances
-    when(tbf.makeBucket(anyLong())).thenAnswer(inv -> new ArrayBucket());
+    when(tbf.makeBucket(anyLong())).thenAnswer(_ -> new ArrayBucket());
     ClientContext ctx =
         minimalContext(
             jobRunner,
@@ -372,7 +372,7 @@ class USKRetrieverTest {
     // Assert: uskManager updated
     verify(uskManager, times(1)).updateKnownGood(usk, 77L, ctx);
 
-    // Assert: callback notified with correct result
+    // Assert: callback notified with the correct result
     ArgumentCaptor<FetchResult> cap = ArgumentCaptor.forClass(FetchResult.class);
     verify(callback, times(1)).onFound(eq(usk), eq(77L), cap.capture());
     FetchResult res = cap.getValue();
@@ -389,7 +389,7 @@ class USKRetrieverTest {
 
   @Test
   void onSuccess_whenStreamGeneratorThrows_callsOnFailureWithInternalError() throws Exception {
-    when(tbf.makeBucket(anyLong())).thenAnswer(inv -> new ArrayBucket());
+    when(tbf.makeBucket(anyLong())).thenAnswer(_ -> new ArrayBucket());
     ClientContext ctx =
         minimalContext(
             jobRunner,
@@ -407,7 +407,7 @@ class USKRetrieverTest {
 
     StreamGenerator generator = Mockito.mock(StreamGenerator.class);
     doAnswer(
-            inv -> {
+            _ -> {
               throw new IOException("boom");
             })
         .when(generator)
@@ -494,13 +494,19 @@ class USKRetrieverTest {
     assertDoesNotThrow(
         () ->
             retriever.onFoundEdition(
-                new USKFoundEdition(-1L, usk, ctx, false, (short) -1, null, false, false)));
+                new USKFoundEdition(
+                    new USKFoundEditionPayload(-1L, usk, false, (short) -1, null),
+                    ctx,
+                    new USKFoundEditionProgress(false, false))));
 
     // Lower than requested (origUSK.suggestedEdition == 100): early return
     assertDoesNotThrow(
         () ->
             retriever.onFoundEdition(
-                new USKFoundEdition(50L, usk, ctx, false, (short) -1, null, false, false)));
+                new USKFoundEdition(
+                    new USKFoundEditionPayload(50L, usk, false, (short) -1, null),
+                    ctx,
+                    new USKFoundEditionProgress(false, false))));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
+++ b/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
@@ -237,10 +237,10 @@ class USKSparseProxyCallbackTest {
     // Assert: no call yet
     verify(target, never()).onFoundEdition(any(USKFoundEdition.class));
 
-    // Act: finish the round; should flush a single latest notification (edition 2)
+    // Act: finish the round; should flush the single latest notification (edition 2)
     proxy.onRoundFinished(context);
 
-    // Assert: exactly once with latest values and knownGood propagated
+    // Assert: exactly once with the latest values and knownGood propagated
     verify(target, times(1))
         .onFoundEdition(foundEdition(2L, usk, context, false, (short) 9, data345, true, true));
 
@@ -294,9 +294,10 @@ class USKSparseProxyCallbackTest {
     USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
     byte[] data1 = new byte[] {1};
     proxy.onFoundEdition(foundEdition(5L, usk, context, false, (short) 0, data1, false, false));
-    proxy.onRoundFinished(context); // finish the round so subsequent older edition may pass through
+    proxy.onRoundFinished(
+        context); // finish the round so the following older edition may pass through
 
-    // Act: older edition but newKnownGood=true should call through immediately
+    // Act: the older edition but newKnownGood=true should call through immediately
     byte[] data9 = new byte[] {9};
     proxy.onFoundEdition(foundEdition(4L, usk, context, true, (short) 2, data9, true, false));
 
@@ -313,7 +314,7 @@ class USKSparseProxyCallbackTest {
     // Arrange
     USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
 
-    // Act: first store the edition (knownGood=false), then mark same edition as knownGood
+    // Act: first store the edition (knownGood=false), then mark the same edition as knownGood
     byte[] data23 = new byte[] {2, 3};
     proxy.onFoundEdition(foundEdition(7L, usk, context, true, (short) 11, data23, false, false));
     proxy.onFoundEdition(foundEdition(7L, usk, context, true, (short) 11, data23, true, false));
@@ -346,6 +347,8 @@ class USKSparseProxyCallbackTest {
       boolean newKnownGood,
       boolean newSlotToo) {
     return new USKFoundEdition(
-        edition, key, context, metadata, codec, data, newKnownGood, newSlotToo);
+        new USKFoundEditionPayload(edition, key, metadata, codec, data),
+        context,
+        new USKFoundEditionProgress(newKnownGood, newSlotToo));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientPutPutterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutPutterFactoryTest.java
@@ -15,6 +15,7 @@ import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientPutterOptions;
 import network.crypta.client.async.ClientPutterRequest;
+import network.crypta.client.async.InsertRequestParams;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
 import network.crypta.support.io.ArrayBucket;
@@ -41,7 +42,10 @@ class ClientPutPutterFactoryTest {
     InsertContext insertContext = new InsertContext(InsertContextOptions.builder().build());
     ClientPutterRequest request =
         new ClientPutterRequest(
-            callback, data, targetUri, metadata, insertContext, (short) 3, true);
+            new InsertRequestParams(callback, targetUri, insertContext, (short) 3),
+            data,
+            metadata,
+            true);
     byte[] overrideCrypto = new byte[] {1, 2, 3};
     ClientPutterOptions options = new ClientPutterOptions("file.txt", true, overrideCrypto, 42L);
 

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.when;
 
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.USKFoundEdition;
+import network.crypta.client.async.USKFoundEditionPayload;
+import network.crypta.client.async.USKFoundEditionProgress;
 import network.crypta.client.async.USKManager;
 import network.crypta.client.async.USKSparseProxyCallback;
 import network.crypta.keys.USK;
@@ -92,7 +94,9 @@ class SubscribeUSKTest {
 
     subscription.onFoundEdition(
         new USKFoundEdition(
-            7L, message.key, clientContext, false, (short) 1, new byte[0], true, false));
+            new USKFoundEditionPayload(7L, message.key, false, (short) 1, new byte[0]),
+            clientContext,
+            new USKFoundEditionProgress(true, false)));
 
     verify(uskManager).unsubscribe(message.key, subscription);
     verify(handler, never()).send(any());
@@ -107,7 +111,10 @@ class SubscribeUSKTest {
     when(handler.isClosed()).thenReturn(false);
 
     subscription.onFoundEdition(
-        new USKFoundEdition(12L, message.key, clientContext, false, (short) 1, null, true, false));
+        new USKFoundEdition(
+            new USKFoundEditionPayload(12L, message.key, false, (short) 1, null),
+            clientContext,
+            new USKFoundEditionProgress(true, false)));
 
     ArgumentCaptor<SubscribedUSKUpdate> captor = ArgumentCaptor.forClass(SubscribedUSKUpdate.class);
     verify(handler).send(captor.capture());

--- a/src/test/java/network/crypta/store/RAMSaltMigrationTest.java
+++ b/src/test/java/network/crypta/store/RAMSaltMigrationTest.java
@@ -32,6 +32,10 @@ import network.crypta.keys.Key;
 import network.crypta.node.SemiOrderedShutdownHook;
 import network.crypta.store.saltedhash.ResizablePersistentIntBuffer;
 import network.crypta.store.saltedhash.SaltedHashFreenetStore;
+import network.crypta.store.saltedhash.SaltedHashStoreDependencies;
+import network.crypta.store.saltedhash.SaltedHashStoreLocation;
+import network.crypta.store.saltedhash.SaltedHashStoreParams;
+import network.crypta.store.saltedhash.SaltedHashStoreSizing;
 import network.crypta.support.PooledExecutor;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.Ticker;
@@ -308,16 +312,11 @@ class RAMSaltMigrationTest {
     File f = getStorePath(testName);
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            store,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       saltStore.start(null, true);
 
       for (int i = 0; i < 5; i++) {
@@ -348,16 +347,11 @@ class RAMSaltMigrationTest {
     List<ClientCHKBlock> blockActuallyStoredList = new ArrayList<>(keycount);
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            store,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       saltStore.start(null, true);
 
       List<String> dummyValueInsertedList = new ArrayList<>(keycount);
@@ -381,16 +375,11 @@ class RAMSaltMigrationTest {
     store = new CHKStore();
     try (var _ =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            store,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       checkStandardTestBlocks(store, dummyValueActuallyStoredList, blockActuallyStoredList, true);
     }
   }
@@ -431,16 +420,11 @@ class RAMSaltMigrationTest {
     CHKStore store = new CHKStore();
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            store,
-            weakPRNG,
-            10,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, true, true, true)))) {
       saltStore.start(ticker, true);
 
       // Make sure it's clear.
@@ -454,16 +438,11 @@ class RAMSaltMigrationTest {
     store = new CHKStore();
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            store,
-            weakPRNG,
-            10,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, true, true, true)))) {
       saltStore.start(ticker, true);
       if (forceValidEmpty) saltStore.forceValidEmpty();
 
@@ -623,16 +602,11 @@ class RAMSaltMigrationTest {
     File f = getStorePath(testName);
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            store,
-            weakPRNG,
-            size,
-            useSlotFilter,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(size, useSlotFilter, true, true)))) {
       saltStore.start(null, true);
 
       List<String> dummyValueInsertedList = new ArrayList<>(keycount);
@@ -764,16 +738,11 @@ class RAMSaltMigrationTest {
     List<ClientCHKBlock> blockActuallyStoredList = new ArrayList<>(keycount);
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            store,
-            weakPRNG,
-            size,
-            useSlotFilter,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(size, useSlotFilter, true, true)))) {
       saltStore.start(ticker, true);
 
       List<String> dummyValueInsertedList = new ArrayList<>(keycount);
@@ -799,16 +768,12 @@ class RAMSaltMigrationTest {
     store = new CHKStore();
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            store,
-            weakPRNG,
-            openNewSize ? newSize : size,
-            useSlotFilter,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(
+                    openNewSize ? newSize : size, useSlotFilter, true, true)))) {
       saltStore.start(ticker, true);
 
       // If we did open the new size, we expect all previously matched keys to be present.
@@ -845,16 +810,11 @@ class RAMSaltMigrationTest {
     File f = getStorePath("migrate_whenRAMStoreMigrated_expectBlockReadableInNewStore");
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            newStore,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    newStore, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       saltStore.start(null, true);
 
       ramStore.migrateTo(newStore, false);
@@ -893,16 +853,11 @@ class RAMSaltMigrationTest {
     File f = getStorePath("migrate_whenKeyedRAMStoreMigrated_expectBlockReadableInNewStore");
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            STORE_NAME,
-            newStore,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            storeKey)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, STORE_NAME),
+                new SaltedHashStoreDependencies<>(
+                    newStore, weakPRNG, SemiOrderedShutdownHook.get(), storeKey),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       saltStore.start(null, true);
 
       ramStore.migrateTo(newStore, false);

--- a/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
@@ -64,6 +64,10 @@ import network.crypta.store.StoreCallback;
 import network.crypta.store.WriteBlockableFreenetStore;
 import network.crypta.store.saltedhash.ResizablePersistentIntBuffer;
 import network.crypta.store.saltedhash.SaltedHashFreenetStore;
+import network.crypta.store.saltedhash.SaltedHashStoreDependencies;
+import network.crypta.store.saltedhash.SaltedHashStoreLocation;
+import network.crypta.store.saltedhash.SaltedHashStoreParams;
+import network.crypta.store.saltedhash.SaltedHashStoreSizing;
 import network.crypta.support.Fields;
 import network.crypta.support.PooledExecutor;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
@@ -220,16 +224,11 @@ class CachingFreenetStoreTest {
 
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            howManyBlocks * 5L,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(howManyBlocks * 5L, false, true, true)))) {
       WaitableCachingFreenetStoreTracker tracker =
           new WaitableCachingFreenetStoreTracker(
               cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
@@ -304,16 +303,11 @@ class CachingFreenetStoreTest {
       File f = getStorePath("testCollisionsOverMaximumSize");
       try (SaltedHashFreenetStore<SSKBlock> saltStore =
           SaltedHashFreenetStore.construct(
-              f,
-              TEST_CACHING_FREENET_STORE_SSK,
-              store,
-              weakPRNG,
-              20,
-              true,
-              SemiOrderedShutdownHook.get(),
-              true,
-              true,
-              null)) {
+              SaltedHashStoreParams.of(
+                  new SaltedHashStoreLocation(f, TEST_CACHING_FREENET_STORE_SSK),
+                  new SaltedHashStoreDependencies<>(
+                      store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                  new SaltedHashStoreSizing(20, true, true, true)))) {
         WaitableCachingFreenetStoreTracker tracker =
             new WaitableCachingFreenetStoreTracker(
                 (sskBlockSize * 3L) / 2, cachingFreenetStorePeriod, ticker);
@@ -450,16 +444,11 @@ class CachingFreenetStoreTest {
       File f = getStorePath("testSimpleManualWrite");
       try (SaltedHashFreenetStore<SSKBlock> saltStore =
           SaltedHashFreenetStore.construct(
-              f,
-              TEST_CACHING_FREENET_STORE_SSK,
-              store,
-              weakPRNG,
-              20,
-              true,
-              SemiOrderedShutdownHook.get(),
-              true,
-              true,
-              null)) {
+              SaltedHashStoreParams.of(
+                  new SaltedHashStoreLocation(f, TEST_CACHING_FREENET_STORE_SSK),
+                  new SaltedHashStoreDependencies<>(
+                      store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                  new SaltedHashStoreSizing(20, true, true, true)))) {
         CachingFreenetStoreTracker tracker =
             new CachingFreenetStoreTracker((sskBlockSize * 3L), cachingFreenetStorePeriod, ticker);
         try (CachingFreenetStore<SSKBlock> cachingStore =
@@ -544,16 +533,11 @@ class CachingFreenetStoreTest {
     File f = getStorePath("testManualWriteCollision");
     try (SaltedHashFreenetStore<SSKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            TEST_CACHING_FREENET_STORE_SSK,
-            store,
-            weakPRNG,
-            20,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, TEST_CACHING_FREENET_STORE_SSK),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(20, true, true, true)))) {
       // Don't let the writing complete until we say so...
       WriteBlockableFreenetStore<SSKBlock> delayStore =
           new WriteBlockableFreenetStore<>(saltStore, true);
@@ -686,16 +670,11 @@ class CachingFreenetStoreTest {
     File f = getStorePath("testSimpleSSK");
     try (SaltedHashFreenetStore<SSKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            TEST_CACHING_FREENET_STORE_SSK,
-            store,
-            weakPRNG,
-            20,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, TEST_CACHING_FREENET_STORE_SSK),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(20, true, true, true)))) {
       CachingFreenetStoreTracker tracker =
           new CachingFreenetStoreTracker(
               cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
@@ -741,16 +720,11 @@ class CachingFreenetStoreTest {
 
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreOnClose",
-            store,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreOnClose"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       try (CachingFreenetStore<CHKBlock> cachingStore =
           new CachingFreenetStore<>(store, saltStore, tracker)) {
         cachingStore.start(null, true);
@@ -778,16 +752,11 @@ class CachingFreenetStoreTest {
     store = new CHKStore();
     try (SaltedHashFreenetStore<CHKBlock> saltStore2 =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreOnClose",
-            store,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreOnClose"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       try (CachingFreenetStore<CHKBlock> cachingStore =
           new CachingFreenetStore<>(store, saltStore2, tracker)) {
         cachingStore.start(null, true);
@@ -838,16 +807,11 @@ class CachingFreenetStoreTest {
     CHKStore store = new CHKStore();
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreTimeExpire",
-            store,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreTimeExpire"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       WaitableCachingFreenetStoreTracker tracker =
           new WaitableCachingFreenetStoreTracker(cachingFreenetStoreMaxSize, delay, ticker);
       try (CachingFreenetStore<CHKBlock> cachingStore =
@@ -937,16 +901,11 @@ class CachingFreenetStoreTest {
 
     try (SaltedHashFreenetStore<SSKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            TEST_CACHING_FREENET_STORE_ON_CLOSE_SSK,
-            store,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, TEST_CACHING_FREENET_STORE_ON_CLOSE_SSK),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       try (CachingFreenetStore<SSKBlock> cachingStore =
           new CachingFreenetStore<>(store, saltStore, tracker)) {
         cachingStore.start(null, true);
@@ -973,16 +932,11 @@ class CachingFreenetStoreTest {
 
     try (SaltedHashFreenetStore<SSKBlock> saltStore2 =
         SaltedHashFreenetStore.construct(
-            f,
-            TEST_CACHING_FREENET_STORE_ON_CLOSE_SSK,
-            store,
-            weakPRNG,
-            10,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, TEST_CACHING_FREENET_STORE_ON_CLOSE_SSK),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, false, true, true)))) {
       try (CachingFreenetStore<SSKBlock> cachingStore =
           new CachingFreenetStore<>(store, saltStore2, tracker)) {
         cachingStore.start(null, true);
@@ -1043,16 +997,11 @@ class CachingFreenetStoreTest {
 
     try (SaltedHashFreenetStore<SSKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            TEST_CACHING_FREENET_STORE_ON_CLOSE_SSK,
-            store,
-            weakPRNG,
-            10,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, TEST_CACHING_FREENET_STORE_ON_CLOSE_SSK),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, true, true, true)))) {
       WaitableCachingFreenetStoreTracker tracker =
           new WaitableCachingFreenetStoreTracker(cachingFreenetStoreMaxSize, 100, ticker);
       try (CachingFreenetStore<SSKBlock> cachingStore =
@@ -1150,17 +1099,13 @@ class CachingFreenetStoreTest {
   // Common helper with constants used by the simple CHK tests
   private <T extends StorableBlock> SaltedHashFreenetStore<T> newSaltedHashStore(
       File dir, StoreCallback<T> frontStore) throws IOException {
-    return SaltedHashFreenetStore.construct(
-        dir,
-        "testCachingFreenetStoreCHK",
-        frontStore,
-        weakPRNG,
-        10L,
-        false,
-        SemiOrderedShutdownHook.get(),
-        true,
-        true,
-        null);
+    SaltedHashStoreParams<T> params =
+        SaltedHashStoreParams.of(
+            new SaltedHashStoreLocation(dir, "testCachingFreenetStoreCHK"),
+            new SaltedHashStoreDependencies<>(
+                frontStore, weakPRNG, SemiOrderedShutdownHook.get(), null),
+            new SaltedHashStoreSizing(10L, false, true, true));
+    return SaltedHashFreenetStore.construct(params);
   }
 
   private CachingFreenetStoreTracker newTracker(long maxSize) {
@@ -1211,16 +1156,11 @@ class CachingFreenetStoreTest {
 
     try (SaltedHashFreenetStore<SSKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            TEST_CACHING_FREENET_STORE_ON_CLOSE_SSK,
-            store,
-            weakPRNG,
-            10,
-            useSlotFilter,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, TEST_CACHING_FREENET_STORE_ON_CLOSE_SSK),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(10, useSlotFilter, true, true)))) {
       CachingFreenetStoreTracker tracker =
           new CachingFreenetStoreTracker(
               cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);

--- a/src/test/java/network/crypta/store/saltedhash/CipherManagerTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/CipherManagerTest.java
@@ -56,7 +56,10 @@ class CipherManagerTest {
     Random weak = new Random(1234);
     // Minimal store, not started; used only to instantiate Entry via reflection.
     return SaltedHashFreenetStore.construct(
-        tmp, name, cb, weak, 2, false, SemiOrderedShutdownHook.get(), false, false, null);
+        SaltedHashStoreParams.of(
+            new SaltedHashStoreLocation(tmp, name),
+            new SaltedHashStoreDependencies<>(cb, weak, SemiOrderedShutdownHook.get(), null),
+            new SaltedHashStoreSizing(2, false, false, false)));
   }
 
   private SaltedHashFreenetStore<StubBlock>.Entry newEntry(

--- a/src/test/java/network/crypta/store/saltedhash/SaltedHashFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/SaltedHashFreenetStoreTest.java
@@ -227,40 +227,25 @@ class SaltedHashFreenetStoreTest {
 
     try (SaltedHashFreenetStore<TestBlock> a =
             SaltedHashFreenetStore.construct(
-                aDir,
-                "a",
-                cb,
-                rnd,
-                4,
-                true,
-                SemiOrderedShutdownHook.get(),
-                false,
-                true,
-                new byte[32]);
+                SaltedHashStoreParams.of(
+                    new SaltedHashStoreLocation(aDir, "a"),
+                    new SaltedHashStoreDependencies<>(
+                        cb, rnd, SemiOrderedShutdownHook.get(), new byte[32]),
+                    new SaltedHashStoreSizing(4, true, false, true)));
         SaltedHashFreenetStore<TestBlock> b =
             SaltedHashFreenetStore.construct(
-                bDir,
-                "b",
-                cb,
-                rnd,
-                4,
-                true,
-                SemiOrderedShutdownHook.get(),
-                false,
-                true,
-                new byte[32]);
+                SaltedHashStoreParams.of(
+                    new SaltedHashStoreLocation(bDir, "b"),
+                    new SaltedHashStoreDependencies<>(
+                        cb, rnd, SemiOrderedShutdownHook.get(), new byte[32]),
+                    new SaltedHashStoreSizing(4, true, false, true)));
         SaltedHashFreenetStore<TestBlock> c =
             SaltedHashFreenetStore.construct(
-                cDir,
-                "c",
-                cb,
-                rnd,
-                4,
-                true,
-                SemiOrderedShutdownHook.get(),
-                false,
-                true,
-                new byte[32])) {
+                SaltedHashStoreParams.of(
+                    new SaltedHashStoreLocation(cDir, "c"),
+                    new SaltedHashStoreDependencies<>(
+                        cb, rnd, SemiOrderedShutdownHook.get(), new byte[32]),
+                    new SaltedHashStoreSizing(4, true, false, true)))) {
 
       a.start(ticker, true);
       b.start(ticker, true);
@@ -376,28 +361,18 @@ class SaltedHashFreenetStoreTest {
 
     try (SaltedHashFreenetStore<TestBlock> a =
             SaltedHashFreenetStore.construct(
-                aDir,
-                "a",
-                cb,
-                rnd,
-                1,
-                false,
-                SemiOrderedShutdownHook.get(),
-                false,
-                true,
-                new byte[32]);
+                SaltedHashStoreParams.of(
+                    new SaltedHashStoreLocation(aDir, "a"),
+                    new SaltedHashStoreDependencies<>(
+                        cb, rnd, SemiOrderedShutdownHook.get(), new byte[32]),
+                    new SaltedHashStoreSizing(1, false, false, true)));
         SaltedHashFreenetStore<TestBlock> b =
             SaltedHashFreenetStore.construct(
-                bDir,
-                "b",
-                cb,
-                rnd,
-                1,
-                false,
-                SemiOrderedShutdownHook.get(),
-                false,
-                true,
-                new byte[32])) {
+                SaltedHashStoreParams.of(
+                    new SaltedHashStoreLocation(bDir, "b"),
+                    new SaltedHashStoreDependencies<>(
+                        cb, rnd, SemiOrderedShutdownHook.get(), new byte[32]),
+                    new SaltedHashStoreSizing(1, false, false, true)))) {
 
       a.start(ticker, true);
       b.start(ticker, true);

--- a/src/test/java/network/crypta/store/saltedhash/SaltedHashSlotFilterTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/SaltedHashSlotFilterTest.java
@@ -167,16 +167,11 @@ class SaltedHashSlotFilterTest {
     int falsePositives;
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            STORE_SIZE,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(STORE_SIZE, true, true, true)))) {
       saltStore.start(null, true);
 
       falsePositives = populateStore(store, saltStore, TEST_COUNT);
@@ -187,16 +182,11 @@ class SaltedHashSlotFilterTest {
     int verifiedKeys;
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            STORE_SIZE,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(STORE_SIZE, true, true, true)))) {
       saltStore.start(null, true);
 
       verifiedKeys = checkStore(store, saltStore, TEST_COUNT, false);
@@ -216,16 +206,11 @@ class SaltedHashSlotFilterTest {
     int falsePositives;
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            STORE_SIZE,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(STORE_SIZE, true, true, true)))) {
       saltStore.start(null, true);
 
       falsePositives = populateStore(store, saltStore, TEST_COUNT);
@@ -236,16 +221,11 @@ class SaltedHashSlotFilterTest {
     int verifiedKeys;
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            STORE_SIZE,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(STORE_SIZE, true, true, true)))) {
       saltStore.start(null, true);
 
       verifiedKeys = checkStore(store, saltStore, TEST_COUNT, false);
@@ -268,16 +248,11 @@ class SaltedHashSlotFilterTest {
     int falsePositives;
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            STORE_SIZE,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(STORE_SIZE, false, true, true)))) {
       saltStore.start(null, true);
 
       falsePositives = populateStore(store, saltStore, TEST_COUNT);
@@ -288,16 +263,11 @@ class SaltedHashSlotFilterTest {
     int verifiedKeys;
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            STORE_SIZE,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(STORE_SIZE, true, true, true)))) {
       saltStore.start(null, true);
 
       verifiedKeys = checkStore(store, saltStore, TEST_COUNT, false);
@@ -324,16 +294,11 @@ class SaltedHashSlotFilterTest {
     int falsePositives;
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            STORE_SIZE,
-            false,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(STORE_SIZE, false, true, true)))) {
       saltStore.start(null, true);
 
       falsePositives = populateStore(store, saltStore, TEST_COUNT);
@@ -345,16 +310,11 @@ class SaltedHashSlotFilterTest {
     int verifiedKeys;
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            STORE_SIZE,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(STORE_SIZE, true, true, true)))) {
       saltStore.start(null, true);
       saltStore.testingWaitForCleanerDone();
 
@@ -429,16 +389,11 @@ class SaltedHashSlotFilterTest {
     int verifiedKeys;
     try (SaltedHashFreenetStore<CHKBlock> saltStore =
         SaltedHashFreenetStore.construct(
-            f,
-            "testCachingFreenetStoreCHK",
-            store,
-            weakPRNG,
-            storeSize,
-            true,
-            SemiOrderedShutdownHook.get(),
-            true,
-            true,
-            null)) {
+            SaltedHashStoreParams.of(
+                new SaltedHashStoreLocation(f, "testCachingFreenetStoreCHK"),
+                new SaltedHashStoreDependencies<>(
+                    store, weakPRNG, SemiOrderedShutdownHook.get(), null),
+                new SaltedHashStoreSizing(storeSize, true, true, true)))) {
       saltStore.start(null, true);
 
       falsePositives = populateStore(store, saltStore, testCount);


### PR DESCRIPTION
## Summary
- Introduce parameter/value bundles to reduce large constructor/method signatures across client, FEC, ODE, and store modules
- Update related tests and docs to align with the new grouped inputs
- Keep behavior intact while clarifying data flow and construction sites