### PR TITLE
docs(create-pr): Add configurable base branch handling

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -65,7 +65,8 @@ Set/confirm the base branch:
 - If the user specified a base branch, set `BASE_BRANCH` to it.
 - Validate it exists on `origin`.
 
-Resolve and validate base selection with the bundled script `scripts/resolve_base_branch.sh`:
+Resolve and validate base selection with the bundled script `scripts/resolve_base_branch.sh`
+(or `<path-to-skill>/scripts/resolve_base_branch.sh` if running from another directory):
 
 ```bash
 if [ -n "${BASE_BRANCH:-}" ]; then

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,16 +1,26 @@
 ---
 name: create-pr
-description: Review the current branch’s commit history and source diffs, format/commit any pending changes, then open a GitHub PR targeting the develop branch via the GitHub MCP server.
+description: Review the current branch’s commit history and source diffs, format/commit any pending changes, then open a GitHub PR targeting the develop branch by default (or another specified base branch) via the GitHub MCP server.
 allowed-tools: Bash(git:*), Bash(./gradlew:*), Bash(gradle:*), Read, Grep, Glob, MCP(github:*)
 ---
 
-# Create Pull Request (to develop)
+# Create Pull Request (default: develop)
 
-Create a GitHub pull request **into `develop`** by first reviewing the current branch’s commit history and diffs, ensuring any pending local changes are formatted and committed, then opening the PR via the GitHub MCP server.
+Create a GitHub pull request **into `develop` by default** by first reviewing the current branch’s commit history and diffs, ensuring any pending local changes are formatted and committed, then opening the PR via the GitHub MCP server.
+
+## Target branch selection
+
+- **Default base branch:** `develop`
+- **Override:** If the user explicitly specifies a different target base branch (e.g., “into `release/1.2`”, “base=`hotfix`”, “target `main`”), use that branch instead of `develop`.
+- **Validation:** Always `git fetch` first, then verify the remote base branch exists as `origin/<base>`. If `origin/develop` does not exist *and the user did not specify a base*, fall back to `main`.
+
+> In the commands below, treat `BASE_BRANCH` as the chosen base branch name (default `develop`).
 
 ## Branch safety rules
 
-- **Never commit directly on `develop` or `main`.** If the current branch is `develop` or `main`, create a new `feature/…` or `bugfix/…` branch **before** running formatters or creating commits.
+- **Never commit directly on `develop` or `main`.**
+- **Also never commit directly on the chosen base branch** (if different).
+- If the current branch is `develop`, `main`, or equals `BASE_BRANCH`, create a new `feature/…` or `bugfix/…` branch **before** running formatters or creating commits.
 - Keep PRs focused: avoid mixing unrelated refactors/features/fixes.
 
 ## PR title format
@@ -32,6 +42,7 @@ Create a GitHub pull request **into `develop`** by first reviewing the current b
 | `build`    | Build system or dependencies                     |
 | `ci`       | CI configuration                                 |
 | `chore`    | Routine tasks, maintenance                       |
+| `revert`   | Reverting a previous change                      |
 
 ### Summary rules
 
@@ -41,20 +52,45 @@ Create a GitHub pull request **into `develop`** by first reviewing the current b
 
 ## Steps
 
-### 1) Fetch + identify base branch
+### 1) Fetch + identify current branch + choose base branch
 
 ```bash
 git fetch origin --prune
 git rev-parse --abbrev-ref HEAD
 ```
 
-Base is `origin/develop`.
+Set/confirm the base branch:
 
-### 2) If on `develop` or `main`, create a new branch first
+- Default: `develop`
+- If the user specified a base branch, set `BASE_BRANCH` to it.
+- Validate it exists on `origin`.
+
+Example bash snippet (adjust if you set `BASE_BRANCH` some other way):
+
+```bash
+# If the user explicitly asked for a base branch, set it here; otherwise leave default.
+BASE_BRANCH="${BASE_BRANCH:-develop}"
+
+# Ensure the remote base exists (fallback to main only if develop is missing and not user-specified).
+if ! git show-ref --verify --quiet "refs/remotes/origin/$BASE_BRANCH"; then
+  if [ "$BASE_BRANCH" = "develop" ]; then
+    BASE_BRANCH="main"
+  fi
+fi
+
+git show-ref --verify --quiet "refs/remotes/origin/$BASE_BRANCH" || {
+  echo "Base branch origin/$BASE_BRANCH not found"; exit 1;
+}
+echo "Using base branch: $BASE_BRANCH"
+```
+
+### 2) If on `develop` / `main` / base branch, create a new branch first
 
 ```bash
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$BRANCH" = "develop" ] || [ "$BRANCH" = "main" ]; then
+
+# BASE_BRANCH should already be set from Step 1
+if [ "$BRANCH" = "develop" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "$BASE_BRANCH" ]; then
   # Pick one:
   #   feature/<short-slug>
   #   bugfix/<short-slug>
