### PR TITLE
fix(build): run NodeStarter with gradle run

### DIFF
--- a/.opencode/skills/cryptad-build-test/SKILL.md
+++ b/.opencode/skills/cryptad-build-test/SKILL.md
@@ -43,6 +43,15 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
 - Compile only:
   - `./gradlew compileJava`
 
+## Run tasks
+- Run daemon entrypoint (`NodeStarter`):
+  - `./gradlew run`
+- Pass daemon CLI args:
+  - `./gradlew run --args="--help"`
+  - `./gradlew run --args="--version"`
+- Run Swing launcher entrypoint (`LauncherKt`):
+  - `./gradlew runLauncher`
+
 ## Run your build (manual deployment)
 1. Build: `./gradlew buildJar`
 2. Stop the running node

--- a/.opencode/skills/cryptad-launcher-ui/SKILL.md
+++ b/.opencode/skills/cryptad-launcher-ui/SKILL.md
@@ -64,6 +64,10 @@ If `script` exists, the launcher may wrap the process to reduce buffering.
 - `build/cryptad-dist/bin/cryptad-launcher`
 - `build/cryptad-dist/bin/cryptad-launcher.bat`
 
+## Local launcher entrypoint
+- For local development without packaging, start the launcher directly with:
+  - `./gradlew runLauncher`
+
 ## Local testing aid
 - `-PuseDummyCryptad=true` replaces `bin/cryptad` with `tools/cryptad-dummy.sh` in the dist for local testing.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,7 @@ tasks.named<JavaExec>("run") {
 tasks.register<JavaExec>("runLauncher") {
   group = "application"
   description = "Runs the Cryptad Swing launcher"
+  javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) })
   mainClass.set("network.crypta.launcher.LauncherKt")
   classpath = sourceSets.main.get().runtimeClasspath
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,8 +74,32 @@ tasks.register("printVersion") {
 // Application entrypoint (used by jpackage). This does not change how we build the wrapper
 // distribution; it's only to inform launchers that invoke the Kotlin main directly.
 // Align with actual top-level entry in Launcher.kt
-application {
+application { mainClass.set("network.crypta.launcher.LauncherKt") }
+
+val nodeRuntimeJvmArgs =
+  listOf(
+    "-Dnetworkaddress.cache.ttl=0",
+    "-Dnetworkaddress.cache.negative.ttl=0",
+    "-Djava.net.preferIPv4Stack=false",
+    "--enable-native-access=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.util=ALL-UNNAMED",
+    "--add-opens=java.base/java.io=ALL-UNNAMED",
+    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+    "-enableassertions:freenet",
+  )
+
+tasks.named<JavaExec>("run") {
+  description = "Runs Cryptad daemon via NodeStarter"
+  mainClass.set("network.crypta.node.NodeStarter")
+  jvmArgs(nodeRuntimeJvmArgs)
+}
+
+tasks.register<JavaExec>("runLauncher") {
+  group = "application"
+  description = "Runs the Cryptad Swing launcher"
   mainClass.set("network.crypta.launcher.LauncherKt")
+  classpath = sourceSets.main.get().runtimeClasspath
 }
 
 // Sonar configuration is applied via the build-logic convention plugin 'cryptad.sonar'


### PR DESCRIPTION
## Summary
- Rewire Gradle `run` to launch `network.crypta.node.NodeStarter` and apply wrapper-aligned JVM arguments needed by the daemon path.
- Add `runLauncher` as an explicit application task so launcher startup remains available during development.
- Update skill docs to reflect the new run task behavior and launcher entrypoint command.

## Verification
- `./gradlew spotlessApply`
- `./gradlew clean classes`
- `./gradlew tasks --group application`
- `./gradlew run --args=\"--help\"`
- `./gradlew run --args=\"--version\"`
- `./gradlew runLauncher` (launcher remains running; command timeout expected in CLI)