### PR TITLE
refactor(fcp): Migrate remaining runtime calls to SPI

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -767,11 +767,11 @@ public abstract class ClientRequest implements Serializable {
    * Schedules an asynchronous restart of this request on the appropriate executor.
    *
    * <p>For forever-persistent requests the restart is queued on the persistent job runner so that
-   * it can survive node restarts; for other requests it is dispatched to the core executor as a
-   * {@link PrioRunnable}. Status caches are updated before the restart is enqueued, and the {@link
-   * #started} flag is cleared so that callers can observe the pending restart.
+   * it can survive node restarts; for other requests it is dispatched through the runtime execution
+   * port as a {@link PrioRunnable}. Status caches are updated before the restart is enqueued, and
+   * the {@link #started} flag is cleared so that callers can observe the pending restart.
    *
-   * @param server server instance used to access the core execution and persistence infrastructure
+   * @param server server instance used to access persistence infrastructure and runtime execution
    * @param disableFilterData whether associated filter data should be disabled for the restart
    * @throws PersistenceDisabledException if the underlying persistence layer cannot support restart
    */
@@ -805,10 +805,8 @@ public abstract class ClientRequest implements Serializable {
               NativeThread.PriorityLevel.HIGH_PRIORITY.value);
     } else {
       server
-          .getCore()
-          .getNode()
-          .network()
-          .executor()
+          .runtime()
+          .execution()
           .execute(
               new PrioRunnable() {
 

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -22,9 +22,9 @@ import network.crypta.support.api.Bucket;
  * coordinates request lifecycle management for external clients. It wires persistent request queues
  * and the download cache so clients can resume work across node restarts. The server is created
  * from configured defaults, started lazily through {@link #maybeStart()}, and runs a dedicated
- * accept-loop on a daemon thread so shutdown does not block. Concurrency is managed through the
- * executor supplied by {@link Node}, and request jobs are marshaled onto the {@link ClientContext}
- * job runner.
+ * accept-loop on a daemon thread so shutdown does not block. Runtime-facing listener work is
+ * scheduled through {@link RuntimePorts#execution()}, and request jobs are marshaled onto the
+ * {@link ClientContext} job runner.
  *
  * <p>Responsibilities include:
  *
@@ -116,7 +116,7 @@ public class FCPServer implements Runnable, DownloadCache {
     this.assumeUploadDDAIsAllowed = config.assumeUploadDDAAllowed();
     this.neverDropAMessage = config.neverDropAMessage();
     this.maxMessageQueueLength = config.maxMessageQueueLength();
-    this.listener = new FcpServerListener(this, node, config);
+    this.listener = new FcpServerListener(this, runtime, config);
     this.persistentOps = new FcpServerPersistentOps(this, core, dependencies.persistentRoot());
   }
 
@@ -134,7 +134,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @param allowedHostsFullAccess allowlist used for privileged operations that bypass client-side
    *     restrictions.
    * @param port TCP port number for the FCP listener, in the host byte order.
-   * @param node owning {@link Node} providing executors and lifecycle hooks.
+   * @param node owning {@link Node} providing daemon services still required by legacy FCP code.
    * @param core node client core exposing persistence, download directories, and cache factories.
    * @param runtime runtime SPI bridge for infrastructure code that avoids daemon internals.
    * @param isEnabled whether networked FCP should start.
@@ -220,7 +220,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * point. The returned server is fully wired to the supplied node, client core, and persistence
    * root, so it can immediately serve FCP traffic once started.
    *
-   * @param node the owning node providing executors and core services for the server.
+   * @param node the owning node providing daemon services still required by legacy FCP code.
    * @param core client core used for persistence and endpoint access.
    * @param runtime runtime SPI bridge used by infrastructure code inside the server.
    * @param config configuration registry where the {@code fcp} subsection is registered.

--- a/src/main/java/network/crypta/clients/fcp/FcpRuntimeAdapters.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpRuntimeAdapters.java
@@ -1,0 +1,229 @@
+package network.crypta.clients.fcp;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import network.crypta.crypt.EntropySource;
+import network.crypta.crypt.RandomSource;
+import network.crypta.runtime.spi.ExecutionPort;
+import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.PriorityAwareExecutor;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Package-local adapters that let FCP consume runtime SPI capabilities through legacy interfaces.
+ *
+ * <p>This helper keeps the migration boundary inside {@code clients.fcp}. Callers that already
+ * depend on FCP-local behavior can obtain a {@link PriorityAwareExecutor}, a {@link RandomSource},
+ * or a one-off secure {@code long} without reaching back into daemon-only runtime objects. The
+ * class deliberately translates only the narrow behavior needed by the remaining call sites in this
+ * package.
+ *
+ * <p>The adapters are intentionally conservative. Execution introspection methods report empty
+ * snapshots rather than guessing at daemon thread state, and the randomness bridge does not claim
+ * ownership of the underlying {@link RandomnessPort}. Treat the returned adapters as short-lived
+ * views over the live runtime rather than as stable serialization or lifecycle boundaries.
+ */
+final class FcpRuntimeAdapters {
+  /** Prevents instantiation of this utility holder. */
+  private FcpRuntimeAdapters() {}
+
+  /**
+   * Returns a {@link PriorityAwareExecutor} backed by the runtime execution port.
+   *
+   * <p>The adapter preserves the legacy FCP call shape for code that still expects an executor-like
+   * type. Task submission flows through {@link ExecutionPort#execute(Runnable, String)}, while the
+   * optional thread-count methods continue to report conservative empty snapshots because the SPI
+   * does not expose daemon worker internals.
+   *
+   * @param runtime aggregate runtime SPI view that supplies the execution capability
+   * @return executor adapter that forwards named work to the live runtime
+   */
+  static PriorityAwareExecutor priorityAwareExecutor(RuntimePorts runtime) {
+    return new ExecutionPortPriorityAwareExecutor(runtime.execution());
+  }
+
+  /**
+   * Returns a {@link RandomSource} backed by the runtime secure-random capability.
+   *
+   * <p>This bridge exists for legacy APIs that still accept the daemon's {@link RandomSource}
+   * abstraction. Calls that need random bytes delegate to {@link RandomnessPort#fillSecureRandom
+   * (byte[])}, while entropy-acceptance hooks remain inert because the SPI does not publish mutable
+   * entropy-pool controls.
+   *
+   * @param randomness runtime randomness capability that supplies secure bytes
+   * @return random-source adapter that reads secure randomness from the runtime
+   */
+  static RandomSource secureRandomSource(RandomnessPort randomness) {
+    return new RandomnessPortRandomSource(randomness);
+  }
+
+  /**
+   * Returns a secure pseudo-random {@code long} generated from the runtime randomness port.
+   *
+   * <p>The helper allocates an eight-byte buffer, fills it with secure random data, and interprets
+   * the resulting bytes as a {@code long}. It is intended for FCP call sites that need a single
+   * secure identifier value without depending on the daemon's bootstrap randomness classes.
+   *
+   * @param randomness runtime randomness capability used to fill the temporary byte buffer
+   * @return a {@code long} assembled from eight secure random bytes
+   */
+  static long nextSecureLong(RandomnessPort randomness) {
+    byte[] bytes = new byte[Long.BYTES];
+    randomness.fillSecureRandom(bytes);
+    return ByteBuffer.wrap(bytes).getLong();
+  }
+
+  /**
+   * Minimal {@link PriorityAwareExecutor} implementation that delegates scheduling to {@link
+   * ExecutionPort}.
+   *
+   * <p>The adapter preserves the legacy submission overloads used by FCP without widening the SPI.
+   * It normalizes missing job names to the runnable class name and ignores the {@code fromTicker}
+   * hint because the runtime execution port does not expose ticker-aware scheduling controls.
+   */
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class ExecutionPortPriorityAwareExecutor implements PriorityAwareExecutor {
+    /** Underlying runtime execution capability that receives all submitted jobs. */
+    private final ExecutionPort execution;
+
+    /**
+     * Creates an executor adapter for the supplied runtime execution capability.
+     *
+     * @param execution runtime execution port that accepts named background work
+     */
+    private ExecutionPortPriorityAwareExecutor(ExecutionPort execution) {
+      this.execution = Objects.requireNonNull(execution);
+    }
+
+    @Override
+    public void execute(@NotNull Runnable job) {
+      execution.execute(Objects.requireNonNull(job), defaultJobName(job));
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName) {
+      execution.execute(Objects.requireNonNull(job), normalizeJobName(job, jobName));
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName, boolean fromTicker) {
+      execution.execute(Objects.requireNonNull(job), normalizeJobName(job, jobName));
+    }
+
+    @Override
+    public int[] waitingThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int[] runningThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int getWaitingThreadsCount() {
+      return 0;
+    }
+
+    /**
+     * Derives a fallback job label from the runnable implementation type.
+     *
+     * @param job submitted runnable whose implementation class names the work item
+     * @return non-empty default job name used for diagnostics
+     */
+    private static String defaultJobName(Runnable job) {
+      return job.getClass().getName();
+    }
+
+    /**
+     * Normalizes an optional job name before it is passed to the runtime.
+     *
+     * @param job submitted runnable used as the fallback naming source
+     * @param jobName caller-provided label that may be {@code null} or blank
+     * @return caller label when present, otherwise the runnable class name
+     */
+    private static String normalizeJobName(Runnable job, String jobName) {
+      return (jobName == null || jobName.isBlank()) ? defaultJobName(job) : jobName;
+    }
+  }
+
+  /**
+   * {@link RandomSource} adapter that sources secure bytes from {@link RandomnessPort}.
+   *
+   * <p>The bridge supports legacy APIs that still require {@link RandomSource} while keeping the
+   * daemon-specific random implementation out of the runtime SPI. It only models the read side of
+   * the old abstraction. Entropy-ingest methods return zero, and callers should treat instances as
+   * non-owning views over a live runtime port.
+   */
+  private static final class RandomnessPortRandomSource extends RandomSource {
+    /**
+     * Live runtime randomness capability backing this adapter.
+     *
+     * <p>The field is transient so misuse after Java serialization fails explicitly instead of
+     * silently reviving a disconnected runtime handle.
+     */
+    private final transient RandomnessPort randomness;
+
+    /**
+     * Creates a random-source adapter for the supplied runtime randomness capability.
+     *
+     * @param randomness runtime randomness port that supplies secure bytes on demand
+     */
+    private RandomnessPortRandomSource(RandomnessPort randomness) {
+      this.randomness = Objects.requireNonNull(randomness);
+    }
+
+    @Override
+    public void nextBytes(byte[] bytes) {
+      requireRandomness().fillSecureRandom(bytes);
+    }
+
+    @Override
+    protected synchronized int next(int bits) {
+      if (bits <= 0) {
+        return 0;
+      }
+      byte[] bytes = new byte[Integer.BYTES];
+      requireRandomness().fillSecureRandom(bytes);
+      return ByteBuffer.wrap(bytes).getInt() >>> (Integer.SIZE - bits);
+    }
+
+    @Override
+    public int acceptEntropy(EntropySource source, long data, int entropyGuess) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(EntropySource timer) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(EntropySource fnpTimingSource, double bias) {
+      return 0;
+    }
+
+    @Override
+    public int acceptEntropyBytes(
+        EntropySource myPacketDataSource, byte[] buf, int offset, int length, double bias) {
+      return 0;
+    }
+
+    @Override
+    public void close() {
+      // This adapter does not own the runtime randomness port, so there is nothing to release.
+    }
+
+    /**
+     * Returns the live runtime randomness capability or fails clearly after serialization.
+     *
+     * @return runtime randomness port currently backing this adapter
+     * @throws NullPointerException if the adapter has been deserialized without a live runtime port
+     */
+    private RandomnessPort requireRandomness() {
+      return Objects.requireNonNull(
+          randomness, "RandomnessPortRandomSource must not be used after serialization");
+    }
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
@@ -3,7 +3,8 @@ package network.crypta.clients.fcp;
 import java.net.Socket;
 import network.crypta.io.NetworkInterface;
 import network.crypta.io.SSLNetworkInterface;
-import network.crypta.node.Node;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.PriorityAwareExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -15,9 +16,11 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * creating the listening {@link NetworkInterface}, binding it to the configured addresses, and
  * accepting incoming connections. Callers typically construct the listener during server
  * initialization and invoke {@link #maybeStart()} once; the accept-loop then runs on a daemon
- * thread, dispatching sockets to {@link FCPConnectionHandler} instances. Configuration updates such
- * as {@link #updateBindTo(String)} and {@link #setAllowedHosts(String)} are delegated to the
- * underlying interface when available, while SSL mode is tracked via static flag accessors.
+ * thread, dispatching sockets to {@link FCPConnectionHandler} instances. Runtime lifecycle and
+ * execution concerns are consumed through {@link RuntimePorts} so the listener does not depend on
+ * daemon executor implementations directly. Configuration updates such as {@link
+ * #updateBindTo(String)} and {@link #setAllowedHosts(String)} are delegated to the underlying
+ * interface when available, while SSL mode is tracked via static flag accessors.
  *
  * <p>The listener is intentionally conservative about re-binding: it caches the created interface
  * and only creates a new one once per instance. Shutdown handling relies on the Tanuki Wrapper
@@ -43,8 +46,11 @@ final class FcpServerListener implements Runnable {
   /** Owning server used to construct connection handlers for accepted sockets. */
   private final FCPServer server;
 
-  /** Node used to get executors and startup lifecycle information. */
-  private final Node node;
+  /** Runtime SPI bridge supplying execution and lifecycle views for listener infrastructure. */
+  private final RuntimePorts runtime;
+
+  /** Executor adapter expected by the legacy network-interface factories. */
+  private final PriorityAwareExecutor executor;
 
   /** TCP port to bind when creating the network interface. */
   private final int port;
@@ -62,19 +68,22 @@ final class FcpServerListener implements Runnable {
   private NetworkInterface networkInterface;
 
   /**
-   * Creates a listener bound to the provided server, node, and configuration snapshot.
+   * Creates a listener bound to the provided server, runtime SPI bridge, and configuration
+   * snapshot.
    *
    * <p>The constructor captures immutable configuration such as port, bind address, and allowed
    * hosts. It does not create sockets or start threads; callers must invoke {@link #maybeStart()}
    * to initialize the {@link NetworkInterface} and begin accepting connections.
    *
    * @param server the owning server that constructs connection handlers for clients.
-   * @param node node supplying executors and lifecycle state used by the accept-loop.
+   * @param runtime runtime SPI bridge supplying execution and lifecycle state used by the
+   *     accept-loop.
    * @param config snapshot of listener configuration values at construction time.
    */
-  FcpServerListener(FCPServer server, Node node, FcpServerConfig config) {
+  FcpServerListener(FCPServer server, RuntimePorts runtime, FcpServerConfig config) {
     this.server = server;
-    this.node = node;
+    this.runtime = runtime;
+    this.executor = FcpRuntimeAdapters.priorityAwareExecutor(runtime);
     this.port = config.port();
     this.enabled = config.enabled();
     this.allowedHosts = config.allowedHosts();
@@ -174,11 +183,9 @@ final class FcpServerListener implements Runnable {
     NetworkInterface tempNetworkInterface;
     if (ssl) {
       tempNetworkInterface =
-          SSLNetworkInterface.createSsl(
-              port, bindTo, allowedHosts, node.network().executor(), true);
+          SSLNetworkInterface.createSsl(port, bindTo, allowedHosts, executor, true);
     } else {
-      tempNetworkInterface =
-          NetworkInterface.create(port, bindTo, allowedHosts, node.network().executor(), true);
+      tempNetworkInterface = NetworkInterface.create(port, bindTo, allowedHosts, executor, true);
     }
 
     this.networkInterface = tempNetworkInterface;
@@ -229,13 +236,13 @@ final class FcpServerListener implements Runnable {
   }
 
   /**
-   * Accepts a single connection and starts a handler when the node is running.
+   * Accepts a single connection and starts a handler when the runtime is running.
    *
-   * <p>If the node has not yet started, the method returns without accepting. Otherwise, it accepts
-   * one socket and dispatches it to a new {@link FCPConnectionHandler} instance.
+   * <p>If the runtime has not yet started, the method returns without accepting. Otherwise, it
+   * accepts one socket and dispatches it to a new {@link FCPConnectionHandler} instance.
    */
   private void realRun() {
-    if (!node.isHasStarted()) return;
+    if (!runtime.lifecycle().hasStarted()) return;
     Socket s = networkInterface.accept();
     FCPConnectionHandler ch = new FCPConnectionHandler(s, server);
     ch.start();

--- a/src/main/java/network/crypta/clients/fcp/GenerateSSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/GenerateSSKMessage.java
@@ -8,9 +8,9 @@ import network.crypta.support.SimpleFieldSet;
 /**
  * Generates a new signed subspace key (SSK) pair for an FCP client and relays it back over the
  * connection. The message is created from the parsed field set of an inbound request and, when
- * executed, allocates a fresh {@link InsertableClientSSK} using the node's secure random source.
- * Clients use this flow when they need a write-capable insert URI and a corresponding request URI
- * without transmitting their own key material.
+ * executed, allocates a fresh {@link InsertableClientSSK} using the server runtime's secure random
+ * source. Clients use this flow when they need a write-capable insert URI and a corresponding
+ * request URI without transmitting their own key material.
  *
  * <p>The instance is intentionally lightweight and stateless: all protocol information lives in the
  * supplied {@link SimpleFieldSet}, and all cryptographic material is produced during {@link
@@ -68,20 +68,22 @@ public class GenerateSSKMessage extends FCPMessage {
   /**
    * Generates a new random SSK keypair and sends it to the client as an {@link SSKKeypairMessage}.
    * The method is synchronous with respect to the caller: key generation occurs immediately using
-   * the node's random source, and the response is dispatched on the provided connection handler. No
-   * state is retained after sending; callers may invoke this repeatedly to obtain multiple
+   * the runtime's secure random source, and the response is dispatched on the provided connection
+   * handler. No state is retained after sending; callers may invoke this repeatedly to get multiple
    * independent keypairs.
    *
    * @param handler active connection handler that delivers the generated keypair back to the
    *     requesting client; must not be {@code null}.
-   * @param node running node that supplies randomness and environment context for creating the SSK
-   *     pair; expected to be fully initialized.
+   * @param node running node supplied by the unchanged FCP message signature; not consulted for
+   *     randomness because the handler's server runtime provides that capability.
    * @throws MessageInvalidException if the response message cannot be encoded or sent according to
-   *     FCP protocol rules or if the handler rejects the outbound payload.
+   *     FCP protocol rules, or if the handler rejects the outbound payload.
    */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    InsertableClientSSK key = InsertableClientSSK.createRandom(node.bootstrap().random(), "");
+    InsertableClientSSK key =
+        InsertableClientSSK.createRandom(
+            FcpRuntimeAdapters.secureRandomSource(handler.getServer().runtime().randomness()), "");
     FreenetURI insertURI = key.getInsertURI();
     FreenetURI requestURI = key.getURI();
     SSKKeypairMessage msg = new SSKKeypairMessage(insertURI, requestURI, clientIdentifier);

--- a/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
@@ -13,16 +13,17 @@ import network.crypta.support.SimpleFieldSet;
  * client.
  *
  * <p>This message is created from a parsed {@link SimpleFieldSet} and validates the probe type and
- * optional hop budget before execution. Callers typically obtain it through the FCP dispatch layer
- * and then invoke {@link #run(FCPConnectionHandler, Node)} to start the probe asynchronously. The
- * request retains the identifier, type, and hop budget as immutable state; it is not intended to be
- * reused across unrelated client sessions. A {@code null} identifier is supported and results in
+ * optional hop budget before execution. Callers typically get it through the FCP dispatch layer and
+ * then invoke {@link #run(FCPConnectionHandler, Node)} to start the probe asynchronously. The
+ * request retains the identifier, type, and hop budget as an immutable state; it is not intended to
+ * be reused across unrelated client sessions. A {@code null} identifier is supported and results in
  * response messages that omit the {@code Identifier} field.
  *
  * <p>Execution requires full-access credentials. When authorized, {@link #run(FCPConnectionHandler,
  * Node)} constructs a {@link Listener} that adapts probe callbacks into concrete {@link FCPMessage}
- * responses, and delegates to {@code node.network().startProbe(...)}. The method does not block for
- * completion; responses arrive asynchronously via the handler.
+ * responses, gets a secure probe UID from the handler's server runtime, and delegates to {@code
+ * node.network().startProbe(...)}. The method does not block for completion; responses arrive
+ * asynchronously via the handler.
  *
  * <ul>
  *   <li><strong>Responsibilities:</strong> validate fields, enforce access, and bridge callbacks.
@@ -69,8 +70,8 @@ public final class ProbeRequest extends FCPMessage {
    * @throws MessageInvalidException if the type is invalid or hopsToLive cannot be parsed.
    */
   public ProbeRequest(SimpleFieldSet fs) throws MessageInvalidException {
-    /* If not defined in the field set Identifier will be null. As adding a null value to the field set does
-     * not actually add something under the key, it will also be omitted in the response messages.
+    /* If not defined in the field set, Identifier will be null. As adding a null value to the field set does
+     * not add something under the key, it will also be omitted in the response messages.
      */
     this.requestIdentifier = fs.get(IDENTIFIER);
 
@@ -92,7 +93,7 @@ public final class ProbeRequest extends FCPMessage {
           null,
           false);
     } catch (FSParseException e) {
-      // Getting a String from a SimpleFieldSet does not throw - it can at worst return null.
+      // Getting a String from a SimpleFieldSet does not throw - it can, at worst, return null.
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_MESSAGE,
           "Unable to parse hopsToLive \"" + fs.get(HTL) + "\": " + e,
@@ -122,7 +123,7 @@ public final class ProbeRequest extends FCPMessage {
    *
    * <p>The name is constant and matches the identifier expected by FCP clients. It is used when
    * serializing outbound messages and when routing inbound messages to this implementation. The
-   * method is side-effect free and performs no allocation beyond returning the constant string.
+   * method is side-effect-free and performs no allocation beyond returning the constant string.
    *
    * @return stable protocol name token, never null, matching {@link #NAME}.
    */
@@ -138,12 +139,13 @@ public final class ProbeRequest extends FCPMessage {
    * ProtocolErrorMessage#ACCESS_DENIED} is thrown and no probe is started. When authorized, this
    * method builds a {@link Listener} that maps each callback to the corresponding {@link
    * FCPResponse} message and then delegates to {@code node.network().startProbe(...)} using the
-   * stored hop budget and a fresh random UID from the node. The call is non-blocking and returns
-   * immediately while responses are emitted asynchronously via {@link
+   * stored hop budget and a fresh secure random UID from the server runtime. The call is
+   * non-blocking and returns immediately while responses are emitted asynchronously via {@link
    * FCPConnectionHandler#send(FCPMessage)}.
    *
    * @param handler connection handler used to authorize and send probe responses.
-   * @param node node instance that executes the probe and supplies randomness.
+   * @param node node instance that executes the probe while the handler's server runtime supplies
+   *     the probe UID.
    * @throws MessageInvalidException if the caller lacks full access for probe execution.
    */
   @Override
@@ -216,7 +218,7 @@ public final class ProbeRequest extends FCPMessage {
                     requestIdentifier, bandwidthClassForCapacityUsage, capacityUsage));
           }
         };
-    node.network()
-        .startProbe(hopsToLive, node.bootstrap().random().nextLong(), probeType, listener);
+    long probeUid = FcpRuntimeAdapters.nextSecureLong(handler.getServer().runtime().randomness());
+    node.network().startProbe(hopsToLive, probeUid, probeType, listener);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
@@ -1,0 +1,271 @@
+package network.crypta.clients.fcp;
+
+import java.lang.reflect.Field;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.PrioRunnable;
+import network.crypta.runtime.spi.ExecutionPort;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.io.NativeThread;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class ClientRequestRestartAsyncTest {
+
+  @Test
+  void restartAsync_whenPersistenceNotForever_submitsPrioRunnableThroughRuntimeExecution()
+      throws Exception {
+    // Arrange
+    ExecutionPort executionPort = mock(ExecutionPort.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    when(runtimePorts.execution()).thenReturn(executionPort);
+    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
+    ClientContext context = newContextWithJobRunner(jobRunner);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.getClientContext()).thenReturn(context);
+    FCPServer server = mock(FCPServer.class);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(server.getCore()).thenReturn(core);
+    TestClientRequest request = TestClientRequest.connection();
+    request.markStarted();
+
+    // Act
+    request.restartAsync(server, true);
+
+    // Assert
+    assertFalse(request.isStarted());
+    ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executionPort).execute(taskCaptor.capture(), eq("Restart request"));
+    verify(jobRunner, never()).queue(any(PersistentJob.class), anyInt());
+    Runnable submittedTask = taskCaptor.getValue();
+    PrioRunnable prioRunnable = assertInstanceOf(PrioRunnable.class, submittedTask);
+    assertEquals(NativeThread.PriorityLevel.NORM_PRIORITY.value, prioRunnable.getPriority());
+
+    submittedTask.run();
+
+    assertEquals(1, request.restartCalls);
+    assertSame(context, request.lastRestartContext);
+    assertTrue(request.lastDisableFilterData);
+  }
+
+  @Test
+  void restartAsync_whenPersistenceForever_queuesPersistentJobRunnerAndLeavesExecutionPortUnused()
+      throws Exception {
+    // Arrange
+    ExecutionPort executionPort = mock(ExecutionPort.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    when(runtimePorts.execution()).thenReturn(executionPort);
+    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
+    ClientContext context = newContextWithJobRunner(jobRunner);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.getClientContext()).thenReturn(context);
+    FCPServer server = mock(FCPServer.class);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(server.getCore()).thenReturn(core);
+    TestClientRequest request = TestClientRequest.forever();
+    request.markStarted();
+
+    // Act
+    request.restartAsync(server, false);
+
+    // Assert
+    assertFalse(request.isStarted());
+    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
+    verify(jobRunner)
+        .queue(jobCaptor.capture(), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
+    verify(executionPort, never()).execute(any(), anyString());
+
+    boolean checkpointRequested = jobCaptor.getValue().run(context);
+
+    assertTrue(checkpointRequested);
+    assertEquals(1, request.restartCalls);
+    assertSame(context, request.lastRestartContext);
+    assertFalse(request.lastDisableFilterData);
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static ClientContext newContextWithJobRunner(PersistentJobRunner jobRunner) {
+    ClientContext context =
+        Mockito.mock(
+            ClientContext.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    try {
+      Field field = ClientContext.class.getDeclaredField("jobRunner");
+      field.setAccessible(true);
+      field.set(context, jobRunner);
+      return context;
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed to set ClientContext.jobRunner", e);
+    }
+  }
+
+  private static final class TestClientRequest extends ClientRequest {
+    private ClientContext lastRestartContext;
+    private boolean lastDisableFilterData;
+    private int restartCalls;
+
+    private TestClientRequest(ConstructorInit init) {
+      super(init);
+    }
+
+    static TestClientRequest connection() {
+      return new TestClientRequest(
+          prepareConstructorInit(
+              new ClientRequestParams(
+                  null,
+                  "connection-request",
+                  0,
+                  (short) 1,
+                  Persistence.CONNECTION,
+                  false,
+                  null,
+                  false),
+              null));
+    }
+
+    static TestClientRequest forever() {
+      PersistentRequestRoot root = new PersistentRequestRoot();
+      PersistentRequestClient client = root.registerForeverClient("restart-client", null);
+      return new TestClientRequest(
+          prepareConstructorInit(
+              new ClientRequestParams(
+                  null, "forever-request", 0, (short) 1, Persistence.FOREVER, false, null, false),
+              null,
+              client));
+    }
+
+    void markStarted() {
+      started = true;
+    }
+
+    @Override
+    public void onLostConnection(ClientContext context) {
+      // This test double only exercises restart scheduling and does not simulate connection loss.
+    }
+
+    @Override
+    public void sendPendingMessages(
+        FCPConnectionOutputHandler handler,
+        String listRequestIdentifier,
+        boolean includeData,
+        boolean onlyData) {
+      // Restart scheduling does not emit pending FCP messages in this focused test.
+    }
+
+    @Override
+    void register(boolean noTags) {
+      // The test invokes restartAsync() directly and does not participate in normal registration.
+    }
+
+    @Override
+    protected ClientRequester getClientRequest() {
+      return null;
+    }
+
+    @Override
+    protected void freeData() {
+      // The test request never allocates external data that needs explicit cleanup.
+    }
+
+    @Override
+    public double getSuccessFraction() {
+      return 0;
+    }
+
+    @Override
+    public double getTotalBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getMinBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFetchedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFatalyFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public String getFailureReason(boolean longDescription) {
+      return "failure";
+    }
+
+    @Override
+    public boolean isTotalFinalized() {
+      return true;
+    }
+
+    @Override
+    public void start(ClientContext context) {
+      // Starting the request is outside this test's scope; only restart dispatch is validated.
+    }
+
+    @Override
+    public boolean hasSucceeded() {
+      return false;
+    }
+
+    @Override
+    public boolean canRestart() {
+      return true;
+    }
+
+    @Override
+    public boolean restart(ClientContext context, boolean disableFilterData) {
+      restartCalls++;
+      lastRestartContext = context;
+      lastDisableFilterData = disableFilterData;
+      return true;
+    }
+
+    @Override
+    RequestStatus getStatus() {
+      return null;
+    }
+
+    @Override
+    protected void innerResume(ClientContext context) {
+      // This focused test covers restartAsync() only and does not model resume behavior.
+    }
+
+    @Override
+    RequestIdentifier.RequestType getType() {
+      return RequestIdentifier.RequestType.GET;
+    }
+
+    @Override
+    public boolean fullyResumed() {
+      return true;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -6,6 +6,7 @@ import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.api.Bucket;
 import org.junit.jupiter.api.Test;
@@ -27,8 +28,10 @@ class FCPServerTest {
 
   @Mock private NodeClientCore core;
   @Mock private RuntimePorts runtimePorts;
+  @Mock private ExecutionPort executionPort;
 
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
+    when(runtimePorts.execution()).thenReturn(executionPort);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -95,6 +98,7 @@ class FCPServerTest {
   void unregisterClient_whenForeverClient_delegatesToRoot() {
     // Arrange
     PersistentRequestRoot root = spy(new PersistentRequestRoot());
+    when(runtimePorts.execution()).thenReturn(executionPort);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -161,28 +165,10 @@ class FCPServerTest {
     FCPServer server = newServer(false, false);
     PersistentRequestClient rebootClient = server.getGlobalRebootClient();
     FreenetURI uri = mock(FreenetURI.class);
-    RequestStatusSnapshot statusSnapshot =
-        new RequestStatusSnapshot(
-            "id-1",
-            Persistence.REBOOT,
-            false,
-            false,
-            false,
-            0,
-            0,
-            0,
-            null,
-            0,
-            0,
-            null,
-            false,
-            (short) 0);
-    DownloadOutcomeInfo outcome =
-        new DownloadOutcomeInfo(10, "text/plain", null, null, null, mock(Bucket.class), false);
-    DownloadRequestStatusDetails details =
-        new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
-    DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
-    rebootClient.getRequestStatusCache().addDownload(status);
+    DownloadRequestStatus status =
+        newDownloadStatus(
+            "id-1", Persistence.REBOOT, false, 10, "text/plain", mock(Bucket.class), uri);
+    requireStatusCache(rebootClient).addDownload(status);
 
     // Act
     RequestStatus[] result = server.getGlobalRequests();
@@ -196,32 +182,13 @@ class FCPServerTest {
   void lookupInstant_whenShadowBucketPresent_returnsCachedResult() {
     // Arrange
     FCPServer server = newServer(false, false);
-    PersistentRequestClient foreverClient = server.getGlobalForeverClient();
+    PersistentRequestClient foreverClient = requireClient(server.getGlobalForeverClient());
     FreenetURI uri = mock(FreenetURI.class);
     Bucket bucket = mock(Bucket.class);
     when(bucket.size()).thenReturn(5L);
-    RequestStatusSnapshot statusSnapshot =
-        new RequestStatusSnapshot(
-            "cached",
-            Persistence.FOREVER,
-            false,
-            false,
-            true,
-            0,
-            0,
-            0,
-            null,
-            0,
-            0,
-            null,
-            true,
-            (short) 0);
-    DownloadOutcomeInfo outcome =
-        new DownloadOutcomeInfo(5, "image/png", null, null, null, bucket, false);
-    DownloadRequestStatusDetails details =
-        new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
-    DownloadRequestStatus status = new DownloadRequestStatus(statusSnapshot, details);
-    foreverClient.getRequestStatusCache().addDownload(status);
+    DownloadRequestStatus status =
+        newDownloadStatus("cached", Persistence.FOREVER, true, 5, "image/png", bucket, uri);
+    requireStatusCache(foreverClient).addDownload(status);
 
     // Act
     CacheFetchResult result = server.lookupInstant(uri, false, false, null);
@@ -234,5 +201,51 @@ class FCPServerTest {
       assertNotSame(bucket, resultBucket);
       assertEquals(5L, resultBucket.size());
     }
+  }
+
+  private static RequestStatusCache requireStatusCache(PersistentRequestClient client) {
+    RequestStatusCache cache = client.getRequestStatusCache();
+    if (cache == null) {
+      throw new AssertionError("Expected global client to expose a request status cache");
+    }
+    return cache;
+  }
+
+  private static PersistentRequestClient requireClient(PersistentRequestClient client) {
+    if (client == null) {
+      throw new AssertionError("Expected global forever client to be available");
+    }
+    return client;
+  }
+
+  private static DownloadRequestStatus newDownloadStatus(
+      String identifier,
+      Persistence persistence,
+      boolean success,
+      long dataSize,
+      String mimeType,
+      Bucket dataShadow,
+      FreenetURI uri) {
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            identifier,
+            persistence,
+            false,
+            false,
+            success,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            success,
+            (short) 0);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(dataSize, mimeType, null, null, null, dataShadow, false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(outcome, null, null, null, uri, false, false);
+    return new DownloadRequestStatus(statusSnapshot, details);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FcpRuntimeAdaptersTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpRuntimeAdaptersTest.java
@@ -1,0 +1,251 @@
+package network.crypta.clients.fcp;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import network.crypta.crypt.EntropySource;
+import network.crypta.crypt.RandomSource;
+import network.crypta.runtime.spi.ExecutionPort;
+import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.PriorityAwareExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class FcpRuntimeAdaptersTest {
+
+  @Mock private RuntimePorts runtime;
+
+  @Mock private ExecutionPort execution;
+
+  @Mock private RandomnessPort randomness;
+
+  @Test
+  void priorityAwareExecutor_whenExecuteCalledWithoutName_usesRunnableClassName() {
+    // Arrange
+    when(runtime.execution()).thenReturn(execution);
+    PriorityAwareExecutor adapter = FcpRuntimeAdapters.priorityAwareExecutor(runtime);
+    Runnable job = new TestRunnable();
+
+    // Act
+    adapter.execute(job);
+
+    // Assert
+    verify(runtime).execution();
+    verify(execution).execute(job, TestRunnable.class.getName());
+  }
+
+  @ParameterizedTest
+  @MethodSource("blankOrNullNames")
+  void priorityAwareExecutor_whenJobNameMissing_usesRunnableClassName(String jobName) {
+    // Arrange
+    when(runtime.execution()).thenReturn(execution);
+    PriorityAwareExecutor adapter = FcpRuntimeAdapters.priorityAwareExecutor(runtime);
+    Runnable job = new TestRunnable();
+
+    // Act
+    adapter.execute(job, jobName);
+
+    // Assert
+    verify(execution).execute(job, TestRunnable.class.getName());
+  }
+
+  @Test
+  void priorityAwareExecutor_whenExecuteCalledWithTickerHint_delegatesProvidedJobName() {
+    // Arrange
+    when(runtime.execution()).thenReturn(execution);
+    PriorityAwareExecutor adapter = FcpRuntimeAdapters.priorityAwareExecutor(runtime);
+    Runnable job = new TestRunnable();
+
+    // Act
+    adapter.execute(job, "restart-request", true);
+
+    // Assert
+    verify(execution).execute(job, "restart-request");
+  }
+
+  @Test
+  void priorityAwareExecutor_whenIntrospectionRequested_returnsIndependentEmptySnapshots() {
+    // Arrange
+    when(runtime.execution()).thenReturn(execution);
+    PriorityAwareExecutor adapter = FcpRuntimeAdapters.priorityAwareExecutor(runtime);
+
+    // Act
+    int[] waitingThreads = adapter.waitingThreads();
+    int[] nextWaitingThreads = adapter.waitingThreads();
+    int[] runningThreads = adapter.runningThreads();
+    int waitingThreadsCount = adapter.getWaitingThreadsCount();
+
+    // Assert
+    assertArrayEquals(new int[0], waitingThreads);
+    assertArrayEquals(new int[0], runningThreads);
+    assertNotSame(waitingThreads, nextWaitingThreads);
+    assertEquals(0, waitingThreadsCount);
+  }
+
+  @Test
+  void priorityAwareExecutor_whenJobIsNull_throwsNullPointerException() {
+    // Arrange
+    when(runtime.execution()).thenReturn(execution);
+    PriorityAwareExecutor adapter = FcpRuntimeAdapters.priorityAwareExecutor(runtime);
+
+    // Act + Assert
+    assertThrows(NullPointerException.class, () -> adapter.execute(null, "null-job"));
+  }
+
+  @Test
+  void secureRandomSource_whenNextBytesCalled_fillsTargetFromRandomnessPort() {
+    // Arrange
+    byte[] expected = new byte[] {1, 2, 3, 4};
+    RandomSource source = FcpRuntimeAdapters.secureRandomSource(randomness);
+    byte[] target = new byte[expected.length];
+    doAnswer(
+            invocation -> {
+              byte[] bytes = invocation.getArgument(0);
+              System.arraycopy(expected, 0, bytes, 0, expected.length);
+              return null;
+            })
+        .when(randomness)
+        .fillSecureRandom(same(target));
+
+    // Act
+    source.nextBytes(target);
+
+    // Assert
+    assertArrayEquals(expected, target);
+    verify(randomness).fillSecureRandom(same(target));
+  }
+
+  @Test
+  void secureRandomSource_whenPrimitiveRandomMethodsCalled_usesSecureRandomBytes() {
+    // Arrange
+    RandomSource source = FcpRuntimeAdapters.secureRandomSource(randomness);
+    stubSecureRandomResponses(
+        randomness, new byte[] {0x12, 0x34, 0x56, 0x78}, new byte[] {(byte) 0x80, 0, 0, 0});
+
+    // Act
+    int value = source.nextInt();
+    boolean flag = source.nextBoolean();
+
+    // Assert
+    assertEquals(0x12345678, value);
+    assertTrue(flag);
+  }
+
+  @Test
+  void secureRandomSource_whenEntropyMethodsAndCloseCalled_returnsZeroWithoutUsingPort() {
+    // Arrange
+    RandomSource source = FcpRuntimeAdapters.secureRandomSource(randomness);
+    EntropySource entropySource = new EntropySource();
+    byte[] entropyBytes = new byte[] {9, 8, 7};
+
+    // Act
+    int acceptEntropy = source.acceptEntropy(entropySource, 42L, 12);
+    int acceptTimerEntropy = source.acceptTimerEntropy(entropySource);
+    int acceptTimerEntropyWithBias = source.acceptTimerEntropy(entropySource, 0.5d);
+    int acceptEntropyBytes = source.acceptEntropyBytes(entropySource, entropyBytes, 0, 2, 0.25d);
+
+    // Assert
+    assertEquals(0, acceptEntropy);
+    assertEquals(0, acceptTimerEntropy);
+    assertEquals(0, acceptTimerEntropyWithBias);
+    assertEquals(0, acceptEntropyBytes);
+    assertDoesNotThrow(source::close);
+    verifyNoInteractions(randomness);
+  }
+
+  @Test
+  void secureRandomSource_whenDeserialized_randomCallsFailWithClearMessage() throws Exception {
+    // Arrange
+    RandomSource original = FcpRuntimeAdapters.secureRandomSource(randomness);
+    RandomSource restored = serializeRoundTrip(original);
+
+    // Act + Assert
+    NullPointerException exception =
+        assertThrows(NullPointerException.class, () -> restored.nextBytes(new byte[1]));
+    assertEquals(
+        "RandomnessPortRandomSource must not be used after serialization", exception.getMessage());
+    assertDoesNotThrow(restored::close);
+  }
+
+  @Test
+  void nextSecureLong_whenCalled_returnsLongFromSecureBytes() {
+    // Arrange
+    byte[] expectedBytes = new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
+    doAnswer(
+            invocation -> {
+              byte[] target = invocation.getArgument(0);
+              assertEquals(Long.BYTES, target.length);
+              System.arraycopy(expectedBytes, 0, target, 0, target.length);
+              return null;
+            })
+        .when(randomness)
+        .fillSecureRandom(any(byte[].class));
+
+    // Act
+    long value = FcpRuntimeAdapters.nextSecureLong(randomness);
+
+    // Assert
+    assertEquals(0x0102030405060708L, value);
+  }
+
+  private static Stream<String> blankOrNullNames() {
+    return Stream.of(null, "", "   ");
+  }
+
+  private static RandomSource serializeRoundTrip(RandomSource source) throws Exception {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+      objectOutput.writeObject(source);
+    }
+
+    try (ObjectInputStream objectInput =
+        new ObjectInputStream(new ByteArrayInputStream(output.toByteArray()))) {
+      return (RandomSource) objectInput.readObject();
+    }
+  }
+
+  private static void stubSecureRandomResponses(RandomnessPort randomness, byte[]... responses) {
+    AtomicInteger callCount = new AtomicInteger();
+    doAnswer(
+            invocation -> {
+              int index = callCount.getAndIncrement();
+              byte[] target = invocation.getArgument(0);
+              byte[] response = responses[index];
+              assertEquals(response.length, target.length);
+              System.arraycopy(response, 0, target, 0, target.length);
+              return null;
+            })
+        .when(randomness)
+        .fillSecureRandom(any(byte[].class));
+  }
+
+  private static final class TestRunnable implements Runnable {
+    @Override
+    public void run() {
+      // No-op test task used to verify executor delegation.
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
@@ -6,6 +6,7 @@ import network.crypta.config.SubConfig;
 import network.crypta.io.NetworkInterface;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,12 +33,14 @@ class FcpServerConfigRegistrarTest {
   private NodeClientCore core;
 
   @Mock private RuntimePorts runtimePorts;
+  @Mock private ExecutionPort executionPort;
 
   @Test
   void maybeCreate_whenDefaults_expectConfiguredServerAndInitializedSubConfig() {
     // Arrange
     Config config = new Config();
     PersistentRequestRoot root = new PersistentRequestRoot();
+    when(runtimePorts.execution()).thenReturn(executionPort);
 
     // Act
     FCPServer server = FcpServerConfigRegistrar.maybeCreate(node, core, runtimePorts, config, root);
@@ -221,6 +224,7 @@ class FcpServerConfigRegistrarTest {
   }
 
   private FCPServer newServer() {
+    when(runtimePorts.execution()).thenReturn(executionPort);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",

--- a/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
@@ -1,11 +1,16 @@
 package network.crypta.clients.fcp;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.Socket;
 import network.crypta.io.NetworkInterface;
-import network.crypta.node.Node;
+import network.crypta.runtime.spi.ExecutionPort;
+import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.RuntimePorts;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.tanukisoftware.wrapper.WrapperManager;
 
@@ -17,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,7 +32,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class FcpServerListenerTest {
 
-  @Mock private Node node;
+  @Mock private FCPServer server;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private ExecutionPort executionPort;
+  @Mock private LifecyclePort lifecyclePort;
 
   @Test
   void isSslEnabled_whenToggled_expectUpdatedValue() {
@@ -155,8 +165,47 @@ class FcpServerListenerTest {
     verify(networkInterface).waitBound();
   }
 
+  @Test
+  void realRun_whenRuntimeNotStarted_expectAcceptSkipped() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+    NetworkInterface networkInterface = mock(NetworkInterface.class);
+    setNetworkInterface(listener, networkInterface);
+    when(runtimePorts.lifecycle()).thenReturn(lifecyclePort);
+    when(lifecyclePort.hasStarted()).thenReturn(false);
+
+    // Act
+    invokeRealRun(listener);
+
+    // Assert
+    verify(networkInterface, never()).accept();
+  }
+
+  @Test
+  void realRun_whenRuntimeStarted_expectConnectionHandlerStarted() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+    NetworkInterface networkInterface = mock(NetworkInterface.class);
+    Socket socket = mock(Socket.class);
+    setNetworkInterface(listener, networkInterface);
+    when(runtimePorts.lifecycle()).thenReturn(lifecyclePort);
+    when(lifecyclePort.hasStarted()).thenReturn(true);
+    when(networkInterface.accept()).thenReturn(socket);
+
+    // Act
+    try (MockedConstruction<FCPConnectionHandler> construction =
+        mockConstruction(FCPConnectionHandler.class)) {
+      invokeRealRun(listener);
+
+      // Assert
+      assertEquals(1, construction.constructed().size());
+      verify(networkInterface).accept();
+      verify(construction.constructed().getFirst()).start();
+    }
+  }
+
   private FcpServerListener newListener(boolean enabled) {
-    FCPServer server = mock(FCPServer.class);
+    when(runtimePorts.execution()).thenReturn(executionPort);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -168,7 +217,7 @@ class FcpServerListenerTest {
             false,
             false,
             10);
-    return new FcpServerListener(server, node, config);
+    return new FcpServerListener(server, runtimePorts, config);
   }
 
   private void setNetworkInterface(FcpServerListener listener, NetworkInterface value)
@@ -190,5 +239,11 @@ class FcpServerListenerTest {
     Object value = field.get(listener);
     assertNotNull(value);
     return (String) value;
+  }
+
+  private void invokeRealRun(FcpServerListener listener) throws Exception {
+    Method method = FcpServerListener.class.getDeclaredMethod("realRun");
+    method.setAccessible(true);
+    method.invoke(listener);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/GenerateSSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GenerateSSKMessageTest.java
@@ -1,9 +1,12 @@
 package network.crypta.clients.fcp;
 
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +15,10 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -57,9 +63,13 @@ class GenerateSSKMessageTest {
     GenerateSSKMessage message = new GenerateSSKMessage(fs);
 
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    RandomSource randomSource = mock(RandomSource.class);
-    when(node.bootstrap().random()).thenReturn(randomSource);
+    FCPServer server = mock(FCPServer.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    RandomnessPort randomnessPort = mock(RandomnessPort.class);
+    Node node = mock(Node.class);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.randomness()).thenReturn(randomnessPort);
 
     FreenetURI insertUri =
         new FreenetURI("SSK", "insert", new byte[] {1, 2}, new byte[32], new byte[] {3});
@@ -69,16 +79,26 @@ class GenerateSSKMessageTest {
     InsertableClientSSK generatedKey = mock(InsertableClientSSK.class);
     when(generatedKey.getInsertURI()).thenReturn(insertUri);
     when(generatedKey.getURI()).thenReturn(requestUri);
+    AtomicReference<RandomSource> randomAdapterRef = new AtomicReference<>();
 
     try (MockedStatic<InsertableClientSSK> mocked = mockStatic(InsertableClientSSK.class)) {
       mocked
-          .when(() -> InsertableClientSSK.createRandom(randomSource, ""))
-          .thenReturn(generatedKey);
+          .when(() -> InsertableClientSSK.createRandom(any(RandomSource.class), eq("")))
+          .thenAnswer(
+              invocation -> {
+                RandomSource randomSource = invocation.getArgument(0);
+                randomAdapterRef.set(randomSource);
+                randomSource.nextBytes(new byte[16]);
+                return generatedKey;
+              });
 
       message.run(handler, node);
 
-      mocked.verify(() -> InsertableClientSSK.createRandom(randomSource, ""), times(1));
-      verify(node.bootstrap(), times(1)).random();
+      mocked.verify(
+          () -> InsertableClientSSK.createRandom(any(RandomSource.class), eq("")), times(1));
+      assertNotNull(randomAdapterRef.get());
+      verify(randomnessPort, times(1)).fillSecureRandom(any(byte[].class));
+      verify(runtimePorts, times(1)).randomness();
 
       ArgumentCaptor<SSKKeypairMessage> captor = ArgumentCaptor.forClass(SSKKeypairMessage.class);
       verify(handler, times(1)).send(captor.capture());
@@ -95,9 +115,13 @@ class GenerateSSKMessageTest {
     GenerateSSKMessage message = new GenerateSSKMessage(new SimpleFieldSet(true));
 
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    RandomSource randomSource = mock(RandomSource.class);
-    when(node.bootstrap().random()).thenReturn(randomSource);
+    FCPServer server = mock(FCPServer.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    RandomnessPort randomnessPort = mock(RandomnessPort.class);
+    Node node = mock(Node.class);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.randomness()).thenReturn(randomnessPort);
 
     FreenetURI insertUri =
         new FreenetURI("SSK", "insert", new byte[] {7, 8}, new byte[32], new byte[] {9});
@@ -110,10 +134,17 @@ class GenerateSSKMessageTest {
 
     try (MockedStatic<InsertableClientSSK> mocked = mockStatic(InsertableClientSSK.class)) {
       mocked
-          .when(() -> InsertableClientSSK.createRandom(randomSource, ""))
-          .thenReturn(generatedKey);
+          .when(() -> InsertableClientSSK.createRandom(any(RandomSource.class), eq("")))
+          .thenAnswer(
+              invocation -> {
+                RandomSource randomSource = invocation.getArgument(0);
+                randomSource.nextBytes(new byte[16]);
+                return generatedKey;
+              });
 
       message.run(handler, node);
+
+      verify(randomnessPort, times(1)).fillSecureRandom(any(byte[].class));
 
       ArgumentCaptor<SSKKeypairMessage> captor = ArgumentCaptor.forClass(SSKKeypairMessage.class);
       verify(handler, times(1)).send(captor.capture());

--- a/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
@@ -1,15 +1,16 @@
 package network.crypta.clients.fcp;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.crypt.RandomSource;
 import network.crypta.node.FSParseException;
 import network.crypta.node.Node;
 import network.crypta.node.probe.Error;
 import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Probe;
 import network.crypta.node.probe.Type;
-import network.crypta.node.subsystem.NodeBootstrap;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -121,12 +122,14 @@ class ProbeRequestTest {
   void run_whenHtlMissing_usesProbeMaxHtl() throws MessageInvalidException {
     ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, null));
     when(handler.hasFullAccess()).thenReturn(true);
-    RandomSource random = mock(RandomSource.class);
-    NodeBootstrap bootstrap = mock(NodeBootstrap.class);
+    FCPServer server = mock(FCPServer.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    RandomnessPort randomnessPort = mock(RandomnessPort.class);
     NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
-    when(random.nextLong()).thenReturn(REQUEST_UID);
-    when(node.bootstrap()).thenReturn(bootstrap);
-    when(bootstrap.random()).thenReturn(random);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.randomness()).thenReturn(randomnessPort);
+    stubProbeUid(randomnessPort);
     when(node.network()).thenReturn(network);
     ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
 
@@ -141,12 +144,14 @@ class ProbeRequestTest {
   void run_whenHtlProvided_usesProvidedValue() throws MessageInvalidException {
     ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 12));
     when(handler.hasFullAccess()).thenReturn(true);
-    RandomSource random = mock(RandomSource.class);
-    NodeBootstrap bootstrap = mock(NodeBootstrap.class);
+    FCPServer server = mock(FCPServer.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    RandomnessPort randomnessPort = mock(RandomnessPort.class);
     NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
-    when(random.nextLong()).thenReturn(REQUEST_UID);
-    when(node.bootstrap()).thenReturn(bootstrap);
-    when(bootstrap.random()).thenReturn(random);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.randomness()).thenReturn(randomnessPort);
+    stubProbeUid(randomnessPort);
     when(node.network()).thenReturn(network);
     ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
 
@@ -358,12 +363,14 @@ class ProbeRequestTest {
 
   private Listener runAndCaptureListener(ProbeRequest request) throws MessageInvalidException {
     when(handler.hasFullAccess()).thenReturn(true);
-    RandomSource random = mock(RandomSource.class);
-    NodeBootstrap bootstrap = mock(NodeBootstrap.class);
+    FCPServer server = mock(FCPServer.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    RandomnessPort randomnessPort = mock(RandomnessPort.class);
     NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
-    when(random.nextLong()).thenReturn(REQUEST_UID);
-    when(node.bootstrap()).thenReturn(bootstrap);
-    when(bootstrap.random()).thenReturn(random);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.randomness()).thenReturn(randomnessPort);
+    stubProbeUid(randomnessPort);
     when(node.network()).thenReturn(network);
     AtomicReference<Listener> listenerRef = new AtomicReference<>();
     doAnswer(
@@ -377,6 +384,18 @@ class ProbeRequestTest {
     request.run(handler, node);
 
     return listenerRef.get();
+  }
+
+  private void stubProbeUid(RandomnessPort randomnessPort) {
+    byte[] probeUid = ByteBuffer.allocate(Long.BYTES).putLong(REQUEST_UID).array();
+    doAnswer(
+            invocation -> {
+              byte[] target = invocation.getArgument(0);
+              System.arraycopy(probeUid, 0, target, 0, probeUid.length);
+              return null;
+            })
+        .when(randomnessPort)
+        .fillSecureRandom(any(byte[].class));
   }
 
   private static SimpleFieldSet fieldSet(String identifier, Type type, Byte htl) {


### PR DESCRIPTION
## Summary
- migrate the remaining FCP runtime-capability call sites to the existing runtime SPI
- route `FcpServerListener` lifecycle and execution behavior through `RuntimePorts`
- route `ClientRequest.restartAsync(...)` non-`FOREVER` scheduling through `ExecutionPort`
- route `GenerateSSKMessage` and `ProbeRequest` secure randomness through `RandomnessPort`
- keep daemon-only types local to `clients/fcp` via `FcpRuntimeAdapters`
- add focused tests for restart scheduling and runtime adapters, and update related Javadocs/comments

## Testing
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests "network.crypta.clients.fcp.FcpServerListenerTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.GenerateSSKMessageTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.ProbeRequestTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.FCPServerTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.ClientRequestRestartAsyncTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.FcpServerConfigRegistrarTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.FcpRuntimeAdaptersTest"`
- `./gradlew compileJava test --tests "network.crypta.clients.fcp.GenerateSSKMessageTest" --tests "network.crypta.clients.fcp.ProbeRequestTest"`
- `./gradlew sonarlintFile -Psonarlint.file=src/test/java/network/crypta/clients/fcp/FcpRuntimeAdaptersTest.java`
- `./gradlew test`
- `./gradlew buildJar`

## Intentionally deferred
- broader `Node` removal from `clients/fcp`
- changes to `FCPMessage.run(handler, node)`
- migrations outside the targeted FCP runtime execution/lifecycle/randomness slice