### PR TITLE
refactor: tidy filters and node helpers

### DIFF
--- a/src/main/java/network/crypta/client/async/USKFetcher.java
+++ b/src/main/java/network/crypta/client/async/USKFetcher.java
@@ -541,7 +541,7 @@ public class USKFetcher
     boolean decode;
     List<USKAttempt> killAttempts = null;
     boolean shouldFillKeysWatching;
-    long effectiveLatest = curLatest;
+    long effectiveLatest;
     synchronized (this) {
       if (att != null) attempts.removeRunningAttempt(att.number);
       if (completed || cancelled) {
@@ -1014,7 +1014,7 @@ public class USKFetcher
     boolean decode;
     List<USKAttempt> killAttempts = null;
     boolean shouldFillKeysWatching;
-    long effectiveEd = ed;
+    long effectiveEd;
     synchronized (this) {
       if (completed || cancelled) return null;
       decode = lastEd == ed && data != null;

--- a/src/main/java/network/crypta/client/filter/FlacPacketFilter.java
+++ b/src/main/java/network/crypta/client/filter/FlacPacketFilter.java
@@ -18,13 +18,13 @@ import org.slf4j.LoggerFactory;
  * only the metadata portion. While in the initial {@code UNINITIALIZED} state it expects the
  * STREAMINFO block and extracts core stream characteristics such as block sizes, frame sizes,
  * sample rate, channel count, sample depth, total samples, and the on-disk hash. After STREAMINFO
- * is observed, subsequent metadata blocks are examined and—when appropriate— sanitized before being
- * passed onward.
+ * is observed, the following metadata blocks are examined and—when appropriate— sanitized before
+ * being passed onward.
  *
- * <p>The primary goal is to redact optional, potentially large or identifying metadata. In
+ * <p>The primary goal is to redact optional, potentially large, or identifying metadata. In
  * particular, APPLICATION, VORBIS_COMMENT, and PICTURE blocks are replaced with zero-filled payload
- * and re-tagged as PADDING, preserving overall layout without exposing their original content.
- * Other block types are forwarded unchanged. The class maintains minimal state to track parsing
+ * and re-tagged as PADDING, preserving the overall layout without exposing their original content.
+ * Other block types are forwarded unchanged. The class maintains a minimal state to track parsing
  * progress and does not attempt to parse audio frames.
  *
  * <ul>
@@ -67,7 +67,7 @@ public class FlacPacketFilter implements CodecPacketFilter {
    * essential stream parameters. While metadata is being processed, selective redaction is applied:
    * APPLICATION, VORBIS_COMMENT, and PICTURE blocks are transformed into PADDING with a zero-filled
    * payload of the same length, preserving alignment while removing content. All other blocks pass
-   * through unchanged. Audio frames are not interpreted by this filter.
+   * through unchanged. This filter does not interpret audio frames.
    *
    * <p>If the filter has already concluded the stream is invalid, the method returns {@code null}.
    * Callers should provide packets in order and should not reuse the same instance concurrently
@@ -93,7 +93,7 @@ public class FlacPacketFilter implements CodecPacketFilter {
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(packet.toArray()));
     switch (currentState) {
       case UNINITIALIZED -> {
-        // Cast intentionally throws ClassCastException when first packet isn't metadata (test
+        // Cast intentionally throws ClassCastException when the first packet isn't metadata (test
         // expects this). Any metadata type is treated as STREAMINFO for field extraction.
         @SuppressWarnings("unused")
         FlacMetadataBlock firstMeta = (FlacMetadataBlock) packet;
@@ -115,29 +115,40 @@ public class FlacPacketFilter implements CodecPacketFilter {
         currentState = State.STREAMINFO_FOUND;
       }
       case STREAMINFO_FOUND -> {
-        if (packet instanceof FlacMetadataBlock block2) {
-          if (block2.isLastMetadataBlock()) currentState = State.METADATA_FOUND;
-          switch (block2.getMetadataBlockType()) {
-            case APPLICATION, VORBIS_COMMENT, PICTURE -> {
-              byte[] payload = new byte[packet.payload.length];
-              Arrays.fill(payload, (byte) 0);
-              FlacMetadataBlockHeader header = block2.getHeader();
-              packet = new FlacMetadataBlock(header.toInt(), payload);
-              ((FlacMetadataBlock) packet).setMetadataBlockType(BlockType.PADDING);
-            }
-            default -> {
-              // No change for other block types.
-            }
+        switch (packet) {
+          case FlacMetadataBlock block2 when block2.isLastMetadataBlock() -> {
+            currentState = State.METADATA_FOUND;
+            packet = redactIfNeeded(block2, packet);
+          }
+          case FlacMetadataBlock block2 -> packet = redactIfNeeded(block2, packet);
+          default -> {
+            // Non-metadata packets (audio frames) pass through unchanged in this state.
           }
         }
         // Non-metadata packets (audio frames) pass through unchanged in this state.
       }
       case METADATA_FOUND -> {
-        // Audio frames and any subsequent packets pass through unchanged.
+        // Audio frames and any following packets pass through unchanged.
       }
     }
     if (packet instanceof FlacMetadataBlock block && logMINOR)
       LOG.debug("Returning packet of type {}", block.getMetadataBlockType());
+    return packet;
+  }
+
+  private static CodecPacket redactIfNeeded(FlacMetadataBlock block, CodecPacket packet) {
+    switch (block.getMetadataBlockType()) {
+      case APPLICATION, VORBIS_COMMENT, PICTURE -> {
+        byte[] payload = new byte[packet.payload.length];
+        Arrays.fill(payload, (byte) 0);
+        FlacMetadataBlockHeader header = block.getHeader();
+        packet = new FlacMetadataBlock(header.toInt(), payload);
+        ((FlacMetadataBlock) packet).setMetadataBlockType(BlockType.PADDING);
+      }
+      default -> {
+        // No change for other block types.
+      }
+    }
     return packet;
   }
 }

--- a/src/main/java/network/crypta/client/filter/PNGFilter.java
+++ b/src/main/java/network/crypta/client/filter/PNGFilter.java
@@ -20,11 +20,11 @@ import org.slf4j.LoggerFactory;
  * Filters PNG images to a safe, standards‑conforming byte stream.
  *
  * <p>This filter parses the PNG container, validates chunk structure and ordering, and forwards
- * only content that is known to be safe for delivery to user agents. It performs a positive
- * (allow‑list) validation of well‑formed chunks and, when configured by the caller, can remove
- * human‑readable metadata such as {@code tEXt}/{@code iTXt}/{@code zTXt} as well as the optional
- * {@code tIME} timestamp. The filter may also verify per‑chunk CRCs and drop chunks with invalid
- * checksums to prevent partially corrupted or deliberately malformed data from reaching clients.
+ * only content known to be safe for delivery to user agents. It performs a positive (allow‑list)
+ * validation of well‑formed chunks and, when configured by the caller, can remove human‑readable
+ * metadata such as {@code tEXt}/{@code iTXt}/{@code zTXt} as well as the optional {@code tIME}
+ * timestamp. The filter may also verify per‑chunk CRCs and drop chunks with invalid checksums to
+ * prevent partially corrupted or deliberately malformed data from reaching clients.
  *
  * <p>The implementation enforces core PNG invariants, including a single {@code IHDR} at the start
  * of the stream, zero or more consecutive {@code IDAT} chunks, and a single {@code IEND} at the
@@ -79,11 +79,11 @@ public class PNGFilter implements ContentDataFilter {
     "acTL",
     "fcTL",
     "fdAT"
-    // MNG isn't supported by Firefox and IE because of lack of market demand. Big surprise
-    // given nobody supports it! It is supported by Konqueror though. Complex standard,
+    // MNG isn't supported by Firefox and IE because of a lack of market demand. Big surprise
+    // given nobody supports it! It is supported by Konqueror, though. Complex standard,
     // not worth it for the time being.
 
-    // This might be a useful source of info too (e.g. on private chunks):
+    // This might be a useful source of info too (e.g., on private chunks):
     // http://fresh.t-systems-sfr.com/unix/privat/pngcheck-2.3.0.tar.gz:a/pngcheck-2.3.0/pngcheck.c
   };
 
@@ -109,9 +109,9 @@ public class PNGFilter implements ContentDataFilter {
    * filter.readFilter(inStream, outStream, null, Map.of(), null, null);
    * }</pre>
    *
-   * @param input the source PNG byte stream to validate and sanitize; may be network‑backed and is
-   *     read sequentially without relying on {@code available()} for termination; must begin with a
-   *     valid 8‑byte PNG signature.
+   * @param input the source PNG byte stream to validate and sanitize; may be networking‑backed and
+   *     is read sequentially without relying on {@code available()} for termination; must begin
+   *     with a valid 8‑byte PNG signature.
    * @param output the destination for the filtered PNG; receives only validated bytes; the method
    *     flushes on completion but does not close the stream.
    * @param charset ignored for PNG (a binary format); callers may pass {@code null} or any value;
@@ -426,6 +426,7 @@ public class PNGFilter implements ContentDataFilter {
     dos.write(chunk.crcBytes);
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class ChunkData {
     final int length;
     final String type;
@@ -484,27 +485,24 @@ public class PNGFilter implements ContentDataFilter {
       "Invalid colourType/bitDepth combination!";
 
   private void throwOnInvalidColour(int bitDepth, int colourType) throws DataFilterException {
-    switch (bitDepth) {
-      case 1, 2, 4 -> {
-        if (colourType != 0 && colourType != 3) invalidColourCombo(colourType, bitDepth);
-      }
-      case 16 -> {
-        if (colourType == 3) invalidColourCombo(colourType, bitDepth);
-        if (!isValidColourType8(colourType)) invalidColourCombo(colourType, bitDepth);
-      }
-      case 8 -> {
-        if (!isValidColourType8(colourType)) invalidColourCombo(colourType, bitDepth);
-      }
-      default -> invalidColourCombo(colourType, bitDepth);
+    boolean invalid =
+        switch (bitDepth) {
+          case 1, 2, 4 -> colourType != 0 && colourType != 3;
+          case 16 -> colourType == 3 || isInvalidColourType8(colourType);
+          case 8 -> isInvalidColourType8(colourType);
+          default -> true;
+        };
+    if (invalid) {
+      invalidColourCombo(colourType, bitDepth);
     }
   }
 
-  private boolean isValidColourType8(int colourType) {
-    return colourType == 0
-        || colourType == 2
-        || colourType == 3
-        || colourType == 4
-        || colourType == 6;
+  private boolean isInvalidColourType8(int colourType) {
+    return colourType != 0
+        && colourType != 2
+        && colourType != 3
+        && colourType != 4
+        && colourType != 6;
   }
 
   private void invalidColourCombo(int colourType, int bitDepth) throws DataFilterException {

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>Load bookmark state from disk with a backup/default fallback.
  *   <li>Maintain a path-to-bookmark index for categories and items.
- *   <li>Serialize and write bookmark state (backup write then rename).
+ *   <li>Serialize and write bookmark state (backup write then rename it).
  *   <li>Subscribe/unsubscribe to USK updates for USK-typed bookmark items.
  * </ul>
  */
@@ -60,7 +60,7 @@ public class BookmarkManager implements RequestClient {
   private static final Logger LOG = LoggerFactory.getLogger(BookmarkManager.class);
 
   /**
-   * Parsed default bookmark set loaded from the bundled {@code defaultbookmarks.dat} resource.
+   * Parsed the default bookmark set loaded from the bundled {@code defaultbookmarks.dat} resource.
    *
    * <p>This value may be {@code null} if the resource cannot be loaded or parsed; code that
    * populates defaults should tolerate the absence of bundled defaults.
@@ -112,7 +112,7 @@ public class BookmarkManager implements RequestClient {
   // Legacy threshold callback removed.
 
   /**
-   * Creates a new manager, loads bookmarks from disk, and registers a shutdown hook to persist
+   * Creates a new manager, loads bookmarks from the disk, and registers a shutdown hook to persist
    * changes.
    *
    * <p>The constructor attempts to read {@code bookmarks.dat} from the node user directory. When
@@ -139,7 +139,7 @@ public class BookmarkManager implements RequestClient {
       SimpleFieldSet sfs = SimpleFieldSet.readFrom(bookmarksFile, false, true);
       readBookmarks(MAIN_CATEGORY, sfs);
     } catch (MalformedURLException _) {
-      // Bookmark file contains a malformed key; ignore and fall back to backup/defaults.
+      // Bookmark file contains a malformed key; ignore and fall back to the backup/defaults.
     } catch (IOException ioe) {
       LOG.error("Error reading the bookmark file ({}):{}", bookmarksFile, ioe.getMessage(), ioe);
 
@@ -364,7 +364,7 @@ public class BookmarkManager implements RequestClient {
    * up to date.
    *
    * <p>This method does not persist changes by itself. Callers are expected to choose between
-   * immediate persistence ({@link #storeBookmarks()}) and a delayed/coalesced write ({@link
+   * immediate persistence ({@link #storeBookmarks()}) and a delayed/coalesced writing ({@link
    * #storeBookmarksLazy()}) depending on the update pattern.
    *
    * <pre>{@code
@@ -496,8 +496,8 @@ public class BookmarkManager implements RequestClient {
   private boolean wantUSK(USK u, BookmarkItem ignore) {
     List<BookmarkItem> items = MAIN_CATEGORY.getAllItems();
     for (BookmarkItem item : items) {
-      if (ignore != null && item.instanceId() == ignore.instanceId()) continue;
-      if (!"USK".equals(item.getKeyType())) continue;
+      if ((ignore != null && item.instanceId() == ignore.instanceId())
+          || !"USK".equals(item.getKeyType())) continue;
 
       try {
         FreenetURI furi = new FreenetURI(item.getKey());
@@ -593,7 +593,7 @@ public class BookmarkManager implements RequestClient {
   }
 
   /**
-   * Schedules a delayed persistence of bookmarks, coalescing multiple updates into one write.
+   * Schedules the delayed persistence of bookmarks, coalescing multiple updates into one writing.
    *
    * <p>If a delayed save is already scheduled, this method is a no-op. Otherwise, it queues a job
    * on the node ticker to invoke {@link #storeBookmarks()} after approximately 5 minutes. This is
@@ -601,7 +601,7 @@ public class BookmarkManager implements RequestClient {
    *
    * <p>The method returns immediately and does not wait for I/O. A best-effort guard ensures only
    * one delayed job is queued at a time, so repeated calls within the delay window are collapsed
-   * into the same scheduled write.
+   * into the same scheduled writing.
    */
   public void storeBookmarksLazy() {
     synchronized (bookmarks) {
@@ -627,7 +627,7 @@ public class BookmarkManager implements RequestClient {
    *
    * <p>This method serializes the current tree to a {@link SimpleFieldSet}, writes it to {@code
    * bookmarks.dat.bak}, and then attempts to move it into place as {@code bookmarks.dat}. A
-   * re-entrant guard prevents concurrent writers from executing the write simultaneously.
+   * re-entrant guard prevents concurrent writers from executing the writing simultaneously.
    *
    * <p>Failures are logged and do not throw to callers. The write operation uses regular file I/O
    * and may block while data is flushed to disk.
@@ -648,7 +648,7 @@ public class BookmarkManager implements RequestClient {
       if (!FileUtil.moveTo(backupBookmarksFile, bookmarksFile))
         LOG.error("Unable to rename {} to {}", backupBookmarksFile, bookmarksFile);
     } catch (IOException ioe) {
-      LOG.error("An error has occured saving the bookmark file :{}", ioe.getMessage(), ioe);
+      LOG.error("An error has occurred saving the bookmark file :{}", ioe.getMessage(), ioe);
     } finally {
       synchronized (bookmarks) {
         isSavingBookmarks = false;
@@ -812,7 +812,7 @@ public class BookmarkManager implements RequestClient {
   /**
    * {@inheritDoc}
    *
-   * <p>Bookmark-related requests are not treated as real-time traffic by this client.
+   * <p>This client does not treat bookmark-related requests as real-time traffic.
    *
    * @return always {@code false}
    */

--- a/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
+++ b/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
@@ -35,6 +35,8 @@ import org.slf4j.LoggerFactory;
  */
 public final class RijndaelAlgorithm // implicit no-argument constructor
  {
+  private RijndaelAlgorithm() {}
+
   private static final Logger LOG = LoggerFactory.getLogger(RijndaelAlgorithm.class);
 
   //	Debugging methods and variables
@@ -1234,6 +1236,7 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
     }
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class KeyScheduleCtx {
     private final int[][] ke;
     private final int[][] kd;

--- a/src/main/java/network/crypta/io/comm/MessageFilter.java
+++ b/src/main/java/network/crypta/io/comm/MessageFilter.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * {@link #setAsyncCallback(AsyncMessageFilterCallback, ByteCounter)}.
  *
  * <p>Thread safety: instances synchronize on {@code this}. Waiting and signaling use the same
- * monitor so waiters are reliably woken when a match, disconnect, or restart occurs.
+ * monitor, so waiters are reliably woken when a match, disconnect, or restart occurs.
  */
 public final class MessageFilter {
   private static final Logger LOG = LoggerFactory.getLogger(MessageFilter.class);
@@ -81,7 +81,7 @@ public final class MessageFilter {
   }
 
   /**
-   * Set whether the timeout is relative to the creation of the filter, or the start of waitFor().
+   * Set whether the timeout is relative to the creation of the filter or the start of waitFor().
    *
    * @param b If true, the timeout is relative to the time at which setTimeout() was called, if
    *     false, it's relative to the start of waitFor().
@@ -93,7 +93,7 @@ public final class MessageFilter {
   }
 
   /**
-   * Sets an absolute expiry relative to now.
+   * Sets absolute expiry relative now.
    *
    * <p>When multiple filters match the same message, the filter with the earlier expiry is favored.
    *
@@ -211,7 +211,7 @@ public final class MessageFilter {
   }
 
   /**
-   * Adds an alternative filter that is evaluated before this one.
+   * Adds an alternative filter evaluated before this one.
    *
    * <p>The resulting chain matches if either the alternate filter or this filter matches. Nest
    * multiple alternates: {@code f1.or(f2.or(f3))}. The right-most filter is tested first; place the
@@ -266,7 +266,7 @@ public final class MessageFilter {
     FOUND,
     /** The filter has expired without a match. */
     TIMED_OUT,
-    /** The message matches but the filter expired by the time it was checked. */
+    /** The message matches, but the filter expired by the time it was checked. */
     TIMED_OUT_AND_MATCHED,
     /** No match; the filter remains active. */
     NONE
@@ -556,7 +556,7 @@ public final class MessageFilter {
       msg = message;
       cb = callback;
       ctr = byteCounter;
-      // Clear matched before calling callback in case we are re-added.
+      // Clear the matched before calling callback in case we are re-added.
       if (callback != null) clearMatched();
     }
     if (cb != null) {
@@ -624,7 +624,7 @@ public final class MessageFilter {
 
   /**
    * Block on this filter's monitor until a message is matched, the peer is dropped/restarted, or
-   * the filter times out. This encapsulates the wait/notify pattern so callers don't need to
+   * the filter times out. This encapsulates the wait/notify pattern, so callers don't need to
    * synchronize on the filter reference directly.
    *
    * <p>Threading: Uses this filter instance as the monitor. Matching and connection events call
@@ -637,14 +637,19 @@ public final class MessageFilter {
     synchronized (this) {
       try {
         long now;
-        while (true) {
+        boolean waiting = true;
+        while (waiting) {
           now = System.currentTimeMillis();
           if (matchedFlag || droppedConnection != null || reallyTimedOut(now)) {
-            break;
+            waiting = false;
+          } else {
+            long wait = timeout - now;
+            if (wait > 0) {
+              this.wait(wait);
+            } else {
+              waiting = false;
+            }
           }
-          long wait = timeout - now;
-          if (wait <= 0) break;
-          this.wait(wait);
         }
         if (droppedConnection != null) throw new DisconnectedException();
       } catch (InterruptedException _) {

--- a/src/main/java/network/crypta/node/CHKInsertHandler.java
+++ b/src/main/java/network/crypta/node/CHKInsertHandler.java
@@ -293,19 +293,16 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
   }
 
   private void handleTerminalStatus(int status) {
-    if (status == CHKInsertSender.TIMED_OUT
-        || status == CHKInsertSender.GENERATED_REJECTED_OVERLOAD
-        || status == CHKInsertSender.INTERNAL_ERROR) {
-      handleFatalOverload(status);
-    } else if (status == CHKInsertSender.ROUTE_NOT_FOUND
-        || status == CHKInsertSender.ROUTE_REALLY_NOT_FOUND) {
-      handleRouteNotFound(status);
-    } else if (status == CHKInsertSender.RECEIVE_FAILED) {
-      handleReceiveFailed();
-    } else if (status == CHKInsertSender.SUCCESS) {
-      handleSuccess(status);
-    } else {
-      handleUnknownStatus();
+    switch (status) {
+      case CHKInsertSender.TIMED_OUT,
+          CHKInsertSender.GENERATED_REJECTED_OVERLOAD,
+          CHKInsertSender.INTERNAL_ERROR ->
+          handleFatalOverload(status);
+      case CHKInsertSender.ROUTE_NOT_FOUND, CHKInsertSender.ROUTE_REALLY_NOT_FOUND ->
+          handleRouteNotFound(status);
+      case CHKInsertSender.RECEIVE_FAILED -> handleReceiveFailed();
+      case CHKInsertSender.SUCCESS -> handleSuccess(status);
+      default -> handleUnknownStatus();
     }
   }
 

--- a/src/main/java/network/crypta/node/NodeStats.java
+++ b/src/main/java/network/crypta/node/NodeStats.java
@@ -111,23 +111,22 @@ public class NodeStats implements Persistable, BlockTimeCallback {
   }
 
   /** Histogram for request locations. */
-  private static class RequestsByLocation {
-    private final AtomicIntegerArray bins;
+  private record RequestsByLocation(AtomicIntegerArray bins) {
 
     /** Constructs a request location histogram with the given number of bins. */
     RequestsByLocation(int numBins) {
-      bins = new AtomicIntegerArray(numBins);
+      this(new AtomicIntegerArray(numBins));
     }
 
     /** Update the request counts with a request for the given location. */
-    final void report(final double loc) {
+    void report(final double loc) {
       assert loc >= 0 && loc < 1.0;
       int bin = (int) Math.floor(loc * bins.length());
       bins.incrementAndGet(bin);
     }
 
     /** Get the request count bins. */
-    final int[] getCounts() {
+    int[] getCounts() {
       int[] counts = new int[bins.length()];
       for (int i = 0; i < counts.length; i++) {
         counts[i] = bins.get(i);
@@ -141,6 +140,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
    *
    * <p>Each bucket maintains a running average of reported values.
    */
+  @SuppressWarnings("ClassCanBeRecord")
   private static class SuccessRateHistogram {
     private final double max;
     private final RunningAverage[] bars;
@@ -1301,7 +1301,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
     // Consider using a shorter average; evaluate behavior when bwlimit changes
 
     double totalCouldSend =
-        Math.max((double) totalSent, (node.network().outputBandwidthLimit() * uptime) / 1000.0);
+        Math.max(totalSent, (node.network().outputBandwidthLimit() * uptime) / 1000.0);
     double nonOverheadFraction = (totalCouldSend - totalOverhead) / totalCouldSend;
     long timeFirstAnyConnections = peers.timeFirstAnyConnections;
     if (timeFirstAnyConnections > 0) {

--- a/src/main/java/network/crypta/node/NodeStats.java
+++ b/src/main/java/network/crypta/node/NodeStats.java
@@ -1290,6 +1290,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
     return node.network().inputBandwidthLimit() * (double) limit;
   }
 
+  @SuppressWarnings("java:S1905")
   private double getNonOverheadFraction(long now) {
 
     long[] total = node.network().collector().getTotalIO();
@@ -1301,7 +1302,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
     // Consider using a shorter average; evaluate behavior when bwlimit changes
 
     double totalCouldSend =
-        Math.max(totalSent, (node.network().outputBandwidthLimit() * uptime) / 1000.0);
+        Math.max((double) totalSent, (node.network().outputBandwidthLimit() * uptime) / 1000.0);
     double nonOverheadFraction = (totalCouldSend - totalOverhead) / totalCouldSend;
     long timeFirstAnyConnections = peers.timeFirstAnyConnections;
     if (timeFirstAnyConnections > 0) {

--- a/src/main/java/network/crypta/node/PeerRoutingSelector.java
+++ b/src/main/java/network/crypta/node/PeerRoutingSelector.java
@@ -72,7 +72,7 @@ public class PeerRoutingSelector {
    * and does not mutate peers directly. Callers remain responsible for updating per-request state
    * and for respecting a {@code null} result.
    *
-   * <pre>{@code
+   * <pre>
    * PeerRoutingSelectionParams params = ...;
    * PeerNode nextHop = selector.closerPeer(params);
    * </pre>

--- a/src/main/java/network/crypta/node/probe/Probe.java
+++ b/src/main/java/network/crypta/node/probe/Probe.java
@@ -71,8 +71,6 @@ import org.slf4j.LoggerFactory;
 public class Probe implements ByteCounter {
   private static final Logger LOG = LoggerFactory.getLogger(Probe.class);
 
-  // SLF4J-level guard used instead of legacy logWARNING flag.
-
   private static final String SOURCE_DISCONNECT =
       "Previous step in probe chain no longer connected.";
 
@@ -101,7 +99,7 @@ public class Probe implements ByteCounter {
    * Probability that HTL decrements at {@code HTL==1} rather than forwarding.
    *
    * <p>This small chance protects the responding node by avoiding deterministic behavior at the
-   * final hop while keeping overall walk length distribution stable.
+   * final hop while keeping the overall walk length distribution stable.
    */
   public static final float DECREMENT_PROBABILITY = 0.2f;
 
@@ -147,16 +145,17 @@ public class Probe implements ByteCounter {
   public static final int COUNTER_MAX_PEER = 10;
 
   /**
-   * Maximum number of probes started locally in the past minute. This is the maximum conceivable
-   * value; the probes should be used with a number of requests per minute closer to the per-peer
-   * limit times the minimum expected number of peers. Around this value, and certainly above it,
-   * remote OVERLOADs may start coming in, which are not useful. The Metropolis-Hastings correction
-   * makes behavior potentially inconsistent, so keeping an eye on remote OVERLOADs is wise.
+   * The maximum number of probes started locally in the past minute. This is the maximum
+   * conceivable value; the probes should be used with a number of requests per minute closer to the
+   * per-peer limit times the minimum expected number of peers. Around this value, and certainly
+   * above it, remote OVERLOADs may start coming in, which are not useful. The Metropolis-Hastings
+   * correction makes behavior potentially inconsistent, so keeping an eye on remote OVERLOADs is
+   * wise.
    */
   public static final int COUNTER_MAX_LOCAL =
       COUNTER_MAX_PEER * OpennetManager.MAX_PEERS_FOR_SCALING;
 
-  /** Number of accepted probes in the last minute, keyed by peer. */
+  /** Number of accepted probes at the last minute, keyed by peer. */
   private final Map<PeerNode, Counter> accepted;
 
   private final Node node;
@@ -420,7 +419,7 @@ public class Probe implements ByteCounter {
     probeIdentifier = nodeConfig.getLong(IDENTIFIER_KEY);
 
     /*
-     * set() is not used when setting up an option with its default value, so do so manually to avoid using
+     * set() is not used when setting up an option with its default value, thus do so manually to avoid using
      * an identifier of -1.
      */
     try {
@@ -593,8 +592,8 @@ public class Probe implements ByteCounter {
   }
 
   /**
-   * Attempts to route the message to a peer. If the maximum number of send attempts is exceeded,
-   * fails with the error CANNOT_FORWARD.
+   * Attempts to route the message to a peer. If the maximum number of sending attempts is exceeded,
+   * it fails with the error CANNOT_FORWARD.
    *
    * @return True if no further action needed; false if HTL decremented to zero and a local response
    *     is needed.
@@ -620,7 +619,7 @@ public class Probe implements ByteCounter {
         if (trySendToCandidate(candidate, type, uid, htl, message, listener)) {
           return true;
         }
-        // Else: candidate disconnected during send/filter; try again.
+        // Else: the candidate disconnected during send/filter; try again.
       } else {
         htl = probabilisticDecrement(htl);
         if (htl == 0) return false;
@@ -670,7 +669,7 @@ public class Probe implements ByteCounter {
    * @param type probe result type requested.
    * @param candidate node to filter for response from.
    * @param uid probe request uid, also to be used in any result.
-   * @param htl current probe HTL; used to calculate timeout.
+   * @param htl the current probe HTL; used to calculate timeout.
    * @return filter for the requested result type, probe error, and probe refusal.
    */
   private static MessageFilter createResponseFilter(
@@ -707,7 +706,7 @@ public class Probe implements ByteCounter {
   }
 
   /**
-   * Depending on node settings, sends a message to source containing either a refusal or the
+   * Depending on node settings, sends a message to the source containing either a refusal or the
    * requested result.
    */
   private void respond(final Type type, final Listener listener) {
@@ -718,34 +717,34 @@ public class Probe implements ByteCounter {
     }
 
     /*
-     * This adds noise to the results to make information less identifiable. The goal is making it difficult
+     * This adds noise to the results to make information less identifiable. The goal is to make it difficult
      * to determine which value a node actually has; that any given value could mean a small range of common
      * values. Different result types have different sigma values such that one sigma contains multiple
      * reasonable values.
      */
     switch (type) {
-      case BANDWIDTH -> {
-        /*
-         * 5% noise:
-         * Reasonable output bandwidth limit is 20 KiB and people are likely to set limits in increments
-         * of 1 KiB. 1 KiB / 20 KiB = 0.05 sigma.
-         * 1,024 (2^10) bytes per KiB.
-         */
-        listener.onOutputBandwidth(
-            (float) randomNoise((double) node.network().outputBandwidthLimit() / (1 << 10), 0.05));
-      }
+      /*
+       * 5% noise:
+       * Reasonable output bandwidth limit is 20 KiB, and people are likely to set limits in increments
+       * of 1 KiB. 1 KiB / 20 KiB = 0.05 sigma.
+       * 1,024 (2^10) bytes per KiB.
+       */
+      case BANDWIDTH ->
+          listener.onOutputBandwidth(
+              (float)
+                  randomNoise((double) node.network().outputBandwidthLimit() / (1 << 10), 0.05));
       case BUILD -> listener.onBuild(node.services().nodeUpdater().getMainVersion());
       case IDENTIFIER -> {
         /*
          * 5% noise:
          * Reasonable uptime percentage is at least ~40 hours a week, or ~20%. This uptime is
-         * quantized so only something above a full percentage point (0.01 * 168 hours = 1.68 hours) of
+         *  quantized, so only something above a full percentage point (0.01 * 168 hours = 1.68 hours) of
          * change will be guaranteed (from a percentage with a decimal component close to zero) to be
          * reflected. 1% / 20% = 0.05 sigma.
          *
          * 7-day uptime with random noise, then quantized. Quantization is to make it very, very
          * difficult to get useful information out of any given result because it is included with an
-         * identifier,
+         * identifier.
          */
         long percent =
             Math.round(randomNoise(100 * node.network().uptimeEstimator().getUptimeWeek(), 0.05));
@@ -777,34 +776,31 @@ public class Probe implements ByteCounter {
         listener.onLinkLengths(linkLengths);
       }
       case LOCATION -> listener.onLocation((float) node.network().location());
-      case STORE_SIZE -> {
-        /*
-         * 5% noise:
-         * Reasonable datastore size is 20 GiB, and size is likely set in, at most, increments of 1 GiB.
-         * 1 GiB / 20 GiB = 0.05 sigma.
-         * 1,073,741,824 bytes (2^30) per GiB.
-         */
-        listener.onStoreSize((float) randomNoise((double) node.getStoreSize() / (1 << 30), 0.05));
-      }
-      case UPTIME_48H -> {
-        /*
-         * 8% noise:
-         * Continuing with the assumption that reasonable weekly uptime is around 40 hours, this allows
-         * for 6 hours per day, 12 hours per 48 hours, or 25%. A half-hour seems a sufficient amount of
-         * ambiguity, so 0.5 hours / 48 hours ~= 1%, and 1% / 25% = 0.04 sigma.
-         */
-        listener.onUptime(
-            (float) randomNoise(100 * node.network().uptimeEstimator().getUptime(), 0.04));
-      }
-      case UPTIME_7D -> {
-        /*
-         * 2.4% noise:
-         * As a 168-hour uptime covers a longer period 1 hour of ambiguity seems sufficient.
-         * 1 hour / 168 hours ~= 0.6%, and 0.6% / 20% = 0.03 sigma.
-         */
-        listener.onUptime(
-            (float) randomNoise(100 * node.network().uptimeEstimator().getUptimeWeek(), 0.03));
-      }
+      /*
+       * 5% noise:
+       * Reasonable datastore size is 20 GiB, and size is likely set in, at most, increments of 1 GiB.
+       * 1 GiB / 20 GiB = 0.05 sigma.
+       * 1,073,741,824 bytes (2^30) per GiB.
+       */
+      case STORE_SIZE ->
+          listener.onStoreSize((float) randomNoise((double) node.getStoreSize() / (1 << 30), 0.05));
+      /*
+       * 8% noise:
+       * Continuing with the assumption that reasonable weekly uptime is around 40 hours, this allows
+       * for 6 hours per day, 12 hours per 48 hours, or 25%. A half-hour seems enough
+       * ambiguity, so 0.5 hours / 48 hours ~= 1%, and 1% / 25% = 0.04 sigma.
+       */
+      case UPTIME_48H ->
+          listener.onUptime(
+              (float) randomNoise(100 * node.network().uptimeEstimator().getUptime(), 0.04));
+      /*
+       * 2.4% noise:
+       * As a 168-hour uptime covers a longer period, 1 hour of ambiguity seems enough.
+       * 1 hour / 168 hours ~= 0.6%, and 0.6% / 20% = 0.03 sigma.
+       */
+      case UPTIME_7D ->
+          listener.onUptime(
+              (float) randomNoise(100 * node.network().uptimeEstimator().getUptimeWeek(), 0.03));
       case REJECT_STATS -> {
         byte[] stats = node.network().stats().getNoisyRejectStats();
         listener.onRejectStats(stats);
@@ -854,6 +850,7 @@ public class Probe implements ByteCounter {
    * Filter listener which determines the type of result and calls the appropriate probe listener
    * method.
    */
+  @SuppressWarnings("ClassCanBeRecord")
   private static class ResultListener implements AsyncMessageFilterCallback {
 
     private final Listener listener;
@@ -872,7 +869,8 @@ public class Probe implements ByteCounter {
     }
 
     /**
-     * Parses provided message and calls appropriate Probe.Listener method for the type of result.
+     * Parses provided a message and called the appropriate "Probe.Listener" method for the type of
+     * result.
      *
      * @param message Probe result.
      */
@@ -934,9 +932,9 @@ public class Probe implements ByteCounter {
 
   /**
    * Listener which relays responses to the node specified during construction. Used for received
-   * probe requests. This leads to reconstructing the messages, but removes potentially harmful
+   * probe requests. This leads to reconstructing the messages but removes potentially harmful
    * sub-messages and also removes the need for duplicate message sending code elsewhere, If the
-   * result includes a trace this would be the place to add local results to it.
+   * result includes a trace, this would be the place to add local results to it.
    */
   private class ResultRelay implements Listener {
 
@@ -945,7 +943,7 @@ public class Probe implements ByteCounter {
 
     /**
      * @param source peer from which the request was received and to which send the response.
-     * @throws IllegalArgumentException if source is null.
+     * @throws IllegalArgumentException if a source is null.
      */
     public ResultRelay(PeerNode source, Long uid) {
       this.source = source;

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -369,7 +369,7 @@ public class NodeUpdateManager {
                     .nextInt(
                         (int)
                             SECONDS.toMillis(
-                                (long) Math.min(Math.pow(2, i), (double) MINUTES.toSeconds(15)))));
+                                (long) Math.min(Math.pow(2, i), MINUTES.toSeconds(15)))));
       } catch (InterruptedException _) {
         Thread.currentThread().interrupt();
       }

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -360,6 +360,7 @@ public class NodeUpdateManager {
       }
     }
 
+    @SuppressWarnings("java:S1905")
     private void sleepWithBackoff(int i) {
       try {
         Thread.sleep(
@@ -369,7 +370,7 @@ public class NodeUpdateManager {
                     .nextInt(
                         (int)
                             SECONDS.toMillis(
-                                (long) Math.min(Math.pow(2, i), MINUTES.toSeconds(15)))));
+                                (long) Math.min(Math.pow(2, i), (double) MINUTES.toSeconds(15)))));
       } catch (InterruptedException _) {
         Thread.currentThread().interrupt();
       }

--- a/src/test/java/network/crypta/node/NodeCryptoTest.java
+++ b/src/test/java/network/crypta/node/NodeCryptoTest.java
@@ -77,7 +77,7 @@ class NodeCryptoTest {
     } catch (UnsupportedCipherException e) {
       throw new RuntimeException(e);
     }
-    // Needed for synchronized section inside exportPublicFieldSet
+    // Needed for the synchronized section inside exportPublicFieldSet
     setField(nc, "referenceSync", new Object());
     return nc;
   }
@@ -209,7 +209,7 @@ class NodeCryptoTest {
 
     SimpleFieldSet fs = nc.exportPublicCryptoFieldSet(false, false);
 
-    // identity present and matches
+    // identity presents and matches
     assertEquals(Base64.encode(nc.getMyIdentity()), fs.get("identity"));
     // auth.negTypes present and contains the negotiated values
     assertArrayEquals(new String[] {"1", "2"}, fs.getAll("auth.negTypes"));
@@ -226,7 +226,7 @@ class NodeCryptoTest {
   }
 
   @Test
-  void exportPublicFieldSet_addsIPsLocationAndSignature() throws Exception {
+  void exportPublicFieldSet_addsIPsLocationAndSignature() {
     NodeCrypto nc = bare(node, true);
     nc.initCrypto();
 


### PR DESCRIPTION
## Summary
- streamline filter redaction handling and documentation tweaks in FLAC/PNG filters
- simplify node-side control paths and helper structures in probe/message handling
- apply small consistency cleanups across bookmarks, crypto, and tests

## Testing
- ./gradlew spotlessApply