### PR TITLE
build(version): Bump Crypta version to 3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 // Update version manually before a new release development starts
-version = "2"
+version = "3"
 
 val internalLeafProjects =
   listOf(


### PR DESCRIPTION
## Summary
- update the root Gradle project version from `2` to `3`
- keep the change limited to the single source of truth in `build.gradle.kts`
- allow generated version metadata and leaf-module inherited versions to resolve to build `3`

## How to test
- `./gradlew spotlessApply`
- `./gradlew printVersion`
- `./gradlew test --tests network.crypta.node.VersionTest`

## Notes
- no release branch was created for this change