### PR TITLE
docs(agents): Remove Kotlin guidance from skills

### DIFF
--- a/.agents/skills/convert-tests-to-aaa/SKILL.md
+++ b/.agents/skills/convert-tests-to-aaa/SKILL.md
@@ -18,7 +18,7 @@ Use either format:
 **Two lines**
 ```
 $convert-tests-to-aaa
-Target file: src/test/kotlin/com/acme/FooServiceTest.kt
+Target file: src/test/java/com/acme/FooServiceTest.java
 ```
 
 Treat the file path as **relative to the repository root**, unless the user clearly indicates otherwise.

--- a/.agents/skills/cryptad-appenv/SKILL.md
+++ b/.agents/skills/cryptad-appenv/SKILL.md
@@ -35,22 +35,7 @@ Use `network.crypta.fs.AppEnv` instead.
 - Display-only strings:
   - `osNameRaw()`, `osVersionRaw()`
 
-## Usage examples
-### Kotlin
-```kotlin
-val env = AppEnv()
-if (env.isWindows()) {
-  // ...
-}
-
-val det = AppEnv().detectEnvironment()
-when (det.os) {
-  AppEnv.OsKind.LINUX -> { /* ... */ }
-  else -> { /* ... */ }
-}
-```
-
-### Java
+## Usage example (Java)
 ```java
 AppEnv env = new AppEnv();
 if (env.isServiceMode()) {

--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -81,6 +81,6 @@ Use this skill when you need to:
 
 ## Versioning system
 - A single integer build number is set in `build.gradle.kts` (`version = "<int>"`).
-- Version tokens are replaced into `network/crypta/node/Version.kt` during build (`@build_number@`, `@git_rev@`).
+- Version tokens are replaced into `network/crypta/node/Version.java` during build (`@build_number@`, `@git_rev@`).
 - Version strings support both Cryptad and Fred formats; compatibility enforces protocol match and minimum builds.
 - Freenet interop uses historical identifiers (e.g., `"Fred,0.7"`) for wire compatibility where applicable.

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -5,7 +5,7 @@ compatibility: opencode
 metadata:
   area: build
   domain: cryptad
-  lang: java-kotlin
+  lang: java
 ---
 
 ## When to use
@@ -13,7 +13,7 @@ Use this skill when you need to:
 - Build the node JAR, run tests, or compile the project.
 - Run a single test class/method during debugging.
 - Validate that your local build can be deployed to a running node.
-- Diagnose Gradle/Java toolchain issues (Java 25+, Kotlin 2.3+).
+- Diagnose Gradle/Java toolchain issues (Java 25+).
 
 ## Guardrails (must follow)
 - Always use the Gradle wrapper: `./gradlew …`
@@ -49,7 +49,7 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
 - Pass daemon CLI args:
   - `./gradlew run --args="--help"`
   - `./gradlew run --args="--version"`
-- Run Swing launcher entrypoint (`LauncherKt`):
+- Run Swing launcher entrypoint (`Launcher`):
   - `./gradlew runLauncher`
 
 ## Run your build (manual deployment)
@@ -60,12 +60,10 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
 
 ## Environment expectations
 - Java: 25 or higher
-- Kotlin: 2.3.0 or higher (matches `gradle/libs.versions.toml`)
-- The `ki` shell is installed in the environment.
 
 ## JUnit 6 notes (when touching tests)
 - Tests run on the JUnit Platform (`useJUnitPlatform()` in build logic).
-- Prefer JUnit Jupiter + Kotlin test utilities; do not add JUnit 4/Vintage unless explicitly requested for migration-only work.
+- Prefer JUnit Jupiter APIs; do not add JUnit 4/Vintage unless explicitly requested for migration-only work.
 - JUnit 6 introduces `org.jspecify:jspecify` (nullability annotations). If strict dependency verification blocks resolution, follow the project’s dependency-verification refresh procedure (see the build tooling skill).
 
 ## Test helpers (test sources only)

--- a/.agents/skills/cryptad-build-tooling/SKILL.md
+++ b/.agents/skills/cryptad-build-tooling/SKILL.md
@@ -72,7 +72,7 @@ Notes:
 ### Current repo wiring
 - Version catalog pins SpotBugs at `6.4.8` and exposes a plugin alias in `gradle/libs.versions.toml`.
 - Build logic includes the plugin marker dependency in `build-logic/build.gradle.kts`.
-- The shared convention plugin applies `com.github.spotbugs` in `build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts`.
+- The shared convention plugin applies `com.github.spotbugs` in build logic.
 - Default behavior is non-blocking: `spotbugs { ignoreFailures = true }`.
 - All SpotBugs tasks are configured via `tasks.withType<SpotBugsTask>()` to emit XML reports at `build/reports/spotbugs/<taskName>.xml`.
 - Text reports are disabled (`reports.matching { it.name == "text" }`) so findings are read from XML files instead of large stdout dumps.
@@ -95,7 +95,7 @@ If strict verification blocks SpotBugs/plugin marker resolution:
 1) Set `org.gradle.dependency.verification=lenient`
 2) Run:
 ```bash
