### PR TITLE
fix(spotbugs): Resolve VO_VOLATILE_INCREMENT findings

### DIFF
--- a/src/main/java/network/crypta/io/AddressTrackerItem.java
+++ b/src/main/java/network/crypta/io/AddressTrackerItem.java
@@ -1,5 +1,6 @@
 package network.crypta.io;
 
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import network.crypta.node.FSParseException;
 import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
@@ -23,6 +24,12 @@ import org.slf4j.LoggerFactory;
  */
 public class AddressTrackerItem {
   private static final Logger LOG = LoggerFactory.getLogger(AddressTrackerItem.class);
+
+  private static final AtomicLongFieldUpdater<AddressTrackerItem> PACKETS_SENT_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(AddressTrackerItem.class, "packetsSent");
+
+  private static final AtomicLongFieldUpdater<AddressTrackerItem> PACKETS_RECEIVED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(AddressTrackerItem.class, "packetsReceived");
 
   /**
    * Time of the first observed receive from this address, in milliseconds since epoch, or {@code
@@ -138,7 +145,7 @@ public class AddressTrackerItem {
    * @param now timestamp in milliseconds since epoch
    */
   public synchronized void sentPacket(long now) {
-    packetsSent++;
+    PACKETS_SENT_UPDATER.incrementAndGet(this);
     if (timeFirstSentPacket < 0) timeFirstSentPacket = now;
     timeLastSentPacket = now;
   }
@@ -153,7 +160,7 @@ public class AddressTrackerItem {
    * @param now timestamp in milliseconds since epoch
    */
   public synchronized void receivedPacket(long now) {
-    packetsReceived++;
+    PACKETS_RECEIVED_UPDATER.incrementAndGet(this);
     if (timeFirstReceivedPacket < 0) timeFirstReceivedPacket = now;
     long oldTimeLastReceivedPacket = timeLastReceivedPacket;
     timeLastReceivedPacket = now;

--- a/src/main/java/network/crypta/node/BaseSender.java
+++ b/src/main/java/network/crypta/node/BaseSender.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.io.comm.ByteCounter;
 import network.crypta.io.comm.DMT;
@@ -46,6 +47,9 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseSender implements ByteCounter, HighHtlAware {
   private static final Logger LOG = LoggerFactory.getLogger(BaseSender.class);
   private static final String TOOK_MSG = "Took {} tries in {}{}";
+
+  protected static final AtomicIntegerFieldUpdater<BaseSender> ROUTE_ATTEMPTS_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(BaseSender.class, "routeAttempts");
 
   final boolean realTimeFlag;
   final Key key;

--- a/src/main/java/network/crypta/node/RequestSender.java
+++ b/src/main/java/network/crypta/node/RequestSender.java
@@ -386,7 +386,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     boolean failed;
     synchronized (this) {
       failed = reassignedToSelfDueToMultipleTimeouts;
-      if (!failed) routeAttempts++;
+      if (!failed) ROUTE_ATTEMPTS_UPDATER.incrementAndGet(this);
     }
     if (failed) {
       finish(TIMED_OUT, null, false);

--- a/src/main/java/network/crypta/node/ThrottleWindowManager.java
+++ b/src/main/java/network/crypta/node/ThrottleWindowManager.java
@@ -1,5 +1,6 @@
 package network.crypta.node;
 
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +19,12 @@ import org.slf4j.LoggerFactory;
  */
 public class ThrottleWindowManager {
   private static final Logger LOG = LoggerFactory.getLogger(ThrottleWindowManager.class);
+
+  private static final AtomicLongFieldUpdater<ThrottleWindowManager> TOTAL_PACKETS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(ThrottleWindowManager.class, "totalPackets");
+
+  private static final AtomicLongFieldUpdater<ThrottleWindowManager> DROPPED_PACKETS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(ThrottleWindowManager.class, "droppedPackets");
 
   // On overload, scale the window down by this factor (< 1.0).
   static final float PACKET_DROP_DECREASE_MULTIPLE = 0.97f;
@@ -76,8 +83,8 @@ public class ThrottleWindowManager {
    * #PACKET_DROP_DECREASE_MULTIPLE}.
    */
   public synchronized void rejectedOverload() {
-    droppedPackets++;
-    totalPackets++;
+    DROPPED_PACKETS_UPDATER.incrementAndGet(this);
+    TOTAL_PACKETS_UPDATER.incrementAndGet(this);
     simulatedWindowSize *= PACKET_DROP_DECREASE_MULTIPLE;
     if (LOG.isDebugEnabled()) LOG.debug("Overload rejection recorded (state={})", this);
   }
@@ -89,7 +96,7 @@ public class ThrottleWindowManager {
    * simulatedWindowSize}.
    */
   public synchronized void requestCompleted() {
-    totalPackets++;
+    TOTAL_PACKETS_UPDATER.incrementAndGet(this);
     simulatedWindowSize += (PACKET_TRANSMIT_INCREMENT / simulatedWindowSize);
     if (LOG.isDebugEnabled()) LOG.debug("Request completes (state={})", this);
   }

--- a/src/main/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
+++ b/src/main/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
@@ -14,6 +14,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.PCFBMode;
@@ -48,6 +49,10 @@ import org.slf4j.LoggerFactory;
  */
 public class PaddedEphemerallyEncryptedBucket implements Bucket, Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(PaddedEphemerallyEncryptedBucket.class);
+
+  private static final AtomicLongFieldUpdater<PaddedEphemerallyEncryptedBucket>
+      DATA_LENGTH_UPDATER =
+          AtomicLongFieldUpdater.newUpdater(PaddedEphemerallyEncryptedBucket.class, "dataLength");
 
   /**
    * Serial version for Java serialization. Bumped to 2 to reflect the change in the on-wire Java
@@ -199,7 +204,7 @@ public class PaddedEphemerallyEncryptedBucket implements Bucket, Serializable {
       int toWrite = pcfb.encipher(b);
       synchronized (PaddedEphemerallyEncryptedBucket.this) {
         out.write(toWrite);
-        dataLength++;
+        DATA_LENGTH_UPDATER.incrementAndGet(PaddedEphemerallyEncryptedBucket.this);
       }
     }
 
@@ -226,7 +231,7 @@ public class PaddedEphemerallyEncryptedBucket implements Bucket, Serializable {
       pcfb.blockEncipher(enc, 0, enc.length);
       synchronized (PaddedEphemerallyEncryptedBucket.this) {
         out.write(enc, 0, enc.length);
-        dataLength += enc.length;
+        DATA_LENGTH_UPDATER.addAndGet(PaddedEphemerallyEncryptedBucket.this, enc.length);
       }
     }
 

--- a/src/test/java/com/onionnetworks/fec/Native8CodeTest.java
+++ b/src/test/java/com/onionnetworks/fec/Native8CodeTest.java
@@ -11,7 +11,7 @@ class Native8CodeTest {
   private static final class StubNative8Code extends Native8Code {
     int encodeCalls;
     int decodeCalls;
-    volatile int freeCalls;
+    int freeCalls;
     int newFecCalls;
     volatile boolean throwOnFree;
 

--- a/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
+++ b/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
@@ -293,7 +293,7 @@ class IPAddressDetectorTest {
 
   /** Test subclass that counts checkpoint invocations and supplies a deterministic snapshot. */
   private static final class CountingDetector extends IPAddressDetector {
-    volatile int checkpointCalls = 0;
+    int checkpointCalls = 0;
 
     CountingDetector(long interval, NodeIPDetector detector) {
       super(interval, detector);


### PR DESCRIPTION
## Summary
- Replace volatile increment operations with atomic field updaters in production counters to make updates explicit and SpotBugs-clean.
- Update `AddressTrackerItem`, `BaseSender`/`RequestSender`, `ThrottleWindowManager`, and `PaddedEphemerallyEncryptedBucket` where `++`/`+=` was applied to volatile fields.
- Remove unnecessary `volatile` from synchronized test-only counters in `Native8CodeTest` and `IPAddressDetectorTest`.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `rg "VO_VOLATILE_INCREMENT" build/reports/spotbugs/spotbugsMain.xml build/reports/spotbugs/spotbugsTest.xml` (expect no output)