### PR TITLE
fix(spotbugs): Resolve ignored return-value warnings

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -1638,11 +1638,12 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       HTMLNode option = optionList.addChild("li");
       try {
         MediaType textMediaType = new MediaType("text/plain");
-        textMediaType.setParameter(
-            "charset",
-            (e.getExpectedMimeType() != null)
-                ? MediaType.getCharsetRobust(e.getExpectedMimeType())
-                : null);
+        textMediaType =
+            textMediaType.setParameter(
+                "charset",
+                (e.getExpectedMimeType() != null)
+                    ? MediaType.getCharsetRobust(e.getExpectedMimeType())
+                    : null);
         NodeL10n.getBase()
             .addL10nSubstitution(
                 option,

--- a/src/test/java/network/crypta/keys/FreenetURITest.java
+++ b/src/test/java/network/crypta/keys/FreenetURITest.java
@@ -42,18 +42,8 @@ class FreenetURITest {
     assertEquals(uri2, uri1.sskForUSK());
     assertEquals(uri1, uri2.uskForSSK());
 
-    try {
-      uri1.uskForSSK();
-      fail("no exception throw!");
-    } catch (IllegalStateException _) {
-      // pass
-    }
-    try {
-      uri2.sskForUSK();
-      fail("no exception throw!");
-    } catch (IllegalStateException _) {
-      // pass
-    }
+    assertThrows(IllegalStateException.class, uri1::uskForSSK);
+    assertThrows(IllegalStateException.class, uri2::sskForUSK);
 
     FreenetURI chkUriForThrows = new FreenetURI(WANNA_CHK_1);
     assertThrows(IllegalStateException.class, chkUriForThrows::sskForUSK);
@@ -232,7 +222,7 @@ class FreenetURITest {
 
     FreenetURI withMeta = chk1.pushMetaString("file.txt");
     assertNotEquals(chk1, withMeta);
-    assertTrue(chk1.equalsKeypair(withMeta)); // keypair unaffected by meta strings
+    assertTrue(chk1.equalsKeypair(withMeta)); // keypair unaffected by meta-strings
   }
 
   @Test
@@ -329,7 +319,7 @@ class FreenetURITest {
     FreenetURI uri = FreenetURI.generateRandomCHK(new Random(1)).pushMetaString("file");
     // Disambiguate overloaded methods by using explicit lambdas
     assertThrows(network.crypta.client.InsertException.class, uri::checkInsertURI);
-    assertDoesNotThrow(() -> FreenetURI.EMPTY_CHK_URI.checkInsertURI());
+    assertDoesNotThrow(FreenetURI.EMPTY_CHK_URI::checkInsertURI);
   }
 
   @Test
@@ -361,7 +351,7 @@ class FreenetURITest {
             + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI.html";
     // Act
     FreenetURI chk = new FreenetURI(chkWithExt);
-    // Assert: extension is ignored; there are no meta strings and toString omits the extension
+    // Assert: extension is ignored; there are no meta-strings, and toString omits the extension
     assertEquals(
         "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,"
             + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI",

--- a/src/test/java/network/crypta/support/ByteBufferInputStreamTest.java
+++ b/src/test/java/network/crypta/support/ByteBufferInputStreamTest.java
@@ -221,15 +221,20 @@ class ByteBufferInputStreamTest {
   @Test
   void slice_whenInsufficientRemaining_throwsEOF() throws IOException {
     try (ByteBufferInputStream in = new ByteBufferInputStream(new byte[] {1})) {
-      assertThrows(EOFException.class, () -> in.slice(2));
+      assertThrows(EOFException.class, () -> sliceAndClose(in, 2));
     }
   }
 
   @Test
   void slice_whenNegativeSize_throwsIllegalArgument() throws IOException {
     try (ByteBufferInputStream in = new ByteBufferInputStream(new byte[] {1, 2, 3})) {
-      assertThrows(IllegalArgumentException.class, () -> in.slice(-1));
+      assertThrows(IllegalArgumentException.class, () -> sliceAndClose(in, -1));
     }
+  }
+
+  private static void sliceAndClose(ByteBufferInputStream in, int size) throws IOException {
+    ByteBufferInputStream slice = in.slice(size);
+    slice.close();
   }
 
   // -------------------- Underflow → EOFException tests --------------------


### PR DESCRIPTION
## Summary
- Fix `RV_RETURN_VALUE_IGNORED_INFERRED` in `FProxyToadlet` by using the immutable return value from `MediaType.setParameter(...)`.
- Update `FreenetURITest` exception assertions to `assertThrows(...)` instead of manual try/catch blocks.
- Refactor `ByteBufferInputStreamTest` slice exception checks to a helper so assertion lambdas stay focused and static-analysis friendly.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `./gradlew test --tests "*FreenetURITest" --tests "*ByteBufferInputStreamTest"`

## Notes
- SpotBugs reports no remaining `RV_RETURN_VALUE_IGNORED_INFERRED` findings in the generated XML reports under `build/reports/spotbugs/`.