### PR TITLE
fix(spotbugs): Fix questionable unsigned right-shift casts

### DIFF
--- a/src/main/java/network/crypta/client/filter/MP3Filter.java
+++ b/src/main/java/network/crypta/client/filter/MP3Filter.java
@@ -280,19 +280,19 @@ public class MP3Filter implements ContentDataFilter {
   private static void processFrame(DataInputStream in, DataOutputStream out, State st)
       throws IOException {
     final int frameHeader = st.frameHeader;
-    final byte version = (byte) ((frameHeader & 0x00180000) >>> 19); // 2 bits
+    final int version = (frameHeader >>> 19) & 0x03; // 2 bits
     if (version == 1) {
       st.foundStream = false;
       return; // Not valid
     }
-    final byte layer = (byte) ((frameHeader & 0x00060000) >>> 17); // 2 bits
+    final int layer = (frameHeader >>> 17) & 0x03; // 2 bits
     if (layer == 0) {
       st.foundStream = false;
       return; // Not valid
     }
     // WARNING: layer is encoded! 1 = layer 3, 2 = layer 2, 3 = layer 1!
     final boolean hasCRC = ((frameHeader & 0x00010000) >>> 16) != 1; // 1 bit, but inverted
-    final byte bitrateIndex = (byte) ((frameHeader & 0x0000f000) >>> 12); // 4 bits
+    final int bitrateIndex = (frameHeader >>> 12) & 0x0F; // 4 bits
     if (bitrateIndex == 0) {
       // Free bitrate ("freeformat") is hard to support and uncommon.
       st.foundStream = false;
@@ -303,7 +303,7 @@ public class MP3Filter implements ContentDataFilter {
       st.foundStream = false;
       return; // Not valid
     }
-    final byte samplerateIndex = (byte) ((frameHeader & 0x00000c00) >>> 10); // 2 bits
+    final int samplerateIndex = (frameHeader >>> 10) & 0x03; // 2 bits
     if (samplerateIndex == 3) {
       st.foundStream = false;
       return; // Not valid

--- a/src/main/java/network/crypta/support/Fields.java
+++ b/src/main/java/network/crypta/support/Fields.java
@@ -833,9 +833,10 @@ public abstract class Fields {
    */
   public static byte[] shortToBytes(short x) {
     byte[] buf = new byte[2];
+    int unsigned = x & 0xFFFF;
     for (int j = 0; j < 2; j++) {
-      buf[j] = (byte) x;
-      x = (short) (x >>> 8);
+      buf[j] = (byte) unsigned;
+      unsigned >>>= 8;
     }
     return buf;
   }


### PR DESCRIPTION
## Summary
- Fix SpotBugs `ICAST_QUESTIONABLE_UNSIGNED_RIGHT_SHIFT` findings in `MP3Filter.processFrame` by extracting header bit-fields as masked `int` values instead of casting unsigned shifts to `byte`.
- Fix `Fields.shortToBytes(short)` by shifting an unsigned `int` accumulator (`x & 0xFFFF`) rather than right-shifting and recasting a `short`.
- Preserve existing behavior while removing the questionable cast pattern SpotBugs flags.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain`
- `./gradlew test --tests "*FieldsTest" --tests "*MP3FilterTest"`

## Notes
- SpotBugs `spotbugsMain` report no longer contains `ICAST_QUESTIONABLE_UNSIGNED_RIGHT_SHIFT` for these paths.