### PR TITLE
refactor(node): Extract PeerNode runtime and handshake lifecycle

### DIFF
--- a/src/main/java/network/crypta/node/OpennetNoderefValidator.java
+++ b/src/main/java/network/crypta/node/OpennetNoderefValidator.java
@@ -31,7 +31,7 @@ public final class OpennetNoderefValidator {
       byte[] noderef, PeerNode from, boolean forceOpennetEnabled) {
     SimpleFieldSet ref;
     try {
-      ref = PeerNode.compressedNoderefToFieldSet(noderef, noderef.length);
+      ref = PeerNodeReferenceSupport.compressedNoderefToFieldSet(noderef, 0, noderef.length);
     } catch (FSParseException e) {
       LOG.error("Invalid noderef: {}", e, e);
       return null;

--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -7,11 +7,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.lang.ref.WeakReference;
 import java.security.interfaces.ECPublicKey;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import network.crypta.io.comm.Peer;
@@ -52,7 +51,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
 
   // SFS keys used more than once: keep as constants to avoid duplication warnings
   private static final String SFS_KEY_VERSION = "version";
-  private static final String SFS_KEY_LOCATION = "location";
+  static final String SFS_KEY_LOCATION = "location";
   private static final String SFS_KEY_LAST_GOOD_VERSION = "lastGoodVersion";
   static final String SFS_KEY_TESTNET = "testnet";
   private static final String SFS_KEY_NEG_TYPES = "auth.negTypes";
@@ -63,7 +62,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private static final String SFS_KEY_PEER_ADDED_TIME = "peerAddedTime";
   private static final String SFS_KEY_DETECTED_UDP = "detected.udp";
   private static final String STR_MS_FOR = "ms for ";
-  private static final String STR_FOR = " for ";
+  static final String STR_FOR = " for ";
   private static final String STR_MS_ON = "ms on ";
   static final String STR_ON = ") on ";
   private static final String STR_WORKING_ON = ") working on ";
@@ -74,7 +73,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   static final String SFS_KEY_ARK_NUMBER = "ark.number";
   static final String SFS_KEY_SIG_P256 = "sigP256";
 
-  private final PeerNodeInternals internals;
+  private final PeerNodeRuntime internals;
 
   private String lastGoodVersion;
 
@@ -213,8 +212,8 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   /** My OutgoingPacketMangler i.e., the object which encrypts packets sent to this node */
   private final OutgoingPacketMangler outgoingMangler;
 
-  /** Advertised addresses */
-  volatile List<Peer> nominalPeer;
+  /** Advertised addresses. CopyOnWriteArrayList supports lock-free iteration by readers. */
+  CopyOnWriteArrayList<Peer> nominalPeer;
 
   /** The PeerNode's report of our IP address */
   private Peer remoteDetectedPeer;
@@ -223,34 +222,34 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   public final boolean testnetEnabled;
 
   /** Packets sent/received on the current preferred key */
-  private SessionKey currentTracker;
+  SessionKey currentTracker;
 
   /** Previous key - has a separate packet number space */
-  private SessionKey previousTracker;
+  SessionKey previousTracker;
 
   /** When did we last rekey (promote the unverified tracker to new)? */
-  private volatile long timeLastRekeyed;
+  volatile long timeLastRekeyed;
 
   /** How much data did we send with the current tracker? */
-  private volatile long totalBytesExchangedWithCurrentTracker = 0;
+  volatile long totalBytesExchangedWithCurrentTracker = 0;
 
   /** Are we rekeying? */
-  private volatile boolean isRekeying = false;
+  volatile boolean isRekeying = false;
 
   /** Unverified tracker - will be promoted to the currentTracker if we receive packets on it */
-  private SessionKey unverifiedTracker;
+  SessionKey unverifiedTracker;
 
   /** When did we last send a packet? */
-  private volatile long timeLastSentPacket;
+  volatile long timeLastSentPacket;
 
   /** When did we last receive a packet? */
-  private volatile long timeLastReceivedPacket;
+  volatile long timeLastReceivedPacket;
 
   /** When did we last receive a non-auth packet? */
-  private volatile long timeLastReceivedDataPacket;
+  volatile long timeLastReceivedDataPacket;
 
   /** When did we last receive an ack? */
-  private volatile long timeLastReceivedAck;
+  volatile long timeLastReceivedAck;
 
   /** When was isRoutingCompatible() last true? */
   private long timeLastRoutable;
@@ -258,7 +257,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   /** Time added or restarted (reset on startup unlike peerAddedTime) */
   private final long timeAddedOrRestarted;
 
-  private final AtomicLong countSelectionsSinceConnected = new AtomicLong();
+  final AtomicLong countSelectionsSinceConnected = new AtomicLong();
 
   /**
    * Percentage threshold that triggers a selection warning for this peer. The value is expressed as
@@ -276,7 +275,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   public static final int SELECTION_MIN_PEERS = 5;
 
   // Note: isRoutable() depends on more than this flag.
-  private volatile boolean isRoutable;
+  volatile boolean isRoutable;
 
   /** Used by maybeOnConnect */
   private volatile boolean wasDisconnected = true;
@@ -288,7 +287,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private boolean removed;
 
   /** Number of handshake attempts since the last successful connection or ARK fetch */
-  private final AtomicInteger handshakeCount = new AtomicInteger();
+  final AtomicInteger handshakeCount = new AtomicInteger();
 
   /** After these many failed handshakes, we start the ARK fetcher. */
   private static final int MAX_HANDSHAKE_COUNT = 2;
@@ -400,7 +399,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     long completedHandshake(Object params);
   }
 
-  private final HandshakeState handshake;
+  final HandshakeState handshake;
 
   /**
    * The other side's boot ID. This is a random number generated at startup. LOCKING: It is far too
@@ -409,23 +408,23 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * really a consistency issue with the rest of PeerNode. So it's okay to effectively use a
    * separate lock for it.
    */
-  private volatile long bootID;
+  volatile long bootID;
 
   /**
    * Our boot ID. This is set to a random number on startup, and then reset whenever we dump the
    * in-flight messages and call disconnected() on their clients, i.e., whenever we call
    * disconnected(true, ...)
    */
-  private volatile long myBootID;
+  volatile long myBootID;
 
   /** myBootID at the time of the last successful completed handshake. */
-  private long myLastSuccessfulBootID;
+  long myLastSuccessfulBootID;
 
   /** If true, this means the last time we tried, we got a bogus noderef */
-  private volatile boolean bogusNoderef;
+  volatile boolean bogusNoderef;
 
   /** The time at which we last completed a connection setup. */
-  private volatile long connectedTime;
+  volatile long connectedTime;
 
   /** The status of this peer node in terms of Node.PEER_NODE_STATUS_* */
   private volatile int peerNodeStatus = PeerManager.PEER_NODE_STATUS_DISCONNECTED;
@@ -473,7 +472,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * Delta between our clock and his clock (positive = his clock is fast, negative = our clock is
    * fast)
    */
-  private volatile long clockDelta;
+  volatile long clockDelta;
 
   /** Percentage uptime of this node, 0 if they haven't said */
   private volatile byte uptime;
@@ -482,7 +481,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * If the clock delta is more than this constant, we don't talk to the node. Reason: It may not be
    * up to date, it will have difficulty resolving date-based content etc.
    */
-  private static final long MAX_CLOCK_DELTA = DAYS.toMillis(1);
+  static final long MAX_CLOCK_DELTA = DAYS.toMillis(1);
 
   /**
    * 1 hour after the node is disconnected, if it is still disconnected and hasn't connected in that
@@ -503,7 +502,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   private final WeakReference<PeerContext> contextRef;
 
   /** The node is being disconnected, but it may take a while. */
-  private boolean disconnecting;
+  boolean disconnecting;
 
   /** When did we last disconnect? Not Disconnected because of a discrete event */
   long timeLastDisconnect;
@@ -697,14 +696,13 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     // Core finals
     myRef = new WeakReference<>(selfPeerNode());
     contextRef = castPeerContextRef(myRef);
-    this.checkStatusAfterBackoff = new PeerNodeBackoffStatusChecker(myRef);
+    this.checkStatusAfterBackoff = PeerNodeRuntime.createBackoffStatusChecker(myRef);
     this.outgoingMangler = init.outgoingMangler;
     this.node = init.node;
     this.crypto = init.crypto;
     this.random = node.bootstrap().createRandom();
     this.peers = init.peers;
-    this.internals =
-        new PeerNodeInternals(selfPeerNode(), init.node, init.fs.get(SFS_KEY_LOCATION));
+    this.internals = new PeerNodeRuntime(selfPeerNode(), init.node, init.fs.get(SFS_KEY_LOCATION));
     this.myBootID = init.node.getBootId();
     this.bootID = 0;
 
@@ -802,16 +800,16 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   private void parseNominalPeers(SimpleFieldSet fs, boolean fromLocal) {
-    List<Peer> parsedNominalPeer = new ArrayList<>();
+    List<Peer> parsedNominalPeer = List.of();
     String[] physical = fs.getAll(SFS_KEY_PHYSICAL_UDP);
     if (physical != null) {
       for (String phys : physical) {
         for (Peer p : parsePeerEntryCompat(phys, fromLocal)) {
-          if (p != null && !parsedNominalPeer.contains(p)) parsedNominalPeer.add(p);
+          parsedNominalPeer = appendPeerIfAbsent(parsedNominalPeer, p);
         }
       }
     }
-    nominalPeer = List.copyOf(parsedNominalPeer);
+    nominalPeer = new CopyOnWriteArrayList<>(parsedNominalPeer);
     if (parsedNominalPeer.isEmpty()) {
       LOG.atInfo()
           .addArgument(() -> identityAsBase64String)
@@ -919,735 +917,6 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     long routableConnectionCheckCount;
   }
 
-  private static final class PeerNodeInternals {
-    private final PeerNode peerNode;
-    private final Node node;
-    private final PeerNodeReferenceSupport referenceSupport;
-    private final PeerNodeOfferSupport offerSupport;
-    private final PeerNodeTransport transport;
-    private final PeerNodeArkManager arkManager;
-    private final PeerNodeAddressManager addressManager;
-    private final PeerNodeRoutingStats routingStats;
-    private final PeerLocation location;
-    private final PeerNodeLoadTracker loadTracker;
-    private final PeerNodeJfkNonces jfkNoncesSent = new PeerNodeJfkNonces();
-
-    private PeerNodeConnectionState connectionState = new PeerNodeConnectionState(0);
-    private PacketFormat packetFormat;
-
-    PeerNodeInternals(PeerNode peerNode, Node node, String locationString) {
-      this.peerNode = peerNode;
-      this.node = node;
-      referenceSupport = new PeerNodeReferenceSupport(peerNode);
-      offerSupport = new PeerNodeOfferSupport(peerNode);
-      transport = new PeerNodeTransport(peerNode);
-      arkManager = new PeerNodeArkManager(peerNode);
-      addressManager = new PeerNodeAddressManager(peerNode);
-      routingStats = new PeerNodeRoutingStats(node);
-      location = new PeerLocation(locationString);
-      loadTracker = new PeerNodeLoadTracker(peerNode);
-    }
-
-    byte[] computeIncomingSetupKey(NodeCrypto crypto, byte[] identityHashHash) {
-      return referenceSupport.computeIncomingSetupKey(crypto, identityHashHash);
-    }
-
-    byte[] computeOutgoingSetupKey(NodeCrypto crypto, byte[] identityHash) {
-      return referenceSupport.computeOutgoingSetupKey(crypto, identityHash);
-    }
-
-    String formatDuration(long millis) {
-      return referenceSupport.formatDuration(millis);
-    }
-
-    String formatPeerKeyHash(byte[] hash) {
-      return referenceSupport.formatPeerKeyHash(hash);
-    }
-
-    boolean verifyReferenceSignature(SimpleFieldSet fs) throws FSParseException {
-      try {
-        return referenceSupport.verifyReferenceSignature(fs);
-      } catch (Exception e) {
-        throw new FSParseException("Invalid signature", e);
-      }
-    }
-
-    Peer tryParsePeer(String phys) {
-      return referenceSupport.tryParsePeer(phys);
-    }
-
-    void checkTestnetAndOpennet(SimpleFieldSet fs, boolean forDiffNodeRef, boolean forFullNodeRef)
-        throws FSParseException {
-      referenceSupport.checkTestnetAndOpennet(fs, forDiffNodeRef, forFullNodeRef);
-    }
-
-    void validateIdentity(SimpleFieldSet fs, boolean forDiffNodeRef, boolean forFullNodeRef)
-        throws FSParseException {
-      referenceSupport.validateIdentity(fs, forDiffNodeRef, forFullNodeRef);
-    }
-
-    void parseEcdsaFields(SimpleFieldSet fs) throws FSParseException {
-      referenceSupport.parseEcdsaFields(fs);
-    }
-
-    void putEcdsaFields(SimpleFieldSet fs, ECPublicKey key) {
-      referenceSupport.putEcdsaFields(fs, key);
-    }
-
-    boolean parseArk(SimpleFieldSet fs, boolean onStartup, boolean forDiffNodeRef) {
-      return arkManager.parseArk(fs, onStartup, forDiffNodeRef);
-    }
-
-    void appendArkFields(SimpleFieldSet fs) {
-      arkManager.appendArkFields(fs);
-    }
-
-    void handleArkUpdate(SimpleFieldSet fs, long fetchedEdition) {
-      arkManager.handleArkUpdate(fs, fetchedEdition);
-    }
-
-    boolean isFetchingArk() {
-      return arkManager.isFetching();
-    }
-
-    void startArkFetcher() {
-      arkManager.startFetcher();
-    }
-
-    void stopArkFetcher() {
-      arkManager.stopFetcher();
-    }
-
-    void offer(Key key) {
-      offerSupport.offer(key);
-    }
-
-    void notifyOpennetOnDisconnect(Node node) {
-      OpennetManager om = node.network().opennet();
-      if (om != null) om.onDisconnect();
-    }
-
-    void notifyOpennetOnConnect(Node node, PeerNode peerNode) {
-      OpennetManager om = node.network().opennet();
-      if (om != null) {
-        // OpennetManager must be notified of a new connection even if it is a darknet peer.
-        om.onConnectedPeer(peerNode);
-      }
-    }
-
-    void resetHandshakeIpUpdateTimer() {
-      addressManager.resetHandshakeIpUpdateTimer();
-    }
-
-    Peer parseDetectedPeer(SimpleFieldSet metadata) {
-      return addressManager.parseDetectedPeer(metadata);
-    }
-
-    List<Peer> parsePeerEntryCompat(String phys, boolean fromLocal) {
-      return referenceSupport.parsePeerEntryCompat(phys, fromLocal);
-    }
-
-    void maybeUpdateHandshakeIPs(boolean ignoreHostnames) {
-      addressManager.maybeUpdateHandshakeIPs(ignoreHostnames);
-    }
-
-    Peer getHandshakeIP() {
-      return addressManager.getHandshakeIP();
-    }
-
-    void markHandshakeIpUpdateAttempted(long now) {
-      addressManager.markHandshakeIpUpdateAttempted(now);
-    }
-
-    HandshakeState createHandshakeState(
-        byte[] incomingSetupKey, byte[] outgoingSetupKey, byte[] anonymousInitiatorKey) {
-      return new PeerNodeHandshake(
-          peerNode, incomingSetupKey, outgoingSetupKey, anonymousInitiatorKey);
-    }
-
-    boolean shouldThrottle() {
-      return PeerNodeAddressManager.shouldThrottle(peerNode.getPeer(), node);
-    }
-
-    boolean isConnected() {
-      return connectionState.isConnected();
-    }
-
-    boolean setConnected(boolean connected, long now) {
-      return connectionState.setConnected(connected, now);
-    }
-
-    long timeLastConnected(long now) {
-      return connectionState.timeLastConnected(now);
-    }
-
-    boolean isBurstOnly(OutgoingPacketMangler outgoingMangler, Random random) {
-      return connectionState.isBurstOnly(outgoingMangler, random);
-    }
-
-    void registerStatusChangeListener(Object listener) {
-      connectionState.registerStatusChangeListener((PeerManager.PeerStatusChangeListener) listener);
-    }
-
-    void notifyStatusChangeListeners() {
-      connectionState.notifyStatusChangeListeners();
-    }
-
-    void initConnectionState(long lastConnectedTime) {
-      connectionState = new PeerNodeConnectionState(lastConnectedTime);
-    }
-
-    PeerTransport transport() {
-      return transport;
-    }
-
-    void maybeDisconnected() {
-      transport.getThrottle().maybeDisconnected();
-    }
-
-    double bandwidth() {
-      return transport.getThrottle().getBandwidth();
-    }
-
-    void sendIPAddressMessage() {
-      transport.sendIPAddressMessage();
-    }
-
-    void sendInitialMessages() {
-      transport.sendInitialMessages();
-    }
-
-    void sendNodeToNodeMessage(
-        SimpleFieldSet fs,
-        int n2nType,
-        boolean includeSentTime,
-        long now,
-        boolean queueOnNotConnected) {
-      transport.sendNodeToNodeMessage(fs, n2nType, includeSentTime, now, queueOnNotConnected);
-    }
-
-    long getResendBytesSent() {
-      return transport.getResendBytesSent();
-    }
-
-    void resendBytes(int bytesToResend) {
-      transport.resendBytes(bytesToResend);
-    }
-
-    @SuppressWarnings("unused")
-    PeerNodeJfkNonces jfkNoncesSent() {
-      return jfkNoncesSent;
-    }
-
-    void clearJfkNoncesSent() {
-      jfkNoncesSent.clear();
-    }
-
-    void rememberJfkNonce(byte[] nonce, int maxNoncesPerPeer) {
-      jfkNoncesSent.rememberNonce(nonce, maxNoncesPerPeer);
-    }
-
-    byte[] findOriginalJfkNonceByHash(byte[] nonceHash) {
-      return jfkNoncesSent.findOriginalNonceByHash(nonceHash);
-    }
-
-    void setPacketFormat(PacketFormat packetFormat) {
-      this.packetFormat = packetFormat;
-    }
-
-    void clearPacketFormat() {
-      packetFormat = null;
-    }
-
-    PacketFormat packetFormat() {
-      return packetFormat;
-    }
-
-    boolean maybeSendPacket(long now, boolean ackOnly) {
-      PacketFormat pf;
-      synchronized (peerNode) {
-        pf = packetFormat;
-        if (pf == null) return false;
-      }
-      try {
-        return pf.maybeSendPacket(now, ackOnly);
-      } catch (BlockedTooLongException e) {
-        LOG.error(
-            "Packet number allocation blocked {} (peer={}, version={}) - disconnecting",
-            formatDuration(e.delta),
-            peerNode,
-            peerNode.getBuildNumber());
-        peerNode.forceDisconnect();
-        return false;
-      }
-    }
-
-    void reportLoadStatus(Object stat) {
-      loadTracker.reportLoadStatus((PeerLoadStats) stat);
-    }
-
-    void noLongerRoutingTo(Object tag, boolean offeredKey) {
-      loadTracker.noLongerRoutingTo(tag, offeredKey);
-    }
-
-    void maybeNotifySlotWaiter(boolean realTime) {
-      loadTracker.maybeNotifySlotWaiter(realTime);
-    }
-
-    void postUnlock(Object tag) {
-      loadTracker.postUnlock(tag);
-    }
-
-    PeerNodeLoadTracker.OutputLoadTracker outputLoadTracker(boolean realTime) {
-      return loadTracker.outputLoadTracker(realTime);
-    }
-
-    PeerNodeLoadTracker.IncomingLoadSummaryStats getIncomingLoadStats(boolean realTime) {
-      return loadTracker.getIncomingLoadStats(realTime);
-    }
-
-    boolean missingLastIncomingLoadStats(boolean realTime) {
-      return loadTracker.getLastIncomingLoadStats(realTime) == null;
-    }
-
-    boolean isLowCapacity(boolean isRealtime) {
-      PeerLoadStats stats = loadTracker.getLastIncomingLoadStats(isRealtime);
-      if (stats == null) return false;
-      NodePinger pinger = node.network().stats().nodePinger;
-      if (pinger.capacityThreshold(isRealtime, true) > stats.peerLimit(true)) return true;
-      return pinger.capacityThreshold(isRealtime, false) > stats.peerLimit(false);
-    }
-
-    void failSlotWaiters(boolean realTime) {
-      loadTracker.failSlotWaiters(realTime);
-    }
-
-    void setPeerLocations(String[] peerLocationsString) {
-      location.setPeerLocations(peerLocationsString);
-    }
-
-    double getLocation() {
-      return location.getLocation();
-    }
-
-    double[] getPeersLocationArray() {
-      return location.getPeersLocationArray();
-    }
-
-    long getLocationSetTime() {
-      return location.getLocationSetTime();
-    }
-
-    boolean isValidLocation() {
-      return location.isValidLocation();
-    }
-
-    int getLocationDegree() {
-      return location.getDegree();
-    }
-
-    boolean updateLocation(double newLoc, double[] newLocs) {
-      return location.updateLocation(newLoc, newLocs);
-    }
-
-    double setLocation(double newLoc) {
-      return location.setLocation(newLoc);
-    }
-
-    boolean parseLocationAndMaybePeerCounts(SimpleFieldSet fs, boolean[] shouldUpdatePeerCounts) {
-      boolean changedAnything = false;
-      String locationString = fs.get(SFS_KEY_LOCATION);
-      if (locationString != null) {
-        double newLoc = Location.getLocation(locationString);
-        if (!Location.isValid(newLoc)) {
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "Invalid or null location, waiting for FNPLocChangeNotification: locationString={}",
-                locationString);
-        } else {
-          double oldLoc = setLocation(newLoc);
-          if (!Location.equals(oldLoc, newLoc)) {
-            if (!Location.isValid(oldLoc)) shouldUpdatePeerCounts[0] = true;
-            changedAnything = true;
-          }
-        }
-      }
-      return changedAnything;
-    }
-
-    String locationToString() {
-      return location.toString();
-    }
-
-    long[] getLocationSnapshot() {
-      synchronized (location) {
-        return new long[] {
-          Double.doubleToRawLongBits(location.getLocation()), location.getLocationSetTime()
-        };
-      }
-    }
-
-    @SuppressWarnings("unchecked")
-    double getClosestPeerLocation(double target, Object excludeLocations) {
-      java.util.Set<Double> exclude = null;
-      if (excludeLocations != null) {
-        exclude = (java.util.Set<Double>) excludeLocations;
-      }
-      return location.getClosestPeerLocation(target, exclude);
-    }
-
-    void reportSwapInterval(long timeSinceLastTime) {
-      routingStats.reportSwapInterval(timeSinceLastTime);
-    }
-
-    double averageSwapInterval() {
-      return routingStats.averageSwapInterval();
-    }
-
-    void reportProbeInterval(long timeSinceLastTime) {
-      routingStats.reportProbeInterval(timeSinceLastTime);
-    }
-
-    double averageProbeInterval() {
-      return routingStats.averageProbeInterval();
-    }
-
-    double backedOffPercent() {
-      return routingStats.backedOffPercent();
-    }
-
-    void reportBackoffStatus(
-        long now, long routingBackedOffUntilRT, long routingBackedOffUntilBulk) {
-      routingStats.reportBackoffStatus(now, routingBackedOffUntilRT, routingBackedOffUntilBulk);
-    }
-
-    void reportRejectedOverload() {
-      routingStats.reportRejectedOverload();
-    }
-
-    void reportNotRejectedOverload() {
-      routingStats.reportNotRejectedOverload();
-    }
-
-    double pRejected() {
-      return routingStats.pRejected();
-    }
-
-    double averagePingTime() {
-      return routingStats.averagePingTime();
-    }
-
-    void reportPing(long t) {
-      routingStats.reportPing(t);
-    }
-
-    double backedOffPercentRT() {
-      return routingStats.backedOffPercentRT();
-    }
-
-    double backedOffPercentBulk() {
-      return routingStats.backedOffPercentBulk();
-    }
-
-    long completeHandshake(Object paramsObject) {
-      HandshakeCompletionParams params = (HandshakeCompletionParams) paramsObject;
-      long now = System.currentTimeMillis();
-      long trackerID = params.trackerID;
-      // If trackerID is negative, pick a random positive ID; then keep using trackerID.
-      // Avoid Math.abs(Long.MIN_VALUE) overflow; mask a sign bit instead.
-      trackerID = trackerID < 0 ? (peerNode.random.nextLong() & Long.MAX_VALUE) : trackerID;
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "Tracker ID {} isJFK4={} jfk4SameAsOld={}",
-            trackerID,
-            params.isJFK4,
-            params.jfk4SameAsOld);
-
-      // Update sendHandshakeTime; don't send another handshake for a while.
-      // If unverified, "a while" determines the timeout; if not, it's just good practice to avoid a
-      // race below.
-      if (!(peerNode.isSeed() && peerNode instanceof SeedServerPeerNode))
-        peerNode.calcNextHandshake(true, true, false);
-      peerNode.stopARKFetcher();
-      try {
-        // First, the new noderef
-        processHandshakeNoderef(params.data, params.length);
-      } catch (FSParseException e1) {
-        synchronized (peerNode) {
-          peerNode.bogusNoderef = true;
-          // Disconnect, something broke
-          setConnected(false, now);
-        }
-        LOG.error("Failed to parse new noderef for {}: {}", peerNode, e1, e1);
-        node.network().peers().disconnected(peerNode.selfPeerNode());
-        return -1;
-      }
-      RoutabilityDecision rd = decideRoutability();
-      peerNode.changedIP(params.replyTo);
-      HandshakeApplyResult har = applyHandshakeState(params, rd, trackerID, now);
-      if (har == null) return -1;
-      finalizeHandshake(har, rd, params.replyTo, params.thisBootID, now);
-
-      return trackerID;
-    }
-
-    private void finalizeHandshake(
-        HandshakeApplyResult har, RoutabilityDecision rd, Peer replyTo, long thisBootID, long now) {
-      applyDisconnectSideEffects(har);
-      logAndUpdateThrottle(replyTo, thisBootID);
-      peerNode.setPeerNodeStatus(now);
-      if (rd.newer() || rd.older() || !peerNode.isConnected())
-        node.network().peers().disconnected(peerNode.selfPeerNode());
-      else if (!har.wasARekey) {
-        node.network().peers().addConnectedPeer(peerNode.selfPeerNode());
-        peerNode.maybeOnConnect();
-      }
-      peerNode.crypto.maybeBootConnection(peerNode.selfPeerNode(), replyTo.getFreenetAddress());
-    }
-
-    private void applyDisconnectSideEffects(HandshakeApplyResult har) {
-      if (har.messagesTellDisconnected != null) {
-        for (MessageItem item : har.messagesTellDisconnected) item.onDisconnect();
-      }
-      if (har.bootIDChanged) {
-        node.network().locationManager().lostOrRestartedNode(peerNode.selfPeerNode());
-        node.network().usm().onRestart(peerNode);
-        node.routing().tracker().onRestartOrDisconnect(peerNode.selfPeerNode());
-      }
-      if (har.oldPrev != null) har.oldPrev.disconnected();
-      if (har.oldCur != null) har.oldCur.disconnected();
-      if (har.oldPacketFormat != null) {
-        List<MessageItem> tellDisconnect = har.oldPacketFormat.onDisconnect();
-        if (tellDisconnect != null) for (MessageItem item : tellDisconnect) item.onDisconnect();
-      }
-    }
-
-    private void logAndUpdateThrottle(Peer replyTo, long thisBootID) {
-      maybeDisconnected();
-      LOG.info(
-          "Completed handshake with {} on {} - current: {} old: {} unverified: {} bootID: {}"
-              + STR_FOR
-              + "{}",
-          peerNode,
-          replyTo,
-          peerNode.currentTracker,
-          peerNode.previousTracker,
-          peerNode.unverifiedTracker,
-          thisBootID,
-          peerNode.shortToString());
-    }
-
-    private record RoutabilityDecision(boolean routable, boolean newer, boolean older) {}
-
-    private RoutabilityDecision decideRoutability() {
-      boolean routable = true;
-      boolean newer = false;
-      boolean older = false;
-      if (peerNode.isSeed()) {
-        routable = false;
-        if (LOG.isDebugEnabled())
-          LOG.debug("Routing disabled (announcement-only seed): peer={}", peerNode);
-      } else if (peerNode.bogusNoderef) {
-        LOG.info("Routing disabled (bogus noderef): peer={}", peerNode);
-        routable = false;
-      } else if (peerNode.reverseInvalidVersion()) {
-        LOG.info(
-            "Routing disabled (reverse version check): peer={}, localVersion={},"
-                + " peerLastGoodVersion={}",
-            peerNode,
-            Version.getVersionString(),
-            peerNode.getLastGoodVersion());
-        newer = true;
-      }
-      if (peerNode.forwardInvalidVersion()) {
-        LOG.info(
-            "Routing disabled (forward version check): peer={}, peerVersion={}",
-            peerNode,
-            peerNode.getVersion());
-        older = true;
-        routable = false;
-      } else if (Math.abs(peerNode.clockDelta) > MAX_CLOCK_DELTA) {
-        LOG.info("Routing disabled (clock skew): peer={}", peerNode);
-        routable = false;
-      }
-      return new RoutabilityDecision(routable, newer, older);
-    }
-
-    private static final class HandshakeApplyResult {
-      boolean bootIDChanged;
-      boolean wasARekey;
-      SessionKey oldPrev;
-      SessionKey oldCur;
-      MessageItem[] messagesTellDisconnected;
-      PacketFormat oldPacketFormat;
-    }
-
-    private HandshakeApplyResult applyHandshakeState(
-        HandshakeCompletionParams params, RoutabilityDecision rd, long trackerID, long now) {
-      HandshakeApplyResult result = new HandshakeApplyResult();
-      synchronized (peerNode) {
-        peerNode.disconnecting = false;
-        if (isReplayedKey(params)) return null;
-        updateRoutabilityAndBootId(params, rd, now, result);
-        SessionKey newTracker = buildSessionKey(params, trackerID);
-        if (LOG.isDebugEnabled())
-          LOG.debug(
-              "New key tracker in completedHandshake: {}" + STR_FOR + "{} neg type {}",
-              newTracker,
-              peerNode.shortToString(),
-              params.negType);
-        assignTrackersAndTimes(params, now, result, newTracker);
-      }
-      return result;
-    }
-
-    private boolean isReplayedKey(HandshakeCompletionParams params) {
-      if (peerNode.currentTracker != null
-          && Arrays.equals(params.outgoingKey, peerNode.currentTracker.outgoingKey)
-          && Arrays.equals(params.incommingKey, peerNode.currentTracker.incommingKey)) {
-        LOG.error("Handshake replay suspected: new keys match current tracker");
-        return true;
-      }
-      if (peerNode.previousTracker != null
-          && Arrays.equals(params.outgoingKey, peerNode.previousTracker.outgoingKey)
-          && Arrays.equals(params.incommingKey, peerNode.previousTracker.incommingKey)) {
-        LOG.error("Handshake replay suspected: new keys match previous tracker");
-        return true;
-      }
-      if (peerNode.unverifiedTracker != null
-          && Arrays.equals(params.outgoingKey, peerNode.unverifiedTracker.outgoingKey)
-          && Arrays.equals(params.incommingKey, peerNode.unverifiedTracker.incommingKey)) {
-        LOG.error("Handshake replay suspected: new keys match unverified tracker");
-        return true;
-      }
-      return false;
-    }
-
-    private void updateRoutabilityAndBootId(
-        HandshakeCompletionParams params,
-        RoutabilityDecision rd,
-        long now,
-        HandshakeApplyResult result) {
-      peerNode.handshakeCount.set(0);
-      peerNode.bogusNoderef = false;
-      if (!peerNode.isConnected()) {
-        peerNode.connectedTime = now;
-        peerNode.countSelectionsSinceConnected.set(0);
-        peerNode.sentInitialMessages = false;
-      } else result.wasARekey = true;
-      peerNode.disableRouting =
-          peerNode.disableRoutingHasBeenSetLocally || peerNode.disableRoutingHasBeenSetRemotely;
-      peerNode.isRoutable = rd.routable();
-      peerNode.unroutableNewerVersion = rd.newer();
-      peerNode.unroutableOlderVersion = rd.older();
-      long oldBootID = peerNode.bootID;
-      peerNode.bootID = params.thisBootID;
-      result.bootIDChanged = oldBootID != params.thisBootID;
-      if (peerNode.myLastSuccessfulBootID != peerNode.myBootID) {
-        result.bootIDChanged = true;
-        peerNode.myLastSuccessfulBootID = peerNode.myBootID;
-      }
-      if (result.bootIDChanged && result.wasARekey) {
-        LOG.info(
-            "Changed boot ID while rekeying! from {} to {}" + STR_FOR + "{}",
-            oldBootID,
-            params.thisBootID,
-            peerNode.getPeer());
-        result.wasARekey = false;
-        peerNode.connectedTime = now;
-        peerNode.countSelectionsSinceConnected.set(0);
-        peerNode.sentInitialMessages = false;
-      } else if (result.bootIDChanged && LOG.isDebugEnabled())
-        LOG.debug(
-            "Changed boot ID from {} to {}" + STR_FOR + "{}",
-            oldBootID,
-            params.thisBootID,
-            peerNode.getPeer());
-      if (result.bootIDChanged) {
-        result.oldPrev = peerNode.previousTracker;
-        result.oldCur = peerNode.currentTracker;
-        peerNode.previousTracker = null;
-        peerNode.currentTracker = null;
-        result.messagesTellDisconnected = peerNode.grabQueuedMessageItems();
-        peerNode.offeredMainJarVersion = 0;
-        result.oldPacketFormat = packetFormat();
-        clearPacketFormat();
-      }
-    }
-
-    private SessionKey buildSessionKey(HandshakeCompletionParams params, long trackerID) {
-      return new SessionKey(
-          peerNode.selfPeerNode(),
-          new SessionKeyCryptoMaterial(
-              params.outgoingCipher,
-              params.outgoingKey,
-              params.incommingCipher,
-              params.incommingKey,
-              params.ivCipher,
-              params.ivNonce,
-              params.hmacKey),
-          new NewPacketFormatKeyContext(params.ourInitialSeqNum, params.theirInitialSeqNum),
-          trackerID);
-    }
-
-    private void assignTrackersAndTimes(
-        HandshakeCompletionParams params,
-        long now,
-        HandshakeApplyResult result,
-        SessionKey newTracker) {
-      if (params.unverified) {
-        if (peerNode.unverifiedTracker != null && peerNode.previousTracker == null)
-          peerNode.previousTracker = peerNode.unverifiedTracker;
-        peerNode.unverifiedTracker = newTracker;
-      } else {
-        result.oldPrev = peerNode.previousTracker;
-        peerNode.previousTracker = peerNode.currentTracker;
-        peerNode.currentTracker = newTracker;
-        peerNode.neverConnected = false;
-        peerNode.maybeClearPeerAddedTimeOnConnect();
-      }
-      setConnected(peerNode.currentTracker != null, now);
-      peerNode.handshake.clearKeyAgreementSchemeContext();
-      peerNode.isRekeying = false;
-      peerNode.timeLastRekeyed =
-          now - (params.unverified ? 0 : FNPPacketMangler.MAX_SESSION_KEY_REKEYING_DELAY / 2);
-      peerNode.totalBytesExchangedWithCurrentTracker = 0;
-      if (peerNode.currentTracker != null
-          && peerNode.previousTracker != null
-          && Arrays.equals(
-              peerNode.currentTracker.outgoingKey, peerNode.previousTracker.outgoingKey)
-          && Arrays.equals(
-              peerNode.currentTracker.incommingKey, peerNode.previousTracker.incommingKey))
-        LOG.error(
-            "currentTracker key equals previousTracker key: cur {} prev {}",
-            peerNode.currentTracker,
-            peerNode.previousTracker);
-      if (peerNode.previousTracker != null
-          && peerNode.unverifiedTracker != null
-          && Arrays.equals(
-              peerNode.previousTracker.outgoingKey, peerNode.unverifiedTracker.outgoingKey)
-          && Arrays.equals(
-              peerNode.previousTracker.incommingKey, peerNode.unverifiedTracker.incommingKey))
-        LOG.error(
-            "previousTracker key equals unverifiedTracker key: prev {} unv {}",
-            peerNode.previousTracker,
-            peerNode.unverifiedTracker);
-      peerNode.timeLastSentPacket = now;
-      if (packetFormat() == null) {
-        setPacketFormat(
-            new NewPacketFormat(peerNode, params.ourInitialMsgID, params.theirInitialMsgID));
-      }
-      peerNode.timeLastReceivedPacket = now;
-      peerNode.timeLastReceivedDataPacket = now;
-      peerNode.timeLastReceivedAck = now;
-    }
-
-    private void processHandshakeNoderef(byte[] data, int length) throws FSParseException {
-      SimpleFieldSet fs = compressedNoderefToFieldSet(data, length);
-      peerNode.processNewNoderef(fs, false, false, false);
-    }
-  }
-
   long completeHandshake(Object params) {
     return internals.completeHandshake(params);
   }
