### PR TITLE
fix(updater): Remove dead UOM takeover condition

### DIFF
--- a/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
+++ b/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
@@ -278,13 +278,12 @@ public class UpdateOverMandatoryManager implements RequestClient {
     if (!stopProcessing) {
       tellFetchers(source);
 
-      // Don't proceed with main-jar logic if blown or disabled
-      if (!updateManager.isBlown() && updateManager.isEnabled()) {
+      // In package-based updater mode there is no main-jar UOM; only revocation is handled.
+      if (!updateManager.isBlown()
+          && updateManager.isEnabled()
+          && NodeUpdateManager.SUPPORTS_JAR_UOM) {
         long now = System.currentTimeMillis();
-        // In package-based updater mode there is no main-jar UOM; only revocation is handled.
-        if (NodeUpdateManager.SUPPORTS_JAR_UOM) {
-          handleMainJarOffer(now, mainJarFileLength, mainJarVersion, source, mainJarKey);
-        }
+        handleMainJarOffer(now, mainJarFileLength, mainJarVersion, source, mainJarKey);
       }
     }
 
@@ -464,8 +463,9 @@ public class UpdateOverMandatoryManager implements RequestClient {
       long now, long mainJarFileLength, int mainJarVersion, PeerNode source, String jarKey) {
 
     long started = NodeUpdateManager.STARTED_FETCHING_NEXT_MAIN_JAR_TIMESTAMP;
-    long whenToTakeOverTheNormalUpdater =
-        (started > 0) ? started + GRACE_TIME : System.currentTimeMillis() + GRACE_TIME;
+    // Legacy main-jar updater start time is not tracked in CoreUpdater mode; use the current offer
+    // time.
+    long whenToTakeOverTheNormalUpdater = now + GRACE_TIME;
     boolean isOutdated = updateManager.getNode().isOutdated();
     // if the new build is self-mandatory, or if the "normal" updater has been trying to update for
     // more than one hour


### PR DESCRIPTION
## Summary
- merge the nested `handleAnnounce()` main-jar UOM guards into one condition to avoid a constant nested branch
- remove the legacy `started > 0` ternary in `handleMainJarOffer()` and compute takeover time as `now + GRACE_TIME`
- keep behavior unchanged for current CoreUpdater mode where `STARTED_FETCHING_NEXT_MAIN_JAR_TIMESTAMP` is `0L`

## How To Test
- run `./gradlew spotlessApply`
- run `./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java`
- optionally run `./gradlew spotbugsMain` and verify no `DLS_DEAD_LOCAL_STORE` findings remain in `build/reports/spotbugs/spotbugsMain.xml`

## Files
- `src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java`