### PR TITLE
fix(spotbugs): Specify UTF-8 for default streams

### DIFF
--- a/src/main/java/org/sevenzip/LzmaAlone.java
+++ b/src/main/java/org/sevenzip/LzmaAlone.java
@@ -8,6 +8,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Handler;
@@ -72,7 +73,9 @@ public class LzmaAlone {
 
   private static final class SystemOutHandler extends Handler {
     private static final AtomicReference<PrintStream> LOG_STREAM =
-        new AtomicReference<>(new PrintStream(new FileOutputStream(FileDescriptor.out)));
+        new AtomicReference<>(
+            new PrintStream(
+                new FileOutputStream(FileDescriptor.out), false, StandardCharsets.UTF_8));
     private final SimpleFormatter formatter = new SimpleFormatter();
 
     SystemOutHandler() {

--- a/src/main/java/org/sevenzip/LzmaBench.java
+++ b/src/main/java/org/sevenzip/LzmaBench.java
@@ -7,6 +7,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -511,7 +512,7 @@ public class LzmaBench {
 
   private static final class NonClosingPrintStream extends PrintStream {
     NonClosingPrintStream(PrintStream delegate) {
-      super(delegate);
+      super(delegate, false, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/src/main/kotlin/network/crypta/node/NodeCli.kt
+++ b/src/main/kotlin/network/crypta/node/NodeCli.kt
@@ -1,6 +1,7 @@
 package network.crypta.node
 
 import java.io.PrintWriter
+import java.nio.charset.StandardCharsets
 import network.crypta.fs.APP_RUNTIME_SUBPATH
 import picocli.CommandLine
 import picocli.CommandLine.*
@@ -50,7 +51,6 @@ import picocli.CommandLine.*
   versionProvider = NodeCli.CryptadVersionProvider::class,
 )
 class NodeCli {
-
   /** Optional explicit config file path (flag). */
   @Option(
     names = ["-c", "--config-file"],
@@ -99,7 +99,7 @@ class NodeCli {
   )
   var runDir: String? = null
 
-  /** Override the logs directory. */
+  /** Override the logs' directory. */
   @Option(
     names = ["-L", "--logs-dir"],
     paramLabel = "PATH",
@@ -128,6 +128,7 @@ class NodeCli {
       description = ["Shortcut for --service-mode=service"],
     )
     var service: Boolean = false
+
     @Option(names = ["--user", "--app"], description = ["Shortcut for --service-mode=user"])
     var user: Boolean = false
   }
@@ -179,7 +180,8 @@ class NodeCli {
       commandLine: CommandLine?,
       parseResult: ParseResult?,
     ): Int {
-      val out: PrintWriter = commandLine?.err ?: PrintWriter(System.err)
+      val out: PrintWriter =
+        commandLine?.err ?: PrintWriter(System.err, false, StandardCharsets.UTF_8)
       out.println("Error: ${ex?.message}")
       out.println()
       commandLine?.usage(out)

--- a/src/test/java/com/onionnetworks/util/SimUtilTest.java
+++ b/src/test/java/com/onionnetworks/util/SimUtilTest.java
@@ -40,7 +40,7 @@ class SimUtilTest {
 
     originalOut = System.out;
     stdout = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(stdout));
+    System.setOut(new PrintStream(stdout, false, StandardCharsets.UTF_8));
   }
 
   @AfterEach

--- a/src/test/java/network/crypta/node/TextModeClientInterfaceServerTest.java
+++ b/src/test/java/network/crypta/node/TextModeClientInterfaceServerTest.java
@@ -57,7 +57,7 @@ class TextModeClientInterfaceServerTest {
   void resetStatics() throws Exception {
     // Ensure SSL.available() returns false by default for tests that rely on it.
     setStaticField(SSL.class, "ssf", null);
-    // Reset TMCI SSL flag to a known state.
+    // Reset the TMCI SSL flag to a known state.
     setStaticField(TextModeClientInterfaceServer.class, "ssl", false);
     Mockito.lenient().when(core.getEndpoints()).thenReturn(endpoints);
   }
@@ -111,7 +111,7 @@ class TextModeClientInterfaceServerTest {
     // Capture stdout
     ByteArrayOutputStream bout = new ByteArrayOutputStream();
     PrintStream originalOut = System.out;
-    System.setOut(new PrintStream(bout));
+    System.setOut(new PrintStream(bout, false, StandardCharsets.UTF_8));
     try {
       // Act
       tmci.start();
@@ -201,7 +201,7 @@ class TextModeClientInterfaceServerTest {
         new TextModeClientInterfaceServer.TMCIBindtoCallback(core);
 
     assertEquals(NetworkInterface.DEFAULT_BIND_TO, cb.get());
-    // set(equal) should be a no-op (and not throw) even when server is null.
+    // set(equal) should be a no-op (and not throw) even when the server is null.
     assertDoesNotThrow(() -> cb.set(NetworkInterface.DEFAULT_BIND_TO));
   }
 

--- a/src/test/java/org/sevenzip/LzmaAloneTest.java
+++ b/src/test/java/org/sevenzip/LzmaAloneTest.java
@@ -27,7 +27,7 @@ class LzmaAloneTest {
     originalOut = System.out;
     originalLogStream = LzmaAlone.getLogStream();
     capturedOut = new ByteArrayOutputStream();
-    LzmaAlone.setLogStream(new PrintStream(capturedOut));
+    LzmaAlone.setLogStream(new PrintStream(capturedOut, false, StandardCharsets.UTF_8));
   }
 
   @AfterEach
@@ -91,7 +91,7 @@ class LzmaAloneTest {
 
   @Test
   void main_whenArgsMissing_printsHelp() throws Exception {
-    System.setOut(new PrintStream(capturedOut));
+    System.setOut(new PrintStream(capturedOut, false, StandardCharsets.UTF_8));
 
     LzmaAlone.main(new String[] {});
 
@@ -101,7 +101,7 @@ class LzmaAloneTest {
 
   @Test
   void main_whenDecodeWithTooShortInput_throws() throws Exception {
-    System.setOut(new PrintStream(capturedOut));
+    System.setOut(new PrintStream(capturedOut, false, StandardCharsets.UTF_8));
     Path tempFile = Files.createTempFile("lzma-empty", ".lzma");
     Path outFile = Files.createTempFile("lzma-empty-out", ".bin");
     String[] decodeArgs = new String[] {"d", tempFile.toString(), outFile.toString()};
@@ -119,7 +119,7 @@ class LzmaAloneTest {
     Path decoded = tempDir.resolve("decoded.txt");
     Files.writeString(source, "Crypta LZMA test payload", StandardCharsets.UTF_8);
 
-    System.setOut(new PrintStream(capturedOut));
+    System.setOut(new PrintStream(capturedOut, false, StandardCharsets.UTF_8));
     LzmaAlone.main(new String[] {"e", source.toString(), encoded.toString()});
     LzmaAlone.main(new String[] {"d", encoded.toString(), decoded.toString()});
 

--- a/src/test/java/org/sevenzip/LzmaBenchTest.java
+++ b/src/test/java/org/sevenzip/LzmaBenchTest.java
@@ -31,7 +31,7 @@ class LzmaBenchTest {
   void setUpStreams() {
     originalOut = System.out;
     outContent = new ByteArrayOutputStream();
-    testOut = new PrintStream(outContent);
+    testOut = new PrintStream(outContent, false, StandardCharsets.UTF_8);
     System.setOut(testOut);
   }
 
@@ -173,7 +173,7 @@ class LzmaBenchTest {
     try (MockedConstruction<Encoder> encoderConstruction =
             Mockito.mockConstruction(
                 Encoder.class,
-                (mock, context) -> {
+                (mock, _) -> {
                   Mockito.when(mock.setDictionarySize(dictionarySize)).thenReturn(true);
                   Mockito.doAnswer(
                           invocation -> {
@@ -198,7 +198,7 @@ class LzmaBenchTest {
         MockedConstruction<Decoder> decoderConstruction =
             Mockito.mockConstruction(
                 Decoder.class,
-                (mock, context) ->
+                (mock, _) ->
                     Mockito.when(
                             mock.code(
                                 Mockito.any(java.io.InputStream.class),
@@ -207,11 +207,11 @@ class LzmaBenchTest {
                         .thenReturn(true));
         MockedConstruction<CRC> crcConstruction =
             Mockito.mockConstruction(
-                CRC.class, (mock, context) -> Mockito.when(mock.getDigest()).thenReturn(123));
+                CRC.class, (mock, _) -> Mockito.when(mock.getDigest()).thenReturn(123));
         MockedConstruction<LzmaBench.CrcOutStream> crcOutConstruction =
             Mockito.mockConstruction(
                 LzmaBench.CrcOutStream.class,
-                (mock, context) -> Mockito.when(mock.getDigest()).thenReturn(123))) {
+                (mock, _) -> Mockito.when(mock.getDigest()).thenReturn(123))) {
       LzmaBench.lzmaBenchmark(1, dictionarySize);
 
       String output = outContent.toString(StandardCharsets.UTF_8);


### PR DESCRIPTION
## Summary
- Fix SpotBugs `DM_DEFAULT_ENCODING` findings by making stream/writer construction explicit about UTF-8 instead of relying on the platform default.
- Update runtime code paths in `NodeCli`, `LzmaAlone`, and `LzmaBench` where `PrintWriter`/`PrintStream` previously used default encoding.
- Update affected tests that capture stdout to use explicit UTF-8 `PrintStream` construction.

## How To Test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `python3 - <<'PY'
import xml.etree.ElementTree as ET
for p in ['build/reports/spotbugs/spotbugsMain.xml','build/reports/spotbugs/spotbugsTest.xml']:
    root=ET.parse(p).getroot()
    print(p, sum(1 for b in root.findall('BugInstance') if b.attrib.get('type')=='DM_DEFAULT_ENCODING'))
PY`
- `./gradlew test --tests com.onionnetworks.util.SimUtilTest --tests network.crypta.node.TextModeClientInterfaceServerTest --tests org.sevenzip.LzmaAloneTest --tests org.sevenzip.LzmaBenchTest`