### PR TITLE
fix(spotbugs): Resolve FProxy Queue initialization circularity

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -316,7 +316,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     }
   }
 
-  static final HTMLNode DOWNLOADS_LINK = QueueToadlet.DOWNLOADS_LINK;
+  static final HTMLNode DOWNLOADS_LINK = HTMLNode.link(DOWNLOADS_PATH).setReadOnly();
 
   private static void addDownloadOptions(
       ToadletContext ctx,


### PR DESCRIPTION
## Summary
- remove the static `FProxyToadlet -> QueueToadlet` link initialization dependency by building `FProxyToadlet.DOWNLOADS_LINK` directly from `DOWNLOADS_PATH`
- break the SpotBugs-reported class initialization cycle between `FProxyToadlet` and `QueueToadlet`
- keep runtime behavior unchanged (same downloads path and read-only link node)

## How to test
- run `./gradlew spotlessApply`
- run `./gradlew spotbugsMain`
- verify `build/reports/spotbugs/spotbugsMain.xml` no longer contains `IC_INIT_CIRCULARITY`
- (optional) run `./gradlew spotbugsTest`