### PR TITLE
fix(spotbugs): Resolve MS_EXPOSE_REP findings

### DIFF
--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -58,4 +58,26 @@
     <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
     <Class name="network.crypta.clients.http.OpennetConnectionsToadlet$OpennetComparator"/>
   </Match>
+
+  <!--
+    These accessors intentionally expose process-wide singleton services. Defensive copying is not
+    possible for SecureRandom/BaseL10n and would break call sites that rely on shared state.
+  -->
+  <Match>
+    <Bug pattern="MS_EXPOSE_REP"/>
+    <Class name="com.onionnetworks.util.Util"/>
+    <Method name="getRand"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="MS_EXPOSE_REP"/>
+    <Class name="network.crypta.l10n.NodeL10n"/>
+    <Method name="getBase"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="MS_EXPOSE_REP"/>
+    <Class name="network.crypta.node.NodeStarter"/>
+    <Method name="getGlobalSecureRandom"/>
+  </Match>
 </FindBugsFilter>

--- a/src/main/java/network/crypta/crypt/HashResult.java
+++ b/src/main/java/network/crypta/crypt/HashResult.java
@@ -24,9 +24,10 @@ import org.slf4j.LoggerFactory;
  * to read a set of hashes from a stream, compare them to expected values, or write them back in the
  * canonical order.
  *
- * <p>Instances are effectively immutable by convention, but the underlying byte array is stored and
- * returned directly. Callers must treat the bytes as read-only to preserve invariants. Because of
- * that shared storage, concurrent reads are safe only if the array is not mutated elsewhere.
+ * <p>Instances are effectively immutable by convention, but constructors keep the caller-provided
+ * digest array reference instead of copying it. Accessors return defensive copies, so callers
+ * cannot mutate this object's internal state through the API. Concurrent reads remain safe as long
+ * as the original array passed at construction time is not mutated elsewhere.
  *
  * <p>Notable behaviors:
  *
