### PR TITLE
fix(launcher): Add default branch for Windows message hook

### DIFF
--- a/src/main/kotlin/network/crypta/launcher/WindowsMessageHooks.kt
+++ b/src/main/kotlin/network/crypta/launcher/WindowsMessageHooks.kt
@@ -65,6 +65,7 @@ object WindowsMessageHooks {
   /** Window procedure hook forwarding unhandled messages to the original WNDPROC. */
   private class WndProcHook(hWnd: HWND, private val onQuit: () -> Unit) : WinUser.WindowProc {
     private val prevWndProc: Pointer
+
     @Volatile private var invoked = false
 
     init {
@@ -74,23 +75,29 @@ object WindowsMessageHooks {
       prevWndProc = U32EX.SetWindowLongPtr(hWnd, WinUser.GWL_WNDPROC, fnPtr)
     }
 
-    override fun callback(h: HWND?, uMsg: Int, wParam: WPARAM?, lParam: LPARAM?): LRESULT {
+    override fun callback(h: HWND?, uMsg: Int, wParam: WPARAM?, lParam: LPARAM?): LRESULT =
       when (uMsg) {
         WM_QUERYENDSESSION -> {
           // Begin graceful quit but allow shutdown to continue
           triggerQuitOnce()
-          return LRESULT(1) // TRUE
+          LRESULT(1) // TRUE
         }
+
         WM_ENDSESSION -> {
           if ((wParam?.toInt() ?: 0) != 0) triggerQuitOnce()
+          U32EX.CallWindowProc(prevWndProc, h, uMsg, wParam, lParam)
         }
+
         WinUser.WM_CLOSE -> {
           triggerQuitOnce()
+          U32EX.CallWindowProc(prevWndProc, h, uMsg, wParam, lParam)
+        }
+
+        // Forward all other messages for normal processing.
+        else -> {
+          U32EX.CallWindowProc(prevWndProc, h, uMsg, wParam, lParam)
         }
       }
-      // Forward to the previous window procedure for normal processing
-      return U32EX.CallWindowProc(prevWndProc, h, uMsg, wParam, lParam)
-    }
 
     private fun triggerQuitOnce() {
       if (invoked) return


### PR DESCRIPTION
## Summary
- Refactor `WndProcHook.callback` in `WindowsMessageHooks` to use an exhaustive `when` expression.
- Add explicit handling for non-target Windows messages via an `else` branch that forwards to `CallWindowProc`.
- Preserve existing shutdown-trigger behavior for `WM_QUERYENDSESSION`, `WM_ENDSESSION`, and `WM_CLOSE` while removing the SpotBugs `SF_SWITCH_NO_DEFAULT` finding.

## How to test
- Run `./gradlew spotlessApply`.
- Run `./gradlew spotbugsMain` and verify `SF_SWITCH_NO_DEFAULT` is no longer reported for `WindowsMessageHooks$WndProcHook.callback`.
- (Optional) Run `./gradlew spotbugsTest` to ensure no regressions in SpotBugs task wiring.