### PR TITLE
fix(fs): Handle Snap mount lookup failures in ensureDir

### DIFF
--- a/src/main/java/network/crypta/fs/Dirs.java
+++ b/src/main/java/network/crypta/fs/Dirs.java
@@ -92,11 +92,20 @@ public final class Dirs {
         throw new UncheckedIOException("Failed to create directory: " + path, e);
       }
     }
+    Set<PosixFilePermission> set;
     try {
-      if (Files.getFileStore(path).supportsFileAttributeView("posix")) {
-        Set<PosixFilePermission> set = PosixFilePermissions.fromString(perms);
-        Files.setPosixFilePermissions(path, set);
-      }
+      set = PosixFilePermissions.fromString(perms);
+    } catch (IllegalArgumentException e) {
+      LOG.warn("Failed to set POSIX permissions '{}' on {}: {}", perms, path, e.getMessage(), e);
+      return;
+    }
+    try {
+      Files.setPosixFilePermissions(path, set);
+    } catch (UnsupportedOperationException _) {
+      LOG.debug(
+          "Skipping POSIX permissions '{}' on {} because POSIX attributes are unsupported",
+          perms,
+          path);
     } catch (Exception e) {
       LOG.warn("Failed to set POSIX permissions '{}' on {}: {}", perms, path, e.getMessage(), e);
     }

--- a/src/test/java/network/crypta/fs/DirsTest.java
+++ b/src/test/java/network/crypta/fs/DirsTest.java
@@ -1,11 +1,14 @@
 package network.crypta.fs;
 
+import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
@@ -55,6 +58,48 @@ class DirsTest {
 
     // Act
     assertDoesNotThrow(() -> Dirs.ensureDir(target, "invalid"));
+
+    // Assert
+    assertTrue(Files.isDirectory(target));
+  }
+
+  @Test
+  void ensureDir_whenSettingPermissionsThrowsIOException_expectNoException() {
+    // Arrange
+    Path target = tempDir.resolve("io-permissions-error");
+
+    // Act
+    try (MockedStatic<Files> files = Mockito.mockStatic(Files.class, Mockito.CALLS_REAL_METHODS)) {
+      files
+          .when(
+              () ->
+                  Files.setPosixFilePermissions(
+                      Mockito.eq(target), Mockito.<Set<PosixFilePermission>>any()))
+          .thenThrow(new IOException("Mount point not found"));
+
+      assertDoesNotThrow(() -> Dirs.ensureDir(target, Dirs.PERM_GROUP_RX));
+    }
+
+    // Assert
+    assertTrue(Files.isDirectory(target));
+  }
+
+  @Test
+  void ensureDir_whenPosixUnsupported_expectNoException() {
+    // Arrange
+    Path target = tempDir.resolve("unsupported-posix");
+
+    // Act
+    try (MockedStatic<Files> files = Mockito.mockStatic(Files.class, Mockito.CALLS_REAL_METHODS)) {
+      files
+          .when(
+              () ->
+                  Files.setPosixFilePermissions(
+                      Mockito.eq(target), Mockito.<Set<PosixFilePermission>>any()))
+          .thenThrow(new UnsupportedOperationException("posix unsupported"));
+
+      assertDoesNotThrow(() -> Dirs.ensureDir(target, Dirs.PERM_GROUP_RX));
+    }
 
     // Assert
     assertTrue(Files.isDirectory(target));


### PR DESCRIPTION
## Summary
- remove the `Files.getFileStore(path)` probe from `Dirs.ensureDir`, which can throw `Mount point not found` under Snap mount namespaces
- set POSIX permissions directly via `Files.setPosixFilePermissions` and keep permission failures non-fatal
- treat unsupported POSIX attributes as a debug-level skip
- add tests covering `IOException` and `UnsupportedOperationException` during permission setting

## How to test
- run `./gradlew test --tests *DirsTest`
- run the node in an Ubuntu Snap container and verify startup no longer logs the `Mount point not found` warning from `network.crypta.fs.Dirs`

## Notes
- base branch for this PR is `release/2` (requested current branch)
- behavior remains best-effort for filesystem permissions and startup is unchanged aside from eliminating the FileStore lookup failure path