### PR TITLE
fix(spotbugs): Fix NN_NAKED_NOTIFY monitor signaling

### DIFF
--- a/src/main/java/network/crypta/io/xfer/BulkTransmitter.java
+++ b/src/main/java/network/crypta/io/xfer/BulkTransmitter.java
@@ -261,10 +261,7 @@ public class BulkTransmitter {
    * Idempotent.
    */
   public void onAborted() {
-    sendAbortedMessage();
-    synchronized (this) {
-      notifyAll();
-    }
+    cancel("PartiallyReceivedBulk aborted");
   }
 
   /** Sends {@code FNPBulkSendAborted} once. Subsequent calls are no-ops. */

--- a/src/main/java/network/crypta/io/xfer/PacketThrottle.java
+++ b/src/main/java/network/crypta/io/xfer/PacketThrottle.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * <p>Units and invariants:
  *
  * <ul>
- *   <li>Window size is in logical packets and never less than 1.0.
+ *   <li>Window size is in logical packets and never fewer than 1.0.
  *   <li>Round-trip time (RTT) is in milliseconds.
  *   <li>{@link #getDelay()} returns a pacing delay in milliseconds; it is lower-bounded by {@link
  *       #MIN_DELAY} to avoid zero/unstable delays.
@@ -56,8 +56,8 @@ public class PacketThrottle {
   private long droppedPackets;
 
   /**
-   * Congestion window, measured in packets. It never drops below 1.0 so at least one packet can be
-   * sent and divisions by window size remain well-defined.
+   * Congestion window, measured in packets. It never drops below 1.0, so at least one packet can be
+   * sent, and divisions by window size remain well-defined.
    */
   private float windowSize = 2;
 
@@ -128,7 +128,7 @@ public class PacketThrottle {
     if (slowStart) {
       if (LOG.isDebugEnabled()) LOG.debug("Still in slow start");
       windowSize += windowSize / (float) SLOW_START_DIVISOR;
-      // Avoid craziness if there is lag in detecting packet loss.
+      // Avoid craziness if there is a lag in detecting packet loss.
       if (windowSize > maxWindowSize) slowStart = false;
       // Ensure window >= 1.0 so we can send at least one packet and keep divisions defined.
       if (windowSize < 1.0F) windowSize = 1.0F;
@@ -189,7 +189,7 @@ public class PacketThrottle {
   }
 
   /**
-   * Returns an estimated throughput based on the current delay.
+   * Returns estimated throughput based on the current delay.
    *
    * <p>The result is expressed in {@code packetSize} units per second (e.g., bytes/second when
    * {@code packetSize} is bytes). Because {@link #getDelay()} is lower-bounded by {@link
@@ -203,10 +203,12 @@ public class PacketThrottle {
   }
 
   /**
-   * Wakes threads waiting on this instance so they can re-check pacing conditions (e.g., when the
-   * connection state may have changed).
+   * Lifecycle hook invoked when the associated connection may have disconnected.
+   *
+   * <p>The throttle no longer blocks on its own monitor, so this hook intentionally performs no
+   * signaling.
    */
-  public synchronized void maybeDisconnected() {
-    notifyAll();
+  public void maybeDisconnected() {
+    // No-op: PacketThrottle currently has no internal waiters.
   }
 }

--- a/src/main/java/network/crypta/node/PacketSender.java
+++ b/src/main/java/network/crypta/node/PacketSender.java
@@ -57,6 +57,7 @@ public class PacketSender implements Runnable {
   long lastReceivedPacketFromAnyNode;
   private final Random localRandom;
   private volatile boolean stopping;
+  private boolean wakeUpRequested;
 
   public PacketSender(Node node) {
     this.node = node;
@@ -132,7 +133,7 @@ public class PacketSender implements Runnable {
    * continues on unexpected {@link Throwable}s so the thread remains alive.
    */
   @Override
-  @SuppressWarnings({"java:S2189", "java:S1181", "InfiniteLoopStatement"})
+  @SuppressWarnings({"java:S2189", "java:S1181"})
   public void run() {
     if (LOG.isDebugEnabled()) LOG.debug("In PacketSender.run()");
 
@@ -483,12 +484,15 @@ public class PacketSender implements Runnable {
       synchronized (this) {
         long remaining;
         try {
-          while ((remaining = deadline - System.currentTimeMillis()) > 0) {
+          while (!wakeUpRequested
+              && !stopping
+              && (remaining = deadline - System.currentTimeMillis()) > 0) {
             wait(remaining);
           }
         } catch (InterruptedException _) {
           // Swallow to treat interrupt as a wake-up without latching the flag.
         }
+        wakeUpRequested = false;
       }
     } else {
       if (LOG.isTraceEnabled())
@@ -505,6 +509,7 @@ public class PacketSender implements Runnable {
   void wakeUp() {
     // Wake up if needed
     synchronized (this) {
+      wakeUpRequested = true;
       notifyAll();
     }
   }

--- a/src/main/java/network/crypta/node/RequestStarter.java
+++ b/src/main/java/network/crypta/node/RequestStarter.java
@@ -75,6 +75,7 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
   private final boolean isInsert;
   private final boolean isSSK;
   final boolean realTime;
+  private boolean wakeUpRequested;
 
   /**
    * Creates a new starter for a specific flow (type and mode).
@@ -174,10 +175,9 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
 
   private boolean waitOneSecond() {
     synchronized (this) {
-      long millis = 1000L;
-      long end = System.currentTimeMillis() + millis;
-      long remaining = millis;
-      while (remaining > 0) {
+      long deadline = System.currentTimeMillis() + 1000L;
+      long remaining = 1000L;
+      while (!wakeUpRequested && remaining > 0) {
         try {
           wait(remaining);
         } catch (InterruptedException e) {
@@ -185,11 +185,9 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
           if (LOG.isDebugEnabled()) LOG.debug("One-second wait interrupted", e);
           return true; // signal interrupt to caller to avoid spin under opennet deferring
         }
-        // If we were notified (or spuriously woke) before the timeout, exit early so wakeUp()
-        // remains responsive during opennet bootstrap.
-        remaining = end - System.currentTimeMillis();
-        if (remaining > 0) remaining = 0;
+        remaining = deadline - System.currentTimeMillis();
       }
+      wakeUpRequested = false;
       return false;
     }
   }
@@ -251,13 +249,16 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
       ChosenBlock r = sched.grabRequest();
       while (r == null) {
         try {
-          wait();
+          while (!wakeUpRequested && (r = sched.grabRequest()) == null) {
+            wait();
+          }
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           if (LOG.isDebugEnabled()) LOG.debug("Wait for request interrupted", e);
           return null;
         }
-        r = sched.grabRequest();
+        wakeUpRequested = false;
+        if (r == null) r = sched.grabRequest();
       }
       return r;
     }
@@ -346,6 +347,7 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
    */
   public void wakeUp() {
     synchronized (this) {
+      wakeUpRequested = true;
       notifyAll();
     }
   }

--- a/src/main/java/network/crypta/node/WaitingMultiMessageCallback.java
+++ b/src/main/java/network/crypta/node/WaitingMultiMessageCallback.java
@@ -8,7 +8,7 @@ package network.crypta.node;
  * #finished()} returns {@code true}). The intermediate group event {@link #sent(boolean)} is
  * intentionally ignored.
  *
- * <p>Thread-safety: All methods synchronize on this instance. Waiters call {@link #waitFor()}, and
+ * <p>Thread-safety: All methods synchronize in this instance. Waiters call {@link #waitFor()}, and
  * completion notifies them via {@code notifyAll()} on the same monitor.
  *
  * <p>Usage overview:
@@ -22,6 +22,8 @@ package network.crypta.node;
  */
 public class WaitingMultiMessageCallback extends MultiMessageCallback {
 
+  private boolean completionNotified;
+
   /**
    * Wakes all threads blocked in {@link #waitFor()} once aggregation completes.
    *
@@ -34,6 +36,7 @@ public class WaitingMultiMessageCallback extends MultiMessageCallback {
   @Override
   synchronized void finish(boolean success) {
     // Notify all waiters that completion has been reached.
+    completionNotified = true;
     notifyAll();
   }
 
@@ -45,9 +48,9 @@ public class WaitingMultiMessageCallback extends MultiMessageCallback {
    * invoked). Propagating or restoring the interrupt status would allow an early return. Tests in
    * {@code WaitingMultiMessageCallbackTest} cover this behavior.
    */
-  @SuppressWarnings("java:S2142") // InterruptedException intentionally ignored; see method javadoc
+  @SuppressWarnings("java:S2142") // InterruptedException intentionally ignored; see method Javadoc
   public synchronized void waitFor() {
-    while (!finished()) {
+    while (!completionNotified && !finished()) {
       try {
         wait();
       } catch (InterruptedException _) {

--- a/src/main/java/network/crypta/support/PrioritizedTicker.java
+++ b/src/main/java/network/crypta/support/PrioritizedTicker.java
@@ -63,6 +63,7 @@ public class PrioritizedTicker implements Ticker, Runnable {
   final NativeThread myThread;
   final PriorityAwareExecutor executor;
   static final int MAX_SLEEP_TIME = 200;
+  private boolean wakeUpRequested;
 
   /**
    * Creates a ticker backed by the given executor and a dedicated high‑priority thread.
@@ -222,28 +223,18 @@ public class PrioritizedTicker implements Ticker, Runnable {
   }
 
   /**
-   * Sleeps up to {@code sleepTime} milliseconds or until {@link #wakeUp()} notifies this monitor.
-   *
-   * <p>Design notes: - This uses a single timed {@code wait(sleepTime)} (no {@code while} loop) on
-   * purpose to maximize wake-up responsiveness. When notified, we return promptly, so the ticker
-   * can re-check the timed-job queue outside the monitor and run any newly scheduled work without
-   * waiting out the remainder of the original sleep window. - Spurious wakeup is acceptable for
-   * this method: an early return only causes an early re-drain of the queue, which is safe and
-   * desirable for latency. The queue/predicate is not tied to this monitor; it lives in {@code
-   * timedJobsByTime} and is checked immediately after this method returns.
-   *
-   * <p>Suppression rationale: Sonar rule S2274 recommends guarding {@code wait} in a loop to
-   * re-check a predicate after spurious wakeups. Here, the predicate lives outside the monitor and
-   * is intentionally re-checked by the caller after returning. Wrapping the wait in a loop to
-   * "sleep until the original deadline" would reintroduce latency and defeat the purpose of {@link
-   * #wakeUp()}.
+   * Sleeps up to {@code sleepTime} milliseconds or until {@link #wakeUp()} requests an early wake.
    */
-  @SuppressWarnings({"java:S2274", "WaitNotInLoop"})
   protected void sleep(long sleepTime) throws InterruptedException {
     if (LOG.isDebugEnabled()) LOG.debug("Sleeping for {}", sleepTime);
     synchronized (this) {
-      // Return early when notified to preserve wake-up responsiveness.
-      wait(sleepTime);
+      long deadline = System.currentTimeMillis() + sleepTime;
+      long remaining = sleepTime;
+      while (!wakeUpRequested && remaining > 0) {
+        wait(remaining);
+        remaining = deadline - System.currentTimeMillis();
+      }
+      wakeUpRequested = false;
     }
   }
 
@@ -372,6 +363,7 @@ public class PrioritizedTicker implements Ticker, Runnable {
   void wakeUp() {
     // Wake up if needed
     synchronized (this) {
+      wakeUpRequested = true;
       notifyAll();
     }
   }

--- a/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
@@ -211,8 +211,8 @@ class ClientRequestSelectorTest {
     }
 
     @Override
-    public synchronized void onHasKeys() {
-      notifyAll();
+    public void onHasKeys() {
+      // Ignore.
     }
 
     @Override
@@ -424,7 +424,7 @@ class ClientRequestSelectorTest {
     ChosenBlock block = selector.maybeMakeChosenRequest(ins, ctx, System.currentTimeMillis());
     assertNotNull(block);
     assertSame(token, block.token);
-    assertNull(block.key); // inserts don't expose low-level key here
+    assertNull(block.key); // inserts don't expose the low-level key here
     assertNull(block.ckey);
     assertTrue(block.localRequestOnly);
     assertFalse(block.ignoreStore); // inserts set ignoreStore=false
@@ -538,7 +538,7 @@ class ClientRequestSelectorTest {
     when(offered.realTimeFlag()).thenReturn(true);
 
     RandomSource random = mock(RandomSource.class);
-    when(random.nextBoolean()).thenReturn(true); // choose offered keys path
+    when(random.nextBoolean()).thenReturn(true); // choose an offered keys path
 
     ClientRequestSelector.SelectorReturn ret =
         selector.chooseRequestInner(

--- a/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
+++ b/src/test/java/network/crypta/store/caching/CachingFreenetStoreTest.java
@@ -1305,8 +1305,12 @@ class CachingFreenetStoreTest {
 
     public void waitForZero() throws InterruptedException {
       synchronized (sync) {
+        long observedPushGeneration = pushGeneration;
         while (getSizeOfCache() > 0) {
-          sync.wait();
+          while (getSizeOfCache() > 0 && observedPushGeneration == pushGeneration) {
+            sync.wait();
+          }
+          observedPushGeneration = pushGeneration;
         }
       }
     }
@@ -1315,12 +1319,14 @@ class CachingFreenetStoreTest {
     void pushAllCachingStores() {
       super.pushAllCachingStores();
       synchronized (sync) {
+        pushGeneration++;
         sync.notifyAll();
       }
     }
 
     /* Don't reuse (this), avoid changing locking behavior of the parent class */
     private final Object sync = new Object();
+    private long pushGeneration;
   }
 
   private static final File TEMP_DIR = new File("tmp-CachingFreenetStoreTest");
@@ -1360,6 +1366,7 @@ class CachingFreenetStoreTest {
     }
 
     @Override
+    @SuppressWarnings("RedundantMethodOverride")
     public boolean equals(Object other) {
       return this == other;
     }


### PR DESCRIPTION
## Summary
- Replace naked `notifyAll()` paths with explicit state transitions in `BulkTransmitter`, `PacketSender`, `RequestStarter`, `WaitingMultiMessageCallback`, and `PrioritizedTicker`.
- Remove monitor signaling from `PacketThrottle.maybeDisconnected()` now that the class has no internal waiters.
- Update affected tests to keep wait/notify behavior explicit while avoiding naked notify patterns.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `./gradlew test --tests '*PacketThrottleTest' --tests '*RequestStarterTest' --tests '*WaitingMultiMessageCallbackTest' --tests '*ClientRequestSelectorTest' --tests '*CachingFreenetStoreTest'`