### PR TITLE
build(spotbugs): Exclude DMI_RANDOM_USED_ONLY_ONCE from test analysis

### DIFF
--- a/build-logic/spotbugs-exclude-test.xml
+++ b/build-logic/spotbugs-exclude-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    Test code frequently creates short-lived, seed-fixed Random/SecureRandom instances
+    to produce deterministic fixtures. SpotBugs DMI_RANDOM_USED_ONLY_ONCE is intended for
+    production entropy use and is noisy for these test-only deterministic data generators.
+  -->
+  <Match>
+    <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>
+  </Match>
+</FindBugsFilter>

--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -90,8 +90,13 @@ spotbugs { ignoreFailures = true }
 val spotbugsExcludeFilter =
   rootProject.layout.projectDirectory.file("build-logic/spotbugs-exclude.xml")
 
+val spotbugsTestExcludeFilter =
+  rootProject.layout.projectDirectory.file("build-logic/spotbugs-exclude-test.xml")
+
 tasks.withType<SpotBugsTask>().configureEach {
-  excludeFilter.set(spotbugsExcludeFilter)
+  excludeFilter.set(
+    if (name == "spotbugsTest") spotbugsTestExcludeFilter else spotbugsExcludeFilter
+  )
 
   val xmlReport = reports.maybeCreate("xml")
   xmlReport.required.set(true)


### PR DESCRIPTION
## Summary
- Route `spotbugsTest` to a dedicated exclude filter file instead of sharing the main filter.
- Add a test-only SpotBugs exclusion for `DMI_RANDOM_USED_ONLY_ONCE` to suppress deterministic fixture noise in test code.
- Keep `spotbugsMain` behavior unchanged by retaining the existing production filter file.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- Confirm SpotBugs reports no `DMI_RANDOM_USED_ONLY_ONCE` findings in `build/reports/spotbugs/spotbugsTest.xml` while main analysis still uses `build-logic/spotbugs-exclude.xml`.