### PR TITLE
fix(spotbugs): Fix SE_BAD_FIELD_STORE handling in insert and launcher flows

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientPutter.java
+++ b/src/main/java/network/crypta/client/async/ClientPutter.java
@@ -106,6 +106,13 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
   @SuppressWarnings("java:S1948")
   private ClientPutState currentState;
 
+  /**
+   * Non-persistent runtime-only insert state.
+   *
+   * <p>Used for states that must never be serialized (for example {@link BinaryBlobInserter}).
+   */
+  private transient ClientPutState transientState;
+
   /** Whether the insert has finished. */
   private boolean finished;
 
@@ -292,17 +299,23 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
   }
 
   private void scheduleCurrentState(ClientContext context) throws InsertException {
-    if (LOG.isDebugEnabled()) LOG.debug("Scheduling insert state: {}", currentState);
-    if (currentState instanceof SingleFileInserter inserter) inserter.start(context);
-    else currentState.schedule(context);
+    ClientPutState state = currentState != null ? currentState : transientState;
+    if (state == null) {
+      throw new InsertException(
+          InsertExceptionMode.INTERNAL_ERROR, "No active insert state to schedule", null);
+    }
+    if (LOG.isDebugEnabled()) LOG.debug("Scheduling insert state: {}", state);
+    if (state instanceof SingleFileInserter inserter) inserter.start(context);
+    else state.schedule(context);
   }
 
   private boolean handleRestartGuard(boolean restart) {
     if (restart) {
       clearCountersOnRestart();
-      if (currentState != null && !finished) {
+      ClientPutState activeState = currentState != null ? currentState : transientState;
+      if (activeState != null && !finished) {
         if (LOG.isDebugEnabled())
-          LOG.debug("Restart blocked: insert still running with state {}", currentState);
+          LOG.debug("Restart blocked: insert still running with state {}", activeState);
         return false;
       }
       if (finished) startedStarting = false;
@@ -318,12 +331,13 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
       return false;
     }
     startedStarting = true;
-    if (currentState != null) {
+    ClientPutState activeState = currentState != null ? currentState : transientState;
+    if (activeState != null) {
       if (LOG.isDebugEnabled())
         LOG.debug(
             "Start guard rejected {}: existing state {}",
             restart ? "restart" : "start",
-            currentState);
+            activeState);
       return false;
     }
     return true;
@@ -371,7 +385,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
               .withMetadataThreshold(metadataThreshold);
       currentState = new SingleFileInserter(params);
     } else {
-      currentState =
+      transientState =
           new BinaryBlobInserter(data, this, getClient(), false, priorityClass, ctx, context);
     }
   }
@@ -381,6 +395,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
     synchronized (this) {
       finished = true;
       currentState = null;
+      transientState = null;
     }
     if (this.callback != null) this.callback.onFailure(e, this);
   }
@@ -425,6 +440,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
     synchronized (this) {
       finished = true;
       currentState = null;
+      transientState = null;
     }
     if ((super.failedBlocks > 0
             || super.fatallyFailedBlocks > 0
@@ -456,6 +472,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
     synchronized (this) {
       finished = true;
       currentState = null;
+      transientState = null;
     }
     callback.onFailure(e, this);
   }
@@ -526,7 +543,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
       if (cancelled) return;
       if (finished) return;
       super.cancel();
-      oldState = currentState;
+      oldState = currentState != null ? currentState : transientState;
     }
     if (oldState != null) oldState.cancel(context);
     onFailure(new InsertException(InsertExceptionMode.CANCELLED), null, context);
@@ -596,9 +613,14 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
         currentState = newState;
         return;
       }
+      if (transientState == oldState) {
+        transientState = newState;
+        return;
+      }
     }
     if (persistent()) context.jobRunner.setCheckpointASAP();
