### PR TITLE
fix(sonar): Add sonarIssues task and resolve S1172 findings

### DIFF
--- a/.agents/skills/cryptad-build-tooling/SKILL.md
+++ b/.agents/skills/cryptad-build-tooling/SKILL.md
@@ -114,6 +114,11 @@ Confirm `gradle/verification-metadata.xml` contains SpotBugs entries such as:
 - SonarLint does **not** run during regular lifecycles (`build`, `check`).
 - `sonarlintMain` / `sonarlintTest` run only when explicitly requested (task name contains `sonarlint`).
 - Default config: `ignoreFailures = true` (non-failing by default).
+- `sonarIssues` queries server-side issues from SonarQube/SonarCloud (`/api/issues/search`) for a
+  specified rule set and can report issues that local `sonarlintMain`, `sonarlintTest`, and
+  `sonarlintFile` do not.
+- `sonarIssues` reads the latest uploaded server analysis; after fixing code locally, its issue list
+  can remain stale until CI runs analysis successfully and uploads fresh results.
 
 ### Tasks
 - Full main sources:
@@ -124,6 +129,27 @@ Confirm `gradle/verification-metadata.xml` contains SpotBugs entries such as:
   - `./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/SevenZip/LzmaAlone.java`
   - Aliases: `-Pfile=...`, `-Psonarlint.sources=...`
   - Report: `build/reports/sonarLint/sonarlintFile/sonarlintFile.xml`
+- Server-side rule query:
+  - `./gradlew sonarIssues -PsonarIssues.rules=java:S1172`
+  - Task name is `sonarIssues` (sometimes informally referred to as “sonarlintIssues”).
+  - Uses `SONAR_TOKEN` automatically when present (required for private projects).
+  - Default report: `build/reports/sonar/issues-page-1.json`
+  - Useful properties:
+    - `-PsonarIssues.rules=<repo:rule>` (comma-separated supported by API)
+    - `-PsonarIssues.page=<n>`
+    - `-PsonarIssues.pageSize=<1..500>`
+    - `-PsonarIssues.output=<path>`
+
+### Rule-specific investigation workflow
+When investigating a specific SonarLint/Sonar rule, always run all three:
+1) `./gradlew sonarlintMain`
+2) `./gradlew sonarlintTest`
+3) `./gradlew sonarIssues -PsonarIssues.rules=<repo:rule>`
+
+Interpretation:
+- Local SonarLint tasks (`sonarlintMain`, `sonarlintTest`, optionally `sonarlintFile`) show what the
+  current local analyzer run reports.
+- `sonarIssues` shows what the server currently reports (may lag until CI analysis completes).
 
 ### Verification refresh on SonarLint bumps
 If strict verification blocks resolution:

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -1,3 +1,9 @@
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
 import javax.xml.stream.XMLInputFactory
 import javax.xml.stream.XMLOutputFactory
 import javax.xml.stream.XMLStreamConstants
