### PR TITLE
build(spotbugs): Suppress intentional absolute path findings

### DIFF
--- a/build-logic/spotbugs-exclude-test.xml
+++ b/build-logic/spotbugs-exclude-test.xml
@@ -32,4 +32,13 @@
     <Bug pattern="CT_CONSTRUCTOR_THROW"/>
     <Class name="network.crypta.support.io.PaddedRandomAccessBucketTest$InMemoryUnderlying"/>
   </Match>
+
+  <!--
+    Path-oriented tests intentionally use absolute path literals to verify resolution behavior for
+    Linux/macOS/Windows scenarios. DMI_HARDCODED_ABSOLUTE_FILENAME is production-oriented and
+    creates high-volume noise for these deterministic test fixtures.
+  -->
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+  </Match>
 </FindBugsFilter>

--- a/build-logic/spotbugs-exclude-test.xml
+++ b/build-logic/spotbugs-exclude-test.xml
@@ -34,11 +34,113 @@
   </Match>
 
   <!--
-    Path-oriented tests intentionally use absolute path literals to verify resolution behavior for
-    Linux/macOS/Windows scenarios. DMI_HARDCODED_ABSOLUTE_FILENAME is production-oriented and
-    creates high-volume noise for these deterministic test fixtures.
+    Path-resolution fixtures intentionally use absolute literals to verify behavior across
+    Linux/macOS/Windows path handling. Keep suppression scoped to known test methods only so
+    new hardcoded-path usage in unrelated tests remains visible.
   -->
   <Match>
     <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.clients.fcp.DownloadRequestStatusTest"/>
+    <Method name="getPreferredFilename_whenDestFileExists_returnsBasename"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.clients.http.LocalDirectoryConfigToadletTest"/>
+    <Method name="allowedDir_whenCalledWithAnyFile_returnsTrue"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.clients.http.LocalDownloadDirectoryToadletTest"/>
+    <Method name="startingDirScenarios"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.clients.http.LocalFileFilterToadletTest"/>
+    <Method name="startingDir_whenAllowedDirsConfigured_returnsFirstPath"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.clients.http.LocalFileInsertToadletTest"/>
+    <Method name="startingDir_whenExplicitUploadDirectoryConfigured_returnsFirstEntry"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="computeWrapperFilePath_whenAbsoluteSpec_expectReturnedAsIs"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="computeWrapperFilePath_whenBlankSpec_expectNull"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="computeWrapperFilePath_whenRelativeAndWorkingDirAbsolute_expectResolvedAgainstWorkingDir"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="computeWrapperFilePath_whenRelativeAndWorkingDirRelative_expectResolvedAgainstConfDir"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="computeWrapperLogPath_whenAbsolute_expectReturnedAsIs"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="computeWrapperLogPath_whenRelative_expectResolvedAgainstConfDir"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="resolveCryptadPath_whenJarMissing_expectCwdFallback"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="resolveCryptadPath_whenJarSameDirExists_expectLocalScript"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="resolveCryptadPath_whenJarSiblingBinExists_expectBinScript"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="scanWrapperConfPath_whenCFlagPresent_expectParsedPath"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="scanWrapperConfPath_whenConfAssignmentPresent_expectParsedPath"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.WrapperConfUtilsTest"/>
+    <Method name="computesLogPathAbsolute"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.WrapperConfUtilsTest"/>
+    <Method name="computesLogPathRelative"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.node.NodeCliTest"/>
+    <Method name="config_file_flag_overrides_positional"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.node.useralerts.DiskSpaceUserAlertTest"/>
+    <Method name="basic_properties_areConsistent"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.node.useralerts.DiskSpaceUserAlertTest"/>
+    <Method name="isValid_boolean_noop_doesNotChangeValidity"/>
   </Match>
 </FindBugsFilter>

--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -110,4 +110,37 @@
     <Class name="~network\.crypta\.launcher\.CryptaLauncher\$quitApp\$.*"/>
     <Method name="invokeSuspend"/>
   </Match>
+
+  <!--
+    These methods intentionally use absolute filesystem paths mandated by platform conventions:
+    - Linux service paths under /etc, /var, /run
+    - macOS system Library roots
+    - XDG runtime fallback under /run/user
+    - rpm-ostree marker file at /run/ostree-booted
+    SpotBugs flags them generically as hardcoded absolute filenames, but they are not derived from
+    untrusted input and are required for correct OS integration.
+  -->
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.fs.DirsKt"/>
+    <Method name="computeStandardXdgRuntime"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.fs.DirsKt"/>
+    <Method name="computeSnapRuntime"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.fs.ServiceDirs"/>
+    <Method name="computeBase"/>
+  </Match>
+
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.node.updater.CoreActionToadlet"/>
+    <Method name="isOstree"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary
- suppress `DMI_HARDCODED_ABSOLUTE_FILENAME` for production methods that intentionally use platform-mandated absolute paths (`/run/user`, Linux service dirs, macOS system dirs, and `/run/ostree-booted` marker)
- suppress `DMI_HARDCODED_ABSOLUTE_FILENAME` in test scope where absolute path literals are intentional fixtures for path-resolution scenarios
- document rationale inline in both SpotBugs exclude files to keep future triage explicit

## Files changed
- `build-logic/spotbugs-exclude.xml`
- `build-logic/spotbugs-exclude-test.xml`

## How to test
1. Run `./gradlew spotbugsMain spotbugsTest --console=plain`
2. Confirm build succeeds
3. Optionally verify reports contain no `DMI_HARDCODED_ABSOLUTE_FILENAME` entries:
   - `build/reports/spotbugs/spotbugsMain.xml`
   - `build/reports/spotbugs/spotbugsTest.xml`

## Notes
- This change removes false-positive noise only; it does not change runtime path resolution behavior.