### PR TITLE
fix(async): Remove redundant throws declarations for SonarLint S1130

### DIFF
--- a/src/main/java/network/crypta/client/async/SingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SingleFileFetcher.java
@@ -901,8 +901,7 @@ public final class SingleFileFetcher extends BaseSingleFileFetcher implements Cl
     };
   }
 
-  private StepDecision handleOtherKind(MetaKind kind, ClientContext context)
-      throws FetchException, MetadataParseException {
+  private StepDecision handleOtherKind(MetaKind kind, ClientContext context) throws FetchException {
     return switch (kind) {
       case SIMPLE_MANIFEST -> {
         processSimpleManifestStep();
@@ -1332,8 +1331,7 @@ public final class SingleFileFetcher extends BaseSingleFileFetcher implements Cl
     return p;
   }
 
-  private boolean processSplitfileStep(final ClientContext context)
-      throws FetchException, MetadataParseException {
+  private boolean processSplitfileStep(final ClientContext context) throws FetchException {
     Metadata current = currentMetadata();
     if (LOG.isDebugEnabled()) LOG.debug("Fetching splitfile");
     clientMetadata.mergeNoOverwrite(current.getClientMetadata());

--- a/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
+++ b/src/test/java/network/crypta/client/async/PlainManifestPutterTest.java
@@ -111,8 +111,7 @@ class PlainManifestPutterTest {
         Map<String, Object> manifest,
         InsertContext ctx,
         byte[] forceKey,
-        ClientContext context)
-        throws TooManyFilesInsertException {
+        ClientContext context) {
       super(
           new ManifestPutterParams(
               new InsertRequestParams(cb, FreenetURI.EMPTY_CHK_URI, ctx, /*prioClass*/ (short) 0),
@@ -172,7 +171,7 @@ class PlainManifestPutterTest {
     // Act: invoke the protected method under test directly
     putter.makePutHandlers(root, "index.html");
 
-    // Assert: directory navigation for the subdir and two adds (default doc in subdir only)
+    // Assert: directory navigation for the subdir and two adding (default doc in subdir only)
     verify(builder, times(1)).pushCurrentDir();
     verify(builder, times(1)).makeSubDirCD("dir");
     verify(builder, times(1)).popCurrentDir();
@@ -226,7 +225,7 @@ class PlainManifestPutterTest {
   }
 
   @Test
-  void makePutHandlers_whenInvalidElement_throwsClassCastException() throws Exception {
+  void makePutHandlers_whenInvalidElement_throwsClassCastException() {
     // Arrange
     HashMap<String, Object> root = new HashMap<>();
     root.put("bad", 123); // not a HashMap nor ManifestElement

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherStorageTest.java
@@ -555,7 +555,7 @@ class SplitFileFetcherStorageTest {
   }
 
   private void testDataBlocksOnly(TestSplitfile test)
-      throws IOException, CHKEncodeException, FetchException, MetadataParseException {
+      throws IOException, CHKEncodeException, FetchException {
     StorageCallback cb = test.createStorageCallback();
     SplitFileFetcherStorage storage = test.createStorage(cb);
     SplitFileFetcherSegmentStorage segment = storage.segments[0];
@@ -585,7 +585,7 @@ class SplitFileFetcherStorageTest {
   }
 
   private void testCheckBlocksOnly(TestSplitfile test)
-      throws IOException, CHKEncodeException, FetchException, MetadataParseException {
+      throws IOException, CHKEncodeException, FetchException {
     StorageCallback cb = test.createStorageCallback();
     SplitFileFetcherStorage storage = test.createStorage(cb);
     SplitFileFetcherSegmentStorage segment = storage.segments[0];
@@ -618,7 +618,7 @@ class SplitFileFetcherStorageTest {
   }
 
   private void testRandomMixture(TestSplitfile test)
-      throws FetchException, MetadataParseException, IOException, CHKEncodeException {
+      throws FetchException, IOException, CHKEncodeException {
     StorageCallback cb = test.createStorageCallback();
     SplitFileFetcherStorage storage = test.createStorage(cb);
     SplitFileFetcherSegmentStorage segment = storage.segments[0];
@@ -825,7 +825,7 @@ class SplitFileFetcherStorageTest {
   }
 
   private void testRandomMixtureMultiSegment(TestSplitfile test)
-      throws CHKEncodeException, IOException, FetchException, MetadataParseException {
+      throws CHKEncodeException, IOException, FetchException {
     StorageCallback cb = test.createStorageCallback();
     SplitFileFetcherStorage storage = test.createStorage(cb);
     int total = test.dataBlocks.length + test.checkBlocks.length;
@@ -984,7 +984,7 @@ class SplitFileFetcherStorageTest {
 
   private SplitFileFetcherStorage createSplitFileFetcherStorageTwice(
       TestSplitfile test, StorageCallback cb)
-      throws FetchException, MetadataParseException, IOException, StorageFormatException {
+      throws FetchException, IOException, StorageFormatException {
     test.createStorage(cb);
     // No need to shut down the old storage.
     return test.createStorage(cb, test.makeFetchContext(), cb.getRAF());


### PR DESCRIPTION
## Summary
- Remove superfluous checked-exception declarations flagged by SonarLint `java:S1130` in `SingleFileFetcher` private helpers.
- Remove unused throws declarations in async tests (`PlainManifestPutterTest`, `SplitFileFetcherStorageTest`).
- Keep behavior unchanged; this is signature cleanup only.

## Verification
- `./gradlew spotlessApply --console=plain`
- `./gradlew sonarlintMain sonarlintTest --console=plain` (no remaining `java:S1130` in reports)
- `./gradlew test --tests network.crypta.client.async.PlainManifestPutterTest --tests network.crypta.client.async.SplitFileFetcherStorageTest --console=plain`
