### PR TITLE
build(tooling): Configure SpotBugs XML reports

### DIFF
--- a/.agents/skills/cryptad-build-tooling/SKILL.md
+++ b/.agents/skills/cryptad-build-tooling/SKILL.md
@@ -63,12 +63,16 @@ Notes:
 - Build logic includes the plugin marker dependency in `build-logic/build.gradle.kts`.
 - The shared convention plugin applies `com.github.spotbugs` in `build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts`.
 - Default behavior is non-blocking: `spotbugs { ignoreFailures = true }`.
+- All SpotBugs tasks are configured via `tasks.withType<SpotBugsTask>()` to emit XML reports at `build/reports/spotbugs/<taskName>.xml`.
+- Text reports are disabled (`reports.matching { it.name == "text" }`) so findings are read from XML files instead of large stdout dumps.
 
 ### Tasks
 - Run main analysis:
   - `./gradlew spotbugsMain`
+  - Report: `build/reports/spotbugs/spotbugsMain.xml`
 - Run test analysis:
   - `./gradlew spotbugsTest`
+  - Report: `build/reports/spotbugs/spotbugsTest.xml`
 - SpotBugs tasks are also part of `check` once the plugin is applied.
 
 ### Enforcing SpotBugs failures
@@ -87,6 +91,7 @@ If strict verification blocks SpotBugs/plugin marker resolution:
 ```bash
 ./gradlew help
 ./gradlew spotbugsMain
+./gradlew spotbugsTest
 ```
 
 Confirm `gradle/verification-metadata.xml` contains SpotBugs entries such as:

--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.spotbugs.snom.SpotBugsTask
 import java.time.Instant
 import javax.xml.stream.XMLOutputFactory
 import net.ltgt.gradle.errorprone.errorprone
@@ -85,6 +86,14 @@ val errorproneReportEnabled =
   }
 
 spotbugs { ignoreFailures = true }
+
+tasks.withType<SpotBugsTask>().configureEach {
+  val xmlReport = reports.maybeCreate("xml")
+  xmlReport.required.set(true)
+  xmlReport.outputLocation.set(layout.buildDirectory.file("reports/spotbugs/$name.xml"))
+
+  reports.matching { it.name == "text" }.configureEach { required.set(false) }
+}
 
 java {
   toolchain { languageVersion.set(JavaLanguageVersion.of(25)) }


### PR DESCRIPTION
## Summary
- Configure all `SpotBugsTask` tasks in the shared Java/Kotlin conventions plugin to generate XML reports.
- Write reports to `build/reports/spotbugs/<taskName>.xml` for stable machine-readable output.
- Disable the text report so SpotBugs findings are no longer emitted as large stdout dumps during task execution.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain`
- `./gradlew spotbugsTest`
- Confirm report files exist:
  - `build/reports/spotbugs/spotbugsMain.xml`
  - `build/reports/spotbugs/spotbugsTest.xml`