@@ -1705,9 +974,9 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   /**
-   * Captures a consistent snapshot of address state used for IP matching.
+   * Captures a consistent snapshot of the address state used for IP matching.
    *
-   * <p>The returned values are read while holding this peer's monitor so callers can evaluate
+   * <p>The returned values are read while holding this peer's monitor, so callers can evaluate
    * detected and nominal addresses from the same synchronization point.
    *
    * @return snapshot containing the detected peer and a defensive copy of nominal peers
@@ -1727,9 +996,9 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     if (localNominalPeer == null || localNominalPeer.size() < 2) {
       return;
     }
-    List<Peer> sorted = new ArrayList<>(localNominalPeer);
-    sorted.sort(Peer.PEER_COMPARATOR);
-    nominalPeer = List.copyOf(sorted);
+    Peer[] sorted = localNominalPeer.toArray(Peer[]::new);
+    Arrays.sort(sorted, Peer.PEER_COMPARATOR);
+    nominalPeer = new CopyOnWriteArrayList<>(Arrays.asList(sorted));
   }
 
   /**
@@ -2960,11 +2229,11 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     return bogusNoderef || forwardInvalidVersion() || reverseInvalidVersion();
   }
 
-  private synchronized boolean forwardInvalidVersion() {
+  synchronized boolean forwardInvalidVersion() {
     return !Version.isCompatibleVersion(version);
   }
 
-  private synchronized boolean reverseInvalidVersion() {
+  synchronized boolean reverseInvalidVersion() {
     if (ignoreLastGoodVersion()) return false;
     return !Version.isCompatibleVersionWithLastGood(Version.getVersionString(), lastGoodVersion);
   }
@@ -3006,11 +2275,6 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     processNewNoderef(fs, false, true, false);
     // Send UOMAnnouncement only *after* we know what the other side's version.
     if (isRealConnection()) node.services().nodeUpdater().maybeSendUOMAnnounce(selfPeerNode());
-  }
-
-  static SimpleFieldSet compressedNoderefToFieldSet(byte[] data, int length)
-      throws FSParseException {
-    return PeerNodeReferenceSupport.compressedNoderefToFieldSet(data, 0, length);
   }
 
   /**
@@ -3139,7 +2403,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
       List<Peer> oldNominalPeer = nominalPeer;
       if (oldNominalPeer == null) oldNominalPeer = List.of();
       Peer[] oldPeers = oldNominalPeer.toArray(new Peer[0]);
-      nominalPeer = collectPeersFromPhysical(physical);
+      nominalPeer = new CopyOnWriteArrayList<>(collectPeersFromPhysical(physical));
       sortNominalPeer();
       changedAnything = applyNominalPeersChange(oldPeers);
     } else if (forARK || forFullNodeRef) {
@@ -3152,19 +2416,28 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   private List<Peer> collectPeersFromPhysical(String[] physical) {
-    List<Peer> list = new ArrayList<>(physical.length);
+    List<Peer> list = List.of();
     for (String phys : physical) {
       if (phys.indexOf(',') >= 0) {
         // Apply the same compatibility splitting we use for local parsing.
         for (Peer p : parsePeerEntryCompat(phys, /* fromLocal= */ false)) {
-          if (p != null && !list.contains(p)) list.add(p);
+          list = appendPeerIfAbsent(list, p);
         }
         continue;
       }
       Peer p = tryParsePeer(phys);
