### PR TITLE
test(sonarlint): Refactor exception assertions for S5778

### DIFF
--- a/src/test/java/network/crypta/support/io/NullInputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/NullInputStreamTest.java
@@ -19,11 +19,6 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("java:S100") // test naming style: method_whenCondition_expectOutcome
 class NullInputStreamTest {
 
-  @SuppressWarnings("java:S1172")
-  private static void ignoreInt(int ignored) {
-    // Intentionally empty helper to consume values in assertions.
-  }
-
   @Test
   void read_whenCalled_expectEOF() throws Exception {
     try (InputStream in = new NullInputStream()) {
@@ -104,7 +99,7 @@ class NullInputStreamTest {
   void readWithOffset_whenInvalidArgs_expectIndexOutOfBounds(byte[] buf, int off, int len)
       throws Exception {
     try (InputStream in = new NullInputStream()) {
-      assertThrows(IndexOutOfBoundsException.class, () -> ignoreInt(in.read(buf, off, len)));
+      assertThrows(IndexOutOfBoundsException.class, () -> in.read(buf, off, len));
     }
   }
 
@@ -112,7 +107,7 @@ class NullInputStreamTest {
   @Test
   void readWithNullArray_whenCalled_expectNullPointerException() {
     try (InputStream in = new NullInputStream()) {
-      assertThrows(NullPointerException.class, () -> ignoreInt(in.read(null, 0, 1)));
+      assertThrows(NullPointerException.class, () -> in.read(null, 0, 1));
     } catch (IOException e) {
       fail(e);
     }

--- a/src/test/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucketTest.java
+++ b/src/test/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucketTest.java
@@ -38,11 +38,6 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"java:S100", "java:S2245"})
 class PaddedEphemerallyEncryptedBucketTest {
 
-  @SuppressWarnings("java:S1172")
-  private static void ignoreInt(int ignored) {
-    // Intentionally empty helper to consume values in assertions.
-  }
-
   private static int invalidNegativeOffset() {
     return -Math.abs(System.identityHashCode(new Object()) | 1);
   }
@@ -227,10 +222,8 @@ class PaddedEphemerallyEncryptedBucketTest {
       // Invalid bounds
       int invalidOffset = invalidNegativeOffset();
       int invalidLength = outOfBoundsLength(buf);
-      assertThrows(
-          ArrayIndexOutOfBoundsException.class, () -> ignoreInt(is.read(buf, invalidOffset, 1)));
-      assertThrows(
-          ArrayIndexOutOfBoundsException.class, () -> ignoreInt(is.read(buf, 0, invalidLength)));
+      assertThrows(ArrayIndexOutOfBoundsException.class, () -> is.read(buf, invalidOffset, 1));
+      assertThrows(ArrayIndexOutOfBoundsException.class, () -> is.read(buf, 0, invalidLength));
 
       // Read rest
       byte[] rest = is.readAllBytes();

--- a/src/test/java/network/crypta/support/io/RAFInputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/RAFInputStreamTest.java
@@ -203,7 +203,7 @@ class RAFInputStreamTest {
     RandomAccessBuffer raf = stubRaf(patternBytes(4));
     try (RAFInputStream is = new RAFInputStream(raf, 0, 4)) {
       // Act & Assert
-      assertThrows(NullPointerException.class, () -> ignoreInt(is.read(null)));
+      assertThrows(NullPointerException.class, () -> is.read(null));
     }
   }
 
@@ -217,8 +217,8 @@ class RAFInputStreamTest {
       byte[] buf = new byte[8];
 
       // Act & Assert
-      assertThrows(IndexOutOfBoundsException.class, () -> ignoreInt(is.read(buf, -1, 1)));
-      assertThrows(IndexOutOfBoundsException.class, () -> ignoreInt(is.read(buf, 0, 9)));
+      assertThrows(IndexOutOfBoundsException.class, () -> is.read(buf, -1, 1));
+      assertThrows(IndexOutOfBoundsException.class, () -> is.read(buf, 0, 9));
     }
   }
 
@@ -244,7 +244,7 @@ class RAFInputStreamTest {
     RandomAccessBuffer raf = stubRaf(content);
     try (RAFInputStream is = new RAFInputStream(raf, -1, 2)) {
       // Act & Assert
-      assertThrows(IllegalArgumentException.class, () -> ignoreInt(is.read(new byte[1])));
+      assertThrows(IllegalArgumentException.class, () -> is.read(new byte[1]));
     }
   }
 

--- a/src/test/java/network/crypta/support/math/SimpleRunningAverageTest.java
+++ b/src/test/java/network/crypta/support/math/SimpleRunningAverageTest.java
@@ -15,11 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class SimpleRunningAverageTest {
   private static final double EPS = 1e-9;
 
-  @SuppressWarnings("java:S1172")
-  private static void ignoreDouble(double ignored) {
-    // Intentionally empty helper to consume values in assertions.
-  }
-
   private static void constructAverage(int window, double init) {
     new SimpleRunningAverage(window, init);
   }
@@ -213,8 +208,7 @@ class SimpleRunningAverageTest {
     assertEquals(0L, avg.countReports());
 
     // Act & Assert: operations that access storage fail
-    assertThrows(
-        ArrayIndexOutOfBoundsException.class, () -> ignoreDouble(avg.valueIfReported(1.0)));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> avg.valueIfReported(1.0));
     assertThrows(ArrayIndexOutOfBoundsException.class, () -> avg.report(1.0));
     assertThrows(ArrayIndexOutOfBoundsException.class, () -> avg.report(1L));
   }

--- a/src/test/java/org/bitpedia/util/ArrayUtilsTest.java
+++ b/src/test/java/org/bitpedia/util/ArrayUtilsTest.java
@@ -11,11 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("java:S100")
 class ArrayUtilsTest {
 
-  @SuppressWarnings("java:S1172")
-  private static void ignoreString(String ignored) {
-    // Intentionally empty helper to consume values in assertions.
-  }
-
   @ParameterizedTest
   @CsvSource({"0,00", "1,01", "15,0f", "16,10", "127,7f", "-1,ff", "-128,80"})
   @DisplayName("byteToHex returns two lowercase hex chars for any byte value")
@@ -61,8 +56,7 @@ class ArrayUtilsTest {
 
     // Act + Assert
     assertThrows(
-        ArrayIndexOutOfBoundsException.class,
-        () -> ignoreString(ArrayUtils.byteArrayToHex(data, -1, 1)));
+        ArrayIndexOutOfBoundsException.class, () -> ArrayUtils.byteArrayToHex(data, -1, 1));
   }
 
   @Test
@@ -71,15 +65,12 @@ class ArrayUtilsTest {
     byte[] data = new byte[] {0x01, 0x02};
 
     // Act + Assert
-    assertThrows(
-        ArrayIndexOutOfBoundsException.class,
-        () -> ignoreString(ArrayUtils.byteArrayToHex(data, 2, 1)));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> ArrayUtils.byteArrayToHex(data, 2, 1));
   }
 
   @Test
   void byteArrayToHex_whenArrayIsNull_throwsNullPointerException() {
     // Act + Assert
-    assertThrows(
-        NullPointerException.class, () -> ignoreString(ArrayUtils.byteArrayToHex(null, 0, 1)));
+    assertThrows(NullPointerException.class, () -> ArrayUtils.byteArrayToHex(null, 0, 1));
   }
 }

--- a/src/test/java/org/sevenzip/LzmaBenchTest.java
+++ b/src/test/java/org/sevenzip/LzmaBenchTest.java
@@ -27,11 +27,6 @@ class LzmaBenchTest {
   private ByteArrayOutputStream outContent;
   private PrintStream testOut;
 
-  @SuppressWarnings("java:S1172")
-  private static void ignoreInt(int ignored) {
-    // Intentionally empty helper to consume values in assertions.
-  }
-
   @BeforeEach
   void setUpStreams() {
     originalOut = System.out;
@@ -115,8 +110,7 @@ class LzmaBenchTest {
   @Test
   void myInputStream_readWithInvalidRange_throwsIndexOutOfBounds() throws Exception {
     try (LzmaBench.MyInputStream stream = new LzmaBench.MyInputStream(new byte[2], 2)) {
-      assertThrows(
-          IndexOutOfBoundsException.class, () -> ignoreInt(stream.read(new byte[1], 1, 1)));
+      assertThrows(IndexOutOfBoundsException.class, () -> stream.read(new byte[1], 1, 1));
     }
   }
 

--- a/src/test/java/org/spaceroots/mantissa/functions/vectorial/VectorialValuedPairTest.java
+++ b/src/test/java/org/spaceroots/mantissa/functions/vectorial/VectorialValuedPairTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -54,7 +53,7 @@ class VectorialValuedPairTest {
   @Test
   @SuppressWarnings("DataFlowIssue")
   void constructor_whenNullArray_throwsNullPointerException() {
-    assertThrows(NullPointerException.class, () -> assertNotNull(constructPair(2.0, null)));
+    assertThrows(NullPointerException.class, () -> constructPair(2.0, null));
   }
 
   @Test

--- a/src/test/java/org/spaceroots/mantissa/optimization/PointCostPairTest.java
+++ b/src/test/java/org/spaceroots/mantissa/optimization/PointCostPairTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -53,8 +52,7 @@ class PointCostPairTest {
   void constructor_whenPointIsNull_throwsNullPointerException() {
     // Arrange
     // Act / Assert
-    assertThrows(
-        NullPointerException.class, () -> assertNotNull(constructPointCostPair(null, 1.0)));
+    assertThrows(NullPointerException.class, () -> constructPointCostPair(null, 1.0));
   }
 
   @Test

--- a/src/test/java/org/spaceroots/mantissa/utilities/IntervalsListTest.java
+++ b/src/test/java/org/spaceroots/mantissa/utilities/IntervalsListTest.java
@@ -22,11 +22,6 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("java:S100")
 class IntervalsListTest {
 
-  @SuppressWarnings("java:S1172")
-  private static void ignoreInterval(Interval ignored) {
-    // Intentionally empty helper to consume values in assertions.
-  }
-
   @Test
   void constructor_whenNoArgs_expectEmptyListWithNaNBounds() {
     // Arrange
@@ -129,8 +124,8 @@ class IntervalsListTest {
     IntervalsList list = new IntervalsList(0.0, 1.0);
 
     // Act + Assert
-    assertThrows(IndexOutOfBoundsException.class, () -> ignoreInterval(list.getInterval(-1)));
-    assertThrows(IndexOutOfBoundsException.class, () -> ignoreInterval(list.getInterval(1)));
+    assertThrows(IndexOutOfBoundsException.class, () -> list.getInterval(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> list.getInterval(1));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary
- Refactor `assertThrows` lambdas flagged by SonarLint `java:S5778` so each lambda contains a single potentially-throwing invocation.
- Remove now-unused no-op assertion helpers and redundant assertion wrappers introduced for prior exception-path tests.
- Keep test behavior unchanged while making failure source attribution explicit.

## Scope
- `src/test/java/network/crypta/support/io/NullInputStreamTest.java`
- `src/test/java/network/crypta/support/io/PaddedEphemerallyEncryptedBucketTest.java`
- `src/test/java/network/crypta/support/io/RAFInputStreamTest.java`
- `src/test/java/network/crypta/support/math/SimpleRunningAverageTest.java`
- `src/test/java/org/bitpedia/util/ArrayUtilsTest.java`
- `src/test/java/org/sevenzip/LzmaBenchTest.java`
- `src/test/java/org/spaceroots/mantissa/functions/vectorial/VectorialValuedPairTest.java`
- `src/test/java/org/spaceroots/mantissa/optimization/PointCostPairTest.java`
- `src/test/java/org/spaceroots/mantissa/utilities/IntervalsListTest.java`

## Validation
- `./gradlew sonarlintTest --rerun-tasks`
- `./gradlew sonarlintMain --rerun-tasks`
- `./gradlew test --tests *IntervalsListTest --tests *SimpleRunningAverageTest --tests *PointCostPairTest --tests *PaddedEphemerallyEncryptedBucketTest --tests *LzmaBenchTest --tests *ArrayUtilsTest --tests *NullInputStreamTest --tests *RAFInputStreamTest --tests *VectorialValuedPairTest`

## Notes
- `S5778` is absent from both `sonarlintMain.xml` and `sonarlintTest.xml` after the changes.