### PR TITLE
fix(spotbugs): Fix PA_PUBLIC_PRIMITIVE_ATTRIBUTE findings

### DIFF
--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -25,4 +25,23 @@
     <Bug pattern="SE_INNER_CLASS"/>
     <Class name="network.crypta.support.io.MultiReaderBucket$ReaderBucket"/>
   </Match>
+
+  <!--
+    InsertBlock is a long-lived public client API object. Its desiredURI/clientMetadata
+    fields are intentionally mutable and publicly readable to preserve compatibility with
+    existing integrations that construct and hand off blocks across subsystems.
+    SpotBugs PA warns when such fields are also written by class methods (nullURI/
+    nullMetadata), but tightening visibility would be a breaking API change.
+  -->
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="network.crypta.client.InsertBlock"/>
+    <Field name="desiredURI"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="network.crypta.client.InsertBlock"/>
+    <Field name="clientMetadata"/>
+  </Match>
 </FindBugsFilter>

--- a/src/test/kotlin/network/crypta/fs/AppDirsTest.kt
+++ b/src/test/kotlin/network/crypta/fs/AppDirsTest.kt
@@ -11,12 +11,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
 class AppDirsTest {
+  @TempDir private lateinit var tmp: Path
 
-  @TempDir lateinit var tmp: Path
-
-  private fun norm(value: String): String {
-    return value.replace('\\', '/')
-  }
+  private fun norm(value: String): String = value.replace('\\', '/')
 
   private fun sysProps(home: Path, tmpdir: Path): Map<String, String> {
     val props = HashMap<String, String>()
@@ -246,7 +243,7 @@ class AppDirsTest {
 
     val resolved = dirs.resolve()
 
-    // Without XDG_RUNTIME_DIR and without writable /run parent, runDir should be <cache>/rt
+    // Without XDG_RUNTIME_DIR and without a writable /run parent, runDir should be <cache>/rt
     assertTrue(resolved.runDir.startsWith(xdgCache.resolve("rt")))
   }
 

--- a/src/test/kotlin/network/crypta/launcher/LauncherControllerTest.kt
+++ b/src/test/kotlin/network/crypta/launcher/LauncherControllerTest.kt
@@ -34,7 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 @Suppress("java:S100", "kotlin:S100")
 @ExtendWith(MockitoExtension::class)
 internal class LauncherControllerTest {
-  @TempDir lateinit var tempDir: Path
+  @TempDir private lateinit var tempDir: Path
 
   private companion object {
     private const val TEST_PORT = 8888


### PR DESCRIPTION
## Summary
- make `@TempDir` fields private in `AppDirsTest` and `LauncherControllerTest` so SpotBugs no longer flags them as exposed mutable attributes
- add targeted SpotBugs exclusions for `InsertBlock.desiredURI` and `InsertBlock.clientMetadata` because those public mutable fields are intentional client API surface
- document the compatibility rationale in `build-logic/spotbugs-exclude.xml`

## Testing
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `./gradlew test`