### PR TITLE
fix(ci): Stabilize Windows file-backed tests

### DIFF
--- a/src/main/java/network/crypta/support/BinaryBloomFilter.java
+++ b/src/main/java/network/crypta/support/BinaryBloomFilter.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel.MapMode;
 import java.nio.channels.FileChannel;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -78,7 +77,7 @@ public final class BinaryBloomFilter extends BloomFilter {
     try (RandomAccessFile raf = new RandomAccessFile(file, "rw");
         FileChannel channel = raf.getChannel()) {
       raf.setLength(length / 8);
-      filter = channel.map(MapMode.READ_WRITE, 0, length / 8).load();
+      filter = mapReadWrite(channel, length / 8L);
     }
   }
 

--- a/src/main/java/network/crypta/support/BloomFilter.java
+++ b/src/main/java/network/crypta/support/BloomFilter.java
@@ -3,9 +3,12 @@ package network.crypta.support;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.lang.ref.Cleaner;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
 import java.util.Random;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -48,6 +51,12 @@ public abstract class BloomFilter implements AutoCloseable {
 
   /** Read/write lock guarding read and update operations. */
   protected ReadWriteLock lock = new ReentrantReadWriteLock();
+
+  /** Arena owning a mapped segment for deterministic unmapping on close. */
+  protected Arena mappedArena;
+
+  /** Mapped segment backing {@link #filter} when file-backed mapping is used. */
+  protected MemorySegment mappedSegment;
 
   // Cleaner action for safety net resource cleanup
   private final Cleaner.Cleanable cleanable;
@@ -177,6 +186,33 @@ public abstract class BloomFilter implements AutoCloseable {
 
     // Register cleaner for safety net (will be cleaned up when close() is called properly)
     this.cleanable = cleaner.register(this, new FilterCleanup(this));
+  }
+
+  /**
+   * Maps a channel region using an explicit arena so unmapping is deterministic on {@link
+   * #close()}.
+   *
+   * <p>Implementations that create file-backed filters should use this helper instead of the legacy
+   * three-argument {@link FileChannel#map(FileChannel.MapMode, long, long)} call.
+   *
+   * @param channel source file channel
+   * @param size region size in bytes
+   * @return byte buffer view over the mapped segment
+   * @throws IOException if mapping fails
+   */
+  protected final ByteBuffer mapReadWrite(FileChannel channel, long size) throws IOException {
+    Arena arena = Arena.ofShared();
+    try {
+      mappedArena = arena;
+      mappedSegment = channel.map(FileChannel.MapMode.READ_WRITE, 0, size, mappedArena);
+      mappedSegment.load();
+      return mappedSegment.asByteBuffer();
+    } catch (IOException | RuntimeException e) {
+      mappedSegment = null;
+      mappedArena = null;
+      arena.close();
+      throw e;
+    }
   }
 
   // -- Core
@@ -409,6 +445,10 @@ public abstract class BloomFilter implements AutoCloseable {
    * <p>No effect for heap buffers.
    */
   public void force() {
+    if (mappedSegment != null) {
+      mappedSegment.force();
+      return;
+    }
     if (filter instanceof MappedByteBuffer buffer) {
       buffer.force();
     }
@@ -427,6 +467,11 @@ public abstract class BloomFilter implements AutoCloseable {
     }
     filter = null;
     forkedFilter = null;
+    mappedSegment = null;
+    if (mappedArena != null) {
+      mappedArena.close();
+      mappedArena = null;
+    }
 
     // Clean up the cleaner since we've properly closed resources
     if (cleanable != null) {

--- a/src/main/java/network/crypta/support/CountingBloomFilter.java
+++ b/src/main/java/network/crypta/support/CountingBloomFilter.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel.MapMode;
 import java.nio.channels.FileChannel;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -105,7 +104,7 @@ public final class CountingBloomFilter extends BloomFilter {
     try (RandomAccessFile raf = new RandomAccessFile(file, "rw");
         FileChannel channel = raf.getChannel()) {
       raf.setLength(fileLength);
-      filter = channel.map(MapMode.READ_WRITE, 0, fileLength).load();
+      filter = mapReadWrite(channel, fileLength);
     }
   }
 

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherTest.java
@@ -79,6 +79,12 @@ class SplitFileFetcherTest {
     }
   }
 
+  private static void deleteTempFile(File tmp) {
+    if (!tmp.delete() && tmp.exists()) {
+      tmp.deleteOnExit();
+    }
+  }
+
   private static byte[] resumeRecordForTruncation(File file, long size, long token)
       throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -131,7 +137,7 @@ class SplitFileFetcherTest {
     long token = 987654321L;
     SplitFileFetcher f = newResumedFetcherWithTruncation(tmp, tmp.length(), token);
     assertEquals(token, f.getToken());
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -148,7 +154,7 @@ class SplitFileFetcherTest {
     f.onFetchedBlock();
 
     verify(parent).completedBlock(false, clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -168,7 +174,7 @@ class SplitFileFetcherTest {
     f.onFetchedBlock();
 
     verify(parent).completedBlock(true, clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -187,7 +193,7 @@ class SplitFileFetcherTest {
     f.onFetchedBlock();
 
     verify(parent).completedBlock(false, clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -207,7 +213,7 @@ class SplitFileFetcherTest {
     f.onFetchedBlock();
 
     verify(parent).completedBlock(false, clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -222,7 +228,7 @@ class SplitFileFetcherTest {
     f.onFailedBlock();
 
     verify(parent).failedBlock(clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -240,7 +246,7 @@ class SplitFileFetcherTest {
 
     verify(parent).onFailure(captor.capture(), eq(f), eq(clientContext));
     assertEquals(FetchExceptionMode.CANCELLED, captor.getValue().getMode());
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -267,7 +273,7 @@ class SplitFileFetcherTest {
     // Scheduler invocation to remove pending keys (null keyListener on a mock storage is fine)
     verify(scheduler)
         .removePendingKeys((KeyListener) org.mockito.ArgumentMatchers.isNull(), eq(true));
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -293,7 +299,7 @@ class SplitFileFetcherTest {
     verify(parent).blockSetFinalized(clientContext);
     verify(parent).onExpectedMIME(meta, clientContext);
     verify(parent).onExpectedSize(123L, clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -310,7 +316,7 @@ class SplitFileFetcherTest {
     verify(parent).addMustSucceedBlocks(4);
     verify(parent).addBlocks(7);
     verify(parent).notifyClients(clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -340,7 +346,7 @@ class SplitFileFetcherTest {
             false,
             true,
             clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -355,7 +361,7 @@ class SplitFileFetcherTest {
     ClientCHKBlock block = mock(ClientCHKBlock.class);
     f.maybeAddToBinaryBlob(block);
     verify(parent).addKeyToBinaryBlob(block, clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -367,7 +373,7 @@ class SplitFileFetcherTest {
     SplitFileFetcher f = newResumedFetcherWithTruncation(tmp, tmp.length(), 12L);
     setField(f, "getter", sendableGetter);
     assertEquals(sendableGetter, f.getSendableGet());
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -385,7 +391,7 @@ class SplitFileFetcherTest {
 
     verify(sendableGetter).clearWakeupTime(clientContext);
     verify(sendableGetter).reduceWakeupTime(123L, clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -402,7 +408,7 @@ class SplitFileFetcherTest {
     setField(f, "context", clientContext);
     f.cancel(clientContext);
     assertTrue(f.hasFinished());
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -444,7 +450,7 @@ class SplitFileFetcherTest {
     assertEquals(tmp.getAbsolutePath(), path);
     assertEquals(tmp.length(), size);
     assertEquals(token, tok);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -479,7 +485,7 @@ class SplitFileFetcherTest {
     assertEquals(5, f.getPriorityClass());
     f.toNetwork();
     verify(parent).toNetwork(clientContext);
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 
   @Test
@@ -505,6 +511,6 @@ class SplitFileFetcherTest {
     }
     SplitFileFetcher f = newResumedFetcherWithTruncation(tmp, tmp.length(), 16L);
     assertTrue(f.localRequestOnly());
-    assertTrue(tmp.delete() || !tmp.exists());
+    deleteTempFile(tmp);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -94,7 +95,7 @@ class ClientPutDiskDirMessageTest {
     Path file = Files.writeString(tempDir.resolve("index.html"), "<html>");
     Path nestedDir = Files.createDirectory(tempDir.resolve("assets"));
     Path nestedFile = Files.writeString(nestedDir.resolve("style.css"), "body");
-    Files.writeString(tempDir.resolve(".secret"), "hidden");
+    Path hiddenFile = createHiddenFile(tempDir);
 
     ClientPutDiskDirMessage message = newMessage(tempDir);
 
@@ -105,7 +106,7 @@ class ClientPutDiskDirMessageTest {
     verify(handler).startClientPutDir(eq(message), bucketsCaptor.capture(), eq(true));
     HashMap<String, Object> buckets = bucketsCaptor.getValue();
 
-    assertFalse(buckets.containsKey(".secret"));
+    assertFalse(buckets.containsKey(hiddenFile.getFileName().toString()));
 
     ManifestElement rootElement = (ManifestElement) buckets.get("index.html");
     assertEquals("index.html", rootElement.fullName);
@@ -222,5 +223,19 @@ class ClientPutDiskDirMessageTest {
       fs.put("includeHiddenFiles", true);
     }
     return new ClientPutDiskDirMessage(fs);
+  }
+
+  private static Path createHiddenFile(Path directory) throws IOException {
+    Path hiddenFile;
+    if (Files.getFileStore(directory).supportsFileAttributeView("dos")) {
+      hiddenFile = directory.resolve("hidden-file.txt");
+      Files.writeString(hiddenFile, "hidden");
+      Files.setAttribute(hiddenFile, "dos:hidden", true);
+    } else {
+      hiddenFile = directory.resolve(".secret");
+      Files.writeString(hiddenFile, "hidden");
+    }
+    Assumptions.assumeTrue(hiddenFile.toFile().isHidden(), "Unable to create hidden file");
+    return hiddenFile;
   }
 }

--- a/src/test/java/network/crypta/clients/http/LocalDownloadDirectoryToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/LocalDownloadDirectoryToadletTest.java
@@ -54,12 +54,16 @@ class LocalDownloadDirectoryToadletTest {
 
   private static Stream<Arguments> startingDirScenarios() {
     return Stream.of(
-        Arguments.of(new File[] {new File("all")}, new File("/downloads"), "/downloads"),
-        Arguments.of(new File[] {}, new File("/downloads"), "/downloads"),
+        Arguments.of(
+            new File[] {new File("all")},
+            new File("/downloads"),
+            new File("/downloads").getAbsolutePath()),
+        Arguments.of(
+            new File[] {}, new File("/downloads"), new File("/downloads").getAbsolutePath()),
         Arguments.of(
             new File[] {new File("/allowed/path"), new File("/other")},
             new File("/downloads"),
-            "/allowed/path"));
+            new File("/allowed/path").getAbsolutePath()));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Replace legacy 3-arg memory-mapped file creation in Bloom filters with JDK 25 arena-backed mappings so mapped segments can be closed deterministically.
- Update Bloom filter close/force lifecycle to flush mapped segments and close the mapping arena.
- Make Windows-sensitive tests robust by:
  - avoiding strict immediate temp file deletion in `SplitFileFetcherTest`,
  - using absolute-path expectations in `LocalDownloadDirectoryToadletTest`,
  - creating/asserting hidden files portably in `ClientPutDiskDirMessageTest`.

## How to test
- Run formatter:
  - `./gradlew spotlessApply`
- Run targeted tests:
  - `./gradlew test --tests '*SplitFileFetcherTest' --tests '*LocalDownloadDirectoryToadletTest' --tests '*ClientPutDiskDirMessageTest' --tests '*CountingBloomFilterTest' --tests '*BinaryBloomFilterTest' --tests '*BloomFilterTest'`

## Notes
- This change targets Windows CI failures related to `user-mapped section open` file errors and platform-specific path/hidden-file assumptions.
