### PR TITLE
fix(node): stop packet sender during shutdown

### DIFF
--- a/src/main/java/network/crypta/io/comm/UdpSocketHandler.java
+++ b/src/main/java/network/crypta/io/comm/UdpSocketHandler.java
@@ -378,7 +378,11 @@ public class UdpSocketHandler
   public void sendPacket(byte[] blockToSend, Peer destination, boolean allowLocalAddresses)
       throws LocalAddressException {
     if (!active) {
-      LOG.error("Trying to send packet but no longer active");
+      if (node.isStopping()) {
+        if (LOG.isDebugEnabled()) LOG.debug("Trying to send packet but no longer active");
+      } else {
+        LOG.error("Trying to send packet but no longer active");
+      }
       // Do not send during shutdown to keep AddressTracker data accurate.
       return;
     }

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -2305,6 +2305,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
       isStopping = true;
     }
 
+    network.stopPacketSender();
     network.broadcastDisconnect();
 
     config.store();

--- a/src/main/java/network/crypta/node/PacketSender.java
+++ b/src/main/java/network/crypta/node/PacketSender.java
@@ -56,6 +56,7 @@ public class PacketSender implements Runnable {
   long lastReportedNoPackets;
   long lastReceivedPacketFromAnyNode;
   private final Random localRandom;
+  private volatile boolean stopping;
 
   public PacketSender(Node node) {
     this.node = node;
@@ -80,6 +81,17 @@ public class PacketSender implements Runnable {
     myThread.start();
   }
 
+  /**
+   * Requests the packet sender thread to stop and wake up promptly.
+   *
+   * <p>This is a best-effort signal used during shutdown. It is safe to call multiple times.
+   */
+  public void stop() {
+    if (stopping) return;
+    stopping = true;
+    wakeUp();
+  }
+
   private void schedulePeriodicJob() {
 
     node.network()
@@ -89,6 +101,7 @@ public class PacketSender implements Runnable {
 
               @Override
               public void run() {
+                if (stopping) return;
                 try {
                   long now = System.currentTimeMillis();
                   if (LOG.isDebugEnabled()) LOG.debug("Start schedulePeriodicJob at {}", now);
@@ -102,7 +115,9 @@ public class PacketSender implements Runnable {
                   if (LOG.isDebugEnabled())
                     LOG.debug("Complete schedulePeriodicJob at {}", System.currentTimeMillis());
                 } finally {
-                  node.network().ticker().queueTimedJob(this, 1000);
+                  if (!stopping) {
+                    node.network().ticker().queueTimedJob(this, 1000);
+                  }
                 }
               }
             },
@@ -121,9 +136,10 @@ public class PacketSender implements Runnable {
   public void run() {
     if (LOG.isDebugEnabled()) LOG.debug("In PacketSender.run()");
 
+    if (stopping) return;
     schedulePeriodicJob();
     // Process peers perform the selected action, then sleep until the next action time.
-    while (true) {
+    while (!stopping) {
       lastReceivedPacketFromAnyNode = lastReportedNoPackets;
       try {
         realRun();
@@ -446,6 +462,7 @@ public class PacketSender implements Runnable {
 
   @SuppressWarnings("java:S2142")
   private void sleepUntilNextAction(long nowBeforeSend, long nextActionTime) {
+    if (stopping) return;
     long now = System.currentTimeMillis();
     if ((now - nowBeforeSend) > SECONDS.toMillis(10))
       LOG.error("Loop delay {} ms exceeds 10000 ms in PacketSender", now - nowBeforeSend);

--- a/src/main/java/network/crypta/node/PeerNodeTransport.java
+++ b/src/main/java/network/crypta/node/PeerNodeTransport.java
@@ -122,6 +122,10 @@ final class PeerNodeTransport implements PeerTransport {
   @Override
   public MessageItem sendAsync(Message msg, AsyncMessageCallback cb, ByteCounter ctr)
       throws NotConnectedException {
+    if (peer.node.isStopping()) {
+      if (cb != null) cb.disconnected();
+      throw new NotConnectedException("Node shutting down");
+    }
     if (ctr == null)
       LOG.error(
           "ByteCounter null, so bandwidth usage cannot be logged. Refusing to send.",

--- a/src/main/java/network/crypta/node/subsystem/NodeNetworkSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeNetworkSubsystem.java
@@ -211,6 +211,17 @@ public final class NodeNetworkSubsystem {
   }
 
   /**
+   * Requests the packet sender thread to stop.
+   *
+   * <p>Used during shutdown to prevent new outbound sends once the node is quiescing.
+   */
+  public void stopPacketSender() {
+    if (packetSender != null) {
+      packetSender.stop();
+    }
+  }
+
+  /**
    * Exports a volatile field set describing current load and routing statistics.
    *
    * <p>The returned field set is produced by {@link NodeStats} and contains transient values
@@ -447,6 +458,8 @@ public final class NodeNetworkSubsystem {
     if (executor instanceof PooledExecutor pooledExecutor) pooledExecutor.setTicker(ticker);
 
     LOG.info("Creating node...");
+
+    shutdownHook.addEarlyJob(new Thread(this::stopPacketSender));
 
     shutdownHook.addEarlyJob(
         new Thread(


### PR DESCRIPTION
## Summary
- stop PacketSender during shutdown and avoid rescheduling periodic jobs
- gate outbound sends once shutdown starts and downgrade inactive UDP logs

## Testing
- ./gradlew spotlessApply