### PR TITLE
docs(agents): Add codebase-retrieval usage guidance

### DIFF
--- a/.agents/skills/codebase-retrieval/SKILL.md
+++ b/.agents/skills/codebase-retrieval/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: codebase-retrieval
+description: Use the codebase MCP server to semantically search the repo, narrow to 1–5 target files, and only then read/edit. Prefer evidence from repository code over guesses.
+---
+
+## What I do
+- Turn vague repo questions into high-signal semantic retrieval queries.
+- Iterate retrieval 1–4 times to converge on the right files/symbols.
+- Produce a small, evidence-backed target set (usually 1–5 files) before any significant reading or edits.
+
+## When to use me
+Use me when the task depends on **this repository’s reality**, e.g.:
+- “Where is X implemented?”, “How does Y work in this repo?”
+- Debugging stack traces / logs that reference repo code
+- Refactors that must match existing patterns
+- Any time you’re not sure which files are relevant
+
+## How to use the codebase MCP (playbook)
+1) **Start with semantic retrieval** (never skip unless the user already gave exact file paths).
+2) Run **at least one** query. If the results are weak/ambiguous, run 1–3 more:
+    - include synonyms / alternative component names
+    - include exact error text or log fragments
+    - include likely entrypoints (CLI command, HTTP route, job name, config key)
+3) From hits, pick **1–5 candidate files**, then read only the necessary sections:
+    - definitions, call sites, config wiring, and tests
+4) If still unclear:
+    - run another retrieval pass with refined terms
+    - only then fall back to grep/glob/list (when you have exact strings)
+
+## Output expectations
+- Always cite evidence: file paths + symbol names + what you observed.
+- Avoid “repo-wide” claims unless you truly verified broadly.
+
+## Anti-patterns
+- Jumping straight to editing without any retrieval.
+- Treating external/library behavior as repo facts (use the `context7-docs` skill for that).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,13 +21,14 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **$cryptad-launcher-ui** — Work on the Swing launcher: start/stop logic, logging, keyboard shortcuts, FlatLaf/theme handling, and Windows specifics.
 - **$cryptad-packaging** — Build and troubleshoot distributions and installers (assembleCryptadDist, jpackage, Windows wrapper assets, Flatpak, Linux DEB/RPM behavior).
 - **$cryptad-style-docs** — Apply Cryptad Kotlin/Java style, file layout rules, and long-lived documentation/commenting practices.
+- **$codebase-retrieval** — Use semantic codebase retrieval to identify 1–5 target files before significant reading or edits when the file scope is unclear.
 - **$web-search** — Use both Exa and Tavily for external/current web research, then cross-check sources before answering.
 
 ### Skill-first workflow
 
 1. Identify the task domain(s) (build/test, tooling, packaging, updater, platform detection, crypto formats, UI, etc.).
 2. Load the matching skill(s) via `skill(...)`.
-3. Inspect code and run targeted searches (don’t guess).
+3. If relevant files are not already known, load `$codebase-retrieval` first, then inspect code, and run targeted searches (don’t guess).
 4. Make the smallest safe change.
 5. Run the relevant Gradle checks (see `$cryptad-build-test` / `$cryptad-build-tooling`).
 6. Update docs/tests when needed.
@@ -38,12 +39,13 @@ Load only what you need. It’s normal to load multiple skills for one task.
   - Kotlin sources must live under `src/*/kotlin` (including tests). Do not add Kotlin files under `src/*/java/`.
 - **OpenCode LSP:** Treat LSP/typechecker diagnostics as blockers for touched files.
   - If the OpenCode `lsp` tool is enabled, prefer it for definition/reference/hover instead of guessing
+- **Repository discovery:** If the task does not provide exact paths/symbols, load `$codebase-retrieval` before making code changes.
 - **Compatibility:** Avoid breaking persistent formats, on-disk layouts, and wire protocols without an explicit migration plan.
   - For AEAD stream / format changes, load `$cryptad-crypto-aead` first.
 - **Environment detection:** Treat `AppEnv` as the single source of truth. Load `$cryptad-appenv` before touching OS/arch/sandbox/service detection code.
 - **Updater:** For any changes touching CoreUpdater descriptors, endpoints, or UI, load `$cryptad-core-updater`.
 - **Packaging/Installers:** For dist builds, installers, or Flatpak, load `$cryptad-packaging`.
-- **Web research:** For latest/current external information or multi-source fact checks, load `$web-search`.
+- **Web research:** For the latest/current external information or multi-source fact checks, load `$web-search`.
 
 ## Quick commands (high-level)
 


### PR DESCRIPTION
## Summary
- add `.agents/skills/codebase-retrieval/SKILL.md` to define semantic retrieval workflow and expected evidence-based output
- update `AGENTS.md` skill catalog to include `$codebase-retrieval`
- require `$codebase-retrieval` in the skill-first workflow and always-on rules when file/symbol scope is unclear

## How to test
- run `./gradlew spotlessApply`
- inspect `git diff origin/develop...HEAD` to confirm only docs/skill guidance updates are included