### PR TITLE
fix(spotbugs): Fix unchecked read and skip return values

### DIFF
--- a/src/main/java/network/crypta/client/filter/VorbisPacketFilter.java
+++ b/src/main/java/network/crypta/client/filter/VorbisPacketFilter.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This filter performs a minimal, stateful pass over the Vorbis header sequence (identification
  * → comment → setup). It validates the identification header, removes or normalizes the comment
- * header content, and then yields subsequent packets unchanged. The intent is to enforce basic
+ * header content, and then yields the following packets unchanged. The intent is to enforce basic
  * invariants and to ensure that embedded metadata does not leak undesired information while keeping
  * processing lightweight. The class maintains a simple state machine and therefore is designed for
  * single-stream use: create one instance per logical Vorbis stream and feed packets in order.
@@ -67,7 +67,7 @@ public class VorbisPacketFilter implements CodecPacketFilter {
    * }</pre>
    */
   public VorbisPacketFilter() {
-    // Intentionally empty: the filter starts in UNINITIALIZED state and requires
+    // Intentionally empty: the filter starts in the UNINITIALIZED state and requires
     // no additional setup beyond the default field values.
   }
 
@@ -77,7 +77,7 @@ public class VorbisPacketFilter implements CodecPacketFilter {
    * <p>Call this method with packets in stream order. The identification header is validated for
    * version, channel count, sample rate, block size ordering, and framing. The comment header is
    * reduced to a minimal, empty form while preserving required framing bytes. The setup header and
-   * all subsequent packets are returned unchanged.
+   * all following packets are returned unchanged.
    *
    * <pre>{@code
    * VorbisPacketFilter filter = new VorbisPacketFilter();
@@ -152,8 +152,9 @@ public class VorbisPacketFilter implements CodecPacketFilter {
     input.readFully(vendorString);
     long userCommentListLength = Integer.reverseBytes(input.readInt());
     for (long i = 0; i < userCommentListLength; i++) {
-      for (long j = Integer.reverseBytes(input.readInt()); j > 0; j--) {
-        input.skipBytes(1);
+      int userCommentLength = Integer.reverseBytes(input.readInt());
+      if ((userCommentLength < 0) || !skipBytesFully(input, userCommentLength)) {
+        return null;
       }
     }
     if (!input.readBoolean()) return null;
@@ -169,5 +170,17 @@ public class VorbisPacketFilter implements CodecPacketFilter {
     LOG.debug("Packet size: {}", rewritten.payload.length);
     currentState = State.COMMENT_FOUND;
     return rewritten;
+  }
+
+  private static boolean skipBytesFully(DataInputStream input, int count) throws IOException {
+    int remaining = count;
+    while (remaining > 0) {
+      int skipped = input.skipBytes(remaining);
+      if (skipped == 0) {
+        return false;
+      }
+      remaining -= skipped;
+    }
+    return true;
   }
 }

--- a/src/main/java/org/bitpedia/collider/core/Id3Handler.java
+++ b/src/main/java/org/bitpedia/collider/core/Id3Handler.java
@@ -229,7 +229,7 @@ public class Id3Handler {
       byte[] buf = new byte[128];
       try {
         f.seek(f.length() - 128);
-        f.read(buf);
+        f.readFully(buf);
 
         Id3v1 info = new Id3v1();
         info.id = new String(buf, 0, 3, StandardCharsets.ISO_8859_1);
@@ -298,7 +298,7 @@ public class Id3Handler {
 
       byte[] buf = new byte[10];
       try {
-        f.read(buf);
+        f.readFully(buf);
 
         Id3Header h = new Id3Header();
         h.tag = new String(buf, 0, 3, StandardCharsets.ISO_8859_1);
@@ -343,7 +343,7 @@ public class Id3Handler {
         FrameHeaderv23 h = new FrameHeaderv23();
 
         byte[] buf = new byte[4];
-        f.read(buf);
+        f.readFully(buf);
         h.tag = new String(buf, StandardCharsets.ISO_8859_1);
         h.size = f.readInt();
         h.flags = f.readUnsignedShort();
@@ -382,9 +382,9 @@ public class Id3Handler {
         FrameHeaderv22 h = new FrameHeaderv22();
 
         byte[] buf = new byte[3];
-        f.read(buf);
+        f.readFully(buf);
         h.tag = new String(buf, 0, 3, StandardCharsets.ISO_8859_1);
-        f.read(h.size);
+        f.readFully(h.size);
 
         return h;
       } catch (Exception _) {
@@ -497,7 +497,9 @@ public class Id3Handler {
       if (0 != (head.flags & (1 << 6))) {
 
         int extHeaderSize = f.readInt();
-        f.skipBytes(extHeaderSize);
+        if (!skipFully(f, extHeaderSize)) {
+          return null;
+        }
       }
 
       Id3Info info = new Id3Info();
@@ -536,6 +538,22 @@ public class Id3Handler {
     } catch (IOException _) {
       return info;
     }
+  }
+
+  private static boolean skipFully(RandomAccessFile f, int count) throws IOException {
+    if (count < 0) {
+      return false;
+    }
+
+    int remaining = count;
+    while (remaining > 0) {
+      int skipped = f.skipBytes(remaining);
+      if (skipped <= 0) {
+        return false;
+      }
+      remaining -= skipped;
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix SpotBugs `RR_NOT_CHECKED`/`SR_NOT_CHECKED` issues in production parser code by checking skip progress in Vorbis comment handling.
- Replace unchecked `RandomAccessFile.read(...)` calls in ID3 parsing with `readFully(...)` so short reads are not silently accepted.
- Validate extended-header skipping in ID3v2 parsing with a bounded `skipFully(...)` helper and fail parsing cleanly when progress is impossible.

## How to test
- Run `./gradlew spotbugsMain` and verify no `RR_NOT_CHECKED` / `SR_NOT_CHECKED` findings remain in `build/reports/spotbugs/spotbugsMain.xml`.
- Run `./gradlew test --tests org.bitpedia.collider.core.Id3HandlerTest --tests network.crypta.client.filter.VorbisPacketFilterTest`.