### PR TITLE
fix(fcp): Guard ClientGet restart context and expand unit test coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGetRestartCoordinator.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetRestartCoordinator.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.util.Objects;
+import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientGetter;
@@ -85,10 +86,15 @@ final class ClientGetRestartCoordinator {
    */
   boolean restart(ClientContext context, boolean disableFilterData) {
     if (!canRestart()) return false;
-    FreenetURI redirect = resetStateForRestart(disableFilterData);
+    FetchContext fetchContext = request.fetchContextForGetter();
+    if (fetchContext == null) {
+      LOG.warn("Cannot restart because fetch context is missing for {}", request.identifier);
+      return false;
+    }
+    FreenetURI redirect = resetStateForRestart(disableFilterData, fetchContext);
     notifyCacheAboutRedirect(redirect);
     try {
-      if (getter().restart(redirect, request.fetchContextForGetter().getFilterData(), context)) {
+      if (getter().restart(redirect, fetchContext.getFilterData(), context)) {
         markRestarted(redirect);
       }
       notifyCacheStartedFlag();
@@ -122,9 +128,10 @@ final class ClientGetRestartCoordinator {
    * the fetch context. The returned redirect, if present, should be applied before restarting.
    *
    * @param disableFilterData true to disable filtering for the next attempt.
+   * @param fetchContext fetch context bound to the request.
    * @return redirect URI to apply, or {@code null} if none was stored.
    */
-  private FreenetURI resetStateForRestart(boolean disableFilterData) {
+  private FreenetURI resetStateForRestart(boolean disableFilterData, FetchContext fetchContext) {
     synchronized (request.persistenceLock()) {
       request.finished = false;
       GetFailedMessage failure = request.state().getFailedMessage();
@@ -135,7 +142,7 @@ final class ClientGetRestartCoordinator {
       request.state().clearExpectedHashes();
       request.started = false;
       if (disableFilterData) {
-        request.fetchContextForGetter().setFilterData(false);
+        fetchContext.setFilterData(false);
       }
       return redirect;
     }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -1,0 +1,408 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.file.Path;
+import network.crypta.client.FetchContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.client.events.ClientEventProducer;
+import network.crypta.clients.fcp.ClientGet.GlobalRequestConfig;
+import network.crypta.clients.fcp.ClientGet.ReturnType;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.BucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetFactoryTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private ClientContext clientContext;
+  @Mock private FetchContext fetchContext;
+  @Mock private ClientEventProducer eventProducer;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Test
+  void fromGlobal_whenIdentifierAlreadyRegistered_throwsIdentifierCollisionException()
+      throws Exception {
+    PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);
+    client.register(new StubClientRequest(client, "dup-global"));
+
+    GlobalRequestConfig config =
+        new GlobalRequestConfig(
+            false,
+            false,
+            false,
+            0,
+            0,
+            1024,
+            ReturnType.DIRECT,
+            true,
+            "dup-global",
+            0,
+            (short) 2,
+            null,
+            null,
+            true,
+            false,
+            false);
+
+    assertThrows(
+        IdentifierCollisionException.class,
+        () ->
+            ClientGetFactory.fromGlobal(
+                client, new FreenetURI("KSK@global-collision"), config, core));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true,false", "false,true"})
+  void fromGlobal_whenValidConfig_buildsRequestAndAppliesFetchContext(
+      boolean persistRebootOnly, boolean expectedForever) throws Exception {
+    configureCoreWithFetchContext();
+    PersistentRequestClient client =
+        newPersistentClient(persistRebootOnly ? Persistence.REBOOT : Persistence.FOREVER);
+    FreenetURI uri = new FreenetURI("KSK@global-ok-" + persistRebootOnly);
+    GlobalRequestConfig config =
+        new GlobalRequestConfig(
+            true,
+            true,
+            true,
+            7,
+            8,
+            4096,
+            ReturnType.DIRECT,
+            persistRebootOnly,
+            "global-id-" + persistRebootOnly,
+            123,
+            (short) 4,
+            null,
+            "UTF-8",
+            false,
+            true,
+            false);
+
+    ClientGet request = ClientGetFactory.fromGlobal(client, uri, config, core);
+
+    assertNotNull(request);
+    assertEquals(config.identifier(), request.getIdentifier());
+    assertSame(uri, request.getURI());
+    assertEquals(config.prioClass(), request.getPriority());
+    assertTrue(request.isPersistent());
+    assertEquals(expectedForever, request.isPersistentForever());
+    assertTrue(request.isDirect());
+    assertFalse(request.isToDisk());
+
+    RequestClient lowLevelClient = request.getRequestClient();
+    assertEquals(expectedForever, lowLevelClient.persistent());
+    assertTrue(lowLevelClient.realTimeFlag());
+
+    verify(fetchContext).setLocalRequestOnly(config.dsOnly());
+    verify(fetchContext).setIgnoreStore(config.ignoreDS());
+    verify(fetchContext).setMaxNonSplitfileRetries(config.maxNonSplitfileRetries());
+    verify(fetchContext).setMaxSplitfileBlockRetries(config.maxSplitfileRetries());
+    verify(fetchContext).setFilterData(config.filterData());
+    verify(fetchContext).setMaxOutputLength(config.maxOutputLength());
+    verify(fetchContext).setMaxTempLength(config.maxOutputLength());
+    verify(fetchContext).setCanWriteClientCache(config.writeToClientCache());
+    verify(eventProducer).addEventListener(any(ClientGetEventHandling.class));
+  }
+
+  @Test
+  void fromGlobal_whenDiskReturnDenied_throwsNotAllowedException(@TempDir Path tempDir) {
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
+    PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);
+    File target = tempDir.resolve("target.bin").toFile();
+    when(core.allowDownloadTo(target)).thenReturn(false);
+    GlobalRequestConfig config =
+        new GlobalRequestConfig(
+            false,
+            false,
+            false,
+            1,
+            1,
+            512,
+            ReturnType.DISK,
+            true,
+            "disk-id",
+            0,
+            (short) 2,
+            target,
+            null,
+            true,
+            false,
+            false);
+
+    assertThrows(
+        NotAllowedException.class,
+        () -> ClientGetFactory.fromGlobal(client, new FreenetURI("KSK@global-disk"), config, core));
+  }
+
+  @Test
+  void fromMessage_whenConnectionIdentifierAlreadyUsed_throwsIdentifierCollisionException()
+      throws Exception {
+    try (FCPConnectionHandler handler = newConnectionHandler()) {
+      handler.setKilledDupe();
+      handler.requestsByIdentifier.put("dup-msg", mock(ClientRequest.class));
+      ClientGetMessage message = new ClientGetMessage(baseMessageFieldSet("dup-msg"));
+
+      assertThrows(
+          IdentifierCollisionException.class,
+          () -> ClientGetFactory.fromMessage(handler, message, core));
+      handler.requestsByIdentifier.clear();
+    }
+  }
+
+  @Test
+  void fromMessage_whenValidConnectionMessage_buildsRequestAndAppliesFetchContext()
+      throws Exception {
+    configureCoreWithFetchContext();
+    SimpleFieldSet fs = baseMessageFieldSet("message-ok");
+    fs.putOverwrite("DSOnly", "true");
+    fs.putOverwrite("IgnoreDS", "true");
+    fs.putOverwrite("FilterData", "true");
+    fs.putOverwrite("IgnoreUSKDatehints", "true");
+    fs.putOverwrite("WriteToClientCache", "false");
+    fs.putOverwrite("MaxRetries", "9");
+    fs.putOverwrite("MaxSize", "2048");
+    fs.putOverwrite("MaxTempSize", "1024");
+    fs.putOverwrite("PriorityClass", "3");
+    fs.putOverwrite("RealTimeFlag", "true");
+    ClientGetMessage message = new ClientGetMessage(fs);
+
+    ClientGet request = ClientGetFactory.fromMessage(null, message, core);
+
+    assertNotNull(request);
+    assertEquals("message-ok", request.getIdentifier());
+    assertEquals((short) 3, request.getPriority());
+    assertTrue(request.isDirect());
+    assertFalse(request.isToDisk());
+    assertFalse(request.isPersistent());
+    assertFalse(request.isPersistentForever());
+    assertFalse(request.getRequestClient().persistent());
+    assertTrue(request.getRequestClient().realTimeFlag());
+
+    verify(fetchContext).setLocalRequestOnly(true);
+    verify(fetchContext).setIgnoreStore(true);
+    verify(fetchContext).setMaxNonSplitfileRetries(9);
+    verify(fetchContext).setMaxSplitfileBlockRetries(9);
+    verify(fetchContext).setMaxOutputLength(2048);
+    verify(fetchContext).setMaxTempLength(1024);
+    verify(fetchContext).setCanWriteClientCache(false);
+    verify(fetchContext).setFilterData(true);
+    verify(fetchContext).setIgnoreUSKDatehints(true);
+    verify(eventProducer).addEventListener(any(ClientGetEventHandling.class));
+  }
+
+  @Test
+  void fromMessage_whenBinaryBlobBucketCreationFails_wrapsIntoMessageInvalidException()
+      throws Exception {
+    configureCoreWithFetchContext();
+    BucketFactory bucketFactory = mock(BucketFactory.class);
+    IOException ioFailure = new IOException("disk-full");
+    when(fetchContext.getMaxOutputLength()).thenReturn(333L);
+    when(clientContext.getBucketFactory(false)).thenReturn(bucketFactory);
+    when(bucketFactory.makeBucket(333L)).thenThrow(ioFailure);
+
+    SimpleFieldSet fs = baseMessageFieldSet("blob-io");
+    fs.putOverwrite("BinaryBlob", "true");
+    ClientGetMessage message = new ClientGetMessage(fs);
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class, () -> ClientGetFactory.fromMessage(null, message, core));
+
+    assertEquals(ProtocolErrorMessage.INTERNAL_ERROR, exception.protocolCode);
+    assertEquals("blob-io", exception.ident);
+    assertFalse(exception.global);
+    assertSame(ioFailure, exception.getCause());
+    assertTrue(exception.getMessage().contains("Cannot create bucket for temporary storage"));
+  }
+
+  private void configureCoreWithFetchContext() {
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
+    when(fetchContext.getEventProducer()).thenReturn(eventProducer);
+  }
+
+  private FCPConnectionHandler newConnectionHandler() {
+    FCPServer server = mock(FCPServer.class);
+    Socket socket = mock(Socket.class);
+    when(server.getNode()).thenReturn(node);
+    return new FCPConnectionHandler(socket, server);
+  }
+
+  private static PersistentRequestClient newPersistentClient(Persistence persistence) {
+    PersistentRequestRoot root =
+        persistence == Persistence.FOREVER ? mock(PersistentRequestRoot.class) : null;
+    return new PersistentRequestClient("client", null, false, null, persistence, root);
+  }
+
+  private static SimpleFieldSet baseMessageFieldSet(String identifier) {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", identifier);
+    fs.putSingle("URI", "KSK@" + identifier + ".txt");
+    fs.put("IgnoreDS", false);
+    fs.put("DSOnly", false);
+    fs.put("FilterData", false);
+    fs.putSingle("Charset", "UTF-8");
+    fs.put("Verbosity", 2);
+    fs.putSingle("ReturnType", ReturnType.DIRECT.name());
+    fs.put("MaxSize", 4096);
+    fs.put("MaxTempSize", 8192);
+    fs.put("MaxRetries", 2);
+    fs.putSingle("PriorityClass", "2");
+    fs.put("BinaryBlob", false);
+    fs.putSingle("Persistence", Persistence.CONNECTION.name());
+    fs.put("Global", false);
+    fs.put("RealTimeFlag", false);
+    return fs;
+  }
+
+  private static final class StubClientRequest extends ClientRequest {
+    StubClientRequest(PersistentRequestClient client, String identifier) {
+      super(
+          prepareConstructorInit(
+              new ClientRequestParams(
+                  null, identifier, 0, (short) 1, client.persistence, false, null, false),
+              null,
+              client));
+    }
+
+    @Override
+    public void onLostConnection(ClientContext context) {
+      // No-op for this focused registration stub.
+    }
+
+    @Override
+    public void sendPendingMessages(
+        FCPConnectionOutputHandler handler,
+        String listRequestIdentifier,
+        boolean includeData,
+        boolean onlyData) {
+      // No replay behavior is needed for collision-only tests.
+    }
+
+    @Override
+    void register(boolean noTags) {
+      // The registration lifecycle is managed by the surrounding test setup.
+    }
+
+    @Override
+    protected ClientRequester getClientRequest() {
+      return null;
+    }
+
+    @Override
+    protected void freeData() {
+      // Stub does not allocate buckets or files.
+    }
+
+    @Override
+    public double getSuccessFraction() {
+      return 0;
+    }
+
+    @Override
+    public double getTotalBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getMinBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFetchedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFatalyFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public String getFailureReason(boolean longDescription) {
+      return "failure";
+    }
+
+    @Override
+    public boolean isTotalFinalized() {
+      return true;
+    }
+
+    @Override
+    public void start(ClientContext context) {
+      // Start semantics are irrelevant to identifier collision coverage.
+    }
+
+    @Override
+    public boolean hasSucceeded() {
+      return false;
+    }
+
+    @Override
+    public boolean canRestart() {
+      return false;
+    }
+
+    @Override
+    public boolean restart(ClientContext context, boolean disableFilterData) {
+      return false;
+    }
+
+    @Override
+    RequestStatus getStatus() {
+      return null;
+    }
+
+    @Override
+    protected void innerResume(ClientContext context) {
+      // Resume is intentionally unsupported for this lightweight test double.
+    }
+
+    @Override
+    RequestIdentifier.RequestType getType() {
+      return RequestIdentifier.RequestType.GET;
+    }
+
+    @Override
+    public boolean fullyResumed() {
+      return true;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
@@ -1,0 +1,508 @@
+package network.crypta.clients.fcp;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import network.crypta.client.FetchContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.CompatibilityAnalyser;
+import network.crypta.client.events.ClientEventProducer;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.HashResult;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.StorageFormatException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetPersistenceCodecTest {
+  private static final long CLIENT_DETAIL_MAGIC = 0x67145b675d2e22f4L;
+  private static final int CLIENT_DETAIL_VERSION = 1;
+
+  @Test
+  void readBasicRestoreData_whenValidDiskData_returnsParsedBundleAndRegistersListener()
+      throws Exception {
+    ClientGet request = new ClientGet();
+    ClientContext context = mock(ClientContext.class);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    ClientEventProducer eventProducer = mock(ClientEventProducer.class);
+    Bucket initialMetadata = mock(Bucket.class);
+    when(fetchContext.getEventProducer()).thenReturn(eventProducer);
+    try (DataInputStream input = input(basicRestoreHeaderPayload());
+        MockedStatic<ClientGetGetterFactory> mocked =
+            Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      mocked
+          .when(() -> ClientGetGetterFactory.readFetchContextOrDefault(input, context, checker))
+          .thenReturn(fetchContext);
+      mocked
+          .when(() -> ClientGetGetterFactory.readInitialMetadata(input, context, checker))
+          .thenReturn(initialMetadata);
+
+      ClientGetPersistenceCodec.BasicRestoreData restored =
+          ClientGetPersistenceCodec.readBasicRestoreData(request, input, context, checker);
+
+      assertEquals("KSK@codec-restore", restored.uri().toString());
+      assertEquals(ClientGet.ReturnType.DISK, restored.returnType());
+      assertEquals("target.bin", restored.targetFile().getPath());
+      assertTrue(restored.binaryBlob());
+      assertSame(fetchContext, restored.fetchContext());
+      assertEquals("txt", restored.extensionCheck());
+      assertSame(initialMetadata, restored.initialMetadata());
+      verify(eventProducer).addEventListener(any(ClientGetEventHandling.class));
+    }
+  }
+
+  @Test
+  void readBasicRestoreData_whenMagicIsInvalid_throwsStorageFormatException() throws IOException {
+    ClientGet request = new ClientGet();
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeLong(123L);
+      out.writeInt(CLIENT_DETAIL_VERSION);
+    }
+    try (DataInputStream input = input(buffer.toByteArray())) {
+      StorageFormatException error =
+          assertThrows(
+              StorageFormatException.class,
+              () ->
+                  ClientGetPersistenceCodec.readBasicRestoreData(
+                      request, input, mock(ClientContext.class), mock(ChecksumChecker.class)));
+
+      assertEquals("Bad magic for request", error.getMessage());
+    }
+  }
+
+  @Test
+  void readBasicRestoreData_whenVersionIsInvalid_throwsStorageFormatException() throws IOException {
+    ClientGet request = new ClientGet();
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeLong(CLIENT_DETAIL_MAGIC);
+      out.writeInt(CLIENT_DETAIL_VERSION + 1);
+    }
+    try (DataInputStream input = input(buffer.toByteArray())) {
+      StorageFormatException error =
+          assertThrows(
+              StorageFormatException.class,
+              () ->
+                  ClientGetPersistenceCodec.readBasicRestoreData(
+                      request, input, mock(ClientContext.class), mock(ChecksumChecker.class)));
+
+      assertEquals("Bad version 2", error.getMessage());
+    }
+  }
+
+  @Test
+  void readBasicRestoreData_whenUriIsInvalid_throwsStorageFormatException() throws IOException {
+    ClientGet request = new ClientGet();
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeLong(CLIENT_DETAIL_MAGIC);
+      out.writeInt(CLIENT_DETAIL_VERSION);
+      out.writeUTF("not-a-freenet-uri");
+    }
+    try (DataInputStream input = input(buffer.toByteArray())) {
+      StorageFormatException error =
+          assertThrows(
+              StorageFormatException.class,
+              () ->
+                  ClientGetPersistenceCodec.readBasicRestoreData(
+                      request, input, mock(ClientContext.class), mock(ChecksumChecker.class)));
+
+      assertEquals("Bad URI", error.getMessage());
+    }
+  }
+
+  @Test
+  void readBasicRestoreData_whenReturnTypeIsInvalid_throwsStorageFormatException()
+      throws IOException {
+    ClientGet request = new ClientGet();
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeLong(CLIENT_DETAIL_MAGIC);
+      out.writeInt(CLIENT_DETAIL_VERSION);
+      out.writeUTF("KSK@codec-invalid-type");
+      out.writeShort(99);
+    }
+    try (DataInputStream input = input(buffer.toByteArray())) {
+      StorageFormatException error =
+          assertThrows(
+              StorageFormatException.class,
+              () ->
+                  ClientGetPersistenceCodec.readBasicRestoreData(
+                      request, input, mock(ClientContext.class), mock(ChecksumChecker.class)));
+
+      assertEquals("Bad return type 99", error.getMessage());
+    }
+  }
+
+  @Test
+  void readTransientProgressFields_whenExplicitIdentifier_updatesStateAndExpectedHashes()
+      throws Exception {
+    ClientGet request = new ClientGet();
+    ExpectedHashes expected = new ExpectedHashes(new HashResult[0], "req-explicit", true);
+    try (DataInputStream input = input(transientPayload(42L, "text/plain"));
+        MockedStatic<ClientGetGetterFactory> mocked =
+            Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      mocked
+          .when(() -> ClientGetGetterFactory.readExpectedHashes(input, "req-explicit", true))
+          .thenReturn(expected);
+
+      ClientGetPersistenceCodec.readTransientProgressFields(request, input, "req-explicit", true);
+
+      assertEquals(42L, request.state().getFoundDataLength());
+      assertEquals("text/plain", request.state().getFoundDataMimeType());
+      assertSame(expected, request.state().getExpectedHashes());
+      assertNotNull(request.state().getCompatibilityAnalyser());
+    }
+  }
+
+  @Test
+  void readTransientProgressFields_whenUsingRequestIdentifier_usesRequestScope() throws Exception {
+    ClientGet request = new ClientGet();
+    setField(request, ClientRequest.class, "identifier", "req-overload");
+    setField(request, ClientRequest.class, "global", true);
+    try (DataInputStream input = input(transientPayload(7L, null));
+        MockedStatic<ClientGetGetterFactory> mocked =
+            Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      mocked
+          .when(() -> ClientGetGetterFactory.readExpectedHashes(input, "req-overload", true))
+          .thenReturn(null);
+
+      ClientGetPersistenceCodec.readTransientProgressFields(request, input);
+
+      assertEquals(7L, request.state().getFoundDataLength());
+      assertNull(request.state().getFoundDataMimeType());
+      mocked.verify(
+          () -> ClientGetGetterFactory.readExpectedHashes(input, "req-overload", true), times(1));
+    }
+  }
+
+  @Test
+  void restoreState_whenInProgress_returnsGetterAndDelegatesRestore() throws Exception {
+    ClientGet request = Mockito.spy(new ClientGet());
+    ClientContext context = mock(ClientContext.class);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    RequestIdentifier reqID =
+        new RequestIdentifier(false, "client", "req-restore", RequestIdentifier.RequestType.GET);
+    Bucket bucket = mock(Bucket.class);
+    ClientGetter getter = mock(ClientGetter.class);
+    //noinspection resource
+    doReturn(bucket).when(request).makeBucket(false);
+    doReturn(getter).when(request).makeGetterForPersistence(bucket);
+
+    try (DataInputStream input = input(new byte[0]);
+        MockedStatic<ClientGetGetterFactory> mocked =
+            Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      ClientGetter restored =
+          ClientGetPersistenceCodec.restoreState(request, input, reqID, context, checker);
+
+      assertSame(getter, restored);
+      mocked.verify(
+          () ->
+              ClientGetGetterFactory.restoreInProgressState(
+                  any(DataInputStream.class), eq(context), eq(checker), eq(getter), eq(request)),
+          times(1));
+    }
+  }
+
+  @Test
+  void restoreState_whenFinishedDirectAndBucketMissing_marksRequestUnfinished() throws Exception {
+    ClientGet request = bareRequest("req-finished-direct");
+    setField(request, ClientRequest.class, "finished", true);
+    ClientContext context = mock(ClientContext.class);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    RequestIdentifier reqID =
+        new RequestIdentifier(
+            false, "client", "req-finished-direct", RequestIdentifier.RequestType.GET);
+
+    try (DataInputStream input = input(finishedPayload(true, transientPayload(55L, null)));
+        MockedStatic<ClientGetGetterFactory> mocked =
+            Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      mocked
+          .when(() -> ClientGetGetterFactory.readExpectedHashes(any(), any(), anyBoolean()))
+          .thenReturn(null);
+      mocked
+          .when(
+              () ->
+                  ClientGetGetterFactory.restoreCompletedDirectBucketOrNull(
+                      any(DataInputStream.class), eq(context), eq(checker)))
+          .thenReturn(null);
+
+      ClientGetter restored =
+          ClientGetPersistenceCodec.restoreState(request, input, reqID, context, checker);
+
+      assertNull(restored);
+      assertFalse(request.state().hasSucceeded());
+      assertFalse(getClientRequestBooleanField(request, "finished"));
+      assertNull(request.state().getReturnBucketDirect());
+    }
+  }
+
+  @Test
+  void restoreState_whenFinishedFailureWithMessage_setsFailedMessageAndStarted() throws Exception {
+    ClientGet request = bareRequest("req-finished-failure");
+    setField(request, ClientRequest.class, "finished", true);
+    ClientContext context = mock(ClientContext.class);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    RequestIdentifier reqID =
+        new RequestIdentifier(
+            false, "client", "req-finished-failure", RequestIdentifier.RequestType.GET);
+    GetFailedMessage failure = mock(GetFailedMessage.class);
+
+    try (DataInputStream input =
+            input(finishedPayload(false, transientPayload(91L, "application/json")));
+        MockedStatic<ClientGetGetterFactory> mocked =
+            Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      mocked
+          .when(() -> ClientGetGetterFactory.readExpectedHashes(any(), any(), anyBoolean()))
+          .thenReturn(null);
+      mocked
+          .when(
+              () ->
+                  ClientGetGetterFactory.restoreFailureMessageOrNull(
+                      any(DataInputStream.class),
+                      eq(reqID),
+                      eq(91L),
+                      eq("application/json"),
+                      eq(context),
+                      eq(checker)))
+          .thenReturn(failure);
+
+      ClientGetter restored =
+          ClientGetPersistenceCodec.restoreState(request, input, reqID, context, checker);
+
+      assertNull(restored);
+      assertSame(failure, request.state().getFailedMessage());
+      assertTrue(getClientRequestBooleanField(request, "started"));
+    }
+  }
+
+  @Test
+  void writeClientDetail_whenInProgressAndTrivialProgressTrue_writesCoreFieldsAndTransientState()
+      throws Exception {
+    ClientGet request = bareRequest("req-write");
+    setField(request, ClientRequest.class, "uri", new FreenetURI("KSK@req-write"));
+    setField(request, ClientGet.class, "binaryBlob", false);
+    setField(request, ClientGet.class, "extensionCheck", "txt");
+    setField(request, ClientGet.class, "initialMetadata", null);
+    setField(request, ClientRequest.class, "finished", false);
+    FetchContext fetchContext = mock(FetchContext.class);
+    setField(request, ClientGet.class, "fctx", fetchContext);
+    ClientGetter getter = mock(ClientGetter.class);
+    when(getter.writeTrivialProgress(any(DataOutputStream.class))).thenReturn(true);
+    setField(request, ClientGet.class, "getter", getter);
+    request.state().setFoundDataLength(321L);
+    request.state().setFoundDataMimeType("text/plain");
+    request.state().setCompatibilityAnalyser(new CompatibilityAnalyser());
+    request.state().setExpectedHashes(null);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(buffer);
+
+    try (MockedStatic<ClientGetGetterFactory> mocked =
+        Mockito.mockStatic(ClientGetGetterFactory.class, Mockito.CALLS_REAL_METHODS)) {
+      mocked
+          .when(
+              () ->
+                  ClientGetGetterFactory.checksummedWriter(
+                      any(DataOutputStream.class), any(ChecksumChecker.class)))
+          .thenAnswer(
+              invocation -> {
+                DataOutputStream target = invocation.getArgument(0);
+                return new DataOutputStream(new NonClosingOutputStream(target));
+              });
+
+      ClientGetPersistenceCodec.writeClientDetail(request, out, checker);
+    }
+
+    try (DataInputStream in = input(buffer.toByteArray())) {
+      assertEquals(CLIENT_DETAIL_MAGIC, in.readLong());
+      assertEquals(CLIENT_DETAIL_VERSION, in.readInt());
+      assertEquals("KSK@req-write", in.readUTF());
+      assertEquals(ClientGet.ReturnType.DIRECT.code, in.readShort());
+      assertFalse(in.readBoolean());
+      assertTrue(in.readBoolean());
+      assertEquals("txt", in.readUTF());
+      assertFalse(in.readBoolean());
+      assertEquals(321L, in.readLong());
+      assertTrue(in.readBoolean());
+      assertEquals("text/plain", in.readUTF());
+      //noinspection ObviousNullCheck
+      assertNotNull(new CompatibilityAnalyser(in));
+      assertEquals(0, in.readInt());
+    }
+
+    verify(fetchContext).writeTo(any(DataOutputStream.class));
+    verify(getter).writeTrivialProgress(any(DataOutputStream.class));
+  }
+
+  @Test
+  void writeClientDetail_whenFinishedDirectSuccess_writesStoredBucket() throws Exception {
+    ClientGet request = bareRequest("req-finished-write");
+    setField(request, ClientRequest.class, "uri", new FreenetURI("KSK@req-finished-write"));
+    setField(request, ClientGet.class, "binaryBlob", true);
+    setField(request, ClientGet.class, "extensionCheck", null);
+    setField(request, ClientGet.class, "initialMetadata", null);
+    setField(request, ClientRequest.class, "finished", true);
+    FetchContext fetchContext = mock(FetchContext.class);
+    setField(request, ClientGet.class, "fctx", fetchContext);
+    request.state().setSucceeded(true);
+    request.state().setFoundDataLength(999L);
+    request.state().setFoundDataMimeType(null);
+    request.state().setExpectedHashes(null);
+    Bucket directBucket = mock(Bucket.class);
+    doAnswer(
+            invocation -> {
+              DataOutputStream stream = invocation.getArgument(0);
+              stream.writeInt(777);
+              return null;
+            })
+        .when(directBucket)
+        .storeTo(any(DataOutputStream.class));
+    request.state().setReturnBucketDirect(directBucket);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(buffer);
+
+    try (MockedStatic<ClientGetGetterFactory> mocked =
+        Mockito.mockStatic(ClientGetGetterFactory.class, Mockito.CALLS_REAL_METHODS)) {
+      mocked
+          .when(
+              () ->
+                  ClientGetGetterFactory.checksummedWriter(
+                      any(DataOutputStream.class), any(ChecksumChecker.class)))
+          .thenAnswer(
+              invocation -> {
+                DataOutputStream target = invocation.getArgument(0);
+                return new DataOutputStream(new NonClosingOutputStream(target));
+              });
+
+      ClientGetPersistenceCodec.writeClientDetail(request, out, checker);
+    }
+
+    try (DataInputStream in = input(buffer.toByteArray())) {
+      assertEquals(CLIENT_DETAIL_MAGIC, in.readLong());
+      assertEquals(CLIENT_DETAIL_VERSION, in.readInt());
+      assertEquals("KSK@req-finished-write", in.readUTF());
+      assertEquals(ClientGet.ReturnType.DIRECT.code, in.readShort());
+      assertTrue(in.readBoolean());
+      assertFalse(in.readBoolean());
+      assertFalse(in.readBoolean());
+      assertTrue(in.readBoolean());
+      assertEquals(999L, in.readLong());
+      assertFalse(in.readBoolean());
+      //noinspection ObviousNullCheck
+      assertNotNull(new CompatibilityAnalyser(in));
+      assertEquals(0, in.readInt());
+      assertEquals(777, in.readInt());
+    }
+  }
+
+  private static ClientGet bareRequest(String identifier) throws Exception {
+    ClientGet request = new ClientGet();
+    setField(request, ClientRequest.class, "identifier", identifier);
+    setField(request, ClientRequest.class, "global", false);
+    setField(request, ClientGet.class, "returnType", ClientGet.ReturnType.DIRECT);
+    return request;
+  }
+
+  private static byte[] basicRestoreHeaderPayload() throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeLong(CLIENT_DETAIL_MAGIC);
+      out.writeInt(CLIENT_DETAIL_VERSION);
+      out.writeUTF("KSK@codec-restore");
+      out.writeShort(ClientGet.ReturnType.DISK.code);
+      out.writeUTF("target.bin");
+      out.writeBoolean(true);
+      out.writeBoolean(true);
+      out.writeUTF("txt");
+    }
+    return buffer.toByteArray();
+  }
+
+  private static byte[] transientPayload(long foundDataLength, String mimeType) throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeLong(foundDataLength);
+      if (mimeType != null) {
+        out.writeBoolean(true);
+        out.writeUTF(mimeType);
+      } else {
+        out.writeBoolean(false);
+      }
+      new CompatibilityAnalyser().writeTo(out);
+    }
+    return buffer.toByteArray();
+  }
+
+  private static byte[] finishedPayload(boolean succeeded, byte[] transientPayload)
+      throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      out.writeBoolean(succeeded);
+      out.write(transientPayload);
+    }
+    return buffer.toByteArray();
+  }
+
+  private static DataInputStream input(byte[] bytes) {
+    return new DataInputStream(new ByteArrayInputStream(bytes));
+  }
+
+  @SuppressWarnings({"java:S3011"})
+  private static void setField(Object target, Class<?> owner, String fieldName, Object value)
+      throws ReflectiveOperationException {
+    Field field = owner.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  @SuppressWarnings({"java:S3011"})
+  private static boolean getClientRequestBooleanField(Object target, String fieldName)
+      throws ReflectiveOperationException {
+    Field field = ClientRequest.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.getBoolean(target);
+  }
+
+  private static final class NonClosingOutputStream extends FilterOutputStream {
+    private NonClosingOutputStream(DataOutputStream out) {
+      super(out);
+    }
+
+    @Override
+    public void close() throws IOException {
+      flush();
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetRestartCoordinatorTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetRestartCoordinatorTest.java
@@ -1,0 +1,276 @@
+package network.crypta.clients.fcp;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchException;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.crypt.HashResult;
+import network.crypta.keys.FreenetURI;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetRestartCoordinatorTest {
+
+  @Test
+  void constructor_whenRequestNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new ClientGetRestartCoordinator(null));
+  }
+
+  @Test
+  void canRestart_whenRequestNotFinished_returnsFalseWithoutConsultingGetter() throws Exception {
+    ClientGet request = new ClientGet();
+    ClientGetter getter = mock(ClientGetter.class);
+    setClientGetField(request, "getter", getter);
+
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertFalse(coordinator.canRestart());
+    verifyNoInteractions(getter);
+  }
+
+  @Test
+  void canRestart_whenRequestAlreadySucceeded_returnsFalseWithoutConsultingGetter()
+      throws Exception {
+    ClientGet request = new ClientGet();
+    ClientGetter getter = mock(ClientGetter.class);
+    setClientGetField(request, "getter", getter);
+    setClientRequestField(request, "finished", true);
+    request.state().setSucceeded(true);
+
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertFalse(coordinator.canRestart());
+    verifyNoInteractions(getter);
+  }
+
+  @Test
+  void canRestart_whenFinishedAndGetterCanRestart_returnsTrue() throws Exception {
+    ClientGet request = new ClientGet();
+    ClientGetter getter = mock(ClientGetter.class);
+    when(getter.canRestart()).thenReturn(true);
+    setClientGetField(request, "getter", getter);
+    setClientRequestField(request, "finished", true);
+    request.state().setSucceeded(false);
+
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertTrue(coordinator.canRestart());
+    verify(getter).canRestart();
+  }
+
+  @Test
+  void hasPermRedirect_whenFailureContainsRedirect_returnsTrue() throws Exception {
+    ClientGet request = new ClientGet();
+    FreenetURI redirect = new FreenetURI("KSK@redirect");
+    FetchException exception =
+        new FetchException(FetchExceptionMode.PERMANENT_REDIRECT, "redirecting", redirect);
+    request.state().setFailedMessage(new GetFailedMessage(exception, "req", false));
+
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertTrue(coordinator.hasPermRedirect());
+  }
+
+  @Test
+  void hasPermRedirect_whenFailureMissing_returnsFalse() {
+    ClientGet request = new ClientGet();
+    request.state().setFailedMessage(null);
+
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertFalse(coordinator.hasPermRedirect());
+  }
+
+  @Test
+  void restart_whenRequestCannotRestart_returnsFalse() {
+    ClientGet request = new ClientGet();
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertFalse(coordinator.restart(mock(ClientContext.class), false));
+  }
+
+  @Test
+  void restart_whenFetchContextMissing_returnsFalseWithoutRestartingGetter() throws Exception {
+    ClientGet request = new ClientGet();
+    ClientGetter getter = mock(ClientGetter.class);
+    when(getter.canRestart()).thenReturn(true);
+    setClientGetField(request, "getter", getter);
+    setClientRequestField(request, "finished", true);
+    request.state().setSucceeded(false);
+
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertFalse(coordinator.restart(mock(ClientContext.class), false));
+    verify(getter).canRestart();
+    verify(getter, never()).restart(any(), anyBoolean(), any(ClientContext.class));
+  }
+
+  @Test
+  void restart_whenGetterRestartsWithRedirect_resetsStateAndNotifiesCache() throws Exception {
+    ClientGet request = new ClientGet();
+    ClientGetter getter = mock(ClientGetter.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    ClientContext context = mock(ClientContext.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    AtomicBoolean filterData = new AtomicBoolean(true);
+    when(fetchContext.getFilterData()).thenAnswer(_ -> filterData.get());
+    doAnswer(
+            invocation -> {
+              filterData.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(fetchContext)
+        .setFilterData(anyBoolean());
+
+    FreenetURI original = new FreenetURI("KSK@original");
+    FreenetURI redirect = new FreenetURI("KSK@redirect");
+    FetchException failure =
+        new FetchException(FetchExceptionMode.PERMANENT_REDIRECT, "redirecting", redirect);
+
+    when(getter.canRestart()).thenReturn(true);
+    when(getter.restart(redirect, false, context)).thenReturn(true);
+
+    setClientRequestField(request, "identifier", "req-redirect");
+    setClientRequestField(request, "uri", original);
+    setClientRequestField(request, "client", client);
+    setClientRequestField(request, "finished", true);
+    setClientRequestField(request, "started", true);
+    setClientGetField(request, "getter", getter);
+    setClientGetField(request, "fctx", fetchContext);
+
+    request.state().setSucceeded(false);
+    request.state().setFailedMessage(new GetFailedMessage(failure, "req-redirect", false));
+    request.state().setProgressPending(mock(SimpleProgressMessage.class));
+    request.state().setExpectedHashes(new ExpectedHashes(new HashResult[0], "req-redirect", false));
+    Object compatibilityBefore = request.state().getCompatibilityAnalyser();
+
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertTrue(coordinator.restart(context, true));
+
+    verify(fetchContext).setFilterData(false);
+    verify(getter).restart(redirect, false, context);
+    verify(cache).updateStarted("req-redirect", redirect);
+    verify(cache).updateStarted("req-redirect", true);
+    assertFalse(getClientRequestBooleanField(request, "finished"));
+    assertTrue(getClientRequestBooleanField(request, "started"));
+    assertSame(redirect, request.getURI());
+    assertNull(request.state().getFailedMessage());
+    assertNull(request.state().getProgressPending());
+    assertNull(request.state().getExpectedHashes());
+    assertNotNull(request.state().getCompatibilityAnalyser());
+    assertNotSame(compatibilityBefore, request.state().getCompatibilityAnalyser());
+  }
+
+  @Test
+  void restart_whenGetterDeclinesRestart_returnsTrueAndKeepsStartedFalse() throws Exception {
+    ClientGet request = new ClientGet();
+    ClientGetter getter = mock(ClientGetter.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    ClientContext context = mock(ClientContext.class);
+    FreenetURI original = new FreenetURI("KSK@original-no-restart");
+
+    when(getter.canRestart()).thenReturn(true);
+    when(getter.restart(null, true, context)).thenReturn(false);
+    when(fetchContext.getFilterData()).thenReturn(true);
+
+    setClientRequestField(request, "uri", original);
+    setClientRequestField(request, "finished", true);
+    setClientRequestField(request, "started", true);
+    setClientGetField(request, "getter", getter);
+    setClientGetField(request, "fctx", fetchContext);
+
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertTrue(coordinator.restart(context, false));
+
+    verify(fetchContext, never()).setFilterData(anyBoolean());
+    verify(getter).restart(null, true, context);
+    assertFalse(getClientRequestBooleanField(request, "finished"));
+    assertFalse(getClientRequestBooleanField(request, "started"));
+    assertSame(original, request.getURI());
+  }
+
+  @Test
+  void restart_whenGetterThrowsFetchException_invokesOnFailureAndReturnsFalse() throws Exception {
+    ClientGet request = spy(new ClientGet());
+    ClientGetter getter = mock(ClientGetter.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    ClientContext context = mock(ClientContext.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+
+    FetchException failure = new FetchException(FetchExceptionMode.INTERNAL_ERROR, "boom");
+    when(getter.canRestart()).thenReturn(true);
+    when(getter.restart(null, false, context)).thenThrow(failure);
+    when(fetchContext.getFilterData()).thenReturn(false);
+    doNothing().when(request).onFailure(any(FetchException.class));
+
+    setClientRequestField(request, "identifier", "req-failure");
+    setClientRequestField(request, "client", client);
+    setClientRequestField(request, "finished", true);
+    setClientGetField(request, "getter", getter);
+    setClientGetField(request, "fctx", fetchContext);
+
+    ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
+
+    assertFalse(coordinator.restart(context, false));
+
+    verify(request).onFailure(failure);
+    verify(cache).updateStarted(eq("req-failure"), isNull(FreenetURI.class));
+    verify(cache, never()).updateStarted("req-failure", true);
+  }
+
+  @SuppressWarnings({"java:S3011"})
+  private static void setClientRequestField(ClientRequest target, String fieldName, Object value)
+      throws ReflectiveOperationException {
+    Field field = ClientRequest.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  @SuppressWarnings({"java:S3011"})
+  private static void setClientGetField(ClientGet target, String fieldName, Object value)
+      throws ReflectiveOperationException {
+    Field field = ClientGet.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  @SuppressWarnings({"java:S3011"})
+  private static boolean getClientRequestBooleanField(ClientRequest target, String fieldName)
+      throws ReflectiveOperationException {
+    Field field = ClientRequest.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.getBoolean(target);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetStateTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetStateTest.java
@@ -1,0 +1,304 @@
+package network.crypta.clients.fcp;
+
+import java.lang.reflect.Field;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchException;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.CompatibilityAnalyser;
+import network.crypta.crypt.HashResult;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetStateTest {
+
+  @Test
+  void constructor_whenRequestNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new ClientGetState(null));
+  }
+
+  @Test
+  void constructor_whenCreated_initializesDefaultState() {
+    ClientGet request = new ClientGet();
+    ClientGetState state = new ClientGetState(request);
+
+    assertFalse(state.hasSucceeded());
+    assertEquals(-1L, state.getFoundDataLength());
+    assertNull(state.getFoundDataMimeType());
+    assertNull(state.getProgressPending());
+    assertFalse(state.hasSentToNetwork());
+    assertNull(state.getExpectedHashes());
+    assertNull(state.getFailedMessage());
+    assertNotNull(state.getCompatibilityAnalyser());
+    assertArrayEquals(
+        new InsertContext.CompatibilityMode[] {
+          InsertContext.CompatibilityMode.COMPAT_UNKNOWN,
+          InsertContext.CompatibilityMode.COMPAT_UNKNOWN
+        },
+        state.getCompatibilityMode());
+    assertTrue(state.getDontCompress());
+    assertNull(state.getOverriddenSplitfileCryptoKey());
+    assertNull(state.getReturnBucketDirect());
+  }
+
+  @Test
+  void scalarSetters_whenUpdated_reflectLatestValues() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+
+    for (boolean expected : new boolean[] {true, false}) {
+      state.setSucceeded(expected);
+      assertEquals(expected, state.hasSucceeded());
+    }
+    state.setFoundDataLength(42L);
+    state.setFoundDataMimeType("text/plain");
+
+    assertEquals(42L, state.getFoundDataLength());
+    assertEquals("text/plain", state.getFoundDataMimeType());
+  }
+
+  @Test
+  void progressPending_whenSet_reflectsValue() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    SimpleProgressMessage progress = mock(SimpleProgressMessage.class);
+
+    state.setProgressPending(progress);
+    assertSame(progress, state.getProgressPending());
+  }
+
+  @Test
+  void markSentToNetwork_whenInvoked_setsFlagTrue() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+
+    state.markSentToNetwork();
+
+    assertTrue(state.hasSentToNetwork());
+  }
+
+  @Test
+  void expectedHashes_whenInitiallyAbsent_trySetStoresAndReturnsTrue() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    ExpectedHashes hashes = new ExpectedHashes(new HashResult[0], "req", false);
+
+    assertTrue(state.trySetExpectedHashes(hashes));
+    assertSame(hashes, state.getExpectedHashes());
+  }
+
+  @Test
+  void expectedHashes_whenAlreadyPresent_trySetReturnsFalseAndKeepsOriginal() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    ExpectedHashes original = new ExpectedHashes(new HashResult[0], "req-original", false);
+    ExpectedHashes replacement = new ExpectedHashes(new HashResult[0], "req-replacement", false);
+    state.setExpectedHashes(original);
+
+    assertFalse(state.trySetExpectedHashes(replacement));
+    assertSame(original, state.getExpectedHashes());
+  }
+
+  @Test
+  void expectedHashes_whenCleared_becomesNull() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    state.setExpectedHashes(new ExpectedHashes(new HashResult[0], "req", false));
+
+    state.clearExpectedHashes();
+
+    assertNull(state.getExpectedHashes());
+  }
+
+  @Test
+  void failedMessage_whenSetAndReplaced_reflectsLatestMessage() throws Exception {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    FetchException failure =
+        new FetchException(
+            FetchExceptionMode.PERMANENT_REDIRECT, "redirect", new FreenetURI("KSK@redirect"));
+    GetFailedMessage message = new GetFailedMessage(failure, "req", false);
+    GetFailedMessage replacement = new GetFailedMessage(failure, "req-replacement", false);
+
+    state.setFailedMessage(message);
+    assertSame(message, state.getFailedMessage());
+
+    state.setFailedMessage(replacement);
+    assertSame(replacement, state.getFailedMessage());
+  }
+
+  @Test
+  void setCompatibilityAnalyser_whenCustomAnalyserProvided_reflectsMergedValues() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    CompatibilityAnalyser analyser = new CompatibilityAnalyser();
+    byte[] splitfileKey = new byte[] {1, 2, 3, 4};
+    analyser.merge(
+        InsertContext.CompatibilityMode.COMPAT_1250,
+        InsertContext.CompatibilityMode.COMPAT_1468,
+        splitfileKey,
+        true,
+        false);
+
+    state.setCompatibilityAnalyser(analyser);
+
+    assertSame(analyser, state.getCompatibilityAnalyser());
+    assertArrayEquals(
+        new InsertContext.CompatibilityMode[] {
+          InsertContext.CompatibilityMode.COMPAT_1250, InsertContext.CompatibilityMode.COMPAT_1468
+        },
+        state.getCompatibilityMode());
+    assertTrue(state.getDontCompress());
+    assertArrayEquals(splitfileKey, state.getOverriddenSplitfileCryptoKey());
+  }
+
+  @Test
+  void ensureCompatibilityMode_whenAnalyserMissing_createsNewInstance() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    state.setCompatibilityAnalyser(null);
+
+    state.ensureCompatibilityMode();
+
+    assertNotNull(state.getCompatibilityAnalyser());
+  }
+
+  @Test
+  void ensureCompatibilityMode_whenAnalyserPresent_keepsSameInstance() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    CompatibilityAnalyser analyser = state.getCompatibilityAnalyser();
+
+    state.ensureCompatibilityMode();
+
+    assertSame(analyser, state.getCompatibilityAnalyser());
+  }
+
+  @Test
+  void resetCompatibilityMode_whenInvoked_replacesAnalyserInstance() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    CompatibilityAnalyser before = state.getCompatibilityAnalyser();
+
+    state.resetCompatibilityMode();
+
+    assertNotNull(state.getCompatibilityAnalyser());
+    assertNotSame(before, state.getCompatibilityAnalyser());
+  }
+
+  @Test
+  void mergeCompatibilityMode_whenNoClientAndNoVerbosity_updatesAnalyserWithoutQueueing() {
+    ClientGet request = spy(new ClientGet());
+    ClientGetState state = new ClientGetState(request);
+    byte[] splitfileKey = new byte[] {9, 8, 7};
+
+    state.mergeCompatibilityMode(
+        InsertContext.CompatibilityMode.COMPAT_1250,
+        InsertContext.CompatibilityMode.COMPAT_1468,
+        splitfileKey,
+        false,
+        false);
+
+    assertArrayEquals(
+        new InsertContext.CompatibilityMode[] {
+          InsertContext.CompatibilityMode.COMPAT_1250, InsertContext.CompatibilityMode.COMPAT_1468
+        },
+        state.getCompatibilityMode());
+    assertArrayEquals(splitfileKey, state.getOverriddenSplitfileCryptoKey());
+    assertFalse(state.getDontCompress());
+    verify(request, never()).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+  }
+
+  @Test
+  void mergeCompatibilityMode_whenClientAndVerbosityPresent_updatesCacheAndQueuesMessage()
+      throws Exception {
+    ClientGet request = spy(new ClientGet());
+    doNothing().when(request).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+    ClientGetState state = new ClientGetState(request);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    setClientRequestField(request, "client", client);
+    setClientRequestField(request, "identifier", "req-compat");
+    setClientRequestField(request, "global", true);
+    setClientRequestField(request, "verbosity", ClientGet.VERBOSITY_COMPATIBILITY_MODE);
+    byte[] splitfileKey = new byte[] {3, 1, 4};
+
+    state.mergeCompatibilityMode(
+        InsertContext.CompatibilityMode.COMPAT_1250,
+        InsertContext.CompatibilityMode.COMPAT_1468,
+        splitfileKey,
+        true,
+        false);
+
+    ArgumentCaptor<InsertContext.CompatibilityMode[]> modesCaptor =
+        ArgumentCaptor.forClass(InsertContext.CompatibilityMode[].class);
+    verify(cache)
+        .updateDetectedCompatModes(
+            eq("req-compat"), modesCaptor.capture(), eq(splitfileKey), eq(true));
+    assertArrayEquals(
+        new InsertContext.CompatibilityMode[] {
+          InsertContext.CompatibilityMode.COMPAT_1250, InsertContext.CompatibilityMode.COMPAT_1468
+        },
+        modesCaptor.getValue());
+    verify(request)
+        .queueProgressMessageInner(
+            any(network.crypta.clients.fcp.CompatibilityMode.class),
+            eq(ClientGet.VERBOSITY_COMPATIBILITY_MODE));
+  }
+
+  @Test
+  void mergeCompatibilityMode_whenClientCacheMissing_skipsCacheUpdateAndQueueWhenVerbosityOff()
+      throws Exception {
+    ClientGet request = spy(new ClientGet());
+    ClientGetState state = new ClientGetState(request);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    when(client.getRequestStatusCache()).thenReturn(null);
+    setClientRequestField(request, "client", client);
+    setClientRequestField(request, "identifier", "req-no-cache");
+    setClientRequestField(request, "verbosity", 0);
+
+    state.mergeCompatibilityMode(
+        InsertContext.CompatibilityMode.COMPAT_1250,
+        InsertContext.CompatibilityMode.COMPAT_1468,
+        new byte[] {5},
+        false,
+        false);
+
+    verify(client).getRequestStatusCache();
+    verify(request, never()).queueProgressMessageInner(any(FCPMessage.class), anyInt());
+  }
+
+  @Test
+  void returnBucketDirect_whenSetGetAndTake_clearsAfterTake() {
+    ClientGetState state = new ClientGetState(new ClientGet());
+    Bucket bucket = mock(Bucket.class);
+    state.setReturnBucketDirect(bucket);
+
+    assertSame(bucket, state.getReturnBucketDirect());
+    assertSame(bucket, state.takeReturnBucketDirect());
+    assertNull(state.getReturnBucketDirect());
+    assertNull(state.takeReturnBucketDirect());
+  }
+
+  @SuppressWarnings({"java:S3011"})
+  private static void setClientRequestField(ClientRequest target, String fieldName, Object value)
+      throws ReflectiveOperationException {
+    Field field = ClientRequest.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetStatusReporterTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetStatusReporterTest.java
@@ -1,0 +1,303 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchException;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.CompatibilityAnalyser;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetStatusReporterTest {
+
+  @Test
+  void constructor_whenRequestNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new ClientGetStatusReporter(null));
+  }
+
+  @Test
+  void getFailureReason_whenNoFailureRecorded_returnsNull() {
+    ClientGet request = new ClientGet();
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertNull(reporter.getFailureReason(false));
+    assertNull(reporter.getFailureReason(true));
+  }
+
+  @Test
+  void getFailureReason_whenLongDescriptionAndExtraPresent_appendsExtraText() {
+    ClientGet request = new ClientGet();
+    FetchException failure = new FetchException(FetchExceptionMode.ALL_DATA_NOT_FOUND, "details");
+    GetFailedMessage message = new GetFailedMessage(failure, "req", false);
+    request.state().setFailedMessage(message);
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertEquals(message.getShortFailedMessage(), reporter.getFailureReason(false));
+    assertEquals(
+        message.getShortFailedMessage() + ": " + message.extraDescription,
+        reporter.getFailureReason(true));
+  }
+
+  @Test
+  void getFailureReason_whenLongDescriptionWithoutExtra_returnsShortSummaryOnly() {
+    ClientGet request = new ClientGet();
+    FetchException failure = new FetchException(FetchExceptionMode.ALL_DATA_NOT_FOUND);
+    GetFailedMessage message = new GetFailedMessage(failure, "req", false);
+    request.state().setFailedMessage(message);
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertEquals(message.getShortFailedMessage(), reporter.getFailureReason(true));
+  }
+
+  @Test
+  void getFailureReasonCode_whenNoFailureRecorded_returnsNull() {
+    ClientGet request = new ClientGet();
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertNull(reporter.getFailureReasonCode());
+  }
+
+  @Test
+  void getFailureReasonCode_whenFailurePresent_returnsFailureMode() {
+    ClientGet request = new ClientGet();
+    FetchException failure = new FetchException(FetchExceptionMode.CONTENT_HASH_FAILED);
+    request.state().setFailedMessage(new GetFailedMessage(failure, "req", false));
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertEquals(FetchExceptionMode.CONTENT_HASH_FAILED, reporter.getFailureReasonCode());
+  }
+
+  @Test
+  void isTotalFinalized_whenFinishedAndSucceeded_returnsTrue() throws ReflectiveOperationException {
+    ClientGet request = new ClientGet();
+    setClientRequestField(request, "finished", true);
+    request.state().setSucceeded(true);
+    request.state().setProgressPending(null);
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertTrue(reporter.isTotalFinalized());
+  }
+
+  @Test
+  void isTotalFinalized_whenNoProgressAndNotSuccessful_returnsFalse()
+      throws ReflectiveOperationException {
+    ClientGet request = new ClientGet();
+    setClientRequestField(request, "finished", false);
+    request.state().setSucceeded(false);
+    request.state().setProgressPending(null);
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertFalse(reporter.isTotalFinalized());
+  }
+
+  @Test
+  void isTotalFinalized_whenProgressPresent_usesProgressFlag() {
+    ClientGet request = new ClientGet();
+    SimpleProgressMessage progress = mock(SimpleProgressMessage.class);
+    when(progress.isTotalFinalized()).thenReturn(true);
+    request.state().setProgressPending(progress);
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertTrue(reporter.isTotalFinalized());
+  }
+
+  @Test
+  void progressAccessors_whenNoProgress_returnReporterDefaults() {
+    ClientGet request = new ClientGet();
+    request.state().setProgressPending(null);
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertEquals(-1.0, reporter.getSuccessFraction());
+    assertEquals(1.0, reporter.getTotalBlocks());
+    assertEquals(1.0, reporter.getMinBlocks());
+    assertEquals(0.0, reporter.getFailedBlocks());
+    assertEquals(0.0, reporter.getFatalyFailedBlocks());
+    assertEquals(0.0, reporter.getFetchedBlocks());
+  }
+
+  @Test
+  void progressAccessors_whenProgressPresent_returnProgressValues() {
+    ClientGet request = new ClientGet();
+    SimpleProgressMessage progress = mock(SimpleProgressMessage.class);
+    when(progress.getFraction()).thenReturn(0.75);
+    when(progress.getTotalBlocks()).thenReturn(12.0);
+    when(progress.getMinBlocks()).thenReturn(10.0);
+    when(progress.getFailedBlocks()).thenReturn(1.0);
+    when(progress.getFatalyFailedBlocks()).thenReturn(2.0);
+    when(progress.getFetchedBlocks()).thenReturn(9.0);
+    request.state().setProgressPending(progress);
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    assertEquals(0.75, reporter.getSuccessFraction());
+    assertEquals(12.0, reporter.getTotalBlocks());
+    assertEquals(10.0, reporter.getMinBlocks());
+    assertEquals(1.0, reporter.getFailedBlocks());
+    assertEquals(2.0, reporter.getFatalyFailedBlocks());
+    assertEquals(9.0, reporter.getFetchedBlocks());
+  }
+
+  @Test
+  void getStatus_whenCalled_delegatesWithComposedSnapshotAndReturnsBuildResult() throws Exception {
+    ClientGet request = new ClientGet();
+    setClientRequestField(request, "identifier", "req-status");
+    setClientRequestField(request, "started", true);
+    setClientRequestField(request, "finished", false);
+    setClientRequestField(request, "priorityClass", (short) 5);
+    setClientRequestField(request, "uri", new FreenetURI("KSK@status"));
+    setClientGetField(request, "returnType", ClientGet.ReturnType.DIRECT);
+    setClientGetField(request, "targetFile", new File("download.bin"));
+    FetchContext fetchContext = mock(FetchContext.class);
+    setClientGetField(request, "fctx", fetchContext);
+
+    Bucket bucket = mock(Bucket.class);
+    request.state().setReturnBucketDirect(bucket);
+    request.state().setFoundDataLength(123L);
+    request.state().setFoundDataMimeType("text/plain");
+    request.state().setSucceeded(false);
+    byte[] splitfileKey = new byte[] {7, 8, 9, 10};
+    CompatibilityAnalyser analyser = new CompatibilityAnalyser();
+    analyser.merge(
+        InsertContext.CompatibilityMode.COMPAT_1250,
+        InsertContext.CompatibilityMode.COMPAT_1468,
+        splitfileKey,
+        false,
+        false);
+    request.state().setCompatibilityAnalyser(analyser);
+
+    SimpleProgressMessage progress = mock(SimpleProgressMessage.class);
+    when(progress.getTotalBlocks()).thenReturn(20.0);
+    when(progress.getMinBlocks()).thenReturn(15.0);
+    when(progress.getFetchedBlocks()).thenReturn(11.0);
+    when(progress.getFailedBlocks()).thenReturn(2.0);
+    when(progress.getFatalyFailedBlocks()).thenReturn(1.0);
+    when(progress.getLatestSuccess()).thenReturn(Instant.ofEpochMilli(1_000L));
+    when(progress.getLatestFailure()).thenReturn(Instant.ofEpochMilli(2_000L));
+    when(progress.isTotalFinalized()).thenReturn(false);
+    request.state().setProgressPending(progress);
+
+    FetchException failure =
+        new FetchException(FetchExceptionMode.CONTENT_VALIDATION_FAILED, "bad");
+    GetFailedMessage message = new GetFailedMessage(failure, "req-status", false);
+    request.state().setFailedMessage(message);
+
+    RequestStatus expected = mock(RequestStatus.class);
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    try (MockedStatic<ClientGetGetterFactory> mocked =
+        org.mockito.Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      final ClientGetStatusSnapshot[] captured = new ClientGetStatusSnapshot[1];
+      mocked
+          .when(() -> ClientGetGetterFactory.buildStatus(any(ClientGetStatusSnapshot.class)))
+          .thenAnswer(
+              invocation -> {
+                captured[0] = invocation.getArgument(0);
+                return expected;
+              });
+
+      RequestStatus status = reporter.getStatus();
+
+      assertSame(expected, status);
+      ClientGetStatusSnapshot snapshot = captured[0];
+      assertSame(progress, snapshot.progressPending());
+      assertSame(message, snapshot.failedMessage());
+      assertEquals("req-status", snapshot.identifier());
+      assertTrue(snapshot.started());
+      assertEquals("text/plain", snapshot.foundDataMimeType());
+      assertEquals(123L, snapshot.foundDataLength());
+      assertEquals("download.bin", snapshot.destinationFile().getPath());
+      assertSame(bucket, snapshot.dataBucket());
+      assertSame(fetchContext, snapshot.fetchContext());
+      assertArrayEquals(
+          new InsertContext.CompatibilityMode[] {
+            InsertContext.CompatibilityMode.COMPAT_1250, InsertContext.CompatibilityMode.COMPAT_1468
+          },
+          snapshot.compatModes());
+      assertArrayEquals(splitfileKey, snapshot.splitfileKey());
+      assertEquals("KSK@status", snapshot.uri().toString());
+      assertFalse(snapshot.dontCompress());
+      RequestStatusSnapshot statusSnapshot = snapshot.statusSnapshot();
+      assertEquals(20, statusSnapshot.total());
+      assertEquals(11, statusSnapshot.fetched());
+      assertEquals(2, statusSnapshot.failed());
+      assertEquals(1, statusSnapshot.fatal());
+      assertEquals(Instant.ofEpochMilli(1_000L), statusSnapshot.latestSuccess());
+      assertEquals(Instant.ofEpochMilli(2_000L), statusSnapshot.latestFailure());
+      assertFalse(statusSnapshot.totalFinalized());
+    }
+  }
+
+  @Test
+  void getStatus_whenFinishedAndSucceeded_forcesTotalFinalizedInStatusSnapshot() throws Exception {
+    ClientGet request = new ClientGet();
+    setClientRequestField(request, "identifier", "req-finished");
+    setClientRequestField(request, "finished", true);
+    setClientRequestField(request, "started", true);
+    setClientGetField(request, "returnType", ClientGet.ReturnType.NONE);
+    setClientGetField(request, "fctx", mock(FetchContext.class));
+    request.state().setSucceeded(true);
+    SimpleProgressMessage progress = mock(SimpleProgressMessage.class);
+    when(progress.isTotalFinalized()).thenReturn(false);
+    when(progress.getTotalBlocks()).thenReturn(2.0);
+    when(progress.getMinBlocks()).thenReturn(2.0);
+    when(progress.getFetchedBlocks()).thenReturn(2.0);
+    when(progress.getFailedBlocks()).thenReturn(0.0);
+    when(progress.getFatalyFailedBlocks()).thenReturn(0.0);
+    when(progress.getLatestSuccess()).thenReturn(Instant.ofEpochMilli(500L));
+    when(progress.getLatestFailure()).thenReturn(null);
+    request.state().setProgressPending(progress);
+
+    RequestStatus expected = mock(RequestStatus.class);
+    ClientGetStatusReporter reporter = new ClientGetStatusReporter(request);
+
+    try (MockedStatic<ClientGetGetterFactory> mocked =
+        org.mockito.Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      final ClientGetStatusSnapshot[] captured = new ClientGetStatusSnapshot[1];
+      mocked
+          .when(() -> ClientGetGetterFactory.buildStatus(any(ClientGetStatusSnapshot.class)))
+          .thenAnswer(
+              invocation -> {
+                captured[0] = invocation.getArgument(0);
+                return expected;
+              });
+
+      assertSame(expected, reporter.getStatus());
+      assertTrue(captured[0].statusSnapshot().totalFinalized());
+    }
+  }
+
+  @SuppressWarnings({"java:S3011"})
+  private static void setClientRequestField(ClientRequest target, String fieldName, Object value)
+      throws ReflectiveOperationException {
+    Field field = ClientRequest.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  @SuppressWarnings({"java:S3011"})
+  private static void setClientGetField(ClientGet target, String fieldName, Object value)
+      throws ReflectiveOperationException {
+    Field field = ClientGet.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}


### PR DESCRIPTION
## Summary
- Guard `ClientGetRestartCoordinator.restart(...)` against a missing fetch context to avoid null dereference in restart flow.
- Add comprehensive unit coverage for ClientGet FCP helpers:
  - `ClientGetFactoryTest`
  - `ClientGetPersistenceCodecTest`
  - `ClientGetRestartCoordinatorTest`
  - `ClientGetStateTest`
  - `ClientGetStatusReporterTest`
- Keep restart behavior unchanged otherwise while improving test determinism and SonarLint cleanliness in new/updated tests.

## How To Test
- `./gradlew test --tests 'network.crypta.clients.fcp.ClientGetPersistenceCodecTest'`
- `./gradlew test --tests 'network.crypta.clients.fcp.ClientGetRestartCoordinatorTest'`
- `./gradlew test --tests 'network.crypta.clients.fcp.ClientGetStateTest'`
- `./gradlew test --tests 'network.crypta.clients.fcp.ClientGetStatusReporterTest'`
- `./gradlew sonarlintFile -Psonarlint.file=src/test/java/network/crypta/clients/fcp/ClientGetStatusReporterTest.java`
- `./gradlew test`