### PR TITLE
fix(spotbugs): Avoid starting threads in constructors

### DIFF
--- a/src/main/java/com/onionnetworks/util/AsyncPersistentProps.java
+++ b/src/main/java/com/onionnetworks/util/AsyncPersistentProps.java
@@ -38,20 +38,22 @@ public class AsyncPersistentProps implements Runnable {
   private boolean closed;
   private boolean changed;
   private boolean writing;
+  private boolean writerThreadStarted;
+  private final Thread writerThread;
 
   /**
-   * Creates a new asynchronous property store bound to the given file and starts the writer thread.
+   * Creates a new asynchronous property store bound to the given file.
    *
    * <p>If the file already exists, its contents are loaded into an initially mutable {@link
    * Properties} instance. When the file is absent, an empty properties set is created and the file
-   * will be materialized on the first successful write. The constructor spawns a daemon thread
-   * named after the target file to persist snapshots without blocking callers. Callers should
-   * retain the returned instance and eventually invoke {@link #close()} to stop the worker and
-   * surface any deferred I/O failures.
+   * will be materialized on the first successful write. The constructor prepares a daemon thread
+   * named after the target file; the thread starts lazily when a write is first required. Callers
+   * should retain the returned instance and eventually invoke {@link #close()} to stop the worker
+   * and surface any deferred I/O failures.
    *
    * @param f backing file that receives serialized property snapshots; must be readable if it
    *     already exists and writable for future writes; never {@code null}
-   * @throws IOException if loading the existing file fails or the writer thread cannot be started
+   * @throws IOException if loading the existing file fails
    */
   public AsyncPersistentProps(File f) throws IOException {
     this.f = f;
@@ -61,9 +63,8 @@ public class AsyncPersistentProps implements Runnable {
         p.load(in);
       }
     }
-    final Thread thread = new Thread(this, "Props Writer :" + f.getName());
-    thread.setDaemon(true);
-    thread.start();
+    writerThread = new Thread(this, "Props Writer :" + f.getName());
+    writerThread.setDaemon(true);
   }
 
   /**
@@ -107,6 +108,7 @@ public class AsyncPersistentProps implements Runnable {
   public synchronized Object setProperty(String key, String value) {
     checkState();
 
+    startWriterThreadIfNeeded();
     Object result = p.setProperty(key, value);
     changed = true;
     this.notifyAll();
@@ -129,6 +131,7 @@ public class AsyncPersistentProps implements Runnable {
 
     Object result = p.remove(key);
     if (result != null) {
+      startWriterThreadIfNeeded();
       changed = true;
       this.notifyAll();
     }
@@ -146,6 +149,7 @@ public class AsyncPersistentProps implements Runnable {
   public synchronized void clear() {
     checkState();
 
+    startWriterThreadIfNeeded();
     p.clear();
     changed = true;
     this.notifyAll();
@@ -220,6 +224,13 @@ public class AsyncPersistentProps implements Runnable {
       throw new IllegalStateException(ioe.getMessage());
     } else if (closed) {
       throw new IllegalStateException("Sorry, we're closed");
+    }
+  }
+
+  private void startWriterThreadIfNeeded() {
+    if (!writerThreadStarted) {
+      writerThread.start();
+      writerThreadStarted = true;
     }
   }
 

--- a/src/main/java/com/onionnetworks/util/ReflectiveEventDispatch.java
+++ b/src/main/java/com/onionnetworks/util/ReflectiveEventDispatch.java
@@ -52,20 +52,19 @@ public class ReflectiveEventDispatch implements Runnable {
   // Holds either Tuple(event, methodName) or a sentinel (this) to signal shutdown
   private final ArrayDeque<Object> eventQueue = new ArrayDeque<>();
   private final Thread thread;
+  private boolean dispatchThreadStarted;
   private ExceptionHandler handler;
 
   /**
-   * Creates and starts a new dispatcher instance with a dedicated daemon thread.
+   * Creates a new dispatcher instance with a dedicated daemon thread.
    *
-   * <p>The constructor immediately creates the internal queue, spawns the dispatch thread, and
-   * begins processing any events that are enqueued. Callers can adjust the thread priority or
-   * register an {@link ExceptionHandler} after construction; no additional initialization steps are
-   * required.
+   * <p>The constructor initializes internal state and prepares the dispatch thread. The thread
+   * starts lazily when the first event is queued. Callers can register listeners and install an
+   * {@link ExceptionHandler} before any asynchronous work begins.
    */
   public ReflectiveEventDispatch() {
     this.thread = new Thread(this, "Reflective Dispatch#" + hashCode());
     this.thread.setDaemon(true);
-    this.thread.start();
   }
 
   /**
@@ -195,6 +194,7 @@ public class ReflectiveEventDispatch implements Runnable {
    *     against registered names.
    */
   public synchronized void fire(EventObject ev, String methodName) {
+    startDispatchThreadIfNeeded();
     eventQueue.add(new Tuple(ev, methodName));
     this.notifyAll();
   }
@@ -213,6 +213,13 @@ public class ReflectiveEventDispatch implements Runnable {
     this.notifyAll();
   }
 
+  private void startDispatchThreadIfNeeded() {
+    if (!dispatchThreadStarted) {
+      thread.start();
+      dispatchThreadStarted = true;
+    }
+  }
+
   /**
    * Main dispatch loop executed by the internal daemon thread.
    *
@@ -220,7 +227,7 @@ public class ReflectiveEventDispatch implements Runnable {
    * and otherwise delegates each unit of work to {@link #dispatch(DispatchWork)}. It preserves the
    * order in which events were queued and performs listener invocation on the same dedicated thread
    * to simplify synchronization concerns for clients. Applications typically never call this method
-   * directly because it is invoked automatically when the dispatcher is constructed.
+   * directly because it is invoked automatically after the first event is submitted.
    */
   @Override
   public void run() {


### PR DESCRIPTION
## Summary
- eliminate `SC_START_IN_CTOR` in `AsyncPersistentProps` by creating the writer thread in the constructor but starting it lazily on first state mutation
- eliminate `SC_START_IN_CTOR` in `ReflectiveEventDispatch` by starting the dispatch thread lazily on first `fire(...)`
- keep behavior intact by preserving daemon thread configuration and updating Javadocs to match lazy-start lifecycle

## How to test
- `./gradlew spotlessApply`
- `./gradlew test --tests com.onionnetworks.util.AsyncPersistentPropsTest --tests com.onionnetworks.util.ReflectiveEventDispatchTest --tests com.onionnetworks.util.InvokingDispatchTest spotbugsMain`
- `./gradlew test --tests com.onionnetworks.io.JournalTest`
- verify `SC_START_IN_CTOR` count is zero in `build/reports/spotbugs/spotbugsMain.xml` and `build/reports/spotbugs/spotbugsTest.xml`