### PR TITLE
fix(spotbugs): Fix missing serialVersionUID warnings

### DIFF
--- a/src/main/java/com/onionnetworks/util/InvokeEvent.java
+++ b/src/main/java/com/onionnetworks/util/InvokeEvent.java
@@ -1,5 +1,6 @@
 package com.onionnetworks.util;
 
+import java.io.Serial;
 import java.util.EventObject;
 
 /**
@@ -27,15 +28,17 @@ import java.util.EventObject;
  * @see EventObject
  */
 public class InvokeEvent extends EventObject {
+  @Serial private static final long serialVersionUID = 234594476951043607L;
+
   private final transient Runnable r;
 
   /**
-   * Creates a new invoke event that associates the given source object with a runnable callback the
-   * listener may execute. The constructor does not validate the runnable; callers decide whether a
-   * {@code null} runnable is meaningful in their dispatch model. The source parameter must not be
-   * {@code null} because {@link EventObject} enforces that requirement and will throw {@link
-   * NullPointerException} if violated. Once created, the event captures the provided values and
-   * exposes them immutably to downstream handlers.
+   * Creates a new invoking event that associates the given source object with a runnable callback
+   * the listener may execute. The constructor does not validate the runnable; callers decide
+   * whether a {@code null} runnable is meaningful in their dispatch model. The source parameter
+   * must not be {@code null} because {@link EventObject} enforces that requirement and will throw
+   * {@link NullPointerException} if violated. Once created, the event captures the provided values
+   * and exposes them immutably to downstream handlers.
    *
    * @param source non-null origin of the event, typically the publisher or owning component
    * @param r runnable callback to execute when handling the event; may be {@code null} if handled

--- a/src/main/java/network/crypta/client/async/SplitFileInserterSender.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterSender.java
@@ -1,6 +1,7 @@
 package network.crypta.client.async;
 
 import java.io.IOException;
+import java.io.Serial;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.SplitFileInserterSegmentStorage.BlockInsert;
 import network.crypta.keys.CHKBlock;
@@ -32,8 +33,8 @@ import org.slf4j.LoggerFactory;
  * <p>Persistence model: instances of this class are <strong>not</strong> serialized. For persistent
  * inserts the parent {@link SplitFileInserter} reconstructs both its {@link
  * SplitFileInserterStorage} and a fresh {@code SplitFileInserterSender} during {@link
- * SplitFileInserter#onResume(ClientContext)}. Any transient collaborators (for example the internal
- * sender object) are therefore safe to keep non‑serializable.
+ * SplitFileInserter#onResume(ClientContext)}. Any transient collaborators (for example, the
+ * internal sender object) are therefore safe to keep non‑serializable.
  *
  * <p>Concurrency: selection and callbacks are invoked by the client request schedulers. The sender
  * treats disk failures and unexpected throwables as terminal for the affected block: errors are
@@ -45,7 +46,7 @@ import org.slf4j.LoggerFactory;
  *   <li><strong>Responsibilities:</strong> choose a block, encode it, submit a put (local or
  *       remote), and translate success/failure into storage updates and client callbacks.
  *   <li><strong>Notable behaviors:</strong> local‑only mode stores to the node’s store directly;
- *       remote mode uses {@code realPut}. All unexpected throwables during send are caught and
+ *       remote mode uses {@code realPut}. All unexpected throwables during sending are caught and
  *       mapped to an internal‑error failure so the scheduler state remains consistent.
  * </ul>
  *
@@ -55,9 +56,11 @@ import org.slf4j.LoggerFactory;
 public class SplitFileInserterSender extends SendableInsert {
   private static final Logger LOG = LoggerFactory.getLogger(SplitFileInserterSender.class);
 
+  @Serial private static final long serialVersionUID = 1L;
+
   /**
-   * Owning high‑level inserter that coordinates metadata, progress, and completion reporting. The
-   * reference is stable for the lifetime of the sender and is never {@code null}.
+   * The owning high‑level inserter that coordinates metadata, progress, and completion reporting.
+   * The reference is stable for the lifetime of the sender and is never {@code null}.
    */
   final SplitFileInserter parent;
 
@@ -71,7 +74,7 @@ public class SplitFileInserterSender extends SendableInsert {
   /**
    * Creates a sender bound to an existing split‑file inserter and its storage.
    *
-   * <p>The persistence and real‑time flags are inherited from the parent so this sender integrates
+   * <p>The persistence and real‑time flags are inherited from the parent, so this sender integrates
    * with the appropriate schedulers and job runners.
    *
    * @param parent owning inserter that provides context, priority, and client identity; must not be
@@ -82,7 +85,9 @@ public class SplitFileInserterSender extends SendableInsert {
   public SplitFileInserterSender(SplitFileInserter parent, SplitFileInserterStorage storage) {
     super(
         parent.persistent,
-        parent.realTime); // Persistence should be from parent so that e.g. callbacks get run on the
+        parent
+            .realTime); // Persistence should be from the parent so that e.g., callbacks get run on
+    // the
     // right jobRunner.
     this.parent = parent;
     this.storage = storage;
@@ -98,7 +103,7 @@ public class SplitFileInserterSender extends SendableInsert {
    * @param keyNum scheduler token identifying the block within a segment; expected to be a {@link
    *     SplitFileInserterSegmentStorage.BlockInsert}
    * @param key client key produced for the block; ownership is not transferred
-   * @param context execution context used for subsequent callbacks; not {@code null}
+   * @param context execution context used for later callbacks; not {@code null}
    */
   @Override
   public void onSuccess(SendableRequestItem keyNum, ClientKey key, ClientContext context) {
@@ -151,7 +156,7 @@ public class SplitFileInserterSender extends SendableInsert {
    * <p>This callback runs on the appropriate persistence‑aware job runner. If the insert has
    * already finished, the method returns immediately. I/O failures are considered disk errors and
    * delegated to {@link SplitFileInserterStorage#failOnDiskError(IOException)} which will terminate
-   * or retry according to policy.
+   * or retry, according to policy.
    *
    * @param token block token identifying the segment and block number; expected to be a {@link
    *     SplitFileInserterSegmentStorage.BlockInsert}
@@ -191,8 +196,8 @@ public class SplitFileInserterSender extends SendableInsert {
    * Selects the next block to insert, or returns {@code null} when none are eligible.
    *
    * <p>Selection is delegated to the per‑segment chooser in {@link SplitFileInserterStorage}. The
-   * returned token is stable for the duration of the attempted send; the scheduler will not select
-   * the same block concurrently for the same request.
+   * returned token is stable for the duration of the attempted sending; the scheduler will not
+   * select the same block concurrently for the same request.
    *
    * @param keys view of keys currently being inserted locally to avoid duplication
    * @param context execution context supplied by the scheduler; not used for selection
@@ -309,7 +314,7 @@ public class SplitFileInserterSender extends SendableInsert {
    * or failure back to this request, converting unexpected throwables to an internal‑error failure.
    *
    * @param context execution context provided by the scheduler; not {@code null}
-   * @return a sender that performs the blocking send for this request instance
+   * @return a sender that performs the blocking sending for this request instance
    */
   @Override
   public SendableRequestSender getSender(ClientContext context) {
@@ -317,7 +322,7 @@ public class SplitFileInserterSender extends SendableInsert {
   }
 
   /**
-   * Indicates whether the request has finished or been cancelled and should no longer run.
+   * Indicates whether the request has finished or been canceled and should no longer run.
    *
    * @return {@code true} when the underlying storage reports that the insert has finished
    */
@@ -345,7 +350,7 @@ public class SplitFileInserterSender extends SendableInsert {
    * Registers this sender with the CHK insert scheduler when not already registered.
    *
    * <p>The registration uses the parent’s real‑time flag and persistence mode. When already
-   * registered (for example during priority changes), the method returns without side effects.
+   * registered (for example, during priority changes), the method returns without side effects.
    *
    * @param context execution context that provides the CHK insert scheduler; must not be {@code
    *     null}

--- a/src/main/java/network/crypta/client/async/USKStoreCheckerGetter.java
+++ b/src/main/java/network/crypta/client/async/USKStoreCheckerGetter.java
@@ -1,5 +1,6 @@
 package network.crypta.client.async;
 
+import java.io.Serial;
 import network.crypta.client.FetchContext;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.Key;
@@ -40,6 +41,8 @@ import network.crypta.node.SendableRequestItem;
  * @see USKStoreCheckCoordinator.USKStoreChecker
  */
 final class USKStoreCheckerGetter extends SendableGet {
+  @Serial private static final long serialVersionUID = 1L;
+
   /** Coordinator for store-check lifecycle and callbacks. */
   private final transient USKStoreCheckCoordinator coordinator;
 

--- a/src/main/java/network/crypta/support/io/PooledFileRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/PooledFileRandomAccessBuffer.java
@@ -54,6 +54,8 @@ public class PooledFileRandomAccessBuffer implements LockableRandomAccessBuffer,
    * monitor when accessing or mutating the state.
    */
   static class FDTracker implements Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
     private int maxOpenFDs;
     private int totalOpenFDs = 0;
     private final LinkedHashSet<PooledFileRandomAccessBuffer> closables = new LinkedHashSet<>();
@@ -189,7 +191,7 @@ public class PooledFileRandomAccessBuffer implements LockableRandomAccessBuffer,
     this.fds = fds;
     lockLevel = 0;
     // Check the parameters and get the length.
-    // Also, unlock() adds to the closeables queue, which is essential.
+    // Also, unlock() adds to the closeable queue, which is essential.
     RAFLock lock = lockOpen();
     try {
       long currentLength = raf.length();

--- a/src/test/java/network/crypta/client/async/ContainerInserterTest.java
+++ b/src/test/java/network/crypta/client/async/ContainerInserterTest.java
@@ -204,6 +204,8 @@ class ContainerInserterTest {
   }
 
   private static final class TestPutter extends BaseClientPutter {
+    @Serial private static final long serialVersionUID = 1L;
+
     private transient RequestClient rc;
 
     TestPutter(RequestClient rc) {

--- a/src/test/java/network/crypta/client/async/DatastoreCheckerTest.java
+++ b/src/test/java/network/crypta/client/async/DatastoreCheckerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.Serial;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
@@ -156,6 +157,8 @@ class DatastoreCheckerTest {
   }
 
   private static class TestSendableGet extends SendableGet {
+    @Serial private static final long serialVersionUID = 1L;
+
     private final short prio;
     private final transient Key[] keys;
     private final transient ClientRequestScheduler sched;

--- a/src/test/java/network/crypta/client/async/USKAttemptManagerTest.java
+++ b/src/test/java/network/crypta/client/async/USKAttemptManagerTest.java
@@ -136,6 +136,8 @@ class USKAttemptManagerTest {
   }
 
   private static final class TestRequester extends ClientRequester {
+    @Serial private static final long serialVersionUID = 1L;
+
     private transient ClientBaseCallback callback;
     private final network.crypta.keys.FreenetURI uri;
     private int toNetworkCalls;


### PR DESCRIPTION
## Summary
- Add explicit `@Serial serialVersionUID` fields to SpotBugs-reported `Serializable` classes in main and test code.
- Preserve compatibility for `InvokeEvent` by using its computed default UID value and use explicit `1L` for internal/test helper types.
- Keep the fix focused on `SE_NO_SERIALVERSIONID` findings without changing runtime behavior.

## How to test
- Run `./gradlew spotbugsMain spotbugsTest`
- Confirm SpotBugs reports under `build/reports/spotbugs/` no longer contain `SE_NO_SERIALVERSIONID`

## Notes
- SpotBugs may still print an unrelated missing-analysis-class warning for `oshi.annotation.concurrent.ThreadSafe`; this is pre-existing and not part of this fix.