### PR TITLE
fix(client-async): Harden USK datehint resume and cancel handling

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientRequestScheduler.java
+++ b/src/main/java/network/crypta/client/async/ClientRequestScheduler.java
@@ -597,6 +597,20 @@ public class ClientRequestScheduler implements RequestScheduler {
   }
 
   /**
+   * Returns the absolute wakeup timestamp for a given priority class when that class is currently
+   * in cooldown.
+   *
+   * <p>Returns {@code 0} when no finite cooldown is active for the specified priority class.
+   *
+   * @param priorityClass scheduler priority class to inspect
+   * @param now current wall-clock time in milliseconds
+   * @return absolute wakeup timestamp, or {@code 0} if the priority is currently runnable
+   */
+  public long getPriorityCooldownUntil(short priorityClass, long now) {
+    return selector.getPriorityCooldownUntil(priorityClass, clientContext, now);
+  }
+
+  /**
    * Returns a view of keys currently being fetched locally.
    *
    * @return an implementation of {@link KeysFetchingLocally} backed by the selector

--- a/src/main/java/network/crypta/client/async/ClientRequestSelector.java
+++ b/src/main/java/network/crypta/client/async/ClientRequestSelector.java
@@ -1044,6 +1044,33 @@ public class ClientRequestSelector implements KeysFetchingLocally {
     return total;
   }
 
+  /**
+   * Returns the absolute wakeup timestamp for a specific priority class, if that priority is
+   * currently in cooldown.
+   *
+   * <p>The value is suitable for comparing against {@link System#currentTimeMillis()}. Returns
+   * {@code 0} when the priority is currently runnable or when no finite cooldown is known.
+   *
+   * @param priorityClass scheduler priority class to inspect
+   * @param context client context used by the cooldown tracker
+   * @param now current wall-clock time in milliseconds
+   * @return absolute wakeup timestamp, or {@code 0} when no finite cooldown is active
+   */
+  synchronized long getPriorityCooldownUntil(short priorityClass, ClientContext context, long now) {
+    if (priorityClass < 0 || priorityClass >= priorities.length) {
+      return 0L;
+    }
+    RequestClientRGANode tracker = priorities[priorityClass];
+    if (tracker == null) {
+      return 0L;
+    }
+    long wakeup = tracker.getWakeupTime(context, now);
+    if (wakeup == Long.MAX_VALUE || wakeup <= now) {
+      return 0L;
+    }
+    return wakeup;
+  }
+
   private long printAndCountPriority(int index, RequestClientRGANode prio, ClientContext context) {
     if (prio == null || prio.isEmpty()) {
       LOG.info("{}{} : empty", PRIORITY, index);

--- a/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/src/main/java/network/crypta/client/async/USKInserter.java
@@ -388,6 +388,14 @@ public final class USKInserter
         return;
       }
       if (decision.retryOnStallCancel) {
+        if (isParentRequestCancelled()) {
+          LOG.warn(
+              "Skipping USK datehint retry for {} edition {} because parent request was cancelled"
+                  + " before retry scheduling",
+              USKInserter.this,
+              edition);
+          return;
+        }
         LOG.warn(
             "Retrying USK datehint insert phase for {} edition {} after watchdog cancel (attempt {}"
                 + " of {})",

--- a/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/src/main/java/network/crypta/client/async/USKInserter.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
@@ -125,6 +126,12 @@ public final class USKInserter
   /** After this many attempted slots without success, fall back to re-fetch the latest. */
   private static final long MAX_TRIED_SLOTS = 10;
 
+  /** Maximum time to wait for USK datehint child inserts to make progress before retrying. */
+  private static final long DATEHINT_STALL_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(15);
+
+  /** Retry stalled USK datehint phase at most this many times before surfacing failure. */
+  private static final int MAX_DATEHINT_STALL_RETRIES = 1;
+
   /** If true, frees {@link #data} after completion or terminal failure. */
   private final boolean freeData;
 
@@ -139,6 +146,216 @@ public final class USKInserter
 
   /** Optional override for the crypto key material; {@code null} to auto-generate. */
   final byte[] forceCryptoKey;
+
+  /** Active datehint insert phase; null when not currently inserting datehints. */
+  private transient DateHintPhase activeDateHintPhase;
+
+  /** Monotonic identifier for datehint phases; helps ignore stale callbacks. */
+  private transient long nextDateHintPhaseId = 1;
+
+  /**
+   * Runtime-only state for one active datehint insert phase.
+   *
+   * <p>This state is intentionally transient and rebuilt by the terminal callback's {@link
+   * PutCompletionCallback#onResume(ClientContext)} path after restart.
+   */
+  private static final class DateHintPhase {
+    final long phaseId;
+    final int retryCount;
+    final DateHintTerminalCallback terminalCallback;
+    long lastProgressAtMillis;
+    boolean watchdogCancelIssued;
+
+    DateHintPhase(long phaseId, int retryCount, DateHintTerminalCallback terminalCallback) {
+      this.phaseId = phaseId;
+      this.retryCount = retryCount;
+      this.terminalCallback = terminalCallback;
+      this.lastProgressAtMillis = System.currentTimeMillis();
+      this.watchdogCancelIssued = false;
+    }
+  }
+
+  /**
+   * Terminal callback for a datehint phase.
+   *
+   * <p>Delegates normal notifications to {@link #cb}, while intercepting terminal success/failure
+   * so we can retry a stalled phase once when the watchdog cancels it for lack of progress.
+   */
+  private final class DateHintTerminalCallback implements PutCompletionCallback, Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final long phaseId;
+    private final long edition;
+    private final int retryCount;
+    private MultiPutCompletionCallback group;
+    private transient volatile boolean awaitingPhaseRestore;
+    private transient volatile boolean completedBeforePhaseRestore;
+
+    DateHintTerminalCallback(long phaseId, long edition, int retryCount) {
+      this.phaseId = phaseId;
+      this.edition = edition;
+      this.retryCount = retryCount;
+      this.awaitingPhaseRestore = false;
+    }
+
+    void bindGroup(MultiPutCompletionCallback group) {
+      this.group = group;
+    }
+
+    void cancelGroup(ClientContext context) {
+      MultiPutCompletionCallback localGroup = group;
+      if (localGroup != null) localGroup.cancel(context);
+    }
+
+    private boolean isParentRequestCancelled() {
+      BaseClientPutter parentPutter = parent;
+      return parentPutter == null || parentPutter.isCancelled();
+    }
+
+    private PutCompletionCallback getCompletionCallbackOrNull(String eventName) {
+      PutCompletionCallback callback = cb;
+      if (callback == null && LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Dropping datehint {} callback for {} phase {} because completion callback is null",
+            eventName,
+            USKInserter.this,
+            phaseId);
+      }
+      return callback;
+    }
+
+    private void markDateHintProgress(long phaseId) {
+      synchronized (USKInserter.this) {
+        if (activeDateHintPhase == null || activeDateHintPhase.phaseId != phaseId) return;
+        activeDateHintPhase.lastProgressAtMillis = System.currentTimeMillis();
+      }
+    }
+
+    private void onDateHintPhaseResumed(ClientContext context) {
+      synchronized (USKInserter.this) {
+        DateHintPhase current = activeDateHintPhase;
+        if (current == null || current.phaseId != phaseId) {
+          activeDateHintPhase = new DateHintPhase(phaseId, retryCount, this);
+          nextDateHintPhaseId = Math.max(nextDateHintPhaseId, phaseId + 1);
+        } else {
+          current.lastProgressAtMillis = System.currentTimeMillis();
+        }
+      }
+      scheduleDateHintWatchdog(context, phaseId, DATEHINT_STALL_TIMEOUT_MILLIS);
+    }
+
+    private void onDateHintPhaseFinished(
+        ClientPutState completedState, InsertException failure, ClientContext context) {
+      boolean retryOnStallCancel;
+      synchronized (USKInserter.this) {
+        DateHintPhase phase = activeDateHintPhase;
+        if (phase == null) {
+          // Resume-order race: MultiPut resumes children before callback.onResume() rebuilds phase.
+          if (!awaitingPhaseRestore || completedBeforePhaseRestore) return;
+          retryOnStallCancel = false;
+          completedBeforePhaseRestore = true;
+        } else {
+          if (phase.phaseId != phaseId) return;
+          retryOnStallCancel =
+              failure != null
+                  && phase.watchdogCancelIssued
+                  && failure.getMode() == InsertExceptionMode.CANCELLED
+                  && retryCount < MAX_DATEHINT_STALL_RETRIES
+                  && !isParentRequestCancelled();
+          activeDateHintPhase = null;
+        }
+      }
+      if (retryOnStallCancel) {
+        LOG.warn(
+            "Retrying USK datehint insert phase for {} edition {} after watchdog cancel (attempt {}"
+                + " of {})",
+            USKInserter.this,
+            edition,
+            retryCount + 1,
+            MAX_DATEHINT_STALL_RETRIES);
+        startDateHintInsertPhase(context, edition, retryCount + 1, completedState);
+        return;
+      }
+      PutCompletionCallback callback =
+          getCompletionCallbackOrNull(failure != null ? "onFailure" : "onSuccess");
+      if (callback == null) return;
+      if (failure != null) callback.onFailure(failure, completedState, context);
+      else callback.onSuccess(completedState, context);
+    }
+
+    @Override
+    public void onSuccess(ClientPutState state, ClientContext context) {
+      markDateHintProgress(phaseId);
+      onDateHintPhaseFinished(state, null, context);
+    }
+
+    @Override
+    public void onFailure(InsertException e, ClientPutState state, ClientContext context) {
+      markDateHintProgress(phaseId);
+      onDateHintPhaseFinished(state, e, context);
+    }
+
+    @Override
+    public void onEncode(BaseClientKey usk, ClientPutState state, ClientContext context) {
+      markDateHintProgress(phaseId);
+      PutCompletionCallback callback = getCompletionCallbackOrNull("onEncode");
+      if (callback != null) callback.onEncode(usk, state, context);
+    }
+
+    @Override
+    public void onTransition(
+        ClientPutState oldState, ClientPutState newState, ClientContext context) {
+      markDateHintProgress(phaseId);
+      PutCompletionCallback callback = getCompletionCallbackOrNull("onTransition");
+      if (callback != null) callback.onTransition(oldState, newState, context);
+    }
+
+    @Override
+    public void onMetadata(Metadata m, ClientPutState state, ClientContext context) {
+      markDateHintProgress(phaseId);
+      PutCompletionCallback callback = getCompletionCallbackOrNull("onMetadataMetadata");
+      if (callback != null) callback.onMetadata(m, state, context);
+    }
+
+    @Override
+    public void onMetadata(Bucket meta, ClientPutState state, ClientContext context) {
+      markDateHintProgress(phaseId);
+      PutCompletionCallback callback = getCompletionCallbackOrNull("onMetadataBucket");
+      if (callback != null) callback.onMetadata(meta, state, context);
+    }
+
+    @Override
+    public void onFetchable(ClientPutState state) {
+      markDateHintProgress(phaseId);
+      PutCompletionCallback callback = getCompletionCallbackOrNull("onFetchable");
+      if (callback != null) callback.onFetchable(state);
+    }
+
+    @Override
+    public void onBlockSetFinished(ClientPutState state, ClientContext context) {
+      markDateHintProgress(phaseId);
+      PutCompletionCallback callback = getCompletionCallbackOrNull("onBlockSetFinished");
+      if (callback != null) callback.onBlockSetFinished(state, context);
+    }
+
+    @Override
+    public void onResume(ClientContext context) throws InsertException, ResumeFailedException {
+      if (!completedBeforePhaseRestore) {
+        onDateHintPhaseResumed(context);
+      }
+      awaitingPhaseRestore = false;
+      PutCompletionCallback callback = getCompletionCallbackOrNull("onResume");
+      if (callback != null && callback != parent) callback.onResume(context);
+    }
+
+    @Serial
+    private void readObject(java.io.ObjectInputStream in)
+        throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      awaitingPhaseRestore = true;
+      completedBeforePhaseRestore = false;
+    }
+  }
 
   /**
    * Starts the asynchronous USK insert process.
@@ -264,11 +481,26 @@ public final class USKInserter
       cb.onSuccess(this, context);
       return;
     }
+    startDateHintInsertPhase(context, edition, 0, this);
+  }
+
+  private void startDateHintInsertPhase(
+      ClientContext context, long edition, int retryCount, ClientPutState transitionFrom) {
     if (LOG.isDebugEnabled())
-      LOG.debug("Inserted to edition {} - inserting USK date hints...", edition);
+      LOG.debug(
+          "Inserted to edition {} - inserting USK date hints (retry {} of {})...",
+          edition,
+          retryCount,
+          MAX_DATEHINT_STALL_RETRIES);
     USKDateHint hint = USKDateHint.now();
+    long phaseId = reserveDateHintPhaseId();
+    DateHintTerminalCallback terminalCallback =
+        new DateHintTerminalCallback(phaseId, edition, retryCount);
     MultiPutCompletionCallback m =
-        new MultiPutCompletionCallback(cb, parent, tokenObject, persistent, true);
+        new MultiPutCompletionCallback(terminalCallback, parent, tokenObject, persistent, true);
+    terminalCallback.bindGroup(m);
+    activateDateHintPhase(new DateHintPhase(phaseId, retryCount, terminalCallback));
+
     byte[] hintData = hint.getData(edition).getBytes(StandardCharsets.UTF_8);
     FreenetURI[] hintURIs = hint.getInsertURIs(privUSK);
     boolean added = false;
@@ -290,6 +522,7 @@ public final class USKInserter
       } catch (IOException e) {
         LOG.error("Unable to insert USK date hints due to disk I/O error: {}", e, e);
         if (!added) {
+          clearActiveDateHintPhase(phaseId);
           cb.onFailure(
               new InsertException(
                   InsertExceptionMode.BUCKET_ERROR, e, pubUSK.getSSK(edition).getURI()),
@@ -300,13 +533,74 @@ public final class USKInserter
       } catch (InsertException e) {
         LOG.error("Unable to insert USK date hints due to error: {}", e, e);
         if (!added) {
+          clearActiveDateHintPhase(phaseId);
           cb.onFailure(e, this, context);
           return;
         } // Else try to insert the other hints.
       }
     }
-    cb.onTransition(this, m, context);
+    if (!added) {
+      clearActiveDateHintPhase(phaseId);
+      cb.onSuccess(this, context);
+      return;
+    }
+    cb.onTransition(transitionFrom, m, context);
     m.arm(context);
+    scheduleDateHintWatchdog(context, phaseId, DATEHINT_STALL_TIMEOUT_MILLIS);
+  }
+
+  private synchronized long reserveDateHintPhaseId() {
+    return nextDateHintPhaseId++;
+  }
+
+  private synchronized void activateDateHintPhase(DateHintPhase phase) {
+    activeDateHintPhase = phase;
+    nextDateHintPhaseId = Math.max(nextDateHintPhaseId, phase.phaseId + 1);
+  }
+
+  private synchronized void clearActiveDateHintPhase(long phaseId) {
+    if (activeDateHintPhase != null && activeDateHintPhase.phaseId == phaseId) {
+      activeDateHintPhase = null;
+    }
+  }
+
+  private void scheduleDateHintWatchdog(ClientContext context, long phaseId, long delayMillis) {
+    if (context.ticker == null) return;
+    long boundedDelay = Math.max(1L, delayMillis);
+    context.ticker.queueTimedJob(() -> runDateHintWatchdog(context, phaseId), boundedDelay);
+  }
+
+  private void runDateHintWatchdog(ClientContext context, long phaseId) {
+    DateHintTerminalCallback callbackToCancel = null;
+    long rescheduleDelay = -1L;
+    long stalledFor;
+    int retryCount = 0;
+    synchronized (this) {
+      DateHintPhase phase = activeDateHintPhase;
+      if (phase == null || phase.phaseId != phaseId) return;
+      long now = System.currentTimeMillis();
+      stalledFor = now - phase.lastProgressAtMillis;
+      if (stalledFor < DATEHINT_STALL_TIMEOUT_MILLIS) {
+        rescheduleDelay = DATEHINT_STALL_TIMEOUT_MILLIS - stalledFor;
+      } else if (!phase.watchdogCancelIssued) {
+        phase.watchdogCancelIssued = true;
+        callbackToCancel = phase.terminalCallback;
+        retryCount = phase.retryCount;
+      }
+    }
+    if (rescheduleDelay > 0L) {
+      scheduleDateHintWatchdog(context, phaseId, rescheduleDelay);
+      return;
+    }
+    if (callbackToCancel == null) return;
+    LOG.warn(
+        "USK datehint insert phase {} stalled for {} ms on {} (retry {} of {}) - cancelling phase",
+        phaseId,
+        stalledFor,
+        this,
+        retryCount,
+        MAX_DATEHINT_STALL_RETRIES);
+    callbackToCancel.cancelGroup(context);
   }
 
   private void scheduleInsert(ClientContext context) {
@@ -530,6 +824,7 @@ public final class USKInserter
   public void cancel(ClientContext context) {
     USKFetcherTag tag;
     SingleBlockInserter localSbi;
+    DateHintTerminalCallback localDateHintCallback;
     synchronized (this) {
       if (finished) return;
       finished = true;
@@ -537,12 +832,18 @@ public final class USKInserter
       fetcher = null;
       localSbi = sbi;
       sbi = null;
+      localDateHintCallback =
+          (activeDateHintPhase == null) ? null : activeDateHintPhase.terminalCallback;
+      activeDateHintPhase = null;
     }
     if (tag != null) {
       tag.cancel(context);
     }
     if (localSbi != null) {
       localSbi.cancel(context); // will call onFailure, which will removeFrom()
+    }
+    if (localDateHintCallback != null) {
+      localDateHintCallback.cancelGroup(context);
     }
     if (freeData) {
       Bucket dataToFree;

--- a/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/src/main/java/network/crypta/client/async/USKInserter.java
@@ -129,6 +129,21 @@ public final class USKInserter
   /** Maximum time to wait for USK datehint child inserts to make progress before retrying. */
   private static final long DATEHINT_STALL_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(15);
 
