### PR TITLE
fix(spotbugs): Exclude intentional SE_INNER_CLASS warnings

### DIFF
--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    These callback/state classes are intentionally non-static and serializable:
+    they must keep an enclosing-instance link to resume durable requests using the
+    existing serialized object graph. Refactoring them to static would alter
+    serialization layout and risk breaking persisted state compatibility.
+  -->
+  <Match>
+    <Bug pattern="SE_INNER_CLASS"/>
+    <Class name="network.crypta.client.async.SingleFileFetcher$ArchiveFetcherCallback"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="SE_INNER_CLASS"/>
+    <Class name="network.crypta.client.async.SingleFileFetcher$MultiLevelMetadataCallback"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="SE_INNER_CLASS"/>
+    <Class name="network.crypta.client.async.SingleFileInserter$SplitHandler"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="SE_INNER_CLASS"/>
+    <Class name="network.crypta.support.io.MultiReaderBucket$ReaderBucket"/>
+  </Match>
+</FindBugsFilter>

--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -87,7 +87,12 @@ val errorproneReportEnabled =
 
 spotbugs { ignoreFailures = true }
 
+val spotbugsExcludeFilter =
+  rootProject.layout.projectDirectory.file("build-logic/spotbugs-exclude.xml")
+
 tasks.withType<SpotBugsTask>().configureEach {
+  excludeFilter.set(spotbugsExcludeFilter)
+
   val xmlReport = reports.maybeCreate("xml")
   xmlReport.required.set(true)
   xmlReport.outputLocation.set(layout.buildDirectory.file("reports/spotbugs/$name.xml"))


### PR DESCRIPTION
## Summary
- Add a SpotBugs exclude filter for the four `SE_INNER_CLASS` findings that are intentional due to persistent serialization/resume behavior.
- Configure all `SpotBugsTask` tasks in build logic to load the shared exclude filter file.
- Keep SpotBugs output focused on actionable issues without changing runtime object-graph compatibility.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain`
- `./gradlew test`

## Notes
- The excluded classes are intentionally non-static serializable inner classes whose enclosing-instance link is part of durable request state restoration.