### PR TITLE
fix(node): Handle startup DM_EXIT paths

### DIFF
--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -90,4 +90,24 @@
     <Class name="network.crypta.support.io.BaseFileBucket"/>
     <Method name="setDeleteOnExit"/>
   </Match>
+
+  <!--
+    Panic mode intentionally forces process restart/termination after sensitive cleanup.
+    The wrapper restart request is followed by an immediate JVM exit by design.
+  -->
+  <Match>
+    <Bug pattern="DM_EXIT"/>
+    <Class name="network.crypta.node.Node"/>
+    <Method name="finishPanic"/>
+  </Match>
+
+  <!--
+    Launcher quit intentionally terminates the JVM after daemon shutdown and UI/resource cleanup.
+    This is generated in the coroutine state-machine class for quitApp().
+  -->
+  <Match>
+    <Bug pattern="DM_EXIT"/>
+    <Class name="~network\.crypta\.launcher\.CryptaLauncher\$quitApp\$.*"/>
+    <Method name="invokeSuspend"/>
+  </Match>
 </FindBugsFilter>

--- a/src/main/java/network/crypta/node/NodeStarter.java
+++ b/src/main/java/network/crypta/node/NodeStarter.java
@@ -520,7 +520,11 @@ public class NodeStarter implements WrapperListener {
       LOG.info("Node initialization completed");
     } catch (NodeInitException e) {
       LOG.error("Node load failed (exitCode={}): {}", e.exitCode, e.getMessage(), e);
-      System.exit(e.exitCode);
+      if (WrapperManager.isControlledByNativeWrapper()) {
+        return e.exitCode;
+      }
+      WrapperManager.stop(e.exitCode);
+      return e.exitCode;
     }
 
     return null;

--- a/src/test/java/network/crypta/node/NodeStarterTest.java
+++ b/src/test/java/network/crypta/node/NodeStarterTest.java
@@ -20,6 +20,7 @@ import network.crypta.crypt.DummyRandomSource;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.io.NativeThread;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -121,8 +122,64 @@ class NodeStarterTest {
       File portDir = new File(tmpDir, "12345");
       assertEquals(new File(portDir, "throttle.dat").toString(), sfs.get("node.throttleFile"));
 
-      // And ensure peers list is cleared on the returned node
+      // And ensure the peers list is cleared on the returned node
       verify(node.network().peers(), times(1)).removeAllPeers();
+    }
+  }
+
+  @Test
+  void start_whenNodeStartupThrowsNodeInitException_andWrapperControlled_returnsExitCode(
+      @TempDir File tmpDir) throws ReflectiveOperationException {
+    NodeStarter ns = newNodeStarterViaReflection();
+    int expectedExitCode = NodeInitException.EXIT_COULD_NOT_START_UPDATER;
+    String[] args = startupArgs(tmpDir);
+
+    try (MockedStatic<WrapperManager> wm = Mockito.mockStatic(WrapperManager.class);
+        MockedConstruction<NativeThread> nativeThreadCtor =
+            Mockito.mockConstruction(NativeThread.class);
+        MockedConstruction<Node> nodeCtor =
+            Mockito.mockConstruction(
+                Node.class,
+                (mock, _) ->
+                    Mockito.doThrow(new NodeInitException(expectedExitCode, "simulated startup"))
+                        .when(mock)
+                        .start(false))) {
+      wm.when(WrapperManager::isControlledByNativeWrapper).thenReturn(true);
+      Integer result = ns.start(args);
+
+      assertEquals(expectedExitCode, result);
+      assertEquals(1, nodeCtor.constructed().size());
+      assertEquals(1, nativeThreadCtor.constructed().size());
+      wm.verify(() -> WrapperManager.signalStarting(500000), times(1));
+      wm.verify(() -> WrapperManager.stop(expectedExitCode), times(0));
+    }
+  }
+
+  @Test
+  void start_whenNodeStartupThrowsNodeInitException_andNotWrapper_stopsProcess(@TempDir File tmpDir)
+      throws ReflectiveOperationException {
+    NodeStarter ns = newNodeStarterViaReflection();
+    int expectedExitCode = NodeInitException.EXIT_COULD_NOT_START_UPDATER;
+    String[] args = startupArgs(tmpDir);
+
+    try (MockedStatic<WrapperManager> wm = Mockito.mockStatic(WrapperManager.class);
+        MockedConstruction<NativeThread> nativeThreadCtor =
+            Mockito.mockConstruction(NativeThread.class);
+        MockedConstruction<Node> nodeCtor =
+            Mockito.mockConstruction(
+                Node.class,
+                (mock, _) ->
+                    Mockito.doThrow(new NodeInitException(expectedExitCode, "simulated startup"))
+                        .when(mock)
+                        .start(false))) {
+      wm.when(WrapperManager::isControlledByNativeWrapper).thenReturn(false);
+      Integer result = ns.start(args);
+
+      assertEquals(expectedExitCode, result);
+      assertEquals(1, nodeCtor.constructed().size());
+      assertEquals(1, nativeThreadCtor.constructed().size());
+      wm.verify(() -> WrapperManager.signalStarting(500000), times(1));
+      wm.verify(() -> WrapperManager.stop(expectedExitCode), times(1));
     }
   }
 
