### PR TITLE
refactor(filter): clarify tokenizer defaults

### DIFF
--- a/src/main/java/network/crypta/client/filter/CSSTokenizerFilter.java
+++ b/src/main/java/network/crypta/client/filter/CSSTokenizerFilter.java
@@ -3808,7 +3808,9 @@ class CSSTokenizerFilter {
         case STATE3 -> handleState3();
         case STATE3INQUOTE -> handleState3InQuote();
         case STATECOMMENT -> handleStateComment();
-        default -> {}
+        default -> {
+          // Intentionally ignore unknown state.
+        }
       }
     }
 
@@ -5973,7 +5975,9 @@ class CSSTokenizerFilter {
             case "ti" -> f.time = true;
             case "fr" -> f.frequency = true;
             case "tr" -> f.transform = true;
-            default -> {}
+            default -> {
+              // Intentionally ignore unknown type token.
+            }
           }
         }
         return f;
@@ -6526,7 +6530,7 @@ class CSSTokenizerFilter {
     }
 
     /** Parameters for verifying parse expressions that use the {@code []} repetition operator. */
-    @SuppressWarnings("java:S6206")
+    @SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
     private static final class VariableOccurrenceParams {
       private final int verifierIndex;
       private final ParsedWord[] valueParts;

--- a/src/main/java/network/crypta/client/filter/HTMLFilter.java
+++ b/src/main/java/network/crypta/client/filter/HTMLFilter.java
@@ -459,7 +459,9 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
         case INTAGCOMMENT -> w.write("<!-- truncated page: deleted unfinished comment -->");
         case INTAGCOMMENTCLOSING ->
             w.write("<!-- truncated page: deleted unfinished comment, might be closing -->");
-        default -> {}
+        default -> {
+          // Intentionally ignore unknown tokenizer mode.
+        }
       }
     }
 
@@ -494,7 +496,9 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
         case INTAGCOMMENT -> handleCommentMode();
         case INTAGCOMMENTCLOSING -> handleCommentClosingMode();
         case INTAGWHITESPACE -> handleWhitespaceMode();
-        default -> {}
+        default -> {
+          // Intentionally ignore unknown tokenizer mode.
+        }
       }
     }
 
@@ -813,22 +817,6 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       return errorTag;
     }
     return tagContent;
-  }
-
-  private static String[] splitOnComma(String input) {
-    ArrayList<String> parts = new ArrayList<>();
-    int start = 0;
-    for (int i = 0; i < input.length(); i++) {
-      if (input.charAt(i) == ',') {
-        parts.add(input.substring(start, i));
-        start = i + 1;
-      }
-    }
-    parts.add(input.substring(start));
-    for (int i = parts.size() - 1; i >= 0 && parts.get(i).isEmpty(); i--) {
-      parts.remove(i);
-    }
-    return parts.toArray(new String[0]);
   }
 
   /**
@@ -3844,6 +3832,22 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     static {
       validRobotsValues = new HashSet<>();
       validRobotsValues.addAll(Arrays.asList(validRobotsValue));
+    }
+
+    private static String[] splitOnComma(String input) {
+      ArrayList<String> parts = new ArrayList<>();
+      int start = 0;
+      for (int i = 0; i < input.length(); i++) {
+        if (input.charAt(i) == ',') {
+          parts.add(input.substring(start, i));
+          start = i + 1;
+        }
+      }
+      parts.add(input.substring(start));
+      for (int i = parts.size() - 1; i >= 0 && parts.get(i).isEmpty(); i--) {
+        parts.remove(i);
+      }
+      return parts.toArray(new String[0]);
     }
 
     MetaTagVerifier() {


### PR DESCRIPTION
## Summary
- annotate tokenizer switch defaults to document intentional no-ops
- co-locate HTML meta tag comma helper with verifier setup
- suppress record suggestion for variable occurrence params where it is inappropriate