-./gradlew --write-verification-metadata sha256,pgp :build-logic:compileKotlin
+./gradlew --write-verification-metadata sha256,pgp :build-logic:classes
 ```
 3) Restore `org.gradle.dependency.verification=strict`
 4) Validate:
@@ -156,7 +156,7 @@ If strict verification blocks resolution:
 1) Set `org.gradle.dependency.verification=lenient`
 2) Run:
 ```bash
-./gradlew --write-verification-metadata sha256,pgp :build-logic:compileKotlin
+./gradlew --write-verification-metadata sha256,pgp :build-logic:classes
 ```
 3) Restore `org.gradle.dependency.verification=strict`
 4) Optionally `./gradlew --export-keys`
@@ -167,7 +167,7 @@ Gradle daemon heap was increased to reduce OOM during SonarLint indexing:
 
 ## Error Prone
 ### Key behaviors
-- Enabled via `net.ltgt.errorprone` in the Java/Kotlin convention plugin.
+- Enabled via `net.ltgt.errorprone` in the shared convention plugin.
 - Errors are downgraded to warnings by default (`options.errorprone.allErrorsAsWarnings = true`).
 
 ### Report task
@@ -182,14 +182,14 @@ Gradle daemon heap was increased to reduce OOM during SonarLint indexing:
 
 ### Enforcing errors
 - To fail the build on Error Prone errors, set `allErrorsAsWarnings` to `false` in:
-  - `build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts`
+  - the shared convention plugin under `build-logic/src/main/`
 
 ### Verification refresh on Error Prone bumps
 If strict verification blocks resolution:
 1) Set `org.gradle.dependency.verification=lenient`
 2) Run:
 ```bash
