### PR TITLE
fix(fcp): handle missing remove identifiers

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
@@ -133,7 +133,20 @@ public class RemovePersistentRequest extends FCPMessage {
                       ClientRequest req1 =
                           handler.removePersistentForeverRequest(global, requestIdentifier);
                       if (req1 == null) {
-                        LOG.error("Huh ? the request is null!");
+                        if (LOG.isDebugEnabled()) {
+                          LOG.debug(
+                              "RemovePersistentRequest missing identifier {} (global={})",
+                              requestIdentifier,
+                              global);
+                        }
+                        ProtocolErrorMessage msg =
+                            new ProtocolErrorMessage(
+                                ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
+                                false,
+                                null,
+                                requestIdentifier,
+                                global);
+                        handler.send(msg);
                         return false;
                       }
                       return true;


### PR DESCRIPTION
## Summary
- return NO_SUCH_IDENTIFIER for RemoveRequest when the identifier is missing
- downgrade the missing-identifier log to debug to avoid error spam

## Testing
- `./gradlew test`