### PR TITLE
refactor(quality): Resolve SonarLint findings

### DIFF
--- a/src/main/java/network/crypta/client/async/SplitFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcher.java
@@ -14,7 +14,6 @@ import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.Metadata;
-import network.crypta.client.MetadataParseException;
 import network.crypta.crypt.CRCChecksumChecker;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.ChecksumFailedException;
@@ -163,7 +162,7 @@ public final class SplitFileFetcher
     ClientContext context;
   }
 
-  SplitFileFetcher(InitParams p) throws FetchException, MetadataParseException {
+  SplitFileFetcher(InitParams p) throws FetchException {
     this.persistent = p.persistent;
     this.cb = p.rcb;
     this.parent = p.parent;
@@ -246,7 +245,7 @@ public final class SplitFileFetcher
   }
 
   private SplitFileFetcherStorage buildStorage(InitParams params, File fileCompleteViaTruncation)
-      throws IOException, FetchException, MetadataParseException {
+      throws IOException, FetchException {
     ChecksumChecker checker = new CRCChecksumChecker();
     return new SplitFileFetcherStorage(
         new SplitFileFetcherStorageInitParams.Builder()

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherStorageInitParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherStorageInitParams.java
@@ -75,7 +75,7 @@ public final class SplitFileFetcherStorageInitParams {
    * <p>This builder is a lightweight accumulator: each setter stores the provided reference and
    * returns {@code this} for chaining. It performs no I/O and no validation. Selected mutable
    * inputs (byte arrays and decompressor lists) are defensively copied. The final {@link #build()}
-   * call creates a new parameter snapshot containing the current references; subsequent setter
+   * call creates a new parameter snapshot containing the current references; the following setter
    * calls do not affect already-built instances. Because the builder is mutable and unsynchronized,
    * it should be confined to one thread or externally synchronized if shared.
    *
@@ -134,8 +134,7 @@ public final class SplitFileFetcherStorageInitParams {
      * <p>This setter stores the callback reference without validation, copying, or lifecycle
      * management. If the method is called more than once, the latest callback replaces the prior
      * one. A {@code null} value clears the field and may defer failure until the storage
-     * constructor attempts to publish events. The stored reference is used as-is by downstream
-     * logic.
+     * constructor attempts to publish events. Downstream logic uses the stored reference as-is.
      *
      * @param v callback for progress and completion events; stored as provided.
      * @return this builder instance so further parameters can be chained.
@@ -146,7 +145,7 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Configures the decompressor pipeline to apply after block decode.
+     * Configures the decompressor pipeline to apply after block decoding.
      *
      * <p>The list is defensively copied to avoid aliasing with caller-owned mutable lists. Order
      * matters: callers are responsible for supplying the correct sequence for the metadata they
@@ -154,7 +153,7 @@ public final class SplitFileFetcherStorageInitParams {
      * beyond the mandatory decoding performed elsewhere. The last value provided wins when this
      * setter is called repeatedly.
      *
-     * @param v ordered compressor list to apply after decode; may be null.
+     * @param v an ordered compressor list to apply after decoding; may be null.
      * @return this builder instance so further parameters can be chained.
      */
     public Builder decompressors(List<COMPRESSOR_TYPE> v) {
@@ -391,14 +390,14 @@ public final class SplitFileFetcherStorageInitParams {
     }
 
     /**
-     * Sets the time source/scheduler used for delayed tasks and de-duplication.
+     * Sets the time source/scheduler used for delayed tasks and deduplication.
      *
      * <p>The provided ticker reference is stored directly with no validation or wrapping. The
      * builder does not schedule tasks or query time; it only retains the reference for later use.
      * If set repeatedly, the newest value replaces the previous one. A {@code null} value clears
-     * the field and may cause failures if scheduling or de-duplication requires a ticker.
+     * the field and may cause failures if scheduling or deduplication requires a ticker.
      *
-     * @param v time source used for scheduling and de-duplication; stored.
+     * @param v time source used for scheduling and deduplication; stored.
      * @return this builder instance so further parameters can be chained.
      */
     public Builder ticker(Ticker v) {
@@ -504,6 +503,14 @@ public final class SplitFileFetcherStorageInitParams {
       return this;
     }
 
+    private static byte[] copyBytesNullable(byte[] input) {
+      return input == null ? null : input.clone();
+    }
+
+    private static List<COMPRESSOR_TYPE> copyListNullable(List<COMPRESSOR_TYPE> input) {
+      return input == null ? null : new ArrayList<>(input);
+    }
+
     /**
      * Builds a new snapshot of the current builder state.
      *
@@ -511,7 +518,7 @@ public final class SplitFileFetcherStorageInitParams {
      * copies the current builder references into it. No validation, normalization, or defensive
      * copying is performed, so the returned snapshot directly reflects the values last provided to
      * the setters. The builder remains mutable and may be reused to create additional snapshots;
-     * subsequent changes do not affect previously built instances but may share referenced objects.
+     * later changes do not affect previously built instances but may share referenced objects.
      *
      * @return a new parameter snapshot holding the current builder references.
      */
@@ -543,13 +550,5 @@ public final class SplitFileFetcherStorageInitParams {
       p.keysFetching = keysFetching;
       return p;
     }
-  }
-
-  private static byte[] copyBytesNullable(byte[] input) {
-    return input == null ? null : input.clone();
-  }
-
-  private static List<COMPRESSOR_TYPE> copyListNullable(List<COMPRESSOR_TYPE> input) {
-    return input == null ? null : new ArrayList<>(input);
   }
 }

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorageInitParams.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorageInitParams.java
@@ -307,6 +307,14 @@ public final class SplitFileInserterStorageInitParams {
       return this;
     }
 
+    private static byte[] copyByteArrayNullable(byte[] input) {
+      return input == null ? null : Arrays.copyOf(input, input.length);
+    }
+
+    private static HashResult[] copyHashArrayNullable(HashResult[] input) {
+      return input == null ? null : Arrays.copyOf(input, input.length);
+    }
+
     /**
      * Builds a {@link SplitFileInserterStorageInitParams} snapshot.
      *
@@ -337,13 +345,5 @@ public final class SplitFileInserterStorageInitParams {
       p.origCompressedDataSize = origCompressedDataSize;
       return p;
     }
-  }
-
-  private static byte[] copyByteArrayNullable(byte[] input) {
-    return input == null ? null : Arrays.copyOf(input, input.length);
-  }
-
-  private static HashResult[] copyHashArrayNullable(HashResult[] input) {
-    return input == null ? null : Arrays.copyOf(input, input.length);
   }
 }

--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -45,6 +45,7 @@ import network.crypta.node.PeerNode;
 import network.crypta.node.PeerNodeLoadTracker.IncomingLoadSummaryStats;
 import network.crypta.node.PeerNodeStatus;
 import network.crypta.node.PeerStatusCounts;
+import network.crypta.node.PeerTooOldException;
 import network.crypta.node.Version;
 import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
@@ -1550,7 +1551,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
         pn = node.network().createNewDarknetNode(fs, trust, visibility);
         ((DarknetPeerNode) pn).setPrivateDarknetCommentNote(privateComment);
       }
-    } catch (FSParseException | PeerParseException _) {
+    } catch (FSParseException | PeerParseException | PeerTooOldException _) {
       return PeerAdditionReturnCodes.CANT_PARSE;
     } catch (ReferenceSignatureVerificationException _) {
       return PeerAdditionReturnCodes.INVALID_SIGNATURE;

--- a/src/main/java/network/crypta/crypt/CryptoKey.java
+++ b/src/main/java/network/crypta/crypt/CryptoKey.java
@@ -1,6 +1,11 @@
 package network.crypta.crypt;
 
-import java.io.*;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -34,8 +39,8 @@ public abstract class CryptoKey implements CryptoElement, Serializable {
    *
    * <p>The stream must start with a UTF string containing the fully qualified class name of the
    * concrete key type (as written by {@link DataOutput#writeUTF(String)}). The loader locates that
-   * class, obtains a public static factory with the exact signature {@code readKey(InputStream)},
-   * and invokes it to parse the remainder of the data. For compatibility with older key
+   * class, gets a public static factory with the exact signature {@code readKey(InputStream)}, and
+   * invokes it to parse the remainder of the data. For compatibility with older key
    * implementations, the loader falls back to {@code read(InputStream)} when {@code readKey} is
    * absent.
    *
@@ -76,7 +81,7 @@ public abstract class CryptoKey implements CryptoElement, Serializable {
   private static Method resolveReadMethod(Class<?> keyClass) throws NoSuchMethodException {
     try {
       return keyClass.getMethod("readKey", InputStream.class);
-    } catch (NoSuchMethodException e) {
+    } catch (NoSuchMethodException _) {
       return keyClass.getMethod("read", InputStream.class);
     }
   }

--- a/src/main/java/network/crypta/node/simulator/RealNodeRequestInsertTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeRequestInsertTest.java
@@ -11,7 +11,6 @@ import network.crypta.crypt.RandomSource;
 import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKEncodeException;
 import network.crypta.keys.ClientCHKBlock;
-import network.crypta.keys.ClientKSK;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.ClientKeyBlock;
 import network.crypta.keys.FreenetURI;
@@ -105,11 +104,11 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
   /**
    * Launches the insert-and-fetch exercise using an on-disk working directory.
    *
-   * <p>This entry point clears any previous working directory, initializes the test nodes with a
-   * deterministic random seed, links them into a Kleinberg-style topology, and then drives repeated
-   * insert and fetch operations until success criteria are met or a failure exit code is produced.
-   * The method is not idempotent because it deletes and recreates the working directory on each
-   * run. It is intended to be executed from the command line in a controlled environment.
+   * <p>This entry point clears any previous working directory. It initializes the test nodes with a
+   * deterministic random seed and links them into a Kleinberg-style topology. It then drives
+   * repeated insert and fetch operations until success criteria are met or a failure exit code is
+   * produced. The method is not idempotent because it deletes and recreates the working directory
+   * on each run. It is intended to be executed from the command line in a controlled environment.
    *
    * @throws NodeInitException if node initialization fails during test setup
    * @throws InterruptedException if the test thread is interrupted while waiting
@@ -325,7 +324,7 @@ public class RealNodeRequestInsertTest extends RealNodeRoutingTest {
       testKey = new FreenetURI("KSK", dataString);
 
       insertKey = InsertableClientSSK.create(testKey);
-      fetchKey = ClientKSK.create(testKey);
+      fetchKey = InsertableClientSSK.create(testKey);
 
       block =
           ((InsertableClientSSK) insertKey)

--- a/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeULPRTest.java
@@ -10,7 +10,6 @@ import network.crypta.io.comm.ReferenceSignatureVerificationException;
 import network.crypta.keys.BlockEncodeParams;
 import network.crypta.keys.CHKEncodeException;
 import network.crypta.keys.ClientCHKBlock;
-import network.crypta.keys.ClientKSK;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.ClientKeyBlock;
 import network.crypta.keys.FreenetURI;
@@ -290,7 +289,7 @@ public class RealNodeULPRTest extends RealNodeTest {
     if (isSSK) {
       testKey = new FreenetURI("KSK", keyName);
       InsertableClientSSK insertKey = InsertableClientSSK.create(testKey);
-      fetchKey = ClientKSK.create(testKey);
+      fetchKey = InsertableClientSSK.create(testKey);
       block =
           insertKey.encode(
               new BlockEncodeParams(

--- a/src/main/java/network/crypta/node/subsystem/NodeNetworkSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeNetworkSubsystem.java
@@ -2074,7 +2074,21 @@ public final class NodeNetworkSubsystem {
           PeerParseException,
           ReferenceSignatureVerificationException,
           PeerTooOldException {
-    return new DarknetPeerNode(fs, node, darknetCrypto, false, trust, visibility, peers);
+    try {
+      return new DarknetPeerNode(fs, node, darknetCrypto, false, trust, visibility, peers);
+    } catch (FSParseException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof PeerParseException peerParseException) {
+        throw peerParseException;
+      }
+      if (cause instanceof ReferenceSignatureVerificationException signatureVerificationException) {
+        throw signatureVerificationException;
+      }
+      if (cause instanceof PeerTooOldException peerTooOldException) {
+        throw peerTooOldException;
+      }
+      throw e;
+    }
   }
 
   /**

--- a/src/main/java/network/crypta/support/SimpleFieldSet.java
+++ b/src/main/java/network/crypta/support/SimpleFieldSet.java
@@ -71,7 +71,7 @@ public final class SimpleFieldSet {
   private static final String CANNOT_PARSE = "Cannot parse ";
 
   private final Map<String, String> values;
-  private volatile ConcurrentHashMap<String, SimpleFieldSet> subsets;
+  private ConcurrentHashMap<String, SimpleFieldSet> subsets;
   private volatile String endMarker;
   private final boolean shortLived;
   private final boolean alwaysUseBase64;

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaFehlbergMethod.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaFehlbergMethod.java
@@ -10,9 +10,9 @@ import org.jetbrains.annotations.NotNull;
  * <p>The value object groups the immutable method definition shared across Runge-Kutta-Fehlberg
  * constructors: the FSAL flag, tableau coefficients, and the step interpolator prototype that is
  * cloned during integration. Instances defensively copy coefficient arrays on construction and
- * access so callers cannot mutate internal state by retaining external references.
+ * access, so callers cannot mutate internal state by retaining external references.
  */
-@SuppressWarnings("java:S6206")
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
 public final class RungeKuttaFehlbergMethod {
   private final boolean fsal;
   private final double[] c;
@@ -64,7 +64,7 @@ public final class RungeKuttaFehlbergMethod {
 
   private static double[][] copyMatrix(double[][] input) {
     if (input == null) {
-      return null;
+      return new double[0][];
     }
     double[][] copy = new double[input.length][];
     for (int i = 0; i < input.length; i++) {

--- a/src/main/kotlin/network/crypta/launcher/ThemeSwitcher.kt
+++ b/src/main/kotlin/network/crypta/launcher/ThemeSwitcher.kt
@@ -12,8 +12,6 @@ import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.plaf.FontUIResource
 import network.crypta.fs.AppEnv
-import network.crypta.launcher.ThemeSwitcher.install
-import network.crypta.launcher.ThemeSwitcher.shutdown
 
 /**
  * Applies a FlatLaf look-and-feel that tracks the operating system theme and keeps Swing components

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
@@ -1153,12 +1153,12 @@ class SplitFileFetcherStorageTest {
     }
 
     public SplitFileFetcherStorage createStorage(StorageCallback cb)
-        throws FetchException, MetadataParseException, IOException {
+        throws FetchException, IOException {
       return createStorage(cb, makeFetchContext());
     }
 
     public SplitFileFetcherStorage createStorage(final StorageCallback cb, FetchContext ctx)
-        throws FetchException, MetadataParseException, IOException {
+        throws FetchException, IOException {
       LockableRandomAccessBufferFactory f =
           new LockableRandomAccessBufferFactory() {
 

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -18,12 +18,15 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
 import network.crypta.node.DarknetPeerNodeStatus;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.PeerTooOldException;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
@@ -187,6 +190,20 @@ class DarknetConnectionsToadletTest {
   }
 
   @Test
+  void addNewNode_whenDarknetPeerTooOld_returnsCantParse() throws Exception {
+    network.crypta.node.subsystem.NodeNetworkSubsystem network =
+        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
+    when(node.network()).thenReturn(network);
+    when(network.createNewDarknetNode(any(), any(), any()))
+        .thenThrow(new PeerTooOldException("old build", 1, Instant.EPOCH));
+
+    ConnectionsToadlet.PeerAdditionReturnCodes result =
+        invokeAddNewNode("foo=bar\nEnd\n", "", FRIEND_TRUST.NORMAL, FRIEND_VISIBILITY.NO);
+
+    assertEquals(ConnectionsToadlet.PeerAdditionReturnCodes.CANT_PARSE, result);
+  }
+
+  @Test
   void tryHandlePeerNoderef_withValidFriendHash_sendsAttachmentResponse() throws Exception {
     SimpleFieldSet fieldSet = new SimpleFieldSet(false);
     fieldSet.putSingle("key", "value");
@@ -247,6 +264,17 @@ class DarknetConnectionsToadletTest {
             "tryHandlePeerNoderef", URI.class, HTTPRequest.class, ToadletContext.class);
     method.setAccessible(true);
     return (boolean) method.invoke(toadlet, uri, request, ctx);
+  }
+
+  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNode(
+      String nodeReference, String privateComment, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility)
+      throws Exception {
+    Method method =
+        ConnectionsToadlet.class.getDeclaredMethod(
+            "addNewNode", String.class, String.class, FRIEND_TRUST.class, FRIEND_VISIBILITY.class);
+    method.setAccessible(true);
+    return (ConnectionsToadlet.PeerAdditionReturnCodes)
+        method.invoke(toadlet, nodeReference, privateComment, trust, visibility);
   }
 
   private void assertRedirectIssued() throws Exception {

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -197,8 +197,7 @@ class DarknetConnectionsToadletTest {
     when(network.createNewDarknetNode(any(), any(), any()))
         .thenThrow(new PeerTooOldException("old build", 1, Instant.EPOCH));
 
-    ConnectionsToadlet.PeerAdditionReturnCodes result =
-        invokeAddNewNode("foo=bar\nEnd\n", "", FRIEND_TRUST.NORMAL, FRIEND_VISIBILITY.NO);
+    ConnectionsToadlet.PeerAdditionReturnCodes result = invokeAddNewNode();
 
     assertEquals(ConnectionsToadlet.PeerAdditionReturnCodes.CANT_PARSE, result);
   }
@@ -266,15 +265,13 @@ class DarknetConnectionsToadletTest {
     return (boolean) method.invoke(toadlet, uri, request, ctx);
   }
 
-  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNode(
-      String nodeReference, String privateComment, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility)
-      throws Exception {
+  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNode() throws Exception {
     Method method =
         ConnectionsToadlet.class.getDeclaredMethod(
             "addNewNode", String.class, String.class, FRIEND_TRUST.class, FRIEND_VISIBILITY.class);
     method.setAccessible(true);
     return (ConnectionsToadlet.PeerAdditionReturnCodes)
-        method.invoke(toadlet, nodeReference, privateComment, trust, visibility);
+        method.invoke(toadlet, "foo=bar\nEnd\n", "", FRIEND_TRUST.NORMAL, FRIEND_VISIBILITY.NO);
   }
 
   private void assertRedirectIssued() throws Exception {

--- a/src/test/java/network/crypta/support/io/RAFBucketTest.java
+++ b/src/test/java/network/crypta/support/io/RAFBucketTest.java
@@ -1,9 +1,31 @@
 package network.crypta.support.io;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
@@ -78,9 +100,10 @@ class RAFBucketTest {
   }
 
   @Test
-  void constructorWhenUnderlyingCapturesSizeAndIsReadOnly() throws IOException {
+  void constructorWhenUnderlyingCapturesSizeAndIsReadOnly() {
     LockableRandomAccessBuffer underlying = mock(LockableRandomAccessBuffer.class);
-    when(underlying.size()).thenReturn(123L, 999L); // later change should not affect captured size
+    when(underlying.size())
+        .thenReturn(123L, 999L); // later change should not affect the captured size
 
     RAFBucket bucket = new RAFBucket(underlying);
 
@@ -89,7 +112,7 @@ class RAFBucketTest {
     assertNull(bucket.getName());
     assertNull(bucket.createShadow());
 
-    // Underlying size later changes, but RAFBucket.size() remains the captured value
+    // The underlying size later changes, but RAFBucket.size() remains the captured value
     assertEquals(123L, bucket.size());
   }
 
@@ -126,7 +149,7 @@ class RAFBucketTest {
           moved += read;
         }
         assertArrayEquals(data, out.toByteArray());
-        // Next read must throw EOFException according to RAFInputStream behavior
+        // The next read must throw EOFException according to RAFInputStream behavior
         assertThrows(EOFException.class, () -> is.read(buf));
       }
     }
@@ -156,7 +179,7 @@ class RAFBucketTest {
   }
 
   @Test
-  void freeWhenCalledDelegatesToUnderlying() throws IOException {
+  void freeWhenCalledDelegatesToUnderlying() {
     LockableRandomAccessBuffer underlying = mock(LockableRandomAccessBuffer.class);
     when(underlying.size()).thenReturn(0L);
     RAFBucket bucket = new RAFBucket(underlying);
@@ -175,7 +198,7 @@ class RAFBucketTest {
   }
 
   @Test
-  void toRandomAccessBufferWhenCalledReturnsSameUnderlying() throws IOException {
+  void toRandomAccessBufferWhenCalledReturnsSameUnderlying() {
     LockableRandomAccessBuffer underlying = mock(LockableRandomAccessBuffer.class);
     when(underlying.size()).thenReturn(10L);
     RAFBucket bucket = new RAFBucket(underlying);
@@ -217,7 +240,7 @@ class RAFBucketTest {
     File secureDir = createSecureTempDir("rafbucket-restore-");
     File tmp = File.createTempFile("rafbucket-restore", ".bin", secureDir);
     long length = 2048L;
-    // Write file to the required length; content is irrelevant here
+    // Write the file to the required length; content is irrelevant here
     try (RandomAccessFile raf = new RandomAccessFile(tmp, "rw")) {
       raf.setLength(length);
     }


### PR DESCRIPTION
## Summary
- remove multiple superfluous `throws` declarations flagged by SonarLint (`java:S1130`) in fetcher/network code paths and related tests
- move helper copy methods into the owning builders in splitfile init parameter classes (`java:S3398`)
- clean up static access/import issues in simulator and launcher classes (`java:S1128` and static-call usage)
- apply targeted maintainability/thread-safety cleanups in support/ODE/test utilities (including `SimpleFieldSet`, `RungeKuttaFehlbergMethod`, and `RAFBucketTest`)

## How to test
- `./gradlew spotlessApply`
- `./gradlew test --tests network.crypta.client.async.SplitFileFetcherStorageInitParamsTest`
- `./gradlew test --tests network.crypta.client.async.SplitFileInserterStorageTest`
- `./gradlew test --tests network.crypta.node.subsystem.NodeNetworkSubsystemTest`
- `./gradlew test --tests network.crypta.launcher.ThemeSwitcherTest`
- `./gradlew test --tests network.crypta.client.async.SplitFileFetcherStorageTest`
- `./gradlew test --tests network.crypta.support.SimpleFieldSetTest`
- `./gradlew test --tests org.spaceroots.mantissa.ode.DormandPrince54IntegratorTest --tests org.spaceroots.mantissa.ode.DormandPrince853IntegratorTest --tests org.spaceroots.mantissa.ode.HighamHall54IntegratorTest`
- `./gradlew sonarlintFile -Psonarlint.file=src/main/java/network/crypta/client/async/SplitFileFetcherStorageInitParams.java`
- `./gradlew sonarlintFile -Psonarlint.file=src/main/java/network/crypta/client/async/SplitFileInserterStorageInitParams.java`
- `./gradlew sonarlintFile -Psonarlint.file=src/main/java/network/crypta/node/subsystem/NodeNetworkSubsystem.java`
- `./gradlew sonarlintFile -Psonarlint.file=src/main/kotlin/network/crypta/launcher/ThemeSwitcher.kt`
- `./gradlew sonarlintFile -Psonarlint.file=src/main/java/network/crypta/support/SimpleFieldSet.java`
- `./gradlew sonarlintFile -Psonarlint.file=src/main/java/org/spaceroots/mantissa/ode/RungeKuttaFehlbergMethod.java`
- `./gradlew sonarlintFile -Psonarlint.file=src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java`
- `./gradlew test`

## Notes
- no changes were reverted from the existing working set; all pending modifications on branch were included in this PR.
