### PR TITLE
fix(spotbugs): Remove redundant non-null null checks

### DIFF
--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -1272,7 +1272,6 @@ class SingleFileInserter implements ClientPutState, Serializable {
         meta = Metadata.mkRedirectionManifestWithMetadata(hm);
         metaPutterTargetFilename = null;
         metaBytes = toMetaBytesOrFail(meta, context);
-        if (metaBytes == null) metaBytes = new byte[0];
       }
       return new RedirectResult(meta, metaBytes, metaPutterTargetFilename);
     }

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherCrossSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherCrossSegmentStorage.java
@@ -337,7 +337,6 @@ public class SplitFileFetcherCrossSegmentStorage {
           try {
             // Note: consider adding a segment API to avoid re-decoding and reduce CPU usage.
             SplitFileSegmentKeys keys = segments[blockNo].getSegmentKeys();
-            if (keys == null) return false;
             boolean success =
                 segments[blockNo].innerOnGotKey(
                     key.getNodeCHK(), block, keys, blockNumbers[blockNo], data);

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherSegmentStorage.java
@@ -341,8 +341,7 @@ public class SplitFileFetcherSegmentStorage {
    * parent storage is closed.
    *
    * @return a cached {@link SplitFileSegmentKeys} instance representing decryption/verification
-   *     keys for data and check blocks; {@code null} only when the segment was initialized without
-   *     persisted keys.
+   *     keys for data and check blocks.
    * @throws IOException if reading the checksummed key list fails or a checksum mismatch is
    *     detected.
    */
@@ -360,7 +359,6 @@ public class SplitFileFetcherSegmentStorage {
         // Treat as IOException, i.e., fatal.
         throw new IOException(e);
       }
-      if (keys == null) return null;
       keysCache = new SoftReference<>(keys);
       return keys;
     }
@@ -483,7 +481,6 @@ public class SplitFileFetcherSegmentStorage {
     int totalBlocks = totalBlocks();
     byte[][] allBlocks = readAllBlocks();
     SplitFileSegmentKeys keys = getSegmentKeys();
-    if (keys == null) return;
     BlocksBuildResult build = buildBlockCandidates(totalBlocks, allBlocks);
     if (build.fetchedCount() < blocksForDecode()) {
       handleInsufficientBlocksAndReturn();
@@ -918,7 +915,6 @@ public class SplitFileFetcherSegmentStorage {
    */
   public boolean onGotKey(NodeCHK key, CHKBlock block) throws IOException {
     SplitFileSegmentKeys keys = getSegmentKeys();
-    if (keys == null) return false;
     int blockNumber;
     ClientCHK decodeKey;
     synchronized (this) {
@@ -1659,7 +1655,6 @@ public class SplitFileFetcherSegmentStorage {
     } catch (IOException _) {
       return null;
     }
-    if (keys == null) return null;
     return keys.getKey(blockNum, null, false);
   }
 

--- a/src/main/java/network/crypta/node/NodeIPDetector.java
+++ b/src/main/java/network/crypta/node/NodeIPDetector.java
@@ -495,7 +495,6 @@ public class NodeIPDetector {
 
   public boolean hasDirectlyDetectedIP() {
     InetAddress[] addrs = ipDetector.getAddress(node.network().executor());
-    if (addrs == null) return false;
     for (InetAddress addr : addrs) {
       if (IPUtil.isValidAddress(addr, false)) {
         if (LOG.isDebugEnabled()) LOG.debug("Direct detection available: {}", addr);

--- a/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
+++ b/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
@@ -220,12 +220,7 @@ public class PluginJarUpdater extends NodeUpdater {
       if (this.result != null) oldResult = this.result.asBucket();
       this.result = result;
     }
-    if (oldResult != null) {
-      //noinspection EmptyTryBlock
-      try (var _ = oldResult) {
-        // release previous result bucket
-      }
-    }
+    if (oldResult != null) oldResult.close();
 
     PluginInfoWrapper loaded = pluginManager.findPluginByIdentifier(pluginName);
 

--- a/src/main/kotlin/network/crypta/node/Version.kt
+++ b/src/main/kotlin/network/crypta/node/Version.kt
@@ -306,7 +306,7 @@ fun parseBuildNumberFromVersionStr(
  * @param versionStr The version string from a peer
  */
 fun seenVersion(versionStr: String?) {
-    val v = Fields.commaList(versionStr) ?: return
+    val v = Fields.commaList(versionStr)
     if (v.size < 3) return // bad, but that will be discovered elsewhere
 
     val version =
@@ -422,7 +422,7 @@ private fun parseVersionOrNull(
         return null
     }
 
-    val v = Fields.commaList(version) ?: return null
+    val v = Fields.commaList(version)
     return if (v.size < 3 || !isValidProtocol(v[2])) null else v
 }
 
@@ -614,4 +614,4 @@ fun isBuildAtLeast(
  * @return The node name ("Cryptad", "Fred") or null if the version string
  *    is invalid
  */
-fun parseNodeNameFromVersionStr(version: String?): String? = version?.let { Fields.commaList(it)?.firstOrNull() }
+fun parseNodeNameFromVersionStr(version: String?): String? = version?.let { Fields.commaList(it).firstOrNull() }

--- a/src/test/java/network/crypta/client/filter/ContentFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/ContentFilterTest.java
@@ -344,7 +344,7 @@ class ContentFilterTest {
         "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; "
             + "charset=UTF-16\"></head><body><a href=\"http://www.freenetproject"
             + ".org/\">Blah</a></body></html>";
-    // Ensure even-length boundary before appending the closing HTML so the subsequent
+    // Ensure an even-length boundary before appending the closing HTML so the following
     // UTF-16 segment starts on a 2-byte boundary in the mixed stream.
     s += " ";
     s = s + end;
@@ -393,7 +393,7 @@ class ContentFilterTest {
     }
 
     // Assert: no failure conditions should have been recorded. On failure, dump input for
-    // debugging and include first failure message.
+    // debugging and include the first failure message.
     assertTrue(
         failures.isEmpty(),
         () -> {
@@ -449,10 +449,6 @@ class ContentFilterTest {
 
   private String headFilter(String data) throws Exception {
     String s = htmlFilter(HEAD_OPEN + data + HEAD_CLOSE);
-    if (s == null) {
-      return null;
-    }
-
     MatcherAssert.assertThat(s, startsWith(HEAD_OPEN));
     MatcherAssert.assertThat(s, endsWith(HEAD_CLOSE));
 
@@ -857,7 +853,7 @@ class ContentFilterTest {
     assertEquals(WINDOWS_1252, status.charset);
     assertEquals(typeName, status.mimeType);
 
-    // Ensure extractor was consulted
+    // Ensure the extractor was consulted
     Mockito.verify(extractor, Mockito.atLeastOnce()).getCharsetBufferSize();
     Mockito.verify(extractor, Mockito.atLeastOnce())
         .getCharset(Mockito.any(), Mockito.anyInt(), Mockito.eq(WINDOWS_1252));


### PR DESCRIPTION
## Summary
- Remove redundant null checks that SpotBugs reported as `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` across async fetchers, node version parsing, updater cleanup, and content-filter tests.
- Keep runtime behavior unchanged by deleting dead branches and nullable chaining that cannot be reached under existing API contracts.
- Align `SplitFileFetcherSegmentStorage#getSegmentKeys()` documentation with its effective non-null return behavior.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain spotbugsTest`
- Confirm no `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` entries remain in `build/reports/spotbugs/spotbugsMain.xml` and `build/reports/spotbugs/spotbugsTest.xml`.