### PR TITLE
docs(runtime-spi): Update docs and skills

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -21,10 +21,15 @@ Use this skill when you need to:
 - Leaf subprojects:
   - `:foundation-fs` → `network.crypta.fs`
   - `:foundation-compat` → `network.crypta.compat`
+  - `:runtime-spi` → `network.crypta.runtime.spi` (JDK-only runtime/config boundary)
   - `:thirdparty-onion` → `com.onionnetworks` plus `lib/fec.properties`
   - `:thirdparty-legacy` → `org.bitpedia`, `org.sevenzip`, `org.spaceroots`
   - `:launcher-desktop` → `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, launcher
     resources
+- The runtime boundary is split intentionally:
+  - `:runtime-spi` exposes small JDK-only ports and immutable config DTOs.
+  - The root project implements those ports in `network.crypta.node.runtime.LegacyRuntimePorts`
+    and `LegacyConfigPort`.
 - The large cyclic daemon core still lives in the root project:
   `network.crypta.node`, `network.crypta.io`, `network.crypta.client`,
   `network.crypta.clients`, `network.crypta.support`, `network.crypta.config`,
@@ -58,7 +63,19 @@ Use this skill when you need to:
 ### Client APIs
 - High-level client: `network.crypta.client`
 - FCP: `network.crypta.clients.fcp`
+  - Runtime-facing execution, randomness, lifecycle, transfer-policy, and config access now come
+    through `RuntimePorts`.
+  - `FcpRuntimeAdapters` preserves legacy FCP-local shapes such as `PriorityAwareExecutor` and
+    `RandomSource` on top of the SPI.
 - HTTP interface: `network.crypta.clients.http`
+
+### Runtime SPI (`network.crypta.runtime.spi`)
+- Aggregate boundary: `RuntimePorts`
+- Small ports: `ExecutionPort`, `RandomnessPort`, `TransferAccessPort`, `LifecyclePort`,
+  `ConfigPort`
+- Immutable config DTOs: `ConfigSnapshot`, `ConfigFieldSet`, `ConfigSection`
+- Root adapters: `network.crypta.node.runtime.LegacyRuntimePorts`,
+  `network.crypta.node.runtime.LegacyConfigPort`
 
 ### Plugin system (`network.crypta.pluginmanager`)
 - Management: `PluginManager`
@@ -67,6 +84,8 @@ Use this skill when you need to:
 
 ### Configuration (`network.crypta.config`)
 - Type-safe configuration with persistence
+- Higher layers should prefer `RuntimePorts#config()` over traversing daemon config internals
+  directly when the SPI already covers the needed operation
 
 ### Supporting infrastructure (`network.crypta.support`)
 - Logging, data structures, threading, helpers
@@ -79,6 +98,7 @@ Use this skill when you need to:
 ### Foundation leaf modules
 - `:foundation-fs`: `network.crypta.fs`
 - `:foundation-compat`: `network.crypta.compat`
+- `:runtime-spi`: `network.crypta.runtime.spi`
 
 ### Vendored library leaf modules
 - `:thirdparty-onion`: `com.onionnetworks`

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -18,10 +18,14 @@ Use this skill when you need to:
 ## Build layout
 - Cryptad now uses a partial multi-project Gradle build.
 - Use root-project tasks by default; the root project remains the daemon/application target.
+- Current leaf projects are `:foundation-fs`, `:foundation-compat`, `:runtime-spi`,
+  `:thirdparty-onion`, `:thirdparty-legacy`, and `:launcher-desktop`.
 - The extracted leaf projects compile separately, but `buildJar`, `run`, `runLauncher`,
   `assembleCryptadDist`, and jpackage tasks are still rooted at `:cryptad`.
-- All tests remain in the root project for now and compile against the leaf subprojects through the
-  root build.
+- `:runtime-spi` is the JDK-only runtime/config API leaf. Its focused unit tests still live in the
+  root test tree and run through the root build.
+- All tests remain in the root project for now and compile against the leaf subprojects through
+  the root build.
 
 ## Guardrails (must follow)
 - Always use the Gradle wrapper: `./gradlew …`
@@ -50,6 +54,8 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
 ## Compile-only / quick checks
 - Compile only:
   - `./gradlew compileJava`
+- Compile only the runtime SPI leaf when you touched just that JDK-only API surface:
+  - `./gradlew :runtime-spi:compileJava`
 - Compile the root project and its unchanged test tree against the leaf-module layout:
   - `./gradlew compileJava compileTestJava`
 

--- a/.agents/skills/cryptad-packaging/SKILL.md
+++ b/.agents/skills/cryptad-packaging/SKILL.md
@@ -20,7 +20,11 @@ Use this skill when working on:
 - Packaging remains root-owned.
 - The root project `:cryptad` still owns `buildJar`, `assembleCryptadDist`, `dist*`, `run`,
   `runLauncher`, and jpackage tasks.
+- Current contributing leaf modules are `:foundation-fs`, `:foundation-compat`, `:runtime-spi`,
+  `:thirdparty-onion`, `:thirdparty-legacy`, and `:launcher-desktop`.
 - Extracted leaf modules contribute jars and resources through the root runtime classpath.
+- The `:runtime-spi` JAR is packaged like the other leaf artifacts; packaging still produces one
+  daemon distribution rooted at `:cryptad`.
 - Packaging does not have separate entrypoints per leaf project; it still assembles a single daemon
   artifact and distribution layout from the root build.
 

