### PR TITLE
fix(node): Synchronize darknet peer metadata access

### DIFF
--- a/src/main/java/network/crypta/node/DarknetPeerNode.java
+++ b/src/main/java/network/crypta/node/DarknetPeerNode.java
@@ -282,7 +282,7 @@ public final class DarknetPeerNode extends PeerNode {
     queuedToSendN2NMExtraPeerDataFileNumbers = new LinkedHashSet<>();
   }
 
-  private void initializeFromLocalMetadata(SimpleFieldSet fs, String name) {
+  private synchronized void initializeFromLocalMetadata(SimpleFieldSet fs, String name) {
     SimpleFieldSet metadata = fs.subset("metadata");
     if (metadata == null) metadata = new SimpleFieldSet(true);
 
@@ -317,7 +317,8 @@ public final class DarknetPeerNode extends PeerNode {
     }
   }
 
-  private void initializeFromRemoteDefaults(FRIEND_TRUST trust, FRIEND_VISIBILITY visibility2) {
+  private synchronized void initializeFromRemoteDefaults(
+      FRIEND_TRUST trust, FRIEND_VISIBILITY visibility2) {
     if (trust == null) throw new IllegalArgumentException();
     trustLevel = trust;
     ourVisibility = visibility2;
@@ -598,7 +599,7 @@ public final class DarknetPeerNode extends PeerNode {
 
   /** Returns whether the observed source port is ignored when picking a contact address. */
   @Override
-  public boolean isIgnoreSource() {
+  public synchronized boolean isIgnoreSource() {
     return ignoreSourcePort;
   }
 


### PR DESCRIPTION
## Summary
Fix SpotBugs `IS2_INCONSISTENT_SYNC` findings in `DarknetPeerNode` by making synchronization consistent for metadata fields that are read/written across synchronized methods.

## Changes
- Make `initializeFromLocalMetadata(...)` synchronized
- Make `initializeFromRemoteDefaults(...)` synchronized
- Make `isIgnoreSource()` synchronized

These are synchronization-only changes; behavior and data formats are unchanged.

## How to test
- `./gradlew spotbugsMain`
- `./gradlew spotbugsTest`
- `./gradlew test`

## Notes
- This PR intentionally excludes local/staged `SKILL.md` workspace changes.