### PR TITLE
fix(spotbugs): Resolve DCN null-pointer findings

### DIFF
--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -80,4 +80,14 @@
     <Class name="network.crypta.node.NodeStarter"/>
     <Method name="getGlobalSecureRandom"/>
   </Match>
+
+  <!--
+    File#deleteOnExit() can throw NullPointerException during JVM shutdown in wrapper-managed
+    environments. We intentionally catch and log that specific failure mode in this one method.
+  -->
+  <Match>
+    <Bug pattern="DCN_NULLPOINTER_EXCEPTION"/>
+    <Class name="network.crypta.support.io.BaseFileBucket"/>
+    <Method name="setDeleteOnExit"/>
+  </Match>
 </FindBugsFilter>

--- a/src/main/java/network/crypta/clients/fcp/AddPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/AddPeer.java
@@ -96,12 +96,15 @@ public class AddPeer extends FCPMessage {
     this.fs = fs;
     this.messageIdentifier = fs.get("Identifier");
     fs.removeValue("Identifier");
-    try {
-      this.trust = FRIEND_TRUST.valueOf(fs.get("Trust"));
-      fs.removeValue("Trust");
-    } catch (NullPointerException _) {
+
+    String trustValue = fs.get("Trust");
+    if (trustValue == null) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "AddPeer requires Trust", messageIdentifier, false);
+    }
+    try {
+      this.trust = FRIEND_TRUST.valueOf(trustValue);
+      fs.removeValue("Trust");
     } catch (IllegalArgumentException _) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_FIELD,
@@ -109,15 +112,18 @@ public class AddPeer extends FCPMessage {
           messageIdentifier,
           false);
     }
-    try {
-      this.visibility = FRIEND_VISIBILITY.valueOf(fs.get("Visibility"));
-      fs.removeValue("Visibility");
-    } catch (NullPointerException _) {
+
+    String visibilityValue = fs.get("Visibility");
+    if (visibilityValue == null) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "AddPeer requires Visibility",
           messageIdentifier,
           false);
+    }
+    try {
+      this.visibility = FRIEND_VISIBILITY.valueOf(visibilityValue);
+      fs.removeValue("Visibility");
     } catch (IllegalArgumentException _) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_FIELD,


### PR DESCRIPTION
## Summary
- Replace `NullPointerException`-driven enum parsing in `AddPeer` with explicit null checks for `Trust` and `Visibility` while preserving protocol error behavior.
- Add a targeted SpotBugs exclusion for `BaseFileBucket#setDeleteOnExit` where `File#deleteOnExit()` may throw `NullPointerException` during JVM shutdown in wrapper-managed environments.
- Keep the change focused to the DCN findings without unrelated refactors.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain`
- `./gradlew spotbugsTest`
- `./gradlew test --tests '*AddPeerTest' --tests '*FileBucketTest' --tests '*TempFileBucketTest' --tests '*PersistentTempFileBucketTest'`

## Notes
- SpotBugs report no longer contains `DCN_NULLPOINTER_EXCEPTION` for this branch.