### PR TITLE
fix(spotbugs): Remove Serializable from DummyStepHandler singleton

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/ode/DummyStepHandler.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DummyStepHandler.java
@@ -1,8 +1,5 @@
 package org.spaceroots.mantissa.ode;
 
-import java.io.Serial;
-import java.io.Serializable;
-
 /**
  * A minimal {@link StepHandler} implementation that deliberately discards all step callbacks.
  *
@@ -28,7 +25,7 @@ import java.io.Serializable;
  * @version $Id: DummyStepHandler.java 1721 2007-10-07 20:21:25Z luc $
  * @author L. Maisonobe
  */
-public class DummyStepHandler implements StepHandler, Serializable {
+public class DummyStepHandler implements StepHandler {
 
   /**
    * Private constructor. The constructor is private to prevent users from creating instances
@@ -46,7 +43,7 @@ public class DummyStepHandler implements StepHandler, Serializable {
    *
    * @return the singleton instance reused for all no-op step handling needs
    */
-  public static DummyStepHandler getInstance() {
+  public static synchronized DummyStepHandler getInstance() {
     if (instance == null) {
       instance = new DummyStepHandler();
     }
@@ -102,6 +99,4 @@ public class DummyStepHandler implements StepHandler, Serializable {
 
   /** The only instance. */
   private static DummyStepHandler instance = null;
-
-  @Serial private static final long serialVersionUID = 1804704906852043886L;
 }

--- a/src/test/java/org/spaceroots/mantissa/ode/DummyStepHandlerTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/DummyStepHandlerTest.java
@@ -4,11 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
+import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -65,25 +65,16 @@ class DummyStepHandlerTest {
   }
 
   @Test
-  void serializationRoundTrip_whenDeserialized_instanceRemainsStateless() throws Exception {
+  void serialization_whenSerialized_throwsNotSerializableException() {
     DummyStepHandler handler = DummyStepHandler.getInstance();
-
     ByteArrayOutputStream bout = new ByteArrayOutputStream();
-    try (ObjectOutputStream oos = new ObjectOutputStream(bout)) {
-      oos.writeObject(handler);
-    }
 
-    DummyStepHandler restored;
-    try (ObjectInputStream ois =
-        new ObjectInputStream(new ByteArrayInputStream(bout.toByteArray()))) {
-      restored = (DummyStepHandler) ois.readObject();
-    }
-
-    assertNotNull(restored);
-    assertFalse(restored.requiresDenseOutput());
-    assertSame(handler, DummyStepHandler.getInstance());
-
-    restored.handleStep(interpolator, false);
-    verifyNoInteractions(interpolator);
+    assertThrows(
+        NotSerializableException.class,
+        () -> {
+          try (ObjectOutputStream oos = new ObjectOutputStream(bout)) {
+            oos.writeObject(handler);
+          }
+        });
   }
 }


### PR DESCRIPTION
## Summary
- Remove `Serializable` from `DummyStepHandler` so it no longer matches SpotBugs singleton-serializable detection.
- Keep singleton behavior explicit by synchronizing `getInstance()` lazy initialization.
- Update `DummyStepHandlerTest` to assert serialization is rejected with `NotSerializableException` instead of round-tripping serialized state.

## How to test
- `./gradlew spotlessApply`
- `./gradlew test --tests org.spaceroots.mantissa.ode.DummyStepHandlerTest`
- `./gradlew spotbugsMain`

## Expected result
- `build/reports/spotbugs/spotbugsMain.xml` contains no `SING_SINGLETON_IMPLEMENTS_SERIALIZABLE` finding for `org.spaceroots.mantissa.ode.DummyStepHandler`.