### PR TITLE
refactor(runtime): Move FCP config to runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigFieldSet.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigFieldSet.java
@@ -1,0 +1,97 @@
+package network.crypta.runtime.spi;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents one immutable node in a hierarchical configuration field tree.
+ *
+ * <p>{@code ConfigFieldSet} mirrors the shape of the daemon's legacy field-set export without
+ * exposing root-module transport classes through the runtime SPI. Each node stores only the direct
+ * scalar values and direct named subsets that appear at that level. Callers can therefore rebuild a
+ * nested response structure by walking the tree from the root outward instead of depending on a
+ * flattened dotted-key representation.
+ *
+ * <p>Instances are immutable and safe to share after construction. The constructor copies supplied
+ * maps into encounter-order-preserving {@link LinkedHashMap} instances and then exposes
+ * unmodifiable views. Empty maps are normalized to shared empty instances so adapters can return
+ * compact snapshots without leaking mutability.
+ *
+ * @param directValues direct scalar values stored at this tree level
+ * @param directSubsets direct child subsets keyed by the subset name that appears at this level
+ * @see ConfigSnapshot
+ */
+public record ConfigFieldSet(
+    Map<String, String> directValues, Map<String, ConfigFieldSet> directSubsets) {
+  /**
+   * Creates an immutable tree node from direct values and direct child subsets.
+   *
+   * <p>The constructor defensively copies both maps, preserves their encounter order where
+   * possible, and rejects {@code null} keys and values. Passing empty maps is valid and produces an
+   * empty node, but callers should prefer {@link #empty()} when no content exists.
+   *
+   * @param directValues direct scalar values to store at this tree level
+   * @param directSubsets direct child subsets to store at this tree level
+   * @throws NullPointerException if either map, any key, or any value is {@code null}
+   */
+  public ConfigFieldSet {
+    directValues = immutableDirectValues(directValues);
+    directSubsets = immutableDirectSubsets(directSubsets);
+  }
+
+  /**
+   * Returns an empty immutable tree node.
+   *
+   * <p>This is a convenience factory for callers that need a canonical representation of "no direct
+   * values and no direct subsets" without allocating mutable maps first.
+   *
+   * @return empty field-set value with no direct values and no direct subsets
+   */
+  public static ConfigFieldSet empty() {
+    return new ConfigFieldSet(Map.of(), Map.of());
+  }
+
+  /**
+   * Returns whether this node contains neither direct values nor direct subsets.
+   *
+   * <p>This is a structural check only. It does not inspect descendant nodes beyond the already
+   * stored direct subsets because empty descendant nodes should normally have been filtered before
+   * construction by the exporting adapter.
+   *
+   * @return {@code true} when this node contains no direct values and no direct subsets
+   */
+  public boolean isEmpty() {
+    return directValues.isEmpty() && directSubsets.isEmpty();
+  }
+
+  private static Map<String, String> immutableDirectValues(Map<String, String> source) {
+    Objects.requireNonNull(source, "directValues");
+    if (source.isEmpty()) {
+      return Map.of();
+    }
+    LinkedHashMap<String, String> copy = LinkedHashMap.newLinkedHashMap(source.size());
+    for (Map.Entry<String, String> entry : source.entrySet()) {
+      copy.put(
+          Objects.requireNonNull(entry.getKey(), "directValues key"),
+          Objects.requireNonNull(entry.getValue(), "directValues value"));
+    }
+    return Collections.unmodifiableMap(copy);
+  }
+
+  private static Map<String, ConfigFieldSet> immutableDirectSubsets(
+      Map<String, ConfigFieldSet> source) {
+    Objects.requireNonNull(source, "directSubsets");
+    if (source.isEmpty()) {
+      return Map.of();
+    }
+    LinkedHashMap<String, ConfigFieldSet> copy = LinkedHashMap.newLinkedHashMap(source.size());
+    for (Map.Entry<String, ConfigFieldSet> entry : source.entrySet()) {
+      copy.put(
+          Objects.requireNonNull(entry.getKey(), "directSubsets key"),
+          Objects.requireNonNull(entry.getValue(), "directSubsets value"));
+    }
+    return Collections.unmodifiableMap(copy);
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigPort.java
@@ -1,0 +1,65 @@
+package network.crypta.runtime.spi;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Exposes runtime configuration export and update capabilities without leaking daemon-only types.
+ *
+ * <p>This management-facing port gives infrastructure code a narrow closed loop around the
+ * configuration state: export one or more logical sections, apply textual overrides keyed by a
+ * dotted option name, and then persist the resulting state through the runtime's existing
+ * persistence path. The SPI deliberately does not expose daemon config registries, option objects,
+ * storage internals, or transport-specific field-set implementations.
+ *
+ * <p>Typical callers are request handlers that need to:
+ *
+ * <ul>
+ *   <li>perform access control in a higher layer;
+ *   <li>request a point-in-time configuration snapshot;
+ *   <li>apply validated textual overrides; and
+ *   <li>persist the resulting runtime state when appropriate.
+ * </ul>
+ *
+ * <p>Implementations may preserve legacy semantics such as ignoring unknown keys or logging invalid
+ * values. Those policies remain implementation details so the SPI can stay JDK-only and stable
+ * across runtime adapters.
+ *
+ * @see RuntimePorts
+ * @see ConfigSnapshot
+ */
+public interface ConfigPort {
+  /**
+   * Exports the requested configuration sections as an immutable snapshot.
+   *
+   * <p>The returned snapshot represents a point-in-time view that is suitable for immediate
+   * response serialization. Implementations may omit sections that were not requested or that
+   * resolve to empty exports. Callers should therefore treat the result as sparse rather than
+   * assuming that every requested section will be present.
+   *
+   * @param sections configuration sections to export for the current request
+   * @return immutable snapshot containing the requested sections that exported non-empty content
+   */
+  ConfigSnapshot export(Set<ConfigSection> sections);
+
+  /**
+   * Applies textual overrides keyed by the dotted configuration name.
+   *
+   * <p>The SPI accepts already-parsed textual values and leaves validation, lookup, and error
+   * handling to the runtime implementation. Unknown keys may be ignored according to existing
+   * behavior, and a successful application does not imply persistence. Callers that need durable
+   * changes should invoke {@link #persist()} explicitly after the update pass completes.
+   *
+   * @param overrides requested overrides keyed by dotted option name such as {@code node.maxPeers}
+   */
+  void applyOverrides(Map<String, String> overrides);
+
+  /**
+   * Persists the current configuration state using the runtime's existing persistence path.
+   *
+   * <p>This method does not define transactional or change-detection behavior. Implementations may
+   * persist even when no values changed, when some overrides were ignored, or when validation
+   * failures were logged during a prior {@link #applyOverrides(Map)} call.
+   */
+  void persist();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigSection.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigSection.java
@@ -1,0 +1,47 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Names the configuration sections that management-facing code may request from the runtime.
+ *
+ * <p>This enum preserves the existing FCP configuration export families while keeping the runtime
+ * SPI free of daemon-only types such as {@code Config.RequestType}. Callers usually combine one or
+ * more constants in a {@link java.util.Set} and pass that set to {@link
+ * ConfigPort#export(java.util.Set)} to request only the slices needed for a specific response. The
+ * enum does not define storage layout or wire encoding. It only names the logical views that the
+ * runtime can export at a point in time.
+ *
+ * <p>The sections are intentionally small and stable:
+ *
+ * <ul>
+ *   <li>value-oriented sections describe effective or default option values;
+ *   <li>metadata sections describe presentation, ordering, or operator-facing text;
+ *   <li>flag sections expose boolean attributes used by existing FCP clients.
+ * </ul>
+ *
+ * @see ConfigPort
+ * @see ConfigSnapshot
+ */
+public enum ConfigSection {
+  /**
+   * Exports the current effective values after defaults and persisted overrides have been applied.
+   */
+  CURRENT,
+  /** Exports the default values that apply before an operator or node process overrides them. */
+  DEFAULTS,
+  /**
+   * Exports relative ordering hints so clients can present sibling options in a stable sequence.
+   */
+  SORT_ORDER,
+  /** Exports whether each option is marked as expert-only in the underlying configuration model. */
+  EXPERT_FLAG,
+  /** Exports whether each option is force-written even when persistence would otherwise omit it. */
+  FORCE_WRITE_FLAG,
+  /**
+   * Exports the short operator-facing description string associated with each configuration item.
+   */
+  SHORT_DESCRIPTION,
+  /** Exports the longer descriptive text that explains a configuration item in more detail. */
+  LONG_DESCRIPTION,
+  /** Exports the declared data-type label that existing clients use to interpret option values. */
+  DATA_TYPES
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigSnapshot.java
@@ -1,0 +1,85 @@
+package network.crypta.runtime.spi;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents an immutable point-in-time export of runtime configuration sections.
+ *
+ * <p>A snapshot groups one or more {@link ConfigSection} values with their corresponding
+ * hierarchical {@link ConfigFieldSet} payloads. It is the management-facing response object that
+ * flows through the runtime SPI after the daemon adapter has exported configuration data and before
+ * higher layers serialize that data into a wire-specific form. Keeping this value object in the SPI
+ * prevents request handlers from depending on daemon configuration internals.
+ *
+ * <p>The snapshot is intentionally sparse. It retains only sections that were requested and that
+ * produced non-empty content. That keeps responses compact, avoids empty structural noise, and lets
+ * callers distinguish between "not requested or empty" and "present with data" by checking the
+ * returned map directly.
+ *
+ * @param sections exported configuration sections keyed by {@link ConfigSection}
+ * @see ConfigFieldSet
+ * @see ConfigPort
+ */
+public record ConfigSnapshot(Map<ConfigSection, ConfigFieldSet> sections) {
+  /**
+   * Creates an immutable snapshot of exported configuration sections.
+   *
+   * <p>The constructor copies the supplied map into an {@link EnumMap}, rejects {@code null} keys
+   * and values, and filters out sections whose field-set payload is empty. Callers may therefore
+   * pass a broader intermediate map and rely on the snapshot to normalize it into a compact,
+   * immutable view.
+   *
+   * @param sections section payloads keyed by the exported section name
+   * @throws NullPointerException if the map, any section key, or any field-set value is {@code
+   *     null}
+   */
+  public ConfigSnapshot {
+    sections = immutableSections(sections);
+  }
+
+  /**
+   * Returns an empty configuration snapshot.
+   *
+   * <p>This convenience factory returns a snapshot with no exported sections. It is useful when a
+   * caller has no matching data or when a runtime adapter can short-circuit an export request
+   * without building an intermediate map.
+   *
+   * @return empty snapshot with no exported sections
+   */
+  public static ConfigSnapshot empty() {
+    return new ConfigSnapshot(Map.of());
+  }
+
+  /**
+   * Returns whether the snapshot contains no exported sections.
+   *
+   * <p>This check reflects the normalized stored state after empty sections have been filtered out
+   * by the constructor. A snapshot can therefore be empty either because nothing was requested or
+   * because every requested section exported as empty content.
+   *
+   * @return {@code true} when the snapshot contains no exported sections
+   */
+  public boolean isEmpty() {
+    return sections.isEmpty();
+  }
+
+  private static Map<ConfigSection, ConfigFieldSet> immutableSections(
+      Map<ConfigSection, ConfigFieldSet> source) {
+    Objects.requireNonNull(source, "sections");
+    if (source.isEmpty()) {
+      return Map.of();
+    }
+    EnumMap<ConfigSection, ConfigFieldSet> copy = new EnumMap<>(ConfigSection.class);
+    for (Map.Entry<ConfigSection, ConfigFieldSet> entry : source.entrySet()) {
+      ConfigSection section = Objects.requireNonNull(entry.getKey(), "sections key");
+      ConfigFieldSet fieldSet = Objects.requireNonNull(entry.getValue(), "sections value");
+      if (!fieldSet.isEmpty()) {
+        copy.put(section, fieldSet);
+      }
+    }
+    return copy.isEmpty() ? Map.of() : Collections.unmodifiableMap(copy);
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -3,11 +3,11 @@ package network.crypta.runtime.spi;
 /**
  * Aggregate entry point for runtime-facing SPI adapters used by higher layers.
  *
- * <p>This interface groups the small set of runtime capabilities that PR-2 makes available outside
- * the daemon root module. Instead of injecting several unrelated services into infrastructure code,
- * the runtime exposes one stable handle that can be threaded through legacy code paths with minimal
+ * <p>This interface groups the small set of runtime capabilities currently exposed outside the
+ * daemon root module. Instead of injecting several unrelated services into infrastructure code, the
+ * runtime exposes one stable handle that can be threaded through legacy code paths with minimal
  * disruption. Each sub-port narrows access to a specific concern such as execution, randomness,
- * file-transfer policy, or lifecycle observation.
+ * file-transfer policy, lifecycle observation, or configuration management.
  *
  * <p>The aggregate is intentionally small and JDK-only. It is not a general domain API for the
  * node, and it does not attempt to model every daemon subsystem. Future adapters can depend on this
@@ -18,6 +18,7 @@ package network.crypta.runtime.spi;
  * @see RandomnessPort
  * @see TransferAccessPort
  * @see LifecyclePort
+ * @see ConfigPort
  */
 public interface RuntimePorts {
   /**
@@ -65,4 +66,16 @@ public interface RuntimePorts {
    * @return lifecycle runtime port for observing startup time and state flags
    */
   LifecyclePort lifecycle();
+
+  /**
+   * Returns the configuration capability exposed to infrastructure code.
+   *
+   * <p>This port lets higher layers export selected configuration sections, apply dotted-name
+   * overrides, and request persistence without depending on daemon configuration classes. The
+   * returned object should be treated as a live runtime view backed by the node's existing config
+   * subsystem.
+   *
+   * @return configuration runtime port for export, update, and persistence operations
+   */
+  ConfigPort config();
 }

--- a/src/main/java/network/crypta/clients/fcp/ConfigData.java
+++ b/src/main/java/network/crypta/clients/fcp/ConfigData.java
@@ -1,25 +1,27 @@
 package network.crypta.clients.fcp;
 
 import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-import network.crypta.config.Config;
-import network.crypta.config.PersistentConfig;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
 import network.crypta.support.SimpleFieldSet;
 
 /**
  * Server-to-client FCP message that transports slices of the node configuration.
  *
- * <p>This type assembles a {@link SimpleFieldSet} containing whichever option categories a caller
- * requests (current values, defaults, metadata flags, descriptions, and data types). The resulting
- * tree mirrors the structure returned by {@link PersistentConfig#exportFieldSet(Config.RequestType,
- * boolean)} for each category, letting remote tooling reconstruct the node's configuration dialog
- * without needing multiple round trips.
+ * <p>This type holds an immutable {@link ConfigSnapshot} produced by the runtime SPI and rebuilds
+ * the corresponding {@link SimpleFieldSet} only when the FCP layer serializes the response. The
+ * resulting payload mirrors the historical configuration export tree without keeping live daemon
+ * objects in the message itself.
  *
  * <p>Each instance is immutable once constructed. Callers decide at construction time which
- * sections should be included and whether an identifier should be attached so that asynchronous
- * responses can be correlated. The exporter queries the {@link Node} configuration only if at least
- * one section is requested, preventing unnecessary work when the message would otherwise be empty.
+ * snapshot should be returned and whether an identifier should be attached so that asynchronous
+ * responses can be correlated. Empty sections are omitted from the serialized payload, matching the
+ * compact wire behavior of earlier implementations.
  *
  * <ul>
  *   <li>Intended consumers are FCP clients that need a snapshot of the configuration state.
@@ -27,47 +29,29 @@ import network.crypta.support.SimpleFieldSet;
  *   <li>The produced field set omits empty subsections so payloads stay compact.
  * </ul>
  *
- * <p>Thread-safety: instances rely on the underlying {@link PersistentConfig}; only construct them
- * in threads that can safely read configuration state, and avoid sharing mutable {@link Node}
- * references across threads without external coordination.
+ * <p>Thread-safety: instances are pure immutable values and are safe to share across threads after
+ * construction.
  */
 public class ConfigData extends FCPMessage {
   static final String NAME = "ConfigData";
 
-  /** Flags describing which configuration subsections to export. */
-  public enum Section {
-    CURRENT,
-    DEFAULTS,
-    SORT_ORDER,
-    EXPERT_FLAG,
-    FORCE_WRITE_FLAG,
-    SHORT_DESCRIPTION,
-    LONG_DESCRIPTION,
-    DATA_TYPES
-  }
-
-  final Node node;
-  private final EnumSet<Section> sections;
+  final ConfigSnapshot snapshot;
   final String requestIdentifier;
 
   /**
-   * Creates a configuration snapshot request with a precisely scoped payload budget.
+   * Creates a configuration snapshot response with a precisely scoped payload.
    *
-   * <p>The supplied section set determines which subsections are exported, allowing callers to
-   * tailor the trade-off between completeness and serialization cost. Use {@link EnumSet#noneOf} to
-   * request only an identifier, or {@link EnumSet#allOf} to include every available section. The
-   * identifier is optional but recommended for clients that expect multiple outstanding responses.
+   * <p>The supplied snapshot is already detached from daemon-only configuration types, so this
+   * message becomes a transport value that can be queued and serialized without additional runtime
+   * lookups. The identifier is optional but recommended for clients that expect multiple
+   * outstanding responses.
    *
-   * @param node node instance providing the backing {@link PersistentConfig}; must be non-null and
-   *     ready for read-only queries.
-   * @param sections subset of {@link Section} values describing which configuration views to
-   *     include.
+   * @param snapshot runtime-exported configuration snapshot to serialize
    * @param identifier identifier echoed into the payload via {@link FCPMessage#IDENTIFIER}; may be
    *     {@code null} when the caller does not need correlation.
    */
-  public ConfigData(Node node, Set<Section> sections, String identifier) {
-    this.node = node;
-    this.sections = sections.isEmpty() ? EnumSet.noneOf(Section.class) : EnumSet.copyOf(sections);
+  public ConfigData(ConfigSnapshot snapshot, String identifier) {
+    this.snapshot = Objects.requireNonNull(snapshot);
     this.requestIdentifier = identifier;
   }
 
@@ -75,115 +59,70 @@ public class ConfigData extends FCPMessage {
    * Builds the {@link SimpleFieldSet} payload that will be serialized into the outgoing FCP
    * message.
    *
-   * <p>The exporter requests each enabled subsection from {@link PersistentConfig} exactly once and
-   * attaches it under a stable key (for example {@code current}, {@code default}, or {@code
-   * shortDescription}). Empty subsections are suppressed to avoid emitting redundant braces. When
-   * no sections are enabled, the returned field set is empty unless an identifier is present.
+   * <p>The exporter rebuilds each section under its historical FCP key (for example {@code
+   * current}, {@code default}, or {@code shortDescription}). Nested values and subsets are copied
+   * recursively into a fresh {@link SimpleFieldSet}. Empty subsections are suppressed to avoid
+   * emitting redundant braces. When no sections are enabled, the returned field set is empty unless
+   * an identifier is present.
    *
    * <pre>{@code
-   * ConfigData data = new ConfigData(
-   *     node,
-   *     EnumSet.of(Section.CURRENT, Section.SHORT_DESCRIPTION),
-   *     "cfg-1");
+   * ConfigData data =
+   *     new ConfigData(
+   *         new ConfigSnapshot(
+   *             Map.of(
+   *                 ConfigSection.CURRENT,
+   *                 new ConfigFieldSet(Map.of("enabled", "true"), Map.of()))),
+   *         "cfg-1");
    * SimpleFieldSet payload = data.getFieldSet();
    * }</pre>
    *
-   * @return a short-lived field set containing the requested subsections and optional identifier;
-   *     callers must not mutate subsets that are also owned by {@link PersistentConfig}.
+   * @return a short-lived field set containing the snapshot subsections and optional identifier
    */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    PersistentConfig config = needsConfigLookup() ? node.getConfig() : null;
-    addSection(
-        fs,
-        config,
-        sections.contains(Section.CURRENT),
-        Config.RequestType.CURRENT_SETTINGS,
-        true,
-        "current");
-    addSection(
-        fs,
-        config,
-        sections.contains(Section.DEFAULTS),
-        Config.RequestType.DEFAULT_SETTINGS,
-        false,
-        "default");
-    addSection(
-        fs,
-        config,
-        sections.contains(Section.SORT_ORDER),
-        Config.RequestType.SORT_ORDER,
-        false,
-        "sortOrder");
-    addSection(
-        fs,
-        config,
-        sections.contains(Section.EXPERT_FLAG),
-        Config.RequestType.EXPERT_FLAG,
-        false,
-        "expertFlag");
-    addSection(
-        fs,
-        config,
-        sections.contains(Section.FORCE_WRITE_FLAG),
-        Config.RequestType.FORCE_WRITE_FLAG,
-        false,
-        "forceWriteFlag");
-    addSection(
-        fs,
-        config,
-        sections.contains(Section.SHORT_DESCRIPTION),
-        Config.RequestType.SHORT_DESCRIPTION,
-        false,
-        "shortDescription");
-    addSection(
-        fs,
-        config,
-        sections.contains(Section.LONG_DESCRIPTION),
-        Config.RequestType.LONG_DESCRIPTION,
-        false,
-        "longDescription");
-    addSection(
-        fs,
-        config,
-        sections.contains(Section.DATA_TYPES),
-        Config.RequestType.DATA_TYPE,
-        false,
-        "dataType");
-    if (requestIdentifier != null) fs.putSingle("Identifier", requestIdentifier);
+    for (Map.Entry<ConfigSection, ConfigFieldSet> entry : snapshot.sections().entrySet()) {
+      fs.tput(sectionKey(entry.getKey()), toSimpleFieldSet(entry.getValue()));
+    }
+    if (requestIdentifier != null) {
+      fs.putSingle("Identifier", requestIdentifier);
+    }
     return fs;
   }
 
   /**
    * Returns a snapshot of the enabled configuration sections.
    *
-   * @return a new {@link Set} containing the enabled {@link Section} values.
+   * @return a new {@link Set} containing the exported {@link ConfigSection} values.
    */
-  public Set<Section> getSections() {
-    return EnumSet.copyOf(sections);
+  public Set<ConfigSection> getSections() {
+    return snapshot.sections().isEmpty()
+        ? EnumSet.noneOf(ConfigSection.class)
+        : EnumSet.copyOf(snapshot.sections().keySet());
   }
 
-  /** Returns {@code true} if any section flag is enabled and a configuration lookup is required. */
-  private boolean needsConfigLookup() {
-    return !sections.isEmpty();
+  private static String sectionKey(ConfigSection section) {
+    return switch (section) {
+      case CURRENT -> "current";
+      case DEFAULTS -> "default";
+      case SORT_ORDER -> "sortOrder";
+      case EXPERT_FLAG -> "expertFlag";
+      case FORCE_WRITE_FLAG -> "forceWriteFlag";
+      case SHORT_DESCRIPTION -> "shortDescription";
+      case LONG_DESCRIPTION -> "longDescription";
+      case DATA_TYPES -> "dataType";
+    };
   }
 
-  /** Adds a subsection when the flag is enabled and the exported data is non-empty. */
-  private static void addSection(
-      SimpleFieldSet target,
-      PersistentConfig config,
-      boolean includeSection,
-      Config.RequestType type,
-      boolean defaults,
-      String subsetKey) {
-    if (!includeSection || config == null) {
-      return;
+  private static SimpleFieldSet toSimpleFieldSet(ConfigFieldSet source) {
+    SimpleFieldSet target = new SimpleFieldSet(true);
+    for (Map.Entry<String, String> entry : source.directValues().entrySet()) {
+      target.putSingle(entry.getKey(), entry.getValue());
     }
-    SimpleFieldSet section = config.exportFieldSet(type, defaults);
-    if (!section.isEmpty()) {
-      target.put(subsetKey, section);
+    for (Map.Entry<String, ConfigFieldSet> entry : source.directSubsets().entrySet()) {
+      target.tput(entry.getKey(), toSimpleFieldSet(entry.getValue()));
     }
+    return target;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -747,8 +747,9 @@ public class FCPServer implements Runnable, DownloadCache {
    * Returns the runtime SPI bridge used by FCP infrastructure code.
    *
    * <p>The returned {@link RuntimePorts} instance is the same adapter supplied during server
-   * construction. It exposes execution, randomness, transfer policy, and lifecycle metadata without
-   * forcing infrastructure classes to depend directly on daemon-internal types.
+   * construction. It exposes execution, randomness, transfer policy, lifecycle metadata, and
+   * configuration management without forcing infrastructure classes to depend directly on
+   * daemon-internal types.
    *
    * @return runtime SPI bridge backing this server instance.
    */

--- a/src/main/java/network/crypta/clients/fcp/GetConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/GetConfig.java
@@ -2,6 +2,7 @@ package network.crypta.clients.fcp;
 
 import java.util.EnumSet;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.ConfigSection;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -102,11 +103,10 @@ public class GetConfig extends FCPMessage {
    *
    * <p>The handler must present full-access credentials; otherwise this method halts execution by
    * raising a {@link MessageInvalidException} describing the access denial. When authorized, it
-   * constructs a {@link ConfigData} response using the cached flags to decide whether to include
-   * current values, defaults, sort order, expert-only markers, force-write allowances, short or
-   * long descriptions, and data-type metadata. The response is streamed via the provided handler
-   * without mutating the {@link Node}. Invocations are single-shot per instance; repeated calls
-   * would resend identical configuration data until the connection closes.
+   * requests the selected configuration sections from the runtime SPI and constructs a {@link
+   * ConfigData} response from the returned snapshot. The response is streamed via the provided
+   * handler without mutating the {@link Node}. Invocations are single-shot per instance; repeated
+   * calls would resend identical configuration data until the connection closes.
    *
    * @param handler connection context responsible for permission checks and outbound delivery; must
    *     not be {@code null} and must expose full access for the call to proceed.
@@ -123,34 +123,36 @@ public class GetConfig extends FCPMessage {
           requestIdentifier,
           false);
     }
-    handler.send(new ConfigData(node, buildSections(), requestIdentifier));
+    handler.send(
+        new ConfigData(
+            handler.getServer().runtime().config().export(buildSections()), requestIdentifier));
   }
 
-  private EnumSet<ConfigData.Section> buildSections() {
-    EnumSet<ConfigData.Section> sections = EnumSet.noneOf(ConfigData.Section.class);
+  private EnumSet<ConfigSection> buildSections() {
+    EnumSet<ConfigSection> sections = EnumSet.noneOf(ConfigSection.class);
     if (withCurrent) {
-      sections.add(ConfigData.Section.CURRENT);
+      sections.add(ConfigSection.CURRENT);
     }
     if (withDefaults) {
-      sections.add(ConfigData.Section.DEFAULTS);
+      sections.add(ConfigSection.DEFAULTS);
     }
     if (withSortOrder) {
-      sections.add(ConfigData.Section.SORT_ORDER);
+      sections.add(ConfigSection.SORT_ORDER);
     }
     if (withExpertFlag) {
-      sections.add(ConfigData.Section.EXPERT_FLAG);
+      sections.add(ConfigSection.EXPERT_FLAG);
     }
     if (withForceWriteFlag) {
-      sections.add(ConfigData.Section.FORCE_WRITE_FLAG);
+      sections.add(ConfigSection.FORCE_WRITE_FLAG);
     }
     if (withShortDescription) {
-      sections.add(ConfigData.Section.SHORT_DESCRIPTION);
+      sections.add(ConfigSection.SHORT_DESCRIPTION);
     }
     if (withLongDescription) {
-      sections.add(ConfigData.Section.LONG_DESCRIPTION);
+      sections.add(ConfigSection.LONG_DESCRIPTION);
     }
     if (withDataTypes) {
-      sections.add(ConfigData.Section.DATA_TYPES);
+      sections.add(ConfigSection.DATA_TYPES);
     }
     return sections;
   }

--- a/src/main/java/network/crypta/clients/fcp/ModifyConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyConfig.java
@@ -1,43 +1,37 @@
 package network.crypta.clients.fcp;
 
 import java.util.EnumSet;
-import network.crypta.config.Config;
-import network.crypta.config.Option;
-import network.crypta.config.SubConfig;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConfigSection;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handles the {@code ModifyConfig} FCP request by applying configuration updates supplied by the
  * client.
  *
- * <p>This message consumes a {@link SimpleFieldSet} whose keys mirror the hierarchical names of
- * {@link Option} instances in the node configuration. The constructor captures the request
- * identifier up front and strips it from the field set so only option names remain. During {@link
- * #run(FCPConnectionHandler, Node)} every {@link SubConfig} is traversed and each option is updated
- * when a matching key exists. Values identical to the current configuration are ignored to avoid
- * redundant writes.
+ * <p>This message consumes a {@link SimpleFieldSet} whose keys mirror dotted option names in the
+ * node configuration. The constructor captures the request identifier up front and strips it from
+ * the field set so only option overrides remain. During {@link #run(FCPConnectionHandler, Node)}
+ * the overrides are handed to the runtime SPI, which preserves the legacy config-update semantics.
  *
  * <p>The message requires the connection to possess full access; otherwise it terminates early with
- * a {@link MessageInvalidException}. After successful updates, the configuration is persisted via
- * the client core and a fresh {@link ConfigData} response is sent so callers can confirm the
- * effective state.
+ * a {@link MessageInvalidException}. After the update pass, the configuration is persisted and a
+ * fresh {@link ConfigData} response is sent so callers can confirm the effective state.
  *
  * <ul>
- *   <li>Responsibility: reconcile client-supplied option values with the in-memory configuration.
+ *   <li>Responsibility: hand client-supplied overrides to the runtime config port.
  *   <li>Persistence: flushes changes to disk before replying.
  *   <li>Threading: intended for use on the handler thread; no internal synchronization is added.
  * </ul>
  *
  * @see ConfigData
- * @see Option
- * @see SubConfig
+ * @see ConfigPort
  */
 public class ModifyConfig extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ModifyConfig.class);
-
   static final String NAME = "ModifyConfig";
 
   final SimpleFieldSet fs;
@@ -97,11 +91,10 @@ public class ModifyConfig extends FCPMessage {
    * Applies the requested configuration updates and emits the latest configuration snapshot.
    *
    * <p>The method first enforces that the connection holds full access privileges; otherwise a
-   * {@link MessageInvalidException} is thrown back to the caller. It then iterates through every
-   * {@link SubConfig} and {@link Option} pairing, invoking {@link #updateOption(String, Option)} to
-   * reconcile differences between the incoming field set and the node's current configuration. When
-   * modifications occur, the configuration is persisted before a {@link ConfigData} message is
-   * returned so clients can verify the applied values.
+   * {@link MessageInvalidException} is thrown back to the caller. It then forwards the requested
+   * dotted-name overrides to the runtime config port, persists the current config state, and
+   * returns a current-settings {@link ConfigData} snapshot so clients can verify the applied
+   * values.
    *
    * <pre>{@code
    * // Typical server-side handling path
@@ -124,43 +117,22 @@ public class ModifyConfig extends FCPMessage {
           requestIdentifier,
           false);
     }
-    Config config = node.getConfig();
-
-    for (SubConfig sc : config.getConfigs()) {
-      String prefix = sc.getPrefix();
-      for (Option<?> option : sc.getOptions()) {
-        updateOption(prefix, option);
-      }
-    }
-    node.services().clientCore().storeConfig();
-    handler.send(new ConfigData(node, EnumSet.of(ConfigData.Section.CURRENT), requestIdentifier));
+    ConfigPort config = handler.getServer().runtime().config();
+    config.applyOverrides(extractOverrides());
+    config.persist();
+    handler.send(
+        new ConfigData(config.export(EnumSet.of(ConfigSection.CURRENT)), requestIdentifier));
   }
 
-  /**
-   * Updates a single option when the incoming field set provides a new value.
-   *
-   * <p>Only different values are applied; unchanged entries are skipped to avoid unnecessary work
-   * and log noise. Invalid values are reported via the logger but do not interrupt processing, so
-   * the remaining options can still be evaluated.
-   */
-  private void updateOption(String prefix, Option<?> option) {
-    String configName = option.getName();
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Setting {}.{}", prefix, configName);
+  private Map<String, String> extractOverrides() {
+    LinkedHashMap<String, String> overrides = new LinkedHashMap<>();
+    for (Iterator<String> keys = fs.keyIterator(); keys.hasNext(); ) {
+      String key = keys.next();
+      String value = fs.get(key);
+      if (value != null) {
+        overrides.put(key, value);
+      }
     }
-    String value = fs.get(prefix + '.' + configName);
-    if (value == null || option.getValueString().equals(value)) {
-      return;
-    }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Setting {}.{} to {}", prefix, configName, value);
-    }
-    try {
-      option.setValue(value);
-    } catch (Exception e) {
-      // Bad values silently fail from an FCP perspective, but the FCP client can tell if a change
-      // took by comparing ConfigData messages before and after
-      LOG.error("Caught {}", e, e);
-    }
+    return overrides;
   }
 }

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -1148,7 +1148,8 @@ public final class NodeClientCore implements Persistable {
    *
    * <p>The returned {@link RuntimePorts} instance delegates back into the current node and client
    * core without adding new business logic. It is created during construction and shared for the
-   * lifetime of the core.
+   * lifetime of the core, covering execution, randomness, transfer policy, lifecycle, and config
+   * access.
    *
    * @return runtime SPI bridge backed by this node and client core.
    */

--- a/src/main/java/network/crypta/node/runtime/LegacyConfigPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyConfigPort.java
@@ -1,0 +1,175 @@
+package network.crypta.node.runtime;
+
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import network.crypta.config.Config;
+import network.crypta.config.Option;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+import network.crypta.support.SimpleFieldSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Adapts the daemon's legacy configuration subsystem to the runtime SPI's {@link ConfigPort}.
+ *
+ * <p>This package-private bridge keeps knowledge of {@link PersistentConfig}, {@link SubConfig},
+ * {@link Option}, and {@link SimpleFieldSet} inside the daemon root module while exposing only
+ * SPI-local DTOs to higher layers. FCP handlers and other management-facing code can therefore use
+ * the runtime aggregate without traversing daemon configuration internals directly.
+ *
+ * <p>The adapter preserves the current daemon behavior instead of redesigning it. Export requests
+ * delegate to the existing field-set export logic and are then mapped into immutable SPI values.
+ * Override application still ignores unknown dotted names, skips unchanged values, logs invalid
+ * values, and continues processing subsequent options. Persistence remains delegated to {@link
+ * NodeClientCore#storeConfig()}.
+ */
+final class LegacyConfigPort implements ConfigPort {
+  /** Logger for legacy configuration export and override application failures. */
+  private static final Logger LOG = LoggerFactory.getLogger(LegacyConfigPort.class);
+
+  /** Owning daemon node that still exposes the legacy configuration subsystem. */
+  private final Node node;
+
+  /** Client-core entry point that persists the daemon configuration to durable storage. */
+  private final NodeClientCore core;
+
+  /**
+   * Creates a legacy-backed config port for the current daemon runtime.
+   *
+   * @param node daemon node that exposes the legacy configuration registry
+   * @param core client-core entry point used for persistence
+   */
+  LegacyConfigPort(Node node, NodeClientCore core) {
+    this.node = Objects.requireNonNull(node);
+    this.core = Objects.requireNonNull(core);
+  }
+
+  @Override
+  public ConfigSnapshot export(Set<ConfigSection> sections) {
+    Objects.requireNonNull(sections, "sections");
+    if (sections.isEmpty()) {
+      return ConfigSnapshot.empty();
+    }
+
+    PersistentConfig config = node.getConfig();
+    EnumMap<ConfigSection, ConfigFieldSet> exported = new EnumMap<>(ConfigSection.class);
+    for (ConfigSection section : sections) {
+      ConfigFieldSet fieldSet =
+          toConfigFieldSet(config.exportFieldSet(requestType(section), includeDefaults(section)));
+      if (!fieldSet.isEmpty()) {
+        exported.put(section, fieldSet);
+      }
+    }
+    return new ConfigSnapshot(exported);
+  }
+
+  @Override
+  public void applyOverrides(Map<String, String> overrides) {
+    Objects.requireNonNull(overrides, "overrides");
+    if (overrides.isEmpty()) {
+      return;
+    }
+
+    Config config = node.getConfig();
+    for (SubConfig subConfig : config.getConfigs()) {
+      String prefix = subConfig.getPrefix();
+      for (Option<?> option : subConfig.getOptions()) {
+        updateOption(prefix, option, overrides);
+      }
+    }
+  }
+
+  @Override
+  public void persist() {
+    core.storeConfig();
+  }
+
+  /**
+   * Maps an SPI section request to the legacy daemon export type.
+   *
+   * @param section logical section requested through the runtime SPI
+   * @return matching legacy request type for the daemon config exporter
+   */
+  private static Config.RequestType requestType(ConfigSection section) {
+    return switch (section) {
+      case CURRENT -> Config.RequestType.CURRENT_SETTINGS;
+      case DEFAULTS -> Config.RequestType.DEFAULT_SETTINGS;
+      case SORT_ORDER -> Config.RequestType.SORT_ORDER;
+      case EXPERT_FLAG -> Config.RequestType.EXPERT_FLAG;
+      case FORCE_WRITE_FLAG -> Config.RequestType.FORCE_WRITE_FLAG;
+      case SHORT_DESCRIPTION -> Config.RequestType.SHORT_DESCRIPTION;
+      case LONG_DESCRIPTION -> Config.RequestType.LONG_DESCRIPTION;
+      case DATA_TYPES -> Config.RequestType.DATA_TYPE;
+    };
+  }
+
+  /**
+   * Returns whether the legacy exporter should include default values for the requested section.
+   *
+   * @param section logical section requested through the runtime SPI
+   * @return {@code true} when the legacy exporter should merge defaults into the response
+   */
+  private static boolean includeDefaults(ConfigSection section) {
+    return section == ConfigSection.CURRENT;
+  }
+
+  /**
+   * Applies one override value to a legacy option when the dotted name matches.
+   *
+   * @param prefix legacy sub-config prefix used to build the dotted option name
+   * @param option legacy option candidate that may receive the override
+   * @param overrides textual overrides keyed by dotted option name
+   */
+  private void updateOption(String prefix, Option<?> option, Map<String, String> overrides) {
+    String configName = option.getName();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Setting {}.{}", prefix, configName);
+    }
+    String value = overrides.get(prefix + '.' + configName);
+    if (value == null || option.getValueString().equals(value)) {
+      return;
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Setting {}.{} to {}", prefix, configName, value);
+    }
+    try {
+      option.setValue(value);
+    } catch (Exception e) {
+      // Bad values silently fail from an FCP perspective, but the FCP client can tell if a change
+      // took by comparing ConfigData messages before and after.
+      LOG.error("Caught {}", e, e);
+    }
+  }
+
+  /**
+   * Recursively maps a legacy {@link SimpleFieldSet} tree into an SPI-local field-set tree.
+   *
+   * @param fieldSet legacy field-set node to convert
+   * @return immutable SPI field-set node with empty descendants removed
+   */
+  private static ConfigFieldSet toConfigFieldSet(SimpleFieldSet fieldSet) {
+    if (fieldSet.isEmpty()) {
+      return ConfigFieldSet.empty();
+    }
+
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>(fieldSet.directKeyValues());
+    LinkedHashMap<String, ConfigFieldSet> directSubsets = new LinkedHashMap<>();
+    for (Map.Entry<String, SimpleFieldSet> entry : fieldSet.directSubsets().entrySet()) {
+      ConfigFieldSet subset = toConfigFieldSet(entry.getValue());
+      if (!subset.isEmpty()) {
+        directSubsets.put(entry.getKey(), subset);
+      }
+    }
+    return new ConfigFieldSet(directValues, directSubsets);
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Random;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.RandomnessPort;
@@ -17,8 +18,8 @@ import network.crypta.runtime.spi.TransferAccessPort;
  * captures the existing {@link Node} and {@link NodeClientCore} instances and exposes their
  * already-available capabilities through the smaller {@link RuntimePorts} surface. The class adds
  * no policy of its own; each sub-port delegates directly to the legacy implementation, so behavior,
- * timing, and file-access semantics remain aligned with the daemon that existed before the SPI was
- * introduced.
+ * timing, file-access semantics, and configuration-management semantics remain aligned with the
+ * daemon that existed before the SPI was introduced.
  *
  * <p>The adapter is immutable after construction. It is safe to share the instance anywhere the
  * daemon currently threads runtime dependencies, but callers should remember that the returned
@@ -31,6 +32,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final RandomnessPort randomnessPort;
   private final TransferAccessPort transferAccessPort;
   private final LifecyclePort lifecyclePort;
+  private final ConfigPort configPort;
 
   /**
    * Creates a runtime SPI adapter backed by the current daemon internals.
@@ -38,7 +40,8 @@ public final class LegacyRuntimePorts implements RuntimePorts {
    * <p>The constructed adapter keeps direct references to {@code node} and {@code core} and uses
    * them to implement each runtime sub-port with thin delegation only. No data is copied and no
    * validation or normalization is introduced here, so existing daemon semantics remain the source
-   * of truth for execution, randomness, transfer policy, and lifecycle state.
+   * of truth for execution, randomness, transfer policy, lifecycle state, and configuration
+   * management.
    *
    * @param node live daemon node that provides execution, randomness, and lifecycle behavior
    * @param core live client core that provides transfer-policy checks and directory access
@@ -109,6 +112,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
             return LegacyRuntimePorts.this.node.getStartupTime();
           }
         };
+    this.configPort = new LegacyConfigPort(node, core);
   }
 
   /**
@@ -151,5 +155,16 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public LifecyclePort lifecycle() {
     return lifecyclePort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps all legacy configuration traversals and persistence inside the
+   * daemon root module while exposing only SPI-local DTOs upstream.
+   */
+  @Override
+  public ConfigPort config() {
+    return configPort;
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ConfigDataTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ConfigDataTest.java
@@ -1,10 +1,11 @@
 package network.crypta.clients.fcp;
 
-import java.util.EnumSet;
+import java.util.EnumMap;
 import java.util.Map;
-import network.crypta.config.Config.RequestType;
-import network.crypta.config.PersistentConfig;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,101 +14,91 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class ConfigDataTest {
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private PersistentConfig config;
   @Mock private FCPConnectionHandler connectionHandler;
+
+  @Mock private Node node;
 
   @Test
   void getFieldSet_whenAllSectionsRequested_expectCorrespondingSubsets() {
-    when(node.getConfig()).thenReturn(config);
-    SimpleFieldSet current = nonEmptyFieldSet("Current", "true");
-    SimpleFieldSet defaults = nonEmptyFieldSet("Default", "42");
-    SimpleFieldSet sort = nonEmptyFieldSet("Sort", "10");
-    SimpleFieldSet expert = nonEmptyFieldSet("Expert", "yes");
-    SimpleFieldSet forceWrite = nonEmptyFieldSet("Force", "confirm");
-    SimpleFieldSet shortDesc = nonEmptyFieldSet("Short", "sh");
-    SimpleFieldSet longDesc = nonEmptyFieldSet("Long", "loooooong");
-    SimpleFieldSet dataTypes = nonEmptyFieldSet("Type", "string");
-
-    when(config.exportFieldSet(RequestType.CURRENT_SETTINGS, true)).thenReturn(current);
-    when(config.exportFieldSet(RequestType.DEFAULT_SETTINGS, false)).thenReturn(defaults);
-    when(config.exportFieldSet(RequestType.SORT_ORDER, false)).thenReturn(sort);
-    when(config.exportFieldSet(RequestType.EXPERT_FLAG, false)).thenReturn(expert);
-    when(config.exportFieldSet(RequestType.FORCE_WRITE_FLAG, false)).thenReturn(forceWrite);
-    when(config.exportFieldSet(RequestType.SHORT_DESCRIPTION, false)).thenReturn(shortDesc);
-    when(config.exportFieldSet(RequestType.LONG_DESCRIPTION, false)).thenReturn(longDesc);
-    when(config.exportFieldSet(RequestType.DATA_TYPE, false)).thenReturn(dataTypes);
-
-    ConfigData configData =
-        new ConfigData(node, EnumSet.allOf(ConfigData.Section.class), "request-42");
+    EnumMap<ConfigSection, ConfigFieldSet> sections = new EnumMap<>(ConfigSection.class);
+    sections.put(
+        ConfigSection.CURRENT,
+        new ConfigFieldSet(
+            Map.of("enabled", "true"),
+            Map.of("node", new ConfigFieldSet(Map.of("name", "alpha"), Map.of()))));
+    sections.put(ConfigSection.DEFAULTS, new ConfigFieldSet(Map.of("enabled", "false"), Map.of()));
+    sections.put(ConfigSection.SORT_ORDER, new ConfigFieldSet(Map.of("enabled", "10"), Map.of()));
+    sections.put(ConfigSection.EXPERT_FLAG, new ConfigFieldSet(Map.of("enabled", "yes"), Map.of()));
+    sections.put(
+        ConfigSection.FORCE_WRITE_FLAG, new ConfigFieldSet(Map.of("enabled", "confirm"), Map.of()));
+    sections.put(
+        ConfigSection.SHORT_DESCRIPTION, new ConfigFieldSet(Map.of("enabled", "short"), Map.of()));
+    sections.put(
+        ConfigSection.LONG_DESCRIPTION, new ConfigFieldSet(Map.of("enabled", "long"), Map.of()));
+    sections.put(
+        ConfigSection.DATA_TYPES, new ConfigFieldSet(Map.of("enabled", "boolean"), Map.of()));
+    ConfigData configData = new ConfigData(new ConfigSnapshot(sections), "request-42");
 
     SimpleFieldSet result = configData.getFieldSet();
 
     Map<String, SimpleFieldSet> subsets = result.directSubsets();
     assertEquals(8, subsets.size());
-    assertSame(current, subsets.get("current"));
-    assertSame(defaults, subsets.get("default"));
-    assertSame(sort, subsets.get("sortOrder"));
-    assertSame(expert, subsets.get("expertFlag"));
-    assertSame(forceWrite, subsets.get("forceWriteFlag"));
-    assertSame(shortDesc, subsets.get("shortDescription"));
-    assertSame(longDesc, subsets.get("longDescription"));
-    assertSame(dataTypes, subsets.get("dataType"));
+    assertEquals("true", result.get("current.enabled"));
+    assertEquals("alpha", result.get("current.node.name"));
+    assertEquals("false", result.get("default.enabled"));
+    assertEquals("10", result.get("sortOrder.enabled"));
+    assertEquals("yes", result.get("expertFlag.enabled"));
+    assertEquals("confirm", result.get("forceWriteFlag.enabled"));
+    assertEquals("short", result.get("shortDescription.enabled"));
+    assertEquals("long", result.get("longDescription.enabled"));
+    assertEquals("boolean", result.get("dataType.enabled"));
     assertEquals("request-42", result.get("Identifier"));
   }
 
   @Test
-  void getFieldSet_whenNoFlagsEnabled_expectEmptyResultAndNoConfigAccess() {
-    ConfigData configData = new ConfigData(node, EnumSet.noneOf(ConfigData.Section.class), null);
+  void getFieldSet_whenSnapshotEmpty_expectEmptyResult() {
+    ConfigData configData = new ConfigData(ConfigSnapshot.empty(), null);
 
     SimpleFieldSet result = configData.getFieldSet();
 
     assertTrue(result.directSubsets().isEmpty());
     assertNull(result.get("Identifier"));
-    verify(node, never()).getConfig();
-    verifyNoInteractions(config);
   }
 
   @Test
-  void getFieldSet_whenExportReturnsEmptySubset_expectSubsetOmitted() {
-    when(node.getConfig()).thenReturn(config);
-    when(config.exportFieldSet(RequestType.SHORT_DESCRIPTION, false))
-        .thenReturn(new SimpleFieldSet(true));
-
-    ConfigData configData =
-        new ConfigData(node, EnumSet.of(ConfigData.Section.SHORT_DESCRIPTION), "id");
+  void getFieldSet_whenSubsetIsEmpty_expectSubsetOmitted() {
+    ConfigSnapshot snapshot =
+        new ConfigSnapshot(
+            Map.of(
+                ConfigSection.SHORT_DESCRIPTION,
+                new ConfigFieldSet(
+                    Map.of("visible", "value"), Map.of("empty", ConfigFieldSet.empty()))));
+    ConfigData configData = new ConfigData(snapshot, "id");
 
     SimpleFieldSet result = configData.getFieldSet();
 
-    assertTrue(result.directSubsets().isEmpty());
+    assertEquals("value", result.get("shortDescription.visible"));
+    assertNull(result.subset("shortDescription.empty"));
     assertEquals("id", result.get("Identifier"));
-    verify(config).exportFieldSet(RequestType.SHORT_DESCRIPTION, false);
   }
 
   @Test
   void getName_whenCalled_returnsStaticName() {
-    ConfigData configData = new ConfigData(node, EnumSet.noneOf(ConfigData.Section.class), null);
+    ConfigData configData = new ConfigData(ConfigSnapshot.empty(), null);
 
     assertEquals("ConfigData", configData.getName());
   }
 
   @Test
   void run_whenInvoked_throwsMessageInvalidException() {
-    ConfigData configData = new ConfigData(node, EnumSet.noneOf(ConfigData.Section.class), null);
+    ConfigData configData = new ConfigData(ConfigSnapshot.empty(), null);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> configData.run(connectionHandler, node));
@@ -115,11 +106,5 @@ class ConfigDataTest {
     assertEquals(
         "ConfigData goes from server to client not the other way around", exception.getMessage());
     assertNull(exception.ident);
-  }
-
-  private static SimpleFieldSet nonEmptyFieldSet(String key, String value) {
-    SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle(key, value);
-    return fs;
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
@@ -1,7 +1,14 @@
 package network.crypta.clients.fcp;
 
+import java.util.EnumSet;
+import java.util.Map;
 import java.util.Set;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,6 +35,12 @@ class GetConfigTest {
   @Mock FCPConnectionHandler handler;
 
   @Mock Node node;
+
+  @Mock FCPServer server;
+
+  @Mock RuntimePorts runtimePorts;
+
+  @Mock ConfigPort configPort;
 
   @Test
   void constructor_whenFieldsPresent_setsFlagsAndIdentifierAndRemovesIdentifierFromSource() {
@@ -85,10 +99,12 @@ class GetConfigTest {
     assertEquals("GetConfig requires full access", thrown.getMessage());
     assertFalse(thrown.global);
     verify(handler, never()).send(any(FCPMessage.class));
+    verifyNoInteractions(server, runtimePorts, configPort, node);
   }
 
   @Test
-  void run_whenHandlerHasFullAccess_sendsConfigDataWithMatchingFlags() throws Exception {
+  @SuppressWarnings("unchecked")
+  void run_whenHandlerHasFullAccess_exportsMatchingSectionsAndSendsConfigData() throws Exception {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("WithCurrent", "true");
     fs.putSingle("WithDefaults", "true");
@@ -100,24 +116,34 @@ class GetConfigTest {
     fs.putSingle("WithDataTypes", "true");
     fs.putSingle("Identifier", "cfg-7");
     GetConfig getConfig = new GetConfig(fs);
+    ConfigSnapshot snapshot =
+        new ConfigSnapshot(
+            Map.of(ConfigSection.CURRENT, new ConfigFieldSet(Map.of("enabled", "true"), Map.of())));
     when(handler.hasFullAccess()).thenReturn(true);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.config()).thenReturn(configPort);
+    when(configPort.export(any())).thenReturn(snapshot);
 
     getConfig.run(handler, node);
+
+    ArgumentCaptor<Set<ConfigSection>> sectionsCaptor = ArgumentCaptor.forClass(Set.class);
+    verify(configPort).export(sectionsCaptor.capture());
+    assertEquals(
+        EnumSet.of(
+            ConfigSection.CURRENT,
+            ConfigSection.DEFAULTS,
+            ConfigSection.EXPERT_FLAG,
+            ConfigSection.SHORT_DESCRIPTION,
+            ConfigSection.DATA_TYPES),
+        sectionsCaptor.getValue());
 
     ArgumentCaptor<ConfigData> captor = ArgumentCaptor.forClass(ConfigData.class);
     verify(handler).send(captor.capture());
     ConfigData sent = captor.getValue();
 
-    assertEquals(node, sent.node);
-    Set<ConfigData.Section> sections = sent.getSections();
-    assertTrue(sections.contains(ConfigData.Section.CURRENT));
-    assertTrue(sections.contains(ConfigData.Section.DEFAULTS));
-    assertFalse(sections.contains(ConfigData.Section.SORT_ORDER));
-    assertTrue(sections.contains(ConfigData.Section.EXPERT_FLAG));
-    assertFalse(sections.contains(ConfigData.Section.FORCE_WRITE_FLAG));
-    assertTrue(sections.contains(ConfigData.Section.SHORT_DESCRIPTION));
-    assertFalse(sections.contains(ConfigData.Section.LONG_DESCRIPTION));
-    assertTrue(sections.contains(ConfigData.Section.DATA_TYPES));
+    assertEquals(snapshot, sent.snapshot);
     assertEquals("cfg-7", sent.requestIdentifier);
+    verifyNoInteractions(node);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ModifyConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyConfigTest.java
@@ -1,14 +1,14 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.config.InvalidConfigValueException;
-import network.crypta.config.Option;
-import network.crypta.config.PersistentConfig;
-import network.crypta.config.StringOption;
-import network.crypta.config.SubConfig;
+import java.util.EnumSet;
+import java.util.Map;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.api.StringCallback;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,10 +35,13 @@ class ModifyConfigTest {
 
   @Mock FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  Node node;
+  @Mock Node node;
 
-  @Mock NodeClientCore clientCore;
+  @Mock FCPServer server;
+
+  @Mock RuntimePorts runtimePorts;
+
+  @Mock ConfigPort configPort;
 
   @Test
   void constructor_whenIdentifierPresent_storesItAndRemovesFromFieldSet() {
@@ -82,140 +86,41 @@ class ModifyConfigTest {
     assertEquals("ModifyConfig requires full access", thrown.getMessage());
     assertFalse(thrown.global);
     verify(handler, never()).send(any(FCPMessage.class));
+    verifyNoInteractions(server, runtimePorts, configPort, node);
   }
 
   @Test
-  void run_whenValueDiffers_updatesOptionStoresConfigAndSendsReply() throws Exception {
-    PersistentConfig config = new PersistentConfig(null);
-    SubConfig subConfig = config.createSubConfig("node");
-    CountingStringCallback callback = new CountingStringCallback("5");
-    StringOption option =
-        new StringOption(
-            subConfig, "maxPeers", "5", new Option.Meta(0, false, false, null, null), callback);
-    subConfig.register(option);
-    when(node.getConfig()).thenReturn(config);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(clientCore);
-    when(handler.hasFullAccess()).thenReturn(true);
+  @SuppressWarnings("unchecked")
+  void run_whenHandlerHasFullAccess_appliesOverridesPersistsExportsCurrentAndSendsReply()
+      throws Exception {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "cfg-1");
     fs.putSingle("node.maxPeers", "10");
-    ModifyConfig modifyConfig = new ModifyConfig(fs);
-
-    modifyConfig.run(handler, node);
-
-    assertEquals(1, callback.getSetCount());
-    assertEquals("10", option.getValueString());
-    assertEquals("10", callback.getCurrentValue());
-    InOrder order = inOrder(clientCore, handler);
-    order.verify(clientCore).storeConfig();
-    ArgumentCaptor<ConfigData> captor = ArgumentCaptor.forClass(ConfigData.class);
-    order.verify(handler).send(captor.capture());
-    ConfigData sent = captor.getValue();
-    assertEquals(node, sent.node);
-    assertEquals("cfg-1", sent.requestIdentifier);
-  }
-
-  @Test
-  void run_whenValueUnchanged_doesNotInvokeSetValueButStillStoresAndSends() throws Exception {
-    PersistentConfig config = new PersistentConfig(null);
-    SubConfig subConfig = config.createSubConfig("ui");
-    CountingStringCallback callback = new CountingStringCallback("light");
-    StringOption option =
-        new StringOption(
-            subConfig, "theme", "light", new Option.Meta(0, false, false, null, null), callback);
-    subConfig.register(option);
-    when(node.getConfig()).thenReturn(config);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(clientCore);
-    when(handler.hasFullAccess()).thenReturn(true);
-    SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", "cfg-2");
     fs.putSingle("ui.theme", "light");
     ModifyConfig modifyConfig = new ModifyConfig(fs);
-
-    modifyConfig.run(handler, node);
-
-    assertEquals(0, callback.getSetCount());
-    assertEquals("light", option.getValueString());
-    verify(clientCore).storeConfig();
-    verify(handler).send(any(ConfigData.class));
-  }
-
-  @Test
-  void run_whenOptionUpdateFails_continuesToStoreAndRespond() throws Exception {
-    PersistentConfig config = new PersistentConfig(null);
-    SubConfig subConfig = config.createSubConfig("net");
-    ThrowingStringCallback callback = new ThrowingStringCallback("8080");
-    StringOption failingOption =
-        new StringOption(
-            subConfig, "port", "8080", new Option.Meta(0, false, false, null, null), callback);
-    subConfig.register(failingOption);
-    when(node.getConfig()).thenReturn(config);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(clientCore);
+    ConfigSnapshot snapshot =
+        new ConfigSnapshot(
+            Map.of(ConfigSection.CURRENT, new ConfigFieldSet(Map.of("enabled", "true"), Map.of())));
     when(handler.hasFullAccess()).thenReturn(true);
-    SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", "cfg-3");
-    fs.putSingle("net.port", "9090");
-    ModifyConfig modifyConfig = new ModifyConfig(fs);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.config()).thenReturn(configPort);
+    when(configPort.export(EnumSet.of(ConfigSection.CURRENT))).thenReturn(snapshot);
 
     modifyConfig.run(handler, node);
 
-    assertEquals("8080", failingOption.getValueString());
-    verify(clientCore).storeConfig();
-    verify(handler).send(any(ConfigData.class));
-  }
+    InOrder order = inOrder(configPort, handler);
+    ArgumentCaptor<Map<String, String>> overridesCaptor = ArgumentCaptor.forClass(Map.class);
+    order.verify(configPort).applyOverrides(overridesCaptor.capture());
+    assertEquals(Map.of("node.maxPeers", "10", "ui.theme", "light"), overridesCaptor.getValue());
+    order.verify(configPort).persist();
+    order.verify(configPort).export(EnumSet.of(ConfigSection.CURRENT));
+    ArgumentCaptor<ConfigData> responseCaptor = ArgumentCaptor.forClass(ConfigData.class);
+    order.verify(handler).send(responseCaptor.capture());
 
-  private static final class CountingStringCallback extends StringCallback {
-    private int setCount;
-    private String currentValue;
-
-    CountingStringCallback(String initialValue) {
-      this.currentValue = initialValue;
-    }
-
-    @Override
-    public String get() {
-      return currentValue;
-    }
-
-    @Override
-    public void set(String val) {
-      setCount++;
-      currentValue = val;
-    }
-
-    int getSetCount() {
-      return setCount;
-    }
-
-    String getCurrentValue() {
-      return currentValue;
-    }
-  }
-
-  private static final class ThrowingStringCallback extends StringCallback {
-    private final String currentValue;
-
-    ThrowingStringCallback(String currentValue) {
-      this.currentValue = currentValue;
-    }
-
-    @Override
-    public String get() {
-      return currentValue;
-    }
-
-    @Override
-    public void set(String val) throws InvalidConfigValueException {
-      throw new InvalidConfigValueException("boom");
-    }
+    ConfigData sent = responseCaptor.getValue();
+    assertEquals(snapshot, sent.snapshot);
+    assertEquals("cfg-1", sent.requestIdentifier);
+    verifyNoInteractions(node);
   }
 }

--- a/src/test/java/network/crypta/node/runtime/LegacyConfigPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyConfigPortTest.java
@@ -1,0 +1,164 @@
+package network.crypta.node.runtime;
+
+import java.util.EnumSet;
+import java.util.Map;
+import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.StringOption;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.StringCallback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyConfigPortTest {
+
+  @Mock private Node node;
+
+  @Mock private NodeClientCore core;
+
+  @Mock private PersistentConfig config;
+
+  @Test
+  void export_whenSectionRequested_mapsSimpleFieldSetToSnapshot() {
+    LegacyConfigPort port = new LegacyConfigPort(node, core);
+    SimpleFieldSet current = new SimpleFieldSet(true);
+    current.putSingle("enabled", "true");
+    SimpleFieldSet nested = new SimpleFieldSet(true);
+    nested.putSingle("name", "alpha");
+    current.put("node", nested);
+    when(node.getConfig()).thenReturn(config);
+    when(config.exportFieldSet(network.crypta.config.Config.RequestType.CURRENT_SETTINGS, true))
+        .thenReturn(current);
+
+    ConfigSnapshot snapshot = port.export(EnumSet.of(ConfigSection.CURRENT));
+
+    assertEquals(
+        new ConfigSnapshot(
+            Map.of(
+                ConfigSection.CURRENT,
+                new ConfigFieldSet(
+                    Map.of("enabled", "true"),
+                    Map.of("node", new ConfigFieldSet(Map.of("name", "alpha"), Map.of()))))),
+        snapshot);
+  }
+
+  @Test
+  void persist_whenCalled_delegatesToClientCoreStoreConfig() {
+    LegacyConfigPort port = new LegacyConfigPort(node, core);
+
+    port.persist();
+
+    verify(core).storeConfig();
+  }
+
+  @Test
+  void applyOverrides_whenChangedUnchangedInvalidAndUnknown_expectLegacySemanticsPreserved() {
+    LegacyConfigPort port = new LegacyConfigPort(node, core);
+    PersistentConfig persistentConfig = new PersistentConfig(null);
+    SubConfig nodeConfig = persistentConfig.createSubConfig("node");
+    CountingStringCallback maxPeersCallback = new CountingStringCallback("5");
+    StringOption maxPeers =
+        new StringOption(
+            nodeConfig,
+            "maxPeers",
+            "5",
+            new Option.Meta(0, false, false, null, null),
+            maxPeersCallback);
+    nodeConfig.register(maxPeers);
+
+    SubConfig uiConfig = persistentConfig.createSubConfig("ui");
+    CountingStringCallback themeCallback = new CountingStringCallback("light");
+    StringOption theme =
+        new StringOption(
+            uiConfig,
+            "theme",
+            "light",
+            new Option.Meta(0, false, false, null, null),
+            themeCallback);
+    uiConfig.register(theme);
+
+    SubConfig netConfig = persistentConfig.createSubConfig("net");
+    ThrowingStringCallback portCallback = new ThrowingStringCallback("8080");
+    StringOption portOption =
+        new StringOption(
+            netConfig, "port", "8080", new Option.Meta(0, false, false, null, null), portCallback);
+    netConfig.register(portOption);
+
+    when(node.getConfig()).thenReturn(persistentConfig);
+
+    port.applyOverrides(
+        Map.of(
+            "node.maxPeers", "10",
+            "ui.theme", "light",
+            "net.port", "9090",
+            "missing.value", "ignored"));
+
+    assertEquals(1, maxPeersCallback.getSetCount());
+    assertEquals("10", maxPeers.getValueString());
+    assertEquals("10", maxPeersCallback.getCurrentValue());
+    assertEquals(0, themeCallback.getSetCount());
+    assertEquals("light", theme.getValueString());
+    assertEquals("8080", portOption.getValueString());
+  }
+
+  private static final class CountingStringCallback extends StringCallback {
+    private int setCount;
+    private String currentValue;
+
+    CountingStringCallback(String initialValue) {
+      this.currentValue = initialValue;
+    }
+
+    @Override
+    public String get() {
+      return currentValue;
+    }
+
+    @Override
+    public void set(String val) {
+      setCount++;
+      currentValue = val;
+    }
+
+    int getSetCount() {
+      return setCount;
+    }
+
+    String getCurrentValue() {
+      return currentValue;
+    }
+  }
+
+  private static final class ThrowingStringCallback extends StringCallback {
+    private final String currentValue;
+
+    ThrowingStringCallback(String currentValue) {
+      this.currentValue = currentValue;
+    }
+
+    @Override
+    public String get() {
+      return currentValue;
+    }
+
+    @Override
+    public void set(String val) throws InvalidConfigValueException {
+      throw new InvalidConfigValueException("boom");
+    }
+  }
+}

--- a/src/test/java/network/crypta/runtime/spi/ConfigFieldSetTest.java
+++ b/src/test/java/network/crypta/runtime/spi/ConfigFieldSetTest.java
@@ -1,0 +1,140 @@
+package network.crypta.runtime.spi;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class ConfigFieldSetTest {
+
+  @Test
+  void empty_whenCalled_expectEmptyFieldSet() {
+    ConfigFieldSet fieldSet = ConfigFieldSet.empty();
+
+    assertTrue(fieldSet.isEmpty());
+    assertTrue(fieldSet.directValues().isEmpty());
+    assertTrue(fieldSet.directSubsets().isEmpty());
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonEmptyFieldSets")
+  void isEmpty_whenFieldSetContainsEntries_expectFalse(ConfigFieldSet fieldSet) {
+    assertFalse(fieldSet.isEmpty());
+  }
+
+  @Test
+  void constructor_whenSourceMapsMutatedAfterCreation_expectDefensiveCopies() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put("alpha", "1");
+    LinkedHashMap<String, ConfigFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put("nested", new ConfigFieldSet(Map.of("enabled", "true"), Map.of()));
+
+    ConfigFieldSet fieldSet = new ConfigFieldSet(directValues, directSubsets);
+
+    directValues.put("alpha", "updated");
+    directValues.put("beta", "2");
+    directSubsets.clear();
+
+    assertEquals(Map.of("alpha", "1"), fieldSet.directValues());
+    assertEquals(
+        Map.of("nested", new ConfigFieldSet(Map.of("enabled", "true"), Map.of())),
+        fieldSet.directSubsets());
+  }
+
+  @Test
+  void constructor_whenMapsExposed_expectUnmodifiableViews() {
+    ConfigFieldSet fieldSet =
+        new ConfigFieldSet(
+            Map.of("alpha", "1"), Map.of("nested", new ConfigFieldSet(Map.of(), Map.of())));
+    Map<String, String> directValues = fieldSet.directValues();
+    Map<String, ConfigFieldSet> directSubsets = fieldSet.directSubsets();
+    ConfigFieldSet emptyFieldSet = ConfigFieldSet.empty();
+
+    assertThrows(UnsupportedOperationException.class, () -> directValues.put("beta", "2"));
+    assertThrows(
+        UnsupportedOperationException.class, () -> directSubsets.put("second", emptyFieldSet));
+  }
+
+  @Test
+  void constructor_whenLinkedHashMapsProvided_expectEncounterOrderPreserved() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put("alpha", "1");
+    directValues.put("beta", "2");
+    directValues.put("gamma", "3");
+    LinkedHashMap<String, ConfigFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put("first", ConfigFieldSet.empty());
+    directSubsets.put("second", new ConfigFieldSet(Map.of("name", "value"), Map.of()));
+
+    ConfigFieldSet fieldSet = new ConfigFieldSet(directValues, directSubsets);
+
+    assertEquals(
+        List.of("alpha", "beta", "gamma"), new ArrayList<>(fieldSet.directValues().keySet()));
+    assertEquals(List.of("first", "second"), new ArrayList<>(fieldSet.directSubsets().keySet()));
+  }
+
+  @Test
+  void constructor_whenDirectValuesNull_expectNullPointerException() {
+    Map<String, ConfigFieldSet> directSubsets = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new ConfigFieldSet(null, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectSubsetsNull_expectNullPointerException() {
+    Map<String, String> directValues = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new ConfigFieldSet(directValues, null));
+  }
+
+  @Test
+  void constructor_whenDirectValuesContainNullKey_expectNullPointerException() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put(null, "value");
+    Map<String, ConfigFieldSet> directSubsets = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new ConfigFieldSet(directValues, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectValuesContainNullValue_expectNullPointerException() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put("key", null);
+    Map<String, ConfigFieldSet> directSubsets = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new ConfigFieldSet(directValues, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectSubsetsContainNullKey_expectNullPointerException() {
+    LinkedHashMap<String, ConfigFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put(null, ConfigFieldSet.empty());
+    Map<String, String> directValues = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new ConfigFieldSet(directValues, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectSubsetsContainNullValue_expectNullPointerException() {
+    LinkedHashMap<String, ConfigFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put("nested", null);
+    Map<String, String> directValues = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new ConfigFieldSet(directValues, directSubsets));
+  }
+
+  private static Stream<ConfigFieldSet> nonEmptyFieldSets() {
+    return Stream.of(
+        new ConfigFieldSet(Map.of("enabled", "true"), Map.of()),
+        new ConfigFieldSet(Map.of(), Map.of("nested", ConfigFieldSet.empty())));
+  }
+}

--- a/src/test/java/network/crypta/runtime/spi/ConfigSnapshotTest.java
+++ b/src/test/java/network/crypta/runtime/spi/ConfigSnapshotTest.java
@@ -1,0 +1,117 @@
+package network.crypta.runtime.spi;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class ConfigSnapshotTest {
+
+  @Test
+  void empty_whenCalled_expectEmptySnapshot() {
+    ConfigSnapshot snapshot = ConfigSnapshot.empty();
+
+    assertTrue(snapshot.isEmpty());
+    assertTrue(snapshot.sections().isEmpty());
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonEmptySnapshots")
+  void isEmpty_whenSnapshotContainsNonEmptySection_expectFalse(ConfigSnapshot snapshot) {
+    assertFalse(snapshot.isEmpty());
+  }
+
+  @Test
+  void constructor_whenSectionsContainOnlyEmptyFieldSets_expectEmptySnapshot() {
+    ConfigSnapshot snapshot =
+        new ConfigSnapshot(
+            Map.of(
+                ConfigSection.CURRENT,
+                ConfigFieldSet.empty(),
+                ConfigSection.DEFAULTS,
+                ConfigFieldSet.empty()));
+
+    assertTrue(snapshot.isEmpty());
+    assertTrue(snapshot.sections().isEmpty());
+  }
+
+  @Test
+  void
+      constructor_whenSectionsContainEmptyAndNonEmptyFieldSets_expectOnlyNonEmptySectionsRetained() {
+    ConfigFieldSet current =
+        new ConfigFieldSet(Map.of("enabled", "true"), Map.of("node", ConfigFieldSet.empty()));
+    ConfigSnapshot snapshot =
+        new ConfigSnapshot(
+            Map.of(ConfigSection.CURRENT, current, ConfigSection.DEFAULTS, ConfigFieldSet.empty()));
+
+    assertEquals(Map.of(ConfigSection.CURRENT, current), snapshot.sections());
+  }
+
+  @Test
+  void constructor_whenSourceMapMutatedAfterCreation_expectDefensiveCopy() {
+    EnumMap<ConfigSection, ConfigFieldSet> sections = new EnumMap<>(ConfigSection.class);
+    ConfigFieldSet current = new ConfigFieldSet(Map.of("enabled", "true"), Map.of());
+    sections.put(ConfigSection.CURRENT, current);
+
+    ConfigSnapshot snapshot = new ConfigSnapshot(sections);
+
+    sections.put(ConfigSection.DEFAULTS, new ConfigFieldSet(Map.of("enabled", "false"), Map.of()));
+    sections.clear();
+
+    assertEquals(Map.of(ConfigSection.CURRENT, current), snapshot.sections());
+  }
+
+  @Test
+  void constructor_whenSectionsExposed_expectUnmodifiableView() {
+    ConfigFieldSet current = new ConfigFieldSet(Map.of("enabled", "true"), Map.of());
+    ConfigSnapshot snapshot = new ConfigSnapshot(Map.of(ConfigSection.CURRENT, current));
+    Map<ConfigSection, ConfigFieldSet> sections = snapshot.sections();
+    ConfigFieldSet defaults = new ConfigFieldSet(Map.of("enabled", "false"), Map.of());
+
+    assertThrows(
+        UnsupportedOperationException.class, () -> sections.put(ConfigSection.DEFAULTS, defaults));
+  }
+
+  @Test
+  void constructor_whenSectionsNull_expectNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new ConfigSnapshot(null));
+  }
+
+  @Test
+  void constructor_whenSectionsContainNullKey_expectNullPointerException() {
+    Map<ConfigSection, ConfigFieldSet> sections =
+        new java.util.LinkedHashMap<>(Map.of(ConfigSection.CURRENT, ConfigFieldSet.empty()));
+    sections.put(null, ConfigFieldSet.empty());
+
+    assertThrows(NullPointerException.class, () -> new ConfigSnapshot(sections));
+  }
+
+  @Test
+  void constructor_whenSectionsContainNullValue_expectNullPointerException() {
+    Map<ConfigSection, ConfigFieldSet> sections =
+        new java.util.LinkedHashMap<>(Map.of(ConfigSection.CURRENT, ConfigFieldSet.empty()));
+    sections.put(ConfigSection.DEFAULTS, null);
+
+    assertThrows(NullPointerException.class, () -> new ConfigSnapshot(sections));
+  }
+
+  private static Stream<ConfigSnapshot> nonEmptySnapshots() {
+    return Stream.of(
+        new ConfigSnapshot(
+            Map.of(ConfigSection.CURRENT, new ConfigFieldSet(Map.of("enabled", "true"), Map.of()))),
+        new ConfigSnapshot(
+            Map.of(
+                ConfigSection.CURRENT,
+                ConfigFieldSet.empty(),
+                ConfigSection.DEFAULTS,
+                new ConfigFieldSet(Map.of("enabled", "false"), Map.of()))));
+  }
+}


### PR DESCRIPTION
## Summary
- add a config-focused runtime SPI with `ConfigPort`, `ConfigSection`, `ConfigFieldSet`, and `ConfigSnapshot`, and expose it through `RuntimePorts`
- move the legacy config export, override, and persist behavior into `LegacyConfigPort` so FCP config messages stop traversing daemon config internals directly
- migrate `ConfigData`, `GetConfig`, and `ModifyConfig` to the runtime aggregate, update the focused FCP tests, and add runtime-spi value-object coverage
- enrich Javadocs for the new production config SPI files and the legacy adapter

## Testing
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests "network.crypta.clients.fcp.ConfigDataTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.GetConfigTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.ModifyConfigTest"`
- `./gradlew test --tests "network.crypta.node.runtime.LegacyConfigPortTest"`
- `./gradlew test --tests 'network.crypta.runtime.spi.ConfigFieldSetTest'`
- `./gradlew test --tests 'network.crypta.runtime.spi.ConfigSnapshotTest'`
- `./gradlew test`
- `./gradlew buildJar`
- `./gradlew classes`
- per-file `javadoc -Xdoclint:all` validation for the new production config SPI files and `LegacyConfigPort.java`