### PR TITLE
fix(fcp): Avoid input-output lock-order deadlock

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionOutputHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionOutputHandler.java
@@ -160,9 +160,11 @@ public class FCPConnectionOutputHandler implements Runnable {
   }
 
   private QueueAction nextQueueAction(boolean flushedSinceLastSend) throws InterruptedException {
-    synchronized (outQueue) {
-      while (true) {
-        boolean closed = handler.isClosed();
+    while (true) {
+      // Read the handler state before taking the queue monitor to keep lock ordering consistent
+      // with input-side code paths that already hold the handler lock and then inspect outQueue.
+      boolean closed = handler.isClosed();
+      synchronized (outQueue) {
         if (!outQueue.isEmpty()) {
           return QueueAction.message(outQueue.removeFirst());
         }

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionOutputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionOutputHandlerTest.java
@@ -18,10 +18,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -81,6 +83,27 @@ class FCPConnectionOutputHandlerTest {
     when(handler.getSocket()).thenReturn(socket);
     when(socket.getOutputStream()).thenReturn(outputStream);
     when(handler.isClosed()).thenReturn(true);
+
+    outputHandler.run();
+
+    verify(outputStream, atLeastOnce()).flush();
+    verify(outputStream).close();
+    verify(handler).close();
+    verify(handler).closedOutput();
+    assertTrue(outputHandler.closedOutputQueue);
+  }
+
+  @Test
+  void run_whenCheckingClosedState_doesNotHoldQueueMonitor() throws IOException {
+    when(handler.getSocket()).thenReturn(socket);
+    when(socket.getOutputStream()).thenReturn(outputStream);
+    doAnswer(
+            invocation -> {
+              assertFalse(Thread.holdsLock(outputHandler.outQueue));
+              return true;
+            })
+        .when(handler)
+        .isClosed();
 
     outputHandler.run();
 


### PR DESCRIPTION
## Summary
- break the FCP output-thread lock inversion by reading `handler.isClosed()` before acquiring `outQueue` in `nextQueueAction()`
- add a regression test that asserts `isClosed()` is never invoked while holding `outQueue`
- preserve existing queue behavior while removing the `outQueue -> handler` ordering that deadlocked against input-side `handler -> outQueue` paths

## How To Test
- `./gradlew test --tests *FCPConnectionOutputHandlerTest`
- `./gradlew test`

## Context
- investigated `threads_report.txt` and found repeated mutual wait cycles between FCP input/output handlers (ArrayDeque vs FCPConnectionHandler monitor)
- this patch targets that lock-order cycle directly