### PR TITLE
fix(spotbugs): Restore transient field state after deserialization

### DIFF
--- a/src/main/java/com/onionnetworks/util/InvokingDispatch.java
+++ b/src/main/java/com/onionnetworks/util/InvokingDispatch.java
@@ -1,5 +1,7 @@
 package com.onionnetworks.util;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serial;
 import java.util.EventListener;
 import java.util.EventObject;
@@ -38,8 +40,8 @@ public class InvokingDispatch extends ReflectiveEventDispatch implements EventLi
   public static final String INVOKE_EVENT_NAME = "invoke";
 
   /**
-   * Creates a new dispatcher and registers it to listen for its own invoke events, enabling
-   * subsequent calls to {@link #invokeLater(Runnable)} and {@link #invokeAndWait(Runnable)}.
+   * Creates a new dispatcher and registers it to listen for its own invoking events, enabling later
+   * calls to {@link #invokeLater(Runnable)} and {@link #invokeAndWait(Runnable)}.
    */
   public InvokingDispatch() {
     super();
@@ -71,7 +73,7 @@ public class InvokingDispatch extends ReflectiveEventDispatch implements EventLi
    * Callers should prefer this method for fire-and-forget tasks or when they do not need to observe
    * completion.
    *
-   * @param r runnable to execute; must be non-null and ready for single invocation.
+   * @param r runnable to execute; must be non-null and ready for a single invocation.
    */
   public void invokeLater(Runnable r) {
     fire(new InvokeEvent(this, r), INVOKE_EVENT_NAME);
@@ -81,7 +83,7 @@ public class InvokingDispatch extends ReflectiveEventDispatch implements EventLi
    * Submits a runnable to the dispatch thread and blocks until it completes or the thread is
    * interrupted.
    *
-   * <p>The caller waits on a per-event lock so different submissions do not interfere with one
+   * <p>The caller waits on a per-event lock, so different submissions do not interfere with one
    * another. If the current thread is interrupted while waiting, the method throws {@link
    * InterruptedException} and leaves the interrupt status cleared. The runnable still executes
    * unless dispatching is interrupted upstream.
@@ -122,13 +124,13 @@ public class InvokingDispatch extends ReflectiveEventDispatch implements EventLi
     private final transient Runnable runnable;
 
     /** Per-event monitor used to coordinate waiting callers and completion notification. */
-    private final transient Object lock = new Object();
+    private transient Object lock = new Object();
 
     /** Tracks whether the runnable has finished executing; guarded by {@link #lock}. */
     private boolean completed;
 
     /**
-     * Creates a new invoke event carrying the specified runnable and source reference.
+     * Creates a new invoking event carrying the specified runnable and source reference.
      *
      * @param source originator of the event, passed to {@link EventObject}; must be non-null.
      * @param r runnable to execute when dispatched; must be non-null.
@@ -136,6 +138,12 @@ public class InvokingDispatch extends ReflectiveEventDispatch implements EventLi
     public InvokeEvent(Object source, Runnable r) {
       super(source);
       this.runnable = Objects.requireNonNull(r);
+    }
+
+    @Serial
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      this.lock = new Object();
     }
 
     /**

--- a/src/main/java/network/crypta/client/FetchContext.java
+++ b/src/main/java/network/crypta/client/FetchContext.java
@@ -4,6 +4,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashSet;
@@ -35,7 +37,7 @@ import network.crypta.support.io.StorageFormatException;
  *
  * <p>Instances are mutable and not thread-safe. A context is intended to be owned by a single
  * request at a time; copying is supported via the masking constructors to derive variants for
- * sub-operations (for example fetching a container member). Invariants include non‑negative sizes
+ * sub-operations (for example, fetching a container member). Invariants include non‑negative sizes
  * and retry counts (or {@code -1} for unlimited retries where supported). Cooldown settings are
  * bounded by constants in {@link RequestScheduler}.
  *
@@ -74,18 +76,16 @@ public class FetchContext implements Serializable {
   /** Maximum length of the final returned data */
   private long maxOutputLength;
 
-  /**
-   * Maximum length of data fetched in order to obtain the final data - metadata, containers, etc.
-   */
+  /** Maximum length of data fetched to gather the final data - metadata, containers, etc. */
   private long maxTempLength;
 
   /**
-   * 1 = only fetch a single block. 2 = allow one redirect, e.g. metadata block pointing to actual
-   * data block. Etc. 0 may work sometimes but is not recommended.
+   * 1 = only fetch a single block. 2 = allow one redirect, e.g., metadata block pointing to the
+   * actual data block. Etc. 0 may work sometimes but is not recommended.
    */
   private int maxRecursionLevel;
 
-  /** Maximum number of times an archive read may be restarted. */
+  /** The maximum number of times an archive read may be restarted. */
   private int maxArchiveRestarts;
 
   /**
@@ -94,8 +94,8 @@ public class FetchContext implements Serializable {
    * are inside containers (archives), which are usually tar files, which may or may not be
    * compressed (compression occurs transparently on a different level). This is not necessarily the
    * same as the number of slashes in the key after the part for the key itself, since keys can
-   * redirect to other keys. If you are fetching user-uploaded keys, e.g. in fproxy, especially
-   * freesites, you will want this to be non-zero. However, if you are using keys only internally,
+   * redirect to other keys. If you are fetching user-uploaded keys, e.g., in fproxy, especially
+   * freesites, you will want this to be non-zero. However, if you are using keys only internally
    * and never upload freesites, you should set this to 0.
    *
    * @see ArchiveContext where this is enforced.
@@ -110,7 +110,7 @@ public class FetchContext implements Serializable {
    * or until success or a fatal error. A fatal error is either an internal error (problem with the
    * node) or something resulting from the original data being corrupt as inserted. So with retries
    * = -1 we will not report Data not found, Route not found, All data not found, etc., because
-   * these are nonfatal errors and we will retry. Note that after every 3 attempts the request is
+   * these are nonfatal errors and we will retry. Note that after every 3 attempts, the request is
    * put on the cooldown queue for 30 minutes, so the cost of retries = -1 is really not that high.
    */
   private int maxSplitfileBlockRetries;
@@ -121,7 +121,7 @@ public class FetchContext implements Serializable {
    * A fatal error is either an internal error (problem with the node) or something resulting from
    * the original data being corrupt as inserted. So with retries = -1 we will not report Data not
    * found, Route not found, All data not found, etc., because these are nonfatal errors and we will
-   * retry. Note that after every 3 attempts the request is put on the cooldown queue for 30
+   * retry. Note that after every 3 attempts, the request is put on the cooldown queue for 30
    * minutes, so the cost of retries = -1 is really not that high.
    */
   private int maxNonSplitfileRetries;
@@ -145,7 +145,7 @@ public class FetchContext implements Serializable {
   private boolean ignoreStore;
 
   /** Client events will be published to this, you can subscribe to them */
-  private final transient ClientEventProducer eventProducer;
+  private transient ClientEventProducer eventProducer;
 
   /** Maximum metadata size permitted for the request, in bytes. */
   private int maxMetadataSize;
@@ -172,7 +172,7 @@ public class FetchContext implements Serializable {
   public final transient BlockSet blocks;
 
   /**
-   * If non-null, the request will be stopped if it has a MIME type that is not one of these, or has
+   * If non-null, the request will be stopped if it has a MIME type that is not one of these or has
    * no MIME type.
    */
   private transient Set<String> allowedMIMETypes;
@@ -188,7 +188,7 @@ public class FetchContext implements Serializable {
 
   /**
    * Can this request write to the client-cache? We don't store all requests in the client cache, in
-   * particular big stuff usually isn't written to it, to maximise its effectiveness.
+   * particular big stuff usually isn't written to it, to maximize its effectiveness.
    */
   private boolean canWriteClientCache;
 
@@ -198,7 +198,7 @@ public class FetchContext implements Serializable {
   /** Callback needed for web-pushing */
   private transient TagReplacerCallback tagReplacer;
 
-  /** Force the content fiter to use this MIME type */
+  /** Force the content filter to use this MIME type */
   private String overrideMIME;
 
   /**
@@ -218,7 +218,7 @@ public class FetchContext implements Serializable {
   private boolean ignoreUSKDatehints;
 
   /**
-   * scheme, host and port: force the prefix of a URI. Example: <a
+   * Scheme, host, and port: force the prefix of a URI. Example: <a
    * href="https://localhost:1234">https://localhost:1234</a>
    */
   private final String schemeHostAndPort;
@@ -284,7 +284,7 @@ public class FetchContext implements Serializable {
    * Copy a FetchContext, creating a new EventProducer and not changing the blocks list.
    *
    * @param ctx The old FetchContext to copy.
-   * @param maskID Mask mode for the copy operation e.g. SPLITFILE_DEFAULT_BLOCK_MASK.
+   * @param maskID Mask mode for the copy operation e.g., SPLITFILE_DEFAULT_BLOCK_MASK.
    */
   public FetchContext(FetchContext ctx, int maskID) {
     this(ctx, maskID, false, null);
@@ -294,11 +294,11 @@ public class FetchContext implements Serializable {
    * Copy a FetchContext.
    *
    * @param ctx The old FetchContext to copy.
-   * @param maskID Mask mode for the copy operation e.g. SPLITFILE_DEFAULT_BLOCK_MASK.
+   * @param maskID Mask mode for the copy operation e.g., SPLITFILE_DEFAULT_BLOCK_MASK.
    * @param keepProducer If true, keep the existing EventProducer. Must be false if we are creating
-   *     a new request. Can be true if we are masking the FetchContext within a single request, e.g.
-   *     to download a container. This is important so that we see the progress updates for the
-   *     request and not for other requests sharing the FetchContext, but also it could break
+   *     a new request. Can be true if we are masking the FetchContext within a single request,
+   *     e.g., to download a container. This is important so that we see the progress updates for
+   *     the request and not for other requests sharing the FetchContext, but also it could break
    *     serialization.
    * @param blocks Storing a BlockSet to the database is not supported, see comments on
    *     SimpleBlockSet.objectCanNew().
@@ -588,7 +588,7 @@ public class FetchContext implements Serializable {
   }
 
   /**
-   * Whether simple redirects are followed by the fetcher.
+   * Whether the fetcher follows simple redirects.
    *
    * @return {@code true} when redirects are followed automatically.
    */
@@ -597,7 +597,7 @@ public class FetchContext implements Serializable {
   }
 
   /**
-   * Control whether simple redirects are followed by the fetcher.
+   * Control whether the fetcher follows simple redirects.
    *
    * @param followRedirects {@code true} to follow redirects; {@code false} to disable following.
    */
@@ -798,7 +798,7 @@ public class FetchContext implements Serializable {
   }
 
   /**
-   * Whether the client cache may be written to by this request.
+   * Whether this request may write to the client cache.
    *
    * @return {@code true} when writing to the client cache is allowed.
    */
@@ -807,7 +807,7 @@ public class FetchContext implements Serializable {
   }
 
   /**
-   * Control whether the client cache may be written to by this request.
+   * Control whether this request may write to the client cache.
    *
    * @param canWriteClientCache {@code true} to enable writing; {@code false} to disable.
    */
@@ -870,7 +870,7 @@ public class FetchContext implements Serializable {
   }
 
   /**
-   * Whether USK DATEHINTs should be ignored by the client.
+   * Whether the client should ignore USK DATEHINTs.
    *
    * @return {@code true} when date hints are ignored.
    */
@@ -879,7 +879,7 @@ public class FetchContext implements Serializable {
   }
 
   /**
-   * Control whether USK DATEHINTs should be ignored by the client.
+   * Control whether the client should ignore USK DATEHINTs.
    *
    * @param ignoreUSKDatehints {@code true} to ignore date hints; otherwise {@code false}.
    */
@@ -888,7 +888,7 @@ public class FetchContext implements Serializable {
   }
 
   /**
-   * Get the forced URI prefix composed of scheme, host, and port.
+   * Get the forced URI prefix composed of the scheme, host, and port.
    *
    * @return A string such as {@code "https://localhost:1234"}, or {@code null} when unset.
    */
@@ -903,6 +903,39 @@ public class FetchContext implements Serializable {
    */
   public long getCooldownTime() {
     return cooldownTime;
+  }
+
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    if (allowedMIMETypes == null || allowedMIMETypes.isEmpty()) {
+      out.writeInt(0);
+      return;
+    }
+    out.writeInt(allowedMIMETypes.size());
+    for (String mime : allowedMIMETypes) {
+      out.writeUTF(mime);
+    }
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    eventProducer = new SimpleEventProducer();
+    try {
+      int size = in.readInt();
+      if (size <= 0) {
+        allowedMIMETypes = null;
+        return;
+      }
+      Set<String> mimes = HashSet.newHashSet(size);
+      for (int i = 0; i < size; i++) {
+        mimes.add(in.readUTF());
+      }
+      allowedMIMETypes = mimes;
+    } catch (EOFException _) {
+      allowedMIMETypes = null;
+    }
   }
 
   private static final long CLIENT_DETAIL_MAGIC = 0x5ae53b0ce18dd821L;
@@ -965,7 +998,7 @@ public class FetchContext implements Serializable {
   }
 
   /**
-   * Create from a saved form, e.g. for restarting a request from scratch. Will create its own
+   * Create from a saved form, e.g., for restarting a request from scratch. Will create its own
    * SimpleEventProducer.
    *
    * @param dis Data stream positioned at the beginning of a context previously written by {@link
@@ -1026,7 +1059,8 @@ public class FetchContext implements Serializable {
     try {
       s = dis.readUTF();
     } catch (EOFException _) {
-      // input stream reached EOF, so it must have been and old version without scehmeHostAndPort.
+      // the input stream reached EOF, so it must have been and old version without
+      // scehmeHostAndPort.
       s = "";
     }
     this.schemeHostAndPort = s.isEmpty() ? null : s;
@@ -1110,8 +1144,7 @@ public class FetchContext implements Serializable {
   }
 
   /**
-   * Are two InsertContext's equal? Ignores the EventProducer, compares only the actual config
-   * values.
+   * Are two InsertContext equal? Ignores the EventProducer, compares only the actual config values.
    */
   @Override
   public boolean equals(Object obj) {

--- a/src/main/java/network/crypta/client/FetchContext.java
+++ b/src/main/java/network/crypta/client/FetchContext.java
@@ -762,8 +762,8 @@ public class FetchContext implements Serializable {
   /**
    * Get the set of MIME types that are allowed when filtering is enabled.
    *
-   * @return A possibly {@code null} set of allowed MIME type strings; empty when no constraints are
-   *     configured.
+   * @return A possibly {@code null} set of allowed MIME type strings; {@code null} means no
+   *     constraints and an empty set means no MIME types are accepted.
    */
   public Set<String> getAllowedMIMETypes() {
     return allowedMIMETypes;
@@ -908,8 +908,8 @@ public class FetchContext implements Serializable {
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
     out.defaultWriteObject();
-    if (allowedMIMETypes == null || allowedMIMETypes.isEmpty()) {
-      out.writeInt(0);
+    if (allowedMIMETypes == null) {
+      out.writeInt(-1);
       return;
     }
     out.writeInt(allowedMIMETypes.size());
@@ -924,7 +924,7 @@ public class FetchContext implements Serializable {
     eventProducer = new SimpleEventProducer();
     try {
       int size = in.readInt();
-      if (size <= 0) {
+      if (size < 0) {
         allowedMIMETypes = null;
         return;
       }

--- a/src/main/java/network/crypta/client/async/SimpleHealingQueue.java
+++ b/src/main/java/network/crypta/client/async/SimpleHealingQueue.java
@@ -1,5 +1,7 @@
 package network.crypta.client.async;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serial;
 import java.util.HashMap;
 import java.util.Map;
@@ -59,7 +61,7 @@ public class SimpleHealingQueue extends BaseClientPutter
   /**
    * Monotonically increasing counter used to tag and correlate healing attempts in diagnostics.
    *
-   * <p>The counter value is assigned at enqueue time and may appear in debug log messages to aid
+   * <p>The counter-value is assigned at enqueue time and may appear in debug log messages to aid
    * troubleshooting. It has no semantic meaning beyond identification.
    */
   int counter;
@@ -73,7 +75,7 @@ public class SimpleHealingQueue extends BaseClientPutter
   InsertContext ctx;
 
   private final transient HealingDecisionSupplier healingDecisionSupplier;
-  final transient Map<Bucket, SingleBlockInserter> runningInserters;
+  transient Map<Bucket, SingleBlockInserter> runningInserters;
 
   static final RequestClient REQUEST_CLIENT = new RequestClientBuilder().build();
 
@@ -116,8 +118,8 @@ public class SimpleHealingQueue extends BaseClientPutter
    *
    * @param data the block-sized bucket to insert; must contain the correct number of bytes for a
    *     single CHK block and remain readable until the operation completes; never {@code null}.
-   * @param cryptoKey the raw key material used to encrypt the block; contents are implementation
-   *     dependent and must match the algorithm parameter.
+   * @param cryptoKey the raw key material used to encrypt the block; contents are
+   *     implementation-dependent and must match the algorithm parameter.
    * @param cryptoAlgorithm identifier of the encryption algorithm to use; valid values are defined
    *     by the surrounding client stack.
    * @param context the client context on which to schedule work; must be non-null and suitable for
@@ -264,7 +266,7 @@ public class SimpleHealingQueue extends BaseClientPutter
    * <p>Removes the corresponding entry from the in-flight map, logs a diagnostic message including
    * the failure, and frees the associated bucket.
    *
-   * @param e the failure cause as reported by the client putter; may carry detailed diagnostics.
+   * @param e the failure cause, as reported by the client putter, may carry detailed diagnostics.
    * @param state the put state representing the failed operation; expected to be a single-block
    *     putter instance.
    * @param context the client context active at failure time; not modified.
@@ -404,7 +406,7 @@ public class SimpleHealingQueue extends BaseClientPutter
   }
 
   /**
-   * Minimum number of successfully fetched blocks required by this request.
+   * A minimum number of successfully fetched blocks required by this request.
    *
    * <p>Healing insertions do not perform fetches as part of completion, so the value is zero.
    *
@@ -481,5 +483,11 @@ public class SimpleHealingQueue extends BaseClientPutter
   public int hashCode() {
     // Preserve the stable, identity-based hash code from the superclass.
     return super.hashCode();
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    this.runningInserters = new HashMap<>();
   }
 }

--- a/src/main/java/network/crypta/client/async/SingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SingleFileFetcher.java
@@ -481,6 +481,12 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
     this.topCompatibilityMode = fetcher.topCompatibilityMode;
   }
 
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    this.ah = null;
+  }
+
   // Completion callback + token (needed now that we don't extend SimpleSingleFileFetcher)
   /** Completion callback used to surface success, failure, and progress to the requester. */
   @SuppressWarnings("java:S1948")

--- a/src/main/java/network/crypta/client/async/SplitFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcher.java
@@ -4,6 +4,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
@@ -56,7 +57,7 @@ import org.slf4j.LoggerFactory;
  *   <li>Responsibilities: orchestration and progress reporting; scheduling and cooldown control.
  *   <li>Notable behaviors: optional completion via file truncation; resumable after corruption.
  *   <li>Thread-safety: external methods may be called from multiple threads; internal state changes
- *       are synchronized where necessary and long‑running work is delegated to schedulers.
+ *       are synchronized where necessary, and long‑running work is delegated to schedulers.
  * </ul>
  *
  * @author toad
@@ -142,7 +143,7 @@ public class SplitFileFetcher
   /** Whether the parent wants keys collected into a binary blob during fetching. */
   private final boolean wantBinaryBlob;
 
-  /** True when the fetcher and on‑disk state should survive node restarts. */
+  /** True, when the fetcher and on‑disk state should survive node restarts. */
   private final boolean persistent;
 
   static final class InitParams {
@@ -295,6 +296,13 @@ public class SplitFileFetcher
     fileCompleteViaTruncation = null;
   }
 
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    this.raf = null;
+    this.getter = null;
+  }
+
   /**
    * Schedules initial fetching work with the underlying sendable getter and storage.
    *
@@ -313,7 +321,7 @@ public class SplitFileFetcher
   /**
    * Fail the whole splitfile request when we get an IOException on writing to or reading from the
    * on-disk storage. Can be called asynchronously by SplitFileFetcher*Storage if an off-thread job
-   * (e.g. FEC decoding) breaks, or may be called when SplitFileFetcher*Storage throws.
+   * (e.g., FEC decoding) breaks, or may be called when SplitFileFetcher*Storage throws.
    *
    * @param e The IOException, generated when accessing the on-disk storage.
    */
@@ -564,7 +572,7 @@ public class SplitFileFetcher
     parent.completedBlock(dontNotify, context);
   }
 
-  /** Reports that a block retrieval failed so the parent can update progress. */
+  /** Reports that block retrieval failed so the parent can update progress. */
   @Override
   public void onFailedBlock() {
     parent.failedBlock(context);
@@ -572,7 +580,7 @@ public class SplitFileFetcher
 
   /**
    * Restores high‑level progress counters and notifies the client of expected metadata after a
-   * storage resume.
+   * storage resuming.
    *
    * @param succeededBlocks number of blocks already completed at resume time
    * @param failedBlocks number of blocks known to have failed at resume time
@@ -646,7 +654,7 @@ public class SplitFileFetcher
   }
 
   /**
-   * Lowers the scheduled wakeup time to the given value if it would wake the request earlier.
+   * Lowers the scheduled wakeup time to the given value if it wakes the request earlier.
    *
    * @param wakeupTime target absolute time (milliseconds since epoch) to consider work again
    */
@@ -666,7 +674,7 @@ public class SplitFileFetcher
   }
 
   /**
-   * Reattaches resources and reconstructs storage and scheduling state after a persisted resume.
+   * Reattaches resources and reconstructs storage and scheduling state after a persisted resuming.
    *
    * <p>On success the getter is recreated and, if storage indicates readiness, the request is
    * scheduled using the stored knowledge of blocks present in the local store. Errors from invalid

--- a/src/main/java/network/crypta/client/async/SplitFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserter.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * #onResume(ClientContext)}).
  *
  * <ul>
- *   <li>Persists progress in an RAF to enable reliable resume.
+ *   <li>Persists progress in an RAF to enable a reliable resuming.
  *   <li>Streams metadata to the caller early when configured to do so.
  *   <li>Honors real-time priority settings via the provided {@link InsertContext}.
  * </ul>
@@ -75,7 +75,7 @@ public class SplitFileInserter
   private final LockableRandomAccessBuffer originalData;
 
   /**
-   * Whether to free the data when the insert completes/fails. E.g. this is true if the data is the
+   * Whether to free the data when the insert completes/fails. E.g., this is true if the data is the
    * result of compression.
    */
   private final boolean freeData;
@@ -117,14 +117,13 @@ public class SplitFileInserter
    * ensure that referenced buffers and contexts outlive the construction phase and remain valid
    * until the insert is started or resumed.
    */
-  public static final class Options implements Serializable {
-    @Serial private static final long serialVersionUID = 1L;
+  public static final class Options {
 
-    /** Insert behavior, scheduling and encoding options used by the client layer. */
+    /** Insert behavior, scheduling, and encoding options used by the client layer. */
     final InsertContext ctx;
 
-    /** Execution context and facilities; transient and provided by the runtime. */
-    final transient ClientContext context;
+    /** Execution context and facilities provided by the runtime. */
+    final ClientContext context;
 
     /** Length of the content after decompression; used when the original is compressed. */
     final long decompressedLength;
@@ -172,7 +171,7 @@ public class SplitFileInserter
     final boolean realTime;
 
     /** Opaque caller token associated with this insert; returned unchanged in callbacks. */
-    final transient Object token;
+    final Object token;
 
     private Options(Builder b) {
       this.ctx = b.ctx;
@@ -345,7 +344,7 @@ public class SplitFileInserter
       }
 
       /**
-       * Provides precomputed hash results for segments or blocks to accelerate verification.
+       * Provides precomputed hash results for segments or blocks to speed up verification.
        *
        * @param v array of hash results; elements may be {@code null} if unavailable
        * @return this builder for fluent chaining; stores the array reference
@@ -528,8 +527,8 @@ public class SplitFileInserter
    * Requests cancellation of the insert and fails the operation.
    *
    * <p>This method propagates a {@link InsertExceptionMode#CANCELLED} to the underlying storage,
-   * which triggers cleanup and completion callbacks. It is safe to call multiple times; subsequent
-   * calls have no additional effect once failure handling has begun.
+   * which triggers cleanup and completion callbacks. It is safe to call multiple times; later calls
+   * have no additional effect once failure handling has begun.
    *
    * @param context execution context used by the caller; ignored for cancellation semantics
    */
@@ -573,11 +572,11 @@ public class SplitFileInserter
    *
    * <p>This method re-initializes transient collaborators, replays storage state from the RAF,
    * updates internals, and then calls {@link #schedule(ClientContext)} to continue. It is
-   * idempotent: only the first call takes effect; subsequent calls are ignored.
+   * idempotent: only the first call takes effect; later calls are ignored.
    *
    * @param context execution context for persistent resumes; must be a persistent-capable context
    * @throws InsertException if a storage or scheduling error occurs during resume
-   * @throws ResumeFailedException if on-disk state is corrupt or cannot be reconciled
+   * @throws ResumeFailedException if the on-disk state is corrupt or cannot be reconciled
    */
   @Override
   public void onResume(ClientContext context) throws InsertException, ResumeFailedException {
@@ -662,7 +661,7 @@ public class SplitFileInserter
       context
           .getJobRunner(persistent)
           .queueNormalOrDrop(
-              jobCtx -> {
+              _ -> {
                 try {
                   Metadata metadata = storageRef.get().encodeMetadata();
                   reportMetadata(metadata);
@@ -712,7 +711,7 @@ public class SplitFileInserter
   }
 
   /**
-   * Unregisters the sender with schedulers so it no longer participates in network activity.
+   * Unregisters the sender with schedulers, so it no longer participates in network activity.
    *
    * <p>This helper is invoked on success and failure paths to ensure resources are released and the
    * scheduler state is updated consistently.

--- a/src/main/java/network/crypta/client/async/USKRetriever.java
+++ b/src/main/java/network/crypta/client/async/USKRetriever.java
@@ -3,6 +3,7 @@ package network.crypta.client.async;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -65,7 +66,7 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
 
   /**
    * Context used for fetch operations initiated by this retriever. It defines limits such as
-   * maximum output/temp sizes, retry policy and link filtering behavior. The instance is provided
+   * maximum output/temp sizes, retry policy, and link filtering behavior. The instance is provided
    * by the caller and is not modified.
    */
   final FetchContext ctx;
@@ -79,7 +80,6 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
    */
   final USK origUSK;
 
-  // In wierd
   /**
    * The USKCallback that is actually subscribed. This is used when we may be going through a
    * USKSparseProxyCallback.
@@ -99,7 +99,7 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
    * <p>The retriever is explicitly non‑persistent. If a persistent {@link RequestClient} is
    * provided this constructor throws {@link UnsupportedOperationException}.
    *
-   * @param fctx fetch configuration that defines size limits, retries and filtering; must remain
+   * @param fctx fetch configuration that defines size limits, retries, and filtering; must remain
    *     valid for the lifetime of the retriever
    * @param prio request priority used when scheduling network activity; higher values generally
    *     indicate greater urgency
@@ -357,8 +357,8 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
   }
 
   /**
-   * Called when we subscribe() in USKManager, if we don't directly subscribe the USKRetriever.
-   * Usually this happens when we put a proxy between them, e.g. USKProxyCompletionCallback, which
+   * Called when we subscribe() in USKManager if we don't directly subscribe the USKRetriever.
+   * Usually this happens when we put a proxy between them, e.g., USKProxyCompletionCallback, which
    * hides updates for efficiency.
    *
    * @param cb The callback that is actually USKManager.subscribe()'ed.
@@ -383,7 +383,7 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
    * Unsubscribes this retriever from the given manager and cancels any active fetcher associated
    * with it.
    *
-   * <p>After this call the retriever will no longer receive edition updates and will not schedule
+   * <p>After this call, the retriever will no longer receive edition updates and will not schedule
    * further network activity.
    *
    * @param manager the manager from which the retriever should be detached; must be non‑null and
@@ -409,7 +409,7 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
    * @param time the new cooldown interval between polling cycles, in milliseconds; values shorter
    *     than roughly 30 minutes are rejected
    * @param tries the number of attempts performed after each cooldown; must be greater than zero
-   *     and less than three or an exception is thrown
+   *     and less than three, or an exception is thrown
    * @param context execution context used to apply the change; provides access to manager state and
    *     scheduling facilities and must be non‑null
    * @throws IllegalStateException if no fetcher has been associated with this instance via {@code
@@ -470,6 +470,12 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
             null,
             null,
             context.linkFilterExceptionProvider));
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    this.proxy = this;
   }
 
   @Override

--- a/src/main/java/network/crypta/node/SimpleSendableInsert.java
+++ b/src/main/java/network/crypta/node/SimpleSendableInsert.java
@@ -1,5 +1,7 @@
 package network.crypta.node;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serial;
 import java.util.Objects;
 import network.crypta.client.InsertException;
@@ -74,7 +76,7 @@ public class SimpleSendableInsert extends SendableInsert {
    * client when constructing the insert explicitly. The reference is transient and expected to
    * remain valid only for the short lifetime of this insert.
    */
-  public final transient RequestClient client;
+  private transient RequestClient client;
 
   /**
    * Scheduler that executes this insert.
@@ -518,6 +520,12 @@ public class SimpleSendableInsert extends SendableInsert {
   @Override
   public boolean localRequestOnly() {
     return false;
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    this.client = new RequestClientBuilder().build();
   }
 
   /**

--- a/src/test/java/network/crypta/client/FetchContextTest.java
+++ b/src/test/java/network/crypta/client/FetchContextTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -15,6 +16,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.HashSet;
 import java.util.Set;
 import network.crypta.client.async.BlockSet;
@@ -176,7 +179,7 @@ class FetchContextTest {
     FetchContext base = createValidContext();
     FetchContext copy = new FetchContext(base, FetchContext.IDENTICAL_MASK);
 
-    // Event producer should be a new SimpleEventProducer, not the same mock
+    // Event producer should be a new SimpleEventProducer, differently mock
     assertNotSame(base.getEventProducer(), copy.getEventProducer());
     assertInstanceOf(SimpleEventProducer.class, copy.getEventProducer());
 
@@ -400,6 +403,27 @@ class FetchContextTest {
   }
 
   @Test
+  void javaSerialization_whenAllowedMimeTypesNull_restoresNull() throws Exception {
+    FetchContext ctx = createValidContext();
+    ctx.setAllowedMIMETypes(null);
+
+    FetchContext read = javaRoundTrip(ctx);
+
+    assertNull(read.getAllowedMIMETypes());
+  }
+
+  @Test
+  void javaSerialization_whenAllowedMimeTypesEmpty_preservesEmptySet() throws Exception {
+    FetchContext ctx = createValidContext();
+    ctx.setAllowedMIMETypes(new HashSet<>());
+
+    FetchContext read = javaRoundTrip(ctx);
+
+    assertNotNull(read.getAllowedMIMETypes());
+    assertTrue(read.getAllowedMIMETypes().isEmpty());
+  }
+
+  @Test
   void readFrom_whenStreamOmitsSchemeHostAndPort_setsNull() throws Exception {
     // Manually serialize the "old" format without the final schemeHostAndPort UTF string.
     FetchContext ctx = createValidContext();
@@ -487,5 +511,21 @@ class FetchContextTest {
 
   private FetchContext createValidContext() {
     return new FetchContext(validOptionsBuilder().build());
+  }
+
+  private static FetchContext javaRoundTrip(FetchContext context)
+      throws IOException, ClassNotFoundException {
+    byte[] bytes;
+    try (var baos = new ByteArrayOutputStream();
+        var oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(context);
+      oos.flush();
+      bytes = baos.toByteArray();
+    }
+
+    try (var bais = new ByteArrayInputStream(bytes);
+        var ois = new ObjectInputStream(bais)) {
+      return (FetchContext) ois.readObject();
+    }
   }
 }

--- a/src/test/java/network/crypta/client/async/ContainerInserterTest.java
+++ b/src/test/java/network/crypta/client/async/ContainerInserterTest.java
@@ -14,7 +14,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
 import java.io.OutputStream;
+import java.io.Serial;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -202,7 +204,7 @@ class ContainerInserterTest {
   }
 
   private static final class TestPutter extends BaseClientPutter {
-    private final transient RequestClient rc;
+    private transient RequestClient rc;
 
     TestPutter(RequestClient rc) {
       super((short) 0, rc);
@@ -267,14 +269,20 @@ class ContainerInserterTest {
 
     @Override
     public boolean equals(Object obj) {
-      // identity semantics are sufficient for test helper; delegate to super
+      // identity semantics are enough for test helper; delegate to super class
       return super.equals(obj);
     }
 
     @Override
     public int hashCode() {
-      // delegate to super to preserve identity-based semantics
+      // delegate to super class to preserve identity-based semantics
       return super.hashCode();
+    }
+
+    @Serial
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      rc = new RequestClientBuilder().persistent(false).build();
     }
   }
 
@@ -413,7 +421,7 @@ class ContainerInserterTest {
     // Act
     inserter.onResume(clientContext);
 
-    // Assert: callback gets onResume, and bucket got resumed via resumeMetadata()
+    // Assert: callback gets onResume, and the bucket got resumed via resumeMetadata()
     verify(callback, times(1)).onResume(clientContext);
     assertEquals(1, bucketResume.get());
   }
@@ -431,7 +439,7 @@ class ContainerInserterTest {
     manifest.put(FILENAME_A, new ManifestElement(FILENAME_A, file, null, 5));
 
     when(clientContext.getBucketFactory(false))
-        .thenReturn(size -> new InMemoryBucket("bucket-" + java.util.UUID.randomUUID()));
+        .thenReturn(_ -> new InMemoryBucket("bucket-" + java.util.UUID.randomUUID()));
 
     // Callback captures the SingleFileInserter to inspect the produced archive and aborts the flow
     PutCompletionCallback inspectingCb =
@@ -445,9 +453,12 @@ class ContainerInserterTest {
           public void onTransition(ClientPutState from, ClientPutState to, ClientContext ctx) {
             // Assert mime via block metadata
             SingleFileInserter sfi = (SingleFileInserter) to;
-            assertEquals("application/zip", sfi.block.clientMetadata.getMIMEType());
+            ClientMetadata metadata =
+                java.util.Objects.requireNonNull(
+                    java.util.Objects.requireNonNull(sfi.block).clientMetadata);
+            assertEquals("application/zip", metadata.getMIMEType());
 
-            // Safely enumerate entries without extracting to filesystem
+            // Safely list entries without extracting to filesystem
             Set<String> names = new HashSet<>();
             try {
               java.nio.file.Path tmp = java.nio.file.Files.createTempFile("ziptest", ".zip");
@@ -475,7 +486,7 @@ class ContainerInserterTest {
             assertTrue(names.contains(".metadata"));
             assertTrue(names.contains(FILENAME_A));
 
-            // Abort further scheduling; this is expected by the test
+            // Abort further scheduling; the test expects this
             throw new IllegalStateException("stop-after-inspection");
           }
 
@@ -553,7 +564,7 @@ class ContainerInserterTest {
     manifest.put(FILENAME_A, new ManifestElement(FILENAME_A, fileBucket, null, 5));
 
     when(clientContext.getBucketFactory(false))
-        .thenReturn(size -> new InMemoryBucket("bucket-" + java.util.UUID.randomUUID()));
+        .thenReturn(_ -> new InMemoryBucket("bucket-" + java.util.UUID.randomUUID()));
 
     PutCompletionCallback inspectingCb =
         new PutCompletionCallback() {
@@ -565,7 +576,10 @@ class ContainerInserterTest {
           @Override
           public void onTransition(ClientPutState from, ClientPutState to, ClientContext ctx) {
             SingleFileInserter sfi = (SingleFileInserter) to;
-            assertEquals("application/x-tar", sfi.block.clientMetadata.getMIMEType());
+            ClientMetadata metadata =
+                java.util.Objects.requireNonNull(
+                    java.util.Objects.requireNonNull(sfi.block).clientMetadata);
+            assertEquals("application/x-tar", metadata.getMIMEType());
 
             Set<String> names = new HashSet<>();
             try (InputStream is = sfi.block.getData().getInputStream();
@@ -644,13 +658,13 @@ class ContainerInserterTest {
     RequestClient rc = new RequestClientBuilder().persistent(false).build();
     BaseClientPutter parent = new TestPutter(rc);
     HashMap<String, Object> manifest = new HashMap<>();
-    // Include at least one file entry so makeManifest will add it; irrelevant here
+    // Include at least one file entry, so makeManifest will add it; irrelevant here
     InMemoryBucket fileBucket = new InMemoryBucket("in");
     fileBucket.getOutputStream().write(new byte[] {1});
     fileBucket.setReadOnly();
     manifest.put("a.bin", new ManifestElement("a.bin", fileBucket, null, 1));
 
-    BucketFactory failing = size -> new FailingBucket();
+    BucketFactory failing = _ -> new FailingBucket();
     when(clientContext.getBucketFactory(false)).thenReturn(failing);
 
     ContainerInserter inserter =

--- a/src/test/java/network/crypta/client/async/USKAttemptManagerTest.java
+++ b/src/test/java/network/crypta/client/async/USKAttemptManagerTest.java
@@ -13,6 +13,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,26 +136,29 @@ class USKAttemptManagerTest {
   }
 
   private static final class TestRequester extends ClientRequester {
-    private final transient ClientBaseCallback callback;
+    private transient ClientBaseCallback callback;
     private final network.crypta.keys.FreenetURI uri;
     private int toNetworkCalls;
     private boolean wasCancelled;
 
+    private static ClientBaseCallback newCallback(RequestClient client) {
+      return new ClientBaseCallback() {
+        @Override
+        public void onResume(ClientContext context) {
+          // no-op
+        }
+
+        @Override
+        public RequestClient getRequestClient() {
+          return client;
+        }
+      };
+    }
+
     private TestRequester(network.crypta.keys.FreenetURI uri, RequestClient client) {
       super((short) 1, client);
       this.uri = uri;
-      this.callback =
-          new ClientBaseCallback() {
-            @Override
-            public void onResume(ClientContext context) {
-              // no-op
-            }
-
-            @Override
-            public RequestClient getRequestClient() {
-              return client;
-            }
-          };
+      this.callback = newCallback(client);
     }
 
     @Override
@@ -193,6 +199,12 @@ class USKAttemptManagerTest {
 
     int toNetworkCalls() {
       return toNetworkCalls;
+    }
+
+    @Serial
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      this.callback = newCallback(TRANSIENT_CLIENT);
     }
   }
 


### PR DESCRIPTION
## Summary
- Restore runtime-only transient collaborators during Java deserialization to resolve `SE_TRANSIENT_FIELD_NOT_RESTORED` findings across fetch/insert request classes and related helpers.
- Keep `SplitFileInserter.Options` as a non-serializable options carrier and remove redundant `transient` modifiers flagged by SonarLint.
- Tighten `ContainerInserterTest` MIME assertions against nullable metadata and encapsulate `SimpleSendableInsert.client` behind accessors.

## Testing
- `./gradlew spotbugsMain spotbugsTest`
- `./gradlew test`