### PR TITLE
test(tests): Clean up SonarLint warnings in unit tests

### DIFF
--- a/src/test/java/com/onionnetworks/io/FiniteInputStreamTest.java
+++ b/src/test/java/com/onionnetworks/io/FiniteInputStreamTest.java
@@ -18,8 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class FiniteInputStreamTest {
 
-  private static void ignoreInt(int ignored) {}
-
   @Test
   void constructor_whenInputStreamNull_throwsNullPointerException() {
     assertThrows(NullPointerException.class, FiniteInputStreamTest::createStreamWithNullParent);
@@ -74,7 +72,7 @@ class FiniteInputStreamTest {
       int read = stream.read(buffer, 0, buffer.length);
       assertEquals(2, read);
 
-      assertThrows(EOFException.class, () -> ignoreInt(stream.read(new byte[1], 0, 1)));
+      assertThrows(EOFException.class, () -> stream.read(new byte[1], 0, 1));
     }
   }
 

--- a/src/test/java/com/onionnetworks/io/JoiningInputStreamTest.java
+++ b/src/test/java/com/onionnetworks/io/JoiningInputStreamTest.java
@@ -20,8 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class JoiningInputStreamTest {
 
-  private static void ignoreInt(int ignored) {}
-
   @Test
   void constructor_whenFirstIsNull_throwsNullPointerException() {
     InputStream second = new ByteArrayInputStream(new byte[0]);
@@ -101,8 +99,8 @@ class JoiningInputStreamTest {
       int read = joiningInputStream.read(buffer, 0, buffer.length);
 
       assertEquals(2, read);
-      ignoreInt(verify(first).read(buffer, 0, buffer.length));
-      ignoreInt(verify(second).read(buffer, 0, buffer.length));
+      verify(first).read(buffer, 0, buffer.length);
+      verify(second).read(buffer, 0, buffer.length);
     }
   }
 

--- a/src/test/java/com/onionnetworks/io/RAFInputStreamTest.java
+++ b/src/test/java/com/onionnetworks/io/RAFInputStreamTest.java
@@ -20,10 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @SuppressWarnings("java:S100")
 class RAFInputStreamTest {
 
-  private static void ignoreInt(int ignored) {
-    // Intentional no-op for exception-path assertions.
-  }
-
   @Test
   void read_whenDataAvailable_returnsUnsignedByteAndAdvancesPosition() throws Exception {
     byte[] data = new byte[] {(byte) 0xFF};
@@ -79,7 +75,7 @@ class RAFInputStreamTest {
     RAFInputStream stream = new RAFInputStream(raf);
     stream.close();
 
-    assertThrows(EOFException.class, () -> ignoreInt(stream.read(new byte[1], 0, 1)));
+    assertThrows(EOFException.class, () -> stream.read(new byte[1], 0, 1));
     verifyNoMoreInteractions(raf);
   }
 
@@ -95,7 +91,7 @@ class RAFInputStreamTest {
             })
         .when(raf)
         .seekAndRead(anyLong(), any(byte[].class), anyInt(), anyInt());
-    doAnswer(invocation -> 10L).when(raf).length();
+    doAnswer(_ -> 10L).when(raf).length();
 
     try (RAFInputStream stream = new RAFInputStream(raf)) {
       long firstSkip = stream.skip(4);
@@ -118,9 +114,7 @@ class RAFInputStreamTest {
   void skip_whenRequestExceedsFileLength_clampsToRemainingBytes() throws Exception {
     RAF raf = mock(RAF.class);
     org.mockito.Mockito.when(raf.length()).thenReturn(5L);
-    doAnswer(invocation -> -1)
-        .when(raf)
-        .seekAndRead(anyLong(), any(byte[].class), anyInt(), anyInt());
+    doAnswer(_ -> -1).when(raf).seekAndRead(anyLong(), any(byte[].class), anyInt(), anyInt());
 
     try (RAFInputStream stream = new RAFInputStream(raf)) {
       long skipped = stream.skip(10);

--- a/src/test/java/com/onionnetworks/io/UnpredictableInputStreamTest.java
+++ b/src/test/java/com/onionnetworks/io/UnpredictableInputStreamTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("java:S100")
 class UnpredictableInputStreamTest {
 
-  private static void ignoreLong(long ignored) {}
-
   @Test
   void skip_whenRandomChoosesZero_returnsZeroAndDoesNotAdvance() throws Exception {
     ByteArrayInputStream base = new ByteArrayInputStream(new byte[] {1, 2, 3});
@@ -106,7 +104,7 @@ class UnpredictableInputStreamTest {
       setRandom(stream, new SequenceRandom(0));
       stream.close();
 
-      assertThrows(IOException.class, () -> ignoreLong(stream.skip(1)));
+      assertThrows(IOException.class, () -> stream.skip(1));
     }
   }
 

--- a/src/test/java/network/crypta/client/async/ReadBucketAndFreeInputStreamTest.java
+++ b/src/test/java/network/crypta/client/async/ReadBucketAndFreeInputStreamTest.java
@@ -24,8 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ReadBucketAndFreeInputStreamTest {
 
-  private static void ignoreInt(int ignored) {}
-
   private static int invalidNegativeOffset() {
     return -Math.abs(System.identityHashCode(new Object()) | 1);
   }
@@ -91,7 +89,7 @@ class ReadBucketAndFreeInputStreamTest {
       // Act + Assert: read(byte[], off, len)
       byte[] buf2 = new byte[4];
       int r2 = is.read(buf2, 1, 3);
-      assertEquals(2, r2); // remaining bytes are 13,14 → only 2 available
+      assertEquals(2, r2); // the remaining bytes are 13,14 → only 2 available
       assertArrayEquals(new byte[] {0, 13, 14, 0}, buf2);
     }
   }
@@ -106,8 +104,8 @@ class ReadBucketAndFreeInputStreamTest {
       byte[] buf = new byte[2];
       int negativeOff = invalidNegativeOffset();
       int tooLargeLen = invalidLength(buf);
-      assertThrows(IndexOutOfBoundsException.class, () -> ignoreInt(is.read(buf, negativeOff, 1)));
-      assertThrows(IndexOutOfBoundsException.class, () -> ignoreInt(is.read(buf, 0, tooLargeLen)));
+      assertThrows(IndexOutOfBoundsException.class, () -> is.read(buf, negativeOff, 1));
+      assertThrows(IndexOutOfBoundsException.class, () -> is.read(buf, 0, tooLargeLen));
     }
   }
 
@@ -119,7 +117,7 @@ class ReadBucketAndFreeInputStreamTest {
     try (InputStream is = ReadBucketAndFreeInputStream.create(bucket)) {
       // Act + Assert
       //noinspection DataFlowIssue
-      assertThrows(NullPointerException.class, () -> ignoreInt(is.read(null)));
+      assertThrows(NullPointerException.class, () -> is.read(null));
     }
   }
 
@@ -182,7 +180,7 @@ class ReadBucketAndFreeInputStreamTest {
     try (InputStream is = ReadBucketAndFreeInputStream.create(bucket)) {
       // Act + Assert
       byte[] buf = new byte[2];
-      IOException ex = assertThrows(IOException.class, () -> ignoreInt(is.read(buf)));
+      IOException ex = assertThrows(IOException.class, () -> is.read(buf));
       assertEquals("read-fail", ex.getMessage());
     }
   }

--- a/src/test/java/network/crypta/client/async/SingleFileStreamGeneratorTest.java
+++ b/src/test/java/network/crypta/client/async/SingleFileStreamGeneratorTest.java
@@ -166,7 +166,7 @@ class SingleFileStreamGeneratorTest {
       assertEquals("fail", ex.getMessage());
       assertTrue(bucket.isFreed(), "Bucket should be closed on write failure");
       assertTrue(tis.isClosed(), "InputStream should be closed on write failure");
-    } catch (IOException ignored) {
+    } catch (IOException _) {
       // close() on this stream is a no-op and does not throw
     }
   }

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodecTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageSettingsCodecTest.java
@@ -42,7 +42,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
 
     ParsedBasicSettings parsed =
         SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-            buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH);
+            buffer,
+            BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+            values.completeViaTruncation,
+            RAF_LENGTH);
 
     assertParsedValues(values, parsed);
 
@@ -136,7 +139,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
 
     ParsedBasicSettings parsed =
         SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-            encoded, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH);
+            encoded,
+            BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+            values.completeViaTruncation,
+            RAF_LENGTH);
 
     assertParsedValues(values, parsed);
 
@@ -154,7 +160,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -167,7 +176,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -180,7 +192,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -193,7 +208,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -206,7 +224,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -219,7 +240,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -232,7 +256,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -244,7 +271,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings + 1, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS + 1,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -257,7 +287,7 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, false, RAF_LENGTH));
+                buffer, BasicSettingsValues.OFFSET_BASIC_SETTINGS, false, RAF_LENGTH));
   }
 
   @Test
