### PR TITLE
fix(crypt): Fix Yarrow byte packing and 16-bit indexing

### DIFF
--- a/src/main/java/network/crypta/crypt/Yarrow.java
+++ b/src/main/java/network/crypta/crypt/Yarrow.java
@@ -483,16 +483,16 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
     int[] parameters = bitTable[bits];
     int offset = getBytes(parameters[0]);
 
-    int val = outputBuffer[offset];
+    int val = outputBuffer[offset] & 0xFF;
 
     if (parameters[0] == 4)
       val +=
-          (outputBuffer[offset + 1] << 24)
-              + (outputBuffer[offset + 2] << 16)
-              + (outputBuffer[offset + 3] << 8);
+          ((outputBuffer[offset + 1] & 0xFF) << 24)
+              + ((outputBuffer[offset + 2] & 0xFF) << 16)
+              + ((outputBuffer[offset + 3] & 0xFF) << 8);
     else if (parameters[0] == 3)
-      val += (outputBuffer[offset + 1] << 16) + (outputBuffer[offset + 2] << 8);
-    else if (parameters[0] == 2) val += outputBuffer[offset + 2] << 8;
+      val += ((outputBuffer[offset + 1] & 0xFF) << 16) + ((outputBuffer[offset + 2] & 0xFF) << 8);
+    else if (parameters[0] == 2) val += (outputBuffer[offset + 1] & 0xFF) << 8;
 
     return val & parameters[1];
   }

--- a/src/test/java/network/crypta/crypt/YarrowTest.java
+++ b/src/test/java/network/crypta/crypt/YarrowTest.java
@@ -82,6 +82,18 @@ class YarrowTest {
   }
 
   @Test
+  void next_whenRequestingSixteenBitsRepeatedly_expectNoArrayBoundsAndInRange() {
+    // Arrange
+    Yarrow y = new Yarrow(seedFile, "SHA1", "Rijndael", false, false, false);
+
+    // Act + Assert: repeatedly crossing output buffer boundaries must remain safe.
+    for (int i = 0; i < 10_000; i++) {
+      int value = y.next(16);
+      assertTrue(value >= 0 && value <= 0xFFFF);
+    }
+  }
+
+  @Test
   void nextBoolean_whenSamplingLarge_expectBalancedCounts() {
     // Arrange
     Yarrow y = new Yarrow(seedFile, "SHA1", "Rijndael", false, false, false);


### PR DESCRIPTION
## Summary
- Fix `Yarrow.next(int)` byte packing to treat generator bytes as unsigned (`& 0xFF`) before shifts/adds.
- Correct the 2-byte assembly path to read `offset + 1` (not `offset + 2`), preventing out-of-bounds access when repeatedly requesting 9-16 bits.
- Add a regression test that repeatedly calls `next(16)` to validate boundary safety and output range.

## How to test
- `./gradlew test --tests "*YarrowTest"`
- `./gradlew test`
