### PR TITLE
refactor(fcp): Use TransferAccessPort for file policy

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import network.crypta.client.FetchContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,15 +74,15 @@ final class ClientGetFactory {
           "Charset parameter is ignored for ClientGet global queue requests: {}",
           requestConfig.charset());
     }
+    TransferAccessPort transferAccess = core.getRuntimePorts().transferAccess();
     ClientGetReturnPlanner.ReturnSetup returnSetup =
         ClientGetGetterFactory.planReturnForGlobal(
             requestConfig.identifier(),
-            true,
             fctx,
             requestConfig.returnType(),
             requestConfig.returnFilename(),
             requestConfig.filterData(),
-            core);
+            transferAccess);
     ClientRequestParams params =
         new ClientRequestParams(
             uri,
@@ -135,9 +136,10 @@ final class ClientGetFactory {
       ensureConnectionIdentifierAvailable(handler, message.identifier);
     }
     FetchContext fctx = buildFetchContextForMessage(core, message);
+    TransferAccessPort transferAccess = core.getRuntimePorts().transferAccess();
     ClientGetReturnPlanner.ReturnSetup returnSetup =
         ClientGetGetterFactory.planReturnForMessage(
-            message.identifier, message.global, fctx, message, core, handler);
+            message.identifier, message.global, fctx, message, transferAccess, handler);
     Bucket initialMetadata = message.getInitialMetadata();
     try {
       ClientGet.ClientGetSetup requestSetup =

--- a/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
@@ -56,6 +56,7 @@ final class ClientGetFactory {
    * @param uri target {@link FreenetURI} describing the key to fetch; must be non-null.
    * @param requestConfig immutable configuration with limits, flags, and return preferences.
    * @param core node core providing fetch contexts, planners, and bucket factories.
+   * @param transferAccess transfer policy used for disk-return planning in this request flow.
    * @return configured {@link ClientGet} instance ready for registration and start.
    * @throws IdentifierCollisionException if the identifier is already registered globally.
    * @throws NotAllowedException if disk output violates policy or DDA restrictions.
@@ -65,7 +66,8 @@ final class ClientGetFactory {
       PersistentRequestClient globalClient,
       FreenetURI uri,
       ClientGet.GlobalRequestConfig requestConfig,
-      NodeClientCore core)
+      NodeClientCore core,
+      TransferAccessPort transferAccess)
       throws IdentifierCollisionException, NotAllowedException, IOException {
     ensureGlobalIdentifierAvailable(globalClient, requestConfig.identifier());
     FetchContext fctx = buildFetchContextForGlobal(core, requestConfig);
@@ -74,7 +76,6 @@ final class ClientGetFactory {
           "Charset parameter is ignored for ClientGet global queue requests: {}",
           requestConfig.charset());
     }
-    TransferAccessPort transferAccess = core.getRuntimePorts().transferAccess();
     ClientGetReturnPlanner.ReturnSetup returnSetup =
         ClientGetGetterFactory.planReturnForGlobal(
             requestConfig.identifier(),

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -26,6 +26,7 @@ import network.crypta.crypt.HashResult;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucketFactory;
 import network.crypta.support.io.FileBucket;
@@ -253,28 +254,26 @@ final class ClientGetGetterFactory {
    * order.
    *
    * @param identifier request identifier used for policy checks.
-   * @param global whether the request uses the global identifier namespace.
    * @param fetchContext fetch context for return planning.
    * @param returnType configured return type.
    * @param returnFilename target file for disk returns.
    * @param filterData whether to derive an extension hint when filtering.
-   * @param core node core used for policy checks.
+   * @param transferAccess transfer policy used for policy checks.
    * @return setup containing {@link Bucket}, {@link File}, and extension {@link String}.
-   * @throws NotAllowedException if the node policy rejects the requested target path.
+   * @throws NotAllowedException if the transfer policy rejects the requested target path.
    * @throws IOException if an existing target file cannot be removed or is unsafe to overwrite.
    */
   static ClientGetReturnPlanner.ReturnSetup planReturnForGlobal(
       String identifier,
-      boolean global,
       FetchContext fetchContext,
       ClientGet.ReturnType returnType,
       File returnFilename,
       boolean filterData,
-      NodeClientCore core)
+      TransferAccessPort transferAccess)
       throws NotAllowedException, IOException {
     ClientGetReturnPlanner returnPlanner =
-        new ClientGetReturnPlanner(identifier, global, fetchContext);
-    return returnPlanner.forGlobalRequest(returnType, returnFilename, filterData, core);
+        new ClientGetReturnPlanner(identifier, true, fetchContext);
+    return returnPlanner.forGlobalRequest(returnType, returnFilename, filterData, transferAccess);
   }
 
   /**
@@ -287,7 +286,7 @@ final class ClientGetGetterFactory {
    * @param global whether the request uses the global identifier namespace.
    * @param fetchContext fetch context for return planning.
    * @param message message containing return settings.
-   * @param core node core used for policy checks.
+   * @param transferAccess transfer policy used for policy checks.
    * @param handler connection handler providing DDA validation.
    * @return setup containing {@link Bucket}, {@link File}, and extension {@link String}.
    * @throws MessageInvalidException if policy checks fail or the target file is unsafe to use.
@@ -297,12 +296,12 @@ final class ClientGetGetterFactory {
       boolean global,
       FetchContext fetchContext,
       ClientGetMessage message,
-      NodeClientCore core,
+      TransferAccessPort transferAccess,
       FCPConnectionHandler handler)
       throws MessageInvalidException {
     ClientGetReturnPlanner returnPlanner =
         new ClientGetReturnPlanner(identifier, global, fetchContext);
-    return returnPlanner.forMessage(message, core, handler);
+    return returnPlanner.forMessage(message, transferAccess, handler);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/ClientGetReturnPlanner.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetReturnPlanner.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Objects;
 import network.crypta.client.FetchContext;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,19 +19,19 @@ import org.slf4j.LoggerFactory;
  * validation.
  *
  * <p>Typical usage is to construct one planner per request and call either {@link
- * #forGlobalRequest(ClientGet.ReturnType, File, boolean, NodeClientCore)} for global requests or
- * {@link #forMessage(ClientGetMessage, NodeClientCore, FCPConnectionHandler)} for FCP message
- * handling. The planner enforces policy checks (node download permissions and DDA access),
+ * #forGlobalRequest(ClientGet.ReturnType, File, boolean, TransferAccessPort)} for global requests
+ * or {@link #forMessage(ClientGetMessage, TransferAccessPort, FCPConnectionHandler)} for FCP
+ * message handling. The planner enforces policy checks (download permissions and DDA access),
  * validates that disk targets are safe to use, and prepares a {@link Bucket} plus optional file
  * extension hint for filtered data. It does not perform I/O beyond basic file existence checks and
  * deletion of zero-length stale files.
  *
  * <p>The class is not thread-safe and is designed for single-request, single-threaded use. All
- * state is immutable after construction; methods derive a {@link ReturnSetup} based on inputs and
+ * states are immutable after construction; methods derive a {@link ReturnSetup} based on inputs and
  * may throw exceptions to signal invalid requests or unsafe targets.
  *
  * <ul>
- *   <li>Validates node policy and DDA access for disk destinations.
+ *   <li>Validates transfer policy and DDA access for disk destinations.
  *   <li>Normalizes existing file handling to avoid overwriting data.
  *   <li>Derives extension hints when filtered output is requested.
  * </ul>
@@ -52,8 +52,8 @@ final class ClientGetReturnPlanner {
   /**
    * Creates a planner for a single request using the supplied identifier and fetch settings.
    *
-   * <p>The planner retains the identifier and global flag for subsequent error reporting and uses
-   * the fetch context to decide whether to derive file extensions for filtered data. Instances are
+   * <p>The planner retains the identifier and global flag for further error reporting and uses the
+   * fetch context to decide whether to derive file extensions for filtered data. Instances are
    * lightweight and intended to be short-lived for the lifetime of a single {@link ClientGet}
    * request.
    *
@@ -71,27 +71,30 @@ final class ClientGetReturnPlanner {
   /**
    * Builds return handling for a global request with explicit disk parameters.
    *
-   * <p>The method validates node policy for disk downloads, checks whether the target file is safe
-   * to use, and prepares a disk-backed bucket when the return type is {@link
+   * <p>The method validates transfer policy for disk downloads, checks whether the target file is
+   * safe to use, and prepares a disk-backed bucket when the return type is {@link
    * ClientGet.ReturnType#DISK}. For non-disk return types, the returned setup is empty with all
-   * fields set to {@code null}. The caller is expected to pass a valid {@link NodeClientCore}
+   * fields set to {@code null}. The caller is expected to pass a valid {@link TransferAccessPort}
    * instance and, for disk requests, a concrete target file.
    *
    * @param type return strategy describing whether disk output is required.
    * @param returnFilename target file to write to when {@code type} is disk.
    * @param filterData whether to derive an extension hint for filtered output.
-   * @param core node core that enforces download policy checks.
+   * @param transferAccess transfer policy that enforces download permission checks.
    * @return a prepared {@link ReturnSetup} describing bucket, target, and extension hint.
-   * @throws NotAllowedException if the node policy rejects the requested target path.
+   * @throws NotAllowedException if the transfer policy rejects the requested target path.
    * @throws IOException if an existing target file cannot be removed or is unsafe to overwrite.
    * @throws NullPointerException if {@code returnFilename} is null when disk output is requested.
    */
   ReturnSetup forGlobalRequest(
-      ClientGet.ReturnType type, File returnFilename, boolean filterData, NodeClientCore core)
+      ClientGet.ReturnType type,
+      File returnFilename,
+      boolean filterData,
+      TransferAccessPort transferAccess)
       throws NotAllowedException, IOException {
     if (type == ClientGet.ReturnType.DISK) {
       File file = Objects.requireNonNull(returnFilename, "returnFilename");
-      ensureDownloadAllowed(core, file);
+      ensureDownloadAllowed(transferAccess, file);
       return createDiskReturnSetup(file, filterData);
     }
     return new ReturnSetup(null, null, null);
@@ -100,23 +103,24 @@ final class ClientGetReturnPlanner {
   /**
    * Builds return handling from an already-parsed {@link ClientGetMessage}.
    *
-   * <p>The method performs node policy checks and DDA validation before returning a disk setup for
-   * {@link ClientGet.ReturnType#DISK} messages. Any invalid condition results in a {@link
+   * <p>The method performs transfer-policy checks and DDA validation before returning a disk setup
+   * for {@link ClientGet.ReturnType#DISK} messages. Any invalid condition results in a {@link
    * MessageInvalidException} carrying an appropriate protocol error code and identifier. For
    * non-disk return types, the returned setup is empty with all fields set to {@code null}.
    *
-   * @param message parsed request message containing return type and disk filename.
-   * @param core node core used to validate download policy for disk targets.
+   * @param message parsed request message containing the return type and disk filename.
+   * @param transferAccess transfer policy used to validate download permission for disk targets.
    * @param handler connection handler providing DDA access control decisions.
    * @return a prepared {@link ReturnSetup} describing bucket, target, and extension hint.
    * @throws MessageInvalidException if policy checks fail or the target file is unsafe to use.
-   * @throws NullPointerException if {@code message}, {@code core}, or {@code handler} is null.
+   * @throws NullPointerException if {@code message}, {@code transferAccess}, or {@code handler} is
+   *     null.
    */
   ReturnSetup forMessage(
-      ClientGetMessage message, NodeClientCore core, FCPConnectionHandler handler)
+      ClientGetMessage message, TransferAccessPort transferAccess, FCPConnectionHandler handler)
       throws MessageInvalidException {
     if (message.returnType == ClientGet.ReturnType.DISK) {
-      return buildDiskSetupForMessage(message, core, handler);
+      return buildDiskSetupForMessage(message, transferAccess, handler);
     }
     return new ReturnSetup(null, null, null);
   }
@@ -124,22 +128,22 @@ final class ClientGetReturnPlanner {
   /**
    * Validates and prepares disk return handling for an FCP message.
    *
-   * <p>This method enforces node download policy, DDA access permission, and target file safety
-   * before constructing the {@link ReturnSetup}. It maps failures to {@link
-   * MessageInvalidException} instances with protocol-appropriate error codes to allow callers to
-   * respond to the remote peer deterministically.
+   * <p>This method enforces transfer policy, DDA access permission, and target file safety before
+   * constructing the {@link ReturnSetup}. It maps failures to {@link MessageInvalidException}
+   * instances with protocol-appropriate error codes to allow callers to respond to the remote peer
+   * deterministically.
    *
    * @param message parsed message providing the disk target and return settings.
-   * @param core node core that enforces download policy for the target.
+   * @param transferAccess transfer policy that enforces download permission for the target.
    * @param handler connection handler that provides DDA access validation.
    * @return prepared disk return setup with bucket, target file, and optional extension.
    * @throws MessageInvalidException if any policy or disk checks fail.
    */
   private ReturnSetup buildDiskSetupForMessage(
-      ClientGetMessage message, NodeClientCore core, FCPConnectionHandler handler)
+      ClientGetMessage message, TransferAccessPort transferAccess, FCPConnectionHandler handler)
       throws MessageInvalidException {
     File diskFile = message.diskFile;
-    if (!core.allowDownloadTo(diskFile)) {
+    if (!transferAccess.allowDownloadTo(diskFile)) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,
           "Not allowed to download to " + diskFile,
@@ -179,7 +183,7 @@ final class ClientGetReturnPlanner {
    * includes an extension hint when filtering is enabled. The method does not verify the file
    * itself; callers must ensure it is safe to use before invoking this helper.
    *
-   * @param file disk target file to back the return bucket.
+   * @param file the disk target file to back the return bucket.
    * @param filterData whether to derive a file extension hint for filtered data.
    * @return a {@link ReturnSetup} holding the disk bucket, target file, and optional extension.
    */
@@ -207,21 +211,22 @@ final class ClientGetReturnPlanner {
   }
 
   /**
-   * Verifies that the node allows disk downloads and that the target file is safe to use.
+   * Verifies that the transfer policy allows disk downloads and that the target file is safe to
+   * use.
    *
-   * <p>The method delegates policy validation to {@link NodeClientCore#allowDownloadTo(File)} and
-   * then ensures the destination does not already exist, except for the special case where a
+   * <p>The method delegates policy validation to {@link TransferAccessPort#allowDownloadTo(File)}
+   * and then ensures the destination does not already exist, except for the special case where a
    * zero-length file is deleted as a stale placeholder. It does not create directories or touch the
    * filesystem beyond existence checks and optional deletion of a zero-length file.
    *
-   * @param core node core used to verify download policy for the target path.
+   * @param transferAccess transfer policy used to verify download permission for the target path.
    * @param file destination file for disk output.
-   * @throws NotAllowedException if the node policy rejects the target file location.
+   * @throws NotAllowedException if the transfer policy rejects the target file location.
    * @throws IOException if the target file exists and cannot be safely removed.
    */
-  private void ensureDownloadAllowed(NodeClientCore core, File file)
+  private void ensureDownloadAllowed(TransferAccessPort transferAccess, File file)
       throws NotAllowedException, IOException {
-    if (!core.allowDownloadTo(file)) {
+    if (!transferAccess.allowDownloadTo(file)) {
       throw new NotAllowedException();
     }
     handleExistingTargetFile(file);

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -19,6 +19,7 @@ import network.crypta.client.async.InsertRequestParams;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.ResumeFailedException;
 import org.slf4j.Logger;
@@ -250,10 +251,11 @@ public final class ClientPut extends ClientPutBase {
             message.global);
     super(requestParams, null, options, handler, server, derivePublicURI(requestParams.uri()));
     binaryBlob = message.binaryBlob;
+    TransferAccessPort transferAccess = server.getCore().getRuntimePorts().transferAccess();
 
     DiskUploadContext diskContext =
         ClientPutDiskUploadValidator.validateDiskUpload(
-            handler, message, message.identifier, message.global);
+            transferAccess, handler, message, message.identifier, message.global);
 
     this.targetFilename = message.targetFilename;
     this.uploadFrom = message.uploadFromType;

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -158,7 +158,8 @@ public final class ClientPut extends ClientPutBase {
     RandomAccessBucket tempData = upload.data();
 
     if (uploadFromType == UploadFrom.DISK) {
-      ClientPutDiskUploadValidator.validatePersistentDiskUpload(core, uploadOrigFilename);
+      ClientPutDiskUploadValidator.validatePersistentDiskUpload(
+          core.getRuntimePorts().transferAccess(), uploadOrigFilename);
     }
 
     this.binaryBlob = upload.binaryBlob();

--- a/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import network.crypta.client.Metadata;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.node.Node;
-import network.crypta.node.subsystem.NodeServicesSubsystem;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.ManifestElement;
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>Builds a nested {@code Map} structure that mirrors directory layout before dispatch.
  *   <li>Streams {@code UploadFrom=direct} payloads in alphabetical order to avoid buffering.
- *   <li>Validates disk-sourced files against {@link NodeServicesSubsystem#clientCore()} upload
- *       policy.
+ *   <li>Validates disk-sourced files against {@link
+ *       TransferAccessPort#allowUploadFrom(java.io.File)} upload policy.
  * </ul>
  *
  * <p>Example payload:
@@ -89,14 +89,13 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
   public ClientPutComplexDirMessage(
       SimpleFieldSet fs, BucketFactory bfTemp, PersistentTempBucketFactory bfPersistent)
       throws MessageInvalidException {
-    requireFilesSection(fs);
+    SimpleFieldSet files = requireFilesSection(fs);
     super(parseCommonFields(fs));
 
     filesByName = new HashMap<>();
     filesToRead = new ArrayList<>();
     long totalBytes = 0;
     // Now parse the meat
-    SimpleFieldSet files = fs.subset("Files");
     for (int i = 0; ; i++) {
       SimpleFieldSet subset = files.subset(Integer.toString(i));
       if (subset == null) break;
@@ -227,15 +226,15 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
    * Converts parsed files into {@link ManifestElement} trees and instructs the handler to start the
    * directory insert.
    *
-   * <p>During execution the method validates disk-backed files through {@link
-   * NodeServicesSubsystem#clientCore()} before constructing the manifest, thereby ensuring policy
-   * compliance without touching the network. The resulting map mirrors the original hierarchy, so
-   * downstream components can process nested directories without recomputing paths. The insert
-   * begins immediately afterward, and any {@link MessageInvalidException} bubbles up to the caller
-   * so the FCP client receives actionable feedback.
+   * <p>During execution the method validates disk-backed files through {@link TransferAccessPort}
+   * before constructing the manifest, thereby ensuring policy compliance without touching the
+   * network. The resulting map mirrors the original hierarchy, so downstream components can process
+   * nested directories without recomputing paths. The insert begins immediately afterward, and any
+   * {@link MessageInvalidException} bubbles up to the caller so the FCP client receives actionable
+   * feedback.
    *
    * @param handler active connection handler responsible for initiating the put job
-   * @param node node instance that supplies policy checks and storage context for the request
+   * @param node legacy execution parameter retained by the message API; unused here
    * @throws MessageInvalidException if conversion detects disallowed files or inconsistent input
    */
   @Override
@@ -244,7 +243,8 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
     // of ManifestElement's.
     // Then simply create the ClientPutDir.
     HashMap<String, Object> manifestElements = new HashMap<>();
-    convertFilesByNameToManifestElements(filesByName, manifestElements, node);
+    convertFilesByNameToManifestElements(
+        filesByName, manifestElements, handler.getServer().runtime().transferAccess());
     handler.startClientPutDir(this, manifestElements, false);
   }
 
@@ -253,7 +253,9 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
    * containing ManifestElement's.
    */
   private void convertFilesByNameToManifestElements(
-      Map<String, Object> filesByName, Map<String, Object> manifestElements, Node node)
+      Map<String, Object> filesByName,
+      Map<String, Object> manifestElements,
+      TransferAccessPort transferAccess)
       throws MessageInvalidException {
 
     for (Map.Entry<String, Object> entry : filesByName.entrySet()) {
@@ -263,11 +265,10 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
         Map<String, Object> h = Metadata.forceMap(val);
         HashMap<String, Object> manifests = new HashMap<>();
         manifestElements.put(tempName, manifests);
-        convertFilesByNameToManifestElements(h, manifests, node);
+        convertFilesByNameToManifestElements(h, manifests, transferAccess);
       } else {
         DirPutFile f = (DirPutFile) val;
-        if (f instanceof DiskDirPutFile file
-            && !node.services().clientCore().allowUploadFrom(file.getFile()))
+        if (f instanceof DiskDirPutFile file && !transferAccess.allowUploadFrom(file.getFile()))
           throw new MessageInvalidException(
               ProtocolErrorMessage.ACCESS_DENIED,
               "Not allowed to upload " + file.getFile(),
@@ -279,13 +280,16 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
     }
   }
 
-  private static void requireFilesSection(SimpleFieldSet fs) throws MessageInvalidException {
-    if (fs.subset("Files") == null) {
+  private static SimpleFieldSet requireFilesSection(SimpleFieldSet fs)
+      throws MessageInvalidException {
+    SimpleFieldSet files = fs.subset("Files");
+    if (files == null) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "Missing Files section",
           fs.get("Identifier"),
           fs.getBoolean("Global", false));
     }
+    return files;
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
@@ -68,11 +68,11 @@ public final class ClientPutDiskDirMessage extends ClientPutDirMessage {
    * @throws MessageInvalidException if the {@code Filename} field is absent.
    */
   public ClientPutDiskDirMessage(SimpleFieldSet fs) throws MessageInvalidException {
-    requireFilename(fs);
+    String filename = requireFilename(fs);
     super(parseCommonFields(fs));
     allowUnreadableFiles = fs.getBoolean("AllowUnreadableFiles", false);
     includeHiddenFiles = fs.getBoolean("includeHiddenFiles", false);
-    dirname = new File(fs.get("Filename"));
+    dirname = new File(filename);
   }
 
   /**
@@ -93,17 +93,17 @@ public final class ClientPutDiskDirMessage extends ClientPutDirMessage {
    * performs a full recursive traversal via {@link #makeBucketsByName(File, String)}, and hands the
    * resulting manifest tree to {@link FCPConnectionHandler#startClientPutDir}. Errors are raised
    * immediately if the directory is blocked or if the traversal encounters unreadable entries when
-   * such failures are not allowed by the client flag. This call is synchronous for traversal but
+   * such failures are not allowed by the client flag. This call is synchronous for traversal, but
    * the returned buckets may be consumed asynchronously by upload workers.
    *
    * @param handler connection handler owning this message; must be non-null and connected.
-   * @param node node instance that enforces upload policy and owns the datastore.
-   * @throws MessageInvalidException if the directory is not permitted or traversal fails under the
+   * @param node legacy execution parameter retained by the message API; unused here.
+   * @throws MessageInvalidException if the directory is not permitted, or traversal fails under the
    *     configured validation rules.
    */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    if (!handler.getServer().getCore().allowUploadFrom(dirname))
+    if (!handler.getServer().runtime().transferAccess().allowUploadFrom(dirname))
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,
           "Not allowed to upload from " + dirname,
@@ -120,11 +120,11 @@ public final class ClientPutDiskDirMessage extends ClientPutDirMessage {
    * filenames.
    *
    * @param thisdir directory whose immediate children are inspected; must already exist on disk.
-   * @param prefix logical path prefix appended to every discovered file or directory name for the
+   * @param prefix a logical path prefix appended to every discovered file or directory name for the
    *     manifest.
    * @return mutable map where keys are child names and values are {@link ManifestElement} instances
    *     or nested maps representing subdirectories.
-   * @throws MessageInvalidException if a directory does not exist or a child violates the
+   * @throws MessageInvalidException if a directory does not exist, or a child violates the
    *     configured readability rules.
    */
   private Map<String, Object> makeBucketsByName(File thisdir, String prefix)
@@ -242,7 +242,7 @@ public final class ClientPutDiskDirMessage extends ClientPutDirMessage {
    * <p>No additional data is written because the entire manifest content is produced from the local
    * filesystem instead of a pre-serialized buffer.
    *
-   * @param os ignored output stream provided by the protocol framework.
+   * @param os ignored the output stream provided by the protocol framework.
    * @throws IOException never thrown because the method writes nothing.
    */
   @Override
@@ -250,13 +250,15 @@ public final class ClientPutDiskDirMessage extends ClientPutDirMessage {
     // Do nothing
   }
 
-  private static void requireFilename(SimpleFieldSet fs) throws MessageInvalidException {
-    if (fs.get("Filename") == null) {
+  private static String requireFilename(SimpleFieldSet fs) throws MessageInvalidException {
+    String filename = fs.get("Filename");
+    if (filename == null) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "Filename missing",
           fs.get("Identifier"),
           fs.getBoolean("Global", false));
     }
+    return filename;
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
@@ -9,7 +9,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Objects;
 import network.crypta.crypt.SHA256;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.Base64;
 import network.crypta.support.IllegalBase64Exception;
 import network.crypta.support.api.RandomAccessBucket;
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * setup code without additional synchronization.
  *
  * <ul>
- *   <li>Checks whether a disk upload is allowed by node policy and DDA rules.
+ *   <li>Checks whether a disk upload is allowed by transfer policy and DDA rules.
  *   <li>Decodes and verifies salted SHA-256 hashes when provided by clients.
  *   <li>Produces {@link DiskUploadContext} instances for downstream verification steps.
  * </ul>
@@ -48,21 +48,22 @@ final class ClientPutDiskUploadValidator {
   private ClientPutDiskUploadValidator() {}
 
   /**
-   * Validates a persistent disk upload against core permissions and file readability.
+   * Validates a persistent disk upload against transfer permissions and file readability.
    *
    * <p>This method is used for persistent inserts where the node must be able to reopen the source
-   * file across restarts. It first checks the node policy via {@link
-   * NodeClientCore#allowUploadFrom} and then verifies that the file exists and can be read. It
-   * performs no hashing and does not mutate the input file.
+   * file across restarts. It first checks the transfer policy via {@link
+   * TransferAccessPort#allowUploadFrom(File)} and then verifies that the file exists and can be
+   * read. It performs no hashing and does not mutate the input file.
    *
-   * @param core node core used to evaluate disk upload policy; must not be {@code null}.
+   * @param transferAccess transfer policy used to evaluate disk upload permission; must not be
+   *     {@code null}.
    * @param origFilename original file submitted by the client; must not be {@code null}.
-   * @throws NotAllowedException when the node policy disallows the requested disk upload.
+   * @throws NotAllowedException when the transfer policy disallows the requested disk upload.
    * @throws IOException when the file does not exist or cannot be read.
    */
-  static void validatePersistentDiskUpload(NodeClientCore core, File origFilename)
+  static void validatePersistentDiskUpload(TransferAccessPort transferAccess, File origFilename)
       throws NotAllowedException, IOException {
-    if (!core.allowUploadFrom(origFilename)) {
+    if (!transferAccess.allowUploadFrom(origFilename)) {
       throw new NotAllowedException();
     }
     if (!(origFilename.exists() && origFilename.canRead())) {
@@ -93,7 +94,8 @@ final class ClientPutDiskUploadValidator {
     if (message.uploadFromType != ClientPutBase.UploadFrom.DISK) {
       return DiskUploadContext.empty();
     }
-    if (!handler.getServer().getCore().allowUploadFrom(message.origFilename)) {
+    TransferAccessPort transferAccess = handler.getServer().runtime().transferAccess();
+    if (!transferAccess.allowUploadFrom(message.origFilename)) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,
           "Not allowed to upload from " + message.origFilename,
@@ -207,7 +209,7 @@ final class ClientPutDiskUploadValidator {
  * null} components. Downstream checks can call {@link #hasSalt()} to determine whether verification
  * should occur.
  */
-@SuppressWarnings("java:S6206")
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
 final class DiskUploadContext {
   private final String salt;
   private final byte[] saltedHash;

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDiskUploadValidator.java
@@ -79,6 +79,8 @@ final class ClientPutDiskUploadValidator {
    * hash is decoded and returned in a {@link DiskUploadContext} so later steps can verify it
    * against the upload bucket. When no hash is provided, DDA access is validated directly.
    *
+   * @param transferAccess transfer policy used to evaluate disk upload permission; must not be
+   *     {@code null}.
    * @param handler active connection handler that supplies policy and identifiers; must not be
    *     {@code null}.
    * @param message parsed FCP put message containing upload fields; must not be {@code null}.
@@ -89,12 +91,15 @@ final class ClientPutDiskUploadValidator {
    * @throws MessageInvalidException when the request violates DDA rules or contains bad hash data.
    */
   static DiskUploadContext validateDiskUpload(
-      FCPConnectionHandler handler, ClientPutMessage message, String identifier, boolean global)
+      TransferAccessPort transferAccess,
+      FCPConnectionHandler handler,
+      ClientPutMessage message,
+      String identifier,
+      boolean global)
       throws MessageInvalidException {
     if (message.uploadFromType != ClientPutBase.UploadFrom.DISK) {
       return DiskUploadContext.empty();
     }
-    TransferAccessPort transferAccess = handler.getServer().runtime().transferAccess();
     if (!transferAccess.allowUploadFrom(message.origFilename)) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -471,10 +471,10 @@ public class FCPServer implements Runnable, DownloadCache {
    * Convenience overload that enqueues a persistent request using the default downloads directory.
    *
    * <p>All parameters mirror {@link #makePersistentGlobalRequest(PersistentGlobalRequestParams)},
-   * substituting {@link NodeClientCore#getDownloadsDir()} for the target directory. The request is
-   * created synchronously but does not block on completion. This method is suitable for callers
-   * that rely on the node's configured downloads directory and do not require fine-grained output
-   * path selection.
+   * substituting the downloads directory exposed through {@link RuntimePorts#transferAccess()} for
+   * the target directory. The request is created synchronously but does not block on completion.
+   * This method is suitable for callers that rely on the node's configured downloads directory and
+   * do not require fine-grained output path selection.
    *
    * @param fetchURI URI to fetch from the network.
    * @param filterData whether content should be filtered prior to delivery.

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -23,6 +23,7 @@ import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.Base64;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.BucketTools;
@@ -543,7 +544,7 @@ final class FcpServerPersistentOps implements DownloadCache {
             persistenceTypeString,
             returnTypeString,
             realTimeFlag,
-            core.getDownloadsDir()));
+            transferAccess().downloadsDir()));
   }
 
   void makePersistentGlobalRequest(
@@ -574,6 +575,10 @@ final class FcpServerPersistentOps implements DownloadCache {
     } catch (IdentifierCollisionException _) {
       return false;
     }
+  }
+
+  private TransferAccessPort transferAccess() {
+    return server.runtime().transferAccess();
   }
 
   private File makeReturnFilename(FreenetURI uri, String expectedMimeType, File downloadsDir) {

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -632,7 +632,8 @@ final class FcpServerPersistentOps implements DownloadCache {
             spec.persistRebootOnly() ? globalRebootClient : globalForeverClient,
             spec.fetchURI(),
             requestConfig,
-            core);
+            core,
+            transferAccess());
     cg.register(false);
     cg.start(core.getClientContext());
   }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -80,7 +80,7 @@ class ClientGetFactoryTest {
         IdentifierCollisionException.class,
         () ->
             ClientGetFactory.fromGlobal(
-                client, new FreenetURI("KSK@global-collision"), config, core));
+                client, new FreenetURI("KSK@global-collision"), config, core, transferAccess));
   }
 
   @ParameterizedTest
@@ -110,7 +110,7 @@ class ClientGetFactoryTest {
             true,
             false);
 
-    ClientGet request = ClientGetFactory.fromGlobal(client, uri, config, core);
+    ClientGet request = ClientGetFactory.fromGlobal(client, uri, config, core, transferAccess);
 
     assertNotNull(request);
     assertEquals(config.identifier(), request.getIdentifier());
@@ -140,8 +140,6 @@ class ClientGetFactoryTest {
   void fromGlobal_whenDiskReturnDenied_throwsNotAllowedException(@TempDir Path tempDir) {
     when(core.getClientContext()).thenReturn(clientContext);
     when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
-    when(core.getRuntimePorts()).thenReturn(runtimePorts);
-    when(runtimePorts.transferAccess()).thenReturn(transferAccess);
     PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);
     File target = tempDir.resolve("target.bin").toFile();
     when(transferAccess.allowDownloadTo(target)).thenReturn(false);
@@ -166,7 +164,9 @@ class ClientGetFactoryTest {
 
     assertThrows(
         NotAllowedException.class,
-        () -> ClientGetFactory.fromGlobal(client, new FreenetURI("KSK@global-disk"), config, core));
+        () ->
+            ClientGetFactory.fromGlobal(
+                client, new FreenetURI("KSK@global-disk"), config, core, transferAccess));
   }
 
   @Test
@@ -188,6 +188,7 @@ class ClientGetFactoryTest {
   void fromMessage_whenValidConnectionMessage_buildsRequestAndAppliesFetchContext()
       throws Exception {
     configureCoreWithFetchContext();
+    configureRuntimePorts();
     SimpleFieldSet fs = baseMessageFieldSet("message-ok");
     fs.putOverwrite("DSOnly", "true");
     fs.putOverwrite("IgnoreDS", "true");
@@ -229,6 +230,7 @@ class ClientGetFactoryTest {
   void fromMessage_whenBinaryBlobBucketCreationFails_wrapsIntoMessageInvalidException()
       throws Exception {
     configureCoreWithFetchContext();
+    configureRuntimePorts();
     BucketFactory bucketFactory = mock(BucketFactory.class);
     IOException ioFailure = new IOException("disk-full");
     when(fetchContext.getMaxOutputLength()).thenReturn(333L);
@@ -254,6 +256,9 @@ class ClientGetFactoryTest {
     when(core.getClientContext()).thenReturn(clientContext);
     when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
     when(fetchContext.getEventProducer()).thenReturn(eventProducer);
+  }
+
+  private void configureRuntimePorts() {
     when(core.getRuntimePorts()).thenReturn(runtimePorts);
     when(runtimePorts.transferAccess()).thenReturn(transferAccess);
   }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -17,6 +17,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,8 @@ class ClientGetFactoryTest {
   @Mock private ClientContext clientContext;
   @Mock private FetchContext fetchContext;
   @Mock private ClientEventProducer eventProducer;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private TransferAccessPort transferAccess;
 
   @Test
   void fromGlobal_whenIdentifierAlreadyRegistered_throwsIdentifierCollisionException()
@@ -137,9 +140,11 @@ class ClientGetFactoryTest {
   void fromGlobal_whenDiskReturnDenied_throwsNotAllowedException(@TempDir Path tempDir) {
     when(core.getClientContext()).thenReturn(clientContext);
     when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
+    when(core.getRuntimePorts()).thenReturn(runtimePorts);
+    when(runtimePorts.transferAccess()).thenReturn(transferAccess);
     PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);
     File target = tempDir.resolve("target.bin").toFile();
-    when(core.allowDownloadTo(target)).thenReturn(false);
+    when(transferAccess.allowDownloadTo(target)).thenReturn(false);
     GlobalRequestConfig config =
         new GlobalRequestConfig(
             false,
@@ -249,15 +254,17 @@ class ClientGetFactoryTest {
     when(core.getClientContext()).thenReturn(clientContext);
     when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
     when(fetchContext.getEventProducer()).thenReturn(eventProducer);
+    when(core.getRuntimePorts()).thenReturn(runtimePorts);
+    when(runtimePorts.transferAccess()).thenReturn(transferAccess);
   }
 
   private FCPConnectionHandler newConnectionHandler() {
     FCPServer server = mock(FCPServer.class);
     Socket socket = mock(Socket.class);
-    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    RuntimePorts handlerRuntimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
-    when(server.runtime()).thenReturn(runtimePorts);
-    when(runtimePorts.randomness()).thenReturn(randomnessPort);
+    when(server.runtime()).thenReturn(handlerRuntimePorts);
+    when(handlerRuntimePorts.randomness()).thenReturn(randomnessPort);
     doAnswer(
             invocation -> {
               byte[] target = invocation.getArgument(0);

--- a/src/test/java/network/crypta/clients/fcp/ClientGetReturnPlannerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetReturnPlannerTest.java
@@ -6,7 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import network.crypta.client.FetchContext;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.FileBucket;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ class ClientGetReturnPlannerTest {
   private static final String REQUEST_ID = "id";
 
   @Mock private FetchContext fetchContext;
-  @Mock private NodeClientCore core;
+  @Mock private TransferAccessPort transferAccess;
   @Mock private FCPConnectionHandler handler;
   @Mock private DdaAccessController ddaAccessController;
 
@@ -60,26 +60,26 @@ class ClientGetReturnPlannerTest {
     ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
 
     ClientGetReturnPlanner.ReturnSetup setup =
-        planner.forGlobalRequest(ReturnType.DIRECT, null, false, core);
+        planner.forGlobalRequest(ReturnType.DIRECT, null, false, transferAccess);
 
     assertAll(
         () -> assertNull(setup.bucket()),
         () -> assertNull(setup.targetFile()),
         () -> assertNull(setup.extension()));
-    verifyNoInteractions(core);
+    verifyNoInteractions(transferAccess);
   }
 
   @Test
   void forGlobalRequest_whenDiskNotAllowed_throwsNotAllowedException() {
     ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
     File target = tempDir.resolve(PAYLOAD_BIN).toFile();
-    when(core.allowDownloadTo(target)).thenReturn(false);
+    when(transferAccess.allowDownloadTo(target)).thenReturn(false);
 
     assertThrows(
         NotAllowedException.class,
-        () -> planner.forGlobalRequest(ReturnType.DISK, target, false, core));
+        () -> planner.forGlobalRequest(ReturnType.DISK, target, false, transferAccess));
 
-    verify(core).allowDownloadTo(target);
+    verify(transferAccess).allowDownloadTo(target);
   }
 
   @Test
@@ -87,10 +87,10 @@ class ClientGetReturnPlannerTest {
     ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
     File target = tempDir.resolve(PAYLOAD_BIN).toFile();
     assertTrue(target.createNewFile());
-    when(core.allowDownloadTo(target)).thenReturn(true);
+    when(transferAccess.allowDownloadTo(target)).thenReturn(true);
 
     ClientGetReturnPlanner.ReturnSetup setup =
-        planner.forGlobalRequest(ReturnType.DISK, target, true, core);
+        planner.forGlobalRequest(ReturnType.DISK, target, true, transferAccess);
 
     assertAll(
         () -> assertInstanceOf(FileBucket.class, setup.bucket()),
@@ -105,12 +105,12 @@ class ClientGetReturnPlannerTest {
     Path targetPath = tempDir.resolve(PAYLOAD_BIN);
     Files.writeString(targetPath, "data");
     File target = targetPath.toFile();
-    when(core.allowDownloadTo(target)).thenReturn(true);
+    when(transferAccess.allowDownloadTo(target)).thenReturn(true);
 
     IOException thrown =
         assertThrows(
             IOException.class,
-            () -> planner.forGlobalRequest(ReturnType.DISK, target, false, core));
+            () -> planner.forGlobalRequest(ReturnType.DISK, target, false, transferAccess));
 
     assertTrue(thrown.getMessage().contains("Target filename exists already"));
     assertTrue(target.exists());
@@ -121,13 +121,13 @@ class ClientGetReturnPlannerTest {
     ClientGetMessage message = buildMessage(ReturnType.NONE, null);
     ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
 
-    ClientGetReturnPlanner.ReturnSetup setup = planner.forMessage(message, core, handler);
+    ClientGetReturnPlanner.ReturnSetup setup = planner.forMessage(message, transferAccess, handler);
 
     assertAll(
         () -> assertNull(setup.bucket()),
         () -> assertNull(setup.targetFile()),
         () -> assertNull(setup.extension()));
-    verifyNoInteractions(core, handler);
+    verifyNoInteractions(transferAccess, handler);
   }
 
   @Test
@@ -135,11 +135,12 @@ class ClientGetReturnPlannerTest {
     Path targetPath = tempDir.resolve(PAYLOAD_BIN);
     ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
     ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, true, fetchContext);
-    when(core.allowDownloadTo(targetPath.toFile())).thenReturn(false);
+    when(transferAccess.allowDownloadTo(targetPath.toFile())).thenReturn(false);
 
     MessageInvalidException thrown =
         assertThrows(
-            MessageInvalidException.class, () -> planner.forMessage(message, core, handler));
+            MessageInvalidException.class,
+            () -> planner.forMessage(message, transferAccess, handler));
 
     assertAll(
         () -> assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode),
@@ -152,13 +153,14 @@ class ClientGetReturnPlannerTest {
     Path targetPath = tempDir.resolve(PAYLOAD_BIN);
     ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
     ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
-    when(core.allowDownloadTo(targetPath.toFile())).thenReturn(true);
+    when(transferAccess.allowDownloadTo(targetPath.toFile())).thenReturn(true);
     when(handler.ddaAccessController()).thenReturn(ddaAccessController);
     when(ddaAccessController.allowDDAFrom(targetPath.toFile(), true)).thenReturn(false);
 
     MessageInvalidException thrown =
         assertThrows(
-            MessageInvalidException.class, () -> planner.forMessage(message, core, handler));
+            MessageInvalidException.class,
+            () -> planner.forMessage(message, transferAccess, handler));
 
     assertEquals(ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED, thrown.protocolCode);
   }
@@ -170,13 +172,14 @@ class ClientGetReturnPlannerTest {
     ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
     Files.writeString(targetPath, "data");
     ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
-    when(core.allowDownloadTo(targetPath.toFile())).thenReturn(true);
+    when(transferAccess.allowDownloadTo(targetPath.toFile())).thenReturn(true);
     when(handler.ddaAccessController()).thenReturn(ddaAccessController);
     when(ddaAccessController.allowDDAFrom(targetPath.toFile(), true)).thenReturn(true);
 
     MessageInvalidException thrown =
         assertThrows(
-            MessageInvalidException.class, () -> planner.forMessage(message, core, handler));
+            MessageInvalidException.class,
+            () -> planner.forMessage(message, transferAccess, handler));
 
     assertAll(
         () -> assertEquals(ProtocolErrorMessage.INTERNAL_ERROR, thrown.protocolCode),
@@ -189,12 +192,12 @@ class ClientGetReturnPlannerTest {
     Path targetPath = tempDir.resolve("payload.txt");
     ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
     ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
-    when(core.allowDownloadTo(targetPath.toFile())).thenReturn(true);
+    when(transferAccess.allowDownloadTo(targetPath.toFile())).thenReturn(true);
     when(handler.ddaAccessController()).thenReturn(ddaAccessController);
     when(ddaAccessController.allowDDAFrom(targetPath.toFile(), true)).thenReturn(true);
     when(fetchContext.getFilterData()).thenReturn(true);
 
-    ClientGetReturnPlanner.ReturnSetup setup = planner.forMessage(message, core, handler);
+    ClientGetReturnPlanner.ReturnSetup setup = planner.forMessage(message, transferAccess, handler);
 
     assertAll(
         () -> assertInstanceOf(FileBucket.class, setup.bucket()),

--- a/src/test/java/network/crypta/clients/fcp/ClientPutComplexDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutComplexDirMessageTest.java
@@ -9,7 +9,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.ManifestElement;
@@ -50,21 +51,20 @@ class ClientPutComplexDirMessageTest {
   @Mock private PersistentTempBucketFactory persistentBucketFactory;
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPServer server;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private TransferAccessPort transferAccess;
 
   @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
   private Node node;
-
-  @Mock private NodeClientCore core;
 
   @TempDir Path tempDir;
 
   @BeforeEach
   void setUp() throws IOException {
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    lenient().when(node.services()).thenReturn(services);
-    lenient().when(services.clientCore()).thenReturn(core);
-    lenient().when(core.allowUploadFrom(any(File.class))).thenReturn(true);
+    lenient().when(handler.getServer()).thenReturn(server);
+    lenient().when(server.runtime()).thenReturn(runtimePorts);
+    lenient().when(runtimePorts.transferAccess()).thenReturn(transferAccess);
+    lenient().when(transferAccess.allowUploadFrom(any(File.class))).thenReturn(true);
     lenient()
         .when(persistentBucketFactory.makeBucket(anyLong()))
         .thenAnswer(_ -> new ArrayBucket());
@@ -132,7 +132,7 @@ class ClientPutComplexDirMessageTest {
   @Test
   void run_whenDiskFileNotAllowed_expectAccessDenied() throws Exception {
     Path diskFile = Files.writeString(tempDir.resolve("disk.txt"), "denied");
-    when(core.allowUploadFrom(diskFile.toFile())).thenReturn(false);
+    when(transferAccess.allowUploadFrom(diskFile.toFile())).thenReturn(false);
     SimpleFieldSet fs = baseFieldSet();
     addDiskFile(fs, 0, "disk.txt", diskFile);
     ClientPutComplexDirMessage message =
@@ -148,7 +148,7 @@ class ClientPutComplexDirMessageTest {
   @Test
   void run_whenFilesInSubdirectories_expectManifestTreeAndData() throws Exception {
     Path diskFile = Files.writeString(tempDir.resolve("disk.txt"), "disk-data");
-    when(core.allowUploadFrom(diskFile.toFile())).thenReturn(true);
+    when(transferAccess.allowUploadFrom(diskFile.toFile())).thenReturn(true);
     byte[] directBytes = "hello".getBytes(UTF_8);
     SimpleFieldSet fs = baseFieldSet();
     addDirectFile(fs, 0, "docs/direct.txt", directBytes.length);

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
@@ -8,7 +8,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.ManifestElement;
@@ -42,7 +43,8 @@ class ClientPutDiskDirMessageTest {
 
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPServer server;
-  @Mock private NodeClientCore core;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private TransferAccessPort transferAccess;
 
   @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
   private Node node;
@@ -57,8 +59,9 @@ class ClientPutDiskDirMessageTest {
   @BeforeEach
   void setUp() {
     lenient().when(handler.getServer()).thenReturn(server);
-    lenient().when(server.getCore()).thenReturn(core);
-    lenient().when(core.allowUploadFrom(any())).thenReturn(true);
+    lenient().when(server.runtime()).thenReturn(runtimePorts);
+    lenient().when(runtimePorts.transferAccess()).thenReturn(transferAccess);
+    lenient().when(transferAccess.allowUploadFrom(any())).thenReturn(true);
   }
 
   @Test
@@ -80,7 +83,7 @@ class ClientPutDiskDirMessageTest {
 
   @Test
   void run_whenUploadNotAllowed_expectAccessDenied() throws Exception {
-    when(core.allowUploadFrom(any())).thenReturn(false);
+    when(transferAccess.allowUploadFrom(any())).thenReturn(false);
     ClientPutDiskDirMessage message = newMessage(tempDir);
 
     MessageInvalidException ex =
@@ -124,7 +127,9 @@ class ClientPutDiskDirMessageTest {
     assertEquals("index.html", rootElement.fullName);
     assertEquals(Files.size(file), rootElement.getSize());
     FileBucket bucket = (FileBucket) rootElement.getData();
-    assertEquals(file.toFile().getAbsolutePath(), bucket.getFile().getAbsolutePath());
+    File bucketFile = bucket.getFile();
+    assertNotNull(bucketFile);
+    assertEquals(file.toFile().getAbsolutePath(), bucketFile.getAbsolutePath());
 
     @SuppressWarnings("unchecked")
     HashMap<String, Object> nested = (HashMap<String, Object>) buckets.get("assets");

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDiskUploadValidatorTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDiskUploadValidatorTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.UUID;
 import network.crypta.crypt.SHA256;
-import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.Base64;
 import network.crypta.support.SimpleFieldSet;
@@ -70,20 +69,21 @@ class ClientPutDiskUploadValidatorTest {
   @Test
   void validateDiskUpload_whenNotDisk_returnsEmptyContext() throws Exception {
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
     ClientPutMessage message =
         buildMessage(ClientPutBase.UploadFrom.DIRECT, tempDir.resolve("direct.dat").toFile(), null);
 
     DiskUploadContext context =
-        ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", false);
+        ClientPutDiskUploadValidator.validateDiskUpload(
+            transferAccess, handler, message, "id", false);
 
     assertSame(DiskUploadContext.empty(), context);
   }
 
   @Test
   void validateDiskUpload_whenUploadNotAllowed_throwsMessageInvalid() throws Exception {
-    FCPServer server = mock(FCPServer.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
     File file = createFile("blocked.dat");
 
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, null);
@@ -92,16 +92,17 @@ class ClientPutDiskUploadValidatorTest {
     MessageInvalidException error =
         assertThrows(
             MessageInvalidException.class,
-            () -> ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", true));
+            () ->
+                ClientPutDiskUploadValidator.validateDiskUpload(
+                    transferAccess, handler, message, "id", true));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, error.protocolCode);
   }
 
   @Test
   void validateDiskUpload_whenFileHashProvided_buildsSaltedContext() throws Exception {
-    FCPServer server = mock(FCPServer.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
     File file = createFile("file.dat");
     UUID connectionId = UUID.fromString("f81d4fae-7dec-11d0-a765-00a0c91e6bf6");
     byte[] expectedHash = new byte[] {1, 2, 3, 4};
@@ -112,7 +113,8 @@ class ClientPutDiskUploadValidatorTest {
     when(handler.getConnectionIdentifierUUID()).thenReturn(connectionId);
 
     DiskUploadContext context =
-        ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "request-1", false);
+        ClientPutDiskUploadValidator.validateDiskUpload(
+            transferAccess, handler, message, "request-1", false);
 
     assertEquals(connectionId + "-request-1-", context.salt());
     assertArrayEquals(expectedHash, context.saltedHash());
@@ -120,10 +122,9 @@ class ClientPutDiskUploadValidatorTest {
 
   @Test
   void validateDiskUpload_whenDdaDenied_throwsMessageInvalid() throws Exception {
-    FCPServer server = mock(FCPServer.class);
     DdaAccessController ddaController = mock(DdaAccessController.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
     File file = createFile("file.dat");
 
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, null);
@@ -134,17 +135,18 @@ class ClientPutDiskUploadValidatorTest {
     MessageInvalidException error =
         assertThrows(
             MessageInvalidException.class,
-            () -> ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", true));
+            () ->
+                ClientPutDiskUploadValidator.validateDiskUpload(
+                    transferAccess, handler, message, "id", true));
 
     assertEquals(ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED, error.protocolCode);
   }
 
   @Test
   void validateDiskUpload_whenDdaAllowed_returnsEmptyContext() throws Exception {
-    FCPServer server = mock(FCPServer.class);
     DdaAccessController ddaController = mock(DdaAccessController.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
     File file = createFile("file.dat");
 
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, null);
@@ -153,16 +155,16 @@ class ClientPutDiskUploadValidatorTest {
     when(ddaController.allowDDAFrom(file, false)).thenReturn(true);
 
     DiskUploadContext context =
-        ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", false);
+        ClientPutDiskUploadValidator.validateDiskUpload(
+            transferAccess, handler, message, "id", false);
 
     assertSame(DiskUploadContext.empty(), context);
   }
 
   @Test
   void validateDiskUpload_whenInvalidFileHash_throwsMessageInvalid() throws Exception {
-    FCPServer server = mock(FCPServer.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
     File file = createFile("file.dat");
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, "@@@");
 
@@ -173,7 +175,9 @@ class ClientPutDiskUploadValidatorTest {
     MessageInvalidException error =
         assertThrows(
             MessageInvalidException.class,
-            () -> ClientPutDiskUploadValidator.validateDiskUpload(handler, message, "id", false));
+            () ->
+                ClientPutDiskUploadValidator.validateDiskUpload(
+                    transferAccess, handler, message, "id", false));
 
     assertEquals(ProtocolErrorMessage.INVALID_FIELD, error.protocolCode);
   }
@@ -285,15 +289,5 @@ class ClientPutDiskUploadValidatorTest {
     File file = tempDir.resolve(name).toFile();
     assertTrue(file.createNewFile());
     return file;
-  }
-
-  private static TransferAccessPort configureTransferAccess(
-      FCPConnectionHandler handler, FCPServer server) {
-    RuntimePorts runtimePorts = mock(RuntimePorts.class);
-    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
-    when(handler.getServer()).thenReturn(server);
-    when(server.runtime()).thenReturn(runtimePorts);
-    when(runtimePorts.transferAccess()).thenReturn(transferAccess);
-    return transferAccess;
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDiskUploadValidatorTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDiskUploadValidatorTest.java
@@ -9,7 +9,8 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.UUID;
 import network.crypta.crypt.SHA256;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.Base64;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.RandomAccessBucket;
@@ -36,34 +37,34 @@ class ClientPutDiskUploadValidatorTest {
 
   @Test
   void validatePersistentDiskUpload_whenNotAllowed_throwsNotAllowed() {
-    NodeClientCore core = mock(NodeClientCore.class);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
     File file = tempDir.resolve("upload.dat").toFile();
-    when(core.allowUploadFrom(file)).thenReturn(false);
+    when(transferAccess.allowUploadFrom(file)).thenReturn(false);
 
     assertThrows(
         NotAllowedException.class,
-        () -> ClientPutDiskUploadValidator.validatePersistentDiskUpload(core, file));
+        () -> ClientPutDiskUploadValidator.validatePersistentDiskUpload(transferAccess, file));
   }
 
   @Test
   void validatePersistentDiskUpload_whenMissingFile_throwsFileNotFound() {
-    NodeClientCore core = mock(NodeClientCore.class);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
     File file = tempDir.resolve("missing.dat").toFile();
-    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(transferAccess.allowUploadFrom(file)).thenReturn(true);
 
     assertThrows(
         FileNotFoundException.class,
-        () -> ClientPutDiskUploadValidator.validatePersistentDiskUpload(core, file));
+        () -> ClientPutDiskUploadValidator.validatePersistentDiskUpload(transferAccess, file));
   }
 
   @Test
   void validatePersistentDiskUpload_whenReadableFile_allowsUpload() throws Exception {
-    NodeClientCore core = mock(NodeClientCore.class);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
     File file = tempDir.resolve("data.bin").toFile();
     assertTrue(file.createNewFile());
-    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(transferAccess.allowUploadFrom(file)).thenReturn(true);
 
-    ClientPutDiskUploadValidator.validatePersistentDiskUpload(core, file);
+    ClientPutDiskUploadValidator.validatePersistentDiskUpload(transferAccess, file);
   }
 
   @Test
@@ -80,15 +81,13 @@ class ClientPutDiskUploadValidatorTest {
 
   @Test
   void validateDiskUpload_whenUploadNotAllowed_throwsMessageInvalid() throws Exception {
-    NodeClientCore core = mock(NodeClientCore.class);
     FCPServer server = mock(FCPServer.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
     File file = createFile("blocked.dat");
 
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, null);
-    when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.allowUploadFrom(file)).thenReturn(false);
+    when(transferAccess.allowUploadFrom(file)).thenReturn(false);
 
     MessageInvalidException error =
         assertThrows(
@@ -100,18 +99,16 @@ class ClientPutDiskUploadValidatorTest {
 
   @Test
   void validateDiskUpload_whenFileHashProvided_buildsSaltedContext() throws Exception {
-    NodeClientCore core = mock(NodeClientCore.class);
     FCPServer server = mock(FCPServer.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
     File file = createFile("file.dat");
     UUID connectionId = UUID.fromString("f81d4fae-7dec-11d0-a765-00a0c91e6bf6");
     byte[] expectedHash = new byte[] {1, 2, 3, 4};
 
     ClientPutMessage message =
         buildMessage(ClientPutBase.UploadFrom.DISK, file, Base64.encodeStandard(expectedHash));
-    when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(transferAccess.allowUploadFrom(file)).thenReturn(true);
     when(handler.getConnectionIdentifierUUID()).thenReturn(connectionId);
 
     DiskUploadContext context =
@@ -123,16 +120,14 @@ class ClientPutDiskUploadValidatorTest {
 
   @Test
   void validateDiskUpload_whenDdaDenied_throwsMessageInvalid() throws Exception {
-    NodeClientCore core = mock(NodeClientCore.class);
     FCPServer server = mock(FCPServer.class);
     DdaAccessController ddaController = mock(DdaAccessController.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
     File file = createFile("file.dat");
 
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, null);
-    when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(transferAccess.allowUploadFrom(file)).thenReturn(true);
     when(handler.ddaAccessController()).thenReturn(ddaController);
     when(ddaController.allowDDAFrom(file, false)).thenReturn(false);
 
@@ -146,16 +141,14 @@ class ClientPutDiskUploadValidatorTest {
 
   @Test
   void validateDiskUpload_whenDdaAllowed_returnsEmptyContext() throws Exception {
-    NodeClientCore core = mock(NodeClientCore.class);
     FCPServer server = mock(FCPServer.class);
     DdaAccessController ddaController = mock(DdaAccessController.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
     File file = createFile("file.dat");
 
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, null);
-    when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(transferAccess.allowUploadFrom(file)).thenReturn(true);
     when(handler.ddaAccessController()).thenReturn(ddaController);
     when(ddaController.allowDDAFrom(file, false)).thenReturn(true);
 
@@ -167,15 +160,13 @@ class ClientPutDiskUploadValidatorTest {
 
   @Test
   void validateDiskUpload_whenInvalidFileHash_throwsMessageInvalid() throws Exception {
-    NodeClientCore core = mock(NodeClientCore.class);
     FCPServer server = mock(FCPServer.class);
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    TransferAccessPort transferAccess = configureTransferAccess(handler, server);
     File file = createFile("file.dat");
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DISK, file, "@@@");
 
-    when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.allowUploadFrom(file)).thenReturn(true);
+    when(transferAccess.allowUploadFrom(file)).thenReturn(true);
     when(handler.getConnectionIdentifierUUID())
         .thenReturn(UUID.fromString("f81d4fae-7dec-11d0-a765-00a0c91e6bf6"));
 
@@ -294,5 +285,15 @@ class ClientPutDiskUploadValidatorTest {
     File file = tempDir.resolve(name).toFile();
     assertTrue(file.createNewFile());
     return file;
+  }
+
+  private static TransferAccessPort configureTransferAccess(
+      FCPConnectionHandler handler, FCPServer server) {
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    TransferAccessPort transferAccess = mock(TransferAccessPort.class);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.transferAccess()).thenReturn(transferAccess);
+    return transferAccess;
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
@@ -13,6 +13,8 @@ import network.crypta.client.async.PersistentJobRunner;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +33,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -44,6 +47,8 @@ class FcpServerPersistentOpsTest {
   @Mock private NodeClientCore core;
 
   @Mock private FCPServer server;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private TransferAccessPort transferAccess;
 
   @Test
   void load_whenInvoked_expectNoException() {
@@ -188,7 +193,9 @@ class FcpServerPersistentOpsTest {
     DownloadRequestStatusDetails details =
         new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
     DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
-    rebootClient.getRequestStatusCache().addDownload(status);
+    var requestStatusCache = rebootClient.getRequestStatusCache();
+    assertNotNull(requestStatusCache);
+    requestStatusCache.addDownload(status);
 
     // Act
     RequestStatus[] result = ops.getGlobalRequests();
@@ -383,7 +390,7 @@ class FcpServerPersistentOpsTest {
     FcpServerPersistentOps ops = spy(newOps(new PersistentRequestRoot()));
     FreenetURI uri = mock(FreenetURI.class);
     File downloads = new File("/tmp/downloads");
-    when(core.getDownloadsDir()).thenReturn(downloads);
+    when(transferAccess.downloadsDir()).thenReturn(downloads);
     AtomicReference<PersistentGlobalRequestParams> captured = new AtomicReference<>();
     doAnswer(
             invocation -> {
@@ -627,6 +634,8 @@ class FcpServerPersistentOpsTest {
   }
 
   private FcpServerPersistentOps newOps(PersistentRequestRoot root) {
+    lenient().when(server.runtime()).thenReturn(runtimePorts);
+    lenient().when(runtimePorts.transferAccess()).thenReturn(transferAccess);
     return new FcpServerPersistentOps(server, core, root);
   }
 


### PR DESCRIPTION
## Summary
- migrate the FCP file-policy call sites and default downloads-dir lookup from `NodeClientCore` to `TransferAccessPort`
- thread `TransferAccessPort` through the `ClientGet`/`ClientPut` helper chain while leaving unrelated `Node`/`NodeClientCore` responsibilities in place
- update the focused FCP tests to assert against `RuntimePorts`/`TransferAccessPort` and clean up the touched null-safety findings

## How to test
- `./gradlew spotlessApply`
- `./gradlew compileJava`
- `./gradlew compileTestJava`
- `./gradlew test --tests "network.crypta.clients.fcp.ClientGetReturnPlannerTest" --tests "network.crypta.clients.fcp.ClientPutDiskUploadValidatorTest" --tests "network.crypta.clients.fcp.ClientPutDiskDirMessageTest" --tests "network.crypta.clients.fcp.ClientPutComplexDirMessageTest" --tests "network.crypta.clients.fcp.ClientGetFactoryTest" --tests "network.crypta.clients.fcp.FcpServerPersistentOpsTest"`