### PR TITLE
fix(core): Validate constructor inputs before super calls

### DIFF
--- a/src/main/java/com/onionnetworks/io/FiniteInputStream.java
+++ b/src/main/java/com/onionnetworks/io/FiniteInputStream.java
@@ -53,14 +53,22 @@ public final class FiniteInputStream extends FilterInputStream {
    * @throws IllegalArgumentException if {@code count} is negative.
    */
   public FiniteInputStream(InputStream is, long count) {
+    requireNonNullStream(is);
+    requireNonNegativeCount(count);
     super(is);
+    left = count;
+  }
+
+  private static void requireNonNullStream(InputStream is) {
     if (is == null) {
       throw new NullPointerException();
     }
+  }
+
+  private static void requireNonNegativeCount(long count) {
     if (count < 0) {
       throw new IllegalArgumentException("count must be > 0");
     }
-    left = count;
   }
 
   /**

--- a/src/main/java/com/onionnetworks/io/JoiningInputStream.java
+++ b/src/main/java/com/onionnetworks/io/JoiningInputStream.java
@@ -47,12 +47,16 @@ public final class JoiningInputStream extends FilterInputStream {
    *     non-null and ready to read without further initialization
    */
   public JoiningInputStream(InputStream first, InputStream second) {
+    requireNonNullStreams(first, second);
     super(first);
+    this.first = first;
+    this.second = second;
+  }
+
+  private static void requireNonNullStreams(InputStream first, InputStream second) {
     if (first == null || second == null) {
       throw new NullPointerException();
     }
-    this.first = first;
-    this.second = second;
   }
 
   /**

--- a/src/main/java/com/onionnetworks/io/JournalingRAF.java
+++ b/src/main/java/com/onionnetworks/io/JournalingRAF.java
@@ -50,15 +50,19 @@ public final class JournalingRAF extends FilterRAF {
    * @throws IllegalStateException if the provided RAF is open in read-only mode.
    */
   public JournalingRAF(RAF raf, Journal journal) {
+    requireWritableRaf(raf);
     super(raf);
-    if (raf.getMode().equals("r")) {
-      throw new IllegalStateException("Can't create a journal for a " + "read-only file.");
-    }
 
     this.journal = journal;
 
     // Track the initial file path.
     journal.setTargetFile(raf.getFile());
+  }
+
+  private static void requireWritableRaf(RAF raf) {
+    if (raf.getMode().equals("r")) {
+      throw new IllegalStateException("Can't create a journal for a " + "read-only file.");
+    }
   }
 
   /**

--- a/src/main/java/com/onionnetworks/util/Range.java
+++ b/src/main/java/com/onionnetworks/util/Range.java
@@ -78,10 +78,8 @@ public final class Range {
    * @throws IllegalArgumentException if {@code posInf} is {@code false}
    */
   public Range(long min, boolean posInf) {
+    requirePositiveInfinity(posInf);
     this(min, Long.MAX_VALUE, false, posInf);
-    if (!posInf) {
-      throw new IllegalArgumentException("posInf must be true");
-    }
   }
 
   /**
@@ -97,10 +95,8 @@ public final class Range {
    * @throws IllegalArgumentException if {@code negInf} is {@code false}
    */
   public Range(boolean negInf, long max) {
+    requireNegativeInfinity(negInf);
     this(Long.MIN_VALUE, max, negInf, false);
-    if (!negInf) {
-      throw new IllegalArgumentException("negInf must be true");
-    }
   }
 
   /**
@@ -116,10 +112,8 @@ public final class Range {
    * @throws IllegalArgumentException if either flag is {@code false}
    */
   public Range(boolean negInf, boolean posInf) {
+    requireInfiniteBounds(negInf, posInf);
     this(Long.MIN_VALUE, Long.MAX_VALUE, negInf, posInf);
-    if (!negInf || !posInf) {
-      throw new IllegalArgumentException("negInf && posInf must be true");
-    }
   }
 
   private Range(long min, long max, boolean negInf, boolean posInf) {
@@ -137,6 +131,24 @@ public final class Range {
     this.max = max;
     this.negInf = negInf;
     this.posInf = posInf;
+  }
+
+  private static void requirePositiveInfinity(boolean posInf) {
+    if (!posInf) {
+      throw new IllegalArgumentException("posInf must be true");
+    }
+  }
+
+  private static void requireNegativeInfinity(boolean negInf) {
+    if (!negInf) {
+      throw new IllegalArgumentException("negInf must be true");
+    }
+  }
+
+  private static void requireInfiniteBounds(boolean negInf, boolean posInf) {
+    if (!negInf || !posInf) {
+      throw new IllegalArgumentException("negInf && posInf must be true");
+    }
   }
 
   /**

--- a/src/main/java/network/crypta/client/RealArchiveStoreItem.java
+++ b/src/main/java/network/crypta/client/RealArchiveStoreItem.java
@@ -74,13 +74,17 @@ final class RealArchiveStoreItem extends ArchiveStoreItem {
    *     with the cache and the bucket is set read-only by this constructor
    */
   RealArchiveStoreItem(ArchiveStoreContext ctx, FreenetURI key2, String realName, Bucket bucket) {
+    requireBucket(bucket);
     super(new ArchiveKey(key2, realName), ctx);
-    if (bucket == null) throw new NullPointerException();
     mb = new MultiReaderBucket(bucket);
     this.bucket = mb.getReaderBucket();
     if (this.bucket == null) throw new NullPointerException();
     this.bucket.setReadOnly();
     spaceUsed = this.bucket.size();
+  }
+
+  private static void requireBucket(Bucket bucket) {
+    if (bucket == null) throw new NullPointerException();
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/USKRetriever.java
+++ b/src/main/java/network/crypta/client/async/USKRetriever.java
@@ -116,13 +116,18 @@ public final class USKRetriever extends BaseClientGetter implements USKCallback 
       final RequestClient client,
       USKRetrieverCallback cb,
       USK origUSK) {
+    requireNonPersistentClient(client);
     super(prio, client);
-    if (client.persistent())
-      throw new UnsupportedOperationException("USKRetriever cannot be persistent");
     this.ctx = fctx;
     this.cb = cb;
     this.origUSK = origUSK;
     this.proxy = this;
+  }
+
+  private static void requireNonPersistentClient(RequestClient client) {
+    if (client != null && client.persistent()) {
+      throw new UnsupportedOperationException("USKRetriever cannot be persistent");
+    }
   }
 
   @Override

--- a/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
@@ -89,7 +89,7 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
   public ClientPutComplexDirMessage(
       SimpleFieldSet fs, BucketFactory bfTemp, PersistentTempBucketFactory bfPersistent)
       throws MessageInvalidException {
-    // Parse the standard ClientPutDir headers - URI, etc.
+    requireFilesSection(fs);
     super(parseCommonFields(fs));
 
     filesByName = new HashMap<>();
@@ -97,9 +97,6 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
     long totalBytes = 0;
     // Now parse the meat
     SimpleFieldSet files = fs.subset("Files");
-    if (files == null)
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "Missing Files section", identifier, global);
     for (int i = 0; ; i++) {
       SimpleFieldSet subset = files.subset(Integer.toString(i));
       if (subset == null) break;
@@ -279,6 +276,16 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
         ManifestElement e = f.getElement();
         manifestElements.put(tempName, e);
       }
+    }
+  }
+
+  private static void requireFilesSection(SimpleFieldSet fs) throws MessageInvalidException {
+    if (fs.subset("Files") == null) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.MISSING_FIELD,
+          "Missing Files section",
+          fs.get("Identifier"),
+          fs.getBoolean("Global", false));
     }
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
@@ -68,14 +68,11 @@ public final class ClientPutDiskDirMessage extends ClientPutDirMessage {
    * @throws MessageInvalidException if the {@code Filename} field is absent.
    */
   public ClientPutDiskDirMessage(SimpleFieldSet fs) throws MessageInvalidException {
+    requireFilename(fs);
     super(parseCommonFields(fs));
     allowUnreadableFiles = fs.getBoolean("AllowUnreadableFiles", false);
     includeHiddenFiles = fs.getBoolean("includeHiddenFiles", false);
-    String fnam = fs.get("Filename");
-    if (fnam == null)
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "Filename missing", identifier, global);
-    dirname = new File(fnam);
+    dirname = new File(fs.get("Filename"));
   }
 
   /**
@@ -251,5 +248,15 @@ public final class ClientPutDiskDirMessage extends ClientPutDirMessage {
   @Override
   protected void writeData(OutputStream os) throws IOException {
     // Do nothing
+  }
+
+  private static void requireFilename(SimpleFieldSet fs) throws MessageInvalidException {
+    if (fs.get("Filename") == null) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.MISSING_FIELD,
+          "Filename missing",
+          fs.get("Identifier"),
+          fs.getBoolean("Global", false));
+    }
   }
 }

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -337,11 +337,11 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
    */
   public QueueToadlet(
       NodeClientCore core, FCPServer fcp, HighLevelSimpleClient client, boolean uploads) {
+    requireFcpServer(fcp);
     super(client);
     this.core = core;
     this.fcp = fcp;
     this.uploads = uploads;
-    if (fcp == null) throw new NullPointerException();
     this.postHandler = new QueuePostHandler();
     QueueCompletionTracker completionTracker = new QueueCompletionTracker();
     fcp.setCompletionCallback(completionTracker);
@@ -350,6 +350,10 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     } catch (PersistenceDisabledException _) {
       // The user will know soon enoughUpdate Toadlet.java
     }