-./gradlew --write-verification-metadata sha256,pgp :build-logic:compileKotlin
+./gradlew --write-verification-metadata sha256,pgp :build-logic:classes
 ```
 3) Restore `org.gradle.dependency.verification=strict`
 4) Optionally `./gradlew --export-keys`

--- a/.agents/skills/cryptad-launcher-ui/SKILL.md
+++ b/.agents/skills/cryptad-launcher-ui/SKILL.md
@@ -17,8 +17,8 @@ Use this skill when working on:
 
 ## Swing launcher overview
 - Package: `network.crypta.launcher`
-- Entry point: top-level `fun main()`
-- UI: Java Swing (three rows — buttons, scrolling log, status bar), System LAF, 900×600.
+- Entry point: `Launcher.main()`
+- UI: Java Swing (buttons + scrolling log + status bar), System LAF.
 
 ## Starting Cryptad (wrapper script resolution order)
 The launcher starts the wrapper script using this resolution order (first match wins):
@@ -52,10 +52,8 @@ Global shortcuts via `KeyEventDispatcher`:
 - `s` start/stop; `q` quit
 
 ## Concurrency model
-- Uses `kotlinx-coroutines-swing` with:
-  - `Dispatchers.Main.immediate` for UI
-  - `Dispatchers.IO` for process I/O and file tailing
-- Dedicated `shutdownScope` for quit
+- UI updates run on the Swing EDT (`SwingUtilities.invokeLater` / `invokeAndWait`).
+- Process lifecycle, log streaming, and port/browser coordination run on `LauncherController`'s executor service.
 
 ## Unix PTY fallback
 If `script` exists, the launcher may wrap the process to reduce buffering.
@@ -88,8 +86,8 @@ If `script` exists, the launcher may wrap the process to reduce buffering.
 - Decide dark/light based on OS theme **before** any Swing components are created (EDT).
 - Flatpak:
   - OS theme detection reads the XDG Desktop Portal setting `org.freedesktop.appearance/color-scheme` via dbus-java.
-  - Portal detector: `src/main/kotlin/com/jthemedetecor/PortalThemeDetector.kt`
-  - Factory: `src/main/kotlin/network/crypta/launcher/FlatpakAwareOsThemeDetector.kt` prefers the portal and falls back to upstream detector when unavailable.
+  - Portal detector: `src/main/java/com/jthemedetecor/PortalThemeDetector.java`
+  - Factory: `src/main/java/network/crypta/launcher/FlatpakAwareOsThemeDetector.java` prefers the portal and falls back to upstream detector when unavailable.
 - Ordering matters:
   - Register the browser theme change listener (`matchMedia('(prefers-color-scheme: dark)')`) before creating UI controls.
 

--- a/.agents/skills/cryptad-packaging/SKILL.md
+++ b/.agents/skills/cryptad-packaging/SKILL.md
@@ -50,7 +50,7 @@ We ship Gradle tasks that build a desktop app image and (on macOS/Linux) native 
 
 ### Metadata and entrypoint
 - Name: `Crypta`, Vendor: `crypta.network`, App ID: `network.crypta.cryptad`
-- Main entry: `network.crypta.launcher.LauncherKt`
+- Main entry: `network.crypta.launcher.Launcher`
 - Versioning: jpackage requires numeric `--app-version`; we use the project version integer.
 
 ### Icons and resources
@@ -72,7 +72,7 @@ We ship Gradle tasks that build a desktop app image and (on macOS/Linux) native 
   - `build\jpackage\Crypta\app\cryptad-dist\lib\cryptad.jar`
   - `build\jpackage\Crypta\app\Crypta.cfg`
 - Verify `Crypta.cfg` includes:
-  - `app.mainclass=network.crypta.launcher.LauncherKt`
+  - `app.mainclass=network.crypta.launcher.Launcher`
   - one or more `app.classpath=$APPDIR/cryptad-dist/lib/*.jar` lines
 
 ## Linux installer behavior (DEB/RPM)
@@ -112,8 +112,8 @@ Requirements: `flatpak`, `org.freedesktop.Platform//24.08`, `org.freedesktop.Sdk
 
 Typical flow:
 ```bash
-./gradlew -x spotlessKotlin -x spotlessApply -x spotlessJava -x spotlessKotlinGradle buildJar
-./gradlew -x spotlessKotlin -x spotlessApply -x spotlessJava -x spotlessKotlinGradle distJlinkCryptad
+./gradlew buildJar
+./gradlew distJlinkCryptad
 cp -f "build/distributions/cryptad-jlink-v$(./gradlew -q printVersion).tar.gz" tools/flatpak/local/cryptad-jlink-v1.tar.gz
 rm -rf builddir repo .flatpak-builder
 flatpak run org.flatpak.Builder --force-clean --user --arch=$(flatpak --default-arch) \

--- a/.agents/skills/cryptad-style-docs/SKILL.md
+++ b/.agents/skills/cryptad-style-docs/SKILL.md
@@ -1,33 +1,30 @@
 ---
 name: cryptad-style-docs
-description: "Apply Cryptad Kotlin/Java style, file layout rules, and long-lived documentation/commenting practices."
+description: "Apply Cryptad Java style, file layout rules, and long-lived documentation/commenting practices."
 compatibility: opencode
 metadata:
   area: style
   domain: cryptad
-  lang: java-kotlin
+  lang: java
 ---
 
 ## When to use
 Use this skill when you:
-- Add/edit Kotlin or Java sources.
+- Add/edit Java sources.
 - Touch comments, deprecations, or docs.
 - Need to ensure changes match the repo’s style and documentation practices.
 
-## Kotlin/Java layout rules
-- Kotlin sources go under `src/*/kotlin/` (for example `src/main/kotlin`, `src/test/kotlin`).
-  - Do **not** add Kotlin files under `src/*/java/`.
-- Prefer top-level functions in Kotlin instead of wrapping in objects/classes when appropriate (idiomatic Kotlin).
+## Java layout rules
+- Java sources go under `src/*/java/` (for example `src/main/java`, `src/test/java`).
 
 ## Style guides
-- Kotlin: follow the official Kotlin coding conventions.
 - Java: follow the Google Java Style Guide.
 
 (Use the canonical upstream docs; do not invent new local style rules unless the repo already enforces them.)
 
-## Documentation expectations (Javadoc/KDoc)
-After editing any Java or Kotlin file:
-- Check for missing/poor Javadoc (Java) or KDoc (Kotlin).
+## Documentation expectations (Javadoc)
+After editing any Java file:
+- Check for missing/poor Javadoc.
 - Add or improve them as needed, especially for public APIs, non-obvious invariants, and protocol/format details.
 
 ## Commenting guidelines (very important)
@@ -37,7 +34,7 @@ Prefer clean diffs over in-code historical explanations.
 
 ### Deprecations
 When deprecating behavior that remains in code:
-- Use standard `@Deprecated` (Java/Kotlin).
+- Use standard `@Deprecated`.
 - Add a brief forward-looking note (preferably linking to an issue/PR).
 - Avoid PR-number narratives or “history of the removal” in comments.
 

--- a/.agents/skills/write-javadoc/SKILL.md
+++ b/.agents/skills/write-javadoc/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: write-javadoc
 description: |
-  For a single file, fix doclint-clean Javadoc (Java) or KDoc (Kotlin) issues and enrich
-  public/protected API docs with substantive long-form documentation, without changing code behavior.
+  For a single file, fix doclint-clean Javadoc (Java) issues and enrich public/protected API docs
+  with substantive long-form documentation, without changing code behavior.
 ---
 
-# Doclint-clean Javadoc/KDoc for one file (long-form for large files)
+# Doclint-clean Javadoc for one file (long-form for large files)
 
 ## How to invoke (provide the “input” in your message)
 Skills don’t take positional/structured parameters. When you invoke this skill, include the target file path.
@@ -18,7 +18,7 @@ Use either format:
 **Two lines**
 ```
 $write-javadoc
