### PR TITLE
Refactor ClientGet state and persistence helpers

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -5,6 +5,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
+import java.io.Serializable;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
@@ -13,7 +14,6 @@ import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientRequester;
-import network.crypta.client.async.CompatibilityAnalyser;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.FreenetURI;
@@ -34,11 +34,10 @@ import org.slf4j.LoggerFactory;
  * bucket, disk file, chunked stream, or acknowledgement only). The class therefore acts as the
  * boundary between long-lived persistent jobs and transient FCP sessions.
  *
- * <p>The implementation is largely thread-safe through fine-grained {@code synchronized} sections.
- * State transitions such as success, failure, cancellation, or restart update cached progress
- * snapshots and immediately propagate notifications to any registered listeners. During restarts,
- * it rehydrates buckets, metadata, and compatibility hints from the serialized form before
- * delegating back to {@link ClientGetter}.
+ * <p>The request behaves as a long-lived, mutable state machine. Mutable fields and persistence
+ * snapshots are guarded by a single request lock, so lifecycle updates, replay, and serialization
+ * observe a consistent state. Accessors return point-in-time views; callers should avoid mutating
+ * returned objects or assuming immediate cross-thread visibility without synchronization.
  *
  * <p>Typical usage is to construct the request from a {@link ClientGetMessage}, register it with
  * the owning client queue, and then invoke {@link #start(ClientContext)}. The request may persist
@@ -78,9 +77,11 @@ public class ClientGet extends ClientRequest {
   /** Destination file when {@link ReturnType#DISK} is in effect; {@code null} otherwise. */
   private final File targetFile;
 
-  /** Bucket returned when the request was completed, if returnType == RETURN_TYPE_DIRECT. */
-  @SuppressWarnings("java:S1948")
-  private Bucket returnBucketDirect;
+  /** Holds mutable state such as progress snapshots and cached buckets. */
+  private final ClientGetState state;
+
+  /** Stable lock used for persistence-related synchronization. */
+  private final PersistenceLock persistenceLock = new PersistenceLock();
 
   /** Indicates that the caller expects the result as a BinaryBlob stream rather than a bucket. */
   private final boolean binaryBlob;
@@ -95,6 +96,8 @@ public class ClientGet extends ClientRequest {
   private transient ClientGetMessageReplay messageReplay;
   private transient ClientGetLifecycle lifecycle;
   private transient ClientGetStatusSnapshotBuilder statusSnapshotBuilder;
+  private transient ClientGetRestartCoordinator restartCoordinator;
+  private transient ClientGetStatusReporter statusReporter;
 
   // Verbosity bitmasks
   static final int VERBOSITY_SPLITFILE_PROGRESS = 1;
@@ -104,44 +107,6 @@ public class ClientGet extends ClientRequest {
   static final int VERBOSITY_EXPECTED_TYPE = 32;
   static final int VERBOSITY_EXPECTED_SIZE = 64;
   static final int VERBOSITY_ENTER_FINITE_COOLDOWN = 128;
-
-  // Stuff waiting for reconnection
-  /** Did the request succeed? Valid if finished. */
-  private boolean succeeded;
-
-  /**
-   * Length of the found data. Will be updated from ClientGetter in onResume(), but we persist it
-   * anyway.
-   */
-  private long foundDataLength = -1;
-
-  /**
-   * MIME type of the found data. Will be updated from ClientGetter in onResume(), but we persist it
-   * anyway.
-   */
-  private String foundDataMimeType;
-
-  /** Details of the request failure. */
-  private GetFailedMessage getFailedMessage;
-
-  /** Last progress message. Not persistently, ClientGetter will update on onResume(). */
-  private transient SimpleProgressMessage progressPending;
-
-  /** Have we received a SendingToNetworkEvent? */
-  private boolean sentToNetwork;
-
-  /**
-   * Current compatibility mode. This is updated over time as the request progresses and can be used
-   * e.g., to reinsert the file. This is NOT transient, as the ClientGetter does not retain this
-   * information.
-   */
-  private CompatibilityAnalyser compatMode;
-
-  /**
-   * Expected hashes of the final data. Will be updated from ClientGetter in onResume(), but we
-   * persist it anyway.
-   */
-  private ExpectedHashes expectedHashes;
 
   // Legacy threshold callback removed.
 
@@ -206,9 +171,12 @@ public class ClientGet extends ClientRequest {
      * request pipeline. Unknown codes indicate corrupt persistence data or an incompatible sender
      * and are rejected immediately to avoid ambiguous delivery behavior.
      *
-     * @param x numeric tag emitted by persistent storage or remote clients to decode.
-     * @return matching {@link ReturnType} describing the expected delivery semantics.
-     * @throws IllegalArgumentException if the provided code does not map to a known constant.
+     * <p>This method is pure and has no side effects. It should be used whenever decoding persisted
+     * state or remote inputs so that return-type semantics remain centralized and consistent.
+     *
+     * @param x numeric tag from persistence or FCP messages; expected range 0-3.
+     * @return matching {@link ReturnType} describing the delivery semantics for the code.
+     * @throws IllegalArgumentException if the code is outside the recognized return-type range.
      */
     public static ReturnType getByCode(short x) {
       return switch (x) {
@@ -236,22 +204,23 @@ public class ClientGet extends ClientRequest {
    *   <li>Behavior flags: datastore reachability, filtering, and cache-write preferences.
    * </ul>
    *
-   * @param dsOnly true to confine fetching to the local datastore only.
-   * @param ignoreDS bypasses the datastore entirely when evaluating availability hints.
-   * @param filterData applies MIME filtering before writing or returning data.
-   * @param maxSplitfileRetries maximum block retries for splitfile reconstruction attempts.
-   * @param maxNonSplitfileRetries retry the ceiling for non-splitfile requests before failing.
-   * @param maxOutputLength upper bound in bytes for payload and temporary storage usage.
-   * @param returnType delivery strategy describing whether bytes stream, persist, or skip.
-   * @param persistRebootOnly true to persist only across reboots instead of forever.
-   * @param identifier application-supplied identifier echoed through FCP status events.
-   * @param verbosity bitmask controlling which progress events get forwarded back.
-   * @param prioClass priority class guiding scheduler fairness and bandwidth allocation.
-   * @param returnFilename destination filesystem path used solely when disk output requested.
-   * @param charset legacy charset hint ignored but retained for compatibility logging.
-   * @param writeToClientCache allows writing the payload into the client HTTP cache.
-   * @param realTimeFlag true when the request participates in the realtime scheduler lane.
-   * @param binaryBlob enables BinaryBlob writer semantics instead of classic bucket delivery.
+   * @param dsOnly true to restrict fetches to the local datastore only.
+   * @param ignoreDS true to bypass datastore reads when evaluating availability hints.
+   * @param filterData true to apply content filtering before delivery or disk write.
+   * @param maxSplitfileRetries maximum retry count per splitfile block; must be non-negative.
+   * @param maxNonSplitfileRetries maximum retry count for non-splitfile requests; must be
+   *     non-negative.
+   * @param maxOutputLength maximum bytes allowed for payload and temporary storage.
+   * @param returnType delivery mode describing how payload bytes are surfaced.
+   * @param persistRebootOnly true to persist across reboots, false for forever.
+   * @param identifier caller-supplied identifier echoed in progress and status messages.
+   * @param verbosity bitmask controlling which progress events are emitted.
+   * @param prioClass priority class guiding scheduler ordering and bandwidth share.
+   * @param returnFilename disk destination path used only when ReturnType.DISK applies.
+   * @param charset legacy charset hint; ignored but preserved for compatibility logging.
+   * @param writeToClientCache true to allow writing the payload into the client cache.
+   * @param realTimeFlag true for realtime scheduler lane, false for bulk queue.
+   * @param binaryBlob true to return BinaryBlob output instead of a raw bucket.
    */
   public record GlobalRequestConfig(
       boolean dsOnly,
@@ -271,173 +240,57 @@ public class ClientGet extends ClientRequest {
       boolean realTimeFlag,
       boolean binaryBlob) {}
 
-  /**
-   * Builds a persistent GET request for callers that enqueue work outside live FCP sessions.
-   *
-   * <p>This constructor clones the node's default {@link FetchContext}, wires up event listeners,
-   * normalizes retry limits, and resolves the return path before handing everything to a dedicated
-   * {@link ClientGetter}. It is typically used by built-in services that want their requests to be
-   * restartable across reboots and obey the global queue semantics rather than the per-connection
-   * queue. The supplied {@link GlobalRequestConfig} controls datastore reachability, filtering,
-   * cache writes, and the maximum size of the temporary buckets allocated for the request. The
-   * resulting instance is ready to register and start once constructed.
-   *
-   * @param globalClient persistent client facade owning the global queue slot.
-   * @param uri FreenetURI describing the content key and optional metadata.
-   * @param requestConfig configuration bundle describing retry limits and return handling.
-   * @param core node client core providing factories, permission checks, and trackers.
-   * @throws IdentifierCollisionException identifier already present on the owning persistent
-   *     client.
-   * @throws NotAllowedException download target rejected by DDA or security policy.
-   * @throws IOException filesystem errors while preparing disk buckets or output locations.
-   */
-  public ClientGet(
-      PersistentRequestClient globalClient,
-      FreenetURI uri,
-      GlobalRequestConfig requestConfig,
-      NodeClientCore core)
-      throws IdentifierCollisionException, NotAllowedException, IOException {
-    super(
-        new ClientRequestParams(
-            uri,
-            requestConfig.identifier(),
-            requestConfig.verbosity(),
-            requestConfig.prioClass(),
-            (requestConfig.persistRebootOnly() ? Persistence.REBOOT : Persistence.FOREVER),
-            requestConfig.realTimeFlag(),
-            null,
-            true),
-        null,
-        globalClient);
+  /** Bundles construction inputs to keep request constructors compact. */
+  record ClientGetSetup(
+      FetchContext fetchContext,
+      ClientGetReturnPlanner.ReturnSetup returnSetup,
+      ReturnType returnType,
+      boolean binaryBlob,
+      Bucket initialMetadata,
+      NodeClientCore core) {}
 
-    ensureGlobalIdentifierAvailable(globalClient, requestConfig.identifier());
-    fctx = core.getClientContext().getDefaultPersistentFetchContext();
+  /**
+   * Creates a new request that has already been validated and configured by {@link
+   * ClientGetFactory}.
+   *
+   * <p>Callers are expected to supply an initialized {@link FetchContext}, return routing data, and
+   * any initial metadata buckets. The constructor wires up request state, event listeners, and the
+   * underlying {@link ClientGetter} but performs no validation on the inputs.
+   */
+  ClientGet(ClientRequestParams params, PersistentRequestClient globalClient, ClientGetSetup setup)
+      throws IOException {
+    super(params, null, globalClient);
+    state = new ClientGetState(this);
+    fctx = setup.fetchContext();
     fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
-    fctx.setLocalRequestOnly(requestConfig.dsOnly());
-    fctx.setIgnoreStore(requestConfig.ignoreDS());
-    fctx.setMaxNonSplitfileRetries(requestConfig.maxNonSplitfileRetries());
-    fctx.setMaxSplitfileBlockRetries(requestConfig.maxSplitfileRetries());
-    fctx.setFilterData(requestConfig.filterData());
-    fctx.setMaxOutputLength(requestConfig.maxOutputLength());
-    fctx.setMaxTempLength(requestConfig.maxOutputLength());
-    fctx.setCanWriteClientCache(requestConfig.writeToClientCache());
-    compatMode = new CompatibilityAnalyser();
-    // USK date hints are configured explicitly for FCP messages.
-    this.returnType = requestConfig.returnType();
-    this.binaryBlob = requestConfig.binaryBlob();
-    if (requestConfig.charset() != null && LOG.isDebugEnabled()) {
-      LOG.debug(
-          "Charset parameter is ignored for ClientGet global queue requests: {}",
-          requestConfig.charset());
-    }
-    ClientGetReturnPlanner.ReturnSetup setup =
-        ClientGetGetterFactory.planReturnForGlobal(
-            identifier,
-            global,
-            fctx,
-            returnType,
-            requestConfig.returnFilename(),
-            requestConfig.filterData(),
-            core);
-    Bucket returnBucket = setup.bucket();
-    this.targetFile = setup.targetFile();
-    this.extensionCheck = setup.extension();
-    this.initialMetadata = null;
-    getter = makeGetter(core, returnBucket);
+    this.returnType = setup.returnType();
+    this.binaryBlob = setup.binaryBlob();
+    ClientGetReturnPlanner.ReturnSetup returnSetup = setup.returnSetup();
+    this.targetFile = returnSetup.targetFile();
+    this.extensionCheck = returnSetup.extension();
+    this.initialMetadata = setup.initialMetadata();
+    getter = makeGetter(setup.core(), returnSetup.bucket());
     initHelpers();
   }
 
   /**
-   * Creates a {@code ClientGet} sourced from an incoming {@link ClientGetMessage} on an FCP link.
-   *
-   * <p>This path mirrors the caller's parameters as closely as possible: it validates DDA
-   * permissions, copies {@link FetchContext} overrides, seeds allowed MIME lists, and prepares any
-   * disk buckets before instantiating the {@link ClientGetter}. Identifiers can be scoped either to
-   * the connection or to the global queue, so both handler-level and persistent collision checks
-   * are performed before the request becomes visible to other components. The resulting request is
-   * ready to register and start immediately.
-   *
-   * @param handler connection handler responsible for per-client identifiers and DDA checks.
-   * @param message parsed message containing caller preferences, flags, and return settings.
-   * @param core node client core granting fetch contexts, caches, and permission evaluators.
-   * @throws IdentifierCollisionException identifier already active on this handler or its client.
-   * @throws MessageInvalidException message failed validation or violated configured DDA policies.
+   * Creates a connection-scoped request that has already been validated and configured by {@link
+   * ClientGetFactory}.
    */
-  public ClientGet(FCPConnectionHandler handler, ClientGetMessage message, NodeClientCore core)
-      throws IdentifierCollisionException, MessageInvalidException {
-    super(
-        new ClientRequestParams(
-            message.uri,
-            message.identifier,
-            message.verbosity,
-            message.priorityClass,
-            message.persistence,
-            message.realTimeFlag,
-            message.clientToken,
-            message.global),
-        handler);
-    if (message.persistence == Persistence.CONNECTION) {
-      ensureConnectionIdentifierAvailable(handler, message.identifier);
-    }
-    // Create a Fetcher directly to get more fine-grained control,
-    // since the client may override a few context elements.
-    fctx = core.getClientContext().getDefaultPersistentFetchContext();
+  ClientGet(ClientRequestParams params, FCPConnectionHandler handler, ClientGetSetup setup)
+      throws IOException {
+    super(params, handler);
+    state = new ClientGetState(this);
+    fctx = setup.fetchContext();
     fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
-    // ignoreDS
-    fctx.setLocalRequestOnly(message.dsOnly);
-    fctx.setIgnoreStore(message.ignoreDS);
-    fctx.setMaxNonSplitfileRetries(message.maxRetries);
-    fctx.setMaxSplitfileBlockRetries(message.maxRetries);
-    // Verbosity has already been validated upstream.
-    fctx.setMaxOutputLength(message.maxSize);
-    fctx.setMaxTempLength(message.maxTempSize);
-    fctx.setCanWriteClientCache(message.shouldWriteToClientCache());
-    fctx.setFilterData(message.filterData);
-    fctx.setIgnoreUSKDatehints(message.ignoreUSKDatehints);
-    compatMode = new CompatibilityAnalyser();
-
-    ClientGetGetterFactory.applyAllowedMimeTypes(fctx, message.allowedMIMETypes);
-
-    this.returnType = message.returnType;
-    this.binaryBlob = message.binaryBlob;
-    ClientGetReturnPlanner.ReturnSetup setup =
-        ClientGetGetterFactory.planReturnForMessage(
-            identifier, global, fctx, message, core, handler);
-    Bucket returnBucket = setup.bucket();
-    this.targetFile = setup.targetFile();
-    this.extensionCheck = setup.extension();
-    initialMetadata = message.getInitialMetadata();
-    try {
-      getter = makeGetter(core, returnBucket);
-    } catch (IOException e) {
-      throw bucketCreationFailure(e);
-    }
+    this.returnType = setup.returnType();
+    this.binaryBlob = setup.binaryBlob();
+    ClientGetReturnPlanner.ReturnSetup returnSetup = setup.returnSetup();
+    this.targetFile = returnSetup.targetFile();
+    this.extensionCheck = returnSetup.extension();
+    this.initialMetadata = setup.initialMetadata();
+    getter = makeGetter(setup.core(), returnSetup.bucket());
     initHelpers();
-  }
-
-  private MessageInvalidException bucketCreationFailure(IOException e) {
-    MessageInvalidException mie =
-        new MessageInvalidException(
-            ProtocolErrorMessage.INTERNAL_ERROR,
-            "Cannot create bucket for temporary storage (out of disk space?): " + e,
-            identifier,
-            global);
-    mie.initCause(e);
-    return mie;
-  }
-
-  private void ensureGlobalIdentifierAvailable(PersistentRequestClient client, String identifier)
-      throws IdentifierCollisionException {
-    if (client != null && client.getRequest(identifier) != null) {
-      throw new IdentifierCollisionException();
-    }
-  }
-
-  private void ensureConnectionIdentifierAvailable(FCPConnectionHandler handler, String identifier)
-      throws IdentifierCollisionException {
-    if (handler != null && handler.requestsByIdentifier.containsKey(identifier)) {
-      throw new IdentifierCollisionException();
-    }
   }
 
   private ClientGetter makeGetter(Bucket ret) throws IOException {
@@ -446,6 +299,10 @@ public class ClientGet extends ClientRequest {
 
   private ClientGetter makeGetter(NodeClientCore core, Bucket ret) throws IOException {
     return ClientGetGetterFactory.createGetterForRequest(this, ret, core);
+  }
+
+  ClientGetter makeGetterForPersistence(Bucket ret) throws IOException {
+    return makeGetter(ret);
   }
 
   /**
@@ -460,6 +317,7 @@ public class ClientGet extends ClientRequest {
    */
   protected ClientGet() {
     // For serialization.
+    state = new ClientGetState(this);
     fctx = null;
     getter = null;
     returnType = null;
@@ -479,6 +337,12 @@ public class ClientGet extends ClientRequest {
     if (statusSnapshotBuilder == null) {
       statusSnapshotBuilder = new ClientGetStatusSnapshotBuilder(this);
     }
+    if (restartCoordinator == null) {
+      restartCoordinator = new ClientGetRestartCoordinator(this);
+    }
+    if (statusReporter == null) {
+      statusReporter = new ClientGetStatusReporter(this);
+    }
   }
 
   private ClientGetMessageReplay messageReplay() {
@@ -494,6 +358,44 @@ public class ClientGet extends ClientRequest {
   private ClientGetStatusSnapshotBuilder statusSnapshotBuilder() {
     initHelpers();
     return statusSnapshotBuilder;
+  }
+
+  private ClientGetRestartCoordinator restartCoordinator() {
+    initHelpers();
+    return restartCoordinator;
+  }
+
+  private ClientGetStatusReporter statusReporter() {
+    initHelpers();
+    return statusReporter;
+  }
+
+  ClientGetState state() {
+    return state;
+  }
+
+  Object persistenceLock() {
+    return persistenceLock;
+  }
+
+  /**
+   * Returns the lock that guards shared request lifecycle state.
+   *
+   * <p>The base request class mutates the started and finished flags under this lock, and this
+   * subclass uses the same lock for persistence snapshots and replay data. Using a single lock
+   * establishes a consistent happens-before relationship across lifecycle updates and
+   * serialization. Callers should synchronize only for short, state-centric operations and should
+   * not expose this lock outside the request.
+   *
+   * @return stable lock object shared by base and subclass state transitions.
+   */
+  @Override
+  protected Object requestLock() {
+    return persistenceLock;
+  }
+
+  private static final class PersistenceLock implements Serializable {
+    @Serial private static final long serialVersionUID = 1L;
   }
 
   /**
@@ -539,7 +441,7 @@ public class ClientGet extends ClientRequest {
   @Override
   public void start(ClientContext context) {
     try {
-      synchronized (this) {
+      synchronized (persistenceLock) {
         if (finished) return;
       }
       getter.start(context);
@@ -547,7 +449,7 @@ public class ClientGet extends ClientRequest {
         FCPMessage msg = persistentTagMessage();
         client.queueClientRequestMessage(msg, 0);
       }
-      synchronized (this) {
+      synchronized (persistenceLock) {
         started = true;
       }
       if (client != null) {
@@ -557,12 +459,12 @@ public class ClientGet extends ClientRequest {
         }
       }
     } catch (FetchException e) {
-      synchronized (this) {
+      synchronized (persistenceLock) {
         started = true;
       } // before the failure handler
       onFailure(e);
     } catch (Exception t) {
-      synchronized (this) {
+      synchronized (persistenceLock) {
         started = true;
       }
       onFailure(new FetchException(FetchExceptionMode.INTERNAL_ERROR, t));
@@ -570,7 +472,7 @@ public class ClientGet extends ClientRequest {
   }
 
   private boolean shouldSendPersistentTag() {
-    synchronized (this) {
+    synchronized (persistenceLock) {
       return persistence != Persistence.CONNECTION && !finished;
     }
   }
@@ -737,118 +639,8 @@ public class ClientGet extends ClientRequest {
     super.requestWasRemoved(context);
   }
 
-  synchronized void markSentToNetwork() {
-    sentToNetwork = true;
-  }
-
-  synchronized void recordSplitfileProgress(SimpleProgressMessage message) {
-    progressPending = message;
-  }
-
-  synchronized boolean trySetExpectedHashes(ExpectedHashes message) {
-    if (expectedHashes != null) {
-      LOG.warn("Got a new ExpectedHashes");
-      return false;
-    }
-    expectedHashes = message;
-    return true;
-  }
-
-  synchronized void recordExpectedMimeType(String mimeType) {
-    foundDataMimeType = mimeType;
-  }
-
-  synchronized void recordExpectedDataLength(long length) {
-    foundDataLength = length;
-  }
-
-  void mergeCompatibilityMode(
-      InsertContext.CompatibilityMode minCompatibilityMode,
-      InsertContext.CompatibilityMode maxCompatibilityMode,
-      byte[] splitfileCryptoKey,
-      boolean dontCompress,
-      boolean bottomLayer) {
-    compatMode.merge(
-        minCompatibilityMode, maxCompatibilityMode, splitfileCryptoKey, dontCompress, bottomLayer);
-    if (client != null) {
-      RequestStatusCache cache = client.getRequestStatusCache();
-      if (cache != null) {
-        cache.updateDetectedCompatModes(
-            identifier,
-            compatMode.getModes(),
-            compatMode.getCryptoKey(),
-            compatMode.dontCompress());
-      }
-    }
-    if ((verbosity & VERBOSITY_COMPATIBILITY_MODE) != 0) {
-      queueProgressMessageInner(
-          new CompatibilityMode(identifier, global, compatMode), VERBOSITY_COMPATIBILITY_MODE);
-    }
-  }
-
   ReturnType returnTypeForReplay() {
     return returnType;
-  }
-
-  Bucket returnBucketDirectForReplay() {
-    return returnBucketDirect;
-  }
-
-  void setReturnBucketDirect(Bucket bucket) {
-    returnBucketDirect = bucket;
-  }
-
-  boolean hasSucceededForReplay() {
-    return succeeded;
-  }
-
-  void setSucceeded(boolean succeeded) {
-    this.succeeded = succeeded;
-  }
-
-  long foundDataLengthForReplay() {
-    return foundDataLength;
-  }
-
-  void setFoundDataLength(long foundDataLength) {
-    this.foundDataLength = foundDataLength;
-  }
-
-  String foundDataMimeTypeForReplay() {
-    return foundDataMimeType;
-  }
-
-  void setFoundDataMimeType(String foundDataMimeType) {
-    this.foundDataMimeType = foundDataMimeType;
-  }
-
-  SimpleProgressMessage progressPendingForReplay() {
-    return progressPending;
-  }
-
-  @SuppressWarnings("SameParameterValue")
-  void setProgressPending(SimpleProgressMessage progressPending) {
-    this.progressPending = progressPending;
-  }
-
-  boolean sentToNetworkForReplay() {
-    return sentToNetwork;
-  }
-
-  CompatibilityAnalyser compatModeForReplay() {
-    return compatMode;
-  }
-
-  ExpectedHashes expectedHashesForReplay() {
-    return expectedHashes;
-  }
-
-  GetFailedMessage getFailedMessageForReplay() {
-    return getFailedMessage;
-  }
-
-  void setFailedMessage(GetFailedMessage message) {
-    getFailedMessage = message;
   }
 
   File targetFileForLifecycle() {
@@ -882,12 +674,11 @@ public class ClientGet extends ClientRequest {
   protected void freeData() {
     // We don't remove the data if written to a file.
     Bucket data;
-    synchronized (this) {
-      data = returnBucketDirect;
-      returnBucketDirect = null;
+    synchronized (persistenceLock) {
+      data = state.takeReturnBucketDirect();
     }
     if (data != null) {
-      data.free();
+      data.close();
     }
     if (initialMetadata != null) initialMetadata.free();
   }
@@ -908,7 +699,7 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   public boolean hasSucceeded() {
-    return succeeded;
+    return state.hasSucceeded();
   }
 
   /**
@@ -961,7 +752,7 @@ public class ClientGet extends ClientRequest {
   /**
    * Exposes the fetch context for package-local helpers.
    *
-   * @return live {@link FetchContext} backing this request.
+   * @return live {@link FetchContext} backing this request for internal helper access.
    */
   FetchContext fetchContextForGetter() {
     return fctx;
@@ -970,7 +761,7 @@ public class ClientGet extends ClientRequest {
   /**
    * Exposes the metadata bucket associated with this request.
    *
-   * @return initial metadata bucket, or {@code null} when unset.
+   * @return initial metadata bucket, or {@code null} when no metadata is provided.
    */
   Bucket initialMetadataBucket() {
     return initialMetadata;
@@ -988,7 +779,7 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the configured delivery strategy for the request.
    *
-   * @return configured {@link ReturnType} for result delivery.
+   * @return configured {@link ReturnType} used to decide how results are delivered.
    */
   ReturnType returnTypeForGetter() {
     return returnType;
@@ -997,7 +788,7 @@ public class ClientGet extends ClientRequest {
   /**
    * Indicates whether Binary Blob recording is enabled for this request.
    *
-   * @return {@code true} when Binary Blob output is expected.
+   * @return {@code true} when Binary Blob output is expected for this request.
    */
   boolean binaryBlobRequested() {
     return binaryBlob;
@@ -1017,7 +808,7 @@ public class ClientGet extends ClientRequest {
    * @return recorded payload length in bytes, or {@code -1} when unknown.
    */
   public long getDataSize() {
-    if (foundDataLength > 0) return foundDataLength;
+    if (state.getFoundDataLength() > 0) return state.getFoundDataLength();
     return -1;
   }
 
@@ -1035,7 +826,7 @@ public class ClientGet extends ClientRequest {
    * @return MIME type reported for the payload, or {@code null} if undetermined.
    */
   public String getMIMEType() {
-    if (foundDataMimeType != null) return foundDataMimeType;
+    if (state.getFoundDataMimeType() != null) return state.getFoundDataMimeType();
     return null;
   }
 
@@ -1058,18 +849,16 @@ public class ClientGet extends ClientRequest {
   /**
    * Returns the fraction of splitfile blocks downloaded successfully.
    *
-   * <p>The metric reflects the most recent {@code SplitfileProgressEvent} cached via {@link
-   * #progressPending}, making it useful for dashboards that prefer percentages to raw block counts.
-   * When no progress has been recorded it returns {@code -1} to signal an unknown fraction. The
-   * value is a snapshot and may lag behind the underlying fetcher in highly concurrent flows.
+   * <p>The metric reflects the most recent {@code SplitfileProgressEvent} cached by the request,
+   * making it useful for dashboards that prefer percentages to raw block counts. When no progress
+   * has been recorded it returns {@code -1} to signal an unknown fraction. The value is a snapshot
+   * and may lag behind the underlying fetcher in highly concurrent flows.
    *
    * @return value between {@code 0.0} and {@code 1.0}, or {@code -1} when unavailable.
    */
   @Override
   public double getSuccessFraction() {
-    if (progressPending != null) {
-      return progressPending.getFraction();
-    } else return -1;
+    return statusReporter().getSuccessFraction();
   }
 
   /**
@@ -1083,9 +872,7 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   public double getTotalBlocks() {
-    if (progressPending != null) {
-      return progressPending.getTotalBlocks();
-    } else return 1;
+    return statusReporter().getTotalBlocks();
   }
 
   /**
@@ -1099,9 +886,7 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   public double getMinBlocks() {
-    if (progressPending != null) {
-      return progressPending.getMinBlocks();
-    } else return 1;
+    return statusReporter().getMinBlocks();
   }
 
   /**
@@ -1115,9 +900,7 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   public double getFailedBlocks() {
-    if (progressPending != null) {
-      return progressPending.getFailedBlocks();
-    } else return 0;
+    return statusReporter().getFailedBlocks();
   }
 
   /**
@@ -1131,9 +914,7 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   public double getFatalyFailedBlocks() {
-    if (progressPending != null) {
-      return progressPending.getFatalyFailedBlocks();
-    } else return 0;
+    return statusReporter().getFatalyFailedBlocks();
   }
 
   /**
@@ -1148,9 +929,7 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   public double getFetchedBlocks() {
-    if (progressPending != null) {
-      return progressPending.getFetchedBlocks();
-    } else return 0;
+    return statusReporter().getFetchedBlocks();
   }
 
   /**
@@ -1164,7 +943,7 @@ public class ClientGet extends ClientRequest {
    * @return array of compatibility modes; may be empty but never {@code null}.
    */
   public InsertContext.CompatibilityMode[] getCompatibilityMode() {
-    return compatMode.getModes();
+    return state.getCompatibilityMode();
   }
 
   /**
@@ -1179,7 +958,7 @@ public class ClientGet extends ClientRequest {
    * @return {@code true} when compression should not be applied to later insert contexts.
    */
   public boolean getDontCompress() {
-    return compatMode.dontCompress();
+    return state.getDontCompress();
   }
 
   /**
@@ -1192,7 +971,7 @@ public class ClientGet extends ClientRequest {
    * @return copy of the crypto key bytes, or {@code null} when no override was observed.
    */
   public byte[] getOverriddenSplitfileCryptoKey() {
-    return compatMode.getCryptoKey();
+    return state.getOverriddenSplitfileCryptoKey();
   }
 
   /**
@@ -1211,16 +990,11 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   public String getFailureReason(boolean longDescription) {
-    if (getFailedMessage == null) return null;
-    String s = getFailedMessage.getShortFailedMessage();
-    if (longDescription && getFailedMessage.extraDescription != null)
-      s += ": " + getFailedMessage.extraDescription;
-    return s;
+    return statusReporter().getFailureReason(longDescription);
   }
 
   GetFailedMessage getFailureMessage() {
-    if (getFailedMessage == null) return null;
-    return getFailedMessage;
+    return state.getFailedMessage();
   }
 
   /**
@@ -1236,8 +1010,7 @@ public class ClientGet extends ClientRequest {
    * @return failure classification mode, or {@code null} when no failure exists.
    */
   public FetchExceptionMode getFailureReasonCode() {
-    if (getFailedMessage == null) return null;
-    return getFailedMessage.failureMode;
+    return statusReporter().getFailureReasonCode();
   }
 
   /**
@@ -1254,11 +1027,7 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   public boolean isTotalFinalized() {
-    if (finished && succeeded) return true;
-    if (progressPending == null) return false;
-    else {
-      return progressPending.isTotalFinalized();
-    }
+    return statusReporter().isTotalFinalized();
   }
 
   /**
@@ -1277,11 +1046,11 @@ public class ClientGet extends ClientRequest {
     return makeBucket(true);
   }
 
-  private Bucket makeBucket(boolean readOnly) {
+  Bucket makeBucket(boolean readOnly) {
     return switch (returnType) {
       case DIRECT -> {
-        synchronized (this) {
-          yield returnBucketDirect;
+        synchronized (persistenceLock) {
+          yield state.getReturnBucketDirect();
         }
       }
       case DISK -> ClientGetGetterFactory.diskBucket(targetFile, readOnly);
@@ -1300,19 +1069,11 @@ public class ClientGet extends ClientRequest {
    * <p>This method does not modify the state; it is intended for UI or scheduler decisions before
    * initiating a restart.
    *
-   * @return {@code true} when {@link #restart(ClientContext, boolean)} may be invoked.
+   * @return {@code true} when the request is finished, failed, and restartable.
    */
   @Override
   public boolean canRestart() {
-    if (!finished) {
-      LOG.debug("Cannot restart because not finished for {}", identifier);
-      return false;
-    }
-    if (succeeded) {
-      LOG.debug("Cannot restart because succeeded for {}", identifier);
-      return false;
-    }
-    return getter.canRestart();
+    return restartCoordinator().canRestart();
   }
 
   /**
@@ -1329,68 +1090,11 @@ public class ClientGet extends ClientRequest {
    *
    * @param context client context providing schedulers and bucket factories for restart logic.
    * @param disableFilterData {@code true} to disable filtering for the next attempt.
-   * @return {@code true} when the restart was initiated successfully.
+   * @return {@code true} when the restart is accepted and scheduled by the getter.
    */
   @Override
   public boolean restart(ClientContext context, final boolean disableFilterData) {
-    if (!canRestart()) return false;
-    FreenetURI redirect = resetStateForRestart(disableFilterData);
-    notifyCacheAboutRedirect(redirect);
-    try {
-      if (getter.restart(redirect, fctx.getFilterData(), context)) {
-        markRestarted(redirect);
-      }
-      notifyCacheStartedFlag();
-      return true;
-    } catch (FetchException e) {
-      onFailure(e);
-      return false;
-    }
-  }
-
-  private FreenetURI resetStateForRestart(boolean disableFilterData) {
-    synchronized (this) {
-      finished = false;
-      FreenetURI redirect = getFailedMessage == null ? null : getFailedMessage.redirectURI;
-      getFailedMessage = null;
-      progressPending = null;
-      compatMode = new CompatibilityAnalyser();
-      expectedHashes = null;
-      started = false;
-      if (disableFilterData) {
-        fctx.setFilterData(false);
-      }
-      return redirect;
-    }
-  }
-
-  private void markRestarted(FreenetURI redirect) {
-    synchronized (this) {
-      if (redirect != null) {
-        this.uri = redirect;
-      }
-      started = true;
-    }
-  }
-
-  private void notifyCacheAboutRedirect(FreenetURI redirect) {
-    if (client == null) {
-      return;
-    }
-    RequestStatusCache cache = client.getRequestStatusCache();
-    if (cache != null) {
-      cache.updateStarted(identifier, redirect);
-    }
-  }
-
-  private void notifyCacheStartedFlag() {
-    if (client == null) {
-      return;
-    }
-    RequestStatusCache cache = client.getRequestStatusCache();
-    if (cache != null) {
-      cache.updateStarted(identifier, true);
-    }
+    return restartCoordinator().restart(context, disableFilterData);
   }
 
   /**
@@ -1405,10 +1109,10 @@ public class ClientGet extends ClientRequest {
    *
    * <p>Callers should treat the result as a hint rather than a definitive redirect requirement.
    *
-   * @return {@code true} when {@link GetFailedMessage#redirectURI} is non-null.
+   * @return {@code true} when a permanent redirect URI is stored in failure state.
    */
   public synchronized boolean hasPermRedirect() {
-    return getFailedMessage != null && getFailedMessage.redirectURI != null;
+    return restartCoordinator().hasPermRedirect();
   }
 
   /**
@@ -1429,29 +1133,11 @@ public class ClientGet extends ClientRequest {
   }
 
   @Override
-  synchronized RequestStatus getStatus() {
-    RequestStatusSnapshot statusSnapshot =
-        ClientGetStatusSnapshot.buildRequestStatusSnapshot(
-            identifier, persistence, started, finished, succeeded, progressPending, priorityClass);
-    DownloadProgressSnapshot progressSnapshot =
-        new DownloadProgressSnapshot(progressPending, getFailedMessage);
-    DownloadDataSnapshot dataSnapshot =
-        new DownloadDataSnapshot(
-            foundDataMimeType, foundDataLength, getDestFilename(), getBucket());
-    DownloadContextSnapshot contextSnapshot =
-        new DownloadContextSnapshot(
-            fctx,
-            getCompatibilityMode(),
-            getOverriddenSplitfileCryptoKey(),
-            getURI(),
-            getDontCompress());
-    return ClientGetGetterFactory.buildStatus(
-        new ClientGetStatusSnapshot(
-            statusSnapshot, progressSnapshot, dataSnapshot, contextSnapshot));
+  RequestStatus getStatus() {
+    synchronized (persistenceLock()) {
+      return statusReporter().getStatus();
+    }
   }
-
-  private static final long CLIENT_DETAIL_MAGIC = 0x67145b675d2e22f4L;
-  private static final int CLIENT_DETAIL_VERSION = 1;
 
   /**
    * Serializes the request state for persistence so that it can be resumed later.
@@ -1462,8 +1148,8 @@ public class ClientGet extends ClientRequest {
    * so restarts can resume without re-downloading already verified blocks. Callers should provide a
    * stream already framed by the persistence layer.
    *
-   * <p>The serialization format is versioned; if it changes, the version constants in this class
-   * must be updated in lockstep with the restore logic.
+   * <p>The serialization format is versioned; if it changes, the version constants in {@link
+   * ClientGetPersistenceCodec} must be updated in lockstep with the restore logic.
    *
    * @param dos destination stream receiving the serialized form with checksums embedded.
    * @param checker checksum helper that wraps streams to guard against corruption.
@@ -1473,61 +1159,7 @@ public class ClientGet extends ClientRequest {
   public void getClientDetail(DataOutputStream dos, ChecksumChecker checker) throws IOException {
     if (persistence != Persistence.FOREVER) return;
     super.getClientDetail(dos, checker);
-    dos.writeLong(CLIENT_DETAIL_MAGIC);
-    dos.writeInt(CLIENT_DETAIL_VERSION);
-    dos.writeUTF(uri.toString());
-    // Basic details needed for restarting the request.
-    dos.writeShort(returnType.code);
-    if (returnType == ReturnType.DISK) {
-      dos.writeUTF(targetFile.toString());
-    }
-    dos.writeBoolean(binaryBlob);
-    try (DataOutputStream ctxStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
-      fctx.writeTo(ctxStream);
-    }
-    if (extensionCheck != null) {
-      dos.writeBoolean(true);
-      dos.writeUTF(extensionCheck);
-    } else {
-      dos.writeBoolean(false);
-    }
-    if (initialMetadata != null) {
-      dos.writeBoolean(true);
-      try (DataOutputStream metadataStream =
-          ClientGetGetterFactory.checksummedWriter(dos, checker)) {
-        initialMetadata.storeTo(metadataStream);
-      }
-    } else {
-      dos.writeBoolean(false);
-    }
-    synchronized (this) {
-      if (finished) {
-        dos.writeBoolean(succeeded);
-        writeTransientProgressFields(dos);
-        if (succeeded) {
-          if (returnType == ReturnType.DIRECT) {
-            try (DataOutputStream bucketStream =
-                ClientGetGetterFactory.checksummedWriter(dos, checker)) {
-              returnBucketDirect.storeTo(bucketStream);
-            }
-          }
-        } else {
-          try (DataOutputStream failureStream =
-              ClientGetGetterFactory.checksummedWriter(dos, checker)) {
-            getFailedMessage.writeTo(failureStream);
-          }
-        }
-        return;
-      }
-    }
-    // Not finished, or was recently not finished.
-    // Don't hold the lock while calling getter.
-    // If it's just finished, we get a race and restart. That's okay.
-    try (DataOutputStream progressStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
-      if (getter.writeTrivialProgress(progressStream)) {
-        writeTransientProgressFields(progressStream);
-      }
-    }
+    ClientGetPersistenceCodec.writeClientDetail(this, dos, checker);
   }
 
   /**
@@ -1545,134 +1177,45 @@ public class ClientGet extends ClientRequest {
    * @param reqID identifier tuple describing the owner and reference type.
    * @param context client context supplying factories used during restoration.
    * @param checker checksum helper verifying the integrity of embedded buckets.
-   * @return fully reconstructed {@link ClientRequest} instance ready for resumption.
+   * @return fully reconstructed {@link ClientRequest} instance ready for registration and
+   *     resumption.
    * @throws StorageFormatException when serialized data fails validation or version checks.
    * @throws IOException when stream IO fails while reading buckets or metadata.
    * @throws ResumeFailedException when the request must restart due to inconsistencies.
    */
+  @SuppressWarnings("unused")
   public static ClientRequest restartFrom(
       DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
       throws StorageFormatException, IOException, ResumeFailedException {
-    return new ClientGet(dis, reqID, context, checker);
+    return ClientGetPersistenceCodec.restartFrom(dis, reqID, context, checker);
   }
 
-  private ClientGet(
+  ClientGet(
       DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
       throws IOException, StorageFormatException, ResumeFailedException {
     super(dis, reqID, context);
-    validateClientDetailHeader(dis);
-    uri = parseUri(dis.readUTF());
-    returnType = parseReturnType(dis.readShort());
-    targetFile = returnType == ReturnType.DISK ? new File(dis.readUTF()) : null;
-    binaryBlob = dis.readBoolean();
-    this.fctx = ClientGetGetterFactory.readFetchContextOrDefault(dis, context, checker);
-    fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
-    extensionCheck = dis.readBoolean() ? dis.readUTF() : null;
-    initialMetadata = ClientGetGetterFactory.readInitialMetadata(dis, context, checker);
-    ClientGetter restoredGetter = restoreState(dis, reqID, context, checker);
-    if (compatMode == null) {
-      compatMode = new CompatibilityAnalyser();
-    }
+    state = new ClientGetState(this);
+    ClientGetPersistenceCodec.BasicRestoreData restoreData =
+        ClientGetPersistenceCodec.readBasicRestoreData(this, dis, context, checker);
+    uri = restoreData.uri();
+    returnType = restoreData.returnType();
+    targetFile = restoreData.targetFile();
+    binaryBlob = restoreData.binaryBlob();
+    fctx = restoreData.fetchContext();
+    extensionCheck = restoreData.extensionCheck();
+    initialMetadata = restoreData.initialMetadata();
+    ClientGetter restoredGetter =
+        ClientGetPersistenceCodec.restoreState(this, dis, reqID, context, checker);
+    state.ensureCompatibilityMode();
     if (restoredGetter == null) {
-      restoredGetter = makeGetter(makeBucket(false));
+      restoredGetter = makeGetterForPersistence(makeBucket(false));
     }
-    this.getter = restoredGetter;
+    getter = restoredGetter;
     initHelpers();
   }
 
-  private void validateClientDetailHeader(DataInputStream dis)
-      throws IOException, StorageFormatException {
-    long magic = dis.readLong();
-    if (magic != CLIENT_DETAIL_MAGIC) {
-      throw new StorageFormatException("Bad magic for request");
-    }
-    int version = dis.readInt();
-    if (version != CLIENT_DETAIL_VERSION) {
-      throw new StorageFormatException("Bad version " + version);
-    }
-  }
-
-  private FreenetURI parseUri(String serializedUri) throws StorageFormatException {
-    try {
-      return new FreenetURI(serializedUri);
-    } catch (Exception _) {
-      throw new StorageFormatException("Bad URI");
-    }
-  }
-
-  private ReturnType parseReturnType(short code) throws StorageFormatException {
-    try {
-      return ReturnType.getByCode(code);
-    } catch (IllegalArgumentException _) {
-      throw new StorageFormatException("Bad return type " + code);
-    }
-  }
-
-  private ClientGetter restoreState(
-      DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
-      throws IOException, StorageFormatException, ResumeFailedException {
-    if (finished) {
-      restoreFinishedState(dis, reqID, context, checker);
-      return null;
-    }
-    ClientGetter inProgressGetter = makeGetter(makeBucket(false));
-    ClientGetGetterFactory.restoreInProgressState(dis, context, checker, inProgressGetter, this);
-    return inProgressGetter;
-  }
-
-  private void restoreFinishedState(
-      DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
-      throws IOException, StorageFormatException, ResumeFailedException {
-    succeeded = dis.readBoolean();
-    readTransientProgressFields(dis);
-    if (succeeded) {
-      if (returnType == ReturnType.DIRECT) {
-        Bucket restoredBucket =
-            ClientGetGetterFactory.restoreCompletedDirectBucketOrNull(dis, context, checker);
-        if (restoredBucket != null) {
-          returnBucketDirect = restoredBucket;
-        } else {
-          returnBucketDirect = null;
-          succeeded = false;
-          finished = false;
-        }
-      }
-    } else {
-      GetFailedMessage restoredMessage =
-          ClientGetGetterFactory.restoreFailureMessageOrNull(
-              dis, reqID, foundDataLength, foundDataMimeType, context, checker);
-      if (restoredMessage != null) {
-        getFailedMessage = restoredMessage;
-        started = true;
-      } else {
-        finished = false;
-        getFailedMessage = null;
-      }
-    }
-  }
-
-  void readTransientProgressFields(DataInputStream dis) throws IOException, StorageFormatException {
-    foundDataLength = dis.readLong();
-    if (dis.readBoolean()) foundDataMimeType = dis.readUTF();
-    else foundDataMimeType = null;
-    compatMode = new CompatibilityAnalyser(dis);
-    expectedHashes = ClientGetGetterFactory.readExpectedHashes(dis, identifier, global);
-  }
-
-  private synchronized void writeTransientProgressFields(DataOutputStream dos) throws IOException {
-    dos.writeLong(foundDataLength);
-    if (foundDataMimeType != null) {
-      dos.writeBoolean(true);
-      dos.writeUTF(foundDataMimeType);
-    } else {
-      dos.writeBoolean(false);
-    }
-    compatMode.writeTo(dos);
-    ClientGetGetterFactory.writeExpectedHashes(dos, expectedHashes);
-  }
-
   /**
-   * Rehydrates transient state after a persistent resume has restored core fields.
+   * Rehydrates transient state after a persistent resuming has restored core fields.
    *
    * <p>This hook is invoked by the base resume flow once serialization has recreated the request
    * and the {@link ClientGetter}. It forwards the resume signal to any retained buckets and then
@@ -1687,11 +1230,11 @@ public class ClientGet extends ClientRequest {
    */
   @Override
   protected void innerResume(ClientContext context) throws ResumeFailedException {
-    if (returnBucketDirect != null) returnBucketDirect.onResume(context);
+    if (state.getReturnBucketDirect() != null) state.getReturnBucketDirect().onResume(context);
     if (initialMetadata != null) initialMetadata.onResume(context);
     // We might already have these if we've just restored.
-    if (foundDataLength <= 0) this.foundDataLength = getter.expectedSize();
-    if (foundDataMimeType == null) this.foundDataMimeType = getter.expectedMIME();
+    if (state.getFoundDataLength() <= 0) state.setFoundDataLength(getter.expectedSize());
+    if (state.getFoundDataMimeType() == null) state.setFoundDataMimeType(getter.expectedMIME());
   }
 
   @Override
@@ -1709,7 +1252,7 @@ public class ClientGet extends ClientRequest {
    *
    * <p>The method has no side effects and should be safe to call repeatedly.
    *
-   * @return {@code true} when {@link ClientGetter#resumedFetcher()} confirms a valid resume.
+   * @return {@code true} when the getter reports a valid, fully resumed fetcher.
    */
   @Override
   public boolean fullyResumed() {
@@ -1722,6 +1265,10 @@ public class ClientGet extends ClientRequest {
    * <p>Equality is defined by {@link ClientRequest} and typically reflects request identity rather
    * than mutable progress state. This override exists to preserve the base semantics while keeping
    * the contract explicit in this subtype. The comparison is side-effect-free.
+   *
+   * <p>Because the result is identity-based, two requests with identical progress snapshots may
+   * still compare as unequal. This method does not synchronize; callers that need a stable view of
+   * the mutable state should take a snapshot under the request lock separately.
    *
    * @param obj object to compare against, possibly {@code null}.
    * @return {@code true} when the base implementation considers the objects equal.
@@ -1738,7 +1285,11 @@ public class ClientGet extends ClientRequest {
    * incorporate mutable progress state. This makes the value suitable for hash-based collections
    * that store requests by identity. The computation has no side effects.
    *
-   * @return hash code derived from {@link ClientRequest} identity fields.
+   * <p>Callers should not cache the value across serialization boundaries unless the identifier is
+   * known to remain constant. The method avoids synchronization because identity fields are
+   * immutable after construction.
+   *
+   * @return hash code derived from {@link ClientRequest} identity fields and stability rules.
    */
   @Override
   public int hashCode() {

--- a/src/main/java/network/crypta/clients/fcp/ClientGetEventHandling.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetEventHandling.java
@@ -59,7 +59,9 @@ final class ClientGetEventHandling implements ClientEventListener {
       return handleSplitfileProgress(progressEvent);
     }
     if (event instanceof SendingToNetworkEvent) {
-      request.markSentToNetwork();
+      synchronized (request.persistenceLock()) {
+        request.state().markSentToNetwork();
+      }
       return new EventProgress(
           new SendingToNetworkMessage(request.identifier, request.global),
           ClientGet.VERBOSITY_SENT_TO_NETWORK);
@@ -85,7 +87,9 @@ final class ClientGetEventHandling implements ClientEventListener {
   private EventProgress handleSplitfileProgress(SplitfileProgressEvent event) {
     SimpleProgressMessage message =
         new SimpleProgressMessage(request.identifier, request.global, event);
-    request.recordSplitfileProgress(message);
+    synchronized (request.persistenceLock()) {
+      request.state().setProgressPending(message);
+    }
     if (request.client != null) {
       RequestStatusCache cache = request.client.getRequestStatusCache();
       if (cache != null) {
@@ -97,14 +101,20 @@ final class ClientGetEventHandling implements ClientEventListener {
 
   private EventProgress handleExpectedHashes(ExpectedHashesEvent event) {
     ExpectedHashes hashes = new ExpectedHashes(event, request.identifier, request.global);
-    if (!request.trySetExpectedHashes(hashes)) {
+    boolean accepted;
+    synchronized (request.persistenceLock()) {
+      accepted = request.state().trySetExpectedHashes(hashes);
+    }
+    if (!accepted) {
       return null;
     }
     return new EventProgress(hashes, ClientGet.VERBOSITY_EXPECTED_HASHES);
   }
 
   private EventProgress handleExpectedMime(ExpectedMIMEEvent event) {
-    request.recordExpectedMimeType(event.expectedMIMEType);
+    synchronized (request.persistenceLock()) {
+      request.state().setFoundDataMimeType(event.expectedMIMEType);
+    }
     if (request.client != null) {
       RequestStatusCache cache = request.client.getRequestStatusCache();
       if (cache != null) {
@@ -117,7 +127,9 @@ final class ClientGetEventHandling implements ClientEventListener {
   }
 
   private EventProgress handleExpectedSize(ExpectedFileSizeEvent event) {
-    request.recordExpectedDataLength(event.expectedSize);
+    synchronized (request.persistenceLock()) {
+      request.state().setFoundDataLength(event.expectedSize);
+    }
     if (request.client != null) {
       RequestStatusCache cache = request.client.getRequestStatusCache();
       if (cache != null) {
@@ -136,12 +148,16 @@ final class ClientGetEventHandling implements ClientEventListener {
         context.jobRunner.queue(
             (PersistentJob)
                 _ -> {
-                  request.mergeCompatibilityMode(
-                      event.minCompatibilityMode,
-                      event.maxCompatibilityMode,
-                      event.splitfileCryptoKey,
-                      event.dontCompress,
-                      event.bottomLayer);
+                  synchronized (request.persistenceLock()) {
+                    request
+                        .state()
+                        .mergeCompatibilityMode(
+                            event.minCompatibilityMode,
+                            event.maxCompatibilityMode,
+                            event.splitfileCryptoKey,
+                            event.dontCompress,
+                            event.bottomLayer);
+                  }
                   return false;
                 },
             NativeThread.PriorityLevel.HIGH_PRIORITY.value);
@@ -149,12 +165,16 @@ final class ClientGetEventHandling implements ClientEventListener {
         // Not much we can do.
       }
     } else {
-      request.mergeCompatibilityMode(
-          event.minCompatibilityMode,
-          event.maxCompatibilityMode,
-          event.splitfileCryptoKey,
-          event.dontCompress,
-          event.bottomLayer);
+      synchronized (request.persistenceLock()) {
+        request
+            .state()
+            .mergeCompatibilityMode(
+                event.minCompatibilityMode,
+                event.maxCompatibilityMode,
+                event.splitfileCryptoKey,
+                event.dontCompress,
+                event.bottomLayer);
+      }
     }
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
@@ -1,0 +1,262 @@
+package network.crypta.clients.fcp;
+
+import java.io.IOException;
+import network.crypta.client.FetchContext;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.api.Bucket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Builds fully configured {@link ClientGet} instances from FCP inputs.
+ *
+ * <p>The factory performs the deterministic wiring for GET requests: it validates identifiers,
+ * assembles an appropriate {@link FetchContext}, plans return handling, and packages everything
+ * into a {@link ClientGet.ClientGetSetup}. Callers use the resulting request object for
+ * registration and execution; the factory does not start or enqueue the request itself. Because it
+ * is stateless and uses only local variables, the class is thread-safe and can be called
+ * concurrently.
+ *
+ * <p>The factory is intentionally conservative about side effects: it only logs ignored parameters
+ * (such as a legacy charset hint) and throws explicit exceptions for identifier collisions or
+ * invalid return targets. This makes it suitable for both connection-scoped requests and global
+ * queue requests where persistence and DDA checks are required.
+ *
+ * <ul>
+ *   <li><strong>Validation</strong>: checks identifier uniqueness in the appropriate scope.
+ *   <li><strong>Context setup</strong>: clones and adjusts a persistent {@link FetchContext}.
+ *   <li><strong>Return planning</strong>: resolves disk/bucket targets and metadata buckets.
+ * </ul>
+ *
+ * @see ClientGet
+ * @see ClientGetMessage
+ * @see ClientGetReturnPlanner
+ */
+final class ClientGetFactory {
+  /** Logger for configuration-related diagnostics during request construction. */
+  private static final Logger LOG = LoggerFactory.getLogger(ClientGetFactory.class);
+
+  /** Prevents instantiation; this class exposes only static factory helpers. */
+  private ClientGetFactory() {}
+
+  /**
+   * Creates a persistent, global-queue {@link ClientGet} from a validated configuration.
+   *
+   * <p>The method derives a persistent {@link FetchContext} from the node core, applies the
+   * configuration's limits and flags, and plans the return path according to {@link
+   * ClientGet.ReturnType}. It then constructs a {@link ClientGet} instance without starting it. The
+   * returned request is ready to be registered with a persistent client and subsequently started.
+   *
+   * <p>This factory is strict about identifier collisions and output policy. It will throw if the
+   * identifier is already in use or if disk output is disallowed by the configured DDA policy.
+   *
+   * @param globalClient persistent client used for global-queue ownership and id checks.
+   * @param uri target {@link FreenetURI} describing the key to fetch; must be non-null.
+   * @param requestConfig immutable configuration with limits, flags, and return preferences.
+   * @param core node core providing fetch contexts, planners, and bucket factories.
+   * @return configured {@link ClientGet} instance ready for registration and start.
+   * @throws IdentifierCollisionException if the identifier is already registered globally.
+   * @throws NotAllowedException if disk output violates policy or DDA restrictions.
+   * @throws IOException if bucket or file initialization fails during setup.
+   */
+  static ClientGet fromGlobal(
+      PersistentRequestClient globalClient,
+      FreenetURI uri,
+      ClientGet.GlobalRequestConfig requestConfig,
+      NodeClientCore core)
+      throws IdentifierCollisionException, NotAllowedException, IOException {
+    ensureGlobalIdentifierAvailable(globalClient, requestConfig.identifier());
+    FetchContext fctx = buildFetchContextForGlobal(core, requestConfig);
+    if (requestConfig.charset() != null && LOG.isDebugEnabled()) {
+      LOG.debug(
+          "Charset parameter is ignored for ClientGet global queue requests: {}",
+          requestConfig.charset());
+    }
+    ClientGetReturnPlanner.ReturnSetup returnSetup =
+        ClientGetGetterFactory.planReturnForGlobal(
+            requestConfig.identifier(),
+            true,
+            fctx,
+            requestConfig.returnType(),
+            requestConfig.returnFilename(),
+            requestConfig.filterData(),
+            core);
+    ClientRequestParams params =
+        new ClientRequestParams(
+            uri,
+            requestConfig.identifier(),
+            requestConfig.verbosity(),
+            requestConfig.prioClass(),
+            (requestConfig.persistRebootOnly()
+                ? ClientRequest.Persistence.REBOOT
+                : ClientRequest.Persistence.FOREVER),
+            requestConfig.realTimeFlag(),
+            null,
+            true);
+    ClientGet.ClientGetSetup requestSetup =
+        new ClientGet.ClientGetSetup(
+            fctx, returnSetup, requestConfig.returnType(), requestConfig.binaryBlob(), null, core);
+    return new ClientGet(params, globalClient, requestSetup);
+  }
+
+  /**
+   * Creates a connection-scoped or global {@link ClientGet} from a parsed FCP message.
+   *
+   * <p>The method constructs request parameters from the message, validates identifier scope, and
+   * applies message-specific fetch context overrides. It also resolves any requested return targets
+   * and optional initial metadata buckets. The request is returned in a configured but not started
+   * state, so the caller can register it and schedule execution explicitly.
+   *
+   * <p>Any bucket creation failures are wrapped into a {@link MessageInvalidException} with an
+   * internal-error code to match FCP error reporting expectations.
+   *
+   * @param handler connection handler supplying scope checks and DDA enforcement hooks.
+   * @param message parsed FCP GET message containing identifiers, flags, and limits.
+   * @param core node core providing contexts, planners, and bucket factories.
+   * @return configured {@link ClientGet} instance ready for registration and start.
+   * @throws IdentifierCollisionException if the identifier is already used in scope.
+   * @throws MessageInvalidException if validation fails or bucket setup throws I/O errors.
+   */
+  static ClientGet fromMessage(
+      FCPConnectionHandler handler, ClientGetMessage message, NodeClientCore core)
+      throws IdentifierCollisionException, MessageInvalidException {
+    ClientRequestParams params =
+        new ClientRequestParams(
+            message.uri,
+            message.identifier,
+            message.verbosity,
+            message.priorityClass,
+            message.persistence,
+            message.realTimeFlag,
+            message.clientToken,
+            message.global);
+    if (message.persistence == ClientRequest.Persistence.CONNECTION) {
+      ensureConnectionIdentifierAvailable(handler, message.identifier);
+    }
+    FetchContext fctx = buildFetchContextForMessage(core, message);
+    ClientGetReturnPlanner.ReturnSetup returnSetup =
+        ClientGetGetterFactory.planReturnForMessage(
+            message.identifier, message.global, fctx, message, core, handler);
+    Bucket initialMetadata = message.getInitialMetadata();
+    try {
+      ClientGet.ClientGetSetup requestSetup =
+          new ClientGet.ClientGetSetup(
+              fctx, returnSetup, message.returnType, message.binaryBlob, initialMetadata, core);
+      return new ClientGet(params, handler, requestSetup);
+    } catch (IOException e) {
+      throw bucketCreationFailure(e, message.identifier, message.global);
+    }
+  }
+
+  /**
+   * Ensures the global identifier is not already registered on the persistent client.
+   *
+   * <p>This method performs a lightweight lookup against the persistent client map and throws when
+   * the identifier is already reserved. When the client is {@code null}, the check is skipped to
+   * allow callers to validate other aspects without requiring a backing queue.
+   *
+   * @param client persistent client whose identifier map is checked for collisions.
+   * @param identifier candidate identifier that must be unique in the global queue.
+   * @throws IdentifierCollisionException if the identifier is already present.
+   */
+  private static void ensureGlobalIdentifierAvailable(
+      PersistentRequestClient client, String identifier) throws IdentifierCollisionException {
+    if (client != null && client.getRequest(identifier) != null) {
+      throw new IdentifierCollisionException();
+    }
+  }
+
+  /**
+   * Ensures the connection-scoped identifier is not already in use by the handler.
+   *
+   * <p>This check protects per-connection namespaces, so multiple requests do not share an
+   * identifier. If the handler is {@code null}, the check is skipped to allow callers to validate
+   * other parameters first.
+   *
+   * @param handler connection handler tracking identifiers for the active session.
+   * @param identifier candidate identifier that must be unique for the connection.
+   * @throws IdentifierCollisionException if the identifier already exists in scope.
+   */
+  private static void ensureConnectionIdentifierAvailable(
+      FCPConnectionHandler handler, String identifier) throws IdentifierCollisionException {
+    if (handler != null && handler.requestsByIdentifier.containsKey(identifier)) {
+      throw new IdentifierCollisionException();
+    }
+  }
+
+  /**
+   * Builds a {@link FetchContext} for global-queue requests using default persistent settings.
+   *
+   * <p>The context is cloned from the node core's persistent template and then adjusted with the
+   * configuration's limits, datastore flags, and filtering preferences. The returned context is
+   * mutable and owned by the caller; further modifications affect only the request being built.
+   *
+   * @param core node core providing the default persistent fetch context.
+   * @param requestConfig configuration containing datastore flags and retry limits.
+   * @return configured fetch context instance tailored for this request.
+   */
+  private static FetchContext buildFetchContextForGlobal(
+      NodeClientCore core, ClientGet.GlobalRequestConfig requestConfig) {
+    FetchContext fctx = core.getClientContext().getDefaultPersistentFetchContext();
+    fctx.setLocalRequestOnly(requestConfig.dsOnly());
+    fctx.setIgnoreStore(requestConfig.ignoreDS());
+    fctx.setMaxNonSplitfileRetries(requestConfig.maxNonSplitfileRetries());
+    fctx.setMaxSplitfileBlockRetries(requestConfig.maxSplitfileRetries());
+    fctx.setFilterData(requestConfig.filterData());
+    fctx.setMaxOutputLength(requestConfig.maxOutputLength());
+    fctx.setMaxTempLength(requestConfig.maxOutputLength());
+    fctx.setCanWriteClientCache(requestConfig.writeToClientCache());
+    return fctx;
+  }
+
+  /**
+   * Builds a {@link FetchContext} for message-driven requests with per-message overrides.
+   *
+   * <p>The context starts from the persistent defaults and is then updated with message-specific
+   * retry limits, size limits, allowed MIME types, and USK date hint behavior. The returned context
+   * is owned by the caller and can be further adjusted before the request starts.
+   *
+   * @param core node core providing the default persistent fetch context.
+   * @param message the parsed message supplying overrides and allowed MIME type hints.
+   * @return configured fetch context instance tailored for the message.
+   */
+  private static FetchContext buildFetchContextForMessage(
+      NodeClientCore core, ClientGetMessage message) {
+    FetchContext fctx = core.getClientContext().getDefaultPersistentFetchContext();
+    fctx.setLocalRequestOnly(message.dsOnly);
+    fctx.setIgnoreStore(message.ignoreDS);
+    fctx.setMaxNonSplitfileRetries(message.maxRetries);
+    fctx.setMaxSplitfileBlockRetries(message.maxRetries);
+    fctx.setMaxOutputLength(message.maxSize);
+    fctx.setMaxTempLength(message.maxTempSize);
+    fctx.setCanWriteClientCache(message.shouldWriteToClientCache());
+    fctx.setFilterData(message.filterData);
+    fctx.setIgnoreUSKDatehints(message.ignoreUSKDatehints);
+    ClientGetGetterFactory.applyAllowedMimeTypes(fctx, message.allowedMIMETypes);
+    return fctx;
+  }
+
+  /**
+   * Wraps bucket creation failures in a protocol error suitable for FCP clients.
+   *
+   * <p>The returned {@link MessageInvalidException} preserves the original cause and uses the
+   * standard internal-error code so the caller can relay a consistent error message upstream.
+   *
+   * @param e underlying I/O failure that prevented temporary bucket creation.
+   * @param identifier request identifier associated with the failing request.
+   * @param global true when the request targets the global queue.
+   * @return FCP error wrapper that retains the original cause and identifier.
+   */
+  private static MessageInvalidException bucketCreationFailure(
+      IOException e, String identifier, boolean global) {
+    MessageInvalidException mie =
+        new MessageInvalidException(
+            ProtocolErrorMessage.INTERNAL_ERROR,
+            "Cannot create bucket for temporary storage (out of disk space?): " + e,
+            identifier,
+            global);
+    mie.initCause(e);
+    return mie;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetLifecycle.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetLifecycle.java
@@ -66,28 +66,29 @@ final class ClientGetLifecycle {
   void onSuccess(FetchResult result, ClientGetter state) {
     LOG.debug("Succeeded: {}", request.identifier);
     Bucket data = request.binaryBlobRequested() ? state.getBlobBucket() : result.asBucket();
-    synchronized (request) {
-      if (request.hasSucceededForReplay()) {
+    ClientGetState requestState = request.state();
+    synchronized (request.persistenceLock()) {
+      if (requestState.hasSucceeded()) {
         LOG.error("onSuccess called twice for {} ({})", request, request.identifier);
         return; // We might be called twice; ignore it if so.
       }
       request.started = true;
       if (!request.binaryBlobRequested()) {
-        request.setFoundDataMimeType(result.getMimeType());
+        requestState.setFoundDataMimeType(result.getMimeType());
       } else {
-        request.setFoundDataMimeType(ClientGetGetterFactory.binaryBlobMimeType());
+        requestState.setFoundDataMimeType(ClientGetGetterFactory.binaryBlobMimeType());
       }
 
       // completionTime is set here rather than in finish() for two reasons:
       // 1. It must be set inside the lock.
       // 2. It must be set before AllData is sent so it is consistent.
       request.completionTime = System.currentTimeMillis();
-      request.setProgressPending(null);
-      request.setFoundDataLength(data.size());
-      request.setSucceeded(true);
+      requestState.setProgressPending(null);
+      requestState.setFoundDataLength(data.size());
+      requestState.setSucceeded(true);
       request.finished = true;
       if (request.returnTypeForReplay() == ClientGet.ReturnType.DIRECT) {
-        request.setReturnBucketDirect(data);
+        requestState.setReturnBucketDirect(data);
       }
     }
     request.trySendDataFoundOrGetFailed(null, null);
@@ -118,8 +119,9 @@ final class ClientGetLifecycle {
     if (context == null) {
       throw new NullPointerException("context");
     }
-    synchronized (request) {
-      request.setSucceeded(true);
+    ClientGetState requestState = request.state();
+    synchronized (request.persistenceLock()) {
+      requestState.setSucceeded(true);
       request.started = true;
       request.finished = true;
       request.completionTime = completionTime;
@@ -132,20 +134,20 @@ final class ClientGetLifecycle {
             when type == ClientGet.ReturnType.DISK
                 && (!request.targetFileForLifecycle().exists()
                     || request.targetFileForLifecycle().length()
-                        != request.foundDataLengthForReplay()) ->
+                        != requestState.getFoundDataLength()) ->
             throw new ResumeFailedException("Success but target file doesn't exist or isn't valid");
         case ClientGet.ReturnType type when type == ClientGet.ReturnType.DISK -> {
           // Validation already passed.
         }
         case ClientGet.ReturnType type
             when type == ClientGet.ReturnType.DIRECT
-                && data.size() != request.foundDataLengthForReplay() -> {
-          request.setReturnBucketDirect(data);
+                && data.size() != requestState.getFoundDataLength() -> {
+          requestState.setReturnBucketDirect(data);
           throw new ResumeFailedException(
               "Success but temporary data bucket doesn't exist or isn't valid");
         }
         case ClientGet.ReturnType type when type == ClientGet.ReturnType.DIRECT ->
-            request.setReturnBucketDirect(data);
+            requestState.setReturnBucketDirect(data);
         case ClientGet.ReturnType type when type == ClientGet.ReturnType.CHUNKED ->
             throw new ResumeFailedException("Chunked return type not supported for migration");
         default -> throw new IllegalStateException("Unexpected return type: " + returnType);
@@ -167,15 +169,16 @@ final class ClientGetLifecycle {
     if (request.finished) {
       return;
     }
-    synchronized (request) {
+    ClientGetState requestState = request.state();
+    synchronized (request.persistenceLock()) {
       if (e.getExpectedSize() != 0) {
-        request.setFoundDataLength(e.getExpectedSize());
+        requestState.setFoundDataLength(e.getExpectedSize());
       }
       if (e.getExpectedMimeType() != null) {
-        request.setFoundDataMimeType(e.getExpectedMimeType());
+        requestState.setFoundDataMimeType(e.getExpectedMimeType());
       }
-      request.setSucceeded(false);
-      request.setFailedMessage(new GetFailedMessage(e, request.identifier, request.global));
+      requestState.setSucceeded(false);
+      requestState.setFailedMessage(new GetFailedMessage(e, request.identifier, request.global));
       request.finished = true;
       request.started = true;
       request.completionTime = System.currentTimeMillis();
@@ -203,11 +206,12 @@ final class ClientGetLifecycle {
   void requestWasRemoved() {
     // if the request is still running, send a GetFailed with code=canceled
     if (!request.finished) {
-      synchronized (request) {
-        request.setSucceeded(false);
+      ClientGetState requestState = request.state();
+      synchronized (request.persistenceLock()) {
+        requestState.setSucceeded(false);
         request.finished = true;
         FetchException cancelled = new FetchException(FetchExceptionMode.CANCELLED);
-        request.setFailedMessage(
+        requestState.setFailedMessage(
             new GetFailedMessage(cancelled, request.identifier, request.global));
       }
       request.trySendDataFoundOrGetFailed(null, null);

--- a/src/main/java/network/crypta/clients/fcp/ClientGetMessageReplay.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetMessageReplay.java
@@ -65,11 +65,11 @@ final class ClientGetMessageReplay {
     if (!onlyData) {
       FCPMessage msg = request.persistentTagMessage();
       handler.handler.send(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
-      SimpleProgressMessage progress = request.progressPendingForReplay();
+      SimpleProgressMessage progress = request.state().getProgressPending();
       if (progress != null) {
         handler.handler.send(FCPMessage.withListRequestIdentifier(progress, listRequestIdentifier));
       }
-      if (request.sentToNetworkForReplay()) {
+      if (request.state().hasSentToNetwork()) {
         handler.handler.send(
             FCPMessage.withListRequestIdentifier(
                 new SendingToNetworkMessage(request.identifier, request.global),
@@ -98,19 +98,19 @@ final class ClientGetMessageReplay {
     ExpectedHashes hashesMessage;
     ExpectedMIME mimeMsg = null;
     ExpectedDataLength lengthMsg = null;
-    synchronized (request) {
+    synchronized (request.persistenceLock()) {
+      ClientGetState state = request.state();
       cmsg =
-          new CompatibilityMode(request.identifier, request.global, request.compatModeForReplay());
-      hashesMessage = request.expectedHashesForReplay();
-      if (request.foundDataMimeTypeForReplay() != null) {
+          new CompatibilityMode(
+              request.identifier, request.global, state.getCompatibilityAnalyser());
+      hashesMessage = state.getExpectedHashes();
+      if (state.getFoundDataMimeType() != null) {
         mimeMsg =
-            new ExpectedMIME(
-                request.identifier, request.global, request.foundDataMimeTypeForReplay());
+            new ExpectedMIME(request.identifier, request.global, state.getFoundDataMimeType());
       }
-      if (request.foundDataLengthForReplay() > 0) {
+      if (state.getFoundDataLength() > 0) {
         lengthMsg =
-            new ExpectedDataLength(
-                request.identifier, request.global, request.foundDataLengthForReplay());
+            new ExpectedDataLength(request.identifier, request.global, state.getFoundDataLength());
       }
     }
     handler.handler.send(FCPMessage.withListRequestIdentifier(cmsg, listRequestIdentifier));
@@ -164,19 +164,19 @@ final class ClientGetMessageReplay {
 
     // Don't need to lock. succeeded is only ever set, never unset.
     // and succeeded and getFailedMessage are both atomic.
-    if (request.hasSucceededForReplay()) {
+    if (request.state().hasSucceeded()) {
       // Mirrors AllDataMessage so connection-scoped clients receive DataFound with consistent
       // timestamps even if completionTime was not set by finish().
       msg =
           new DataFoundMessage(
-              request.foundDataLengthForReplay(),
-              request.foundDataMimeTypeForReplay(),
+              request.state().getFoundDataLength(),
+              request.state().getFoundDataMimeType(),
               request.identifier,
               request.global,
               request.startupTime,
               request.completionTime != 0 ? request.completionTime : System.currentTimeMillis());
     } else {
-      msg = request.getFailedMessageForReplay();
+      msg = request.state().getFailedMessage();
     }
 
     if (handler == null && request.persistence == ClientRequest.Persistence.CONNECTION) {
@@ -237,9 +237,10 @@ final class ClientGetMessageReplay {
     Bucket bucket;
     String mimeType;
     long completionTime;
-    synchronized (request) {
-      bucket = request.returnBucketDirectForReplay();
-      mimeType = request.foundDataMimeTypeForReplay();
+    synchronized (request.persistenceLock()) {
+      ClientGetState state = request.state();
+      bucket = state.getReturnBucketDirect();
+      mimeType = state.getFoundDataMimeType();
       completionTime = request.completionTime;
     }
     AllDataMessage msg =

--- a/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceCodec.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceCodec.java
@@ -1,0 +1,533 @@
+package network.crypta.clients.fcp;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import network.crypta.client.FetchContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.CompatibilityAnalyser;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ResumeFailedException;
+import network.crypta.support.io.StorageFormatException;
+
+/**
+ * Serializes and restores persistent state for {@link ClientGet} requests.
+ *
+ * <p>The codec reads and writes the binary client-detail format used by persistent queues. It is
+ * responsible for emitting a stable header, encoding request configuration, and capturing progress
+ * hints so a request can resume after a restart. The format is order-sensitive and versioned; any
+ * changes must preserve backward compatibility with on-disk data.
+ *
+ * <p>This class is stateless and thread-safe. Callers are responsible for synchronization when
+ * reading or writing mutable request state; the codec does not manage locking beyond honoring the
+ * locks used by its callers. It also avoids side effects beyond the supplied streams and requests
+ * state updates.
+ *
+ * <ul>
+ *   <li><strong>Serialization</strong>: writes headers, configuration, and transient progress.
+ *   <li><strong>Restoration</strong>: validates headers and rebuilds request state from streams.
+ *   <li><strong>Compatibility</strong>: preserves field order and version numbers.
+ * </ul>
+ *
+ * @see ClientGet
+ * @see ClientGetPersistenceIO
+ */
+final class ClientGetPersistenceCodec {
+  /**
+   * Magic number guarding the serialized client-detail section.
+   *
+   * <p>The value is written at the start of each serialized request and used to detect corruption
+   * or mismatched stream positions. It must remain stable across versions to preserve backward
+   * compatibility.
+   */
+  private static final long CLIENT_DETAIL_MAGIC = 0x67145b675d2e22f4L;
+
+  /**
+   * Version number for the client-detail format.
+   *
+   * <p>The codec uses this value to validate that the stream layout matches the expected schema.
+   * Increment only when the field ordering or encoding changes and retains compatibility logic as
+   * needed for older versions.
+   */
+  private static final int CLIENT_DETAIL_VERSION = 1;
+
+  /** Prevents instantiation; this class exposes only static codec utilities. */
+  private ClientGetPersistenceCodec() {}
+
+  /**
+   * Restores a {@link ClientGet} instance from the serialized client-detail stream.
+   *
+   * <p>The method delegates to the {@link ClientGet} persistence constructor, which validates the
+   * header and reconstructs configuration, buckets, and transient progress. The returned request is
+   * configured but not started; callers should register it with the appropriate queue before
+   * resuming. The input stream must be positioned at the start of the client-detail block.
+   *
+   * @param dis input stream positioned at the serialized client-detail payload.
+   * @param reqID identifier tuple describing the request owner and scope.
+   * @param context client context providing factories for restoration.
+   * @param checker checksum helper verifying embedded bucket sections.
+   * @return reconstructed {@link ClientGet} instance ready for registration.
+   * @throws StorageFormatException when magic or version checks fail.
+   * @throws IOException when stream I/O fails during restoration.
+   * @throws ResumeFailedException when state cannot be safely resumed.
+   */
+  static ClientGet restartFrom(
+      DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
+      throws StorageFormatException, IOException, ResumeFailedException {
+    return new ClientGet(dis, reqID, context, checker);
+  }
+
+  /**
+   * Writes the client-detail section for a {@link ClientGet} into the provided stream.
+   *
+   * <p>The method emits a magic header, version tag, request configuration, and any available
+   * progress metadata. When the request is finished, it also serializes the final success bucket or
+   * failure descriptor. The caller supplies the framing stream; this method does not close the
+   * outer stream but does close any checksummed substreams it creates.
+   *
+   * @param request request whose state and configuration are serialized.
+   * @param dos destination stream receiving the serialized client-detail payload.
+   * @param checker checksum helper used to wrap embedded bucket segments.
+   * @throws IOException when writing to the stream fails or a bucket cannot be stored.
+   */
+  static void writeClientDetail(ClientGet request, DataOutputStream dos, ChecksumChecker checker)
+      throws IOException {
+    dos.writeLong(CLIENT_DETAIL_MAGIC);
+    dos.writeInt(CLIENT_DETAIL_VERSION);
+    dos.writeUTF(request.getURI().toString());
+    ClientGet.ReturnType returnType = request.returnTypeForGetter();
+    dos.writeShort(returnType.code);
+    if (returnType == ClientGet.ReturnType.DISK) {
+      dos.writeUTF(request.targetFileForLifecycle().toString());
+    }
+    dos.writeBoolean(request.binaryBlobRequested());
+    try (DataOutputStream ctxStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
+      request.fetchContextForGetter().writeTo(ctxStream);
+    }
+    String extensionCheck = request.extensionCheckForGetter();
+    if (extensionCheck != null) {
+      dos.writeBoolean(true);
+      dos.writeUTF(extensionCheck);
+    } else {
+      dos.writeBoolean(false);
+    }
+    // Request-owned bucket; closing here would free it prematurely.
+    @SuppressWarnings({"resource", "java:S2095"})
+    Bucket initialMetadata = request.initialMetadataBucket();
+    if (initialMetadata != null) {
+      dos.writeBoolean(true);
+      try (DataOutputStream metadataStream =
+          ClientGetGetterFactory.checksummedWriter(dos, checker)) {
+        initialMetadata.storeTo(metadataStream);
+      }
+    } else {
+      dos.writeBoolean(false);
+    }
+    ClientGetState state = request.state();
+    synchronized (request.persistenceLock()) {
+      if (request.finished) {
+        dos.writeBoolean(state.hasSucceeded());
+        writeTransientProgressFields(request, dos);
+        if (state.hasSucceeded()) {
+          if (returnType == ClientGet.ReturnType.DIRECT) {
+            try (DataOutputStream bucketStream =
+                ClientGetGetterFactory.checksummedWriter(dos, checker)) {
+              state.getReturnBucketDirect().storeTo(bucketStream);
+            }
+          }
+        } else {
+          try (DataOutputStream failureStream =
+              ClientGetGetterFactory.checksummedWriter(dos, checker)) {
+            state.getFailedMessage().writeTo(failureStream);
+          }
+        }
+        return;
+      }
+    }
+    try (DataOutputStream progressStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
+      if (((ClientGetter) request.getClientRequest()).writeTrivialProgress(progressStream)) {
+        synchronized (request.persistenceLock()) {
+          writeTransientProgressFields(request, progressStream);
+        }
+      }
+    }
+  }
+
+  /**
+   * Reads core configuration and metadata needed to reconstruct a {@link ClientGet}.
+   *
+   * <p>This method validates the header, parses the return type, fetch context, optional extension
+   * check, and initial metadata bucket. It does not restore progress or final success/failure
+   * state; that work happens in {@link #restoreState(ClientGet, DataInputStream, RequestIdentifier,
+   * ClientContext, ChecksumChecker)}.
+   *
+   * @param request the request instance that will own the reconstructed state.
+   * @param dis input stream positioned at the client-detail payload.
+   * @param context client context providing bucket factories and event handlers.
+   * @param checker checksum helper used to read embedded bucket data.
+   * @return basic restore data bundle with configuration and metadata buckets.
+   * @throws IOException when reading from the stream fails.
+   * @throws StorageFormatException when headers or encoded values are invalid.
+   * @throws ResumeFailedException when metadata buckets fail to resume.
+   */
+  static BasicRestoreData readBasicRestoreData(
+      ClientGet request, DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      throws IOException, StorageFormatException, ResumeFailedException {
+    validateClientDetailHeader(dis);
+    FreenetURI uri = parseUri(dis.readUTF());
+    ClientGet.ReturnType returnType = parseReturnType(dis.readShort());
+    File targetFile = returnType == ClientGet.ReturnType.DISK ? new File(dis.readUTF()) : null;
+    boolean binaryBlob = dis.readBoolean();
+    FetchContext fctx = ClientGetGetterFactory.readFetchContextOrDefault(dis, context, checker);
+    fctx.getEventProducer().addEventListener(new ClientGetEventHandling(request));
+    String extensionCheck = dis.readBoolean() ? dis.readUTF() : null;
+    Bucket initialMetadata = ClientGetGetterFactory.readInitialMetadata(dis, context, checker);
+    return new BasicRestoreData(
+        uri, returnType, targetFile, binaryBlob, fctx, extensionCheck, initialMetadata);
+  }
+
+  /**
+   * Restores progress or terminal state for a {@link ClientGet} from the stream.
+   *
+   * <p>If the request is already marked as finished, this method reads the final success or failure
+   * payload and updates the request state accordingly. Otherwise, it creates a getter suitable for
+   * resuming and delegates to the lower-level progress restoration helpers. The returned getter is
+   * owned by the caller and should be installed on the request.
+   *
+   * @param request request whose mutable state is updated from persistence.
+   * @param dis input stream positioned at the progress or terminal section.
+   * @param reqID identifier tuple describing the request owner and scope.
+   * @param context client context used to rehydrate buckets and caches.
+   * @param checker checksum helper for embedded bucket segments.
+   * @return restored {@link ClientGetter}, or {@code null} when already finished.
+   * @throws IOException when stream I/O fails during restoration.
+   * @throws StorageFormatException when encoded values are invalid.
+   * @throws ResumeFailedException when the request must restart instead of resuming.
+   */
+  static ClientGetter restoreState(
+      ClientGet request,
+      DataInputStream dis,
+      RequestIdentifier reqID,
+      ClientContext context,
+      ChecksumChecker checker)
+      throws IOException, StorageFormatException, ResumeFailedException {
+    if (request.finished) {
+      restoreFinishedState(request, dis, reqID, context, checker);
+      return null;
+    }
+    ClientGetter inProgressGetter = request.makeGetterForPersistence(request.makeBucket(false));
+    ClientGetGetterFactory.restoreInProgressState(dis, context, checker, inProgressGetter, request);
+    return inProgressGetter;
+  }
+
+  /**
+   * Validates the magic number and version header for a client-detail payload.
+   *
+   * <p>The method reads the header values from the stream and throws if they do not match the
+   * expected constants. Callers should invoke this before parsing any following fields to ensure
+   * the stream is positioned correctly and the format is compatible.
+   *
+   * @param dis input stream positioned at the start of the header.
+   * @throws IOException when reading from the stream fails.
+   * @throws StorageFormatException when the header does not match expected values.
+   */
+  private static void validateClientDetailHeader(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    long magic = dis.readLong();
+    if (magic != CLIENT_DETAIL_MAGIC) {
+      throw new StorageFormatException("Bad magic for request");
+    }
+    int version = dis.readInt();
+    if (version != CLIENT_DETAIL_VERSION) {
+      throw new StorageFormatException("Bad version " + version);
+    }
+  }
+
+  /**
+   * Parses a serialized URI string into a {@link FreenetURI} instance.
+   *
+   * <p>Any parsing failure is converted into a {@link StorageFormatException} to keep persistence
+   * error handling consistent across the codec.
+   *
+   * @param serializedUri URI string read from persistent storage.
+   * @return parsed {@link FreenetURI} instance corresponding to the string.
+   * @throws StorageFormatException when the string is not a valid Freenet URI.
+   */
+  private static FreenetURI parseUri(String serializedUri) throws StorageFormatException {
+    try {
+      return new FreenetURI(serializedUri);
+    } catch (Exception _) {
+      throw new StorageFormatException("Bad URI");
+    }
+  }
+
+  /**
+   * Parses a serialized return-type code into a {@link ClientGet.ReturnType} value.
+   *
+   * <p>Unknown codes indicate corruption or incompatible versions and are rejected with a storage
+   * exception.
+   *
+   * @param code encoded return-type tag from the persistence stream.
+   * @return matching {@link ClientGet.ReturnType} value.
+   * @throws StorageFormatException when the code does not map to a known return type.
+   */
+  private static ClientGet.ReturnType parseReturnType(short code) throws StorageFormatException {
+    try {
+      return ClientGet.ReturnType.getByCode(code);
+    } catch (IllegalArgumentException _) {
+      throw new StorageFormatException("Bad return type " + code);
+    }
+  }
+
+  /**
+   * Restores the terminal success or failure state for a finished request.
+   *
+   * <p>The method reads the success flag and transient progress fields, then either restores the
+   * direct-return bucket or a {@link GetFailedMessage} depending on the outcome. If expected data
+   * is missing or inconsistent, it downgrades the request to a non-finished state so the caller can
+   * restart rather than trust corrupt payloads.
+   *
+   * @param request request whose terminal state is being reconstructed.
+   * @param dis input stream positioned at the finished-state payload.
+   * @param reqID identifier tuple used for failure message decoding.
+   * @param context client context used to restore buckets and metadata.
+   * @param checker checksum helper verifying embedded bucket sections.
+   * @throws IOException when stream I/O fails while reading data.
+   * @throws StorageFormatException when encoded, data is invalid or incompatible.
+   * @throws ResumeFailedException when bucket restoration fails unrecoverably.
+   */
+  private static void restoreFinishedState(
+      ClientGet request,
+      DataInputStream dis,
+      RequestIdentifier reqID,
+      ClientContext context,
+      ChecksumChecker checker)
+      throws IOException, StorageFormatException, ResumeFailedException {
+    ClientGetState state = request.state();
+    state.setSucceeded(dis.readBoolean());
+    readTransientProgressFields(request, dis, reqID.identifier, reqID.globalQueue);
+    if (state.hasSucceeded()) {
+      if (request.returnTypeForGetter() == ClientGet.ReturnType.DIRECT) {
+        Bucket restoredBucket =
+            ClientGetGetterFactory.restoreCompletedDirectBucketOrNull(dis, context, checker);
+        if (restoredBucket != null) {
+          state.setReturnBucketDirect(restoredBucket);
+        } else {
+          state.setReturnBucketDirect(null);
+          state.setSucceeded(false);
+          request.finished = false;
+        }
+      }
+    } else {
+      GetFailedMessage restoredMessage =
+          ClientGetGetterFactory.restoreFailureMessageOrNull(
+              dis,
+              reqID,
+              state.getFoundDataLength(),
+              state.getFoundDataMimeType(),
+              context,
+              checker);
+      if (restoredMessage != null) {
+        state.setFailedMessage(restoredMessage);
+        request.started = true;
+      } else {
+        request.finished = false;
+        state.setFailedMessage(null);
+      }
+    }
+  }
+
+  /**
+   * Reads transient progress fields using the request's identifier and scope.
+   *
+   * <p>This overload is used when the identifier and global scope are already available on the
+   * request instance. It updates length, MIME hints, compatibility metadata, and expected hashes
+   * from the provided stream.
+   *
+   * @param request request whose progress fields are updated.
+   * @param dis input stream positioned at the transient progress section.
+   * @throws IOException when stream I/O fails while reading fields.
+   * @throws StorageFormatException when encoded values are invalid.
+   */
+  static void readTransientProgressFields(ClientGet request, DataInputStream dis)
+      throws IOException, StorageFormatException {
+    readTransientProgressFields(request, dis, request.identifier, request.global);
+  }
+
+  /**
+   * Reads transient progress fields with an explicit identifier and scope.
+   *
+   * <p>This overload is used when the identifier and global flag are supplied externally, such as
+   * during restore operations that have not yet populated the request identity. It updates the
+   * request's cached size, MIME, compatibility, and expected-hash data.
+   *
+   * @param request request whose progress fields are updated.
+   * @param dis input stream positioned at the transient progress section.
+   * @param identifier identifier used to decode expected hashes.
+   * @param global true when the request is in the global queue scope.
+   * @throws IOException when stream I/O fails while reading fields.
+   * @throws StorageFormatException when encoded values are invalid.
+   */
+  static void readTransientProgressFields(
+      ClientGet request, DataInputStream dis, String identifier, boolean global)
+      throws IOException, StorageFormatException {
+    ClientGetState state = request.state();
+    state.setFoundDataLength(dis.readLong());
+    if (dis.readBoolean()) state.setFoundDataMimeType(dis.readUTF());
+    else state.setFoundDataMimeType(null);
+    state.setCompatibilityAnalyser(new CompatibilityAnalyser(dis));
+    state.setExpectedHashes(ClientGetGetterFactory.readExpectedHashes(dis, identifier, global));
+  }
+
+  /**
+   * Writes transient progress fields for persistence.
+   *
+   * <p>The method writes the best-known length, MIME type, compatibility metadata, and expected
+   * hashes so that resuming requests retain progress hints. Callers should synchronize on the
+   * request lock before invoking this helper to ensure a consistent snapshot.
+   *
+   * @param request request providing progress fields to serialize.
+   * @param dos output stream receiving the encoded fields.
+   * @throws IOException when writing to the output stream fails.
+   */
+  private static void writeTransientProgressFields(ClientGet request, DataOutputStream dos)
+      throws IOException {
+    ClientGetState state = request.state();
+    dos.writeLong(state.getFoundDataLength());
+    if (state.getFoundDataMimeType() != null) {
+      dos.writeBoolean(true);
+      dos.writeUTF(state.getFoundDataMimeType());
+    } else {
+      dos.writeBoolean(false);
+    }
+    state.ensureCompatibilityMode();
+    state.getCompatibilityAnalyser().writeTo(dos);
+    ClientGetGetterFactory.writeExpectedHashes(dos, state.getExpectedHashes());
+  }
+
+  /**
+   * Bundles the minimal configuration needed to reconstruct a {@link ClientGet}.
+   *
+   * <p>The container holds immutable values parsed from persistence, such as the target URI, return
+   * type, output destination, and fetch context. It does not carry transient progress or terminal
+   * success/failure state. Callers use these values to populate the request before restoring
+   * progress and completion metadata.
+   */
+  static final class BasicRestoreData {
+    /** The target URI parsed from the persistence stream. */
+    private final FreenetURI uri;
+
+    /** The return type describing how the payload should be delivered. */
+    private final ClientGet.ReturnType returnType;
+
+    /** The disk target file when disk delivery is configured, or {@code null} otherwise. */
+    private final File targetFile;
+
+    /** True when the request is configured for BinaryBlob output instead of raw buckets. */
+    private final boolean binaryBlob;
+
+    /** Fetch context reconstructed from the persistence stream and ready for reuse. */
+    private final FetchContext fetchContext;
+
+    /** Optional filename extension hint used to validate filtering output. */
+    private final String extensionCheck;
+
+    /** Optional initial metadata bucket associated with the original request. */
+    private final Bucket initialMetadata;
+
+    /**
+     * Creates a new restore data bundle with immutable configuration values.
+     *
+     * @param uri target URI parsed from persistence; must be non-null.
+     * @param returnType return type describing delivery semantics; must be non-null.
+     * @param targetFile disk target when return type is disk; otherwise {@code null}.
+     * @param binaryBlob true when BinaryBlob output is enabled for the request.
+     * @param fetchContext reconstructed fetch context for the request.
+     * @param extensionCheck optional extension hint used for validation, or {@code null}.
+     * @param initialMetadata optional metadata bucket, or {@code null} when absent.
+     */
+    private BasicRestoreData(
+        FreenetURI uri,
+        ClientGet.ReturnType returnType,
+        File targetFile,
+        boolean binaryBlob,
+        FetchContext fetchContext,
+        String extensionCheck,
+        Bucket initialMetadata) {
+      this.uri = uri;
+      this.returnType = returnType;
+      this.targetFile = targetFile;
+      this.binaryBlob = binaryBlob;
+      this.fetchContext = fetchContext;
+      this.extensionCheck = extensionCheck;
+      this.initialMetadata = initialMetadata;
+    }
+
+    /**
+     * Returns the URI that the restored request should fetch.
+     *
+     * @return target {@link FreenetURI} parsed from persistence data.
+     */
+    FreenetURI uri() {
+      return uri;
+    }
+
+    /**
+     * Returns the return type encoded in the persistence stream.
+     *
+     * @return configured {@link ClientGet.ReturnType} for delivery semantics.
+     */
+    ClientGet.ReturnType returnType() {
+      return returnType;
+    }
+
+    /**
+     * Returns the target file for disk delivery, if configured.
+     *
+     * @return disk target file, or {@code null} when not applicable.
+     */
+    File targetFile() {
+      return targetFile;
+    }
+
+    /**
+     * Indicates whether BinaryBlob output was requested.
+     *
+     * @return {@code true} when BinaryBlob output is enabled.
+     */
+    boolean binaryBlob() {
+      return binaryBlob;
+    }
+
+    /**
+     * Returns the fetch context reconstructed from persistence.
+     *
+     * @return fetch context ready to be used by the restored request.
+     */
+    FetchContext fetchContext() {
+      return fetchContext;
+    }
+
+    /**
+     * Returns the optional extension check hint stored in persistence.
+     *
+     * @return extension hint string, or {@code null} when absent.
+     */
+    String extensionCheck() {
+      return extensionCheck;
+    }
+
+    /**
+     * Returns the optional initial metadata bucket associated with the request.
+     *
+     * @return initial metadata bucket, or {@code null} when none was stored.
+     */
+    Bucket initialMetadata() {
+      return initialMetadata;
+    }
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
@@ -206,7 +206,7 @@ final class ClientGetPersistenceIO {
     try (DataInputStream inner =
         openChecksummed(dis, context, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
       if (inProgressGetter.resumeFromTrivialProgress(inner, context)) {
-        request.readTransientProgressFields(inner);
+        ClientGetPersistenceCodec.readTransientProgressFields(request, inner);
       }
     } catch (IOException e) {
       LOG.error("Unable to restore splitfile, restarting: {}", e.toString());

--- a/src/main/java/network/crypta/clients/fcp/ClientGetRestartCoordinator.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetRestartCoordinator.java
@@ -1,0 +1,203 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+import network.crypta.client.FetchException;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.keys.FreenetURI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Coordinates restart eligibility and redirect handling for {@link ClientGet}.
+ *
+ * <p>The coordinator encapsulates the restart state machine for GET requests: it checks restart
+ * eligibility, clears failure metadata, applies redirect updates, and notifies cache listeners. It
+ * does not start or stop the underlying {@link ClientGetter} directly; instead it delegates to the
+ * getter and then updates the request's bookkeeping fields to reflect the new attempt.
+ *
+ * <p>The class is intentionally thin and relies on the {@link ClientGet} request lock to guard
+ * state changes. Callers should treat the coordinator as request-scoped and not reuse it across
+ * different requests.
+ *
+ * <ul>
+ *   <li><strong>Eligibility</strong>: validates finished state and getter restart capability.
+ *   <li><strong>State reset</strong>: clears cached failures, progress, and compatibility hints.
+ *   <li><strong>Redirects</strong>: applies permanent redirect URIs when available.
+ * </ul>
+ *
+ * @see ClientGet
+ * @see ClientGetter
+ */
+final class ClientGetRestartCoordinator {
+  /** Logger for restart eligibility and flow diagnostics. */
+  private static final Logger LOG = LoggerFactory.getLogger(ClientGetRestartCoordinator.class);
+
+  /** The owning request whose lifecycle state is mutated by this coordinator. */
+  private final ClientGet request;
+
+  /**
+   * Creates a coordinator bound to a single {@link ClientGet} instance.
+   *
+   * <p>The coordinator assumes ownership of no resources and performs no side effects during
+   * construction. The provided request is stored and used for all state changes and cache
+   * notifications.
+   *
+   * @param request owning request; must be non-null.
+   */
+  ClientGetRestartCoordinator(ClientGet request) {
+    this.request = Objects.requireNonNull(request, "request");
+  }
+
+  /**
+   * Determines whether the request can be restarted at this time.
+   *
+   * <p>A request is restartable only after it has finished, has not succeeded, and the underlying
+   * {@link ClientGetter} reports that it supports restart semantics. The method is side-effect-free
+   * and logs the reason for non-restartability at debug level.
+   *
+   * @return {@code true} when the request is finished, failed, and restartable.
+   */
+  boolean canRestart() {
+    if (!request.finished) {
+      LOG.debug("Cannot restart because not finished for {}", request.identifier);
+      return false;
+    }
+    if (request.state().hasSucceeded()) {
+      LOG.debug("Cannot restart because succeeded for {}", request.identifier);
+      return false;
+    }
+    return getter().canRestart();
+  }
+
+  /**
+   * Attempts to restart the request and update cached state for a new attempt.
+   *
+   * <p>The method clears failure metadata, optionally disables filtering for the next run, and
+   * delegates the restart to the underlying {@link ClientGetter}. If a permanent redirect is stored
+   * in the failure message, it is applied before restart, so the new attempt uses the redirected
+   * URI. Any restart failure is routed through {@link ClientGet#onFailure(FetchException)} to keep
+   * error handling consistent with normal fetch errors.
+   *
+   * @param context client context providing schedulers and bucket factories.
+   * @param disableFilterData true to disable filtering for the next attempt.
+   * @return {@code true} when the restart is accepted and scheduled by the getter.
+   */
+  boolean restart(ClientContext context, boolean disableFilterData) {
+    if (!canRestart()) return false;
+    FreenetURI redirect = resetStateForRestart(disableFilterData);
+    notifyCacheAboutRedirect(redirect);
+    try {
+      if (getter().restart(redirect, request.fetchContextForGetter().getFilterData(), context)) {
+        markRestarted(redirect);
+      }
+      notifyCacheStartedFlag();
+      return true;
+    } catch (FetchException e) {
+      request.onFailure(e);
+      return false;
+    }
+  }
+
+  /**
+   * Checks whether the most recent failure recorded a permanent redirect.
+   *
+   * <p>The method inspects the cached {@link GetFailedMessage} under the request lock and returns
+   * {@code true} when a redirect URI is present. It does not perform any network activity.
+   *
+   * @return {@code true} when a permanent redirect URI is stored in failure state.
+   */
+  boolean hasPermRedirect() {
+    synchronized (request.persistenceLock()) {
+      GetFailedMessage failure = request.state().getFailedMessage();
+      return failure != null && failure.redirectURI != null;
+    }
+  }
+
+  /**
+   * Resets the request state and returns any stored redirect URI for the next attempt.
+   *
+   * <p>The method clears cached failures, progress snapshots, compatibility metadata, and expected
+   * hashes. It also marks the request as not started/finished and optionally disables filtering in
+   * the fetch context. The returned redirect, if present, should be applied before restarting.
+   *
+   * @param disableFilterData true to disable filtering for the next attempt.
+   * @return redirect URI to apply, or {@code null} if none was stored.
+   */
+  private FreenetURI resetStateForRestart(boolean disableFilterData) {
+    synchronized (request.persistenceLock()) {
+      request.finished = false;
+      GetFailedMessage failure = request.state().getFailedMessage();
+      FreenetURI redirect = failure == null ? null : failure.redirectURI;
+      request.state().setFailedMessage(null);
+      request.state().setProgressPending(null);
+      request.state().resetCompatibilityMode();
+      request.state().clearExpectedHashes();
+      request.started = false;
+      if (disableFilterData) {
+        request.fetchContextForGetter().setFilterData(false);
+      }
+      return redirect;
+    }
+  }
+
+  /**
+   * Marks the request as started and applies any redirect URI to the request.
+   *
+   * <p>This helper updates the request's URI and started flag under the request lock after the
+   * underlying getter acknowledges a restart. It does not emit any messages itself.
+   *
+   * @param redirect redirect URI to apply, or {@code null} to keep the existing URI.
+   */
+  private void markRestarted(FreenetURI redirect) {
+    synchronized (request.persistenceLock()) {
+      if (redirect != null) {
+        request.uri = redirect;
+      }
+      request.started = true;
+    }
+  }
+
+  /**
+   * Notifies the request status cache about a restart and optional redirect.
+   *
+   * <p>This update is used by UI surfaces to reflect a redirected restart promptly. If no cache is
+   * configured, the method returns without side effects.
+   *
+   * @param redirect redirect URI used for the restart, or {@code null} if none.
+   */
+  private void notifyCacheAboutRedirect(FreenetURI redirect) {
+    if (request.client == null) {
+      return;
+    }
+    RequestStatusCache cache = request.client.getRequestStatusCache();
+    if (cache != null) {
+      cache.updateStarted(request.identifier, redirect);
+    }
+  }
+
+  /**
+   * Updates the request status cache to reflect the started flag.
+   *
+   * <p>The update is emitted after the getter accepts a restart so observers can display the new
+   * attempt. If no cache is configured, the method returns without side effects.
+   */
+  private void notifyCacheStartedFlag() {
+    if (request.client == null) {
+      return;
+    }
+    RequestStatusCache cache = request.client.getRequestStatusCache();
+    if (cache != null) {
+      cache.updateStarted(request.identifier, true);
+    }
+  }
+
+  /**
+   * Returns the underlying {@link ClientGetter} associated with the request.
+   *
+   * @return the request's {@link ClientGetter}, cast from the base requester.
+   */
+  private ClientGetter getter() {
+    return (ClientGetter) request.getClientRequest();
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetState.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetState.java
@@ -1,0 +1,348 @@
+package network.crypta.clients.fcp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.CompatibilityAnalyser;
+import network.crypta.support.api.Bucket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stores mutable runtime state for a {@link ClientGet} request.
+ *
+ * <p>The state object centralizes data that evolves during a fetch: progress snapshots, failure
+ * metadata, compatibility hints, and any buckets retained for direct delivery. It keeps the core
+ * request class focused on orchestration while allowing helper classes to update specific fields.
+ * The state does not enforce synchronization; callers must coordinate access using the owning
+ * request's lock to maintain consistent snapshots across threads.
+ *
+ * <p>Values stored here are intentionally mutable and are not safe to read concurrently without
+ * locking. Accessors should be treated as point-in-time views, especially when a request is
+ * actively fetching or restarting.
+ *
+ * <ul>
+ *   <li><strong>Progress</strong>: length, MIME, and splitfile progress hints.
+ *   <li><strong>Failure</strong>: cached {@link GetFailedMessage} and expected hashes.
+ *   <li><strong>Compatibility</strong>: mode analysis and optional crypto key hints.
+ * </ul>
+ *
+ * @see ClientGet
+ */
+final class ClientGetState implements Serializable {
+  /** Serialization version for the mutable request state container. */
+  @Serial private static final long serialVersionUID = 1L;
+
+  /** Logger for unexpected state transitions or duplicate metadata. */
+  private static final Logger LOG = LoggerFactory.getLogger(ClientGetState.class);
+
+  /** Owning request used for cache updates and message routing. */
+  private final ClientGet request;
+
+  /** True, once the request has recorded a terminal success. */
+  private boolean succeeded;
+
+  /** Best-known payload length in bytes, or {@code -1} when unknown. */
+  private long foundDataLength = -1;
+
+  /** Best-known MIME type string, or {@code null} when not yet reported. */
+  private String foundDataMimeType;
+
+  /** Cached failure message for the most recent terminal failure, if any. */
+  private GetFailedMessage getFailedMessage;
+
+  /** The last splitfile progress snapshot captured for status reporting. */
+  private transient SimpleProgressMessage progressPending;
+
+  /** True once a {@link SendingToNetworkMessage} has been observed. */
+  private boolean sentToNetwork;
+
+  /** Compatibility analyzer accumulating splitfile compatibility hints. */
+  private CompatibilityAnalyser compatMode;
+
+  /** Expected hashes derived from splitfile metadata, or {@code null} when unknown. */
+  private ExpectedHashes expectedHashes;
+
+  /** Bucket retained for direct delivery, or {@code null} when unused. */
+  @SuppressWarnings("java:S1948")
+  private Bucket returnBucketDirect;
+
+  /**
+   * Creates a new state container bound to a specific request.
+   *
+   * <p>The constructor initializes the compatibility analyzer so that compatibility hints can be
+   * merged immediately when events arrive.
+   *
+   * @param request owning request used for cache updates and message routing.
+   */
+  ClientGetState(ClientGet request) {
+    this.request = Objects.requireNonNull(request, "request");
+    this.compatMode = new CompatibilityAnalyser();
+  }
+
+  /**
+   * Reports whether the request has recorded a successful terminal state.
+   *
+   * @return {@code true} once success is recorded, {@code false} otherwise.
+   */
+  boolean hasSucceeded() {
+    return succeeded;
+  }
+
+  /**
+   * Records whether the request has reached a successful terminal state.
+   *
+   * @param succeeded {@code true} to mark success, {@code false} otherwise.
+   */
+  void setSucceeded(boolean succeeded) {
+    this.succeeded = succeeded;
+  }
+
+  /**
+   * Returns the best-known payload length in bytes.
+   *
+   * @return payload length, or {@code -1} when unknown.
+   */
+  long getFoundDataLength() {
+    return foundDataLength;
+  }
+
+  /**
+   * Updates the cached payload length in bytes.
+   *
+   * @param foundDataLength non-negative payload length, or {@code -1} when unknown.
+   */
+  void setFoundDataLength(long foundDataLength) {
+    this.foundDataLength = foundDataLength;
+  }
+
+  /**
+   * Returns the best-known MIME type reported for the payload.
+   *
+   * @return MIME type string, or {@code null} when not yet reported.
+   */
+  String getFoundDataMimeType() {
+    return foundDataMimeType;
+  }
+
+  /**
+   * Updates the cached MIME type for the payload.
+   *
+   * @param foundDataMimeType MIME type string, or {@code null} when unknown.
+   */
+  void setFoundDataMimeType(String foundDataMimeType) {
+    this.foundDataMimeType = foundDataMimeType;
+  }
+
+  /**
+   * Returns the most recent splitfile progress snapshot.
+   *
+   * @return last {@link SimpleProgressMessage}, or {@code null} when none exists.
+   */
+  SimpleProgressMessage getProgressPending() {
+    return progressPending;
+  }
+
+  /**
+   * Records the latest splitfile progress snapshot.
+   *
+   * @param progressPending progress snapshot to cache, or {@code null} to clear.
+   */
+  void setProgressPending(SimpleProgressMessage progressPending) {
+    this.progressPending = progressPending;
+  }
+
+  /**
+   * Returns whether a sending-to-network event has been observed.
+   *
+   * @return {@code true} when the event has been recorded.
+   */
+  boolean hasSentToNetwork() {
+    return sentToNetwork;
+  }
+
+  /** Marks that a sending-to-network event has been received. */
+  void markSentToNetwork() {
+    sentToNetwork = true;
+  }
+
+  /**
+   * Returns the expected hash metadata, if available.
+   *
+   * @return expected hashes instance, or {@code null} when unknown.
+   */
+  ExpectedHashes getExpectedHashes() {
+    return expectedHashes;
+  }
+
+  /**
+   * Sets the expected hash metadata directly.
+   *
+   * @param expectedHashes expected hash metadata, or {@code null} to clear.
+   */
+  void setExpectedHashes(ExpectedHashes expectedHashes) {
+    this.expectedHashes = expectedHashes;
+  }
+
+  /**
+   * Attempts to set the expected hash metadata only if it has not been set.
+   *
+   * @param hashes expected hash metadata to record.
+   * @return {@code true} when the metadata was stored, {@code false} if already present.
+   */
+  boolean trySetExpectedHashes(ExpectedHashes hashes) {
+    if (expectedHashes != null) {
+      LOG.warn("Got a new ExpectedHashes");
+      return false;
+    }
+    expectedHashes = hashes;
+    return true;
+  }
+
+  /** Clears any cached expected hash metadata. */
+  void clearExpectedHashes() {
+    expectedHashes = null;
+  }
+
+  /**
+   * Returns the cached failure message for the last terminal failure.
+   *
+   * @return failure message, or {@code null} when no failure is recorded.
+   */
+  GetFailedMessage getFailedMessage() {
+    return getFailedMessage;
+  }
+
+  /**
+   * Updates the cached failure message.
+   *
+   * @param message failure message to store, or {@code null} to clear.
+   */
+  void setFailedMessage(GetFailedMessage message) {
+    getFailedMessage = message;
+  }
+
+  /**
+   * Returns the compatibility analyzer used to accumulate splitfile metadata.
+   *
+   * @return compatibility analyzer instance; may be {@code null} if not initialized.
+   */
+  CompatibilityAnalyser getCompatibilityAnalyser() {
+    return compatMode;
+  }
+
+  /**
+   * Replaces the compatibility analyzer instance.
+   *
+   * @param compatMode analyzer instance to store; may be {@code null}.
+   */
+  void setCompatibilityAnalyser(CompatibilityAnalyser compatMode) {
+    this.compatMode = compatMode;
+  }
+
+  /** Ensures a compatibility analyzer exists, creating one if missing. */
+  void ensureCompatibilityMode() {
+    if (compatMode == null) {
+      compatMode = new CompatibilityAnalyser();
+    }
+  }
+
+  /** Resets the compatibility analyzer to a fresh, empty instance. */
+  void resetCompatibilityMode() {
+    compatMode = new CompatibilityAnalyser();
+  }
+
+  /**
+   * Returns the compatibility modes accumulated so far.
+   *
+   * @return array of compatibility modes; never {@code null}.
+   */
+  InsertContext.CompatibilityMode[] getCompatibilityMode() {
+    return compatMode.getModes();
+  }
+
+  /**
+   * Indicates whether compression should be skipped for reinsertion.
+   *
+   * @return {@code true} when the payload is already compressed.
+   */
+  boolean getDontCompress() {
+    return compatMode.dontCompress();
+  }
+
+  /**
+   * Returns the optional crypto key inferred from splitfile metadata.
+   *
+   * @return crypto key bytes, or {@code null} when no override exists.
+   */
+  byte[] getOverriddenSplitfileCryptoKey() {
+    return compatMode.getCryptoKey();
+  }
+
+  /**
+   * Merges new compatibility hints and notifies caches if configured.
+   *
+   * <p>The method updates the compatibility analyzer, emits cache updates, and optionally enqueues
+   * a {@link CompatibilityMode} message based on request verbosity.
+   *
+   * @param minCompatibilityMode minimum compatibility mode hint.
+   * @param maxCompatibilityMode maximum compatibility mode hint.
+   * @param splitfileCryptoKey optional crypto key override from metadata.
+   * @param dontCompress true when the payload should not be recompressed.
+   * @param bottomLayer true when hints apply to the bottom layer of the splitfile.
+   */
+  void mergeCompatibilityMode(
+      InsertContext.CompatibilityMode minCompatibilityMode,
+      InsertContext.CompatibilityMode maxCompatibilityMode,
+      byte[] splitfileCryptoKey,
+      boolean dontCompress,
+      boolean bottomLayer) {
+    compatMode.merge(
+        minCompatibilityMode, maxCompatibilityMode, splitfileCryptoKey, dontCompress, bottomLayer);
+    if (request.client != null) {
+      RequestStatusCache cache = request.client.getRequestStatusCache();
+      if (cache != null) {
+        cache.updateDetectedCompatModes(
+            request.identifier,
+            compatMode.getModes(),
+            compatMode.getCryptoKey(),
+            compatMode.dontCompress());
+      }
+    }
+    if ((request.verbosity & ClientGet.VERBOSITY_COMPATIBILITY_MODE) != 0) {
+      request.queueProgressMessageInner(
+          new CompatibilityMode(request.identifier, request.global, compatMode),
+          ClientGet.VERBOSITY_COMPATIBILITY_MODE);
+    }
+  }
+
+  /**
+   * Returns the direct-delivery bucket if one is retained.
+   *
+   * @return bucket containing payload bytes, or {@code null} when not retained.
+   */
+  Bucket getReturnBucketDirect() {
+    return returnBucketDirect;
+  }
+
+  /**
+   * Stores the direct-delivery bucket for later replay.
+   *
+   * @param bucket payload bucket to retain, or {@code null} to clear.
+   */
+  void setReturnBucketDirect(Bucket bucket) {
+    returnBucketDirect = bucket;
+  }
+
+  /**
+   * Returns and clears the direct-delivery bucket.
+   *
+   * @return previously stored bucket, or {@code null} if none was stored.
+   */
+  Bucket takeReturnBucketDirect() {
+    Bucket data = returnBucketDirect;
+    returnBucketDirect = null;
+    return data;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetStatusReporter.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetStatusReporter.java
@@ -1,0 +1,210 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+import network.crypta.client.FetchException.FetchExceptionMode;
+
+/**
+ * Builds status and failure summaries for {@link ClientGet} without bloating the request class.
+ *
+ * <p>The reporter reads a cached request state to produce UI-friendly status snapshots, progress
+ * metrics, and failure summaries. It is read-only: callers are expected to synchronize on the
+ * owning request lock before invoking these methods so that snapshots are consistent with the
+ * latest lifecycle updates.
+ *
+ * <p>The helper keeps status construction logic separate from request orchestration. This makes it
+ * easier to evolve the status model without increasing the dependency footprint of {@link
+ * ClientGet} itself.
+ *
+ * <ul>
+ *   <li><strong>Failure summaries</strong>: converts failure metadata into user-facing text.
+ *   <li><strong>Progress metrics</strong>: exposes block counts and completion percentages.
+ *   <li><strong>Status snapshots</strong>: assembles {@link RequestStatus} for UIs and caches.
+ * </ul>
+ *
+ * @see ClientGet
+ * @see RequestStatus
+ */
+final class ClientGetStatusReporter {
+  /** The owning request whose cached state is read to build status views. */
+  private final ClientGet request;
+
+  /**
+   * Creates a reporter bound to a specific {@link ClientGet} instance.
+   *
+   * <p>The reporter does not capture mutable snapshots at construction time; it only stores the
+   * request reference and reads state lazily during each call.
+   *
+   * @param request owning request to read for status and progress data.
+   */
+  ClientGetStatusReporter(ClientGet request) {
+    this.request = Objects.requireNonNull(request, "request");
+  }
+
+  /**
+   * Returns a human-readable summary of the most recent failure, if any.
+   *
+   * <p>The summary is derived from {@link GetFailedMessage} metadata and optionally includes the
+   * extended description when {@code longDescription} is {@code true}. If no failure has been
+   * recorded, the method returns {@code null}.
+   *
+   * @param longDescription true to append extended diagnostic detail when available.
+   * @return failure summary string, or {@code null} when no failure exists.
+   */
+  String getFailureReason(boolean longDescription) {
+    GetFailedMessage failure = request.state().getFailedMessage();
+    if (failure == null) return null;
+    String summary = failure.getShortFailedMessage();
+    if (longDescription && failure.extraDescription != null) {
+      summary += ": " + failure.extraDescription;
+    }
+    return summary;
+  }
+
+  /**
+   * Returns the failure classification associated with the last recorded failure.
+   *
+   * <p>The classification is derived from the cached {@link GetFailedMessage}. It returns {@code
+   * null} when no failure is recorded yet.
+   *
+   * @return failure classification mode, or {@code null} when no failure exists.
+   */
+  FetchExceptionMode getFailureReasonCode() {
+    GetFailedMessage failure = request.state().getFailedMessage();
+    if (failure == null) return null;
+    return failure.failureMode;
+  }
+
+  /**
+   * Reports whether the total block count has been finalized for progress reporting.
+   *
+   * <p>A {@code true} result indicates either a completed successful request or progress snapshot
+   * that has finalized totals. This value is intended for UI percentage calculations.
+   *
+   * @return {@code true} when the total block count is finalized.
+   */
+  boolean isTotalFinalized() {
+    ClientGetState state = request.state();
+    if (request.finished && state.hasSucceeded()) return true;
+    SimpleProgressMessage progress = state.getProgressPending();
+    if (progress == null) return false;
+    return progress.isTotalFinalized();
+  }
+
+  /**
+   * Returns the current success fraction from the latest progress snapshot.
+   *
+   * @return fraction in the range {@code 0.0} to {@code 1.0}, or {@code -1} when unknown.
+   */
+  double getSuccessFraction() {
+    SimpleProgressMessage progress = request.state().getProgressPending();
+    if (progress != null) {
+      return progress.getFraction();
+    }
+    return -1;
+  }
+
+  /**
+   * Returns the total block count from the latest progress snapshot.
+   *
+   * @return total block count, or {@code 1} when unknown.
+   */
+  double getTotalBlocks() {
+    SimpleProgressMessage progress = request.state().getProgressPending();
+    if (progress != null) {
+      return progress.getTotalBlocks();
+    }
+    return 1;
+  }
+
+  /**
+   * Returns the minimum block count required for decoding from the latest snapshot.
+   *
+   * @return minimum required block count, or {@code 1} when unknown.
+   */
+  double getMinBlocks() {
+    SimpleProgressMessage progress = request.state().getProgressPending();
+    if (progress != null) {
+      return progress.getMinBlocks();
+    }
+    return 1;
+  }
+
+  /**
+   * Returns the non-fatal failed block count from the latest snapshot.
+   *
+   * @return non-fatal failed block count, or {@code 0} when unknown.
+   */
+  double getFailedBlocks() {
+    SimpleProgressMessage progress = request.state().getProgressPending();
+    if (progress != null) {
+      return progress.getFailedBlocks();
+    }
+    return 0;
+  }
+
+  /**
+   * Returns the fatal failed block count from the latest snapshot.
+   *
+   * @return fatal failed block count, or {@code 0} when unknown.
+   */
+  double getFatalyFailedBlocks() {
+    SimpleProgressMessage progress = request.state().getProgressPending();
+    if (progress != null) {
+      return progress.getFatalyFailedBlocks();
+    }
+    return 0;
+  }
+
+  /**
+   * Returns the fetched block count from the latest snapshot.
+   *
+   * @return fetched block count, or {@code 0} when unknown.
+   */
+  double getFetchedBlocks() {
+    SimpleProgressMessage progress = request.state().getProgressPending();
+    if (progress != null) {
+      return progress.getFetchedBlocks();
+    }
+    return 0;
+  }
+
+  /**
+   * Builds a composite {@link RequestStatus} snapshot for UI and cache consumers.
+   *
+   * <p>The snapshot includes request lifecycle state, progress metrics, payload metadata, and
+   * context information such as compatibility modes. The method does not mutate the request and
+   * should be called under the request lock to ensure consistent reads.
+   *
+   * @return fully populated {@link RequestStatus} snapshot for the current request state.
+   */
+  RequestStatus getStatus() {
+    ClientGetState state = request.state();
+    RequestStatusSnapshot statusSnapshot =
+        ClientGetStatusSnapshot.buildRequestStatusSnapshot(
+            request.identifier,
+            request.persistence,
+            request.started,
+            request.finished,
+            state.hasSucceeded(),
+            state.getProgressPending(),
+            request.priorityClass);
+    DownloadProgressSnapshot progressSnapshot =
+        new DownloadProgressSnapshot(state.getProgressPending(), state.getFailedMessage());
+    DownloadDataSnapshot dataSnapshot =
+        new DownloadDataSnapshot(
+            state.getFoundDataMimeType(),
+            state.getFoundDataLength(),
+            request.getDestFilename(),
+            request.getBucket());
+    DownloadContextSnapshot contextSnapshot =
+        new DownloadContextSnapshot(
+            request.fetchContextForGetter(),
+            request.getCompatibilityMode(),
+            request.getOverriddenSplitfileCryptoKey(),
+            request.getURI(),
+            request.getDontCompress());
+    return ClientGetGetterFactory.buildStatus(
+        new ClientGetStatusSnapshot(
+            statusSnapshot, progressSnapshot, dataSnapshot, contextSnapshot));
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -710,7 +710,7 @@ public abstract class ClientRequest implements Serializable {
   @SuppressWarnings("unused")
   public void restartAsync(final FCPServer server, final boolean disableFilterData)
       throws PersistenceDisabledException {
-    synchronized (this) {
+    synchronized (requestLock()) {
       this.started = false;
     }
     if (client != null) {
@@ -760,6 +760,16 @@ public abstract class ClientRequest implements Serializable {
               },
               "Restart request");
     }
+  }
+
+  /**
+   * Lock used to guard shared request state such as {@link #started} and {@link #finished}.
+   *
+   * <p>Subclasses may override to supply a dedicated lock that is used consistently across request
+   * lifecycle updates.
+   */
+  protected Object requestLock() {
+    return this;
   }
 
   /**
@@ -970,7 +980,9 @@ public abstract class ClientRequest implements Serializable {
   public static ClientRequest restartFrom(
       DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
       throws StorageFormatException, IOException, ResumeFailedException {
-    return reqID.type == GET ? ClientGet.restartFrom(dis, reqID, context, checker) : null;
+    return reqID.type == GET
+        ? ClientGetPersistenceCodec.restartFrom(dis, reqID, context, checker)
+        : null;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -519,7 +519,7 @@ public class FCPConnectionHandler implements Closeable {
 
   private ClientGet buildClientGet(ClientGetMessage message) {
     try {
-      return new ClientGet(this, message, server.getCore());
+      return ClientGetFactory.fromMessage(this, message, server.getCore());
     } catch (IdentifierCollisionException _) {
       handleIdentifierCollision(message.identifier, message.global);
     } catch (MessageInvalidException e) {

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -623,7 +623,7 @@ final class FcpServerPersistentOps implements DownloadCache {
             spec.realTimeFlag(),
             false);
     final ClientGet cg =
-        new ClientGet(
+        ClientGetFactory.fromGlobal(
             spec.persistRebootOnly() ? globalRebootClient : globalForeverClient,
             spec.fetchURI(),
             requestConfig,

--- a/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
@@ -2,10 +2,11 @@ package network.crypta.clients.fcp;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -76,7 +77,7 @@ class ClientGetEventHandlingTest {
 
     // Assert
     ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
-    verify(request).recordSplitfileProgress(any(SimpleProgressMessage.class));
+    assertInstanceOf(SimpleProgressMessage.class, request.state().getProgressPending());
     verify(cache).updateStatus(IDENTIFIER, event);
     verify(request)
         .queueProgressMessageInner(
@@ -95,7 +96,7 @@ class ClientGetEventHandlingTest {
     handler.receive(event, Mockito.mock(ClientContext.class));
 
     // Assert
-    verify(request).recordSplitfileProgress(any(SimpleProgressMessage.class));
+    assertInstanceOf(SimpleProgressMessage.class, request.state().getProgressPending());
     verify(request, never()).queueProgressMessageInner(any(FCPMessage.class), anyInt());
   }
 
@@ -116,11 +117,11 @@ class ClientGetEventHandlingTest {
 
     // Assert
     ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
-    verify(request).markSentToNetwork();
     verify(request)
         .queueProgressMessageInner(
             messageCaptor.capture(), eq(ClientGet.VERBOSITY_SENT_TO_NETWORK));
     assertInstanceOf(SendingToNetworkMessage.class, messageCaptor.getValue());
+    assertTrue(request.state().hasSentToNetwork());
   }
 
   @Test
@@ -132,15 +133,14 @@ class ClientGetEventHandlingTest {
             ClientGet.VERBOSITY_EXPECTED_HASHES,
             false,
             ClientRequest.Persistence.CONNECTION);
-    Mockito.doReturn(false).when(request).trySetExpectedHashes(any(ExpectedHashes.class));
     ClientGetEventHandling handler = new ClientGetEventHandling(request);
     ExpectedHashesEvent event = new ExpectedHashesEvent(new HashResult[] {newSha256Hash()});
+    request.state().trySetExpectedHashes(new ExpectedHashes(event, IDENTIFIER, false));
 
     // Act
     handler.receive(event, Mockito.mock(ClientContext.class));
 
     // Assert
-    verify(request).trySetExpectedHashes(any(ExpectedHashes.class));
     verify(request, never()).queueProgressMessageInner(any(FCPMessage.class), anyInt());
   }
 
@@ -190,7 +190,7 @@ class ClientGetEventHandlingTest {
 
     // Assert
     ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
-    verify(request).recordExpectedMimeType(EXPECTED_MIME);
+    assertEquals(EXPECTED_MIME, request.state().getFoundDataMimeType());
     verify(cache).updateExpectedMIME(IDENTIFIER, EXPECTED_MIME);
     verify(request)
         .queueProgressMessageInner(messageCaptor.capture(), eq(ClientGet.VERBOSITY_EXPECTED_TYPE));
@@ -219,7 +219,7 @@ class ClientGetEventHandlingTest {
 
     // Assert
     ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
-    verify(request).recordExpectedDataLength(42L);
+    assertEquals(42L, request.state().getFoundDataLength());
     verify(cache).updateExpectedDataLength(IDENTIFIER, 42L);
     verify(request)
         .queueProgressMessageInner(messageCaptor.capture(), eq(ClientGet.VERBOSITY_EXPECTED_SIZE));
@@ -255,14 +255,6 @@ class ClientGetEventHandlingTest {
       throws PersistenceDisabledException {
     // Arrange
     ClientGet request = newRequestWith(IDENTIFIER, 0, false, ClientRequest.Persistence.FOREVER);
-    doNothing()
-        .when(request)
-        .mergeCompatibilityMode(
-            any(CompatibilityMode.class),
-            any(CompatibilityMode.class),
-            any(),
-            anyBoolean(),
-            anyBoolean());
     PersistentJobRunner jobRunner = Mockito.mock(PersistentJobRunner.class);
     when(jobRunner.hasLoaded()).thenReturn(true);
     doNothing().when(jobRunner).queue(any(PersistentJob.class), anyInt());
@@ -281,18 +273,13 @@ class ClientGetEventHandlingTest {
 
     // Assert
     ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
-    ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
     verify(jobRunner)
         .queue(jobCaptor.capture(), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
     jobCaptor.getValue().run(Mockito.mock(ClientContext.class));
-    verify(request)
-        .mergeCompatibilityMode(
-            eq(CompatibilityMode.COMPAT_1250),
-            eq(CompatibilityMode.COMPAT_1468),
-            keyCaptor.capture(),
-            eq(true),
-            eq(false));
-    assertArrayEquals(new byte[] {1, 2, 3}, keyCaptor.getValue());
+    assertArrayEquals(
+        new CompatibilityMode[] {CompatibilityMode.COMPAT_1250, CompatibilityMode.COMPAT_1468},
+        request.state().getCompatibilityMode());
+    assertArrayEquals(new byte[] {1, 2, 3}, request.state().getOverriddenSplitfileCryptoKey());
   }
 
   @Test
@@ -300,14 +287,6 @@ class ClientGetEventHandlingTest {
       throws PersistenceDisabledException {
     // Arrange
     ClientGet request = newRequestWith(IDENTIFIER, 0, false, ClientRequest.Persistence.CONNECTION);
-    doNothing()
-        .when(request)
-        .mergeCompatibilityMode(
-            any(CompatibilityMode.class),
-            any(CompatibilityMode.class),
-            any(),
-            anyBoolean(),
-            anyBoolean());
     PersistentJobRunner jobRunner = Mockito.mock(PersistentJobRunner.class);
     ClientContext context = newContextWithJobRunner(jobRunner);
     ClientGetEventHandling handler = new ClientGetEventHandling(request);
@@ -323,15 +302,10 @@ class ClientGetEventHandlingTest {
     handler.receive(event, context);
 
     // Assert
-    ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
-    verify(request)
-        .mergeCompatibilityMode(
-            eq(CompatibilityMode.COMPAT_1250),
-            eq(CompatibilityMode.COMPAT_1468),
-            keyCaptor.capture(),
-            eq(false),
-            eq(true));
-    assertArrayEquals(new byte[] {4, 5, 6}, keyCaptor.getValue());
+    assertArrayEquals(
+        new CompatibilityMode[] {CompatibilityMode.COMPAT_1250, CompatibilityMode.COMPAT_1468},
+        request.state().getCompatibilityMode());
+    assertArrayEquals(new byte[] {4, 5, 6}, request.state().getOverriddenSplitfileCryptoKey());
     verify(jobRunner, never()).queue(any(PersistentJob.class), anyInt());
   }
 
@@ -402,6 +376,8 @@ class ClientGetEventHandlingTest {
     setField(request, ClientRequest.class, "verbosity", verbosity);
     setField(request, ClientRequest.class, "global", global);
     setField(request, ClientRequest.class, "persistence", persistence);
+    setField(request, ClientGet.class, "state", new ClientGetState(request));
+    setField(request, ClientGet.class, "persistenceLock", new ClientGet().persistenceLock());
     return request;
   }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientGetLifecycleTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetLifecycleTest.java
@@ -52,10 +52,10 @@ class ClientGetLifecycleTest {
     // Assert
     assertTrue(getBooleanField(request, "started"));
     assertTrue(getBooleanField(request, "finished"));
-    assertTrue(getBooleanField(request, "succeeded"));
-    assertEquals(123L, (long) getField(request, "foundDataLength"));
-    assertEquals("text/plain", getField(request, "foundDataMimeType"));
-    assertEquals(bucket, getField(request, "returnBucketDirect"));
+    assertTrue(request.state().hasSucceeded());
+    assertEquals(123L, request.state().getFoundDataLength());
+    assertEquals("text/plain", request.state().getFoundDataMimeType());
+    assertEquals(bucket, request.state().getReturnBucketDirect());
     verify(request).trySendDataFoundOrGetFailed(null, null);
     verify(request).trySendAllDataMessage(null, null);
     verify(request).finish();
@@ -81,9 +81,9 @@ class ClientGetLifecycleTest {
     lifecycle.onSuccess(result, getter);
 
     // Assert
-    assertEquals(50L, (long) getField(request, "foundDataLength"));
+    assertEquals(50L, request.state().getFoundDataLength());
     assertEquals(
-        ClientGetGetterFactory.binaryBlobMimeType(), getField(request, "foundDataMimeType"));
+        ClientGetGetterFactory.binaryBlobMimeType(), request.state().getFoundDataMimeType());
   }
 
   @Test
@@ -107,14 +107,14 @@ class ClientGetLifecycleTest {
     Bucket bucket = Mockito.mock(Bucket.class);
     when(bucket.size()).thenReturn(7L);
     setField(request, "returnType", ReturnType.DIRECT);
-    setField(request, "foundDataLength", 5L);
+    request.state().setFoundDataLength(5L);
     ClientContext context = Mockito.mock(ClientContext.class);
     ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
 
     // Act + Assert
     assertThrows(
         ResumeFailedException.class, () -> lifecycle.setSuccessForMigration(context, 10L, bucket));
-    assertEquals(bucket, getField(request, "returnBucketDirect"));
+    assertEquals(bucket, request.state().getReturnBucketDirect());
   }
 
   @Test
@@ -148,9 +148,9 @@ class ClientGetLifecycleTest {
     // Assert
     assertTrue(getBooleanField(request, "finished"));
     assertTrue(getBooleanField(request, "started"));
-    assertEquals(256L, (long) getField(request, "foundDataLength"));
-    assertEquals("text/plain", getField(request, "foundDataMimeType"));
-    assertNotNull(getField(request, "getFailedMessage"));
+    assertEquals(256L, request.state().getFoundDataLength());
+    assertEquals("text/plain", request.state().getFoundDataMimeType());
+    assertNotNull(request.state().getFailedMessage());
     verify(request).trySendDataFoundOrGetFailed(null, null);
     verify(request).finish();
     verify(client).notifyFailure(request);
@@ -186,15 +186,10 @@ class ClientGetLifecycleTest {
     setField(request, "global", false);
     setField(request, "started", false);
     setField(request, "finished", false);
-    setField(request, "succeeded", false);
-    setField(request, "foundDataLength", -1L);
+    request.state().setSucceeded(false);
+    request.state().setFoundDataLength(-1L);
     setField(request, "targetFile", new File("target.bin"));
     return request;
-  }
-
-  private static Object getField(Object target, String fieldName) throws Exception {
-    Field field = findField(target, fieldName);
-    return field.get(target);
   }
 
   private static boolean getBooleanField(Object target, String fieldName) throws Exception {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetMessageReplayTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetMessageReplayTest.java
@@ -64,13 +64,13 @@ class ClientGetMessageReplayTest {
             fetchContext,
             requestClient,
             ReturnType.DIRECT);
-    setField(request, "progressPending", progressMessage);
-    setField(request, "sentToNetwork", true);
+    request.state().setProgressPending(progressMessage);
+    request.state().markSentToNetwork();
     setField(request, "finished", false);
-    setField(request, "compatMode", new CompatibilityAnalyser());
-    setField(request, "expectedHashes", expectedHashes);
-    setField(request, "foundDataMimeType", "text/plain");
-    setField(request, "foundDataLength", 64L);
+    request.state().setCompatibilityAnalyser(new CompatibilityAnalyser());
+    request.state().setExpectedHashes(expectedHashes);
+    request.state().setFoundDataMimeType("text/plain");
+    request.state().setFoundDataLength(64L);
     ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
     FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
     FCPConnectionOutputHandler outputHandler = new FCPConnectionOutputHandler(handler);
@@ -173,9 +173,9 @@ class ClientGetMessageReplayTest {
     setField(request, "origHandler", origHandler);
     setField(request, "startupTime", 5L);
     setField(request, "completionTime", 12L);
-    setField(request, "foundDataLength", 99L);
-    setField(request, "foundDataMimeType", "text/plain");
-    setField(request, "succeeded", true);
+    request.state().setFoundDataLength(99L);
+    request.state().setFoundDataMimeType("text/plain");
+    request.state().setSucceeded(true);
     ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
 
@@ -206,8 +206,8 @@ class ClientGetMessageReplayTest {
     setField(request, "global", true);
     setField(request, "persistence", Persistence.REBOOT);
     setField(request, "client", client);
-    setField(request, "succeeded", false);
-    setField(request, "getFailedMessage", failedMessage);
+    request.state().setSucceeded(false);
+    request.state().setFailedMessage(failedMessage);
     ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
 
     // Act
@@ -230,9 +230,9 @@ class ClientGetMessageReplayTest {
     setField(request, "global", false);
     setField(request, "startupTime", 1L);
     setField(request, "completionTime", 2L);
-    setField(request, "foundDataMimeType", "application/octet-stream");
+    request.state().setFoundDataMimeType("application/octet-stream");
     setField(request, "returnType", ReturnType.DIRECT);
-    setField(request, "returnBucketDirect", bucket);
+    request.state().setReturnBucketDirect(bucket);
     setField(request, "persistence", Persistence.REBOOT);
     ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
     FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.security.SecureRandom;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
@@ -34,6 +35,7 @@ import network.crypta.client.async.ClientContextServices;
 import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientLayerPersister;
+import network.crypta.client.async.CompatibilityAnalyser;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.HealingQueue;
 import network.crypta.client.async.USKManager;
@@ -62,6 +64,7 @@ import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -291,18 +294,20 @@ class ClientGetPersistenceIOTest {
     ClientContext context = newClientContext();
     ChecksumChecker checker = mock(ChecksumChecker.class);
     ClientGetter getter = mock(ClientGetter.class);
-    ClientGet request = mock(ClientGet.class);
+    ClientGet request = newRequestWithState("req-1", false);
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
 
+    byte[] payload = serializeTransientProgress(42L, "text/plain");
     when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenReturn(new ByteArrayInputStream(new byte[0]));
+        .thenReturn(new ByteArrayInputStream(payload));
     when(getter.resumeFromTrivialProgress(any(DataInputStream.class), eq(context)))
         .thenReturn(true);
 
     ClientGetPersistenceIO.restoreInProgressState(input, context, checker, getter, request);
 
     verify(getter).resumeFromTrivialProgress(any(DataInputStream.class), eq(context));
-    verify(request).readTransientProgressFields(any(DataInputStream.class));
+    assertEquals(42L, request.state().getFoundDataLength());
+    assertEquals("text/plain", request.state().getFoundDataMimeType());
   }
 
   @Test
@@ -408,6 +413,46 @@ class ClientGetPersistenceIOTest {
             .redundancy(0, 0)
             .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
             .build());
+  }
+
+  private static ClientGet newRequestWithState(String identifier, boolean global) {
+    ClientGet request =
+        mock(ClientGet.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    setField(request, ClientRequest.class, "identifier", identifier);
+    setField(request, ClientRequest.class, "global", global);
+    setField(request, ClientGet.class, "state", new ClientGetState(request));
+    setField(request, ClientGet.class, "persistenceLock", new ClientGet().persistenceLock());
+    return request;
+  }
+
+  private static byte[] serializeTransientProgress(long length, String mimeType)
+      throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeLong(length);
+      if (mimeType != null) {
+        out.writeBoolean(true);
+        out.writeUTF(mimeType);
+      } else {
+        out.writeBoolean(false);
+      }
+      new CompatibilityAnalyser().writeTo(out);
+      ClientGetGetterFactory.writeExpectedHashes(out, null);
+    }
+    return buffer.toByteArray();
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void setField(Object target, Class<?> owner, String fieldName, Object value) {
+    try {
+      Field field = owner.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (ReflectiveOperationException e) {
+      LinkageError error = new LinkageError("Failed to set field: " + fieldName);
+      error.initCause(e);
+      throw error;
+    }
   }
 
   private static byte[] serializeFetchContext(FetchContext context) throws IOException {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
@@ -42,7 +42,7 @@ class ClientGetTest {
   void getBucket_whenReturnTypeDirect_returnsSameBucket() {
     ClientGet clientGet = newClientGet();
     setField(clientGet, "returnType", ReturnType.DIRECT);
-    setField(clientGet, "returnBucketDirect", directBucket);
+    clientGet.state().setReturnBucketDirect(directBucket);
 
     Bucket bucket = clientGet.getBucket();
 
@@ -80,7 +80,7 @@ class ClientGetTest {
             new SplitfileProgressTimestamps(
                 Instant.ofEpochMilli(1_000L), Instant.ofEpochMilli(2_000L)));
     SimpleProgressMessage progress = new SimpleProgressMessage("req", false, event);
-    setField(clientGet, "progressPending", progress);
+    clientGet.state().setProgressPending(progress);
 
     assertEquals(0.7, clientGet.getSuccessFraction());
     assertEquals(10, clientGet.getTotalBlocks());
@@ -94,9 +94,9 @@ class ClientGetTest {
   @Test
   void progressAccessors_whenProgressMissing_returnDefaultValues() {
     ClientGet clientGet = newClientGet();
-    setField(clientGet, "progressPending", null);
+    clientGet.state().setProgressPending(null);
     setField(clientGet, "finished", false);
-    setField(clientGet, "succeeded", false);
+    clientGet.state().setSucceeded(false);
 
     assertEquals(-1, clientGet.getSuccessFraction());
     assertEquals(1, clientGet.getTotalBlocks());
@@ -113,7 +113,7 @@ class ClientGetTest {
     FetchException exception =
         new FetchException(FetchExceptionMode.ALL_DATA_NOT_FOUND, "explanation");
     GetFailedMessage message = new GetFailedMessage(exception, "req", false);
-    setField(clientGet, "getFailedMessage", message);
+    clientGet.state().setFailedMessage(message);
 
     String result = clientGet.getFailureReason(true);
 
@@ -125,7 +125,7 @@ class ClientGetTest {
     ClientGet clientGet = newClientGet();
     FetchException exception = new FetchException(FetchExceptionMode.ALL_DATA_NOT_FOUND, "details");
     GetFailedMessage message = new GetFailedMessage(exception, "req", false);
-    setField(clientGet, "getFailedMessage", message);
+    clientGet.state().setFailedMessage(message);
 
     assertEquals(message.getShortFailedMessage(), clientGet.getFailureReason(false));
   }
@@ -133,7 +133,7 @@ class ClientGetTest {
   @Test
   void getFailureReason_whenNoFailureRecorded_returnsNull() {
     ClientGet clientGet = newClientGet();
-    setField(clientGet, "getFailedMessage", null);
+    clientGet.state().setFailedMessage(null);
 
     assertNull(clientGet.getFailureReason(true));
   }
@@ -143,7 +143,7 @@ class ClientGetTest {
     ClientGet clientGet = newClientGet();
     FetchException exception = new FetchException(FetchExceptionMode.INTERNAL_ERROR, "boom");
     GetFailedMessage message = new GetFailedMessage(exception, "req", false);
-    setField(clientGet, "getFailedMessage", message);
+    clientGet.state().setFailedMessage(message);
 
     assertEquals(FetchExceptionMode.INTERNAL_ERROR, clientGet.getFailureReasonCode());
   }
@@ -155,7 +155,7 @@ class ClientGetTest {
     FetchException exception =
         new FetchException(FetchExceptionMode.PERMANENT_REDIRECT, "redirecting", redirect);
     GetFailedMessage message = new GetFailedMessage(exception, "req", false);
-    setField(clientGet, "getFailedMessage", message);
+    clientGet.state().setFailedMessage(message);
 
     assertTrue(clientGet.hasPermRedirect());
   }
@@ -163,7 +163,7 @@ class ClientGetTest {
   @Test
   void hasPermRedirect_whenFailureMissing_returnsFalse() {
     ClientGet clientGet = newClientGet();
-    setField(clientGet, "getFailedMessage", null);
+    clientGet.state().setFailedMessage(null);
 
     assertFalse(clientGet.hasPermRedirect());
   }
@@ -174,7 +174,7 @@ class ClientGetTest {
     CompatibilityAnalyser analyser = new CompatibilityAnalyser();
     byte[] key = new byte[] {1, 2, 3, 4};
     analyser.merge(CompatibilityMode.COMPAT_1250, CompatibilityMode.COMPAT_1468, key, false, false);
-    setField(clientGet, "compatMode", analyser);
+    clientGet.state().setCompatibilityAnalyser(analyser);
 
     assertArrayEquals(
         new CompatibilityMode[] {CompatibilityMode.COMPAT_1250, CompatibilityMode.COMPAT_1468},
@@ -194,7 +194,7 @@ class ClientGetTest {
   @Test
   void getDataSize_whenLengthProvided_returnsValue() {
     ClientGet clientGet = newClientGet();
-    setField(clientGet, "foundDataLength", 42L);
+    clientGet.state().setFoundDataLength(42L);
 
     assertEquals(42L, clientGet.getDataSize());
   }
@@ -202,7 +202,7 @@ class ClientGetTest {
   @Test
   void getDataSize_whenLengthMissing_returnsNegativeOne() {
     ClientGet clientGet = newClientGet();
-    setField(clientGet, "foundDataLength", 0L);
+    clientGet.state().setFoundDataLength(0L);
 
     assertEquals(-1L, clientGet.getDataSize());
   }
@@ -210,7 +210,7 @@ class ClientGetTest {
   @Test
   void getMimeType_whenValueProvided_returnsIt() {
     ClientGet clientGet = newClientGet();
-    setField(clientGet, "foundDataMimeType", "text/plain");
+    clientGet.state().setFoundDataMimeType("text/plain");
 
     assertEquals("text/plain", clientGet.getMIMEType());
   }
@@ -235,7 +235,7 @@ class ClientGetTest {
 
   private ClientGet newClientGet() {
     ClientGet clientGet = new ClientGet();
-    setField(clientGet, "compatMode", new CompatibilityAnalyser());
+    clientGet.state().setCompatibilityAnalyser(new CompatibilityAnalyser());
     setField(clientGet, "fctx", fetchContext);
     return clientGet;
   }


### PR DESCRIPTION
## Summary
- Extract ClientGet mutable state, status reporting, restart flow, and persistence codec into dedicated helpers guarded by a shared request lock.
- Centralize ClientGet construction in ClientGetFactory and update FCP handlers/lifecycle/replay flows to use the new setup.
- Update persistence IO and tests to use the new state helpers and codec.

## Testing
- Not run (spotlessApply)