### PR TITLE
fix(spotbugs): Fix unconditional waits in persistent job runner

### DIFF
--- a/src/main/java/network/crypta/client/async/PersistentJobRunnerImpl.java
+++ b/src/main/java/network/crypta/client/async/PersistentJobRunnerImpl.java
@@ -514,32 +514,32 @@ public abstract class PersistentJobRunnerImpl implements PersistentJobRunner {
   }
 
   private void waitForRunningJobs() throws PersistenceDisabledException {
-    while (runningJobs > 0) {
-      if (!enableCheckpointing) return;
-      if (killed) throw new PersistenceDisabledException();
-      LOG.error("Waiting for {} to finish before checkpoint", runningJobs);
-      try {
-        synchronized (sync) {
+    synchronized (sync) {
+      while (runningJobs > 0) {
+        if (!enableCheckpointing) return;
+        if (killed) throw new PersistenceDisabledException();
+        LOG.error("Waiting for {} to finish before checkpoint", runningJobs);
+        try {
           sync.wait();
+        } catch (InterruptedException _) {
+          Thread.currentThread().interrupt();
+          throw new PersistenceDisabledException();
         }
-      } catch (InterruptedException _) {
-        Thread.currentThread().interrupt();
-        throw new PersistenceDisabledException();
       }
     }
   }
 
   private void waitWhileWriting() throws PersistenceDisabledException {
-    while (writing) {
-      if (!enableCheckpointing) return;
-      if (killed) throw new PersistenceDisabledException();
-      try {
-        synchronized (sync) {
+    synchronized (sync) {
+      while (writing) {
+        if (!enableCheckpointing) return;
+        if (killed) throw new PersistenceDisabledException();
+        try {
           sync.wait();
+        } catch (InterruptedException _) {
+          Thread.currentThread().interrupt();
+          throw new PersistenceDisabledException();
         }
-      } catch (InterruptedException _) {
-        Thread.currentThread().interrupt();
-        throw new PersistenceDisabledException();
       }
     }
   }


### PR DESCRIPTION
## Summary
- Guard `waitForRunningJobs()` with `synchronized (sync)` so the `runningJobs` predicate and `wait()` are evaluated under the same monitor.
- Guard `waitWhileWriting()` the same way for the `writing` predicate.
- Remove SpotBugs `UW_UNCOND_WAIT` findings in `PersistentJobRunnerImpl` without changing interrupt/exception handling behavior.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `./gradlew test --tests "*PersistentJobRunnerImplTest"`

## Validation notes
- `build/reports/spotbugs/spotbugsMain.xml` and `build/reports/spotbugs/spotbugsTest.xml` contain zero `UW_UNCOND_WAIT` instances after this change.