### PR TITLE
fix(spotbugs): Remove abstract collection cast warnings

### DIFF
--- a/src/main/kotlin/network/crypta/launcher/LauncherController.kt
+++ b/src/main/kotlin/network/crypta/launcher/LauncherController.kt
@@ -329,7 +329,9 @@ class LauncherController(
       val isWindows = AppEnv().isWindows()
       // Snapshot descendants before we start signaling to avoid losing them if the root dies early
       val snapshot = getDescendantTreePids(pid)
-      val allPids = listOf(pid) + snapshot
+      val allPids = ArrayList<Long>(snapshot.size + 1)
+      allPids.add(pid)
+      allPids.addAll(snapshot)
 
       if (isWindows) {
         // Prefer a graceful stop via a Wrapper anchor file on Windows. Falls back to task-kill.
@@ -345,10 +347,10 @@ class LauncherController(
         killUnixSignalPids(allPids, "INT")
         if (!waitForPidsToExit(allPids, 20_000)) {
           logLine(ts() + " Escalating: sending SIGTERM to remaining processes ...")
-          killUnixSignalPids(allPids.filter { isPidAlive(it) }, "TERM")
+          killUnixSignalPids(alivePids(allPids), "TERM")
           if (!waitForPidsToExit(allPids, 5_000)) {
             logLine(ts() + " Escalating: sending SIGKILL to remaining processes ...")
-            killUnixSignalPids(allPids.filter { isPidAlive(it) }, "KILL")
+            killUnixSignalPids(alivePids(allPids), "KILL")
             waitForPidsToExit(allPids, 2_000)
           }
         }
@@ -394,6 +396,16 @@ class LauncherController(
       delay(200)
     }
     return pids.none { isPidAlive(it) }
+  }
+
+  private fun alivePids(pids: List<Long>): List<Long> {
+    val alive = ArrayList<Long>(pids.size)
+    for (pid in pids) {
+      if (isPidAlive(pid)) {
+        alive.add(pid)
+      }
+    }
+    return alive
   }
 
   private fun killUnixSignalPids(pids: List<Long>, signal: String) {

--- a/src/main/kotlin/network/crypta/launcher/LauncherUtils.kt
+++ b/src/main/kotlin/network/crypta/launcher/LauncherUtils.kt
@@ -89,14 +89,22 @@ fun parseWrapperProperties(lines: List<String>): Map<String, String> = buildMap 
  * @param lines original wrapper configuration lines in their existing order.
  * @param key property key to upsert; compared after trimming whitespace.
  * @param value property value to write as a single line after the `=` delimiter.
- * @return new list of lines with the update applied, preserving unrelated content.
+ * @return a new list of lines with the update applied, preserving unrelated content.
  */
 fun upsertWrapperProperty(lines: List<String>, key: String, value: String): List<String> {
+  val updatedLine = "$key=$value"
   val index = lines.indexOfFirst { matchesWrapperKey(it, key) }
   if (index >= 0) {
-    return lines.mapIndexed { i, raw -> if (i == index) "$key=$value" else raw }
+    val updated = ArrayList<String>(lines.size)
+    for (i in lines.indices) {
+      updated.add(if (i == index) updatedLine else lines[i])
+    }
+    return updated
   }
-  return lines + "$key=$value"
+  val appended = ArrayList<String>(lines.size + 1)
+  appended.addAll(lines)
+  appended.add(updatedLine)
+  return appended
 }
 
 /**

--- a/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
+++ b/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
@@ -47,9 +47,14 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
   /** Resolves CoreActionToadlet strings from the localization bundle. */
   private fun t(key: String, replacements: Map<String, String> = emptyMap()): String {
     if (replacements.isEmpty()) return l10n.getString("CoreActionToadlet.$key")
-    val entries = replacements.entries.toList()
-    val patterns = entries.map { it.key }.toTypedArray()
-    val values = entries.map { it.value }.toTypedArray()
+    val patterns = Array(replacements.size) { "" }
+    val values = Array(replacements.size) { "" }
+    var index = 0
+    for ((pattern, replacementValue) in replacements) {
+      patterns[index] = pattern
+      values[index] = replacementValue
+      index++
+    }
     return l10n.getString("CoreActionToadlet.$key", patterns, values)
   }
 

--- a/src/main/kotlin/network/crypta/support/Logging.kt
+++ b/src/main/kotlin/network/crypta/support/Logging.kt
@@ -20,7 +20,7 @@ object Logging {
     applyDetails(details)
   }
 
-  /** Sets the level for the named logger, when running with Logback. */
+  /** Sets the level for the named logger when running with Logback. */
   @JvmStatic
   fun setLevel(loggerName: String, level: Level) {
     val (ctx, logger) = resolveLogbackLogger(loggerName) ?: return
@@ -28,7 +28,7 @@ object Logging {
     ctx.resetTurboFilterList() // best-effort nudge
   }
 
-  /** Sets the root logger level, when running with Logback. */
+  /** Sets the root logger level when running with Logback. */
   @JvmStatic
   fun setRootLevel(level: Level) {
     val (ctx, logger) = resolveLogbackLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) ?: return
@@ -43,34 +43,39 @@ object Logging {
     clearOverrides(ctx)
     if (details.isNullOrBlank()) return
     // Comma-separated "section:LEVEL" pairs
-    details
-      .split(',')
-      .map { it.trim() }
-      .filter { it.isNotEmpty() && it.contains(':') }
-      .forEach { token ->
-        val idx = token.indexOf(':')
-        val section = token.take(idx)
-        val lvl = token.substring(idx + 1).trim()
-        val up = lvl.uppercase()
-        if (up == "NONE" || up == "OFF") {
-          setOff(section)
-          appliedLoggerNames.add(section)
-          return@forEach
-        }
-        val level = up.toSlf4jLevelOrNull() ?: return@forEach
-        setLevel(section, level)
-        appliedLoggerNames.add(section)
+    details.split(',').forEach { rawToken ->
+      val token = rawToken.trim()
+      if (token.isEmpty() || !token.contains(':')) {
+        return@forEach
       }
+      val idx = token.indexOf(':')
+      val section = token.take(idx)
+      val lvl = token.substring(idx + 1).trim()
+      val up = lvl.uppercase()
+      if (up == "NONE" || up == "OFF") {
+        setOff(section)
+        appliedLoggerNames.add(section)
+        return@forEach
+      }
+      val level = up.toSlf4jLevelOrNull() ?: return@forEach
+      setLevel(section, level)
+      appliedLoggerNames.add(section)
+    }
   }
 
   private fun String.toSlf4jLevelOrNull(): Level? =
     when (this) {
       // Accept only standard SLF4J names
       "ERROR" -> Level.ERROR
+
       "WARN" -> Level.WARN
+
       "INFO" -> Level.INFO
+
       "DEBUG" -> Level.DEBUG
+
       "TRACE" -> Level.TRACE
+
       else -> null
     }
 
@@ -98,7 +103,9 @@ object Logging {
     return if (factory is ch.qos.logback.classic.LoggerContext) {
       val logger = factory.getLogger(name)
       Pair(factory, logger)
-    } else null
+    } else {
+      null
+    }
   }
 
   @Synchronized


### PR DESCRIPTION
## Summary
- Eliminate `BC_BAD_CAST_TO_ABSTRACT_COLLECTION` findings by replacing Kotlin collection-chain constructs that SpotBugs interpreted as questionable `Collection` -> `List` casts.
- Update launcher process shutdown PID handling, wrapper property upsert logic, core updater localization replacement arrays, and logging detail parsing to use explicit list/array construction.
- Keep behavior unchanged while limiting the diff to SpotBugs-oriented fixes.

## How to test
- Run `./gradlew spotlessApply`
- Run `./gradlew spotbugsMain`
- Run `./gradlew spotbugsTest`
- Verify no matches in SpotBugs reports:
  - `rg "BC_BAD_CAST_TO_ABSTRACT_COLLECTION" build/reports/spotbugs/spotbugsMain.xml`
  - `rg "BC_BAD_CAST_TO_ABSTRACT_COLLECTION" build/reports/spotbugs/spotbugsTest.xml`

## Notes
- SpotBugs may still print existing analysis-environment warnings (for example missing `oshi.annotation.concurrent.ThreadSafe`), but this change removes the targeted `BC_BAD_CAST_TO_ABSTRACT_COLLECTION` findings.