### PR TITLE
fix(spotbugs): Fix non-atomic shared long updates

### DIFF
--- a/src/main/java/network/crypta/client/ArchiveStoreContext.java
+++ b/src/main/java/network/crypta/client/ArchiveStoreContext.java
@@ -10,15 +10,15 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This context is the per-key index used by {@link ArchiveManager} to remember which {@link
  * ArchiveStoreItem}s are currently cached for an archive and to retain lightweight state about the
- * last successful extraction. It records the last known archive size and hash so callers can detect
- * when the underlying container has changed and refresh cached members accordingly. The class
- * itself performs no I/O; it provides bookkeeping and coordination hooks invoked by the manager
- * during extraction and eviction.
+ * last successful extraction. It records the last known archive size and hash, so callers can
+ * detect when the underlying container has changed and refresh cached members accordingly. The
+ * class itself performs no I/O; it provides bookkeeping and coordination hooks invoked by the
+ * manager during extraction and eviction.
  *
  * <p>Typical usage is: the manager creates a context for a key, extracts members, and registers
  * resulting items with {@link #addItem(ArchiveStoreItem)}. If a later fetch discovers a changed
  * hash or size, the manager calls {@link #removeAllCachedItems(ArchiveManager)} to evict previous
- * items and then repopulates the cache before signalling a restart to the caller.
+ * items and then repopulates the cache before signaling a restart to the caller.
  *
  * <p>Thread-safety: the internal item list is guarded by its own monitor. Code outside this class
  * must always lock the {@code ArchiveStoreContext} (or its {@code myItems} list) before acquiring
@@ -49,7 +49,7 @@ class ArchiveStoreContext {
   private final ArchiveManager.ARCHIVE_TYPE archiveType;
 
   /** Archive size */
-  private long lastSize = -1;
+  private volatile long lastSize = -1;
 
   /** Archive hash */
   private byte[] lastHash;
@@ -132,7 +132,7 @@ class ArchiveStoreContext {
   /**
    * Removes all {@link ArchiveStoreItem} instances with this key from the manager's cache.
    *
-   * <p>The method repeatedly obtains the head of the internal stack and asks the {@link
+   * <p>The method repeatedly gets the head of the internal stack and asks the {@link
    * ArchiveManager} to remove it. Removal proceeds until the local index is empty. Items perform
    * their own minimal cleanup during removal.
    *

--- a/src/main/java/network/crypta/client/async/BaseSingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/BaseSingleFileFetcher.java
@@ -1,6 +1,7 @@
 package network.crypta.client.async;
 
 import java.io.Serial;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import network.crypta.client.FetchContext;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.ClientKeyBlock;
@@ -36,8 +37,8 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>The fetcher represents one logical block fetch; {@link #finished} becomes {@code true} when
- *       a terminal outcome is reached and it will no longer emit results.
- *   <li>{@link #cancelled} ends participation in scheduling; subsequent callbacks become no-ops.
+ *       a terminal outcome is reached, and it will no longer emit results.
+ *   <li>{@link #cancelled} ends participation in scheduling; later callbacks become no-ops.
  *   <li>Retry attempts are bounded by {@link #maxRetries} (or unbounded when {@code -1}) and may be
  *       spaced using context-defined cooldowns.
  * </ul>
@@ -58,12 +59,15 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseSingleFileFetcher extends SendableGet implements HasKeyListener {
   private static final Logger LOG = LoggerFactory.getLogger(BaseSingleFileFetcher.class);
 
+  private static final AtomicLongFieldUpdater<BaseSingleFileFetcher> COOLDOWN_WAKEUP_TIME_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(BaseSingleFileFetcher.class, "cooldownWakeupTime");
+
   @Serial private static final long serialVersionUID = 1L;
 
   /** Immutable client-level key that identifies the single block being fetched. */
   protected final ClientKey key;
 
-  /** Flag that becomes {@code true} once the request is explicitly cancelled. */
+  /** Flag that becomes {@code true} once the request is explicitly canceled. */
   protected boolean cancelled;
 
   /** Flag set when the fetch has reached a terminal state and will not emit more events. */
@@ -95,12 +99,12 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
   private int cachedCooldownTries;
 
   /** Cached cooldown duration in milliseconds, derived from {@link #ctx}. */
-  private long cachedCooldownTime;
+  private volatile long cachedCooldownTime;
 
   /**
    * Absolute wake-up time in milliseconds since the epoch for the current cooldown, or {@code 0}.
    */
-  private transient long cooldownWakeupTime;
+  private transient volatile long cooldownWakeupTime;
 
   /**
    * Creates a fetcher for a single block.
@@ -115,8 +119,8 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
    * @param ctx fetch context carrying cooldown timing and local/remote behavior; must not be {@code
    *     null}
    * @param parent requester that owns this fetch and supplies priority and client identity
-   * @param deleteFetchContext whether the associated fetch context may be deleted by the owner when
-   *     the request completes
+   * @param deleteFetchContext whether the owner may delete the associated fetch context when the
+   *     request completes
    * @param realTimeFlag whether this request is considered real-time for scheduling purposes
    */
   protected BaseSingleFileFetcher(
@@ -157,7 +161,7 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
         if (LOG.isDebugEnabled())
           LOG.debug(
               "RecentlyFailed -> cooldown until {} on {}", TimeUtil.formatTime(l - now), this);
-        cooldownWakeupTime = Math.max(cooldownWakeupTime, l);
+        COOLDOWN_WAKEUP_TIME_UPDATER.accumulateAndGet(this, l, Math::max);
       } else {
         this.onFailure(
             new LowLevelGetException(LowLevelGetException.RECENTLY_FAILED), null, context);
@@ -185,7 +189,7 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
   /**
    * Attempts to schedule a retry according to the current policy.
    *
-   * <p>When the request is empty (already finished or cancelled) the retry is suppressed. If the
+   * <p>When the request is empty (already finished or canceled), the retry is suppressed. If the
    * retry limit is exceeded, the request is unregistered. Otherwise, this method either enters a
    * finite cooldown (deferring the retry) or clears the wakeup time to retry promptly.
    *
@@ -196,7 +200,7 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
   protected boolean retry(ClientContext context) {
     if (isEmpty()) {
       if (LOG.isDebugEnabled()) LOG.debug("Not retrying because empty");
-      return false; // Fatal errors (e.g. decode failure) should not retry.
+      return false; // Fatal errors (e.g., decode failure) should not retry.
     }
     // We want 0, 1, ... maxRetries i.e. maxRetries+1 attempts (maxRetries=0 => try once, no
     // retries, maxRetries=1 = original try + 1 retry)
@@ -217,10 +221,10 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     if (shouldEnterCooldown(r)) {
       enterCooldown(context);
     } else {
-      // Wake the CRS after clearing cache.
+      // Wake the CRS after clearing the cache.
       clearWakeupTime(context);
     }
-    // We will retry in any case, maybe not just not yet.
+    // We will retry in any case, maybe not for now.
     return true;
   }
 
@@ -323,9 +327,9 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
   /**
    * Returns whether there is nothing left to do for this request.
    *
-   * <p>The method returns {@code true} when the request has been cancelled or already finished.
+   * <p>The method returns {@code true} when the request has been canceled or already finished.
    *
-   * @return {@code true} if cancelled or finished; otherwise {@code false}
+   * @return {@code true} if canceled or finished; otherwise {@code false}
    */
   public synchronized boolean isEmpty() {
     return cancelled || finished;
@@ -506,9 +510,9 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
    * Refreshes the cached cooldown parameters from the current {@link FetchContext} after it has
    * changed.
    *
-   * <p>Ideally this would be handled by a shared configuration change mechanism, but here we take a
-   * pragmatic approach so changes such as USK polling intervals take effect without rebuilding the
-   * request.
+   * <p>Ideally, this would be handled by a shared configuration change mechanism, but here we take
+   * a pragmatic approach so changes such as USK polling intervals take effect without rebuilding
+   * the request.
    *
    * @see <a href="https://bugs.freenetproject.org/view.php?id=4984">Freenet bug 4984</a>
    */

--- a/src/main/java/network/crypta/client/async/ClientGetter.java
+++ b/src/main/java/network/crypta/client/async/ClientGetter.java
@@ -145,7 +145,7 @@ public class ClientGetter extends BaseClientGetter
   private String expectedMIME;
 
   /** The expected size of the file, if we know it. */
-  private long expectedSize;
+  private volatile long expectedSize;
 
   /** If true, the metadata (mostly the expected size) shouldn't change further. */
   private boolean finalizedMetadata;

--- a/src/main/java/network/crypta/io/comm/MessageFilter.java
+++ b/src/main/java/network/crypta/io/comm/MessageFilter.java
@@ -32,7 +32,7 @@ public final class MessageFilter {
   private final List<Object> fields = new ArrayList<>();
   private final List<String> fieldNames = new ArrayList<>();
   private PeerContext source;
-  private long timeout;
+  private volatile long timeout;
 
   /**
    * When {@code true}, the effective timeout is measured from the start of waiting; when {@code
@@ -41,10 +41,10 @@ public final class MessageFilter {
    */
   private boolean timeoutFromWait;
 
-  private long initialTimeout;
+  private volatile long initialTimeout;
   private MessageFilter orFilter;
   private Message message;
-  private long oldBootId;
+  private volatile long oldBootId;
   private AsyncMessageFilterCallback callback;
   private ByteCounter byteCounter;
   private boolean timeoutSet = false;

--- a/src/main/java/network/crypta/node/IPDetectorPluginManager.java
+++ b/src/main/java/network/crypta/node/IPDetectorPluginManager.java
@@ -558,7 +558,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
   private final HashMap<FredPluginIPDetector, DetectorRunner> runners = new HashMap<>();
   private final HashSet<FredPluginIPDetector> failedRunners = new HashSet<>();
   private long lastDetectAttemptEndedTime;
-  private long firstTimeUrgent;
+  private volatile long firstTimeUrgent;
 
   /**
    * Evaluates the current state and runs detection plugins when heuristics allow.

--- a/src/main/java/network/crypta/node/LocationManager.java
+++ b/src/main/java/network/crypta/node/LocationManager.java
@@ -101,8 +101,8 @@ public class LocationManager implements ByteCounter {
   public static final String FOIL_PITCH_BLACK_ATTACK_PREFIX = "mitigate-pitch-black-attack-";
 
   // Renamed to lowerCamelCase; encapsulated via accessors for tests/simulators to adjust.
-  private static long pitchBlackMitigationFrequencyOneDay = DAYS.toMillis(1);
-  private static long pitchBlackMitigationStartupDelay = HOURS.toMillis(2);
+  private static volatile long pitchBlackMitigationFrequencyOneDay = DAYS.toMillis(1);
+  private static volatile long pitchBlackMitigationStartupDelay = HOURS.toMillis(2);
 
   /**
    * Returns the nominal frequency for the pitch‑black mitigation task.
@@ -1144,6 +1144,7 @@ public class LocationManager implements ByteCounter {
     }
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static class CommitPayload {
     final long hisRandom;
     final double hisLoc;

--- a/src/main/java/network/crypta/node/NewPacketFormat.java
+++ b/src/main/java/network/crypta/node/NewPacketFormat.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Packet format and transport for encrypted peer communication.
  *
- * <p>This implementation handles packet assembly and parsing including:
+ * <p>This implementation handles packet assembly and parsing, including:
  *
  * <ul>
  *   <li>Fragmenting and reassembling messages up to {@link #MAX_MESSAGE_SIZE} bytes.
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * <p>Thread safety: this class uses fine‑grained locks. The send buffer and its counters are
- * protected by {@code sendBufferLock}. The receive buffer usage counter is protected by {@code
+ * protected by {@code sendBufferLock}. The receiving buffer usage counter is protected by {@code
  * receiveBufferSizeLock}. Window pointers and some shared structures synchronize on {@code this} or
  * their own monitors as documented. Callers may use an instance from multiple threads.
  *
@@ -91,7 +91,7 @@ public class NewPacketFormat implements PacketFormat {
 
   /**
    * Total bytes currently used by partially received buffers. This mirrors how much of the sender's
-   * send window we occupy. Guarded by {@code receiveBufferSizeLock}.
+   * sending window we occupy. Guarded by {@code receiveBufferSizeLock}.
    */
   private int receiveBufferUsed = 0;
 
@@ -556,7 +556,7 @@ public class NewPacketFormat implements PacketFormat {
    *
    * <p>When {@code ackOnly} is {@code true}, the packet contains only acks or keepalive payloads
    * (no message fragments). When {@code false}, the method may coalesce queued message fragments
-   * according to priorities and deadlines.
+   * according to prioritize and deadlines.
    *
    * @param now current time in milliseconds.
    * @param ackOnly whether to limit the packet to acks/keepalives.
@@ -1096,8 +1096,8 @@ public class NewPacketFormat implements PacketFormat {
    * Returns whether a packet with data can be sent now under current constraints.
    *
    * <p>Checks include message ID availability, sequence-number allocation for the given key, remote
-   * buffer usage, and throttle window. When message ID allocation is not possible but there are
-   * partially started messages, a send may still be performed to finish them.
+   * buffer usage, and throttle window. When message ID allocation is not possible, but there are
+   * partially started messages, a sending may still be performed to finish them.
    *
    * @param tracker the session key whose sequence numbers will be used; may be {@code null} to
    *     indicate that only throttling and buffering should be considered.
@@ -1217,7 +1217,7 @@ public class NewPacketFormat implements PacketFormat {
     final NewPacketFormat npf;
     final List<MessageWrapper> messages = new ArrayList<>();
     final List<int[]> ranges = new ArrayList<>();
-    long sentTime;
+    volatile long sentTime;
 
     SentPacket(NewPacketFormat npf, SessionKey key) {
       this.npf = npf;

--- a/src/main/java/network/crypta/node/NodeCrypto.java
+++ b/src/main/java/network/crypta/node/NodeCrypto.java
@@ -30,10 +30,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Manages the node's cryptographic identity and UDP transport parameters.
  *
- * <p>This component owns the long‑lived identity (random {@code identity} bytes and their hashes),
- * the ECDSA P‑256 key pair used for signatures, the Address Resolution Key (ARK) used for updatable
- * references, and the UDP socket / packet mangler used by the FNP transport. It also builds, signs,
- * and compresses noderefs that peers consume during handshake.
+ * <p>This component owns the long‑lived identity (random {@code identity} bytes and their hashes).
+ * It also owns the ECDSA P‑256 key pair used for signatures and the Address Resolution Key (ARK)
+ * used for updatable references. It manages the UDP socket and packet mangler used by the FNP
+ * transport, and builds, signs, and compresses noderefs that peers consume during handshake.
  *
  * <p>Construction binds a UDP port (deterministic or random) and wires the packet pipeline, but the
  * I/O threads only start after a call to {@link #start()}.
@@ -70,13 +70,13 @@ public class NodeCrypto {
    */
   private byte[] myIdentity;
 
-  /** Hash of identity. Used as setup key. */
+  /** Hash of identity. Used as the setup key. */
   private byte[] identityHash;
 
-  /** Hash of hash of identity i.e. hash of setup key. */
+  /** Hash of hash of identity i.e., hash of the setup key. */
   private byte[] identityHashHash;
 
-  /** Nonce used to generate ?secureid= for fproxy etc */
+  /** Nonce used to generate ?secureid= for fproxy etc. */
   byte[] clientNonce;
 
   /** My ECDSA/P256 keypair and context */
@@ -88,7 +88,7 @@ public class NodeCrypto {
   private InsertableClientSSK myARK;
 
   /** My ARK sequence number */
-  private long myARKNumber;
+  private volatile long myARKNumber;
 
   private final NodeCryptoConfig config;
 
@@ -370,12 +370,12 @@ public class NodeCrypto {
   /**
    * Export my reference so that another node can connect to me.
    *
-   * @param forSetup If true, strip out everything that isn't needed for the references exchanged
-   *     immediately after connection setup. I.e. strip out everything that is invariant, or that
+   * @param forSetup If true, strip out everything aren't needed for the references exchanged
+   *     immediately after connection setup. I.e., strip out everything that is invariant, or that
    *     can safely be exchanged later.
    * @param forAnonInitiator If true, we are adding a node from an anonymous initiator noderef
    *     exchange. Minimal noderef which we can construct a PeerNode from. Short-lived so no ARK
-   *     etc. Already signed so dump the signature.
+   *     etc. Already signed, so dump the signature.
    */
   SimpleFieldSet exportPublicFieldSet(boolean forSetup, boolean forAnonInitiator, boolean forARK) {
     SimpleFieldSet fs = exportPublicCryptoFieldSet(forSetup || forARK, forAnonInitiator);
@@ -538,7 +538,7 @@ public class NodeCrypto {
   }
 
   /**
-   * Sign data with the node's ECDSA key. The data does not need to be hashed, the signing code will
+   * Sign data with the node's ECDSA key. The data does not need to be hashed; the signing code will
    * handle that for us, using an algorithm appropriate for the keysize.
    */
   byte[] ecdsaSign(byte[]... data) {
@@ -596,7 +596,7 @@ public class NodeCrypto {
    */
   public boolean allowConnection(PeerNode pn, FreenetInetAddress addr) {
     // Disallow multiple connections to the same address.
-    // For IPv6, a configurable same-/64 subnet rule may be more appropriate than exact match.
+    // For IPv6, a configurable same-/64 subnet rule may be more appropriate than the exact match.
     if (config.oneConnectionPerAddress()
         && node.network().peers().roster().anyConnectedPeerHasAddress(addr, pn)
         && !detector.includes(addr)

--- a/src/main/java/network/crypta/node/NodeStats.java
+++ b/src/main/java/network/crypta/node/NodeStats.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicLong;
 import network.crypta.io.comm.ByteCounter;
 import network.crypta.io.xfer.BlockTransmitter.BlockTimeCallback;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
@@ -220,10 +221,10 @@ public class NodeStats implements Persistable, BlockTimeCallback {
   // static initializer intentionally removed (no-op)
 
   /** the first time bwlimitDelay was over PeerManagerUserAlert threshold */
-  private long firstBwlimitDelayTimeThresholdBreak;
+  private volatile long firstBwlimitDelayTimeThresholdBreak;
 
   /** the first time nodeAveragePing was over PeerManagerUserAlert threshold */
-  private long firstNodeAveragePingTimeThresholdBreak;
+  private volatile long firstNodeAveragePingTimeThresholdBreak;
 
   /** bwlimitDelay PeerManagerUserAlert should happen if true */
   private boolean bwlimitDelayAlertRelevant;
@@ -2924,7 +2925,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
     return routedMessageBytesSent;
   }
 
-  private long disconnBytesSent;
+  private final AtomicLong disconnBytesSent = new AtomicLong();
 
   @SuppressWarnings("unused")
   void disconnBytesReceived(int x) {
@@ -2932,7 +2933,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
   }
 
   void disconnBytesSent(int x) {
-    this.disconnBytesSent += x;
+    disconnBytesSent.addAndGet(x);
   }
 
   /**
@@ -2944,7 +2945,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
    * @return total disconnect bytes sent.
    */
   public long getDisconnBytesSent() {
-    return disconnBytesSent;
+    return disconnBytesSent.get();
   }
 
   private long initialMessagesBytesSent;
@@ -3151,7 +3152,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
         + pingBytesSent // ping bytes
         + probeRequestSentBytes // probe requests
         + routedMessageBytesSent // routed test messages
-        + disconnBytesSent // disconnection related bytes
+        + disconnBytesSent.get() // disconnection related bytes
         + initialMessagesBytesSent // initial messages
         + changedIPBytesSent // changed IP
         + nodeToNodeSentBytes // n2n messages

--- a/src/main/java/network/crypta/node/OpennetPeerNode.java
+++ b/src/main/java/network/crypta/node/OpennetPeerNode.java
@@ -25,7 +25,7 @@ public class OpennetPeerNode extends PeerNode {
   private static final Logger LOG = LoggerFactory.getLogger(OpennetPeerNode.class);
 
   final OpennetManager opennet;
-  private long timeLastSuccess;
+  private volatile long timeLastSuccess;
   // Not persisted across restarts: startup resets grace semantics (disconnection handling is
   // managed separately).
   private int opennetNodeAddedReason = ADDED_REASON_UNKNOWN;
@@ -108,11 +108,11 @@ public class OpennetPeerNode extends PeerNode {
     return false;
   }
 
-  /** Enumerates reasons why a peer must not be dropped during pruning. */
+  /** Lists reasons why a peer must not be dropped during pruning. */
   public enum NOT_DROP_REASON {
     /** No reason to keep the peer; it is eligible for dropping. */
     DROPPABLE,
-    /** Peer was added recently and has not had sufficient time to connect. */
+    /** Peer was added recently and has not had enough time to connect. */
     TOO_NEW_PEER,
     /** Our node uptime is still low; allow time for initial connections. */
     TOO_LOW_UPTIME,
@@ -164,11 +164,11 @@ public class OpennetPeerNode extends PeerNode {
       }
     }
     if (now - node.network().usm().getStartedTime() < OpennetManager.DROP_STARTUP_DELAY)
-      return NOT_DROP_REASON.TOO_LOW_UPTIME; // Give them time to connect after we startup
+      return NOT_DROP_REASON.TOO_LOW_UPTIME; // Give them time to connect after we start up
     if (!ignoreDisconnect) {
       synchronized (this) {
         // This only applies after it has connected, and only if !ignoreDisconnect.
-        // Hence only DISCONNECTED and not NEVER CONNECTED.
+        // Hence, only DISCONNECTED and not NEVER CONNECTED.
         if ((status == PeerManager.PEER_NODE_STATUS_DISCONNECTED)
             && !super.neverConnected()
             && now - timeLastDisconnect < OpennetManager.DROP_DISCONNECT_DELAY
@@ -284,9 +284,9 @@ public class OpennetPeerNode extends PeerNode {
   }
 
   /**
-   * If a node is TOO OLD, we should keep it connected for a brief period for it to allow it to
-   * issue a UOM request, we should keep it connected while the UOM transfer is in progress, but
-   * otherwise we should disconnect.
+   * If a node is too old, keep it connected briefly so it can issue a UOM request.
+   *
+   * <p>Keep it connected while the UOM transfer is in progress. Otherwise, disconnect it.
    */
   private boolean shouldDisconnectTooOld() {
     long uptime = System.currentTimeMillis() - timeLastConnectionCompleted();
@@ -309,7 +309,7 @@ public class OpennetPeerNode extends PeerNode {
   }
 
   /**
-   * Called on successful connect. Marks the address as presumed guilty for a short period so that
+   * Called on successful connection. Marks the address as presumed guilty of a short period so that
    * address tracking can prefer other paths temporarily.
    */
   @Override
@@ -353,7 +353,7 @@ public class OpennetPeerNode extends PeerNode {
   /**
    * Schedules deferred clearing of the added-time markers once the grace period has elapsed.
    *
-   * <p>Opennet peers keep the markers across the first successful connect to enforce the initial
+   * <p>Opennet peers keep the markers across the first successful connection to enforce the initial
    * grace period; the timed job will trigger {@link #isDroppableWithReason(boolean)} after the
    * minimum age to clear them.
    */

--- a/src/main/java/network/crypta/node/PacketSender.java
+++ b/src/main/java/network/crypta/node/PacketSender.java
@@ -7,6 +7,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.ArrayList;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.TimeUtil;
 import network.crypta.support.io.NativeThread;
@@ -53,8 +54,8 @@ public class PacketSender implements Runnable {
   final NativeThread myThread;
   final Node node;
   NodeStats stats;
-  long lastReportedNoPackets;
-  long lastReceivedPacketFromAnyNode;
+  volatile long lastReportedNoPackets;
+  final AtomicLong lastReceivedPacketFromAnyNode = new AtomicLong();
   private final Random localRandom;
   private volatile boolean stopping;
   private boolean wakeUpRequested;
@@ -141,7 +142,7 @@ public class PacketSender implements Runnable {
     schedulePeriodicJob();
     // Process peers perform the selected action, then sleep until the next action time.
     while (!stopping) {
-      lastReceivedPacketFromAnyNode = lastReportedNoPackets;
+      lastReceivedPacketFromAnyNode.set(lastReportedNoPackets);
       try {
         realRun();
       } catch (Throwable t) {
@@ -237,8 +238,7 @@ public class PacketSender implements Runnable {
   }
 
   private void preProcessPeer(PeerNode pn) {
-    lastReceivedPacketFromAnyNode =
-        Math.max(pn.lastReceivedPacketTime(), lastReceivedPacketFromAnyNode);
+    lastReceivedPacketFromAnyNode.accumulateAndGet(pn.lastReceivedPacketTime(), Math::max);
     pn.maybeOnConnect();
     if (pn.shouldDisconnectAndRemoveNow() && !pn.isDisconnecting()) {
       node.network().peers().messenger().disconnectAndRemove(pn, true, true, false);
@@ -471,7 +471,7 @@ public class PacketSender implements Runnable {
     long sleepTime = Math.min(nextActionTime - now, MAX_COALESCING_DELAY);
 
     if ((now - node.getStartupTime()) > MINUTES.toMillis(5)
-        && (now - lastReceivedPacketFromAnyNode) > Node.ALARM_TIME) {
+        && (now - lastReceivedPacketFromAnyNode.get()) > Node.ALARM_TIME) {
       LOG.error(
           "No packets received from any node in {} seconds",
           SECONDS.convert(Node.ALARM_TIME, MILLISECONDS));

--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -243,7 +243,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private SessionKey unverifiedTracker;
 
   /** When did we last send a packet? */
-  private long timeLastSentPacket;
+  private volatile long timeLastSentPacket;
 
   /** When did we last receive a packet? */
   private long timeLastReceivedPacket;

--- a/src/main/java/network/crypta/node/PeerStatusBook.java
+++ b/src/main/java/network/crypta/node/PeerStatusBook.java
@@ -45,9 +45,9 @@ public class PeerStatusBook {
   private final PeerStatusTracker<String> peerNodeRoutingBackoffReasonsBulk =
       new PeerStatusTracker<>();
 
-  private long oldestNeverConnectedDarknetPeerAge = 0L;
+  private volatile long oldestNeverConnectedDarknetPeerAge = 0L;
   private long nextOldestNeverConnectedDarknetPeerAgeUpdateTime = -1L;
-  private long nextPeerNodeStatusLogTime = -1L;
+  private volatile long nextPeerNodeStatusLogTime = -1L;
   private long nextRoutableConnectionStatsUpdateTime = -1L;
 
   /**

--- a/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
@@ -152,13 +152,13 @@ public final class NodeStorageSubsystem {
   private int storeSaltHashSlotFilterPersistenceTime;
 
   /** The maximum number of keys stored in each of the datastores, cache and store combined. */
-  private long maxTotalKeys;
+  private volatile long maxTotalKeys;
 
-  private long maxCacheKeys;
-  private long maxStoreKeys;
+  private volatile long maxCacheKeys;
+  private volatile long maxStoreKeys;
 
   /** The maximum size of the datastore. Kept to avoid rounding turning 5G into 5,368,698,672 */
-  private long maxTotalDatastoreSize;
+  private volatile long maxTotalDatastoreSize;
 
   /**
    * If true, store shrinks occur immediately even if they are over 10% of the store size. If false,
@@ -185,10 +185,10 @@ public final class NodeStorageSubsystem {
   private boolean databaseAwaitingPassword;
 
   /** Client caches maximum cached keys for each type */
-  private long maxClientCacheKeys;
+  private volatile long maxClientCacheKeys;
 
   /** Maximum size of the client cache. Kept to avoid rounding problems. */
-  private long maxTotalClientCacheSize;
+  private volatile long maxTotalClientCacheSize;
 
   /** The CHK datacache. */
   private CHKStore chkDatacache;
@@ -209,7 +209,7 @@ public final class NodeStorageSubsystem {
   private PubkeyStore pubKeyClientcache;
 
   /** Slashdot cache sizing. */
-  private long maxSlashdotCacheSize;
+  private volatile long maxSlashdotCacheSize;
 
   private int maxSlashdotCacheKeys;
 
@@ -223,8 +223,8 @@ public final class NodeStorageSubsystem {
   private boolean useSlashdotCache;
   private boolean writeLocalToDatastore;
 
-  private long cachingFreenetStoreMaxSize;
-  private long cachingFreenetStorePeriod;
+  private volatile long cachingFreenetStoreMaxSize;
+  private volatile long cachingFreenetStorePeriod;
   private CachingFreenetStoreTracker cachingFreenetStoreTracker;
 
   private boolean storePreallocate;


### PR DESCRIPTION
## Summary
- Resolve SpotBugs shared-state atomicity findings by adding safe cross-thread semantics to long timing/counter fields.
- Replace non-atomic read-modify-write paths with atomic primitives (`AtomicLongFieldUpdater` in `BaseSingleFileFetcher`, `AtomicLong` in `PacketSender` and `NodeStats`).
- Keep touched documentation readable with minor sentence-splitting updates in `NodeCrypto` and `OpennetPeerNode`.

## How to test
- `./gradlew spotlessApply`
- `./gradlew compileJava`
- `./gradlew spotbugsMain`
- `./gradlew spotbugsTest`
- Confirm `AT_NONATOMIC_64BIT_PRIMITIVE` findings are zero in:
  - `build/reports/spotbugs/spotbugsMain.xml`
  - `build/reports/spotbugs/spotbugsTest.xml`