### PR TITLE
fix(spotbugs): Fix concurrent subset insertion in SimpleFieldSet

### DIFF
--- a/src/main/java/network/crypta/support/SimpleFieldSet.java
+++ b/src/main/java/network/crypta/support/SimpleFieldSet.java
@@ -635,12 +635,9 @@ public class SimpleFieldSet {
       boolean overwrite,
       boolean fromRead) {
     if (subsets == null) subsets = new ConcurrentHashMap<>();
-    SimpleFieldSet fs = subsets.get(before);
-    if (fs == null) {
-      fs = new SimpleFieldSet(shortLived, alwaysUseBase64);
-      if (!shortLived) before = before.intern();
-      subsets.put(before, fs);
-    }
+    String subsetKey = shortLived ? before : before.intern();
+    SimpleFieldSet fs =
+        subsets.computeIfAbsent(subsetKey, _ -> new SimpleFieldSet(shortLived, alwaysUseBase64));
     fs.put(after, value, allowMultiple, overwrite, fromRead);
   }
 


### PR DESCRIPTION
## Summary
- Replace the non-atomic `ConcurrentHashMap` access pattern in `SimpleFieldSet.putInSubset()` with `computeIfAbsent()`.
- Preserve existing key interning behavior by interning subset keys when `shortLived` is false before map insertion.
- Resolve the SpotBugs `AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION` finding for this code path.

## How to test
- Run `./gradlew spotlessApply`
- Run `./gradlew spotbugsMain spotbugsTest`
- Confirm `AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION` is no longer present in `build/reports/spotbugs/spotbugsMain.xml` and `build/reports/spotbugs/spotbugsTest.xml` (e.g., search the reports for that bug type).