### PR TITLE
docs(repo): Remove Kotlin authoring guidance

### DIFF
--- a/.opencode/command/fix-similar-log-messages.md
+++ b/.opencode/command/fix-similar-log-messages.md
@@ -1,4 +1,4 @@
-You are a refactoring agent working in a JVM codebase (Java/Kotlin). Your goal is to eliminate IntelliJ IDEA/Qodana inspection warnings for: “Non-distinguishable logging calls” (inspection ID: LoggingSimilarMessage).
+You are a refactoring agent working in a Java codebase. Your goal is to eliminate IntelliJ IDEA/Qodana inspection warnings for: “Non-distinguishable logging calls” (inspection ID: LoggingSimilarMessage).
 
 What the inspection means:
 Multiple SLF4J / Log4j2 logging statements within the same class have message templates that are too similar, making it hard to tell which call site emitted a given line.

--- a/.opencode/command/write-code-docs.md
+++ b/.opencode/command/write-code-docs.md
@@ -7,7 +7,6 @@
 ## File Type & Scope
 
 - If `$1` ends with **`.java`**, apply **Javadoc** rules and run **doclint** (see loop below).
-- If `$1` ends with **`.kt`**, apply **KDoc** rules; **do not** run doclint.
 - Otherwise, **return unchanged**.
 
 **Edits allowed:** comments and log message strings only.  
@@ -135,15 +134,7 @@ When the file has many public/protected members (e.g., **> 30**):
 
 ---
 
-## KDoc Rules (Kotlin)
-
-- Markdown allowed; backticks for code.
-- Tags: `@param`, `@return`, `@throws`, `@receiver`, `@constructor`, `@property`, type params via `@param T`.
-- Same scope constraints as Java. No doclint.
-
----
-
-## Inline Comments (both languages)
+## Inline Comments
 
 - Prefer short `//` comments for non-obvious intent (invariants, edge cases, concurrency), ≤ 2 short lines, placed **above** the code.
 - Use `/* … */` for slightly longer local notes (not doc blocks).
@@ -168,7 +159,7 @@ When the file has many public/protected members (e.g., **> 30**):
 ## Preservation & Promotion
 
 - Preserve license headers, annotations, and any **valid** existing docs; improve wording and formatting where helpful.
-- Promote meaningful `//` explanations of **public/protected** behavior to proper Javadoc/KDoc when appropriate (without moving/duplicating placeholder markers).
+- Promote meaningful `//` explanations of **public/protected** behavior to proper Javadoc when appropriate (without moving/duplicating placeholder markers).
 - Keep private/internal docs concise.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Project Configuration
 
 ## Project Overview
-Crypta is a peer-to-peer network providing a distributed, encrypted, and decentralized datastore. It is a fork of Hyphanet (formerly Freenet), building upon its technology for censorship-resistant communication and publishing. This repository contains the reference node implementation (the "Crypta reference daemon") written primarily in Java with some Kotlin components.
+Crypta is a peer-to-peer network providing a distributed, encrypted, and decentralized datastore. It is a fork of Hyphanet (formerly Freenet), building upon its technology for censorship-resistant communication and publishing. This repository contains the reference node implementation (the "Crypta reference daemon").
 
 ## Skills: load on demand
 
@@ -26,7 +26,7 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **$cryptad-runtime-debugging** — Debug live or reproducible Cryptad JVM failures on Windows, macOS, and Linux using `jcmd`, `jdb`, thread dumps, and the default JDWP listener on `127.0.0.1:5005`.
 - **$cryptad-write-release-notes** — Draft or review GitHub release notes and changelog artifacts for Cryptad builds, including `changelog-full.md`, `changelog-short.txt`, and `changelog-full.txt`.
 - **$cryptad-writing-guides** — Apply Cryptad prose conventions for README/docs content, release notes, migration notes, and other operator-facing writing.
-- **$cryptad-style-docs** — Apply Cryptad Kotlin/Java style, file layout rules, and long-lived documentation/commenting practices.
+- **$cryptad-style-docs** — Apply Cryptad Java style, file layout rules, and long-lived documentation/commenting practices.
 - **$codebase-retrieval** — Use semantic codebase retrieval to identify 1–5 target files before significant reading or edits when the file scope is unclear.
 - **$web-search** — Use both Exa and Tavily for external/current web research, then cross-check sources before answering.
 
@@ -41,8 +41,8 @@ Load only what you need. It’s normal to load multiple skills for one task.
 
 ## Always-on rules (keep these in mind)
 
-- **Languages:** Kotlin + Java.
-  - Kotlin sources must live under `src/*/kotlin` (including tests). Do not add Kotlin files under `src/*/java/`.
+- **Language:** Java.
+  - Java sources must live under `src/*/java/` (including tests).
 - **OpenCode LSP:** Treat LSP/typechecker diagnostics as blockers for touched files.
   - If the OpenCode `lsp` tool is enabled, prefer it for definition/reference/hover instead of guessing
 - **Repository discovery:** If the task does not provide exact paths/symbols, load `$codebase-retrieval` before making code changes.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
     <img alt="License: GPLv3" src="https://img.shields.io/badge/license-GPLv3-blue.svg" />
   </a>
   <img alt="Java 25+" src="https://img.shields.io/badge/Java-25%2B-007396?logo=openjdk" />
