### PR TITLE
fix(spotbugs): Resolve comparator serializable warnings

### DIFF
--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -44,4 +44,18 @@
     <Class name="network.crypta.client.InsertBlock"/>
     <Field name="clientMetadata"/>
   </Match>
+
+  <!--
+    These comparators are request-scoped UI helpers. They carry transient sort parameters for
+    rendering and are never persisted or sent over the wire, so forcing Serializable adds no value.
+  -->
+  <Match>
+    <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
+    <Class name="network.crypta.clients.http.DarknetConnectionsToadlet$DarknetComparator"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
+    <Class name="network.crypta.clients.http.OpennetConnectionsToadlet$OpennetComparator"/>
+  </Match>
 </FindBugsFilter>

--- a/src/main/java/network/crypta/io/comm/Peer.java
+++ b/src/main/java/network/crypta/io/comm/Peer.java
@@ -4,6 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serial;
+import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Comparator;
@@ -78,7 +79,7 @@ public class Peer implements WritableToDataOutputStream {
 
   /**
    * Constructs a peer from a concrete {@link InetAddress} and port. The numeric address is
-   * considered primary and does not change with subsequent DNS updates.
+   * considered primary and does not change with later DNS updates.
    *
    * @param address resolved numeric address
    * @param port TCP port in {@code [0, 65535]}
@@ -100,7 +101,7 @@ public class Peer implements WritableToDataOutputStream {
    * @param physical input in the form {@code <host>:<port>}
    * @param allowUnknown when {@code true}, allow construction even if the DNS name cannot be
    *     resolved at this time
-   * @throws PeerParseException if the input is malformed or the port is missing/invalid
+   * @throws PeerParseException if the input is malformed, or the port is missing/invalid
    * @throws UnknownHostException if {@code allowUnknown} is {@code false} and the DNS lookup fails
    */
   public Peer(String physical, boolean allowUnknown)
@@ -128,7 +129,7 @@ public class Peer implements WritableToDataOutputStream {
    * @param checkHostnameOrIPSyntax when {@code true}, validate the DNS hostname or IPv4 literal
    *     syntax
    * @throws HostnameSyntaxException if syntax validation fails
-   * @throws PeerParseException if the input is malformed or the port is missing/invalid
+   * @throws PeerParseException if the input is malformed, or the port is missing/invalid
    * @throws UnknownHostException if {@code allowUnknown} is {@code false} and the DNS lookup fails
    */
   public Peer(String physical, boolean allowUnknown, boolean checkHostnameOrIPSyntax)
@@ -265,7 +266,7 @@ public class Peer implements WritableToDataOutputStream {
 
   /**
    * Forces a re‑lookup when the hostname is primary, even if a previous resolution exists. This is
-   * typically used before reconnect attempts when a dynamic DNS address may have changed.
+   * typically used before reconnection attempts when a dynamic DNS address may have changed.
    */
   @SuppressWarnings("UnusedReturnValue")
   public InetAddress getHandshakeAddress() {
@@ -381,7 +382,9 @@ public class Peer implements WritableToDataOutputStream {
    * <p>This is not a strict total ordering. Callers that require a complete order should apply an
    * additional tie‑breaker.
    */
-  public static class PeerComparator implements Comparator<Peer> {
+  public static class PeerComparator implements Comparator<Peer>, Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
     /**
      * Compares two peers according to {@link PeerComparator} rules.
      *

--- a/src/main/java/network/crypta/node/NPFPacket.java
+++ b/src/main/java/network/crypta/node/NPFPacket.java
@@ -1,5 +1,7 @@
 package network.crypta.node;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -751,7 +753,10 @@ class NPFPacket {
         + " fragments";
   }
 
-  private static class MessageFragmentComparator implements Comparator<MessageFragment> {
+  private static class MessageFragmentComparator
+      implements Comparator<MessageFragment>, Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
     @Override
     public int compare(MessageFragment frag1, MessageFragment frag2) {
       return Integer.compare(frag1.messageID, frag2.messageID);

--- a/src/main/java/network/crypta/support/Fields.java
+++ b/src/main/java/network/crypta/support/Fields.java
@@ -1,5 +1,7 @@
 package network.crypta.support;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -9,6 +11,7 @@ import java.util.Comparator;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.StringTokenizer;
+import java.util.TimeZone;
 import network.crypta.config.Dimension;
 import network.crypta.l10n.NodeL10n;
 import org.slf4j.Logger;
@@ -502,7 +505,9 @@ public abstract class Fields {
   }
 
   /** Comparator that delegates to {@link Fields#compareBytes(byte[], byte[])}. */
-  public static final class ByteArrayComparator implements Comparator<byte[]> {
+  public static final class ByteArrayComparator implements Comparator<byte[]>, Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
 
     @Override
     public int compare(byte[] o1, byte[] o2) {

--- a/src/main/java/network/crypta/support/SparseBitmap.java
+++ b/src/main/java/network/crypta/support/SparseBitmap.java
@@ -1,5 +1,7 @@
 package network.crypta.support;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -230,6 +232,7 @@ public class SparseBitmap implements Iterable<int[]> {
     return ranges.subSet(startRange, true, endRange, upperInclusive);
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static class SparseBitmapIterator implements Iterator<int[]> {
     private final Iterator<Range> it;
 
@@ -266,7 +269,10 @@ public class SparseBitmap implements Iterable<int[]> {
     }
   }
 
-  private static class RangeComparator implements Comparator<Range> {
+  private static class RangeComparator implements Comparator<Range>, Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
+
     @Override
     public int compare(Range r1, Range r2) {
       return Integer.compare(r1.start, r2.start);
@@ -276,7 +282,7 @@ public class SparseBitmap implements Iterable<int[]> {
   /**
    * Counts the number of slots in {@code [start, end]} that are not present.
    *
-   * <p>This is equivalent to {@code (end - start + 1) - covered}, where {@code covered} is the
+   * <p>This is an equivalent to {@code (end - start + 1) - covered}, where {@code covered} is the
    * total size of intersections between the query range and the stored intervals.
    *
    * <p>Precondition: {@code start <= end}.


### PR DESCRIPTION
## Summary
- Make SpotBugs-targeted utility comparators serializable by adding `Serializable` and `serialVersionUID` in `Peer`, `NPFPacket`, `Fields`, and `SparseBitmap`.
- Exclude request-scoped HTTP toadlet comparators (`DarknetComparator`, `OpennetComparator`) from `SE_COMPARATOR_SHOULD_BE_SERIALIZABLE` in `build-logic/spotbugs-exclude.xml` because they are transient UI sort helpers and not persisted.
- Keep the change focused to SpotBugs comparator findings and run formatting before commit.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain`
- `./gradlew spotbugsTest`
- Verify no `SE_COMPARATOR_SHOULD_BE_SERIALIZABLE` entries remain in `build/reports/spotbugs/*.xml`.