### PR TITLE
fix(spotbugs): Eliminate static writes from instance methods

### DIFF
--- a/src/main/java/network/crypta/crypt/SSL.java
+++ b/src/main/java/network/crypta/crypt/SSL.java
@@ -189,27 +189,31 @@ public class SSL {
       @Override
       public void set(Boolean newValue) throws InvalidConfigValueException {
         if (!get().equals(newValue)) {
-          enable = newValue;
-          if (enable)
-            try {
-              loadKeyStoreAndCreateCertificate();
-              createSSLContext();
-            } catch (Exception e) {
-              enable = false;
-              LOG.error("SSL could not be enabled", e);
-              throwConfigError("SSL could not be enabled", e);
-            }
-          else {
-            ssf = null;
-            try {
-              keystore.load(null, keyStorePass.toCharArray());
-            } catch (Exception _) {
-              // Just clear the key store
-            }
-          }
+          updateEnable(newValue);
         }
       }
     };
+  }
+
+  private static void updateEnable(boolean newValue) throws InvalidConfigValueException {
+    enable = newValue;
+    if (enable)
+      try {
+        loadKeyStoreAndCreateCertificate();
+        createSSLContext();
+      } catch (Exception e) {
+        enable = false;
+        LOG.error("SSL could not be enabled", e);
+        throwConfigError("SSL could not be enabled", e);
+      }
+    else {
+      ssf = null;
+      try {
+        keystore.load(null, keyStorePass.toCharArray());
+      } catch (Exception _) {
+        // Just clear the key store
+      }
+    }
   }
 
   private static StringCallback keyStorePathCallback() {

--- a/src/main/java/network/crypta/node/NodeStarter.java
+++ b/src/main/java/network/crypta/node/NodeStarter.java
@@ -125,14 +125,7 @@ public class NodeStarter implements WrapperListener {
       String details,
       boolean noDNS,
       RandomSource randomSource) {
-
-    synchronized (NodeStarter.class) {
-      if (isStarted) {
-        throw new IllegalStateException();
-      }
-      isStarted = true;
-      isTestingVM = true;
-    }
+    markStarted(true);
 
     ensureDirectoryExists(baseDirectory);
 
@@ -153,6 +146,16 @@ public class NodeStarter implements WrapperListener {
     DNSRequester.disable = noDNS;
 
     return random;
+  }
+
+  private static void markStarted(boolean testingVm) {
+    synchronized (NodeStarter.class) {
+      if (isStarted) {
+        throw new IllegalStateException();
+      }
+      isStarted = true;
+      isTestingVM = testingVm;
+    }
   }
 
   private static void ensureDirectoryExists(File dir) {
@@ -455,13 +458,7 @@ public class NodeStarter implements WrapperListener {
    */
   @Override
   public Integer start(String[] args) {
-    synchronized (NodeStarter.class) {
-      if (isStarted) {
-        throw new IllegalStateException();
-      }
-      isStarted = true;
-      isTestingVM = false;
-    }
+    markStarted(false);
 
     NodeCli cli = new NodeCli();
     CommandLine cmd = new CommandLine(cli);

--- a/src/main/kotlin/network/crypta/launcher/Launcher.kt
+++ b/src/main/kotlin/network/crypta/launcher/Launcher.kt
@@ -56,11 +56,13 @@ class CryptaLauncher : JFrame(APP_NAME) {
         e.consume()
         return@KeyEventDispatcher true
       }
+
       KeyEvent.VK_RIGHT -> {
         cycleFocus(+1)
         e.consume()
         return@KeyEventDispatcher true
       }
+
       KeyEvent.VK_S -> {
         val st = controller.state.value
         if (st.isStoppingOrShuttingDown) return@KeyEventDispatcher true
@@ -68,26 +70,31 @@ class CryptaLauncher : JFrame(APP_NAME) {
         e.consume()
         return@KeyEventDispatcher true
       }
+
       KeyEvent.VK_Q -> {
         quitApp()
         e.consume()
         return@KeyEventDispatcher true
       }
+
       KeyEvent.VK_UP -> {
         scrollRows(-1)
         e.consume()
         return@KeyEventDispatcher true
       }
+
       KeyEvent.VK_DOWN -> {
         scrollRows(+1)
         e.consume()
         return@KeyEventDispatcher true
       }
+
       KeyEvent.VK_PAGE_UP -> {
         scrollPage(-1)
         e.consume()
         return@KeyEventDispatcher true
       }
+
       KeyEvent.VK_PAGE_DOWN -> {
         scrollPage(+1)
         e.consume()
@@ -98,7 +105,7 @@ class CryptaLauncher : JFrame(APP_NAME) {
   }
 
   init {
-    instance = this
+    registerLauncherInstance(this)
     defaultCloseOperation = DO_NOTHING_ON_CLOSE
     // Allow shrinking to half of the default size
     minimumSize = Dimension(450, 300)
@@ -218,8 +225,11 @@ class CryptaLauncher : JFrame(APP_NAME) {
         launchBtn.isEnabled = st.isRunning && st.knownPort != null && !st.isShuttingDown
         // Update tooltip with actual port when known
         launchBtn.toolTipText =
-          if (st.knownPort != null) "Open http://localhost:${st.knownPort}/ in your browser"
-          else "Open http://localhost:<port>/ in your browser"
+          if (st.knownPort != null) {
+            "Open http://localhost:${st.knownPort}/ in your browser"
+          } else {
+            "Open http://localhost:<port>/ in your browser"
+          }
       }
     }
 
@@ -456,6 +466,10 @@ private fun createAndShowLauncherUi() {
   setWindowAndDockIcons(f)
   centerAndShow(f, Dimension(900, 600))
   installWindowsHooksIfNeeded(f)
+}
+
+private fun registerLauncherInstance(launcher: CryptaLauncher) {
+  CryptaLauncher.instance = launcher
 }
 
 private fun setWindowAndDockIcons(f: JFrame) {

--- a/src/main/kotlin/network/crypta/launcher/ThemeSwitcher.kt
+++ b/src/main/kotlin/network/crypta/launcher/ThemeSwitcher.kt
@@ -12,6 +12,8 @@ import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.plaf.FontUIResource
 import network.crypta.fs.AppEnv
+import network.crypta.launcher.ThemeSwitcher.install
+import network.crypta.launcher.ThemeSwitcher.shutdown
 
 /**
  * Applies a FlatLaf look-and-feel that tracks the operating system theme and keeps Swing components
@@ -36,8 +38,13 @@ import network.crypta.fs.AppEnv
  * @see AppEnv
  */
 object ThemeSwitcher {
-  @Volatile private var detector: OsThemeDetector? = null
-  @Volatile private var listener: Consumer<Boolean>? = null
+  private class ThemeDetectionState {
+    @Volatile var detector: OsThemeDetector? = null
+
+    @Volatile var listener: Consumer<Boolean>? = null
+  }
+
+  private val state = ThemeDetectionState()
 
   /**
    * Initialize OS theme detection and apply the matching FlatLaf before UI creation.
@@ -46,8 +53,8 @@ object ThemeSwitcher {
    * initial theme is applied synchronously on the EDT and remains stable. The method configures
    * platform-specific details (macOS appearance hint and Linux client decorations), creates a
    * detector via [FlatpakAwareOsThemeDetector], applies the current theme immediately, and then
-   * registers a listener for subsequent OS theme changes. Repeated calls replace the stored
-   * detector reference, but the intent is a single early call to avoid redundant listeners.
+   * registers a listener for later OS theme changes. Repeated calls replace the stored detector
+   * reference, but the intent is a single early call to avoid redundant listeners.
    */
   fun install() {
     // macOS: ensure the system appearance is reported to Java/Swing
@@ -65,15 +72,15 @@ object ThemeSwitcher {
       logDebug("Failed to enable client decorations on Linux/Flatpak", t)
     }
     val det = FlatpakAwareOsThemeDetector.getDetector()
-    detector = det
+    state.detector = det
 
-    // Apply current theme synchronously (must happen before any Swing components are created)
+    // Apply the current theme synchronously (must happen before any Swing components are created)
     val initialDark = det.isDark
     applyFor(initialDark, synchronous = true)
 
     // Listen for changes and switch LAF live
     val consumer = Consumer<Boolean> { isDark -> applyFor(isDark) }
-    listener = consumer
+    state.listener = consumer
     det.registerListener(consumer)
   }
 
@@ -86,11 +93,11 @@ object ThemeSwitcher {
    * look-and-feel state.
    */
   fun shutdown() {
-    val det = detector
-    val c = listener
+    val det = state.detector
+    val c = state.listener
     if (det != null && c != null) det.removeListener(c)
-    detector = null
-    listener = null
+    state.detector = null
+    state.listener = null
   }
 
   private fun applyFor(useDark: Boolean, synchronous: Boolean = false) {
@@ -150,7 +157,7 @@ object ThemeSwitcher {
   }
 
   private fun applyLookAndFeel(laf: LookAndFeel) {
-    // Apply LAF explicitly via UIManager to catch errors, then let FlatLaf do extra set up
+    // Apply LAF explicitly via UIManager to catch errors, then let FlatLaf do extra setup
     try {
       UIManager.setLookAndFeel(laf)
     } catch (t: Throwable) {

--- a/src/test/java/network/crypta/node/NewPacketFormatTest.java
+++ b/src/test/java/network/crypta/node/NewPacketFormatTest.java
@@ -34,7 +34,7 @@ class NewPacketFormatTest {
   void setUp() {
     // Because we don't call maybeSendPacket, the packet sent times are not updated,
     // so let's turn off the keepalives.
-    NewPacketFormat.doKeepalives = false;
+    setDoKeepalives(false);
   }
 
   @Test
@@ -80,12 +80,12 @@ class NewPacketFormatTest {
     // Act
     assertEquals(1, npf.handleDecryptedPacket(generated, s).size());
     boolean keepalivesOrig = NewPacketFormat.doKeepalives;
-    NewPacketFormat.doKeepalives = true; // force sending without sleeping
+    setDoKeepalives(true); // force sending without sleeping
     NPFPacket ackOnly;
     try {
       ackOnly = npf.createPacket(1400, pmq, s, false);
     } finally {
-      NewPacketFormat.doKeepalives = keepalivesOrig;
+      setDoKeepalives(keepalivesOrig);
     }
 
     // Assert
@@ -97,7 +97,7 @@ class NewPacketFormatTest {
   void resend_whenAckLost_triggersAckOnlyLater() throws BlockedTooLongException {
     // Arrange
     boolean keepalivesOrig = NewPacketFormat.doKeepalives;
-    NewPacketFormat.doKeepalives = true; // avoid sleeps for ack scheduling
+    setDoKeepalives(true); // avoid sleeps for ack scheduling
     NullBasePeerNode senderNode = new NullBasePeerNode();
     NewPacketFormat sender = new NewPacketFormat(senderNode, 0, 0);
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
@@ -142,7 +142,7 @@ class NewPacketFormatTest {
     NPFPacket ack2 = receiver.createPacket(512, receiverQueue, receiverKey, false);
     assertNotNull(ack2);
     assertEquals(1, ack2.getAcks().size());
-    NewPacketFormat.doKeepalives = keepalivesOrig;
+    setDoKeepalives(keepalivesOrig);
   }
 
   @Test
@@ -397,7 +397,7 @@ class NewPacketFormatTest {
     assertNotNull(p, "Expected a packet with one fragment before disconnect");
     assertEquals(1, p.getFragments().size());
 
-    // Now disconnect and ensure the caller returns the item for requeueing.
+    // Now disconnect and ensure the caller returns the item for requeue-ing.
     List<MessageItem> returned = npf.onDisconnect();
     assertEquals(1, returned.size());
     assertEquals(payload.length, returned.getFirst().getLength());
@@ -620,10 +620,12 @@ class NewPacketFormatTest {
     }
   }
 
+  private static void setDoKeepalives(boolean enabled) {
+    NewPacketFormat.doKeepalives = enabled;
+  }
+
   private static LinkageError linkageError(String message, ReflectiveOperationException e) {
-    LinkageError error = new LinkageError(message);
-    error.initCause(e);
-    return error;
+    return new LinkageError(message, e);
   }
 
   @Test

--- a/src/test/java/network/crypta/node/NodeStarterTest.java
+++ b/src/test/java/network/crypta/node/NodeStarterTest.java
@@ -38,7 +38,7 @@ class NodeStarterTest {
   @BeforeEach
   void resetStatics_before() throws ReflectiveOperationException {
     resetNodeStarterStatics();
-    DNSRequester.disable = false;
+    clearDnsRequesterDisable();
   }
 
   @AfterEach
@@ -236,6 +236,10 @@ class NodeStarterTest {
     clearStaticBoolean("isTestingVM");
     clearStaticObject("globalSecureRandom");
     clearStaticObject("nodestarter_osgi");
+  }
+
+  private static void clearDnsRequesterDisable() {
+    DNSRequester.disable = false;
   }
 
   private static void clearStaticBoolean(String field)

--- a/src/test/kotlin/network/crypta/launcher/ThemeSwitcherTest.kt
+++ b/src/test/kotlin/network/crypta/launcher/ThemeSwitcherTest.kt
@@ -261,11 +261,14 @@ internal class ThemeSwitcherTest {
 
       assertTrue(portalConstruction.constructed().isNotEmpty())
       val detector = portalConstruction.constructed().first()
-      val listenerField = ThemeSwitcher::class.java.getDeclaredField("listener")
-      listenerField.isAccessible = true
-      @Suppress("UNCHECKED_CAST", "kotlin:S6518")
-      val listener = requireNotNull(listenerField.get(null) as Consumer<Boolean>?)
-      Mockito.verify(detector).registerListener(listener)
+
+      @Suppress("UNCHECKED_CAST")
+      val listener =
+        Mockito.mockingDetails(detector)
+          .invocations
+          .first { it.method.name == "registerListener" }
+          .arguments
+          .first() as Consumer<Boolean>
 
       ThemeSwitcher.shutdown()
 


### PR DESCRIPTION
## Summary
- Remove SpotBugs `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` findings by moving static writes out of instance methods and constructors in `SSL`, `NodeStarter`, and launcher theme/instance wiring.
- Update launcher/theme and node packet tests to preserve behavior while avoiding new static-write and Sonar warnings.
- Keep behavior unchanged while making the static mutation paths explicit and centralized.

## How to test
- `./gradlew spotlessApply`
- `./gradlew test --tests "network.crypta.node.NewPacketFormatTest"`
- `./gradlew test --tests "network.crypta.node.NodeStarterTest"`
- `./gradlew test --tests "network.crypta.launcher.ThemeSwitcherTest"`
- `./gradlew spotbugsMain`
- `./gradlew spotbugsTest`
- Verify `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` count is `0` in:
  - `build/reports/spotbugs/spotbugsMain.xml`
  - `build/reports/spotbugs/spotbugsTest.xml`