### PR TITLE
fix(node): Fix peer queue byte accounting for non-urgent messages

### DIFF
--- a/src/main/java/network/crypta/node/PeerMessageQueue.java
+++ b/src/main/java/network/crypta/node/PeerMessageQueue.java
@@ -818,6 +818,8 @@ public class PeerMessageQueue {
   public synchronized long getMessageQueueLengthBytes() {
     long x = 0;
     for (PrioQueue pq : queuesByPriority) {
+      if (pq.itemsNonUrgent != null)
+        for (MessageItem it : pq.itemsNonUrgent) x += it.getLength() + 2;
       if (pq.nonEmptyItemsWithID != null)
         for (PrioQueue.Items q : pq.nonEmptyItemsWithID)
           for (MessageItem it : q.messages) x += it.getLength() + 2;

--- a/src/test/java/network/crypta/node/PeerMessageQueueTest.java
+++ b/src/test/java/network/crypta/node/PeerMessageQueueTest.java
@@ -189,17 +189,54 @@ class PeerMessageQueueTest {
   }
 
   @Test
-  void getMessageQueueLengthBytes_withOnlyNonUrgent_returnsZero() {
+  void getMessageQueueLengthBytes_withOnlyNonUrgent_returnsTotalBytes() {
     // Arrange
     PeerMessageQueue pmq = new PeerMessageQueue(new DummyRandomSource(5));
-    MessageItem item = new MessageItem(new byte[4], null, false, null, DMT.PRIORITY_UNSPECIFIED);
-    pmq.queueAndEstimateSize(item, 1024);
+    MessageItem first = new MessageItem(new byte[4], null, false, null, DMT.PRIORITY_UNSPECIFIED);
+    MessageItem second = new MessageItem(new byte[6], null, false, null, DMT.PRIORITY_LOW);
+    pmq.queueAndEstimateSize(first, 1024);
+    pmq.queueAndEstimateSize(second, 1024);
 
     // Act
-    long urgentBytes = pmq.getMessageQueueLengthBytes();
+    long queueBytes = pmq.getMessageQueueLengthBytes();
 
     // Assert
-    assertEquals(0L, urgentBytes); // nothing has been promoted to urgent
+    assertEquals(14L, queueBytes);
+  }
+
+  @Test
+  void getMessageQueueLengthBytes_withOnlyNonEmptyItemsWithId_returnsTotalBytes() {
+    // Arrange
+    PeerMessageQueue pmq = new PeerMessageQueue(new DummyRandomSource(6));
+    MessageItem first = new MessageItem(new byte[3], null, false, null, DMT.PRIORITY_REALTIME_DATA);
+    MessageItem second =
+        new MessageItem(new byte[5], null, false, null, DMT.PRIORITY_REALTIME_DATA);
+    pmq.pushfrontPrioritizedMessageItem(first);
+    pmq.pushfrontPrioritizedMessageItem(second);
+
+    // Act
+    long queueBytes = pmq.getMessageQueueLengthBytes();
+
+    // Assert
+    assertEquals(12L, queueBytes);
+  }
+
+  @Test
+  void getMessageQueueLengthBytes_withBothQueueStructures_returnsCombinedTotalBytes() {
+    // Arrange
+    PeerMessageQueue pmq = new PeerMessageQueue(new DummyRandomSource(7));
+    MessageItem nonUrgent =
+        new MessageItem(new byte[4], null, false, null, DMT.PRIORITY_UNSPECIFIED);
+    MessageItem urgent =
+        new MessageItem(new byte[8], null, false, null, DMT.PRIORITY_REALTIME_DATA);
+    pmq.queueAndEstimateSize(nonUrgent, 1024);
+    pmq.pushfrontPrioritizedMessageItem(urgent);
+
+    // Act
+    long queueBytes = pmq.getMessageQueueLengthBytes();
+
+    // Assert
+    assertEquals(16L, queueBytes);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Include `itemsNonUrgent` entries in `PeerMessageQueue.getMessageQueueLengthBytes()` so backlog accounting reflects all queued outbound messages.
- Keep the existing per-message size formula (`getLength() + 2`) unchanged while adding the missing non-urgent contribution.
- Extend `PeerMessageQueueTest` to cover non-urgent-only, urgent-only (`nonEmptyItemsWithID`), and mixed queue-population cases.

## How to test
- Run `./gradlew test --tests '*PeerMessageQueueTest'`
- Confirm the new `getMessageQueueLengthBytes_*` tests pass and that total bytes include both queue structures.

## Notes
- Change is synchronized and linear over existing in-memory queue structures.
- Queue semantics are unchanged; this is accounting-only.