### PR TITLE
fix(spotbugs): Resolve HSM_HIDING_METHOD findings

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -1162,34 +1162,6 @@ public class ClientGet extends ClientRequest {
     ClientGetPersistenceCodec.writeClientDetail(this, dos, checker);
   }
 
-  /**
-   * Recreates a {@link ClientGet} from serialized persistent storage.
-   *
-   * <p>This factory method is used during startup to restore previously persisted requests. It
-   * validates the serialized header, rebuilds the {@link FetchContext}, restores progress state,
-   * and reconstructs the underlying {@link ClientGetter} where possible. If the stored data is
-   * incomplete or inconsistent, it throws a {@link ResumeFailedException} to signal that the
-   * request should restart rather than trust corrupted state.
-   *
-   * <p>The returned request is fully initialized and ready to re-register with queues.
-   *
-   * @param dis input stream positioned at the serialized client detail block.
-   * @param reqID identifier tuple describing the owner and reference type.
-   * @param context client context supplying factories used during restoration.
-   * @param checker checksum helper verifying the integrity of embedded buckets.
-   * @return fully reconstructed {@link ClientRequest} instance ready for registration and
-   *     resumption.
-   * @throws StorageFormatException when serialized data fails validation or version checks.
-   * @throws IOException when stream IO fails while reading buckets or metadata.
-   * @throws ResumeFailedException when the request must restart due to inconsistencies.
-   */
-  @SuppressWarnings("unused")
-  public static ClientRequest restartFrom(
-      DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
-      throws StorageFormatException, IOException, ResumeFailedException {
-    return ClientGetPersistenceCodec.restartFrom(dis, reqID, context, checker);
-  }
-
   ClientGet(
       DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
       throws IOException, StorageFormatException, ResumeFailedException {

--- a/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
@@ -174,7 +174,8 @@ final class FcpServerListener implements Runnable {
     NetworkInterface tempNetworkInterface;
     if (ssl) {
       tempNetworkInterface =
-          SSLNetworkInterface.create(port, bindTo, allowedHosts, node.network().executor(), true);
+          SSLNetworkInterface.createSsl(
+              port, bindTo, allowedHosts, node.network().executor(), true);
     } else {
       tempNetworkInterface =
           NetworkInterface.create(port, bindTo, allowedHosts, node.network().executor(), true);

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -1215,7 +1215,7 @@ public final class SimpleToadletServer
     if (this.networkInterface != null) return;
     if (ssl) {
       this.networkInterface =
-          SSLNetworkInterface.create(port, this.bindTo, allowedHosts, executor, true);
+          SSLNetworkInterface.createSsl(port, this.bindTo, allowedHosts, executor, true);
     } else {
       this.networkInterface =
           NetworkInterface.create(port, this.bindTo, allowedHosts, executor, true);

--- a/src/main/java/network/crypta/clients/http/Toadlet.java
+++ b/src/main/java/network/crypta/clients/http/Toadlet.java
@@ -91,7 +91,7 @@ public abstract class Toadlet {
         .getString("Toadlet." + key, new String[] {REASON_PATTERN}, new String[] {value});
   }
 
-  private static String l10n(String key) {
+  private static String l10nToadlet(String key) {
     return NodeL10n.getBase().getString("Toadlet." + key);
   }
 
@@ -120,7 +120,7 @@ public abstract class Toadlet {
             + "</h1><a href=\""
             + HTMLEncoder.encode(location)
             + "\">"
-            + l10n("clickHere")
+            + l10nToadlet("clickHere")
             + "</a></body></html>";
     byte[] buf = redirDoc.getBytes(StandardCharsets.UTF_8);
     MultiValueTable<String, String> headers = MultiValueTable.from("Location", location);
@@ -140,8 +140,8 @@ public abstract class Toadlet {
     content.addChild(
         "a",
         new String[] {"href", "title"},
-        new String[] {"/", l10n("homepage")},
-        l10n("returnToNodeHomepage"));
+        new String[] {"/", l10nToadlet("homepage")},
+        l10nToadlet("returnToNodeHomepage"));
   }
 
   /**
@@ -520,7 +520,7 @@ public abstract class Toadlet {
             + "</h1><a href=\""
             + HTMLEncoder.encode(location)
             + "\">"
-            + l10n("clickHere")
+            + l10nToadlet("clickHere")
             + "</a></body></html>";
     byte[] buf = redirDoc.getBytes(StandardCharsets.UTF_8);
     MultiValueTable<String, String> mvt = MultiValueTable.from("Location", location);
@@ -568,7 +568,7 @@ public abstract class Toadlet {
         ctx.getPageMaker().getInfobox("infobox-error", desc, contentNode, null, true);
     infoboxContent.addChild(message);
     infoboxContent.addChild("br");
-    infoboxContent.addChild("a", "href", ".", l10n("returnToPrevPage"));
+    infoboxContent.addChild("a", "href", ".", l10nToadlet("returnToPrevPage"));
     infoboxContent.addChild("br");
     addHomepageLink(infoboxContent);
 
@@ -602,7 +602,7 @@ public abstract class Toadlet {
     // Consider replacing <pre> with CSS-based styling when modernizing the markup.
     infoboxContent.addChild("pre", sw.toString());
     infoboxContent.addChild("br");
-    infoboxContent.addChild("a", "href", ".", l10n("returnToPrevPage"));
+    infoboxContent.addChild("a", "href", ".", l10nToadlet("returnToPrevPage"));
     addHomepageLink(infoboxContent);
 
     writeHTMLReply(ctx, 500, desc, page.generate());

--- a/src/main/java/network/crypta/crypt/CryptoKey.java
+++ b/src/main/java/network/crypta/crypt/CryptoKey.java
@@ -19,8 +19,8 @@ import org.slf4j.LoggerFactory;
  * <p>Serialization helpers in this class support a simple polymorphic format in which the first
  * field is the fully qualified class name of the concrete key, written with {@link
  * java.io.DataOutput#writeUTF(String)}. The corresponding {@link #read(InputStream)} method
- * resolves that class and delegates to a public static {@code read(InputStream)} factory on the key
- * type.
+ * resolves that class and delegates to a public static {@code readKey(InputStream)} factory on the
+ * key type, with a fallback to legacy {@code read(InputStream)} factories.
  */
 public abstract class CryptoKey implements CryptoElement, Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(CryptoKey.class);
@@ -34,8 +34,10 @@ public abstract class CryptoKey implements CryptoElement, Serializable {
    *
    * <p>The stream must start with a UTF string containing the fully qualified class name of the
    * concrete key type (as written by {@link DataOutput#writeUTF(String)}). The loader locates that
-   * class, obtains a public static factory with the exact signature {@code read(InputStream)}, and
-   * invokes it to parse the remainder of the data.
+   * class, obtains a public static factory with the exact signature {@code readKey(InputStream)},
+   * and invokes it to parse the remainder of the data. For compatibility with older key
+   * implementations, the loader falls back to {@code read(InputStream)} when {@code readKey} is
+   * absent.
    *
    * <p>On failures that represent normal parse conditions, such as malformed input, this method
    * propagates the underlying {@link CryptFormatException} or {@link IOException}. Other failures
@@ -53,7 +55,7 @@ public abstract class CryptoKey implements CryptoElement, Serializable {
     String type = dis.readUTF();
     try {
       Class<?> keyClass = Class.forName(type);
-      Method m = keyClass.getMethod("read", InputStream.class);
+      Method m = resolveReadMethod(keyClass);
       return (CryptoKey) m.invoke(null, dis);
     } catch (InvocationTargetException e) {
       // Unwrap and rethrow expected checked exceptions from the delegate factory.
@@ -68,6 +70,14 @@ public abstract class CryptoKey implements CryptoElement, Serializable {
     } catch (RuntimeException e) {
       LOG.error("Runtime exception while reading CryptoKey", e);
       return null;
+    }
+  }
+
+  private static Method resolveReadMethod(Class<?> keyClass) throws NoSuchMethodException {
+    try {
+      return keyClass.getMethod("readKey", InputStream.class);
+    } catch (NoSuchMethodException e) {
+      return keyClass.getMethod("read", InputStream.class);
     }
   }
 

--- a/src/main/java/network/crypta/crypt/DSAGroup.java
+++ b/src/main/java/network/crypta/crypt/DSAGroup.java
@@ -57,7 +57,7 @@ public class DSAGroup extends CryptoKey {
    * No‑arg constructor for Java serialization frameworks.
    *
    * <p>Not intended for direct use. Regular code should build instances via {@link
-   * #DSAGroup(BigInteger, BigInteger, BigInteger)} or parse with {@link #read(InputStream)}.
+   * #DSAGroup(BigInteger, BigInteger, BigInteger)} or parse with {@link #readKey(InputStream)}.
    */
   protected DSAGroup() {
     p = null;
@@ -77,7 +77,7 @@ public class DSAGroup extends CryptoKey {
    * @throws IOException if the stream cannot be read
    * @throws CryptFormatException if the values are syntactically valid but form an invalid group
    */
-  public static CryptoKey read(InputStream i) throws IOException, CryptFormatException {
+  public static CryptoKey readKey(InputStream i) throws IOException, CryptFormatException {
     BigInteger p;
     BigInteger q;
     BigInteger g;

--- a/src/main/java/network/crypta/crypt/DSAPublicKey.java
+++ b/src/main/java/network/crypta/crypt/DSAPublicKey.java
@@ -98,7 +98,7 @@ public class DSAPublicKey extends CryptoKey implements StorableBlock {
    * @throws IllegalArgumentException if the parsed {@code y} is not in {@code [1, p)}.
    */
   public DSAPublicKey(InputStream is) throws IOException, CryptFormatException {
-    DSAGroup g = (DSAGroup) DSAGroup.read(is);
+    DSAGroup g = (DSAGroup) DSAGroup.readKey(is);
     if (Global.DSAgroupBigA.equals(g)) g = null;
     group = g;
     y = Util.readMPI(is);
@@ -212,7 +212,7 @@ public class DSAPublicKey extends CryptoKey implements StorableBlock {
    * @throws IOException on I/O errors.
    * @throws CryptFormatException if the input is malformed.
    */
-  public static CryptoKey read(InputStream i) throws IOException, CryptFormatException {
+  public static CryptoKey readKey(InputStream i) throws IOException, CryptFormatException {
     return new DSAPublicKey(i);
   }
 

--- a/src/main/java/network/crypta/io/SSLNetworkInterface.java
+++ b/src/main/java/network/crypta/io/SSLNetworkInterface.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 public class SSLNetworkInterface extends NetworkInterface {
   private static final Logger LOG = LoggerFactory.getLogger(SSLNetworkInterface.class);
 
-  public static NetworkInterface create(
+  public static NetworkInterface createSsl(
       int port,
       String bindTo,
       String allowedHosts,

--- a/src/main/java/network/crypta/keys/ClientKSK.java
+++ b/src/main/java/network/crypta/keys/ClientKSK.java
@@ -121,7 +121,7 @@ public class ClientKSK extends InsertableClientSSK {
    * @return a new {@code ClientKSK} derived from {@code uri}
    * @throws IllegalArgumentException if {@code uri} does not have key type {@code "KSK"}
    */
-  public static InsertableClientSSK create(FreenetURI uri) {
+  public static InsertableClientSSK fromUri(FreenetURI uri) {
     if (!uri.getKeyType().equals("KSK")) throw new IllegalArgumentException();
     return create(uri.getDocName());
   }

--- a/src/main/java/network/crypta/keys/InsertableClientSSK.java
+++ b/src/main/java/network/crypta/keys/InsertableClientSSK.java
@@ -107,7 +107,7 @@ public class InsertableClientSSK extends ClientSSK {
    *     key, wrong type, or invalid extras), or if key material is malformed
    */
   public static InsertableClientSSK create(FreenetURI uri) throws MalformedURLException {
-    if (uri.getKeyType().equalsIgnoreCase("KSK")) return ClientKSK.create(uri);
+    if (uri.getKeyType().equalsIgnoreCase("KSK")) return ClientKSK.fromUri(uri);
 
     if (uri.getRoutingKey() == null)
       throw new MalformedURLException("Insertable SSK URIs must have a private key!: " + uri);

--- a/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
+++ b/src/main/java/network/crypta/node/TextModeClientInterfaceServer.java
@@ -90,7 +90,7 @@ public class TextModeClientInterfaceServer implements Runnable {
     this.isEnabled = true;
     if (ssl) {
       networkInterface =
-          SSLNetworkInterface.create(port, bindTo, allowedHosts, n.network().executor(), true);
+          SSLNetworkInterface.createSsl(port, bindTo, allowedHosts, n.network().executor(), true);
     } else {
       networkInterface =
           NetworkInterface.create(port, bindTo, allowedHosts, n.network().executor(), true);

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -149,7 +149,7 @@ class SimpleToadletServerTest {
           .when(() -> NetworkInterface.create(anyInt(), any(), any(), any(), anyBoolean()))
           .thenReturn(iface);
       sslMock
-          .when(() -> SSLNetworkInterface.create(anyInt(), any(), any(), any(), anyBoolean()))
+          .when(() -> SSLNetworkInterface.createSsl(anyInt(), any(), any(), any(), anyBoolean()))
           .thenReturn(iface);
       return new SimpleToadletServer(config, bucketFactory, executor, node);
     }

--- a/src/test/java/network/crypta/crypt/DSAGroupTest.java
+++ b/src/test/java/network/crypta/crypt/DSAGroupTest.java
@@ -157,7 +157,7 @@ class DSAGroupTest {
     Util.writeMPI(bigA.getG(), bos);
     ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
 
-    CryptoKey parsed = DSAGroup.read(bis);
+    CryptoKey parsed = DSAGroup.readKey(bis);
     assertSame(bigA, parsed, "Expected canonical Global.DSAgroupBigA instance");
   }
 
@@ -167,7 +167,7 @@ class DSAGroupTest {
     byte[] mpiZero = Util.mpiBytes(BigInteger.ZERO);
     byte[] threeZeros = concat(mpiZero, mpiZero, mpiZero);
     ByteArrayInputStream bis = new ByteArrayInputStream(threeZeros);
-    assertThrows(CryptFormatException.class, () -> DSAGroup.read(bis));
+    assertThrows(CryptFormatException.class, () -> DSAGroup.readKey(bis));
   }
 
   @Test

--- a/src/test/java/network/crypta/crypt/DSAPublicKeyTest.java
+++ b/src/test/java/network/crypta/crypt/DSAPublicKeyTest.java
@@ -82,7 +82,7 @@ class DSAPublicKeyTest {
   void read_staticMethod_readsFromStream() throws IOException, CryptFormatException {
     DSAPublicKey original = new DSAPublicKey(GROUP, BigInteger.valueOf(3));
     ByteArrayInputStream in = new ByteArrayInputStream(original.asBytes());
-    CryptoKey parsed = DSAPublicKey.read(in);
+    CryptoKey parsed = DSAPublicKey.readKey(in);
     assertInstanceOf(DSAPublicKey.class, parsed);
     assertTrue(original.equals((DSAPublicKey) parsed));
   }

--- a/src/test/java/network/crypta/keys/ClientKSKTest.java
+++ b/src/test/java/network/crypta/keys/ClientKSKTest.java
@@ -113,7 +113,7 @@ class ClientKSKTest {
     FreenetURI uriWithMeta = new FreenetURI("KSK@" + raw + "/meta1/meta2");
 
     // Act
-    InsertableClientSSK fromUri = ClientKSK.create(uriWithMeta);
+    InsertableClientSSK fromUri = ClientKSK.fromUri(uriWithMeta);
     // For KSK, the docName is the first path segment after '@'
     String expectedDocName = uriWithMeta.getDocName();
     assertNotNull(expectedDocName);
@@ -132,6 +132,6 @@ class ClientKSKTest {
     FreenetURI chk = new FreenetURI("CHK", null, rkey, ckey, null);
 
     // Act / Assert
-    assertThrows(IllegalArgumentException.class, () -> ClientKSK.create(chk));
+    assertThrows(IllegalArgumentException.class, () -> ClientKSK.fromUri(chk));
   }
 }

--- a/src/test/java/network/crypta/keys/InsertableClientSSKTest.java
+++ b/src/test/java/network/crypta/keys/InsertableClientSSKTest.java
@@ -87,7 +87,7 @@ class InsertableClientSSKTest {
 
     // Assert
     assertInstanceOf(ClientKSK.class, fromInsertable);
-    assertEquals(ClientKSK.create(ksk), fromInsertable);
+    assertEquals(ClientKSK.fromUri(ksk), fromInsertable);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Remove and rename static methods that were hiding inherited methods and triggering `HSM_HIDING_METHOD` (FCP restore path, crypto key readers, SSL factory, and KSK URI factory).
- Update call sites and tests to use the new non-hiding method names.
- Keep crypto key deserialization compatibility by adding `readKey(InputStream)` lookup with fallback to legacy `read(InputStream)` in `CryptoKey`.

## How to test
- Run `./gradlew spotlessApply`
- Run `./gradlew compileJava compileTestJava`
- Run `./gradlew test --tests "*DSAGroupTest" --tests "*DSAPublicKeyTest" --tests "*ClientKSKTest" --tests "*InsertableClientSSKTest" --tests "*SimpleToadletServerTest"`
- Run `./gradlew spotbugsMain spotbugsTest`
- Verify `build/reports/spotbugs/spotbugsMain.xml` and `build/reports/spotbugs/spotbugsTest.xml` contain zero `HSM_HIDING_METHOD` entries
- Run `./gradlew test`

## Notes
- SpotBugs still reports unrelated environment issues (`oshi.annotation.concurrent.ThreadSafe` missing for analysis and non-HSM findings), but `HSM_HIDING_METHOD` is reduced to zero in both reports.