+  /**
+   * Extra grace added when the SSK insert scheduler reports an explicit cooldown for this priority
+   * class.
+   */
+  private static final long DATEHINT_SCHEDULER_COOLDOWN_GRACE_MILLIS = TimeUnit.SECONDS.toMillis(5);
+
+  /**
+   * Time to wait after issuing a watchdog cancel before force-completing a stuck datehint phase.
+   *
+   * <p>This guards cases where child states never deliver terminal callbacks after cancel and the
+   * phase would otherwise remain pending indefinitely.
+   */
+  private static final long DATEHINT_CANCEL_COMPLETION_TIMEOUT_MILLIS =
+      TimeUnit.MINUTES.toMillis(1);
+
   /** Retry stalled USK datehint phase at most this many times before surfacing failure. */
   private static final int MAX_DATEHINT_STALL_RETRIES = 1;
 
@@ -147,6 +162,13 @@ public final class USKInserter
   /** Optional override for the crypto key material; {@code null} to auto-generate. */
   final byte[] forceCryptoKey;
 
+  /**
+   * Last known non-null external request identifier for diagnostics correlation.
+   *
+   * <p>Persisted so datehint child inserts can restore correlation metadata after restart.
+   */
+  private String externalRequestIdentifierSnapshot;
+
   /** Active datehint insert phase; null when not currently inserting datehints. */
   private transient DateHintPhase activeDateHintPhase;
 
