### PR TITLE
fix(spotbugs): Resolve OS_OPEN_STREAM stream handling

### DIFF
--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
@@ -481,90 +481,95 @@ public class SplitFileInserterStorage {
     this.random = runtime.random;
     this.raf = params.raf;
     rafLength = params.raf.size();
-    InputStream ois = new RAFInputStream(this.raf, 0, rafLength);
-    DataInputStream dis = new DataInputStream(ois);
-    validateMagic(dis.readLong());
-    int checksumType = dis.readInt();
-    this.checker = createChecksumChecker(checksumType);
-
     long maxLength = Long.MAX_VALUE;
+    try (InputStream ois = new RAFInputStream(this.raf, 0, rafLength);
+        DataInputStream header = new DataInputStream(ois)) {
+      validateMagic(header.readLong());
+      int checksumType = header.readInt();
+      this.checker = createChecksumChecker(checksumType);
 
-    InputStream is = checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
-    dis = new DataInputStream(is);
-    validateVersion(dis.readInt());
-    LockableRandomAccessBuffer rafOrig =
-        BucketTools.restoreRAFFrom(
-            dis, params.persistentFG, params.persistentFileTracker, params.masterKey);
-    LockableRandomAccessBuffer resumeOriginalData = params.originalData;
-    this.originalData = chooseOriginalData(resumeOriginalData, rafOrig);
-    this.totalDataBlocks = readPositiveInt(dis, "total data blocks");
-    this.totalCheckBlocks = readPositiveInt(dis, "total check blocks");
-    this.splitfileType = readSplitfileAlgorithm(dis);
-    this.codec = getCodecFor(splitfileType);
-    this.dataLength = readPositiveLong(dis, "data length");
-    validateDataLengthMatches(dataLength, resumeOriginalData);
-    validateBlockCountCompatibility(dataLength, totalDataBlocks);
-    decompressedLength = readPositiveLong(dis, "decompressed length");
-    isMetadata = dis.readBoolean();
-    archiveType = readArchiveType(dis.readShort());
-    clientMetadata = readClientMetadata(dis);
-    compressionCodec = readCompressionCodec(dis);
-    int segmentCount = readPositiveInt(dis, "segment count");
-    this.segmentSize = readPositiveInt(dis, "segment size");
-    // Allow zero for NON_REDUNDANT splitfiles (codec == null), where no check blocks exist.
-    this.checkSegmentSize = readCheckSegmentSize(dis);
-    int ccb = dis.readInt();
-    if (ccb < 0) throw new StorageFormatException("Bad cross-check block count");
-    this.crossCheckBlocks = ccb;
-    validateSegmentTotals(segmentSize, checkSegmentSize, crossCheckBlocks);
-    this.splitfileCryptoAlgorithm = dis.readByte();
-    validateCryptoAlgorithm(splitfileCryptoAlgorithm);
-    splitfileCryptoKey = readOptionalCryptoKey(dis);
-    this.keyLength = dis.readInt();
-    validateKeyLength(keyLength);
-    this.cmode = readCompatibilityModeChecked(dis);
-    this.deductBlocksFromSegments = dis.readInt();
-    validateDeductBlocksRange(deductBlocksFromSegments, segmentCount);
-    this.maxRetries = dis.readInt();
-    validateMaxRetries(maxRetries);
-    this.consecutiveRNFsCountAsSuccess = dis.readInt();
-    if (consecutiveRNFsCountAsSuccess < 0)
-      throw new StorageFormatException("Bad consecutiveRNFsCountAsSuccess");
-    specifySplitfileKeyInMetadata = dis.readBoolean();
-    hashThisLayerOnly = readOptionalHashThisLayerOnly(dis);
-    topDontCompress = dis.readBoolean();
-    topRequiredBlocks = dis.readInt();
-    topTotalBlocks = dis.readInt();
-    origDataSize = dis.readLong();
-    origCompressedDataSize = dis.readLong();
-    hashes = HashResult.readHashes(dis);
-    dis.close();
-    this.hasPaddedLastBlock = (dataLength % CHKBlock.DATA_LENGTH != 0);
-    this.segments = new SplitFileInserterSegmentStorage[segmentCount];
-    randomSegmentIterator = new RandomArrayIterator<>(segments);
-    this.crossSegments = initCrossSegmentsArrayIfAny(segmentCount);
-    // Read offsets.
-    is = checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
-    dis = new DataInputStream(is);
-    OffsetsData od = readOffsets(dis, rafLength, segmentCount);
-    dis.close();
-    offsetPaddedLastBlock = od.offsetPaddedLastBlock;
-    offsetOverallStatus = od.offsetOverallStatus;
-    overallStatusLength = od.overallStatusLength;
-    offsetCrossSegmentBlocks = od.arrays.offsetCrossSegmentBlocks;
-    offsetSegmentCheckBlocks = od.arrays.offsetSegmentCheckBlocks;
-    offsetSegmentStatus = od.arrays.offsetSegmentStatus;
-    offsetCrossSegmentStatus = od.arrays.offsetCrossSegmentStatus;
-    offsetSegmentKeys = od.arrays.offsetSegmentKeys;
-    // Set up segments...
-    underlyingOffsetDataSegments = new long[segmentCount];
-    is = checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
-    long blocks = initSegmentsAndComputeBlocks(is, segmentCount, runtime.keysFetching);
-    if (blocks != totalDataBlocks)
-      throw new StorageFormatException(
-          "Total data blocks should be " + totalDataBlocks + " but is " + blocks);
-    readCrossSegmentsFromDisk(ois, maxLength);
-    ois.close();
+      int segmentCount;
+      try (InputStream is =
+              checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
+          DataInputStream dis = new DataInputStream(is)) {
+        validateVersion(dis.readInt());
+        LockableRandomAccessBuffer rafOrig =
+            BucketTools.restoreRAFFrom(
+                dis, params.persistentFG, params.persistentFileTracker, params.masterKey);
+        LockableRandomAccessBuffer resumeOriginalData = params.originalData;
+        this.originalData = chooseOriginalData(resumeOriginalData, rafOrig);
+        this.totalDataBlocks = readPositiveInt(dis, "total data blocks");
+        this.totalCheckBlocks = readPositiveInt(dis, "total check blocks");
+        this.splitfileType = readSplitfileAlgorithm(dis);
+        this.codec = getCodecFor(splitfileType);
+        this.dataLength = readPositiveLong(dis, "data length");
+        validateDataLengthMatches(dataLength, resumeOriginalData);
+        validateBlockCountCompatibility(dataLength, totalDataBlocks);
+        decompressedLength = readPositiveLong(dis, "decompressed length");
+        isMetadata = dis.readBoolean();
+        archiveType = readArchiveType(dis.readShort());
+        clientMetadata = readClientMetadata(dis);
+        compressionCodec = readCompressionCodec(dis);
+        segmentCount = readPositiveInt(dis, "segment count");
+        this.segmentSize = readPositiveInt(dis, "segment size");
+        // Allow zero for NON_REDUNDANT splitfiles (codec == null), where no check blocks exist.
+        this.checkSegmentSize = readCheckSegmentSize(dis);
+        int ccb = dis.readInt();
+        if (ccb < 0) throw new StorageFormatException("Bad cross-check block count");
+        this.crossCheckBlocks = ccb;
+        validateSegmentTotals(segmentSize, checkSegmentSize, crossCheckBlocks);
+        this.splitfileCryptoAlgorithm = dis.readByte();
+        validateCryptoAlgorithm(splitfileCryptoAlgorithm);
+        splitfileCryptoKey = readOptionalCryptoKey(dis);
+        this.keyLength = dis.readInt();
+        validateKeyLength(keyLength);
+        this.cmode = readCompatibilityModeChecked(dis);
+        this.deductBlocksFromSegments = dis.readInt();
+        validateDeductBlocksRange(deductBlocksFromSegments, segmentCount);
+        this.maxRetries = dis.readInt();
+        validateMaxRetries(maxRetries);
+        this.consecutiveRNFsCountAsSuccess = dis.readInt();
+        if (consecutiveRNFsCountAsSuccess < 0)
+          throw new StorageFormatException("Bad consecutiveRNFsCountAsSuccess");
+        specifySplitfileKeyInMetadata = dis.readBoolean();
+        hashThisLayerOnly = readOptionalHashThisLayerOnly(dis);
+        topDontCompress = dis.readBoolean();
+        topRequiredBlocks = dis.readInt();
+        topTotalBlocks = dis.readInt();
+        origDataSize = dis.readLong();
+        origCompressedDataSize = dis.readLong();
+        hashes = HashResult.readHashes(dis);
+      }
+      this.hasPaddedLastBlock = (dataLength % CHKBlock.DATA_LENGTH != 0);
+      this.segments = new SplitFileInserterSegmentStorage[segmentCount];
+      randomSegmentIterator = new RandomArrayIterator<>(segments);
+      this.crossSegments = initCrossSegmentsArrayIfAny(segmentCount);
+      // Read offsets.
+      OffsetsData od;
+      try (InputStream is =
+              checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
+          DataInputStream dis = new DataInputStream(is)) {
+        od = readOffsets(dis, rafLength, segmentCount);
+      }
+      offsetPaddedLastBlock = od.offsetPaddedLastBlock;
+      offsetOverallStatus = od.offsetOverallStatus;
+      overallStatusLength = od.overallStatusLength;
+      offsetCrossSegmentBlocks = od.arrays.offsetCrossSegmentBlocks;
+      offsetSegmentCheckBlocks = od.arrays.offsetSegmentCheckBlocks;
+      offsetSegmentStatus = od.arrays.offsetSegmentStatus;
+      offsetCrossSegmentStatus = od.arrays.offsetCrossSegmentStatus;
+      offsetSegmentKeys = od.arrays.offsetSegmentKeys;
+      // Set up segments...
+      underlyingOffsetDataSegments = new long[segmentCount];
+      try (InputStream is =
+          checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength)) {
+        long blocks = initSegmentsAndComputeBlocks(is, segmentCount, runtime.keysFetching);
+        if (blocks != totalDataBlocks)
+          throw new StorageFormatException(
+              "Total data blocks should be " + totalDataBlocks + " but is " + blocks);
+      }
+      readCrossSegmentsFromDisk(ois, maxLength);
+    }
     errors = readStatusesFromDisk(maxLength);
     computeStatus();
 