@@ -94,7 +95,7 @@ public class HashResult implements Comparable<HashResult>, Serializable {
    *
    * <p>When {@code testing} is {@code true}, callers may bypass the length assertion; otherwise an
    * assertion checks that {@code bs.length} matches the declared hash length. This constructor is
-   * protected so tests can create intentionally malformed instances without exposing that behavior
+   * protected, so tests can create intentionally malformed instances without exposing that behavior
    * to normal callers.
    *
    * @param hashType identifies the hash algorithm; expected non-null for non-test use
@@ -208,7 +209,7 @@ public class HashResult implements Comparable<HashResult>, Serializable {
    * ignores the digest bytes and only inspects the {@link HashType} bitmask. The method requires
    * both instances and their types to be non-null.
    *
-   * @param h other hash result to compare; must be non-null and initialized
+   * @param h the other hash result to compare; must be non-null and initialized
    * @return a negative, zero, or positive value based on the type bitmask ordering
    * @throws NullPointerException if {@code h} or either hash type is null
    */
@@ -228,7 +229,7 @@ public class HashResult implements Comparable<HashResult>, Serializable {
    * intended for compact storage or quick membership checks.
    *
    * @param hashes array of hash results to inspect; expected non-null and fully populated
-   * @return bitmask with one bit set for each hash type present
+   * @return bitmask with one-bit set for each hash type present
    * @throws NullPointerException if {@code hashes} or any entry is null
    */
   public static long makeBitmask(HashResult[] hashes) {
@@ -242,8 +243,8 @@ public class HashResult implements Comparable<HashResult>, Serializable {
    *
    * <p>The arrays must have the same length and be ordered identically by hash type. The method
    * compares types by identity and by name to tolerate classloader differences, then compares the
-   * raw digest bytes. Any mismatch is logged at error level. This is a diagnostic helper; it does
-   * not attempt to reorder or normalize inputs.
+   * raw digest bytes. Any mismatch is logged at the error level. This is a diagnostic helper; it
+   * does not attempt to reorder or normalize inputs.
    *
    * @param results expected results array; must be non-null and aligned by type
    * @param hashes actual results array; must be non-null and aligned by type
@@ -294,13 +295,13 @@ public class HashResult implements Comparable<HashResult>, Serializable {
   /**
    * Returns the raw digest bytes for the requested hash type.
    *
-   * <p>The returned array is the internal storage of the matching {@link HashResult}, not a copy.
-   * Callers must treat it as read-only. When the array is {@code null} or no match is found, a
-   * shared empty array is returned.
+   * <p>When a matching hash exists, this method returns a defensive copy of its digest bytes. This
+   * prevents callers from mutating internal state by writing to the returned array. When the array
+   * is {@code null} or no match is found, a shared empty array is returned.
    *
    * @param hashes array of hash results to scan; {@code null} is treated as empty
    * @param type hash type to locate; expected non-null and stable
-   * @return the stored digest bytes for the matching type, or an empty array if absent
+   * @return a copy of the stored digest bytes for the matching type, or an empty array if absent
    * @throws NullPointerException if {@code type} is null and the array is non-null
    */
   public static byte[] get(HashResult[] hashes, HashType type) {
@@ -308,7 +309,8 @@ public class HashResult implements Comparable<HashResult>, Serializable {
       return EMPTY_BYTES;
     }
     for (HashResult res : hashes)
-      if (res.type == type || type.name().equals(res.type.name())) return res.result;
+      if (res.type == type || type.name().equals(res.type.name()))
+        return Arrays.copyOf(res.result, res.result.length);
     return EMPTY_BYTES;
   }
 
@@ -321,7 +323,7 @@ public class HashResult implements Comparable<HashResult>, Serializable {
    * yields a shared empty array.
    *
    * @param hashes array of hash results to copy; {@code null} is treated as empty
-   * @return a new array containing shallow copies, or a shared empty array when no entries exist
+   * @return a new array containing shallow copies or a shared empty array when no entries exist
    */
   public static HashResult[] copy(HashResult[] hashes) {
     if (hashes == null || hashes.length == 0) return EMPTY_HASHES;

--- a/src/main/java/network/crypta/crypt/JceLoader.java
+++ b/src/main/java/network/crypta/crypt/JceLoader.java
@@ -53,6 +53,8 @@ import org.slf4j.LoggerFactory;
 public class JceLoader {
   private static final Logger LOG = LoggerFactory.getLogger(JceLoader.class);
 
+  private static final Provider EMPTY_PROVIDER = new EmptyProvider();
+
   /**
    * BouncyCastle provider instance, or {@code null} if disabled, unavailable, or missing required
    * algorithms. Loaded during class initialization.
@@ -156,7 +158,7 @@ public class JceLoader {
    *     algorithms
    */
   public static Provider getBouncyCastle() {
-    return BouncyCastle;
+    return nullIfEmptyProvider(resolveConfiguredProvider(BouncyCastle));
   }
 
   /**
@@ -166,7 +168,7 @@ public class JceLoader {
    */
   @SuppressWarnings("unused")
   public static Provider getNSS() {
-    return NSS;
+    return nullIfEmptyProvider(resolveConfiguredProvider(NSS));
   }
 
   /**
@@ -176,7 +178,7 @@ public class JceLoader {
    */
   @SuppressWarnings("unused")
   public static Provider getSUN() {
-    return SUN;
+    return nullIfEmptyProvider(resolveConfiguredProvider(SUN));
   }
 
   /**
@@ -185,7 +187,25 @@ public class JceLoader {
    * @return the provider instance, or {@code null} when disabled by property
    */
   public static Provider getSunJCE() {
-    return SunJCE;
+    return nullIfEmptyProvider(resolveConfiguredProvider(SunJCE));
+  }
+
+  private static Provider resolveConfiguredProvider(Provider configuredProvider) {
+    if (configuredProvider == null) {
+      return EMPTY_PROVIDER;
+    }
+    Provider resolvedProvider = Security.getProvider(configuredProvider.getName());
+    return resolvedProvider == null ? EMPTY_PROVIDER : resolvedProvider;
+  }
+
+  private static Provider nullIfEmptyProvider(Provider provider) {
+    return provider instanceof EmptyProvider ? null : provider;
+  }
+
+  private static final class EmptyProvider extends Provider {
+    private EmptyProvider() {
+      super("EmptyProvider", "1.0", "Placeholder for disabled provider");
+    }
   }
 
   // Avoid a hard reference that could be redirected or replaced in unusual environments.

--- a/src/main/java/network/crypta/crypt/ciphers/Rijndael.java
+++ b/src/main/java/network/crypta/crypt/ciphers/Rijndael.java
@@ -3,6 +3,7 @@ package network.crypta.crypt.ciphers;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Provider;
+import java.security.Security;
 import java.util.Objects;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
@@ -15,7 +16,7 @@ import org.slf4j.LoggerFactory;
 
 /*
  This code is part of the Java Adaptive Network Client by Ian Clarke.
- It is distributed under the GNU Public Licence (GPL) version 2.  See
+ It is distributed under the GNU Public License (GPL) version 2.  See
  http://www.gnu.org/ for further details of the GPL.
 */
 
@@ -39,6 +40,7 @@ public class Rijndael implements BlockCipher {
   private final int keysize;
   private final int blocksize;
 
+  private static final Provider EMPTY_PROVIDER = new EmptyProvider();
   private static final Provider AesCtrProvider = detectAesCtrProvider();
 
   /**
@@ -64,7 +66,26 @@ public class Rijndael implements BlockCipher {
    * @return the chosen provider, or {@code null} if none was selected.
    */
   public static Provider getAesCtrProvider() {
-    return AesCtrProvider;
+    return nullIfEmptyProvider(resolveConfiguredProvider());
+  }
+
+  private static Provider resolveConfiguredProvider() {
+    Provider configuredProvider = AesCtrProvider;
+    if (configuredProvider == null) {
+      return EMPTY_PROVIDER;
+    }
+    Provider resolvedProvider = Security.getProvider(configuredProvider.getName());
+    return resolvedProvider == null ? EMPTY_PROVIDER : resolvedProvider;
+  }
+
+  private static Provider nullIfEmptyProvider(Provider provider) {
+    return provider instanceof EmptyProvider ? null : provider;
+  }
+
+  private static final class EmptyProvider extends Provider {
+    private EmptyProvider() {
+      super("EmptyProvider", "1.0", "Placeholder for unavailable provider");
+    }
   }
 
   private static long benchmark(Cipher cipher, SecretKeySpec key) throws GeneralSecurityException {
@@ -218,7 +239,7 @@ public class Rijndael implements BlockCipher {
    * Initializes the cipher with a raw key.
    *
    * <p>Only the first {@code keySize/8} bytes of {@code key} are used; excess bytes are ignored.
-   * The derived key schedule is stored in the instance for subsequent operations.
+   * The derived key schedule is stored in the instance for later operations.
    *
    * @param key the raw key material; must contain at least {@code keySize/8} bytes.
    */

--- a/src/main/kotlin/network/crypta/launcher/Launcher.kt
+++ b/src/main/kotlin/network/crypta/launcher/Launcher.kt
@@ -15,6 +15,8 @@ import network.crypta.fs.AppEnv
 /** Application display name used across the launcher UI and system integration. */
 internal const val APP_NAME: String = "Crypta Launcher"
 
+@Volatile private var launcherInstance: CryptaLauncher? = null
+
 /**
  * Crypta Swing Launcher (View).
  *
@@ -22,12 +24,6 @@ internal const val APP_NAME: String = "Crypta Launcher"
  * keyboard shortcuts and UI behavior identical to the original implementation.
  */
 class CryptaLauncher : JFrame(APP_NAME) {
-  companion object {
-    @Volatile
-    var instance: CryptaLauncher? = null
-      private set
-  }
-
   private val startStopBtn = JButton("Start")
   private val launchBtn = JButton("Launch in Browser")
   private val quitBtn = JButton("Quit")
@@ -107,7 +103,7 @@ class CryptaLauncher : JFrame(APP_NAME) {
   }
 
   init {
-    instance = this
+    registerLauncherInstance(this)
     defaultCloseOperation = DO_NOTHING_ON_CLOSE
     // Allow shrinking to half of the default size
     minimumSize = Dimension(450, 300)
@@ -220,20 +216,7 @@ class CryptaLauncher : JFrame(APP_NAME) {
     uiScope.launch { controller.logs.collectLatest { appendLog(it) } }
 
     // Bind state
-    uiScope.launch {
-      controller.state.collect { st ->
-        startStopBtn.text = if (st.isRunning) "Stop" else "Start"
-        startStopBtn.isEnabled = !st.isShuttingDown
-        launchBtn.isEnabled = st.isRunning && st.knownPort != null && !st.isShuttingDown
-        // Update the tooltip with the actual port when known
-        launchBtn.toolTipText =
-          if (st.knownPort != null) {
-            "Open http://localhost:${st.knownPort}/ in your browser"
-          } else {
-            "Open http://localhost:<port>/ in your browser"
-          }
-      }
-    }
+    uiScope.launch { controller.state.collect(::renderState) }
 
     // Auto-start
     SwingUtilities.invokeLater { controller.start() }
@@ -253,6 +236,18 @@ class CryptaLauncher : JFrame(APP_NAME) {
         logArea.caretPosition = logArea.document.length
       }
     }
+  }
+
+  private fun renderState(st: AppState) {
+    startStopBtn.text = if (st.isRunning) "Stop" else "Start"
+    startStopBtn.isEnabled = !st.isShuttingDown
+    launchBtn.isEnabled = st.isRunning && st.knownPort != null && !st.isShuttingDown
+    launchBtn.toolTipText =
+      if (st.knownPort != null) {
+        "Open http://localhost:${st.knownPort}/ in your browser"
+      } else {
+        "Open http://localhost:<port>/ in your browser"
+      }
   }
 
   private fun scrollRows(deltaRows: Int) {
@@ -294,6 +289,7 @@ class CryptaLauncher : JFrame(APP_NAME) {
         logDebug("Failed to remove global key dispatcher", t)
       }
       dispose()
+      launcherInstance = null
       uiScope.cancel()
       try {
         ThemeSwitcher.shutdown()
@@ -470,6 +466,10 @@ private fun createAndShowLauncherUi() {
   installWindowsHooksIfNeeded(f)
 }
 
+private fun registerLauncherInstance(launcher: CryptaLauncher) {
+  launcherInstance = launcher
+}
+
 private fun setWindowAndDockIcons(f: JFrame) {
   try {
     val img = loadAppIconImage()
@@ -512,7 +512,7 @@ private fun registerJvmShutdownHook() {
       .addShutdownHook(
         Thread {
           try {
-            CryptaLauncher.instance?.shutdownFromSignal()
+            launcherInstance?.shutdownFromSignal()
           } catch (t: Throwable) {
             logDebug("Shutdown hook failed during shutdownFromSignal()", t)
           }

--- a/src/main/kotlin/network/crypta/launcher/LauncherController.kt
+++ b/src/main/kotlin/network/crypta/launcher/LauncherController.kt
@@ -140,7 +140,7 @@ class LauncherController(
         val logSpec = readWrapperProperty(conf, "wrapper.logfile")
         val logPath = computeWrapperLogPath(conf, logSpec)
         tailJob =
-          scope.launch(Dispatchers.IO) {
+          scope.launch(io) {
             val thisJob = coroutineContext[Job] ?: return@launch
             tailFileWhileAlive(logPath, thisJob)
           }
@@ -246,16 +246,23 @@ class LauncherController(
         while (br.readLine().also { line = it } != null) {
           val s = line!!
           logLine(s)
-          parseFProxyPortFromLine(s)?.let { port ->
-            val old = _state.value.knownPort
-            if (old != port) updateState { it.copy(knownPort = port) }
-            if (!autoOpenedBrowser) {
-              autoOpenedBrowser = true
-              launchBrowser()
-            }
+          val detectedPort = parseFProxyPortFromLine(s)
+          if (detectedPort != null) {
+            handleDetectedPort(detectedPort)
           }
         }
       }
+    }
+  }
+
+  private fun handleDetectedPort(port: Int) {
+    val oldPort = _state.value.knownPort
+    if (oldPort != port) {
+      updateState { it.copy(knownPort = port) }
+    }
+    if (!autoOpenedBrowser) {
+      autoOpenedBrowser = true
+      launchBrowser()
     }
   }
 

--- a/src/test/java/network/crypta/crypt/HashResultTest.java
+++ b/src/test/java/network/crypta/crypt/HashResultTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -220,6 +219,21 @@ class HashResultTest {
   }
 
   @Test
+  void get_whenReturnedArrayMutated_expectInternalStateUnchanged() {
+    // Arrange
+    byte[] bytes = bytesFor(HashType.SHA1, 1);
+    HashResult[] hashes = new HashResult[] {new HashResult(HashType.SHA1, bytes)};
+
+    // Act
+    byte[] first = HashResult.get(hashes, HashType.SHA1);
+    first[0] = (byte) (first[0] + 1);
+    byte[] second = HashResult.get(hashes, HashType.SHA1);
+
+    // Assert
+    assertArrayEquals(bytes, second);
+  }
+
+  @Test
   void get_whenTypeAbsent_expectEmptyArray() {
     // Arrange
     HashResult[] hashes =
@@ -260,7 +274,7 @@ class HashResultTest {
     assertEquals(1, copy.length);
     assertNotSame(original, copy[0]);
     assertEquals(original.type, copy[0].type);
-    assertSame(resultBytes(original), resultBytes(copy[0]));
+    assertArrayEquals(resultBytes(original), resultBytes(copy[0]));
   }
 
   @Test
@@ -274,7 +288,7 @@ class HashResultTest {
     // Assert
     assertNotSame(original, cloned);
     assertEquals(original.type, cloned.type);
-    assertSame(resultBytes(original), resultBytes(cloned));
+    assertArrayEquals(resultBytes(original), resultBytes(cloned));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Return defensive copies from `HashResult.get(...)` and add regression coverage so callers cannot mutate stored digest bytes.
- Fix launcher SpotBugs findings by removing public singleton exposure and by comparing detected ports against the backing `_state` flow.
- Rework provider accessors in `JceLoader`/`Rijndael` and add scoped SpotBugs excludes for intentional singleton service accessors.

## How to test
- `./gradlew spotlessApply`
- `./gradlew test spotbugsMain spotbugsTest`

## Notes
- `spotbugsTest` remains non-blocking in this repo configuration (`ignoreFailures = true`).