-Target file: src/main/kotlin/com/acme/FooService.kt
+Target file: src/main/java/com/acme/FooService.java
 ```
 
 Treat the file path as **relative to the repository root**, unless the user clearly indicates otherwise.
@@ -35,7 +35,6 @@ For the target file:
 
 ## File type & scope
 - If the target ends with **`.java`**: apply **Javadoc** rules and run **doclint** (loop below).
-- If the target ends with **`.kt`**: apply **KDoc** rules; **do not** run doclint.
 - Otherwise: return unchanged.
 
 ### Allowed edits
@@ -142,7 +141,6 @@ Expand docs per **Length & Depth Controls** and **Prioritization** below (still 
   - Concurrency/thread-safety and mutability (if applicable).
 - Bullets: add a short list when helpful (e.g., Responsibilities, Notable behaviors).
   - Java: valid HTML lists.
-  - Kotlin: Markdown lists.
 - See also: `@see` or inline `{@link ...}` for closely related symbols that resolve.
 
 ### Methods / constructors (public & protected)
@@ -188,14 +186,7 @@ When the file has many public/protected members (e.g., > 30):
 
 ---
 
-## KDoc rules (Kotlin)
-- Markdown allowed; backticks for code.
-- Tags: `@param`, `@return`, `@throws`, `@receiver`, `@constructor`, `@property`, and type params via `@param T`.
-- Same scope constraints as Java; no doclint.
-
----
-
-## Inline comments (both languages)
+## Inline comments
 - Prefer short `//` comments for non-obvious intent (invariants, edge cases, concurrency), <= 2 short lines, placed above the code.
 - Use `/* … */` for slightly longer local notes (not doc blocks).
 - Remove stale or self-evident comments; fix grammar and outdated names.
