### PR TITLE
fix(spotbugs): Fix non-atomic shared variable updates

### DIFF
--- a/src/main/java/network/crypta/client/async/BaseSingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/BaseSingleFileFetcher.java
@@ -161,7 +161,9 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
         if (LOG.isDebugEnabled())
           LOG.debug(
               "RecentlyFailed -> cooldown until {} on {}", TimeUtil.formatTime(l - now), this);
-        COOLDOWN_WAKEUP_TIME_UPDATER.accumulateAndGet(this, l, Math::max);
+        synchronized (this) {
+          COOLDOWN_WAKEUP_TIME_UPDATER.accumulateAndGet(this, l, Math::max);
+        }
       } else {
         this.onFailure(
             new LowLevelGetException(LowLevelGetException.RECENTLY_FAILED), null, context);

--- a/src/main/java/network/crypta/client/async/SplitFileInserterCrossSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterCrossSegmentStorage.java
@@ -74,7 +74,7 @@ public class SplitFileInserterCrossSegmentStorage {
 
   private final int statusLength;
 
-  // Set to true to encode block keys during *cross-segment* encoding, and thus detect e.g. storage
+  // Set to true to encode block keys during *cross-segment* encoding, and thus detect e.g., storage
   // bugs.
   // This will cause more disk I/O as we have to write the keys (more or less randomly).
   // Intended for additional verification during cross-segment encoding.
@@ -131,7 +131,7 @@ public class SplitFileInserterCrossSegmentStorage {
   }
 
   /** Only used during construction */
-  void addBlock(SplitFileInserterSegmentStorage seg, int blockNum) {
+  private synchronized void addBlock(SplitFileInserterSegmentStorage seg, int blockNum) {
     segments[counter] = seg;
     blockNumbers[counter] = blockNum;
     if (LOG.isDebugEnabled())
@@ -144,14 +144,14 @@ public class SplitFileInserterCrossSegmentStorage {
     counter++;
   }
 
-  void addDataBlock(SplitFileInserterSegmentStorage seg, int blockNum) {
+  synchronized void addDataBlock(SplitFileInserterSegmentStorage seg, int blockNum) {
     assert (counter < dataBlockCount);
     assert (blockNum < seg.dataBlockCount);
     addBlock(seg, blockNum);
   }
 
   /** Only used during construction */
-  void addCheckBlock(SplitFileInserterSegmentStorage seg, int blockNum) {
+  synchronized void addCheckBlock(SplitFileInserterSegmentStorage seg, int blockNum) {
     assert (counter >= dataBlockCount);
     assert (blockNum >= seg.dataBlockCount
         && blockNum < seg.dataBlockCount + seg.crossCheckBlockCount);
@@ -261,7 +261,7 @@ public class SplitFileInserterCrossSegmentStorage {
   /**
    * Schedules asynchronous encoding of cross-check (parity) blocks for this segment.
    *
-   * <p>The call is idempotent and returns immediately: when first invoked it enqueues a
+   * <p>The call is idempotent and returns immediately: when first invoked, it enqueues a
    * memory-bounded job that reads all data blocks, computes parity via the configured codec, writes
    * each cross-check block to its owning segment, and persists status where enabled. Subsequent
    * calls while encoding is in progress are ignored.
@@ -374,7 +374,7 @@ public class SplitFileInserterCrossSegmentStorage {
    * @param blockNoWithinSegment block index inside {@code segmentNumber} that is expected to match
    *     the recorded block number for the provided slot.
    * @return a newly allocated byte array containing the cross-check block data as stored on disk.
-   * @throws IOException if the underlying storage cannot read the requested block or an I/O error
+   * @throws IOException if the underlying storage cannot read the requested block, or an I/O error
    *     occurs during the read operation.
    */
   byte[] readCheckBlock(
@@ -424,7 +424,7 @@ public class SplitFileInserterCrossSegmentStorage {
    *
    * @return the number of allocated block slots recorded at construction time.
    */
-  public int getAllocatedCrossCheckBlocks() {
+  public synchronized int getAllocatedCrossCheckBlocks() {
     return counter;
   }
 
@@ -480,12 +480,14 @@ public class SplitFileInserterCrossSegmentStorage {
     encoded = dis.readBoolean();
   }
 
+  @SuppressWarnings("unused")
   int[] getSegmentNumbers() {
     int[] ret = new int[totalBlocks];
     for (int i = 0; i < totalBlocks; i++) ret[i] = segments[i].segNo;
     return ret;
   }
 
+  @SuppressWarnings("unused")
   int[] getBlockNumbers() {
     return blockNumbers.clone();
   }
@@ -493,8 +495,8 @@ public class SplitFileInserterCrossSegmentStorage {
   /**
    * Cancel the encode.
    *
-   * @return True if we can complete cancelling now, false if we are encoding, in which case parent
-   *     will get the usual callback when it is done.
+   * @return True if we can complete cancelling now, false if we are encoding, in which case the
+   *     parent will get the usual callback when it is done.
    */
   public synchronized boolean cancel() {
     cancelled = true;
@@ -502,14 +504,14 @@ public class SplitFileInserterCrossSegmentStorage {
   }
 
   /**
-   * Indicates whether the encode job has either completed or been cancelled.
+   * Indicates whether the encoding job has either completed or been canceled.
    *
    * <p>The method returns {@code false} while the job is running. Once the job finishes it returns
    * {@code true} for both success and cancellation. Call {@link #isFinishedEncoding()} to
    * distinguish a successful completion from cancellation.
    *
-   * @return {@code true} if the job is not running and the segment is either encoded or was
-   *     cancelled; {@code false} while encoding is in progress.
+   * @return {@code true} if the job is not running, and the segment is either encoded or was
+   *     canceled; {@code false} while encoding is in progress.
    */
   public synchronized boolean hasCompletedOrFailed() {
     if (encoding) return false;

--- a/src/main/java/network/crypta/crypt/ChecksumOutputStream.java
+++ b/src/main/java/network/crypta/crypt/ChecksumOutputStream.java
@@ -12,12 +12,12 @@ import org.jetbrains.annotations.NotNull;
  *
  * <p>All bytes are forwarded unmodified to the underlying stream. For checksum computation, the
  * first {@code skipPrefix} bytes written through this wrapper are <em>not</em> included; all
- * subsequent bytes contribute to the checksum. Optionally, on {@link #close()}, the current
- * checksum value is appended to the underlying stream as a 4-byte little-endian integer (equivalent
- * to {@link Fields#intToBytes(int)} of the low 32 bits).
+ * following bytes contribute to the checksum. Optionally, on {@link #close()}, the current checksum
+ * value is appended to the underlying stream as a 4-byte little-endian integer (equivalent to
+ * {@link Fields#intToBytes(int)} of the low 32 bits).
  *
- * <p>Ordering note: the checksum is updated before delegating the corresponding write to the
- * wrapped stream. If the underlying write throws, the checksum may already reflect the attempted
+ * <p>Ordering note: the checksum is updated before delegating the corresponding writing to the
+ * wrapped stream. If the underlying writing throws, the checksum may already reflect the attempted
  * bytes (except those within the prefix).
  *
  * <p>Thread-safety: instances are not thread-safe. Use from a single thread or coordinate
@@ -58,7 +58,7 @@ public class ChecksumOutputStream extends FilterOutputStream {
    * @throws IOException if the underlying stream fails to write.
    */
   @Override
-  public void write(int b) throws IOException {
+  public synchronized void write(int b) throws IOException {
     if (bytesInsidePrefix >= skipPrefix) {
       crc.update(b);
     } else bytesInsidePrefix++;
@@ -78,7 +78,7 @@ public class ChecksumOutputStream extends FilterOutputStream {
    * @throws IndexOutOfBoundsException if {@code offset} or {@code length} is invalid.
    */
   @Override
-  public void write(byte @NotNull [] buf, int offset, int length) throws IOException {
+  public synchronized void write(byte @NotNull [] buf, int offset, int length) throws IOException {
     int chop = Math.min(skipPrefix - bytesInsidePrefix, length);
     if (chop <= 0) {
       // Prefix already consumed: count the entire slice.
@@ -103,7 +103,7 @@ public class ChecksumOutputStream extends FilterOutputStream {
    * @throws IOException if the underlying stream fails to write.
    */
   @Override
-  public void write(byte @NotNull [] buf) throws IOException {
+  public synchronized void write(byte @NotNull [] buf) throws IOException {
     write(buf, 0, buf.length);
   }
 
@@ -118,12 +118,10 @@ public class ChecksumOutputStream extends FilterOutputStream {
    * @throws IOException if writing the trailer or closing the underlying stream fails.
    */
   @Override
-  public void close() throws IOException {
+  public synchronized void close() throws IOException {
     if (writeChecksum) {
-      synchronized (this) {
-        if (closed) return; // Idempotent close: avoid duplicate trailer writes
-        closed = true;
-      }
+      if (closed) return; // Idempotent close: avoid duplicate trailer writes
+      closed = true;
       out.write(Fields.intToBytes((int) crc.getValue()));
     }
     super.close(); // Always close the underlying stream
@@ -138,7 +136,7 @@ public class ChecksumOutputStream extends FilterOutputStream {
    *
    * @return the running checksum value.
    */
-  public long getValue() {
+  public synchronized long getValue() {
     return crc.getValue();
   }
 }

--- a/src/main/java/network/crypta/node/LocationManager.java
+++ b/src/main/java/network/crypta/node/LocationManager.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClient;
@@ -194,31 +195,31 @@ public class LocationManager implements ByteCounter {
   static final long MAX_SWAP_TIME = MINUTES.toMillis(1);
 
   private static void incrementSwaps() {
-    swaps++;
+    swaps.incrementAndGet();
   }
 
   private static void incrementNoSwaps() {
-    noSwaps++;
+    noSwaps.incrementAndGet();
   }
 
   private static void incrementStartedSwaps() {
-    startedSwaps++;
+    startedSwaps.incrementAndGet();
   }
 
   private static void incrementSwapsRejectedAlreadyLocked() {
-    swapsRejectedAlreadyLocked++;
+    swapsRejectedAlreadyLocked.incrementAndGet();
   }
 
   private static void incrementSwapsRejectedNowhereToGo() {
-    swapsRejectedNowhereToGo++;
+    swapsRejectedNowhereToGo.incrementAndGet();
   }
 
   private static void incrementSwapsRejectedRecognizedID() {
-    swapsRejectedRecognizedID++;
+    swapsRejectedRecognizedID.incrementAndGet();
   }
 
   private static void incrementSwapsRejectedRateLimit() {
-    swapsRejectedRateLimit++;
+    swapsRejectedRateLimit.incrementAndGet();
   }
 
   /** Don't start swapping until our peers have had a reasonable chance to reconnect. */
@@ -1210,47 +1211,47 @@ public class LocationManager implements ByteCounter {
 
   private boolean locked;
 
-  private static int swaps;
-  private static int noSwaps;
-  private static int startedSwaps;
-  private static int swapsRejectedAlreadyLocked;
-  private static int swapsRejectedNowhereToGo;
-  private static int swapsRejectedRateLimit;
-  private static int swapsRejectedRecognizedID;
+  private static final AtomicInteger swaps = new AtomicInteger();
+  private static final AtomicInteger noSwaps = new AtomicInteger();
+  private static final AtomicInteger startedSwaps = new AtomicInteger();
+  private static final AtomicInteger swapsRejectedAlreadyLocked = new AtomicInteger();
+  private static final AtomicInteger swapsRejectedNowhereToGo = new AtomicInteger();
+  private static final AtomicInteger swapsRejectedRateLimit = new AtomicInteger();
+  private static final AtomicInteger swapsRejectedRecognizedID = new AtomicInteger();
 
   /** Returns the number of successful swaps since start. */
   public static int getSwaps() {
-    return swaps;
+    return swaps.get();
   }
 
   /** Returns the number of swap attempts that did not result in a swap. */
   public static int getNoSwaps() {
-    return noSwaps;
+    return noSwaps.get();
   }
 
   /** Returns the number of outgoing swap attempts started. */
   public static int getStartedSwaps() {
-    return startedSwaps;
+    return startedSwaps.get();
   }
 
   /** Returns the number of rejections due to lock contention or queue limits. */
   public static int getSwapsRejectedAlreadyLocked() {
-    return swapsRejectedAlreadyLocked;
+    return swapsRejectedAlreadyLocked.get();
   }
 
   /** Returns the number of rejections due to no available peer to forward to. */
   public static int getSwapsRejectedNowhereToGo() {
-    return swapsRejectedNowhereToGo;
+    return swapsRejectedNowhereToGo.get();
   }
 
   /** Returns the number of rejections due to peer-advised rate limiting. */
   public static int getSwapsRejectedRateLimit() {
-    return swapsRejectedRateLimit;
+    return swapsRejectedRateLimit.get();
   }
 
   /** Returns the number of rejections due to duplicate or recognized IDs. */
   public static int getSwapsRejectedRecognizedID() {
-    return swapsRejectedRecognizedID;
+    return swapsRejectedRecognizedID.get();
   }
 
   long lockedTime;

--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.crypt.BlockCipher;
 import network.crypta.crypt.KeyAgreementSchemeContext;
@@ -2302,7 +2303,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
         unverifiedTracker = null;
       }
       sendHandshakeTime = now;
-      countFailedRevocationTransfers = 0;
+      countFailedRevocationTransfers.set(0);
       timePrevDisconnect = timeLastDisconnect;
       timeLastDisconnect = now;
       if (dumpMessageQueue) {
@@ -5408,13 +5409,13 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   // Note: lastFailedRevocationTransfer was unused; removing avoids dead code.
 
   /** Reset on disconnection */
-  private int countFailedRevocationTransfers;
+  private final AtomicInteger countFailedRevocationTransfers = new AtomicInteger();
 
   /** Records a failed revocation transfer and schedules a fresh handshake IP update attempt. */
   public void failedRevocationTransfer() {
     // Something odd happened, possibly a disconnect, maybe looking up the DNS names will help?
     internals.markHandshakeIpUpdateAttempted(System.currentTimeMillis());
-    countFailedRevocationTransfers++;
+    countFailedRevocationTransfers.incrementAndGet();
   }
 
   /**
@@ -5426,7 +5427,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * @return count of failed revocation transfers since last disconnect
    */
   public int countFailedRevocationTransfers() {
-    return countFailedRevocationTransfers;
+    return countFailedRevocationTransfers.get();
   }
 
   /**

--- a/src/main/java/org/spaceroots/mantissa/random/MersenneTwister.java
+++ b/src/main/java/org/spaceroots/mantissa/random/MersenneTwister.java
@@ -11,7 +11,7 @@ import java.util.Random;
  * significantly better statistical properties for simulation, sampling, and randomized algorithms
  * that are sensitive to correlation artifacts. The generator maintains an internal 624‑element
  * state vector and produces 32‑bit values in batches; the public {@code nextInt()}, {@code
- * nextLong()}, and other {@code Random} methods all delegate to {@link #next(int)} to obtain the
+ * nextLong()}, and other {@code Random} methods all delegate to {@link #next(int)} to get the
  * requested number of bits. Calling any {@code setSeed} method fully resets that internal state so
  * that two instances seeded identically will produce the same sequence of values.
  *
@@ -21,7 +21,7 @@ import java.util.Random;
  * determinism and avoid races during state refresh.
  *
  * <p>This generator features an extremely long period (2<sup>19937</sup>-1) and 623-dimensional
- * equidistribution up to 32 bits accuracy. The home page for this generator is located at <a
+ * equidistribution up to 32-bit accuracy. The home page for this generator is located at <a
  * href="http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html">
  * http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html</a>.
  *
@@ -31,8 +31,8 @@ import java.util.Random;
  * Modeling and Computer Simulation, Vol. 8, No. 1, January 1998, pp 3--30
  *
  * <p>The class is implemented as a specialization of the standard <code>java.util.Random</code>
- * class. This allows to use it in algorithms expecting a standard random generator, and hence
- * benefit from a better generator without code change.
+ * class. This allows using it in algorithms expecting a standard random generator and hence
+ * benefiting from a better generator without code change.
  *
  * <p>This class is mainly a Java port of the 2002-01-26 version of the generator written in C by
  * Makoto Matsumoto and Takuji Nishimura. The following license text is reproduced from the original
@@ -48,9 +48,9 @@ import java.util.Random;
  *
  * <ol>
  *   <li>Redistributions of source code must retain the above copyright notice, this list of
- *       conditions and the following disclaimer.
+ *       conditions, and the following disclaimer.
  *   <li>Redistributions in binary form must reproduce the above copyright notice, this list of
- *       conditions and the following disclaimer in the documentation and/or other materials
+ *       conditions, and the following disclaimer in the documentation and/or other materials
  *       provided with the distribution.
  *   <li>The names of its contributors may not be used to endorse or promote products derived from
  *       this software without specific prior written permission.
@@ -61,10 +61,10 @@ import java.util.Random;
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
  * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
- * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
- * OF SUCH DAMAGE.</strong>
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER, CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.</strong>
  *
  * @author Makoto Matsumoto and Takuji Nishimura (C version), Luc Maisonobe (Java port)
  * @version $Id: MersenneTwister.java 1666 2005-12-15 16:37:55Z luc $
@@ -149,12 +149,13 @@ public class MersenneTwister extends Random {
     // we use a long masked by 0xffffffffL as a poor man unsigned int
     long longMT = seed;
     mt[0] = (int) longMT;
-    for (mti = 1; mti < N; ++mti) {
+    for (int i = 1; i < N; ++i) {
       // See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier.
       // initializer from the 2002-01-09 C version by Makoto Matsumoto
-      longMT = (1812433253L * (longMT ^ (longMT >> 30)) + mti) & 0xffffffffL;
-      mt[mti] = (int) longMT;
+      longMT = (1812433253L * (longMT ^ (longMT >> 30)) + i) & 0xffffffffL;
+      mt[i] = (int) longMT;
     }
+    mti = N;
   }
 
   /**
@@ -202,7 +203,7 @@ public class MersenneTwister extends Random {
   }
 
   /**
-   * Generate next pseudorandom number.
+   * Generate the next pseudorandom number.
    *
    * <p>This method is the core generation algorithm. As per {@link Random Random } contract, it is
    * used by all the public generation methods for the various primitive types {@link


### PR DESCRIPTION
## Summary
- fix SpotBugs `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` findings across async fetcher, inserter cross-segment storage, checksum stream, node counters, peer revocation counter, and Mersenne Twister seeding
- replace shared int counters with `AtomicInteger` where updates happen across threads, and synchronize read-modify-write paths where locking is the existing design
- keep behavior unchanged while removing non-atomic shared-state warnings in SpotBugs reports

## How to test
- `./gradlew spotbugsMain`
- `./gradlew spotbugsTest`
- `./gradlew test`