-  <img alt="Kotlin 2.3.0+" src="https://img.shields.io/badge/Kotlin-2.3.0%2B-7F52FF?logo=kotlin" />
   <img alt="Gradle" src="https://img.shields.io/badge/Build-Gradle-02303A?logo=gradle" />
 </p>
 
@@ -41,7 +40,7 @@ on:
   latency.
 - Safe observability: privacy‑preserving telemetry and reproducible benchmarking harnesses to inform tuning without
   leaking user data.
-- A better platform: Kotlin‑first codebase, typed configuration, and testable interfaces to make extending the network
+- A better platform: typed configuration and testable interfaces to make extending the network
   straightforward.
 
 This repository contains the reference node (the “**Crypta** reference daemon”) that participates in the network, stores
@@ -148,7 +147,6 @@ wrapper, you can build immediately.
 Prerequisites:
 
 - Java 25 or newer
-- Kotlin 2.3.0+ (tooling; the project includes Kotlin Gradle plugins)
 - A POSIX shell or Windows terminal
 
 Build the node JAR (prints SHA‑256 of the output):
@@ -416,19 +414,16 @@ cd build/jpackage/Crypta.app/Contents
 
 ## Development Guidelines
 
-- Primary languages: Kotlin/Java
-  - New files should be written in Kotlin
-  - Prefer top‑level functions where idiomatic in Kotlin
+- Primary language: Java
 - Code style:
-  - Kotlin: https://kotlinlang.org/docs/coding-conventions.html
   - Java: https://google.github.io/styleguide/javaguide.html
-- Tests: JUnit and kotlin‑test; target 80%+ coverage
-- Documentation: Add/update JavaDoc/KDoc when editing Java/Kotlin files
+- Tests: JUnit; target 80%+ coverage
+- Documentation: Add or update Javadoc when editing Java files
 
 ## Dependencies
 
 - Runtime: Java 25+
-- Language/Tooling: Kotlin 2.3.0+, Gradle Wrapper (provided in this repo)
+- Tooling: Gradle Wrapper (provided in this repo)
 - External libraries are managed via Gradle.
 - Dependency verification is enabled. When adding or updating libraries:
   - Declare versions in `gradle/libs.versions.toml` and add usages in `build.gradle.kts`.
@@ -436,7 +431,7 @@ cd build/jpackage/Crypta.app/Contents
     artifacts; use the commands in “Spotless + Dependency Verification” below.
 
 Launcher adds:
-- `org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2` for Swing + coroutine integration.
+- additional Swing support libraries used by the launcher.
 
 ### Spotless + Dependency Verification
 
@@ -461,7 +456,7 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 ## Versioning
 
 - The build number is a single integer in `build.gradle.kts` (e.g., `version = "<int>"`).
-- During build, tokens are replaced into `network/crypta/node/Version.kt` (e.g., `@build_number@`, `@git_rev@`).
+- During build, tokens are replaced into the generated version source file (e.g., `@build_number@`, `@git_rev@`).
 - Version strings support both Cryptad and Fred formats for wire compatibility; protocol compatibility enforces minimum builds.
 
 ## Branching & Releases

--- a/tools/README.md
+++ b/tools/README.md
@@ -20,8 +20,8 @@ This directory contains the Flatpak manifest and metadata used to build and test
 Quick build and run (requires `flatpak` and Freedesktop 24.08 runtime/SDK):
 
 ```bash
-./gradlew -x spotlessKotlin -x spotlessApply -x spotlessJava -x spotlessKotlinGradle buildJar
-./gradlew -x spotlessKotlin -x spotlessApply -x spotlessJava -x spotlessKotlinGradle distJlinkCryptad
+./gradlew buildJar
+./gradlew distJlinkCryptad
 mkdir -p tools/flatpak/local
 cp -f build/distributions/cryptad-jlink-v1.tar.gz tools/flatpak/local/
 rm -rf builddir repo .flatpak-builder


### PR DESCRIPTION
## Summary

Remove stale Kotlin authoring guidance from the repo's contributor and agent-facing docs now that new work is Java-only.

Update:
- `AGENTS.md` to describe Java-only authoring guidance
- `README.md` to remove Kotlin badges, prerequisites, and contributor instructions
- `tools/README.md` to simplify the Flatpak build commands
- `.opencode` prompts to use Java/Javadoc-only wording

## How to test

- Run `./gradlew spotlessApply`
- Run `git diff --check`
- Run `rg -n --hidden --glob 'AGENTS.md' --glob 'README.md' --glob 'tools/README.md' --glob '.opencode/command/*.md' --glob '.agents/skills/**/SKILL.md' 'Kotlin|kotlin|\\.kt\\b|src/.*/kotlin|src/\\*/kotlin' /work/cryptad` and confirm it returns no matches

## Notes

- No production code changes
- PR base: `develop`