@@ -163,16 +185,41 @@ public final class USKInserter
     final long phaseId;
     final int retryCount;
     final DateHintTerminalCallback terminalCallback;
+    final ClientPutState completionState;
     long lastProgressAtMillis;
     boolean watchdogCancelIssued;
+    long watchdogCancelIssuedAtMillis;
 
-    DateHintPhase(long phaseId, int retryCount, DateHintTerminalCallback terminalCallback) {
+    DateHintPhase(
+        long phaseId,
+        int retryCount,
+        DateHintTerminalCallback terminalCallback,
+        ClientPutState completionState) {
       this.phaseId = phaseId;
       this.retryCount = retryCount;
       this.terminalCallback = terminalCallback;
+      this.completionState = completionState;
       this.lastProgressAtMillis = System.currentTimeMillis();
       this.watchdogCancelIssued = false;
+      this.watchdogCancelIssuedAtMillis = 0L;
     }
+  }
+
+  private record DateHintPhaseFinishDecision(
+      boolean ignoreEvent,
+      boolean retryOnStallCancel,
+      boolean treatWatchdogCancelAsBestEffortSuccess) {}
+
+  private static final class DateHintWatchdogState {
+    DateHintTerminalCallback callbackToCancel;
+    DateHintTerminalCallback callbackToForceComplete;
+    ClientPutState forceCompletionState;
+    long rescheduleDelay = -1L;
+    long stalledFor;
+    long cancelAge;
+    int retryCount;
+    boolean evaluateSchedulerCooldown;
+    long schedulerCooldownDelay;
   }
 
   /**
@@ -233,45 +280,114 @@ public final class USKInserter
       }
     }
 
+    private long resumedPhaseWatchdogDelayMillis(DateHintPhase phase) {
+      if (!phase.watchdogCancelIssued) {
+        return DATEHINT_STALL_TIMEOUT_MILLIS;
+      }
+      long now = System.currentTimeMillis();
+      if (phase.watchdogCancelIssuedAtMillis <= 0L) {
+        phase.watchdogCancelIssuedAtMillis = now;
+      }
+      long cancelAge = now - phase.watchdogCancelIssuedAtMillis;
+      if (cancelAge >= DATEHINT_CANCEL_COMPLETION_TIMEOUT_MILLIS) {
+        return 1L;
+      }
+      return DATEHINT_CANCEL_COMPLETION_TIMEOUT_MILLIS - cancelAge;
+    }
+
     private void onDateHintPhaseResumed(ClientContext context) {
+      long watchdogDelayMillis;
       synchronized (USKInserter.this) {
         DateHintPhase current = activeDateHintPhase;
         if (current == null || current.phaseId != phaseId) {
-          DateHintPhase restored = new DateHintPhase(phaseId, retryCount, this);
+          ClientPutState resumedState = (group != null) ? group : USKInserter.this;
+          DateHintPhase restored = new DateHintPhase(phaseId, retryCount, this, resumedState);
           restored.watchdogCancelIssued = watchdogCancelIssued;
+          restored.watchdogCancelIssuedAtMillis =
+              watchdogCancelIssued ? System.currentTimeMillis() : 0L;
           activeDateHintPhase = restored;
           nextDateHintPhaseId = Math.max(nextDateHintPhaseId, phaseId + 1);
+          watchdogDelayMillis = resumedPhaseWatchdogDelayMillis(restored);
         } else {
           current.watchdogCancelIssued |= watchdogCancelIssued;
+          if (current.watchdogCancelIssued && current.watchdogCancelIssuedAtMillis <= 0L) {
+            current.watchdogCancelIssuedAtMillis = System.currentTimeMillis();
+          }
           current.lastProgressAtMillis = System.currentTimeMillis();
+          watchdogDelayMillis = resumedPhaseWatchdogDelayMillis(current);
         }
       }
-      scheduleDateHintWatchdog(context, phaseId, DATEHINT_STALL_TIMEOUT_MILLIS);
+      scheduleDateHintWatchdog(context, phaseId, watchdogDelayMillis);
+    }
+
+    private DateHintPhaseFinishDecision decideDateHintPhaseCompletion(InsertException failure) {
+      synchronized (USKInserter.this) {
+        DateHintPhase phase = activeDateHintPhase;
+        if (phase == null) {
+          return decideDateHintCompletionWithoutActivePhase();
+        }
+        if (phase.phaseId != phaseId) {
+          return new DateHintPhaseFinishDecision(true, false, false);
+        }
+        return decideDateHintCompletionWithActivePhase(phase, failure);
+      }
+    }
+
+    private DateHintPhaseFinishDecision decideDateHintCompletionWithoutActivePhase() {
+      // Resume-order race: MultiPut resumes children before callback.onResume() rebuilds phase.
+      if (!awaitingPhaseRestore || completedBeforePhaseRestore) {
+        return new DateHintPhaseFinishDecision(true, false, false);
+      }
+      completedBeforePhaseRestore = true;
+      return new DateHintPhaseFinishDecision(false, false, false);
+    }
+
+    private DateHintPhaseFinishDecision decideDateHintCompletionWithActivePhase(
+        DateHintPhase phase, InsertException failure) {
+      boolean watchdogCancelled = phase.watchdogCancelIssued || watchdogCancelIssued;
+      boolean parentCancelled = isParentRequestCancelled();
+      boolean watchdogCancelFailure = isWatchdogCancelFailure(failure, watchdogCancelled);
+      boolean retryOnStallCancel =
+          watchdogCancelFailure && retryCount < MAX_DATEHINT_STALL_RETRIES && !parentCancelled;
+      boolean treatWatchdogCancelAsBestEffortSuccess =
+          watchdogCancelFailure && !retryOnStallCancel && !parentCancelled;
+      activeDateHintPhase = null;
+      return new DateHintPhaseFinishDecision(
+          false, retryOnStallCancel, treatWatchdogCancelAsBestEffortSuccess);
+    }
+
+    private static boolean isWatchdogCancelFailure(
+        InsertException failure, boolean watchdogCancelled) {
+      return failure != null
+          && watchdogCancelled
+          && failure.getMode() == InsertExceptionMode.CANCELLED;
+    }
+
+    private void forwardDateHintCompletion(
+        ClientPutState completedState,
+        InsertException failure,
+        boolean treatWatchdogCancelAsBestEffortSuccess,
+        ClientContext context) {
+      boolean shouldForwardFailure = failure != null && !treatWatchdogCancelAsBestEffortSuccess;
+      PutCompletionCallback callback =
+          getCompletionCallbackOrNull(shouldForwardFailure ? "onFailure" : "onSuccess");
+      if (callback == null) {
+        return;
+      }
+      if (shouldForwardFailure) {
+        callback.onFailure(failure, completedState, context);
+      } else {
+        callback.onSuccess(completedState, context);
+      }
     }
 
     private void onDateHintPhaseFinished(
         ClientPutState completedState, InsertException failure, ClientContext context) {
-      boolean retryOnStallCancel;
-      synchronized (USKInserter.this) {
-        DateHintPhase phase = activeDateHintPhase;
-        if (phase == null) {
-          // Resume-order race: MultiPut resumes children before callback.onResume() rebuilds phase.
-          if (!awaitingPhaseRestore || completedBeforePhaseRestore) return;
-          retryOnStallCancel = false;
-          completedBeforePhaseRestore = true;
-        } else {
-          if (phase.phaseId != phaseId) return;
-          boolean watchdogCancelled = phase.watchdogCancelIssued || watchdogCancelIssued;
-          retryOnStallCancel =
-              failure != null
-                  && watchdogCancelled
-                  && failure.getMode() == InsertExceptionMode.CANCELLED
-                  && retryCount < MAX_DATEHINT_STALL_RETRIES
-                  && !isParentRequestCancelled();
-          activeDateHintPhase = null;
-        }
+      DateHintPhaseFinishDecision decision = decideDateHintPhaseCompletion(failure);
+      if (decision.ignoreEvent) {
+        return;
       }
-      if (retryOnStallCancel) {
+      if (decision.retryOnStallCancel) {
         LOG.warn(
             "Retrying USK datehint insert phase for {} edition {} after watchdog cancel (attempt {}"
                 + " of {})",
@@ -282,11 +398,16 @@ public final class USKInserter
         startDateHintInsertPhase(context, edition, retryCount + 1, completedState);
         return;
       }
-      PutCompletionCallback callback =
-          getCompletionCallbackOrNull(failure != null ? "onFailure" : "onSuccess");
-      if (callback == null) return;
-      if (failure != null) callback.onFailure(failure, completedState, context);
-      else callback.onSuccess(completedState, context);
+      if (decision.treatWatchdogCancelAsBestEffortSuccess) {
+        LOG.warn(
+            "USK datehint insert phase for {} edition {} remained cancelled after {} retry attempt"
+                + "(s); continuing as success without datehint completion",
+            USKInserter.this,
+            edition,
+            MAX_DATEHINT_STALL_RETRIES);
+      }
+      forwardDateHintCompletion(
+          completedState, failure, decision.treatWatchdogCancelAsBestEffortSuccess, context);
     }
 
     @Override
@@ -299,6 +420,11 @@ public final class USKInserter
     public void onFailure(InsertException e, ClientPutState state, ClientContext context) {
       markDateHintProgress(phaseId);
       onDateHintPhaseFinished(state, e, context);
+    }
+
+    void forceCompletionAfterWatchdogTimeout(ClientContext context, ClientPutState completedState) {
+      ClientPutState state = (completedState != null) ? completedState : USKInserter.this;
+      onDateHintPhaseFinished(state, new InsertException(InsertExceptionMode.CANCELLED), context);
     }
 
     @Override
@@ -492,6 +618,7 @@ public final class USKInserter
 
   private void startDateHintInsertPhase(
       ClientContext context, long edition, int retryCount, ClientPutState transitionFrom) {
+    reapplyExternalRequestIdentifierIfNeeded();
     if (LOG.isDebugEnabled())
       LOG.debug(
           "Inserted to edition {} - inserting USK date hints (retry {} of {})...",
@@ -505,7 +632,7 @@ public final class USKInserter
     MultiPutCompletionCallback m =
         new MultiPutCompletionCallback(terminalCallback, parent, tokenObject, persistent, true);
     terminalCallback.bindGroup(m);
-    activateDateHintPhase(new DateHintPhase(phaseId, retryCount, terminalCallback));
+    activateDateHintPhase(new DateHintPhase(phaseId, retryCount, terminalCallback, m));
 
     byte[] hintData = hint.getData(edition).getBytes(StandardCharsets.UTF_8);
     FreenetURI[] hintURIs = hint.getInsertURIs(privUSK);
@@ -570,44 +697,163 @@ public final class USKInserter
     }
   }
 
+  private void reapplyExternalRequestIdentifierIfNeeded() {
+    BaseClientPutter parentPutter = parent;
+    if (parentPutter == null) {
+      return;
+    }
+    String current = parentPutter.getExternalRequestIdentifier();
+    if (current != null) {
+      externalRequestIdentifierSnapshot = current;
+      return;
+    }
+    if (externalRequestIdentifierSnapshot != null) {
+      parentPutter.setExternalRequestIdentifier(externalRequestIdentifierSnapshot);
+    }
+  }
+
+  private long dateHintSchedulerCooldownDelayMillis(ClientContext context, long now) {
+    BaseClientPutter parentPutter = parent;
+    if (parentPutter == null) {
+      return 0L;
+    }
+    ClientRequestScheduler scheduler = context.getSskInsertScheduler(realTimeFlag);
+    if (scheduler == null) {
+      return 0L;
+    }
+    long wakeupTime = scheduler.getPriorityCooldownUntil(parentPutter.getPriorityClass(), now);
+    if (wakeupTime <= now) {
+      return 0L;
+    }
+    return wakeupTime - now;
+  }
+
   private void scheduleDateHintWatchdog(ClientContext context, long phaseId, long delayMillis) {
     if (context.ticker == null) return;
     long boundedDelay = Math.max(1L, delayMillis);
     context.ticker.queueTimedJob(() -> runDateHintWatchdog(context, phaseId), boundedDelay);
   }
 
-  private void runDateHintWatchdog(ClientContext context, long phaseId) {
-    DateHintTerminalCallback callbackToCancel = null;
-    long rescheduleDelay = -1L;
-    long stalledFor;
-    int retryCount = 0;
+  private DateHintWatchdogState snapshotDateHintWatchdogState(long phaseId) {
+    DateHintWatchdogState state = new DateHintWatchdogState();
     synchronized (this) {
       DateHintPhase phase = activeDateHintPhase;
-      if (phase == null || phase.phaseId != phaseId) return;
-      long now = System.currentTimeMillis();
-      stalledFor = now - phase.lastProgressAtMillis;
-      if (stalledFor < DATEHINT_STALL_TIMEOUT_MILLIS) {
-        rescheduleDelay = DATEHINT_STALL_TIMEOUT_MILLIS - stalledFor;
-      } else if (!phase.watchdogCancelIssued) {
-        phase.watchdogCancelIssued = true;
-        phase.terminalCallback.watchdogCancelIssued = true;
-        callbackToCancel = phase.terminalCallback;
-        retryCount = phase.retryCount;
+      if (phase == null || phase.phaseId != phaseId) {
+        return null;
       }
+      long now = System.currentTimeMillis();
+      state.stalledFor = now - phase.lastProgressAtMillis;
+      if (state.stalledFor < DATEHINT_STALL_TIMEOUT_MILLIS) {
+        state.rescheduleDelay = DATEHINT_STALL_TIMEOUT_MILLIS - state.stalledFor;
+        return state;
+      }
+      if (phase.watchdogCancelIssued) {
+        if (phase.watchdogCancelIssuedAtMillis <= 0L) {
+          phase.watchdogCancelIssuedAtMillis = now;
+        }
+        state.cancelAge = now - phase.watchdogCancelIssuedAtMillis;
+        if (state.cancelAge < DATEHINT_CANCEL_COMPLETION_TIMEOUT_MILLIS) {
+          state.rescheduleDelay = DATEHINT_CANCEL_COMPLETION_TIMEOUT_MILLIS - state.cancelAge;
+        } else {
+          state.callbackToForceComplete = phase.terminalCallback;
+          state.forceCompletionState = phase.completionState;
+        }
+        return state;
+      }
+      state.evaluateSchedulerCooldown = true;
+      state.retryCount = phase.retryCount;
+      return state;
     }
-    if (rescheduleDelay > 0L) {
-      scheduleDateHintWatchdog(context, phaseId, rescheduleDelay);
+  }
+
+  private DateHintWatchdogState evaluateDateHintSchedulerCooldown(
+      ClientContext context, long phaseId, DateHintWatchdogState state) {
+    state.schedulerCooldownDelay =
+        dateHintSchedulerCooldownDelayMillis(context, System.currentTimeMillis());
+    if (state.schedulerCooldownDelay > 0L) {
+      state.rescheduleDelay =
+          state.schedulerCooldownDelay + DATEHINT_SCHEDULER_COOLDOWN_GRACE_MILLIS;
+      return state;
+    }
+    synchronized (this) {
+      DateHintPhase phase = activeDateHintPhase;
+      if (phase == null || phase.phaseId != phaseId || phase.watchdogCancelIssued) {
+        return null;
+      }
+      phase.watchdogCancelIssued = true;
+      phase.watchdogCancelIssuedAtMillis = System.currentTimeMillis();
+      phase.terminalCallback.watchdogCancelIssued = true;
+      state.callbackToCancel = phase.terminalCallback;
+      state.retryCount = phase.retryCount;
+      return state;
+    }
+  }
+
+  private boolean rescheduleDateHintWatchdogIfNeeded(
+      ClientContext context, long phaseId, DateHintWatchdogState state) {
+    if (state.rescheduleDelay <= 0L) {
+      return false;
+    }
+    if (state.evaluateSchedulerCooldown
+        && state.schedulerCooldownDelay > 0L
+        && LOG.isInfoEnabled()) {
+      LOG.info(
+          "Deferring USK datehint watchdog cancel for {} phase {} due to scheduler cooldown {}"
+              + " ms at priority {}",
+          this,
+          phaseId,
+          state.schedulerCooldownDelay,
+          (parent == null) ? -1 : parent.getPriorityClass());
+    }
+    scheduleDateHintWatchdog(context, phaseId, state.rescheduleDelay);
+    return true;
+  }
+
+  private boolean forceCompleteDateHintWatchdogIfNeeded(
+      ClientContext context, long phaseId, DateHintWatchdogState state) {
+    if (state.callbackToForceComplete == null) {
+      return false;
+    }
+    LOG.warn(
+        "USK datehint insert phase {} did not deliver terminal callback {} ms after watchdog"
+            + " cancel on {} - forcing completion",
+        phaseId,
+        state.cancelAge,
+        this);
+    state.callbackToForceComplete.forceCompletionAfterWatchdogTimeout(
+        context, state.forceCompletionState);
+    return true;
+  }
+
+  private void runDateHintWatchdog(ClientContext context, long phaseId) {
+    DateHintWatchdogState state = snapshotDateHintWatchdogState(phaseId);
+    if (state == null) {
       return;
     }
-    if (callbackToCancel == null) return;
+    if (state.evaluateSchedulerCooldown) {
+      state = evaluateDateHintSchedulerCooldown(context, phaseId, state);
+      if (state == null) {
+        return;
+      }
+    }
+    if (rescheduleDateHintWatchdogIfNeeded(context, phaseId, state)) {
+      return;
+    }
+    if (forceCompleteDateHintWatchdogIfNeeded(context, phaseId, state)) {
+      return;
+    }
+    if (state.callbackToCancel == null) {
+      return;
+    }
     LOG.warn(
         "USK datehint insert phase {} stalled for {} ms on {} (retry {} of {}) - cancelling phase",
         phaseId,
-        stalledFor,
+        state.stalledFor,
         this,
-        retryCount,
+        state.retryCount,
         MAX_DATEHINT_STALL_RETRIES);
-    callbackToCancel.cancelGroup(context);
+    state.callbackToCancel.cancelGroup(context);
+    scheduleDateHintWatchdog(context, phaseId, DATEHINT_CANCEL_COMPLETION_TIMEOUT_MILLIS);
   }
 
   private void scheduleInsert(ClientContext context) {
@@ -776,6 +1022,8 @@ public final class USKInserter
     this.cryptoAlgorithm = payload.cryptoAlgorithm();
     this.forceCryptoKey = payload.cryptoKey();
     this.realTimeFlag = options.realTimeFlag();
+    this.externalRequestIdentifierSnapshot = null;
+    reapplyExternalRequestIdentifierIfNeeded();
   }
 
   /**
@@ -806,6 +1054,7 @@ public final class USKInserter
     this.cryptoAlgorithm = 0;
     this.forceCryptoKey = null;
     this.realTimeFlag = false;
+    this.externalRequestIdentifierSnapshot = null;
   }
 
   /**
@@ -1026,6 +1275,7 @@ public final class USKInserter
       localFetcher = fetcher;
       localSbi = sbi;
     }
+    reapplyExternalRequestIdentifierIfNeeded();
     if (localData != null) localData.onResume(context);
     if (cb != null && cb != parent) cb.onResume(context);
     if (localFetcher != null) localFetcher.onResume(context);

--- a/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/src/main/java/network/crypta/client/async/USKInserter.java
@@ -188,6 +188,7 @@ public final class USKInserter
     private final long edition;
     private final int retryCount;
     private MultiPutCompletionCallback group;
+    private volatile boolean watchdogCancelIssued;
     private transient volatile boolean awaitingPhaseRestore;
     private transient volatile boolean completedBeforePhaseRestore;
 
@@ -195,6 +196,7 @@ public final class USKInserter
       this.phaseId = phaseId;
       this.edition = edition;
       this.retryCount = retryCount;
+      this.watchdogCancelIssued = false;
       this.awaitingPhaseRestore = false;
     }
 
@@ -235,9 +237,12 @@ public final class USKInserter
       synchronized (USKInserter.this) {
         DateHintPhase current = activeDateHintPhase;
         if (current == null || current.phaseId != phaseId) {
-          activeDateHintPhase = new DateHintPhase(phaseId, retryCount, this);
+          DateHintPhase restored = new DateHintPhase(phaseId, retryCount, this);
+          restored.watchdogCancelIssued = watchdogCancelIssued;
+          activeDateHintPhase = restored;
           nextDateHintPhaseId = Math.max(nextDateHintPhaseId, phaseId + 1);
         } else {
+          current.watchdogCancelIssued |= watchdogCancelIssued;
           current.lastProgressAtMillis = System.currentTimeMillis();
         }
       }
@@ -256,9 +261,10 @@ public final class USKInserter
           completedBeforePhaseRestore = true;
         } else {
           if (phase.phaseId != phaseId) return;
+          boolean watchdogCancelled = phase.watchdogCancelIssued || watchdogCancelIssued;
           retryOnStallCancel =
               failure != null
-                  && phase.watchdogCancelIssued
+                  && watchdogCancelled
                   && failure.getMode() == InsertExceptionMode.CANCELLED
                   && retryCount < MAX_DATEHINT_STALL_RETRIES
                   && !isParentRequestCancelled();
@@ -584,6 +590,7 @@ public final class USKInserter
         rescheduleDelay = DATEHINT_STALL_TIMEOUT_MILLIS - stalledFor;
       } else if (!phase.watchdogCancelIssued) {
         phase.watchdogCancelIssued = true;
+        phase.terminalCallback.watchdogCancelIssued = true;
         callbackToCancel = phase.terminalCallback;
         retryCount = phase.retryCount;
       }

--- a/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/src/main/java/network/crypta/client/async/USKInserter.java
@@ -324,7 +324,7 @@ public final class USKInserter
       synchronized (USKInserter.this) {
         DateHintPhase phase = activeDateHintPhase;
         if (phase == null) {
-          return decideDateHintCompletionWithoutActivePhase();
+          return decideDateHintCompletionWithoutActivePhase(failure);
         }
         if (phase.phaseId != phaseId) {
           return new DateHintPhaseFinishDecision(true, false, false);
@@ -333,13 +333,21 @@ public final class USKInserter
       }
     }
 
-    private DateHintPhaseFinishDecision decideDateHintCompletionWithoutActivePhase() {
+    private DateHintPhaseFinishDecision decideDateHintCompletionWithoutActivePhase(
+        InsertException failure) {
       // Resume-order race: MultiPut resumes children before callback.onResume() rebuilds phase.
       if (!awaitingPhaseRestore || completedBeforePhaseRestore) {
         return new DateHintPhaseFinishDecision(true, false, false);
       }
       completedBeforePhaseRestore = true;
-      return new DateHintPhaseFinishDecision(false, false, false);
+      boolean parentCancelled = isParentRequestCancelled();
+      boolean watchdogCancelFailure = isWatchdogCancelFailure(failure, watchdogCancelIssued);
+      boolean retryOnStallCancel =
+          watchdogCancelFailure && retryCount < MAX_DATEHINT_STALL_RETRIES && !parentCancelled;
+      boolean treatWatchdogCancelAsBestEffortSuccess =
+          watchdogCancelFailure && !retryOnStallCancel && !parentCancelled;
+      return new DateHintPhaseFinishDecision(
+          false, retryOnStallCancel, treatWatchdogCancelAsBestEffortSuccess);
     }
 
     private DateHintPhaseFinishDecision decideDateHintCompletionWithActivePhase(

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
 import network.crypta.client.InsertContext;
@@ -38,6 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -291,21 +293,34 @@ class USKInserterTest {
 
   private static Object newDateHintTerminalCallback(
       USKInserter inserter, long phaseId, long edition) throws Exception {
+    return newDateHintTerminalCallback(inserter, phaseId, edition, 0);
+  }
+
+  private static Object newDateHintTerminalCallback(
+      USKInserter inserter, long phaseId, long edition, int retryCount) throws Exception {
     Class<?> callbackClass =
         Class.forName(USKInserter.class.getName() + "$DateHintTerminalCallback");
     Constructor<?> ctor =
         callbackClass.getDeclaredConstructor(USKInserter.class, long.class, long.class, int.class);
     ctor.setAccessible(true);
-    return ctor.newInstance(inserter, phaseId, edition, 0);
+    return ctor.newInstance(inserter, phaseId, edition, retryCount);
   }
 
   private static Object newDateHintPhase(long phaseId, Object callback) throws Exception {
+    return newDateHintPhase(phaseId, 0, callback, Mockito.mock(ClientPutState.class));
+  }
+
+  private static Object newDateHintPhase(
+      long phaseId, int retryCount, Object callback, ClientPutState completionState)
+      throws Exception {
     Class<?> callbackClass =
         Class.forName(USKInserter.class.getName() + "$DateHintTerminalCallback");
     Class<?> phaseClass = Class.forName(USKInserter.class.getName() + "$DateHintPhase");
-    Constructor<?> ctor = phaseClass.getDeclaredConstructor(long.class, int.class, callbackClass);
+    Constructor<?> ctor =
+        phaseClass.getDeclaredConstructor(
+            long.class, int.class, callbackClass, ClientPutState.class);
     ctor.setAccessible(true);
-    return ctor.newInstance(phaseId, 0, callback);
+    return ctor.newInstance(phaseId, retryCount, callback, completionState);
   }
 
   private static void setDateHintCallbackGroup(Object callback, MultiPutCompletionCallback group)
@@ -333,6 +348,19 @@ class USKInserterTest {
     f.setBoolean(phase, true);
   }
 
+  private static void setDateHintWatchdogCancelIssuedAtMillis(Object phase, long value)
+      throws Exception {
+    Field f = phase.getClass().getDeclaredField("watchdogCancelIssuedAtMillis");
+    f.setAccessible(true);
+    f.setLong(phase, value);
+  }
+
+  private static long getDateHintCancelCompletionTimeoutMillis() throws Exception {
+    Field f = USKInserter.class.getDeclaredField("DATEHINT_CANCEL_COMPLETION_TIMEOUT_MILLIS");
+    f.setAccessible(true);
+    return f.getLong(null);
+  }
+
   private static void setActiveDateHintPhase(USKInserter inserter, Object phase) throws Exception {
     Field activeField = USKInserter.class.getDeclaredField("activeDateHintPhase");
     activeField.setAccessible(true);
@@ -350,6 +378,19 @@ class USKInserterTest {
     Field restoreField = callback.getClass().getDeclaredField("awaitingPhaseRestore");
     restoreField.setAccessible(true);
     restoreField.setBoolean(callback, inProgress);
+  }
+
+  private static void setDateHintTerminalWatchdogCancelIssued(
+      PutCompletionCallback callback, boolean value) throws Exception {
+    Field f = callback.getClass().getDeclaredField("watchdogCancelIssued");
+    f.setAccessible(true);
+    f.setBoolean(callback, value);
+  }
+
+  private static long getDateHintStallTimeoutMillis() throws Exception {
+    Field f = USKInserter.class.getDeclaredField("DATEHINT_STALL_TIMEOUT_MILLIS");
+    f.setAccessible(true);
+    return f.getLong(null);
   }
 
   private static void runDateHintWatchdog(USKInserter inserter, ClientContext context, long phaseId)
@@ -680,6 +721,111 @@ class USKInserterTest {
   }
 
   @Test
+  void runDateHintWatchdog_whenSchedulerCooldownActive_reschedulesWithoutCancelling()
+      throws Exception {
+    // Arrange
+    Ticker ticker = Mockito.mock(Ticker.class);
+    ClientContext contextWithTicker = Mockito.spy(newContext(ticker));
+    ClientRequestScheduler scheduler = Mockito.mock(ClientRequestScheduler.class);
+    when(contextWithTicker.getSskInsertScheduler(false)).thenReturn(scheduler);
+    when(parent.getPriorityClass()).thenReturn((short) 2);
+    when(scheduler.getPriorityCooldownUntil(Mockito.eq((short) 2), Mockito.anyLong()))
+        .thenAnswer(
+            invocation -> ((Long) invocation.getArgument(1)) + TimeUnit.MINUTES.toMillis(20));
+
+    byte[] bytes = "scheduler-cooldown-datehint".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "watchdog-scheduler-cooldown";
+    long edition = 10L;
+    long phaseId = 94L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, false, false));
+
+    MultiPutCompletionCallback group = Mockito.mock(MultiPutCompletionCallback.class);
+    Object callback = newDateHintTerminalCallback(inserter, phaseId, edition);
+    setDateHintCallbackGroup(callback, group);
+    Object phase = newDateHintPhase(phaseId, callback);
+    setDateHintLastProgressAtMillis(phase, 0L);
+    setActiveDateHintPhase(inserter, phase);
+
+    // Act
+    runDateHintWatchdog(inserter, contextWithTicker, phaseId);
+
+    // Assert
+    verify(group, never()).cancel(any(ClientContext.class));
+    verify(scheduler, times(1)).getPriorityCooldownUntil(Mockito.eq((short) 2), Mockito.anyLong());
+    verify(ticker, times(1))
+        .queueTimedJob(
+            any(Runnable.class), Mockito.longThat(delay -> delay >= TimeUnit.MINUTES.toMillis(20)));
+    assertFalse(isDateHintWatchdogCancelIssued(phase));
+  }
+
+  @Test
+  void runDateHintWatchdog_whenCancelDoesNotComplete_forceCompletesPhaseAsBestEffortSuccess()
+      throws Exception {
+    // Arrange
+    Ticker ticker = Mockito.mock(Ticker.class);
+    ClientContext contextWithTicker = newContext(ticker);
+    byte[] bytes = "watchdog-force-complete".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "watchdog-force-complete-site";
+    long edition = 12L;
+    long phaseId = 95L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, false, false));
+
+    MultiPutCompletionCallback group = Mockito.mock(MultiPutCompletionCallback.class);
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition, 1);
+    setDateHintCallbackGroup(terminalCallback, group);
+    ClientPutState transitionedState = Mockito.mock(ClientPutState.class);
+    Object phase = newDateHintPhase(phaseId, 1, terminalCallback, transitionedState);
+    setDateHintLastProgressAtMillis(phase, 0L);
+    setActiveDateHintPhase(inserter, phase);
+
+    // Act: the first watchdog pass cancels, the second pass force-completes after grace timeout.
+    runDateHintWatchdog(inserter, contextWithTicker, phaseId);
+    long timeoutMillis = getDateHintCancelCompletionTimeoutMillis();
+    setDateHintWatchdogCancelIssuedAtMillis(
+        phase, System.currentTimeMillis() - timeoutMillis - TimeUnit.SECONDS.toMillis(1));
+    runDateHintWatchdog(inserter, contextWithTicker, phaseId);
+
+    // Assert
+    verify(group, times(1)).cancel(contextWithTicker);
+    verify(ticker, times(1)).queueTimedJob(any(Runnable.class), Mockito.eq(timeoutMillis));
+    ArgumentCaptor<ClientPutState> stateCaptor = ArgumentCaptor.forClass(ClientPutState.class);
+    verify(cb, times(1)).onSuccess(stateCaptor.capture(), any(ClientContext.class));
+    assertSame(transitionedState, stateCaptor.getValue());
+    verify(cb, never()).onFailure(any(InsertException.class), any(ClientPutState.class), any());
+    assertNull(getActiveDateHintPhase(inserter));
+  }
+
+  @Test
   void dateHintTerminalCallback_onResume_restoresWatchdogCancelMarker() throws Exception {
     // Arrange
     byte[] bytes = "watchdog-restore-marker".getBytes(StandardCharsets.UTF_8);
@@ -710,7 +856,8 @@ class USKInserterTest {
     setDateHintLastProgressAtMillis(phase, 0L);
     setActiveDateHintPhase(inserter, phase);
 
-    // Trigger watchdog cancellation marker, then simulate restart by dropping transient phase
+    // Trigger the watchdog cancellation marker, then simulate restart by dropping the transient
+    // phase
     // state.
     runDateHintWatchdog(inserter, context, phaseId);
     setActiveDateHintPhase(inserter, null);
@@ -721,6 +868,53 @@ class USKInserterTest {
     // Assert
     Object restoredPhase = getActiveDateHintPhase(inserter);
     assertTrue(isDateHintWatchdogCancelIssued(restoredPhase));
+  }
+
+  @Test
+  void dateHintTerminalCallback_onResume_whenWatchdogCancelled_usesCancelTimeoutWatchdog()
+      throws Exception {
+    // Arrange
+    Ticker ticker = Mockito.mock(Ticker.class);
+    ClientContext contextWithTicker = newContext(ticker);
+    byte[] bytes = "watchdog-resume-cancel-timeout".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "watchdog-resume-cancel-timeout";
+    long edition = 12L;
+    long phaseId = 96L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, true, false));
+
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition, 1);
+    setDateHintTerminalWatchdogCancelIssued(terminalCallback, true);
+
+    // Simulate restored callback where transient phase must be rebuilt on resume.
+    setActiveDateHintPhase(inserter, null);
+
+    // Act
+    terminalCallback.onResume(contextWithTicker);
+
+    // Assert
+    long cancelTimeoutMillis = getDateHintCancelCompletionTimeoutMillis();
+    long stallTimeoutMillis = getDateHintStallTimeoutMillis();
+    verify(ticker, times(1))
+        .queueTimedJob(
+            any(Runnable.class),
+            Mockito.longThat(delay -> delay > 0L && delay <= cancelTimeoutMillis));
+    verify(ticker, never())
+        .queueTimedJob(any(Runnable.class), Mockito.longThat(delay -> delay >= stallTimeoutMillis));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -5,6 +5,9 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import network.crypta.client.FetchContext;
@@ -21,6 +24,7 @@ import network.crypta.keys.Key;
 import network.crypta.keys.USK;
 import network.crypta.node.ClientContextResources;
 import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
 import network.crypta.support.api.Bucket;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,10 +37,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -133,38 +140,7 @@ class USKInserterTest {
 
   @BeforeEach
   void setup() {
-    // Minimal ClientContext: only fields touched by these tests are used.
-    // Many collaborators are irrelevant here and can be passed as null or simple stubs.
-    context =
-        new ClientContext(
-            1L,
-            new ClientContextRuntime(
-                Mockito.mock(ClientLayerPersister.class),
-                new InlineExecutor(),
-                null,
-                null,
-                new DummyRandomSource(),
-                new SecureRandom(),
-                null),
-            new ClientContextStorageFactories(null, null, null, null, null, null, null),
-            new ClientContextRafFactories(null, null),
-            new ClientContextServices(
-                new ClientContextResources(null, null), uskManager, null, null, null, null),
-            new ClientContextDefaults(
-                // Default persistent contexts used only when building fetchers internally; not
-                // exercised in these tests.
-                new FetchContext(
-                    FetchContextOptions.builder()
-                        .limits(0, 0, 0)
-                        .archiveLimits(1, 0, 0, true)
-                        .retryLimits(0, 0, 0)
-                        .splitfileLimits(false, 0, 0)
-                        .behavior(false, false, false)
-                        .clientOptions(new SimpleEventProducer(), false, false)
-                        .filterOverrides(null, null, null)
-                        .build()),
-                newInsertContext(),
-                null));
+    context = newContext(null);
   }
 
   // Helpers in tests create per-test SSKs to build consistent public/insertable USK URIs.
@@ -253,6 +229,40 @@ class USKInserterTest {
     };
   }
 
+  private ClientContext newContext(Ticker ticker) {
+    // Minimal ClientContext: only fields touched by these tests are used.
+    // Many collaborators are irrelevant here and can be passed as null or simple stubs.
+    return new ClientContext(
+        1L,
+        new ClientContextRuntime(
+            Mockito.mock(ClientLayerPersister.class),
+            new InlineExecutor(),
+            null,
+            ticker,
+            new DummyRandomSource(),
+            new SecureRandom(),
+            null),
+        new ClientContextStorageFactories(null, null, null, null, null, null, null),
+        new ClientContextRafFactories(null, null),
+        new ClientContextServices(
+            new ClientContextResources(null, null), uskManager, null, null, null, null),
+        new ClientContextDefaults(
+            // Default persistent contexts used only when building fetchers internally; not
+            // exercised in these tests.
+            new FetchContext(
+                FetchContextOptions.builder()
+                    .limits(0, 0, 0)
+                    .archiveLimits(1, 0, 0, true)
+                    .retryLimits(0, 0, 0)
+                    .splitfileLimits(false, 0, 0)
+                    .behavior(false, false, false)
+                    .clientOptions(new SimpleEventProducer(), false, false)
+                    .filterOverrides(null, null, null)
+                    .build()),
+            newInsertContext(),
+            null));
+  }
+
   private USKInserter newInserter(
       Bucket data,
       short compressionCodec,
@@ -277,6 +287,71 @@ class USKInserterTest {
             null),
         new BlockInsertParams(parent, insertCtx, cb, 123, "token", cfg.addToParent, context),
         new BlockInsertOptions(cfg.persistent, cfg.realTimeFlag, cfg.freeData, 0));
+  }
+
+  private static Object newDateHintTerminalCallback(
+      USKInserter inserter, long phaseId, long edition) throws Exception {
+    Class<?> callbackClass =
+        Class.forName(USKInserter.class.getName() + "$DateHintTerminalCallback");
+    Constructor<?> ctor =
+        callbackClass.getDeclaredConstructor(USKInserter.class, long.class, long.class, int.class);
+    ctor.setAccessible(true);
+    return ctor.newInstance(inserter, phaseId, edition, 0);
+  }
+
+  private static Object newDateHintPhase(long phaseId, Object callback) throws Exception {
+    Class<?> callbackClass =
+        Class.forName(USKInserter.class.getName() + "$DateHintTerminalCallback");
+    Class<?> phaseClass = Class.forName(USKInserter.class.getName() + "$DateHintPhase");
+    Constructor<?> ctor = phaseClass.getDeclaredConstructor(long.class, int.class, callbackClass);
+    ctor.setAccessible(true);
+    return ctor.newInstance(phaseId, 0, callback);
+  }
+
+  private static void setDateHintCallbackGroup(Object callback, MultiPutCompletionCallback group)
+      throws Exception {
+    Field f = callback.getClass().getDeclaredField("group");
+    f.setAccessible(true);
+    f.set(callback, group);
+  }
+
+  private static void setDateHintLastProgressAtMillis(Object phase, long value) throws Exception {
+    Field f = phase.getClass().getDeclaredField("lastProgressAtMillis");
+    f.setAccessible(true);
+    f.setLong(phase, value);
+  }
+
+  private static boolean isDateHintWatchdogCancelIssued(Object phase) throws Exception {
+    Field f = phase.getClass().getDeclaredField("watchdogCancelIssued");
+    f.setAccessible(true);
+    return f.getBoolean(phase);
+  }
+
+  private static void setDateHintWatchdogCancelIssued(Object phase) throws Exception {
+    Field f = phase.getClass().getDeclaredField("watchdogCancelIssued");
+    f.setAccessible(true);
+    f.setBoolean(phase, true);
+  }
+
+  private static void setActiveDateHintPhase(USKInserter inserter, Object phase) throws Exception {
+    Field activeField = USKInserter.class.getDeclaredField("activeDateHintPhase");
+    activeField.setAccessible(true);
+    activeField.set(inserter, phase);
+  }
+
+  private static void setDateHintTerminalAwaitingPhaseRestore(
+      PutCompletionCallback callback, boolean inProgress) throws Exception {
+    Field restoreField = callback.getClass().getDeclaredField("awaitingPhaseRestore");
+    restoreField.setAccessible(true);
+    restoreField.setBoolean(callback, inProgress);
+  }
+
+  private static void runDateHintWatchdog(USKInserter inserter, ClientContext context, long phaseId)
+      throws Exception {
+    Method watchdog =
+        USKInserter.class.getDeclaredMethod("runDateHintWatchdog", ClientContext.class, long.class);
+    watchdog.setAccessible(true);
+    watchdog.invoke(inserter, context, phaseId);
   }
 
   @Test
@@ -517,6 +592,286 @@ class USKInserterTest {
   }
 
   @Test
+  void runDateHintWatchdog_whenPhaseStalled_cancelsActiveDateHintGroup() throws Exception {
+    // Arrange
+    byte[] bytes = "stalled-datehint".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "watchdog-stall";
+    long edition = 5L;
+    long phaseId = 91L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, false, false));
+
+    MultiPutCompletionCallback group = Mockito.mock(MultiPutCompletionCallback.class);
+    Object callback = newDateHintTerminalCallback(inserter, phaseId, edition);
+    setDateHintCallbackGroup(callback, group);
+    Object phase = newDateHintPhase(phaseId, callback);
+    setDateHintLastProgressAtMillis(phase, 0L);
+    setActiveDateHintPhase(inserter, phase);
+
+    // Act
+    runDateHintWatchdog(inserter, context, phaseId);
+
+    // Assert
+    verify(group, times(1)).cancel(context);
+    assertTrue(isDateHintWatchdogCancelIssued(phase));
+  }
+
+  @Test
+  void runDateHintWatchdog_whenRecentProgress_reschedulesWithoutCancelling() throws Exception {
+    // Arrange
+    Ticker ticker = Mockito.mock(Ticker.class);
+    ClientContext contextWithTicker = newContext(ticker);
+    byte[] bytes = "recent-datehint".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "watchdog-reschedule";
+    long edition = 9L;
+    long phaseId = 92L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, false, false));
+
+    MultiPutCompletionCallback group = Mockito.mock(MultiPutCompletionCallback.class);
+    Object callback = newDateHintTerminalCallback(inserter, phaseId, edition);
+    setDateHintCallbackGroup(callback, group);
+    Object phase = newDateHintPhase(phaseId, callback);
+    setDateHintLastProgressAtMillis(phase, System.currentTimeMillis());
+    setActiveDateHintPhase(inserter, phase);
+
+    // Act
+    runDateHintWatchdog(inserter, contextWithTicker, phaseId);
+
+    // Assert
+    verify(group, never()).cancel(any(ClientContext.class));
+    verify(ticker, times(1))
+        .queueTimedJob(any(Runnable.class), Mockito.longThat(delay -> delay > 0L));
+    assertFalse(isDateHintWatchdogCancelIssued(phase));
+  }
+
+  @Test
+  void dateHintTerminalCallback_onSuccess_forwardsTransitionedStateToParentCallback()
+      throws Exception {
+    // Arrange
+    byte[] bytes = "datehint-success".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "datehint-success-site";
+    long edition = 4L;
+    long phaseId = 301L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, false, false));
+
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition);
+    Object phase = newDateHintPhase(phaseId, terminalCallback);
+    setActiveDateHintPhase(inserter, phase);
+
+    ClientPutState transitionedState = Mockito.mock(ClientPutState.class);
+
+    // Act
+    terminalCallback.onSuccess(transitionedState, context);
+
+    // Assert
+    ArgumentCaptor<ClientPutState> stateCaptor = ArgumentCaptor.forClass(ClientPutState.class);
+    verify(cb, times(1)).onSuccess(stateCaptor.capture(), any(ClientContext.class));
+    assertSame(transitionedState, stateCaptor.getValue());
+  }
+
+  @Test
+  void dateHintTerminalCallback_onFailure_forwardsTransitionedStateToParentCallback()
+      throws Exception {
+    // Arrange
+    byte[] bytes = "datehint-failure".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "datehint-failure-site";
+    long edition = 6L;
+    long phaseId = 302L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, false, false));
+
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition);
+    Object phase = newDateHintPhase(phaseId, terminalCallback);
+    setActiveDateHintPhase(inserter, phase);
+
+    ClientPutState transitionedState = Mockito.mock(ClientPutState.class);
+    InsertException failure = new InsertException(InsertExceptionMode.INTERNAL_ERROR);
+
+    // Act
+    terminalCallback.onFailure(failure, transitionedState, context);
+
+    // Assert
+    ArgumentCaptor<ClientPutState> stateCaptor = ArgumentCaptor.forClass(ClientPutState.class);
+    verify(cb, times(1)).onFailure(any(InsertException.class), stateCaptor.capture(), any());
+    assertSame(transitionedState, stateCaptor.getValue());
+  }
+
+  @Test
+  void dateHintTerminalCallback_onSuccess_whenPhaseMissingDuringResumeRestore_forwardsSuccess()
+      throws Exception {
+    // Arrange
+    byte[] bytes = "datehint-resume-race".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "datehint-resume-race-site";
+    long edition = 7L;
+    long phaseId = 401L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, true, false));
+
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition);
+    setDateHintTerminalAwaitingPhaseRestore(terminalCallback, true);
+
+    ClientPutState transitionedState = Mockito.mock(ClientPutState.class);
+
+    // Act
+    terminalCallback.onSuccess(transitionedState, context);
+
+    // Assert
+    verify(cb, times(1)).onSuccess(Mockito.eq(transitionedState), any(ClientContext.class));
+  }
+
+  @Test
+  void dateHintTerminalCallback_onSuccess_whenPhaseMissingOutsideResumeRestore_ignoresEvent()
+      throws Exception {
+    // Arrange
+    byte[] bytes = "datehint-missing-phase".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "datehint-missing-phase-site";
+    long edition = 8L;
+    long phaseId = 402L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, true, false));
+
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition);
+    setDateHintTerminalAwaitingPhaseRestore(terminalCallback, false);
+
+    ClientPutState transitionedState = Mockito.mock(ClientPutState.class);
+
+    // Act
+    terminalCallback.onSuccess(transitionedState, context);
+
+    // Assert
+    verify(cb, never()).onSuccess(any(ClientPutState.class), any(ClientContext.class));
+  }
+
+  @Test
+  void dateHintTerminalCallback_onFailure_whenParentCancelled_doesNotRetryDatehintPhase()
+      throws Exception {
+    // Arrange
+    byte[] bytes = "datehint-cancel-guard".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "datehint-cancel-guard-site";
+    long edition = 9L;
+    long phaseId = 403L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, false, false));
+    when(parent.isCancelled()).thenReturn(true);
+
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition);
+    Object phase = newDateHintPhase(phaseId, terminalCallback);
+    setDateHintWatchdogCancelIssued(phase);
+    setActiveDateHintPhase(inserter, phase);
+
+    ClientPutState transitionedState = Mockito.mock(ClientPutState.class);
+    InsertException cancelled = new InsertException(InsertExceptionMode.CANCELLED);
+
+    // Act
+    terminalCallback.onFailure(cancelled, transitionedState, context);
+
+    // Assert
+    verify(cb, times(1))
+        .onFailure(Mockito.eq(cancelled), Mockito.eq(transitionedState), any(ClientContext.class));
+    verify(cb, never()).onTransition(any(ClientPutState.class), any(ClientPutState.class), any());
+  }
+
+  @Test
   void onFailure_afterCancelAndDataReleased_doesNotThrow() throws Exception {
     byte[] bytes = "late-cancel".getBytes(StandardCharsets.UTF_8);
     Bucket data = Mockito.spy(makeBucket(bytes));
@@ -693,6 +1048,4 @@ class USKInserterTest {
     verify(cb, times(1)).onFailure(Mockito.eq(ex2), any(), any());
     verify(data2, times(1)).free();
   }
-
-  // Reflection helpers are intentionally omitted; tests use public APIs to prime state.
 }

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -380,11 +380,11 @@ class USKInserterTest {
     restoreField.setBoolean(callback, inProgress);
   }
 
-  private static void setDateHintTerminalWatchdogCancelIssued(
-      PutCompletionCallback callback, boolean value) throws Exception {
+  private static void setDateHintTerminalWatchdogCancelIssued(PutCompletionCallback callback)
+      throws Exception {
     Field f = callback.getClass().getDeclaredField("watchdogCancelIssued");
     f.setAccessible(true);
-    f.setBoolean(callback, value);
+    f.setBoolean(callback, true);
   }
 
   private static long getDateHintStallTimeoutMillis() throws Exception {
@@ -898,9 +898,9 @@ class USKInserterTest {
 
     PutCompletionCallback terminalCallback =
         (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition, 1);
-    setDateHintTerminalWatchdogCancelIssued(terminalCallback, true);
+    setDateHintTerminalWatchdogCancelIssued(terminalCallback);
 
-    // Simulate restored callback where transient phase must be rebuilt on resume.
+    // Simulate a restored callback where the transient phase must be rebuilt on resume.
     setActiveDateHintPhase(inserter, null);
 
     // Act
@@ -1113,6 +1113,50 @@ class USKInserterTest {
     verify(cb, times(1))
         .onFailure(Mockito.eq(cancelled), Mockito.eq(transitionedState), any(ClientContext.class));
     verify(cb, never()).onTransition(any(ClientPutState.class), any(ClientPutState.class), any());
+  }
+
+  @Test
+  void dateHintTerminalCallback_onFailure_whenParentCancelsBeforeRetryStart_skipsRetry()
+      throws Exception {
+    // Arrange
+    byte[] bytes = "datehint-cancel-race".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "datehint-cancel-race-site";
+    long edition = 10L;
+    long phaseId = 404L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, false, false));
+    when(parent.isCancelled()).thenReturn(false, true);
+
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition);
+    Object phase = newDateHintPhase(phaseId, terminalCallback);
+    setDateHintWatchdogCancelIssued(phase);
+    setActiveDateHintPhase(inserter, phase);
+
+    ClientPutState transitionedState = Mockito.mock(ClientPutState.class);
+    InsertException cancelled = new InsertException(InsertExceptionMode.CANCELLED);
+
+    // Act
+    terminalCallback.onFailure(cancelled, transitionedState, context);
+
+    // Assert
+    verify(cb, never()).onTransition(any(ClientPutState.class), any(ClientPutState.class), any());
+    verify(cb, never()).onSuccess(any(ClientPutState.class), any(ClientContext.class));
+    verify(cb, never()).onFailure(any(InsertException.class), any(ClientPutState.class), any());
+    assertNull(getActiveDateHintPhase(inserter));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -1036,6 +1036,46 @@ class USKInserterTest {
   }
 
   @Test
+  void dateHintTerminalCallback_onFailure_whenWatchdogCancelledBeforePhaseRestore_treatsAsSuccess()
+      throws Exception {
+    // Arrange
+    byte[] bytes = "datehint-resume-watchdog-cancel".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "datehint-resume-watchdog-cancel-site";
+    long edition = 7L;
+    long phaseId = 405L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, true, false));
+
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition, 1);
+    setDateHintTerminalAwaitingPhaseRestore(terminalCallback, true);
+    setDateHintTerminalWatchdogCancelIssued(terminalCallback);
+
+    ClientPutState transitionedState = Mockito.mock(ClientPutState.class);
+    InsertException cancelled = new InsertException(InsertExceptionMode.CANCELLED);
+
+    // Act
+    terminalCallback.onFailure(cancelled, transitionedState, context);
+
+    // Assert
+    verify(cb, times(1)).onSuccess(Mockito.eq(transitionedState), any(ClientContext.class));
+    verify(cb, never()).onFailure(any(InsertException.class), any(ClientPutState.class), any());
+  }
+
+  @Test
   void dateHintTerminalCallback_onSuccess_whenPhaseMissingOutsideResumeRestore_ignoresEvent()
       throws Exception {
     // Arrange

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -339,6 +339,12 @@ class USKInserterTest {
     activeField.set(inserter, phase);
   }
 
+  private static Object getActiveDateHintPhase(USKInserter inserter) throws Exception {
+    Field activeField = USKInserter.class.getDeclaredField("activeDateHintPhase");
+    activeField.setAccessible(true);
+    return activeField.get(inserter);
+  }
+
   private static void setDateHintTerminalAwaitingPhaseRestore(
       PutCompletionCallback callback, boolean inProgress) throws Exception {
     Field restoreField = callback.getClass().getDeclaredField("awaitingPhaseRestore");
@@ -671,6 +677,50 @@ class USKInserterTest {
     verify(ticker, times(1))
         .queueTimedJob(any(Runnable.class), Mockito.longThat(delay -> delay > 0L));
     assertFalse(isDateHintWatchdogCancelIssued(phase));
+  }
+
+  @Test
+  void dateHintTerminalCallback_onResume_restoresWatchdogCancelMarker() throws Exception {
+    // Arrange
+    byte[] bytes = "watchdog-restore-marker".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "watchdog-restore";
+    long edition = 11L;
+    long phaseId = 93L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic = newInsertContext();
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, false, true, false));
+
+    MultiPutCompletionCallback group = Mockito.mock(MultiPutCompletionCallback.class);
+    PutCompletionCallback terminalCallback =
+        (PutCompletionCallback) newDateHintTerminalCallback(inserter, phaseId, edition);
+    setDateHintCallbackGroup(terminalCallback, group);
+    Object phase = newDateHintPhase(phaseId, terminalCallback);
+    setDateHintLastProgressAtMillis(phase, 0L);
+    setActiveDateHintPhase(inserter, phase);
+
+    // Trigger watchdog cancellation marker, then simulate restart by dropping transient phase
+    // state.
+    runDateHintWatchdog(inserter, context, phaseId);
+    setActiveDateHintPhase(inserter, null);
+
+    // Act
+    terminalCallback.onResume(context);
+
+    // Assert
+    Object restoredPhase = getActiveDateHintPhase(inserter);
+    assertTrue(isDateHintWatchdogCancelIssued(restoredPhase));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- harden `USKInserter` datehint terminal callback handling for restart/resume windows so terminal events are not lost while phase state is being rebuilt
- keep callback identity consistent by forwarding transitioned child state on terminal success/failure
- add guards so stalled datehint retry does not restart after explicit parent cancellation and avoid null-sensitive parent cancellation checks
- preserve FCP diagnostics correlation across restart by reapplying external request identifiers to resumed datehint child inserts
- make datehint watchdog scheduler-aware (defer cancel while priority cooldown is active)
- add force-completion when watchdog-cancelled datehint phases never deliver terminal callbacks
- treat exhausted watchdog-cancel retries as best-effort success instead of failing the parent insert
- re-arm resumed watchdog-cancelled datehint phases with cancel-timeout delay (not full stall timeout)
- extend `USKInserterTest` with regression coverage for watchdog behavior, resume race windows, transitioned-state forwarding, cancel-timeout resume behavior, and cancel-vs-retry guard paths

## How to test
- run `./gradlew test --tests '*USKInserterTest'`
- run `./gradlew sonarlintFile -Psonarlint.file=src/main/java/network/crypta/client/async/USKInserter.java`
- run `./gradlew test`

## Notes
- base branch for this PR is `release/2`.
- branch: `bugfix/usk-datehint-resume-retry-guards`.