@@ -88,37 +124,37 @@ git status --porcelain
 - `git add` / `git commit`
 - `git push` (set upstream if needed)
 
-> Important: do not create commits until you have left `develop`/`main` (Step 2).
+> Important: do not create commits until you have left `develop`/`main`/`BASE_BRANCH` (Step 2).
 
-### 4) Review commit history on the current branch
+### 4) Review commit history on the current branch (relative to base)
 
 List commits that will go into the PR:
 
 ```bash
-git log --oneline --decorate --no-merges origin/develop..HEAD
+git log --oneline --decorate --no-merges "origin/$BASE_BRANCH..HEAD"
 ```
 
 Optionally, review details commit-by-commit:
 
 ```bash
-git log --reverse --no-merges --pretty=format:'%h %s' origin/develop..HEAD
+git log --reverse --no-merges --pretty=format:'%h %s' "origin/$BASE_BRANCH..HEAD"
 # then for each sha:
 #   git show --name-status <sha>
 #   git show <sha> -- <key-path>
 ```
 
-### 5) Read the source diffs that will be in the PR
+### 5) Read the source diffs that will be in the PR (relative to base)
 
 High-level summary:
 
 ```bash
-git diff --stat origin/develop...HEAD
+git diff --stat "origin/$BASE_BRANCH...HEAD"
 ```
 
 Full diff (focus on source code paths):
 
 ```bash
-git diff origin/develop...HEAD
+git diff "origin/$BASE_BRANCH...HEAD"
 ```
 
 Use the commit history + diff to determine the PR’s:
@@ -134,12 +170,12 @@ If `$git-commit-helper` already pushed, this may be a no-op. Otherwise:
 git push -u origin HEAD
 ```
 
-### 7) Create the PR via the GitHub MCP server (base: develop)
+### 7) Create the PR via the GitHub MCP server (base: default `develop`, override allowed)
 
 Use the GitHub MCP server’s PR creation capability (tool names vary; look for an operation like “create pull request”).
 
 Provide at minimum:
-- `base`: `develop`
+- `base`: `BASE_BRANCH` (default `develop`, unless overridden)
 - `head`: current branch name (or `owner:branch` if required)
 - `title`: `<type>(<scope>): <summary>`
 - `body`: include summary + test plan; incorporate `.github/pull_request_template.md` if present
@@ -151,7 +187,7 @@ Example shape (adjust to the MCP server you have configured):
 tool: github.create_pull_request
 args:
   repo: <owner>/<repo>
-  base: develop
+  base: <BASE_BRANCH>
   head: <branch>
   title: "feat(core): Add …"
   body: |
@@ -166,6 +202,7 @@ args:
 After creation:
 - return the PR URL
 - summarize key changes and how to test
+- clearly state which base branch was used (e.g., “PR opened into `develop`” / “PR opened into `release/1.2`”)
 
 ## Validation
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -65,28 +65,16 @@ Set/confirm the base branch:
 - If the user specified a base branch, set `BASE_BRANCH` to it.
 - Validate it exists on `origin`.
 
-Example bash snippet (adjust if you set `BASE_BRANCH` some other way):
+Resolve and validate base selection with the bundled script `scripts/resolve_base_branch.sh`:
 
 ```bash
