### PR TITLE
fix(spotbugs): Resolve inconsistent synchronization warnings

### DIFF
--- a/src/main/java/network/crypta/client/FailureCodeTracker.java
+++ b/src/main/java/network/crypta/client/FailureCodeTracker.java
@@ -291,15 +291,23 @@ public class FailureCodeTracker implements Serializable {
    *     {@code null}
    * @return this tracker for call chaining
    */
-  public synchronized FailureCodeTracker merge(FailureCodeTracker source) {
-    if (source.map == null) return this;
-    if (map == null) map = new HashMap<>();
-    for (Map.Entry<Integer, Integer> e : source.map.entrySet()) {
-      Integer k = e.getKey();
-      Integer item = e.getValue();
-      inc(k, item);
+  public FailureCodeTracker merge(FailureCodeTracker source) {
+    if (source == null) return this;
+    Map<Integer, Integer> sourceMapSnapshot = source.snapshotMap();
+    if (sourceMapSnapshot.isEmpty()) return this;
+    synchronized (this) {
+      for (Map.Entry<Integer, Integer> e : sourceMapSnapshot.entrySet()) {
+        Integer k = e.getKey();
+        Integer item = e.getValue();
+        inc(k, item);
+      }
+      return this;
     }
-    return this;
+  }
+
+  private synchronized Map<Integer, Integer> snapshotMap() {
+    if (map == null) return Map.of();
+    return new HashMap<>(map);
   }
 
   /**

--- a/src/main/java/network/crypta/client/InsertBlock.java
+++ b/src/main/java/network/crypta/client/InsertBlock.java
@@ -17,11 +17,10 @@ import org.jetbrains.annotations.Nullable;
  * invoking {@link #free()} or by transferring ownership via {@link #nullData()} when the bucket
  * becomes managed elsewhere.
  *
- * <p>Concurrency: {@link #free()} is idempotent and synchronized to avoid double-free. The actual
+ * <p>Concurrency: state transitions that affect ownership ({@link #getData()}, {@link #nullData()},
+ * and the synchronized portion of {@link #free()}) are serialized on {@code this}. The actual
  * {@code RandomAccessBucket#free()} call occurs outside the monitor to prevent blocking other
- * threads on potentially slow I/O. Reads such as {@link #getData()} are not synchronized and may
- * race with {@link #free()}; callers should not retain a reference to the bucket if they plan to
- * free it concurrently.
+ * threads on potentially slow I/O.
  *
  * <ul>
  *   <li>Mutability: fields are mutable and can be nulled to denote transfer of ownership.
@@ -55,8 +54,9 @@ public class InsertBlock implements Serializable {
   @Nullable public FreenetURI desiredURI;
 
   /**
-   * Optional metadata supplied by the client to accompany the insert. This object may carry content
-   * type or other advisory attributes; it is not interpreted by this class. May be {@code null}.
+   * Optional metadata supplied by the client to accompany the insert. This object may carry a
+   * content type or other advisory attributes; it is not interpreted by this class. May be {@code
+   * null}.
    */
   @Nullable public ClientMetadata clientMetadata;
 
@@ -94,15 +94,15 @@ public class InsertBlock implements Serializable {
    * @return the current {@link RandomAccessBucket} if not yet freed or disowned; otherwise {@code
    *     null}. The caller does not acquire ownership and should not free it here.
    */
-  public RandomAccessBucket getData() {
+  public synchronized RandomAccessBucket getData() {
     return (isFreed ? null : data);
   }
 
   /**
    * Releases the owned payload bucket, if any, and marks this block as freed.
    *
-   * <p>This operation is safe to call multiple times; subsequent invocations are no-ops. The method
-   * synchronizes only during state transition and obtains a local reference, then performs the
+   * <p>This operation is safe to call multiple times; further invocations are no-ops. The method
+   * synchronizes only during state transition and gets a local reference, then performs the
    * potentially slow {@link RandomAccessBucket#free()} call outside the monitor to avoid blocking
    * contending threads. After completion, {@link #getData()} will return {@code null}.
    */
@@ -113,6 +113,7 @@ public class InsertBlock implements Serializable {
       isFreed = true;
       if (data == null) return;
       toFree = data;
+      data = null;
     }
     // Call outside synchronized block to avoid holding the monitor during external I/O.
     toFree.free();
@@ -125,7 +126,7 @@ public class InsertBlock implements Serializable {
    * the recipient will manage its lifecycle. After calling, {@link #getData()} returns {@code null}
    * and invoking {@link #free()} will not release the previously attached bucket.
    */
-  public void nullData() {
+  public synchronized void nullData() {
     data = null;
   }
 

--- a/src/main/java/network/crypta/client/Metadata.java
+++ b/src/main/java/network/crypta/client/Metadata.java
@@ -735,7 +735,7 @@ public class Metadata implements Serializable {
   int crossCheckBlocks;
 
   /** Per‑segment key lists; may be {@code null} until built. */
-  SplitFileSegmentKeys[] segments;
+  volatile SplitFileSegmentKeys[] segments;
 
   /** Minimum compatibility mode inferred for this metadata. */
   CompatibilityMode minCompatMode = CompatibilityMode.COMPAT_UNKNOWN;

--- a/src/main/java/network/crypta/client/Metadata.java
+++ b/src/main/java/network/crypta/client/Metadata.java
@@ -734,8 +734,8 @@ public class Metadata implements Serializable {
   /** Number of cross‑segment parity blocks per segment (0 when not used). */
   int crossCheckBlocks;
 
-  /** Per‑segment key lists; may be {@code null} until built. */
-  volatile SplitFileSegmentKeys[] segments;
+  /** Per-segment key lists; may be {@code null} until built. */
+  SplitFileSegmentKeys[] segments;
 
   /** Minimum compatibility mode inferred for this metadata. */
   CompatibilityMode minCompatMode = CompatibilityMode.COMPAT_UNKNOWN;
@@ -890,8 +890,8 @@ public class Metadata implements Serializable {
    *     version, or otherwise fails structural validation.
    */
   public static Metadata construct(byte[] data) throws MetadataParseException {
-    try {
-      return new Metadata(data);
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data))) {
+      return new Metadata(dis, data.length);
     } catch (IOException e) {
       throw (MetadataParseException) new MetadataParseException("Caught " + e).initCause(e);
     }
@@ -916,18 +916,6 @@ public class Metadata implements Serializable {
       m = new Metadata(dis, data.size());
     }
     return m;
-  }
-
-  /**
-   * Parse some metadata from a byte[].
-   *
-   * @throws IOException if the data is incomplete or an I/O error occurs while reading from the
-   *     in‑memory stream.
-   * @throws MetadataParseException if the serialized bytes are malformed or unsupported for the
-   *     current parser version.
-   */
-  private Metadata(byte[] data) throws IOException, MetadataParseException {
-    this(new DataInputStream(new ByteArrayInputStream(data)), data.length);
   }
 
   @Override
@@ -1999,9 +1987,10 @@ public class Metadata implements Serializable {
   }
 
   private void writeSplitfileKeys(DataOutputStream dos) throws IOException {
-    if (segments != null) {
-      for (int i = 0; i < segmentCount; i++) segments[i].writeKeys(dos, false);
-      for (int i = 0; i < segmentCount; i++) segments[i].writeKeys(dos, true);
+    SplitFileSegmentKeys[] localSegments = segments;
+    if (localSegments != null) {
+      for (int i = 0; i < segmentCount; i++) localSegments[i].writeKeys(dos, false);
+      for (int i = 0; i < segmentCount; i++) localSegments[i].writeKeys(dos, true);
       return;
     }
     if (splitfileSingleCryptoKey == null) {
@@ -2646,13 +2635,13 @@ public class Metadata implements Serializable {
   @SuppressWarnings("unused")
   public SplitFileSegmentKeys[] grabSegmentKeys() throws FetchException {
     synchronized (this) {
-      if (segments == null && splitfileDataKeys != null && splitfileCheckKeys != null)
+      SplitFileSegmentKeys[] localSegments = segments;
+      if (localSegments == null && splitfileDataKeys != null && splitfileCheckKeys != null)
         throw new FetchException(
             FetchExceptionMode.INTERNAL_ERROR,
             "Please restart the download, need to re-parse metadata due to internal changes");
-      SplitFileSegmentKeys[] segs = segments;
       segments = null;
-      return segs;
+      return localSegments;
     }
   }
 
@@ -2665,11 +2654,12 @@ public class Metadata implements Serializable {
    */
   public SplitFileSegmentKeys[] getSegmentKeys() throws FetchException {
     synchronized (this) {
-      if (segments == null && splitfileDataKeys != null && splitfileCheckKeys != null)
+      SplitFileSegmentKeys[] localSegments = segments;
+      if (localSegments == null && splitfileDataKeys != null && splitfileCheckKeys != null)
         throw new FetchException(
             FetchExceptionMode.INTERNAL_ERROR,
             "Please restart the download, need to re-parse metadata due to internal changes");
-      return segments;
+      return localSegments;
     }
   }
 

--- a/src/main/java/network/crypta/client/async/BaseManifestPutter.java
+++ b/src/main/java/network/crypta/client/async/BaseManifestPutter.java
@@ -661,7 +661,7 @@ public abstract class BaseManifestPutter extends ManifestPutter {
     @Override
     public boolean isFinished() {
       if (LOG.isDebugEnabled()) LOG.debug("Finished {}", this);
-      return BaseManifestPutter.this.finished || cancelled || BaseManifestPutter.this.cancelled;
+      return BaseManifestPutter.this.isFinished() || cancelled;
     }
 
     @Override
@@ -942,7 +942,11 @@ public abstract class BaseManifestPutter extends ManifestPutter {
     public void innerOnResume(ClientContext context) throws ResumeFailedException {
       super.innerOnResume(context);
       try {
-        if (currentState != null) currentState.onResume(context);
+        ClientPutState currentStateSnapshot;
+        synchronized (this) {
+          currentStateSnapshot = currentState;
+        }
+        if (currentStateSnapshot != null) currentStateSnapshot.onResume(context);
         if (origSFI != null) origSFI.onResume(context);
       } catch (InsertException e) {
         throw new ResumeFailedException(e);
@@ -1773,7 +1777,7 @@ public abstract class BaseManifestPutter extends ManifestPutter {
         addRedirect(name, element.targetURI, cm, isDefaultDoc);
         return;
       }
-      throw new IllegalStateException("ME is neither a redirect nor dircet data. " + element);
+      throw new IllegalStateException("ME is neither a redirect nor direct data. " + element);
     }
 
     /**
@@ -1902,11 +1906,12 @@ public abstract class BaseManifestPutter extends ManifestPutter {
         throw new IllegalStateException("You can not add containers in free form mode!");
       }
       /*
-       * Tree containing the status of the insert. Can have ManifestElement's (original files to
-       * insert or bundle inside a container), HashMap's (more subdirs), Metadata (to be put into a
-       * container as metadata for e.g., an external file), a ContainerPutHandler or an
-       * ArchivePutHandler (for containers that are part of the structure and external containers
-       * for overflow, respectively).
+       * Tree containing the status of the insert.
+       *
+       * Entries can be ManifestElements (original files to insert or bundle in a container),
+       * HashMaps (subdirectories), Metadata (container metadata, e.g., for an external file),
+       * ContainerPutHandler instances (containers in the structure), or ArchivePutHandler
+       * instances (external overflow containers).
        */
       HashMap<String, Object> rootDirMap = new HashMap<>();
       if (isArchive)

--- a/src/main/java/network/crypta/client/async/BaseSingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/BaseSingleFileFetcher.java
@@ -207,14 +207,20 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     // We want 0, 1, ... maxRetries i.e. maxRetries+1 attempts (maxRetries=0 => try once, no
     // retries, maxRetries=1 = original try + 1 retry)
     int r = ++retryCount;
+    boolean finishedSnapshot;
+    boolean cancelledSnapshot;
+    synchronized (this) {
+      finishedSnapshot = finished;
+      cancelledSnapshot = cancelled;
+    }
     if (LOG.isDebugEnabled())
       LOG.debug(
           "Attempting to retry... (max {}, current {}) on {} finished={} cancelled={}",
           maxRetries,
           r,
           this,
-          finished,
-          cancelled);
+          finishedSnapshot,
+          cancelledSnapshot);
     if (!withinRetryLimit(r)) {
       unregister(context, getPriorityClass());
       return false;

--- a/src/main/java/network/crypta/client/async/BinaryBlobInserter.java
+++ b/src/main/java/network/crypta/client/async/BinaryBlobInserter.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Concurrency: block-level inserts run concurrently via their schedulers; this class maintains
  * thread-safe counters and uses synchronization only for small critical sections (e.g., updating
- * counters and completion state). Instances are single-use: once all blocks complete and a final
+ * counters and completion state). Instances are single-use: once all blocks are complete and an
  * outcome is delivered, the object should not be reused. The class is not intended to be shared
  * across multiple parents.
  *
@@ -116,7 +116,7 @@ public class BinaryBlobInserter implements ClientPutState {
   }
 
   /**
-   * Cancels all outstanding block inserts and reports a cancelled outcome to the parent.
+   * Cancels all outstanding block inserts and reports a canceled outcome to the parent.
    *
    * <p>Any block that has already finished will be ignored. In-flight blocks are asked to cancel,
    * and the parent is notified with an {@link InsertException} of mode {@link
@@ -136,7 +136,7 @@ public class BinaryBlobInserter implements ClientPutState {
   }
 
   /**
-   * Returns the owning parent that receives progress and final outcome notifications.
+   * Returns the owning parent that receives progress and outcome notifications.
    *
    * @return the non-null parent instance; the caller does not gain ownership and must not mutate
    *     its internal state.
@@ -200,7 +200,7 @@ public class BinaryBlobInserter implements ClientPutState {
 
     @Override
     public void onSuccess(SendableRequestItem keyNum, ClientKey key, ClientContext context) {
-      synchronized (this) {
+      synchronized (BinaryBlobInserter.this) {
         if (inserters[blockNum] == null) return;
         inserters[blockNum] = null;
         completedBlocks++;
@@ -276,7 +276,7 @@ public class BinaryBlobInserter implements ClientPutState {
    * <p>When the final block finishes, the method decides between overall success, fatal failure, or
    * too many retries based on internal counters. Success requires that every block succeed, or that
    * the configured consecutive route-not-found threshold be met where applicable. The method is
-   * idempotent within the completion window and ignores subsequent calls once an outcome has been
+   * idempotent within the completion window and ignores later calls once an outcome has been
    * reported.
    *
    * @param context execution context forwarded to the parent callback. The reference is not
@@ -313,7 +313,7 @@ public class BinaryBlobInserter implements ClientPutState {
    * if a pause/resume cycle is desired.
    *
    * @param context execution context required by the interface; ignored by this implementation.
-   * @throws InsertException always thrown to signal that resume is not supported by this type.
+   * @throws InsertException always thrown to signal that this type does not support resume.
    */
   @Override
   public void onResume(ClientContext context) throws InsertException {
@@ -325,8 +325,8 @@ public class BinaryBlobInserter implements ClientPutState {
   /**
    * Notifies the inserter of a system shutdown. This implementation performs no action.
    *
-   * <p>Callers may use this hook to align with framework lifecycles. Any in-flight work is managed
-   * by the schedulers; blocks that complete after shutdown will be ignored once the parent has
+   * <p>Callers may use this hook to align with framework lifecycles. The schedulers manage any
+   * in-flight work; blocks that complete after shutdown will be ignored once the parent has
    * transitioned out of the active state.
    *
    * @param context execution context supplied by the framework; not used.

--- a/src/main/java/network/crypta/client/async/ClientGetter.java
+++ b/src/main/java/network/crypta/client/async/ClientGetter.java
@@ -439,13 +439,19 @@ public class ClientGetter extends BaseClientGetter
 
   private void scheduleIfReady(ClientContext context) {
     // schedule() may deactivate stuff, so store it now.
-    if (currentState != null && !finished) {
+    ClientGetState state;
+    boolean alreadyFinished;
+    synchronized (this) {
+      state = currentState;
+      alreadyFinished = finished;
+    }
+    if (state != null && !alreadyFinished) {
       if (initialMetadata != null
-          && currentState instanceof SingleFileFetcher fetcher
+          && state instanceof SingleFileFetcher fetcher
           && !resumedFetcher) {
         fetcher.startWithMetadata(initialMetadata, context);
       } else {
-        currentState.schedule(context);
+        state.schedule(context);
       }
     }
   }
@@ -629,13 +635,17 @@ public class ClientGetter extends BaseClientGetter
       ClientContext context)
       throws IOException, URISyntaxException {
     FetchResult result = new FetchResult(initialMetadata, finalResult);
+    HashResult[] localHashes;
+    synchronized (this) {
+      localHashes = hashes;
+    }
     try (OutputStream output = finalResult.getOutputStream()) {
       ClientGetWorkerThread worker =
           new ClientGetWorkerThread(
               new BufferedInputStream(processedDataInput),
               output,
               uri,
-              hashes,
+              localHashes,
               new ClientGetWorkerThread.Options(
                   computeMime(initialMetadata),
                   ctx.getSchemeHostAndPort(),
@@ -673,6 +683,11 @@ public class ClientGetter extends BaseClientGetter
   }
 
   private FetchException mapToFetchException(Throwable t) {
+    String localExpectedMIME;
+    long localExpectedSize = expectedSize;
+    synchronized (this) {
+      localExpectedMIME = expectedMIME;
+    }
     if (t == null) {
       LOG.error("Caught null Throwable while mapping to FetchException");
       return new FetchException(FetchExceptionMode.INTERNAL_ERROR);
@@ -681,7 +696,8 @@ public class ClientGetter extends BaseClientGetter
       case UnsafeContentTypeException e -> {
         LOG.info("Error filtering content: will not validate", e);
         return e.createFetchException(
-            ctx.getOverrideMIME() != null ? ctx.getOverrideMIME() : expectedMIME, expectedSize);
+            ctx.getOverrideMIME() != null ? ctx.getOverrideMIME() : localExpectedMIME,
+            localExpectedSize);
       }
       case URISyntaxException e -> {
         LOG.error("URISyntaxException converting a Crypta URI to a URI!: {}", e, e);
@@ -746,6 +762,10 @@ public class ClientGetter extends BaseClientGetter
       File completionFile,
       ClientContext context)
       throws IOException, FetchException, URISyntaxException {
+    HashResult[] localHashes;
+    synchronized (this) {
+      localHashes = hashes;
+    }
     try (RandomAccessFile raf = new RandomAccessFile(tempFile, "rw");
         InputStream is = new BufferedInputStream(new FileInputStream(raf.getFD()))) {
       if (raf.length() < length)
@@ -757,7 +777,7 @@ public class ClientGetter extends BaseClientGetter
               is,
               new NullOutputStream(),
               uri,
-              hashes,
+              localHashes,
               new ClientGetWorkerThread.Options(
                   null,
                   ctx.getSchemeHostAndPort(),
@@ -1044,9 +1064,11 @@ public class ClientGetter extends BaseClientGetter
    *     {@code false}
    */
   public boolean canRestart() {
-    if (currentState != null && !finished) {
-      if (LOG.isDebugEnabled()) LOG.debug("Cannot restart because not finished for {}", uri);
-      return false;
+    synchronized (this) {
+      if (currentState != null && !finished) {
+        if (LOG.isDebugEnabled()) LOG.debug("Cannot restart because not finished for {}", uri);
+        return false;
+      }
     }
     return true;
   }
@@ -1422,11 +1444,17 @@ public class ClientGetter extends BaseClientGetter
   @Override
   public void innerOnResume(ClientContext context) throws ResumeFailedException {
     super.innerOnResume(context);
-    if (currentState != null)
+    ClientGetState state;
+    synchronized (this) {
+      state = currentState;
+    }
+    if (state != null)
       try {
-        currentState.onResume(context);
+        state.onResume(context);
       } catch (FetchException e) {
-        currentState = null;
+        synchronized (this) {
+          if (currentState == state) currentState = null;
+        }
         throw new ResumeFailedException(e);
       } catch (RuntimeException e) {
         // Severe serialization problems, lost a class silently etc.
@@ -1494,8 +1522,11 @@ public class ClientGetter extends BaseClientGetter
       throws IOException {
     if (dis.readBoolean()) {
       try {
-        currentState = new SplitFileFetcher(this, dis, context);
-        resumedFetcher = true;
+        SplitFileFetcher restored = new SplitFileFetcher(this, dis, context);
+        synchronized (this) {
+          currentState = restored;
+          resumedFetcher = true;
+        }
         return true;
       } catch (StorageFormatException | ResumeFailedException | IOException e) {
         LOG.error(RESTORE_FROM_SPLITFILE_FAILED_MSG, e, e);

--- a/src/main/java/network/crypta/client/async/ClientPutter.java
+++ b/src/main/java/network/crypta/client/async/ClientPutter.java
@@ -299,7 +299,10 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
   }
 
   private void scheduleCurrentState(ClientContext context) throws InsertException {
-    ClientPutState state = currentState != null ? currentState : transientState;
+    ClientPutState state;
+    synchronized (this) {
+      state = currentState != null ? currentState : transientState;
+    }
     if (state == null) {
       throw new InsertException(
           InsertExceptionMode.INTERNAL_ERROR, "No active insert state to schedule", null);
@@ -437,15 +440,17 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
    */
   @Override
   public void onSuccess(ClientPutState state, ClientContext context) {
+    FreenetURI finalURI;
     synchronized (this) {
       finished = true;
       currentState = null;
       transientState = null;
+      finalURI = uri;
     }
     if ((super.failedBlocks > 0
             || super.fatallyFailedBlocks > 0
             || super.successfulBlocks < super.totalBlocks)
-        && !uri.isUSK()
+        && !finalURI.isUSK()
         && !ctx.isGetCHKOnly())
       // USK auxiliary inserts are allowed to fail.
       // If only generating the key, the splitfile may not have reported the blocks as inserted.
@@ -585,8 +590,8 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
    *     produced the top-level key; includes a filename segment when applicable.
    */
   @Override
-  public FreenetURI getURI() {
-    return uri;
+  public synchronized FreenetURI getURI() {
+    return this.uri;
   }
 
   /**
@@ -607,6 +612,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
   public void onTransition(
       ClientPutState oldState, ClientPutState newState, ClientContext context) {
     if (newState == null) throw new NullPointerException();
+    ClientPutState activeStateForLog;
 
     synchronized (this) {
       if (currentState == oldState) {
@@ -617,10 +623,10 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
         transientState = newState;
         return;
       }
+      activeStateForLog = currentState != null ? currentState : transientState;
     }
     if (persistent()) context.jobRunner.setCheckpointASAP();
-    ClientPutState activeState = currentState != null ? currentState : transientState;
-    LOG.info("onTransition: cur={}, old={}, new={}", activeState, oldState, newState);
+    LOG.info("onTransition: cur={}, old={}, new={}", activeStateForLog, oldState, newState);
   }
 
   /**
@@ -739,9 +745,16 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
    *     false} otherwise.
    */
   public boolean canRestart() {
-    ClientPutState activeState = currentState != null ? currentState : transientState;
-    if (activeState != null && !finished) {
-      LOG.debug("Cannot restart because not finished for {}", uri);
+    ClientPutState activeState;
+    boolean alreadyFinished;
+    FreenetURI currentURI;
+    synchronized (this) {
+      activeState = currentState != null ? currentState : transientState;
+      alreadyFinished = finished;
+      currentURI = uri;
+    }
+    if (activeState != null && !alreadyFinished) {
+      LOG.debug("Cannot restart because not finished for {}", currentURI);
       return false;
     }
     return data != null;
@@ -771,9 +784,15 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
 
   @Override
   public void dump() {
-    LOG.info("URI: {}", uri);
+    FreenetURI currentURI;
+    boolean done;
+    synchronized (this) {
+      currentURI = uri;
+      done = finished;
+    }
+    LOG.info("URI: {}", currentURI);
     LOG.info("Client: {}", callback);
-    LOG.info("Finished: {}", finished);
+    LOG.info("Finished: {}", done);
     LOG.info("Data: {}", data);
   }
 
@@ -805,9 +824,13 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
         return;
       }
     }
-    if (currentState != null) {
+    ClientPutState activeState;
+    synchronized (this) {
+      activeState = currentState;
+    }
+    if (activeState != null) {
       try {
-        currentState.onResume(context);
+        activeState.onResume(context);
       } catch (InsertException e) {
         this.onFailure(e, null, context);
         return;

--- a/src/main/java/network/crypta/client/async/ClientRequester.java
+++ b/src/main/java/network/crypta/client/async/ClientRequester.java
@@ -74,7 +74,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
       ClientGetState oldState, ClientGetState newState, ClientContext context);
 
   /** Priority class of the request or insert. */
-  protected short priorityClass;
+  protected volatile short priorityClass;
 
   /** Whether this is a real-time request */
   protected final boolean realTimeFlag;
@@ -230,7 +230,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
    * #getLatestSuccess()} for the precise semantics and defaulting behavior that keeps the user
    * interface sortable even before any blocks complete.
    */
-  protected Instant latestSuccess = Instant.now();
+  protected volatile Instant latestSuccess = Instant.now();
 
   /** Number of blocks which have failed. */
   protected volatile int failedBlocks;
@@ -239,7 +239,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
   protected volatile int fatallyFailedBlocks;
 
   /** Timestamp of the most recent failed or fatally failed block, if any. */
-  protected Instant latestFailure = null;
+  protected volatile Instant latestFailure = null;
 
   /** Minimum number of blocks required to succeed for success. */
   protected volatile int minSuccessBlocks;

--- a/src/main/java/network/crypta/client/async/CooldownBlockChooser.java
+++ b/src/main/java/network/crypta/client/async/CooldownBlockChooser.java
@@ -6,12 +6,12 @@ import java.util.Random;
  * A {@link SimpleBlockChooser} variant that introduces per-block cooldown windows after repeated
  * non‑fatal failures.
  *
- * <p>This chooser behaves like the base implementation for tracking completion and retry counts,
- * but augments selection with a configurable cooldown policy. After a block accumulates a defined
+ * <p>This chooser behaves like the base implementation for tracking completion and retry counts but
+ * augments selection with a configurable cooldown policy. After a block accumulates a defined
  * number of consecutive non‑fatal failures, it becomes temporarily ineligible for selection. The
  * goal is to avoid continuously hammering problematic blocks while allowing other work to proceed
  * and potentially change the network or cache state. Cooldowns are tracked per block, while a
- * cached "overall" wake‑up time exposes when any block may next become eligible again.
+ * cached "overall" wakeup time exposes when any block may next become eligible again.
  *
  * <p>Instances are stateful and use synchronized methods; individual operations are thread‑safe
  * with respect to a single instance. The supplied {@link Random} is used only to break ties among
@@ -56,9 +56,7 @@ public class CooldownBlockChooser extends SimpleBlockChooser {
     blockCooldownTimes = new long[blocks];
   }
 
-  /**
-   * Every cooldownTries attempts, a key will enter cooldown, and won't be re-tried for a period.
-   */
+  /** Every cooldownTries attempts, a key will enter cooldown and won't be re-tried for a period. */
   private final int cooldownTries;
 
   /** Cooldown lasts this long for each key. */
@@ -102,7 +100,7 @@ public class CooldownBlockChooser extends SimpleBlockChooser {
   }
 
   @Override
-  protected boolean checkValid(int blockNo) {
+  protected synchronized boolean checkValid(int blockNo) {
     if (!super.checkValid(blockNo)) return false;
     long wakeUp = blockCooldownTimes[blockNo];
     // Consider cooldown ending exactly at 'now' as expired to avoid edge races
@@ -154,10 +152,10 @@ public class CooldownBlockChooser extends SimpleBlockChooser {
    * Marks a block as no longer successful and clears any associated cooldown.
    *
    * <p>This override resets the per‑block cooldown timer for {@code blockNo} and clears the cached
-   * overall cooldown gate so that subsequent calls to {@link #chooseKey()} consider eligibility
+   * overall cooldown gate so that further calls to {@link #chooseKey()} consider eligibility
    * immediately. Callers use this when previously downloaded data becomes unusable (for example,
-   * after validation failure or corruption) and the block needs to be retried without an artificial
-   * delay.
+   * after validation failure or corruption), and the block needs to be retried without an
+   * artificial delay.
    *
    * @param blockNo zero‑based index of the block to mark as not successful; must be within range
    *     and refer to a block tracked by this chooser.
@@ -171,13 +169,14 @@ public class CooldownBlockChooser extends SimpleBlockChooser {
   /**
    * Returns the earliest time at which any block may next be eligible for selection.
    *
-   * <p>The value is a wall‑clock timestamp in milliseconds since the epoch, as produced by {@link
-   * System#currentTimeMillis()}. A return value of {@code 0} means no global cooldown applies and a
-   * block may be immediately available if other eligibility conditions hold. While best‑effort and
-   * safe to be conservative, this time is never later than the actual earliest per‑block wake‑up.
+   * <p>The value has been a wall‑clock timestamp in milliseconds since the epoch, as produced by
+   * {@link System#currentTimeMillis()}. A return value of {@code 0} means no global cooldown
+   * applies and a block may be immediately available if other eligibility conditions hold. While
+   * best‑effort and safe to be conservative, this time is never later than the actual earliest
+   * per‑block wake‑up.
    *
    * @return timestamp in milliseconds for the next potential eligibility across all blocks, or
-   *     {@code 0} when selection is not globally delayed by cooldown.
+   *     {@code 0} when cooldown does not globally delay selection.
    */
   public synchronized long overallCooldownTime() {
     return overallCooldownTime;

--- a/src/main/java/network/crypta/client/async/DatastoreChecker.java
+++ b/src/main/java/network/crypta/client/async/DatastoreChecker.java
@@ -107,11 +107,11 @@ public class DatastoreChecker implements PrioRunnable {
   /** List of requests to check the datastore for, bucketed by priority. */
   private final ArrayList<ArrayDeque<QueueItem>> queue;
 
-  private ClientContext context;
+  private volatile ClientContext context;
   private final Node node;
 
   /**
-   * Sets the client context used to obtain schedulers and to queue persistence-related jobs.
+   * Sets the client context used to get schedulers and to queue persistence-related jobs.
    *
    * <p>The context must be set before processing begins. This method is synchronized because the
    * checker may read the context from its worker thread while clients may update it during
@@ -191,7 +191,7 @@ public class DatastoreChecker implements PrioRunnable {
    *
    * <p>The loop processes a single queue item at a time and blocks with a bounded wait when the
    * queue is empty. In lazy mode, the method returns once the queue has drained so the caller can
-   * release the thread. Any unexpected exceptions are logged and the loop continues to reduce the
+   * release the thread. Any unexpected exceptions are logged, and the loop continues to reduce the
    * chance of losing queued work.
    */
   @Override
@@ -208,7 +208,7 @@ public class DatastoreChecker implements PrioRunnable {
   /**
    * Process a single job, waiting if necessary.
    *
-   * @return True if lazy=true and there are no jobs to run.
+   * @return True if lazy=true, and there are no jobs to run.
    */
   private boolean realRun() {
     Random random = (killBlocks != 0) ? new MersenneTwister() : null;
@@ -256,7 +256,7 @@ public class DatastoreChecker implements PrioRunnable {
       try {
         wait(SECONDS.toMillis(100));
       } catch (InterruptedException _) {
-        // Swallow and continue waiting; do not re-interrupt to avoid hot loop
+        // Swallow and continue waiting; do not re-interrupt to avoid the hot loop
       }
     }
   }

--- a/src/main/java/network/crypta/client/async/DatastoreChecker.java
+++ b/src/main/java/network/crypta/client/async/DatastoreChecker.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.keys.Key;
 import network.crypta.keys.KeyBlock;
 import network.crypta.node.LowLevelGetException;
@@ -107,7 +108,7 @@ public class DatastoreChecker implements PrioRunnable {
   /** List of requests to check the datastore for, bucketed by priority. */
   private final ArrayList<ArrayDeque<QueueItem>> queue;
 
-  private volatile ClientContext context;
+  private final AtomicReference<ClientContext> context = new AtomicReference<>();
   private final Node node;
 
   /**
@@ -121,7 +122,7 @@ public class DatastoreChecker implements PrioRunnable {
    *     later accessed from the checker thread.
    */
   public synchronized void setContext(ClientContext context) {
-    this.context = context;
+    this.context.set(Objects.requireNonNull(context, "context"));
   }
 
   /**
@@ -224,7 +225,7 @@ public class DatastoreChecker implements PrioRunnable {
 
     ClientRequestScheduler sched;
     synchronized (this) {
-      sched = getter.getScheduler(context);
+      sched = getter.getScheduler(context.get());
     }
     boolean anyValid = processKeys(keys, blocks, random, sched);
 
@@ -296,8 +297,9 @@ public class DatastoreChecker implements PrioRunnable {
 
   private void queueFinishRegisterPersistent(
       final SendableGet getter, final ClientRequestScheduler sched, final boolean anyValid) {
+    ClientContext localContext = context.get();
     try {
-      context.jobRunner.queue(
+      localContext.jobRunner.queue(
           new PersistentJob() {
             @Override
             public boolean run(ClientContext context) {

--- a/src/main/java/network/crypta/client/async/MultiPutCompletionCallback.java
+++ b/src/main/java/network/crypta/client/async/MultiPutCompletionCallback.java
@@ -356,17 +356,19 @@ public class MultiPutCompletionCallback
     boolean allDone;
     boolean allGotBlocks;
     boolean doCancel;
+    InsertException failureSnapshot;
     synchronized (this) {
       started = true;
       allDone = waitingFor.isEmpty();
       allGotBlocks = waitingForBlockSet.isEmpty();
       doCancel = cancelling;
+      failureSnapshot = e;
     }
     if (allGotBlocks) {
       cb.onBlockSetFinished(this, context);
     }
     if (allDone) {
-      complete(e, context);
+      complete(failureSnapshot, context);
     } else if (doCancel) {
       cancel(context);
     }

--- a/src/main/java/network/crypta/client/async/SimpleBlockChooser.java
+++ b/src/main/java/network/crypta/client/async/SimpleBlockChooser.java
@@ -115,7 +115,7 @@ public class SimpleBlockChooser {
   /**
    * Records a non-fatal failure for a block and reports whether the retry limit is now exceeded.
    *
-   * <p>Call this when an attempt fails but the caller wishes to retry according to the configured
+   * <p>Call this when an attempt fails, but the caller wishes to retry, according to the configured
    * policy. The internal counter for the block is incremented, and the method returns {@code true}
    * if retries have now surpassed {@link #maxRetries} (when a limit applies).
    *
@@ -176,7 +176,7 @@ public class SimpleBlockChooser {
   }
 
   /**
-   * Notify that a block has no longer succeeded. E.g. we downloaded it but now the data is no
+   * Notify that a block has no longer succeeded. E.g., we downloaded it, but now the data is no
    * longer available due to disk corruption.
    *
    * @param blockNo zero-based index of the block to mark as not complete any longer; the block must
@@ -199,7 +199,7 @@ public class SimpleBlockChooser {
   }
 
   /**
-   * Is the proposed block valid? Override to implement custom logic e.g. checking which requests
+   * Is the proposed block valid? Override to implement custom logic e.g., checking which requests
    * are already running.
    *
    * @param chosen candidate block index to evaluate for eligibility; the value is within {@code [0,
@@ -223,7 +223,7 @@ public class SimpleBlockChooser {
   }
 
   /**
-   * Mass replace of success/failure. Used by fetchers when we try to decode and fail, possibly
+   * Mass replacement of success/failure. Used by fetchers when we try to decode and fail, possibly
    * because of disk corruption.
    *
    * <p>The {@code used} array represents the authoritative completion state and must have a length
@@ -263,7 +263,7 @@ public class SimpleBlockChooser {
   }
 
   /**
-   * Returns the block number for a known key, taking completed state into account.
+   * Returns the block number for a known key, taking the completed state into account.
    *
    * <p>This convenience delegates to {@link SplitFileSegmentKeys#getBlockNumber(NodeCHK,
    * boolean[])} while keeping the internal {@code completed} array encapsulated.
@@ -332,7 +332,8 @@ public class SimpleBlockChooser {
    * the configured {@code maxRetries} (int), and then retry counters via {@link
    * #writeRetries(DataOutputStream)}. The method leaves the supplied stream open.
    *
-   * @param dos destination stream that receives the serialized state; not closed by this method.
+   * @param dos the destination stream that receives the serialized state; not closed by this
+   *     method.
    * @throws IOException if writing to the destination stream fails at any point.
    */
   public void write(DataOutputStream dos) throws IOException {
@@ -356,7 +357,7 @@ public class SimpleBlockChooser {
    *     maxRetries} differs from this instance's configuration.
    * @throws IOException if reading from the stream fails.
    */
-  public void read(DataInputStream dis) throws StorageFormatException, IOException {
+  public synchronized void read(DataInputStream dis) throws StorageFormatException, IOException {
     if (dis.readInt() != VERSION) throw new StorageFormatException("Bad version in block chooser");
     for (int i = 0; i < completed.length; i++) {
       completed[i] = dis.readBoolean();
@@ -400,7 +401,7 @@ public class SimpleBlockChooser {
   }
 
   /**
-   * Counts blocks that are currently eligible for fetching according to policy.
+   * Counts blocks that are currently eligible for fetching, according to policy.
    *
    * <p>Eligibility requires that a block is not completed, {@link #checkValid(int)} returns {@code
    * true}, and either unlimited retries are configured or the retry counter has not reached the

--- a/src/main/java/network/crypta/client/async/SimpleSingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SimpleSingleFileFetcher.java
@@ -238,7 +238,7 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
    */
   protected void onFailure(FetchException e, boolean forceFatal, ClientContext context) {
     if (LOG.isDebugEnabled()) LOG.debug("onFailure( {} , {})", e, forceFatal, e);
-    if (parent.isCancelled() || cancelled) {
+    if (parent.isCancelled() || isCancelled()) {
       if (LOG.isDebugEnabled()) LOG.debug("Failing: cancelled");
       e = new FetchException(FetchExceptionMode.CANCELLED);
       forceFatal = true;

--- a/src/main/java/network/crypta/client/async/SingleBlockInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleBlockInserter.java
@@ -363,7 +363,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     if (LOG.isDebugEnabled())
       LOG.debug(
           "Encoded {} for {} shouldSend={} dontSendEncoded={}",
-          resultingKey.getURI(),
+          block.getClientKey().getURI(),
           this,
           shouldSend,
           dontSendEncoded);
@@ -631,6 +631,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     return isEmpty();
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   static class MySendableRequestSender implements SendableRequestSender {
 
     final String compressorDescriptor;
@@ -998,7 +999,12 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
   public void innerOnResume(ClientContext context) throws InsertException, ResumeFailedException {
     sourceData.onResume(context);
     if (cb != parent) cb.onResume(context);
-    if (resultingKey != null) cb.onEncode(resultingKey, SingleBlockInserter.this, context);
+    ClientKey resultingKeySnapshot;
+    synchronized (this) {
+      resultingKeySnapshot = resultingKey;
+    }
+    if (resultingKeySnapshot != null)
+      cb.onEncode(resultingKeySnapshot, SingleBlockInserter.this, context);
     this.schedule(context);
   }
 

--- a/src/main/java/network/crypta/client/async/SingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SingleFileFetcher.java
@@ -17,6 +17,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.ArchiveContext;
 import network.crypta.client.ArchiveExtractCallback;
 import network.crypta.client.ArchiveFailureException;
@@ -121,6 +122,8 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
    * depending on progress through the state machine.
    */
   private Metadata metadata;
+
+  private transient AtomicReference<Metadata> metadataRef = new AtomicReference<>();
 
   /**
    * Metadata for the enclosing archive when the requested item lives inside a container. Populated
@@ -314,7 +317,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
    */
   protected void onFailure(FetchException e, boolean forceFatal, ClientContext context) {
     if (LOG.isDebugEnabled()) LOG.debug("onFailure( {} , {})", e, forceFatal, e);
-    if (parent.isCancelled() || cancelled) {
+    if (parent.isCancelled() || isCancelled()) {
       if (LOG.isDebugEnabled()) LOG.debug("Failing: cancelled");
       e = new FetchException(FetchExceptionMode.CANCELLED);
       forceFatal = true;
@@ -462,7 +465,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
         (fetcher.clientMetadata != null
             ? ClientMetadata.copyOf(fetcher.clientMetadata)
             : new ClientMetadata());
-    this.metadata = newMeta;
+    updateMetadata(newMeta);
     this.metaStrings = new ArrayList<>();
     this.addedMetaStrings = 0;
     this.recursionLevel = fetcher.recursionLevel + 1;
@@ -484,6 +487,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
   @Serial
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
+    metadataRef = new AtomicReference<>(metadata);
     this.ah = null;
   }
 
@@ -497,6 +501,15 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
    * with higher‑level requests or UI elements.
    */
   final long token;
+
+  private Metadata currentMetadata() {
+    return metadataRef.get();
+  }
+
+  private void updateMetadata(Metadata newMetadata) {
+    metadata = newMetadata;
+    metadataRef.set(newMetadata);
+  }
 
   // Process the completed data. May result in us going to a
   // splitfile, or another SingleFileFetcher, etc.
@@ -565,7 +578,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
     }
     // Parse metadata
     try {
-      metadata = Metadata.construct(data);
+      updateMetadata(Metadata.construct(data));
       data.free();
       data = null;
       innerWrapHandleMetadata(false, context);
@@ -780,7 +793,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
           // no-op, continue loop
         }
         case UNKNOWN -> {
-          LOG.error("Don't know what to do with metadata: {}", metadata);
+          LOG.error("Don't know what to do with metadata: {}", currentMetadata());
           throw new FetchException(FetchExceptionMode.UNKNOWN_METADATA);
         }
       }
@@ -788,7 +801,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
   }
 
   private boolean snoopAndMaybeCancel(ClientContext context) {
-    if (metaSnoop != null && metaSnoop.snoopMetadata(metadata, context)) {
+    if (metaSnoop != null && metaSnoop.snoopMetadata(currentMetadata(), context)) {
       cancel(context);
       return true;
     }
@@ -797,24 +810,25 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
 
   private void handleTopDataAndHashesIfNoMetaStrings(ClientContext context) throws FetchException {
     if (!metaStrings.isEmpty()) return;
-    if (metadata.hasTopData()) {
-      if ((metadata.topSize > ctx.getMaxOutputLength())
-          || (metadata.topCompressedSize > ctx.getMaxTempLength())) {
-        if (metadata.isSimpleRedirect() || metadata.isSplitfile())
-          clientMetadata.mergeNoOverwrite(metadata.getClientMetadata());
+    Metadata current = currentMetadata();
+    if (current.hasTopData()) {
+      if ((current.topSize > ctx.getMaxOutputLength())
+          || (current.topCompressedSize > ctx.getMaxTempLength())) {
+        if (current.isSimpleRedirect() || current.isSplitfile())
+          clientMetadata.mergeNoOverwrite(current.getClientMetadata());
         throw new FetchException(
-            FetchExceptionMode.TOO_BIG, metadata.topSize, true, clientMetadata.getMIMEType());
+            FetchExceptionMode.TOO_BIG, current.topSize, true, clientMetadata.getMIMEType());
       }
       rcb.onExpectedTopSize(
-          metadata.topSize,
-          metadata.topCompressedSize,
-          metadata.topBlocksRequired,
-          metadata.topBlocksTotal,
+          current.topSize,
+          current.topCompressedSize,
+          current.topBlocksRequired,
+          current.topBlocksTotal,
           context);
-      topCompatibilityMode = metadata.getTopCompatibilityCode();
-      topDontCompress = metadata.getTopDontCompress();
+      topCompatibilityMode = current.getTopCompatibilityCode();
+      topDontCompress = current.getTopDontCompress();
     }
-    HashResult[] hashes = metadata.getHashes();
+    HashResult[] hashes = current.getHashes();
     if (hashes != null) {
       rcb.onHashes(hashes, context);
     }
@@ -833,13 +847,14 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
   }
 
   private MetaKind detectMetaKind() {
-    if (metadata.isSimpleManifest()) return MetaKind.SIMPLE_MANIFEST;
-    if (metadata.isArchiveManifest()) return MetaKind.ARCHIVE_MANIFEST;
-    if (metadata.isArchiveMetadataRedirect()) return MetaKind.ARCHIVE_METADATA_REDIRECT;
-    if (metadata.isArchiveInternalRedirect()) return MetaKind.ARCHIVE_INTERNAL_REDIRECT;
-    if (metadata.isMultiLevelMetadata()) return MetaKind.MULTI_LEVEL_METADATA;
-    if (metadata.isSingleFileRedirect()) return MetaKind.SINGLE_FILE_REDIRECT;
-    if (metadata.isSplitfile()) return MetaKind.SPLITFILE;
+    Metadata current = currentMetadata();
+    if (current.isSimpleManifest()) return MetaKind.SIMPLE_MANIFEST;
+    if (current.isArchiveManifest()) return MetaKind.ARCHIVE_MANIFEST;
+    if (current.isArchiveMetadataRedirect()) return MetaKind.ARCHIVE_METADATA_REDIRECT;
+    if (current.isArchiveInternalRedirect()) return MetaKind.ARCHIVE_INTERNAL_REDIRECT;
+    if (current.isMultiLevelMetadata()) return MetaKind.MULTI_LEVEL_METADATA;
+    if (current.isSingleFileRedirect()) return MetaKind.SINGLE_FILE_REDIRECT;
+    if (current.isSplitfile()) return MetaKind.SPLITFILE;
     return MetaKind.UNKNOWN;
   }
 
@@ -920,30 +935,32 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
           ArchiveFailureException,
           ArchiveRestartException,
           MetadataParseException {
+    Metadata current = currentMetadata();
     if (LOG.isDebugEnabled())
       LOG.debug(
           "Is archive manifest (type={} codec={})",
-          metadata.getArchiveType(),
-          metadata.getCompressionCodec());
+          current.getArchiveType(),
+          current.getCompressionCodec());
     if (metaStrings.isEmpty() && ctx.getReturnZIPManifests()) {
-      metadata.setSimpleRedirect();
+      current.setSimpleRedirect();
       return false; // continue outer loop
     }
     ensureArchiveHandler(context);
-    archiveMetadata = metadata;
-    metadata = null;
+    archiveMetadata = current;
+    updateMetadata(null);
     Bucket metadataBucket = ah.getMetadata(actx, context.archiveManager);
     return handleArchiveManifestBucketOrSchedule(metadataBucket, context);
   }
 
   private void ensureArchiveHandler(ClientContext context) throws ArchiveFailureException {
+    Metadata current = currentMetadata();
     if (ah == null || !ah.getKey().equals(thisKey)) {
       actx.doLoopDetection(thisKey);
       ah =
           context.archiveManager.makeHandler(
               thisKey,
-              metadata.getArchiveType(),
-              metadata.getCompressionCodec(),
+              current.getArchiveType(),
+              current.getCompressionCodec(),
               (parent instanceof ClientGetter cg && cg.collectingBinaryBlob()),
               persistent);
     }
@@ -953,7 +970,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
       Bucket metadataBucket, ClientContext context) throws FetchException, MetadataParseException {
     if (metadataBucket != null) {
       try {
-        metadata = Metadata.construct(metadataBucket);
+        updateMetadata(Metadata.construct(metadataBucket));
       } catch (InsufficientDiskSpaceException _) {
         throw new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE);
       } catch (IOException e) {
@@ -976,7 +993,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
             if (LOG.isDebugEnabled())
               LOG.debug("gotBucket on {} persistent={}", SingleFileFetcher.this, persistentLocal);
             try {
-              metadata = Metadata.construct(data);
+              updateMetadata(Metadata.construct(data));
               innerWrapHandleMetadata(true, ctx1);
             } catch (MetadataParseException e) {
               onFailure(new FetchException(FetchExceptionMode.INVALID_METADATA, e), false, ctx1);
@@ -1014,11 +1031,12 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
 
   private boolean processArchiveMetadataRedirectStep(final ClientContext context)
       throws FetchException {
+    Metadata current = currentMetadata();
     if (LOG.isDebugEnabled()) LOG.debug("Is archive-metadata");
     if (ah == null)
       throw new FetchException(
           FetchExceptionMode.UNKNOWN_METADATA, "Archive redirect not in an archive manifest");
-    String filename = metadata.getArchiveInternalName();
+    String filename = current.getArchiveInternalName();
     if (LOG.isDebugEnabled()) LOG.debug("Fetching archive-metadata entry {}", filename);
     Bucket dataBucket;
     try {
@@ -1039,7 +1057,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
     try {
       Metadata newMetadata = Metadata.construct(dataBucket);
       synchronized (this) {
-        metadata = newMetadata;
+        updateMetadata(newMetadata);
       }
     } catch (InsufficientDiskSpaceException _) {
       throw new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE);
@@ -1070,7 +1088,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
             try {
               Metadata newMetadata = Metadata.construct(data);
               synchronized (SingleFileFetcher.this) {
-                metadata = newMetadata;
+                updateMetadata(newMetadata);
               }
               innerWrapHandleMetadata(true, ctx1);
             } catch (IOException _) {
@@ -1102,15 +1120,16 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
 
   private void processArchiveInternalRedirectStep(final ClientContext context)
       throws FetchException {
+    Metadata current = currentMetadata();
     if (LOG.isDebugEnabled()) LOG.debug("Is archive-internal redirect");
-    clientMetadata.mergeNoOverwrite(metadata.getClientMetadata());
+    clientMetadata.mergeNoOverwrite(current.getClientMetadata());
     String mime = clientMetadata.getMIMEType();
     if (mime != null) rcb.onExpectedMIME(clientMetadata, context);
     validateAllowedMimeForArchiveInternal();
     if (ah == null)
       throw new FetchException(
           FetchExceptionMode.UNKNOWN_METADATA, "Archive redirect not in an archive manifest");
-    String filename = metadata.getArchiveInternalName();
+    String filename = current.getArchiveInternalName();
     if (LOG.isDebugEnabled()) LOG.debug("Fetching archive-internal entry {}", filename);
     Bucket dataBucket;
     try {
@@ -1189,12 +1208,13 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
   }
 
   private void processMultiLevelMetadataStep(final ClientContext context) throws FetchException {
+    Metadata current = currentMetadata();
     if (LOG.isDebugEnabled()) LOG.debug("Is multi-level metadata");
-    metadata.setSimpleRedirect();
+    current.setSimpleRedirect();
     final SingleFileFetcher f =
         new SingleFileFetcher(
-            this, persistent, false, metadata, new MultiLevelMetadataCallback(), ctx);
-    this.metadata = null;
+            this, persistent, false, current, new MultiLevelMetadataCallback(), ctx);
+    updateMetadata(null);
     parent.onTransition(this, f, context);
     context
         .getJobRunner(persistent)
@@ -1207,20 +1227,21 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
   }
 
   private boolean processSingleFileRedirectStep(final ClientContext context) throws FetchException {
+    Metadata current = currentMetadata();
     if (LOG.isDebugEnabled()) LOG.debug("Is single-file redirect");
-    clientMetadata.mergeNoOverwrite(metadata.getClientMetadata());
+    clientMetadata.mergeNoOverwrite(current.getClientMetadata());
     emitExpectedMimeIfPresent(context);
     String mimeType = clientMetadata.getMIMETypeNoParams();
     if (mimeType != null
         && ArchiveManager.ARCHIVE_TYPE.isUsableArchiveType(mimeType)
         && !metaStrings.isEmpty()) {
-      metadata.setArchiveManifest();
+      current.setArchiveManifest();
       clientMetadata.clear();
       if (LOG.isDebugEnabled()) LOG.debug("Handling implicit container... (redirect)");
       return false; // continue loop
     }
     validateAllowedMimeForSingleRedirect(mimeType);
-    FreenetURI newURI = metadata.getSingleTarget();
+    FreenetURI newURI = current.getSingleTarget();
     if (LOG.isDebugEnabled()) LOG.debug("Redirecting to {}", newURI);
     ClientKey redirectedKey = resolveRedirectedKey(newURI);
     addNewMetaStringsFrom(newURI);
@@ -1233,16 +1254,16 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
       if (key instanceof ClientCHK hK && !Arrays.equals(hK.getCryptoKey(), redirectedCryptoKey))
         redirectedCryptoKey = null;
       rcb.onSplitfileCompatibilityMode(
-          metadata.getMinCompatMode(),
-          metadata.getMaxCompatMode(),
+          current.getMinCompatMode(),
+          current.getMaxCompatMode(),
           redirectedCryptoKey,
           !hK1.isCompressed(),
           true,
           true,
           context);
     }
-    if (metadata.isCompressed()) {
-      COMPRESSOR_TYPE codec = metadata.getCompressionCodec();
+    if (current.isCompressed()) {
+      COMPRESSOR_TYPE codec = current.getCompressionCodec();
       f.addDecompressor(codec);
     }
     parent.onTransition(this, f, context);
@@ -1312,13 +1333,14 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
 
   private boolean processSplitfileStep(final ClientContext context)
       throws FetchException, MetadataParseException {
+    Metadata current = currentMetadata();
     if (LOG.isDebugEnabled()) LOG.debug("Fetching splitfile");
-    clientMetadata.mergeNoOverwrite(metadata.getClientMetadata());
+    clientMetadata.mergeNoOverwrite(current.getClientMetadata());
     String mimeType = clientMetadata.getMIMETypeNoParams();
     if (mimeType != null
         && ArchiveManager.ARCHIVE_TYPE.isUsableArchiveType(mimeType)
         && !metaStrings.isEmpty()) {
-      metadata.setArchiveManifest();
+      current.setArchiveManifest();
       clientMetadata.clear();
       if (LOG.isDebugEnabled()) LOG.debug("Handling implicit container... (splitfile)");
       return false; // continue loop
@@ -1328,10 +1350,10 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
     validateAllowedMimeForSplitfile(mimeType);
     applyDecompressorIfCompressed();
     if (handleTooManyPathComponentsIfNeeded(context)) return true;
-    final long len = metadata.dataLength();
-    final long uncompressedLen = metadata.isCompressed() ? metadata.uncompressedDataLength() : len;
+    final long len = current.dataLength();
+    final long uncompressedLen = current.isCompressed() ? current.uncompressedDataLength() : len;
     if ((uncompressedLen > ctx.getMaxOutputLength()) || (len > ctx.getMaxTempLength())) {
-      boolean compressed = metadata.isCompressed();
+      boolean compressed = current.isCompressed();
       throw new FetchException(
           FetchExceptionMode.TOO_BIG,
           uncompressedLen,
@@ -1344,7 +1366,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
       reallyFinal = false;
     }
     SplitFileFetcher.InitParams p = new SplitFileFetcher.InitParams();
-    p.metadata = metadata;
+    p.metadata = current;
     p.rcb = rcb;
     p.parent = parent;
     p.fetchContext = ctx;
@@ -1367,8 +1389,9 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
   }
 
   private void applyDecompressorIfCompressed() {
-    if (metadata.isCompressed()) {
-      COMPRESSOR_TYPE codec = metadata.getCompressionCodec();
+    Metadata current = currentMetadata();
+    if (current.isCompressed()) {
+      COMPRESSOR_TYPE codec = current.getCompressionCodec();
       addDecompressor(codec);
     }
   }
@@ -1379,7 +1402,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
         && mimeType != null
         && ctx.getAllowedMIMETypes() != null
         && !ctx.getAllowedMIMETypes().contains(mimeType)) {
-      long len = metadata.uncompressedDataLength();
+      long len = currentMetadata().uncompressedDataLength();
       throw new FetchException(
           FetchExceptionMode.WRONG_MIME_TYPE, len, false, clientMetadata.getMIMEType());
     }
@@ -1401,7 +1424,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
           rcb.onFailure(
               new FetchException(
                   FetchExceptionMode.TOO_MANY_PATH_COMPONENTS,
-                  metadata.uncompressedDataLength(),
+                  currentMetadata().uncompressedDataLength(),
                   (rcb == parent),
                   clientMetadata.getMIMEType(),
                   tryURI),
@@ -1432,9 +1455,10 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
   }
 
   private String resolveManifestName() throws FetchException {
-    if (metadata.countDocuments() == 1
-        && metadata.getDocument("") != null
-        && metadata.getDocument("").isSimpleManifest()) {
+    Metadata current = currentMetadata();
+    if (current.countDocuments() == 1
+        && current.getDocument("") != null
+        && current.getDocument("").isSimpleManifest()) {
       LOG.error("Manifest is called \"\" for {}", this);
       return "";
     } else if (metaStrings.isEmpty()) {
@@ -1449,12 +1473,13 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
   }
 
   private void selectDefaultManifestDocument() throws FetchException {
+    Metadata current = currentMetadata();
     if (!persistent) {
-      metadata = metadata.getDefaultDocument();
+      updateMetadata(current.getDefaultDocument());
     } else {
-      metadata = metadata.grabDefaultDocument();
+      updateMetadata(current.grabDefaultDocument());
     }
-    if (metadata == null)
+    if (currentMetadata() == null)
       throw new FetchException(
           FetchExceptionMode.NOT_ENOUGH_PATH_COMPONENTS,
           -1,
@@ -1464,30 +1489,31 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
   }
 
   private void selectManifestDocumentByName(String name) throws FetchException {
+    Metadata current = currentMetadata();
     if (!persistent) {
-      Metadata origMd = metadata;
-      metadata = origMd.getDocument(name);
-      if (metadata != null && metadata.isSymbolicShortlink()) {
+      Metadata newMetadata = current.getDocument(name);
+      if (newMetadata != null && newMetadata.isSymbolicShortlink()) {
         String oldName = name;
-        name = metadata.getSymbolicShortlinkTargetName();
+        name = newMetadata.getSymbolicShortlinkTargetName();
         if (oldName.equals(name))
           throw new FetchException(FetchExceptionMode.INVALID_METADATA, "redirect loop: " + name);
-        metadata = origMd.getDocument(name);
+        newMetadata = current.getDocument(name);
       }
+      updateMetadata(newMetadata);
       thisKey = thisKey.pushMetaString(name);
     } else {
-      Metadata newMeta = metadata.grabDocument(name);
+      Metadata newMeta = current.grabDocument(name);
       if (newMeta != null && newMeta.isSymbolicShortlink()) {
         String oldName = name;
         name = newMeta.getSymbolicShortlinkTargetName();
         if (oldName.equals(name))
           throw new FetchException(FetchExceptionMode.INVALID_METADATA, "redirect loop: " + name);
-        newMeta = metadata.getDocument(name);
+        newMeta = current.getDocument(name);
       }
-      metadata = newMeta;
+      updateMetadata(newMeta);
       thisKey = thisKey.pushMetaString(name);
     }
-    if (metadata == null)
+    if (currentMetadata() == null)
       throw new FetchException(FetchExceptionMode.NOT_IN_ARCHIVE, "can't find " + name);
   }
 
@@ -1805,7 +1831,7 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
         // Note: Pass an InputStream here and save ourselves a Bucket
         Metadata meta = Metadata.construct(finalData);
         synchronized (SingleFileFetcher.this) {
-          metadata = meta;
+          updateMetadata(meta);
         }
         innerWrapHandleMetadata(true, context);
       } catch (MetadataParseException e) {

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -1597,9 +1597,12 @@ class SingleFileInserter implements ClientPutState, Serializable {
       ClientPutState metadataState = getMetadataPutter();
       if (splitState != null) splitState.onResume(context);
       if (metadataState != null) metadataState.onResume(context);
-      if (splitState != null) splitState.schedule(context);
-      if (metadataState != null && (ctx.isEarlyEncode() || splitState == null || metaInsertStarted))
-        metadataState.schedule(context);
+      ClientPutState splitStateAfterResume = getSfi();
+      if (splitStateAfterResume != null) splitStateAfterResume.schedule(context);
+      ClientPutState metadataStateAfterResume = getMetadataPutter();
+      if (metadataStateAfterResume != null
+          && (ctx.isEarlyEncode() || getSfi() == null || metaInsertStarted))
+        metadataStateAfterResume.schedule(context);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertBlock;
@@ -671,7 +672,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
               .build();
       SplitFileInserter sfi =
           new SplitFileInserter(persistent, parent, sh, dataRAF, shouldFreeData, opts);
-      sh.sfi = sfi;
+      sh.setSfi(sfi);
       if (LOG.isTraceEnabled())
         LOG.trace("Inserting as splitfile: {} for {} for {}", sfi, sh, this);
       cb.onTransition(this, sh, context);
@@ -921,15 +922,19 @@ class SingleFileInserter implements ClientPutState, Serializable {
     @SuppressWarnings("java:S1948")
     ClientPutState sfi;
 
+    private transient AtomicReference<ClientPutState> sfiRef = new AtomicReference<>();
+
     @SuppressWarnings("java:S1948")
     ClientPutState metadataPutter;
+
+    private transient AtomicReference<ClientPutState> metadataPutterRef = new AtomicReference<>();
 
     boolean finished;
     boolean splitInsertSuccess;
     boolean metaInsertSuccess;
     boolean splitInsertSetBlocks;
     boolean metaInsertSetBlocks;
-    boolean metaInsertStarted;
+    volatile boolean metaInsertStarted;
     boolean metaFetchable;
     final boolean persistent;
     final long origDataLength;
@@ -969,6 +974,24 @@ class SingleFileInserter implements ClientPutState, Serializable {
       this.origCompressedDataLength = allowSizes ? origCompressedDataLength : 0;
     }
 
+    private ClientPutState getSfi() {
+      return sfiRef.get();
+    }
+
+    private void setSfi(ClientPutState state) {
+      sfi = state;
+      sfiRef.set(state);
+    }
+
+    private ClientPutState getMetadataPutter() {
+      return metadataPutterRef.get();
+    }
+
+    private void setMetadataPutter(ClientPutState state) {
+      metadataPutter = state;
+      metadataPutterRef.set(state);
+    }
+
     /**
      * Rewire callbacks for deserialized children to this handler when missing.
      *
@@ -979,8 +1002,11 @@ class SingleFileInserter implements ClientPutState, Serializable {
     @Serial
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
       in.defaultReadObject();
+      sfiRef = new AtomicReference<>(sfi);
+      metadataPutterRef = new AtomicReference<>(metadataPutter);
       // Only fix when the callback is absent or points to the parent putter (unsafe fallback).
-      if (metadataPutter instanceof SingleFileInserter childSfi
+      ClientPutState metadataState = getMetadataPutter();
+      if (metadataState instanceof SingleFileInserter childSfi
           && (childSfi.cb == null || childSfi.cb == parent)) {
         childSfi.cb = this;
       }
@@ -993,8 +1019,8 @@ class SingleFileInserter implements ClientPutState, Serializable {
       if (persistent && LOG.isTraceEnabled()) {
         LOG.trace("Transition: {} -> {}", oldState, newState);
       }
-      if (oldState == sfi) sfi = newState;
-      if (oldState == metadataPutter) metadataPutter = newState;
+      if (oldState == getSfi()) setSfi(newState);
+      if (oldState == getMetadataPutter()) setMetadataPutter(newState);
     }
 
     /**
@@ -1011,9 +1037,9 @@ class SingleFileInserter implements ClientPutState, Serializable {
     public void onSuccess(ClientPutState state, ClientContext context) {
       if (LOG.isDebugEnabled()) LOG.debug("onSuccess({}) for {}", state, this);
       boolean lateStart = false;
-      if (state == sfi) {
+      if (state == getSfi()) {
         lateStart = markSfiSuccess();
-      } else if (state == metadataPutter) {
+      } else if (state == getMetadataPutter()) {
         markMetadataPutterSuccess();
       } else {
         LOG.warn("Unknown: {} for {}", state, this);
@@ -1031,7 +1057,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       }
       if (lateStart && startMetadata(context)) {
         synchronized (this) {
-          sfi = null;
+          setSfi(null);
         }
       }
       if (finishedNow) cb.onSuccess(this, context);
@@ -1042,7 +1068,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
         if (LOG.isTraceEnabled()) LOG.trace("Splitfile insert succeeded for {}", this);
         splitInsertSuccess = true;
         if (!metaInsertSuccess && !metaInsertStarted) return true; // lateStart
-        sfi = null;
+        setSfi(null);
         if (LOG.isDebugEnabled())
           LOG.debug(
               "Metadata already started for {} : success={} started={}",
@@ -1057,7 +1083,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       synchronized (this) {
         if (LOG.isTraceEnabled()) LOG.trace("Metadata insert succeeded for {}", this);
         metaInsertSuccess = true;
-        metadataPutter = null;
+        setMetadataPutter(null);
       }
     }
 
@@ -1075,18 +1101,20 @@ class SingleFileInserter implements ClientPutState, Serializable {
     public void onFailure(InsertException e, ClientPutState state, ClientContext context) {
       boolean toFail = true;
       synchronized (this) {
+        ClientPutState currentSfi = getSfi();
+        ClientPutState currentMetadataPutter = getMetadataPutter();
         if (LOG.isDebugEnabled())
           LOG.debug(
               "onFailure(): {} on {} on {} sfi = {} metadataPutter = {}",
               e,
               state,
               this,
-              sfi,
-              metadataPutter);
-        if (state == sfi) {
-          sfi = null;
-        } else if (state == metadataPutter) {
-          metadataPutter = null;
+              currentSfi,
+              currentMetadataPutter);
+        if (state == currentSfi) {
+          setSfi(null);
+        } else if (state == currentMetadataPutter) {
+          setMetadataPutter(null);
         } else {
           LOG.error("onFailure() on unknown state {} on {}", state, this, new Exception("debug"));
         }
@@ -1116,7 +1144,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       if (LOG.isDebugEnabled()) LOG.debug("Got metadata for {} from {}", this, state);
       // Allow metadata produced by the metadata inserter itself; forward upstream without
       // starting another metadata inserter.
-      if (state == metadataPutter) {
+      if (state == getMetadataPutter()) {
         cb.onMetadata(meta, this, context);
         return;
       }
@@ -1150,7 +1178,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
 
     private boolean isDuplicateSplitMetadata(ClientPutState state) {
       synchronized (this) {
-        if (state == sfi && (metadataPutter != null || metaInsertSuccess)) {
+        if (state == getSfi() && (getMetadataPutter() != null || metaInsertSuccess)) {
           if (LOG.isDebugEnabled())
             LOG.debug("Ignoring duplicate onMetadata from splitfile inserter for {}", this);
           return true;
@@ -1252,16 +1280,18 @@ class SingleFileInserter implements ClientPutState, Serializable {
     private InsertException precheckMetadataState(ClientPutState state) {
       InsertException e = null;
       synchronized (this) {
+        ClientPutState currentSfi = getSfi();
+        ClientPutState currentMetadataPutter = getMetadataPutter();
         if (finished)
           return new InsertException(InsertExceptionMode.INTERNAL_ERROR, "Finished", null);
         if (reportMetadataOnly) {
           metaInsertSuccess = true;
-        } else if (state != sfi) {
+        } else if (state != currentSfi) {
           LOG.error(
               "Got metadata from unknown state {} sfi={} metadataPutter={} on {} persistent={}",
               state,
-              sfi,
-              metadataPutter,
+              currentSfi,
+              currentMetadataPutter,
               this,
               persistent,
               new Exception("debug"));
@@ -1310,7 +1340,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
                 .withOrigCompressedDataLength(origCompressedDataLength)
                 .withOrigHashes(origHashes)
                 .withMetadataThreshold(metadataThreshold);
-        metadataPutter = new SingleFileInserter(params);
+        setMetadataPutter(new SingleFileInserter(params));
         if (origHashes != null) {
           SingleFileInserter.this.origHashes = null;
         }
@@ -1318,17 +1348,19 @@ class SingleFileInserter implements ClientPutState, Serializable {
           LOG.debug(
               "Created metadata putter for {} : {} bucket {} size {}",
               this,
-              metadataPutter,
+              getMetadataPutter(),
               metadataBucket,
               metadataBucket.size());
         if (!(ctx.isEarlyEncode() || splitInsertSuccess)) return;
       }
+      ClientPutState metadataState = getMetadataPutter();
+      ClientPutState splitState = getSfi();
       if (LOG.isDebugEnabled())
         LOG.debug(
             "Putting metadata on {} from {} ({})",
-            metadataPutter,
-            sfi,
-            ((SplitFileInserter) sfi).getLength());
+            metadataState,
+            splitState,
+            ((SplitFileInserter) splitState).getLength());
       if (!startMetadata(context)) {
         LOG.error("onMetadata() yet unable to start metadata due to not having all URIs?!?!");
         fail(
@@ -1340,8 +1372,8 @@ class SingleFileInserter implements ClientPutState, Serializable {
         return;
       }
       synchronized (this) {
-        if (splitInsertSuccess && sfi != null) {
-          sfi = null;
+        if (splitInsertSuccess && getSfi() != null) {
+          setSfi(null);
         }
       }
     }
@@ -1378,8 +1410,8 @@ class SingleFileInserter implements ClientPutState, Serializable {
           return;
         }
         finished = true;
-        oldSFI = sfi;
-        oldMetadataPutter = metadataPutter;
+        oldSFI = getSfi();
+        oldMetadataPutter = getMetadataPutter();
       }
       if (oldSFI != null) oldSFI.cancel(context);
       if (oldMetadataPutter != null) oldMetadataPutter.cancel(context);
@@ -1404,7 +1436,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
       if (persistent && LOG.isTraceEnabled())
         LOG.trace("onEncode() for {} : {} : {}", this, state, key);
       synchronized (this) {
-        if (state != metadataPutter) {
+        if (state != getMetadataPutter()) {
           if (LOG.isTraceEnabled()) LOG.trace("ignored onEncode() for {} : {}", this, state);
           return;
         }
@@ -1419,8 +1451,8 @@ class SingleFileInserter implements ClientPutState, Serializable {
       ClientPutState oldSFI;
       ClientPutState oldMetadataPutter;
       synchronized (this) {
-        oldSFI = sfi;
-        oldMetadataPutter = metadataPutter;
+        oldSFI = getSfi();
+        oldMetadataPutter = getMetadataPutter();
       }
       if (oldSFI != null) oldSFI.cancel(context);
       if (oldMetadataPutter != null) oldMetadataPutter.cancel(context);
@@ -1438,8 +1470,8 @@ class SingleFileInserter implements ClientPutState, Serializable {
     @Override
     public void onBlockSetFinished(ClientPutState state, ClientContext context) {
       synchronized (this) {
-        if (state == sfi) splitInsertSetBlocks = true;
-        else if (state == metadataPutter) metaInsertSetBlocks = true;
+        if (state == getSfi()) splitInsertSetBlocks = true;
+        else if (state == getMetadataPutter()) metaInsertSetBlocks = true;
         else if (LOG.isTraceEnabled()) LOG.trace("Unrecognised: {} in onBlockSetFinished()", state);
         if (!(splitInsertSetBlocks && metaInsertSetBlocks)) return;
       }
@@ -1449,7 +1481,8 @@ class SingleFileInserter implements ClientPutState, Serializable {
     /** {@inheritDoc} */
     @Override
     public void schedule(ClientContext context) throws InsertException {
-      sfi.schedule(context);
+      ClientPutState splitState = getSfi();
+      if (splitState != null) splitState.schedule(context);
     }
 
     /** {@inheritDoc} */
@@ -1465,8 +1498,10 @@ class SingleFileInserter implements ClientPutState, Serializable {
         if (persistent) LOG.debug("onFetchable on {}", this);
         LOG.debug("onFetchable({})", state);
       }
-      boolean isMeta = state == metadataPutter;
-      if (!(isMeta || state == sfi)) {
+      ClientPutState currentSfi = getSfi();
+      ClientPutState currentMetadataPutter = getMetadataPutter();
+      boolean isMeta = state == currentMetadataPutter;
+      if (!(isMeta || state == currentSfi)) {
         LOG.error("onFetchable for unknown state {}", state);
         return;
       }
@@ -1495,7 +1530,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
         ClientPutState putter;
         synchronized (this) {
           if (metaInsertStarted) return true;
-          putter = metadataPutter;
+          putter = getMetadataPutter();
           if (putter == null) {
             if (LOG.isTraceEnabled()) LOG.trace("Cannot start metadata yet: no metadataPutter");
           } else metaInsertStarted = true;
@@ -1522,13 +1557,15 @@ class SingleFileInserter implements ClientPutState, Serializable {
       if (LOG.isDebugEnabled()) LOG.debug("Got metadata bucket for {} from {}", this, state);
       boolean freeIt = false;
       synchronized (this) {
+        ClientPutState currentSfi = getSfi();
+        ClientPutState currentMetadataPutter = getMetadataPutter();
         if (finished) return;
-        if (state == sfi) {
-          if (metadataPutter != null) {
+        if (state == currentSfi) {
+          if (currentMetadataPutter != null) {
             LOG.error(
                 "Got metadata from {} even though already started inserting metadata on the next"
                     + " layer on {} !!",
-                sfi,
+                currentSfi,
                 this);
             freeIt = true;
           } else {
@@ -1537,7 +1574,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
           }
         } else if (reportMetadataOnly) {
           metaInsertSuccess = true;
-        } else if (state != metadataPutter) {
+        } else if (state != currentMetadataPutter) {
           LOG.error("Got metadata from unknown object {}", state);
           freeIt = true;
         } // else state == metadataPutter: default path, hand metadata to callback below
@@ -1556,11 +1593,13 @@ class SingleFileInserter implements ClientPutState, Serializable {
         if (resumed) return;
         resumed = true;
       }
-      if (sfi != null) sfi.onResume(context);
-      if (metadataPutter != null) metadataPutter.onResume(context);
-      if (sfi != null) sfi.schedule(context);
-      if (metadataPutter != null && (ctx.isEarlyEncode() || sfi == null || metaInsertStarted))
-        metadataPutter.schedule(context);
+      ClientPutState splitState = getSfi();
+      ClientPutState metadataState = getMetadataPutter();
+      if (splitState != null) splitState.onResume(context);
+      if (metadataState != null) metadataState.onResume(context);
+      if (splitState != null) splitState.schedule(context);
+      if (metadataState != null && (ctx.isEarlyEncode() || splitState == null || metaInsertStarted))
+        metadataState.schedule(context);
     }
 
     /** {@inheritDoc} */
@@ -1569,8 +1608,8 @@ class SingleFileInserter implements ClientPutState, Serializable {
       ClientPutState splitfileInserter;
       ClientPutState metadataInserter;
       synchronized (this) {
-        splitfileInserter = sfi;
-        metadataInserter = metadataPutter;
+        splitfileInserter = getSfi();
+        metadataInserter = getMetadataPutter();
       }
       if (splitfileInserter != null) splitfileInserter.onShutdown(context);
       if (metadataInserter != null) metadataInserter.onShutdown(context);

--- a/src/main/java/network/crypta/client/async/SplitFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcher.java
@@ -532,7 +532,7 @@ public class SplitFileFetcher
    *
    * @return {@code true} once either {@link #onSuccess()} or {@link #fail(FetchException)} occurred
    */
-  public boolean hasFinished() {
+  public synchronized boolean hasFinished() {
     return failed || succeeded;
   }
 

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherCrossSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherCrossSegmentStorage.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Tracks membership: which segment and block number provide each cross‑segment block.
- *   <li>Reads and validates blocks from disk with defensive handling of I/O failures.
+ *   <li>Reads and validates blocks from the disk with defensive handling of I/O failures.
  *   <li>Performs FEC decode/encode and reports recovered blocks back to their segments.
  *   <li>Bounds memory via {@link network.crypta.support.MemoryLimitedJobRunner} jobs.
  * </ul>
@@ -59,7 +59,7 @@ public class SplitFileFetcherCrossSegmentStorage {
 
   /**
    * Owning storage that coordinates all segments for the overall split‑file request. The parent is
-   * used to obtain priorities, schedule persistent jobs, and report success or fatal errors. The
+   * used to get priorities, schedule persistent jobs, and report success or fatal errors. The
    * reference remains valid until the fetch completes or is canceled.
    */
   public final SplitFileFetcherStorage parent;
@@ -92,7 +92,7 @@ public class SplitFileFetcherCrossSegmentStorage {
   private boolean cancelled;
 
   /**
-   * If true, the segment has completed. Once a segment decode starts, finished must not be set
+   * If true, the segment has completed. Once a segment decoding starts, finished must not be set
    * until it exits.
    */
   private boolean succeeded;
@@ -378,7 +378,7 @@ public class SplitFileFetcherCrossSegmentStorage {
   private static boolean[] wasNonNullFill(byte[][] blocks) {
     boolean[] nonNulls = new boolean[blocks.length];
     for (int i = 0; i < blocks.length; i++) {
-      // Treat null or empty arrays as absent; provide zero-filled buffer for codec.
+      // Treat null or empty arrays as absent; provide a zero-filled buffer for codec.
       if (blocks[i] == null || blocks[i].length == 0) {
         blocks[i] = new byte[CHKBlock.DATA_LENGTH];
       } else {
@@ -479,7 +479,7 @@ public class SplitFileFetcherCrossSegmentStorage {
    *
    * <p>The format consists of two integers (data block count, check block count) followed by, for
    * each cross‑segment position, the segment number and the block number within that segment. The
-   * output is sufficient to reconstruct the mapping using the stream constructor.
+   * output is enough to reconstruct the mapping using the stream constructor.
    *
    * @param dos destination stream; the caller owns the stream’s lifetime and buffering policy and
    *     must not be {@code null}
@@ -539,13 +539,13 @@ public class SplitFileFetcherCrossSegmentStorage {
   }
 
   /**
-   * Scan referenced segments and mark blocks already present on disk.
+   * Scan referenced segments and mark blocks already present on the disk.
    *
    * <p>Invoked after the parent has read segment metadata, this method initializes internal
    * availability counters from the current on‑disk state. It performs no locking; callers typically
-   * use it during construction prior to scheduling any decode attempts.
+   * use it during construction before scheduling any decoding attempts.
    */
-  public void checkBlocks() {
+  public synchronized void checkBlocks() {
     for (int i = 0; i < totalBlocks; i++) {
       if (segments[i].hasBlock(blockNumbers[i])) {
         blocksFound[i] = true;
@@ -577,7 +577,7 @@ public class SplitFileFetcherCrossSegmentStorage {
    *
    * <p>If a decode/encode job is in progress, the completion callback will not be invoked until the
    * job exits; otherwise the method schedules the usual completion notification on the parent.
-   * After cancellation, subsequent notifications are ignored.
+   * After cancellation, further notifications are ignored.
    */
   public void cancel() {
     synchronized (this) {

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherKeyListener.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherKeyListener.java
@@ -119,7 +119,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
   /** The per-segment bloom filters, containing the keys for each segment. These are not changed. */
   private final BinaryBloomFilter[] segmentFilters;
 
-  private boolean finishedSetup;
+  private volatile boolean finishedSetup;
   private final boolean persistent;
 
   /** Does the main bloom filter need writing? */
@@ -284,7 +284,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
           storage.offsetSegmentBloomFilters, segmentsFilterBuffer, 0, segmentsFilterBuffer.length);
     } catch (ChecksumFailedException e) {
       LOG.error(
-          "Checksummed read for segment filters at {} failed for {}",
+          "Check-summed read for segment filters at {} failed for {}",
           storage.offsetSegmentBloomFilters,
           this,
           e);
@@ -312,7 +312,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
             storage.offsetMainBloomFilter, filterBuffer, 0, mainBloomFilterSizeBytes);
       } catch (ChecksumFailedException e) {
         LOG.error(
-            "Checksummed read for main filters at {} failed for {}",
+            "Check-summed read for main filters at {} failed for {}",
             storage.offsetMainBloomFilter,
             this,
             e);
@@ -576,7 +576,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
    * <p>The method writes, in order: {@code localSalt} (32 bytes), {@code mainBloomFilterSizeBytes},
    * {@code mainBloomK}, {@code perSegmentBloomFilterSizeBytes}, and {@code perSegmentK}. It does
    * not write the main or per‑segment filter contents; those regions are handled separately using
-   * checksummed blobs.
+   * check-summed blobs.
    *
    * @param dos target stream used to serialize settings; must remain open for further writes by the
    *     caller; the method does not close the stream

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentBlockChooser.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentBlockChooser.java
@@ -15,10 +15,10 @@ import network.crypta.node.KeysFetchingLocally;
  * block) until other work completes or additional context is available.
  *
  * <p>Instances are stateful. The selection path in the parent class is synchronized and invokes the
- * {@link #checkValid(int)} hook to filter candidates for the current attempt. Callers obtain the
- * next eligible block index by invoking {@code chooseKey()} on this chooser; a return value of
- * {@code -1} indicates a global cooldown is in effect. No I/O is performed during construction, but
- * validating a candidate may read the segment's key list from disk.
+ * {@link #checkValid(int)} hook to filter candidates for the current attempt. Callers get the next
+ * eligible block index by invoking {@code chooseKey()} on this chooser; a return value of {@code
+ * -1} indicates a global cooldown is in effect. No I/O is performed during construction, but
+ * validating a candidate may read the segment's key list from the disk.
  *
  * <ul>
  *   <li>Cooldown: inherits per‑block cooldown after repeated non‑fatal failures.
@@ -49,7 +49,7 @@ public class SplitFileFetcherSegmentBlockChooser extends CooldownBlockChooser {
    * @param cooldownTries number of attempts between cooldowns; when non‑zero, every {@code
    *     cooldownTries}th attempt schedules a temporary cooldown window for a block.
    * @param cooldownTime cooldown duration in milliseconds added to {@link
-   *     System#currentTimeMillis()} to compute per‑block wake‑up times.
+   *     System#currentTimeMillis()} to compute per‑block wakeup times.
    * @param params segment-specific chooser parameters such as key storage and in-flight tracking.
    */
   public SplitFileFetcherSegmentBlockChooser(
@@ -81,10 +81,10 @@ public class SplitFileFetcherSegmentBlockChooser extends CooldownBlockChooser {
    * @param chosen zero‑based block index to validate for selection; must lie within the configured
    *     range for this chooser instance.
    * @return {@code true} when the index passes base checks, is not the ignored index, and is not
-   *     already being fetched locally; {@code false} otherwise.
+   *     yet being fetched locally; {@code false} otherwise.
    */
   @Override
-  protected boolean checkValid(int chosen) {
+  protected synchronized boolean checkValid(int chosen) {
     if (!super.checkValid(chosen)) return false;
     if (chosen == ignoreLastBlock) return false;
     try {

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentStorage.java
@@ -542,6 +542,7 @@ public class SplitFileFetcherSegmentStorage {
     return fail;
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class SplitFileFetcherBlock {
     final byte[] buf;
     final int blockNumber;
@@ -604,6 +605,7 @@ public class SplitFileFetcherSegmentStorage {
     parent.restartedAfterDataCorruption();
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class DecodePrep {
     final byte[][] dataBlocks;
     final byte[][] checkBlocks;
@@ -1144,7 +1146,8 @@ public class SplitFileFetcherSegmentStorage {
    *     invariants.
    * @throws ChecksumFailedException if the persisted checksum does not match the payload.
    */
-  void readMetadata() throws IOException, StorageFormatException, ChecksumFailedException {
+  synchronized void readMetadata()
+      throws IOException, StorageFormatException, ChecksumFailedException {
     byte[] buf = new byte[segmentStatusPaddedLength];
     try {
       parent.preadChecksummed(
@@ -1428,7 +1431,7 @@ public class SplitFileFetcherSegmentStorage {
    * Only called during creation. Writes the segment key list and its checksum; callers must not
    * trigger a read of the keys before they have been persisted.
    */
-  void writeKeysWithChecksum(SplitFileSegmentKeys keys) throws IOException {
+  synchronized void writeKeysWithChecksum(SplitFileSegmentKeys keys) throws IOException {
     assert Objects.equals(keysCache.get(), keys);
     assert (this.dataBlocks + this.crossSegmentCheckBlocks == keys.dataBlocks);
     assert (this.checkBlocks == keys.checkBlocks);

--- a/src/main/java/network/crypta/client/async/SplitFileInserterSegmentBlockChooser.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterSegmentBlockChooser.java
@@ -43,7 +43,7 @@ public class SplitFileInserterSegmentBlockChooser extends SimpleBlockChooser {
   final KeysFetchingLocally keysFetching;
   final int[] consecutiveRNFs;
 
-  /** If positive, this many RNFs count as success. */
+  /** If positive, these many RNFs count as success. */
   final int consecutiveRNFsCountAsSuccess;
 
   /**
@@ -60,8 +60,8 @@ public class SplitFileInserterSegmentBlockChooser extends SimpleBlockChooser {
    * @param maxRetries maximum number of non-fatal failures per block before giving up;
    *     non-negative.
    * @param keysFetching coordinator that tracks keys being inserted to avoid duplicate work.
-   * @param consecutiveRNFsCountAsSuccess if greater than zero, treat N consecutive RNFs as success;
-   *     zero or negative disables the policy.
+   * @param consecutiveRNFsCountAsSuccess if greater than zero, treat N consecutive RNFs as a
+   *     success; zero or negative disables the policy.
    */
   public SplitFileInserterSegmentBlockChooser(
       SplitFileInserterSegmentStorage segment,
@@ -109,11 +109,11 @@ public class SplitFileInserterSegmentBlockChooser extends SimpleBlockChooser {
   /**
    * Checks whether a candidate block is currently eligible for insertion.
    *
-   * <p>Combines the base validity checks with a de-duplication guard that skips blocks already
-   * being inserted as reported by {@link KeysFetchingLocally}.
+   * <p>Combines the base validity checks with a deduplication guard that skips blocks already being
+   * inserted as reported by {@link KeysFetchingLocally}.
    *
    * @param chosen zero-based block index to validate for selection.
-   * @return {@code true} if the block passes base checks and is not already being inserted; {@code
+   * @return {@code true} if the block passes base checks and is not yet being inserted; {@code
    *     false} otherwise.
    */
   @Override
@@ -196,7 +196,7 @@ public class SplitFileInserterSegmentBlockChooser extends SimpleBlockChooser {
    * @throws StorageFormatException if the serialized data is structurally invalid for this type.
    */
   @Override
-  public void read(DataInputStream dis) throws IOException, StorageFormatException {
+  public synchronized void read(DataInputStream dis) throws IOException, StorageFormatException {
     super.read(dis);
     if (consecutiveRNFsCountAsSuccess > 0) {
       int[] rnfs = this.consecutiveRNFs;

--- a/src/main/java/network/crypta/client/async/SplitFileInserterSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterSegmentStorage.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * and two kinds of redundancy blocks: per-segment check blocks and cross-segment check blocks. This
  * class owns the per-segment state for one segment during an insert: tracking which blocks exist on
  * disk, generating and persisting keys, running FEC encoding, and coordinating block transmission.
- * It is instantiated either from fixed settings (for new inserts), or from persisted metadata (for
+ * It is instantiated either from fixed settings (for new inserts) or from persisted metadata (for
  * restarts).
  *
  * <p>Typical flow: the caller constructs the instance, optionally restores persisted status via
@@ -54,10 +54,10 @@ import org.slf4j.LoggerFactory;
  * completion or cancellation.
  *
  * <ul>
- *   <li>Responsibilities: encode blocks, persist keys/status, choose next block
+ *   <li>Responsibilities: encode blocks, persist keys/status, choose the next block
  *   <li>Notable behavior: lazy metadata writes; restart-friendly status format
- *   <li>Error handling: disk errors fail the parent; RNF may be treated as success under configured
- *       heuristics
+ *   <li>Error handling: disk errors fail the parent; RNF may be treated as a success under
+ *       configured heuristics
  * </ul>
  *
  * @see SplitFileInserterStorage
@@ -69,7 +69,7 @@ public class SplitFileInserterSegmentStorage {
   /**
    * Parameter object used to configure segment construction.
    *
-   * <p>This simple builder groups the knobs required to create a segment: block counts,
+   * <p>This basic builder groups the knobs required to create a segment: block counts,
    * cryptographic parameters, and block-choosing/codec related settings. Using an explicit
    * parameter object keeps the constructor readable and stable while allowing callers to assemble
    * values in a fluent style.
@@ -164,13 +164,13 @@ public class SplitFileInserterSegmentStorage {
   final int totalBlockCount;
 
   /** Has the segment been encoded? If so, all the check blocks have been written. */
-  private boolean encoded;
+  private volatile boolean encoded;
 
   private boolean encoding;
 
   private final int statusLength;
 
-  /** Length of a single key stored on disk. Includes checksum. */
+  /** Length of a single key stored on the disk. Includes checksum. */
   private final int keyLength;
 
   // Populated by SplitFileInserterCrossSegmentStorage during construction.
@@ -201,7 +201,7 @@ public class SplitFileInserterSegmentStorage {
 
   private boolean metadataDirty;
 
-  /** Set if the insert is cancelled. */
+  /** Set if the insert is canceled. */
   private boolean cancelled;
 
   /**
@@ -255,7 +255,7 @@ public class SplitFileInserterSegmentStorage {
    * Recreate a segment from on-disk fixed settings previously written by {@link
    * #writeFixedSettings(DataOutputStream)}.
    *
-   * <p>The constructor reads basic block counts and status sizing, rebuilds chooser state, and
+   * <p>The constructor reads basic block counts and status sizing, rebuilds the chooser state, and
    * validates that values are within reasonable limits. It does not read per-block keys or variable
    * status; call {@link #readStatus()} for that after construction.
    *
@@ -326,7 +326,7 @@ public class SplitFileInserterSegmentStorage {
    * splitfile compatibility; the Random seed is actually determined by the splitfile metadata.
    *
    * @param random PRNG seeded from the splitfile metadata, which determines which blocks to
-   *     allocate in a deterministic manner.
+   *     allocate deterministically.
    * @return The data block number allocated.
    */
   int allocateCrossDataBlock(Random random) {
@@ -360,7 +360,7 @@ public class SplitFileInserterSegmentStorage {
    *
    * @param seg The cross-segment to allocate a block for.
    * @param random PRNG seeded from the splitfile metadata, which determines which blocks to
-   *     allocate in a deterministic manner.
+   *     allocate deterministically.
    * @param crossSegmentBlockNumber Block number within the cross-segment.
    * @return The block number allocated (between dataBlockCount and
    *     dataBlockCount+crossSegmentCheckBlocks).
@@ -387,8 +387,8 @@ public class SplitFileInserterSegmentStorage {
    * Persist the current status for this segment when appropriate.
    *
    * <p>When persistence is enabled and the overall insert is still active, this method writes the
-   * status record unless metadata is already up-to-date. The write is skipped when the segment has
-   * been cancelled, and failures are reported back to the parent as disk errors.
+   * status record unless metadata is already up to date. The writing is skipped when the segment
+   * has been canceled, and failures are reported back to the parent as disk errors.
    *
    * @param force when {@code true}, write status regardless of the in-memory dirty flag; when
    *     {@code false}, write only if metadata changed.
@@ -408,7 +408,7 @@ public class SplitFileInserterSegmentStorage {
         }
         metadataDirty = false;
       }
-      // Outside the lock is safe since if we fail we will fail the whole splitfile.
+      // Outside the lock is safe since if we fail, we will fail the whole splitfile.
       dos.close();
     } catch (IOException e) {
       LOG.error("I/O error writing segment status?: {}", e, e);
@@ -751,7 +751,7 @@ public class SplitFileInserterSegmentStorage {
   /**
    * Generate keys for each block and record them.
    *
-   * @throws IOException if persisting a generated key for any block fails due to an I/O error in
+   * @throws IOException if persisting, a generated key for any block fails due to an I/O error in
    *     the underlying storage.
    */
   private void generateKeys(byte[][] dataBlocks, int offset) throws IOException {
@@ -784,14 +784,16 @@ public class SplitFileInserterSegmentStorage {
    * @return {@code true} when all per-segment and cross-segment check blocks have been generated
    *     and written; {@code false} otherwise.
    */
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   public synchronized boolean isFinishedEncoding() {
     return encoded;
   }
 
   /**
    * For unit tests. Generally for concurrency purposes we want something that won't change back,
-   * hence e.g. isFinishedEncoding().
+   * hence e.g., isFinishedEncoding().
    */
+  @SuppressWarnings("unused")
   synchronized boolean isEncoding() {
     return encoding;
   }
@@ -801,12 +803,12 @@ public class SplitFileInserterSegmentStorage {
    *
    * <p>This method reads the block content (data, cross-check, or check) based on the index,
    * validates preconditions (not already successfully inserted), and applies the splitfile crypto.
-   * It does not modify persistent state.
+   * It does not modify the persistent state.
    *
    * @param blockNo zero-based block index spanning data, cross-check, and check regions.
    * @return an immutable encoded block that exposes the derived {@linkplain ClientCHK client key}
    *     for uploads.
-   * @throws IOException if the block cannot be read or if an already-inserted block is requested.
+   * @throws IOException if the block cannot be read, or if an already-inserted block is requested.
    */
   public ClientCHKBlock encodeBlock(int blockNo) throws IOException {
     if (parent.isFinishing()) {
@@ -867,7 +869,7 @@ public class SplitFileInserterSegmentStorage {
   }
 
   /**
-   * Signals that a requested per-block key is not present on disk.
+   * Signals that a requested per-block key is not present on the disk.
    *
    * <p>Thrown by {@link #readKey(int)} when the on-disk marker indicates the key is missing.
    * Callers typically trigger re-encoding to regenerate keys in such cases.
@@ -890,10 +892,10 @@ public class SplitFileInserterSegmentStorage {
    * Return whether all required blocks for this segment have been inserted.
    *
    * <p>The outcome is final under normal operation. In rare circumstances involving local data loss
-   * (for example, keys removed from disk), the state may be reconsidered by higher layers.
+   * (for example, keys removed from the disk), the state may be reconsidered by higher layers.
    *
    * @return {@code true} if the chooser reports success for all required blocks; {@code false} if
-   *     any block remains or the segment was cancelled.
+   *     any block remains or the segment was canceled.
    */
   public synchronized boolean hasSucceeded() {
     if (cancelled) return false;
@@ -912,8 +914,8 @@ public class SplitFileInserterSegmentStorage {
   /**
    * Notify this segment that a block insert succeeded.
    *
-   * <p>The method records the key when not already present, updates chooser state, and triggers a
-   * lazy metadata write. The parent callback is invoked when success completes the segment.
+   * <p>The method records the key when not already present, updates the chooser state, and triggers
+   * a lazy metadata writing. The parent callback is invoked when success completes the segment.
    *
    * @param blockNo zero-based block index whose insert succeeded.
    * @param key the {@link ClientCHK} associated with the inserted block; must match the value
@@ -1008,7 +1010,7 @@ public class SplitFileInserterSegmentStorage {
    */
   public synchronized boolean hasCompletedOrFailed() {
     if (encoded) return true; // No more encoding jobs will run.
-    if (encoding) return false; // Waiting for job to finish.
+    if (encoding) return false; // Waiting for the job to finish.
     if (cancelled) return true;
     return blockChooser.hasSucceededAll();
   }
@@ -1017,9 +1019,9 @@ public class SplitFileInserterSegmentStorage {
    * Request cancellation of this segment.
    *
    * <p>The caller must separately check {@link #hasCompletedOrFailed()} after all segments are
-   * cancelled to observe completion of any in-flight encode work.
+   * canceled to observe completion of any in-flight encode work.
    *
-   * @return {@code true} if the segment is now done (no work pending); {@code false} if an encode
+   * @return {@code true} if the segment is now done (no work pending); {@code false} if an encoding
    *     was already in progress and a callback will be issued to the parent when it finishes.
    */
   public synchronized boolean cancel() {
@@ -1029,7 +1031,7 @@ public class SplitFileInserterSegmentStorage {
   }
 
   /**
-   * Choose the next block to insert according to the internal policy.
+   * Choose the next block to insert, according to the internal policy.
    *
    * @return a {@link BlockInsert} handle representing the chosen block, or {@code null} if no
    *     further blocks should be sent at this time.
@@ -1108,7 +1110,7 @@ public class SplitFileInserterSegmentStorage {
 
   /**
    * Set the cross-segment associated with a cross-check block, which tells us how to read that
-   * block from disk.
+   * block from the disk.
    *
    * @param crossSegment The cross-segment.
    * @param segmentBlockNumber The block number within this segment

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
@@ -221,7 +221,7 @@ public class SplitFileInserterStorage {
     FAILED
   }
 
-  private Status status;
+  private volatile Status status;
   private final FailureCodeTracker errors;
   private boolean overallStatusDirty;
 

--- a/src/main/java/network/crypta/client/async/USKAttempt.java
+++ b/src/main/java/network/crypta/client/async/USKAttempt.java
@@ -39,7 +39,7 @@ public final class USKAttempt implements USKCheckerCallback {
   USKChecker checker;
 
   /** Successful fetch? */
-  boolean succeeded;
+  volatile boolean succeeded;
 
   /** DNF? */
   boolean dnf;

--- a/src/main/java/network/crypta/client/async/USKFetcher.java
+++ b/src/main/java/network/crypta/client/async/USKFetcher.java
@@ -309,7 +309,7 @@ public class USKFetcher
       needSchedule = schedulingCoordinator.scheduleAfterDBRsDone();
     }
     if (needSchedule) schedule(context);
-    pollingRound.checkFinishedForNow(context, cancelled, completed);
+    checkFinishedForNow(context);
   }
 
   /**
@@ -336,7 +336,13 @@ public class USKFetcher
    * @param context client context used to notify progress callbacks; must not be null
    */
   private void checkFinishedForNow(ClientContext context) {
-    pollingRound.checkFinishedForNow(context, cancelled, completed);
+    boolean cancelledSnapshot;
+    boolean completedSnapshot;
+    synchronized (this) {
+      cancelledSnapshot = cancelled;
+      completedSnapshot = completed;
+    }
+    pollingRound.checkFinishedForNow(context, cancelledSnapshot, completedSnapshot);
   }
 
   // moved into USKStoreCheckerGetter to satisfy S3398
@@ -417,7 +423,7 @@ public class USKFetcher
     long delay =
         pollingRound.rescheduleBackgroundPoll(context, schedulingCoordinator.valueAtSchedule());
     schedule(delay, context);
-    pollingRound.checkFinishedForNow(context, cancelled, completed);
+    checkFinishedForNow(context);
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/USKFetcherTag.java
+++ b/src/main/java/network/crypta/client/async/USKFetcherTag.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * <p>This type exists to decouple long-lived request intent from the short-lived mechanics of a
  * running fetch. Typical usage is to construct a tag via {@link #create(USK, USKFetcherCallback,
  * FetchContext, int, Flag...)} and then hand it to code that schedules work. On startup the node
- * reinstates pending USK fetches from persistent state; tags are reused while a new transient
+ * reinstates pending USK fetches from a persistent state; tags are reused while a new transient
  * fetcher is created and wired to the original callback.
  *
  * <p>Concurrency: instances are designed to be passed across threads managed by {@code
@@ -67,7 +67,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
   public final boolean persistent;
 
   /**
-   * Fetch context controlling policies such as timeouts, routing and verification. The context is
+   * Fetch context controlling policies such as timeouts, routing, and verification. The context is
    * supplied by the caller and is treated as read‑only by this type; ownership and lifecycle remain
    * with the caller.
    */
@@ -85,7 +85,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
 
   /**
    * Opaque application token preserved across callbacks. Useful for correlating fetch completion
-   * with the original request or UI action. The value is not interpreted by this class.
+   * with the original request or UI action. This class does not interpret the value.
    */
   private final long token;
 
@@ -146,8 +146,8 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
    * constructed when the tag is scheduled or resumed.
    *
    * <p>For persistent requests, the caller is responsible for removing the request from persistent
-   * storage when it is no longer needed; the lifecycle of the {@link USKFetcherCallback} and {@link
-   * FetchContext} remains under the caller’s control.
+   * storage when it is no longer necessary; the lifecycle of the {@link USKFetcherCallback} and
+   * {@link FetchContext} remains under the caller’s control.
    *
    * @param usk The original {@link USK} to fetch; must be non‑null. The edition may be adjusted
    *     internally when scheduling.
@@ -157,7 +157,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
    *     treated as read‑only by this tag.
    * @param token Application‑supplied token for correlation; preserved and returned from {@link
    *     #getToken()} unchanged.
-   * @param flags Optional behavior switches influencing persistence, realtime scheduling and store
+   * @param flags Optional behavior switches influencing persistence, realtime scheduling, and store
    *     probing. Omit for defaults; duplicates are ignored.
    * @return A new {@code USKFetcherTag} instance encapsulating the provided arguments and options;
    *     never {@code null}.
@@ -207,8 +207,12 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
    */
   public void start(USKManager manager, ClientContext context) {
     USK usk = origUSK;
-    if (usk.suggestedEdition < edition) {
-      usk = usk.copy(edition);
+    long editionSnapshot;
+    synchronized (this) {
+      editionSnapshot = edition;
+    }
+    if (usk.suggestedEdition < editionSnapshot) {
+      usk = usk.copy(editionSnapshot);
     } else if (persistent) { // Copy it to avoid deactivation issues
       usk = usk.copy();
     }
@@ -228,7 +232,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
   /**
    * Requests cancellation of the in‑flight fetch, if any, and marks this tag as finished. For
    * persistent requests, a follow‑up callback is delivered on the persistent job runner so callers
-   * can update durable state.
+   * can update the durable state.
    *
    * @param context The client context used to route the cancellation and potential callback.
    */
@@ -264,7 +268,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
   }
 
   /**
-   * Notification that the fetch was cancelled before producing a result. Ensures callbacks are
+   * Notification that the fetch was canceled before producing a result. Ensures callbacks are
    * delivered on the appropriate executor depending on persistence and marks this tag as finished.
    * Subsequent terminal events are ignored.
    *
@@ -300,7 +304,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
   }
 
   /**
-   * Notification that the fetch failed with a terminal error. The callback is invoked and this tag
+   * Notification that the fetch failed with a terminal error. The callback is invoked, and this tag
    * is marked as finished. When persistent, the notification is delivered via the persistent job
    * runner to preserve ordering with durable state updates.
    *
@@ -405,12 +409,12 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
   }
 
   /**
-   * Indicates whether this tag has already received a terminal event (cancelled, failure, or
-   * edition found). Once {@code true}, no further callbacks are emitted for this instance.
+   * Indicates whether this tag has already received a terminal event (canceled, failure, or edition
+   * found). Once {@code true}, no further callbacks are emitted for this instance.
    *
    * @return {@code true} when a terminal event was processed; otherwise {@code false}.
    */
-  public final boolean isFinished() {
+  public final synchronized boolean isFinished() {
     return finished;
   }
 
@@ -435,7 +439,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
    */
   @Override
   public void onResume(ClientContext context) {
-    if (finished) return;
+    if (isFinished()) return;
     start(context.uskManager, context);
   }
 
@@ -470,7 +474,7 @@ public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serial
 
     /**
      * Retain the last successfully fetched data while probing for newer editions. Useful when
-     * consumers prefer a best‑effort result even during upgrades.
+     * consumers prefer the best‑effort result even during upgrades.
      */
     KEEP_LAST_DATA,
 

--- a/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/src/main/java/network/crypta/client/async/USKInserter.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Concurrency: instances are stateful and not intended for reuse across multiple inserts.
  * Internal state transitions occur on callbacks driven by the client framework; externally visible
- * methods guard state via synchronization where necessary. Callers should treat an instance as
+ * methods guard the state via synchronization where necessary. Callers should treat an instance as
  * single-use and avoid concurrent calls other than lifecycle hooks invoked by the framework.
  *
  * <ul>
@@ -75,7 +75,7 @@ public class USKInserter
   /** Per-insert configuration including retry policy, priorities, and flags. */
   final InsertContext ctx;
 
-  /** Callback notified of encode, success, failure, and state transitions. */
+  /** Callback notified of encoding, success, failure, and state transitions. */
   @SuppressWarnings("java:S1948")
   final PutCompletionCallback cb;
 
@@ -107,7 +107,7 @@ public class USKInserter
   /** Corresponding public USK used to resolve and report editions to consumers. */
   final USK pubUSK;
 
-  /** Fetcher used to discover the latest inserted edition (scanning for latest slot). */
+  /** Fetcher used to discover the latest inserted edition (scanning for the latest slot). */
   private USKFetcherTag fetcher;
 
   /** Helper that inserts the actual SSK block for a given edition. */
@@ -146,7 +146,7 @@ public class USKInserter
    * <p>Schedules a discovery pass to find the latest known edition and then attempts to insert the
    * provided data at the next edition. Progress and completion are delivered to the configured
    * {@link PutCompletionCallback}. Idempotent with respect to repeated calls before completion;
-   * subsequent calls after a terminal state have no effect.
+   * later calls after a terminal state have no effect.
    *
    * @param context the client context providing executors, managers, and factories; must be
    *     non-{@code null} and valid for the lifetime of the operation
@@ -173,21 +173,31 @@ public class USKInserter
    * errors and so on.
    */
   private void scheduleFetcher(ClientContext context) {
+    USKFetcherTag localFetcher;
     synchronized (this) {
       if (LOG.isDebugEnabled()) LOG.debug("scheduling fetcher for {}", pubUSK.getURI());
       if (finished) return;
-      fetcher =
-          context.uskManager.getFetcherForInsertDontSchedule(
-              persistent ? pubUSK.copy() : pubUSK,
-              parent.priorityClass,
-              this,
-              parent.getClient(),
-              context,
-              persistent,
-              ctx.isIgnoreUSKDatehints());
+      localFetcher =
+          fetcher =
+              context.uskManager.getFetcherForInsertDontSchedule(
+                  persistent ? pubUSK.copy() : pubUSK,
+                  parent.priorityClass,
+                  this,
+                  parent.getClient(),
+                  context,
+                  persistent,
+                  ctx.isIgnoreUSKDatehints());
       if (LOG.isDebugEnabled()) LOG.debug("scheduled: {}", fetcher);
     }
-    fetcher.schedule(context);
+    boolean shouldSchedule;
+    synchronized (this) {
+      shouldSchedule = !finished && fetcher != null && fetcher.equals(localFetcher);
+    }
+    if (shouldSchedule) {
+      localFetcher.schedule(context);
+    } else if (LOG.isDebugEnabled()) {
+      LOG.debug("Skipping stale fetcher schedule on {}", this);
+    }
   }
 
   /**
@@ -195,7 +205,7 @@ public class USKInserter
    *
    * <p>Updates the candidate edition and, when possible, determines whether the content is already
    * present by comparing data and codec. If the payload is already inserted at the reported
-   * edition, completes successfully. Otherwise, schedules an insert attempt at the next edition.
+   * edition, it completes successfully. Otherwise, schedules an insert attempt at the next edition.
    *
    * @param foundEdition The payload describing the discovered edition and its metadata.
    */
@@ -207,8 +217,11 @@ public class USKInserter
     short codec = foundEdition.codec();
     byte[] hisData = foundEdition.data();
     boolean alreadyInserted = false;
+    long currentEdition;
+    Bucket dataToFree = null;
     synchronized (this) {
       edition = Math.max(editionFound, edition);
+      currentEdition = edition;
       consecutiveCollisions = 0;
       if ((lastContentWasMetadata == isMetadata)
           && hisData != null
@@ -220,6 +233,10 @@ public class USKInserter
             alreadyInserted = true;
             finished = true;
             sbi = null;
+            if (freeData) {
+              dataToFree = data;
+              data = null;
+            }
           }
         } catch (IOException e) {
           LOG.error("Could not decode: {}", e, e);
@@ -232,11 +249,9 @@ public class USKInserter
     if (alreadyInserted) {
       // Success!
       parent.completedBlock(true, context);
-      cb.onEncode(pubUSK.copy(edition), this, context);
+      cb.onEncode(pubUSK.copy(currentEdition), this, context);
       insertSucceeded(context, editionFound);
-      if (freeData) {
-        data.free();
-      }
+      if (dataToFree != null) dataToFree.free();
     } else {
       scheduleInsert(context);
     }
@@ -296,37 +311,39 @@ public class USKInserter
 
   private void scheduleInsert(ClientContext context) {
     // Schedules a single-block insert for the current candidate edition.
-    long edNo = Math.max(edition, context.uskManager.lookupLatestSlot(pubUSK) + 1);
+    long latestKnownSlot = context.uskManager.lookupLatestSlot(pubUSK) + 1;
+    SingleBlockInserter localSbi;
     synchronized (this) {
       if (finished) return;
-      edition = edNo;
+      edition = Math.max(edition, latestKnownSlot);
       if (LOG.isDebugEnabled()) LOG.debug("scheduling insert for {} {}", pubUSK.getURI(), edition);
-      sbi =
-          new SingleBlockInserter(
-              new BlockInsertPayload(
-                  data,
-                  privUSK.getInsertableSSK(edition).getInsertURI(),
-                  compressionCodec,
-                  isMetadata,
-                  sourceLength,
-                  cryptoAlgorithm,
-                  forceCryptoKey),
-              new BlockInsertParams(parent, ctx, this, token, tokenObject, false, context),
-              new BlockInsertOptions(persistent, realTimeFlag, false, extraInserts),
-              true /* we don't use it */);
+      localSbi =
+          sbi =
+              new SingleBlockInserter(
+                  new BlockInsertPayload(
+                      data,
+                      privUSK.getInsertableSSK(edition).getInsertURI(),
+                      compressionCodec,
+                      isMetadata,
+                      sourceLength,
+                      cryptoAlgorithm,
+                      forceCryptoKey),
+                  new BlockInsertParams(parent, ctx, this, token, tokenObject, false, context),
+                  new BlockInsertOptions(persistent, realTimeFlag, false, extraInserts),
+                  true /* we don't use it */);
     }
     try {
-      sbi.schedule(context);
+      localSbi.schedule(context);
     } catch (InsertException e) {
+      Bucket dataToFree = null;
       synchronized (this) {
         finished = true;
-      }
-      if (freeData) {
-        data.free();
-        synchronized (this) {
+        if (freeData) {
+          dataToFree = data;
           data = null;
         }
       }
+      if (dataToFree != null) dataToFree.free();
       cb.onFailure(e, this, context);
     }
   }
@@ -335,8 +352,8 @@ public class USKInserter
    * Notifies that the single-block insert succeeded.
    *
    * <p>Updates the USK manager with the confirmed edition, frees data if configured, and reports
-   * the encoded USK (with concrete edition) to the completion callback. Also triggers optional USK
-   * date hint insertion when enabled by the insert context.
+   * the encoded USK (with a concrete edition) to the completion callback. Also triggers optional
+   * USK date hint insertion when enabled by the insert context.
    *
    * @param state the originating state that completed, expected to be a {@link SingleBlockInserter}
    * @param context the client context for follow-up work and bookkeeping
@@ -377,6 +394,7 @@ public class USKInserter
   @Override
   public void onFailure(InsertException e, ClientPutState state, ClientContext context) {
     synchronized (this) {
+      if (finished) return;
       sbi = null;
       if (e.getMode() == InsertExceptionMode.COLLISION) {
         // Try the next slot
@@ -385,17 +403,13 @@ public class USKInserter
         if (consecutiveCollisions > MAX_TRIED_SLOTS) scheduleFetcher(context);
         else scheduleInsert(context);
       } else {
-        Bucket d = null;
-        synchronized (this) {
-          finished = true;
-          if (freeData) {
-            d = data;
-            data = null;
-          }
-        }
+        Bucket dataToFree = null;
+        finished = true;
         if (freeData) {
-          d.free();
+          dataToFree = data;
+          data = null;
         }
+        if (dataToFree != null) dataToFree.free();
         cb.onFailure(e, state, context);
       }
     }
@@ -466,8 +480,8 @@ public class USKInserter
   /**
    * No-arg constructor for serialization frameworks.
    *
-   * <p>Not intended for direct use by application code. Fields are initialized to defaults only to
-   * satisfy deserialization requirements.
+   * <p>Not intended for direct use by application code. Fields are initialized to the defaults only
+   * to satisfy deserialization requirements.
    */
   @SuppressWarnings("unused")
   protected USKInserter() {
@@ -508,34 +522,35 @@ public class USKInserter
    *
    * <p>Cancels any outstanding discovery and insert tasks, frees data when configured, and reports
    * a {@link InsertExceptionMode#CANCELLED} failure to the completion callback. Safe to call more
-   * than once; subsequent calls after completion have no effect.
+   * than once; later calls after completion have no effect.
    *
    * @param context the client context used to propagate cancellation downstream
    */
   @Override
   public void cancel(ClientContext context) {
     USKFetcherTag tag;
+    SingleBlockInserter localSbi;
     synchronized (this) {
       if (finished) return;
       finished = true;
       tag = fetcher;
       fetcher = null;
+      localSbi = sbi;
+      sbi = null;
     }
     if (tag != null) {
       tag.cancel(context);
     }
-    if (sbi != null) {
-      sbi.cancel(context); // will call onFailure, which will removeFrom()
+    if (localSbi != null) {
+      localSbi.cancel(context); // will call onFailure, which will removeFrom()
     }
     if (freeData) {
-      if (data == null) {
-        LOG.error("data == null in cancel() on {}", this);
-      } else {
-        data.free();
-        synchronized (this) {
-          data = null;
-        }
+      Bucket dataToFree;
+      synchronized (this) {
+        dataToFree = data;
+        data = null;
       }
+      if (dataToFree != null) dataToFree.free();
     }
     cb.onFailure(new InsertException(InsertExceptionMode.CANCELLED), this, context);
   }
@@ -573,10 +588,10 @@ public class USKInserter
   }
 
   /**
-   * Notifies that an encode event occurred during the insert pipeline. This implementation does not
-   * take action for encode events; the final success path reports the encoded USK separately.
+   * Notifies that an encoding event occurred during the insert pipeline. This implementation does
+   * not take action for encoding events; the final success path reports the encoded USK separately.
    *
-   * @param key the key associated with the encode event
+   * @param key the key associated with the encoding event
    * @param state the state reporting the event
    * @param context the client context at the time of the event
    */
@@ -693,12 +708,20 @@ public class USKInserter
    */
   @Override
   public void onResume(ClientContext context) throws InsertException, ResumeFailedException {
-    if (resumed) return;
-    resumed = true;
-    if (data != null) data.onResume(context);
+    Bucket localData;
+    USKFetcherTag localFetcher;
+    SingleBlockInserter localSbi;
+    synchronized (this) {
+      if (resumed) return;
+      resumed = true;
+      localData = data;
+      localFetcher = fetcher;
+      localSbi = sbi;
+    }
+    if (localData != null) localData.onResume(context);
     if (cb != null && cb != parent) cb.onResume(context);
-    if (fetcher != null) fetcher.onResume(context);
-    if (sbi != null) sbi.onResume(context);
+    if (localFetcher != null) localFetcher.onResume(context);
+    if (localSbi != null) localSbi.onResume(context);
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/USKStoreCheckCoordinator.java
+++ b/src/main/java/network/crypta/client/async/USKStoreCheckCoordinator.java
@@ -3,6 +3,7 @@ package network.crypta.client.async;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.FetchContext;
 import network.crypta.keys.Key;
 import network.crypta.keys.USK;
@@ -37,7 +38,8 @@ final class USKStoreCheckCoordinator {
   private static final Logger LOG = LoggerFactory.getLogger(USKStoreCheckCoordinator.class);
 
   /** Active store checker getter, or {@code null} when no store scan is running. */
-  private USKStoreCheckerGetter runningStoreChecker;
+  private final AtomicReference<USKStoreCheckerGetter> runningStoreChecker =
+      new AtomicReference<>();
 
   /** Watched key set used to derive datastore checks. */
   private final USKKeyWatchSet watchingKeys;
@@ -287,29 +289,31 @@ final class USKStoreCheckCoordinator {
    */
   @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   boolean fillKeysWatching(long ed, ClientContext context) {
+    USKStoreCheckerGetter activeChecker;
     synchronized (this) {
       // Do not run a new one until this one has finished.
       // USKStoreCheckerGetter itself will automatically call back to fillKeysWatching, so there is
       // no
       // chance of losing it.
-      if (runningStoreChecker != null) return true;
+      if (runningStoreChecker.get() != null) return true;
       USKStoreChecker checker = buildStoreChecker(ed);
       if (checker == null) {
         if (LOG.isDebugEnabled()) LOG.debug("No datastore checker");
         return false;
       }
 
-      runningStoreChecker = new USKStoreCheckerGetter(this, callbacks, parent, checker);
+      activeChecker = new USKStoreCheckerGetter(this, callbacks, parent, checker);
+      runningStoreChecker.set(activeChecker);
     }
     try {
       context
           .getSskFetchScheduler(realTimeFlag)
-          .register(null, new SendableGet[] {runningStoreChecker}, false, null, false);
+          .register(null, new SendableGet[] {activeChecker}, false, null, false);
     } catch (Exception t) {
       USKStoreCheckerGetter storeChecker;
       synchronized (this) {
-        storeChecker = runningStoreChecker;
-        runningStoreChecker = null;
+        storeChecker = runningStoreChecker.get();
+        runningStoreChecker.set(null);
       }
       LOG.error("Unable to start: {}", t, t);
       if (storeChecker != null) {
@@ -320,7 +324,7 @@ final class USKStoreCheckCoordinator {
         }
       }
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Registered {} for {}", runningStoreChecker, callbacks);
+    if (LOG.isDebugEnabled()) LOG.debug("Registered {} for {}", activeChecker, callbacks);
     return true;
   }
 
@@ -346,7 +350,7 @@ final class USKStoreCheckCoordinator {
     if (callbacks.isCancelled()) {
       storeChecker.unregister(context, storeChecker.getPriorityClass());
       synchronized (this) {
-        runningStoreChecker = null;
+        runningStoreChecker.set(null);
       }
       if (LOG.isDebugEnabled())
         LOG.debug("StoreChecker preRegister aborted: fetcher cancelled/completed");
@@ -358,7 +362,7 @@ final class USKStoreCheckCoordinator {
 
     USKAttempt[] attemptsToStart;
     synchronized (this) {
-      runningStoreChecker = null;
+      runningStoreChecker.set(null);
       // Note: optionally start USKAttempts only when a datastore check shows no progress.
       attemptsToStart = attempts.snapshotAttemptsToStart();
       attempts.clearAttemptsToStart();
@@ -401,7 +405,7 @@ final class USKStoreCheckCoordinator {
    */
   boolean isStoreCheckRunning() {
     synchronized (this) {
-      return runningStoreChecker != null;
+      return runningStoreChecker.get() != null;
     }
   }
 
@@ -415,8 +419,8 @@ final class USKStoreCheckCoordinator {
   void cancelStoreChecker(ClientContext context) {
     USKStoreCheckerGetter checker;
     synchronized (this) {
-      checker = runningStoreChecker;
-      runningStoreChecker = null;
+      checker = runningStoreChecker.get();
+      runningStoreChecker.set(null);
     }
     if (checker != null) {
       checker.unregister(context, checker.getPriorityClass());
@@ -441,6 +445,7 @@ final class USKStoreCheckCoordinator {
    * <p>This helper merges keys from multiple sources and forwards completion notifications back to
    * the underlying sub-checkers.
    */
+  @SuppressWarnings("ClassCanBeRecord")
   static final class USKStoreChecker {
 
     /** Sub-checkers contributing keys to a query in the datastore. */

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -85,7 +85,7 @@ public class ClientPut extends ClientPutBase {
   private final ClientMetadata clientMetadata;
 
   /** We store the size of inserted data before freeing it */
-  private long finishedSize;
+  private volatile long finishedSize;
 
   /** Filename if the file has one */
   private final String targetFilename;

--- a/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
@@ -873,6 +873,10 @@ public abstract class ClientPutBase extends ClientRequest
     return s;
   }
 
+  final synchronized FCPMessage getProgressMessageSnapshot() {
+    return progressMessage;
+  }
+
   /**
    * Exposes the entire {@link PutFailedMessage} object so that higher-level components can
    * serialize or inspect the fine-grained failure codes before freeing state. Callers must not
@@ -881,8 +885,7 @@ public abstract class ClientPutBase extends ClientRequest
    *
    * @return failure message object or {@code null} if the insert never failed
    */
-  public PutFailedMessage getFailureMessage() {
-    if (putFailedMessage == null) return null;
+  public synchronized PutFailedMessage getFailureMessage() {
     return putFailedMessage;
   }
 

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -722,9 +722,10 @@ public class ClientPutDir extends ClientPutBase {
     FreenetURI finalURI = getFinalURI();
     InsertExceptionMode failureCode = null;
     String failureReasonShort = null;
-    if (putFailedMessage != null) {
-      failureCode = putFailedMessage.failureMode;
-      failureReasonShort = putFailedMessage.getLongFailedMessage();
+    PutFailedMessage failureMessage = getFailureMessage();
+    if (failureMessage != null) {
+      failureCode = failureMessage.failureMode;
+      failureReasonShort = failureMessage.getLongFailedMessage();
     }
 
     int total = 0;
@@ -737,7 +738,8 @@ public class ClientPutDir extends ClientPutBase {
     Instant latestFailure = null;
     boolean totalFinalized = false;
 
-    if (progressMessage instanceof SimpleProgressMessage msg) {
+    FCPMessage progressSnapshot = getProgressMessageSnapshot();
+    if (progressSnapshot instanceof SimpleProgressMessage msg) {
       total = (int) msg.getTotalBlocks();
       min = (int) msg.getMinBlocks();
       fetched = (int) msg.getFetchedBlocks();

--- a/src/main/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilder.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutStatusSnapshotBuilder.java
@@ -58,10 +58,11 @@ final class ClientPutStatusSnapshotBuilder {
     InsertExceptionMode failureCode = null;
     String failureReasonShort = null;
     String failureReasonLong = null;
-    if (request.putFailedMessage != null) {
-      failureCode = request.putFailedMessage.failureMode;
-      failureReasonShort = request.putFailedMessage.getShortFailedMessage();
-      failureReasonLong = request.putFailedMessage.getLongFailedMessage();
+    PutFailedMessage failureMessage = request.getFailureMessage();
+    if (failureMessage != null) {
+      failureCode = failureMessage.failureMode;
+      failureReasonShort = failureMessage.getShortFailedMessage();
+      failureReasonLong = failureMessage.getLongFailedMessage();
     }
     String mimeType = null;
     if (request.persistence == ClientRequest.Persistence.FOREVER) {
@@ -103,7 +104,8 @@ final class ClientPutStatusSnapshotBuilder {
     Instant latestFailure = null;
     boolean totalFinalized = false;
 
-    if (request.progressMessage instanceof SimpleProgressMessage msg) {
+    FCPMessage progressSnapshot = request.getProgressMessageSnapshot();
+    if (progressSnapshot instanceof SimpleProgressMessage msg) {
       total = (int) msg.getTotalBlocks();
       min = (int) msg.getMinBlocks();
       fetched = (int) msg.getFetchedBlocks();

--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -101,7 +101,7 @@ public abstract class ClientRequest implements Serializable {
   protected final long startupTime;
 
   /** Timestamp : completion time */
-  protected long completionTime;
+  protected volatile long completionTime;
 
   /**
    * Low-level node-side request handle used to communicate with the core routing and scheduling
@@ -765,7 +765,7 @@ public abstract class ClientRequest implements Serializable {
   /**
    * Lock used to guard shared request state such as {@link #started} and {@link #finished}.
    *
-   * <p>Subclasses may override to supply a dedicated lock that is used consistently across request
+   * <p>Subclasses may override to supply a dedicated lock used consistently across request
    * lifecycle updates.
    */
   protected Object requestLock() {
@@ -822,7 +822,7 @@ public abstract class ClientRequest implements Serializable {
   private static final int CLIENT_DETAIL_VERSION = 1;
 
   /**
-   * Writes a compact, checksummed representation of this request’s client-visible state.
+   * Writes a compact, check-summed representation of this request’s client-visible state.
    *
    * @param dos destination stream used to serialize the client detail
    * @param checker checksum helper that callers can use to wrap or verify the serialized data

--- a/src/main/java/network/crypta/clients/fcp/DownloadRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/DownloadRequestStatus.java
@@ -251,7 +251,7 @@ public class DownloadRequestStatus extends RequestStatus {
    * @return the requested failure reason flavor, or {@code null} when the information is missing.
    */
   @Override
-  public String getFailureReason(boolean longDescription) {
+  public synchronized String getFailureReason(boolean longDescription) {
     if (longDescription) return failureReasonLong;
     else return failureReasonShort;
   }

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.TooManyFilesInsertException;
@@ -68,7 +69,7 @@ public class FCPConnectionHandler implements Closeable {
   private boolean outputClosed;
   private String clientName;
   private PersistentRequestClient rebootClient;
-  private PersistentRequestClient foreverClient;
+  private final AtomicReference<PersistentRequestClient> foreverClient = new AtomicReference<>();
   final HashMap<String, ClientRequest> requestsByIdentifier;
 
   private final PluginConnectionRegistry pluginConnectionRegistry = new PluginConnectionRegistry();
@@ -77,6 +78,7 @@ public class FCPConnectionHandler implements Closeable {
     return pluginConnectionRegistry;
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class CloseSnapshot {
     final ClientRequest[] requests;
     final SubscribeUSK[] subscriptions;
@@ -96,7 +98,7 @@ public class FCPConnectionHandler implements Closeable {
   }
 
   /**
-   * Legacy 16-byte hexadecimal identifier mirrored from older protocol versions so existing client
+   * Legacy 16-byte hexadecimal identifier mirrored from older protocol versions, so existing client
    * libraries can continue to correlate reconnect attempts and queue state without having to
    * understand UUIDs. The value is immutable and scoped to this connection instance only.
    */
@@ -184,9 +186,9 @@ public class FCPConnectionHandler implements Closeable {
    *
    * <p>The method only synchronizes long enough to place the message into the bounded outbound
    * queue, respecting the server's drop policy when limits are exceeded. Because the actual socket
-   * write happens on the output thread, callers must treat this method as fire-and-forget: a return
-   * value simply means queuing succeeded, not that the peer received or acknowledged anything. Use
-   * the handler's logging output when diagnosing queue pressure or dropped messages.
+   * writing happens on the output thread, callers must treat this method as fire-and-forget: a
+   * return value simply means queuing succeeded, not that the peer received or acknowledged
+   * anything. Use the handler's logging output when diagnosing queue pressure or dropped messages.
    *
    * @param message Non-null message that has already been fully constructed and validated for
    *     network serialization.
@@ -241,8 +243,9 @@ public class FCPConnectionHandler implements Closeable {
     if (rebootClient != null) {
       rebootClient.onLostConnection(this);
     }
-    if (foreverClient != null) {
-      foreverClient.onLostConnection(this);
+    PersistentRequestClient connectionForeverClient = foreverClient.get();
+    if (connectionForeverClient != null) {
+      connectionForeverClient.onLostConnection(this);
     }
     CloseSnapshot snapshot = prepareCloseSnapshot();
     if (snapshot == null) {
@@ -293,14 +296,16 @@ public class FCPConnectionHandler implements Closeable {
                     if ((rebootClient != null) && !rebootClient.hasPersistentRequests()) {
                       server.unregisterClient(rebootClient);
                     }
-                    if ((foreverClient != null) && !foreverClient.hasPersistentRequests()) {
-                      server.unregisterClient(foreverClient);
+                    PersistentRequestClient cleanupForeverClient = foreverClient.get();
+                    if ((cleanupForeverClient != null)
+                        && !cleanupForeverClient.hasPersistentRequests()) {
+                      server.unregisterClient(cleanupForeverClient);
                     }
                     return false;
                   },
               NativeThread.PriorityLevel.NORM_PRIORITY.value);
     } catch (PersistenceDisabledException _) {
-      // Ignore: cleanup already best-effort.
+      // Ignore: cleanups already best-effort.
     }
   }
 
@@ -381,7 +386,7 @@ public class FCPConnectionHandler implements Closeable {
    * safe to call once per connection handshake before any request scheduling occurs.
    *
    * @param name Logical identifier supplied by the peer; should be non-null and consistent across
-   *     reconnects to benefit from persistence.
+   *     reconnections to benefit from persistence.
    */
   public void setClientName(final String name) {
     this.clientName = name;
@@ -394,9 +399,9 @@ public class FCPConnectionHandler implements Closeable {
     PersistentRequestClient client = server.getForeverClient(name, this);
     if (client != null) {
       synchronized (this) {
-        foreverClient = client;
+        foreverClient.set(client);
       }
-      foreverClient.queuePendingMessagesOnConnectionRestartAsync(
+      client.queuePendingMessagesOnConnectionRestartAsync(
           outputHandler, server.getCore().getClientContext());
     }
   }
@@ -410,20 +415,21 @@ public class FCPConnectionHandler implements Closeable {
    * returned client immediately begins replaying pending messages on the current connection.
    *
    * @param name Identifier shared across reconnections so persistent requests remain addressable.
-   * @return Initialized persistent client ready to accept forever-scope requests.
+   * @return The initialized persistent client ready to accept forever-scope requests.
    */
   protected PersistentRequestClient createForeverClient(String name) {
     synchronized (FCPConnectionHandler.this) {
-      if (foreverClient != null) return foreverClient;
+      PersistentRequestClient existing = foreverClient.get();
+      if (existing != null) return existing;
     }
     PersistentRequestClient client = server.registerForeverClient(name, FCPConnectionHandler.this);
     synchronized (FCPConnectionHandler.this) {
-      foreverClient = client;
+      foreverClient.set(client);
       FCPConnectionHandler.this.notifyAll();
     }
     client.queuePendingMessagesOnConnectionRestartAsync(
         outputHandler, server.getCore().getClientContext());
-    return foreverClient;
+    return client;
   }
 
   /**
@@ -872,14 +878,15 @@ public class FCPConnectionHandler implements Closeable {
    * returned instance queues pending messages back to the output handler automatically.
    *
    * @return Non-null persistent client once the connection has an assigned name; the reference is
-   *     cached for subsequent calls.
+   *     cached for later calls.
    */
   public PersistentRequestClient getForeverClient() {
     synchronized (this) {
-      if (foreverClient == null) {
-        foreverClient = createForeverClient(clientName);
+      PersistentRequestClient client = foreverClient.get();
+      if (client == null) {
+        client = createForeverClient(clientName);
       }
-      return foreverClient;
+      return client;
     }
   }
 
@@ -902,8 +909,8 @@ public class FCPConnectionHandler implements Closeable {
    * Reports whether the reboot-scope persistent client currently watches the global queue, meaning
    * it receives broadcasts rather than only this connection's identifiers.
    *
-   * <p>This is primarily surfaced for diagnostics and tests so they can assert that a connection is
-   * subscribed before sending synthetic updates.
+   * <p>This is primarily surfaced for diagnostics and tests, so they can assert that a connection
+   * is subscribed before sending synthetic updates.
    *
    * @return {@code true} when {@link #rebootClient} is configured for global traffic, otherwise
    *     {@code false}. Primarily used by diagnostic commands.
@@ -965,7 +972,7 @@ public class FCPConnectionHandler implements Closeable {
   /**
    * Retrieves and removes the pending DDA check for the specified path if one exists.
    *
-   * <p>This is typically called once the peer has responded so we can resume the original request
+   * <p>This is typically called once the peer has responded, so we can resume the original request
    * using the recorded permissions.
    *
    * @param path Path originally used to queue the DDA job; must match exactly.
@@ -978,7 +985,7 @@ public class FCPConnectionHandler implements Closeable {
 
   /**
    * Deletes any temporary files left behind by outstanding DDA tests and clears the tracking
-   * structures so the handler can be safely closed or recycled between reconnects.
+   * structures so the handler can be safely closed or recycled between reconnections.
    *
    * <p>Invoke this after the peer completes DDA verification or when the handler disconnects so
    * background checks do not leak disk state.
@@ -992,7 +999,7 @@ public class FCPConnectionHandler implements Closeable {
    * identifier.
    *
    * <p>If {@code kill} is {@code true}, the request receives a cancel callback before the handler
-   * notifies it about removal, which lets callers align cleanup with de-registration.
+   * notifies it about removal, which lets callers align cleanup with deregistration.
    *
    * @param identifier Unique token previously provided by the client; must not be {@code null}.
    * @param kill {@code true} to cancel the request before removal, {@code false} otherwise.
@@ -1042,7 +1049,7 @@ public class FCPConnectionHandler implements Closeable {
    * Registers a {@link SubscribeUSK} under the provided identifier, enforcing uniqueness across the
    * connection.
    *
-   * <p>The subscription map is guarded by this handler's monitor so concurrent add/remove
+   * <p>The subscription map is guarded by this handler's monitor, so concurrent add/remove
    * operations stay consistent even when clients open many subscriptions at once.
    *
    * @param identifier Token supplied by the client to track the subscription lifecycle.
@@ -1060,7 +1067,7 @@ public class FCPConnectionHandler implements Closeable {
    * the change.
    *
    * <p>The removal is synchronized with {@link #addUSKSubscription(String, SubscribeUSK)} so no
-   * updates race while the unsubscribe runs.
+   * updates race while the unsubscribing runs.
    *
    * @param identifier Subscription token previously registered via {@link
    *     #addUSKSubscription(String, SubscribeUSK)}.

--- a/src/main/java/network/crypta/clients/fcp/UploadRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadRequestStatus.java
@@ -90,7 +90,7 @@ public abstract class UploadRequestStatus extends RequestStatus {
   }
 
   /**
-   * Returns the URI that was ultimately published by the upload, if a value exists yet.
+   * Returns the URI ultimately published by the upload if a value exists yet.
    *
    * <p>The reference represents the canonical URI under which the inserted data became available.
    * When the upload is still running or failed before committing, the value may be {@code null} and
@@ -153,13 +153,14 @@ public abstract class UploadRequestStatus extends RequestStatus {
   public abstract long getDataSize();
 
   /**
-   * Obtains the most recent textual explanation describing why the upload failed or stalled.
+   * Gets the most recent textual explanation describing why the upload failed or stalled.
    *
-   * <p>The status maintains both concise and expanded variants so different presentation layers can
-   * select an appropriate verbosity. The short text typically fits notifications or compact tables,
-   * while the long text is suitable for logs, REST responses, or troubleshooting dialogs. Messages
-   * are updated whenever the associated request transitions into a fatal state, so callers should
-   * not cache the result unless they also snapshot the surrounding {@link RequestStatus} fields.
+   * <p>The status maintains both concise and expanded variants, so different presentation layers
+   * can select appropriate verbosity. The short text typically fits notifications or compact
+   * tables, while the long text is suitable for logs, REST responses, or troubleshooting dialogs.
+   * Messages are updated whenever the associated request transitions into a fatal state, so callers
+   * should not cache the result unless they also snapshot the surrounding {@link RequestStatus}
+   * fields.
    *
    * @param longDescription {@code true} to request the expanded explanation, {@code false} for the
    *     concise human-readable summary
@@ -167,7 +168,7 @@ public abstract class UploadRequestStatus extends RequestStatus {
    *     recorded yet
    */
   @Override
-  public String getFailureReason(boolean longDescription) {
+  public synchronized String getFailureReason(boolean longDescription) {
     return longDescription ? failureReasonLong : failureReasonShort;
   }
 
@@ -179,13 +180,13 @@ public abstract class UploadRequestStatus extends RequestStatus {
    * Suggests a filename derived from the known URIs for display in client save dialogs.
    *
    * <p>The method inspects the final URI first to honor any filenames assigned by the completed
-   * insert, including meta strings distributed through Freenet. If the upload has not produced a
-   * final URI, it falls back to the target URI so callers can still infer a meaningful label, for
-   * example when pre-populating a download request. No normalization is performed beyond delegating
-   * to {@link FreenetURI#getPreferredFilename()}, therefore callers should sanitize values before
-   * writing them to disk.
+   * insert, including meta-strings distributed through Freenet. If the upload has not produced a
+   * final URI, it falls back to the target URI, so callers can still infer a meaningful label, for
+   * example, when pre-populating a download request. No normalization is performed beyond
+   * delegating to {@link FreenetURI#getPreferredFilename()}, therefore, callers should sanitize
+   * values before writing them to disk.
    *
-   * @return filename hint derived from meta strings or doc names, or {@code null} when neither URI
+   * @return filename hint derived from meta-strings or doc names, or {@code null} when neither URI
    *     contains sufficient metadata
    */
   @Override

--- a/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
@@ -140,7 +140,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   private String mimeType;
 
   /** Gone to network? */
-  private boolean goneToNetwork;
+  private volatile boolean goneToNetwork;
 
   /** Total blocks */
   private int totalBlocks;

--- a/src/main/java/network/crypta/clients/http/FProxyFetchTracker.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchTracker.java
@@ -21,9 +21,9 @@ import org.slf4j.LoggerFactory;
  * state changes rely on {@link ClientContext#ticker} to avoid blocking the calling thread.
  *
  * <p>Typical call flow: a servlet asks for a fetcher via {@link #makeFetcher(FProxyFetchCriteria,
- * REFILTER_POLICY)}, obtains a waiter, and later the tracker culls abandoned instances through
- * {@link #run()}. Instances are intentionally short-lived; they are cancelled when a fetch
- * completes, fails fatally, or the scheduled cleanup fires.
+ * REFILTER_POLICY)}, gets a waiter, and later the tracker culls abandoned instances through {@link
+ * #run()}. Instances are intentionally short-lived; they are canceled when a fetch completes, fails
+ * fatally, or the scheduled cleanup fires.
  *
  * <ul>
  *   <li>Responsibility: deduplicate fetch requests and manage their lifetime.
@@ -42,7 +42,7 @@ public class FProxyFetchTracker implements Runnable {
   private long fetchIdentifiers;
   private final FetchContext fctx;
   private final RequestClient rc;
-  private boolean queuedJob;
+  private volatile boolean queuedJob;
   private boolean requeue;
 
   /**
@@ -151,9 +151,9 @@ public class FProxyFetchTracker implements Runnable {
    * Locates an existing {@link FProxyFetchInProgress} by URI, size limit, and optional context.
    *
    * <p>The lookup runs under the registry lock to avoid races with creation or cleanup. Only
-   * fetches that are still usable (not finished fatally, or already holding data) and satisfy the
-   * size and context constraints are returned. This helper underpins both waiter lookups and fetch
-   * reuse decisions elsewhere in the tracker.
+   * fetches that are still usable (not finished fatally or already holding data) and satisfy the
+   * size and context constraints are returned. This helper underpins both waiter lookups and
+   * fetches reuse decisions elsewhere in the tracker.
    *
    * @param criteria immutable criteria containing URI, size limit, and optional fetch context.
    * @return an active {@link FProxyFetchInProgress} if one matches, otherwise {@code null} when

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -119,7 +119,7 @@ public final class SimpleToadletServer
   // Theme
   private THEME cssTheme;
   private File cssOverride;
-  private boolean sendAllThemes;
+  private volatile boolean sendAllThemes;
   private boolean advancedModeEnabled;
   private final PageMaker pageMaker;
   private boolean fetchKeyBoxAboveBookmarks;
@@ -158,7 +158,7 @@ public final class SimpleToadletServer
   private volatile boolean fProxyWebPushingEnabled; // ugh?
   private volatile boolean fproxyHasCompletedWizard; // hmmm..
   private volatile boolean disableProgressPage;
-  private int maxFproxyConnections;
+  private volatile int maxFproxyConnections;
 
   private int fproxyConnections;
 
@@ -353,10 +353,12 @@ public final class SimpleToadletServer
     public void set(Boolean val) {
       if (get().equals(val)) return;
       boolean startServer = Boolean.TRUE.equals(val);
+      Thread threadToStart;
       synchronized (SimpleToadletServer.this) {
         if (startServer) {
           // Start it
-          myThread = new Thread(SimpleToadletServer.this, "SimpleToadletServer");
+          threadToStart = new Thread(SimpleToadletServer.this, "SimpleToadletServer");
+          myThread = threadToStart;
         } else {
           myThread.interrupt();
           myThread = null;
@@ -365,8 +367,8 @@ public final class SimpleToadletServer
         }
       }
       createFproxy();
-      myThread.setDaemon(true);
-      myThread.start();
+      threadToStart.setDaemon(true);
+      threadToStart.start();
     }
   }
 
@@ -1242,9 +1244,13 @@ public final class SimpleToadletServer
    * been started.
    */
   public void start() {
-    if (myThread != null) {
+    Thread thread;
+    synchronized (this) {
+      thread = myThread;
+    }
+    if (thread != null) {
       maybeGetNetworkInterface();
-      myThread.start();
+      thread.start();
       LOG.info("Starting FProxy on {}:{}", bindTo, port);
     }
   }
@@ -1660,7 +1666,9 @@ public final class SimpleToadletServer
    * @return {@code true} when the listener thread exists, {@code false} otherwise.
    */
   public boolean isEnabled() {
-    return myThread != null;
+    synchronized (this) {
+      return myThread != null;
+    }
   }
 
   /**
@@ -1850,7 +1858,7 @@ public final class SimpleToadletServer
 
   @Override
   public long generateUniqueID() {
-    // Generates a unique ID per call; replace with a counter if sequential IDs are required.
+    // Generates a unique ID per call; replace it with a counter if sequential IDs are required.
     return random.nextLong();
   }
 

--- a/src/main/java/network/crypta/config/FilePersistentConfig.java
+++ b/src/main/java/network/crypta/config/FilePersistentConfig.java
@@ -14,7 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Configuration registry that persists to an on-disk file using an atomic write strategy.
+ * Configuration registry that persists to an on-disk file using an atomic writing strategy.
  *
  * <p>At construction, the class loads key/value pairs from the primary configuration file or its
  * temporary counterpart (if present) into a {@link SimpleFieldSet}. During initialization, {@link
@@ -45,7 +45,7 @@ public class FilePersistentConfig extends PersistentConfig {
   protected final Object storeSync = new Object();
 
   /** When {@code true}, defers a requested {@link #store()} until {@link #finishedInit()}. */
-  protected boolean writeOnFinished;
+  protected volatile boolean writeOnFinished;
 
   // No static initialization required.
 
@@ -175,8 +175,8 @@ public class FilePersistentConfig extends PersistentConfig {
    *
    * <p>When {@code throwOnUnreadable} is {@code true} (typically for the temp file), conditions
    * that indicate the file exists but cannot be successfully read—including {@link EOFException}
-   * from a truncated/partial write—are propagated as {@link IOException}. This preserves fail-fast
-   * behavior so we do not silently discard a partially written configuration.
+   * from a truncated/partial writing—are propagated as {@link IOException}. This preserves
+   * fail-fast behavior so we do not silently discard a partially written configuration.
    *
    * @param file the file to read
    * @param throwOnUnreadable whether to propagate unreadable conditions as {@link IOException}
@@ -200,7 +200,7 @@ public class FilePersistentConfig extends PersistentConfig {
         if (throwOnUnreadable) throw e;
         LOG.warn("EOF while reading {} {}", description, file);
       }
-      // Other IOExceptions indicate a more serious problem and will propagate from initialLoad.
+      // Other IOExceptions indicate a more serious problem and will propagate from the initialLoad.
     } else {
       // We probably won't be able to write it either.
       LOG.warn("Cannot read {} {}", description, file);
@@ -214,9 +214,9 @@ public class FilePersistentConfig extends PersistentConfig {
   /**
    * Persists the current configuration to disk.
    *
-   * <p>If initialization has not finished, defers the write and performs it immediately after
+   * <p>If initialization has not finished, defers the writing and performs it immediately after
    * {@link #finishedInit()}. Otherwise, writes to the temporary file and atomically replaces the
-   * destination file. Exceptions during the write are logged.
+   * destination file. Exceptions during the writing are logged.
    */
   @Override
   public void store() {

--- a/src/main/java/network/crypta/config/PersistentConfig.java
+++ b/src/main/java/network/crypta/config/PersistentConfig.java
@@ -1,6 +1,7 @@
 package network.crypta.config;
 
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +28,7 @@ public class PersistentConfig extends Config {
    * SimpleFieldSet#MULTI_LEVEL_CHAR}). Entries are removed as options register. Set to {@code null}
    * once {@link #finishedInit()} completes.
    */
-  protected SimpleFieldSet origConfigFileContents;
+  protected final AtomicReference<SimpleFieldSet> origConfigFileContents = new AtomicReference<>();
 
   /**
    * Indicates whether the configuration has completed initialization.
@@ -43,7 +44,7 @@ public class PersistentConfig extends Config {
    * @param initialContents the source of initial values; may be {@code null}
    */
   public PersistentConfig(SimpleFieldSet initialContents) {
-    this.origConfigFileContents = initialContents;
+    this.origConfigFileContents.set(initialContents);
   }
 
   /**
@@ -56,16 +57,17 @@ public class PersistentConfig extends Config {
   @Override
   public synchronized void finishedInit() {
     finishedInit = true;
-    if (origConfigFileContents == null) return;
-    Iterator<String> i = origConfigFileContents.keyIterator();
+    SimpleFieldSet originalContents = origConfigFileContents.get();
+    if (originalContents == null) return;
+    Iterator<String> i = originalContents.keyIterator();
     while (i.hasNext()) {
       String key = i.next();
       if (LOG.isErrorEnabled()) {
-        String value = origConfigFileContents.get(key);
+        String value = originalContents.get(key);
         LOG.error("Unknown option: {} (value={})", key, value);
       }
     }
-    origConfigFileContents = null;
+    origConfigFileContents.set(null);
     super.finishedInit();
   }
 
@@ -123,8 +125,8 @@ public class PersistentConfig extends Config {
    * Consumes an initial value for a newly registered option from the original field set.
    *
    * <p>If a value exists under {@code <prefix>.<name>}, it is parsed and applied via {@link
-   * Option#setInitialValue(String)}. Parse failures are logged at error level and the option keeps
-   * its default. When called after {@link #finishedInit()}, this method throws.
+   * Option#setInitialValue(String)}. Parse failures are logged at the error level, and the option
+   * keeps its default. When called after {@link #finishedInit()}, this method throws.
    *
    * @param config the owning {@link SubConfig}
    * @param o the option being registered
@@ -138,10 +140,11 @@ public class PersistentConfig extends Config {
       if (finishedInit)
         throw new IllegalStateException(
             "onRegister(" + config + ':' + o + ") called after finishedInit() !!");
-      if (origConfigFileContents == null) return;
+      SimpleFieldSet originalContents = origConfigFileContents.get();
+      if (originalContents == null) return;
       name = config.prefix + SimpleFieldSet.MULTI_LEVEL_CHAR + o.name;
-      val = origConfigFileContents.get(name);
-      origConfigFileContents.removeValue(name);
+      val = originalContents.get(name);
+      originalContents.removeValue(name);
       if (val == null) return;
     }
     try {
@@ -158,6 +161,7 @@ public class PersistentConfig extends Config {
    *     finished or if no original contents were provided
    */
   public synchronized SimpleFieldSet getSimpleFieldSet() {
-    return (origConfigFileContents == null ? null : new SimpleFieldSet(origConfigFileContents));
+    SimpleFieldSet originalContents = origConfigFileContents.get();
+    return (originalContents == null ? null : new SimpleFieldSet(originalContents));
   }
 }

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -660,16 +660,18 @@ public class SubConfig implements Comparable<SubConfig> {
    */
   public String getRawOption(String name) {
     if (config instanceof PersistentConfig pc) {
-      if (pc.finishedInit)
-        throw new IllegalStateException(
-            "getRawOption("
-                + name
-                + ") on "
-                + this
-                + " but persistent config has been finishedInit() already!");
-      SimpleFieldSet fs = pc.origConfigFileContents;
-      if (fs == null) return null;
-      return fs.get(prefix + SimpleFieldSet.MULTI_LEVEL_CHAR + name);
+      synchronized (config) {
+        if (pc.finishedInit)
+          throw new IllegalStateException(
+              "getRawOption("
+                  + name
+                  + ") on "
+                  + this
+                  + " but persistent config has been finishedInit() already!");
+        SimpleFieldSet fs = pc.origConfigFileContents.get();
+        if (fs == null) return null;
+        return fs.get(prefix + SimpleFieldSet.MULTI_LEVEL_CHAR + name);
+      }
     } else return null;
   }
 

--- a/src/main/java/network/crypta/crypt/Yarrow.java
+++ b/src/main/java/network/crypta/crypt/Yarrow.java
@@ -55,8 +55,6 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
 
   @Serial private static final long serialVersionUID = -1;
 
-  // Static initializer not required.
-
   /** Security parameters */
   private static final boolean DEBUG = false;
 
@@ -118,7 +116,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
   }
 
   /**
-   * Creates a generator with fully specified configuration.
+   * Creates a generator with a fully specified configuration.
    *
    * @param seed path to the seed file (string form).
    * @param digest message digest algorithm used by the entropy pools (for example, {@code SHA1}).
@@ -132,7 +130,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
   }
 
   /**
-   * Creates a generator with fully specified configuration.
+   * Creates a generator with a fully specified configuration.
    *
    * @param seed seed file used for persistence and bootstrap.
    * @param digest message digest algorithm used by the entropy pools.
@@ -183,7 +181,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
       seedFromExternalStuff(canBlock);
       /*
        * If we do not reseed at this point, the generator would be predictable because startup
-       * entropy alone might not cross the reseed thresholds.
+       * entropy alone might not cross the reseeding thresholds.
        */
       fastPoolReseed();
       slowPoolReseed();
@@ -299,7 +297,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
    *
    * <p>The method reads up to 32 {@code long} values and credits a conservative amount of entropy
    * for each sample. End‑of‑file is treated as normal, and I/O errors are logged. A fast‑pool
-   * reseed is attempted after processing the file.
+   * reseeding is attempted after processing the file.
    *
    * @param filename seed file to read; must not be {@code null}.
    */
@@ -332,7 +330,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
    * {@code true}, the method writes immediately. The file must be configured at construction time.
    * Errors are logged and do not propagate.
    *
-   * @param force request that the write bypass rate‑limiting.
+   * @param force request that the writing bypass rate‑limiting.
    */
   @Override
   public void writeSeed(boolean force) {
@@ -374,7 +372,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
   private int outputCount;
   private int fetchCounter;
 
-  private void generatorInit(String cipher) {
+  private synchronized void generatorInit(String cipher) {
     cipherCtx = Util.getCipherByName(cipher);
     if (cipherCtx == null) {
       throw new IllegalStateException("Unsupported cipher: '" + cipher + "'");
@@ -391,7 +389,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
     for (int i = counter.length - 1; i >= 0; i--) if (++counter[i] != 0) break;
   }
 
-  private void generateOutput() {
+  private synchronized void generateOutput() {
     counterInc();
 
     outputBuffer = new byte[counter.length];
@@ -404,7 +402,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
     }
   }
 
-  private void rekey(byte[] key) {
+  private synchronized void rekey(byte[] key) {
     // Keep a copy for serialization so we can restore the generator state after deserialization.
     // The input buffer is wiped immediately below.
     generatorKey = Arrays.copyOf(key, key.length);
@@ -507,7 +505,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
   private boolean fastSelect;
   private transient Map<EntropySource, int[]> entropySeen;
 
-  private void accumulatorInit(String digest) throws NoSuchAlgorithmException {
+  private synchronized void accumulatorInit(String digest) throws NoSuchAlgorithmException {
     fastPool = MessageDigest.getInstance(digest, Util.mdProviders.get(digest));
     slowPool = MessageDigest.getInstance(digest, Util.mdProviders.get(digest));
     entropySeen = new HashMap<>();
@@ -518,7 +516,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
    *
    * <p>Yarrow bounds credited entropy per sample and mixes data into alternating fast/slow pools.
    * Reseed may be triggered when pool thresholds are exceeded, which can also cause a seed file
-   * write if configured.
+   * writing if configured.
    */
   @Override
   public int acceptEntropy(EntropySource source, long data, int entropyGuess) {
@@ -702,11 +700,11 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
 
   private transient MessageDigest reseedCtx;
 
-  private void reseedInit(String digest) throws NoSuchAlgorithmException {
+  private synchronized void reseedInit(String digest) throws NoSuchAlgorithmException {
     reseedCtx = MessageDigest.getInstance(digest, Util.mdProviders.get(digest));
   }
 
-  private void fastPoolReseed() {
+  private synchronized void fastPoolReseed() {
     long startTime = System.currentTimeMillis();
     byte[] v0 = fastPool.digest();
     byte[] vi = v0;
@@ -729,7 +727,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
     }
   }
 
-  private void slowPoolReseed() {
+  private synchronized void slowPoolReseed() {
     byte[] slowHash = slowPool.digest();
     fastPool.update(slowHash, 0, slowHash.length);
 
@@ -742,8 +740,8 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
   /**
    * Custom serialization to rebuild transient crypto state after deserialization.
    *
-   * <p>Persisted fields record the selected digest and cipher, along with sufficient generator
-   * state to restore the cipher. Upon deserialization, transient pools and the cipher context are
+   * <p>Persisted fields record the selected digest and cipher, along with enough generator states
+   * to restore the cipher. Upon deserialization, transient pools and the cipher context are
    * recreated and reinitialized.
    */
   @Serial
@@ -763,7 +761,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
       reseedInit(d);
 
       // Recreate only the cipher instance and reinitialize it with the previously serialized key.
-      // Do NOT clobber serialized generator state (counter/outputBuffer/tmp/fetch counters).
+      // Do NOT clobber the serialized generator state (counter/outputBuffer/tmp/fetch counters).
       cipherCtx =
           Objects.requireNonNull(Util.getCipherByName(c), "Unsupported cipher: '" + c + "'");
 
@@ -784,13 +782,14 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
         tmp = new byte[keyBytes];
       }
 
-      // Restore key into cipher. Prefer the explicitly persisted generatorKey; fall back to 'tmp'
+      // Restore the key into cipher. Prefer the explicitly persisted generatorKey; fall back to
+      // 'tmp'
       // for backward compatibility with snapshots taken before this field existed.
       byte[] keyForInit =
           (generatorKey != null && generatorKey.length == keyBytes) ? generatorKey : tmp;
       cipherCtx.initialize(keyForInit);
 
-      // Sanity for fetch pointer after custom streams or old snapshots.
+      // Sanity for the fetch pointer after custom streams or old snapshots.
       if (fetchCounter <= 0 || fetchCounter > outputBuffer.length) {
         fetchCounter = outputBuffer.length;
       }
@@ -824,7 +823,7 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
     consumeBytes(str.getBytes(StandardCharsets.UTF_8));
   }
 
-  private void consumeBytes(byte[] bytes) {
+  private synchronized void consumeBytes(byte[] bytes) {
     if (fastSelect) fastPool.update(bytes, 0, bytes.length);
     else slowPool.update(bytes, 0, bytes.length);
     // Alternate pools to distribute contributions across fast/slow accumulators.

--- a/src/main/java/network/crypta/io/AddressTrackerItem.java
+++ b/src/main/java/network/crypta/io/AddressTrackerItem.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Tracks message activity to and from a single logical address and derives recent inactivity gaps.
  *
- * <p>The concrete address (for example an IP:port, an IP only, or another scheme) is owned by a
+ * <p>The concrete address (for example, an IP:port, an IP only, or another scheme) is owned by a
  * subclass; this type focuses purely on timing and counters:
  *
  * <ul>
@@ -28,37 +28,37 @@ public class AddressTrackerItem {
    * Time of the first observed receive from this address, in milliseconds since epoch, or {@code
    * -1} if none.
    */
-  private long timeFirstReceivedPacket;
+  private volatile long timeFirstReceivedPacket;
 
   /**
    * Time of the first observed send to this address, in milliseconds since epoch, or {@code -1} if
    * none.
    */
-  private long timeFirstSentPacket;
+  private volatile long timeFirstSentPacket;
 
   /**
-   * Earliest time (strict upper bound) at which we know no packet was received. Typically, the
-   * socket startup time; may advance if caches are flushed.
+   * The earliest time (strict upper bound) at which we know no packet was received. Typically, the
+   * socket startup time may advance if caches are flushed.
    */
   private final long timeDefinitelyNoPacketsReceived;
 
   /**
-   * Earliest time (strict upper bound) at which we know no packet was sent. Typically, the node
+   * The earliest time (strict upper bound) at which we know no packet was sent. Typically, the node
    * startup time; may advance if caches are flushed.
    */
   private final long timeDefinitelyNoPacketsSent;
 
-  /** Time of the most recent receive, in milliseconds since epoch, or {@code -1} if none. */
-  private long timeLastReceivedPacket;
+  /** Time of the most recent receiving, in milliseconds since epoch, or {@code -1} if none. */
+  private volatile long timeLastReceivedPacket;
 
-  /** Time of the most recent send, in milliseconds since epoch, or {@code -1} if none. */
-  private long timeLastSentPacket;
+  /** Time of the most recent sending, in milliseconds since epoch, or {@code -1} if none. */
+  private volatile long timeLastSentPacket;
 
   /** Total number of packets sent to this address. */
-  private long packetsSent;
+  private volatile long packetsSent;
 
   /** Total number of packets received from this address. */
-  private long packetsReceived;
+  private volatile long packetsReceived;
 
   /** Number of recent gaps to retain and expose via {@link #getGaps()}. */
   public static final int TRACK_GAPS = 5;
@@ -70,17 +70,17 @@ public class AddressTrackerItem {
   private static final long GAP_THRESHOLD = AddressTracker.MAYBE_TUNNEL_LENGTH;
 
   /**
-   * When true, the interval start considers the last receive as well as the last send. This yields
-   * conservative (longer) gaps when back-to-back receives occur without intervening sends.
+   * When true, the interval start considers the last receiving as well as the last sending. This
+   * yields conservative (longer) gaps when back-to-back receives occur without intervening sending.
    */
   static final boolean INCLUDE_RECEIVED_PACKETS = true;
 
   /**
    * Creates an empty tracker with known upper bounds for the "no packets yet" window.
    *
-   * @param timeDefinitelyNoPacketsReceived earliest time at which receiving is known to have been
-   *     impossible (e.g., socket startup), in milliseconds since epoch
-   * @param timeDefinitelyNoPacketsSent earliest time at which sending is known to have been
+   * @param timeDefinitelyNoPacketsReceived the earliest time at which receiving is known to have
+   *     been impossible (e.g., socket startup), in milliseconds since epoch
+   * @param timeDefinitelyNoPacketsSent the earliest time at which sending is known to have been
    *     impossible (e.g., node startup), in milliseconds since epoch
    */
   public AddressTrackerItem(
@@ -148,7 +148,7 @@ public class AddressTrackerItem {
    * inactivity since the last relevant activity exceeds the threshold.
    *
    * <p>Interval start is the maximum of the last send, the {@code no-sent} bound, and, when {@link
-   * #INCLUDE_RECEIVED_PACKETS} is true, the last receive and the {@code no-recv} bound.
+   * #INCLUDE_RECEIVED_PACKETS} is true, the last receiving and the {@code no-recv} bound.
    *
    * @param now timestamp in milliseconds since epoch
    */
@@ -189,7 +189,7 @@ public class AddressTrackerItem {
    * <p>This is a coarse signal that a long-running tunnel may have been observed recently.
    *
    * @param horizon look-back window in milliseconds
-   * @return {@code true} if the latest gap's receive time is within {@code horizon} of "now"
+   * @return {@code true} if the latest gap's receiving time is within {@code horizon} of "now"
    */
   public synchronized boolean hasLongTunnel(long horizon) {
     return gapLengthRecvTimes[0] > System.currentTimeMillis() - horizon;
@@ -258,7 +258,7 @@ public class AddressTrackerItem {
   }
 
   /**
-   * Returns the time of the most recent receive, or {@code -1} if none.
+   * Returns the time of the most recent receiving, or {@code -1} if none.
    *
    * @return milliseconds since epoch, or {@code -1}
    */
@@ -267,7 +267,7 @@ public class AddressTrackerItem {
   }
 
   /**
-   * Returns the time of the most recent send, or {@code -1} if none.
+   * Returns the time of the most recent sending, or {@code -1} if none.
    *
    * @return milliseconds since epoch, or {@code -1}
    */
@@ -306,8 +306,8 @@ public class AddressTrackerItem {
   /**
    * Returns whether the first observed activity was a sending rather than a receiving.
    *
-   * <p>Returns {@code true} if there has been no receive, {@code false} if there has been no send,
-   * otherwise compares first-send and first-receive times.
+   * <p>Returns {@code true} if there has been no receiving, {@code false} if there has been no
+   * send, otherwise compares first-send and first-receive times.
    *
    * @return {@code true} if the first event was a sending
    */
@@ -318,7 +318,7 @@ public class AddressTrackerItem {
   }
 
   /**
-   * Returns the delay from the {@code no-sent} bound to the first send, or {@code -1} if nothing
+   * Returns the delay from the {@code no-sent} bound to the first sending, or {@code -1} if nothing
    * has been sent.
    *
    * @return milliseconds since the {@code no-sent} bound, or {@code -1}
@@ -329,8 +329,8 @@ public class AddressTrackerItem {
   }
 
   /**
-   * Returns the delay from the {@code no-recv} bound to the first receive, or {@code -1} if nothing
-   * has been received.
+   * Returns the delay from the {@code no-recv} bound to the first receiving, or {@code -1} if
+   * nothing has been received.
    *
    * @return milliseconds since the {@code no-recv} bound, or {@code -1}
    */

--- a/src/main/java/network/crypta/io/comm/MessageFilter.java
+++ b/src/main/java/network/crypta/io/comm/MessageFilter.java
@@ -26,7 +26,7 @@ public final class MessageFilter {
   public static final String VERSION =
       "$Id: MessageFilter.java,v 1.7 2005/08/25 17:28:19 amphibian Exp $";
 
-  private boolean matchedFlag;
+  private volatile boolean matchedFlag;
   private PeerContext droppedConnection;
   private MessageType type;
   private final List<Object> fields = new ArrayList<>();
@@ -87,7 +87,7 @@ public final class MessageFilter {
    *     false, it's relative to the start of waitFor().
    */
   @SuppressWarnings("UnusedReturnValue")
-  public MessageFilter setTimeoutRelativeToCreation(boolean b) {
+  public synchronized MessageFilter setTimeoutRelativeToCreation(boolean b) {
     timeoutFromWait = !b;
     return this;
   }
@@ -254,7 +254,8 @@ public final class MessageFilter {
    * @return this filter instance (for chaining)
    */
   @SuppressWarnings("UnusedReturnValue")
-  public MessageFilter setAsyncCallback(AsyncMessageFilterCallback cb, ByteCounter ctr) {
+  public synchronized MessageFilter setAsyncCallback(
+      AsyncMessageFilterCallback cb, ByteCounter ctr) {
     callback = cb;
     byteCounter = ctr;
     return this;
@@ -356,7 +357,7 @@ public final class MessageFilter {
     return droppedConnection;
   }
 
-  boolean reallyTimedOut(long time) {
+  synchronized boolean reallyTimedOut(long time) {
     if (callback != null && callback.shouldTimeout()) timeout = -1; // timeout immediately
     return timeout < time;
   }

--- a/src/main/java/network/crypta/io/xfer/BlockReceiver.java
+++ b/src/main/java/network/crypta/io/xfer/BlockReceiver.java
@@ -497,7 +497,7 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
       // that we will ignore. If we are cancelling because the sender has told us
       // to, we need to acknowledge that.
       try {
-        sendAborted(prb.abortReason, prb.abortDescription);
+        sendAborted(prb.getAbortReason(), prb.getAbortDescription());
       } catch (NotConnectedException _) {
         // Ignore at this point.
       }
@@ -590,7 +590,8 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
         } catch (AbortedException _) {
           // Intentionally ignored: PRB aborted between attempts to get the block
         }
-        callback.blockReceiveFailed(new RetrievalException(prb.abortReason, prb.abortDescription));
+        callback.blockReceiveFailed(
+            new RetrievalException(prb.getAbortReason(), prb.getAbortDescription()));
         return;
       }
     }

--- a/src/main/java/network/crypta/io/xfer/BlockTransmitter.java
+++ b/src/main/java/network/crypta/io/xfer/BlockTransmitter.java
@@ -796,7 +796,7 @@ public class BlockTransmitter {
       registerAsyncFilters(mfAllReceived, mfSendAborted);
 
     } catch (AbortedException _) {
-      onAborted(prb.abortReason, prb.abortDescription);
+      onAborted(prb.getAbortReason(), prb.getAbortDescription());
     }
   }
 

--- a/src/main/java/network/crypta/io/xfer/PartiallyReceivedBulk.java
+++ b/src/main/java/network/crypta/io/xfer/PartiallyReceivedBulk.java
@@ -116,10 +116,10 @@ public class PartiallyReceivedBulk {
   }
 
   /**
-   * Commits a received block to storage and updates state, then notifies transmitters.
+   * Commits a received block to storage and updates the state, then notifies transmitters.
    *
    * <p>Validates that {@code length} is at least the expected number of bytes for the addressed
-   * block. If validation or storage fails, the transfer is aborted with an appropriate reason.
+   * block. If validation or storage fails, the transfer is aborted for an appropriate reason.
    * Blocks that are already marked as received are ignored.
    *
    * @param blockNum zero-based block index.
@@ -215,7 +215,7 @@ public class PartiallyReceivedBulk {
    *
    * @return {@code true} when every block is present; otherwise {@code false}.
    */
-  public boolean hasWholeFile() {
+  public synchronized boolean hasWholeFile() {
     return blocksReceivedCount >= blocks;
   }
 

--- a/src/main/java/network/crypta/l10n/BaseL10n.java
+++ b/src/main/java/network/crypta/l10n/BaseL10n.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import network.crypta.clients.http.TranslationToadlet;
 import network.crypta.support.HTMLNode;
@@ -47,7 +48,7 @@ import org.slf4j.LoggerFactory;
 public class BaseL10n {
   private static final Logger LOG = LoggerFactory.getLogger(BaseL10n.class);
 
-  // Sonar: de-duplicate common literals used in this class
+  // Sonar: deduplicate common literals used in this class
   private static final String L10N_VAR_PREFIX = "\\$\\{"; // matches "${"
   private static final String L10N_VAR_SUFFIX = "}"; // matches "}"
   private static final String UNLISTED_LITERAL = "unlisted";
@@ -134,30 +135,31 @@ public class BaseL10n {
             "WINDOWS140C",
             "WINDOWS180C")),
     ITALIAN("it", "Italiano", "ita", aliases("WINDOWS0410", "WINDOWS0810")),
-    // RFC 5646 non-compliant. Rename when converting the entire list to RFC 5646; provide a
+    // RFC 5646 non-compliant. Rename it when converting the entire list to RFC 5646; provide a
     // migration path to avoid breaking plugin identifiers.
     NORWEGIAN("nb-no", "Bokmål", "nob", aliases("WINDOWS0414", "WINDOWS0814")),
     POLISH("pl", "Polski", "pol", aliases("WINDOWS0415")),
     SWEDISH("sv", "Svenska", "swe", aliases("WINDOWS041D", "WINDOWS081D")),
-    // RFC 5646 non-compliant. Rename when converting the entire list to RFC 5646; provide a
+    // RFC 5646 non-compliant. Rename it when converting the entire list to RFC 5646; provide a
     // migration path to avoid breaking plugin identifiers.
     CHINESE("zh-cn", "中文(简体)", "chn", aliases("WINDOWS0804", "WINDOWS1004")),
-    // simplified chinese, used on mainland, Singapore and Malaysia
-    // RFC 5646 non-compliant. Rename when converting the entire list to RFC 5646; provide a
+    // simplified chinese, used on the mainland, Singapore and Malaysia
+    // RFC 5646 non-compliant. Rename it when converting the entire list to RFC 5646; provide a
     // migration path to avoid breaking plugin identifiers.
     CHINESE_TAIWAN(
         "zh-tw", "中文(繁體)", "zh-tw", aliases("WINDOWS0404", "WINDOWS0C04", "WINDOWS1404")),
-    // traditional chinese, used in Taiwan, Hong Kong and Macau
+    // traditional Chinese, used in Taiwan, Hong Kong and Macau
     RUSSIAN(
         "ru",
         "Русский",
         "rus",
-        aliases("WINDOWS0419")), // Just one variant for russian. Belorussian is separate, code page
+        aliases(
+            "WINDOWS0419")), // Just one variant for Russian. Belorussian is a separate, code page
     // 423, speakers may or
-    // may not speak russian, I'm not including it.
+    // may not speak Russian, I'm not including it.
     JAPANESE("ja", "日本語", "jpn", aliases("WINDOWS0411")),
     PORTUGUESE("pt-PT", "Português do Portugal", "pt", aliases("WINDOWS0816")),
-    // RFC 5646 non-compliant. Rename when converting the entire list to RFC 5646; provide a
+    // RFC 5646 non-compliant. Rename it when converting the entire list to RFC 5646; provide a
     // migration path to avoid breaking plugin identifiers.
     BRAZILIAN_PORTUGUESE("pt-br", "Português do Brasil", "pt-br", aliases("WINDOWS0416")),
     GREEK("el", "Ελληνικά", "ell", aliases("WINDOWS0408")),
@@ -310,7 +312,8 @@ public class BaseL10n {
 
     private String getFallbackString(String key) {
       BaseL10n.this.loadFallback();
-      String result = BaseL10n.this.fallbackTranslation.get(key);
+      SimpleFieldSet fallback = BaseL10n.this.fallbackTranslation.get();
+      String result = fallback == null ? null : fallback.get(key);
       if (result == null) {
         LOG.error("The default translation for {} hasn't been found!", key);
       }
@@ -323,7 +326,7 @@ public class BaseL10n {
   private final String l10nFilesMask;
   private final String l10nOverrideFilesMask;
   private SimpleFieldSet currentTranslation = null;
-  private SimpleFieldSet fallbackTranslation = null;
+  private final AtomicReference<SimpleFieldSet> fallbackTranslation = new AtomicReference<>();
   private SimpleFieldSet translationOverride;
   private final ClassLoader cl;
 
@@ -495,9 +498,10 @@ public class BaseL10n {
 
   /** Ensure the fallback (default) translation is loaded; synchronized for safe init. */
   private synchronized void loadFallback() {
-    if (this.fallbackTranslation == null) {
-      this.fallbackTranslation = loadTranslation(LANGUAGE.getDefault());
-      if (fallbackTranslation == null) fallbackTranslation = new SimpleFieldSet(true);
+    if (this.fallbackTranslation.get() == null) {
+      SimpleFieldSet loaded = loadTranslation(LANGUAGE.getDefault());
+      if (loaded == null) loaded = new SimpleFieldSet(true);
+      this.fallbackTranslation.set(loaded);
     }
   }
 
@@ -526,7 +530,7 @@ public class BaseL10n {
   /**
    * Write or remove an on-disk override for a key in the selected language.
    *
-   * <p>Whitespace surrounding the key and value is trimmed. When the value is empty, or equals the
+   * <p>Whitespace surrounding the key and value is trimmed. When the value is empty or equals the
    * bundled translation for the current language, the override is removed. Otherwise, the value is
    * normalized by stripping CR/LF/TAB characters and then saved.
    *
@@ -569,7 +573,7 @@ public class BaseL10n {
     File finalFile = new File(this.getL10nOverrideFileName(this.lang));
 
     try {
-      // We don't set deleteOnExit on it : if the save operation fails, we want a backup
+      // We don't set deleteOnExit on it: if the save operation fails, we want a backup
       File tempFile = File.createTempFile(finalFile.getName(), ".bak", finalFile.getParentFile());
       LOG.debug("The temporary filename is : {}", tempFile);
 
@@ -610,7 +614,7 @@ public class BaseL10n {
   public SimpleFieldSet getDefaultLanguageTranslation() {
     this.loadFallback();
 
-    return new SimpleFieldSet(this.fallbackTranslation);
+    return new SimpleFieldSet(this.fallbackTranslation.get());
   }
 
   /**
@@ -673,14 +677,12 @@ public class BaseL10n {
     return result;
   }
 
-  /** Enumerate strings associated with a key in order of preference. */
+  /** List strings associated with a key in order of preference. */
   private Iterable<String> getStrings(final String key) {
     return getStrings(key, FallbackState.CURRENT_LANG);
   }
 
-  /**
-   * Enumerate strings associated with a key in order of preference, starting with a specified one.
-   */
+  /** List strings associated with a key in order of preference, starting with a specified one. */
   private Iterable<String> getStrings(final String key, final FallbackState initialState) {
     return () -> new L10nStringIterator(key, initialState);
   }
@@ -805,7 +807,7 @@ public class BaseL10n {
   }
 
   /**
-   * Escape null, $ and \.
+   * Escape null, $, and \.
    *
    * @param s Replacement string.
    * @return Escaped replacement string.
@@ -1001,11 +1003,12 @@ public class BaseL10n {
    * @return Array of matching keys; empty when the fallback set is not loaded or no match exists.
    */
   public String[] getAllNamesWithPrefix(String prefix) {
-    if (fallbackTranslation == null) {
+    SimpleFieldSet fallback = fallbackTranslation.get();
+    if (fallback == null) {
       return new String[] {};
     }
     List<String> toReturn = new ArrayList<>();
-    Iterator<String> it = fallbackTranslation.keyIterator();
+    Iterator<String> it = fallback.keyIterator();
     while (it.hasNext()) {
       String key = it.next();
       if (key.startsWith(prefix)) {

--- a/src/main/java/network/crypta/node/Announcer.java
+++ b/src/main/java/network/crypta/node/Announcer.java
@@ -968,7 +968,7 @@ public class Announcer {
         int connectedSeednodes = 0;
         int disconnectedSeednodes = 0;
         long coolingOffSeconds = Math.max(0, startTime - System.currentTimeMillis()) / 1000;
-        synchronized (this) {
+        synchronized (Announcer.this) {
           addedNodes = announcementAddedNodes;
           refusedNodes = announcementNotWantedNodes;
           recentSentAnnouncements = sentAnnouncements;

--- a/src/main/java/network/crypta/node/BaseSender.java
+++ b/src/main/java/network/crypta/node/BaseSender.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.io.comm.ByteCounter;
 import network.crypta.io.comm.DMT;
 import network.crypta.io.comm.DisconnectedException;
@@ -132,7 +133,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
   protected abstract Message createDataRequest();
 
   /** The most recent peer that this sender attempted to route to. May be {@code null}. */
-  protected PeerNode lastNode;
+  protected final AtomicReference<PeerNode> lastNode = new AtomicReference<>();
 
   /**
    * Return the most recent peer that this sender routed to.
@@ -140,7 +141,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
    * @return last routed peer, or {@code null} if none
    */
   public synchronized PeerNode routedLast() {
-    return lastNode;
+    return lastNode.get();
   }
 
   /** Set of peers this sender has attempted to route to during the current operation. */
@@ -170,7 +171,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
   protected int rejectOverloads;
 
   /** Number of peers attempted so far (excluding soft retries on the same peer). */
-  protected int routeAttempts = 0;
+  protected volatile int routeAttempts = 0;
 
   private HashMap<PeerNode, Integer> softRejectCount;
 
@@ -217,7 +218,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
   protected void innerRouteRequestsOld(PeerNode next, UIDTag origTag) {
 
     synchronized (this) {
-      lastNode = next;
+      lastNode.set(next);
     }
 
     if (LOG.isDebugEnabled()) LOG.debug("Legacy route: sending request to {}", next);
@@ -361,7 +362,7 @@ public abstract class BaseSender implements ByteCounter, HighHtlAware {
     rememberLastPrediction(state);
 
     synchronized (this) {
-      lastNode = state.next;
+      lastNode.set(state.next);
     }
 
     LOG.debug("NLM route: sending request to {} realtime={}", state.next, realTimeFlag);

--- a/src/main/java/network/crypta/node/CHKInsertHandler.java
+++ b/src/main/java/network/crypta/node/CHKInsertHandler.java
@@ -238,7 +238,9 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
 
     // Receive the data off-thread so downstream routing can proceed concurrently.
     Runnable dataReceiver = new DataReceiver();
-    receiveStarted = true;
+    synchronized (this) {
+      receiveStarted = true;
+    }
     node.network().executor().execute(dataReceiver, "CHKInsertHandler$DataReceiver for UID " + uid);
   }
 

--- a/src/main/java/network/crypta/node/CHKInsertSender.java
+++ b/src/main/java/network/crypta/node/CHKInsertSender.java
@@ -573,7 +573,7 @@ public final class CHKInsertSender extends BaseSender
         LOG.debug("Allowing failure {} htl is still {}", highHTLFailureCount, htl);
       return new HtlDecision(false, highHTLFailureCount, false);
     }
-    htl = node.routing().decrementHTL(hasForwarded ? lastNode : source, htl);
+    htl = node.routing().decrementHTL(hasForwarded ? lastNode.get() : source, htl);
     if (LOG.isDebugEnabled()) LOG.debug("Decremented HTL to {}", htl);
     return new HtlDecision(false, highHTLFailureCount, false);
   }
@@ -1000,7 +1000,8 @@ public final class CHKInsertSender extends BaseSender
 
     completeAfterTransfers(failedRecv);
 
-    if (status == SUCCESS && next != null) next.onSuccess(true, false);
+    int finalStatus = getStatus();
+    if (finalStatus == SUCCESS && next != null) next.onSuccess(true, false);
     if (LOG.isDebugEnabled()) LOG.debug("Returning from finish()");
   }
 

--- a/src/main/java/network/crypta/node/DarknetPeerNode.java
+++ b/src/main/java/network/crypta/node/DarknetPeerNode.java
@@ -337,8 +337,9 @@ public class DarknetPeerNode extends PeerNode {
     if (ignoreSourcePort) {
       FreenetInetAddress addr = detectedPeer == null ? null : detectedPeer.getFreenetAddress();
       int port = detectedPeer == null ? -1 : detectedPeer.getPort();
-      if (nominalPeer == null) return detectedPeer;
-      for (Peer p : nominalPeer) {
+      List<Peer> localNominalPeer = nominalPeer.get();
+      if (localNominalPeer == null) return detectedPeer;
+      for (Peer p : localNominalPeer) {
         if (p.getPort() != port && p.getFreenetAddress().equals(addr)) {
           return p;
         }
@@ -2562,7 +2563,7 @@ public class DarknetPeerNode extends PeerNode {
                       return;
                     }
                     synchronized (DarknetPeerNode.this) {
-                      fullFieldSet = fs;
+                      fullFieldSet.set(fs);
                     }
                     node.network().peers().writePeersDarknet();
                   } else {

--- a/src/main/java/network/crypta/node/DarknetPeerNode.java
+++ b/src/main/java/network/crypta/node/DarknetPeerNode.java
@@ -2316,7 +2316,7 @@ public class DarknetPeerNode extends PeerNode {
   @Override
   public boolean shallWeRouteAccordingToOurPeersLocation(int htl) {
     if (!node.shallWeRouteAccordingToOurPeersLocation(htl)) return false; // Globally disabled
-    return trustLevel != FRIEND_TRUST.LOW;
+    return getTrustLevel() != FRIEND_TRUST.LOW;
   }
 
   /** Sets the trust level and persists peer metadata. */

--- a/src/main/java/network/crypta/node/FailureTableEntry.java
+++ b/src/main/java/network/crypta/node/FailureTableEntry.java
@@ -443,12 +443,12 @@ class FailureTableEntry implements TimedOutNodesList {
    */
   public void offer() {
     HashSet<PeerNodeUnlocked> set = new HashSet<>();
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Sending offers to nodes which requested the key from us: ({}) for {}",
-          requestorNodes.length,
-          key);
     synchronized (this) {
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "Sending offers to nodes which requested the key from us: ({}) for {}",
+            requestorNodes.length,
+            key);
       collectRequestorOfferTargets(set);
       if (LOG.isDebugEnabled())
         LOG.debug(

--- a/src/main/java/network/crypta/node/LocationManager.java
+++ b/src/main/java/network/crypta/node/LocationManager.java
@@ -246,7 +246,7 @@ public class LocationManager implements ByteCounter {
   }
 
   private double loc;
-  private long timeLocSet;
+  private volatile long timeLocSet;
   private double locChangeSession = 0.0;
 
   int numberOfRemotePeerLocationsSeenInSwaps = 0;

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -264,7 +264,7 @@ public class Node implements TimeSkewDetectorCallback {
 
   private short maxHTL;
   private boolean skipWrapperWarning;
-  private int maxPacketSize;
+  private volatile int maxPacketSize;
 
   /** Default policy for ignoring low backoff during inserts. */
   public static final boolean IGNORE_LOW_BACKOFF_DEFAULT = false;

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -153,13 +153,13 @@ public class NodeClientCore implements Persistable {
    * How much disk space must be free when starting a long-term, unpredictable duration job such as
    * a big download?
    */
-  private long minDiskFreeLongTerm;
+  private volatile long minDiskFreeLongTerm;
 
   /**
    * How much disk space must be free when starting a quick but disk-heavy job such as completing a
    * download?
    */
-  private long minDiskFreeShortTerm;
+  private volatile long minDiskFreeShortTerm;
 
   /** Client context. Access via {@link #getClientContext()}. */
   private final ClientContext clientContext;

--- a/src/main/java/network/crypta/node/NodeCryptoConfig.java
+++ b/src/main/java/network/crypta/node/NodeCryptoConfig.java
@@ -41,7 +41,7 @@ public class NodeCryptoConfig {
   private static final String KEY_BIND_TO = "bindTo";
 
   /** Port number; {@code -1} selects a random available port at activation time. */
-  private int portNumber;
+  private volatile int portNumber;
 
   /** Bind address; {@code 0.0.0.0} binds all local interfaces. */
   private final FreenetInetAddress bindTo;
@@ -50,7 +50,7 @@ public class NodeCryptoConfig {
    * Test hook for simulated loss. When {@code > 0}, roughly one in {@code dropProbability} packets
    * is dropped by the UDP handler to emulate lossy networks.
    */
-  private int dropProbability;
+  private volatile int dropProbability;
 
   /** The current {@link NodeCrypto} instance, when started; {@code null} otherwise. */
   private NodeCrypto crypto;
@@ -59,12 +59,12 @@ public class NodeCryptoConfig {
    * Prevents maintaining multiple simultaneous connections to the same peer IP address. Typically
    * enabled for opennet and disabled for darknet.
    */
-  private boolean oneConnectionPerAddress;
+  private volatile boolean oneConnectionPerAddress;
 
   /**
    * When true, allows connecting to peers via local/LAN IP addresses regardless of per‑peer flags.
    */
-  private boolean alwaysAllowLocalAddresses;
+  private volatile boolean alwaysAllowLocalAddresses;
 
   /**
    * When true, assumes the node is behind NAT and enables aggressive handshake behavior
@@ -445,8 +445,8 @@ public class NodeCryptoConfig {
   /**
    * Sets the stored listen port value.
    *
-   * <p>This method updates configuration state only; socket binding is performed elsewhere during
-   * activation.
+   * <p>This method updates the configuration state only; socket binding is performed elsewhere
+   * during activation.
    *
    * @param port the desired port number, or {@code -1} to select a random port at activation
    */

--- a/src/main/java/network/crypta/node/NodeIPDetector.java
+++ b/src/main/java/network/crypta/node/NodeIPDetector.java
@@ -120,7 +120,7 @@ public class NodeIPDetector {
   /** UserAlert shown when {@code ipAddressOverride} has invalid hostname or IP syntax. */
   private final InvalidAddressOverrideUserAlert invalidAddressOverrideAlert;
 
-  private boolean hasValidAddressOverride;
+  private volatile boolean hasValidAddressOverride;
 
   /** UserAlert shown when no usable IP address can be detected. */
   private final IPUndetectedUserAlert primaryIPUndetectedAlert;

--- a/src/main/java/network/crypta/node/NodeStats.java
+++ b/src/main/java/network/crypta/node/NodeStats.java
@@ -1305,7 +1305,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
     double totalCouldSend =
         Math.max((double) totalSent, (node.network().outputBandwidthLimit() * uptime) / 1000.0);
     double nonOverheadFraction = (totalCouldSend - totalOverhead) / totalCouldSend;
-    long timeFirstAnyConnections = peers.timeFirstAnyConnections;
+    long timeFirstAnyConnections = peers.getTimeFirstAnyConnections();
     if (timeFirstAnyConnections > 0) {
       long time = now - timeFirstAnyConnections;
       if (time < DEFAULT_ONLY_PERIOD) {

--- a/src/main/java/network/crypta/node/PeerLocation.java
+++ b/src/main/java/network/crypta/node/PeerLocation.java
@@ -25,7 +25,7 @@ public class PeerLocation {
   /**
    * Sorted locations of our peer's neighbors (FOAF).
    *
-   * <p>Invariant: never mutate in place; only replace with a new, sorted array.
+   * <p>Invariant: never mutate in place; only replace it with a new, sorted array.
    */
   private double[] currentPeersLocation;
 
@@ -70,7 +70,8 @@ public class PeerLocation {
       double[] peerLocations = new double[peerLocationsString.length];
       for (int i = 0; i < peerLocationsString.length; i++)
         peerLocations[i] = Location.getLocation(peerLocationsString[i]);
-      updateLocation(currentLocation, peerLocations);
+      double current = getLocation();
+      updateLocation(current, peerLocations);
     }
   }
 

--- a/src/main/java/network/crypta/node/PeerManager.java
+++ b/src/main/java/network/crypta/node/PeerManager.java
@@ -228,7 +228,7 @@ public class PeerManager {
    *
    * @return Epoch milliseconds of the first connection, or 0 if none yet.
    */
-  public long getTimeFirstAnyConnections() {
+  public synchronized long getTimeFirstAnyConnections() {
     return timeFirstAnyConnections;
   }
 

--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.crypt.BlockCipher;
 import network.crypta.crypt.KeyAgreementSchemeContext;
@@ -85,34 +86,34 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * True if this peer has a build number older than our last-known-good build number. Note that
    * even if this is true, the node can still be 'connected'.
    */
-  protected boolean unroutableOlderVersion;
+  protected volatile boolean unroutableOlderVersion;
 
   /**
    * True if this peer reports that our build number is before their last-known-good build number.
    * Note that even if this is true, the node can still be 'connected'.
    */
-  protected boolean unroutableNewerVersion;
+  protected volatile boolean unroutableNewerVersion;
 
   /**
    * Indicates whether routing to this peer is currently disabled by policy. When true, routing
    * decisions treat the peer as ineligible even if it is otherwise connected; control traffic may
    * still flow. Updated under the peer lock as configuration or remote signals change.
    */
-  protected boolean disableRouting;
+  protected volatile boolean disableRouting;
 
   /**
    * Records whether local configuration explicitly set {@link #disableRouting}. This flag lets the
    * node distinguish local intent from remote requests and preserves local overrides across later
    * updates. It is read and written under the peer lock only.
    */
-  protected boolean disableRoutingHasBeenSetLocally;
+  protected volatile boolean disableRoutingHasBeenSetLocally;
 
   /**
    * Records whether the remote peer has asked us to disable routing. The flag is advisory and may
    * be overridden by local policy. It is maintained under the peer lock and influences the
    * effective routing eligibility calculation.
    */
-  protected boolean disableRoutingHasBeenSetRemotely;
+  protected volatile boolean disableRoutingHasBeenSetRemotely;
 
   /*
    * Buffer of Ni,Nr,g^i,g^r,ID
@@ -217,7 +218,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private final OutgoingPacketMangler outgoingMangler;
 
   /** Advertised addresses */
-  List<Peer> nominalPeer;
+  AtomicReference<List<Peer>> nominalPeer = new AtomicReference<>();
 
   /** The PeerNode's report of our IP address */
   private Peer remoteDetectedPeer;
@@ -232,13 +233,13 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private SessionKey previousTracker;
 
   /** When did we last rekey (promote the unverified tracker to new)? */
-  private long timeLastRekeyed;
+  private volatile long timeLastRekeyed;
 
   /** How much data did we send with the current tracker? */
-  private long totalBytesExchangedWithCurrentTracker = 0;
+  private volatile long totalBytesExchangedWithCurrentTracker = 0;
 
   /** Are we rekeying? */
-  private boolean isRekeying = false;
+  private volatile boolean isRekeying = false;
 
   /** Unverified tracker - will be promoted to the currentTracker if we receive packets on it */
   private SessionKey unverifiedTracker;
@@ -247,13 +248,13 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private volatile long timeLastSentPacket;
 
   /** When did we last receive a packet? */
-  private long timeLastReceivedPacket;
+  private volatile long timeLastReceivedPacket;
 
   /** When did we last receive a non-auth packet? */
-  private long timeLastReceivedDataPacket;
+  private volatile long timeLastReceivedDataPacket;
 
   /** When did we last receive an ack? */
-  private long timeLastReceivedAck;
+  private volatile long timeLastReceivedAck;
 
   /** When was isRoutingCompatible() last true? */
   private long timeLastRoutable;
@@ -261,7 +262,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   /** Time added or restarted (reset on startup unlike peerAddedTime) */
   private final long timeAddedOrRestarted;
 
-  private long countSelectionsSinceConnected = 0;
+  private final AtomicLong countSelectionsSinceConnected = new AtomicLong();
 
   /**
    * Percentage threshold that triggers a selection warning for this peer. The value is expressed as
@@ -279,10 +280,10 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   public static final int SELECTION_MIN_PEERS = 5;
 
   // Note: isRoutable() depends on more than this flag.
-  private boolean isRoutable;
+  private volatile boolean isRoutable;
 
   /** Used by maybeOnConnect */
-  private boolean wasDisconnected = true;
+  private volatile boolean wasDisconnected = true;
 
   /**
    * Were we removed from the routing table? Used as a cache to avoid accessing PeerManager if not
@@ -291,7 +292,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private boolean removed;
 
   /** Number of handshake attempts since the last successful connection or ARK fetch */
-  private int handshakeCount;
+  private final AtomicInteger handshakeCount = new AtomicInteger();
 
   /** After these many failed handshakes, we start the ARK fetcher. */
   private static final int MAX_HANDSHAKE_COUNT = 2;
@@ -351,10 +352,10 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   final boolean decrementHTLAtMinimum;
 
   /** Time at which we should send the next handshake request */
-  protected long sendHandshakeTime;
+  protected volatile long sendHandshakeTime;
 
   /** Version of the node */
-  private String version;
+  private volatile String version;
 
   /** Cached parsed version components to avoid reparsing */
   private final AtomicReference<String[]> parsedVersionComponents = new AtomicReference<>();
@@ -401,19 +402,19 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * in-flight messages and call disconnected() on their clients, i.e., whenever we call
    * disconnected(true, ...)
    */
-  private long myBootID;
+  private volatile long myBootID;
 
   /** myBootID at the time of the last successful completed handshake. */
   private long myLastSuccessfulBootID;
 
   /** If true, this means the last time we tried, we got a bogus noderef */
-  private boolean bogusNoderef;
+  private volatile boolean bogusNoderef;
 
   /** The time at which we last completed a connection setup. */
-  private long connectedTime;
+  private volatile long connectedTime;
 
   /** The status of this peer node in terms of Node.PEER_NODE_STATUS_* */
-  private int peerNodeStatus = PeerManager.PEER_NODE_STATUS_DISCONNECTED;
+  private volatile int peerNodeStatus = PeerManager.PEER_NODE_STATUS_DISCONNECTED;
 
   /**
    * Holds a String-Long pair that shows which message types (as name) have been sent to this peer.
@@ -432,7 +433,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private Peer[] handshakeIPs;
 
   /** True if we have never connected to this peer since it was added to this node */
-  protected boolean neverConnected;
+  protected volatile boolean neverConnected;
 
   /**
    * When this peer was added to this node. This is used differently by opennet and darknet nodes.
@@ -458,7 +459,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * Delta between our clock and his clock (positive = his clock is fast, negative = our clock is
    * fast)
    */
-  private long clockDelta;
+  private volatile long clockDelta;
 
   /** Percentage uptime of this node, 0 if they haven't said */
   private volatile byte uptime;
@@ -501,10 +502,10 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private boolean isBursting;
 
   /** Number of handshake attempts (while in ListenOnly mode) since the beginning of this burst */
-  private int listeningHandshakeBurstCount;
+  private final AtomicInteger listeningHandshakeBurstCount = new AtomicInteger();
 
   /** Total number of handshake attempts (while in ListenOnly mode) to be in this burst */
-  private int listeningHandshakeBurstSize;
+  private volatile int listeningHandshakeBurstSize;
 
   // NodeCrypto for the relevant node reference for this peer's type (Darknet or Opennet at this
   // time)
@@ -528,7 +529,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * noderef has been observed. The value is mutable, accessed under the peer lock, and used for
    * persistence and export.
    */
-  protected SimpleFieldSet fullFieldSet;
+  protected AtomicReference<SimpleFieldSet> fullFieldSet = new AtomicReference<>();
 
   /**
    * Returns whether to ignore last-known-good version checks for this peer.
@@ -667,7 +668,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     this.bytesOutAtStartup = fs.getLong("totalOutput", 0);
     if (fromLocal) {
       SimpleFieldSet f = fs.subset("full");
-      if (fullFieldSet == null && f != null) fullFieldSet = f;
+      if (f != null) fullFieldSet.compareAndSet(null, f);
     }
     // If we got here, odds are we should consider writing to the peer-file
     writePeers();
@@ -753,16 +754,17 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   private void parseNominalPeers(SimpleFieldSet fs, boolean fromLocal) {
-    nominalPeer = new ArrayList<>();
+    List<Peer> parsedNominalPeer = new ArrayList<>();
     String[] physical = fs.getAll(SFS_KEY_PHYSICAL_UDP);
     if (physical != null) {
       for (String phys : physical) {
         for (Peer p : parsePeerEntryCompat(phys, fromLocal)) {
-          if (p != null && !nominalPeer.contains(p)) nominalPeer.add(p);
+          if (p != null && !parsedNominalPeer.contains(p)) parsedNominalPeer.add(p);
         }
       }
     }
-    if (nominalPeer.isEmpty()) {
+    nominalPeer.set(List.copyOf(parsedNominalPeer));
+    if (parsedNominalPeer.isEmpty()) {
       LOG.atInfo()
           .addArgument(() -> identityAsBase64String)
           .addArgument(internals::locationToString)
@@ -817,7 +819,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   private void scheduleFirstHandshake(boolean fromLocal, long now) {
-    listeningHandshakeBurstCount = 0;
+    listeningHandshakeBurstCount.set(0);
     listeningHandshakeBurstSize =
         Node.MIN_BURSTING_HANDSHAKE_BURST_SIZE
             + random.nextInt(Node.RANDOMIZED_BURSTING_HANDSHAKE_BURST_SIZE);
@@ -826,7 +828,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
           "First BurstOnly mode handshake in {}" + STR_MS_FOR + "{} (count: {}, size: {})",
           sendHandshakeTime - now,
           shortToString(),
-          listeningHandshakeBurstCount,
+          listeningHandshakeBurstCount.get(),
           listeningHandshakeBurstSize);
     }
     if (fromLocal)
@@ -1588,11 +1590,11 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     }
 
     private void updateRoutabilityAndBootId(HandshakeParams p, HandshakeApplyResult r) {
-      handshakeCount = 0;
+      handshakeCount.set(0);
       bogusNoderef = false;
       if (!isConnected()) {
         connectedTime = p.now;
-        countSelectionsSinceConnected = 0;
+        countSelectionsSinceConnected.set(0);
         sentInitialMessages = false;
       } else r.wasARekey = true;
       disableRouting = disableRoutingHasBeenSetLocally || disableRoutingHasBeenSetRemotely;
@@ -1614,7 +1616,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
             getPeer());
         r.wasARekey = false;
         connectedTime = p.now;
-        countSelectionsSinceConnected = 0;
+        countSelectionsSinceConnected.set(0);
         sentInitialMessages = false;
       } else if (r.bootIDChanged && LOG.isDebugEnabled())
         LOG.debug(
@@ -1737,9 +1739,13 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    */
   @Override
   public synchronized Peer getPeer() {
-    if (detectedPeer == null && !nominalPeer.isEmpty()) {
+    List<Peer> localNominalPeer = nominalPeer.get();
+    if (detectedPeer == null && localNominalPeer != null && !localNominalPeer.isEmpty()) {
       sortNominalPeer();
-      detectedPeer = nominalPeer.getFirst();
+      localNominalPeer = nominalPeer.get();
+      if (localNominalPeer != null && !localNominalPeer.isEmpty()) {
+        detectedPeer = localNominalPeer.getFirst();
+      }
       updateShortToString();
     }
     return detectedPeer;
@@ -1764,7 +1770,13 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   private void sortNominalPeer() {
-    nominalPeer.sort(Peer.PEER_COMPARATOR);
+    List<Peer> localNominalPeer = nominalPeer.get();
+    if (localNominalPeer == null || localNominalPeer.size() < 2) {
+      return;
+    }
+    List<Peer> sorted = new ArrayList<>(localNominalPeer);
+    sorted.sort(Peer.PEER_COMPARATOR);
+    nominalPeer.set(List.copyOf(sorted));
   }
 
   /**
@@ -1954,7 +1966,8 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   /**
    * Returns true if (apart from actually knowing the peer's location), it is presumed that this
    * peer could route requests. True if this peer's build number is not 'too-old' or 'too-new',
-   * actively connected, and not marked as explicity disabled. Does not reflect any 'backoff' logic.
+   * actively connected, and not marked as explicitly disabled. Does not reflect any 'backoff'
+   * logic.
    *
    * <p>The method updates {@link #timeLastRoutable} when the peer is considered compatible. It is a
    * lightweight eligibility check and does not validate the current location or bandwidth
@@ -2493,20 +2506,20 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
       if (LOG.isDebugEnabled()) LOG.debug("Next handshake in {} on {}", delay, this);
 
       if (successfulHandshakeSend) firstHandshake = false;
-      handshakeCount++;
-      return handshakeCount == MAX_HANDSHAKE_COUNT;
+      return handshakeCount.incrementAndGet() == MAX_HANDSHAKE_COUNT;
     }
   }
 
   private synchronized boolean calcNextHandshakeBurstOnly(long now) {
     boolean fetchARKFlag = false;
-    listeningHandshakeBurstCount++;
-    if (isBurstOnly() && listeningHandshakeBurstCount >= listeningHandshakeBurstSize) {
-      listeningHandshakeBurstCount = 0;
+    int burstCount = listeningHandshakeBurstCount.incrementAndGet();
+    if (isBurstOnly() && burstCount >= listeningHandshakeBurstSize) {
+      listeningHandshakeBurstCount.set(0);
+      burstCount = 0;
       fetchARKFlag = true;
     }
     long delay;
-    if (listeningHandshakeBurstCount == 0) { // 0 only if we just reset it above
+    if (burstCount == 0) { // 0 only if we just reset it above
       delay =
           (long) Node.MIN_TIME_BETWEEN_BURSTING_HANDSHAKE_BURSTS
               + (long) random.nextInt(Node.RANDOMIZED_TIME_BETWEEN_BURSTING_HANDSHAKE_BURSTS);
@@ -2533,7 +2546,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
               + "{}",
           sendHandshakeTime - now,
           shortToString(),
-          listeningHandshakeBurstCount,
+          burstCount,
           listeningHandshakeBurstSize,
           this,
           new Exception("double-called debug"));
@@ -2933,7 +2946,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     return 2;
   }
 
-  boolean sentInitialMessages;
+  volatile boolean sentInitialMessages;
 
   void maybeSendInitialMessages() {
     synchronized (this) {
@@ -3186,9 +3199,10 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     boolean changedAnything = false;
     String[] physical = fs.getAll(SFS_KEY_PHYSICAL_UDP);
     if (physical != null) {
-      List<Peer> oldNominalPeer = nominalPeer;
+      List<Peer> oldNominalPeer = nominalPeer.get();
+      if (oldNominalPeer == null) oldNominalPeer = List.of();
       Peer[] oldPeers = oldNominalPeer.toArray(new Peer[0]);
-      nominalPeer = collectPeersFromPhysical(physical);
+      nominalPeer.set(collectPeersFromPhysical(physical));
       sortNominalPeer();
       changedAnything = applyNominalPeersChange(oldPeers);
     } else if (forARK || forFullNodeRef) {
@@ -3217,9 +3231,12 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   private boolean applyNominalPeersChange(Peer[] oldPeers) {
-    if (!Arrays.equals(oldPeers, nominalPeer.toArray(new Peer[0]))) {
+    List<Peer> localNominalPeer = nominalPeer.get();
+    if (localNominalPeer == null) localNominalPeer = List.of();
+    if (!Arrays.equals(oldPeers, localNominalPeer.toArray(new Peer[0]))) {
       if (LOG.isDebugEnabled())
-        LOG.debug("Got new physical.udp for {} : {}", this, Arrays.toString(nominalPeer.toArray()));
+        LOG.debug(
+            "Got new physical.udp for {} : {}", this, Arrays.toString(localNominalPeer.toArray()));
       // Look up the DNS names if any ASAP
       internals.resetHandshakeIpUpdateTimer();
       // Clear nonces to prevent leak. Will kill any in-progress connect attempts, but that is
@@ -3340,7 +3357,8 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     SimpleFieldSet fs = exportFieldSet();
     SimpleFieldSet meta = exportMetadataFieldSet(System.currentTimeMillis());
     if (!meta.isEmpty()) fs.put(SFS_KEY_METADATA, meta);
-    if (fullFieldSet != null) fs.put("full", fullFieldSet);
+    SimpleFieldSet localFullFieldSet = fullFieldSet.get();
+    if (localFullFieldSet != null) fs.put("full", localFullFieldSet);
     return fs;
   }
 
@@ -3421,7 +3439,10 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   public synchronized SimpleFieldSet exportFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     if (getLastGoodVersion() != null) fs.putSingle(SFS_KEY_LAST_GOOD_VERSION, lastGoodVersion);
-    for (Peer peer : nominalPeer) fs.putAppend(SFS_KEY_PHYSICAL_UDP, peer.toString());
+    List<Peer> localNominalPeer = nominalPeer.get();
+    if (localNominalPeer != null) {
+      for (Peer peer : localNominalPeer) fs.putAppend(SFS_KEY_PHYSICAL_UDP, peer.toString());
+    }
     fs.put(SFS_KEY_NEG_TYPES, negTypes);
     fs.putSingle(SFS_KEY_IDENTITY, getIdentityString());
     fs.put(SFS_KEY_LOCATION, getLocation());
@@ -3574,8 +3595,8 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     return pingTime > maxPeerPingTime();
   }
 
-  long routingBackedOffUntilRT = -1;
-  long routingBackedOffUntilBulk = -1;
+  volatile long routingBackedOffUntilRT = -1;
+  volatile long routingBackedOffUntilBulk = -1;
 
   /** Initial nominal routing backoff length */
   static final int INITIAL_ROUTING_BACKOFF_LENGTH = (int) SECONDS.toMillis(1);
@@ -4126,7 +4147,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    */
   void resetHandshakeCountAfterArkFetch() {
     synchronized (this) {
-      handshakeCount = 0;
+      handshakeCount.set(0);
     }
   }
 
@@ -4137,7 +4158,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    */
   void markHandshakeCountAfterArkFailure() {
     synchronized (this) {
-      handshakeCount = MAX_HANDSHAKE_COUNT;
+      handshakeCount.set(MAX_HANDSHAKE_COUNT);
     }
   }
 
@@ -4478,7 +4499,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * @return number of recent handshake attempts
    */
   public synchronized int getHandshakeCount() {
-    return handshakeCount;
+    return handshakeCount.get();
   }
 
   /**
@@ -5329,7 +5350,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   public void incrementNumberOfSelections() {
     // Note: a compact bit-field could reduce memory; retained simple counter for clarity.
     synchronized (this) {
-      countSelectionsSinceConnected++;
+      countSelectionsSinceConnected.incrementAndGet();
     }
   }
 
@@ -5345,7 +5366,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     long timeSinceConnected = System.currentTimeMillis() - this.connectedTime;
     // Avoid bias due to short uptime.
     if (timeSinceConnected < SECONDS.toMillis(10)) return 0.0;
-    return countSelectionsSinceConnected / (double) timeSinceConnected;
+    return countSelectionsSinceConnected.get() / (double) timeSinceConnected;
   }
 
   private volatile int offeredMainJarVersion;
@@ -5673,8 +5694,9 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    */
   public synchronized boolean matchesPeerAndPort(Peer peer) {
     if (getPeer() != null && getPeer().laxEquals(peer)) return true;
-    if (nominalPeer != null) { // Note: condition retained for safety
-      for (Peer p : nominalPeer) {
+    List<Peer> localNominalPeer = nominalPeer.get();
+    if (localNominalPeer != null) {
+      for (Peer p : localNominalPeer) {
         if (p != null && p.laxEquals(peer)) return true;
       }
     }
@@ -5886,7 +5908,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * @return {@code true} if a full noderef is available
    */
   public synchronized boolean hasFullNoderef() {
-    return fullFieldSet != null;
+    return fullFieldSet.get() != null;
   }
 
   /**
@@ -5898,7 +5920,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * @return full noderef field set, or {@code null} if unavailable
    */
   public synchronized SimpleFieldSet getFullNoderef() {
-    return fullFieldSet;
+    return fullFieldSet.get();
   }
 
   private int consecutiveGuaranteedRejectsRT = 0;

--- a/src/main/java/network/crypta/node/PeerNodeAddressManager.java
+++ b/src/main/java/network/crypta/node/PeerNodeAddressManager.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.io.comm.FreenetInetAddress;
 import network.crypta.io.comm.Peer;
 import network.crypta.io.comm.PeerParseException;
@@ -32,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * policy.
  *
  * <ul>
- *   <li><strong>Handshake address refresh:</strong> throttles DNS lookups and de-duplicates
+ *   <li><strong>Handshake address refresh:</strong> throttles DNS lookups and deduplicates
  *       candidates
  *   <li><strong>Selection:</strong> filters candidates for policy and rotates among valid choices
  *   <li><strong>Matching:</strong> compares incoming addresses using strict or relaxed semantics
@@ -61,18 +62,18 @@ final class PeerNodeAddressManager {
   /** The last time we attempted to update handshake IPs. Guarded by {@code peer}. */
   private long lastAttemptedHandshakeIPUpdateTime;
 
-  /** Alternator used to pick a single handshake address when multiple are available. */
+  /** Alternator used to pick a single handshake address when multiple addresses are available. */
   private int handshakeIPAlternator;
 
   /**
    * Creates a new manager bound to a specific peer node.
    *
    * <p>The instance does not perform any work eagerly. It records the provided peer node, which is
-   * subsequently used for both synchronization and access to cached address state. The caller is
-   * responsible for ensuring the same {@code PeerNodeAddressManager} is reused for the same peer
+   * subsequently used for both synchronization and access to the cached address state. The caller
+   * is responsible for ensuring the same {@code PeerNodeAddressManager} is reused for the same peer
    * node to keep the throttling counters meaningful.
    *
-   * @param peer owning peer node that supplies address state and synchronization.
+   * @param peer the owning peer node that supplies address state and synchronization.
    */
   PeerNodeAddressManager(PeerNode peer) {
     this.peer = peer;
@@ -82,7 +83,7 @@ final class PeerNodeAddressManager {
    * Clears the handshake refresh timer so the next update attempt is not throttled.
    *
    * <p>This method is idempotent and only affects the timestamp used to suppress rapid DNS
-   * refreshes. It does not alter the current handshake candidate list or detected peer values.
+   * refreshes. It does not alter the current handshake candidate list or detect peer values.
    *
    * @see #markHandshakeIpUpdateAttempted(long)
    */
@@ -95,7 +96,7 @@ final class PeerNodeAddressManager {
   /**
    * Records the most recent handshake-IP update attempt time.
    *
-   * <p>The stored timestamp is used to throttle subsequent DNS resolution attempts. Callers should
+   * <p>The stored timestamp is used to throttle further DNS resolution attempts. Callers should
    * pass a millisecond value consistent with {@link System#currentTimeMillis()} to preserve the
    * expected five-minute backoff logic in {@link #maybeUpdateHandshakeIPs(boolean)}.
    *
@@ -114,7 +115,7 @@ final class PeerNodeAddressManager {
    *
    * @param localHandshakeIPs candidate addresses to resolve and de-duplicate
    * @param ignoreHostnames when true, skips hostname resolution
-   * @return the updated, de-duplicated address array
+   * @return the updated, deduplicated address array
    */
   private Peer[] resolveAndDedupe(Peer[] localHandshakeIPs, boolean ignoreHostnames) {
     for (Peer localHandshakeIP : localHandshakeIPs) {
@@ -164,7 +165,10 @@ final class PeerNodeAddressManager {
 
     Peer[] myNominalPeer;
     synchronized (peer) {
-      myNominalPeer = peer.nominalPeer.toArray(new Peer[0]);
+      AtomicReference<List<Peer>> nominalPeerRef = peer.nominalPeer;
+      List<Peer> localNominalPeer = nominalPeerRef == null ? null : nominalPeerRef.get();
+      myNominalPeer =
+          localNominalPeer == null ? new Peer[0] : localNominalPeer.toArray(new Peer[0]);
     }
     if (handleNoNominalPeersCase(localDetectedPeer, myNominalPeer, ignoreHostnames)) return;
 
@@ -172,7 +176,9 @@ final class PeerNodeAddressManager {
     Peer[] nodePeers = peer.getOutgoingMangler().getPrimaryIPAddress();
     List<Peer> basePeers;
     synchronized (peer) {
-      basePeers = new ArrayList<>(peer.nominalPeer);
+      AtomicReference<List<Peer>> nominalPeerRef = peer.nominalPeer;
+      List<Peer> localNominalPeer = nominalPeerRef == null ? null : nominalPeerRef.get();
+      basePeers = localNominalPeer == null ? new ArrayList<>() : new ArrayList<>(localNominalPeer);
     }
     PeersBuildResult build =
         prepareLocalPeers(myNominalPeer, localDetectedPeer, nodePeers, localhost, basePeers);
@@ -268,7 +274,7 @@ final class PeerNodeAddressManager {
    * @return {@code true} if {@code p} is a value-equal duplicate of the detected peer.
    */
   private boolean isDuplicateLocalDetectedPeer(Peer p, Peer localDetectedPeer) {
-    return localDetectedPeer != null && p.equals(localDetectedPeer);
+    return p.equals(localDetectedPeer);
   }
 
   /**
@@ -317,7 +323,7 @@ final class PeerNodeAddressManager {
   /**
    * Holds the intermediate results of composing handshake candidates.
    *
-   * @param localPeers ordered list of candidate peers after filtering and augmentation.
+   * @param localPeers an ordered list of candidate peers after filtering and augmentation.
    * @param detectedDuplicate nominal peer that duplicates the detected peer, if found.
    */
   private record PeersBuildResult(List<Peer> localPeers, Peer detectedDuplicate) {}
@@ -434,20 +440,8 @@ final class PeerNodeAddressManager {
    * @return {@code true} if a detected or nominal address equals {@code addr}.
    */
   static boolean strictMatch(PeerNode peerNode, FreenetInetAddress addr) {
-    Peer p = peerNode.getPeer();
-    if (p != null) {
-      FreenetInetAddress a = p.getFreenetAddress();
-      if (a != null && a.equals(addr)) return true;
-    }
-    if (peerNode.nominalPeer != null) {
-      for (Peer np : peerNode.nominalPeer) {
-        if (np != null) {
-          FreenetInetAddress a = np.getFreenetAddress();
-          if (a != null && a.equals(addr)) return true;
-        }
-      }
-    }
-    return false;
+    return matchesPeerAddress(peerNode.getPeer(), addr, true)
+        || matchesNominalPeers(peerNode.nominalPeer, addr, true);
   }
 
   /**
@@ -463,32 +457,38 @@ final class PeerNodeAddressManager {
    * @return {@code true} if a detected or nominal address matches {@code addr} laxly.
    */
   static boolean nonStrictMatch(PeerNode peerNode, FreenetInetAddress addr) {
-    Peer p = peerNode.getPeer();
-    if (p != null) {
-      FreenetInetAddress a = p.getFreenetAddress();
-      if (a != null && a.laxEquals(addr)) return true;
-    }
-    if (peerNode.nominalPeer != null) {
-      for (Peer np : peerNode.nominalPeer) {
-        if (np != null) {
-          FreenetInetAddress a = np.getFreenetAddress();
-          if (a != null && a.laxEquals(addr)) return true;
-        }
-      }
+    return matchesPeerAddress(peerNode.getPeer(), addr, false)
+        || matchesNominalPeers(peerNode.nominalPeer, addr, false);
+  }
+
+  private static boolean matchesNominalPeers(
+      AtomicReference<List<Peer>> nominalPeerRef, FreenetInetAddress addr, boolean strict) {
+    List<Peer> localNominalPeer = nominalPeerRef == null ? null : nominalPeerRef.get();
+    if (localNominalPeer == null) return false;
+    for (Peer peer : localNominalPeer) {
+      if (matchesPeerAddress(peer, addr, strict)) return true;
     }
     return false;
+  }
+
+  private static boolean matchesPeerAddress(Peer peer, FreenetInetAddress addr, boolean strict) {
+    if (peer == null) return false;
+    FreenetInetAddress peerAddress = peer.getFreenetAddress();
+    if (peerAddress == null) return false;
+    if (strict) return peerAddress.equals(addr);
+    return peerAddress.laxEquals(addr);
   }
 
   /**
    * Determines whether traffic to the peer should be throttled based on locality.
    *
    * <p>Throttle decisions are conservative: if the node is configured to throttle local data, or if
-   * the peer or its resolved address is missing, this method returns {@code true}. Otherwise it
+   * the peer or its resolved address is missing, this method returns {@code true}. Otherwise, it
    * delegates to {@link PeerNodeReferenceSupport#isValidAddress(InetAddress)}; public addresses are
    * treated as throttled, while local-only addresses are not.
    *
    * @param peer peer whose resolved address should be evaluated; may be {@code null}.
-   * @param node owning node that provides configuration flags for throttling.
+   * @param node the owning node that provides configuration flags for throttling.
    * @return {@code true} when throttling should be applied; {@code false} otherwise.
    */
   static boolean shouldThrottle(Peer peer, Node node) {

--- a/src/main/java/network/crypta/node/PeerNodeReferenceSupport.java
+++ b/src/main/java/network/crypta/node/PeerNodeReferenceSupport.java
@@ -79,7 +79,7 @@ final class PeerNodeReferenceSupport {
   private static final Logger LOG = LoggerFactory.getLogger(PeerNodeReferenceSupport.class);
 
   /**
-   * Owning peer whose reference state is parsed and validated by this helper.
+   * The owning peer whose reference state is parsed and validated by this helper.
    *
    * <p>The reference support delegates identity and signature outcomes to this peer and may update
    * flags or cached field sets on it. Callers are expected to pass a stable, non-null instance for
@@ -549,7 +549,7 @@ final class PeerNodeReferenceSupport {
       }
       return;
     }
-    // Missing identity is allowed for differential or partial noderefs (e.g., during handshake).
+    // Missing identity is allowed for differential or partial noderefs (e.g., during a handshake).
     // Only full noderefs must include identity.
     if (forFullNodeRef && !forDiffNodeRef) {
       if (peer.isDarknet()) throw new FSParseException("No identity!");
@@ -663,7 +663,7 @@ final class PeerNodeReferenceSupport {
             "The integrity of the reference has been compromised!" + errCause);
       } else {
         peer.setSignatureVerificationSuccessfull(true);
-        if (!peer.dontKeepFullFieldSet()) peer.fullFieldSet = fs;
+        if (!peer.dontKeepFullFieldSet()) peer.fullFieldSet.set(fs);
       }
     } catch (IllegalBase64Exception e) {
       LOG.error("Invalid reference: {}", e, e);

--- a/src/main/java/network/crypta/node/PeerNodeTransport.java
+++ b/src/main/java/network/crypta/node/PeerNodeTransport.java
@@ -436,7 +436,7 @@ final class PeerNodeTransport implements PeerTransport {
   private class SyncMessageCallback implements AsyncMessageCallback {
 
     /** True, once the sending path completes or terminates with an error. */
-    private boolean done = false;
+    private volatile boolean done = false;
 
     /** True if completion occurred due to a disconnect. */
     private boolean disconnected = false;

--- a/src/main/java/network/crypta/node/RequestHandler.java
+++ b/src/main/java/network/crypta/node/RequestHandler.java
@@ -431,7 +431,9 @@ public class RequestHandler
                 }
               });
     } else {
-      finalTransferFailed = true;
+      synchronized (this) {
+        finalTransferFailed = true;
+      }
       status = rs.getStatus();
       // for byte logging, since the block is the 'terminal' message.
       applyByteCounts();

--- a/src/main/java/network/crypta/node/RequestSender.java
+++ b/src/main/java/network/crypta/node/RequestSender.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.crypt.CryptFormatException;
 import network.crypta.crypt.DSAPublicKey;
 import network.crypta.io.comm.AsyncMessageCallback;
@@ -95,7 +96,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
   // Basics
   final RequestTag origTag;
   private PartiallyReceivedBlock prb;
-  private byte[] finalHeaders;
+  private final AtomicReference<byte[]> finalHeaders = new AtomicReference<>();
   private byte[] finalSskData;
   private DSAPublicKey pubKey;
   private SSKBlock block;
@@ -112,7 +113,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
   // Terminal status
   // Always set finished AFTER setting the reason flag
 
-  private int status = -1;
+  private volatile int status = -1;
   static final int NOT_FINISHED = -1;
   static final int SUCCESS = 0;
   static final int ROUTE_NOT_FOUND = 1;
@@ -646,7 +647,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         try {
           node.network().usm().addAsyncFilter(mf, this, RequestSender.this);
         } catch (DisconnectedException _) {
-          onDisconnect(lastNode);
+          onDisconnect(lastNode.get());
         }
       } else {
         onTimeout();
@@ -850,7 +851,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
           new PartiallyReceivedBlock(Node.PACKETS_IN_BLOCK, Node.PACKET_SIZE);
       boolean failNow = false;
       synchronized (RequestSender.this) {
-        finalHeaders = waiter.headers;
+        finalHeaders.set(waiter.headers);
         if (status == SUCCESS || (RequestSender.this.prb != null && transferringFrom != null))
           failNow = true;
         if (!wasFork
@@ -1060,7 +1061,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         if (node.bootstrap().random().nextInt(RANDOM_REINSERT_INTERVAL) == 0)
           node.services().clientCore().getTransfers().queueRandomReinsert(block);
         synchronized (RequestSender.this) {
-          finalHeaders = headers;
+          finalHeaders.set(headers);
           finalSskData = sskData;
         }
         finish(SUCCESS, next, false);
@@ -1085,8 +1086,8 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
           sskData = block.getRawData();
         }
         synchronized (RequestSender.this) {
-          if (finalHeaders == null || finalSskData == null) {
-            finalHeaders = headers;
+          if (finalHeaders.get() == null || finalSskData == null) {
+            finalHeaders.set(headers);
             finalSskData = sskData;
           }
         }
@@ -1463,7 +1464,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 
   private OFFER_STATUS processChkOfferReply(
       final PeerNode pn, final OfferList offers, final byte[] headers) {
-    finalHeaders = headers;
+    finalHeaders.set(headers);
     origTag.senderTransferBegins((NodeCHK) key, this);
     try {
       prb = new PartiallyReceivedBlock(Node.PACKETS_IN_BLOCK, Node.PACKET_SIZE);
@@ -1484,7 +1485,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
           new BlockReceiverCompletion() {
             @Override
             public void blockReceived(byte[] data) {
-              onChkOfferBlockReceived(pn, offers, finalHeaders, data);
+              onChkOfferBlockReceived(pn, offers, finalHeaders.get(), data);
             }
 
             @Override
@@ -1606,7 +1607,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     try {
       block = new SSKBlock(sskData, headers, (NodeSSK) key, false);
       synchronized (this) {
-        finalHeaders = headers;
+        finalHeaders.set(headers);
         finalSskData = sskData;
       }
       node.storage().storeShallow(block, canWriteClientCache, canWriteDatastore, tryOffersOnly);
@@ -1649,7 +1650,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     if (!isSSK) {
       CHKBlock chkBlock = new CHKBlock(data, headers, (NodeCHK) key);
       synchronized (this) {
-        finalHeaders = headers;
+        finalHeaders.set(headers);
       }
       if (LOG.isDebugEnabled()) LOG.debug("Verified");
       // Cache only in the cache, not the store. The reason for this is that
@@ -1661,7 +1662,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         node.services().clientCore().getTransfers().queueRandomReinsert(chkBlock);
     } else {
       synchronized (this) {
-        finalHeaders = headers;
+        finalHeaders.set(headers);
         finalSskData = data;
       }
       try {
@@ -2138,7 +2139,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
    * @return The header bytes, or {@code null} if unavailable.
    */
   public synchronized byte[] getHeaders() {
-    return finalHeaders;
+    return finalHeaders.get();
   }
 
   /**

--- a/src/main/java/network/crypta/node/RequestTag.java
+++ b/src/main/java/network/crypta/node/RequestTag.java
@@ -275,14 +275,33 @@ public class RequestTag extends UIDTag {
    */
   @Override
   public void logStillPresent(Long uid) {
+    boolean localServedFromDatastore;
+    WeakReference<RequestSender> localSender;
+    boolean localSent;
+    int localRequestSenderFinishedCode;
+    boolean localRejected;
+    Throwable localHandlerThrew;
+    boolean localHandlerDisconnected;
+    WeakReference<PeerNode> localWaitingForOpennet;
+    synchronized (this) {
+      localServedFromDatastore = servedFromDatastore;
+      localSender = sender;
+      localSent = sent;
+      localRequestSenderFinishedCode = requestSenderFinishedCode;
+      localRejected = rejected;
+      localHandlerThrew = handlerThrew;
+      localHandlerDisconnected = handlerDisconnected;
+      localWaitingForOpennet = waitingForOpennet;
+    }
+
     StringBuilder sb = new StringBuilder();
     sb.append("Still present after ").append(TimeUtil.formatTime(age()));
     sb.append(" : ").append(uid).append(" : start=").append(start);
-    sb.append(" ssk=").append(isSSK).append(" from store=").append(servedFromDatastore);
-    if (sender == null) {
+    sb.append(" ssk=").append(isSSK).append(" from store=").append(localServedFromDatastore);
+    if (localSender == null) {
       sb.append(" sender not set");
     } else {
-      RequestSender s = sender.get();
+      RequestSender s = localSender.get();
       if (s == null) {
         sb.append(" sender=null");
       } else {
@@ -293,20 +312,20 @@ public class RequestTag extends UIDTag {
         sb.append(" transferActive=").append(s.isTransferActive());
       }
     }
-    if (sent) sb.append(" sent");
-    sb.append(" finishedCode=").append(requestSenderFinishedCode);
-    sb.append(" rejected=").append(rejected);
-    if (handlerThrew != null) sb.append(" thrown=").append(handlerThrew);
-    if (handlerDisconnected) sb.append(" handlerDisconnected=true");
-    if (waitingForOpennet != null) {
-      PeerNode pn = waitingForOpennet.get();
+    if (localSent) sb.append(" sent");
+    sb.append(" finishedCode=").append(localRequestSenderFinishedCode);
+    sb.append(" rejected=").append(localRejected);
+    if (localHandlerThrew != null) sb.append(" thrown=").append(localHandlerThrew);
+    if (localHandlerDisconnected) sb.append(" handlerDisconnected=true");
+    if (localWaitingForOpennet != null) {
+      PeerNode pn = localWaitingForOpennet.get();
       sb.append(" waitingForOpennet=");
       sb.append(pn == null ? "(null)" : pn.shortToString());
     }
     sb.append(" : ");
     sb.append(super.toString());
-    if (handlerThrew != null) {
-      LOG.atError().setCause(handlerThrew).log("{}", sb);
+    if (localHandlerThrew != null) {
+      LOG.atError().setCause(localHandlerThrew).log("{}", sb);
     } else {
       LOG.atError().log("{}", sb);
     }

--- a/src/main/java/network/crypta/node/SSKInsertSender.java
+++ b/src/main/java/network/crypta/node/SSKInsertSender.java
@@ -95,7 +95,7 @@ public class SSKInsertSender extends BaseSender
   /** Status: no route found (after forwarding at least once). */
   static final int ROUTE_NOT_FOUND = 1;
 
-  /** Status: internal error occurred. */
+  /** Status: an internal error occurred. */
   static final int INTERNAL_ERROR = 3;
 
   /** Status: timed out while waiting for a peer response. */
@@ -167,10 +167,10 @@ public class SSKInsertSender extends BaseSender
       routeRequests();
     } catch (Exception t) {
       LOG.error("Caught {}", t, t);
-      if (status == NOT_FINISHED) finish(INTERNAL_ERROR, null);
+      if (getStatus() == NOT_FINISHED) finish(INTERNAL_ERROR, null);
     } finally {
       if (LOG.isDebugEnabled()) LOG.debug("Finishing {}", this);
-      if (status == NOT_FINISHED) finish(INTERNAL_ERROR, null);
+      if (getStatus() == NOT_FINISHED) finish(INTERNAL_ERROR, null);
       origTag.finishedSender();
       if (forkedRequestTag != null) forkedRequestTag.finishedSender();
     }
@@ -207,7 +207,7 @@ public class SSKInsertSender extends BaseSender
     if (dontDecrementHTLThisTime) {
       dontDecrementHTLThisTime = false;
     } else {
-      htl = node.routing().decrementHTL(hasForwarded ? lastNode : source, htl);
+      htl = node.routing().decrementHTL(hasForwarded ? lastNode.get() : source, htl);
       if (LOG.isDebugEnabled()) LOG.debug("Decremented HTL to {}", htl);
     }
     if (htl <= 0) {

--- a/src/main/java/network/crypta/node/SecurityLevels.java
+++ b/src/main/java/network/crypta/node/SecurityLevels.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  * <p>The node exposes three categories of security levels. The user selects initial values in the
  * first-time wizard and can reconfigure them later. Changing a level adjusts defaults for several
  * other configuration options and notifies listeners; users can still override individual options
- * explicitly. The UI provides per-level explanations and a dedicated configuration sub-page. A
+ * explicitly. The UI provides per-level explanations and a dedicated configuration subpage. A
  * summary is also shown on the homepage as a user alert.
  *
  * <p>Thread-safety: public mutators synchronize on the instance and notify listeners outside the
@@ -48,7 +48,7 @@ public class SecurityLevels {
    * is applied by default.
    */
   public enum NETWORK_THREAT_LEVEL {
-    /** Favor performance; enable opennet; disable most costly hardening. */
+    /** Favor performance; enable opennet; disable the most costly hardening. */
     LOW,
     /** Default hybrid mode; both darknet and opennet allowed. */
     NORMAL,
@@ -113,7 +113,7 @@ public class SecurityLevels {
     MAXIMUM
   }
 
-  NETWORK_THREAT_LEVEL networkThreatLevel;
+  volatile NETWORK_THREAT_LEVEL networkThreatLevel;
   FRIENDS_THREAT_LEVEL friendsThreatLevel;
   PHYSICAL_THREAT_LEVEL physicalThreatLevel;
 
@@ -190,7 +190,7 @@ public class SecurityLevels {
       // Ensure dependent configuration aligns with the initial threat level.
       setThreatLevel(netLevel);
     }
-    // Backward compatibility: read legacy "friendsThreatLevel" option when present.
+    // Backward compatibility: read the legacy "friendsThreatLevel" option when present.
     String s = myConfig.getRawOption("friendsThreatLevel");
     if (s != null) {
       friendsThreatLevel = parseFriendsThreatLevel(s);
@@ -556,8 +556,8 @@ public class SecurityLevels {
   /**
    * Resets the stored physical threat level without notifying listeners.
    *
-   * <p>Intended for internal synchronization with external state when caller will explicitly handle
-   * notifications.
+   * <p>Intended for internal synchronization with external state when the caller will explicitly
+   * handle notifications.
    *
    * @param level the physical level to store
    */

--- a/src/main/java/network/crypta/node/ThrottleWindowManager.java
+++ b/src/main/java/network/crypta/node/ThrottleWindowManager.java
@@ -25,9 +25,9 @@ public class ThrottleWindowManager {
   static final float PACKET_TRANSMIT_INCREMENT =
       (4 * (1 - (PACKET_DROP_DECREASE_MULTIPLE * PACKET_DROP_DECREASE_MULTIPLE))) / 3;
 
-  private long totalPackets = 0;
-  private long droppedPackets = 0;
-  private double simulatedWindowSize;
+  private volatile long totalPackets = 0;
+  private volatile long droppedPackets = 0;
+  private volatile double simulatedWindowSize;
 
   private final Node node;
 

--- a/src/main/java/network/crypta/node/UIDTag.java
+++ b/src/main/java/network/crypta/node/UIDTag.java
@@ -636,15 +636,19 @@ public abstract class UIDTag {
    */
   public void unlockHandler(boolean noRecord) {
     boolean canUnlock;
+    boolean localNoRecordUnlock = false;
     synchronized (this) {
       if (unlockedHandler) return;
       noRecordUnlock = noRecord;
       unlockedHandler = true;
       canUnlock = mustUnlock();
+      if (canUnlock) {
+        localNoRecordUnlock = this.noRecordUnlock;
+      }
     }
     UIDTraceLogger.log(
         "unlockHandler", this, () -> "noRecord=" + noRecord + " canUnlock=" + canUnlock);
-    if (canUnlock) innerUnlock(noRecordUnlock);
+    if (canUnlock) innerUnlock(localNoRecordUnlock);
     else {
       LOG.info("Defer unlock in unlockHandler; still sending requests");
     }

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -422,7 +422,8 @@ public class NodeUpdateManager {
    */
   @SuppressWarnings("unused")
   public FreenetURI getSeednodesURI() {
-    return updateURI.sskForUSK().setDocName("seednodes-" + Version.currentBuildNumber());
+    FreenetURI uri = getURI();
+    return uri.sskForUSK().setDocName("seednodes-" + Version.currentBuildNumber());
   }
 
   /**
@@ -431,7 +432,8 @@ public class NodeUpdateManager {
    * @return a {@link FreenetURI} for {@code installer-<build>} under the update key
    */
   public FreenetURI getInstallerNonWindowsURI() {
-    return updateURI.sskForUSK().setDocName("installer-" + Version.currentBuildNumber());
+    FreenetURI uri = getURI();
+    return uri.sskForUSK().setDocName("installer-" + Version.currentBuildNumber());
   }
 
   /**
@@ -440,7 +442,8 @@ public class NodeUpdateManager {
    * @return a {@link FreenetURI} for {@code wininstaller-<build>} under the update key
    */
   public FreenetURI getInstallerWindowsURI() {
-    return updateURI.sskForUSK().setDocName("wininstaller-" + Version.currentBuildNumber());
+    FreenetURI uri = getURI();
+    return uri.sskForUSK().setDocName("wininstaller-" + Version.currentBuildNumber());
   }
 
   /**
@@ -449,7 +452,8 @@ public class NodeUpdateManager {
    * @return a {@link FreenetURI} for {@code iptocountryv4-<build>} under the update key
    */
   public FreenetURI getIPv4ToCountryURI() {
-    return updateURI.sskForUSK().setDocName("iptocountryv4-" + Version.currentBuildNumber());
+    FreenetURI uri = getURI();
+    return uri.sskForUSK().setDocName("iptocountryv4-" + Version.currentBuildNumber());
   }
 
   /**
@@ -501,10 +505,16 @@ public class NodeUpdateManager {
   }
 
   private Message getNewUOMAnnouncement(long blobSize) {
+    FreenetURI localUpdateURI;
+    FreenetURI localRevocationURI;
+    synchronized (this) {
+      localUpdateURI = updateURI;
+      localRevocationURI = revocationURI;
+    }
     int fetchedVersion = (blobSize <= 0) ? -1 : Version.currentBuildNumber();
     return new DMT.UOMAnnouncementBuilder()
-        .mainKey(updateURI.toString())
-        .revocationKey(revocationURI.toString())
+        .mainKey(localUpdateURI.toString())
+        .revocationKey(localRevocationURI.toString())
         .haveRevocation(getRevocationChecker().hasBlown())
         .mainJarVersion(fetchedVersion)
         .timeLastTriedRevocationFetch(getRevocationChecker().lastSucceededDelta())
@@ -568,6 +578,7 @@ public class NodeUpdateManager {
     // Note: wrapper gating removed in favor of CoreUpdater
     Map<String, PluginJarUpdater> oldPluginUpdaters = null;
     CoreUpdater stoppedCoreUpdater = null;
+    CoreUpdater startedCoreUpdater = null;
     // We need to run the revocation checker even if the auto-update is
     // disabled.
     // Two reasons:
@@ -591,6 +602,7 @@ public class NodeUpdateManager {
       } else {
         // Start CoreUpdater and plugin updaters
         startCoreUpdater();
+        startedCoreUpdater = coreUpdater;
         pluginUpdaters = new HashMap<>();
         // Suppress obsolete an Update-ASAP form in alert; CoreUpdater renders its own buttons
         armed = true;
@@ -602,7 +614,17 @@ public class NodeUpdateManager {
       stoppedCoreUpdater.kill();
       stopPluginUpdaters(oldPluginUpdaters);
     } else {
-      if (coreUpdater != null) coreUpdater.start();
+      if (startedCoreUpdater != null) {
+        boolean stillCurrent;
+        synchronized (this) {
+          stillCurrent = (coreUpdater == startedCoreUpdater);
+        }
+        if (stillCurrent) {
+          startedCoreUpdater.start();
+        } else if (LOG.isDebugEnabled()) {
+          LOG.debug("Skipping stale CoreUpdater start after concurrent state change");
+        }
+      }
       startPluginUpdaters();
     }
   }
@@ -650,7 +672,7 @@ public class NodeUpdateManager {
     if (info != null) {
       minVer = Math.max(minVer, info.getPluginLongVersion());
     }
-    FreenetURI uri = updateURI.setDocName(name).setSuggestedEdition(minVer);
+    FreenetURI uri = getURI().setDocName(name).setSuggestedEdition(minVer);
     NodeUpdaterParams params =
         new NodeUpdaterParams(
             this,
@@ -953,7 +975,7 @@ public class NodeUpdateManager {
       blownCoreUpdater = coreUpdater;
       coreUpdater = null;
     }
-    printRevocationMessage(disabledNotBlown);
+    printRevocationMessage(disabledNotBlown, msg);
     if (blownCoreUpdater != null) {
       blownCoreUpdater.kill();
     }
@@ -967,7 +989,7 @@ public class NodeUpdateManager {
     broadcastUOMAnnounces();
   }
 
-  private void printRevocationMessage(boolean disabledNotBlown) {
+  private void printRevocationMessage(boolean disabledNotBlown, String msg) {
     // We must show the user the message
     try {
       if (disabledNotBlown) {
@@ -976,12 +998,10 @@ public class NodeUpdateManager {
             "We do not know whether this is a local problem or the auto-update system has in fact"
                 + " been compromised. What we do know:{}{}",
             System.lineSeparator(),
-            revocationMessage);
+            msg);
       } else {
         LOG.error("THE AUTO-UPDATING SYSTEM HAS BEEN COMPROMISED!");
-        LOG.error(
-            "The auto-updating system revocation key has been inserted. It says: {}",
-            revocationMessage);
+        LOG.error("The auto-updating system revocation key has been inserted. It says: {}", msg);
       }
     } catch (Exception t) {
       try {
@@ -1076,7 +1096,7 @@ public class NodeUpdateManager {
    *
    * @return {@code true} when a newer version has been fetched and is ready
    */
-  public boolean hasNewMainJar() {
+  public synchronized boolean hasNewMainJar() {
     CoreUpdater cu = coreUpdater;
     return cu != null && cu.canUpdateNow();
   }
@@ -1086,7 +1106,7 @@ public class NodeUpdateManager {
    *
    * @return the fetched version number, or {@code -1} when none is available
    */
-  public int newMainJarVersion() {
+  public synchronized int newMainJarVersion() {
     CoreUpdater cu = coreUpdater;
     return (cu != null) ? cu.getFetchedVersion() : -1;
   }
@@ -1096,7 +1116,7 @@ public class NodeUpdateManager {
    *
    * @return {@code true} when a download is in progress
    */
-  public boolean fetchingNewMainJar() {
+  public synchronized boolean fetchingNewMainJar() {
     CoreUpdater cu = coreUpdater;
     return (cu != null && cu.isFetching());
   }
@@ -1106,7 +1126,7 @@ public class NodeUpdateManager {
    *
    * @return the in‑flight version number, or {@code -1} when idle
    */
-  public int fetchingNewMainJarVersion() {
+  public synchronized int fetchingNewMainJarVersion() {
     CoreUpdater cu = coreUpdater;
     return (cu != null) ? cu.fetchingVersion() : -1;
   }

--- a/src/main/java/network/crypta/node/updater/NodeUpdater.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdater.java
@@ -165,7 +165,11 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
   private void subscribe(Runnable onError) {
     try {
       // because of UoM, this version is actually worth having as well
-      USK myUsk = USK.create(this.uri.setSuggestedEdition(currentVersion));
+      FreenetURI localUri;
+      synchronized (this) {
+        localUri = this.uri;
+      }
+      USK myUsk = USK.create(localUri.setSuggestedEdition(currentVersion));
       core.getUskManager().subscribe(myUsk, this, true, getRequestClient());
     } catch (MalformedURLException _) {
       LOG.error("The auto-update URI isn't valid and can't be used");
@@ -352,7 +356,13 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
 
   @Override
   public void onSuccess(FetchResult result, ClientGetter state) {
-    onSuccess(result, tempBlobFile, fetchingVersion);
+    File localTempBlobFile;
+    int localFetchingVersion;
+    synchronized (this) {
+      localTempBlobFile = tempBlobFile;
+      localFetchingVersion = fetchingVersion;
+    }
+    onSuccess(result, localTempBlobFile, localFetchingVersion);
   }
 
   void onSuccess(FetchResult result, File tempBlobFile, int fetchedVersion) {
@@ -669,17 +679,25 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
     // Debug gating derives from LOG.isDebugEnabled() where needed
     if (!isRunning) return;
     FetchExceptionMode errorCode = e.getMode();
-    try {
-      Files.delete(tempBlobFile.toPath());
-    } catch (IOException ex) {
-      LOG.warn("Unable to delete temp blob {} on failure", tempBlobFile, ex);
-    }
 
-    if (LOG.isDebugEnabled()) LOG.debug("onFailure({},{})", e, cg);
+    File localTempBlobFile;
+    ClientGetter localCg;
     synchronized (this) {
+      localTempBlobFile = tempBlobFile;
+      localCg = this.cg;
       this.cg = null;
       isFetching = false;
     }
+
+    try {
+      if (localTempBlobFile != null) {
+        Files.delete(localTempBlobFile.toPath());
+      }
+    } catch (IOException ex) {
+      LOG.warn("Unable to delete temp blob {} on failure", localTempBlobFile, ex);
+    }
+
+    if (LOG.isDebugEnabled()) LOG.debug("onFailure({},{})", e, localCg);
     if (errorCode == FetchExceptionMode.CANCELLED || !e.isFatal()) {
       LOG.info("Rescheduling new request");
       ticker.queueTimedJob(this::maybeUpdate, 0);
@@ -718,8 +736,8 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
    * @return the immutable update key associated with this updater instance
    */
   @SuppressWarnings("unused")
-  public FreenetURI getUpdateKey() {
-    return uri;
+  public synchronized FreenetURI getUpdateKey() {
+    return this.uri;
   }
 
   /**
@@ -764,7 +782,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
    *
    * @return the last successfully fetched edition, or the current version when none were fetched
    */
-  public int getFetchedVersion() {
+  public synchronized int getFetchedVersion() {
     return fetchedVersion;
   }
 
@@ -773,7 +791,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
    *
    * @return {@code true} if a fetch is active for a newer edition; otherwise {@code false}
    */
-  public boolean isFetching() {
+  public synchronized boolean isFetching() {
     return availableVersion > fetchedVersion && availableVersion > currentVersion;
   }
 
@@ -782,7 +800,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
    *
    * @return an edition number used for progress reporting; never less than the current version
    */
-  public int fetchingVersion() {
+  public synchronized int fetchingVersion() {
     // We will not deploy the currentVersion...
     if (fetchingVersion <= currentVersion) return availableVersion;
     else return fetchingVersion;

--- a/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
+++ b/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
@@ -236,7 +236,8 @@ public class PluginJarUpdater extends NodeUpdater {
       return;
     }
 
-    if (loaded != null && loaded.getPluginLongVersion() >= fetchedVersion) {
+    int latestFetchedVersion = getFetchedVersion();
+    if (loaded != null && loaded.getPluginLongVersion() >= latestFetchedVersion) {
       deleteTempBlobQuietly();
       return;
     }
@@ -362,7 +363,11 @@ public class PluginJarUpdater extends NodeUpdater {
   }
 
   void writeJar() throws IOException {
-    writeJarTo(result, pluginManager.getPluginFilename(pluginName));
+    FetchResult localResult;
+    synchronized (this) {
+      localResult = result;
+    }
+    writeJarTo(localResult, pluginManager.getPluginFilename(pluginName));
     UserAlert a;
     synchronized (this) {
       a = alert;

--- a/src/main/java/network/crypta/node/updater/RevocationChecker.java
+++ b/src/main/java/network/crypta/node/updater/RevocationChecker.java
@@ -42,8 +42,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Typical usage is to construct a single instance tied to the lifetime of {@link
  * NodeUpdateManager}, then call {@link #start(boolean)} on startup and whenever the revocation URI
- * changes. The checker manages its own request state and ensures that low‑priority fetches are
- * replaced by aggressive ones after a successful core update.
+ * changes. The checker manages its own request state and ensures that aggressive ones replace
+ * low‑priority fetches after a successful core update.
  *
  * <p>Concurrency: instances are not immutable, but the critical fields are guarded internally.
  * Methods that mutate state take care to synchronize where required. Callers do not need to add
@@ -113,15 +113,15 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
     // Debug gating derives from LOG.isDebugEnabled() where needed
     ctxRevocation = core.makeClient((short) 0, true, false).getFetchContext();
     // Do not allow redirects etc.
-    // If we allow redirects then it will take too long to download the revocation.
+    // If we allow redirects, then it will take too long to download the revocation.
     // Anyone inserting it should be aware of this fact!
-    // You must insert with no content type, and be less than the size limit, and less than the
+    // You must insert with no content type and be less than the size limit, and less than the
     // block size after compression!
     // If it doesn't fit, we'll still tell the user, but the message may not be easily readable.
     ctxRevocation.setAllowSplitfiles(false);
     ctxRevocation.setMaxArchiveLevels(0);
     ctxRevocation.setFollowRedirects(false);
-    // big enough ?
+    // big enough?
     ctxRevocation.setMaxOutputLength(NodeUpdateManager.MAX_REVOCATION_KEY_LENGTH);
     ctxRevocation.setMaxTempLength(NodeUpdateManager.MAX_REVOCATION_KEY_TEMP_LENGTH);
     // if we find content, try forever to get it; not used because of the above size limits.
@@ -149,7 +149,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
    * Starts a revocation fetch cycle with the default reset behavior.
    *
    * <p>When invoked, the checker schedules a new fetch. If a previous low‑priority request is still
-   * running and {@code aggressive} is {@code true}, that request is cancelled and replaced with an
+   * running and {@code aggressive} is {@code true}, that request is canceled and replaced with an
    * aggressive one. If a previously persisted blob exists, it is processed immediately before the
    * asynchronous fetch completes.
    *
@@ -179,7 +179,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
    * Starts a revocation fetch, optionally resetting counters and adjusting priority.
    *
    * <p>If a fetch is already in progress and {@code aggressive} is {@code true} while the existing
-   * request is not, the existing request is cancelled and replaced. When {@code reset} is {@code
+   * request is not, the existing request is canceled and replaced. When {@code reset} is {@code
    * true} the consecutive {@code DATA_NOT_FOUND} counter is cleared; otherwise it continues from
    * its previous value. The method returns whether an in‑flight request existed prior to this call
    * (useful for callers wanting to know if they took over an existing cycle).
@@ -188,8 +188,8 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
    *     false}, submits at a lower, immediate class suitable for background checking.
    * @param reset when {@code true}, clears the internal DNF counter before queuing a new request;
    *     when {@code false}, preserves the current count across cycles.
-   * @return {@code true} if a previous fetch was running and was not already replaced by an
-   *     aggressive one; {@code false} otherwise.
+   * @return {@code true} if a previous fetch was running and was not yet replaced by an aggressive
+   *     one; {@code false} otherwise.
    */
   public boolean start(boolean aggressive, boolean reset) {
     if (manager.isBlown()) {
@@ -237,7 +237,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
     boolean wasRunning = false;
     synchronized (this) {
       if (shouldCancelOld(aggressive)) {
-        toCancel = revocationGetter; // Ignore old one.
+        toCancel = revocationGetter; // Ignore the old one.
         if (LOG.isDebugEnabled()) LOG.debug("Ignoring old request, because was low priority");
         revocationGetter = null;
         if (toCancel != null) wasRunning = true;
@@ -333,8 +333,8 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
   /**
    * Handles a successful fetch of the revocation message.
    *
-   * <p>Marks the checker as blown, persists the received blob to disk, attempts to extract a user
-   * readable message from the payload, and forwards the message to {@link
+   * <p>Marks the checker as blown, persists the received blob to disk, attempts to extract a
+   * user-readable message from the payload, and forwards the message to {@link
    * NodeUpdateManager#blow(String, boolean)}. Any errors while decoding the payload are logged and
    * do not prevent the revocation from being enforced.
    *
@@ -350,7 +350,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
 
   void onSuccess(FetchResult result, ClientGetter state, Bucket blob) {
     // The key has been blown !
-    // Note: Warning message content kept concise by design.
+    // Note: Warning message content is kept concise by design.
     blown = true;
     if (LOG.isDebugEnabled() && state != null) {
       LOG.debug("Revocation success; state={} (ignored)", state);
@@ -366,7 +366,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
         LOG.error(msg, t);
         // Message already logged above
       } catch (Exception _) {
-        msg = "Internal error after retreiving revocation key";
+        msg = "Internal error after retrieving revocation key";
       }
     }
     manager.blow(msg, false); // Real one, even if we can't extract the message.
@@ -376,7 +376,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
    * Returns whether a revocation message has been observed during this process lifetime.
    *
    * <p>Once {@code true}, this flag remains {@code true} for the life of the process. The overall
-   * node state should be considered revoked even if subsequent fetch cycles fail or if the payload
+   * node state should be considered revoked even if later fetch cycles fail or if the payload
    * cannot be decoded.
    *
    * @return {@code true} if revocation has been detected and propagated; {@code false} otherwise.
@@ -452,8 +452,9 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
    *
    * <p>Non‑fatal failures update the internal {@code DATA_NOT_FOUND} counter and may schedule a
    * retry depending on policy. Fatal failures trigger a blow with a localized, user‑readable
-   * message; when possible the partial blob is persisted for inspection. Redirects are treated as a
-   * configuration error and cause an immediate blow to avoid following potentially unsafe targets.
+   * message; when possible, the partial blob is persisted for inspection. Redirects are treated as
+   * a configuration error and cause an immediate blow to avoid following potentially unsafe
+   * targets.
    *
    * @param e the failure information, including the {@link FetchExceptionMode} and user‑friendly
    *     detail message; never {@code null}.
@@ -475,7 +476,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
     boolean completed;
     long now = System.currentTimeMillis();
     if (errorCode == FetchExceptionMode.CANCELLED) {
-      return; // cancelled by us above, or killed; either way irrelevant and doesn't need to be
+      return; // canceled by us above, or killed; either way irrelevant and doesn't need to be
       // restarted
     }
     if (handleFatalFailure(e, blob)) return;
@@ -500,7 +501,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
   private boolean handleFatalFailure(FetchException e, Bucket blob) {
     if (!e.isFatal()) return false;
     if (!e.isDefinitelyFatal()) {
-      // INTERNAL_ERROR could be related to the key but isn't necessarily.
+      // INTERNAL_ERROR could be related to the key but isn't necessary.
       String message =
           l10n(
               "revocationFetchFailedMaybeInternalError",
@@ -510,7 +511,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
       manager.blow(message, true);
       return true;
     }
-    // Really fatal, i.e. something was inserted but can't be decoded.
+    // Really fatal, i.e., something was inserted but can't be decoded.
     // Strings are intentionally explicit despite being rarely seen.
     String message =
         l10n(
@@ -559,7 +560,11 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
    * in‑flight request. Call {@link #start(boolean)} afterward to begin a fresh cycle if desired.
    */
   public void kill() {
-    if (revocationGetter != null) revocationGetter.cancel(core.getClientContext());
+    ClientGetter getter;
+    synchronized (this) {
+      getter = revocationGetter;
+    }
+    if (getter != null) getter.cancel(core.getClientContext());
   }
 
   /**
@@ -596,7 +601,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
   /**
    * Provides the revocation blob as a read‑only {@link RandomAccessBuffer}, when available.
    *
-   * <p>If the blob is already cached in memory it is returned as a read‑only byte array–backed
+   * <p>If the blob is already cached in memory, it is returned as a read-only byte-array-backed
    * buffer. Otherwise, a file‑backed buffer is opened for the persisted blob. When the node is not
    * blown or the blob cannot be read, {@code null} is returned and details are logged.
    *

--- a/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
+++ b/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
@@ -816,13 +816,12 @@ public class UpdateOverMandatoryManager implements RequestClient {
   }
 
   private void alertUser() {
-    UserAlert currentAlert;
     synchronized (this) {
       if (alert != null) return;
-      alert = new PeersSayKeyBlownAlert();
-      currentAlert = alert;
+      UserAlert newAlert = new PeersSayKeyBlownAlert();
+      updateManager.getNode().services().clientCore().getAlerts().register(newAlert);
+      alert = newAlert;
     }
-    updateManager.getNode().services().clientCore().getAlerts().register(currentAlert);
   }
 
   private class PeersSayKeyBlownAlert extends AbstractUserAlert {
@@ -1639,13 +1638,10 @@ public class UpdateOverMandatoryManager implements RequestClient {
    * It is safe to call even when no alert is registered.
    */
   public void killAlert() {
-    UserAlert currentAlert;
     synchronized (this) {
-      currentAlert = alert;
+      if (alert == null) return;
+      updateManager.getNode().services().clientCore().getAlerts().unregister(alert);
       alert = null;
-    }
-    if (currentAlert != null) {
-      updateManager.getNode().services().clientCore().getAlerts().unregister(currentAlert);
     }
   }
 

--- a/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
+++ b/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
@@ -816,11 +816,13 @@ public class UpdateOverMandatoryManager implements RequestClient {
   }
 
   private void alertUser() {
+    UserAlert currentAlert;
     synchronized (this) {
       if (alert != null) return;
       alert = new PeersSayKeyBlownAlert();
+      currentAlert = alert;
     }
-    updateManager.getNode().services().clientCore().getAlerts().register(alert);
+    updateManager.getNode().services().clientCore().getAlerts().register(currentAlert);
   }
 
   private class PeersSayKeyBlownAlert extends AbstractUserAlert {
@@ -1637,7 +1639,14 @@ public class UpdateOverMandatoryManager implements RequestClient {
    * It is safe to call even when no alert is registered.
    */
   public void killAlert() {
-    updateManager.getNode().services().clientCore().getAlerts().unregister(alert);
+    UserAlert currentAlert;
+    synchronized (this) {
+      currentAlert = alert;
+      alert = null;
+    }
+    if (currentAlert != null) {
+      updateManager.getNode().services().clientCore().getAlerts().unregister(currentAlert);
+    }
   }
 
   /**

--- a/src/main/java/network/crypta/node/useralerts/PeerManagerUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/PeerManagerUserAlert.java
@@ -459,7 +459,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
     return ret;
   }
 
-  private void update() {
+  private synchronized void update() {
     bwlimitDelayTime = (int) n.getBwlimitDelayTime();
     nodeAveragePingTime = (int) n.getNodeAveragePingTime();
     oldestNeverConnectedPeerAge = n.peers.getOldestNeverConnectedDarknetPeerAge();
@@ -573,7 +573,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    * @param value {@code true} if reachability has been confirmed; {@code false} if it has not been
    *     confirmed or is known to be unreachable
    */
-  public void setOpennetDefinitelyPortForwarded(boolean value) {
+  public synchronized void setOpennetDefinitelyPortForwarded(boolean value) {
     this.opennetDefinitelyPortForwarded = value;
   }
 
@@ -584,7 +584,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    * @param value {@code true} if reachability has been confirmed; {@code false} if it has not been
    *     confirmed or is known to be unreachable
    */
-  public void setDarknetDefinitelyPortForwarded(boolean value) {
+  public synchronized void setDarknetDefinitelyPortForwarded(boolean value) {
     this.darknetDefinitelyPortForwarded = value;
   }
 
@@ -595,7 +595,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    * @param value {@code true} to assume a NAT is present; {@code false} to avoid applying that
    *     assumption
    */
-  public void setOpennetAssumeNAT(boolean value) {
+  public synchronized void setOpennetAssumeNAT(boolean value) {
     this.opennetAssumeNAT = value;
   }
 
@@ -606,7 +606,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    * @param value {@code true} to assume a NAT is present; {@code false} to avoid applying that
    *     assumption
    */
-  public void setDarknetAssumeNAT(boolean value) {
+  public synchronized void setDarknetAssumeNAT(boolean value) {
     this.darknetAssumeNAT = value;
   }
 
@@ -615,7 +615,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value number of active darknet connections; negative values are not expected
    */
-  public void setDarknetConns(int value) {
+  public synchronized void setDarknetConns(int value) {
     this.darknetConns = value;
   }
 
@@ -624,7 +624,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value number of active connections; negative values are not expected
    */
-  public void setConns(int value) {
+  public synchronized void setConns(int value) {
     this.conns = value;
   }
 
@@ -633,7 +633,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value count of darknet peers; negative values are not expected
    */
-  public void setDarknetPeers(int value) {
+  public synchronized void setDarknetPeers(int value) {
     this.darknetPeers = value;
   }
 
@@ -642,7 +642,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value count of disconnected darknet peers; negative values are not expected
    */
-  public void setDisconnDarknetPeers(int value) {
+  public synchronized void setDisconnDarknetPeers(int value) {
     this.disconnDarknetPeers = value;
   }
 
@@ -651,7 +651,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value peer count; negative values are not expected
    */
-  public void setPeers(int value) {
+  public synchronized void setPeers(int value) {
     this.peers = value;
   }
 
@@ -660,7 +660,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value count of never-connected peers; negative values are not expected
    */
-  public void setNeverConn(int value) {
+  public synchronized void setNeverConn(int value) {
     this.neverConn = value;
   }
 
@@ -669,7 +669,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value count of peers with clock problems; negative values are not expected
    */
-  public void setClockProblem(int value) {
+  public synchronized void setClockProblem(int value) {
     this.clockProblem = value;
   }
 
@@ -679,7 +679,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value count of peers with connection errors; negative values are not expected
    */
-  public void setConnError(int value) {
+  public synchronized void setConnError(int value) {
     this.connError = value;
   }
 
@@ -689,7 +689,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value {@code true} if opennet is enabled; {@code false} if disabled
    */
-  public void setOpennetEnabled(boolean value) {
+  public synchronized void setOpennetEnabled(boolean value) {
     this.isOpennetEnabled = value;
   }
 
@@ -699,7 +699,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value number of too-new darknet peers; negative values are not expected
    */
-  public void setTooNewPeersDarknet(int value) {
+  public synchronized void setTooNewPeersDarknet(int value) {
     this.tooNewPeersDarknet = value;
   }
 
@@ -709,7 +709,7 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
    *
    * @param value total number of too-new peers; negative values are not expected
    */
-  public void setTooNewPeersTotal(int value) {
+  public synchronized void setTooNewPeersTotal(int value) {
     this.tooNewPeersTotal = value;
   }
 }

--- a/src/main/java/network/crypta/store/caching/CachingFreenetStoreTracker.java
+++ b/src/main/java/network/crypta/store/caching/CachingFreenetStoreTracker.java
@@ -11,12 +11,12 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The tracker accepts size deltas (in bytes) via {@link #add(long)} and schedules cache flushes
  * on a {@link Ticker}: immediately when usage crosses a lower threshold (around 90% of the
- * configured maximum) and otherwise after the given period has elapsed since the last write. The
+ * configured maximum) and otherwise after the given period has elapsed since the last writing. The
  * design aims to avoid disk I/O while holding locks; flushes run off-thread by repeatedly calling
  * {@link CachingFreenetStore#pushLeastRecentlyBlock()} on registered stores.
  *
  * <p>Thread-safety: public methods are safe for concurrent use. At most one flush job runs at a
- * time and at most one delayed job is queued. Internal synchronization ensures that accounting
+ * time, and at most one delayed job is queued. Internal synchronization ensures that accounting
  * updates and job scheduling are consistent without performing blocking I/O inside synchronized
  * sections.
  *
@@ -34,7 +34,7 @@ public class CachingFreenetStoreTracker {
   private static final int NUMBER_OF_KEYS_TO_WRITE = 20;
 
   /**
-   * Lower-usage threshold. When the next add crosses this ratio of {@link #maxSize}, the tracker
+   * Lower-usage threshold. When the next adding crosses this ratio of {@link #maxSize}, the tracker
    * schedules an immediate background flush but still accepts the data.
    */
   private static final double LOWER_THRESHOLD = 0.9;
@@ -118,10 +118,10 @@ public class CachingFreenetStoreTracker {
   /**
    * Accounts for a new block and schedules flushes as needed.
    *
-   * <p>If the new total would exceed the lower threshold (about 90% of {@link #maxSize}), an
-   * immediate background flush is scheduled. If the total would exceed {@link #maxSize}, the block
-   * is rejected and the caller should write directly to the underlying store. Otherwise, the block
-   * is accepted and a delayed flush is scheduled if one is not already pending.
+   * <p>If the new total exceeds the lower threshold (about 90% of {@link #maxSize}), an immediate
+   * background flush is scheduled. If the total would exceed {@link #maxSize}, the block is
+   * rejected and the caller should write directly to the underlying store. Otherwise, the block is
+   * accepted and a delayed flush is scheduled if one is not already pending.
    *
    * @param sizeBlock size of the block in bytes; must be non-negative
    * @return {@code true} if the block is accepted for caching; {@code false} if it should be
@@ -157,7 +157,9 @@ public class CachingFreenetStoreTracker {
           try {
             pushAllCachingStores();
           } finally {
-            runningJob = false;
+            synchronized (CachingFreenetStoreTracker.this) {
+              runningJob = false;
+            }
           }
         },
         0);

--- a/src/main/java/network/crypta/store/saltedhash/ResizablePersistentIntBuffer.java
+++ b/src/main/java/network/crypta/store/saltedhash/ResizablePersistentIntBuffer.java
@@ -93,7 +93,7 @@ public class ResizablePersistentIntBuffer {
    */
   private boolean writing;
 
-  private boolean closed;
+  private volatile boolean closed;
 
   /**
    * Sets the global persistence policy.

--- a/src/main/java/network/crypta/support/PooledExecutor.java
+++ b/src/main/java/network/crypta/support/PooledExecutor.java
@@ -6,6 +6,7 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.node.PrioRunnable;
 import network.crypta.support.io.NativeThread;
 import org.jetbrains.annotations.NotNull;
@@ -291,7 +292,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
     final String defaultName;
     volatile boolean alive = true;
     Job nextJob;
-    Job job;
+    final AtomicReference<Job> job = new AtomicReference<>();
     final long threadNo;
     private boolean removed = false;
 
@@ -324,8 +325,9 @@ public class PooledExecutor implements PriorityAwareExecutor {
      * @return the current job id if running, otherwise the next job id if assigned, or {@code 0}
      *     when none
      */
-    public int getJobId() {
-      if (job != null) return job.id;
+    public synchronized int getJobId() {
+      Job currentJob = job.get();
+      if (currentJob != null) return currentJob.id;
       if (nextJob != null) return nextJob.id;
       return 0;
     }
@@ -357,14 +359,16 @@ public class PooledExecutor implements PriorityAwareExecutor {
       while (true) {
         moveNextJobToCurrent();
 
-        if (job == null && onNoJobWaitAndMaybeExit(nativePriority, ranJobs)) return;
+        if (job.get() == null && onNoJobWaitAndMaybeExit(nativePriority, ranJobs)) return;
+        Job currentJob = job.get();
+        if (currentJob == null) continue;
 
         // Run the job
         try {
-          setName(job.name + "(" + threadNo + ")");
-          job.runnable.run();
+          setName(currentJob.name + "(" + threadNo + ")");
+          currentJob.runnable.run();
         } catch (Throwable t) {
-          LOG.error("Caught {} running job {}", t, job, t);
+          LOG.error("Caught {} running job {}", t, currentJob, t);
         }
         ranJobs++;
       }
@@ -390,7 +394,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
     /** Move any pending assignment into {@link #job} for execution. */
     private void moveNextJobToCurrent() {
       synchronized (this) {
-        job = nextJob;
+        job.set(nextJob);
         nextJob = null;
       }
     }
@@ -440,11 +444,11 @@ public class PooledExecutor implements PriorityAwareExecutor {
           waitingThreadsCount.decrementAndGet();
 
         synchronized (this) {
-          job = nextJob;
+          job.set(nextJob);
           nextJob = null;
           // Note: Some static analyzers flag this as double-checked locking; here we only
           // re-check after waiting to decide whether to exit the worker when no job arrived.
-          if (job == null) alive = false;
+          if (job.get() == null) alive = false;
         }
 
         if (!alive) {

--- a/src/main/java/network/crypta/support/SimpleFieldSet.java
+++ b/src/main/java/network/crypta/support/SimpleFieldSet.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import network.crypta.node.FSParseException;
 import network.crypta.support.io.LineReader;
 import network.crypta.support.io.Readers;
@@ -70,7 +71,7 @@ public class SimpleFieldSet {
   private static final String CANNOT_PARSE = "Cannot parse ";
 
   private final Map<String, String> values;
-  private volatile Map<String, SimpleFieldSet> subsets;
+  private ConcurrentHashMap<String, SimpleFieldSet> subsets;
   private volatile String endMarker;
   private final boolean shortLived;
   private final boolean alwaysUseBase64;
@@ -160,7 +161,7 @@ public class SimpleFieldSet {
    */
   public SimpleFieldSet(SimpleFieldSet sfs) {
     values = new HashMap<>(sfs.values);
-    if (sfs.subsets != null) subsets = new HashMap<>(sfs.subsets);
+    if (sfs.subsets != null) subsets = new ConcurrentHashMap<>(sfs.subsets);
     this.shortLived = false; // it's been copied!
     this.header = sfs.header;
     this.endMarker = sfs.endMarker;
@@ -510,7 +511,7 @@ public class SimpleFieldSet {
     // overwrite old
     values.putAll(fs.values);
     if (fs.subsets == null) return;
-    if (subsets == null) subsets = new HashMap<>();
+    if (subsets == null) subsets = new ConcurrentHashMap<>();
     for (Map.Entry<String, SimpleFieldSet> entry : fs.subsets.entrySet()) {
       String key = entry.getKey();
       SimpleFieldSet hisFS = entry.getValue();
@@ -633,7 +634,7 @@ public class SimpleFieldSet {
       boolean allowMultiple,
       boolean overwrite,
       boolean fromRead) {
-    if (subsets == null) subsets = new HashMap<>();
+    if (subsets == null) subsets = new ConcurrentHashMap<>();
     SimpleFieldSet fs = subsets.get(before);
     if (fs == null) {
       fs = new SimpleFieldSet(shortLived, alwaysUseBase64);
@@ -1118,7 +1119,7 @@ public class SimpleFieldSet {
     if (fs.isEmpty()) { // can't just no-op, because the caller might add the FS then populate it...
       throw new IllegalArgumentException("Empty");
     }
-    if (subsets == null) subsets = new HashMap<>();
+    if (subsets == null) subsets = new ConcurrentHashMap<>();
     if (subsets.containsKey(key))
       throw new IllegalArgumentException(
           "Already contains " + key + " but trying to add a SimpleFieldSet!");

--- a/src/main/java/network/crypta/support/SimpleFieldSet.java
+++ b/src/main/java/network/crypta/support/SimpleFieldSet.java
@@ -70,8 +70,8 @@ public class SimpleFieldSet {
   private static final String CANNOT_PARSE = "Cannot parse ";
 
   private final Map<String, String> values;
-  private Map<String, SimpleFieldSet> subsets;
-  private String endMarker;
+  private volatile Map<String, SimpleFieldSet> subsets;
+  private volatile String endMarker;
   private final boolean shortLived;
   private final boolean alwaysUseBase64;
   protected String[] header;

--- a/src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBuffer.java
@@ -1,6 +1,13 @@
 package network.crypta.support.io;
 
-import java.io.*;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.support.api.LockableRandomAccessBuffer;
@@ -17,8 +24,8 @@ import network.crypta.support.api.LockableRandomAccessBuffer;
  * <h2>Thread-safety</h2>
  *
  * Access to the {@code freed} lifecycle flag is synchronized on {@code this}. All I/O methods check
- * the flag and throw {@link IOException} once the wrapper is freed. Otherwise, operations delegate
- * directly to the underlying buffer.
+ * the flag and throw {@link IOException} once the wrapper is freed. Otherwise, operations are
+ * delegated directly to the underlying buffer.
  *
  * <h2>Persistence</h2>
  *
@@ -47,7 +54,7 @@ public class DelayedFreeRandomAccessBuffer
    * Creates a wrapper around a lockable random-access buffer that will be freed after a commit.
    *
    * <p>The constructor captures {@link PersistentFileTracker#commitID()} to decide later whether
-   * the free can happen immediately or must be delayed until a subsequent commit.
+   * the free can happen immediately or must be delayed until a later commit.
    *
    * @param raf underlying buffer; must be non-{@code null}
    * @param factory tracker responsible for deferred freeing
@@ -97,7 +104,7 @@ public class DelayedFreeRandomAccessBuffer
    * @param buf source array
    * @param bufOffset offset into {@code buf}
    * @param length number of bytes to write
-   * @throws IOException if this wrapper is freed or if the underlying write fails
+   * @throws IOException if this wrapper is freed or if the underlying writing fails
    */
   @Override
   public void pwrite(long fileOffset, byte[] buf, int bufOffset, int length) throws IOException {
@@ -156,7 +163,7 @@ public class DelayedFreeRandomAccessBuffer
    * Reattaches runtime state after a restart.
    *
    * <p>Wires the tracker from {@link ClientContext#persistentBucketFactory} and delegates to the
-   * underlying buffer so it can register itself and avoid premature collection.
+   * underlying buffer so it can register itself and avoid the premature collection.
    *
    * @param context runtime context providing the persistent bucket factory
    * @throws ResumeFailedException if the underlying buffer cannot be resumed
@@ -216,7 +223,7 @@ public class DelayedFreeRandomAccessBuffer
    * @return {@code true} if {@link #free()} has been called; {@code false} otherwise
    */
   @Override
-  public boolean toFree() {
+  public synchronized boolean toFree() {
     return freed;
   }
 
@@ -228,7 +235,7 @@ public class DelayedFreeRandomAccessBuffer
    *
    * @return the underlying buffer, or {@code null} if freed
    */
-  public LockableRandomAccessBuffer getUnderlying() {
+  public synchronized LockableRandomAccessBuffer getUnderlying() {
     if (freed) return null;
     return underlying;
   }
@@ -257,7 +264,7 @@ public class DelayedFreeRandomAccessBuffer
   /**
    * Compares wrappers by the identity of their underlying buffers.
    *
-   * <p>Two delayed-free wrappers may reference the same restored buffer after a resume; they should
+   * <p>Two delayed-free wrappers may reference the same restored buffer after resuming; they should
    * then compare as equal.
    */
   @Override

--- a/src/main/java/network/crypta/support/io/FileRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/FileRandomAccessBuffer.java
@@ -5,10 +5,12 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.RandomAccessFile;
 import java.io.Serial;
 import java.io.Serializable;
 import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.async.ClientContext;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import org.slf4j.Logger;
@@ -37,7 +39,7 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
   private static final Logger LOG = LoggerFactory.getLogger(FileRandomAccessBuffer.class);
 
   @Serial private static final long serialVersionUID = 1L;
-  transient RandomAccessFile raf;
+  transient AtomicReference<RandomAccessFile> raf = new AtomicReference<>();
   final File file;
   private boolean closed = false;
   private final long length;
@@ -58,7 +60,7 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
    */
   public FileRandomAccessBuffer(RandomAccessFile raf, File filename, boolean readOnly)
       throws IOException {
-    this.raf = raf;
+    this.raf.set(raf);
     this.file = filename;
     length = raf.length();
     this.readOnly = readOnly;
@@ -77,8 +79,12 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
    * @throws IOException if the file cannot be opened or resized to {@code length}
    */
   public FileRandomAccessBuffer(File filename, long length, boolean readOnly) throws IOException {
-    raf = new RandomAccessFile(filename, readOnly ? "r" : "rw");
-    raf.setLength(length);
+    raf.set(new RandomAccessFile(filename, readOnly ? "r" : "rw"));
+    try {
+      raf.get().setLength(length);
+    } catch (IOException e) {
+      throw closeOnInitFailure(raf.get(), e);
+    }
     this.length = length;
     this.file = filename;
     this.readOnly = readOnly;
@@ -92,10 +98,30 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
    * @throws IOException if the file cannot be opened or its length cannot be obtained
    */
   public FileRandomAccessBuffer(File filename, boolean readOnly) throws IOException {
-    raf = new RandomAccessFile(filename, readOnly ? "r" : "rw");
-    this.length = raf.length();
+    raf.set(new RandomAccessFile(filename, readOnly ? "r" : "rw"));
+    try {
+      this.length = raf.get().length();
+    } catch (IOException e) {
+      throw closeOnInitFailure(raf.get(), e);
+    }
     this.file = filename;
     this.readOnly = readOnly;
+  }
+
+  private static IOException closeOnInitFailure(
+      RandomAccessFile randomAccessFile, IOException failure) {
+    try {
+      randomAccessFile.close();
+    } catch (IOException closeException) {
+      failure.addSuppressed(closeException);
+    }
+    return failure;
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    raf = new AtomicReference<>();
   }
 
   /**
@@ -125,8 +151,9 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
               + this.length);
     // Serialize access through this instance; RAF itself is not position-safe for concurrency.
     synchronized (this) {
-      raf.seek(fileOffset);
-      raf.readFully(buf, bufOffset, length);
+      RandomAccessFile randomAccessFile = raf.get();
+      randomAccessFile.seek(fileOffset);
+      randomAccessFile.readFully(buf, bufOffset, length);
     }
   }
 
@@ -157,8 +184,9 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
     if (readOnly) throw new IOException("Read only");
     // Serialize access through this instance; RAF writes also move the shared file pointer.
     synchronized (this) {
-      raf.seek(fileOffset);
-      raf.write(buf, bufOffset, length);
+      RandomAccessFile randomAccessFile = raf.get();
+      randomAccessFile.seek(fileOffset);
+      randomAccessFile.write(buf, bufOffset, length);
     }
   }
 
@@ -180,14 +208,16 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
    */
   @Override
   public void close() {
+    RandomAccessFile randomAccessFile;
     synchronized (this) {
       if (closed) return;
       closed = true;
+      randomAccessFile = raf.get();
     }
     try {
-      raf.close();
+      randomAccessFile.close();
     } catch (IOException e) {
-      LOG.error("Could not close {} : {} for {}", raf, e, this, e);
+      LOG.error("Could not close {} : {} for {}", randomAccessFile, e, this, e);
     }
   }
 
@@ -260,7 +290,8 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
     if (!file.exists()) throw new ResumeFailedException("File does not exist any more");
     if (file.length() != length) throw new ResumeFailedException("File is wrong length");
     try {
-      raf = new RandomAccessFile(file, readOnly ? "r" : "rw");
+      if (raf == null) raf = new AtomicReference<>();
+      raf.set(new RandomAccessFile(file, readOnly ? "r" : "rw"));
     } catch (FileNotFoundException _) {
       throw new ResumeFailedException("File does not exist any more");
     }
@@ -321,7 +352,7 @@ public class FileRandomAccessBuffer implements LockableRandomAccessBuffer, Seria
     // Validate existence/length before opening since an RAF is needed immediately after.
     if (!file.exists()) throw new ResumeFailedException("File does not exist");
     if (length > file.length()) throw new ResumeFailedException("Bad length");
-    this.raf = new RandomAccessFile(file, readOnly ? "r" : "rw");
+    this.raf.set(new RandomAccessFile(file, readOnly ? "r" : "rw"));
   }
 
   /**

--- a/src/main/java/network/crypta/support/io/PaddedBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedBucket.java
@@ -173,7 +173,7 @@ public class PaddedBucket implements Bucket, Serializable {
 
     /**
      * Computes the padded length for the given size using a minimum of {@link #MIN_PADDED_SIZE} and
-     * powers of two growth. The result is always {@code >=} the provided size.
+     * powers of two growths. The result is always {@code >=} the provided size.
      */
     private long paddedLength(long size) {
       if (size < MIN_PADDED_SIZE) size = MIN_PADDED_SIZE;
@@ -184,7 +184,7 @@ public class PaddedBucket implements Bucket, Serializable {
         if (max < 0)
           throw new IllegalStateException(
               "Impossible size: " + size + " - min=" + min + ", max=" + max);
-        // size is always >= min at this point; only need to compare to upper bound
+        // size is always >= min at this point; only need to compare to the upper bound
         if (size <= max) {
           return max;
         }
@@ -277,10 +277,12 @@ public class PaddedBucket implements Bucket, Serializable {
     }
 
     @Override
-    public synchronized int available() throws IOException {
-      long max = size - counter;
+    public int available() throws IOException {
       int ret = in.available();
-      if (max < ret) ret = (int) max;
+      synchronized (PaddedBucket.this) {
+        long max = size - counter;
+        if (max < ret) ret = (int) max;
+      }
       return Math.max(ret, 0);
     }
   }
@@ -334,8 +336,12 @@ public class PaddedBucket implements Bucket, Serializable {
    */
   @Override
   public Bucket createShadow() {
+    long currentSize;
+    synchronized (this) {
+      currentSize = size;
+    }
     Bucket shadow = underlying.createShadow();
-    PaddedBucket ret = new PaddedBucket(shadow, size);
+    PaddedBucket ret = new PaddedBucket(shadow, currentSize);
     ret.setReadOnly();
     return ret;
   }
@@ -362,6 +368,7 @@ public class PaddedBucket implements Bucket, Serializable {
   // Preserve backward compatibility with historical Java-serialization layout where 'underlying'
   // was a non-transient field written via default serialization. We keep a declared persistent
   // field for it so readObject() can consume legacy streams that still carry it.
+  @SuppressWarnings("unused")
   @Serial
   private static final ObjectStreamField[] serialPersistentFields = {
     new ObjectStreamField(FIELD_SIZE, long.class),
@@ -380,10 +387,16 @@ public class PaddedBucket implements Bucket, Serializable {
    */
   @Override
   public void storeTo(DataOutputStream dos) throws IOException {
+    long currentSize;
+    boolean currentReadOnly;
+    synchronized (this) {
+      currentSize = size;
+      currentReadOnly = readOnly;
+    }
     dos.writeInt(MAGIC);
     dos.writeInt(VERSION);
-    dos.writeLong(size);
-    dos.writeBoolean(readOnly);
+    dos.writeLong(currentSize);
+    dos.writeBoolean(currentReadOnly);
     underlying.storeTo(dos);
   }
 
@@ -428,7 +441,6 @@ public class PaddedBucket implements Bucket, Serializable {
    */
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
-    assert serialPersistentFields.length > 0;
     ObjectOutputStream.PutField fields = out.putFields();
     fields.put(FIELD_SIZE, size);
     fields.put(FIELD_READ_ONLY, readOnly);

--- a/src/main/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
@@ -64,7 +64,7 @@ public class PaddedEphemerallyEncryptedBucket implements Bucket, Serializable {
 
   private final byte[] iv;
   private transient byte[] randomSeed;
-  private long dataLength;
+  private volatile long dataLength;
   private volatile boolean readOnly;
   private transient int lastOutputStream;
 
@@ -570,6 +570,10 @@ public class PaddedEphemerallyEncryptedBucket implements Bucket, Serializable {
    */
   @Override
   public void storeTo(DataOutputStream dos) throws IOException {
+    long currentDataLength;
+    synchronized (this) {
+      currentDataLength = dataLength;
+    }
     dos.writeInt(MAGIC);
     dos.writeInt(VERSION);
     dos.writeInt(minPaddedSize);
@@ -581,7 +585,7 @@ public class PaddedEphemerallyEncryptedBucket implements Bucket, Serializable {
       dos.writeBoolean(false);
     }
     // randomSeed should be recovered in onResume().
-    dos.writeLong(dataLength);
+    dos.writeLong(currentDataLength);
     dos.writeBoolean(readOnly);
     bucket.storeTo(dos);
   }

--- a/src/main/java/network/crypta/support/io/PaddedRandomAccessBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedRandomAccessBucket.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
  * actual data and stop at {@code size()}, even if the underlying storage is larger due to padding.
  *
  * <p>Thread-safety: instances synchronize on {@code this} to guard internal counters and the
- * single-output-stream invariant. It is safe to obtain streams from different threads as long as
+ * single-output-stream invariant. It is safe to get streams from different threads as long as
  * callers respect the “one open OutputStream at a time” rule.
  *
  * <p>Serialization: this class supports both the versioned persistence used by the recovery path
@@ -92,7 +92,7 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
    * underlying storage reaches the next power-of-two length (minimum {@code 1024} bytes).
    *
    * @return a buffered {@link OutputStream}
-   * @throws IOException if an output stream is already open or the underlying bucket fails to
+   * @throws IOException if an output stream is already open, or the underlying bucket fails to
    *     provide a stream
    */
   @Override
@@ -114,7 +114,7 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
    * stream is closed.
    *
    * @return an unbuffered {@link OutputStream}
-   * @throws IOException if an output stream is already open or the underlying bucket fails to
+   * @throws IOException if an output stream is already open, or the underlying bucket fails to
    *     provide a stream
    */
   @Override
@@ -292,10 +292,12 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
     }
 
     @Override
-    public synchronized int available() throws IOException {
-      long max = size - counter;
+    public int available() throws IOException {
       int ret = in.available();
-      if (max < ret) ret = (int) max;
+      synchronized (PaddedRandomAccessBucket.this) {
+        long max = size - counter;
+        if (max < ret) ret = (int) max;
+      }
       return Math.max(ret, 0);
     }
   }
@@ -324,8 +326,7 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
    * Indicates whether this wrapper is marked read-only.
    *
    * <p>Note: This flag is advisory in this implementation and is not enforced by the class when
-   * obtaining output streams. Callers should treat it as a contract and avoid writes once it is
-   * set.
+   * getting output streams. Callers should treat it as a contract and avoid writing once it is set.
    *
    * @return {@code true} if {@link #setReadOnly()} has been called; otherwise {@code false}
    */
@@ -353,8 +354,12 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
    */
   @Override
   public RandomAccessBucket createShadow() {
+    long currentSize;
+    synchronized (this) {
+      currentSize = size;
+    }
     RandomAccessBucket shadow = underlying.createShadow();
-    PaddedRandomAccessBucket ret = new PaddedRandomAccessBucket(shadow, size);
+    PaddedRandomAccessBucket ret = new PaddedRandomAccessBucket(shadow, currentSize);
     ret.setReadOnly();
     return ret;
   }
@@ -385,10 +390,16 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
    */
   @Override
   public void storeTo(DataOutputStream dos) throws IOException {
+    long currentSize;
+    boolean currentReadOnly;
+    synchronized (this) {
+      currentSize = size;
+      currentReadOnly = readOnly;
+    }
     dos.writeInt(MAGIC);
     dos.writeInt(VERSION);
-    dos.writeLong(size);
-    dos.writeBoolean(readOnly);
+    dos.writeLong(currentSize);
+    dos.writeBoolean(currentReadOnly);
     underlying.storeTo(dos);
   }
 
@@ -431,13 +442,15 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
    */
   @Override
   public LockableRandomAccessBuffer toRandomAccessBuffer() throws IOException {
+    long currentSize;
     synchronized (this) {
       if (outputStreamOpen) throw new IOException("Must close first");
       readOnly = true;
+      currentSize = size;
     }
     underlying.setReadOnly();
     LockableRandomAccessBuffer u = underlying.toRandomAccessBuffer();
-    return new PaddedRandomAccessBuffer(u, size);
+    return new PaddedRandomAccessBuffer(u, currentSize);
   }
 
   /**
@@ -451,8 +464,9 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
   }
 
   /* ===== Java serialization support ===== */
-  // Preserve backward compatibility with legacy Java-serialization layout where 'underlying' was
-  // included in the default field block. We include the actual underlying in the field block so
+  // Preserve backward compatibility with the legacy Java-serialization layout where 'underlying'
+  // was
+  // included in the default field block. We include the actual underlying in the field block, so
   // older readers (serialVersionUID 1) do not need to read any trailing data. Newer readers keep
   // accepting both forms.
 
@@ -460,6 +474,7 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
   private static final String FIELD_READ_ONLY = "readOnly";
   private static final String FIELD_UNDERLYING = "underlying";
 
+  @SuppressWarnings("unused")
   @Serial
   private static final ObjectStreamField[] serialPersistentFields = {
     new ObjectStreamField(FIELD_SIZE, long.class),
@@ -469,7 +484,6 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
 
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
-    assert serialPersistentFields.length > 0;
     ObjectOutputStream.PutField fields = out.putFields();
     fields.put(FIELD_SIZE, size);
     fields.put(FIELD_READ_ONLY, readOnly);
@@ -493,7 +507,7 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
       // Legacy form: underlying was serialized as part of the field set.
       underlying = rab;
     } else {
-      // New form: read trailing underlying object written after the fields.
+      // New form: read a trailing underlying object written after the fields.
       underlying = (RandomAccessBucket) in.readObject();
     }
   }

--- a/src/main/java/network/crypta/support/io/TempBucketFactory.java
+++ b/src/main/java/network/crypta/support/io/TempBucketFactory.java
@@ -84,6 +84,7 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
   private static final Cleaner resourceCleaner = Cleaner.create();
 
   // Cleaner action that avoids capturing the outer TempBucket instance strongly.
+  @SuppressWarnings("ClassCanBeRecord")
   private static class TempBucketCleanup implements Runnable {
     private final RandomAccessBucket currentBucket;
 
@@ -103,6 +104,7 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
   }
 
   // Cleaner action for TempRandomAccessBuffer memory accounting only.
+  @SuppressWarnings("ClassCanBeRecord")
   private static class TempRABCleanup implements Runnable {
     private final long rabId;
     private final long size;
@@ -341,17 +343,28 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
       }
 
       private boolean shouldMigrateDueToOversize(long futureSize) {
+        long maxBucketSize = getMaxRAMBucketSize();
         return futureSize
-            >= Math.min(Integer.MAX_VALUE, maxRAMBucketSize * RAMBUCKET_CONVERSION_FACTOR);
+            >= Math.min(Integer.MAX_VALUE, maxBucketSize * RAMBUCKET_CONVERSION_FACTOR);
       }
 
       private boolean shouldMigrateDueToPoolLimit(long futureSize) {
-        return (futureSize - currentSize) + bytesInUse >= maxRamUsed;
+        long currentBucketSize;
+        synchronized (TempBucket.this) {
+          currentBucketSize = currentSize;
+        }
+        synchronized (TempBucketFactory.this) {
+          return (futureSize - currentBucketSize) + bytesInUse >= maxRamUsed;
+        }
       }
 
       private void ensureDiskSpace(long futureSize) throws InsufficientDiskSpaceException {
-        if (filenameGenerator.getDir().getUsableSpace() + (futureSize - currentSize) < minDiskSpace)
-          throw new InsufficientDiskSpaceException();
+        long currentBucketSize;
+        synchronized (TempBucket.this) {
+          currentBucketSize = currentSize;
+        }
+        if (filenameGenerator.getDir().getUsableSpace() + (futureSize - currentBucketSize)
+            < minDiskSpace) throw new InsufficientDiskSpaceException();
       }
 
       private void logMigration(boolean oversized) {
@@ -360,7 +373,7 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
             LOG.debug(
                 "event=ram_bucket_oversize_migrate bucket={} threshold={}",
                 TempBucket.this,
-                SizeUtil.formatSize(maxRAMBucketSize * RAMBUCKET_CONVERSION_FACTOR));
+                SizeUtil.formatSize(getMaxRAMBucketSize() * RAMBUCKET_CONVERSION_FACTOR));
           else LOG.debug("event=ram_pool_pressure_migrate reason=bucketpool_limit");
         }
       }
@@ -498,13 +511,16 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
       }
 
       public void maybeResetInputStream() throws IOException {
-        if (idx != osIndex) close();
-        else {
-          IOUtils.closeQuietly(currentIS);
-          currentIS = currentBucket.getInputStreamUnbuffered();
-          long toSkip = index;
-          while (toSkip > 0) {
-            toSkip -= currentIS.skip(toSkip);
+        synchronized (TempBucket.this) {
+          if (idx != osIndex) {
+            close();
+          } else {
+            IOUtils.closeQuietly(currentIS);
+            currentIS = currentBucket.getInputStreamUnbuffered();
+            long toSkip = index;
+            while (toSkip > 0) {
+              toSkip -= currentIS.skip(toSkip);
+            }
           }
         }
       }
@@ -649,7 +665,7 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
     // Accounting helper inlined at call sites
 
     @Override
-    public RandomAccessBucket createShadow() {
+    public synchronized RandomAccessBucket createShadow() {
       return currentBucket.createShadow();
     }
 

--- a/src/main/java/network/crypta/support/transport/ip/IPAddressDetector.java
+++ b/src/main/java/network/crypta/support/transport/ip/IPAddressDetector.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import network.crypta.io.AddressIdentifier;
 import network.crypta.node.NodeIPDetector;
 import network.crypta.support.PriorityAwareExecutor;
@@ -55,7 +57,8 @@ public class IPAddressDetector implements Runnable {
     this.detector = detector;
   }
 
-  InetAddress[] lastAddressList = null;
+  final AtomicReference<AtomicReferenceArray<InetAddress>> lastAddressList =
+      new AtomicReference<>();
   long lastDetectedTime = -1;
 
   /**
@@ -71,7 +74,7 @@ public class IPAddressDetector implements Runnable {
     if (System.currentTimeMillis() > (lastDetectedTime + interval)) {
       checkpoint();
     }
-    return lastAddressList == null ? new InetAddress[0] : lastAddressList;
+    return snapshotAddresses(lastAddressList.get());
   }
 
   /**
@@ -90,7 +93,7 @@ public class IPAddressDetector implements Runnable {
     if (System.currentTimeMillis() > (lastDetectedTime + interval) && checkpoint()) {
       executor.execute(detector::redetectAddress);
     }
-    return lastAddressList == null ? new InetAddress[0] : lastAddressList;
+    return snapshotAddresses(lastAddressList.get());
   }
 
   boolean old = false;
@@ -98,9 +101,9 @@ public class IPAddressDetector implements Runnable {
   /**
    * Performs a detection pass.
    *
-   * <p>Enumerates network interfaces, reports MTU information, collects and normalizes addresses,
-   * and updates the cached snapshot. If interface enumeration fails, a best-effort fallback based
-   * on a UDP socket connect is used to determine a single outward-facing address.
+   * <p>Lists network interfaces, reports MTU information, collects and normalizes addresses, and
+   * updates the cached snapshot. If interface enumeration fails, a best-effort fallback based on a
+   * UDP socket connection is used to determine a single outward-facing address.
    *
    * @return {@code true} if the snapshot changed compared to the previous pass
    */
@@ -112,10 +115,19 @@ public class IPAddressDetector implements Runnable {
       collectAddressesFromInterfaces(addrs, interfaces);
     }
 
-    InetAddress[] oldAddressList = lastAddressList;
+    InetAddress[] oldAddressList = snapshotAddresses(lastAddressList.get());
     onGetAddresses(addrs);
     lastDetectedTime = System.currentTimeMillis();
-    return addressListChanged(oldAddressList, lastAddressList);
+    return addressListChanged(oldAddressList, snapshotAddresses(lastAddressList.get()));
+  }
+
+  private static InetAddress[] snapshotAddresses(AtomicReferenceArray<InetAddress> addresses) {
+    if (addresses == null) return new InetAddress[0];
+    InetAddress[] snapshot = new InetAddress[addresses.length()];
+    for (int i = 0; i < snapshot.length; i++) {
+      snapshot[i] = addresses.get(i);
+    }
+    return snapshot;
   }
 
   /** Returns network interfaces or populates a fallback address when enumeration fails. */
@@ -168,7 +180,7 @@ public class IPAddressDetector implements Runnable {
       InetAddress addr = ee.nextElement();
       // telling the NodeIPDetector object about the MTU only if MTU != 0
       // MTU = 0 means error in retrieving it
-      // Note: Consider whether to report MTU for local IPs.
+      // Note: Consider whether reporting MTU for local IPs.
       if (ifaceMTU > 0) detector.reportMTU(ifaceMTU, addr instanceof Inet6Address);
 
       addrs.add(cleanGlobalIPv6(addr));
@@ -249,7 +261,7 @@ public class IPAddressDetector implements Runnable {
   /**
    * Filters and stores the list of detected addresses.
    *
-   * <p>Wildcard (0.0.0.0) and multicast addresses are dropped. Link-local, loopback and site-local
+   * <p>Wildcard (0.0.0.0) and multicast addresses are dropped. Link-local, loopback, and site-local
    * addresses are retained so that higher layers can decide how to handle them. ISATAP-style IPv6
    * addresses are filtered out.
    *
@@ -262,7 +274,7 @@ public class IPAddressDetector implements Runnable {
 
     if (addrs.isEmpty()) {
       LOG.error("No addresses found!");
-      lastAddressList = null;
+      lastAddressList.set(null);
       return;
     }
 
@@ -274,7 +286,7 @@ public class IPAddressDetector implements Runnable {
       }
     }
 
-    lastAddressList = output.toArray(new InetAddress[0]);
+    lastAddressList.set(new AtomicReferenceArray<>(output.toArray(new InetAddress[0])));
   }
 
   /** Returns {@code true} when an address should be kept in the snapshot. */
@@ -312,7 +324,7 @@ public class IPAddressDetector implements Runnable {
    *       that contract.
    *   <li>Lifecycle: the default scheduler uses a non-daemon worker which can keep the JVM alive if
    *       not shut down explicitly.
-   *   <li>Robustness: with a scheduler, any uncaught error in the task suppresses subsequent
+   *   <li>Robustness: with a scheduler, any uncaught error in the task suppresses further
    *       executions. This loop explicitly catches {@link AssertionError} and {@link Exception} to
    *       continue running while still honoring interruption.
    * </ul>

--- a/src/test/java/com/onionnetworks/fec/Native8CodeTest.java
+++ b/src/test/java/com/onionnetworks/fec/Native8CodeTest.java
@@ -11,9 +11,9 @@ class Native8CodeTest {
   private static final class StubNative8Code extends Native8Code {
     int encodeCalls;
     int decodeCalls;
-    int freeCalls;
+    volatile int freeCalls;
     int newFecCalls;
-    boolean throwOnFree;
+    volatile boolean throwOnFree;
 
     byte[][] lastSrc;
     int[] lastSrcOff;

--- a/src/test/java/network/crypta/client/FailureCodeTrackerTest.java
+++ b/src/test/java/network/crypta/client/FailureCodeTrackerTest.java
@@ -280,6 +280,17 @@ class FailureCodeTrackerTest {
   }
 
   @Test
+  void merge_withNullSource_isNoOp() {
+    fetchTracker.inc(FetchExceptionMode.TOO_BIG);
+
+    FailureCodeTracker merged = fetchTracker.merge((FailureCodeTracker) null);
+
+    assertTrue(merged == fetchTracker);
+    assertEquals(1, fetchTracker.getErrorCount(FetchExceptionMode.TOO_BIG.code));
+    assertEquals(1, fetchTracker.totalCount());
+  }
+
+  @Test
   void merge_fetchException_mergesCodesAndIncrementsMode() {
     // Prepare error codes in the exception (count 7 for TOO_BIG)
     FailureCodeTracker codes = trackerFromCounts(false, Map.of(FetchExceptionMode.TOO_BIG.code, 7));

--- a/src/test/java/network/crypta/client/FailureCodeTrackerTest.java
+++ b/src/test/java/network/crypta/client/FailureCodeTrackerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,7 +34,7 @@ class FailureCodeTrackerTest {
     insertTracker = new FailureCodeTracker(true);
   }
 
-  /** Test that the fixed size representation really is fixed size */
+  /** Test that the fixed size representation really is a fixed size */
   @Test
   void testSize() throws IOException {
     testSize(false);
@@ -83,7 +84,7 @@ class FailureCodeTrackerTest {
     assertEquals(5, fetchTracker.totalCount());
     assertEquals(1, fetchTracker.getErrorCount(7));
 
-    // On subsequent adds, the supplied value is added to the existing one.
+    // On later adding, the supplied value is added to the existing one.
     fetchTracker.inc(7, 4);
     assertEquals(9, fetchTracker.totalCount());
     assertEquals(5, fetchTracker.getErrorCount(7));
@@ -153,7 +154,7 @@ class FailureCodeTrackerTest {
   void toFieldSet_andReconstruct_roundTripsCounts_insertAndFetch() throws Exception {
     // Fetch tracker field set
     fetchTracker.inc(FetchExceptionMode.ROUTE_NOT_FOUND);
-    fetchTracker.inc(FetchExceptionMode.TOO_BIG, 3); // stored as 1 on first write, but total += 3
+    fetchTracker.inc(FetchExceptionMode.TOO_BIG, 3); // stored as 1 on first writing, but total += 3
     SimpleFieldSet fsFetch = fetchTracker.toFieldSet(true);
     // Verify description and count entries exist
     String descFetch = fsFetch.get(FetchExceptionMode.ROUTE_NOT_FOUND.code + ".Description");
@@ -205,7 +206,7 @@ class FailureCodeTrackerTest {
     fetchTracker.inc(fatalCode, -1); // now map value becomes 0
     assertFalse(fetchTracker.isFatal(false));
 
-    // Add a fatal with positive count
+    // Add a fatal with a positive count
     fetchTracker.inc(FetchExceptionMode.TOO_BIG);
     assertTrue(fetchTracker.isFatal(false));
   }
@@ -220,7 +221,7 @@ class FailureCodeTrackerTest {
     assertTrue(t.isOneCodeOnly());
     assertFalse(t.isEmpty());
 
-    // Reduce existing key to zero; map not empty, still not considered empty
+    // Reduce the existing key to zero; map not empty, still not considered empty
     t.inc(FetchExceptionMode.DATA_NOT_FOUND.code, -1);
     assertTrue(t.isOneCodeOnly());
     assertFalse(t.isEmpty());
@@ -285,7 +286,7 @@ class FailureCodeTrackerTest {
 
     FailureCodeTracker merged = fetchTracker.merge((FailureCodeTracker) null);
 
-    assertTrue(merged == fetchTracker);
+    assertSame(merged, fetchTracker);
     assertEquals(1, fetchTracker.getErrorCount(FetchExceptionMode.TOO_BIG.code));
     assertEquals(1, fetchTracker.totalCount());
   }
@@ -325,7 +326,7 @@ class FailureCodeTrackerTest {
 
   @Test
   void isDataFound_onInsertTracker_usesFetchCodes() {
-    // Insert tracker expects fetch-style codes in its map for this method.
+    // The insert tracker expects fetch-style codes in its map for this method.
     int tooBigFetchCode = FetchExceptionMode.TOO_BIG.code;
     int routeNotFoundCode = FetchExceptionMode.ROUTE_NOT_FOUND.code;
     insertTracker.inc(tooBigFetchCode); // data found

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -1,8 +1,10 @@
 package network.crypta.client.async;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -320,6 +322,48 @@ class USKInserterTest {
   }
 
   @Test
+  void schedule_whenCancelledBeforeFetcherSchedule_doesNotScheduleFetcher() throws Exception {
+    byte[] bytes = "race".getBytes(StandardCharsets.UTF_8);
+    Bucket bucket = makeBucket(bytes);
+    String site = "race-site";
+    long edition = 10L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            bucket, (short) 1, insertUri, ic, new InserterCfg(false, false, true, false, false));
+
+    doAnswer(
+            _ -> {
+              inserter.cancel(context);
+              return fetcherTag;
+            })
+        .when(uskManager)
+        .getFetcherForInsertDontSchedule(
+            any(USK.class),
+            any(short.class),
+            any(USKFetcherCallback.class),
+            any(),
+            any(ClientContext.class),
+            any(Boolean.class),
+            any(Boolean.class));
+
+    inserter.schedule(context);
+
+    verify(fetcherTag, times(0)).schedule(context);
+  }
+
+  @Test
   void onFoundEdition_whenDataAndCodecMatch_expectAlreadyInsertedAndSuccessCallbacks()
       throws Exception {
     // Arrange: prepare data and matching hisData/codec/metadata
@@ -470,6 +514,40 @@ class USKInserterTest {
     ArgumentCaptor<InsertException> ex = ArgumentCaptor.forClass(InsertException.class);
     verify(cb, times(1)).onFailure(ex.capture(), any(), any());
     assertEquals(InsertExceptionMode.CANCELLED, ex.getValue().getMode());
+  }
+
+  @Test
+  void onFailure_afterCancelAndDataReleased_doesNotThrow() throws Exception {
+    byte[] bytes = "late-cancel".getBytes(StandardCharsets.UTF_8);
+    Bucket data = Mockito.spy(makeBucket(bytes));
+    String site = "late";
+    long edition = 1L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, true, false, false));
+
+    inserter.cancel(context);
+
+    assertDoesNotThrow(
+        () ->
+            inserter.onFailure(
+                new InsertException(InsertExceptionMode.CANCELLED),
+                Mockito.mock(ClientPutState.class),
+                context));
+
+    verify(data, times(1)).free();
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/USKStoreCheckCoordinatorTest.java
+++ b/src/test/java/network/crypta/client/async/USKStoreCheckCoordinatorTest.java
@@ -434,6 +434,9 @@ class USKStoreCheckCoordinatorTest {
     java.lang.reflect.Field field =
         USKStoreCheckCoordinator.class.getDeclaredField("runningStoreChecker");
     field.setAccessible(true);
-    field.set(coordinator, checker);
+    @SuppressWarnings("unchecked")
+    java.util.concurrent.atomic.AtomicReference<USKStoreCheckerGetter> holder =
+        (java.util.concurrent.atomic.AtomicReference<USKStoreCheckerGetter>) field.get(coordinator);
+    holder.set(checker);
   }
 }

--- a/src/test/java/network/crypta/node/NodeIPDetectorTest.java
+++ b/src/test/java/network/crypta/node/NodeIPDetectorTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
@@ -65,7 +67,10 @@ class NodeIPDetectorTest {
 
     Field last = ipd.getClass().getDeclaredField("lastAddressList");
     last.setAccessible(true);
-    last.set(ipd, addrs);
+    @SuppressWarnings("unchecked")
+    AtomicReference<AtomicReferenceArray<InetAddress>> lastRef =
+        (AtomicReference<AtomicReferenceArray<InetAddress>>) last.get(ipd);
+    lastRef.set(new AtomicReferenceArray<>(addrs));
 
     Field ts = ipd.getClass().getDeclaredField("lastDetectedTime");
     ts.setAccessible(true);

--- a/src/test/java/network/crypta/node/PeerNodeAddressManagerTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeAddressManagerTest.java
@@ -18,6 +18,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.io.comm.FreenetInetAddress;
 import network.crypta.io.comm.Peer;
 import network.crypta.support.SimpleFieldSet;
@@ -71,7 +72,7 @@ class PeerNodeAddressManagerTest {
       throws ReflectiveOperationException {
     // Arrange
     PeerNodeAddressManager manager = new PeerNodeAddressManager(peer);
-    peer.nominalPeer = new ArrayList<>();
+    peer.nominalPeer = new AtomicReference<>(new ArrayList<>());
     setLastAttemptedHandshakeIpUpdateTime(
         manager, System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(1));
 
@@ -87,7 +88,7 @@ class PeerNodeAddressManagerTest {
       throws ReflectiveOperationException {
     // Arrange
     PeerNodeAddressManager manager = new PeerNodeAddressManager(peer);
-    peer.nominalPeer = new ArrayList<>();
+    peer.nominalPeer = new AtomicReference<>(new ArrayList<>());
 
     // Act
     manager.maybeUpdateHandshakeIPs(true);
@@ -102,7 +103,7 @@ class PeerNodeAddressManagerTest {
       throws UnknownHostException {
     // Arrange
     PeerNodeAddressManager manager = new PeerNodeAddressManager(peer);
-    peer.nominalPeer = new ArrayList<>();
+    peer.nominalPeer = new AtomicReference<>(new ArrayList<>());
     Peer detectedPeer = new Peer(inetAddress(203, 0, 113, 10), 1234);
     when(peer.getPeer()).thenReturn(detectedPeer);
 
@@ -137,7 +138,9 @@ class PeerNodeAddressManagerTest {
     Peer peerMatchingNode = new Peer(matchingAddress, 2222);
     Peer duplicatePeer = new Peer(matchingAddress, 2222);
 
-    peer.nominalPeer = new ArrayList<>(List.of(detectedDuplicate, peerMatchingNode, duplicatePeer));
+    peer.nominalPeer =
+        new AtomicReference<>(
+            new ArrayList<>(List.of(detectedDuplicate, peerMatchingNode, duplicatePeer)));
 
     FreenetInetAddress localhost = new FreenetInetAddress(inetAddress(127, 0, 0, 1));
     when(node.network().freenetLocalhostAddress()).thenReturn(localhost);
@@ -173,7 +176,7 @@ class PeerNodeAddressManagerTest {
       throws ReflectiveOperationException {
     // Arrange
     PeerNodeAddressManager manager = new PeerNodeAddressManager(peer);
-    peer.nominalPeer = new ArrayList<>();
+    peer.nominalPeer = new AtomicReference<>(new ArrayList<>());
     long before = System.currentTimeMillis();
 
     // Act
@@ -343,7 +346,7 @@ class PeerNodeAddressManagerTest {
     InetAddress address = inetAddress(198, 51, 100, 9);
     Peer nominal = new Peer(address, 2468);
     PeerNode peerNode = Mockito.mock(PeerNode.class, Mockito.CALLS_REAL_METHODS);
-    peerNode.nominalPeer = new ArrayList<>(List.of(nominal));
+    peerNode.nominalPeer = new AtomicReference<>(new ArrayList<>(List.of(nominal)));
     Mockito.doReturn(null).when(peerNode).getPeer();
 
     FreenetInetAddress matchAddress = new FreenetInetAddress(address);
@@ -361,7 +364,7 @@ class PeerNodeAddressManagerTest {
     InetAddress address = inetAddress(198, 51, 100, 10);
     Peer nominal = new Peer(address, 2468);
     PeerNode peerNode = Mockito.mock(PeerNode.class, Mockito.CALLS_REAL_METHODS);
-    peerNode.nominalPeer = new ArrayList<>(List.of(nominal));
+    peerNode.nominalPeer = new AtomicReference<>(new ArrayList<>(List.of(nominal)));
     Mockito.doReturn(null).when(peerNode).getPeer();
 
     FreenetInetAddress otherAddress = new FreenetInetAddress(inetAddress(203, 0, 113, 99));

--- a/src/test/java/network/crypta/node/PeerNodeReferenceSupportTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeReferenceSupportTest.java
@@ -22,6 +22,7 @@ import java.security.SecureRandom;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.util.zip.DeflaterOutputStream;
 import network.crypta.crypt.BlockCipher;
@@ -67,6 +68,7 @@ class PeerNodeReferenceSupportTest {
     setField(peer, "identity", IDENTITY);
     setField(peer, "peerECDSAPubKey", ecdsa.getPublicKey());
     setField(peer, "peerECDSAPubKeyHash", SHA256.digest(ecdsa.getPublicKey().getEncoded()));
+    setField(peer, "fullFieldSet", new AtomicReference<SimpleFieldSet>());
     support = new PeerNodeReferenceSupport(peer);
   }
 
@@ -360,7 +362,11 @@ class PeerNodeReferenceSupportTest {
     assertTrue(support.verifyReferenceSignature(fs));
 
     verify(peer).setSignatureVerificationSuccessfull(true);
-    assertEquals(fs, getField(peer, "fullFieldSet"));
+    @SuppressWarnings("unchecked")
+    AtomicReference<SimpleFieldSet> fullFieldSetRef =
+        (AtomicReference<SimpleFieldSet>) getField(peer, "fullFieldSet");
+    assertNotNull(fullFieldSetRef);
+    assertEquals(fs, fullFieldSetRef.get());
   }
 
   @Test

--- a/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
+++ b/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import network.crypta.node.NodeIPDetector;
 import network.crypta.support.PriorityAwareExecutor;
 import org.jetbrains.annotations.NotNull;
@@ -47,7 +48,7 @@ class IPAddressDetectorTest {
 
     det.onGetAddresses(input);
 
-    InetAddress[] out = det.lastAddressList;
+    InetAddress[] out = toArray(det.lastAddressList.get());
     assertNotNull(out, "Expected filtered addresses");
 
     Set<String> actual = new HashSet<>();
@@ -85,7 +86,7 @@ class IPAddressDetectorTest {
     NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
     IPAddressDetector det = new IPAddressDetector(10, nodeIPDetector);
     det.lastDetectedTime = System.currentTimeMillis();
-    det.lastAddressList = new InetAddress[0];
+    det.lastAddressList.set(new AtomicReferenceArray<>(new InetAddress[0]));
 
     NullPointerException npe = assertThrows(NullPointerException.class, () -> det.getAddress(null));
     assertEquals("executor", npe.getMessage());
@@ -113,7 +114,7 @@ class IPAddressDetectorTest {
     NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
     IPAddressDetector det = new IPAddressDetector(10, nodeIPDetector);
     det.lastDetectedTime = System.currentTimeMillis(); // fresh -> no checkpoint
-    det.lastAddressList = null; // no snapshot yet
+    det.lastAddressList.set(null); // no snapshot yet
 
     InetAddress[] out = assertDoesNotThrow(det::getAddressNoCallback);
     assertNotNull(out);
@@ -122,6 +123,15 @@ class IPAddressDetectorTest {
 
   private static InetAddress addr(String host) throws Exception {
     return InetAddress.getAllByName(host)[0];
+  }
+
+  private static InetAddress[] toArray(AtomicReferenceArray<InetAddress> addresses) {
+    if (addresses == null) return null;
+    InetAddress[] out = new InetAddress[addresses.length()];
+    for (int i = 0; i < out.length; i++) {
+      out[i] = addresses.get(i);
+    }
+    return out;
   }
 
   @Test
@@ -174,7 +184,7 @@ class IPAddressDetectorTest {
     NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
     IPAddressDetector det = new IPAddressDetector(10, nodeIPDetector);
     det.onGetAddresses(new ArrayList<>());
-    assertNull(det.lastAddressList);
+    assertNull(det.lastAddressList.get());
   }
 
   @Test
@@ -186,9 +196,9 @@ class IPAddressDetectorTest {
     InetAddress loopbackV4 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
     input.add(loopbackV4);
     det.onGetAddresses(input);
-    assertNotNull(det.lastAddressList);
-    assertEquals(1, det.lastAddressList.length);
-    assertEquals(loopbackV4.getHostAddress(), det.lastAddressList[0].getHostAddress());
+    assertNotNull(det.lastAddressList.get());
+    assertEquals(1, det.lastAddressList.get().length());
+    assertEquals(loopbackV4.getHostAddress(), det.lastAddressList.get().get(0).getHostAddress());
   }
 
   @Test
@@ -216,7 +226,8 @@ class IPAddressDetectorTest {
     @Override
     protected synchronized boolean checkpoint() {
       try {
-        this.lastAddressList = new InetAddress[] {InetAddress.getByName("8.8.8.8")};
+        this.lastAddressList.set(
+            new AtomicReferenceArray<>(new InetAddress[] {InetAddress.getByName("8.8.8.8")}));
       } catch (Exception e) {
         throw new AssertionError(e);
       }
@@ -270,7 +281,8 @@ class IPAddressDetectorTest {
     @Override
     protected synchronized boolean checkpoint() {
       try {
-        this.lastAddressList = new InetAddress[] {InetAddress.getByName("8.8.4.4")};
+        this.lastAddressList.set(
+            new AtomicReferenceArray<>(new InetAddress[] {InetAddress.getByName("8.8.4.4")}));
       } catch (Exception e) {
         throw new AssertionError(e);
       }
@@ -291,8 +303,11 @@ class IPAddressDetectorTest {
     protected synchronized boolean checkpoint() {
       checkpointCalls++;
       try {
-        this.lastAddressList =
-            new InetAddress[] {InetAddress.getByName("1.1.1.1"), InetAddress.getByName("9.9.9.9")};
+        this.lastAddressList.set(
+            new AtomicReferenceArray<>(
+                new InetAddress[] {
+                  InetAddress.getByName("1.1.1.1"), InetAddress.getByName("9.9.9.9")
+                }));
       } catch (Exception e) {
         throw new AssertionError(e);
       }

--- a/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
+++ b/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
@@ -69,7 +69,7 @@ class IPAddressDetectorTest {
     NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
     // Override checkpoint to inject a deterministic change without touching real interfaces
     TestIPAddressDetector det = new TestIPAddressDetector(1, nodeIPDetector);
-    det.lastDetectedTime = -1; // force checkpoint on first call
+    det.lastDetectedTime = -1; // force checkpoint on the first call
 
     PriorityAwareExecutor directExec = new DirectExecutor();
     InetAddress[] out = det.getAddress(directExec);
@@ -203,7 +203,7 @@ class IPAddressDetectorTest {
     InetAddress cleaned = (InetAddress) m.invoke(det, withScope);
 
     assertEquals("2001:db8:0:0:0:0:0:1", cleaned.getHostAddress());
-    // Ensure original still contains the scope id
+    // Ensure the original still contains the scope id
     assertTrue(withScope.getHostAddress().contains("%"));
   }
 
@@ -221,7 +221,7 @@ class IPAddressDetectorTest {
         throw new AssertionError(e);
       }
       this.lastDetectedTime = System.currentTimeMillis();
-      return true; // indicate list changed
+      return true; // indicate the list changed
     }
   }
 
@@ -281,7 +281,7 @@ class IPAddressDetectorTest {
 
   /** Test subclass that counts checkpoint invocations and supplies a deterministic snapshot. */
   private static final class CountingDetector extends IPAddressDetector {
-    int checkpointCalls = 0;
+    volatile int checkpointCalls = 0;
 
     CountingDetector(long interval, NodeIPDetector detector) {
       super(interval, detector);
@@ -301,7 +301,7 @@ class IPAddressDetectorTest {
     }
   }
 
-  /** Executor that captures submitted runnables without executing them automatically. */
+  /** Executor that captures submitted runnable without executing them automatically. */
   private static final class CapturingExecutor implements PriorityAwareExecutor {
     private final List<Runnable> captured = new ArrayList<>();
 


### PR DESCRIPTION
## Summary
- Resolve SpotBugs `IS2_INCONSISTENT_SYNC` findings across client, node, updater, and support code by replacing unsafe shared mutable references with thread-safe holders (`AtomicReference`/atomics) or synchronized snapshots.
- Harden peer/address synchronization paths in `PeerNode` and related classes (`PeerNodeAddressManager`, `DarknetPeerNode`, `PeerNodeReferenceSupport`) and update corresponding tests for the new atomic-backed fields.
- Refactor strict/non-strict address matching helpers in `PeerNodeAddressManager` to remove SonarLint `java:S3776` complexity findings while preserving matching behavior.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/node/PeerNodeAddressManager.java`
- `./gradlew test --tests "*PeerNodeAddressManagerTest"`
- `./gradlew test --tests "*PeerNode*"`
- `./gradlew test`

## Notes
- `spotbugsMain` may still print the known missing analysis class warning for `oshi.annotation.concurrent.ThreadSafe`; this is non-fatal and does not fail the build in current configuration.