### PR TITLE
build(gradle): Centralize JetBrains annotations version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  // Apply Gradle 9 convention plugins from included build
+  // Apply Gradle 9 convention plugins from the included build
   id("cryptad.java-kotlin-conventions")
   id("cryptad.spotless")
   id("cryptad.versioning")
@@ -44,7 +44,7 @@ dependencies {
   // Compile-time access to Logback classes for runtime reconfiguration
   compileOnly(libs.logbackClassic)
   // Java source annotations used across the codebase
-  compileOnly("org.jetbrains:annotations:23.0.0")
+  compileOnly(libs.jetbrainsAnnotations)
 
   // runtimeOnly
   runtimeOnly(libs.dbusTransportNativeUnix)
@@ -63,7 +63,7 @@ dependencies {
   testImplementation(libs.mockitoInline)
   testImplementation(libs.hamcrest)
   testImplementation(libs.objenesis)
-  testCompileOnly("org.jetbrains:annotations:23.0.0")
+  testCompileOnly(libs.jetbrainsAnnotations)
 
   // testRuntimeOnly
   testRuntimeOnly(libs.junitJupiterEngine)
@@ -79,7 +79,7 @@ tasks.register("printVersion") {
 
 // The default from build-logic (512m) is too small for the full test suite on Windows and can
 // trigger OOM in long-running integration tests.
-tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach { maxHeapSize = "2g" }
+tasks.withType<Test>().configureEach { maxHeapSize = "2g" }
 
 // Application entrypoint (used by jpackage). This does not change how we build the wrapper
 // distribution; it's only to inform launchers that invoke the launcher main class directly.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ spotbugs = "6.4.8"
 jacoco = "0.8.14"
 errorpronePlugin = "5.0.0"
 errorproneCore = "2.38.0"
+jetbrainsAnnotations = "23.0.0"
 
 [libraries]
 bcprov = { group = "org.bouncycastle", name = "bcprov-lts8on", version.ref = "bcprov" }
@@ -53,6 +54,7 @@ junitJupiterEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine
 junitPlatformLauncher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junitPlatform" }
 junitPlatformSuite = { group = "org.junit.platform", name = "junit-platform-suite", version.ref = "junitPlatform" }
 errorproneCore = { group = "com.google.errorprone", name = "error_prone_core", version.ref = "errorproneCore" }
+jetbrainsAnnotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrainsAnnotations" }
 
 [plugins]
 #noinspection UnusedVersionCatalogEntry


### PR DESCRIPTION
## Summary
- Replace hardcoded `org.jetbrains:annotations:23.0.0` entries in `build.gradle.kts` with a version-catalog alias.
- Add `jetbrainsAnnotations` to `gradle/libs.versions.toml` under `[versions]` and `[libraries]`.
- Keep formatting consistent after Spotless.

## How to test
- Run `./gradlew help` and confirm the build config resolves successfully.
- Optionally run `./gradlew spotlessApply` to verify formatting stays clean.

## Notes
- PR base branch is `release/2` (requested: current branch as base).