@@ -212,7 +203,7 @@ When the file has many public/protected members (e.g., > 30):
 
 ## Preservation & promotion
 - Preserve license headers, annotations, and any valid existing docs; improve wording/formatting where helpful.
-- Promote meaningful `//` explanations of public/protected behavior to proper Javadoc/KDoc when appropriate (without moving/duplicating placeholder markers).
+- Promote meaningful `//` explanations of public/protected behavior to proper Javadoc when appropriate (without moving/duplicating placeholder markers).
 - Keep private/internal docs concise.
 
 ---

--- a/.agents/skills/write-or-improve-unit-tests/SKILL.md
+++ b/.agents/skills/write-or-improve-unit-tests/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: write-or-improve-unit-tests
 description: |
-  Write or improve deterministic, maintainable unit tests for a single class under test (Java/Kotlin),
-  using JUnit (project-configured; typically JUnit 6 per repo) and Mockito, without modifying production code.
+  Write or improve deterministic, maintainable unit tests for a single Java class under test, using
+  JUnit (project-configured; typically JUnit 6 per repo) and Mockito, without modifying production code.
 ---
 
 # Write or Improve Unit Tests for one class/file
@@ -22,18 +22,18 @@ or
 **Two lines**
 ```
 $write-or-improve-unit-tests
-Target: src/main/kotlin/com/acme/FooService.kt
+Target: src/main/java/com/acme/FooService.java
 ```
 
 Notes:
 - `Target:` may be a **path** or a **fully-qualified class name**.
-- Infer language from the target (`.java` -> Java, `.kt` -> Kotlin). If you only get an FQCN, locate the source file via repo search.
+- If you only get an FQCN, locate the source file via repo search.
 
 ---
 
 ## Test framework and mocking
 - **Test framework:** JUnit (use the version configured by the repo; target JUnit 6 APIs if present).
-- **Mocking:** Mockito (Kotlin: prefer `mockito-kotlin` helpers if already used in the repo).
+- **Mocking:** Mockito.
 
 ---
 
@@ -112,7 +112,6 @@ Do not run the full suite on every iteration.
 
 ### Language specifics
 - **Java:** Prefer `assertThrows` and explicit static imports from `org.junit.jupiter.api.Assertions` (or the repo’s configured JUnit assertion class).
-- **Kotlin:** Use Mockito + any existing repo helpers (`mockito-kotlin` if present). Use backtick test names only if the project already uses them; otherwise follow the naming rule above.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove Kotlin/KDoc guidance from `.agents` skill docs after the Java migration in PR #1062
- update stale launcher and version references (`LauncherKt` -> `Launcher`, `Version.kt` -> `Version.java`)
- keep build-logic references where operationally needed while removing Kotlin-as-product-language instructions

## How to test
1. Confirm only `.agents/skills/*/SKILL.md` files are changed.
2. Run `rg -n --hidden -S "kotlin|Kotlin|KDoc|LauncherKt|mockito-kotlin" .agents` and verify there are no matches.
3. Run `./gradlew spotlessApply` and verify it succeeds.

## Notes
- Documentation-only change; no production code or tests were modified.