-# If the user explicitly asked for a base branch, set BASE_BRANCH before this block.
-# This flag preserves whether BASE_BRANCH came from user input or the default.
-USER_SPECIFIED_BASE="${USER_SPECIFIED_BASE:-false}"
-if [ -z "${BASE_BRANCH:-}" ]; then
-  BASE_BRANCH="develop"
+if [ -n "${BASE_BRANCH:-}" ]; then
+  # user explicitly requested a base branch
+  BASE_BRANCH="$(bash scripts/resolve_base_branch.sh "$BASE_BRANCH")"
 else
-  USER_SPECIFIED_BASE=true
+  # default behavior: develop, with fallback to main only if origin/develop is missing
+  BASE_BRANCH="$(bash scripts/resolve_base_branch.sh)"
 fi
-
-# Ensure the remote base exists (fallback to main only if develop is missing and not user-specified).
-if ! git show-ref --verify --quiet "refs/remotes/origin/$BASE_BRANCH"; then
-  if [ "$BASE_BRANCH" = "develop" ] && [ "$USER_SPECIFIED_BASE" = "false" ]; then
-    BASE_BRANCH="main"
-  fi
-fi
-
-git show-ref --verify --quiet "refs/remotes/origin/$BASE_BRANCH" || {
-  echo "Base branch origin/$BASE_BRANCH not found"; exit 1;
-}
 echo "Using base branch: $BASE_BRANCH"
 ```
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -68,12 +68,18 @@ Set/confirm the base branch:
 Example bash snippet (adjust if you set `BASE_BRANCH` some other way):
 
 ```bash
-# If the user explicitly asked for a base branch, set it here; otherwise leave default.
-BASE_BRANCH="${BASE_BRANCH:-develop}"
+# If the user explicitly asked for a base branch, set BASE_BRANCH before this block.
+# This flag preserves whether BASE_BRANCH came from user input or the default.
+USER_SPECIFIED_BASE="${USER_SPECIFIED_BASE:-false}"
+if [ -z "${BASE_BRANCH:-}" ]; then
+  BASE_BRANCH="develop"
+else
+  USER_SPECIFIED_BASE=true
+fi
 
 # Ensure the remote base exists (fallback to main only if develop is missing and not user-specified).
 if ! git show-ref --verify --quiet "refs/remotes/origin/$BASE_BRANCH"; then
-  if [ "$BASE_BRANCH" = "develop" ]; then
+  if [ "$BASE_BRANCH" = "develop" ] && [ "$USER_SPECIFIED_BASE" = "false" ]; then
     BASE_BRANCH="main"
   fi
 fi

--- a/.agents/skills/create-pr/scripts/resolve_base_branch.sh
+++ b/.agents/skills/create-pr/scripts/resolve_base_branch.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  resolve_base_branch.sh [base-branch]
+
+Behavior:
+  - No argument: choose develop by default, fall back to main only if origin/develop is missing.
+  - With argument: treat the branch as explicitly requested; do not fall back to main.
+
+Notes:
+  - Run "git fetch origin --prune" before this script to refresh remote refs.
+  - Prints the selected base branch to stdout.
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -gt 1 ]; then
+  usage >&2
+  exit 2
+fi
+
+user_specified_base=false
+if [ "$#" -eq 1 ]; then
+  base_branch="$1"
+  user_specified_base=true
+else
+  base_branch="develop"
+fi
+
+if ! git show-ref --verify --quiet "refs/remotes/origin/$base_branch"; then
+  if [ "$base_branch" = "develop" ] && [ "$user_specified_base" = "false" ]; then
+    base_branch="main"
+  fi
+fi
+
+if ! git show-ref --verify --quiet "refs/remotes/origin/$base_branch"; then
+  echo "Base branch origin/$base_branch not found" >&2
+  exit 1
+fi
+
+printf '%s\n' "$base_branch"


### PR DESCRIPTION
## Summary
- update the `create-pr` skill to default to `develop` but allow explicit base branch overrides
- add validation/fallback guidance for `origin/<base>` and a fallback to `main` only when `develop` is missing and no override was given
- extend branch-safety and review/diff steps so they consistently use `BASE_BRANCH`

## How to test
- read `.agents/skills/create-pr/SKILL.md` and confirm the new Target branch selection section and `BASE_BRANCH`-based command examples
- verify branch-safety now blocks committing directly on `develop`, `main`, and the selected base branch
- verify PR creation instructions now set `base: <BASE_BRANCH>` and require reporting the final base branch used