### PR TITLE
fix(spotbugs): Fix REC_CATCH_EXCEPTION findings

### DIFF
--- a/src/main/java/com/onionnetworks/fec/FECCodeFactory.java
+++ b/src/main/java/com/onionnetworks/fec/FECCodeFactory.java
@@ -86,7 +86,7 @@ public abstract class FECCodeFactory {
                 "com.onionnetworks.fec.DefaultFECCodeFactory");
         Class<?> clazz = Class.forName(factoryClass);
         def = clazz.asSubclass(FECCodeFactory.class).getDeclaredConstructor().newInstance();
-      } catch (Exception _) {
+      } catch (ReflectiveOperationException | RuntimeException _) {
         // krunky structure, but the easiest way to deal with the
         // exception.
         def = new DefaultFECCodeFactory();

--- a/src/main/java/network/crypta/crypt/BlockCiphers.java
+++ b/src/main/java/network/crypta/crypt/BlockCiphers.java
@@ -1,5 +1,6 @@
 package network.crypta.crypt;
 
+import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
@@ -149,7 +150,7 @@ class BlockCiphers {
         new JceEcbBlockCipher("AES").init(false, new KeyParameter(new byte[keySize]));
       }
       return true;
-    } catch (Exception _) {
+    } catch (GeneralSecurityException | RuntimeException _) {
       return false;
     }
   }

--- a/src/main/java/org/bitpedia/collider/core/Id3Handler.java
+++ b/src/main/java/org/bitpedia/collider/core/Id3Handler.java
@@ -518,7 +518,7 @@ public class Id3Handler {
 
       return info;
 
-    } catch (Exception _) {
+    } catch (IOException | RuntimeException _) {
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- Replace broad `catch (Exception)` handlers in three locations flagged by SpotBugs `REC_CATCH_EXCEPTION`.
- Keep existing fallback behavior intact while narrowing exception types to the concrete checked/runtime categories each call path can throw.
- Eliminate all `REC_CATCH_EXCEPTION` findings from current SpotBugs reports.

## How to test
- Run `./gradlew spotlessApply`
- Run `./gradlew spotbugsMain`
- Run `./gradlew spotbugsTest`
- Verify reports contain no `REC_CATCH_EXCEPTION` entries (for example: `rg "REC_CATCH_EXCEPTION" build/reports/spotbugs/spotbugsMain.xml build/reports/spotbugs/spotbugsTest.xml`)

## Notes
- SpotBugs still reports a separate analysis classpath warning for missing `oshi.annotation.concurrent.ThreadSafe`; this PR does not change that behavior.