### PR TITLE
refactor(updater): Rename main-jar APIs to core package and harden URI reset

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -71,7 +71,13 @@ Use this skill when you need to:
 - `NodeUpdateManager` coordinates updates.
 - Core updates use the package-based `CoreUpdater` (see the CoreUpdater skill for details).
 - Plugin updates remain managed by `PluginJarUpdater`.
-- JAR Update-over-Mandatory (UOM) is disabled for core; jar UOM paths are gated/no-ops.
+- Core updater state is exposed through CorePackage APIs in `NodeUpdateManager`:
+  - `hasNewCorePackage()`, `newCorePackageVersion()`, `newCorePackageVersionLabel()`
+  - `fetchingNewCorePackage()`, `fetchingNewCorePackageVersion()`
+- Release gating comes from `core-info.json` `version` (strict integer parse) rather than semantic
+  version strings; invalid/non-integer values are ignored for update availability.
+- JAR Update-over-Mandatory (UOM) payload transfer is disabled for core; revocation/dependency
+  signaling remains and legacy UOM wire names are retained for compatibility.
 - Config keys such as `node.updater.enabled` and `node.updater.autoupdate` remain.
 
 ## Security model (high level)
@@ -84,3 +90,6 @@ Use this skill when you need to:
 - Version tokens are replaced into `network/crypta/node/Version.java` during build (`@build_number@`, `@git_rev@`).
 - Version strings support both Cryptad and Fred formats; compatibility enforces protocol match and minimum builds.
 - Freenet interop uses historical identifiers (e.g., `"Fred,0.7"`) for wire compatibility where applicable.
+- Core update descriptors (`core-info.json`) must publish `version` as an integer string; this value
+  is compared against `Version.currentBuildNumber()` to determine whether a core package update is
+  available.

--- a/.agents/skills/cryptad-core-updater/SKILL.md
+++ b/.agents/skills/cryptad-core-updater/SKILL.md
@@ -18,18 +18,30 @@ Use this skill when working on:
 - Core package-based updates replace self-updating of `cryptad.jar`.
 - The updater:
   - Fetches `info/<N>` JSON from the existing update USK.
+  - Treats `CoreInfo.version` as the release gate: it must be a base-10 integer string and be
+    greater than `Version.currentBuildNumber()` for update availability.
   - Selects an OS/arch-specific installer (deb/rpm/dmg/exe/flatpak/snap).
   - Downloads to `nodeDir/updates/core/<version>/`.
 - Plugin updates remain unchanged.
 
 ## System wiring changes
-- `MainJarUpdater` was removed.
+- Legacy core jar updater was removed.
 - `NodeUpdateManager` now coordinates:
   - `CoreUpdater` for core packages
   - `PluginJarUpdater` for plugins
-- JAR Update-over-Mandatory is disabled:
-  - `supportsJarUOM()` returns false
-  - Legacy jar UOM paths are gated/no-ops.
+- Core updater state surfaces through CorePackage-named APIs:
+  - `hasNewCorePackage()`, `newCorePackageVersion()`, `newCorePackageVersionLabel()`
+  - `fetchingNewCorePackage()`, `fetchingNewCorePackageVersion()`
+- JAR Update-over-Mandatory for core payload transfer is disabled; legacy jar UOM paths remain
+  gated/no-ops while revocation/dependency signaling is still active.
+
+## Versioning and discovery details
+- Discovery still follows USK editions (`info/<N>`) and keeps startup subscribe seeding logic from
+  persisted fetched editions.
+- Release gating and user-facing version labels come from descriptor `version`:
+  - strict integer parse only
+  - missing/non-integer/overflow => do not advertise update available
+- Changelog link resolution still uses edition/build-based URIs when CHK links are absent.
 
 ## Endpoint and UI
 - HTTP endpoint: `/core-update/`
@@ -53,8 +65,14 @@ Use this skill when working on:
 
 ## Descriptor format and integrity
 - JSON includes:
-  - `version`
+  - `version` (required integer string for release gating)
   - `packages` keyed by `<arch>.<ext>`
   - optional `changelog_chk` / `fullchangelog_chk`
 - CHK integrity covers content.
 - Any historical `sha256` fields in descriptors are ignored.
+
+## UOM compatibility note
+- Code identifiers have been renamed to Core/CorePackage terminology.
+- UOM wire compatibility keeps legacy field/type strings where required:
+  - field payload names such as `"mainJarKey"`, `"mainJarVersion"`, `"mainJarFileLength"`
+  - message type strings `"CryptadUOMRequestMainJar"` / `"CryptadUOMSendingMainJar"`

--- a/.agents/skills/cryptad-runtime-debugging/SKILL.md
+++ b/.agents/skills/cryptad-runtime-debugging/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: cryptad-runtime-debugging
+description: Debug live or reproducible Cryptad runtime failures such as deadlocks, hangs, blocked HTTP requests, stalled update flows, or thread contention. Use when Codex needs to inspect a running Cryptad JVM on Windows, macOS, or Linux, capture evidence with jcmd, or attach a remote debugger with jdb to the default JDWP listener on 127.0.0.1:5005.
+---
+
+# Cryptad Runtime Debugging
+
+## Overview
+
+- Capture runtime evidence before editing code or restarting the node.
+- Prefer `jcmd` for first-response diagnosis because it is lower risk and still works when another debugger is already attached.
+- Use `jdb` only when thread dumps and logs are insufficient and interactive inspection or breakpoints are necessary.
+- Pair this skill with [$cryptad-architecture](../cryptad-architecture/SKILL.md) when stacks need package context, [$codebase-retrieval](../codebase-retrieval/SKILL.md) when file scope is unclear, and [$cryptad-build-test](../cryptad-build-test/SKILL.md) after making a fix.
+
+## Guardrails
+
+- Do not restart or kill the running Cryptad process unless the user explicitly asks.
+- Do not attach `jdb` if port `5005` already has an established debugger connection unless the user explicitly wants to replace that debugger.
+- Capture `VM.command_line` and at least one full `Thread.print -l` dump before changing code.
+- Treat `Found one Java-level deadlock` in `jcmd` output as primary evidence; map the waiting thread, owning thread, and monitor objects back to source before proposing a fix.
+- Use the smallest safe code change and add a regression test when the failure can be expressed in a unit or concurrency-focused test.
+
+## Workflow
+
+### 1. Identify the JVM exposing JDWP
+
+On Windows PowerShell, start with:
+
+```powershell
+Get-NetTCPConnection -LocalPort 5005 -ErrorAction SilentlyContinue |
+  Select-Object LocalAddress,LocalPort,RemoteAddress,RemotePort,State,OwningProcess
+Get-Process -Id <pid> | Select-Object Name,Id,Path,StartTime
+jcmd <pid> VM.command_line
+```
+
+On macOS shell, start with:
+
+```bash
+lsof -nP -iTCP:5005
+ps -p <pid> -o pid,ppid,user,lstart,command
+jcmd <pid> VM.command_line
+```
+
+On Linux shell, start with:
+
+```bash
+ss -ltnp '( sport = :5005 )'
+ss -tnp '( sport = :5005 or dport = :5005 )'
+ps -fp <pid>
+jcmd <pid> VM.command_line
+```
+
+Interpret the results:
+
+- If nothing is listening on `5005`, the current process is not exposing JDWP on the default port.
+- If the connection state is `Established` on Windows, or `lsof` / `ss` shows an established peer on macOS or Linux, another debugger is already attached.
+- Confirm the JVM was started with JDWP options similar to `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:5005`.
+- `127.0.0.1:5005` means the listener is local-only; remote attach from another host will fail unless the JVM was started with a different bind address.
+
+### 2. Triage with `jcmd` first
+
+Use `jcmd` against the process ID instead of the JDWP socket. The commands are the same on Windows, macOS, and Linux:
+
+```powershell
+jcmd <pid> VM.command_line
+jcmd <pid> Thread.print -l
+jcmd <pid> GC.class_histogram
+```
+
+Read `Thread.print -l` in this order:
+
+1. Search for `Found one Java-level deadlock`.
+2. Identify the two threads and the monitors each one owns or waits on.
+3. Copy the Java stack frames for both threads.
+4. Find other threads blocked on the same monitor; those often explain user-visible symptoms such as a frozen web UI or stalled announcements.
+
+Typical Cryptad packages to inspect after a dump:
+
+- `network.crypta.node` for peer management, packet sending, announcers, and schedulers
+- `network.crypta.node.updater` for updater state, CoreUpdater, and NodeUpdateManager
+- `network.crypta.clients.http` for stuck HTTP handlers and rendered pages
+- `network.crypta.client.async` for fetcher and callback interactions
+- `network.crypta.support` for pooled threads, timers, and executor behavior
+
+### 3. Use `jdb` for interactive inspection when needed
+
+Attach to the default local listener only after checking whether another debugger is already connected:
+
+```text
+jdb -attach 127.0.0.1:5005
+```
+
+Useful `jdb` commands:
+
+```text
+threads
+thread <thread-id-or-name>
+where
+where all
+locals
+print <expression>
+stop in network.crypta.node.updater.NodeUpdateManager.hasNewCorePackage
+clear network.crypta.node.updater.NodeUpdateManager.hasNewCorePackage
+cont
+exit
+```
+
+Use `jdb` carefully:
+
+- Set breakpoints on narrow methods, not hot loops or broad package entry points.
+- Prefer inspecting blocked threads with `where` and `locals` over stepping through packet-processing code.
+- Remember that breakpoints can perturb timing and may hide or reshape races.
+- On macOS and Linux, run `jdb` from the same JDK major version as the target JVM when possible.
+
+### 4. Correlate runtime evidence with source
+
+- Open the exact methods from the thread dump before reading surrounding code.
+- Look for lock-order inversions such as `A -> B` on one path and `B -> A` on another.
+- Pay attention to synchronized manager methods that call synchronized updater methods, callback paths that re-enter shared state, and code that mixes monitor locks with executor callbacks.
+- If the failure is not a deadlock but a stalled request flow, consider enabling UID trace logging for the next restart:
+
+```text
+logger.priorityDetail=network.crypta.uidtrace:INFO
+```
+
+That writes `crypta-uidtrace-latest.log` under the configured log directory and helps trace long-lived request and insert UIDs.
+
+### 5. Turn the diagnosis into a fix
+
+- Keep the change minimal: shorten a lock scope, snapshot state before cross-object calls, or move callbacks outside synchronized sections when safe.
+- Add or update a focused regression test near the affected updater, node, or support class.
+- Run targeted Gradle verification first:
+
+```powershell
+.\gradlew.bat test --tests *TargetTestClass
+```
+
+```bash
+./gradlew test --tests *TargetTestClass
+```
+
+- If there is no focused test, at least compile and then run the smallest relevant test slice before broader validation.
+
+## Common Patterns
+
+### Deadlock
+
+- `jcmd` reports `Found one Java-level deadlock`.
+- One thread usually holds a manager-level monitor while calling into another synchronized component.
+- Another thread holds the second component and calls back into the manager.
+- Fix by breaking the lock-order inversion, usually by snapshotting state under one lock and calling outward after releasing it.
+
+### Hang without explicit deadlock
+
+- Many worker threads are `BLOCKED` on the same monitor, but `jcmd` reports no Java-level deadlock.
+- Find the owning thread and inspect why it is slow, parked, or waiting on I/O.
+- Check whether the blocked monitor sits on a frequently rendered HTTP path or peer-announcement path.
+
+### Existing debugger attached
+
+- Windows: `Get-NetTCPConnection` shows port `5005` with an `Established` connection.
+- macOS: `lsof -nP -iTCP:5005` shows both the listening JVM socket and an established peer.
+- Linux: `ss -tnp '( sport = :5005 or dport = :5005 )'` shows the established peer.
+- Use `jcmd` against the PID instead of attaching `jdb`.
+- Only replace the existing debugger when the user explicitly asks.

--- a/.agents/skills/cryptad-runtime-debugging/agents/openai.yaml
+++ b/.agents/skills/cryptad-runtime-debugging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cryptad Runtime Debugging"
+  short_description: "Debug a live Cryptad node safely"
+  default_prompt: "Use $cryptad-runtime-debugging to inspect a running Cryptad JVM, capture thread dumps, and attach with jcmd or jdb."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **$cryptad-hotfix-workflow** — Run emergency hotfix flow: cut `hotfix/<build-number>` from `main`, ship fix, tag `v<build>`, and no-squash `--no-ff` merges to `main` and `develop`.
 - **$cryptad-launcher-ui** — Work on the Swing launcher: start/stop logic, logging, keyboard shortcuts, FlatLaf/theme handling, and Windows specifics.
 - **$cryptad-packaging** — Build and troubleshoot distributions and installers (assembleCryptadDist, jpackage, Windows wrapper assets, Flatpak, Linux DEB/RPM behavior).