-    LOG.info("onTransition: cur={}, old={}, new={}", currentState, oldState, newState);
+    ClientPutState activeState = currentState != null ? currentState : transientState;
+    LOG.info("onTransition: cur={}, old={}, new={}", activeState, oldState, newState);
   }
 
   /**
@@ -717,7 +739,8 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
    *     false} otherwise.
    */
   public boolean canRestart() {
-    if (currentState != null && !finished) {
+    ClientPutState activeState = currentState != null ? currentState : transientState;
+    if (activeState != null && !finished) {
       LOG.debug("Cannot restart because not finished for {}", uri);
       return false;
     }
@@ -764,6 +787,24 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
   @Override
   public void innerOnResume(ClientContext context) throws ResumeFailedException {
     super.innerOnResume(context);
+    boolean resumedDataForBinaryRestart = false;
+    if (shouldRestartBinaryBlobOnResume()) {
+      data.onResume(context);
+      resumedDataForBinaryRestart = true;
+      synchronized (this) {
+        // Re-enter restart flow to rebuild a runtime-only BinaryBlobInserter after deserialization.
+        // During normal execution startedStarting stays true while work is active, so explicitly
+        // reset lifecycle guards before delegating to restart logic.
+        startedStarting = false;
+        finished = true;
+      }
+      try {
+        start(true, context);
+      } catch (InsertException e) {
+        this.onFailure(e, null, context);
+        return;
+      }
+    }
     if (currentState != null) {
       try {
         currentState.onResume(context);
@@ -772,8 +813,17 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
         return;
       }
     }
-    if (data != null) data.onResume(context);
+    if (data != null && !resumedDataForBinaryRestart) data.onResume(context);
     notifyClients(context);
+  }
+
+  private synchronized boolean shouldRestartBinaryBlobOnResume() {
+    return binaryBlob
+        && !finished
+        && startedStarting
+        && currentState == null
+        && transientState == null
+        && data != null;
   }
 
   @Override
@@ -785,7 +835,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
   public void onShutdown(ClientContext context) {
     ClientPutState state;
     synchronized (this) {
-      state = currentState;
+      state = currentState != null ? currentState : transientState;
     }
     if (state != null) state.onShutdown(context);
   }

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -1672,6 +1672,57 @@ class SingleFileInserter implements ClientPutState, Serializable {
 
   /* ===== Java serialization support ===== */
 
+  private static final class NoOpPutCompletionCallback
+      implements PutCompletionCallback, Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
+    @Override
+    public void onSuccess(ClientPutState state, ClientContext context) {
+      // no-op
+    }
+
+    @Override
+    public void onFailure(InsertException e, ClientPutState state, ClientContext context) {
+      // no-op
+    }
+
+    @Override
+    public void onEncode(BaseClientKey usk, ClientPutState state, ClientContext context) {
+      // no-op
+    }
+
+    @Override
+    public void onTransition(
+        ClientPutState oldState, ClientPutState newState, ClientContext context) {
+      // no-op
+    }
+
+    @Override
+    public void onMetadata(Metadata m, ClientPutState state, ClientContext context) {
+      // no-op
+    }
+
+    @Override
+    public void onMetadata(Bucket meta, ClientPutState state, ClientContext context) {
+      meta.free();
+    }
+
+    @Override
+    public void onFetchable(ClientPutState state) {
+      // no-op
+    }
+
+    @Override
+    public void onBlockSetFinished(ClientPutState state, ClientContext context) {
+      // no-op
+    }
+
+    @Override
+    public void onResume(ClientContext context) {
+      // no-op
+    }
+  }
+
   /**
    * Custom Java deserialization hook to restore transient/runtime links.
    *
@@ -1696,58 +1747,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
               "Restored SingleFileInserter without callback and parent does not implement "
                   + "PutCompletionCallback; using no-op callback: {}",
               this);
-        cb =
-            new PutCompletionCallback() {
-              @Override
-              public void onSuccess(ClientPutState state, ClientContext context) {
-                // Intentionally no-op: fallback callback for legacy-deserialized inserters.
-                // We only need a safe stub to avoid NPEs when older states resume.
-              }
-
-              @Override
-              public void onFailure(
-                  InsertException e, ClientPutState state, ClientContext context) {
-                // Intentionally no-op: see the rationale above. Failures are observed upstream when
-                // a real callback exists; this stub avoids crashing on legacy resumes.
-              }
-
-              @Override
-              public void onEncode(BaseClientKey usk, ClientPutState state, ClientContext context) {
-                // Intentionally no-op: fallback stub; no external observer to notify.
-              }
-
-              @Override
-              public void onTransition(
-                  ClientPutState oldState, ClientPutState newState, ClientContext context) {
-                // Intentionally no-op: fallback stub; used only to prevent NPEs on legacy resumes.
-              }
-
-              @Override
-              public void onMetadata(Metadata m, ClientPutState state, ClientContext context) {
-                // Intentionally no-op: fallback stub for legacy-deserialized inserters without a
-                // real observer.
-              }
-
-              @Override
-              public void onMetadata(Bucket meta, ClientPutState state, ClientContext context) {
-                meta.free();
-              }
-
-              @Override
-              public void onFetchable(ClientPutState state) {
-                // Intentionally no-op: no observer present for this legacy fallback.
-              }
-
-              @Override
-              public void onBlockSetFinished(ClientPutState state, ClientContext context) {
-                // Intentionally no-op: fallback stub; prevents NPEs only.
-              }
-
-              @Override
-              public void onResume(ClientContext context) {
-                // Intentionally no-op: fallback stub; nothing to re-attach for a no-op observer.
-              }
-            };
+        cb = new NoOpPutCompletionCallback();
       }
     }
   }

--- a/src/main/kotlin/network/crypta/launcher/LauncherController.kt
+++ b/src/main/kotlin/network/crypta/launcher/LauncherController.kt
@@ -22,10 +22,11 @@ private const val LOG_REPLAY: Int = 200
 private const val LOG_EXTRA_CAPACITY: Int = 300
 private const val TAIL_BASE_DELAY_MS: Long = 200
 private const val TAIL_MAX_DELAY_MS: Long = 1500
+private const val TAIL_CANCEL_POLL_MS: Long = 50
 private const val TAIL_READ_CHUNK: Int = 64 * 1024
 
 /**
- * Coordinates the launcher lifecycle for the Crypta daemon process and exposes UI-facing state.
+ * Coordinates the launcher lifecycle for the Crypta daemon process and exposes the UI-facing state.
  *
  * This controller resolves the wrapper script, starts the process, streams combined stdout/stderr,
  * tails `wrapper.log` when available, and updates an in-memory [AppState] snapshot for the UI. It
@@ -49,6 +50,7 @@ class LauncherController(
   private val cwd: Path = Paths.get(System.getProperty("user.dir")),
 ) {
   private val _state = MutableStateFlow(AppState())
+
   /**
    * Read-only stream of the latest [AppState] snapshot for UI rendering. The flow is eagerly
    * started and always available, reflecting changes made by [start], [stop], and shutdown calls.
@@ -59,9 +61,9 @@ class LauncherController(
   /**
    * Bounded, drop-older log stream.
    *
-   * We keep a small replay window so late subscribers (e.g., UI created after controller) still see
-   * the latest lines, and we cap total in-memory buffering to avoid memory pressure when the daemon
-   * is very chatty or the UI is momentarily stalled.
+   * We keep a small replay window so late subscribers still see the latest lines. We also cap total
+   * in-memory buffering to avoid memory pressure when the daemon is chatty or the UI is momentarily
+   * stalled.
    *
    * Total buffer = [LOG_REPLAY] + [LOG_EXTRA_CAPACITY]. When full, the oldest entries are dropped.
    */
@@ -71,6 +73,7 @@ class LauncherController(
       extraBufferCapacity = LOG_EXTRA_CAPACITY,
       onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
+
   /**
    * Bounded, drop-older log stream for launcher and daemon output. A small replay window is kept so
    * late subscribers still receive recent lines; when buffers fill, older entries are dropped to
@@ -82,6 +85,7 @@ class LauncherController(
   private var tailJob: Job? = null
   private var autoOpenedBrowser = false
   private var wrapperConfPath: Path? = null
+
   // Separate shutdown scope so quit can proceed even if the UI scope is canceled
   private val shutdownScope: CoroutineScope = CoroutineScope(SupervisorJob() + io)
 
@@ -135,7 +139,11 @@ class LauncherController(
         wrapperConfPath = conf
         val logSpec = readWrapperProperty(conf, "wrapper.logfile")
         val logPath = computeWrapperLogPath(conf, logSpec)
-        tailJob = scope.launch { tailFileWhileAlive(logPath) }
+        tailJob =
+          scope.launch(Dispatchers.IO) {
+            val thisJob = coroutineContext[Job] ?: return@launch
+            tailFileWhileAlive(logPath, thisJob)
+          }
       }
     }
   }
@@ -143,10 +151,10 @@ class LauncherController(
   /**
    * Request a graceful stop of the wrapper process if it is running.
    *
-   * The controller updates state to indicate a stop is in progress and then attempts platform
-   * appropriate shutdown (anchor-file signaling on Windows, signal escalation on Unix). The call
-   * returns immediately; waiting happens on [io] and is best-effort. If the process is already
-   * stopped, the state is normalized and the method exits without further work.
+   * The controller updates the state to indicate a stop is in progress and then attempts the
+   * platform appropriate shutdown (anchor-file signaling on Windows, signal escalation on Unix).
+   * The call returns immediately; waiting happens on [io] and is best-effort. If the process is
+   * already stopped, the state is normalized and the method exits without further work.
    */
   fun stop() {
     val p = process ?: return
@@ -198,11 +206,11 @@ class LauncherController(
   }
 
   /**
-   * Begin shutdown and return immediately.
+   * Begin to shut down and return immediately.
    *
    * This method marks the controller as shutting down and initiates a stop on a dedicated shutdown
-   * scope so the request is honored even if the UI scope has been canceled. It is safe to call
-   * multiple times; subsequent calls are ignored once shutdown has started.
+   * scope, so the request is honored even if the UI scope has been canceled. It is safe to call
+   * multiple times; further calls are ignored once shutdown has started.
    */
   fun shutdown() {
     if (_state.value.isShuttingDown) return
@@ -270,25 +278,41 @@ class LauncherController(
    * rotation/truncation. All resource operations are guarded and closed in `finally` to avoid leaks
    * on exceptions or coroutine cancellation.
    */
-  private suspend fun tailFileWhileAlive(path: Path) {
+  private fun tailFileWhileAlive(path: Path, tailingJob: Job) {
     // Keep a single RAF open to avoid repeated open/close churn. Add exponential backoff when no
     // new data arrives to reduce filesystem pressure. Re-open on file rotation or truncation.
-    withContext(io) {
-      val state = TailState()
-      try {
-        while (scope.isActive && (process?.isAlive == true)) {
-          try {
-            val madeProgress = tailOnce(path, state)
-            state.idleCount = if (madeProgress) 0 else state.idleCount + 1
-          } catch (_: Throwable) {
-            resetTailOnError(state)
-          }
-          delay(calcTailDelayMs(state.idleCount))
+    val state = TailState()
+    try {
+      while (tailingJob.isActive && (process?.isAlive == true)) {
+        try {
+          val madeProgress = tailOnce(path, state)
+          state.idleCount = if (madeProgress) 0 else state.idleCount + 1
+        } catch (_: Throwable) {
+          resetTailOnError(state)
         }
-      } finally {
-        closeTailFile(state)
+        if (!sleepWhileJobActive(tailingJob, calcTailDelayMs(state.idleCount))) {
+          return
+        }
       }
+    } finally {
+      closeTailFile(state)
     }
+  }
+
+  private fun sleepWhileJobActive(job: Job, delayMs: Long): Boolean {
+    var remaining = delayMs
+    while (remaining > 0) {
+      if (!job.isActive) return false
+      val chunk = minOf(remaining, TAIL_CANCEL_POLL_MS)
+      try {
+        Thread.sleep(chunk)
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        return false
+      }
+      remaining -= chunk
+    }
+    return job.isActive
   }
 
   private suspend fun stopProcessGracefully(p: Process) {
@@ -300,7 +324,7 @@ class LauncherController(
       val allPids = listOf(pid) + snapshot
 
       if (isWindows) {
-        // Prefer a graceful stop via Wrapper anchor file on Windows. Falls back to taskkill.
+        // Prefer a graceful stop via a Wrapper anchor file on Windows. Falls back to task-kill.
         if (!tryWindowsGracefulStopViaAnchor(allPids)) {
           runCmd("cmd", "/c", "taskkill /PID $pid /T")
           if (!waitForPidsToExit(allPids, 20_000)) {
@@ -328,11 +352,12 @@ class LauncherController(
     }
   }
 
-  private fun getDescendantTreePids(rootPid: Long): List<Long> {
-    return try {
+  private fun getDescendantTreePids(rootPid: Long): List<Long> =
+    try {
       val opt = ProcessHandle.of(rootPid)
-      if (!opt.isPresent) emptyList()
-      else {
+      if (!opt.isPresent) {
+        emptyList()
+      } else {
         val root = opt.get()
         root
           .descendants()
@@ -342,15 +367,13 @@ class LauncherController(
     } catch (_: Throwable) {
       emptyList()
     }
-  }
 
-  private fun isPidAlive(pid: Long): Boolean {
-    return try {
+  private fun isPidAlive(pid: Long): Boolean =
+    try {
       ProcessHandle.of(pid).map { it.isAlive }.orElse(false)
     } catch (_: Throwable) {
       false
     }
-  }
 
   /**
    * Suspend until all `pids` have exited or until `millis` has elapsed. Uses coroutines (`delay`)
@@ -448,19 +471,14 @@ class LauncherController(
     }
   }
 
-  /**
-   * Read a single property from `wrapper.conf` on the I/O dispatcher to avoid blocking the caller
-   * context. Returns null on any error or when the key is not present.
-   */
-  private suspend fun readWrapperProperty(conf: Path, key: String): String? =
-    withContext(io) {
-      runCatching {
-          Files.newBufferedReader(conf, StandardCharsets.UTF_8).useLines { lines ->
-            lines.firstNotNullOfOrNull { extractWrapperProperty(it, key) }
-          }
+  /** Read a single property from `wrapper.conf`. Returns null on any error or when absent. */
+  private fun readWrapperProperty(conf: Path, key: String): String? =
+    runCatching {
+        Files.newBufferedReader(conf, StandardCharsets.UTF_8).useLines { lines ->
+          lines.firstNotNullOfOrNull { extractWrapperProperty(it, key) }
         }
-        .getOrNull()
-    }
+      }
+      .getOrNull()
 
   private fun extractWrapperProperty(raw: String, key: String): String? {
     val line = raw.trim()
@@ -528,13 +546,12 @@ class LauncherController(
     return true
   }
 
-  private fun readFileKey(path: Path): Any? {
-    return try {
+  private fun readFileKey(path: Path): Any? =
+    try {
       Files.readAttributes(path, BasicFileAttributes::class.java).fileKey()
     } catch (_: Throwable) {
       null
     }
-  }
 
   private fun openTailFileIfNeeded(path: Path, newKey: Any?, state: TailState) {
     if (
@@ -570,7 +587,7 @@ class LauncherController(
   }
 
   private fun logLine(s: String) {
-    // Non-suspending emission; when buffers are full the oldest entries are dropped per
+    // Non-suspending emission; when buffers are full, the oldest entries are dropped per
     // BufferOverflow.DROP_OLDEST.
     _logs.tryEmit(s)
   }
@@ -579,11 +596,17 @@ class LauncherController(
     val isWindows = AppEnv().isWindows()
     return cmd.joinToString(" ") { arg ->
       if (isWindows) {
-        if (arg.any { it.isWhitespace() || it == '"' }) "\"" + arg.replace("\"", "\\\"") + "\""
-        else arg
+        if (arg.any { it.isWhitespace() || it == '"' }) {
+          "\"" + arg.replace("\"", "\\\"") + "\""
+        } else {
+          arg
+        }
       } else {
-        if (arg.any { it.isWhitespace() || it == '\'' || it == '"' || it == '\\' }) shellQuote(arg)
-        else arg
+        if (arg.any { it.isWhitespace() || it == '\'' || it == '"' || it == '\\' }) {
+          shellQuote(arg)
+        } else {
+          arg
+        }
       }
     }
   }

--- a/src/test/java/network/crypta/client/async/USKAttemptManagerTest.java
+++ b/src/test/java/network/crypta/client/async/USKAttemptManagerTest.java
@@ -133,7 +133,7 @@ class USKAttemptManagerTest {
   }
 
   private static final class TestRequester extends ClientRequester {
-    private final ClientBaseCallback callback;
+    private final transient ClientBaseCallback callback;
     private final network.crypta.keys.FreenetURI uri;
     private int toNetworkCalls;
     private boolean wasCancelled;

--- a/src/test/kotlin/network/crypta/launcher/LauncherControllerTest.kt
+++ b/src/test/kotlin/network/crypta/launcher/LauncherControllerTest.kt
@@ -6,18 +6,18 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import network.crypta.fs.AppEnv
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -34,7 +34,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 @Suppress("java:S100", "kotlin:S100")
 @ExtendWith(MockitoExtension::class)
 internal class LauncherControllerTest {
-
   @TempDir lateinit var tempDir: Path
 
   private companion object {
@@ -42,7 +41,7 @@ internal class LauncherControllerTest {
   }
 
   @Test
-  fun start_whenCryptadMissing_logsErrorAndDoesNotRun() = runBlocking {
+  fun start_whenCryptadMissing_logsErrorAndDoesNotRun() {
     val scope = newScope()
     val controller = LauncherController(scope, Dispatchers.IO, tempDir)
     val logs = startLogCollector(scope, controller)
@@ -50,17 +49,16 @@ internal class LauncherControllerTest {
     try {
       controller.start()
 
-      val line = awaitLog(logs.channel) { it.contains("Cannot find executable 'cryptad'") }
+      val line = awaitLog(logs.lines) { it.contains("Cannot find executable 'cryptad'") }
       assertTrue(line.contains("ERROR: Cannot find executable 'cryptad'"))
       assertFalse(controller.state.value.isRunning)
     } finally {
-      logs.channel.close()
       scope.cancel()
     }
   }
 
   @Test
-  fun start_whenScriptRuns_updatesStateAndReadsPort() = runBlocking {
+  fun start_whenScriptRuns_updatesStateAndReadsPort() {
     val scope = newScope()
     val controller = LauncherController(scope, Dispatchers.IO, tempDir)
     val logs = startLogCollector(scope, controller)
@@ -71,18 +69,14 @@ internal class LauncherControllerTest {
     try {
       controller.start()
 
-      withTimeout(5_000) { controller.state.filter { it.isRunning }.first() }
-      val stateWithPort =
-        withTimeout(5_000) { controller.state.filter { it.knownPort == TEST_PORT }.first() }
+      awaitState(controller) { it.isRunning }
+      val stateWithPort = awaitState(controller) { it.knownPort == TEST_PORT }
       assertEquals(TEST_PORT, stateWithPort.knownPort)
 
-      val stoppedState =
-        withTimeout(5_000) {
-          controller.state.filter { !it.isRunning && it.knownPort == TEST_PORT }.first()
-        }
+      val stoppedState = awaitState(controller) { !it.isRunning && it.knownPort == TEST_PORT }
       assertFalse(stoppedState.isRunning)
 
-      awaitLog(logs.channel) { it.contains("Starting FProxy on") }
+      awaitLog(logs.lines) { it.contains("Starting FProxy on") }
       assertTrue(logs.lines.any { it.contains("Starting 'cryptad'") })
       assertTrue(logs.lines.any { it.contains("exec:") })
       assertTrue(logs.lines.any { it.contains("Starting FProxy on") })
@@ -90,7 +84,6 @@ internal class LauncherControllerTest {
       val confLines = Files.readAllLines(wrapperConf, StandardCharsets.UTF_8).toList()
       assertTrue(confLines.any { it.trim() == "wrapper.console.flush=TRUE" })
     } finally {
-      logs.channel.close()
       scope.cancel()
     }
   }
@@ -154,12 +147,12 @@ internal class LauncherControllerTest {
   }
 
   @Test
-  fun shutdownAndWait_whenNoProcess_setsShuttingDownFlag() = runBlocking {
+  fun shutdownAndWait_whenNoProcess_setsShuttingDownFlag() {
     val scope = newScope()
     val controller = LauncherController(scope, Dispatchers.IO, tempDir)
 
     try {
-      controller.shutdownAndWait()
+      invokeShutdownAndWait(controller)
 
       assertTrue(getPrivateState(controller).isShuttingDown)
     } finally {
@@ -173,19 +166,63 @@ internal class LauncherControllerTest {
     scope: CoroutineScope,
     controller: LauncherController,
   ): LogCollector {
-    val channel = Channel<String>(Channel.UNLIMITED)
     val lines = CopyOnWriteArrayList<String>()
-    scope.launch {
-      controller.logs.collect { line ->
-        lines.add(line)
-        channel.trySend(line)
-      }
-    }
-    return LogCollector(channel, lines)
+    scope.launch { controller.logs.collect { line -> lines.add(line) } }
+    return LogCollector(lines)
   }
 
-  private suspend fun awaitLog(channel: Channel<String>, predicate: (String) -> Boolean): String {
-    return withTimeout(5_000) { channel.receiveAsFlow().first { predicate(it) } }
+  private fun awaitLog(lines: List<String>, predicate: (String) -> Boolean): String {
+    val deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (System.nanoTime() < deadlineNanos) {
+      lines.firstOrNull(predicate)?.let {
+        return it
+      }
+      Thread.sleep(10)
+    }
+    error("Timed out waiting for expected launcher log line")
+  }
+
+  private fun awaitState(
+    controller: LauncherController,
+    predicate: (AppState) -> Boolean,
+  ): AppState {
+    val deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (System.nanoTime() < deadlineNanos) {
+      val state = controller.state.value
+      if (predicate(state)) return state
+      Thread.sleep(10)
+    }
+    error("Timed out waiting for launcher state")
+  }
+
+  private fun invokeShutdownAndWait(controller: LauncherController) {
+    val completionLatch = CountDownLatch(1)
+    var failure: Throwable? = null
+    val continuation =
+      object : Continuation<Unit> {
+        override val context: CoroutineContext = EmptyCoroutineContext
+
+        override fun resumeWith(result: Result<Unit>) {
+          failure = result.exceptionOrNull()
+          completionLatch.countDown()
+        }
+      }
+
+    val method = controller.javaClass.getDeclaredMethod("shutdownAndWait", Continuation::class.java)
+    method.isAccessible = true
+    val result =
+      try {
+        method.invoke(controller, continuation)
+      } catch (e: java.lang.reflect.InvocationTargetException) {
+        throw (e.targetException ?: e)
+      }
+    if (result !== COROUTINE_SUSPENDED) {
+      completionLatch.countDown()
+    }
+    if (!completionLatch.await(5, TimeUnit.SECONDS)) {
+      error("Timed out waiting for shutdownAndWait completion")
+    }
+    failure?.let { throw AssertionError("shutdownAndWait failed", it) }
   }
 
   private fun writeCryptadScript(baseDir: Path): Path {
@@ -196,19 +233,19 @@ internal class LauncherControllerTest {
     val content =
       if (isWindows) {
         """
-        @echo off
-        echo Starting FProxy on 127.0.0.1:$TEST_PORT
-        echo READY
-        ping -n 2 127.0.0.1 > nul
-        """
+                @echo off
+                echo Starting FProxy on 127.0.0.1:$TEST_PORT
+                echo READY
+                ping -n 2 127.0.0.1 > nul
+                """
           .trimIndent()
       } else {
         """
-        #!/usr/bin/env sh
-        echo "Starting FProxy on 127.0.0.1:$TEST_PORT"
-        echo "READY"
-        sleep 0.2
-        """
+                #!/usr/bin/env sh
+                echo "Starting FProxy on 127.0.0.1:$TEST_PORT"
+                echo "READY"
+                sleep 0.2
+                """
           .trimIndent()
       }
     Files.writeString(script, content, StandardCharsets.UTF_8)
@@ -236,9 +273,8 @@ internal class LauncherControllerTest {
     stateFlow.value = state
   }
 
-  private fun getPrivateState(controller: LauncherController): AppState {
-    return getStateFlow(controller).value
-  }
+  private fun getPrivateState(controller: LauncherController): AppState =
+    getStateFlow(controller).value
 
   @Suppress("kotlin:S6518")
   private fun setPrivateField(target: Any, fieldName: String, value: Any?) {
@@ -255,8 +291,5 @@ internal class LauncherControllerTest {
     return field.get(controller) as MutableStateFlow<AppState>
   }
 
-  private data class LogCollector(
-    val channel: Channel<String>,
-    val lines: CopyOnWriteArrayList<String>,
-  )
+  private data class LogCollector(val lines: CopyOnWriteArrayList<String>)
 }


### PR DESCRIPTION
## Summary
- Keep non-serializable runtime insert state out of persisted `ClientPutter` snapshots while preserving restart behavior for binary-blob inserts.
- Resume the insert bucket before rebuilding binary-blob state during persistent resume to avoid restart-time bucket errors.
- Replace the legacy anonymous fallback callback in `SingleFileInserter` with a serializable no-op callback implementation.
- Update launcher tailing cancellation so old tail jobs stop reliably and avoid overlapping file tails.
- Clean up related test fixtures to remove remaining `SE_BAD_FIELD_STORE` reports in test scope.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `./gradlew test --tests "*ClientPutterTest" --tests "*LauncherControllerTest" --tests "*USKAttemptManagerTest"`