@@ -270,7 +300,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -283,7 +316,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   @Test
@@ -298,7 +334,10 @@ class SplitFileFetcherStorageSettingsCodecTest {
         StorageFormatException.class,
         () ->
             SplitFileFetcherStorageSettingsCodec.parseBasicSettings(
-                buffer, values.offsetBasicSettings, values.completeViaTruncation, RAF_LENGTH));
+                buffer,
+                BasicSettingsValues.OFFSET_BASIC_SETTINGS,
+                values.completeViaTruncation,
+                RAF_LENGTH));
   }
 
   private static byte[] fixedKey() {
@@ -326,17 +365,18 @@ class SplitFileFetcherStorageSettingsCodecTest {
     assertEquals(values.cryptoAlgorithm, parsed.getSplitfileSingleCryptoAlgorithm());
     assertArrayEquals(values.cryptoKey, parsed.getSplitfileSingleCryptoKey());
     assertEquals(values.finalLength, parsed.getFinalLength());
-    assertEquals(values.decompressedLength, parsed.getDecompressedLength());
+    assertEquals(BasicSettingsValues.DECOMPRESSED_LENGTH, parsed.getDecompressedLength());
     assertEquals(values.clientMetadata.getMIMEType(), parsed.getClientMetadata().getMIMEType());
     assertEquals(values.decompressors, parsed.getDecompressors());
     assertEquals(values.offsetKeyList, parsed.getOffsetKeyList());
-    assertEquals(values.offsetSegmentStatus, parsed.getOffsetSegmentStatus());
-    assertEquals(values.offsetGeneralProgress, parsed.getOffsetGeneralProgress());
-    assertEquals(values.offsetMainBloomFilter, parsed.getOffsetMainBloomFilter());
-    assertEquals(values.offsetSegmentBloomFilters, parsed.getOffsetSegmentBloomFilters());
-    assertEquals(values.offsetOriginalMetadata, parsed.getOffsetOriginalMetadata());
-    assertEquals(values.offsetOriginalDetails, parsed.getOffsetOriginalDetails());
-    assertEquals(values.offsetBasicSettings, parsed.getOffsetBasicSettings());
+    assertEquals(BasicSettingsValues.OFFSET_SEGMENT_STATUS, parsed.getOffsetSegmentStatus());
+    assertEquals(BasicSettingsValues.OFFSET_GENERAL_PROGRESS, parsed.getOffsetGeneralProgress());
+    assertEquals(BasicSettingsValues.OFFSET_MAIN_BLOOM_FILTER, parsed.getOffsetMainBloomFilter());
+    assertEquals(
+        BasicSettingsValues.OFFSET_SEGMENT_BLOOM_FILTERS, parsed.getOffsetSegmentBloomFilters());
+    assertEquals(BasicSettingsValues.OFFSET_ORIGINAL_METADATA, parsed.getOffsetOriginalMetadata());
+    assertEquals(BasicSettingsValues.OFFSET_ORIGINAL_DETAILS, parsed.getOffsetOriginalDetails());
+    assertEquals(BasicSettingsValues.OFFSET_BASIC_SETTINGS, parsed.getOffsetBasicSettings());
     assertEquals(values.compatMode, parsed.getFinalMinCompatMode());
     assertEquals(values.segmentCount, parsed.getSegmentCount());
     assertEquals(values.totalDataBlocks, parsed.getTotalDataBlocks());
@@ -372,17 +412,18 @@ class SplitFileFetcherStorageSettingsCodecTest {
       setField(storage, "splitfileSingleCryptoAlgorithm", values.cryptoAlgorithm);
       setField(storage, "splitfileSingleCryptoKey", values.cryptoKey);
       setField(storage, "finalLength", values.finalLength);
-      setField(storage, "decompressedLength", values.decompressedLength);
+      setField(storage, "decompressedLength", BasicSettingsValues.DECOMPRESSED_LENGTH);
       setField(storage, "clientMetadata", values.clientMetadata);
       setField(storage, "decompressors", values.decompressors);
       setField(storage, "offsetKeyList", values.offsetKeyList);
-      setField(storage, "offsetSegmentStatus", values.offsetSegmentStatus);
-      setField(storage, "offsetGeneralProgress", values.offsetGeneralProgress);
-      setField(storage, "offsetMainBloomFilter", values.offsetMainBloomFilter);
-      setField(storage, "offsetSegmentBloomFilters", values.offsetSegmentBloomFilters);
-      setField(storage, "offsetOriginalMetadata", values.offsetOriginalMetadata);
-      setField(storage, "offsetOriginalDetails", values.offsetOriginalDetails);
-      setField(storage, "offsetBasicSettings", values.offsetBasicSettings);
+      setField(storage, "offsetSegmentStatus", BasicSettingsValues.OFFSET_SEGMENT_STATUS);
+      setField(storage, "offsetGeneralProgress", BasicSettingsValues.OFFSET_GENERAL_PROGRESS);
+      setField(storage, "offsetMainBloomFilter", BasicSettingsValues.OFFSET_MAIN_BLOOM_FILTER);
+      setField(
+          storage, "offsetSegmentBloomFilters", BasicSettingsValues.OFFSET_SEGMENT_BLOOM_FILTERS);
+      setField(storage, "offsetOriginalMetadata", BasicSettingsValues.OFFSET_ORIGINAL_METADATA);
+      setField(storage, "offsetOriginalDetails", BasicSettingsValues.OFFSET_ORIGINAL_DETAILS);
+      setField(storage, "offsetBasicSettings", BasicSettingsValues.OFFSET_BASIC_SETTINGS);
       setField(storage, "completeViaTruncation", values.completeViaTruncation);
       setField(storage, "finalMinCompatMode", values.compatMode);
       setField(storage, "segments", segments);
@@ -409,7 +450,7 @@ class SplitFileFetcherStorageSettingsCodecTest {
     private byte cryptoAlgorithm = 0;
     private byte[] cryptoKey;
     private long finalLength = 123L;
-    private static final long decompressedLength = 456L;
+    private static final long DECOMPRESSED_LENGTH = 456L;
     private final ClientMetadata clientMetadata = new ClientMetadata("text/plain");
     private boolean writeValidClientMetadata = true;
     private List<COMPRESSOR_TYPE> decompressors =
@@ -417,13 +458,13 @@ class SplitFileFetcherStorageSettingsCodecTest {
     private Integer decompressorCountOverride;
     private List<Short> decompressorIdsOverride;
     private long offsetKeyList = 10L;
-    private static final long offsetSegmentStatus = 20L;
-    private static final long offsetGeneralProgress = 30L;
-    private static final long offsetMainBloomFilter = 40L;
-    private static final long offsetSegmentBloomFilters = 50L;
-    private static final long offsetOriginalMetadata = 60L;
-    private static final long offsetOriginalDetails = 70L;
-    private static final long offsetBasicSettings = 80L;
+    private static final long OFFSET_SEGMENT_STATUS = 20L;
+    private static final long OFFSET_GENERAL_PROGRESS = 30L;
+    private static final long OFFSET_MAIN_BLOOM_FILTER = 40L;
+    private static final long OFFSET_SEGMENT_BLOOM_FILTERS = 50L;
+    private static final long OFFSET_ORIGINAL_METADATA = 60L;
+    private static final long OFFSET_ORIGINAL_DETAILS = 70L;
+    private static final long OFFSET_BASIC_SETTINGS = 80L;
     private boolean completeViaTruncation = false;
     private CompatibilityMode compatMode = CompatibilityMode.COMPAT_1250;
     private Integer compatModeOrdinalOverride;
@@ -443,7 +484,7 @@ class SplitFileFetcherStorageSettingsCodecTest {
         dos.writeShort(resolveSplitfileAlgorithmCode());
         writeCryptoInfo(dos);
         dos.writeLong(finalLength);
-        dos.writeLong(decompressedLength);
+        dos.writeLong(DECOMPRESSED_LENGTH);
         writeClientMetadata(dos);
         writeDecompressors(dos);
         writeOffsets(dos);
@@ -522,13 +563,13 @@ class SplitFileFetcherStorageSettingsCodecTest {
 
     private void writeOffsets(DataOutputStream dos) throws IOException {
       dos.writeLong(offsetKeyList);
-      dos.writeLong(offsetSegmentStatus);
-      dos.writeLong(offsetGeneralProgress);
-      dos.writeLong(offsetMainBloomFilter);
-      dos.writeLong(offsetSegmentBloomFilters);
-      dos.writeLong(offsetOriginalMetadata);
-      dos.writeLong(offsetOriginalDetails);
-      dos.writeLong(offsetBasicSettings);
+      dos.writeLong(OFFSET_SEGMENT_STATUS);
+      dos.writeLong(OFFSET_GENERAL_PROGRESS);
+      dos.writeLong(OFFSET_MAIN_BLOOM_FILTER);
+      dos.writeLong(OFFSET_SEGMENT_BLOOM_FILTERS);
+      dos.writeLong(OFFSET_ORIGINAL_METADATA);
+      dos.writeLong(OFFSET_ORIGINAL_DETAILS);
+      dos.writeLong(OFFSET_BASIC_SETTINGS);
     }
 
     @SuppressWarnings("EnumOrdinal")

--- a/src/test/java/network/crypta/clients/http/bookmark/BookmarkCategoryTest.java
+++ b/src/test/java/network/crypta/clients/http/bookmark/BookmarkCategoryTest.java
@@ -42,8 +42,6 @@ class BookmarkCategoryTest {
 
   @Mock UserAlertManager userAlertManager;
 
-  private static void ignoreBookmark(Bookmark ignored) {}
-
   private BookmarkItem newBookmarkItem(String name, String description, boolean hasAnActiveLink) {
     try {
       FreenetURI uri = new FreenetURI(hasAnActiveLink ? USK_1 : USK_2);
@@ -86,6 +84,7 @@ class BookmarkCategoryTest {
   }
 
   @Test
+  @SuppressWarnings("ConstantValue")
   void addBookmark_whenNull_expectReturnsNullAndDoesNotChangeSize() {
     // Arrange
     BookmarkCategory category = new BookmarkCategory("Root");
@@ -167,7 +166,7 @@ class BookmarkCategoryTest {
     BookmarkCategory root = new BookmarkCategory("Root");
 
     // Act / Assert
-    assertThrows(IndexOutOfBoundsException.class, () -> ignoreBookmark(root.get(index)));
+    assertThrows(IndexOutOfBoundsException.class, () -> root.get(index));
   }
 
   @Test

--- a/src/test/java/network/crypta/crypt/AEADStreamsTest.java
+++ b/src/test/java/network/crypta/crypt/AEADStreamsTest.java
@@ -1,7 +1,11 @@
 package network.crypta.crypt;
 
 import static network.crypta.testsupport.TestRandomData.fillBucketWithRandom;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -25,7 +29,7 @@ class AEADStreamsTest {
   private static void closeIgnoringAeadVerification(AEADInputStream cis) throws IOException {
     try {
       cis.close();
-    } catch (AEADVerificationFailedException ignored) {
+    } catch (AEADVerificationFailedException _) {
       // Expected for intentionally corrupted tails in negative tests.
     }
   }
@@ -44,7 +48,7 @@ class AEADStreamsTest {
 
   @Test
   void testCorruptedRoundTrip() throws IOException {
-    Random random = new Random(0x96231307L); // Same seed as first test, intentionally.
+    Random random = new Random(0x96231307L); // Same seed as the first test, intentionally.
     for (int i = 0; i < 10; i++) {
       ArrayBucket input = new ArrayBucket();
       fillBucketWithRandom(input, random, 65536L, true);
@@ -130,22 +134,23 @@ class AEADStreamsTest {
     Random random = new Random(0x47f6709f);
     byte[] key = new byte[keysize];
     random.nextBytes(key);
-    Bucket output = new ArrayBucket();
-    try (OutputStream os = output.getOutputStream();
-        AEADOutputStream cos = AEADOutputStream.innerCreateAES(os, key, random)) {
-      BucketTools.copyTo(input, cos, 2048);
+    try (ArrayBucket output = new ArrayBucket()) {
+      try (OutputStream os = output.getOutputStream();
+          AEADOutputStream cos = AEADOutputStream.innerCreateAES(os, key, random)) {
+        BucketTools.copyTo(input, cos, 2048);
+      }
+      byte[] first1KReadEncrypted = new byte[1024];
+      byte[] first1KReadOriginal = new byte[1024];
+      try (InputStream is = output.getInputStream();
+          AEADInputStream cis = AEADInputStream.createAES(is, key);
+          DataInputStream encryptedIn = new DataInputStream(cis);
+          InputStream originalIs = input.getInputStream();
+          DataInputStream originalIn = new DataInputStream(originalIs)) {
+        encryptedIn.readFully(first1KReadEncrypted);
+        originalIn.readFully(first1KReadOriginal);
+      }
+      assertArrayEquals(first1KReadEncrypted, first1KReadOriginal);
     }
-    byte[] first1KReadEncrypted = new byte[1024];
-    byte[] first1KReadOriginal = new byte[1024];
-    try (InputStream is = output.getInputStream();
-        AEADInputStream cis = AEADInputStream.createAES(is, key);
-        DataInputStream encryptedIn = new DataInputStream(cis);
-        InputStream originalIs = input.getInputStream();
-        DataInputStream originalIn = new DataInputStream(originalIs)) {
-      encryptedIn.readFully(first1KReadEncrypted);
-      originalIn.readFully(first1KReadOriginal);
-    }
-    assertArrayEquals(first1KReadEncrypted, first1KReadOriginal);
   }
 
   /**
@@ -159,29 +164,30 @@ class AEADStreamsTest {
     Random random = new Random(0x47f6709f);
     byte[] key = new byte[keysize];
     random.nextBytes(key);
-    Bucket output = new ArrayBucket();
-    try (OutputStream os = output.getOutputStream()) {
-      try (AEADOutputStream cos =
-          AEADOutputStream.innerCreateAES(new NoCloseProxyOutputStream(os), key, random)) {
-        BucketTools.copyTo(input, cos, -1);
+    try (ArrayBucket output = new ArrayBucket()) {
+      try (OutputStream os = output.getOutputStream()) {
+        try (AEADOutputStream cos =
+            AEADOutputStream.innerCreateAES(new NoCloseProxyOutputStream(os), key, random)) {
+          BucketTools.copyTo(input, cos, -1);
+        }
+        // Now write garbage.
+        FileUtil.fill(os, 1024);
       }
-      // Now write garbage.
-      FileUtil.fill(os, 1024);
+      byte[] first1KReadEncrypted = new byte[1024];
+      byte[] first1KReadOriginal = new byte[1024];
+      assertThrows(
+          AEADVerificationFailedException.class,
+          () -> {
+            try (InputStream is = output.getInputStream();
+                AEADInputStream cis = AEADInputStream.createAES(is, key);
+                DataInputStream encryptedIn = new DataInputStream(cis);
+                InputStream originalIs = input.getInputStream();
+                DataInputStream originalIn = new DataInputStream(originalIs)) {
+              encryptedIn.readFully(first1KReadEncrypted);
+              originalIn.readFully(first1KReadOriginal);
+              assertArrayEquals(first1KReadEncrypted, first1KReadOriginal);
+            }
+          });
     }
-    byte[] first1KReadEncrypted = new byte[1024];
-    byte[] first1KReadOriginal = new byte[1024];
-    assertThrows(
-        AEADVerificationFailedException.class,
-        () -> {
-          try (InputStream is = output.getInputStream();
-              AEADInputStream cis = AEADInputStream.createAES(is, key);
-              DataInputStream encryptedIn = new DataInputStream(cis);
-              InputStream originalIs = input.getInputStream();
-              DataInputStream originalIn = new DataInputStream(originalIs)) {
-            encryptedIn.readFully(first1KReadEncrypted);
-            originalIn.readFully(first1KReadOriginal);
-            assertArrayEquals(first1KReadEncrypted, first1KReadOriginal);
-          }
-        });
   }
 }

--- a/src/test/java/network/crypta/crypt/HashTest.java
+++ b/src/test/java/network/crypta/crypt/HashTest.java
@@ -25,8 +25,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class HashTest {
   private static final byte[] HELLO_WORLD = "hello world".getBytes(StandardCharsets.UTF_8);
 
-  private static void ignoreBoolean(boolean ignored) {}
-
   private static Stream<Arguments> hashVectors() {
     return Stream.of(
         // type, correct hex for "hello world", incorrect hex (same length)
@@ -232,15 +230,14 @@ class HashTest {
   @EnumSource(HashType.class)
   void verify_whenNullHashResult_expectNpe(HashType type) {
     byte[] bytes = new Hash(type).genHash(HELLO_WORLD);
-    assertThrows(
-        NullPointerException.class, () -> ignoreBoolean(Hash.verify((HashResult) null, bytes)));
+    assertThrows(NullPointerException.class, () -> Hash.verify((HashResult) null, bytes));
   }
 
   @ParameterizedTest(name = "{0}: static verify(hash, null) -> NPE")
   @MethodSource("hashVectors")
   void verify_whenNullDataForStatic_expectNpe(HashType type, String okHex, String ignored) {
     HashResult h = new HashResult(type, Hex.decode(okHex));
-    assertThrows(NullPointerException.class, () -> ignoreBoolean(Hash.verify(h, (byte[][]) null)));
+    assertThrows(NullPointerException.class, () -> Hash.verify(h, (byte[][]) null));
   }
 
   @ParameterizedTest(name = "{0}: static verify(HashResult, HashResult)")
@@ -259,7 +256,7 @@ class HashTest {
   void verify_whenFirstNull_expectNpe_andSecondNull_expectFalse() {
     HashResult some =
         new HashResult(HashType.SHA256, new Hash(HashType.SHA256).genHash(HELLO_WORLD));
-    assertThrows(NullPointerException.class, () -> ignoreBoolean(Hash.verify(null, some)));
+    assertThrows(NullPointerException.class, () -> Hash.verify(null, some));
     // Use an environment-dependent path so static analysis does not flag a constant null,
     // while keeping the outcome deterministically false in both branches.
     HashResult other =
@@ -279,7 +276,7 @@ class HashTest {
     byte[] world = " world".getBytes(StandardCharsets.UTF_8);
     // First compute hash of "hello"
     byte[] first = h.genHash(hello);
-    // Now ensure second hash includes only new input, not a carry-over
+    // Now ensure the second hash includes only new input, not a carry-over
     byte[] second = h.genHash(world);
     byte[] expectedSecond = type.get().digest(world);
     assertArrayEquals(expectedSecond, second);

--- a/src/test/java/network/crypta/crypt/MultiHashInputStreamTest.java
+++ b/src/test/java/network/crypta/crypt/MultiHashInputStreamTest.java
@@ -24,8 +24,6 @@ class MultiHashInputStreamTest {
   private static final byte[] MESSAGE = "Hello, World!".getBytes(StandardCharsets.UTF_8);
   private static final String MESSAGE_MD5 = "65a8e27d8879283831b664bd8b7f0ad4";
 
-  private static void ignoreInt(int ignored) {}
-
   private static MultiHashInputStream newHasher(InputStream in, long bitmask) {
     return new MultiHashInputStream(in, bitmask);
   }
@@ -68,7 +66,7 @@ class MultiHashInputStreamTest {
     assertEquals(0, hash.read(buf, 0, 0));
     assertEquals(0, hash.getReadBytes());
 
-    // MD5 of empty string
+    // MD5 of an empty string
     MessageDigest md5 = HashType.MD5.get();
     byte[] emptyDigest = md5.digest();
     HashResult[] results = hash.getResults();
@@ -83,7 +81,7 @@ class MultiHashInputStreamTest {
     ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
     MultiHashInputStream hash = newHasher(input, HashType.MD5.bitmask);
 
-    assertThrows(NullPointerException.class, () -> ignoreInt(hash.read(null, 0, 1)));
+    assertThrows(NullPointerException.class, () -> hash.read(null, 0, 1));
   }
 
   @Test
@@ -93,10 +91,9 @@ class MultiHashInputStreamTest {
 
     byte[] buf = new byte[4];
     int invalidOffset = Integer.parseInt("-1");
-    assertThrows(
-        IndexOutOfBoundsException.class, () -> ignoreInt(hash.read(buf, invalidOffset, 1)));
-    assertThrows(IndexOutOfBoundsException.class, () -> ignoreInt(hash.read(buf, 0, -1)));
-    assertThrows(IndexOutOfBoundsException.class, () -> ignoreInt(hash.read(buf, 3, 2)));
+    assertThrows(IndexOutOfBoundsException.class, () -> hash.read(buf, invalidOffset, 1));
+    assertThrows(IndexOutOfBoundsException.class, () -> hash.read(buf, 0, -1));
+    assertThrows(IndexOutOfBoundsException.class, () -> hash.read(buf, 3, 2));
   }
 
   @Test
@@ -168,7 +165,7 @@ class MultiHashInputStreamTest {
     ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
     MultiHashInputStream hash = newHasher(input, HashType.SHA1.bitmask);
 
-    // Read first half and capture digest
+    // Read the first half and capture digest
     int half = MESSAGE.length / 2;
     byte[] buf = new byte[half];
     assertEquals(half, hash.read(buf, 0, buf.length));
@@ -241,7 +238,7 @@ class MultiHashInputStreamTest {
       public int read(byte @NotNull [] b, int off, int len) {
         if (first) {
           first = false;
-          return 0; // Simulate non-blocking stream that returns 0
+          return 0; // Simulate a non-blocking stream that returns 0
         }
         return delegate.read(b, off, len);
       }

--- a/src/test/java/network/crypta/crypt/SHA256Test.java
+++ b/src/test/java/network/crypta/crypt/SHA256Test.java
@@ -28,8 +28,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class SHA256Test {
 
-  private static void ignoreInt(int ignored) {}
-
   // ---- Test vectors ----
   static java.util.stream.Stream<Arguments> knownVectors() {
     return java.util.stream.Stream.of(
@@ -87,7 +85,7 @@ class SHA256Test {
     // Assert
     assertArrayEquals(expectedEmpty, md.digest());
     Mockito.verify(is, Mockito.times(1)).close();
-    ignoreInt(Mockito.verify(is, Mockito.atLeastOnce()).read(ArgumentMatchers.any(byte[].class)));
+    Mockito.verify(is, Mockito.atLeastOnce()).read(ArgumentMatchers.any(byte[].class));
   }
 
   @Test

--- a/src/test/java/network/crypta/pluginmanager/ForwardPortTest.java
+++ b/src/test/java/network/crypta/pluginmanager/ForwardPortTest.java
@@ -3,7 +3,6 @@ package network.crypta.pluginmanager;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -19,11 +18,6 @@ class ForwardPortTest {
   private static final String OPENNET = "opennet";
   private static final String DARKNET = "darknet";
 
-  private static ForwardPort constructForwardPort(
-      String name, boolean isIp6, int protocol, int port) {
-    return new ForwardPort(name, isIp6, protocol, port);
-  }
-
   @Test
   void constructor_whenValidArgs_setsPublicFields() {
     ForwardPort forwardPort = new ForwardPort(OPENNET, true, ForwardPort.PROTOCOL_UDP_IPV4, 12345);
@@ -38,8 +32,7 @@ class ForwardPortTest {
   @Test
   void constructor_whenNameIsNull_throwsNullPointerException() {
     //noinspection DataFlowIssue
-    assertThrows(
-        NullPointerException.class, () -> assertNotNull(constructForwardPort(null, false, 0, 0)));
+    assertThrows(NullPointerException.class, () -> new ForwardPort(null, false, 0, 0));
   }
 
   @Test

--- a/src/test/java/network/crypta/pluginmanager/PluginDownLoaderFileTest.java
+++ b/src/test/java/network/crypta/pluginmanager/PluginDownLoaderFileTest.java
@@ -32,8 +32,6 @@ class PluginDownLoaderFileTest {
 
   private static final String PLUGIN_JAR_NAME = "MyPlugin.jar";
 
-  private static void ignoreString(String ignored) {}
-
   @Test
   void checkSource_whenValidPath_expectFileWithMatchingPath() {
     PluginDownLoaderFile downloader = new PluginDownLoaderFile();
@@ -77,7 +75,7 @@ class PluginDownLoaderFileTest {
     PluginDownLoaderFile downloader = new PluginDownLoaderFile();
 
     //noinspection DataFlowIssue
-    assertThrows(NullPointerException.class, () -> ignoreString(downloader.getPluginName(null)));
+    assertThrows(NullPointerException.class, () -> downloader.getPluginName(null));
   }
 
   @Test

--- a/src/test/java/network/crypta/support/Base64Test.java
+++ b/src/test/java/network/crypta/support/Base64Test.java
@@ -29,12 +29,6 @@ class Base64Test {
 
   private static final String ILLEGAL_CHAR_MSG = "illegal Base64 character";
 
-  private static void ignoreString(String ignored) {}
-
-  private static void ignoreBytes(byte[] ignored) {}
-
-  private static void ignoreInt(int ignored) {}
-
   // ----------------------------
   // Happy-path round trips
   // ----------------------------
@@ -283,35 +277,35 @@ class Base64Test {
   @DisplayName("encode_whenNullBytes_expectNullPointerException")
   void encodeWhenNullBytesExpectNullPointerException() {
     // Arrange & Act & Assert
-    assertThrows(NullPointerException.class, () -> ignoreString(Base64.encode(null)));
+    assertThrows(NullPointerException.class, () -> Base64.encode(null));
   }
 
   @Test
   @DisplayName("encodeUTF8_whenNull_expectNullPointerException")
   void encodeUtf8WhenNullExpectNullPointerException() {
     // Arrange & Act & Assert
-    assertThrows(NullPointerException.class, () -> ignoreString(Base64.encodeUTF8(null)));
+    assertThrows(NullPointerException.class, () -> Base64.encodeUTF8(null));
   }
 
   @Test
   @DisplayName("decode_whenNull_expectNullPointerException")
   void decodeWhenNullExpectNullPointerException() {
     // Arrange & Act & Assert
-    assertThrows(NullPointerException.class, () -> ignoreBytes(Base64.decode(null)));
+    assertThrows(NullPointerException.class, () -> Base64.decode(null));
   }
 
   @Test
   @DisplayName("decodeStandard_whenNull_expectNullPointerException")
   void decodeStandardWhenNullExpectNullPointerException() {
     // Arrange & Act & Assert
-    assertThrows(NullPointerException.class, () -> ignoreBytes(Base64.decodeStandard(null)));
+    assertThrows(NullPointerException.class, () -> Base64.decodeStandard(null));
   }
 
   @Test
   @DisplayName("decodeUTF8_whenNull_expectNullPointerException")
   void decodeUtf8WhenNullExpectNullPointerException() {
     // Arrange & Act & Assert
-    assertThrows(NullPointerException.class, () -> ignoreString(Base64.decodeUTF8(null)));
+    assertThrows(NullPointerException.class, () -> Base64.decodeUTF8(null));
   }
 
   // ----------------------------
@@ -349,7 +343,7 @@ class Base64Test {
     // Assert
     assertArrayEquals(data, readAll);
     assertArrayEquals(data, decoded);
-    ignoreInt(verify(is, atLeastOnce()).read(any(byte[].class)));
+    verify(is, atLeastOnce()).read(any(byte[].class));
   }
 
   @Test

--- a/src/test/java/network/crypta/support/BitArrayTest.java
+++ b/src/test/java/network/crypta/support/BitArrayTest.java
@@ -24,8 +24,6 @@ class BitArrayTest {
 
   private static final int SAMPLE_SIZE = 10;
 
-  private static void ignoreBoolean(boolean ignored) {}
-
   private static BitArray newFilled(int size, boolean value) {
     BitArray arr = new BitArray(size);
     for (int i = 0; i < arr.getSize(); i++) {
@@ -56,7 +54,8 @@ class BitArrayTest {
   void toStringWhenAllOnesOrZerosMatchesExpected() {
     // Arrange
     BitArray ones = newFilled(SAMPLE_SIZE, true);
-    BitArray zeros = newFilled(8, false); // use a different size to avoid constant-parameter smell
+    BitArray zeros =
+        newFilled(8, false); // use a different size to avoid a constant-parameter smell
 
     // Act
     String onesStr = ones.toString();
@@ -95,7 +94,7 @@ class BitArrayTest {
 
     // Act & Assert
     assertThrows(ArrayIndexOutOfBoundsException.class, () -> arr.setBit(-1, true));
-    assertThrows(ArrayIndexOutOfBoundsException.class, () -> ignoreBoolean(arr.bitAt(-1)));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> arr.bitAt(-1));
   }
 
   @Test

--- a/src/test/java/network/crypta/support/BufferTest.java
+++ b/src/test/java/network/crypta/support/BufferTest.java
@@ -34,8 +34,6 @@ class BufferTest {
       "asldkjaskjdsakdhasdhaskjdhaskjhbkasbhdjkasbduiwbxgdoudgboewuydxbybuewyxbuewyuwe"
           + "dasdkljasndijwnodhnqweoidhnaouidhbnwoduihwnxodiuhnwuioxdhnwqiouhnxwqoiushdnxwqoiudhxnwqoiudhxni";
 
-  private static void ignoreByte(byte ignored) {}
-
   @Test
   @DisplayName("getData_whenFullArray_expectSameInstanceAndCorrectContent")
   void getData_whenFullArray_expectSameInstanceAndCorrectContent() {
@@ -60,7 +58,7 @@ class BufferTest {
     // Act
     Buffer buffer = new Buffer(data, 4, 5);
 
-    // Assert: returns copies, not the same instance
+    // Assert: returns copies, different instance
     byte[] first = buffer.getData();
     byte[] second = buffer.getData();
     assertNotEquals(dataSub, buffer.getData()); // reference inequality
@@ -68,7 +66,7 @@ class BufferTest {
     assertArrayEquals(dataSub, first);
     assertArrayEquals(dataSub, second);
 
-    // Mutating one snapshot does not affect subsequent calls
+    // Mutating one snapshot does not affect later calls
     first[0] = (byte) 123;
     assertArrayEquals(dataSub, buffer.getData());
 
@@ -151,8 +149,8 @@ class BufferTest {
   @DisplayName("byteAt_whenIndexOutOfBounds_expectArrayIndexOutOfBoundsException")
   void byteAt_whenIndexOutOfBounds_expectArrayIndexOutOfBoundsException() {
     Buffer b = new Buffer(new byte[] {10, 20, 30});
-    assertThrows(ArrayIndexOutOfBoundsException.class, () -> ignoreByte(b.byteAt(3))); // == length
-    assertThrows(ArrayIndexOutOfBoundsException.class, () -> ignoreByte(b.byteAt(-1)));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.byteAt(3)); // == length
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.byteAt(-1));
   }
 
   @Test

--- a/src/test/java/network/crypta/support/ByteBufferInputStreamTest.java
+++ b/src/test/java/network/crypta/support/ByteBufferInputStreamTest.java
@@ -23,8 +23,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class ByteBufferInputStreamTest {
 
-  private static void ignoreInt(int ignored) {}
-
   @Test
   void readUnsigned_whenDataPresent_expectValuesAndEof() throws IOException {
     byte[] b = new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0x00};
@@ -90,10 +88,9 @@ class ByteBufferInputStreamTest {
     try (ByteBufferInputStream in = new ByteBufferInputStream(new byte[] {1, 2, 3})) {
       byte[] dst = new byte[2];
       int invalidOffset = Integer.parseInt("-1");
-      assertThrows(
-          IndexOutOfBoundsException.class, () -> ignoreInt(in.read(dst, invalidOffset, 1)));
-      assertThrows(IndexOutOfBoundsException.class, () -> ignoreInt(in.read(dst, 0, -1)));
-      assertThrows(IndexOutOfBoundsException.class, () -> ignoreInt(in.read(dst, 1, 2)));
+      assertThrows(IndexOutOfBoundsException.class, () -> in.read(dst, invalidOffset, 1));
+      assertThrows(IndexOutOfBoundsException.class, () -> in.read(dst, 0, -1));
+      assertThrows(IndexOutOfBoundsException.class, () -> in.read(dst, 1, 2));
     }
   }
 
@@ -163,7 +160,7 @@ class ByteBufferInputStreamTest {
       assertEquals(3, in.remaining());
       assertEquals(1, in.read());
       assertEquals(2, in.remaining());
-      ignoreInt(in.skipBytes(1));
+      assertEquals(1, in.skipBytes(1));
       assertEquals(1, in.remaining());
     }
   }

--- a/src/test/java/network/crypta/support/HTMLDecoderTest.java
+++ b/src/test/java/network/crypta/support/HTMLDecoderTest.java
@@ -20,14 +20,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 @SuppressWarnings("java:S100") // Allow method names with underscores for readability
 class HTMLDecoderTest {
 
-  private static void ignoreString(String ignored) {}
-
   // -------- decode(String) --------
 
   @Test
   @SuppressWarnings("DataFlowIssue")
   void decode_whenNull_throwsNullPointerException() {
-    assertThrows(NullPointerException.class, () -> ignoreString(HTMLDecoder.decode(null)));
+    assertThrows(NullPointerException.class, () -> HTMLDecoder.decode(null));
   }
 
   @ParameterizedTest
@@ -81,8 +79,8 @@ class HTMLDecoderTest {
         "&1234;", // no leading '#'
         "Phi;", // no leading '&'
         "", // empty
-        "&#229", // decimal without semicolon
-        "&#x6C34", // hex without semicolon
+        "&#229", // decimal without a semicolon
+        "&#x6C34", // hex without a semicolon
         "&#xGG;", // non-hex digits
         "&apos;", // not in decode map
         "abc&", // dangling ampersand
@@ -125,7 +123,7 @@ class HTMLDecoderTest {
   @Test
   @SuppressWarnings("DataFlowIssue")
   void compact_whenNull_throwsNullPointerException() {
-    assertThrows(NullPointerException.class, () -> ignoreString(HTMLDecoder.compact(null)));
+    assertThrows(NullPointerException.class, () -> HTMLDecoder.compact(null));
   }
 
   @Test

--- a/src/test/java/network/crypta/support/RandomArrayIteratorTest.java
+++ b/src/test/java/network/crypta/support/RandomArrayIteratorTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,10 +26,6 @@ class RandomArrayIteratorTest {
   private RandomArrayIterator<Integer> iter;
   private Integer[] numbers;
 
-  private static RandomArrayIterator<Integer> constructIterator(Integer[] data) {
-    return new RandomArrayIterator<>(data);
-  }
-
   @BeforeEach
   void setUp() {
     numbers = new Integer[NUM_ELEMENTS];
@@ -43,7 +38,7 @@ class RandomArrayIteratorTest {
   @Test
   @DisplayName("constructor_whenArrayNull_expectNullPointerException")
   void constructor_whenArrayNull_expectNullPointerException() {
-    assertThrows(NullPointerException.class, () -> assertNotNull(constructIterator(null)));
+    assertThrows(NullPointerException.class, () -> new RandomArrayIterator<>(null));
   }
 
   @Test
@@ -68,7 +63,7 @@ class RandomArrayIteratorTest {
       first.add(iter.next());
     }
 
-    // Act: resetting with null must repeat exact same order
+    // Act: resetting with null must repeat the exact same order
     iter.reset(null);
     List<Integer> second = new ArrayList<>(NUM_ELEMENTS);
     while (iter.hasNext()) {

--- a/src/test/java/network/crypta/support/ShortBufferTest.java
+++ b/src/test/java/network/crypta/support/ShortBufferTest.java
@@ -29,8 +29,6 @@ class ShortBufferTest {
       "asldkjaskjdsakdhasdhaskjdhaskjhbkasbhdjkasbduiwbxgdoudgboewuydxbybuewyxbuewyuwe"
           + "dasdkljasndijwnodhnqweoidhnaouidhbnwoduihwnxodiuhnwuioxdhnwqiouhnxwqoiushdnxwqoiudhxnwqoiudhxni";
 
-  private static void ignoreByte(byte ignored) {}
-
   // ---------- Constructors ----------
 
   @Test
@@ -165,8 +163,8 @@ class ShortBufferTest {
   void byteAt_whenNegativeOrAtLength_throws() {
     byte[] data = {9, 8, 7};
     ShortBuffer b = new ShortBuffer(data);
-    assertThrows(ArrayIndexOutOfBoundsException.class, () -> ignoreByte(b.byteAt(-1)));
-    assertThrows(ArrayIndexOutOfBoundsException.class, () -> ignoreByte(b.byteAt(data.length)));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.byteAt(-1));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.byteAt(data.length));
   }
 
   // ---------- write/copy semantics ----------

--- a/src/test/java/network/crypta/support/StringValidityCheckerTest.java
+++ b/src/test/java/network/crypta/support/StringValidityCheckerTest.java
@@ -16,8 +16,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 @SuppressWarnings("java:S100") // Use method_whenCondition_expectOutcome naming
 class StringValidityCheckerTest {
 
-  private static void ignoreBoolean(boolean ignored) {}
-
   // ---------------------------
   // Windows printable characters
   // ---------------------------
@@ -125,8 +123,7 @@ class StringValidityCheckerTest {
   @Test
   void isWindowsReservedFilename_whenNull_expectNPE() {
     assertThrows(
-        NullPointerException.class,
-        () -> ignoreBoolean(StringValidityChecker.isWindowsReservedFilename(null)));
+        NullPointerException.class, () -> StringValidityChecker.isWindowsReservedFilename(null));
   }
 
   // ---------------------------
@@ -159,7 +156,7 @@ class StringValidityCheckerTest {
   void containsNoIDNBlacklistCharacters_whenNull_expectNPE() {
     assertThrows(
         NullPointerException.class,
-        () -> ignoreBoolean(StringValidityChecker.containsNoIDNBlacklistCharacters(null)));
+        () -> StringValidityChecker.containsNoIDNBlacklistCharacters(null));
   }
 
   // ---------------------------
@@ -186,8 +183,7 @@ class StringValidityCheckerTest {
   @SuppressWarnings("DataFlowIssue")
   void containsNoLinebreaks_whenNull_expectNPE() {
     assertThrows(
-        NullPointerException.class,
-        () -> ignoreBoolean(StringValidityChecker.containsNoLinebreaks(null)));
+        NullPointerException.class, () -> StringValidityChecker.containsNoLinebreaks(null));
   }
 
   // ---------------------------
@@ -215,8 +211,7 @@ class StringValidityCheckerTest {
   @SuppressWarnings("DataFlowIssue")
   void containsNoInvalidCharacters_whenNull_expectNPE() {
     assertThrows(
-        NullPointerException.class,
-        () -> ignoreBoolean(StringValidityChecker.containsNoInvalidCharacters(null)));
+        NullPointerException.class, () -> StringValidityChecker.containsNoInvalidCharacters(null));
   }
 
   // ---------------------------
@@ -243,8 +238,7 @@ class StringValidityCheckerTest {
   @SuppressWarnings("DataFlowIssue")
   void containsNoControlCharacters_whenNull_expectNPE() {
     assertThrows(
-        NullPointerException.class,
-        () -> ignoreBoolean(StringValidityChecker.containsNoControlCharacters(null)));
+        NullPointerException.class, () -> StringValidityChecker.containsNoControlCharacters(null));
   }
 
   // ---------------------------
@@ -265,7 +259,7 @@ class StringValidityCheckerTest {
 
   @Test
   void containsNoInvalidFormatting_whenUnbalancedDirectionalExtraPop_expectFalse() {
-    String s = "\u202Cpop-first"; // POP without push
+    String s = "\u202Cpop-first"; // POP without a push
     assertFalse(StringValidityChecker.containsNoInvalidFormatting(s));
   }
 
@@ -293,8 +287,7 @@ class StringValidityCheckerTest {
   @SuppressWarnings("DataFlowIssue")
   void containsNoInvalidFormatting_whenNull_expectNPE() {
     assertThrows(
-        NullPointerException.class,
-        () -> ignoreBoolean(StringValidityChecker.containsNoInvalidFormatting(null)));
+        NullPointerException.class, () -> StringValidityChecker.containsNoInvalidFormatting(null));
   }
 
   // ---------------------------

--- a/src/test/java/network/crypta/support/URIPreEncoderTest.java
+++ b/src/test/java/network/crypta/support/URIPreEncoderTest.java
@@ -24,10 +24,6 @@ class URIPreEncoderTest {
   private final String printableAscii = new String(UTFUtil.printableAscii());
   private final String stressedUtfChars = new String(UTFUtil.stressedUtf());
 
-  private static void ignoreString(String ignored) {}
-
-  private static void ignoreUri(URI ignored) {}
-
   @Test
   void encode_whenMixedAsciiAndUtf8_expectOnlyAllowedChars() {
     // Arrange
@@ -93,7 +89,7 @@ class URIPreEncoderTest {
   @Test
   @SuppressWarnings("DataFlowIssue")
   void encode_whenNull_expectNullPointerException() {
-    assertThrows(NullPointerException.class, () -> ignoreString(URIPreEncoder.encode(null)));
+    assertThrows(NullPointerException.class, () -> URIPreEncoder.encode(null));
   }
 
   @Test
@@ -112,7 +108,7 @@ class URIPreEncoderTest {
 
   @Test
   void encodeURI_whenInvalidPercentSequence_expectURISyntaxException() {
-    // Arrange: invalid percent-escape in path
+    // Arrange: invalid percent-escape in the path
     String input = "http://example.com/a%2Zb";
 
     // Act + Assert
@@ -121,7 +117,7 @@ class URIPreEncoderTest {
 
   @Test
   void encodeURI_whenNull_expectNullPointerException() {
-    assertThrows(NullPointerException.class, () -> ignoreUri(URIPreEncoder.encodeURI(null)));
+    assertThrows(NullPointerException.class, () -> URIPreEncoder.encodeURI(null));
   }
 
   private static boolean containsOnlyValidChars(String s) {

--- a/src/test/java/network/crypta/support/io/ByteArrayRandomAccessBufferTest.java
+++ b/src/test/java/network/crypta/support/io/ByteArrayRandomAccessBufferTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -35,10 +34,6 @@ import org.mockito.Mockito;
 class ByteArrayRandomAccessBufferTest {
   private static final String READ_ONLY_MESSAGE = "Read-only";
   private static final String UNREACHABLE_MESSAGE = "unreachable";
-
-  private static ByteArrayRandomAccessBuffer constructBufferWithSize(int size) {
-    return new ByteArrayRandomAccessBuffer(size);
-  }
 
   /**
    * Produce a deterministic byte array for test assertions.
@@ -88,16 +83,15 @@ class ByteArrayRandomAccessBufferTest {
   @SuppressWarnings("resource")
   void constructor_withNegativeSize_expectNegativeArraySizeException() {
     // Arrange + Act + Assert
-    assertThrows(
-        NegativeArraySizeException.class, () -> assertNotNull(constructBufferWithSize(-1)));
+    assertThrows(NegativeArraySizeException.class, () -> new ByteArrayRandomAccessBuffer(-1));
   }
 
   /**
    * Ensures the range-copy constructor copies the requested window and honors the {@code readOnly}
    * flag.
    *
-   * <p>Postconditions: subsequent mutations to the source array do not affect the buffer; reads
-   * return the copied range; writes fail with {@link IOException} when the buffer is read-only.
+   * <p>Postconditions: further mutations to the source array do not affect the buffer; reads return
+   * the copied range; writes fail with {@link IOException} when the buffer is read-only.
    *
    * @throws IOException if write is attempted while {@code readOnly} is set
    */
@@ -445,7 +439,7 @@ class ByteArrayRandomAccessBufferTest {
    * <p>Writes bytes {@code 1,2,3} starting at file offset {@code 2} and validates the final buffer
    * image.
    *
-   * @throws IOException if the write unexpectedly fails
+   * @throws IOException if the writing unexpectedly fails
    */
   @Test
   @DisplayName("pwrite: bufOffset respected and data lands at correct file offset")
@@ -542,7 +536,7 @@ class ByteArrayRandomAccessBufferTest {
     try (ByteArrayRandomAccessBuffer raf =
         (ByteArrayRandomAccessBuffer) factory.makeRAF(src, 3, 4, true)) {
 
-      // Mutate source to verify deep copy
+      // Mutate the source to verify deep copy
       src[3] ^= 0x55;
 
       // Assert
@@ -575,7 +569,7 @@ class ByteArrayRandomAccessBufferTest {
         });
   }
 
-  /** Ensures negative offset is rejected by the underlying copy. */
+  /** Ensures a negative offset is rejected by the underlying copy. */
   @Test
   void makeRAF_withInitialContentsNegativeOffset_expectArrayIndexOutOfBoundsException() {
     // Arrange

--- a/src/test/java/network/crypta/support/io/CountedInputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/CountedInputStreamTest.java
@@ -21,10 +21,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 class CountedInputStreamTest {
 
-  private static void ignoreInt(int ignored) {}
-
-  private static void ignoreLong(long ignored) {}
-
   @Test
   void constructor_whenNullInput_expectIllegalStateException() {
     assertThrows(
@@ -55,7 +51,7 @@ class CountedInputStreamTest {
       assertEquals(delegateReturn, ret);
       assertEquals(expectedInc, cis.count());
     }
-    ignoreInt(verify(in, times(1)).read());
+    verify(in, times(1)).read();
   }
 
   @ParameterizedTest
@@ -70,7 +66,7 @@ class CountedInputStreamTest {
       assertEquals(delegateReturn, ret);
       assertEquals(expectedInc, cis.count());
     }
-    ignoreInt(verify(in, times(1)).read(same(buf)));
+    verify(in, times(1)).read(same(buf));
   }
 
   @ParameterizedTest
@@ -87,7 +83,7 @@ class CountedInputStreamTest {
       assertEquals(delegateReturn, ret);
       assertEquals(expectedInc, cis.count());
     }
-    ignoreInt(verify(in, times(1)).read(same(buf), eq(off), eq(len)));
+    verify(in, times(1)).read(same(buf), eq(off), eq(len));
   }
 
   @ParameterizedTest
@@ -101,7 +97,7 @@ class CountedInputStreamTest {
       assertEquals(delegateReturn, ret);
       assertEquals(expectedInc, cis.count());
     }
-    ignoreLong(verify(in, times(1)).skip(10L));
+    verify(in, times(1)).skip(10L);
   }
 
   @Test
@@ -110,7 +106,7 @@ class CountedInputStreamTest {
     when(in.read((byte[]) isNull())).thenThrow(new NullPointerException("buf"));
     try (CountedInputStream cis = new CountedInputStream(in)) {
       //noinspection DataFlowIssue
-      assertThrows(NullPointerException.class, () -> ignoreInt(cis.read(null)));
+      assertThrows(NullPointerException.class, () -> cis.read(null));
       assertEquals(0L, cis.count());
     }
   }
@@ -122,8 +118,7 @@ class CountedInputStreamTest {
     when(in.read(same(buf), eq(-1), eq(2))).thenThrow(new IndexOutOfBoundsException("off < 0"));
     try (CountedInputStream cis = new CountedInputStream(in)) {
       int invalidOffset = Integer.parseInt("-1");
-      assertThrows(
-          IndexOutOfBoundsException.class, () -> ignoreInt(cis.read(buf, invalidOffset, 2)));
+      assertThrows(IndexOutOfBoundsException.class, () -> cis.read(buf, invalidOffset, 2));
       assertEquals(0L, cis.count());
     }
   }
@@ -137,7 +132,7 @@ class CountedInputStreamTest {
       assertEquals(2L, ret);
       assertEquals(2L, cis.count());
     }
-    ignoreLong(verify(in, times(1)).skip(5L));
+    verify(in, times(1)).skip(5L);
   }
 
   @Test

--- a/src/test/java/network/crypta/support/io/FileUtilTest.java
+++ b/src/test/java/network/crypta/support/io/FileUtilTest.java
@@ -1,10 +1,28 @@
 package network.crypta.support.io;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,8 +47,6 @@ import org.mockito.MockedStatic;
 @SuppressWarnings("java:S100")
 class FileUtilTest {
 
-  private static void ignoreLong(long ignored) {}
-
   // ------------------------ sanitizeFileName() ---------------------------------
 
   @ParameterizedTest(name = "{0} → {2} on {1}")
@@ -54,7 +70,7 @@ class FileUtilTest {
         // Slash is forbidden on Unix-like systems → replaced with space
         Arguments.of("a/b", FileUtil.OperatingSystem.LINUX, "a b"),
         Arguments.of("a/b", FileUtil.OperatingSystem.GENERIC_UNIX, "a b"),
-        // Unknown = conservative rules (union); keep behaviour consistent
+        // Unknown = conservative rules (union); keep behavior consistent
         Arguments.of("a/b.", FileUtil.OperatingSystem.UNKNOWN, "a b"));
   }
 
@@ -110,7 +126,7 @@ class FileUtilTest {
     // Arrange
     InputStream in = new ByteArrayInputStream(new byte[] {1, 2, 3});
 
-    // Act + Assert: should not throw and stream remains at start
+    // Act + Assert: should not throw and stream remains at the start
     assertDoesNotThrow(() -> FileUtil.skipFully(in, 0));
     assertEquals(1, in.read());
   }
@@ -124,7 +140,7 @@ class FileUtilTest {
 
     // Act + Assert: should not throw and perform 3 skip calls
     assertDoesNotThrow(() -> FileUtil.skipFully(is, 10));
-    ignoreLong(verify(is, times(3)).skip(anyLong()));
+    verify(is, times(3)).skip(anyLong());
   }
 
   @Test
@@ -136,7 +152,7 @@ class FileUtilTest {
 
     // Act + Assert
     assertThrows(IOException.class, () -> FileUtil.skipFully(is, 5));
-    ignoreLong(verify(is, atLeastOnce()).skip(anyLong()));
+    verify(is, atLeastOnce()).skip(anyLong());
   }
 
   // ------------------------ readUTF() ------------------------------------------
@@ -229,7 +245,7 @@ class FileUtilTest {
     try (MockedStatic<Files> files = mockStatic(Files.class, Answers.CALLS_REAL_METHODS)) {
       files
           .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.ATOMIC_MOVE)))
-          .then(invocation -> dst);
+          .then(_ -> dst);
 
       // Act
       boolean ok = FileUtil.moveTo(src.toFile(), dst.toFile());
@@ -254,7 +270,7 @@ class FileUtilTest {
           .thenThrow(new java.nio.file.AtomicMoveNotSupportedException("a", "b", "nope"));
       files
           .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.REPLACE_EXISTING)))
-          .then(invocation -> dst);
+          .then(_ -> dst);
 
       // Act
       boolean ok = FileUtil.moveTo(src.toFile(), dst.toFile());
@@ -363,7 +379,7 @@ class FileUtilTest {
     // Arrange
     Path f = tmp.resolve("missing.bin");
 
-    // Act + Assert: should not throw, and path remains absent
+    // Act + Assert: should not throw, and the path remains absent
     assertDoesNotThrow(() -> FileUtil.secureDelete(f.toFile()));
     assertTrue(Files.notExists(f));
   }

--- a/src/test/java/network/crypta/support/io/LineReadingInputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/LineReadingInputStreamTest.java
@@ -34,8 +34,6 @@ class LineReadingInputStreamTest {
   private static final int MAX_LENGTH = 128;
   private static final int BUFFER_SIZE = 128;
 
-  private static void ignoreInt(int ignored) {}
-
   @Test
   void testReadLineWithoutMarking() throws Exception {
     // try utf8
@@ -74,7 +72,7 @@ class LineReadingInputStreamTest {
                   LENGTH_CHECKING_LINE_LF - 1, BUFFER_SIZE, true));
     }
 
-    // Same test shouldn't throw
+    // The same test shouldn't throw
     try (LineReadingInputStream instance =
         new LineReadingInputStream(
             new ByteArrayInputStream(LENGTH_CHECKING_LINE.getBytes(StandardCharsets.UTF_8)))) {
@@ -128,7 +126,7 @@ class LineReadingInputStreamTest {
           () -> throwingInstance2.readLine(LENGTH_CHECKING_LINE_LF - 1, BUFFER_SIZE, true));
     }
 
-    // Same test shouldn't throw
+    // The same test shouldn't throw
     try (LineReadingInputStream instance =
         new LineReadingInputStream(
             new ByteArrayInputStream(LENGTH_CHECKING_LINE.getBytes(StandardCharsets.UTF_8)))) {
@@ -185,8 +183,8 @@ class LineReadingInputStreamTest {
 
     try (LineReadingInputStream in = new LineReadingInputStream(mocked)) {
       assertThrows(EOFException.class, () -> in.readLine(MAX_LENGTH, BUFFER_SIZE, true));
-      ignoreInt(verify(mocked, atLeastOnce()).read(any(byte[].class), anyInt(), anyInt()));
-      ignoreInt(verify(mocked, never()).read());
+      verify(mocked, atLeastOnce()).read(any(byte[].class), anyInt(), anyInt());
+      verify(mocked, never()).read();
     }
   }
 
@@ -247,7 +245,7 @@ class LineReadingInputStreamTest {
     }
   }
 
-  /** ByteArrayInputStream that disables mark/reset support to force non-marking path. */
+  /** ByteArrayInputStream that disables mark/reset support to force a non-marking path. */
   private static class NonMarkingInputStream extends ByteArrayInputStream {
     NonMarkingInputStream(byte[] buf) {
       super(buf);


### PR DESCRIPTION
## Summary
- remove no-op `ignore*` helper methods from multiple test classes and inline the asserted call sites
- simplify Mockito verification statements where return values were intentionally ignored
- normalize test constants/imports/comment wording and related style issues reported by SonarLint/Spotless
- keep behavior unchanged while making tests cleaner and static-analysis compliant

## How to test
- `./gradlew spotlessApply`
- `./gradlew test --tests *LineReadingInputStreamTest`
- `./gradlew test`

## Notes
- changes are limited to test sources under `src/test/java`
- branch was reviewed against `origin/develop` before PR creation