+  }
+
+  private static void requireFcpServer(FCPServer fcp) {
+    if (fcp == null) throw new NullPointerException();
   }
 
   /**

--- a/src/main/java/network/crypta/crypt/AEADOutputStream.java
+++ b/src/main/java/network/crypta/crypt/AEADOutputStream.java
@@ -58,11 +58,10 @@ public final class AEADOutputStream extends FilterOutputStream {
   public AEADOutputStream(
       OutputStream os, byte[] key, byte[] writtenNonce, byte[] gcmNonce, BlockCipher mainCipher)
       throws IOException {
+    Objects.requireNonNull(mainCipher, "mainCipher");
     super(os);
     // Persist the 16‑byte prefix (AES block size is 16) to keep the on‑disk overhead stable.
     os.write(writtenNonce);
-    // Validate the cipher parameter to mirror prior behavior and fail early if misused.
-    Objects.requireNonNull(mainCipher, "mainCipher");
     cipher = GCMBlockCipher.newInstance(mainCipher);
     KeyParameter keyParam = new KeyParameter(key);
     AEADParameters params = new AEADParameters(keyParam, MAC_SIZE_BITS, gcmNonce);

--- a/src/main/java/network/crypta/node/DarknetPeerNode.java
+++ b/src/main/java/network/crypta/node/DarknetPeerNode.java
@@ -259,12 +259,11 @@ public final class DarknetPeerNode extends PeerNode {
       FRIEND_VISIBILITY visibility2,
       PeerManager peers)
       throws FSParseException {
+    requirePeerName(fs);
     super(
         PeerNodeConstructorSupport.prepareConstructorInit(
             fs, node2, crypto, fromLocal, peers, ConstructorProfile.DARKNET));
-
     String name = fs.get(FS_KEY_MY_NAME);
-    if (name == null) throw new FSParseException("No name");
     myName = name;
 
     if (fromLocal) {
@@ -282,6 +281,10 @@ public final class DarknetPeerNode extends PeerNode {
 
     // Set up the queuedToSendN2NMExtraPeerDataFileNumbers
     queuedToSendN2NMExtraPeerDataFileNumbers = new LinkedHashSet<>();
+  }
+
+  private static void requirePeerName(SimpleFieldSet fs) throws FSParseException {
+    if (fs.get(FS_KEY_MY_NAME) == null) throw new FSParseException("No name");
   }
 
   private synchronized void initializeFromLocalMetadata(SimpleFieldSet fs, String name) {

--- a/src/main/java/network/crypta/support/CountingBloomFilter.java
+++ b/src/main/java/network/crypta/support/CountingBloomFilter.java
@@ -123,15 +123,8 @@ public final class CountingBloomFilter extends BloomFilter {
    * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
    */
   public CountingBloomFilter(int length, int k, byte[] buffer) {
+    requireBufferForLength(buffer, length);
     super(requireNonNegativeLength(length), requireNonNegativeHashCount(k));
-    if (buffer == null) {
-      throw new NullPointerException("buffer");
-    }
-    int expected = length / 4;
-    if (buffer.length != expected) {
-      throw new IllegalArgumentException(
-          "Invalid buffer length: " + buffer.length + " (expected " + expected + ")");
-    }
     filter = ByteBuffer.wrap(buffer);
   }
 