--- a/README.md
+++ b/README.md
@@ -169,11 +169,16 @@ Cryptad now uses a partial multi-project Gradle build.
   `run`, `runLauncher`, `assembleCryptadDist`, and jpackage task graph.
 - `:foundation-fs` owns `network.crypta.fs`.
 - `:foundation-compat` owns `network.crypta.compat`.
+- `:runtime-spi` owns `network.crypta.runtime.spi` and the JDK-only runtime/config boundary used
+  by higher layers.
 - `:thirdparty-onion` owns `com.onionnetworks` and `lib/fec.properties`.
 - `:thirdparty-legacy` owns `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.
 - `:launcher-desktop` owns `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, and launcher
   resources.
 - The large cyclic daemon core remains in the root project for now, and all tests still live there.
+- Higher-level infrastructure now crosses a narrower boundary through
+  `network.crypta.runtime.spi.RuntimePorts`, implemented in the root project by
+  `network.crypta.node.runtime.LegacyRuntimePorts`.
 
 The wrapper validates the distribution URL (`validateDistributionUrl=true` in
 `gradle/wrapper/gradle-wrapper.properties`). To also verify the download by checksum, add
@@ -437,10 +442,12 @@ cd build/jpackage/Crypta.app/Contents
   - Update verification metadata so `gradle/verification-metadata.xml` and keyrings reflect the new
     artifacts; use the commands in “Spotless + Dependency Verification” below.
 
-Launcher adds:
+Root build also includes:
 - `:launcher-desktop`: Swing launcher code and desktop/theme detection dependencies.
 - `:thirdparty-onion`: Onion FEC and related vendored sources/resources.
 - `:thirdparty-legacy`: Bitpedia, SevenZip, and Spaceroots vendored code.
+- `:runtime-spi`: JDK-only runtime ports plus immutable config snapshot/value types used by FCP
+  and other infrastructure code.
 - `:foundation-fs` and `:foundation-compat`: extracted filesystem/environment and compatibility
   leaf modules used by the root daemon.
 
@@ -486,20 +493,29 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 
 - Build/module layout:
   - Root project `:cryptad` remains the daemon/application build and still owns the strongly
-    coupled core packages, all tests, and packaging/runtime tasks.
-  - Leaf subprojects are `:foundation-fs`, `:foundation-compat`, `:thirdparty-onion`,
-    `:thirdparty-legacy`, and `:launcher-desktop`.
+    coupled core packages, all tests, packaging/runtime tasks, and the current
+    `LegacyRuntimePorts` bridge into the runtime SPI.
+  - Leaf subprojects are `:foundation-fs`, `:foundation-compat`, `:runtime-spi`,
+    `:thirdparty-onion`, `:thirdparty-legacy`, and `:launcher-desktop`.
 - Core network (`network.crypta.node`): `Node`, `PeerNode`, `PeerManager`, `PacketSender`, `RequestStarter`, `RequestScheduler`, `NodeUpdateManager`.
 - Storage (`network.crypta.store`): `FreenetStore`, `CHKStore`, `SSKStore`, `SlashdotStore`.
 - Crypto (`network.crypta.crypt`): AES, DSA/ECDSA, SHA‑256, `RandomSource`/Yarrow.
 - Keys (`network.crypta.keys`): `ClientCHK`, `ClientSSK`, `FreenetURI`, USK.
-- Clients: `network.crypta.client`, FCP (`network.crypta.clients.fcp`), HTTP (`network.crypta.clients.http`).
-- Config (`network.crypta.config`): type‑safe persisted configuration.
+- Clients: `network.crypta.client`, FCP (`network.crypta.clients.fcp`), HTTP
+  (`network.crypta.clients.http`). FCP now consumes execution, randomness, transfer policy,
+  lifecycle, and config access through `RuntimePorts` and FCP-local adapters instead of reaching
+  directly into daemon internals for those concerns.
+- Runtime SPI (`network.crypta.runtime.spi`): JDK-only ports and immutable config DTOs such as
+  `RuntimePorts`, `ConfigPort`, `ConfigSnapshot`, and `ConfigFieldSet`.
+- Config (`network.crypta.config`): type‑safe persisted configuration retained in the root daemon
+  and exposed upstream through `network.crypta.node.runtime.LegacyConfigPort` via
+  `RuntimePorts#config()`.
 - Support (`network.crypta.support`): logging, data structures, threading, helpers.
 - Launcher/Desktop: `:launcher-desktop` provides `network.crypta.launcher`,
   `com.jthemedetecor`, launcher resources, and desktop-theme integration.
 - Extracted foundations: `:foundation-fs` provides `network.crypta.fs`,
   `:foundation-compat` provides `network.crypta.compat`.
+- Runtime boundary leaf: `:runtime-spi` provides `network.crypta.runtime.spi`.
 - Vendored libraries: `:thirdparty-onion` provides `com.onionnetworks`,
   `:thirdparty-legacy` provides `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.
 


### PR DESCRIPTION
## Summary
- add `:runtime-spi` to the README build/module layout and dependency sections
- document the `RuntimePorts` boundary plus the `LegacyRuntimePorts`, `LegacyConfigPort`, and FCP adapter roles in the architecture guidance
- update the build-test and packaging skills to reflect the current leaf-module layout and the focused `:runtime-spi` compile path

## How to test
- `./gradlew spotlessApply`
- `git diff --check`

Docs/skills only; no production code changed.