### PR TITLE
fix(spotbugs): Prevent midpoint overflow in RangeSet binary search

### DIFF
--- a/src/main/java/com/onionnetworks/util/RangeSet.java
+++ b/src/main/java/com/onionnetworks/util/RangeSet.java
@@ -609,7 +609,7 @@ public class RangeSet {
     int high = (rangeCount * 2) - 1;
 
     while (low <= high) {
-      int mid = (low + high) / 2;
+      int mid = low + ((high - low) >>> 1);
       long midVal = ranges[mid];
 
       if (midVal < key) {


### PR DESCRIPTION
## Summary
- Replace the midpoint calculation in `RangeSet.binarySearch(long)` with an overflow-safe formula (`low + ((high - low) >>> 1)`).
- Resolve the SpotBugs `IM_AVERAGE_COMPUTATION_COULD_OVERFLOW` finding reported for `RangeSet`.
- Preserve existing binary search behavior while removing overflow risk in edge cases.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain`
- `./gradlew test --tests "*RangeSetTest"`