@@ -276,6 +269,17 @@ public final class CountingBloomFilter extends BloomFilter {
     }
     f.deleteOnExit();
     return f;
+  }
+
+  private static void requireBufferForLength(byte[] buffer, int length) {
+    if (buffer == null) {
+      throw new NullPointerException("buffer");
+    }
+    int expected = requireNonNegativeLength(length) / 4;
+    if (buffer.length != expected) {
+      throw new IllegalArgumentException(
+          "Invalid buffer length: " + buffer.length + " (expected " + expected + ")");
+    }
   }
 
   private static class LockResource implements Closeable {

--- a/src/main/java/network/crypta/support/SentTimeCache.java
+++ b/src/main/java/network/crypta/support/SentTimeCache.java
@@ -37,11 +37,15 @@ public class SentTimeCache {
      * @throws IllegalArgumentException if {@code maxSize <= 0}
      */
     BoundedSentTimeMap(int maxSize) {
+      requirePositiveMaxSize(maxSize);
       super(maxSize);
+      this.maxSize = maxSize;
+    }
+
+    private static void requirePositiveMaxSize(int maxSize) {
       if (maxSize <= 0) {
         throw new IllegalArgumentException("Negative or zero maxSize");
       }
-      this.maxSize = maxSize;
     }
 
     /**

--- a/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
+++ b/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
@@ -251,9 +251,13 @@ public class NewLZMACompressor extends AbstractCompressor {
     private final long max;
 
     BoundedOutputStream(OutputStream out, long max) {
+      requireNonNegativeMax(max);
       super(out);
-      if (max < 0) throw new IllegalArgumentException("maxWriteLength < 0");
       this.max = max;
+    }
+
+    private static void requireNonNegativeMax(long max) {
+      if (max < 0) throw new IllegalArgumentException("maxWriteLength < 0");
     }
 
     @Override

--- a/src/main/java/network/crypta/support/io/CountedInputStream.java
+++ b/src/main/java/network/crypta/support/io/CountedInputStream.java
@@ -36,9 +36,13 @@ public final class CountedInputStream extends FilterInputStream {
    * @throws IllegalStateException if {@code in} is {@code null}
    */
   public CountedInputStream(InputStream in) {
+    requireNonNullInput(in);
     super(in);
-    // Guard against accidental null wiring. Use IllegalStateException to match historical
-    // behavior in this codebase.
+  }
+
+  private static void requireNonNullInput(InputStream in) {
+    // Guard against accidental null wiring. Use IllegalStateException to match historical behavior
+    // in this codebase.
     if (in == null) throw new IllegalStateException("null fed to CountedInputStream");
   }
 

--- a/src/main/java/network/crypta/support/io/FileBucket.java
+++ b/src/main/java/network/crypta/support/io/FileBucket.java
@@ -108,8 +108,8 @@ public final class FileBucket extends BaseFileBucket implements Bucket, Serializ
       boolean createFileOnly,
       boolean deleteOnExit,
       boolean deleteOnFree) {
-    super(file, deleteOnExit, createFileOnly, false);
     Objects.requireNonNull(file, "file");
+    super(file, deleteOnExit, createFileOnly, false);
     File absFile = file.getAbsoluteFile();
     // Copy it so we can safely delete it.
     if (file.equals(absFile)) absFile = new File(absFile.getPath());
@@ -270,14 +270,16 @@ public final class FileBucket extends BaseFileBucket implements Bucket, Serializ
    * @throws StorageFormatException if the version is unknown or the data is malformed
    */
   FileBucket(DataInputStream dis) throws IOException, StorageFormatException {
-    super(dis);
-    int version = dis.readInt();
-    if (version != VERSION) throw new StorageFormatException("Bad version");
-    file = new File(dis.readUTF());
-    readOnly = dis.readBoolean();
-    deleteOnFreeFlag = dis.readBoolean();
+    this(readStoredState(dis));
+  }
+
+  private FileBucket(StoredState state) {
+    super(state.freed());
+    file = state.file();
+    readOnly = state.readOnly();
+    deleteOnFreeFlag = state.deleteOnFreeFlag();
     deleteOnExitFlag = false;
-    createFileOnlyFlag = dis.readBoolean();
+    createFileOnlyFlag = state.createFileOnlyFlag();
   }
 
   /** {@inheritDoc} */
@@ -320,4 +322,23 @@ public final class FileBucket extends BaseFileBucket implements Bucket, Serializ
     }
     return readOnly == other.readOnly;
   }
