### PR TITLE
fix(launcher): Fix SpotBugs EI_EXPOSE_STATIC_REP2 exposure

### DIFF
--- a/src/main/kotlin/network/crypta/launcher/Launcher.kt
+++ b/src/main/kotlin/network/crypta/launcher/Launcher.kt
@@ -7,6 +7,7 @@ import java.awt.desktop.QuitResponse
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import java.util.concurrent.atomic.AtomicReference
 import javax.swing.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.collectLatest
@@ -15,7 +16,7 @@ import network.crypta.fs.AppEnv
 /** Application display name used across the launcher UI and system integration. */
 internal const val APP_NAME: String = "Crypta Launcher"
 
-@Volatile private var launcherInstance: CryptaLauncher? = null
+private val launcherInstanceRef = AtomicReference<CryptaLauncher?>(null)
 
 /**
  * Crypta Swing Launcher (View).
@@ -289,7 +290,7 @@ class CryptaLauncher : JFrame(APP_NAME) {
         logDebug("Failed to remove global key dispatcher", t)
       }
       dispose()
-      launcherInstance = null
+      launcherInstanceRef.set(null)
       uiScope.cancel()
       try {
         ThemeSwitcher.shutdown()
@@ -467,7 +468,7 @@ private fun createAndShowLauncherUi() {
 }
 
 private fun registerLauncherInstance(launcher: CryptaLauncher) {
-  launcherInstance = launcher
+  launcherInstanceRef.set(launcher)
 }
 
 private fun setWindowAndDockIcons(f: JFrame) {
@@ -512,7 +513,7 @@ private fun registerJvmShutdownHook() {
       .addShutdownHook(
         Thread {
           try {
-            launcherInstance?.shutdownFromSignal()
+            launcherInstanceRef.get()?.shutdownFromSignal()
           } catch (t: Throwable) {
             logDebug("Shutdown hook failed during shutdownFromSignal()", t)
           }


### PR DESCRIPTION
## Summary
- Replace the top-level mutable launcher singleton state with an `AtomicReference` in `Launcher.kt`.
- Update launcher lifecycle call sites (`registerLauncherInstance`, quit flow, and JVM shutdown hook) to use `set()` / `get()`.
- Eliminate the SpotBugs `EI_EXPOSE_STATIC_REP2` finding on `LauncherKt.launcherInstance`.

## How to test
- `./gradlew spotlessApply`
- `./gradlew spotbugsMain`
- `./gradlew spotbugsTest`
- `grep -c "EI_EXPOSE_STATIC_REP2" build/reports/spotbugs/spotbugsMain.xml`
- `grep -c "EI_EXPOSE_STATIC_REP2" build/reports/spotbugs/spotbugsTest.xml`

Expected result: both grep checks return `0`.