### PR TITLE
fix(spotbugs): Fix wrong map iterator usage in load tracker

### DIFF
--- a/src/main/java/network/crypta/node/PeerNodeLoadTracker.java
+++ b/src/main/java/network/crypta/node/PeerNodeLoadTracker.java
@@ -4,8 +4,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
 import network.crypta.node.NodeStats.RequestType;
@@ -841,12 +843,14 @@ public final class PeerNodeLoadTracker {
     public synchronized SlotWaiter removeFirst() {
       if (lru.isEmpty()) return null;
       // Consider using LRUMap; would need to update to use Iterator and other modern APIs.
-      PeerNode source = lru.keySet().iterator().next();
-      TreeMap<Long, SlotWaiter> map = lru.get(source);
+      Iterator<Map.Entry<PeerNode, TreeMap<Long, SlotWaiter>>> sourceIterator =
+          lru.entrySet().iterator();
+      Map.Entry<PeerNode, TreeMap<Long, SlotWaiter>> sourceEntry = sourceIterator.next();
+      PeerNode source = sourceEntry.getKey();
+      TreeMap<Long, SlotWaiter> map = sourceEntry.getValue();
       Long key = map.firstKey();
-      SlotWaiter ret = map.get(key);
-      map.remove(key);
-      lru.remove(source);
+      SlotWaiter ret = map.remove(key);
+      sourceIterator.remove();
       if (!map.isEmpty()) lru.put(source, map);
       return ret;
     }


### PR DESCRIPTION
## Summary
- Replace `keySet().iterator().next()` + `get()` in `SlotWaiterList.removeFirst()` with direct `entrySet()` iteration
- Remove the selected entry via the same iterator and remove the first waiter via `map.remove(key)`
- Preserve existing LRU behavior by re-inserting non-empty per-peer waiter maps

## How to test
- Run `./gradlew spotbugsMain spotbugsTest`
- Verify `build/reports/spotbugs/spotbugsMain.xml` has no `WMI_WRONG_MAP_ITERATOR` findings