@@ -386,3 +392,93 @@ tasks.named("sonarqube").configure {
 tasks
   .findByName("sonar")
   ?.dependsOn("jacocoTestReport", "prepareKotlinTestReports", "prepareTestExecutionReport")
+
+tasks.register("sonarIssues") {
+  group = "verification"
+  description =
+    "Query SonarQube/SonarCloud issues via /api/issues/search and save JSON in build/reports/sonar."
+
+  doLast {
+    val host =
+      providers
+        .gradleProperty("sonarIssues.host")
+        .orElse(providers.gradleProperty("sonar.host.url"))
+        .orElse("https://sonarcloud.io")
+        .get()
+        .trimEnd('/')
+    val organization =
+      providers.gradleProperty("sonarIssues.organization").orElse("crypta-network").get()
+    val componentKeys =
+      providers
+        .gradleProperty("sonarIssues.componentKeys")
+        .orElse(providers.gradleProperty("sonar.projectKey"))
+        .orElse("crypta-network_cryptad")
+        .get()
+    val page = providers.gradleProperty("sonarIssues.page").orElse("1").get()
+    val pageSize = providers.gradleProperty("sonarIssues.pageSize").orElse("500").get()
+    val resolved = providers.gradleProperty("sonarIssues.resolved").orElse("false").get()
+    val rules = providers.gradleProperty("sonarIssues.rules").orNull
+    val branch = providers.gradleProperty("sonarIssues.branch").orNull
+    val pullRequest = providers.gradleProperty("sonarIssues.pullRequest").orNull
+    val statuses = providers.gradleProperty("sonarIssues.statuses").orNull
+    val additionalFields = providers.gradleProperty("sonarIssues.additionalFields").orNull
+    val token = providers.environmentVariable("SONAR_TOKEN").orNull?.takeIf { it.isNotBlank() }
+
+    val params = linkedMapOf<String, String>()
+    params["organization"] = organization
+    params["componentKeys"] = componentKeys
+    params["p"] = page
+    params["ps"] = pageSize
+    params["resolved"] = resolved
+    if (!additionalFields.isNullOrBlank()) params["additionalFields"] = additionalFields
+    if (!rules.isNullOrBlank()) params["rules"] = rules
+    if (!branch.isNullOrBlank()) params["branch"] = branch
+    if (!pullRequest.isNullOrBlank()) params["pullRequest"] = pullRequest
+    if (!statuses.isNullOrBlank()) params["statuses"] = statuses
+
+    val query =
+      params.entries.joinToString("&") { (key, value) ->
+        "${URLEncoder.encode(key, StandardCharsets.UTF_8)}=${URLEncoder.encode(value, StandardCharsets.UTF_8)}"
+      }
+    val endpoint = "$host/api/issues/search?$query"
+
+    val requestBuilder =
+      HttpRequest.newBuilder().uri(URI.create(endpoint)).header("Accept", "application/json").GET()
+    token?.let { requestBuilder.header("Authorization", "Bearer $it") }
+
+    val response =
+      HttpClient.newBuilder()
+        .followRedirects(HttpClient.Redirect.NORMAL)
+        .build()
+        .send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
+
+    if (response.statusCode() !in 200..299) {
+      val bodySnippet = response.body().replace(Regex("\\s+"), " ").take(600)
+      throw GradleException(
+        "Sonar issues query failed with HTTP ${response.statusCode()} at $endpoint. Response: $bodySnippet"
+      )
+    }
+
+    val outputPath =
+      providers
+        .gradleProperty("sonarIssues.output")
+        .orElse("build/reports/sonar/issues-page-$page.json")
+        .get()
+    val outputFile = project.file(outputPath)
+    outputFile.parentFile.mkdirs()
+    outputFile.writeText(response.body(), Charsets.UTF_8)
+
+    val totalIssues =
+      Regex("\"paging\"\\s*:\\s*\\{[^}]*\"total\"\\s*:\\s*(\\d+)", RegexOption.DOT_MATCHES_ALL)
+        .find(response.body())
+        ?.groupValues
+        ?.getOrNull(1)
+    logger.lifecycle("Saved Sonar issues response to ${outputFile.path}")
+    totalIssues?.let { logger.lifecycle("Sonar issues total (server-side): $it") }
+    if (token == null) {
+      logger.lifecycle(
+        "SONAR_TOKEN is not set; request was sent without authentication (works only for public data)."
+      )
+    }
+  }
+}

--- a/src/main/java/network/crypta/node/simulator/RealNodeBusyNetworkTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeBusyNetworkTest.java
@@ -93,10 +93,13 @@ public class RealNodeBusyNetworkTest extends RealNodeRoutingTest {
    * queued requests finish. The method is not idempotent: it deletes prior data, consumes ports,
    * and calls {@link System#exit(int)} on failure or normal completion.
    *
-   * @param args command-line arguments that are currently ignored by this test harness
-   * @throws Exception if node initialization, startup, or waiting is interrupted or fails
+   * @param args command-line arguments; ignored by this simulation harness
+   * @throws Exception if node initialization, inserts, or waiting for completion fails
    */
-  public static void main(@SuppressWarnings("unused") String[] args) throws Exception {
+  public static void main(String[] args) throws Exception {
+    if (args.length > 0) {
+      LOG.info("Ignoring {} command-line arguments for busy-network harness.", args.length);
+    }
     String name = "realNodeRequestInsertTest";
     File wd = new File(name);
     prepareWorkingDirectory(wd);

--- a/src/main/java/network/crypta/node/simulator/RealNodePitchBlackMitigationTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodePitchBlackMitigationTest.java
@@ -172,10 +172,14 @@ public class RealNodePitchBlackMitigationTest extends RealNodeTest {
    * RealNodePitchBlackMitigationTest.main(new String[0]);
    * }</pre>
    *
-   * @param args command-line arguments; unused but accepted for standard entry-point semantics
+   * @param args command-line arguments; ignored by this simulation harness
    * @throws Exception if node initialization or startup fails before the simulation can begin
    */
-  public static void main(@SuppressWarnings("unused") String[] args) throws Exception {
+  public static void main(String[] args) throws Exception {
+    if (args.length > 0) {
+      LOG.info(
+          "Ignoring {} command-line arguments for pitch-black mitigation harness.", args.length);
+    }
     LOG.info("Routing test using real nodes:");
     LOG.info("");
     String dir = "realNodeRequestInsertTest";

--- a/src/main/java/network/crypta/node/simulator/RealNodeProbeTest.java
+++ b/src/main/java/network/crypta/node/simulator/RealNodeProbeTest.java
@@ -30,7 +30,7 @@ import org.slf4j.event.Level;
  *
  * <p>This class spins up a fixed-size test network, waits for routing to settle, and then provides
  * a console-driven menu for executing probe types from a chosen node. It is intended for manual
- * diagnostics and exploratory checks where you want realistic routing behavior, but also need to
+ * diagnostics and exploratory checks where you want realistic routing behavior but also need to
  * control probe selection and HTL values. The setup uses deterministic random seeds to keep the
  * topology and probe routing comparable across runs, while still exercising real routing logic
  * rather than simulator stubs.
@@ -57,8 +57,8 @@ public class RealNodeProbeTest extends RealNodeRoutingTest {
   /**
    * Creates the probe harness with default settings.
    *
-   * <p>Construction performs no setup work; all runtime initialization happens in {@link
-   * #main(String[])} when the harness is executed as a standalone tool.
+   * <p>Construction performs no setup work; all runtime initialization happens in {@link #main()}
+   * when the harness is executed as a standalone tool.
    */
   public RealNodeProbeTest() {
     // Intentionally empty; this harness is executed via the static main entry point.
@@ -77,7 +77,7 @@ public class RealNodeProbeTest extends RealNodeRoutingTest {
   private static final boolean DO_INSERT_TEST = true;
 
   /**
-   * First port assigned to probe-test darknet nodes, starting after the routing-test range.
+   * The first port assigned to probe-test darknet nodes, starting after the routing-test range.
    *
    * <p>The value is derived from {@link RealNodeRoutingTest#DARKNET_PORT_END} to avoid overlaps
    * between the two harnesses. It is constant for a process run and is used to map node indexes to
@@ -104,10 +104,10 @@ public class RealNodeProbeTest extends RealNodeRoutingTest {
    * background threads, the program terminates via {@link System#exit(int)} when the menu loop
    * ends. This entry point is intended for manual, developer-driven experimentation.
    *
-   * @param args command-line arguments; currently ignored and expected to be empty
-   * @throws Exception if node initialization, startup, or probe configuration fails unexpectedly
+   * @throws NodeInitException if any node fails during initialization or startup
+   * @throws InterruptedException if waiting for connectivity or insert completion is interrupted
    */
-  public static void main(String[] args) throws Exception {
+  public static void main() throws NodeInitException, InterruptedException {
     logIntro();
     String dir = "realNodeProbeTest";
     File baseDirectory = prepareBaseDirectory(dir);

--- a/src/main/java/network/crypta/tools/CleanupTranslations.java
+++ b/src/main/java/network/crypta/tools/CleanupTranslations.java
@@ -22,7 +22,7 @@ import org.slf4j.event.Level;
  * <p>This tool treats {@code crypta.l10n.en.properties} as the reference set of translation keys
  * and rewrites other {@code crypta.l10n.*.properties} files to remove entries whose keys are no
  * longer present in the English file. It is intended for repository maintenance (e.g., after
- * renaming or deleting strings) so translators are not left with keys that are never looked up at
+ * renaming or deleting strings), so translators are not left with keys that are never looked up at
  * runtime.
  *
  * <p><b>Notable behaviors</b>:
@@ -63,10 +63,9 @@ public class CleanupTranslations {
    * CLI command. It is not idempotent with respect to formatting because it rewrites the file
    * content exactly as it was read for kept lines.
    *
-   * @param args command-line arguments, currently ignored by this maintenance utility
    * @throws IOException if reading or writing translation files fails with an I/O error
    */
-  public static void main(String[] args) throws IOException {
+  public static void main() throws IOException {
     Logging.bootstrap(Level.ERROR, "");
     File engFile = new File("src/freenet/l10n/crypta.l10n.en.properties");
     SimpleFieldSet english = SimpleFieldSet.readFrom(engFile, false, true);
@@ -93,9 +92,9 @@ public class CleanupTranslations {
   /**
    * Creates a new instance.
    *
-   * <p>This type is primarily used via its {@link #main(String[])} entry point and carries no
-   * instance state. The explicit constructor exists only to satisfy strict doclint checks for the
-   * public default constructor.
+   * <p>This type is primarily used via its {@link #main()} entry point and carries no instance
+   * state. The explicit constructor exists only to satisfy strict doclint checks for the public
+   * default constructor.
    */
   public CleanupTranslations() {
     // Intentionally empty: this utility is invoked via main(...) and has no instance state.

--- a/src/test/java/network/crypta/crypt/JceLoaderTest.java
+++ b/src/test/java/network/crypta/crypt/JceLoaderTest.java
@@ -164,7 +164,7 @@ class JceLoaderTest {
    * system properties controlled by the parent test.
    */
   public static class ProbeMain {
-    public static void main(String[] args) {
+    static void main() {
       boolean bc = JceLoader.BouncyCastle != null;
       boolean nss = JceLoader.NSS != null;
       boolean sun = JceLoader.SUN != null;


### PR DESCRIPTION
## Summary
This PR adds a Gradle task to query SonarQube/SonarCloud issues by rule and fixes current `java:S1172` findings in the affected entry points.

## Changes
- Add `sonarIssues` task in `build-logic/src/main/kotlin/cryptad.sonar.gradle.kts`:
  - Calls `/api/issues/search`
  - Uses `SONAR_TOKEN` automatically when present
  - Supports rule/page/output filters via `-PsonarIssues.*`
  - Writes JSON to `build/reports/sonar/`
- Fix `java:S1172` (unused `args`) in Sonar-reported locations:
  - `src/main/java/network/crypta/node/simulator/RealNodeBusyNetworkTest.java`
  - `src/main/java/network/crypta/node/simulator/RealNodePitchBlackMitigationTest.java`
  - `src/main/java/network/crypta/node/simulator/RealNodeProbeTest.java`
  - `src/main/java/network/crypta/tools/CleanupTranslations.java`
  - `src/test/java/network/crypta/crypt/JceLoaderTest.java`
- Update tooling guidance in `.agents/skills/cryptad-build-tooling/SKILL.md`:
  - Document `sonarIssues`
  - Document server-result staleness vs local SonarLint tasks
  - Add required rule-check workflow (`sonarlintMain`, `sonarlintTest`, `sonarIssues`)

## How To Test
1. `./gradlew spotlessApply`
2. `./gradlew compileJava compileTestJava`
3. `./gradlew sonarlintMain sonarlintTest`
4. `./gradlew sonarIssues -PsonarIssues.rules=java:S1172`

## Notes
- `sonarIssues` reflects the latest uploaded server analysis and can lag behind local fixes until CI uploads a successful analysis run.
- For private project data, set `SONAR_TOKEN` in the environment before running `sonarIssues`.
