### PR TITLE
fix(spotbugs): Handle ignored file operation return values

### DIFF
--- a/src/main/java/network/crypta/node/simulator/LongTermManySingleBlocksTest.java
+++ b/src/main/java/network/crypta/node/simulator/LongTermManySingleBlocksTest.java
@@ -345,10 +345,9 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
     ensureSeednodesReadable(seednodes);
 
     File innerDir = new File(dir, Integer.toString(DARKNET_PORT1));
-    // We only need best-effort directory creation; later operations will fail clearly if it
-    // doesn't exist.
-    //noinspection ResultOfMethodCallIgnored
-    innerDir.mkdir();
+    if (!innerDir.mkdir() && !innerDir.isDirectory()) {
+      throw new IOException("Unable to create seednodes directory: " + innerDir.getAbsolutePath());
+    }
 
     try (FileInputStream seedInputStream = new FileInputStream(seednodes)) {
       FileUtil.writeTo(seedInputStream, new File(innerDir, "seednodes.fref"));
@@ -713,6 +712,7 @@ public class LongTermManySingleBlocksTest extends LongTermTest {
     }
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class ParsedInsertedBlocks {
     private final FreenetURI[] insertedUris;
     private final int[] insertTimes;

--- a/src/test/java/network/crypta/node/LoggingConfigHandlerTest.java
+++ b/src/test/java/network/crypta/node/LoggingConfigHandlerTest.java
@@ -203,7 +203,7 @@ class LoggingConfigHandlerTest {
 
     SizeAndTimeBasedRollingPolicy<?> st = (SizeAndTimeBasedRollingPolicy<?>) rfa.getRollingPolicy();
     String pat = st.getFileNamePattern();
-    // default interval is hourly in the handler
+    // the default interval is hourly in the handler
     String expected = new File(dir, "crypta-%d{yyyy-MM-dd_HH}.%i.log.gz").getAbsolutePath();
     assertEquals(expected, pat);
   }
@@ -220,9 +220,9 @@ class LoggingConfigHandlerTest {
           InvalidConfigValueException.class,
           () -> logging.set("dirname", tmpFile.getAbsolutePath()));
     } finally {
-      // cleanup
-      // noinspection ResultOfMethodCallIgnored
-      tmpFile.delete();
+      if (!tmpFile.delete() && tmpFile.exists()) {
+        tmpFile.deleteOnExit();
+      }
     }
   }
 

--- a/src/test/java/network/crypta/support/NullBloomFilterTest.java
+++ b/src/test/java/network/crypta/support/NullBloomFilterTest.java
@@ -64,9 +64,9 @@ class NullBloomFilterTest {
       assertEquals(0, bf.getK());
       assertEquals(0, bf.getLength());
     }
-    // Best effort cleanup of the temp file (not strictly necessary for correctness of the test)
-    //noinspection ResultOfMethodCallIgnored
-    f.delete();
+    if (!f.delete() && f.exists()) {
+      f.deleteOnExit();
+    }
   }
 
   // -------- Semantics --------

--- a/src/test/java/network/crypta/support/io/RandomAccessFileWrapperTest.java
+++ b/src/test/java/network/crypta/support/io/RandomAccessFileWrapperTest.java
@@ -22,7 +22,7 @@ class RandomAccessFileWrapperTest extends RandomAccessBufferTestBase {
 
   @BeforeEach
   void setUp() {
-    base.mkdir();
+    assertTrue(base.mkdir() || base.isDirectory(), "Failed to create test directory: " + base);
   }
 
   @AfterEach


### PR DESCRIPTION
## Summary
- Handle `File.mkdir()` return values in the long-term simulator seednode directory setup to fail fast with a clear `IOException` when directory creation fails.
- Handle ignored test cleanup `File.delete()` return values by falling back to `deleteOnExit()` only when immediate deletion fails and the file still exists.
- Strengthen test setup in `RandomAccessFileWrapperTest` by asserting test directory creation succeeds (or already exists), eliminating ignored exceptional return values.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `./gradlew test --tests '*LoggingConfigHandlerTest' --tests '*NullBloomFilterTest' --tests '*RandomAccessFileWrapperTest'`

## Notes
- Branch: `bugfix/spotbugs-rv-return-value`
- Base: `develop`