### PR TITLE
fix(spotbugs): Close resources on exception edges

### DIFF
--- a/src/main/java/network/crypta/clients/http/StaticToadlet.java
+++ b/src/main/java/network/crypta/clients/http/StaticToadlet.java
@@ -21,8 +21,8 @@ import network.crypta.support.io.FileBucket;
  * cautious path validation to prevent escaping the allowed roots, sets conservative cache headers
  * so clients refresh modified assets quickly, and hands buckets to the {@link ToadletContext} for
  * streaming without retaining ownership. Typical usage wires an instance into the HTTP server
- * registry so that theme assets, icons, and HTML fragments can be fetched by browsers. The handler
- * is stateless and thread-safe provided callers supply independent {@link ToadletContext} instances
+ * registry so that browsers can fetch theme assets, icons, and HTML fragments. The handler is
+ * stateless and thread-safe provided callers supply independent {@link ToadletContext} instances
  * per request.
  *
  * <p>Responsibilities include:
@@ -35,8 +35,8 @@ import network.crypta.support.io.FileBucket;
  *       the hosting JAR or file.
  * </ul>
  *
- * Clients should prefer this toadlet over ad-hoc file serving to keep consistent validation, cache
- * behavior, and ownership semantics for buckets.
+ * Clients should prefer this toadlet over the ad-hoc file serving to keep consistent validation,
+ * cache behavior, and ownership semantics for buckets.
  */
 public class StaticToadlet extends Toadlet {
   StaticToadlet() {
@@ -128,9 +128,11 @@ public class StaticToadlet extends Toadlet {
   }
 
   /**
-   * Try to find the modification time for a URL, or return null if not possible We usually load our
-   * resources from the JAR, or possibly from a file in some setups, so we check the modification
-   * time of the JAR for resources in a jar and the mtime for files.
+   * Tries to find the modification time for a URL.
+   *
+   * <p>Returns {@code null} when modification time cannot be determined. Resources are usually
+   * loaded from a JAR, but some setups load from plain files. For JAR resources this checks the JAR
+   * file mtime; for file resources it checks the file mtime.
    */
   private Instant getUrlMTime(URL url) {
     if (url == null) {
@@ -227,7 +229,8 @@ public class StaticToadlet extends Toadlet {
       return;
     }
     // Do not use try-with-resources: ToadletContext assumes ownership of the bucket and will free
-    // it after sending the response. Closing it here could discard data before the send completes.
+    // it after sending the response. Closing it here could discard data before the sending
+    // completes.
     FileBucket fb = new FileBucket(from, true, false, false, false);
     boolean handedOff = false;
     try {
@@ -257,14 +260,16 @@ public class StaticToadlet extends Toadlet {
       sendPathNotFound(ctx);
       return;
     }
-    Bucket data = ctx.getBucketFactory().makeBucket(strm.available());
-    try (InputStream inputStream = strm;
-        OutputStream os = data.getOutputStream()) {
-      byte[] cbuf = new byte[4096];
-      while (true) {
-        int r = inputStream.read(cbuf);
-        if (r == -1) break;
-        os.write(cbuf, 0, r);
+    Bucket data;
+    try (InputStream inputStream = strm) {
+      data = ctx.getBucketFactory().makeBucket(inputStream.available());
+      try (OutputStream os = data.getOutputStream()) {
+        byte[] cbuf = new byte[4096];
+        while (true) {
+          int r = inputStream.read(cbuf);
+          if (r == -1) break;
+          os.write(cbuf, 0, r);
+        }
       }
     }
 

--- a/src/test/java/network/crypta/crypt/ciphers/RijndaelTest.java
+++ b/src/test/java/network/crypta/crypt/ciphers/RijndaelTest.java
@@ -1,6 +1,12 @@
 package network.crypta.crypt.ciphers;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -240,93 +246,93 @@ class RijndaelTest {
               + type
               + testNumber
               + ".txt";
-      InputStream is = getClass().getResourceAsStream(path);
-      assertNotNull(is, "Missing test vector resource: " + path);
-      try (is;
-          InputStreamReader isr = new InputStreamReader(is, StandardCharsets.ISO_8859_1);
-          BufferedReader br = new BufferedReader(isr)) {
-        for (int i = 0; i < 7; i++) {
-          assertNotNull(br.readLine()); // Skip header, ensure present
-        }
-        String line = br.readLine();
-        int blockSize = Integer.parseInt(line.substring("BLOCKSIZE=".length()));
-        line = br.readLine();
-        int keySize = Integer.parseInt(line.substring("KEYSIZE=  ".length()));
-        assert (blockSize == 128 || blockSize == 192 || blockSize == 256);
-        assert (keySize == 128 || keySize == 192 || keySize == 256);
-        assertNotNull(br.readLine());
-        byte[] plaintext = null;
-        byte[] key = null;
-        byte[] ciphertext = null;
-        while (true) {
-          line = br.readLine();
-          if (line == null) {
-            break; // End of file.
+      try (InputStream is = getClass().getResourceAsStream(path)) {
+        assertNotNull(is, "Missing test vector resource: " + path);
+        try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.ISO_8859_1);
+            BufferedReader br = new BufferedReader(isr)) {
+          for (int i = 0; i < 7; i++) {
+            assertNotNull(br.readLine()); // Skip header, ensure present
           }
-          String prefix = line.substring(0, 6);
-          if (!prefix.equals("TEST= ")) {
-            byte[] data = HexUtil.hexToBytes(line.substring(6));
-            switch (prefix) {
-              case "PT=   " -> {
-                assertNull(plaintext);
-                plaintext = data;
-                assertEquals(plaintext.length, blockSize / 8);
-              }
-              case "KEY=  " -> {
-                assertNull(key);
-                key = data;
-                assertEquals(key.length, keySize / 8);
-              }
-              case "CT=   " -> {
-                assertNull(ciphertext);
-                ciphertext = data;
-                assertEquals(ciphertext.length, blockSize / 8);
-              }
-              default ->
-                  fail(
-                      "Unexpected prefix '"
-                          + prefix
-                          + "' in Gladman vector (type="
-                          + type
-                          + ", test="
-                          + testNumber
-                          + "): "
-                          + line);
+          String line = br.readLine();
+          int blockSize = Integer.parseInt(line.substring("BLOCKSIZE=".length()));
+          line = br.readLine();
+          int keySize = Integer.parseInt(line.substring("KEYSIZE=  ".length()));
+          assert (blockSize == 128 || blockSize == 192 || blockSize == 256);
+          assert (keySize == 128 || keySize == 192 || keySize == 256);
+          assertNotNull(br.readLine());
+          byte[] plaintext = null;
+          byte[] key = null;
+          byte[] ciphertext = null;
+          while (true) {
+            line = br.readLine();
+            if (line == null) {
+              break; // End of file.
             }
-            if (plaintext != null && ciphertext != null && key != null) {
-              Rijndael cipher = new Rijndael(keySize, blockSize);
-              cipher.initialize(key);
-              // Encrypt
-              byte[] copyOfPlaintext = Arrays.copyOf(plaintext, plaintext.length);
-              byte[] output = new byte[blockSize / 8];
-              cipher.encipher(copyOfPlaintext, output);
-              assertArrayEquals(output, ciphertext);
-              // Decrypt
-              byte[] copyOfCiphertext = Arrays.copyOf(ciphertext, ciphertext.length);
-              Arrays.fill(output, (byte) 0);
-              cipher.decipher(copyOfCiphertext, output);
-              assertArrayEquals(output, plaintext);
-              if (blockSize == 128 && (keySize == 128 || TestJca.AES_CTR_AVAILABLE)) {
-                // We can test with JCA too.
-                // Encrypt.
-                SecretKeySpec k = new SecretKeySpec(key, "AES");
-                Cipher c = Cipher.getInstance(JCA_AES_ECB_NOPADDING);
-                c.init(Cipher.ENCRYPT_MODE, k);
-                output = c.doFinal(plaintext);
+            String prefix = line.substring(0, 6);
+            if (!prefix.equals("TEST= ")) {
+              byte[] data = HexUtil.hexToBytes(line.substring(6));
+              switch (prefix) {
+                case "PT=   " -> {
+                  assertNull(plaintext);
+                  plaintext = data;
+                  assertEquals(plaintext.length, blockSize / 8);
+                }
+                case "KEY=  " -> {
+                  assertNull(key);
+                  key = data;
+                  assertEquals(key.length, keySize / 8);
+                }
+                case "CT=   " -> {
+                  assertNull(ciphertext);
+                  ciphertext = data;
+                  assertEquals(ciphertext.length, blockSize / 8);
+                }
+                default ->
+                    fail(
+                        "Unexpected prefix '"
+                            + prefix
+                            + "' in Gladman vector (type="
+                            + type
+                            + ", test="
+                            + testNumber
+                            + "): "
+                            + line);
+              }
+              if (plaintext != null && ciphertext != null && key != null) {
+                Rijndael cipher = new Rijndael(keySize, blockSize);
+                cipher.initialize(key);
+                // Encrypt
+                byte[] copyOfPlaintext = Arrays.copyOf(plaintext, plaintext.length);
+                byte[] output = new byte[blockSize / 8];
+                cipher.encipher(copyOfPlaintext, output);
                 assertArrayEquals(output, ciphertext);
-
-                // Decrypt.
-                c.init(Cipher.DECRYPT_MODE, k);
-                output = c.doFinal(ciphertext);
+                // Decrypt
+                byte[] copyOfCiphertext = Arrays.copyOf(ciphertext, ciphertext.length);
+                Arrays.fill(output, (byte) 0);
+                cipher.decipher(copyOfCiphertext, output);
                 assertArrayEquals(output, plaintext);
-              }
-              // Clear
-              if (type.equals("t")) {
-                plaintext = null;
-              }
-              ciphertext = null;
-              if (type.equals("k")) {
-                key = null;
+                if (blockSize == 128 && (keySize == 128 || TestJca.AES_CTR_AVAILABLE)) {
+                  // We can test with JCA too.
+                  // Encrypt.
+                  SecretKeySpec k = new SecretKeySpec(key, "AES");
+                  Cipher c = Cipher.getInstance(JCA_AES_ECB_NOPADDING);
+                  c.init(Cipher.ENCRYPT_MODE, k);
+                  output = c.doFinal(plaintext);
+                  assertArrayEquals(output, ciphertext);
+
+                  // Decrypt.
+                  c.init(Cipher.DECRYPT_MODE, k);
+                  output = c.doFinal(ciphertext);
+                  assertArrayEquals(output, plaintext);
+                }
+                // Clear
+                if (type.equals("t")) {
+                  plaintext = null;
+                }
+                ciphertext = null;
+                if (type.equals("k")) {
+                  key = null;
+                }
               }
             }
           }
@@ -1940,7 +1946,7 @@ class RijndaelTest {
       HexUtil.hexToBytes("8BAE4EFB70D33A9792EEA9BE70889D72")
     }, //
   };
-  /* This test vector for Rijndael(256,256) was generated with generic implementation */
+  /* This test vector for Rijndael(256,256) was generated with a generic implementation */
   private static final byte[][][] TEST_VK256x256 = { //
     /* I=1 */
     {


### PR DESCRIPTION
## Summary
- Fix `OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE` in `StaticToadlet.serveClasspathResource(...)` by scoping the classpath `InputStream` in an outer try-with-resources block and creating the bucket inside that scope.
- Fix `OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE` in `RijndaelTest.checkGladmanTestVectors(...)` by acquiring the test-vector `InputStream` directly in try-with-resources before wrapping it in readers.
- Keep formatting/style aligned after edits, including a readability pass on the long `getUrlMTime(...)` Javadoc sentence.

## How to test
- Run `./gradlew spotlessApply`.
- Run `./gradlew spotbugsMain spotbugsTest`.
- Verify SpotBugs reports contain no `OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE` / `OBL_UNSATISFIED_OBLIGATION` entries in:
  - `build/reports/spotbugs/spotbugsMain.xml`
  - `build/reports/spotbugs/spotbugsTest.xml`

## Notes
- SpotBugs still logs unrelated pre-existing issues (for example missing `oshi.annotation.concurrent.ThreadSafe` during main analysis and other non-OBL test findings); these are out of scope for this PR.