### PR TITLE
feat(runtime-spi): Add runtime SPI foundation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ val internalLeafProjects =
   listOf(
     project(":foundation-fs"),
     project(":foundation-compat"),
+    project(":runtime-spi"),
     project(":thirdparty-onion"),
     project(":thirdparty-legacy"),
     project(":launcher-desktop"),
@@ -33,6 +34,7 @@ dependencies {
   // implementation
   implementation(project(":foundation-fs"))
   implementation(project(":foundation-compat"))
+  implementation(project(":runtime-spi"))
   implementation(project(":thirdparty-onion"))
   implementation(project(":thirdparty-legacy"))
   implementation(libs.bcprov)

--- a/runtime-spi/build.gradle.kts
+++ b/runtime-spi/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+  id("cryptad.java-kotlin-conventions")
+  id("cryptad.spotless")
+}
+
+version = rootProject.version

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ExecutionPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ExecutionPort.java
@@ -1,0 +1,7 @@
+package network.crypta.runtime.spi;
+
+/** Schedules named background work without exposing the daemon executor type. */
+@FunctionalInterface
+public interface ExecutionPort {
+  void execute(Runnable task, String name);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ExecutionPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ExecutionPort.java
@@ -1,7 +1,35 @@
 package network.crypta.runtime.spi;
 
-/** Schedules named background work without exposing the daemon executor type. */
+/**
+ * Schedules named background work without exposing the daemon's executor implementation.
+ *
+ * <p>This port is the narrow execution boundary that higher-level adapters use when they need to
+ * hand work back to the running node. Callers submit a fully prepared {@link Runnable} together
+ * with a stable descriptive name, and the runtime implementation decides how that work is queued,
+ * labeled, and executed. The SPI deliberately omits priorities, executor handles, and lifecycle
+ * controls so infrastructure code can depend on the capability without learning daemon-internal
+ * scheduling types.
+ *
+ * <p>Implementations may execute the task on an existing worker pool, on a dedicated service, or on
+ * another runtime-managed mechanism. The caller should therefore treat the submission as
+ * asynchronous and avoid assuming a specific thread or ordering policy unless the implementation
+ * documents one.
+ *
+ * @see RuntimePorts
+ */
 @FunctionalInterface
 public interface ExecutionPort {
+  /**
+   * Schedules a unit of work for runtime-managed execution.
+   *
+   * <p>Implementations submit {@code task} using the daemon's existing scheduling behavior. The
+   * {@code name} identifies the work for diagnostics, thread naming, or logging, but it does not
+   * alter the task's business semantics. Callers should pass a non-blocking task whenever possible
+   * and should assume the work may begin after this method returns rather than immediately on the
+   * current thread.
+   *
+   * @param task runnable work item to submit to the runtime without further wrapping by the caller
+   * @param name descriptive task name used for runtime bookkeeping and operational diagnostics
+   */
   void execute(Runnable task, String name);
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/LifecyclePort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/LifecyclePort.java
@@ -1,10 +1,59 @@
 package network.crypta.runtime.spi;
 
-/** Exposes read-only node lifecycle state needed by infrastructure adapters. */
+/**
+ * Exposes read-only node lifecycle state needed by infrastructure adapters.
+ *
+ * <p>This port provides a minimal view of daemon lifecycle progress to components that need to
+ * adjust behavior during startup, steady-state operation, or shutdown. The SPI stays intentionally
+ * conservative: callers can observe current state and timestamps, but they cannot trigger or alter
+ * lifecycle transitions. That keeps the boundary safe for low-level infrastructure code while still
+ * allowing request handlers, listeners, or status reporters to avoid work at the wrong phase.
+ *
+ * <p>The values reported here preserve the runtime's existing semantics. Implementations should not
+ * synthesize new states or reinterpret timing data. Callers should therefore use these methods as a
+ * thin view over the live daemon rather than as an independent state machine.
+ *
+ * @see RuntimePorts
+ */
 public interface LifecyclePort {
+  /**
+   * Reports whether the runtime considers startup complete.
+   *
+   * <p>This method exposes the daemon's current "started" flag so adapters can avoid assuming the
+   * node is fully available too early. A return value of {@code true} means the runtime has reached
+   * its normal started state according to existing daemon semantics. A return value of {@code
+   * false} may mean startup is still in progress or that the node never completed startup.
+   *
+   * @return {@code true} when the runtime reports that startup has completed, otherwise {@code
+   *     false}
+   */
+  @SuppressWarnings("unused")
   boolean hasStarted();
 
+  /**
+   * Reports whether a shutdown has been initiated.
+   *
+   * <p>This exposes the runtime's current stopping flag for code that should avoid starting new
+   * long-lived work while shutdown is underway. A value of {@code true} does not imply that all
+   * services have already stopped; it only indicates that the runtime has entered its stopping
+   * phase. Callers should treat it as a conservative signal and prefer graceful behavior when it is
+   * set.
+   *
+   * @return {@code true} when the runtime is in its stopping phase, otherwise {@code false}
+   */
   boolean isStopping();
 
+  /**
+   * Returns the startup timestamp recorded by the runtime in milliseconds.
+   *
+   * <p>The value is the daemon's own startup time metadata, exposed without reinterpretation. It is
+   * useful for status reporting and elapsed-time calculations that need a stable runtime-provided
+   * reference point. Callers should not infer more precision than milliseconds, and they should use
+   * the value together with the same time base expected by the surrounding daemon code.
+   *
+   * @return runtime startup time metadata expressed in milliseconds using the daemon's existing
+   *     convention
+   */
+  @SuppressWarnings("unused")
   long startupTimeMillis();
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/LifecyclePort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/LifecyclePort.java
@@ -1,0 +1,10 @@
+package network.crypta.runtime.spi;
+
+/** Exposes read-only node lifecycle state needed by infrastructure adapters. */
+public interface LifecyclePort {
+  boolean hasStarted();
+
+  boolean isStopping();
+
+  long startupTimeMillis();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RandomnessPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RandomnessPort.java
@@ -1,0 +1,10 @@
+package network.crypta.runtime.spi;
+
+import java.util.Random;
+
+/** Exposes secure and weak random services without leaking daemon random-source types. */
+public interface RandomnessPort {
+  void fillSecureRandom(byte[] target);
+
+  Random fastWeakRandom();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RandomnessPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RandomnessPort.java
@@ -2,9 +2,44 @@ package network.crypta.runtime.spi;
 
 import java.util.Random;
 
-/** Exposes secure and weak random services without leaking daemon random-source types. */
+/**
+ * Exposes secure and weak random services without leaking daemon-specific random-source types.
+ *
+ * <p>This port separates two distinct runtime capabilities that already exist inside the daemon: a
+ * stronger source for security-sensitive byte generation and a faster weak generator for low-risk,
+ * infrastructure-oriented randomness. By publishing both through JDK types, higher layers can
+ * request randomness without depending on bootstrap internals or on custom random abstractions that
+ * belong to the root module.
+ *
+ * <p>Callers are responsible for choosing the right method for their use case. Secure byte filling
+ * is appropriate when unpredictability matters. The weak generator exists for cases where
+ * reproducibility is not required and the values are not used as a security boundary.
+ *
+ * @see RuntimePorts
+ */
 public interface RandomnessPort {
+  /**
+   * Fills the supplied byte array with bytes from the runtime's secure random source.
+   *
+   * <p>The contents of {@code target} are replaced in place. The method preserves the daemon's
+   * existing secure-random behavior, including any seeding and implementation details hidden behind
+   * the runtime. Callers may pass an empty array when they need no bytes, but they should provide a
+   * correctly sized buffer up front because this method does not allocate or return a new array.
+   *
+   * @param target destination buffer that receives secure random bytes across its full length
+   */
   void fillSecureRandom(byte[] target);
 
+  /**
+   * Returns the runtime's fast weak random generator.
+   *
+   * <p>The returned {@link Random} preserves the daemon's current non-cryptographic randomness
+   * source. It is suitable for low-risk identifiers, backoff variation, or other operational uses
+   * where speed matters more than strong unpredictability. Callers should not treat values from
+   * this generator as secrets, authentication material, or a replacement for the secure byte source
+   * exposed by {@link #fillSecureRandom(byte[])}.
+   *
+   * @return a live weak random generator supplied by the runtime for non-cryptographic use
+   */
   Random fastWeakRandom();
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -1,12 +1,68 @@
 package network.crypta.runtime.spi;
 
-/** Aggregate entrypoint for runtime-facing SPI adapters used by higher layers. */
+/**
+ * Aggregate entry point for runtime-facing SPI adapters used by higher layers.
+ *
+ * <p>This interface groups the small set of runtime capabilities that PR-2 makes available outside
+ * the daemon root module. Instead of injecting several unrelated services into infrastructure code,
+ * the runtime exposes one stable handle that can be threaded through legacy code paths with minimal
+ * disruption. Each sub-port narrows access to a specific concern such as execution, randomness,
+ * file-transfer policy, or lifecycle observation.
+ *
+ * <p>The aggregate is intentionally small and JDK-only. It is not a general domain API for the
+ * node, and it does not attempt to model every daemon subsystem. Future adapters can depend on this
+ * interface as a conservative platform boundary while legacy code continues to use richer internal
+ * types until later migrations happen.
+ *
+ * @see ExecutionPort
+ * @see RandomnessPort
+ * @see TransferAccessPort
+ * @see LifecyclePort
+ */
 public interface RuntimePorts {
+  /**
+   * Returns the execution capability exposed to infrastructure code.
+   *
+   * <p>Use this port when a caller needs to enqueue background work without depending on the
+   * daemon's executor classes. The returned object should be treated as a long-lived runtime view
+   * rather than as a disposable handle, and callers should keep their own task semantics outside
+   * the SPI.
+   *
+   * @return execution-facing runtime port for submitting named asynchronous work
+   */
   ExecutionPort execution();
 
+  /**
+   * Returns the randomness capability exposed to infrastructure code.
+   *
+   * <p>This groups both secure byte generation and the existing weak random generator behind one
+   * JDK-level abstraction. Callers should choose the secure or weak path based on the sensitivity
+   * of the values they need, not on convenience.
+   *
+   * @return randomness-facing runtime port for secure and weak random operations
+   */
   RandomnessPort randomness();
 
+  /**
+   * Returns the file-transfer policy capability exposed to infrastructure code.
+   *
+   * <p>This port lets adapters ask whether uploads or downloads are permitted for a path and get
+   * the currently configured transfer directories. The returned object intentionally uses only
+   * {@link java.io.File} values so it remains independent of daemon-only policy types.
+   *
+   * @return transfer-policy runtime port for directory metadata and allow/deny checks
+   */
+  @SuppressWarnings("unused")
   TransferAccessPort transferAccess();
 
+  /**
+   * Returns the lifecycle capability exposed to infrastructure code.
+   *
+   * <p>Use this port when code needs to observe a startup or shutdown state without gaining control
+   * over lifecycle transitions. It is read-only by design and should be treated as a lightweight
+   * view of the live daemon state.
+   *
+   * @return lifecycle runtime port for observing startup time and state flags
+   */
   LifecyclePort lifecycle();
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -1,0 +1,12 @@
+package network.crypta.runtime.spi;
+
+/** Aggregate entrypoint for runtime-facing SPI adapters used by higher layers. */
+public interface RuntimePorts {
+  ExecutionPort execution();
+
+  RandomnessPort randomness();
+
+  TransferAccessPort transferAccess();
+
+  LifecyclePort lifecycle();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/TransferAccessPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/TransferAccessPort.java
@@ -1,0 +1,18 @@
+package network.crypta.runtime.spi;
+
+import java.io.File;
+
+/** Exposes file-transfer policy checks and directories using only JDK file types. */
+public interface TransferAccessPort {
+  boolean allowUploadFrom(File file);
+
+  boolean allowDownloadTo(File file);
+
+  File downloadsDir();
+
+  File persistentTempDir();
+
+  File[] allowedUploadDirs();
+
+  File[] allowedDownloadDirs();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/TransferAccessPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/TransferAccessPort.java
@@ -2,17 +2,97 @@ package network.crypta.runtime.spi;
 
 import java.io.File;
 
-/** Exposes file-transfer policy checks and directories using only JDK file types. */
+/**
+ * Exposes file-transfer policy checks and directories using only JDK file types.
+ *
+ * <p>This port gives infrastructure code a narrow way to consult the daemon's existing
+ * disk-transfer policy without depending on {@code NodeClientCore} or other root-module classes.
+ * Callers can ask whether a particular upload or download path is currently permitted and can read
+ * the configured directories that shape those decisions. The SPI intentionally returns {@link File}
+ * values rather than richer internal wrappers so the module stays below the daemon in the
+ * dependency graph.
+ *
+ * <p>Implementations should preserve current policy semantics. The methods in this interface report
+ * what the runtime presently allows; they do not create directories, normalize paths beyond
+ * existing behavior, or change configuration on the caller's behalf.
+ *
+ * @see RuntimePorts
+ */
 public interface TransferAccessPort {
+  /**
+   * Checks whether the runtime currently permits an upload from the supplied file path.
+   *
+   * <p>The runtime evaluates {@code file} using its existing upload-policy rules, including any
+   * configured allowlists or directory restrictions. This method performs policy consultation only;
+   * it does not open the file or guarantee that later file system access will still succeed.
+   * Callers should therefore treat a {@code true} result as permission under current policy, not as
+   * a full liveness or existence check.
+   *
+   * @param file upload source path to validate against the current runtime policy
+   * @return {@code true} when uploads from the supplied path are currently allowed
+   */
   boolean allowUploadFrom(File file);
 
+  /**
+   * Checks whether the runtime currently permits a download to the supplied file path.
+   *
+   * <p>The runtime evaluates {@code file} using its current destination-policy rules. A positive
+   * result means the configured policy accepts the path at the time of the call. It does not create
+   * parent directories, reserve the destination, or guarantee that later writes will succeed if the
+   * file system state changes.
+   *
+   * @param file download destination path to validate against the current runtime policy
+   * @return {@code true} when downloads to the supplied path are currently allowed
+   */
   boolean allowDownloadTo(File file);
 
+  /**
+   * Returns the runtime's configured "downloads" directory.
+   *
+   * <p>This is the path the daemon currently exposes as its downloads location. The returned {@link
+   * File} reflects configuration state only; callers should still perform their own existence,
+   * writability, or creation checks when they need stronger guarantees for a specific operation.
+   *
+   * @return configured "downloads" directory path as exposed by the runtime
+   */
   File downloadsDir();
 
+  /**
+   * Returns the runtime's configured persistent temporary directory.
+   *
+   * <p>This directory is intended for temporary files that survive longer than a single immediate
+   * operation, according to the daemon's existing behavior. The method reports configuration rather
+   * than provisioning state, so callers should not assume the directory already exists or is ready
+   * for use without additional checks.
+   *
+   * @return configured persistent temporary directory path as exposed by the runtime
+   */
+  @SuppressWarnings("unused")
   File persistentTempDir();
 
+  /**
+   * Returns the directories that the runtime currently allows as upload roots.
+   *
+   * <p>The returned array reflects the daemon's current upload policy using plain {@link File}
+   * paths. Implementations may return an empty array when no explicit upload roots are configured.
+   * Callers should treat the array as a snapshot of the current policy and avoid mutating it unless
+   * the implementation explicitly documents such mutation as safe.
+   *
+   * @return current upload-allowed directory roots represented as {@link File} paths
+   */
+  @SuppressWarnings("unused")
   File[] allowedUploadDirs();
 
+  /**
+   * Returns the directories that the runtime currently allows as download roots.
+   *
+   * <p>The returned array reflects the daemon's current download policy using plain {@link File}
+   * paths. Implementations may return an empty array when no explicit download roots are
+   * configured. As with other policy views in this SPI, the result describes current configuration
+   * and should be treated as an advisory state rather than a permanent reservation.
+   *
+   * @return current download-allowed directory roots represented as {@link File} paths
+   */
+  @SuppressWarnings("unused")
   File[] allowedDownloadDirs();
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ rootProject.name = "cryptad"
 include(
   ":foundation-fs",
   ":foundation-compat",
+  ":runtime-spi",
   ":thirdparty-onion",
   ":thirdparty-legacy",
   ":launcher-desktop",

--- a/src/main/java/network/crypta/clients/fcp/DdaAccessController.java
+++ b/src/main/java/network/crypta/clients/fcp/DdaAccessController.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
+import java.util.Random;
 import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
 
@@ -155,12 +156,8 @@ final class DdaAccessController {
       throw new IllegalArgumentException("There is already a TestDDA going on for that directory!");
     }
 
-    File writeFile =
-        write
-            ? new File(
-                path,
-                "DDACheck-" + server.getNode().bootstrap().fastWeakRandom().nextInt() + ".tmp")
-            : null;
+    Random fastWeakRandom = server.runtime().randomness().fastWeakRandom();
+    File writeFile = write ? new File(path, "DDACheck-" + fastWeakRandom.nextInt() + ".tmp") : null;
     File readFile = null;
     if (read) {
       try {
@@ -171,9 +168,7 @@ final class DdaAccessController {
       }
     }
 
-    DdaCheckJob job =
-        new DdaCheckJob(
-            server.getNode().bootstrap().fastWeakRandom(), directory, readFile, writeFile);
+    DdaCheckJob job = new DdaCheckJob(fastWeakRandom, directory, readFile, writeFile);
 
     if (readFile != null) {
       try (FileOutputStream fos = new FileOutputStream(readFile);

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -165,7 +165,7 @@ public class FCPConnectionHandler implements Closeable {
     this.ddaAccessController = new DdaAccessController(server, LOG);
 
     byte[] identifier = new byte[16];
-    server.getNode().bootstrap().random().nextBytes(identifier);
+    server.runtime().randomness().fillSecureRandom(identifier);
     this.connectionIdentifier = HexUtil.bytesToHex(identifier);
 
     // The random 16-byte identifier was used before we added the UUID. Luckily, UUIDs are also

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
@@ -54,9 +54,8 @@ public class FCPConnectionInputHandler implements Runnable {
     if (handler.getSocket() == null) return;
     handler
         .getServer()
-        .getNode()
-        .network()
-        .executor()
+        .runtime()
+        .execution()
         .execute(this, "FCP input handler for " + handler.getSocket().getRemoteSocketAddress());
   }
 

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionOutputHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionOutputHandler.java
@@ -66,9 +66,8 @@ public class FCPConnectionOutputHandler implements Runnable {
     if (handler.getSocket() == null) return;
     handler
         .getServer()
-        .getNode()
-        .network()
-        .executor()
+        .runtime()
+        .execution()
         .execute(
             this,
             "FCP output handler for "

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -12,6 +12,7 @@ import network.crypta.io.AllowedHosts;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.api.Bucket;
 
 /**
@@ -54,6 +55,8 @@ public class FCPServer implements Runnable, DownloadCache {
 
   /* It’s not the field that is deprecated, but accessing it directly is. */
   private final Node node;
+
+  private final RuntimePorts runtime;
 
   final int port;
 
@@ -108,6 +111,7 @@ public class FCPServer implements Runnable, DownloadCache {
     this.enabled = config.enabled();
     this.node = dependencies.node();
     this.core = dependencies.core();
+    this.runtime = dependencies.runtimePorts();
     this.assumeDownloadDDAIsAllowed = config.assumeDownloadDDAAllowed();
     this.assumeUploadDDAIsAllowed = config.assumeUploadDDAAllowed();
     this.neverDropAMessage = config.neverDropAMessage();
@@ -132,6 +136,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @param port TCP port number for the FCP listener, in the host byte order.
    * @param node owning {@link Node} providing executors and lifecycle hooks.
    * @param core node client core exposing persistence, download directories, and cache factories.
+   * @param runtime runtime SPI bridge for infrastructure code that avoids daemon internals.
    * @param isEnabled whether networked FCP should start.
    * @param assumeDDADownloadAllowed flag to treat download DDA as preapproved globally.
    * @param assumeDDAUploadAllowed flag to treat upload DDA as preapproved globally.
@@ -147,6 +152,7 @@ public class FCPServer implements Runnable, DownloadCache {
       int port,
       Node node,
       NodeClientCore core,
+      RuntimePorts runtime,
       boolean isEnabled,
       boolean assumeDDADownloadAllowed,
       boolean assumeDDAUploadAllowed,
@@ -164,7 +170,7 @@ public class FCPServer implements Runnable, DownloadCache {
             assumeDDAUploadAllowed,
             neverDropAMessage,
             maxMessageQueueLength),
-        new FcpServerDependencies(node, core, persistentRoot));
+        new FcpServerDependencies(node, core, runtime, persistentRoot));
   }
 
   /**
@@ -216,13 +222,18 @@ public class FCPServer implements Runnable, DownloadCache {
    *
    * @param node the owning node providing executors and core services for the server.
    * @param core client core used for persistence and endpoint access.
+   * @param runtime runtime SPI bridge used by infrastructure code inside the server.
    * @param config configuration registry where the {@code fcp} subsection is registered.
    * @param root persistence root used to back global request queues.
    * @return configured server instance ready to be started by the caller.
    */
   public static FCPServer maybeCreate(
-      Node node, NodeClientCore core, Config config, PersistentRequestRoot root) {
-    return FcpServerConfigRegistrar.maybeCreate(node, core, config, root);
+      Node node,
+      NodeClientCore core,
+      RuntimePorts runtime,
+      Config config,
+      PersistentRequestRoot root) {
+    return FcpServerConfigRegistrar.maybeCreate(node, core, runtime, config, root);
   }
 
   /**
@@ -730,6 +741,19 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   public NodeClientCore getCore() {
     return core;
+  }
+
+  /**
+   * Returns the runtime SPI bridge used by FCP infrastructure code.
+   *
+   * <p>The returned {@link RuntimePorts} instance is the same adapter supplied during server
+   * construction. It exposes execution, randomness, transfer policy, and lifecycle metadata without
+   * forcing infrastructure classes to depend directly on daemon-internal types.
+   *
+   * @return runtime SPI bridge backing this server instance.
+   */
+  public RuntimePorts runtime() {
+    return runtime;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
@@ -10,6 +10,7 @@ import network.crypta.io.NetworkInterface;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.api.BooleanCallback;
 import network.crypta.support.api.IntCallback;
 import network.crypta.support.api.StringCallback;
@@ -53,18 +54,24 @@ final class FcpServerConfigRegistrar {
    *
    * <pre>{@code
    * Config config = new Config();
-   * FCPServer server = FcpServerConfigRegistrar.maybeCreate(node, core, config, root);
+   * FCPServer server = FcpServerConfigRegistrar.maybeCreate(node, core, runtimePorts, config,
+   * root);
    * server.maybeStart();
    * }</pre>
    *
    * @param node the owning node providing executors and core services for the server.
    * @param core client core used for endpoint access and persisted settings lookups.
+   * @param runtimePorts runtime SPI bridge passed to the created server.
    * @param config root configuration registry where the {@code fcp} subsection is registered.
    * @param root persistent request root used to wire global request queues.
    * @return configured {@link FCPServer} instance ready for {@link FCPServer#maybeStart()}.
    */
   static FCPServer maybeCreate(
-      Node node, NodeClientCore core, Config config, PersistentRequestRoot root) {
+      Node node,
+      NodeClientCore core,
+      RuntimePorts runtimePorts,
+      Config config,
+      PersistentRequestRoot root) {
     SubConfig fcpConfig = config.createSubConfig("fcp");
     short sortOrder = 0;
     fcpConfig.register(
@@ -166,7 +173,7 @@ final class FcpServerConfigRegistrar {
             fcpConfig.getBoolean("assumeUploadDDAIsAllowed"),
             fcpConfig.getBoolean("neverDropAMessage"),
             fcpConfig.getInt("maxMessageQueueLength"));
-    FcpServerDependencies dependencies = new FcpServerDependencies(node, core, root);
+    FcpServerDependencies dependencies = new FcpServerDependencies(node, core, runtimePorts, root);
     FCPServer fcp = new FCPServer(serverConfig, dependencies);
 
     cb4.server = fcp;

--- a/src/main/java/network/crypta/clients/fcp/FcpServerDependencies.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerDependencies.java
@@ -2,13 +2,18 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
 
 /**
  * Core node services required to construct an {@link FCPServer}.
  *
  * @param node owning {@link Node} providing executors and lifecycle hooks.
  * @param core node client core exposing persistence, download directories, and cache factories.
+ * @param runtimePorts runtime SPI bridge for infrastructure code that avoids daemon internals.
  * @param persistentRoot persistence root used to access global clients and caches.
  */
 public record FcpServerDependencies(
-    Node node, NodeClientCore core, PersistentRequestRoot persistentRoot) {}
+    Node node,
+    NodeClientCore core,
+    RuntimePorts runtimePorts,
+    PersistentRequestRoot persistentRoot) {}

--- a/src/main/java/network/crypta/node/ClientEndpoints.java
+++ b/src/main/java/network/crypta/node/ClientEndpoints.java
@@ -7,6 +7,7 @@ import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.io.TempBucketFactory;
 
 /**
@@ -42,7 +43,7 @@ public final class ClientEndpoints {
   private UserAlert startingUpAlert;
 
   /**
-   * Result wrapper for {@link #create(Node, NodeClientCore, NodeClientCoreInit,
+   * Result wrapper for {@link #create(Node, NodeClientCore, RuntimePorts, NodeClientCoreInit,
    * NodeClientPersistence, ClientContext)}.
    *
    * <p>The returned direct TMCI is created but not started. Callers must publish it via {@link
@@ -299,12 +300,13 @@ public final class ClientEndpoints {
    *
    * <pre>{@code
    * ClientEndpoints.InitResult initResult =
-   *     ClientEndpoints.create(node, core, init, persistence, clientContext);
+   *     ClientEndpoints.create(node, core, runtimePorts, init, persistence, clientContext);
    * initResult.endpoints().maybeStart();
    * }</pre>
    *
    * @param node node instance used for endpoint creation and configuration.
    * @param core client core used by endpoint factories and alert registration.
+   * @param runtimePorts runtime SPI bridge passed to the FCP infrastructure.
    * @param init initializer providing configuration and toadlet container access.
    * @param persistence persistence layer responsible for creating the FCP server.
    * @param clientContext client context updated with the FCP download cache.
@@ -314,13 +316,14 @@ public final class ClientEndpoints {
   public static InitResult create(
       Node node,
       NodeClientCore core,
+      RuntimePorts runtimePorts,
       NodeClientCoreInit init,
       NodeClientPersistence persistence,
       ClientContext clientContext) {
     TextModeClientInterfaceServer.InitResult tmciInit =
         TextModeClientInterfaceServer.maybeCreate(node, core, init.config());
     TextModeClientInterfaceServer tmci = tmciInit.server();
-    FCPServer fcpServer = persistence.createFcpServer(node, core);
+    FCPServer fcpServer = persistence.createFcpServer(node, core, runtimePorts);
     clientContext.setDownloadCache(fcpServer);
     if (!core.killedDatabase()) {
       fcpServer.load();

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -18,7 +18,9 @@ import network.crypta.crypt.RandomSource;
 import network.crypta.keys.Key;
 import network.crypta.keys.NodeSSK;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.node.runtime.LegacyRuntimePorts;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.Base64;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.SimpleFieldSet;
@@ -131,6 +133,9 @@ public final class NodeClientCore implements Persistable {
 
   /** Client-facing endpoints (TMCI, FCP, and FProxy wiring). */
   private final ClientEndpoints endpoints;
+
+  /** Runtime SPI bridge used by infrastructure layers that must avoid daemon-internal types. */
+  private final RuntimePorts runtimePorts;
 
   /**
    * Compressor used for network transfers and stored blocks.
@@ -373,6 +378,7 @@ public final class NodeClientCore implements Persistable {
     sortOrder = transferPolicy.registerDownloadAllowedDirs(init, sortOrder);
 
     sortOrder = transferPolicy.registerUploadAllowedDirs(init, sortOrder);
+    runtimePorts = new LegacyRuntimePorts(node, this);
 
     LOG.info("Initializing USK Manager");
     uskManager.init(getClientContext());
@@ -384,7 +390,7 @@ public final class NodeClientCore implements Persistable {
 
     // TMCI and FCP (including persistent requests so needs to start before FProxy)
     ClientEndpoints.InitResult endpointsInit =
-        ClientEndpoints.create(node, this, init, persistence, clientContext);
+        ClientEndpoints.create(node, this, runtimePorts, init, persistence, clientContext);
     endpoints = endpointsInit.endpoints();
     TextModeClientInterface directTMCI = endpointsInit.directTMCI();
     if (directTMCI != null) {
@@ -1134,6 +1140,20 @@ public final class NodeClientCore implements Persistable {
    */
   public ClientEndpoints getEndpoints() {
     return endpoints;
+  }
+
+  /**
+   * Returns the runtime SPI bridge for infrastructure code that should not depend on daemon
+   * internals.
+   *
+   * <p>The returned {@link RuntimePorts} instance delegates back into the current node and client
+   * core without adding new business logic. It is created during construction and shared for the
+   * lifetime of the core.
+   *
+   * @return runtime SPI bridge backed by this node and client core.
+   */
+  public RuntimePorts getRuntimePorts() {
+    return runtimePorts;
   }
 
   /**

--- a/src/main/java/network/crypta/node/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/node/NodeClientPersistence.java
@@ -14,6 +14,7 @@ import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.MasterSecret;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.Ticker;
 import network.crypta.support.io.DiskSpaceCheckingRandomAccessBufferFactory;
@@ -253,16 +254,17 @@ public final class NodeClientPersistence {
    * Creates the FCP server configured for this node and client core.
    *
    * <p>The server is constructed via {@link FCPServer#maybeCreate(Node, NodeClientCore,
-   * network.crypta.config.Config, PersistentRequestRoot)} and shares this instance's persistent
-   * request root so durable requests can be managed consistently across reconnections. This method
-   * performs no side effects beyond the delegation.
+   * RuntimePorts, network.crypta.config.Config, PersistentRequestRoot)} and shares this instance's
+   * persistent request root so durable requests can be managed consistently across reconnections.
+   * This method performs no side effects beyond the delegation.
    *
    * @param node node instance supplying configuration and shared services.
    * @param core client core used by the FCP server for callbacks.
+   * @param runtimePorts runtime SPI bridge passed to the FCP infrastructure.
    * @return the configured FCP server instance from {@code maybeCreate}.
    */
-  public FCPServer createFcpServer(Node node, NodeClientCore core) {
-    return FCPServer.maybeCreate(node, core, node.getConfig(), persistentRoot);
+  public FCPServer createFcpServer(Node node, NodeClientCore core, RuntimePorts runtimePorts) {
+    return FCPServer.maybeCreate(node, core, runtimePorts, node.getConfig(), persistentRoot);
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -1,0 +1,109 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.util.Random;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ExecutionPort;
+import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
+
+/** Bridges the current node/core implementation into the JDK-only runtime SPI. */
+public final class LegacyRuntimePorts implements RuntimePorts {
+  private final Node node;
+  private final NodeClientCore core;
+  private final ExecutionPort executionPort;
+  private final RandomnessPort randomnessPort;
+  private final TransferAccessPort transferAccessPort;
+  private final LifecyclePort lifecyclePort;
+
+  public LegacyRuntimePorts(Node node, NodeClientCore core) {
+    this.node = node;
+    this.core = core;
+    this.executionPort =
+        (task, name) -> LegacyRuntimePorts.this.node.network().executor().execute(task, name);
+    this.randomnessPort =
+        new RandomnessPort() {
+          @Override
+          public void fillSecureRandom(byte[] target) {
+            LegacyRuntimePorts.this.node.bootstrap().random().nextBytes(target);
+          }
+
+          @Override
+          public Random fastWeakRandom() {
+            return LegacyRuntimePorts.this.node.bootstrap().fastWeakRandom();
+          }
+        };
+    this.transferAccessPort =
+        new TransferAccessPort() {
+          @Override
+          public boolean allowUploadFrom(File file) {
+            return LegacyRuntimePorts.this.core.allowUploadFrom(file);
+          }
+
+          @Override
+          public boolean allowDownloadTo(File file) {
+            return LegacyRuntimePorts.this.core.allowDownloadTo(file);
+          }
+
+          @Override
+          public File downloadsDir() {
+            return LegacyRuntimePorts.this.core.getDownloadsDir();
+          }
+
+          @Override
+          public File persistentTempDir() {
+            return LegacyRuntimePorts.this.core.getPersistentTempDir();
+          }
+
+          @Override
+          public File[] allowedUploadDirs() {
+            return LegacyRuntimePorts.this.core.getAllowedUploadDirs();
+          }
+
+          @Override
+          public File[] allowedDownloadDirs() {
+            return LegacyRuntimePorts.this.core.getAllowedDownloadDirs();
+          }
+        };
+    this.lifecyclePort =
+        new LifecyclePort() {
+          @Override
+          public boolean hasStarted() {
+            return LegacyRuntimePorts.this.node.isHasStarted();
+          }
+
+          @Override
+          public boolean isStopping() {
+            return LegacyRuntimePorts.this.node.isStopping();
+          }
+
+          @Override
+          public long startupTimeMillis() {
+            return LegacyRuntimePorts.this.node.getStartupTime();
+          }
+        };
+  }
+
+  @Override
+  public ExecutionPort execution() {
+    return executionPort;
+  }
+
+  @Override
+  public RandomnessPort randomness() {
+    return randomnessPort;
+  }
+
+  @Override
+  public TransferAccessPort transferAccess() {
+    return transferAccessPort;
+  }
+
+  @Override
+  public LifecyclePort lifecycle() {
+    return lifecyclePort;
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -10,7 +10,20 @@ import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
 
-/** Bridges the current node/core implementation into the JDK-only runtime SPI. */
+/**
+ * Bridges the current daemon implementation into the JDK-only runtime SPI.
+ *
+ * <p>This adapter is the conservative compatibility layer for the first runtime SPI extraction. It
+ * captures the existing {@link Node} and {@link NodeClientCore} instances and exposes their
+ * already-available capabilities through the smaller {@link RuntimePorts} surface. The class adds
+ * no policy of its own; each sub-port delegates directly to the legacy implementation, so behavior,
+ * timing, and file-access semantics remain aligned with the daemon that existed before the SPI was
+ * introduced.
+ *
+ * <p>The adapter is immutable after construction. It is safe to share the instance anywhere the
+ * daemon currently threads runtime dependencies, but callers should remember that the returned
+ * ports remain live views over mutable daemon state rather than detached snapshots.
+ */
 public final class LegacyRuntimePorts implements RuntimePorts {
   private final Node node;
   private final NodeClientCore core;
@@ -19,6 +32,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final TransferAccessPort transferAccessPort;
   private final LifecyclePort lifecyclePort;
 
+  /**
+   * Creates a runtime SPI adapter backed by the current daemon internals.
+   *
+   * <p>The constructed adapter keeps direct references to {@code node} and {@code core} and uses
+   * them to implement each runtime sub-port with thin delegation only. No data is copied and no
+   * validation or normalization is introduced here, so existing daemon semantics remain the source
+   * of truth for execution, randomness, transfer policy, and lifecycle state.
+   *
+   * @param node live daemon node that provides execution, randomness, and lifecycle behavior
+   * @param core live client core that provides transfer-policy checks and directory access
+   */
   public LegacyRuntimePorts(Node node, NodeClientCore core) {
     this.node = node;
     this.core = core;
@@ -87,21 +111,43 @@ public final class LegacyRuntimePorts implements RuntimePorts {
         };
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port delegates to the node's existing network executor without adding another
+   * scheduling layer.
+   */
   @Override
   public ExecutionPort execution() {
     return executionPort;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port delegates to the node bootstrap's secure and weak random services.
+   */
   @Override
   public RandomnessPort randomness() {
     return randomnessPort;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port delegates to {@link NodeClientCore} for current file-transfer policy and
+   * directory state.
+   */
   @Override
   public TransferAccessPort transferAccess() {
     return transferAccessPort;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port exposes the node's current lifecycle flags and startup timestamp directly.
+   */
   @Override
   public LifecyclePort lifecycle() {
     return lifecyclePort;

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.file.Path;
+import java.util.Arrays;
 import network.crypta.client.FetchContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
@@ -12,9 +13,10 @@ import network.crypta.clients.fcp.ClientGet.GlobalRequestConfig;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
+import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import org.junit.jupiter.api.Test;
@@ -22,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -33,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,9 +47,6 @@ class ClientGetFactoryTest {
   @Mock private ClientContext clientContext;
   @Mock private FetchContext fetchContext;
   @Mock private ClientEventProducer eventProducer;
-
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void fromGlobal_whenIdentifierAlreadyRegistered_throwsIdentifierCollisionException()
@@ -255,7 +254,18 @@ class ClientGetFactoryTest {
   private FCPConnectionHandler newConnectionHandler() {
     FCPServer server = mock(FCPServer.class);
     Socket socket = mock(Socket.class);
-    when(server.getNode()).thenReturn(node);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    RandomnessPort randomnessPort = mock(RandomnessPort.class);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.randomness()).thenReturn(randomnessPort);
+    doAnswer(
+            invocation -> {
+              byte[] target = invocation.getArgument(0);
+              Arrays.fill(target, (byte) 1);
+              return null;
+            })
+        .when(randomnessPort)
+        .fillSecureRandom(any(byte[].class));
     return new FCPConnectionHandler(socket, server);
   }
 

--- a/src/test/java/network/crypta/clients/fcp/DdaAccessControllerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DdaAccessControllerTest.java
@@ -5,7 +5,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Random;
-import network.crypta.node.Node;
+import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.io.FileUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,9 +32,8 @@ class DdaAccessControllerTest {
 
   @Mock private FCPServer server;
   @Mock private Logger log;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private RandomnessPort randomnessPort;
 
   @TempDir private Path tempDir;
 
@@ -52,8 +52,9 @@ class DdaAccessControllerTest {
   }
 
   private void stubRandomAccess() {
-    when(server.getNode()).thenReturn(node);
-    when(node.bootstrap().fastWeakRandom()).thenReturn(random);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.randomness()).thenReturn(randomnessPort);
+    when(randomnessPort.fastWeakRandom()).thenReturn(random);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
@@ -11,9 +11,10 @@ import java.util.Random;
 import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.EntropySource;
 import network.crypta.crypt.RandomSource;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
+import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -43,9 +45,8 @@ class FCPConnectionHandlerTest {
   @Mock private ClientContext clientContext;
   @Mock private TempBucketFactory tempBucketFactory;
   @Mock private Socket socket;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private RandomnessPort randomnessPort;
 
   private FCPConnectionHandler handler;
   private Random fastRandom;
@@ -57,8 +58,18 @@ class FCPConnectionHandlerTest {
 
     lenient().when(server.getCore()).thenReturn(core);
     lenient().when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);
-    lenient().when(server.getNode()).thenReturn(node);
-    lenient().when(node.getRandom()).thenReturn(randomSource);
+    lenient().when(server.runtime()).thenReturn(runtimePorts);
+    lenient().when(runtimePorts.randomness()).thenReturn(randomnessPort);
+    lenient()
+        .doAnswer(
+            invocation -> {
+              byte[] target = invocation.getArgument(0);
+              randomSource.nextBytes(target);
+              return null;
+            })
+        .when(randomnessPort)
+        .fillSecureRandom(any(byte[].class));
+    lenient().when(randomnessPort.fastWeakRandom()).thenReturn(fastRandom);
 
     handler = new FCPConnectionHandler(socket, server);
   }
@@ -175,7 +186,6 @@ class FCPConnectionHandlerTest {
 
   @Test
   void enqueueDDACheck_whenJobAlreadyInFlight_throws(@TempDir Path tempDir) {
-    when(node.bootstrap().fastWeakRandom()).thenReturn(fastRandom);
     String directory = tempDir.toString();
     handler.enqueueDDACheck(directory, true, false);
 
@@ -185,7 +195,6 @@ class FCPConnectionHandlerTest {
 
   @Test
   void enqueueAndPopDDACheck_roundTripCreatesAndRemovesJob(@TempDir Path tempDir) throws Exception {
-    when(node.bootstrap().fastWeakRandom()).thenReturn(fastRandom);
     DdaCheckJob job = handler.enqueueDDACheck(tempDir.toString(), true, true);
 
     assertNotNull(job);
@@ -205,7 +214,6 @@ class FCPConnectionHandlerTest {
 
   @Test
   void freeDDAJobs_deletesOutstandingFiles(@TempDir Path tempDir) {
-    when(node.bootstrap().fastWeakRandom()).thenReturn(fastRandom);
     DdaCheckJob job = handler.enqueueDDACheck(tempDir.toString(), true, false);
     assertNotNull(job.readFilename);
     assertTrue(job.readFilename.exists());

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
@@ -15,7 +15,8 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.runtime.spi.ExecutionPort;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.LineReadingInputStream;
@@ -67,22 +68,22 @@ class FCPConnectionInputHandlerTest {
   void start_whenSocketPresent_submitsRunnableWithRemoteAddress() {
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
     FCPServer server = mock(FCPServer.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    ExecutionPort executionPort = mock(ExecutionPort.class);
     Socket socket = mock(Socket.class);
     InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 9481);
 
     when(handler.getSocket()).thenReturn(socket);
     when(socket.getRemoteSocketAddress()).thenReturn(address);
     when(handler.getServer()).thenReturn(server);
-    when(server.getNode()).thenReturn(node);
-    when(node.network().executor()).thenReturn(executor);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.execution()).thenReturn(executionPort);
 
     FCPConnectionInputHandler inputHandler = new FCPConnectionInputHandler(handler);
 
     inputHandler.start();
 
-    verify(executor).execute(eq(inputHandler), contains(address.toString()));
+    verify(executionPort).execute(eq(inputHandler), contains(address.toString()));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionOutputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionOutputHandlerTest.java
@@ -6,9 +6,8 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.stream.IntStream;
-import network.crypta.node.Node;
-import network.crypta.node.subsystem.NodeNetworkSubsystem;
-import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.runtime.spi.ExecutionPort;
+import network.crypta.runtime.spi.RuntimePorts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,11 +35,6 @@ class FCPConnectionOutputHandlerTest {
 
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPServer server;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private PriorityAwareExecutor executor;
   @Mock private Socket socket;
   @Mock private OutputStream outputStream;
   @Mock private SocketAddress socketAddress;
@@ -54,19 +48,19 @@ class FCPConnectionOutputHandlerTest {
 
   @Test
   void start_whenSocketPresent_submitsRunnableWithLabel() {
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    ExecutionPort executionPort = mock(ExecutionPort.class);
     when(handler.getSocket()).thenReturn(socket);
     when(socket.getRemoteSocketAddress()).thenReturn(socketAddress);
     when(socketAddress.toString()).thenReturn("remote");
     when(socket.getPort()).thenReturn(9481);
     when(handler.getServer()).thenReturn(server);
-    when(server.getNode()).thenReturn(node);
-    NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.executor()).thenReturn(executor);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.execution()).thenReturn(executionPort);
 
     outputHandler.start();
 
-    verify(executor).execute(outputHandler, "FCP output handler for remote:9481");
+    verify(executionPort).execute(outputHandler, "FCP output handler for remote:9481");
   }
 
   @Test
@@ -75,7 +69,7 @@ class FCPConnectionOutputHandlerTest {
 
     outputHandler.start();
 
-    verifyNoInteractions(executor);
+    verifyNoInteractions(server);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -6,6 +6,7 @@ import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.api.Bucket;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,7 @@ class FCPServerTest {
   private Node node;
 
   @Mock private NodeClientCore core;
+  @Mock private RuntimePorts runtimePorts;
 
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
     FcpServerConfig config =
@@ -39,7 +41,7 @@ class FCPServerTest {
             false,
             10);
     return new FCPServer(
-        config, new FcpServerDependencies(node, core, new PersistentRequestRoot()));
+        config, new FcpServerDependencies(node, core, runtimePorts, new PersistentRequestRoot()));
   }
 
   @Test
@@ -104,7 +106,8 @@ class FCPServerTest {
             false,
             false,
             10);
-    FCPServer server = new FCPServer(config, new FcpServerDependencies(node, core, root));
+    FCPServer server =
+        new FCPServer(config, new FcpServerDependencies(node, core, runtimePorts, root));
     PersistentRequestClient forever = root.registerForeverClient("forever", null);
 
     // Act
@@ -132,6 +135,13 @@ class FCPServerTest {
     // Act & Assert
     assertFalse(server.isDownloadDDAAlwaysAllowed());
     assertTrue(server.isUploadDDAAlwaysAllowed());
+  }
+
+  @Test
+  void runtime_whenQueried_returnsConfiguredPorts() {
+    FCPServer server = newServer(false, false);
+
+    assertSame(runtimePorts, server.runtime());
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
@@ -6,6 +6,7 @@ import network.crypta.config.SubConfig;
 import network.crypta.io.NetworkInterface;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -30,6 +31,8 @@ class FcpServerConfigRegistrarTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private NodeClientCore core;
 
+  @Mock private RuntimePorts runtimePorts;
+
   @Test
   void maybeCreate_whenDefaults_expectConfiguredServerAndInitializedSubConfig() {
     // Arrange
@@ -37,7 +40,7 @@ class FcpServerConfigRegistrarTest {
     PersistentRequestRoot root = new PersistentRequestRoot();
 
     // Act
-    FCPServer server = FcpServerConfigRegistrar.maybeCreate(node, core, config, root);
+    FCPServer server = FcpServerConfigRegistrar.maybeCreate(node, core, runtimePorts, config, root);
     SubConfig subConfig = config.get("fcp");
 
     // Assert
@@ -52,6 +55,7 @@ class FcpServerConfigRegistrarTest {
     assertFalse(server.assumeUploadDDAIsAllowed);
     assertFalse(server.neverDropAMessage);
     assertEquals(1024, server.maxMessageQueueLength);
+    assertEquals(runtimePorts, server.runtime());
     assertNotNull(subConfig.getOption("enabled"));
     assertNotNull(subConfig.getOption("ssl"));
     assertNotNull(subConfig.getOption("port"));
@@ -229,6 +233,6 @@ class FcpServerConfigRegistrarTest {
             false,
             10);
     return new FCPServer(
-        config, new FcpServerDependencies(node, core, new PersistentRequestRoot()));
+        config, new FcpServerDependencies(node, core, runtimePorts, new PersistentRequestRoot()));
   }
 }

--- a/src/test/java/network/crypta/node/ClientEndpointsTest.java
+++ b/src/test/java/network/crypta/node/ClientEndpointsTest.java
@@ -7,6 +7,7 @@ import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.config.Config;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +38,7 @@ class ClientEndpointsTest {
   @Mock private NodeClientCore core;
   @Mock private NodeClientPersistence persistence;
   @Mock private ClientContext clientContext;
+  @Mock private RuntimePorts runtimePorts;
 
   @Test
   void constructor_whenProvidedDependencies_returnsSameInstances() {
@@ -166,7 +168,7 @@ class ClientEndpointsTest {
     SimpleToadletServer toadlets = Mockito.mock(SimpleToadletServer.class);
     NodeClientCoreInit init = new NodeClientCoreInit(config, null, null, toadlets);
 
-    Mockito.when(persistence.createFcpServer(node, core)).thenReturn(fcpServer);
+    Mockito.when(persistence.createFcpServer(node, core, runtimePorts)).thenReturn(fcpServer);
     Mockito.when(core.killedDatabase()).thenReturn(false);
 
     try (MockedStatic<TextModeClientInterfaceServer> tmciMock =
@@ -176,7 +178,7 @@ class ClientEndpointsTest {
           .thenReturn(new TextModeClientInterfaceServer.InitResult(tmci, null));
 
       ClientEndpoints.InitResult initResult =
-          ClientEndpoints.create(node, core, init, persistence, clientContext);
+          ClientEndpoints.create(node, core, runtimePorts, init, persistence, clientContext);
       ClientEndpoints endpoints = initResult.endpoints();
 
       assertSame(fcpServer, endpoints.getFCPServer());
@@ -185,7 +187,7 @@ class ClientEndpointsTest {
       tmciMock.verify(() -> TextModeClientInterfaceServer.maybeCreate(node, core, config));
     }
 
-    Mockito.verify(persistence).createFcpServer(node, core);
+    Mockito.verify(persistence).createFcpServer(node, core, runtimePorts);
     Mockito.verify(clientContext).setDownloadCache(fcpServer);
     Mockito.verify(fcpServer).load();
   }
@@ -196,7 +198,7 @@ class ClientEndpointsTest {
     SimpleToadletServer toadlets = Mockito.mock(SimpleToadletServer.class);
     NodeClientCoreInit init = new NodeClientCoreInit(config, null, null, toadlets);
 
-    Mockito.when(persistence.createFcpServer(node, core)).thenReturn(fcpServer);
+    Mockito.when(persistence.createFcpServer(node, core, runtimePorts)).thenReturn(fcpServer);
     Mockito.when(core.killedDatabase()).thenReturn(true);
 
     try (MockedStatic<TextModeClientInterfaceServer> tmciMock =
@@ -206,7 +208,7 @@ class ClientEndpointsTest {
           .thenReturn(new TextModeClientInterfaceServer.InitResult(tmci, null));
 
       ClientEndpoints.InitResult initResult =
-          ClientEndpoints.create(node, core, init, persistence, clientContext);
+          ClientEndpoints.create(node, core, runtimePorts, init, persistence, clientContext);
       ClientEndpoints endpoints = initResult.endpoints();
 
       assertSame(fcpServer, endpoints.getFCPServer());

--- a/src/test/java/network/crypta/node/NodeClientCoreTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTest.java
@@ -4,19 +4,34 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.ClientRequestScheduler;
+import network.crypta.client.async.DatastoreChecker;
+import network.crypta.client.async.USKManager;
+import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.bookmark.BookmarkManager;
+import network.crypta.config.PersistentConfig;
+import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.NodeSSK;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.node.runtime.LegacyRuntimePorts;
 import network.crypta.node.subsystem.NodeServicesSubsystem;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -26,9 +41,18 @@ import org.mockito.quality.Strictness;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,10 +71,26 @@ class NodeClientCoreTest {
   @Mock private ClientRequestScheduler schedulerBulk;
   @Mock private ClientRequestScheduler schedulerRt;
   @Mock private RandomSource rng;
+  @Mock private NodeClientPersistence persistence;
+  @Mock private ClientLayerPersister clientLayerPersister;
+  @Mock private ClientContext clientContext;
+  @Mock private TempBucketFactory tempBucketFactory;
+  @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
+  @Mock private DatastoreChecker storeChecker;
+  @Mock private UserAlertManager alerts;
+  @Mock private PersistentConfig config;
+  @Mock private PriorityAwareExecutor executor;
+  @Mock private IPDetectorManager ipDetectorManager;
 
   @TempDir Path tempDir; // base dir for downloads and test files
 
   private NodeClientCore core;
+  private RuntimePorts runtimePorts;
+  private NodeClientCoreTransfers transfers;
+  private USKManager uskManager;
+  private File nodeDir;
+  private File coreTempDir;
+  private File persistentTempDir;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -62,16 +102,45 @@ class NodeClientCoreTest {
     // Inject required collaborators/fields via reflection to avoid full Node/Config bootstrapping
     setField(core, "random", rng);
     setField(core, "node", node);
+    setField(core, "persistence", persistence);
+    setField(core, "clientLayerPersister", clientLayerPersister);
+    setField(core, "clientContext", clientContext);
+    setField(core, "tempBucketFactory", tempBucketFactory);
+    setField(core, "persistentTempBucketFactory", persistentTempBucketFactory);
+    setField(core, "storeChecker", storeChecker);
+    setField(core, "alerts", alerts);
+    setField(core, "formPassword", "form-password");
     NodeServicesSubsystem services = Mockito.mock(NodeServicesSubsystem.class);
     when(node.services()).thenReturn(services);
     when(services.securityLevels()).thenReturn(securityLevels);
+    when(node.getConfig()).thenReturn(config);
+    when(node.network().executor()).thenReturn(executor);
 
     setField(core, "downloadsDir", tempDir.toFile());
     setField(core, "transferPolicy", new NodeClientCoreTransferPolicy(node, tempDir.toFile()));
+    nodeDir = tempDir.resolve("node").toFile();
+    coreTempDir = tempDir.resolve("temp").toFile();
+    persistentTempDir = tempDir.resolve("persistent").toFile();
+    Files.createDirectories(coreTempDir.toPath());
+    Files.createDirectories(persistentTempDir.toPath());
+    Files.createDirectories(nodeDir.toPath());
+    setField(core, "tempDir", coreTempDir);
+    setField(core, "persistentTempDir", persistentTempDir);
 
     ClientEndpoints endpoints = new ClientEndpoints(Mockito.mock(FCPServer.class), null, toadlets);
     setField(core, "endpoints", endpoints);
     setField(core, "requestStarters", requestStarters);
+    transfers = Mockito.mock(NodeClientCoreTransfers.class);
+    uskManager = Mockito.mock(USKManager.class);
+    setField(core, "transfers", transfers);
+    setField(core, "uskManager", uskManager);
+    runtimePorts = new LegacyRuntimePorts(node, core);
+    setField(core, "runtimePorts", runtimePorts);
+    NodeIPDetector nodeIpDetector = Mockito.mock(NodeIPDetector.class);
+    setField(nodeIpDetector, NodeIPDetector.class, "ipDetectorManager", ipDetectorManager);
+    when(node.network().ipDetector()).thenReturn(nodeIpDetector);
+    when(node.getNodeDir()).thenReturn(nodeDir);
+    when(tempBucketFactory.getMaxRamUsed()).thenReturn(256L);
 
     // sensible default unless a test overrides
     when(securityLevels.getPhysicalThreatLevel()).thenReturn(PHYSICAL_THREAT_LEVEL.NORMAL);
@@ -219,10 +288,238 @@ class NodeClientCoreTest {
     assertEquals("MyNode", core.getMyName());
   }
 
+  @Test
+  void getters_whenCollaboratorsInjected_expectVerbatimReferencesReturned() {
+    assertSame(runtimePorts, core.getRuntimePorts());
+    assertEquals(tempDir.toFile(), core.getDownloadsDir());
+    assertEquals(persistentTempDir, core.getPersistentTempDir());
+    assertEquals(coreTempDir, core.getTempDir());
+    assertSame(uskManager, core.getUskManager());
+    assertSame(transfers, core.getTransfers());
+    assertSame(requestStarters, core.getRequestStarters());
+    assertEquals("form-password", core.getFormPassword());
+    assertSame(tempBucketFactory, core.getTempBucketFactory());
+    assertSame(persistentTempBucketFactory, core.getPersistentTempBucketFactory());
+    assertSame(clientLayerPersister, core.getClientLayerPersister());
+    assertSame(node, core.getNode());
+    assertSame(rng, core.getRandom());
+    assertSame(alerts, core.getAlerts());
+    assertSame(storeChecker, core.getStoreChecker());
+    assertSame(clientContext, core.getClientContext());
+  }
+
+  @Test
+  void countQueuedRequests_whenRequestStartersProvideCount_expectDelegatedCount() {
+    when(requestStarters.countQueuedRequests()).thenReturn(42L);
+
+    long queued = core.countQueuedRequests();
+
+    assertEquals(42L, queued);
+  }
+
+  @Test
+  void persistThrottlesToFieldSet_whenRequestStartersProvideSnapshot_expectSameSnapshot() {
+    SimpleFieldSet snapshot = new SimpleFieldSet(true);
+    when(requestStarters.persistToFieldSet()).thenReturn(snapshot);
+
+    SimpleFieldSet persisted = core.persistThrottlesToFieldSet();
+
+    assertSame(snapshot, persisted);
+  }
+
+  @Test
+  void wantKey_whenRealtimeSchedulerWantsKey_expectReturnsTrueWithoutCheckingBulk() {
+    NodeSSK key =
+        new NodeSSK(
+            new byte[NodeSSK.PUBKEY_HASH_SIZE], new byte[NodeSSK.E_H_DOCNAME_SIZE], (byte) 2);
+    when(clientContext.getFetchScheduler(true, true)).thenReturn(schedulerRt);
+    when(schedulerRt.wantKey(key)).thenReturn(true);
+
+    boolean wanted = core.wantKey(key);
+
+    assertTrue(wanted);
+    verify(clientContext).getFetchScheduler(true, true);
+    verify(clientContext, never()).getFetchScheduler(true, false);
+  }
+
+  @Test
+  void wantKey_whenBulkSchedulerWantsKey_expectFallsBackAfterRealtimeMiss() {
+    network.crypta.keys.Key key = Mockito.mock(network.crypta.keys.Key.class);
+    when(clientContext.getFetchScheduler(false, true)).thenReturn(schedulerRt);
+    when(clientContext.getFetchScheduler(false, false)).thenReturn(schedulerBulk);
+    when(schedulerRt.wantKey(key)).thenReturn(false);
+    when(schedulerBulk.wantKey(key)).thenReturn(true);
+
+    boolean wanted = core.wantKey(key);
+
+    assertTrue(wanted);
+    verify(clientContext).getFetchScheduler(false, true);
+    verify(clientContext).getFetchScheduler(false, false);
+  }
+
+  @Test
+  void updatePersistentRAFSpaceLimit_whenPersistentFactoryPresent_expectAddsRamAllowance()
+      throws Exception {
+    when(persistence.hasPersistentRafFactory()).thenReturn(true);
+    setField(core, "minDiskFreeLongTerm", 1024L);
+
+    core.updatePersistentRAFSpaceLimit();
+
+    verify(persistence).updateMinDiskSpace(1280L);
+  }
+
+  @Test
+  void updatePersistentRAFSpaceLimit_whenPersistentFactoryMissing_expectNoUpdate()
+      throws Exception {
+    when(persistence.hasPersistentRafFactory()).thenReturn(false);
+    setField(core, "minDiskFreeLongTerm", 1024L);
+
+    core.updatePersistentRAFSpaceLimit();
+
+    verify(persistence, never()).updateMinDiskSpace(anyLong());
+  }
+
+  @Test
+  void setupMasterSecret_whenPersistentSecretAbsent_expectConfiguresContextAndStorage() {
+    MasterSecret secret = new MasterSecret();
+    when(clientContext.getPersistentMasterSecret()).thenReturn(null);
+
+    core.setupMasterSecret(secret);
+
+    verify(clientContext).setPersistentMasterSecret(secret);
+    verify(persistentTempBucketFactory).setMasterSecret(secret);
+    verify(persistence).setPersistentRafMasterSecret(secret);
+  }
+
+  @Test
+  void setupMasterSecret_whenPersistentSecretAlreadyPresent_expectDoesNotOverwriteContextSecret() {
+    MasterSecret existingSecret = new MasterSecret();
+    MasterSecret newSecret = new MasterSecret();
+    when(clientContext.getPersistentMasterSecret()).thenReturn(existingSecret);
+
+    core.setupMasterSecret(newSecret);
+
+    verify(clientContext, never()).setPersistentMasterSecret(any());
+    verify(persistentTempBucketFactory).setMasterSecret(newSecret);
+    verify(persistence).setPersistentRafMasterSecret(newSecret);
+  }
+
+  @Test
+  void storeConfig_whenInvoked_expectDelegatesToNodeConfig() {
+    core.storeConfig();
+
+    verify(config).store();
+  }
+
+  @Test
+  void lateInitDatabase_whenStorageLoads_expectReturnsTrueAndLoadsPersistentRequests()
+      throws Exception {
+    ClientEndpoints endpoints = Mockito.mock(ClientEndpoints.class);
+    DatabaseKey databaseKey = new DatabaseKey(new byte[32]);
+    setField(core, "endpoints", endpoints);
+
+    boolean initialized = core.lateInitDatabase(databaseKey);
+
+    assertTrue(initialized);
+    verify(clientLayerPersister)
+        .setFilesAndLoad(
+            same(nodeDir),
+            eq("client.dat"),
+            eq(false),
+            eq(false),
+            same(databaseKey),
+            same(requestStarters));
+    verify(endpoints).loadPersistentRequestsIfNeeded();
+  }
+
+  @Test
+  void lateInitDatabase_whenMasterKeyWrong_expectReturnsFalseAndSkipsPersistentRequestLoad()
+      throws Exception {
+    ClientEndpoints endpoints = Mockito.mock(ClientEndpoints.class);
+    DatabaseKey databaseKey = new DatabaseKey(new byte[32]);
+    setField(core, "endpoints", endpoints);
+    doThrow(new MasterKeysWrongPasswordException())
+        .when(clientLayerPersister)
+        .setFilesAndLoad(any(), anyString(), anyBoolean(), anyBoolean(), same(databaseKey), any());
+
+    boolean initialized = core.lateInitDatabase(databaseKey);
+
+    assertFalse(initialized);
+    verify(endpoints, never()).loadPersistentRequestsIfNeeded();
+  }
+
+  @Test
+  void loadedDatabase_whenPersisterHasLoaded_expectTrue() {
+    when(clientLayerPersister.hasLoaded()).thenReturn(true);
+
+    boolean loaded = core.loadedDatabase();
+
+    assertTrue(loaded);
+  }
+
+  @Test
+  void killedDatabase_whenPersisterIsUnavailable_expectTrue() {
+    when(clientLayerPersister.isKilledOrNotLoaded()).thenReturn(true);
+
+    boolean killed = core.killedDatabase();
+
+    assertTrue(killed);
+  }
+
+  @Test
+  void getPersistentRequests_whenPersistenceProvidesSnapshot_expectSameArray() {
+    ClientRequest[] requests = new ClientRequest[] {Mockito.mock(ClientRequest.class)};
+    when(persistence.getPersistentRequests()).thenReturn(requests);
+
+    ClientRequest[] persisted = core.getPersistentRequests();
+
+    assertSame(requests, persisted);
+  }
+
+  @Test
+  void start_whenDatabaseKeyPresent_expectStartsServicesAndFinishesStorage() throws Exception {
+    ClientEndpoints endpoints = Mockito.mock(ClientEndpoints.class);
+    DatabaseKey databaseKey = new DatabaseKey(new byte[32]);
+    ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+    setField(core, "endpoints", endpoints);
+    when(node.storage().getDatabaseKey()).thenReturn(databaseKey);
+
+    core.start();
+
+    verify(persistence).startThrottle();
+    verify(requestStarters).start();
+    verify(storeChecker).start();
+    verify(endpoints).maybeStart();
+    verify(ipDetectorManager).start();
+    verify(executor).execute(runnableCaptor.capture(), eq("Startup completion thread"));
+    PrioRunnable startupTask = assertInstanceOf(PrioRunnable.class, runnableCaptor.getValue());
+    assertEquals(
+        network.crypta.support.io.NativeThread.PriorityLevel.LOW_PRIORITY.value,
+        startupTask.getPriority());
+
+    startupTask.run();
+
+    verify(persistentTempBucketFactory).completedInit();
+    verify(endpoints).unregisterStartupAlert(alerts);
+    assertTrue((Boolean) getField(core, "finishedInitStorage"));
+    assertFalse((Boolean) getField(core, "finishingInitStorage"));
+  }
+
   // --- helpers ---
   private static void setField(Object target, String name, Object value) throws Exception {
-    Field f = NodeClientCore.class.getDeclaredField(name);
+    setField(target, NodeClientCore.class, name, value);
+  }
+
+  private static void setField(Object target, Class<?> declaringClass, String name, Object value)
+      throws Exception {
+    Field f = declaringClass.getDeclaredField(name);
     f.setAccessible(true);
     f.set(target, value);
+  }
+
+  private static Object getField(Object target, String name) throws Exception {
+    Field f = NodeClientCore.class.getDeclaredField(name);
+    f.setAccessible(true);
+    return f.get(target);
   }
 }

--- a/src/test/java/network/crypta/node/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/node/NodeClientPersistenceTest.java
@@ -20,6 +20,7 @@ import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.SimpleFieldSet;
@@ -473,6 +474,7 @@ class NodeClientPersistenceTest {
     when(node.getConfig()).thenReturn(config);
     NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 0);
     NodeClientCore core = mock(NodeClientCore.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
     FCPServer expected = mock(FCPServer.class);
 
     // Act
@@ -481,17 +483,25 @@ class NodeClientPersistenceTest {
           .when(
               () ->
                   FCPServer.maybeCreate(
-                      eq(node), eq(core), eq(config), any(PersistentRequestRoot.class)))
+                      eq(node),
+                      eq(core),
+                      eq(runtimePorts),
+                      eq(config),
+                      any(PersistentRequestRoot.class)))
           .thenReturn(expected);
 
-      FCPServer result = persistence.createFcpServer(node, core);
+      FCPServer result = persistence.createFcpServer(node, core, runtimePorts);
 
       // Assert
       assertSame(expected, result);
       fcpServerMock.verify(
           () ->
               FCPServer.maybeCreate(
-                  eq(node), eq(core), eq(config), any(PersistentRequestRoot.class)));
+                  eq(node),
+                  eq(core),
+                  eq(runtimePorts),
+                  eq(config),
+                  any(PersistentRequestRoot.class)));
     }
   }
 


### PR DESCRIPTION
## Summary
- add the new `:runtime-spi` leaf module with a small JDK-only runtime SPI surface
- add `LegacyRuntimePorts` in the root daemon and thread `RuntimePorts` through `NodeClientCore`, `ClientEndpoints`, `NodeClientPersistence`, and `FCPServer` while keeping legacy `getNode()` and `getCore()` accessors
- migrate low-risk FCP infrastructure randomness and execution call sites to `server.runtime()` and update the affected FCP/node tests

## How to test
- `./gradlew projects`
- `./gradlew :runtime-spi:compileJava`
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests *ClientEndpointsTest --tests *NodeClientPersistenceTest --tests *FCPServerTest --tests *FcpServerConfigRegistrarTest --tests *FCPConnectionHandlerTest --tests *FCPConnectionInputHandlerTest --tests *FCPConnectionOutputHandlerTest --tests *DdaAccessControllerTest`
- `./gradlew buildJar`
- `./gradlew test`
