### PR TITLE
fix(http): Prevent Cookie hashCode null dereference

### DIFF
--- a/src/main/java/network/crypta/clients/http/Cookie.java
+++ b/src/main/java/network/crypta/clients/http/Cookie.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import network.crypta.support.TimeUtil;
 
@@ -155,7 +156,7 @@ public class Cookie {
 
   @Override
   public int hashCode() {
-    return domain.hashCode() + path.hashCode() + name.hashCode();
+    return Objects.hash(domain == null ? null : domain.toString(), path.toString(), name);
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/CookieTest.java
+++ b/src/test/java/network/crypta/clients/http/CookieTest.java
@@ -192,6 +192,15 @@ class CookieTest {
   }
 
   @Test
+  void hashCode_withoutDomain_matchesEqualsContract() {
+    Cookie first = new Cookie(VALID_PATH, VALID_NAME, VALID_VALUE, FUTURE_DATE);
+    Cookie second = new Cookie(VALID_PATH, VALID_NAME, "ignored", FUTURE_DATE);
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
   void encodeToHeaderValue_includesAllAttributesInOrder() {
     String encoded = cookie.encodeToHeaderValue();
     String expectedExpires = TimeUtil.makeHTTPDate(FUTURE_DATE.toEpochMilli());


### PR DESCRIPTION
## Summary
- fix `Cookie.hashCode()` to handle cookies without a domain attribute instead of dereferencing a null field
- keep hash computation aligned with `equals()` by hashing the domain/path/name string forms used in comparisons
- add a regression test for the no-domain path to preserve equals/hashCode contract behavior

## How to test
1. `./gradlew test --tests 'network.crypta.clients.http.CookieTest'`
2. `./gradlew spotbugsMain`
3. `./gradlew spotbugsTest`
4. Verify SpotBugs reports no `NP_UNWRITTEN_FIELD` entries in:
   - `build/reports/spotbugs/spotbugsMain.xml`
   - `build/reports/spotbugs/spotbugsTest.xml`

## Context
This addresses the SpotBugs `NP_UNWRITTEN_FIELD` finding in `network.crypta.clients.http.Cookie` where `domain` is currently constructed as null but read directly in `hashCode()`.