### PR TITLE
fix(updater): Fix nullable getter usage in package fetch start

### DIFF
--- a/src/main/kotlin/network/crypta/node/updater/CoreUpdater.kt
+++ b/src/main/kotlin/network/crypta/node/updater/CoreUpdater.kt
@@ -542,7 +542,7 @@ class CoreUpdater(params: NodeUpdaterParams) : NodeUpdater(params) {
       val ctx =
         manager.getNode().services().clientCore().makeClient(0.toShort(), true, false).fetchContext
       val fb = FileBucket(outFile, false, false, false, false)
-      getter =
+      val createdGetter =
         ClientGetter(
           this,
           chk,
@@ -552,9 +552,10 @@ class CoreUpdater(params: NodeUpdaterParams) : NodeUpdater(params) {
           null,
           null,
         )
+      getter = createdGetter
       ctx.eventProducer.addEventListener(this)
       try {
-        manager.getNode().services().clientCore().clientContext.start(getter)
+        manager.getNode().services().clientCore().clientContext.start(createdGetter)
         this@CoreUpdater.logInfo(
           "download started (listener attached): target=${outFile.absolutePath}"
         )


### PR DESCRIPTION
## Summary
- Fix the SpotBugs `NP_NULL_PARAM_DEREF` finding in `CoreUpdater.PackageFetcher.start()`.
- Create a non-null local `createdGetter` and pass it to `clientContext.start(...)` instead of the nullable `getter` field.
- Keep assigning `getter` for existing fetch lifecycle/state behavior while avoiding nullable flow into a non-null API parameter.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- Confirm no `NP_NULL_PARAM_DEREF` entry remains in SpotBugs reports for main sources.