+
+  private static StoredState readStoredState(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    boolean freed = BaseFileBucket.readStoredFreed(dis);
+    int version = dis.readInt();
+    if (version != VERSION) throw new StorageFormatException("Bad version");
+    File file = new File(dis.readUTF());
+    boolean readOnly = dis.readBoolean();
+    boolean deleteOnFreeFlag = dis.readBoolean();
+    boolean createFileOnlyFlag = dis.readBoolean();
+    return new StoredState(freed, file, readOnly, deleteOnFreeFlag, createFileOnlyFlag);
+  }
+
+  private record StoredState(
+      boolean freed,
+      File file,
+      boolean readOnly,
+      boolean deleteOnFreeFlag,
+      boolean createFileOnlyFlag) {}
 }


### PR DESCRIPTION
## Summary
- fix constructor-validation ordering patterns for Sonar `java:S8433` across the 16 server-reported Java files
- ensure validation occurs before explicit constructor invocation paths while preserving existing exception behavior and constructor semantics
- keep compatibility with current Error Prone analysis by using constructor prologue helper calls where direct prologue control-flow patterns trigger tool crashes

## How to test
- `./gradlew compileJava`
- `./gradlew test`
- `./gradlew sonarIssues -PsonarIssues.rules=java:S8433 -PsonarIssues.pageSize=500`

## Notes
- `sonarIssues` reads the current server snapshot, so issue totals remain stale until a fresh CI Sonar analysis is uploaded for this branch.