--- a/src/main/java/network/crypta/support/compress/Bzip2Compressor.java
+++ b/src/main/java/network/crypta/support/compress/Bzip2Compressor.java
@@ -2,6 +2,7 @@ package network.crypta.support.compress;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -139,7 +140,7 @@ public class Bzip2Compressor extends AbstractCompressor {
   /**
    * Decompresses BZip2 data from {@link InputStream} to {@link OutputStream}.
    *
-   * <p>The method enforces {@code maxLength}. If the next read would exceed that limit, and {@code
+   * <p>The method enforces {@code maxLength}. If the next read exceeds that limit, and {@code
    * maxCheckSizeBytes} is positive, it continues reading up to {@code maxLength +
    * maxCheckSizeBytes} to compute an estimated uncompressed size and then throws {@link
    * CompressionOutputSizeException} populated with that estimate. If {@code maxCheckSizeBytes} is
@@ -148,8 +149,8 @@ public class Bzip2Compressor extends AbstractCompressor {
    * @param is source stream containing BZip2 data (without the {@code "BZ"} header)
    * @param os destination stream for uncompressed bytes
    * @param maxLength maximum number of bytes allowed to be written to {@code os}
-   * @param maxCheckSizeBytes additional number of bytes to read when the limit is exceeded in order
-   *     to estimate the total uncompressed size; non-positive disables estimation
+   * @param maxCheckSizeBytes additional number of bytes to read when the limit is exceeded to
+   *     estimate the total uncompressed size; non-positive disables estimation
    * @return number of bytes written to {@code os}
    * @throws IOException on I/O errors or if the source returns a zero-length read
    * @throws CompressionOutputSizeException if the uncompressed output would exceed {@code
@@ -158,44 +159,46 @@ public class Bzip2Compressor extends AbstractCompressor {
   @Override
   public long decompress(InputStream is, OutputStream os, long maxLength, long maxCheckSizeBytes)
       throws IOException {
-    BZip2CompressorInputStream bz2is =
-        new BZip2CompressorInputStream(HeaderStreams.augInput(BZ_HEADER, is));
-    long written = 0;
-    int bufSize = 32768;
-    if (maxLength > 0 && maxLength < bufSize) bufSize = (int) maxLength;
-    byte[] buffer = new byte[bufSize];
-    // Read in a loop, enforcing the maximum on every iteration. We intentionally allow
-    // over-reading by asking for a full buffer and then detecting overflow; this keeps the logic
-    // simple while still bounding output via explicit checks.
-    while (true) {
-      int expectedBytesRead = (int) Math.min(buffer.length, maxLength - written);
-      // Over-read is intentional here to detect when the next chunk would exceed the configured
-      // maximum. We then either estimate the full size (if requested) or fail immediately.
-      int bytesRead = bz2is.read(buffer, 0, buffer.length);
-      if (expectedBytesRead < bytesRead) {
-        LOG.info(
-            "expectedBytesRead={}, bytesRead={}, written={}, maxLength={} throwing a"
-                + " CompressionOutputSizeException",
-            expectedBytesRead,
-            bytesRead,
-            written,
-            maxLength);
-        if (maxCheckSizeBytes > 0) {
-          consumeAndThrowWithEstimate(
-              bz2is, buffer, maxLength, maxCheckSizeBytes, written, bytesRead);
+    try (BZip2CompressorInputStream bz2is =
+        new BZip2CompressorInputStream(
+            HeaderStreams.augInput(BZ_HEADER, new NonClosingInputStream(is)))) {
+      long written = 0;
+      int bufSize = 32768;
+      if (maxLength > 0 && maxLength < bufSize) bufSize = (int) maxLength;
+      byte[] buffer = new byte[bufSize];
+      // Read in a loop, enforcing the maximum on every iteration. We intentionally allow
+      // over-reading by asking for a full buffer and then detecting overflow; this keeps the logic
+      // simple while still bounding output via explicit checks.
+      while (true) {
+        int expectedBytesRead = (int) Math.min(buffer.length, maxLength - written);
+        // Over-read is intentional here to detect when the next chunk would exceed the configured
+        // maximum. We then either estimate the full size (if requested) or fail immediately.
+        int bytesRead = bz2is.read(buffer, 0, buffer.length);
+        if (expectedBytesRead < bytesRead) {
+          LOG.info(
+              "expectedBytesRead={}, bytesRead={}, written={}, maxLength={} throwing a"
+                  + " CompressionOutputSizeException",
+              expectedBytesRead,
+              bytesRead,
+              written,
+              maxLength);
+          if (maxCheckSizeBytes > 0) {
+            consumeAndThrowWithEstimate(
+                bz2is, buffer, maxLength, maxCheckSizeBytes, written, bytesRead);
+          }
+          throw new CompressionOutputSizeException();
         }
-        throw new CompressionOutputSizeException();
+        if (bytesRead <= -1) return written;
+        if (bytesRead == 0) throw new IOException("Returned zero from read()");
+        os.write(buffer, 0, bytesRead);
+        written += bytesRead;
       }
-      if (bytesRead <= -1) return written;
-      if (bytesRead == 0) throw new IOException("Returned zero from read()");
-      os.write(buffer, 0, bytesRead);
-      written += bytesRead;
     }
   }
 
   /**
-   * Continues reading until EOF in order to compute an estimated uncompressed size, then throws a
-   * {@link CompressionOutputSizeException} with that estimate.
+   * Continues reading until EOF to compute an estimated uncompressed size, then throws a {@link
+   * CompressionOutputSizeException} with that estimate.
    *
    * <p>This is only invoked when the uncompressed output has already exceeded {@code maxLength} and
    * the caller requested an estimate via {@code maxCheckSizeBytes}.
@@ -266,5 +269,17 @@ public class Bzip2Compressor extends AbstractCompressor {
     byte[] buf = baos.toByteArray();
     System.arraycopy(buf, 0, output, 0, bytes);
     return bytes;
+  }
+
+  @SuppressWarnings("java:S4929")
+  private static final class NonClosingInputStream extends FilterInputStream {
+    NonClosingInputStream(InputStream in) {
+      super(in);
+    }
+
+    @Override
+    public void close() {
+      // Keep ownership of the caller-provided stream with the caller.
+    }
   }
 }

--- a/src/main/kotlin/network/crypta/launcher/LauncherController.kt
+++ b/src/main/kotlin/network/crypta/launcher/LauncherController.kt
@@ -241,17 +241,18 @@ class LauncherController(
 
   private suspend fun readProcessOutput(p: Process) {
     withContext(io) {
-      val br = BufferedReader(InputStreamReader(p.inputStream, StandardCharsets.UTF_8))
-      var line: String?
-      while (br.readLine().also { line = it } != null) {
-        val s = line!!
-        logLine(s)
-        parseFProxyPortFromLine(s)?.let { port ->
-          val old = _state.value.knownPort
-          if (old != port) updateState { it.copy(knownPort = port) }
-          if (!autoOpenedBrowser) {
-            autoOpenedBrowser = true
-            launchBrowser()
+      BufferedReader(InputStreamReader(p.inputStream, StandardCharsets.UTF_8)).use { br ->
+        var line: String?
+        while (br.readLine().also { line = it } != null) {
+          val s = line!!
+          logLine(s)
+          parseFProxyPortFromLine(s)?.let { port ->
+            val old = _state.value.knownPort
+            if (old != port) updateState { it.copy(knownPort = port) }
+            if (!autoOpenedBrowser) {
+              autoOpenedBrowser = true
+              launchBrowser()
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- Close resume-time stream chains in `SplitFileInserterStorage` with try-with-resources so constructor failures do not leak open streams.
- Close launcher process output readers in `LauncherController` with Kotlin `use` to avoid leaking `BufferedReader` instances.
- Wrap BZip2 decompression input with an intentional non-closing wrapper and keep the local Sonar suppression (`java:S4929`) for that wrapper.

## How to test
- `./gradlew spotlessApply`
- `./gradlew compileJava`
- `./gradlew spotbugsMain`
- Verify `build/reports/spotbugs/spotbugsMain.xml` contains 0 `OS_OPEN_STREAM` findings.