+- **$cryptad-runtime-debugging** — Debug live or reproducible Cryptad JVM failures on Windows, macOS, and Linux using `jcmd`, `jdb`, thread dumps, and the default JDWP listener on `127.0.0.1:5005`.
 - **$cryptad-style-docs** — Apply Cryptad Kotlin/Java style, file layout rules, and long-lived documentation/commenting practices.
 - **$codebase-retrieval** — Use semantic codebase retrieval to identify 1–5 target files before significant reading or edits when the file scope is unclear.
 - **$web-search** — Use both Exa and Tavily for external/current web research, then cross-check sources before answering.
@@ -48,6 +49,7 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **Environment detection:** Treat `AppEnv` as the single source of truth. Load `$cryptad-appenv` before touching OS/arch/sandbox/service detection code.
 - **Updater:** For any changes touching CoreUpdater descriptors, endpoints, or UI, load `$cryptad-core-updater`.
 - **Packaging/Installers:** For dist builds, installers, or Flatpak, load `$cryptad-packaging`.
+- **Runtime debugging:** For live deadlocks, hangs, blocked threads, stalled requests, or JDWP debugging with `jcmd` / `jdb`, load `$cryptad-runtime-debugging`.
 - **Branch workflow questions:** For branch model/merge/tag/version policy questions, load `$cryptad-git-workflow`.
 - **Starting feature/bugfix work:** Before creating a new `feature/*` or `bugfix/*` branch, load `$cryptad-start-work-branch`.
 - **Release operations:** For `release/<build-number>` branch creation/stabilization, version bumping, tagging, and merge-back flow, load `$cryptad-release-workflow`.

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -1,6 +1,6 @@
 # Cryptad Release Workflow and Runbook
 
-> Updated September 16, 2025 to cover the CoreUpdater package-based distribution flow.
+> Updated September 16, 2025, to cover the CoreUpdater package-based distribution flow.
 
 ## Overview
 - Purpose: publish a Cryptad release so running nodes discover a new `info/<edition>` descriptor, download OS-specific installers, and guide operators through installation without self-replacing the running JAR.
@@ -31,6 +31,7 @@
   }
   ```
   - Keys follow `<arch>.<ext>` naming. Supported extensions include `deb`, `rpm`, `tar.gz`, `dmg`, `exe`, `msi`, `flatpak`, `snap`, `pkg`, `zip`.
+  - `version` must be a base-10 integer string (for example `"1501"`). Noninteger values are treated as invalid for release gating and will not be advertised as updates.
   - `store_url` enables the "Open in Store" action when a direct download is not provided (Flatpak/Snap).
   - `changelog_chk` and `fullchangelog_chk` should point to CHK inserts containing Markdown or plaintext.
 - **Optional extras**: continue to publish seed node lists, installer references, or IP databases separately (outside `info/`). Link to them from release notes if needed.
@@ -38,7 +39,7 @@
 ## Pre-Release Checklist
 - **Versioning**: bump the integer `version` in `build.gradle.kts`. Ensure `Version.currentBuildNumber()` reflects the new build after `./gradlew build`.
 - **Release notes**: prepare short (user-facing) and full (developer) changelog text files for CHK publishing.
-- **Package matrix**: decide which OS/arch artifacts to ship this cycle. Minimum recommendation is macOS (DMG), Windows (EXE), Linux desktop/server (DEB + RPM), and Flatpak if maintained.
+- **Package matrix**: decide which OS/arch artifacts to ship this cycle. The minimum recommendation is macOS (DMG), Windows (EXE), Linux desktop/server (DEB + RPM), and Flatpak if maintained.
 - **Environment validation**: run smoke tests on each target OS using `build/jpackage/Crypta`, `build/distributions/`, or the staged Flatpak bundle. Ensure the installers launch and locate `cryptad-dist/` correctly.
 - **Dependency review**: verify updater metadata and package checksums are consistent with produced artifacts.
 
@@ -122,14 +123,14 @@
 
 ## Production Rollout
 - Publish descriptor and artifacts to the production USK.
-- Announce the release with links to installers, release notes, and any manual install guidance.
+- Announce the release with links to installers, release notes, and any manual installation guidance.
 - Monitor:
   - Node logs for `[CoreUpdater] progress` and `Download Completed` entries.
   - Support channels for installer/store issues.
   - Plugin releases remain on their existing USKs; coordinate scheduling if releasing simultaneously.
 
 ## Emergency Procedures
-- **Hotfix**: bump build number, rebuild, generate new descriptor, and publish to `info/<BUILD_N+1>`. Nodes will surface the newer package immediately.
+- **Hotfix**: bump build number, rebuild, generate new descriptor, and publish to `info/<BUILD_N+1>`. Nodes will surface in the newer package immediately.
 - **Revoke updater**: insert a clear message into `REVOKE_SSK`; `NodeUpdateManager` disables auto-downloads and shows the text in Alerts.
 - **Pull a bad release**: publish a replacement descriptor at the same edition with `packages` emptied or pointing to a warning changelog. Communicate manual cleanup steps because cached files under `updates/core/` are retained.
 
@@ -155,7 +156,7 @@ export BUILD_N=<INT_BUILD_NUMBER>
 export STAGING_USK="USK@<staging-update-key>/info/"
 export PROD_USK="USK@<prod-update-key>/info/"
 export REVOKE_SSK="SSK@<revocation-key>/revoked"
-export VERSION_STRING="$BUILD_N"               # or semantic tag if desired
+export VERSION_STRING="$BUILD_N"               # must stay an integer string; used for update gating
 export RELEASE_PAGE="https://crypta.network/releases/$BUILD_N"
 ```
 
@@ -164,7 +165,7 @@ export RELEASE_PAGE="https://crypta.network/releases/$BUILD_N"
 ./gradlew clean build
 ls -lh build/distributions/
 ```
-Confirm presence of:
+Confirm the presence of:
 - `cryptad-v${BUILD_N}.deb`, `cryptad-v${BUILD_N}.rpm`
 - `Crypta-${BUILD_N}.dmg`
 - `Crypta-${BUILD_N}.exe` (or `.msi`)
@@ -217,7 +218,7 @@ Retain the descriptor and package CHKs in the release record.
 ### 7) Post-release Checklist
 - Update the public release page and announcement channels.
 - Monitor `[CoreUpdater] progress` logs across canary nodes.
-- Prepare fallback plan (revocation message, follow-up descriptor) in case regressions surface.
+- Prepare a fallback plan (revocation message, follow-up descriptor) in case regressions surface.
 
 ### 8) Emergency Actions
 ```bash