-      if (p != null && !list.contains(p)) list.add(p);
+      list = appendPeerIfAbsent(list, p);
     }
     return list;
+  }
+
+  private static List<Peer> appendPeerIfAbsent(List<Peer> peers, Peer candidate) {
+    if (candidate == null || peers.contains(candidate)) {
+      return peers;
+    }
+    Peer[] expanded = Arrays.copyOf(peers.toArray(Peer[]::new), peers.size() + 1);
+    expanded[expanded.length - 1] = candidate;
+    return List.of(expanded);
   }
 
   private boolean applyNominalPeersChange(Peer[] oldPeers) {
@@ -3212,7 +2485,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * Returns a {@link PeerNodeStatus} snapshot for this peer.
    *
    * <p>The status summarizes connection, routability, and backoff state for UI and diagnostics.
-   * Implementations may consult runtime counters or caches; callers can request a lightweight
+   * Implementations may consult internal counters or caches; callers can request a lightweight
    * evaluation to avoid expensive lookups. The returned status is a snapshot and may change soon
    * after the call.
    *
@@ -3261,7 +2534,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     return version;
   }
 
-  private synchronized String getLastGoodVersion() {
+  synchronized String getLastGoodVersion() {
     return lastGoodVersion;
   }
 
@@ -4303,7 +3576,8 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   private static boolean nullSafeNotEquals(Object a, Object b) {
-    return !Objects.equals(a, b);
+    if (a == b) return false;
+    return a == null || !a.equals(b);
   }
 
   /**
@@ -4686,13 +3960,41 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
       return new String[0];
     }
 
-    String[] components = PeerNodeReferenceSupport.splitVersionComponents(versionStr);
+    String[] components = splitVersionComponents(versionStr);
     if (components.length >= 3) {
       parsedVersionComponents = components;
       return components;
     }
 
     return new String[0];
+  }
+
+  private static String[] splitVersionComponents(String versionStr) {
+    int maxParts = 1;
+    for (int i = 0; i < versionStr.length(); i++) {
+      if (versionStr.charAt(i) == ',') {
+        maxParts++;
+      }
+    }
+    String[] parts = new String[maxParts];
+    int count = 0;
+    int start = 0;
+    while (start <= versionStr.length()) {
+      int comma = versionStr.indexOf(',', start);
+      int end = comma >= 0 ? comma : versionStr.length();
+      String trimmed = versionStr.substring(start, end).trim();
+      if (!trimmed.isEmpty()) {
+        parts[count++] = trimmed;
+      }
+      if (comma < 0) {
+        break;
+      }
+      start = comma + 1;
+    }
+    if (count == 0) {
+      return new String[0];
+    }
+    return Arrays.copyOf(parts, count);
   }
 
   /**
@@ -5306,7 +4608,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     return countSelectionsSinceConnected.get() / (double) timeSinceConnected;
   }
 
-  private volatile int offeredMainJarVersion;
+  volatile int offeredMainJarVersion;
 
   /**
    * Records the main JAR version most recently offered by this peer.
@@ -5655,10 +4957,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   private long maxPeerPingTime() {
-    if (node == null) return NodeStats.DEFAULT_MAX_PING_TIME * 2;
-    NodeStats stats = node.network().stats();
-    if (node.network().stats() == null) return NodeStats.DEFAULT_MAX_PING_TIME * 2;
-    else return stats.maxPeerPingTime();
+    return internals.maxPeerPingTime();
   }
 
   /** Whether we are sending the main jar to this peer */

--- a/src/main/java/network/crypta/node/PeerNodeHandshakeLifecycle.java
+++ b/src/main/java/network/crypta/node/PeerNodeHandshakeLifecycle.java
@@ -1,0 +1,380 @@
+package network.crypta.node;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.List;
+import network.crypta.io.comm.Peer;
+import network.crypta.support.SimpleFieldSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Coordinates handshake finalization, tracker promotion, and post-handshake side effects for a
+ * {@link PeerNode}.
+ *
+ * <p>This helper centralizes the logic that runs after key negotiation succeeds but before the peer
+ * is considered fully connected. It validates the incoming noderef, derives routability from
+ * version and clock checks, rotates session trackers, and triggers restart/disconnect notifications
+ * when boot IDs or packet formats change. Keeping these steps in one part makes handshake
+ * completion easier to reason about and keeps {@link PeerNodeRuntime} focused on broader runtime
+ * concerns.
+ *
+ * <p>The class is stateful only through references to its owning peer and runtime collaborators.
+ * Callers execute it on handshake paths where peer-level synchronization and ordering already
+ * matter, so this class relies on {@link PeerNode} synchronization rules instead of introducing new
+ * locks.
+ *
+ * <ul>
+ *   <li>Normalizes tracker IDs and applies negotiated key material.
+ *   <li>Detects replayed keys and rejects unsafe promotions.
+ *   <li>Notifies subsystems when a peer reconnects, restarts, or disconnects.
+ * </ul>
+ */
+final class PeerNodeHandshakeLifecycle {
+  private static final Logger LOG = LoggerFactory.getLogger(PeerNodeHandshakeLifecycle.class);
+
+  private final PeerNode peerNode;
+  private final Node node;
+  private final PeerNodeRuntime runtime;
+
+  /**
+   * Creates a lifecycle coordinator bound to a specific peer and runtime context.
+   *
+   * <p>The coordinator keeps references to collaborators and does not perform network or disk work
+   * during construction. Callers should create one instance per {@link PeerNode} lifecycle and
+   * reuse it for later handshake completions.
+   *
+   * @param peerNode owning peer whose trackers and status will be updated during completion
+   * @param node node-level service container used for peer, routing, and restart notifications
+   * @param runtime runtime adapter used for transport and packet-format transitions
+   */
+  PeerNodeHandshakeLifecycle(PeerNode peerNode, Node node, PeerNodeRuntime runtime) {
+    this.peerNode = peerNode;
+    this.node = node;
+    this.runtime = runtime;
+  }
+
+  /**
+   * Builds a runnable that re-evaluates peer backoff status after deferred transitions.
+   *
+   * <p>The returned checker keeps only a weak reference to the peer, so scheduled callbacks do not
+   * prolong the peer lifetime. It is typically registered when routing backoff windows expires.
+   *
+   * @param peerRef weak reference to the peer whose backoff status should be refreshed
+   * @return runnable checker that safely no-ops if the peer has been garbage collected
+   */
+  static Runnable createBackoffStatusChecker(WeakReference<PeerNode> peerRef) {
+    return new PeerNodeBackoffStatusChecker(peerRef);
+  }
+
+  /**
+   * Applies negotiated handshake parameters and transitions the peer into its next session state.
+   *
+   * <p>The method parses the peer's noderef, computes routability flags, performs replay checks,
+   * rotates trackers, and triggers connect/disconnect notifications as needed. A negative tracker
+   * ID from input is normalized to a random non-negative identifier. When parsing fails or replayed
+   * keys are detected, the method aborts and returns {@code -1}.
+   *
+   * @param paramsObject handshake completion payload expected to be a {@link
+   *     HandshakeCompletionParams} instance
+   * @return resolved tracker identifier on success, or {@code -1} when completion is rejected
+   * @throws ClassCastException if {@code paramsObject} is not a {@link HandshakeCompletionParams}
+   *     instance
+   */
+  long completeHandshake(Object paramsObject) {
+    HandshakeCompletionParams params = (HandshakeCompletionParams) paramsObject;
+    long now = System.currentTimeMillis();
+    long trackerID = params.trackerID;
+    // If trackerID is negative, pick a random positive ID; then keep using trackerID.
+    // Avoid Math.abs(Long.MIN_VALUE) overflow; mask a sign bit instead.
+    trackerID = trackerID < 0 ? (peerNode.random.nextLong() & Long.MAX_VALUE) : trackerID;
+    if (LOG.isDebugEnabled())
+      LOG.debug(
+          "Tracker ID {} isJFK4={} jfk4SameAsOld={}",
+          trackerID,
+          params.isJFK4,
+          params.jfk4SameAsOld);
+
+    // Update sendHandshakeTime; don't send another handshake for a while.
+    // If unverified, "a while" determines the timeout; if not, it's just good practice to avoid a
+    // race below.
+    if (!(peerNode.isSeed() && peerNode instanceof SeedServerPeerNode))
+      peerNode.calcNextHandshake(true, true, false);
+    peerNode.stopARKFetcher();
+    try {
+      // First, the new noderef
+      processHandshakeNoderef(params.data, params.length);
+    } catch (FSParseException e1) {
+      synchronized (peerNode) {
+        peerNode.bogusNoderef = true;
+        // Disconnect, something broke
+        runtime.setConnected(false, now);
+      }
+      LOG.error("Failed to parse new noderef for {}: {}", peerNode, e1, e1);
+      node.network().peers().disconnected(peerNode.selfPeerNode());
+      return -1;
+    }
+    RoutabilityDecision rd = decideRoutability();
+    peerNode.changedIP(params.replyTo);
+    HandshakeApplyResult har = applyHandshakeState(params, rd, trackerID, now);
+    if (har == null) return -1;
+    finalizeHandshake(har, rd, params.replyTo, params.thisBootID, now);
+
+    return trackerID;
+  }
+
+  private void finalizeHandshake(
+      HandshakeApplyResult har, RoutabilityDecision rd, Peer replyTo, long thisBootID, long now) {
+    applyDisconnectSideEffects(har);
+    logAndUpdateThrottle(replyTo, thisBootID);
+    peerNode.setPeerNodeStatus(now);
+    if (rd.newer() || rd.older() || !peerNode.isConnected())
+      node.network().peers().disconnected(peerNode.selfPeerNode());
+    else if (!har.wasARekey) {
+      node.network().peers().addConnectedPeer(peerNode.selfPeerNode());
+      peerNode.maybeOnConnect();
+    }
+    peerNode.crypto.maybeBootConnection(peerNode.selfPeerNode(), replyTo.getFreenetAddress());
+  }
+
+  private void applyDisconnectSideEffects(HandshakeApplyResult har) {
+    if (har.messagesTellDisconnected != null) {
+      for (MessageItem item : har.messagesTellDisconnected) item.onDisconnect();
+    }
+    if (har.bootIDChanged) {
+      node.network().locationManager().lostOrRestartedNode(peerNode.selfPeerNode());
+      node.network().usm().onRestart(peerNode);
+      node.routing().tracker().onRestartOrDisconnect(peerNode.selfPeerNode());
+    }
+    if (har.oldPrev != null) har.oldPrev.disconnected();
+    if (har.oldCur != null) har.oldCur.disconnected();
+    if (har.oldPacketFormat != null) {
+      List<MessageItem> tellDisconnect = har.oldPacketFormat.onDisconnect();
+      if (tellDisconnect != null) for (MessageItem item : tellDisconnect) item.onDisconnect();
+    }
+  }
+
+  private void logAndUpdateThrottle(Peer replyTo, long thisBootID) {
+    runtime.maybeDisconnected();
+    LOG.info(
+        "Completed handshake with {} on {} - current: {} old: {} unverified: {} bootID: {}"
+            + PeerNode.STR_FOR
+            + "{}",
+        peerNode,
+        replyTo,
+        peerNode.currentTracker,
+        peerNode.previousTracker,
+        peerNode.unverifiedTracker,
+        thisBootID,
+        peerNode.shortToString());
+  }
+
+  private record RoutabilityDecision(boolean routable, boolean newer, boolean older) {}
+
+  private RoutabilityDecision decideRoutability() {
+    boolean routable = true;
+    boolean newer = false;
+    boolean older = false;
+    if (peerNode.isSeed()) {
+      routable = false;
+      if (LOG.isDebugEnabled())
+        LOG.debug("Routing disabled (announcement-only seed): peer={}", peerNode);
+    } else if (peerNode.bogusNoderef) {
+      LOG.info("Routing disabled (bogus noderef): peer={}", peerNode);
+      routable = false;
+    } else if (peerNode.reverseInvalidVersion()) {
+      LOG.info(
+          "Routing disabled (reverse version check): peer={}, localVersion={},"
+              + " peerLastGoodVersion={}",
+          peerNode,
+          Version.getVersionString(),
+          peerNode.getLastGoodVersion());
+      newer = true;
+    }
+    if (peerNode.forwardInvalidVersion()) {
+      LOG.info(
+          "Routing disabled (forward version check): peer={}, peerVersion={}",
+          peerNode,
+          peerNode.getVersion());
+      older = true;
+      routable = false;
+    } else if (Math.abs(peerNode.clockDelta) > PeerNode.MAX_CLOCK_DELTA) {
+      LOG.info("Routing disabled (clock skew): peer={}", peerNode);
+      routable = false;
+    }
+    return new RoutabilityDecision(routable, newer, older);
+  }
+
+  private static final class HandshakeApplyResult {
+    boolean bootIDChanged;
+    boolean wasARekey;
+    SessionKey oldPrev;
+    SessionKey oldCur;
+    MessageItem[] messagesTellDisconnected;
+    PacketFormat oldPacketFormat;
+  }
+
+  private HandshakeApplyResult applyHandshakeState(
+      HandshakeCompletionParams params, RoutabilityDecision rd, long trackerID, long now) {
+    HandshakeApplyResult result = new HandshakeApplyResult();
+    synchronized (peerNode) {
+      peerNode.disconnecting = false;
+      if (isReplayedKey(params)) return null;
+      updateRoutabilityAndBootId(params, rd, now, result);
+      SessionKey newTracker = buildSessionKey(params, trackerID);
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "New key tracker in completedHandshake: {}" + PeerNode.STR_FOR + "{} neg type {}",
+            newTracker,
+            peerNode.shortToString(),
+            params.negType);
+      assignTrackersAndTimes(params, now, result, newTracker);
+    }
+    return result;
+  }
+
+  private boolean isReplayedKey(HandshakeCompletionParams params) {
+    if (peerNode.currentTracker != null
+        && Arrays.equals(params.outgoingKey, peerNode.currentTracker.outgoingKey)
+        && Arrays.equals(params.incommingKey, peerNode.currentTracker.incommingKey)) {
+      LOG.error("Handshake replay suspected: new keys match current tracker");
+      return true;
+    }
+    if (peerNode.previousTracker != null
+        && Arrays.equals(params.outgoingKey, peerNode.previousTracker.outgoingKey)
+        && Arrays.equals(params.incommingKey, peerNode.previousTracker.incommingKey)) {
+      LOG.error("Handshake replay suspected: new keys match previous tracker");
+      return true;
+    }
+    if (peerNode.unverifiedTracker != null
+        && Arrays.equals(params.outgoingKey, peerNode.unverifiedTracker.outgoingKey)
+        && Arrays.equals(params.incommingKey, peerNode.unverifiedTracker.incommingKey)) {
+      LOG.error("Handshake replay suspected: new keys match unverified tracker");
+      return true;
+    }
+    return false;
+  }
+
+  private void updateRoutabilityAndBootId(
+      HandshakeCompletionParams params,
+      RoutabilityDecision rd,
+      long now,
+      HandshakeApplyResult result) {
+    peerNode.handshakeCount.set(0);
+    peerNode.bogusNoderef = false;
+    if (!peerNode.isConnected()) {
+      peerNode.connectedTime = now;
+      peerNode.countSelectionsSinceConnected.set(0);
+      peerNode.sentInitialMessages = false;
+    } else result.wasARekey = true;
+    peerNode.disableRouting =
+        peerNode.disableRoutingHasBeenSetLocally || peerNode.disableRoutingHasBeenSetRemotely;
+    peerNode.isRoutable = rd.routable();
+    peerNode.unroutableNewerVersion = rd.newer();
+    peerNode.unroutableOlderVersion = rd.older();
+    long oldBootID = peerNode.bootID;
+    peerNode.bootID = params.thisBootID;
+    result.bootIDChanged = oldBootID != params.thisBootID;
+    if (peerNode.myLastSuccessfulBootID != peerNode.myBootID) {
+      result.bootIDChanged = true;
+      peerNode.myLastSuccessfulBootID = peerNode.myBootID;
+    }
+    if (result.bootIDChanged && result.wasARekey) {
+      LOG.info(
+          "Changed boot ID while rekeying! from {} to {}" + PeerNode.STR_FOR + "{}",
+          oldBootID,
+          params.thisBootID,
+          peerNode.getPeer());
+      result.wasARekey = false;
+      peerNode.connectedTime = now;
+      peerNode.countSelectionsSinceConnected.set(0);
+      peerNode.sentInitialMessages = false;
+    } else if (result.bootIDChanged && LOG.isDebugEnabled())
+      LOG.debug(
+          "Changed boot ID from {} to {}" + PeerNode.STR_FOR + "{}",
+          oldBootID,
+          params.thisBootID,
+          peerNode.getPeer());
+    if (result.bootIDChanged) {
+      result.oldPrev = peerNode.previousTracker;
+      result.oldCur = peerNode.currentTracker;
+      peerNode.previousTracker = null;
+      peerNode.currentTracker = null;
+      result.messagesTellDisconnected = peerNode.grabQueuedMessageItems();
+      peerNode.offeredMainJarVersion = 0;
+      result.oldPacketFormat = runtime.packetFormat();
+      runtime.clearPacketFormat();
+    }
+  }
+
+  private SessionKey buildSessionKey(HandshakeCompletionParams params, long trackerID) {
+    return new SessionKey(
+        peerNode.selfPeerNode(),
+        new SessionKeyCryptoMaterial(
+            params.outgoingCipher,
+            params.outgoingKey,
+            params.incommingCipher,
+            params.incommingKey,
+            params.ivCipher,
+            params.ivNonce,
+            params.hmacKey),
+        new NewPacketFormatKeyContext(params.ourInitialSeqNum, params.theirInitialSeqNum),
+        trackerID);
+  }
+
+  private void assignTrackersAndTimes(
+      HandshakeCompletionParams params,
+      long now,
+      HandshakeApplyResult result,
+      SessionKey newTracker) {
+    if (params.unverified) {
+      if (peerNode.unverifiedTracker != null && peerNode.previousTracker == null)
+        peerNode.previousTracker = peerNode.unverifiedTracker;
+      peerNode.unverifiedTracker = newTracker;
+    } else {
+      result.oldPrev = peerNode.previousTracker;
+      peerNode.previousTracker = peerNode.currentTracker;
+      peerNode.currentTracker = newTracker;
+      peerNode.neverConnected = false;
+      peerNode.maybeClearPeerAddedTimeOnConnect();
+    }
+    runtime.setConnected(peerNode.currentTracker != null, now);
+    peerNode.handshake.clearKeyAgreementSchemeContext();
+    peerNode.isRekeying = false;
+    peerNode.timeLastRekeyed =
+        now - (params.unverified ? 0 : FNPPacketMangler.MAX_SESSION_KEY_REKEYING_DELAY / 2);
+    peerNode.totalBytesExchangedWithCurrentTracker = 0;
+    if (peerNode.currentTracker != null
+        && peerNode.previousTracker != null
+        && Arrays.equals(peerNode.currentTracker.outgoingKey, peerNode.previousTracker.outgoingKey)
+        && Arrays.equals(
+            peerNode.currentTracker.incommingKey, peerNode.previousTracker.incommingKey))
+      LOG.error(
+          "currentTracker key equals previousTracker key: cur {} prev {}",
+          peerNode.currentTracker,
+          peerNode.previousTracker);
+    if (peerNode.previousTracker != null
+        && peerNode.unverifiedTracker != null
+        && Arrays.equals(
+            peerNode.previousTracker.outgoingKey, peerNode.unverifiedTracker.outgoingKey)
+        && Arrays.equals(
+            peerNode.previousTracker.incommingKey, peerNode.unverifiedTracker.incommingKey))
+      LOG.error(
+          "previousTracker key equals unverifiedTracker key: prev {} unv {}",
+          peerNode.previousTracker,
+          peerNode.unverifiedTracker);
+    peerNode.timeLastSentPacket = now;
+    if (runtime.packetFormat() == null) {
+      runtime.setPacketFormat(
+          new NewPacketFormat(peerNode, params.ourInitialMsgID, params.theirInitialMsgID));
+    }
+    peerNode.timeLastReceivedPacket = now;
+    peerNode.timeLastReceivedDataPacket = now;
+    peerNode.timeLastReceivedAck = now;
+  }
+
+  private void processHandshakeNoderef(byte[] data, int length) throws FSParseException {
+    SimpleFieldSet fs = PeerNodeReferenceSupport.compressedNoderefToFieldSet(data, 0, length);
+    peerNode.processNewNoderef(fs, false, false, false);
+  }
+}