@@ -183,7 +240,7 @@ class NodeStarterTest {
       props.setProperty(WRAPPER_BITS_KEY, "32");
       assertFalse(NodeStarter.isSomething32bits());
 
-      // 32-bit JVM -> expect false even if wrapper says 64
+      // 32-bit JVM -> expect false even if the wrapper says 64
       props.setProperty(WRAPPER_BITS_KEY, "64");
       jvm.when(network.crypta.support.JVMVersion::is32Bit).thenReturn(true);
       assertFalse(NodeStarter.isSomething32bits());
@@ -230,6 +287,30 @@ class NodeStarterTest {
   }
 
   // --- helpers ---
+
+  private static String[] startupArgs(File tmpDir) {
+    File configDir = new File(tmpDir, "config");
+    File dataDir = new File(tmpDir, "data");
+    File cacheDir = new File(tmpDir, "cache");
+    File runDir = new File(tmpDir, "run");
+    File logsDir = new File(tmpDir, "logs");
+    File configFile = new File(configDir, "cryptad.ini");
+
+    return new String[] {
+      "--config-file",
+      configFile.getAbsolutePath(),
+      "--config-dir",
+      configDir.getAbsolutePath(),
+      "--data-dir",
+      dataDir.getAbsolutePath(),
+      "--cache-dir",
+      cacheDir.getAbsolutePath(),
+      "--run-dir",
+      runDir.getAbsolutePath(),
+      "--logs-dir",
+      logsDir.getAbsolutePath(),
+    };
+  }
 
   private static void resetNodeStarterStatics() throws ReflectiveOperationException {
     clearStaticBoolean("isStarted");


### PR DESCRIPTION
## Summary
- Return `NodeInitException` exit codes from `NodeStarter.start()` instead of calling `System.exit(...)` directly.
- In non-wrapper mode, call `WrapperManager.stop(exitCode)` and return the same exit code.
- Add narrowly scoped SpotBugs `DM_EXIT` exclusions for intentional process-termination paths:
  - `Node.finishPanic()`
  - launcher `quitApp()` coroutine state-machine `invokeSuspend`
- Add `NodeStarter` regression tests covering startup failure behavior in both wrapper-controlled and non-wrapper modes.

## How to test
- `./gradlew test --tests '*NodeStarterTest'`
- `./gradlew spotbugsMain`
- `rg -c "<BugInstance type=\"DM_EXIT\"" build/reports/spotbugs/spotbugsMain.xml || echo 0`

## Notes
- `spotbugsMain` still prints the existing informational line about missing analysis class `oshi.annotation.concurrent.ThreadSafe`, but the Gradle task completes successfully.