### PR TITLE
fix(spotbugs): Replace ConcurrentMap monitor with private lock

### DIFF
--- a/src/main/java/network/crypta/client/filter/ContentFilter.java
+++ b/src/main/java/network/crypta/client/filter/ContentFilter.java
@@ -55,6 +55,7 @@ public class ContentFilter {
 
   // Use a concurrent map to avoid a legacy synchronized Hashtable
   static final ConcurrentMap<String, FilterMIMEType> mimeTypesByName = new ConcurrentHashMap<>();
+  private static final Object MIME_TYPES_REGISTRATION_LOCK = new Object();
 
   /** The HTML mime types are defined here to allow other modules to identify it */
   protected static final String[] HTML_MIME_TYPES =
@@ -288,7 +289,7 @@ public class ContentFilter {
    *     not be {@code null}
    */
   public static void register(FilterMIMEType mimeType) {
-    synchronized (mimeTypesByName) {
+    synchronized (MIME_TYPES_REGISTRATION_LOCK) {
       mimeTypesByName.put(mimeType.primaryMimeType, mimeType);
       String[] alt = mimeType.alternateMimeTypes;
       if (alt != null) {


### PR DESCRIPTION
## Summary
- Fix the SpotBugs `JLM_JSR166_UTILCONCURRENT_MONITORENTER` finding in `ContentFilter.register(...)`.
- Replace `synchronized (mimeTypesByName)` with a dedicated private lock object so synchronization is not performed on a `java.util.concurrent` type.
- Preserve atomic registration of primary and alternate MIME type aliases.

## How to test
- Run `./gradlew spotlessApply`
- Run `./gradlew spotbugsMain spotbugsTest`
- Verify `JLM_JSR166_UTILCONCURRENT_MONITORENTER` is absent from SpotBugs reports (for example: `rg -n "JLM_JSR166_UTILCONCURRENT_MONITORENTER" build/reports/spotbugs`)
