### PR TITLE
fix(spotbugs): Fix Sha1 Cloneable contract

### DIFF
--- a/src/main/java/org/bitpedia/util/Sha1.java
+++ b/src/main/java/org/bitpedia/util/Sha1.java
@@ -46,7 +46,7 @@ import java.security.NoSuchAlgorithmException;
  * @see MessageDigest
  */
 @SuppressWarnings("java:S2257")
-public final class Sha1 extends MessageDigest {
+public final class Sha1 extends MessageDigest implements Cloneable {
 
   /** SHA-1 digest length in bytes. */
   public static final int HASH_LENGTH = 20; // bytes == 160 bits


### PR DESCRIPTION
## Summary
- Make `Sha1` explicitly implement `Cloneable` so its public `clone()` contract matches SpotBugs expectations.
- Keep behavior unchanged: `clone()` still returns `copy()`, which snapshots digest state via a cloned `MessageDigest` delegate.
- Resolve SpotBugs `CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE` for `org.bitpedia.util.Sha1`.

## How to test
- Run `./gradlew spotbugsMain` and verify no `CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE` finding for `Sha1`.
- Run `./gradlew spotbugsTest` to ensure no regressions in test-source SpotBugs analysis.