### PR TITLE
fix(node): Synchronize keep-alive thread lifecycle

### DIFF
--- a/.agents/skills/codebase-retrieval/SKILL.md
+++ b/.agents/skills/codebase-retrieval/SKILL.md
@@ -8,6 +8,11 @@ description: Use the codebase MCP server to semantically search the repo, narrow
 - Iterate retrieval 1–4 times to converge on the right files/symbols.
 - Produce a small, evidence-backed target set (usually 1–5 files) before any significant reading or edits.
 
+## Index scope (important)
+- The codebase MCP index only includes files under the project's `/src` directory.
+- If the task targets files outside `/src` (for example `.agents/`, `build-logic/`, Gradle files, docs, CI config), do **not** query codebase MCP.
+- For non-`/src` work, use deterministic local search/read tools directly (`rg`, `sed`, `ls`, etc.).
+
 ## When to use me
 Use me when the task depends on **this repository’s reality**, e.g.:
 - “Where is X implemented?”, “How does Y work in this repo?”
@@ -16,8 +21,11 @@ Use me when the task depends on **this repository’s reality**, e.g.:
 - Any time you’re not sure which files are relevant
 
 ## How to use the codebase MCP (playbook)
-1) **Start with semantic retrieval** (never skip unless the user already gave exact file paths).
-2) Run **at least one** query. If the results are weak/ambiguous, run 1–3 more:
+1) **Check scope first**:
+    - if likely files are under `/src`, start with semantic retrieval
+    - if likely files are outside `/src`, skip codebase MCP and use local deterministic search instead
+2) For `/src` tasks, run **at least one** retrieval query.
+If the results are weak/ambiguous, run 1–3 more:
     - include synonyms / alternative component names
     - include exact error text or log fragments
     - include likely entrypoints (CLI command, HTTP route, job name, config key)
@@ -33,4 +41,5 @@ Use me when the task depends on **this repository’s reality**, e.g.:
 
 ## Anti-patterns
 - Jumping straight to editing without any retrieval.
+- Querying codebase MCP for files outside `/src`.
 - Treating external/library behavior as repo facts (use the `context7-docs` skill for that).

--- a/.agents/skills/cryptad-build-tooling/SKILL.md
+++ b/.agents/skills/cryptad-build-tooling/SKILL.md
@@ -18,6 +18,17 @@ Use this skill when you:
 ## Spotless + dependency verification (common failure mode)
 When Gradle dependency verification is strict, Spotless may fail to resolve formatter artifacts even with `mavenCentral()`.
 
+### Spotless target path outside the project dir
+If Spotless fails with an error like:
+```text
+Spotless error! All target files must be within the project dir.
+```
+run:
+```bash
+./gradlew clean
+```
+then retry Spotless (`./gradlew spotlessJava` or `./gradlew spotlessApply`).
+
 ### Procedure to refresh verification metadata for Spotless
 1) Temporarily set verification to lenient:
 - Edit `gradle.properties` → `org.gradle.dependency.verification=lenient`
@@ -67,7 +78,7 @@ Notes:
 - Text reports are disabled (`reports.matching { it.name == "text" }`) so findings are read from XML files instead of large stdout dumps.
 
 ### Tasks
-- Run main analysis:
+- Run the main analysis:
   - `./gradlew spotbugsMain`
   - Report: `build/reports/spotbugs/spotbugsMain.xml`
 - Run test analysis:

--- a/src/main/java/network/crypta/node/NodeStarter.java
+++ b/src/main/java/network/crypta/node/NodeStarter.java
@@ -625,7 +625,7 @@ public class NodeStarter implements WrapperListener {
   }
 
   @SuppressWarnings("java:S1181")
-  private static void startKeepAliveNativePlugThread() {
+  private static synchronized void startKeepAliveNativePlugThread() {
     if (nativeKeepAlivePlugThread != null && nativeKeepAlivePlugThread.isAlive()) {
       return;
     }
@@ -654,7 +654,7 @@ public class NodeStarter implements WrapperListener {
     plug.start();
   }
 
-  private static void stopKeepAliveNativePlugThread() {
+  private static synchronized void stopKeepAliveNativePlugThread() {
     Thread keepAlive = nativeKeepAlivePlugThread;
     nativeKeepAlivePlugThread = null;
     if (keepAlive != null) {


### PR DESCRIPTION
## Summary
- Fix SpotBugs `LI_LAZY_INIT_STATIC` in `NodeStarter` by synchronizing `startKeepAliveNativePlugThread()` and `stopKeepAliveNativePlugThread()`.
- Update `cryptad-build-tooling` skill with a Spotless recovery step for `All target files must be within the project dir` (`./gradlew clean` then retry Spotless).
- Update `codebase-retrieval` skill to document that codebase MCP indexing is limited to `/src` and should not be used for non-`/src` files.

## How to test
1. `./gradlew clean`
2. `./gradlew spotlessJava`
3. `./gradlew spotbugsMain`
4. `./gradlew spotbugsTest`

## Notes
- SpotBugs XML reports show zero `LI_LAZY_INIT_STATIC` findings after the synchronization change.
- Changes were committed on branch `bugfix/spotbugs-li-lazy-init-static` (not on `develop`/`main`).