### PR TITLE
fix(launcher): Match Kotlin default window size

### DIFF
--- a/src/main/java/network/crypta/launcher/Launcher.java
+++ b/src/main/java/network/crypta/launcher/Launcher.java
@@ -38,6 +38,8 @@ import static network.crypta.launcher.LauncherLog.logDebug;
  */
 public final class Launcher {
   private static final String APP_NAME = "Crypta Launcher";
+  private static final int DEFAULT_WINDOW_WIDTH = 900;
+  private static final int DEFAULT_WINDOW_HEIGHT = 600;
   private static final AtomicReference<CryptaLauncher> INSTANCE = new AtomicReference<>();
 
   private Launcher() {}
@@ -156,6 +158,7 @@ public final class Launcher {
       }
 
       pack();
+      setSize(new Dimension(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT));
       setLocationRelativeTo(null);
       WindowsMessageHooks.install(this, this::quitApp);
     }


### PR DESCRIPTION
## Summary
- Restore the launcher default startup window size to `900x600` so Java behavior matches the original Kotlin launcher.
- Add explicit default size constants in `Launcher` and apply them after `pack()`.
- Keep the existing minimum size (`450x300`) unchanged.

## How to test
- `./gradlew test --tests '*LauncherTest'`
- `./gradlew runLauncher` and verify the initial window opens larger (900x600 default).