--- a/src/main/java/network/crypta/io/comm/DMT.java
+++ b/src/main/java/network/crypta/io/comm/DMT.java
@@ -99,16 +99,17 @@ public class DMT {
   public static final String PEER_LOCATIONS = "peerLocations";
   public static final String PEER_UIDS = "peerUIDs";
   public static final String BEST_LOCATIONS_NOT_VISITED = "bestLocationsNotVisited";
-  public static final String MAIN_JAR_KEY = "mainJarKey";
+  public static final String CORE_PACKAGE_KEY = "mainJarKey";
   public static final String EXTRA_JAR_KEY = "extraJarKey";
   public static final String REVOCATION_KEY = "revocationKey";
   public static final String HAVE_REVOCATION_KEY = "haveRevocationKey";
-  public static final String MAIN_JAR_VERSION = "mainJarVersion";
+  // Wire field name intentionally preserved for protocol compatibility.
+  public static final String CORE_PACKAGE_VERSION = "mainJarVersion";
   public static final String EXTRA_JAR_VERSION = "extJarVersion";
   public static final String REVOCATION_KEY_TIME_LAST_TRIED = "revocationKeyTimeLastTried";
   public static final String REVOCATION_KEY_DNF_COUNT = "revocationKeyDNFCount";
   public static final String REVOCATION_KEY_FILE_LENGTH = "revocationKeyFileLength";
-  public static final String MAIN_JAR_FILE_LENGTH = "mainJarFileLength";
+  public static final String CORE_PACKAGE_FILE_LENGTH = "mainJarFileLength";
   public static final String EXTRA_JAR_FILE_LENGTH = "extraJarFileLength";
   public static final String PING_TIME = "pingTime";
   public static final String BWLIMIT_DELAY_TIME = "bwlimitDelayTime";
@@ -2365,36 +2366,36 @@ public class DMT {
       new MessageType("CryptadUOMAnnouncement", PRIORITY_LOW);
 
   static {
-    CryptadUOMAnnouncement.addField(MAIN_JAR_KEY, String.class);
+    CryptadUOMAnnouncement.addField(CORE_PACKAGE_KEY, String.class);
     CryptadUOMAnnouncement.addField(REVOCATION_KEY, String.class);
     CryptadUOMAnnouncement.addField(HAVE_REVOCATION_KEY, Boolean.class);
-    CryptadUOMAnnouncement.addField(MAIN_JAR_VERSION, Integer.class);
+    CryptadUOMAnnouncement.addField(CORE_PACKAGE_VERSION, Integer.class);
     // Last time (ms ago) we had 3 DNFs in a row on the revocation checker.
     CryptadUOMAnnouncement.addField(REVOCATION_KEY_TIME_LAST_TRIED, Long.class);
     // Number of DNFs so far this time.
     CryptadUOMAnnouncement.addField(REVOCATION_KEY_DNF_COUNT, Integer.class);
     // For convenience, may change
     CryptadUOMAnnouncement.addField(REVOCATION_KEY_FILE_LENGTH, Long.class);
-    CryptadUOMAnnouncement.addField(MAIN_JAR_FILE_LENGTH, Long.class);
+    CryptadUOMAnnouncement.addField(CORE_PACKAGE_FILE_LENGTH, Long.class);
     CryptadUOMAnnouncement.addField(PING_TIME, Integer.class);
     CryptadUOMAnnouncement.addField(BWLIMIT_DELAY_TIME, Integer.class);
   }
 
   /** Fluent builder for {@link #CryptadUOMAnnouncement} messages. */
   public static final class UOMAnnouncementBuilder {
-    private String mainKey;
+    private String corePackageKey;
     private String revocationKey;
     private boolean haveRevocation;
-    private int mainJarVersion;
+    private int corePackageVersion;
     private long timeLastTriedRevocationFetch;
     private int revocationDNFCount;
     private long revocationKeyLength;
-    private long mainJarLength;
+    private long corePackageLength;
     private int pingTime;
     private int bwlimitDelayTime;
 
-    public UOMAnnouncementBuilder mainKey(String v) {
-      this.mainKey = v;
+    public UOMAnnouncementBuilder corePackageKey(String v) {
+      this.corePackageKey = v;
       return this;
     }
 
@@ -2408,8 +2409,8 @@ public class DMT {
       return this;
     }
 
-    public UOMAnnouncementBuilder mainJarVersion(int v) {
-      this.mainJarVersion = v;
+    public UOMAnnouncementBuilder corePackageVersion(int v) {
+      this.corePackageVersion = v;
       return this;
     }
 
@@ -2428,8 +2429,8 @@ public class DMT {
       return this;
     }
 
-    public UOMAnnouncementBuilder mainJarLength(long v) {
-      this.mainJarLength = v;
+    public UOMAnnouncementBuilder corePackageLength(long v) {
+      this.corePackageLength = v;
       return this;
     }
 
@@ -2445,14 +2446,14 @@ public class DMT {
 
     public Message build() {
       Message msg = new Message(CryptadUOMAnnouncement);
-      msg.set(MAIN_JAR_KEY, mainKey);
+      msg.set(CORE_PACKAGE_KEY, corePackageKey);
       msg.set(REVOCATION_KEY, revocationKey);
       msg.set(HAVE_REVOCATION_KEY, haveRevocation);
-      msg.set(MAIN_JAR_VERSION, mainJarVersion);
+      msg.set(CORE_PACKAGE_VERSION, corePackageVersion);
       msg.set(REVOCATION_KEY_TIME_LAST_TRIED, timeLastTriedRevocationFetch);
       msg.set(REVOCATION_KEY_DNF_COUNT, revocationDNFCount);
       msg.set(REVOCATION_KEY_FILE_LENGTH, revocationKeyLength);
-      msg.set(MAIN_JAR_FILE_LENGTH, mainJarLength);
+      msg.set(CORE_PACKAGE_FILE_LENGTH, corePackageLength);
       msg.set(PING_TIME, pingTime);
       msg.set(BWLIMIT_DELAY_TIME, bwlimitDelayTime);
       return msg;
@@ -2480,22 +2481,22 @@ public class DMT {
   }
 
   // Used by new UOM.
-  /** Requests the main JAR referenced in the announcement. */
-  public static final MessageType CryptadUOMRequestMainJar =
+  /** Requests the core package referenced in the announcement. */
+  public static final MessageType CryptadUOMRequestCorePackage =
       new MessageType("CryptadUOMRequestMainJar", PRIORITY_LOW);
 
   static {
-    CryptadUOMRequestMainJar.addField(UID, Long.class);
+    CryptadUOMRequestCorePackage.addField(UID, Long.class);
   }
 
   /**
-   * Creates a {@code CryptadUOMRequestMainJar} using {@code uid} as the transfer identifier.
+   * Creates a {@code CryptadUOMRequestCorePackage} using {@code uid} as the transfer identifier.
    *
    * @param uid Transfer identifier.
    * @return Initialized message.
    */
-  public static Message createUOMRequestMainJar(long uid) {
-    Message msg = new Message(CryptadUOMRequestMainJar);
+  public static Message createUOMRequestCorePackage(long uid) {
+    Message msg = new Message(CryptadUOMRequestCorePackage);
     msg.set(UID, uid);
     return msg;
   }
@@ -2529,32 +2530,33 @@ public class DMT {
   }
 
   // Used by new UOM. We need to distinguish them in NodeDispatcher.
-  /** Announces that the main JAR will be sent, with length, key, and version. */
-  public static final MessageType CryptadUOMSendingMainJar =
+  /** Announces that the core package will be sent, with length, key, and version. */
+  public static final MessageType CryptadUOMSendingCorePackage =
       new MessageType("CryptadUOMSendingMainJar", PRIORITY_LOW);
 
   static {
-    CryptadUOMSendingMainJar.addField(UID, Long.class);
-    CryptadUOMSendingMainJar.addField(FILE_LENGTH, Long.class);
-    CryptadUOMSendingMainJar.addField(MAIN_JAR_KEY, String.class);
-    CryptadUOMSendingMainJar.addField(MAIN_JAR_VERSION, Integer.class);
+    CryptadUOMSendingCorePackage.addField(UID, Long.class);
+    CryptadUOMSendingCorePackage.addField(FILE_LENGTH, Long.class);
+    CryptadUOMSendingCorePackage.addField(CORE_PACKAGE_KEY, String.class);
+    CryptadUOMSendingCorePackage.addField(CORE_PACKAGE_VERSION, Integer.class);
   }
 
   /**
-   * Creates a {@code CryptadUOMSendingMainJar}.
+   * Creates a {@code CryptadUOMSendingCorePackage}.
    *
    * @param uid Transfer identifier.
    * @param length File length in bytes.
-   * @param key Key (URI string) for the main JAR.
+   * @param key Key (URI string) for the core package.
    * @param version Build version.
    * @return Initialized message.
    */
-  public static Message createUOMSendingMainJar(long uid, long length, String key, int version) {
-    Message msg = new Message(CryptadUOMSendingMainJar);
+  public static Message createUOMSendingCorePackage(
+      long uid, long length, String key, int version) {
+    Message msg = new Message(CryptadUOMSendingCorePackage);
     msg.set(UID, uid);
     msg.set(FILE_LENGTH, length);
-    msg.set(MAIN_JAR_KEY, key);
-    msg.set(MAIN_JAR_VERSION, version);
+    msg.set(CORE_PACKAGE_KEY, key);
+    msg.set(CORE_PACKAGE_VERSION, version);
     return msg;
   }
 

--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -3773,7 +3773,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     synchronized (this) {
       uomCount = 0;
       lastSentUOM = -1;
-      sendingUOMMainJar = false;
+      sendingUOMCorePackage = false;
       sendingUOMLegacyExtJar = false;
     }
     internals.notifyOpennetOnConnect(node, selfPeerNode());
@@ -4609,17 +4609,18 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
     return countSelectionsSinceConnected.get() / (double) timeSinceConnected;
   }
 
-  volatile int offeredMainJarVersion;
+  volatile int offeredCorePackageVersion;
 
   /**
    * Records the main JAR version most recently offered by this peer.
    *
    * <p>This is used by the update subsystem to track advertised core versions.
    *
-   * @param mainJarVersion offered the main JAR version number
+   * @param corePackageVersion offered the main JAR version number
    */
-  public void setMainJarOfferedVersion(int mainJarVersion) {
-    offeredMainJarVersion = mainJarVersion;
+  @SuppressWarnings("unused")
+  public void setCorePackageOfferedVersion(int corePackageVersion) {
+    offeredCorePackageVersion = corePackageVersion;
   }
 
   /**
@@ -4629,8 +4630,9 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    *
    * @return offered the main JAR version number
    */
-  public int getMainJarOfferedVersion() {
-    return offeredMainJarVersion;
+  @SuppressWarnings("unused")
+  public int getCorePackageOfferedVersion() {
+    return offeredCorePackageVersion;
   }
 
   /**
@@ -4962,7 +4964,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   }
 
   /** Whether we are sending the main jar to this peer */
-  protected boolean sendingUOMMainJar;
+  protected boolean sendingUOMCorePackage;
 
   /** Whether we are sending the ext jar (legacy) to this peer */
   protected boolean sendingUOMLegacyExtJar;
@@ -4985,13 +4987,14 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * @param isExt whether the legacy external jar is being sent
    * @return {@code true} unless it was already sending; otherwise {@code false}
    */
+  @SuppressWarnings("unused")
   public synchronized boolean sendingUOMJar(boolean isExt) {
     if (isExt) {
       if (sendingUOMLegacyExtJar) return false;
       sendingUOMLegacyExtJar = true;
     } else {
-      if (sendingUOMMainJar) return false;
-      sendingUOMMainJar = true;
+      if (sendingUOMCorePackage) return false;
+      sendingUOMCorePackage = true;
     }
     return true;
   }
@@ -5004,9 +5007,9 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
   public synchronized void finishedSendingUOMJar(boolean isExt) {
     if (isExt) {
       sendingUOMLegacyExtJar = false;
-      if (!(sendingUOMMainJar || uomCount > 0)) lastSentUOM = System.currentTimeMillis();
+      if (!(sendingUOMCorePackage || uomCount > 0)) lastSentUOM = System.currentTimeMillis();
     } else {
-      sendingUOMMainJar = false;
+      sendingUOMCorePackage = false;
       if (!(sendingUOMLegacyExtJar || uomCount > 0)) lastSentUOM = System.currentTimeMillis();
     }
   }
@@ -5020,7 +5023,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * @return elapsed time in milliseconds since the last completed UOM transfer
    */
   protected synchronized long timeSinceSentUOM() {
-    if (sendingUOMMainJar || sendingUOMLegacyExtJar) return 0;
+    if (sendingUOMCorePackage || sendingUOMLegacyExtJar) return 0;
     if (uomCount > 0) return 0;
     if (lastSentUOM <= 0) return Long.MAX_VALUE;
     return System.currentTimeMillis() - lastSentUOM;
@@ -5031,6 +5034,7 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    *
    * <p>This should be called when a UOM transfer begins.
    */
+  @SuppressWarnings("unused")
   public synchronized void incrementUOMSends() {
     uomCount++;
   }
@@ -5041,9 +5045,10 @@ public abstract class PeerNode implements BasePeerNode, PeerNodeUnlocked {
    * <p>When the count reaches zero and no UOM jar is being sent, the last-sent timestamp is
    * updated.
    */
+  @SuppressWarnings("unused")
   public synchronized void decrementUOMSends() {
     uomCount--;
-    if (uomCount == 0 && !sendingUOMMainJar && !sendingUOMLegacyExtJar)
+    if (uomCount == 0 && !sendingUOMCorePackage && !sendingUOMLegacyExtJar)
       lastSentUOM = System.currentTimeMillis();
   }
 

--- a/src/main/java/network/crypta/node/PeerNodeHandshakeLifecycle.java
+++ b/src/main/java/network/crypta/node/PeerNodeHandshakeLifecycle.java
@@ -301,7 +301,7 @@ final class PeerNodeHandshakeLifecycle {
       peerNode.previousTracker = null;
       peerNode.currentTracker = null;
       result.messagesTellDisconnected = peerNode.grabQueuedMessageItems();
-      peerNode.offeredMainJarVersion = 0;
+      peerNode.offeredCorePackageVersion = 0;
       result.oldPacketFormat = runtime.packetFormat();
       runtime.clearPacketFormat();
     }

--- a/src/main/java/network/crypta/node/updater/CoreUpdater.java
+++ b/src/main/java/network/crypta/node/updater/CoreUpdater.java
@@ -124,6 +124,7 @@ public class CoreUpdater extends NodeUpdater {
     if (manager.isAutoUpdateAllowed()
         && selected != null
         && selected.chk() != null
+        && isNewerThanCurrentBuild(parsedBuild)
         && !hasUsableFetcher()) {
       tryStartDownload();
     }
@@ -204,8 +205,7 @@ public class CoreUpdater extends NodeUpdater {
 
   @Override
   public synchronized boolean canUpdateNow() {
-    Integer parsedBuild = latestVersionBuild.get();
-    return parsedBuild != null && parsedBuild > Version.currentBuildNumber();
+    return isNewerThanCurrentBuild(latestVersionBuild.get());
   }
 
   @Override
@@ -269,6 +269,10 @@ public class CoreUpdater extends NodeUpdater {
     } catch (NumberFormatException _) {
       return null;
     }
+  }
+
+  private static boolean isNewerThanCurrentBuild(Integer parsedBuild) {
+    return parsedBuild != null && parsedBuild > Version.currentBuildNumber();
   }
 
   private void selectArtifact(CoreInfo info, AppEnv.EnvDetection env) {
@@ -735,8 +739,8 @@ public class CoreUpdater extends NodeUpdater {
     private final File outFile;
     private final FreenetURI chk;
     private final String chkString;
-    private volatile FetchContext fetchContext;
-    private volatile ClientGetter clientGetter;
+    private final AtomicReference<FetchContext> fetchContext = new AtomicReference<>();
+    private final AtomicReference<ClientGetter> clientGetter = new AtomicReference<>();
 
     private volatile int lastPct = -1;
     private volatile int lastDone = -1;
@@ -765,8 +769,8 @@ public class CoreUpdater extends NodeUpdater {
       var createdGetter =
           new ClientGetter(
               this, chk, ctx, RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, fb, null, null);
-      fetchContext = ctx;
-      clientGetter = createdGetter;
+      fetchContext.set(ctx);
+      clientGetter.set(createdGetter);
       ctx.getEventProducer().addEventListener(this);
       try {
         manager.getNode().services().clientCore().getClientContext().start(createdGetter);
@@ -792,7 +796,7 @@ public class CoreUpdater extends NodeUpdater {
     }
 
     void cancelForUriChange() {
-      ClientGetter getter = clientGetter;
+      ClientGetter getter = clientGetter.get();
       if (getter == null || getter.isFinished()) {
         detachProgressListener();
         return;
@@ -850,7 +854,7 @@ public class CoreUpdater extends NodeUpdater {
     @Override
     public void onSuccess(FetchResult result, ClientGetter state) {
       detachProgressListener();
-      clientGetter = null;
+      clientGetter.set(null);
       complete = true;
       successFile = outFile;
       failed = false;
@@ -862,7 +866,7 @@ public class CoreUpdater extends NodeUpdater {
     @Override
     public void onFailure(FetchException e) {
       detachProgressListener();
-      clientGetter = null;
+      clientGetter.set(null);
       complete = true;
       successFile = null;
       failed = true;
@@ -939,8 +943,7 @@ public class CoreUpdater extends NodeUpdater {
     }
 
     private void detachProgressListener() {
-      FetchContext localContext = fetchContext;
-      fetchContext = null;
+      FetchContext localContext = fetchContext.getAndSet(null);
       if (localContext == null) {
         return;
       }
@@ -957,7 +960,7 @@ public class CoreUpdater extends NodeUpdater {
       failed = true;
       fatal = fatalFlag;
       errorMsg = message != null ? message : "Failed to start download";
-      clientGetter = null;
+      clientGetter.set(null);
     }
   }
 }

--- a/src/main/java/network/crypta/node/updater/CoreUpdater.java
+++ b/src/main/java/network/crypta/node/updater/CoreUpdater.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
@@ -26,6 +27,7 @@ import network.crypta.fs.AppEnv;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarter;
+import network.crypta.node.Version;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SizeUtil;
 import network.crypta.support.api.Bucket;
@@ -66,6 +68,7 @@ public class CoreUpdater extends NodeUpdater {
   private final AppEnv appEnv = new AppEnv();
 
   private final AtomicReference<CoreInfo> latestInfo = new AtomicReference<>();
+  private final AtomicReference<Integer> latestVersionBuild = new AtomicReference<>();
   private volatile String selectedKey; // "<arch>.<ext>"
   private final AtomicReference<PackageSpec> selectedSpec = new AtomicReference<>();
   private final AtomicReference<PackageFetcher> fetcher = new AtomicReference<>();
@@ -110,10 +113,24 @@ public class CoreUpdater extends NodeUpdater {
   protected void maybeParseManifest(FetchResult result, int build) {
     CoreInfo info = parseInfo(result);
     latestInfo.set(info);
+    Integer parsedBuild = parseStrictIntegerVersion(info.version());
+    latestVersionBuild.set(parsedBuild);
     AppEnv.EnvDetection detected = appEnv.detectEnvironment();
     env.set(detected);
     selectArtifact(info, detected);
+    logParsedDescriptor(info, detected, parsedBuild);
 
+    PackageSpec selected = selectedSpec.get();
+    if (manager.isAutoUpdateAllowed()
+        && selected != null
+        && selected.chk() != null
+        && !hasUsableFetcher()) {
+      tryStartDownload();
+    }
+  }
+
+  private void logParsedDescriptor(
+      CoreInfo info, AppEnv.EnvDetection detected, Integer parsedBuild) {
     try {
       String versionLabel = info.version() != null ? info.version() : "?";
       String managers = String.join(",", detected.getAvailableManagers());
@@ -139,16 +156,14 @@ public class CoreUpdater extends NodeUpdater {
                 + ", full="
                 + (info.fullChangelogChk() != null ? info.fullChangelogChk() : "-"));
       }
+      if (parsedBuild == null) {
+        log.warn(
+            "{} Ignoring core-info version '{}' for release gating: expected an integer build",
+            LOG_TAG,
+            versionLabel);
+      }
     } catch (Exception _) {
       // best effort logging
-    }
-
-    PackageSpec selected = selectedSpec.get();
-    if (manager.isAutoUpdateAllowed()
-        && selected != null
-        && selected.chk() != null
-        && !hasUsableFetcher()) {
-      tryStartDownload();
     }
   }
 
@@ -177,6 +192,44 @@ public class CoreUpdater extends NodeUpdater {
     return info != null ? info.fullChangelogChk() : null;
   }
 
+  /**
+   * Returns the version label advertised by the latest parsed core info descriptor.
+   *
+   * @return descriptor version label, or {@code null} when unavailable
+   */
+  public String getAdvertisedVersionLabel() {
+    CoreInfo info = latestInfo.get();
+    return info != null ? info.version() : null;
+  }
+
+  @Override
+  public synchronized boolean canUpdateNow() {
+    Integer parsedBuild = latestVersionBuild.get();
+    return parsedBuild != null && parsedBuild > Version.currentBuildNumber();
+  }
+
+  @Override
+  public void onChangeURI(FreenetURI newUri, int subscribeEditionSeed) {
+    resetDescriptorStateForUriChange();
+    super.onChangeURI(newUri, subscribeEditionSeed);
+  }
+
+  private void resetDescriptorStateForUriChange() {
+    cancelPackageFetchForUriChange();
+    latestInfo.set(null);
+    latestVersionBuild.set(null);
+    selectedKey = null;
+    selectedSpec.set(null);
+    env.set(null);
+  }
+
+  private void cancelPackageFetchForUriChange() {
+    PackageFetcher previous = fetcher.getAndSet(null);
+    if (previous != null) {
+      previous.cancelForUriChange();
+    }
+  }
+
   private CoreInfo parseInfo(FetchResult result) {
     try (Bucket bucket = result.asBucket();
         InputStream input = bucket.getInputStream();
@@ -196,6 +249,26 @@ public class CoreUpdater extends NodeUpdater {
       sb.append(buf, 0, n);
     }
     return sb.toString();
+  }
+
+  static Integer parseStrictIntegerVersion(String versionLabel) {
+    if (versionLabel == null) {
+      return null;
+    }
+    String trimmed = versionLabel.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    for (int i = 0; i < trimmed.length(); i++) {
+      if (!Character.isDigit(trimmed.charAt(i))) {
+        return null;
+      }
+    }
+    try {
+      return Integer.parseInt(trimmed);
+    } catch (NumberFormatException _) {
+      return null;
+    }
   }
 
   private void selectArtifact(CoreInfo info, AppEnv.EnvDetection env) {
@@ -662,6 +735,8 @@ public class CoreUpdater extends NodeUpdater {
     private final File outFile;
     private final FreenetURI chk;
     private final String chkString;
+    private volatile FetchContext fetchContext;
+    private volatile ClientGetter clientGetter;
 
     private volatile int lastPct = -1;
     private volatile int lastDone = -1;
@@ -690,6 +765,8 @@ public class CoreUpdater extends NodeUpdater {
       var createdGetter =
           new ClientGetter(
               this, chk, ctx, RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, fb, null, null);
+      fetchContext = ctx;
+      clientGetter = createdGetter;
       ctx.getEventProducer().addEventListener(this);
       try {
         manager.getNode().services().clientCore().getClientContext().start(createdGetter);
@@ -698,7 +775,7 @@ public class CoreUpdater extends NodeUpdater {
       } catch (FetchException e) {
         markStartFailure(
             e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName(), safeIsFatal(e));
-        ctx.getEventProducer().removeEventListener(this);
+        detachProgressListener();
         CoreUpdater.this.logError(
             "Failed to start package download: "
                 + (errorMsg != null ? errorMsg : e.getClass().getSimpleName()),
@@ -706,11 +783,28 @@ public class CoreUpdater extends NodeUpdater {
       } catch (Exception e) {
         markStartFailure(
             e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName(), false);
-        ctx.getEventProducer().removeEventListener(this);
+        detachProgressListener();
         CoreUpdater.this.logError(
             "Error starting package download: "
                 + (errorMsg != null ? errorMsg : e.getClass().getSimpleName()),
             e);
+      }
+    }
+
+    void cancelForUriChange() {
+      ClientGetter getter = clientGetter;
+      if (getter == null || getter.isFinished()) {
+        detachProgressListener();
+        return;
+      }
+      try {
+        getter.cancel(manager.getNode().services().clientCore().getClientContext());
+        CoreUpdater.this.logInfo("Cancelled in-flight package download after update URI change");
+      } catch (Exception e) {
+        CoreUpdater.this.logError(
+            "Error while cancelling in-flight package download after URI change", e);
+      } finally {
+        detachProgressListener();
       }
     }
 
@@ -755,6 +849,8 @@ public class CoreUpdater extends NodeUpdater {
 
     @Override
     public void onSuccess(FetchResult result, ClientGetter state) {
+      detachProgressListener();
+      clientGetter = null;
       complete = true;
       successFile = outFile;
       failed = false;
@@ -765,6 +861,8 @@ public class CoreUpdater extends NodeUpdater {
 
     @Override
     public void onFailure(FetchException e) {
+      detachProgressListener();
+      clientGetter = null;
       complete = true;
       successFile = null;
       failed = true;
@@ -840,12 +938,26 @@ public class CoreUpdater extends NodeUpdater {
       }
     }
 
+    private void detachProgressListener() {
+      FetchContext localContext = fetchContext;
+      fetchContext = null;
+      if (localContext == null) {
+        return;
+      }
+      try {
+        localContext.getEventProducer().removeEventListener(this);
+      } catch (Exception _) {
+        // Best-effort listener cleanup.
+      }
+    }
+
     private void markStartFailure(String message, boolean fatalFlag) {
       complete = true;
       successFile = null;
       failed = true;
       fatal = fatalFlag;
       errorMsg = message != null ? message : "Failed to start download";
+      clientGetter = null;
     }
   }
 }

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -140,7 +140,7 @@ public final class NodeUpdateManager {
   private volatile int lastKnownGoodFetchedEdition;
   private volatile String lastKnownGoodFetchedEditionKey;
 
-  // Legacy MainJarUpdater removed; core package updater is used instead.
+  // Legacy jar updater removed; core package updater is used instead.
   // Package-based core updater (Kotlin)
   private CoreUpdater coreUpdater;
 
@@ -557,14 +557,14 @@ public final class NodeUpdateManager {
     }
     int fetchedVersion = (blobSize <= 0) ? -1 : Version.currentBuildNumber();
     return new DMT.UOMAnnouncementBuilder()
-        .mainKey(localUpdateURI.toString())
+        .corePackageKey(localUpdateURI.toString())
         .revocationKey(localRevocationURI.toString())
         .haveRevocation(getRevocationChecker().hasBlown())
-        .mainJarVersion(fetchedVersion)
+        .corePackageVersion(fetchedVersion)
         .timeLastTriedRevocationFetch(getRevocationChecker().lastSucceededDelta())
         .revocationDNFCount(getRevocationChecker().getRevocationDNFCounter())
         .revocationKeyLength(getRevocationChecker().getBlobSize())
-        .mainJarLength(blobSize)
+        .corePackageLength(blobSize)
         .pingTime((int) node.network().stats().getNodeAveragePingTime())
         .bwlimitDelayTime((int) node.network().stats().getBwlimitDelayTime())
         .build();
@@ -1048,7 +1048,7 @@ public final class NodeUpdateManager {
    *
    * @return {@code true} when a newer version has been fetched and is ready
    */
-  public synchronized boolean hasNewMainJar() {
+  public synchronized boolean hasNewCorePackage() {
     CoreUpdater cu = coreUpdater;
     return cu != null && cu.canUpdateNow();
   }
@@ -1058,9 +1058,26 @@ public final class NodeUpdateManager {
    *
    * @return the fetched version number, or {@code -1} when none is available
    */
-  public synchronized int newMainJarVersion() {
+  public synchronized int newCorePackageVersion() {
     CoreUpdater cu = coreUpdater;
     return (cu != null) ? cu.getFetchedVersion() : -1;
+  }
+
+  /**
+   * Returns the advertised core version label from the latest parsed descriptor.
+   *
+   * @return descriptor version label, or a fetched-version fallback when unavailable
+   */
+  public synchronized String newCorePackageVersionLabel() {
+    CoreUpdater cu = coreUpdater;
+    if (cu == null) {
+      return Integer.toString(-1);
+    }
+    String label = cu.getAdvertisedVersionLabel();
+    if (label != null && !label.isBlank()) {
+      return label;
+    }
+    return Integer.toString(cu.getFetchedVersion());
   }
 
   /**
@@ -1068,7 +1085,7 @@ public final class NodeUpdateManager {
    *
    * @return {@code true} when a download is in progress
    */
-  public synchronized boolean fetchingNewMainJar() {
+  public synchronized boolean fetchingNewCorePackage() {
     CoreUpdater cu = coreUpdater;
     return (cu != null && cu.isFetching());
   }
@@ -1078,7 +1095,7 @@ public final class NodeUpdateManager {
    *
    * @return the in‑flight version number, or {@code -1} when idle
    */
-  public synchronized int fetchingNewMainJarVersion() {
+  public synchronized int fetchingNewCorePackageVersion() {
     CoreUpdater cu = coreUpdater;
     return (cu != null) ? cu.fetchingVersion() : -1;
   }
@@ -1116,7 +1133,7 @@ public final class NodeUpdateManager {
    * @return {@code true} when an update would be possible after revocation verification
    */
   public boolean canUpdateNow() {
-    return hasNewMainJar();
+    return hasNewCorePackage();
   }
 
   /**

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -1048,8 +1048,8 @@ public final class NodeUpdateManager {
    *
    * @return {@code true} when a newer version has been fetched and is ready
    */
-  public synchronized boolean hasNewCorePackage() {
-    CoreUpdater cu = coreUpdater;
+  public boolean hasNewCorePackage() {
+    CoreUpdater cu = getCoreUpdaterSnapshot();
     return cu != null && cu.canUpdateNow();
   }
 
@@ -1058,8 +1058,8 @@ public final class NodeUpdateManager {
    *
    * @return the fetched version number, or {@code -1} when none is available
    */
-  public synchronized int newCorePackageVersion() {
-    CoreUpdater cu = coreUpdater;
+  public int newCorePackageVersion() {
+    CoreUpdater cu = getCoreUpdaterSnapshot();
     return (cu != null) ? cu.getFetchedVersion() : -1;
   }
 
@@ -1068,8 +1068,8 @@ public final class NodeUpdateManager {
    *
    * @return descriptor version label, or a fetched-version fallback when unavailable
    */
-  public synchronized String newCorePackageVersionLabel() {
-    CoreUpdater cu = coreUpdater;
+  public String newCorePackageVersionLabel() {
+    CoreUpdater cu = getCoreUpdaterSnapshot();
     if (cu == null) {
       return Integer.toString(-1);
     }
@@ -1085,8 +1085,8 @@ public final class NodeUpdateManager {
    *
    * @return {@code true} when a download is in progress
    */
-  public synchronized boolean fetchingNewCorePackage() {
-    CoreUpdater cu = coreUpdater;
+  public boolean fetchingNewCorePackage() {
+    CoreUpdater cu = getCoreUpdaterSnapshot();
     return (cu != null && cu.isFetching());
   }
 
@@ -1095,9 +1095,13 @@ public final class NodeUpdateManager {
    *
    * @return the in‑flight version number, or {@code -1} when idle
    */
-  public synchronized int fetchingNewCorePackageVersion() {
-    CoreUpdater cu = coreUpdater;
+  public int fetchingNewCorePackageVersion() {
+    CoreUpdater cu = getCoreUpdaterSnapshot();
     return (cu != null) ? cu.fetchingVersion() : -1;
+  }
+
+  private synchronized CoreUpdater getCoreUpdaterSnapshot() {
+    return coreUpdater;
   }
 
   /**

--- a/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
+++ b/src/main/java/network/crypta/node/updater/UpdateOverMandatoryManager.java
@@ -124,7 +124,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
   private final HashSet<PeerNode> nodesSayKeyRevokedTransferring;
 
   /** Peers seen in UoM announcements and considered for dependency fetch attempts. */
-  private final HashSet<PeerNode> allNodesOfferedMainJar;
+  private final HashSet<PeerNode> allNodesOfferedCorePackage;
 
   // 2 for reliability, no more as gets very slow/wasteful
   static final int MAX_NODES_SENDING_JAR = 2;
@@ -163,7 +163,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
     nodesSayKeyRevoked = new HashSet<>();
     nodesSayKeyRevokedFailedTransfer = new HashSet<>();
     nodesSayKeyRevokedTransferring = new HashSet<>();
-    allNodesOfferedMainJar = new HashSet<>();
+    allNodesOfferedCorePackage = new HashSet<>();
     dependencyFetchers = new HashMap<>();
   }
 
@@ -221,7 +221,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
       tellFetchers(source);
 
       synchronized (this) {
-        allNodesOfferedMainJar.add(source);
+        allNodesOfferedCorePackage.add(source);
       }
       startSomeDependencyFetchers();
     }
@@ -1221,15 +1221,15 @@ public class UpdateOverMandatoryManager implements RequestClient {
     }
   }
 
-  // Removed an unused method maybeInsertMainJar: insertion is coordinated via updater flows.
+  // Removed an unused method maybeInsertCorePackage: insertion is coordinated via updater flows.
 
   /**
    * Deletes obsolete persistent temporary files related to UoM transfers.
    *
    * <p>The method scans the persistent temp directory for known UoM patterns (revocation and
-   * main‑jar blobs and their temporary variants). It removes files that are clearly safe to delete,
-   * including old build‑number‑scoped files below the minimum acceptable build. Errors are logged
-   * but otherwise ignored.
+   * core-package blobs and their temporary variants). It removes files that are clearly safe to
+   * delete, including old build‑number‑scoped files below the minimum acceptable build. Errors are
+   * logged but otherwise ignored.
    */
   protected void removeOldTempFiles() {
     File oldTempFilesPeerDir =
@@ -1307,7 +1307,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
       nodesSayKeyRevoked.remove(pn);
       nodesSayKeyRevokedFailedTransfer.remove(pn);
       nodesSayKeyRevokedTransferring.remove(pn);
-      allNodesOfferedMainJar.remove(pn);
+      allNodesOfferedCorePackage.remove(pn);
     }
     maybeNotRevoked();
   }
@@ -1475,7 +1475,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
       while (true) {
         HashSet<PeerNode> uomPeers;
         synchronized (UpdateOverMandatoryManager.this) {
-          uomPeers = new HashSet<>(allNodesOfferedMainJar);
+          uomPeers = new HashSet<>(allNodesOfferedCorePackage);
         }
         PeerNode chosen = chooseRandomPeer(uomPeers);
         if (chosen != null) return chosen;

--- a/src/main/java/network/crypta/node/useralerts/UpdatedVersionAvailableUserAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/UpdatedVersionAvailableUserAlert.java
@@ -43,12 +43,12 @@ public class UpdatedVersionAvailableUserAlert extends AbstractUserAlert {
   private final NodeUpdateManager updater;
 
   /**
-   * Creates an alert bound to the given updater.
+   * Creates an alert bound to the given-updater.
    *
    * <p>The updater supplies all state used to compose user-facing strings, determine whether the
    * alert is currently valid, and compute its priority. The constructor does not perform I/O and
    * does not capture mutable snapshots; instead, methods query the updater each time they are
-   * called so the alert reflects the most recent progress.
+   * called, so the alert reflects the most recent progress.
    *
    * @param updater the {@link NodeUpdateManager} providing update status, progress, and actions;
    *     must be non-null and remain valid for the lifetime of this alert instance
@@ -94,12 +94,12 @@ public class UpdatedVersionAvailableUserAlert extends AbstractUserAlert {
   /**
    * Builds a detailed, human-readable message describing the update state.
    *
-   * <p>The returned string can include a minimal HTML {@code <form>} snippet with a submit button
+   * <p>The returned string can include a minimal HTML {@code <form>} snippet with a Submit button
    * when an immediate action is available (for example, “Update Now” or “Update ASAP”). Callers
    * that cannot render HTML should prefer {@link #getShortText()} or sanitize the markup before
    * display.
    *
-   * @return a localized message describing current update status, optionally including a simple
+   * @return a localized message describing the current update status, optionally including a simple
    *     HTML form with an action button
    */
   @Override
@@ -148,7 +148,7 @@ public class UpdatedVersionAvailableUserAlert extends AbstractUserAlert {
    * Produces a structured HTML representation of this alert.
    *
    * <p>The returned {@link network.crypta.support.HTMLNode} contains the detailed message text and
-   * may also include a small HTML {@code <form>} with a submit button when an action is available.
+   * may also include a small HTML {@code <form>} with a Submit button when an action is available.
    * It appends links to changelogs and renders progress indicators when present.
    *
    * @return an {@code HTMLNode} tree suitable for rendering within the web UI
@@ -181,10 +181,10 @@ public class UpdatedVersionAvailableUserAlert extends AbstractUserAlert {
     alertNode.addChild("br");
 
     int version;
-    if (updater.hasNewMainJar()) {
-      version = updater.newMainJarVersion();
-    } else if (updater.fetchingNewMainJar()) {
-      version = updater.fetchingNewMainJarVersion();
+    if (updater.hasNewCorePackage()) {
+      version = updater.newCorePackageVersion();
+    } else if (updater.fetchingNewCorePackage()) {
+      version = updater.fetchingNewCorePackageVersion();
     } else {
       LOG.debug("Showing version available notification but not fetching or fetched.");
       // Fallback
@@ -240,16 +240,15 @@ public class UpdatedVersionAvailableUserAlert extends AbstractUserAlert {
 
     if (NodeUpdateManager.BROKEN_DEPENDENCIES) {
       sb.append(' ')
-          .append(
-              l10n("brokenDependencies", "version", Integer.toString(updater.newMainJarVersion())));
+          .append(l10n("brokenDependencies", "version", updater.newCorePackageVersionLabel()));
     }
 
     return new UpdateThingy(sb.toString(), formText);
   }
 
   private String appendCanUpdateNowText(StringBuilder sb) {
-    if (updater.hasNewMainJar()) {
-      sb.append(l10n("downloadedNewJar", "version", Integer.toString(updater.newMainJarVersion())))
+    if (updater.hasNewCorePackage()) {
+      sb.append(l10n("downloadedNewJar", "version", updater.newCorePackageVersionLabel()))
           .append(' ');
     }
     if (updater.canUpdateImmediately()) {
@@ -264,12 +263,12 @@ public class UpdatedVersionAvailableUserAlert extends AbstractUserAlert {
   private String appendNotReadyText(StringBuilder sb) {
     if (updater.fetchingFromUOM()) {
       sb.append(l10n("fetchingUOM", "updateScript", getUpdateScriptName()));
-    } else if (updater.fetchingNewMainJar()) {
+    } else if (updater.fetchingNewCorePackage()) {
       sb.append(
           l10n(
               "fetchingNewNode",
               "versionNumber",
-              Long.toString(updater.fetchingNewMainJarVersion())));
+              Long.toString(updater.fetchingNewCorePackageVersion())));
     }
     sb.append(' ').append(l10n("updateASAPQuestion"));
     return l10n("updateASAPButton");
@@ -321,7 +320,9 @@ public class UpdatedVersionAvailableUserAlert extends AbstractUserAlert {
   public boolean isValid() {
     return updater.isEnabled()
         && !updater.isBlown()
-        && (updater.fetchingNewMainJar() || updater.hasNewMainJar() || updater.fetchingFromUOM());
+        && (updater.fetchingNewCorePackage()
+            || updater.hasNewCorePackage()
+            || updater.fetchingFromUOM());
   }
 
   /**

--- a/src/main/templates/cryptad.bat.tpl
+++ b/src/main/templates/cryptad.bat.tpl
@@ -6,6 +6,7 @@ set "ROOT_DIR=%SCRIPT_DIR%.."
 set "BIN_DIR=%ROOT_DIR%\bin"
 set "CONF_DIR=%ROOT_DIR%\conf"
 set "LIB_DIR=%ROOT_DIR%\lib"
+set "TMP_DIR=%ROOT_DIR%\tmp"
 
 set "CONF=%CONF_DIR%\wrapper.conf"
 if not exist "%CONF%" (
@@ -15,12 +16,15 @@ if not exist "%CONF%" (
 
 REM Use bundled runtime when running from a jpackage app image
 set "JPACKAGE_RUNTIME=%ROOT_DIR%\..\..\runtime"
+set "JPKG_JAVA_BIN="
 if exist "%JPACKAGE_RUNTIME%\bin\java.exe" (
   if not defined JAVA_HOME (
     for %%I in ("%JPACKAGE_RUNTIME%") do set "JAVA_HOME=%%~fI"
+    for %%I in ("%JPACKAGE_RUNTIME%\bin\java.exe") do set "JPKG_JAVA_BIN=%%~fI"
   ) else (
     if not exist "%JAVA_HOME%\bin\java.exe" (
       for %%I in ("%JPACKAGE_RUNTIME%") do set "JAVA_HOME=%%~fI"
+      for %%I in ("%JPACKAGE_RUNTIME%\bin\java.exe") do set "JPKG_JAVA_BIN=%%~fI"
     )
   )
 )
@@ -32,13 +36,16 @@ if defined JAVA_HOME (
 )
 
 REM Detect architecture (normalize to amd64/arm64)
-set "ARCH=%PROCESSOR_ARCHITECTURE%"
+set "ARCH_RAW=%PROCESSOR_ARCHITECTURE%"
+set "ARCH_WOW64="
+if defined PROCESSOR_ARCHITEW6432 set "ARCH_WOW64=%PROCESSOR_ARCHITEW6432%"
+set "ARCH=%ARCH_RAW%"
 if /I "%ARCH%"=="AMD64" set "ARCH=amd64"
 if /I "%ARCH%"=="ARM64" set "ARCH=arm64"
 REM Wow64 case: 32-bit process on 64-bit OS
 if /I "%ARCH%"=="x86" (
-  if /I "%PROCESSOR_ARCHITEW6432%"=="AMD64" set "ARCH=amd64"
-  if /I "%PROCESSOR_ARCHITEW6432%"=="ARM64" set "ARCH=arm64"
+  if /I "%ARCH_WOW64%"=="AMD64" set "ARCH=amd64"
+  if /I "%ARCH_WOW64%"=="ARM64" set "ARCH=arm64"
 )
 
 REM Prefer arch-specific wrapper exe; fallback to wrapper.exe if present
@@ -46,10 +53,6 @@ set "WRAPPER_EXE="
 if /I "%ARCH%"=="amd64" set "WRAPPER_EXE=%BIN_DIR%\wrapper-windows-x86-64.exe"
 if /I "%ARCH%"=="arm64" set "WRAPPER_EXE=%BIN_DIR%\wrapper-windows-arm-64.exe"
 if not exist "%WRAPPER_EXE%" set "WRAPPER_EXE=%BIN_DIR%\wrapper.exe"
-if not exist "%WRAPPER_EXE%" (
-  echo No Windows native wrapper found in "%BIN_DIR%" for arch %ARCH% 1>&2
-  exit /b 1
-)
 
 REM Native DLLs are placed directly in lib as:
 REM  - wrapper-windows-x86-64.dll
@@ -65,6 +68,7 @@ REM   CRYPTAD_DEBUG_HOST     default: 127.0.0.1  (use '*' to listen on all inter
 REM   CRYPTAD_DEBUG_SUSPEND  default: n         (use 'y' to wait for debugger)
 REM   CRYPTAD_DEBUG_TIMEOUT  default: unset     (milliseconds; optional)
 set "WRAPPER_ANCHOR=wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor"
+set "DEBUG_DESC=off"
 if not defined CRYPTAD_REMOTE_DEBUG goto run_wrapper
 
 set "DEBUG_HOST=%CRYPTAD_DEBUG_HOST%"
@@ -75,6 +79,10 @@ set "DEBUG_SUSPEND=%CRYPTAD_DEBUG_SUSPEND%"
 if not defined DEBUG_SUSPEND set "DEBUG_SUSPEND=n"
 set "JDWP_OPT=-agentlib:jdwp=transport=dt_socket,server=y,suspend=%DEBUG_SUSPEND%,address=%DEBUG_HOST%:%DEBUG_PORT%"
 if defined CRYPTAD_DEBUG_TIMEOUT set "JDWP_OPT=%JDWP_OPT%,timeout=%CRYPTAD_DEBUG_TIMEOUT%"
+set "DEBUG_DESC=enabled (%DEBUG_HOST%:%DEBUG_PORT% suspend=%DEBUG_SUSPEND%)"
+
+call :print_diagnostics
+if not exist "%WRAPPER_EXE%" goto missing_wrapper
 
 REM Run Tanuki wrapper with our config and set anchorfile to a per-user path.
 REM Command-line properties override wrapper.conf and handle spaces if quoted as one arg.
@@ -82,4 +90,27 @@ REM Command-line properties override wrapper.conf and handle spaces if quoted as
 goto :eof
 
 :run_wrapper
+call :print_diagnostics
+if not exist "%WRAPPER_EXE%" goto missing_wrapper
 "%WRAPPER_EXE%" -c "%CONF%" "%WRAPPER_ANCHOR%" %*
+goto :eof
+
+:missing_wrapper
+echo No native wrapper found or not executable: "%WRAPPER_EXE%" 1>&2
+echo Searched in: "%BIN_DIR%" 1>&2
+echo Please install the appropriate native wrapper for Windows/%ARCH% or rebuild the distribution. 1>&2
+exit /b 1
+
+:print_diagnostics
+echo [cryptad] Directory layout
+echo   SCRIPT_DIR=%SCRIPT_DIR%
+echo   ROOT_DIR=%ROOT_DIR%
+echo   BIN_DIR=%BIN_DIR%
+echo   CONF_DIR=%CONF_DIR%
+echo   LIB_DIR=%LIB_DIR%
+echo   TMP_DIR=%TMP_DIR%
+echo   WRAPPER=%WRAPPER_EXE%
+echo   DETECTED_ARCH=%ARCH% ^(raw=%ARCH_RAW% wow64=%ARCH_WOW64%^)
+echo   REMOTE_DEBUG=%DEBUG_DESC%
+if defined JPKG_JAVA_BIN echo   JPACKAGE_JAVA=%JPKG_JAVA_BIN% ^(prepended to PATH^)
+exit /b 0

--- a/src/main/templates/cryptad.bat.tpl
+++ b/src/main/templates/cryptad.bat.tpl
@@ -56,6 +56,30 @@ REM  - wrapper-windows-x86-64.dll
 REM  - wrapper-windows-arm-64.dll
 REM They are resolved via wrapper.java.library.path=lib in wrapper.conf.
 
-REM Run Tanuki wrapper with our config and set anchorfile to a per-user path
-REM (Command-line properties override wrapper.conf and handle spaces if quoted as one arg.)
-"%WRAPPER_EXE%" -c "%CONF%" "wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor" %*
+REM Optional: enable Java remote debugging when requested via environment.
+REM When CRYPTAD_REMOTE_DEBUG is set (to any value), we append a JDWP agent option
+REM using Wrapper command-line properties so it applies only for this run.
+REM Tuning via env (all optional):
+REM   CRYPTAD_DEBUG_PORT     default: 5005
+REM   CRYPTAD_DEBUG_HOST     default: 127.0.0.1  (use '*' to listen on all interfaces)
+REM   CRYPTAD_DEBUG_SUSPEND  default: n         (use 'y' to wait for debugger)
+REM   CRYPTAD_DEBUG_TIMEOUT  default: unset     (milliseconds; optional)
+set "WRAPPER_ANCHOR=wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor"
+if not defined CRYPTAD_REMOTE_DEBUG goto run_wrapper
+
+set "DEBUG_HOST=%CRYPTAD_DEBUG_HOST%"
+if not defined DEBUG_HOST set "DEBUG_HOST=127.0.0.1"
+set "DEBUG_PORT=%CRYPTAD_DEBUG_PORT%"
+if not defined DEBUG_PORT set "DEBUG_PORT=5005"
+set "DEBUG_SUSPEND=%CRYPTAD_DEBUG_SUSPEND%"
+if not defined DEBUG_SUSPEND set "DEBUG_SUSPEND=n"
+set "JDWP_OPT=-agentlib:jdwp=transport=dt_socket,server=y,suspend=%DEBUG_SUSPEND%,address=%DEBUG_HOST%:%DEBUG_PORT%"
+if defined CRYPTAD_DEBUG_TIMEOUT set "JDWP_OPT=%JDWP_OPT%,timeout=%CRYPTAD_DEBUG_TIMEOUT%"
+
+REM Run Tanuki wrapper with our config and set anchorfile to a per-user path.
+REM Command-line properties override wrapper.conf and handle spaces if quoted as one arg.
+"%WRAPPER_EXE%" -c "%CONF%" "%WRAPPER_ANCHOR%" "wrapper.ignore_sequence_gaps=TRUE" "wrapper.java.additional.250=%JDWP_OPT% " "wrapper.java.additional.251=-Xdebug" %*
+goto :eof
+
+:run_wrapper
+"%WRAPPER_EXE%" -c "%CONF%" "%WRAPPER_ANCHOR%" %*

--- a/src/test/java/network/crypta/node/NodeControlMessageHandlerTest.java
+++ b/src/test/java/network/crypta/node/NodeControlMessageHandlerTest.java
@@ -206,8 +206,8 @@ class NodeControlMessageHandlerTest {
   }
 
   @Test
-  void handle_whenUomRequestMainJarUnsupported_returnsFalse() {
-    when(message.getSpec()).thenReturn(DMT.CryptadUOMRequestMainJar);
+  void handle_whenUomRequestCorePackageUnsupported_returnsFalse() {
+    when(message.getSpec()).thenReturn(DMT.CryptadUOMRequestCorePackage);
     when(peerNode.isRealConnection()).thenReturn(true);
 
     boolean handled = handler.handle(message, peerNode);
@@ -217,8 +217,8 @@ class NodeControlMessageHandlerTest {
   }
 
   @Test
-  void handle_whenUomSendingMainJar_returnsFalse() {
-    when(message.getSpec()).thenReturn(DMT.CryptadUOMSendingMainJar);
+  void handle_whenUomSendingCorePackage_returnsFalse() {
+    when(message.getSpec()).thenReturn(DMT.CryptadUOMSendingCorePackage);
     when(peerNode.isRealConnection()).thenReturn(true);
 
     boolean handled = handler.handle(message, peerNode);

--- a/src/test/java/network/crypta/node/NodeDispatcherTest.java
+++ b/src/test/java/network/crypta/node/NodeDispatcherTest.java
@@ -99,7 +99,7 @@ class NodeDispatcherTest {
           @Override
           public void close() {
             // Test stub: RandomSource has no background collectors or OS handles here.
-            // Intentionally a no-op to satisfy static analysis of empty methods.
+            // Intentionally, a no-op to satisfy static analysis of empty methods.
           }
         };
     when(node.getRandom()).thenReturn(rnd);
@@ -341,7 +341,7 @@ class NodeDispatcherTest {
     routedPing = withSource(routedPing, src);
 
     dispatcher.handleRouted(routedPing, src);
-    // Expect immediate pong to the source with same uid/counter
+    // Expect immediate pong to the source with the same uid / counter
     verify(transport).sendAsync(msgCaptor.capture(), eq(null), eq(stats.routedMessageCtr));
     Message sent = msgCaptor.getValue();
     assertEquals(DMT.FNPRoutedPong, sent.getSpec());
@@ -400,14 +400,14 @@ class NodeDispatcherTest {
     PeerNode src = peerMock();
     Message ann =
         new DMT.UOMAnnouncementBuilder()
-            .mainKey("K")
+            .corePackageKey("K")
             .revocationKey("R")
             .haveRevocation(true)
-            .mainJarVersion(1)
+            .corePackageVersion(1)
             .timeLastTriedRevocationFetch(0)
             .revocationDNFCount(0)
             .revocationKeyLength(1)
-            .mainJarLength(1)
+            .corePackageLength(1)
             .pingTime(10)
             .bwlimitDelayTime(0)
             .build();

--- a/src/test/java/network/crypta/node/updater/CoreUpdaterTest.java
+++ b/src/test/java/network/crypta/node/updater/CoreUpdaterTest.java
@@ -43,4 +43,21 @@ class CoreUpdaterTest {
     assertNotNull(info.packages().get("amd64.exe"));
     assertNull(info.releasePageUrl());
   }
+
+  @Test
+  void parseStrictIntegerVersion_whenInteger_expectParsedBuild() {
+    assertEquals(1501, CoreUpdater.parseStrictIntegerVersion("1501"));
+    assertEquals(1501, CoreUpdater.parseStrictIntegerVersion("001501"));
+    assertEquals(1501, CoreUpdater.parseStrictIntegerVersion(" 1501 "));
+  }
+
+  @Test
+  void parseStrictIntegerVersion_whenInvalid_expectNull() {
+    assertNull(CoreUpdater.parseStrictIntegerVersion(null));
+    assertNull(CoreUpdater.parseStrictIntegerVersion(""));
+    assertNull(CoreUpdater.parseStrictIntegerVersion("  "));
+    assertNull(CoreUpdater.parseStrictIntegerVersion("1.2.3+build123"));
+    assertNull(CoreUpdater.parseStrictIntegerVersion("1501beta"));
+    assertNull(CoreUpdater.parseStrictIntegerVersion("999999999999999999999"));
+  }
 }

--- a/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
+++ b/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
@@ -562,6 +562,69 @@ class NodeUpdateManagerTest {
   }
 
   @Test
+  void maybeParseManifest_whenAutoUpdateEnabledAndVersionNotInteger_expectNoAutoDownload()
+      throws Exception {
+    // Arrange
+    manager.startCoreUpdater();
+    manager.setAutoUpdateAllowed(true);
+    CoreUpdater updater = manager.getCoreUpdater();
+    assertNotNull(updater);
+    String arch = new AppEnv().detectEnvironment().getArch();
+    String descriptorJson =
+        """
+          {
+            "version": "1.2.3+build123",
+            "packages": {
+              "%s.deb": { "chk": "%s" }
+            }
+          }
+        """
+            .formatted(arch, VALID_TEST_CHK);
+    FetchResult descriptor =
+        FetchResult.create(
+            new ClientMetadata("application/json"),
+            new ArrayBucket(descriptorJson.getBytes(StandardCharsets.UTF_8)));
+
+    // Act
+    updater.maybeParseManifest(descriptor, Version.currentBuildNumber() + 9);
+
+    // Assert
+    assertFalse(manager.hasNewCorePackage());
+    verify(clientContext, times(0)).start(any(ClientGetter.class));
+  }
+
+  @Test
+  void maybeParseManifest_whenAutoUpdateEnabledAndVersionNewer_expectAutoDownloadStarted()
+      throws Exception {
+    // Arrange
+    manager.startCoreUpdater();
+    manager.setAutoUpdateAllowed(true);
+    CoreUpdater updater = manager.getCoreUpdater();
+    assertNotNull(updater);
+    String arch = new AppEnv().detectEnvironment().getArch();
+    String descriptorJson =
+        """
+          {
+            "version": "%d",
+            "packages": {
+              "%s.deb": { "chk": "%s" }
+            }
+          }
+        """
+            .formatted(Version.currentBuildNumber() + 9, arch, VALID_TEST_CHK);
+    FetchResult descriptor =
+        FetchResult.create(
+            new ClientMetadata("application/json"),
+            new ArrayBucket(descriptorJson.getBytes(StandardCharsets.UTF_8)));
+
+    // Act
+    updater.maybeParseManifest(descriptor, Version.currentBuildNumber() + 9);
+
+    // Assert
+    verify(clientContext, times(1)).start(any(ClientGetter.class));
+  }
+
+  @Test
   void recordSuccessfulCoreInfoFetch_whenMatchingKey_expectPersistedHintUpdated() {
     // Arrange
     int knownEdition = Version.currentBuildNumber() + 4;

--- a/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
+++ b/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
@@ -2,9 +2,15 @@ package network.crypta.node.updater;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
@@ -139,6 +145,12 @@ class NodeUpdateManagerTest {
             .build());
   }
 
+  private void setCoreUpdater(CoreUpdater updater) throws Exception {
+    Field coreUpdaterField = NodeUpdateManager.class.getDeclaredField("coreUpdater");
+    coreUpdaterField.setAccessible(true);
+    coreUpdaterField.set(manager, updater);
+  }
+
   @Test
   void isEnabled_initiallyFalse_thenStartCoreUpdater_true() {
     // Arrange + Act
@@ -151,6 +163,38 @@ class NodeUpdateManagerTest {
     // Assert
     assertTrue(manager.isEnabled());
     assertNotNull(manager.getCoreUpdater());
+  }
+
+  @Test
+  void hasNewCorePackage_whenUpdaterCallBlocks_expectManagerMonitorReleased() throws Exception {
+    // Arrange
+    CoreUpdater coreUpdater = Mockito.mock(CoreUpdater.class);
+    CountDownLatch enteredUpdater = new CountDownLatch(1);
+    CountDownLatch releaseUpdater = new CountDownLatch(1);
+    when(coreUpdater.canUpdateNow())
+        .thenAnswer(
+            _ -> {
+              enteredUpdater.countDown();
+              assertTrue(releaseUpdater.await(5, TimeUnit.SECONDS));
+              return true;
+            });
+    setCoreUpdater(coreUpdater);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      // Act
+      Future<Boolean> hasNewCorePackage = executor.submit(manager::hasNewCorePackage);
+      assertTrue(enteredUpdater.await(5, TimeUnit.SECONDS));
+      Future<Boolean> autoUpdateAllowed = executor.submit(manager::isAutoUpdateAllowed);
+
+      // Assert
+      assertFalse(autoUpdateAllowed.get(1, TimeUnit.SECONDS));
+      releaseUpdater.countDown();
+      assertTrue(hasNewCorePackage.get(5, TimeUnit.SECONDS));
+    } finally {
+      releaseUpdater.countDown();
+      executor.shutdownNow();
+    }
   }
 
   // CHK preference path requires CoreUpdater state; fallback is exercised below.

--- a/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
+++ b/src/test/java/network/crypta/node/updater/NodeUpdateManagerTest.java
@@ -2,15 +2,21 @@ package network.crypta.node.updater;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
+import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.USKManager;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.config.Config;
 import network.crypta.config.PersistentConfig;
+import network.crypta.fs.AppEnv;
 import network.crypta.io.comm.Message;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
@@ -26,6 +32,7 @@ import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.io.ArrayBucket;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,6 +68,7 @@ class NodeUpdateManagerTest {
   Node node;
 
   @Mock NodeClientCore nodeCore;
+  @Mock ClientContext clientContext;
   @Mock UserAlertManager alerts;
   @Mock PeerManager peerManager;
   @Mock PeerMessenger peerMessenger;
@@ -70,6 +78,9 @@ class NodeUpdateManagerTest {
   private Config config;
   private static final String DEFAULT_FETCHED_SCOPE =
       "USK@" + NodeUpdateManager.UPDATE_URI + "/info/0";
+  private static final String VALID_TEST_CHK =
+      "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,"
+          + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
 
   @BeforeEach
   void setUp() throws Exception {
@@ -96,6 +107,11 @@ class NodeUpdateManagerTest {
 
     // NodeFile lookups for installers use runDir()
     when(node.runDir()).thenReturn(runProgramDir);
+    File nodeDir = tempDir.resolve("node").toFile();
+    assertTrue(nodeDir.mkdirs() || nodeDir.exists());
+    ProgramDirectory nodeProgramDir = new ProgramDirectory();
+    nodeProgramDir.move(nodeDir.getAbsolutePath());
+    when(node.nodeDir()).thenReturn(nodeProgramDir);
 
     // Minimal fetch context for RevocationChecker construction
     HighLevelSimpleClient hlsc = Mockito.mock(HighLevelSimpleClient.class);
@@ -103,7 +119,6 @@ class NodeUpdateManagerTest {
     when(nodeCore.makeClient(Mockito.anyShort(), Mockito.anyBoolean(), Mockito.anyBoolean()))
         .thenReturn(hlsc);
     when(hlsc.getFetchContext()).thenReturn(fctx);
-    ClientContext clientContext = Mockito.mock(ClientContext.class);
     when(nodeCore.getClientContext()).thenReturn(clientContext);
 
     config = new Config();
@@ -472,6 +487,78 @@ class NodeUpdateManagerTest {
     assertEquals(
         "USK@" + NodeUpdateManager.UPDATE_URI + "/" + customDoc + "/0",
         config.get("node.updater").getString("lastKnownGoodFetchedEditionKey"));
+  }
+
+  @Test
+  void setURI_whenScopeChanges_expectHasNewCorePackageReset() {
+    // Arrange
+    USKManager uskManager = Mockito.mock(USKManager.class);
+    when(nodeCore.getUskManager()).thenReturn(uskManager);
+    manager.startCoreUpdater();
+    CoreUpdater updater = manager.getCoreUpdater();
+    assertNotNull(updater);
+    String descriptorJson =
+        """
+          {
+            "version": "%d",
+            "packages": {}
+          }
+        """
+            .formatted(Version.currentBuildNumber() + 5);
+    FetchResult descriptor =
+        FetchResult.create(
+            new ClientMetadata("application/json"),
+            new ArrayBucket(descriptorJson.getBytes(StandardCharsets.UTF_8)));
+
+    // Act + Assert precondition: descriptor marks a new version available.
+    updater.maybeParseManifest(descriptor, Version.currentBuildNumber() + 5);
+    assertTrue(manager.hasNewCorePackage());
+
+    // Act: switch to a different update scope (docname/channel).
+    manager.setURI(manager.getURI().setDocName("alternate-info"));
+
+    // Assert: stale descriptor state from previous scope must not leak.
+    assertFalse(manager.hasNewCorePackage());
+  }
+
+  @Test
+  void setURI_whenPackageDownloadInProgress_expectActiveDownloadCancelled() throws Exception {
+    // Arrange
+    USKManager uskManager = Mockito.mock(USKManager.class);
+    when(nodeCore.getUskManager()).thenReturn(uskManager);
+    manager.startCoreUpdater();
+    CoreUpdater updater = manager.getCoreUpdater();
+    assertNotNull(updater);
+
+    String arch = new AppEnv().detectEnvironment().getArch();
+    String descriptorJson =
+        """
+          {
+            "version": "%d",
+            "packages": {
+              "%s.deb": { "chk": "%s" }
+            }
+          }
+        """
+            .formatted(Version.currentBuildNumber() + 9, arch, VALID_TEST_CHK);
+    FetchResult descriptor =
+        FetchResult.create(
+            new ClientMetadata("application/json"),
+            new ArrayBucket(descriptorJson.getBytes(StandardCharsets.UTF_8)));
+
+    updater.maybeParseManifest(descriptor, Version.currentBuildNumber() + 9);
+    updater.startDownloadFromUI();
+
+    ArgumentCaptor<ClientGetter> getterCaptor = ArgumentCaptor.forClass(ClientGetter.class);
+    verify(clientContext, times(1)).start(getterCaptor.capture());
+    ClientGetter inFlightGetter = getterCaptor.getValue();
+    assertFalse(inFlightGetter.isCancelled());
+
+    // Act
+    manager.setURI(manager.getURI().setDocName("alternate-info"));
+
+    // Assert
+    assertTrue(inFlightGetter.isCancelled());
   }
 
   @Test

--- a/src/test/java/network/crypta/node/updater/UpdateOverMandatoryManagerTest.java
+++ b/src/test/java/network/crypta/node/updater/UpdateOverMandatoryManagerTest.java
@@ -132,12 +132,12 @@ class UpdateOverMandatoryManagerTest {
     when(m.getString(DMT.REVOCATION_KEY)).thenReturn("KSK@revoked");
     when(m.getBoolean(DMT.HAVE_REVOCATION_KEY)).thenReturn(true);
     // Unused here but read; provide safe defaults
-    when(m.getString(DMT.MAIN_JAR_KEY)).thenReturn("KSK@unused");
-    when(m.getInt(DMT.MAIN_JAR_VERSION)).thenReturn(0);
+    when(m.getString(DMT.CORE_PACKAGE_KEY)).thenReturn("KSK@unused");
+    when(m.getInt(DMT.CORE_PACKAGE_VERSION)).thenReturn(0);
     when(m.getLong(DMT.REVOCATION_KEY_TIME_LAST_TRIED)).thenReturn(0L);
     when(m.getInt(DMT.REVOCATION_KEY_DNF_COUNT)).thenReturn(0);
     when(m.getLong(DMT.REVOCATION_KEY_FILE_LENGTH)).thenReturn(1L);
-    when(m.getLong(DMT.MAIN_JAR_FILE_LENGTH)).thenReturn(0L);
+    when(m.getLong(DMT.CORE_PACKAGE_FILE_LENGTH)).thenReturn(0L);
     when(m.getInt(DMT.PING_TIME)).thenReturn(0);
     when(m.getInt(DMT.BWLIMIT_DELAY_TIME)).thenReturn(0);
 
@@ -185,12 +185,12 @@ class UpdateOverMandatoryManagerTest {
     when(updateManager.isBlown()).thenReturn(false);
 
     // Unused fields but read during logging
-    when(m.getString(DMT.MAIN_JAR_KEY)).thenReturn("KSK@unused");
-    when(m.getInt(DMT.MAIN_JAR_VERSION)).thenReturn(0);
+    when(m.getString(DMT.CORE_PACKAGE_KEY)).thenReturn("KSK@unused");
+    when(m.getInt(DMT.CORE_PACKAGE_VERSION)).thenReturn(0);
     when(m.getLong(DMT.REVOCATION_KEY_TIME_LAST_TRIED)).thenReturn(0L);
     when(m.getInt(DMT.REVOCATION_KEY_DNF_COUNT)).thenReturn(0);
     when(m.getLong(DMT.REVOCATION_KEY_FILE_LENGTH)).thenReturn(0L);
-    when(m.getLong(DMT.MAIN_JAR_FILE_LENGTH)).thenReturn(0L);
+    when(m.getLong(DMT.CORE_PACKAGE_FILE_LENGTH)).thenReturn(0L);
     when(m.getInt(DMT.PING_TIME)).thenReturn(0);
     when(m.getInt(DMT.BWLIMIT_DELAY_TIME)).thenReturn(0);
 
@@ -218,12 +218,12 @@ class UpdateOverMandatoryManagerTest {
     when(m.getString(DMT.REVOCATION_KEY)).thenReturn("KSK@revoked");
     when(m.getBoolean(DMT.HAVE_REVOCATION_KEY)).thenReturn(true);
     // Logging related fields
-    when(m.getString(DMT.MAIN_JAR_KEY)).thenReturn("KSK@unused");
-    when(m.getInt(DMT.MAIN_JAR_VERSION)).thenReturn(0);
+    when(m.getString(DMT.CORE_PACKAGE_KEY)).thenReturn("KSK@unused");
+    when(m.getInt(DMT.CORE_PACKAGE_VERSION)).thenReturn(0);
     when(m.getLong(DMT.REVOCATION_KEY_TIME_LAST_TRIED)).thenReturn(0L);
     when(m.getInt(DMT.REVOCATION_KEY_DNF_COUNT)).thenReturn(0);
     when(m.getLong(DMT.REVOCATION_KEY_FILE_LENGTH)).thenReturn(1L);
-    when(m.getLong(DMT.MAIN_JAR_FILE_LENGTH)).thenReturn(0L);
+    when(m.getLong(DMT.CORE_PACKAGE_FILE_LENGTH)).thenReturn(0L);
     when(m.getInt(DMT.PING_TIME)).thenReturn(0);
     when(m.getInt(DMT.BWLIMIT_DELAY_TIME)).thenReturn(0);
 
@@ -257,12 +257,12 @@ class UpdateOverMandatoryManagerTest {
     Message m = org.mockito.Mockito.mock(Message.class);
     when(m.getString(DMT.REVOCATION_KEY)).thenReturn("KSK@revoked");
     when(m.getBoolean(DMT.HAVE_REVOCATION_KEY)).thenReturn(true);
-    when(m.getString(DMT.MAIN_JAR_KEY)).thenReturn("KSK@unused");
-    when(m.getInt(DMT.MAIN_JAR_VERSION)).thenReturn(0);
+    when(m.getString(DMT.CORE_PACKAGE_KEY)).thenReturn("KSK@unused");
+    when(m.getInt(DMT.CORE_PACKAGE_VERSION)).thenReturn(0);
     when(m.getLong(DMT.REVOCATION_KEY_TIME_LAST_TRIED)).thenReturn(0L);
     when(m.getInt(DMT.REVOCATION_KEY_DNF_COUNT)).thenReturn(0);
     when(m.getLong(DMT.REVOCATION_KEY_FILE_LENGTH)).thenReturn(1L);
-    when(m.getLong(DMT.MAIN_JAR_FILE_LENGTH)).thenReturn(0L);
+    when(m.getLong(DMT.CORE_PACKAGE_FILE_LENGTH)).thenReturn(0L);
     when(m.getInt(DMT.PING_TIME)).thenReturn(0);
     when(m.getInt(DMT.BWLIMIT_DELAY_TIME)).thenReturn(0);
 
@@ -328,9 +328,10 @@ class UpdateOverMandatoryManagerTest {
     when(updateManager.isBlown()).thenReturn(false);
 
     Message m = org.mockito.Mockito.mock(Message.class);
-    when(m.getString(DMT.MAIN_JAR_KEY)).thenReturn("KSK@main");
-    when(m.getInt(DMT.MAIN_JAR_VERSION)).thenReturn(5); // > current build number (likely 0 in dev)
-    when(m.getLong(DMT.MAIN_JAR_FILE_LENGTH)).thenReturn(1024L);
+    when(m.getString(DMT.CORE_PACKAGE_KEY)).thenReturn("KSK@main");
+    when(m.getInt(DMT.CORE_PACKAGE_VERSION))
+        .thenReturn(5); // > current build number (likely 0 in dev)
+    when(m.getLong(DMT.CORE_PACKAGE_FILE_LENGTH)).thenReturn(1024L);
     when(m.getBoolean(DMT.HAVE_REVOCATION_KEY)).thenReturn(false);
     when(m.getString(DMT.REVOCATION_KEY)).thenReturn("KSK@revoked");
     when(m.getLong(DMT.REVOCATION_KEY_TIME_LAST_TRIED)).thenReturn(0L);

--- a/src/test/java/network/crypta/node/useralerts/UpdatedVersionAvailableUserAlertTest.java
+++ b/src/test/java/network/crypta/node/useralerts/UpdatedVersionAvailableUserAlertTest.java
@@ -48,7 +48,7 @@ class UpdatedVersionAvailableUserAlertTest {
 
   @BeforeEach
   void setUp() {
-    // Ensure localization base is initialized (default language/resources)
+    // Ensure the localization base is initialized (default language/resources)
     new NodeL10n();
     when(updater.getNode()).thenReturn(node);
   }
@@ -103,21 +103,20 @@ class UpdatedVersionAvailableUserAlertTest {
   }
 
   @Test
-  @DisplayName("text_whenCanUpdateNowImmediate_includesDownloadedAndImmediateButton")
-  void text_whenCanUpdateNowImmediate_includesDownloadedAndImmediateButton() {
+  @DisplayName("text_whenCanUpdateNowImmediate_includesDownloadedLabelAndImmediateButton")
+  void text_whenCanUpdateNowImmediate_includesDownloadedLabelAndImmediateButton() {
     when(updater.isArmed()).thenReturn(false);
     when(updater.canUpdateNow()).thenReturn(true);
-    when(updater.hasNewMainJar()).thenReturn(true);
-    when(updater.newMainJarVersion()).thenReturn(1234);
+    when(updater.hasNewCorePackage()).thenReturn(true);
+    when(updater.newCorePackageVersion()).thenReturn(1234);
+    when(updater.newCorePackageVersionLabel()).thenReturn("1.2.3+build123");
     when(updater.canUpdateImmediately()).thenReturn(true);
     when(node.network().updateIsUrgent()).thenReturn(false);
 
     String downloaded =
         NodeL10n.getBase()
             .getString(
-                "UpdatedVersionAvailableUserAlert.downloadedNewJar",
-                "version",
-                Integer.toString(1234));
+                "UpdatedVersionAvailableUserAlert.downloadedNewJar", "version", "1.2.3+build123");
     String clickNow =
         NodeL10n.getBase().getString("UpdatedVersionAvailableUserAlert.clickToUpdateNow");
     String button =
@@ -135,7 +134,7 @@ class UpdatedVersionAvailableUserAlertTest {
   void text_whenCanUpdateNowASAP_includesASAPPromptAndButton() {
     when(updater.isArmed()).thenReturn(false);
     when(updater.canUpdateNow()).thenReturn(true);
-    when(updater.hasNewMainJar()).thenReturn(false);
+    when(updater.hasNewCorePackage()).thenReturn(false);
     when(updater.canUpdateImmediately()).thenReturn(false);
     when(node.network().updateIsUrgent()).thenReturn(false);
 
@@ -156,12 +155,12 @@ class UpdatedVersionAvailableUserAlertTest {
     when(updater.isArmed()).thenReturn(false);
     when(updater.canUpdateNow()).thenReturn(false);
     when(updater.fetchingFromUOM()).thenReturn(true);
-    when(updater.fetchingNewMainJar()).thenReturn(false);
+    when(updater.fetchingNewCorePackage()).thenReturn(false);
     when(node.network().updateIsUrgent()).thenReturn(false);
 
     Path nodeDir = Files.createTempDirectory("cryptad-node-test");
     try {
-      // Create update script at top-level so getUpdateScriptName returns the absolute path
+      // Create an update script at top-level so getUpdateScriptName returns the absolute path
       String scriptName = (File.separatorChar == '\\') ? "update.cmd" : "update.sh";
       Path script = nodeDir.resolve(scriptName);
       Files.writeString(script, "echo test");
@@ -181,7 +180,7 @@ class UpdatedVersionAvailableUserAlertTest {
       assertTrue(text.contains(fetching), "Should include fetching message with script path");
       assertTrue(text.contains(question), "Should ask the ASAP update question");
     } finally {
-      // Cleanup temp dir using try-with-resources to safely close the stream
+      // Clean up temp dir using try-with-resources to safely close the stream
       try (Stream<Path> walk = Files.walk(nodeDir)) {
         walk.sorted(Comparator.reverseOrder())
             .forEach(
@@ -208,8 +207,8 @@ class UpdatedVersionAvailableUserAlertTest {
     when(clientCore.getFormPassword()).thenReturn("secret-token");
 
     // Version selection path shouldn't matter for this check; take the fallback branch.
-    when(updater.hasNewMainJar()).thenReturn(false);
-    when(updater.fetchingNewMainJar()).thenReturn(false);
+    when(updater.hasNewCorePackage()).thenReturn(false);
+    when(updater.fetchingNewCorePackage()).thenReturn(false);
     when(updater.getMainVersion()).thenReturn(999);
 
     // Capture the version passed into addChangelogLinks
@@ -252,26 +251,27 @@ class UpdatedVersionAvailableUserAlertTest {
         .when(updater)
         .addChangelogLinks(ArgumentMatchers.anyLong(), any(HTMLNode.class));
 
-    // Case 1: hasNewMainJar -> use newMainJarVersion
+    // Case 1: hasNewCorePackage -> use newCorePackageVersion
     when(updater.isArmed()).thenReturn(false);
     when(updater.canUpdateNow()).thenReturn(true);
     when(updater.canUpdateImmediately()).thenReturn(true);
-    when(updater.hasNewMainJar()).thenReturn(true);
-    when(updater.newMainJarVersion()).thenReturn(42);
+    when(updater.hasNewCorePackage()).thenReturn(true);
+    when(updater.newCorePackageVersion()).thenReturn(42);
+    when(updater.newCorePackageVersionLabel()).thenReturn("42");
     HTMLNode html1 = alert.getHTMLText();
     assertNotNull(html1);
     assertEquals(42L, capturedVersion.get());
 
-    // Case 2: not hasNew, fetchingNewMainJar -> use fetchingNewMainJarVersion
-    when(updater.hasNewMainJar()).thenReturn(false);
-    when(updater.fetchingNewMainJar()).thenReturn(true);
-    when(updater.fetchingNewMainJarVersion()).thenReturn(77);
+    // Case 2: not hasNew, fetchingNewCorePackage -> use fetchingNewCorePackageVersion
+    when(updater.hasNewCorePackage()).thenReturn(false);
+    when(updater.fetchingNewCorePackage()).thenReturn(true);
+    when(updater.fetchingNewCorePackageVersion()).thenReturn(77);
     HTMLNode html2 = alert.getHTMLText();
     assertNotNull(html2);
     assertEquals(77L, capturedVersion.get());
 
     // Case 3: neither -> fallback to getMainVersion
-    when(updater.fetchingNewMainJar()).thenReturn(false);
+    when(updater.fetchingNewCorePackage()).thenReturn(false);
     when(updater.getMainVersion()).thenReturn(99);
     HTMLNode html3 = alert.getHTMLText();
     assertNotNull(html3);
@@ -316,9 +316,9 @@ class UpdatedVersionAvailableUserAlertTest {
     when(updater.isEnabled()).thenReturn(true);
     when(updater.isBlown()).thenReturn(false);
 
-    // One of (fetchingNewMainJar, hasNewMainJar, fetchingFromUOM) must be true
-    when(updater.fetchingNewMainJar()).thenReturn(false);
-    when(updater.hasNewMainJar()).thenReturn(true);
+    // One of (fetchingNewCorePackage, hasNewCorePackage, fetchingFromUOM) must be true
+    when(updater.fetchingNewCorePackage()).thenReturn(false);
+    when(updater.hasNewCorePackage()).thenReturn(true);
     when(updater.fetchingFromUOM()).thenReturn(false);
     assertTrue(alert.isValid());
 
@@ -333,8 +333,8 @@ class UpdatedVersionAvailableUserAlertTest {
 
     // None of the three flags -> invalid
     when(updater.isBlown()).thenReturn(false);
-    when(updater.hasNewMainJar()).thenReturn(false);
-    when(updater.fetchingNewMainJar()).thenReturn(false);
+    when(updater.hasNewCorePackage()).thenReturn(false);
+    when(updater.fetchingNewCorePackage()).thenReturn(false);
     when(updater.fetchingFromUOM()).thenReturn(false);
     assertFalse(alert.isValid());
   }


### PR DESCRIPTION
## Summary
- Rename legacy `MainJar` updater/UOM identifiers to `Core` / `CorePackage` terminology across updater flows, peer/UOM handling, alerts, and tests.
- Preserve wire compatibility for legacy UOM field and message type strings while updating code-level constants/builders and call sites.
- Gate core update availability using strict integer parsing of `core-info.json` `version` and expose `newCorePackageVersionLabel()` for alert/UI text.
- Reset URI-scoped `CoreUpdater` descriptor state on update URI changes, and cancel any in-flight package download so stale/orphaned transfers do not continue.
- Update updater architecture/skill docs and release runbook notes to reflect integer version gating and current core package update behavior.

## Testing
- `./gradlew test --tests network.crypta.node.updater.NodeUpdateManagerTest --tests network.crypta.node.updater.CoreUpdaterTest`

## Notes
- Base branch requested for this PR: `release/2`.
- This PR includes new/updated regression coverage for URI-change stale state and in-flight download cancellation behavior.