--- a/src/main/java/network/crypta/node/PeerNodeRuntime.java
+++ b/src/main/java/network/crypta/node/PeerNodeRuntime.java
@@ -1,0 +1,942 @@
+package network.crypta.node;
+
+import java.lang.ref.WeakReference;
+import java.security.interfaces.ECPublicKey;
+import java.util.List;
+import java.util.Random;
+import network.crypta.io.comm.Peer;
+import network.crypta.keys.Key;
+import network.crypta.support.SimpleFieldSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Aggregates peer-runtime helper components and exposes a narrow façade for {@link PeerNode}.
+ *
+ * <p>This class wires together the specialized support helpers that manage noderef parsing,
+ * transport operations, ARK lifecycle, routing statistics, load tracking, and handshake completion.
+ * Most methods are thin delegations that keep {@link PeerNode} focused on state and policy while
+ * moving subsystem-specific logic behind stable entry points. Callers typically create one instance
+ * per peer and reuse it throughout the peer lifetime.
+ *
+ * <p>Mutability is intentional: packet format and connection state evolve as sessions renegotiate,
+ * while helper collaborators remain stable references after construction. Thread-safety is provided
+ * by delegated components and selective synchronization (for example, packet-format reading during
+ * sending). This class does not introduce a global lock and therefore preserves the existing
+ * peer-level lock ordering.
+ *
+ * <ul>
+ *   <li>Centralizes helper composition for the peer runtime path.
+ *   <li>Provides packet send/handshake adapter methods used by {@link PeerNode}.
+ *   <li>Exposes load, location, and routing metrics through delegated readers.
+ * </ul>
+ */
+final class PeerNodeRuntime {
+  private static final Logger LOG = LoggerFactory.getLogger(PeerNodeRuntime.class);
+
+  private final PeerNode peerNode;
+  private final Node node;
+  private final PeerNodeReferenceSupport referenceSupport;
+  private final PeerNodeOfferSupport offerSupport;
+  private final PeerNodeTransport transport;
+  private final PeerNodeArkManager arkManager;
+  private final PeerNodeAddressManager addressManager;
+  private final PeerNodeRoutingStats routingStats;
+  private final PeerLocation location;
+  private final PeerNodeLoadTracker loadTracker;
+  private final PeerNodeHandshakeLifecycle handshakeLifecycle;
+  private final PeerNodeJfkNonces jfkNoncesSent = new PeerNodeJfkNonces();
+
+  private PeerNodeConnectionState connectionState = new PeerNodeConnectionState(0);
+  private PacketFormat packetFormat;
+
+  /**
+   * Creates a backoff checker runnable for a peer reference.
+   *
+   * @param peerRef weak reference to the peer whose backoff status should be refreshed
+   * @return runnable checker that safely does nothing when the reference has been cleared
+   */
+  static Runnable createBackoffStatusChecker(WeakReference<PeerNode> peerRef) {
+    return PeerNodeHandshakeLifecycle.createBackoffStatusChecker(peerRef);
+  }
+
+  /**
+   * Creates a runtime façade and initializes all peer-scoped helper components.
+   *
+   * @param peerNode owning peer used by delegated helpers
+   * @param node node context used for routing, stats, and network services
+   * @param locationString serialized peer location used to initialize location state
+   */
+  PeerNodeRuntime(PeerNode peerNode, Node node, String locationString) {
+    this.peerNode = peerNode;
+    this.node = node;
+    referenceSupport = new PeerNodeReferenceSupport(peerNode);
+    offerSupport = new PeerNodeOfferSupport(peerNode);
+    transport = new PeerNodeTransport(peerNode);
+    arkManager = new PeerNodeArkManager(peerNode);
+    addressManager = new PeerNodeAddressManager(peerNode);
+    routingStats = new PeerNodeRoutingStats(node);
+    location = new PeerLocation(locationString);
+    loadTracker = new PeerNodeLoadTracker(peerNode);
+    handshakeLifecycle = new PeerNodeHandshakeLifecycle(peerNode, node, this);
+  }
+
+  /**
+   * Derives the incoming setup key material used by handshake logic.
+   *
+   * @param crypto crypto context supplying key-derivation material
+   * @param identityHashHash double-hashed identity bytes used by the derivation
+   * @return derived setup key bytes for incoming handshake traffic
+   */
+  byte[] computeIncomingSetupKey(NodeCrypto crypto, byte[] identityHashHash) {
+    return referenceSupport.computeIncomingSetupKey(crypto, identityHashHash);
+  }
+
+  /**
+   * Derives the outgoing setup key material used by handshake logic.
+   *
+   * @param crypto crypto context supplying key-derivation material
+   * @param identityHash hashed peer identity bytes used by the derivation
+   * @return derived setup key bytes for outgoing handshake traffic
+   */
+  byte[] computeOutgoingSetupKey(NodeCrypto crypto, byte[] identityHash) {
+    return referenceSupport.computeOutgoingSetupKey(crypto, identityHash);
+  }
+
+  /**
+   * Formats a duration for diagnostics.
+   *
+   * @param millis duration in milliseconds
+   * @return human-readable duration string suitable for logs
+   */
+  String formatDuration(long millis) {
+    return referenceSupport.formatDuration(millis);
+  }
+
+  /**
+   * Formats a peer key hash for diagnostics.
+   *
+   * @param hash key-hash bytes to format
+   * @return compact string representation of the provided hash bytes
+   */
+  String formatPeerKeyHash(byte[] hash) {
+    return referenceSupport.formatPeerKeyHash(hash);
+  }
+
+  /**
+   * Verifies the noderef signature.
+   *
+   * @param fs noderef fields containing signature and signed data
+   * @return {@code true} when signature verification succeeds
+   * @throws FSParseException when verification fails or underlying parsing throws
+   */
+  boolean verifyReferenceSignature(SimpleFieldSet fs) throws FSParseException {
+    try {
+      return referenceSupport.verifyReferenceSignature(fs);
+    } catch (Exception e) {
+      throw new FSParseException("Invalid signature", e);
+    }
+  }
+
+  /**
+   * Parses a single peer address string.
+   *
+   * @param phys textual peer endpoint representation
+   * @return parsed peer endpoint, or {@code null} when parsing fails
+   */
+  Peer tryParsePeer(String phys) {
+    return referenceSupport.tryParsePeer(phys);
+  }
+
+  /**
+   * Validates testnet and opennet flags from noderef content.
+   *
+   * @param fs noderef fields to validate
+   * @param forDiffNodeRef whether fields came from a differential noderef update
+   * @param forFullNodeRef whether fields came from a full noderef update
+   * @throws FSParseException when required flags are missing or invalid
+   */
+  void checkTestnetAndOpennet(SimpleFieldSet fs, boolean forDiffNodeRef, boolean forFullNodeRef)
+      throws FSParseException {
+    referenceSupport.checkTestnetAndOpennet(fs, forDiffNodeRef, forFullNodeRef);
+  }
+
+  /**
+   * Validates identity fields from noderef content.
+   *
+   * @param fs noderef fields containing identity material
+   * @param forDiffNodeRef whether fields came from a differential noderef update
+   * @param forFullNodeRef whether fields came from a full noderef update
+   * @throws FSParseException when identity data is malformed or inconsistent
+   */
+  void validateIdentity(SimpleFieldSet fs, boolean forDiffNodeRef, boolean forFullNodeRef)
+      throws FSParseException {
+    referenceSupport.validateIdentity(fs, forDiffNodeRef, forFullNodeRef);
+  }
+
+  /**
+   * Parses ECDSA noderef fields.
+   *
+   * @param fs noderef fields containing ECDSA values
+   * @throws FSParseException when ECDSA fields are missing or malformed
+   */
+  void parseEcdsaFields(SimpleFieldSet fs) throws FSParseException {
+    referenceSupport.parseEcdsaFields(fs);
+  }
+
+  /**
+   * Writes ECDSA noderef fields.
+   *
+   * @param fs destination field set to receive ECDSA fields
+   * @param key ECDSA public key to serialize
+   */
+  void putEcdsaFields(SimpleFieldSet fs, ECPublicKey key) {
+    referenceSupport.putEcdsaFields(fs, key);
+  }
+
+  /**
+   * Parses ARK fields from noderef content.
+   *
+   * @param fs noderef fields that may contain ARK metadata
+   * @param onStartup whether parsing is running during startup initialization
+   * @param forDiffNodeRef whether fields came from a differential noderef update
+   * @return {@code true} when ARK state changed, otherwise {@code false}
+   */
+  boolean parseArk(SimpleFieldSet fs, boolean onStartup, boolean forDiffNodeRef) {
+    return arkManager.parseArk(fs, onStartup, forDiffNodeRef);
+  }
+
+  /**
+   * Appends ARK fields to a noderef field set.
+   *
+   * @param fs destination field set for ARK metadata
+   */
+  void appendArkFields(SimpleFieldSet fs) {
+    arkManager.appendArkFields(fs);
+  }
+
+  /**
+   * Applies a fetched ARK update.
+   *
+   * @param fs fetched noderef content to process
+   * @param fetchedEdition ARK edition number associated with the fetched content
+   */
+  void handleArkUpdate(SimpleFieldSet fs, long fetchedEdition) {
+    arkManager.handleArkUpdate(fs, fetchedEdition);
+  }
+
+  /**
+   * Reports whether an ARK fetcher is active.
+   *
+   * @return {@code true} when ARK fetching is currently running
+   */
+  boolean isFetchingArk() {
+    return arkManager.isFetching();
+  }
+
+  /** Starts ARK fetching for this peer. */
+  void startArkFetcher() {
+    arkManager.startFetcher();
+  }
+
+  /** Stops ARK fetching for this peer. */
+  void stopArkFetcher() {
+    arkManager.stopFetcher();
+  }
+
+  /**
+   * Sends a key offer to this peer.
+   *
+   * @param key key to offer to use the peer-offer protocol
+   */
+  void offer(Key key) {
+    offerSupport.offer(key);
+  }
+
+  /**
+   * Notifies opennet manager of a disconnect event when available.
+   *
+   * @param node node context used to look up the opennet manager
+   */
+  void notifyOpennetOnDisconnect(Node node) {
+    OpennetManager om = node.network().opennet();
+    if (om != null) om.onDisconnect();
+  }
+
+  /**
+   * Notifies opennet manager of a connected peer when available.
+   *
+   * @param node node context used to look up the opennet manager
+   * @param peerNode connected peer instance to pass to opennet manager
+   */
+  void notifyOpennetOnConnect(Node node, PeerNode peerNode) {
+    OpennetManager om = node.network().opennet();
+    if (om != null) {
+      // OpennetManager must be notified of a new connection even if it is a darknet peer.
+      om.onConnectedPeer(peerNode);
+    }
+  }
+
+  /** Resets throttling state for handshake IP refresh attempts. */
+  void resetHandshakeIpUpdateTimer() {
+    addressManager.resetHandshakeIpUpdateTimer();
+  }
+
+  /**
+   * Parses a detected peer address from metadata.
+   *
+   * @param metadata metadata field set that may contain detected address values
+   * @return parsed detected peer address, or {@code null} when absent/invalid
+   */
+  Peer parseDetectedPeer(SimpleFieldSet metadata) {
+    return addressManager.parseDetectedPeer(metadata);
+  }
+
+  /**
+   * Parses compatibility peer-address syntax into concrete peers.
+   *
+   * @param phys physical address entry from noderef data
+   * @param fromLocal whether this entry originates from local persisted data
+   * @return parsed peers in encounter order, possibly empty when parsing fails
+   */
+  List<Peer> parsePeerEntryCompat(String phys, boolean fromLocal) {
+    return referenceSupport.parsePeerEntryCompat(phys, fromLocal);
+  }
+
+  /**
+   * Refreshes handshake IP candidates.
+   *
+   * @param ignoreHostnames whether hostname lookups should be skipped for this pass
+   */
+  void maybeUpdateHandshakeIPs(boolean ignoreHostnames) {
+    addressManager.maybeUpdateHandshakeIPs(ignoreHostnames);
+  }
+
+  /**
+   * Selects the next handshake IP candidate.
+   *
+   * @return selected handshake peer endpoint, or {@code null} when none are available
+   */
+  Peer getHandshakeIP() {
+    return addressManager.getHandshakeIP();
+  }
+
+  /**
+   * Records when handshake-IP refresh was attempted.
+   *
+   * @param now wall-clock timestamp in milliseconds
+   */
+  void markHandshakeIpUpdateAttempted(long now) {
+    addressManager.markHandshakeIpUpdateAttempted(now);
+  }
+
+  /**
+   * Creates handshake state using pre-derived setup keys.
+   *
+   * @param incomingSetupKey setup key for inbound handshake processing
+   * @param outgoingSetupKey setup key for outbound handshake processing
+   * @param anonymousInitiatorKey setup key used for anonymous initiator mode
+   * @return initialized handshake-state object bound to this peer
+   */
+  PeerNode.HandshakeState createHandshakeState(
+      byte[] incomingSetupKey, byte[] outgoingSetupKey, byte[] anonymousInitiatorKey) {
+    return new PeerNodeHandshake(
+        peerNode, incomingSetupKey, outgoingSetupKey, anonymousInitiatorKey);
+  }
+
+  /**
+   * Determines whether traffic to this peer should be throttled.
+   *
+   * @return {@code true} when local throttling policy indicates throttling should apply
+   */
+  boolean shouldThrottle() {
+    return PeerNodeAddressManager.shouldThrottle(peerNode.getPeer(), node);
+  }
+
+  /**
+   * Returns the current connection state.
+   *
+   * @return {@code true} when peer connection state is currently connected
+   */
+  boolean isConnected() {
+    return connectionState.isConnected();
+  }
+
+  /**
+   * Updates connection state.
+   *
+   * @param connected new connection-state flag to apply
+   * @param now timestamp used for transition tracking
+   * @return previous connection-state value before update
+   */
+  boolean setConnected(boolean connected, long now) {
+    return connectionState.setConnected(connected, now);
+  }
+
+  /**
+   * Returns the most recent connected timestamp.
+   *
+   * @param now fallback timestamp when currently connected
+   * @return last-connected timestamp for this peer
+   */
+  long timeLastConnected(long now) {
+    return connectionState.timeLastConnected(now);
+  }
+
+  /**
+   * Determines whether burst-only handshakes should be used.
+   *
+   * @param outgoingMangler mangler used to query connectivity status
+   * @param random random source used for probabilistic burst decisions
+   * @return {@code true} when burst-only behavior is currently enabled
+   */
+  boolean isBurstOnly(OutgoingPacketMangler outgoingMangler, Random random) {
+    return connectionState.isBurstOnly(outgoingMangler, random);
+  }
+
+  /**
+   * Registers a peer-status change listener.
+   *
+   * @param listener listener object expected to implement peer-status callback interface
+   * @throws ClassCastException if {@code listener} is not a compatible listener implementation
+   */
+  void registerStatusChangeListener(Object listener) {
+    connectionState.registerStatusChangeListener((PeerManager.PeerStatusChangeListener) listener);
+  }
+
+  /** Notifies registered peer-status listeners. */
+  void notifyStatusChangeListeners() {
+    connectionState.notifyStatusChangeListeners();
+  }
+
+  /**
+   * Reinitializes connection-state tracking with a persisted timestamp.
+   *
+   * @param lastConnectedTime last-known connection timestamp to seed the tracker
+   */
+  void initConnectionState(long lastConnectedTime) {
+    connectionState = new PeerNodeConnectionState(lastConnectedTime);
+  }
+
+  /**
+   * Returns the peer transport adapter.
+   *
+   * @return transport component used for message and packet operations
+   */
+  PeerTransport transport() {
+    return transport;
+  }
+
+  /** Notifies transport throttle state after disconnect-related transitions. */
+  void maybeDisconnected() {
+    transport.getThrottle().maybeDisconnected();
+  }
+
+  /**
+   * Returns current transport bandwidth estimate.
+   *
+   * @return current bandwidth estimate from the transport throttle
+   */
+  double bandwidth() {
+    return transport.getThrottle().getBandwidth();
+  }
+
+  /** Sends the local IP-address announcement message. */
+  void sendIPAddressMessage() {
+    transport.sendIPAddressMessage();
+  }
+
+  /** Sends post-connection initial messages. */
+  void sendInitialMessages() {
+    transport.sendInitialMessages();
+  }
+
+  /**
+   * Sends a node-to-node message via transport.
+   *
+   * @param fs message payload fields
+   * @param n2nType node-to-node message type identifier
+   * @param includeSentTime whether send timestamp should be included in the payload
+   * @param now current wall-clock timestamp in milliseconds
+   * @param queueOnNotConnected whether the message may be queued while disconnected
+   */
+  void sendNodeToNodeMessage(
+      SimpleFieldSet fs,
+      int n2nType,
+      boolean includeSentTime,
+      long now,
+      boolean queueOnNotConnected) {
+    transport.sendNodeToNodeMessage(fs, n2nType, includeSentTime, now, queueOnNotConnected);
+  }
+
+  /**
+   * Returns total resent bytes recorded by transport.
+   *
+   * @return cumulative count of resent bytes for this peer transport
+   */
+  long getResendBytesSent() {
+    return transport.getResendBytesSent();
+  }
+
+  /**
+   * Records resent bytes on the transport counters.
+   *
+   * @param bytesToResend number of bytes resent
+   */
+  void resendBytes(int bytesToResend) {
+    transport.resendBytes(bytesToResend);
+  }
+
+  /**
+   * Returns the nonce tracker used by JFK handshake processing.
+   *
+   * @return nonce tracker maintaining recently seen JFK nonces
+   */
+  @SuppressWarnings("unused")
+  PeerNodeJfkNonces jfkNoncesSent() {
+    return jfkNoncesSent;
+  }
+
+  /** Clears cached JFK nonces for this peer. */
+  void clearJfkNoncesSent() {
+    jfkNoncesSent.clear();
+  }
+
+  /**
+   * Remembers JFK nonce for replay detection.
+   *
+   * @param nonce nonce bytes to cache
+   * @param maxNoncesPerPeer maximum nonce entries to retain for this peer
+   */
+  void rememberJfkNonce(byte[] nonce, int maxNoncesPerPeer) {
+    jfkNoncesSent.rememberNonce(nonce, maxNoncesPerPeer);
+  }
+
+  /**
+   * Finds previously stored JFK nonce by nonce-hash.
+   *
+   * @param nonceHash hash bytes of the nonce to look up
+   * @return original nonce bytes when present, otherwise {@code null}
+   */
+  byte[] findOriginalJfkNonceByHash(byte[] nonceHash) {
+    return jfkNoncesSent.findOriginalNonceByHash(nonceHash);
+  }
+
+  /**
+   * Sets the active packet format implementation.
+   *
+   * @param packetFormat packet format instance to activate, or {@code null} to clear externally
+   */
+  void setPacketFormat(PacketFormat packetFormat) {
+    this.packetFormat = packetFormat;
+  }
+
+  /** Clears the active packet-format reference. */
+  void clearPacketFormat() {
+    packetFormat = null;
+  }
+
+  /**
+   * Returns the currently active packet format.
+   *
+   * @return active packet format instance, or {@code null} when no format is installed
+   */
+  PacketFormat packetFormat() {
+    return packetFormat;
+  }
+
+  /**
+   * Attempts to send a packet using the active packet format.
+   *
+   * @param now current timestamp in milliseconds
+   * @param ackOnly whether only acknowledgment/maintenance packets may be sent
+   * @return {@code true} when a packet was sent, otherwise {@code false}
+   */
+  boolean maybeSendPacket(long now, boolean ackOnly) {
+    PacketFormat pf;
+    synchronized (peerNode) {
+      pf = packetFormat;
+      if (pf == null) return false;
+    }
+    try {
+      return pf.maybeSendPacket(now, ackOnly);
+    } catch (BlockedTooLongException e) {
+      LOG.error(
+          "Packet number allocation blocked {} (peer={}, version={}) - disconnecting",
+          formatDuration(e.delta),
+          peerNode,
+          peerNode.getBuildNumber());
+      peerNode.forceDisconnect();
+      return false;
+    }
+  }
+
+  /**
+   * Reports incoming load status from a peer message.
+   *
+   * @param stat load-status object expected to be a {@link PeerLoadStats} instance
+   * @throws ClassCastException if {@code stat} is not a {@link PeerLoadStats}
+   */
+  void reportLoadStatus(Object stat) {
+    loadTracker.reportLoadStatus((PeerLoadStats) stat);
+  }
+
+  /**
+   * Signals that a routing tag no longer routes through this peer.
+   *
+   * @param tag routing tag previously associated with this peer
+   * @param offeredKey whether the tag originated from offered-key routing
+   */
+  void noLongerRoutingTo(Object tag, boolean offeredKey) {
+    loadTracker.noLongerRoutingTo(tag, offeredKey);
+  }
+
+  /**
+   * Notifies waiting slot selectors that capacity may have changed.
+   *
+   * @param realTime whether to notify real-time or bulk waiters
+   */
+  void maybeNotifySlotWaiter(boolean realTime) {
+    loadTracker.maybeNotifySlotWaiter(realTime);
+  }
+
+  /**
+   * Performs post-unlock load-tracker housekeeping for a routing tag.
+   *
+   * @param tag routing tag that was just unlocked
+   */
+  void postUnlock(Object tag) {
+    loadTracker.postUnlock(tag);
+  }
+
+  /**
+   * Returns the output-load tracker for a traffic class.
+   *
+   * @param realTime {@code true} for real-time tracker, {@code false} for bulk tracker
+   * @return output-load tracker associated with the requested traffic class
+   */
+  PeerNodeLoadTracker.OutputLoadTracker outputLoadTracker(boolean realTime) {
+    return loadTracker.outputLoadTracker(realTime);
+  }
+
+  /**
+   * Returns summarized incoming-load statistics.
+   *
+   * @param realTime {@code true} for real-time summary, {@code false} for bulk summary
+   * @return immutable summary stats for the requested traffic class
+   */
+  PeerNodeLoadTracker.IncomingLoadSummaryStats getIncomingLoadStats(boolean realTime) {
+    return loadTracker.getIncomingLoadStats(realTime);
+  }
+
+  /**
+   * Indicates whether no incoming-load sample is currently cached.
+   *
+   * @param realTime {@code true} to query real-time stats, {@code false} for bulk stats
+   * @return {@code true} when no prior incoming-load sample exists
+   */
+  boolean missingLastIncomingLoadStats(boolean realTime) {
+    return loadTracker.getLastIncomingLoadStats(realTime) == null;
+  }
+
+  /**
+   * Evaluates whether this peer currently appears low-capacity.
+   *
+   * @param isRealtime {@code true} for real-time thresholds, {@code false} for bulk thresholds
+   * @return {@code true} when either directional threshold exceeds peer-advertised capacity
+   */
+  boolean isLowCapacity(boolean isRealtime) {
+    PeerLoadStats stats = loadTracker.getLastIncomingLoadStats(isRealtime);
+    if (stats == null) return false;
+    if (node.network().stats().nodePinger.capacityThreshold(isRealtime, true)
+        > stats.peerLimit(true)) return true;
+    return node.network().stats().nodePinger.capacityThreshold(isRealtime, false)
+        > stats.peerLimit(false);
+  }
+
+  /**
+   * Returns the ping-time cap used for peer selection and diagnostics.
+   *
+   * @return configured maximum peer ping time, or a conservative fallback when stats are missing
+   */
+  long maxPeerPingTime() {
+    if (node == null) return NodeStats.DEFAULT_MAX_PING_TIME * 2L;
+    NodeStats stats = node.network().stats();
+    if (stats == null) return NodeStats.DEFAULT_MAX_PING_TIME * 2L;
+    return stats.maxPeerPingTime();
+  }
+
+  /**
+   * Fails queued slot waiters for the selected traffic class.
+   *
+   * @param realTime {@code true} to fail real-time waiters, {@code false} for bulk waiters
+   */
+  void failSlotWaiters(boolean realTime) {
+    loadTracker.failSlotWaiters(realTime);
+  }
+
+  /**
+   * Updates peer-neighbor location samples.
+   *
+   * @param peerLocationsString serialized peer-neighbor locations, possibly {@code null}
+   */
+  void setPeerLocations(String[] peerLocationsString) {
+    location.setPeerLocations(peerLocationsString);
+  }
+
+  /**
+   * Returns this peer's current location on the routing ring.
+   *
+   * @return location value in ring space
+   */
+  double getLocation() {
+    return location.getLocation();
+  }
+
+  /**
+   * Returns peer-neighbor location samples.
+   *
+   * @return array of neighbor locations, or {@code null} when unknown
+   */
+  double[] getPeersLocationArray() {
+    return location.getPeersLocationArray();
+  }
+
+  /**
+   * Returns the timestamp of the most recent location update.
+   *
+   * @return wall-clock timestamp in milliseconds for the last location change
+   */
+  long getLocationSetTime() {
+    return location.getLocationSetTime();
+  }
+
+  /**
+   * Indicates whether the current location value is valid.
+   *
+   * @return {@code true} when the location is inside valid bounds
+   */
+  boolean isValidLocation() {
+    return location.isValidLocation();
+  }
+
+  /**
+   * Returns the known degree of peer-neighbor location samples.
+   *
+   * @return count of known peer-neighbor locations
+   */
+  int getLocationDegree() {
+    return location.getDegree();
+  }
+
+  /**
+   * Updates both primary and neighbor locations.
+   *
+   * @param newLoc new primary location value
+   * @param newLocs new neighbor-location array
+   * @return {@code true} when the update changed stored values
+   */
+  boolean updateLocation(double newLoc, double[] newLocs) {
+    return location.updateLocation(newLoc, newLocs);
+  }
+
+  /**
+   * Sets the primary location value.
+   *
+   * @param newLoc new primary location value
+   * @return previous location value before update
+   */
+  double setLocation(double newLoc) {
+    return location.setLocation(newLoc);
+  }
+
+  /**
+   * Parses location from noderef fields and updates peer-count refresh hints.
+   *
+   * @param fs noderef fields that may contain a location string
+   * @param shouldUpdatePeerCounts single-element flag array toggled when the unknown location
+   *     becomes known
+   * @return {@code true} when location state changed, otherwise {@code false}
+   */
+  boolean parseLocationAndMaybePeerCounts(SimpleFieldSet fs, boolean[] shouldUpdatePeerCounts) {
+    boolean changedAnything = false;
+    String locationString = fs.get(PeerNode.SFS_KEY_LOCATION);
+    if (locationString != null) {
+      double newLoc = Location.getLocation(locationString);
+      if (!Location.isValid(newLoc)) {
+        if (LOG.isDebugEnabled())
+          LOG.debug(
+              "Invalid or null location, waiting for FNPLocChangeNotification: locationString={}",
+              locationString);
+      } else {
+        double oldLoc = setLocation(newLoc);
+        if (!Location.equals(oldLoc, newLoc)) {
+          if (!Location.isValid(oldLoc)) shouldUpdatePeerCounts[0] = true;
+          changedAnything = true;
+        }
+      }
+    }
+    return changedAnything;
+  }
+
+  /**
+   * Returns the location string used in short diagnostics.
+   *
+   * @return string representation of the current location state
+   */
+  String locationToString() {
+    return location.toString();
+  }
+
+  /**
+   * Returns an atomic location snapshot.
+   *
+   * @return two-element array containing raw location bits and location-set timestamp
+   */
+  long[] getLocationSnapshot() {
+    synchronized (location) {
+      return new long[] {
+        Double.doubleToRawLongBits(location.getLocation()), location.getLocationSetTime()
+      };
+    }
+  }
+
+  /**
+   * Returns the closest known peer-neighbor location to a target.
+   *
+   * @param target target ring location
+   * @param excludeLocations optional set of locations to exclude, expected as {@code Set<Double>}
+   * @return closest eligible location to {@code target}
+   * @throws ClassCastException if {@code excludeLocations} is non-null and not a {@code
+   *     Set<Double>}
+   */
+  @SuppressWarnings("unchecked")
+  double getClosestPeerLocation(double target, Object excludeLocations) {
+    java.util.Set<Double> exclude = null;
+    if (excludeLocations != null) {
+      exclude = (java.util.Set<Double>) excludeLocations;
+    }
+    return location.getClosestPeerLocation(target, exclude);
+  }
+
+  /**
+   * Reports interval between successive swap events.
+   *
+   * @param timeSinceLastTime elapsed milliseconds since the prior swap interval sample
+   */
+  void reportSwapInterval(long timeSinceLastTime) {
+    routingStats.reportSwapInterval(timeSinceLastTime);
+  }
+
+  /**
+   * Returns average swap interval.
+   *
+   * @return smoothed swap interval in milliseconds
+   */
+  double averageSwapInterval() {
+    return routingStats.averageSwapInterval();
+  }
+
+  /**
+   * Reports interval between successive probe events.
+   *
+   * @param timeSinceLastTime elapsed milliseconds since the prior probe interval sample
+   */
+  void reportProbeInterval(long timeSinceLastTime) {
+    routingStats.reportProbeInterval(timeSinceLastTime);
+  }
+
+  /**
+   * Returns average probe interval.
+   *
+   * @return smoothed probe interval in milliseconds
+   */
+  double averageProbeInterval() {
+    return routingStats.averageProbeInterval();
+  }
+
+  /**
+   * Returns combined backoff percentage.
+   *
+   * @return backoff proportion in the range {@code 0.0..1.0}
+   */
+  double backedOffPercent() {
+    return routingStats.backedOffPercent();
+  }
+
+  /**
+   * Reports current routing-backoff window endpoints.
+   *
+   * @param now current wall-clock timestamp in milliseconds
+   * @param routingBackedOffUntilRT end timestamp for real-time routing backoff
+   * @param routingBackedOffUntilBulk end timestamp for bulk routing backoff
+   */
+  void reportBackoffStatus(long now, long routingBackedOffUntilRT, long routingBackedOffUntilBulk) {
+    routingStats.reportBackoffStatus(now, routingBackedOffUntilRT, routingBackedOffUntilBulk);
+  }
+
+  /** Reports an overload rejection sample. */
+  void reportRejectedOverload() {
+    routingStats.reportRejectedOverload();
+  }
+
+  /** Reports a non-rejected overload sample. */
+  void reportNotRejectedOverload() {
+    routingStats.reportNotRejectedOverload();
+  }
+
+  /**
+   * Returns estimated overload rejection probability.
+   *
+   * @return overload rejection probability in the range {@code 0.0..1.0}
+   */
+  double pRejected() {
+    return routingStats.pRejected();
+  }
+
+  /**
+   * Returns average ping latency estimate.
+   *
+   * @return smoothed ping latency value in milliseconds
+   */
+  double averagePingTime() {
+    return routingStats.averagePingTime();
+  }
+
+  /**
+   * Reports a ping latency sample.
+   *
+   * @param t measured ping latency in milliseconds
+   */
+  void reportPing(long t) {
+    routingStats.reportPing(t);
+  }
+
+  /**
+   * Returns real-time backoff percentage.
+   *
+   * @return real-time backoff proportion in the range {@code 0.0..1.0}
+   */
+  double backedOffPercentRT() {
+    return routingStats.backedOffPercentRT();
+  }
+
+  /**
+   * Returns bulk backoff percentage.
+   *
+   * @return bulk backoff proportion in the range {@code 0.0..1.0}
+   */
+  double backedOffPercentBulk() {
+    return routingStats.backedOffPercentBulk();
+  }
+
+  /**
+   * Completes handshake finalization through the lifecycle coordinator.
+   *
+   * @param paramsObject handshake parameters expected by lifecycle completion logic
+   * @return tracker identifier on success or negative value when completion failed
+   */
+  long completeHandshake(Object paramsObject) {
+    return handshakeLifecycle.completeHandshake(paramsObject);
+  }
+}

