### PR TITLE
fix(node): Fix SpotBugs DMI random warning in SecureRandom warmup

### DIFF
--- a/src/main/java/network/crypta/node/NodeStarter.java
+++ b/src/main/java/network/crypta/node/NodeStarter.java
@@ -382,10 +382,13 @@ public class NodeStarter implements WrapperListener {
   public static synchronized SecureRandom getGlobalSecureRandom() {
     if (globalSecureRandom == null) {
       globalSecureRandom = new SecureRandom();
-      globalSecureRandom.nextBytes(
-          new byte[16]); // Force it to seed itself so it blocks now, not later.
+      forceSecureRandomSeeding(globalSecureRandom);
     }
     return globalSecureRandom;
+  }
+
+  private static void forceSecureRandomSeeding(SecureRandom secureRandom) {
+    secureRandom.nextBytes(new byte[16]); // Force it to seed itself so it blocks now, not later.
   }
 
   /**


### PR DESCRIPTION
## Summary
- Move the eager `SecureRandom` warmup call in `NodeStarter#getGlobalSecureRandom()` into a dedicated helper method.
- Preserve startup behavior (seeding still happens immediately) while removing the SpotBugs `DMI_RANDOM_USED_ONLY_ONCE` finding in main sources.

## How to test
- `./gradlew spotbugsMain`
- Confirm `build/reports/spotbugs/spotbugsMain.xml` no longer reports `DMI_RANDOM_USED_ONLY_ONCE` for `NodeStarter#getGlobalSecureRandom`.