### PR TITLE
fix(spotbugs): Remove DLS dead local store findings

### DIFF
--- a/src/main/java/network/crypta/clients/http/Toadlet.java
+++ b/src/main/java/network/crypta/clients/http/Toadlet.java
@@ -16,7 +16,6 @@ import network.crypta.client.FetchWaiter;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertBlock;
 import network.crypta.client.InsertException;
-import network.crypta.client.async.ClientGetter;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.RequestClient;
@@ -316,8 +315,7 @@ public abstract class Toadlet {
       fctx.setMaxTempLength(maxSize);
     }
     FetchWaiter fw = new FetchWaiter(clientContext);
-    @SuppressWarnings("unused")
-    ClientGetter getter = getClientImpl().fetch(uri, fw, fctx);
+    getClientImpl().fetch(uri, fw, fctx);
     return fw.waitForCompletion();
   }
 

--- a/src/main/java/network/crypta/crypt/Yarrow.java
+++ b/src/main/java/network/crypta/crypt/Yarrow.java
@@ -705,7 +705,6 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
   }
 
   private synchronized void fastPoolReseed() {
-    long startTime = System.currentTimeMillis();
     byte[] v0 = fastPool.digest();
     byte[] vi = v0;
 
@@ -721,10 +720,6 @@ public class Yarrow extends RandomSource implements PersistentRandomSource {
     rekey(tmp);
     Arrays.fill(v0, (byte) 0); // Actively wipe intermediate state for security
     fastEntropy = 0;
-    if (DEBUG) {
-      long endTime = System.currentTimeMillis();
-      if (endTime - startTime > 5000) LOG.info("Fast pool reseed took {}ms", endTime - startTime);
-    }
   }
 
   private synchronized void slowPoolReseed() {

--- a/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
+++ b/src/main/java/network/crypta/crypt/ciphers/RijndaelAlgorithm.java
@@ -111,8 +111,6 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
   //	...........................................................................
 
   static {
-    long time = System.currentTimeMillis();
-
     if (RDEBUG && LOG.isDebugEnabled()) {
       LOG.debug("Algorithm Name: {}", FULL_NAME);
       LOG.debug("Electronic Codebook (ECB) Mode");
@@ -151,8 +149,6 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
       r = mul(2, r);
       rcon[t] = (byte) r;
     }
-
-    time = System.currentTimeMillis() - time;
 
     if (RDEBUG && LOG.isDebugEnabled()) {
       LOG.debug("init.banner=begin");
@@ -276,7 +272,6 @@ public final class RijndaelAlgorithm // implicit no-argument constructor
       }
 
       LOG.debug("init.section=rcon.end");
-      LOG.debug("Total initialization time: {} ms.", time);
       LOG.debug("init.section=complete");
     }
   }

--- a/src/test/java/network/crypta/config/ConfigTest.java
+++ b/src/test/java/network/crypta/config/ConfigTest.java
@@ -41,12 +41,12 @@ class ConfigTest {
     /* test if we can register */
     StringBuilder sb = new StringBuilder();
     char[] printableAscii = UTFUtil.printableAscii();
-    for (int i = 0; i < printableAscii.length; i++) {
-      sb.append(printableAscii[i]);
+    for (char value : printableAscii) {
+      sb.append(value);
     }
     char[] stressedUtf = UTFUtil.stressedUtf();
-    for (int i = 0; i < stressedUtf.length; i++) {
-      sb.append(stressedUtf[i]);
+    for (char value : stressedUtf) {
+      sb.append(value);
     }
     assertNotNull(conf.createSubConfig(sb.toString()));
 
@@ -168,9 +168,14 @@ class ConfigTest {
   Config conf;
   SubConfig sc;
 
-  @SuppressWarnings("unused")
   private static void castToLong(Option<Long> opt) {
-    // Trigger a runtime cast to Long without returning a value
-    Long unused = opt.getValue();
+    // Trigger a runtime cast to Long by passing through a Long-typed parameter.
+    consumeLong(opt.getValue());
+  }
+
+  private static void consumeLong(Long value) {
+    if (value == null) {
+      throw new AssertionError("Expected non-null Long");
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Remove SpotBugs `DLS_DEAD_LOCAL_STORE` patterns in production code by eliminating dead local stores in `Toadlet`, `Yarrow`, and `RijndaelAlgorithm`.
- Keep `ConfigTest` behavior (runtime cast path) while removing dead-store and loop-style warnings by switching to enhanced for-loops and using a helper consumption path.
- Keep the change set focused on static-analysis cleanup with no functional behavior changes in runtime paths.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- `./gradlew test --tests "*ConfigTest"`

## Notes
- SpotBugs in this repository may still report non-DLS findings and missing-analysis-class warnings; this PR specifically addresses `DLS_DEAD_LOCAL_STORE` findings.