--- a/src/test/java/network/crypta/node/PacketSenderTest.java
+++ b/src/test/java/network/crypta/node/PacketSenderTest.java
@@ -55,7 +55,7 @@ class PacketSenderTest {
     when(node.network().opennet()).thenReturn(null);
   }
 
-  // Helper to run one iteration of the internal send loop deterministically.
+  // Helper to run one iteration of the internal sending loop deterministically.
   @SuppressWarnings("java:S3011")
   private static void invokeRealRun(PacketSender ps) throws Exception {
     var m = PacketSender.class.getDeclaredMethod("realRun");
@@ -66,7 +66,7 @@ class PacketSenderTest {
   @SuppressWarnings("java:S3011")
   private static void attachPacketFormat(PeerNode peer, Node node, PacketFormat packetFormat)
       throws Exception {
-    Class<?> internalsClass = Class.forName("network.crypta.node.PeerNode$PeerNodeInternals");
+    Class<?> internalsClass = resolvePeerRuntimeClass();
     var ctor = internalsClass.getDeclaredConstructor(PeerNode.class, Node.class, String.class);
     ctor.setAccessible(true);
     Object internals = ctor.newInstance(peer, node, "0");
@@ -77,6 +77,14 @@ class PacketSenderTest {
     var internalsField = PeerNode.class.getDeclaredField("internals");
     internalsField.setAccessible(true);
     internalsField.set(peer, internals);
+  }
+
+  private static Class<?> resolvePeerRuntimeClass() throws ClassNotFoundException {
+    try {
+      return Class.forName("network.crypta.node.PeerNodeRuntime");
+    } catch (ClassNotFoundException _) {
+      return Class.forName("network.crypta.node.PeerNode$PeerNodeInternals");
+    }
   }
 
   @Test
@@ -121,7 +129,7 @@ class PacketSenderTest {
     when(pn.getNextUrgentTime(anyLong())).thenReturn(Long.MAX_VALUE); // no urgent payload
     when(pn.timeSendAcks()).thenReturn(0L); // acks due now
 
-    // Connectivity thresholds not violated
+    // Connectivity thresholds aren't violated
     when(pn.lastReceivedDataPacketTime()).thenReturn(System.currentTimeMillis());
     when(pn.maxTimeBetweenReceivedPackets()).thenReturn(Long.MAX_VALUE);
     when(pn.lastReceivedAckTime()).thenReturn(System.currentTimeMillis());

--- a/src/test/java/network/crypta/node/PeerNodeAddressManagerTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeAddressManagerTest.java
@@ -15,8 +15,8 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import network.crypta.io.comm.FreenetInetAddress;
 import network.crypta.io.comm.Peer;
@@ -71,7 +71,7 @@ class PeerNodeAddressManagerTest {
       throws ReflectiveOperationException {
     // Arrange
     PeerNodeAddressManager manager = new PeerNodeAddressManager(peer);
-    peer.nominalPeer = new ArrayList<>();
+    peer.nominalPeer = new CopyOnWriteArrayList<>();
     setLastAttemptedHandshakeIpUpdateTime(
         manager, System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(1));
 
@@ -87,7 +87,7 @@ class PeerNodeAddressManagerTest {
       throws ReflectiveOperationException {
     // Arrange
     PeerNodeAddressManager manager = new PeerNodeAddressManager(peer);
-    peer.nominalPeer = new ArrayList<>();
+    peer.nominalPeer = new CopyOnWriteArrayList<>();
 
     // Act
     manager.maybeUpdateHandshakeIPs(true);
@@ -102,7 +102,7 @@ class PeerNodeAddressManagerTest {
       throws UnknownHostException {
     // Arrange
     PeerNodeAddressManager manager = new PeerNodeAddressManager(peer);
-    peer.nominalPeer = new ArrayList<>();
+    peer.nominalPeer = new CopyOnWriteArrayList<>();
     Peer detectedPeer = new Peer(inetAddress(203, 0, 113, 10), 1234);
     when(peer.getPeer()).thenReturn(detectedPeer);
 
@@ -137,7 +137,8 @@ class PeerNodeAddressManagerTest {
     Peer peerMatchingNode = new Peer(matchingAddress, 2222);
     Peer duplicatePeer = new Peer(matchingAddress, 2222);
 
-    peer.nominalPeer = new ArrayList<>(List.of(detectedDuplicate, peerMatchingNode, duplicatePeer));
+    peer.nominalPeer =
+        new CopyOnWriteArrayList<>(List.of(detectedDuplicate, peerMatchingNode, duplicatePeer));
 
     FreenetInetAddress localhost = new FreenetInetAddress(inetAddress(127, 0, 0, 1));
     when(node.network().freenetLocalhostAddress()).thenReturn(localhost);
@@ -173,7 +174,7 @@ class PeerNodeAddressManagerTest {
       throws ReflectiveOperationException {
     // Arrange
     PeerNodeAddressManager manager = new PeerNodeAddressManager(peer);
-    peer.nominalPeer = new ArrayList<>();
+    peer.nominalPeer = new CopyOnWriteArrayList<>();
     long before = System.currentTimeMillis();
 
     // Act
@@ -343,7 +344,7 @@ class PeerNodeAddressManagerTest {
     InetAddress address = inetAddress(198, 51, 100, 9);
     Peer nominal = new Peer(address, 2468);
     PeerNode peerNode = Mockito.mock(PeerNode.class, Mockito.CALLS_REAL_METHODS);
-    peerNode.nominalPeer = new ArrayList<>(List.of(nominal));
+    peerNode.nominalPeer = new CopyOnWriteArrayList<>(List.of(nominal));
     Mockito.doReturn(null).when(peerNode).getPeer();
 
     FreenetInetAddress matchAddress = new FreenetInetAddress(address);
@@ -361,7 +362,7 @@ class PeerNodeAddressManagerTest {
     InetAddress address = inetAddress(198, 51, 100, 10);
     Peer nominal = new Peer(address, 2468);
     PeerNode peerNode = Mockito.mock(PeerNode.class, Mockito.CALLS_REAL_METHODS);
-    peerNode.nominalPeer = new ArrayList<>(List.of(nominal));
+    peerNode.nominalPeer = new CopyOnWriteArrayList<>(List.of(nominal));
     Mockito.doReturn(null).when(peerNode).getPeer();
 
     FreenetInetAddress otherAddress = new FreenetInetAddress(inetAddress(203, 0, 113, 99));

--- a/src/test/java/network/crypta/node/PeerNodeHandshakeLifecycleTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeHandshakeLifecycleTest.java
@@ -1,0 +1,234 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import network.crypta.io.comm.FreenetInetAddress;
+import network.crypta.io.comm.Peer;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerNodeHandshakeLifecycleTest {
+
+  @Mock private PeerNode peerNode;
+
+  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock private PeerNodeRuntime runtime;
+
+  @Mock private Peer replyTo;
+
+  @Mock private PeerNode.HandshakeState handshakeState;
+
+  @Mock private PacketFormat packetFormat;
+
+  @Mock private NodeCrypto crypto;
+
+  @Test
+  void createBackoffStatusChecker_whenReferenceProvided_expectCheckerBoundToSameReference() {
+    // Arrange
+    WeakReference<PeerNode> ref = new WeakReference<>(peerNode);
+
+    // Act
+    Runnable checker = PeerNodeHandshakeLifecycle.createBackoffStatusChecker(ref);
+
+    // Assert
+    assertInstanceOf(PeerNodeBackoffStatusChecker.class, checker);
+    assertSame(ref, ((PeerNodeBackoffStatusChecker) checker).ref);
+  }
+
+  @Test
+  void completeHandshake_whenNoderefParsingFails_expectMinusOneAndDisconnected() {
+    // Arrange
+    PeerNodeHandshakeLifecycle lifecycle = new PeerNodeHandshakeLifecycle(peerNode, node, runtime);
+    HandshakeCompletionParams params = newParams(123L);
+    params.replyTo = replyTo;
+
+    try (MockedStatic<PeerNodeReferenceSupport> noderefSupport =
+        mockStatic(PeerNodeReferenceSupport.class)) {
+      noderefSupport
+          .when(
+              () ->
+                  PeerNodeReferenceSupport.compressedNoderefToFieldSet(
+                      params.data, 0, params.length))
+          .thenThrow(new FSParseException("bad noderef"));
+
+      // Act
+      long result = lifecycle.completeHandshake(params);
+
+      // Assert
+      assertEquals(-1L, result);
+    }
+
+    assertTrue(peerNode.bogusNoderef);
+    verify(peerNode).calcNextHandshake(true, true, false);
+    verify(peerNode).stopARKFetcher();
+    verify(runtime).setConnected(eq(false), anyLong());
+    verify(node.network().peers()).disconnected(nullable(PeerNode.class));
+    verify(peerNode, never()).changedIP(any(Peer.class));
+  }
+
+  @Test
+  void completeHandshake_whenCurrentTrackerKeysReplayed_expectMinusOneWithoutStateTransition() {
+    // Arrange
+    PeerNodeHandshakeLifecycle lifecycle = new PeerNodeHandshakeLifecycle(peerNode, node, runtime);
+    HandshakeCompletionParams params = newParams(777L);
+    params.replyTo = replyTo;
+    params.outgoingKey = new byte[] {1, 2, 3, 4};
+    params.incommingKey = new byte[] {5, 6, 7, 8};
+
+    SessionKey existingTracker =
+        new SessionKey(
+            peerNode,
+            new SessionKeyCryptoMaterial(
+                null, params.outgoingKey, null, params.incommingKey, null, null, null),
+            new NewPacketFormatKeyContext(10, 20),
+            42L);
+    peerNode.currentTracker = existingTracker;
+
+    try (MockedStatic<PeerNodeReferenceSupport> noderefSupport =
+        mockStatic(PeerNodeReferenceSupport.class)) {
+      noderefSupport
+          .when(
+              () ->
+                  PeerNodeReferenceSupport.compressedNoderefToFieldSet(
+                      params.data, 0, params.length))
+          .thenReturn(new SimpleFieldSet(true));
+
+      // Act
+      long result = lifecycle.completeHandshake(params);
+
+      // Assert
+      assertEquals(-1L, result);
+    }
+
+    assertSame(existingTracker, peerNode.currentTracker);
+    verify(peerNode).calcNextHandshake(true, true, false);
+    verify(peerNode).stopARKFetcher();
+    verify(peerNode).changedIP(replyTo);
+    verify(runtime, never()).setConnected(anyBoolean(), anyLong());
+    verify(node.network().peers(), never()).disconnected(nullable(PeerNode.class));
+  }
+
+  @Test
+  void completeHandshake_whenParamsHaveWrongType_expectClassCastException() {
+    // Arrange
+    PeerNodeHandshakeLifecycle lifecycle = new PeerNodeHandshakeLifecycle(peerNode, node, runtime);
+    Object invalidParams = new Object();
+
+    // Act + Assert
+    assertThrows(ClassCastException.class, () -> lifecycle.completeHandshake(invalidParams));
+  }
+
+  @Test
+  void completeHandshake_whenVerifiedAndRoutable_expectTrackerPromotionAndConnectCallbacks() {
+    // Arrange
+    PeerNodeHandshakeLifecycle lifecycle = new PeerNodeHandshakeLifecycle(peerNode, node, runtime);
+    HandshakeCompletionParams params = newParams(999L);
+    params.replyTo = replyTo;
+    params.unverified = false;
+    params.thisBootID = 0L;
+    params.ourInitialSeqNum = 1001;
+    params.theirInitialSeqNum = 2002;
+    params.ourInitialMsgID = 3003;
+    params.theirInitialMsgID = 4004;
+
+    setPeerNodeField(peerNode, "handshakeCount", new AtomicInteger(7));
+    setPeerNodeField(peerNode, "countSelectionsSinceConnected", new AtomicLong(12));
+    setPeerNodeField(peerNode, "handshake", handshakeState);
+    setPeerNodeField(peerNode, "crypto", crypto);
+
+    when(runtime.packetFormat()).thenReturn(packetFormat);
+    when(peerNode.isConnected()).thenReturn(false, true);
+
+    try (MockedStatic<PeerNodeReferenceSupport> noderefSupport =
+        mockStatic(PeerNodeReferenceSupport.class)) {
+      noderefSupport
+          .when(
+              () ->
+                  PeerNodeReferenceSupport.compressedNoderefToFieldSet(
+                      params.data, 0, params.length))
+          .thenReturn(new SimpleFieldSet(true));
+
+      // Act
+      long trackerId = lifecycle.completeHandshake(params);
+
+      // Assert
+      assertEquals(999L, trackerId);
+    }
+
+    assertNotNull(peerNode.currentTracker);
+    assertEquals(999L, peerNode.currentTracker.trackerID);
+    assertTrue(peerNode.isRoutable);
+    assertFalse(peerNode.unroutableNewerVersion);
+    assertFalse(peerNode.unroutableOlderVersion);
+    assertFalse(peerNode.neverConnected);
+    assertFalse(peerNode.isRekeying);
+    assertEquals(0L, peerNode.totalBytesExchangedWithCurrentTracker);
+    assertEquals(0, peerNode.handshakeCount.get());
+    assertEquals(0L, peerNode.countSelectionsSinceConnected.get());
+    assertTrue(peerNode.timeLastSentPacket > 0L);
+    assertTrue(peerNode.timeLastReceivedPacket > 0L);
+
+    verify(peerNode).calcNextHandshake(true, true, false);
+    verify(peerNode).stopARKFetcher();
+    verify(peerNode).changedIP(replyTo);
+    verify(peerNode).maybeClearPeerAddedTimeOnConnect();
+    verify(runtime).setConnected(eq(true), anyLong());
+    verify(handshakeState).clearKeyAgreementSchemeContext();
+    verify(runtime).maybeDisconnected();
+    verify(peerNode).setPeerNodeStatus(anyLong());
+    verify(node.network().peers()).addConnectedPeer(nullable(PeerNode.class));
+    verify(node.network().peers(), never()).disconnected(nullable(PeerNode.class));
+    verify(peerNode).maybeOnConnect();
+    verify(crypto)
+        .maybeBootConnection(nullable(PeerNode.class), nullable(FreenetInetAddress.class));
+  }
+
+  private static HandshakeCompletionParams newParams(long trackerID) {
+    HandshakeCompletionParams params = new HandshakeCompletionParams();
+    params.trackerID = trackerID;
+    params.thisBootID = 1L;
+    params.data = new byte[] {11, 22, 33};
+    params.length = params.data.length;
+    params.outgoingKey = new byte[] {9, 9, 9, 9};
+    params.incommingKey = new byte[] {8, 8, 8, 8};
+    return params;
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void setPeerNodeField(PeerNode target, String fieldName, Object value) {
+    try {
+      Field field = PeerNode.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed to set PeerNode field: " + fieldName, e);
+    }
+  }
+}

--- a/src/test/java/network/crypta/node/PeerNodeRuntimeTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeRuntimeTest.java
@@ -1,0 +1,311 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerNodeRuntimeTest {
+
+  @Mock private PeerNode peerNode;
+
+  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  private PeerNodeRuntime runtime;
+
+  @BeforeEach
+  void setUp() {
+    runtime = new PeerNodeRuntime(peerNode, node, null);
+  }
+
+  @Test
+  void createBackoffStatusChecker_whenReferenceProvided_expectCheckerBoundToSameReference() {
+    // Arrange
+    WeakReference<PeerNode> ref = new WeakReference<>(peerNode);
+
+    // Act
+    Runnable checker = PeerNodeRuntime.createBackoffStatusChecker(ref);
+
+    // Assert
+    assertInstanceOf(PeerNodeBackoffStatusChecker.class, checker);
+    assertSame(ref, ((PeerNodeBackoffStatusChecker) checker).ref);
+  }
+
+  @Test
+  void verifyReferenceSignature_whenVerifierThrows_expectWrappedFsParseException()
+      throws Exception {
+    // Arrange
+    PeerNodeReferenceSupport referenceSupport = mock(PeerNodeReferenceSupport.class);
+    setField(runtime, PeerNodeRuntime.class, "referenceSupport", referenceSupport);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    RuntimeException cause = new RuntimeException("invalid");
+    doThrow(cause).when(referenceSupport).verifyReferenceSignature(fs);
+
+    // Act
+    FSParseException thrown =
+        assertThrows(FSParseException.class, () -> runtime.verifyReferenceSignature(fs));
+
+    // Assert
+    assertEquals("Invalid signature", thrown.getMessage());
+    assertSame(cause, thrown.getCause());
+  }
+
+  @Test
+  void maybeSendPacket_whenPacketFormatMissing_expectFalse() {
+    // Arrange + Act
+    boolean sent = runtime.maybeSendPacket(123L, false);
+
+    // Assert
+    assertFalse(sent);
+  }
+
+  @Test
+  void maybeSendPacket_whenPacketFormatSends_expectTrue() throws Exception {
+    // Arrange
+    PacketFormat packetFormat = mock(PacketFormat.class);
+    runtime.setPacketFormat(packetFormat);
+    when(packetFormat.maybeSendPacket(777L, true)).thenReturn(true);
+
+    // Act
+    boolean sent = runtime.maybeSendPacket(777L, true);
+
+    // Assert
+    assertTrue(sent);
+    verify(packetFormat).maybeSendPacket(777L, true);
+  }
+
+  @Test
+  void maybeSendPacket_whenPacketFormatBlocked_expectDisconnectAndFalse() throws Exception {
+    // Arrange
+    PacketFormat packetFormat = mock(PacketFormat.class);
+    runtime.setPacketFormat(packetFormat);
+    when(packetFormat.maybeSendPacket(17L, false)).thenThrow(new BlockedTooLongException(500L));
+
+    // Act
+    boolean sent = runtime.maybeSendPacket(17L, false);
+
+    // Assert
+    assertFalse(sent);
+    verify(peerNode).forceDisconnect();
+  }
+
+  @Test
+  void maxPeerPingTime_whenRuntimeNodeMissing_expectFallbackDefault() {
+    // Arrange
+    setField(runtime, PeerNodeRuntime.class, "node", null);
+
+    // Act
+    long result = runtime.maxPeerPingTime();
+
+    // Assert
+    assertEquals(NodeStats.DEFAULT_MAX_PING_TIME * 2L, result);
+  }
+
+  @Test
+  void maxPeerPingTime_whenNodeStatsMissing_expectFallbackDefault() {
+    // Arrange
+    when(node.network().stats()).thenReturn(null);
+
+    // Act
+    long result = runtime.maxPeerPingTime();
+
+    // Assert
+    assertEquals(NodeStats.DEFAULT_MAX_PING_TIME * 2L, result);
+  }
+
+  @Test
+  void maxPeerPingTime_whenNodeStatsPresent_expectDelegatedValue() {
+    // Arrange
+    NodeStats stats = mock(NodeStats.class);
+    when(node.network().stats()).thenReturn(stats);
+    when(stats.maxPeerPingTime()).thenReturn(4242L);
+
+    // Act
+    long result = runtime.maxPeerPingTime();
+
+    // Assert
+    assertEquals(4242L, result);
+  }
+
+  @Test
+  void isLowCapacity_whenNoIncomingLoadStats_expectFalse() {
+    // Arrange
+    PeerNodeLoadTracker loadTracker = mock(PeerNodeLoadTracker.class);
+    setField(runtime, PeerNodeRuntime.class, "loadTracker", loadTracker);
+    when(loadTracker.getLastIncomingLoadStats(true)).thenReturn(null);
+
+    // Act
+    boolean lowCapacity = runtime.isLowCapacity(true);
+
+    // Assert
+    assertFalse(lowCapacity);
+  }
+
+  @Test
+  void isLowCapacity_whenInputThresholdAbovePeerLimit_expectTrue() {
+    // Arrange
+    PeerNodeLoadTracker loadTracker = mock(PeerNodeLoadTracker.class);
+    setField(runtime, PeerNodeRuntime.class, "loadTracker", loadTracker);
+    PeerLoadStats peerLoadStats = mock(PeerLoadStats.class);
+    when(loadTracker.getLastIncomingLoadStats(true)).thenReturn(peerLoadStats);
+    when(peerLoadStats.peerLimit(true)).thenReturn(100.0);
+
+    NodeStats stats = mock(NodeStats.class);
+    NodePinger nodePinger = mock(NodePinger.class);
+    setField(stats, NodeStats.class, "nodePinger", nodePinger);
+    when(node.network().stats()).thenReturn(stats);
+    when(nodePinger.capacityThreshold(true, true)).thenReturn(100.0001);
+
+    // Act
+    boolean lowCapacity = runtime.isLowCapacity(true);
+
+    // Assert
+    assertTrue(lowCapacity);
+    verify(nodePinger, never()).capacityThreshold(true, false);
+  }
+
+  @Test
+  void isLowCapacity_whenThresholdsWithinPeerLimits_expectFalse() {
+    // Arrange
+    PeerNodeLoadTracker loadTracker = mock(PeerNodeLoadTracker.class);
+    setField(runtime, PeerNodeRuntime.class, "loadTracker", loadTracker);
+    PeerLoadStats peerLoadStats = mock(PeerLoadStats.class);
+    when(loadTracker.getLastIncomingLoadStats(false)).thenReturn(peerLoadStats);
+    when(peerLoadStats.peerLimit(true)).thenReturn(100.0);
+    when(peerLoadStats.peerLimit(false)).thenReturn(100.0);
+
+    NodeStats stats = mock(NodeStats.class);
+    NodePinger nodePinger = mock(NodePinger.class);
+    setField(stats, NodeStats.class, "nodePinger", nodePinger);
+    when(node.network().stats()).thenReturn(stats);
+    when(nodePinger.capacityThreshold(false, true)).thenReturn(90.0);
+    when(nodePinger.capacityThreshold(false, false)).thenReturn(80.0);
+
+    // Act
+    boolean lowCapacity = runtime.isLowCapacity(false);
+
+    // Assert
+    assertFalse(lowCapacity);
+  }
+
+  @Test
+  void
+      parseLocationAndMaybePeerCounts_whenUnknownLocationBecomesValid_expectChangedAndMarkUpdate() {
+    // Arrange
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle(PeerNode.SFS_KEY_LOCATION, "0.25");
+    boolean[] shouldUpdatePeerCounts = new boolean[] {false};
+
+    // Act
+    boolean changed = runtime.parseLocationAndMaybePeerCounts(fs, shouldUpdatePeerCounts);
+
+    // Assert
+    assertTrue(changed);
+    assertTrue(shouldUpdatePeerCounts[0]);
+    assertEquals(0.25, runtime.getLocation(), 1.0e-12);
+  }
+
+  @Test
+  void parseLocationAndMaybePeerCounts_whenLocationInvalid_expectNoChange() {
+    // Arrange
+    runtime.setLocation(0.4);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle(PeerNode.SFS_KEY_LOCATION, "invalid-location");
+    boolean[] shouldUpdatePeerCounts = new boolean[] {false};
+
+    // Act
+    boolean changed = runtime.parseLocationAndMaybePeerCounts(fs, shouldUpdatePeerCounts);
+
+    // Assert
+    assertFalse(changed);
+    assertFalse(shouldUpdatePeerCounts[0]);
+    assertEquals(0.4, runtime.getLocation(), 1.0e-12);
+  }
+
+  @Test
+  void completeHandshake_whenLifecycleReturnsTrackerId_expectDelegation() {
+    // Arrange
+    PeerNodeHandshakeLifecycle handshakeLifecycle = mock(PeerNodeHandshakeLifecycle.class);
+    setField(runtime, PeerNodeRuntime.class, "handshakeLifecycle", handshakeLifecycle);
+    Object params = new Object();
+    when(handshakeLifecycle.completeHandshake(params)).thenReturn(77L);
+
+    // Act
+    long trackerId = runtime.completeHandshake(params);
+
+    // Assert
+    assertEquals(77L, trackerId);
+    verify(handshakeLifecycle).completeHandshake(params);
+  }
+
+  @Test
+  void notifyOpennetOnDisconnect_whenManagerExists_expectOnDisconnectCalled() {
+    // Arrange
+    Node localNode = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+    OpennetManager opennet = mock(OpennetManager.class);
+    when(localNode.network().opennet()).thenReturn(opennet);
+
+    // Act
+    runtime.notifyOpennetOnDisconnect(localNode);
+
+    // Assert
+    verify(opennet).onDisconnect();
+  }
+
+  @Test
+  void notifyOpennetOnConnect_whenManagerExists_expectOnConnectedPeerCalled() {
+    // Arrange
+    Node localNode = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+    OpennetManager opennet = mock(OpennetManager.class);
+    when(localNode.network().opennet()).thenReturn(opennet);
+
+    // Act
+    runtime.notifyOpennetOnConnect(localNode, peerNode);
+
+    // Assert
+    verify(opennet).onConnectedPeer(peerNode);
+  }
+
+  @Test
+  void notifyOpennetHelpers_whenManagerMissing_expectNoThrow() {
+    // Arrange
+    Node localNode = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+    when(localNode.network().opennet()).thenReturn(null);
+
+    // Act + Assert
+    assertDoesNotThrow(() -> runtime.notifyOpennetOnDisconnect(localNode));
+    assertDoesNotThrow(() -> runtime.notifyOpennetOnConnect(localNode, peerNode));
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void setField(
+      Object target, Class<?> declaringClass, String fieldName, Object value) {
+    try {
+      Field field = declaringClass.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed to set field " + fieldName + " on " + declaringClass, e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extract runtime-oriented responsibilities from `PeerNode` into `PeerNodeRuntime`
- extract handshake/connection lifecycle responsibilities into `PeerNodeHandshakeLifecycle`
- update dependent validation/tests to match the refactor boundaries
- add focused unit tests for the new runtime and handshake lifecycle classes
- keep behavior equivalent while reducing `PeerNode` coupling and class size

## How to test
- `./gradlew spotlessApply`
- `./gradlew test`

## Notes
- this PR contains refactoring and test/documentation updates only; no protocol or persistence format changes are intended.