### PR TITLE
fix(spotbugs): Fix nullable Path dereferences in SpotBugs findings

### DIFF
--- a/src/main/kotlin/network/crypta/config/ConfigMigrator.kt
+++ b/src/main/kotlin/network/crypta/config/ConfigMigrator.kt
@@ -52,7 +52,8 @@ fun migrateIfNeeded(dirs: Resolved, executableDir: Path) {
 private fun moveIfPresent(src: Path, dst: Path) {
   if (!Files.exists(src) || Files.exists(dst)) return
   try {
-    if (!Files.exists(dst.parent)) Files.createDirectories(dst.parent)
+    val parent = dst.parent
+    if (parent != null && !Files.exists(parent)) Files.createDirectories(parent)
     Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE)
     LOG.info("Moved {} -> {} (atomic)", src, dst)
   } catch (_: AtomicMoveNotSupportedException) {
@@ -79,6 +80,7 @@ private fun moveIfPresent(src: Path, dst: Path) {
 private fun rewriteLegacyPaths(configFile: Path) {
   try {
     val sfs = SimpleFieldSet.readFrom(Files.newInputStream(configFile), true, true)
+
     fun rewrite(key: String, rel: String, placeholder: String) {
       val v = sfs[key] ?: return
       if (v == rel || v == "./$rel") sfs.putOverwrite(key, placeholder)

--- a/src/main/kotlin/network/crypta/fs/Dirs.kt
+++ b/src/main/kotlin/network/crypta/fs/Dirs.kt
@@ -114,13 +114,18 @@ private fun computeStandardXdgRuntime(
         .resolve(appId)
         .resolve(APP_RUNTIME_SUBPATH)
     }
-    xdgRuntime != null -> xdgRuntime.resolve(APP_RUNTIME_SUBPATH)
+
+    xdgRuntime != null -> {
+      xdgRuntime.resolve(APP_RUNTIME_SUBPATH)
+    }
+
     else -> {
       val uidBased =
         Paths.get(LINUX_RUN_USER_PREFIX)
           .resolve(System.getProperty("user.name") ?: "0")
           .resolve(APP_RUNTIME_SUBPATH)
-      if (Files.isWritable(uidBased.parent)) uidBased else cacheBase.resolve("rt")
+      val parent = uidBased.parent
+      if (parent != null && Files.isWritable(parent)) uidBased else cacheBase.resolve("rt")
     }
   }
 }
@@ -217,7 +222,6 @@ class AppDirs(
   cliOverrides: Map<String, String>,
   appEnv: AppEnv,
 ) : BaseDirs(env, systemProperties, cliOverrides, appEnv) {
-
   // Zero-arg constructor for Java callers
   constructor() :
     this(
@@ -318,7 +322,6 @@ class ServiceDirs(
   cliOverrides: Map<String, String>,
   appEnv: AppEnv,
 ) : BaseDirs(env, systemProperties, cliOverrides, appEnv) {
-
   // Zero-arg constructor for Java callers
   constructor() :
     this(
@@ -349,8 +352,8 @@ class ServiceDirs(
     appEnv,
   )
 
-  override fun computeBase(): Resolved {
-    return when {
+  override fun computeBase(): Resolved =
+    when {
       appEnv.isWindows() -> {
         val programData =
           env["PROGRAMDATA"]
@@ -369,6 +372,7 @@ class ServiceDirs(
           root.resolve("logs"),
         )
       }
+
       appEnv.isMac() -> {
         val root = Paths.get("/$MACOS_LIBRARY_PATH", "Application Support", "Cryptad")
         Resolved(
@@ -379,6 +383,7 @@ class ServiceDirs(
           Paths.get("/$MACOS_LIBRARY_PATH", "Logs", "Cryptad"),
         )
       }
+
       else -> {
         // Linux systemd defaults
         Resolved(
@@ -390,12 +395,12 @@ class ServiceDirs(
         )
       }
     }
-  }
 
   override fun envOverrides(): Overrides {
     // For Linux/systemd environments, prefer exported directories
-    return if (!appEnv.isLinux()) Overrides()
-    else
+    return if (!appEnv.isLinux()) {
+      Overrides()
+    } else {
       Overrides(
         config = env["CONFIGURATION_DIRECTORY"]?.let { Paths.get(it) },
         data = env["STATE_DIRECTORY"]?.let { Paths.get(it) },
@@ -403,6 +408,7 @@ class ServiceDirs(
         run = env["RUNTIME_DIRECTORY"]?.let { Paths.get(it) },
         logs = env["LOGS_DIRECTORY"]?.let { Paths.get(it) },
       )
+    }
   }
 
   override fun shouldEnsureDirectories(): Boolean {

--- a/src/main/kotlin/network/crypta/launcher/LauncherUtils.kt
+++ b/src/main/kotlin/network/crypta/launcher/LauncherUtils.kt
@@ -113,7 +113,7 @@ fun upsertWrapperProperty(lines: List<String>, key: String, value: String): List
 fun computeWrapperLogPath(confPath: Path, logSpec: String?): Path {
   val spec = logSpec?.takeUnless { it.isBlank() } ?: "../logs/wrapper.log"
   val p = Paths.get(spec)
-  return if (p.isAbsolute) p else confPath.parent.resolve(p).normalize()
+  return if (p.isAbsolute) p else wrapperConfDirectory(confPath).resolve(p).normalize()
 }
 
 /**
@@ -133,14 +133,23 @@ fun computeWrapperFilePath(confPath: Path, fileSpec: String?, workingDirSpec: St
   val spec = fileSpec?.takeUnless { it.isBlank() } ?: return null
   val p = Paths.get(spec)
   if (p.isAbsolute) return p.normalize()
+  val confDir = wrapperConfDirectory(confPath)
   val base =
     workingDirSpec
       ?.takeUnless { it.isBlank() }
       ?.let { wdRaw ->
         val wd = Paths.get(wdRaw)
-        if (wd.isAbsolute) wd.normalize() else confPath.parent.resolve(wd).normalize()
-      } ?: confPath.parent
+        if (wd.isAbsolute) wd.normalize() else confDir.resolve(wd).normalize()
+      } ?: confDir
   return base.resolve(p).normalize()
+}
+
+private fun wrapperConfDirectory(confPath: Path): Path {
+  confPath.parent?.let {
+    return it
+  }
+  val normalized = confPath.toAbsolutePath().normalize()
+  return normalized.parent ?: normalized
 }
 
 /**
@@ -261,7 +270,7 @@ internal fun findCryptadJarInClassPath(classPath: String): Path? {
     try {
       val p = Paths.get(raw)
       if (Files.isRegularFile(p)) {
-        val name = p.fileName.toString()
+        val name = p.fileName?.toString() ?: continue
         if (re.matches(name)) return p.normalize()
       }
     } catch (e: Exception) {
@@ -314,7 +323,7 @@ private fun resolveCryptadPathFromCwd(cwd: Path, isWindows: Boolean): Path? {
 
 private fun isCryptadJarFile(path: Path): Boolean {
   if (!Files.isRegularFile(path)) return false
-  val name = path.fileName.toString()
+  val name = path.fileName?.toString() ?: return false
   return name.endsWith(".jar") && name.startsWith("cryptad")
 }
 
@@ -392,8 +401,14 @@ fun loadAppIconImage(): Image? {
 
   val candidates = buildList {
     when {
-      env.isMac() -> add("network/crypta/launcher/crypta-launcher-icon-macos.png")
-      env.isWindows() -> add("network/crypta/launcher/crypta-launcher-icon-windows.png")
+      env.isMac() -> {
+        add("network/crypta/launcher/crypta-launcher-icon-macos.png")
+      }
+
+      env.isWindows() -> {
+        add("network/crypta/launcher/crypta-launcher-icon-windows.png")
+      }
+
       else -> {
         // Prefer macOS artwork as a generic fallback for Linux/others if present
         add("network/crypta/launcher/crypta-launcher-icon-macos.png")

--- a/src/test/java/com/onionnetworks/util/NativeDeployerTest.java
+++ b/src/test/java/com/onionnetworks/util/NativeDeployerTest.java
@@ -19,8 +19,9 @@ class NativeDeployerTest {
   @Test
   void getLocalResourcePath_whenResourceExists_returnsExtractedFile(@TempDir Path tempDir)
       throws IOException {
-    Path resourcePath = tempDir.resolve("resources/libfile.bin");
-    Files.createDirectories(resourcePath.getParent());
+    Path resourceDir = tempDir.resolve("resources");
+    Files.createDirectories(resourceDir);
+    Path resourcePath = resourceDir.resolve("libfile.bin");
     byte[] expected = "native-bytes".getBytes(StandardCharsets.UTF_8);
     Files.write(resourcePath, expected);
 
@@ -46,13 +47,15 @@ class NativeDeployerTest {
   @Test
   void getLibraryPath_whenMatchingOsArchAndResourcePresent_extractsLibrary(@TempDir Path tempDir)
       throws IOException {
-    Path nativeFile = tempDir.resolve("native/libmatched.bin");
-    Files.createDirectories(nativeFile.getParent());
+    Path nativeDir = tempDir.resolve("native");
+    Files.createDirectories(nativeDir);
+    Path nativeFile = nativeDir.resolve("libmatched.bin");
     byte[] expected = "matching-native".getBytes(StandardCharsets.UTF_8);
     Files.write(nativeFile, expected);
 
-    Path propertiesFile = tempDir.resolve("lib/native.properties");
-    Files.createDirectories(propertiesFile.getParent());
+    Path propertiesDir = tempDir.resolve("lib");
+    Files.createDirectories(propertiesDir);
+    Path propertiesFile = propertiesDir.resolve("native.properties");
     String propertiesContent =
         "com.onionnetworks.native.keys=lib1\n"
             + "com.onionnetworks.native.lib1.name=testlib\n"
@@ -73,8 +76,9 @@ class NativeDeployerTest {
 
   @Test
   void getLibraryPath_whenNoOsArchMatch_returnsNull(@TempDir Path tempDir) throws IOException {
-    Path propertiesFile = tempDir.resolve("lib/native.properties");
-    Files.createDirectories(propertiesFile.getParent());
+    Path propertiesDir = tempDir.resolve("lib");
+    Files.createDirectories(propertiesDir);
+    Path propertiesFile = propertiesDir.resolve("native.properties");
     String propertiesContent =
         """
         com.onionnetworks.native.keys=lib1
@@ -93,8 +97,9 @@ class NativeDeployerTest {
 
   @Test
   void getLibraryPath_whenResourceMissing_returnsNull(@TempDir Path tempDir) throws IOException {
-    Path propertiesFile = tempDir.resolve("lib/native.properties");
-    Files.createDirectories(propertiesFile.getParent());
+    Path propertiesDir = tempDir.resolve("lib");
+    Files.createDirectories(propertiesDir);
+    Path propertiesFile = propertiesDir.resolve("native.properties");
     String propertiesContent =
         "com.onionnetworks.native.keys=lib1\n"
             + "com.onionnetworks.native.lib1.name=testlib\n"

--- a/src/test/java/network/crypta/clients/fcp/DiskDirPutFileTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DiskDirPutFileTest.java
@@ -87,7 +87,10 @@ class DiskDirPutFileTest {
 
   private File createTempFile(String name) throws IOException {
     Path path = tempDir.resolve(name);
-    Files.createDirectories(path.getParent());
+    Path parent = path.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
     Files.deleteIfExists(path);
     return Files.createFile(path).toFile();
   }

--- a/src/test/java/network/crypta/node/NodeClientCoreTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTest.java
@@ -109,8 +109,9 @@ class NodeClientCoreTest {
     when(securityLevels.getPhysicalThreatLevel()).thenReturn(PHYSICAL_THREAT_LEVEL.NORMAL);
     core.setDownloadAllowedDirs(new String[] {"downloads"});
 
-    Path inside = tempDir.resolve("sub/inside.dat");
-    Files.createDirectories(inside.getParent());
+    Path insideDir = tempDir.resolve("sub");
+    Files.createDirectories(insideDir);
+    Path inside = insideDir.resolve("inside.dat");
     Path outsideDir = Files.createTempDirectory("outside-");
     File outside = outsideDir.resolve("out.dat").toFile();
 
@@ -147,7 +148,7 @@ class NodeClientCoreTest {
   @Test
   void allowUploadFrom_whenAllEnabled_expectTrueForAnyPath() {
     core.setUploadAllowedDirs(new String[] {"all"});
-    File anywhere = tempDir.getParent().resolve("anywhere.txt").toFile();
+    File anywhere = tempDir.resolve("..").resolve("anywhere.txt").normalize().toFile();
     assertTrue(core.allowUploadFrom(anywhere));
   }
 

--- a/src/test/java/network/crypta/pluginmanager/PluginManagerTest.java
+++ b/src/test/java/network/crypta/pluginmanager/PluginManagerTest.java
@@ -254,7 +254,7 @@ class PluginManagerTest {
   }
 
   private static Path buildTestPluginJar(Path jarPath) throws IOException {
-    Path workDir = jarPath.getParent().resolve("test-plugin-work");
+    Path workDir = jarPath.resolveSibling("test-plugin-work");
     Path srcDir = workDir.resolve("src");
     Path classesDir = workDir.resolve("classes");
     Files.createDirectories(srcDir);
@@ -313,7 +313,10 @@ class PluginManagerTest {
       assertTrue(ok, "Failed to compile test plugin sources");
     }
 
-    Files.createDirectories(jarPath.getParent());
+    Path jarParent = jarPath.getParent();
+    if (jarParent != null) {
+      Files.createDirectories(jarParent);
+    }
 
     Manifest manifest = new Manifest();
     manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");

--- a/src/test/java/network/crypta/support/JarClassLoaderTest.java
+++ b/src/test/java/network/crypta/support/JarClassLoaderTest.java
@@ -365,7 +365,10 @@ class JarClassLoaderTest {
   private void compileJavaClass(String pkg, String cls, String src) throws IOException {
     Path srcDir = Files.createDirectories(tmp.resolve("src"));
     Path javaFile = srcDir.resolve(pkg.replace('.', '/')).resolve(cls + ".java");
-    Files.createDirectories(javaFile.getParent());
+    Path javaParent = javaFile.getParent();
+    if (javaParent != null) {
+      Files.createDirectories(javaParent);
+    }
     Files.writeString(javaFile, src, UTF_8);
     int rc =
         ToolProvider.getSystemJavaCompiler()

--- a/src/test/java/network/crypta/support/io/FileUtilTest.java
+++ b/src/test/java/network/crypta/support/io/FileUtilTest.java
@@ -407,7 +407,9 @@ class FileUtilTest {
     Path file = tmp.resolve("x.txt");
     Files.write(file, List.of("x"));
     File a = file.toFile();
-    File b = new File(file.getParent().toFile(), "." + File.separator + file.getFileName());
+    Path parent = file.getParent();
+    assertNotNull(parent);
+    File b = new File(parent.toFile(), "." + File.separator + file.getFileName());
 
     // Act + Assert
     assertTrue(FileUtil.equals(a, b));

--- a/src/test/java/network/crypta/tools/CleanupTranslationsTest.java
+++ b/src/test/java/network/crypta/tools/CleanupTranslationsTest.java
@@ -148,7 +148,10 @@ class CleanupTranslationsTest {
 
   private static void writeUtf8File(Path file, List<String> lines) throws IOException {
     String content = String.join("\n", lines) + "\n";
-    Files.createDirectories(file.getParent());
+    Path parent = file.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
     Files.writeString(file, content, StandardCharsets.UTF_8);
   }
 

--- a/src/test/java/org/bitpedia/collider/core/SubmissionTest.java
+++ b/src/test/java/org/bitpedia/collider/core/SubmissionTest.java
@@ -207,7 +207,9 @@ class SubmissionTest {
     Submission submission = new Submission(bitcollider, null, false);
 
     setBitprintCountToOne(submission);
-    setFileName(submission, sample.getFileName().toString());
+    Path sampleName = sample.getFileName();
+    assertNotNull(sampleName);
+    setFileName(submission, sampleName.toString());
     submission.addAttribute("tag.custom", "\"<&>");
 
     StringWriter writer = new StringWriter();
@@ -217,7 +219,7 @@ class SubmissionTest {
     String html = writer.toString();
     assertTrue(html.contains("<BODY>"));
     assertFalse(html.contains("onLoad"));
-    assertTrue(html.contains("Bitprint Submission " + sample.getFileName()));
+    assertTrue(html.contains("Bitprint Submission " + sampleName));
     assertTrue(html.contains("&quot;&lt;&amp;&gt;"));
     assertTrue(html.contains("\"<&>"));
   }


### PR DESCRIPTION
## Summary
- Fix all `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` findings reported by SpotBugs in both main and test sources.
- Harden launcher/config/fs path handling by guarding nullable `Path.parent`/`Path.fileName` before dereference.
- Update affected tests to avoid nullable parent/file-name dereferences while preserving existing behavior.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `./gradlew test --tests "*LauncherUtilsTest" --tests "*AppDirsTest" --tests "*NativeDeployerTest" --tests "*DiskDirPutFileTest" --tests "*NodeClientCoreTest" --tests "*PluginManagerTest" --tests "*JarClassLoaderTest" --tests "*FileUtilTest" --tests "*CleanupTranslationsTest" --tests "*SubmissionTest"`

## Notes
- Verified `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` count is `0` in both `build/reports/spotbugs/spotbugsMain.xml` and `build/reports/spotbugs/spotbugsTest.xml` after the fix.