### PR TITLE
fix(spotbugs): Resolve inconsistent sync findings

### DIFF
--- a/src/main/java/network/crypta/support/SimpleFieldSet.java
+++ b/src/main/java/network/crypta/support/SimpleFieldSet.java
@@ -71,7 +71,7 @@ public class SimpleFieldSet {
   private static final String CANNOT_PARSE = "Cannot parse ";
 
   private final Map<String, String> values;
-  private ConcurrentHashMap<String, SimpleFieldSet> subsets;
+  private volatile ConcurrentHashMap<String, SimpleFieldSet> subsets;
   private volatile String endMarker;
   private final boolean shortLived;
   private final boolean alwaysUseBase64;

--- a/src/test/java/com/onionnetworks/fec/Native8CodeTest.java
+++ b/src/test/java/com/onionnetworks/fec/Native8CodeTest.java
@@ -11,7 +11,7 @@ class Native8CodeTest {
   private static final class StubNative8Code extends Native8Code {
     int encodeCalls;
     int decodeCalls;
-    int freeCalls;
+    volatile int freeCalls;
     int newFecCalls;
     volatile boolean throwOnFree;
 

--- a/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
+++ b/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
@@ -293,7 +293,7 @@ class IPAddressDetectorTest {
 
   /** Test subclass that counts checkpoint invocations and supplies a deterministic snapshot. */
   private static final class CountingDetector extends IPAddressDetector {
-    int checkpointCalls = 0;
+    volatile int checkpointCalls = 0;
 
     CountingDetector(long interval, NodeIPDetector detector) {
       super(interval, detector);


### PR DESCRIPTION
## Summary
- Mark `SimpleFieldSet.subsets` as `volatile` so its mixed synchronized and unsynchronized access has explicit visibility semantics.
- Mark `StubNative8Code.freeCalls` and `CountingDetector.checkpointCalls` as `volatile` in tests to align with their access patterns.
- Remove all SpotBugs `IS2_INCONSISTENT_SYNC` findings from both main and test reports.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `rg "IS2_INCONSISTENT_SYNC" build/reports/spotbugs/spotbugsMain.xml build/reports/spotbugs/spotbugsTest.xml` (expect no matches)