### PR TITLE
feat(runtime): Move node-info slice onto runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeFieldSet.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeFieldSet.java
@@ -1,0 +1,101 @@
+package network.crypta.runtime.spi;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents one immutable node in a hierarchical node-info export tree.
+ *
+ * <p>{@code NodeFieldSet} mirrors the structure of legacy node-reference exports without exposing
+ * daemon-only transport classes through the runtime SPI. Each instance stores only the direct
+ * scalar values and direct named subsets at one level, allowing callers to rebuild a wire-specific
+ * tree by walking the snapshot recursively.
+ *
+ * <p>Instances are immutable and safe to share. The constructor defensively copies the supplied
+ * maps into encounter-order-preserving {@link LinkedHashMap} instances and then exposes
+ * unmodifiable views. Empty maps are normalized to shared empty instances so adapters can return
+ * compact snapshots without leaking mutability. Callers should treat the record as a detached
+ * snapshot value rather than a live view into the running daemon. Mutating the source maps after
+ * construction has no effect on the stored tree, and consumers are expected to walk the tree level
+ * by level when rebuilding a transport-specific representation.
+ *
+ * @param directValues direct scalar values stored at this tree level
+ * @param directSubsets direct child subsets keyed by the subset name at this level
+ * @see NodeReferenceSnapshot
+ */
+public record NodeFieldSet(
+    Map<String, String> directValues, Map<String, NodeFieldSet> directSubsets) {
+  /**
+   * Creates an immutable node-info tree node from direct values and direct child subsets.
+   *
+   * <p>The constructor defensively copies both maps, preserves their encounter order where
+   * possible, and rejects {@code null} keys and values. Passing empty maps is valid and produces an
+   * empty node, but callers should prefer {@link #empty()} when no content exists.
+   *
+   * @param directValues direct scalar values to store at this tree level
+   * @param directSubsets direct child subsets to store at this tree level
+   * @throws NullPointerException if either map, any key, or any value is {@code null}
+   */
+  public NodeFieldSet {
+    directValues = immutableDirectValues(directValues);
+    directSubsets = immutableDirectSubsets(directSubsets);
+  }
+
+  /**
+   * Returns an empty immutable tree node.
+   *
+   * <p>This is a convenience factory for callers that need a canonical representation of "no direct
+   * values and no direct subsets" without allocating mutable maps first. Export adapters can use it
+   * when a reference tree or child subset has been filtered down to nothing.
+   *
+   * @return empty node-info field-set value with no direct values or direct subsets
+   */
+  public static NodeFieldSet empty() {
+    return new NodeFieldSet(Map.of(), Map.of());
+  }
+
+  /**
+   * Returns whether this node contains neither direct values nor direct subsets.
+   *
+   * <p>This is a structural check only. It inspects the direct state stored in this node and does
+   * not attempt to infer whether a parent or sibling tree still carries meaningful data. Exporters
+   * can use the result to omit empty optional subsets such as volatile data when rebuilding a
+   * higher-level snapshot.
+   *
+   * @return {@code true} when this node contains no direct values and no direct subsets
+   */
+  public boolean isEmpty() {
+    return directValues.isEmpty() && directSubsets.isEmpty();
+  }
+
+  private static Map<String, String> immutableDirectValues(Map<String, String> source) {
+    Objects.requireNonNull(source, "directValues");
+    if (source.isEmpty()) {
+      return Map.of();
+    }
+    LinkedHashMap<String, String> copy = LinkedHashMap.newLinkedHashMap(source.size());
+    for (Map.Entry<String, String> entry : source.entrySet()) {
+      copy.put(
+          Objects.requireNonNull(entry.getKey(), "directValues key"),
+          Objects.requireNonNull(entry.getValue(), "directValues value"));
+    }
+    return Collections.unmodifiableMap(copy);
+  }
+
+  private static Map<String, NodeFieldSet> immutableDirectSubsets(
+      Map<String, NodeFieldSet> source) {
+    Objects.requireNonNull(source, "directSubsets");
+    if (source.isEmpty()) {
+      return Map.of();
+    }
+    LinkedHashMap<String, NodeFieldSet> copy = LinkedHashMap.newLinkedHashMap(source.size());
+    for (Map.Entry<String, NodeFieldSet> entry : source.entrySet()) {
+      copy.put(
+          Objects.requireNonNull(entry.getKey(), "directSubsets key"),
+          Objects.requireNonNull(entry.getValue(), "directSubsets value"));
+    }
+    return Collections.unmodifiableMap(copy);
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeGreetingSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeGreetingSnapshot.java
@@ -1,0 +1,51 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Represents the runtime metadata required to build an outbound node greeting.
+ *
+ * <p>This value captures the daemon and static metadata currently serialized by the FCP {@code
+ * NodeHello} message while keeping daemon-only classes out of the runtime SPI. It is intentionally
+ * limited to the existing node-greeting fields and excludes protocol-specific values such as the
+ * FCP version or the connection identifier.
+ *
+ * <p>Instances are detached snapshots. They are meant to be collected once by the runtime adapter
+ * and then handed to management-facing protocol code that can serialize the greeting without
+ * reaching back into daemon internals. That keeps per-connection response objects simple while
+ * preserving the current wire fields and allowing future runtime implementations to source the data
+ * differently.
+ *
+ * @param nodeName human-readable node product name advertised to management clients
+ * @param versionString serialized node version descriptor
+ * @param buildNumber build number embedded in the running node
+ * @param revision Git revision string embedded at build time
+ * @param testnetEnabled whether the node currently runs with testnet enabled
+ * @param compressionCodecs serialized compressor descriptor for the greeting payload
+ * @param nodeLanguage selected node language hint for clients
+ */
+public record NodeGreetingSnapshot(
+    String nodeName,
+    String versionString,
+    int buildNumber,
+    String revision,
+    boolean testnetEnabled,
+    String compressionCodecs,
+    String nodeLanguage) {
+  /**
+   * Creates an immutable node-greeting snapshot.
+   *
+   * <p>All string components must already be normalized into their outbound form before
+   * construction. The record stores them exactly as supplied and performs only null checks, so
+   * adapters remain responsible for deciding which daemon values belong in the greeting.
+   *
+   * @throws NullPointerException if any string component is {@code null}
+   */
+  public NodeGreetingSnapshot {
+    Objects.requireNonNull(nodeName, "nodeName");
+    Objects.requireNonNull(versionString, "versionString");
+    Objects.requireNonNull(revision, "revision");
+    Objects.requireNonNull(compressionCodecs, "compressionCodecs");
+    Objects.requireNonNull(nodeLanguage, "nodeLanguage");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeInfoPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeInfoPort.java
@@ -1,0 +1,43 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Exposes the narrow node-info capabilities needed by management-facing protocols.
+ *
+ * <p>This port is intentionally limited to the current FCP node-info family. It provides detached
+ * snapshots for the server greeting metadata and for node-reference exports without exposing daemon
+ * internals such as {@code Node}, {@code Version}, localization services, or legacy field-set
+ * transport types to higher layers.
+ *
+ * <p>Typical callers are protocol or management adapters that need a read-only description of the
+ * running node. The port does not perform access control and does not know about request
+ * identifiers or wire framing. Those concerns remain with the higher layer, which requests a
+ * snapshot here and then decides whether and how that snapshot should be serialized.
+ */
+public interface NodeInfoPort {
+  /**
+   * Returns a point-in-time snapshot of the node greeting metadata.
+   *
+   * <p>The returned value should contain everything a caller needs to build an outbound greeting
+   * message except protocol-owned fields such as the connection identifier. Implementations are
+   * free to source the data from live daemon state, cached metadata, or another runtime backend, as
+   * long as the snapshot is detached from mutable internal types.
+   *
+   * @return immutable snapshot containing the metadata required to build an outbound greeting
+   */
+  NodeGreetingSnapshot greeting();
+
+  /**
+   * Exports one node-reference tree for the requested view.
+   *
+   * <p>The volatile-data choice is kept as a separate flag because it remains orthogonal to the
+   * base view selection and does not justify widening the enum at this stage of the migration. The
+   * returned snapshot should represent the same logical export that the legacy daemon would have
+   * produced for the same view, but without leaking daemon-only types across the SPI boundary.
+   *
+   * @param view requested node-reference export shape
+   * @param includeVolatile whether transient volatile data should be attached under the root tree
+   * @return immutable node-reference snapshot for the requested view
+   * @throws NullPointerException if {@code view} is {@code null}
+   */
+  NodeReferenceSnapshot exportReference(NodeReferenceView view, boolean includeVolatile);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeReferenceSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeReferenceSnapshot.java
@@ -1,0 +1,58 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Represents an immutable point-in-time export of one node-reference tree.
+ *
+ * <p>This snapshot is the management-facing value produced by {@link NodeInfoPort} for the FCP
+ * node-reference family. It intentionally carries only the root tree node and does not encode
+ * request identifiers or other protocol-specific metadata, leaving those concerns to the caller's
+ * wire format.
+ *
+ * <p>Callers normally obtain instances from {@link NodeInfoPort#exportReference(NodeReferenceView,
+ * boolean)} and then adapt the tree to their own response format. The snapshot is safe to retain
+ * for the duration of one request or one serialization pass because it does not hold references to
+ * mutable daemon internals. An empty snapshot is valid and represents an export with no direct
+ * fields or child subsets.
+ *
+ * @param root root field-set tree for the exported node reference
+ * @see NodeFieldSet
+ * @see NodeInfoPort
+ */
+public record NodeReferenceSnapshot(NodeFieldSet root) {
+  /**
+   * Creates an immutable node-reference snapshot.
+   *
+   * @param root root field-set tree for the export; must not be {@code null}
+   * @throws NullPointerException if {@code root} is {@code null}
+   */
+  public NodeReferenceSnapshot {
+    Objects.requireNonNull(root, "root");
+  }
+
+  /**
+   * Returns an empty node-reference snapshot.
+   *
+   * <p>This is primarily a convenience for adapters and tests that need to express the absence of
+   * exported node-reference data without constructing an explicit empty root node first.
+   *
+   * @return snapshot whose root tree has no direct values or subsets
+   */
+  public static NodeReferenceSnapshot empty() {
+    return new NodeReferenceSnapshot(NodeFieldSet.empty());
+  }
+
+  /**
+   * Returns whether the exported root tree contains no data.
+   *
+   * <p>This delegates to the root {@link NodeFieldSet} and therefore reports only whether the
+   * stored snapshot tree is structurally empty. It does not distinguish between different reasons
+   * why the export might have been empty.
+   *
+   * @return {@code true} when the root field-set tree is empty
+   */
+  public boolean isEmpty() {
+    return root.isEmpty();
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeReferenceView.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeReferenceView.java
@@ -1,0 +1,29 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Selects which node-reference export shape the runtime should produce.
+ *
+ * <p>The legacy FCP node-reference flow historically combined two booleans to choose between
+ * darknet or opennet references and between public or private visibility. This enum preserves the
+ * same four outcomes while presenting a clearer, type-safe contract at the runtime SPI boundary.
+ * Callers can still pass the volatile-data choice separately without widening the port into a
+ * broader stats API.
+ *
+ * <p>This enum is intentionally narrow. It exists to model only the current node-reference export
+ * family that management-facing code needs today. Implementations should map each constant to the
+ * same underlying export path that the legacy daemon already exposes, so higher layers can migrate
+ * away from daemon-only booleans without changing wire behavior.
+ */
+public enum NodeReferenceView {
+  /** Public darknet reference intended for standard outbound node-reference export. */
+  DARKNET_PUBLIC,
+
+  /** Private darknet reference that includes trusted-peer-only details. */
+  DARKNET_PRIVATE,
+
+  /** Public opennet reference intended for public opennet export. */
+  OPENNET_PUBLIC,
+
+  /** Private opennet reference that includes trusted-peer-only details. */
+  OPENNET_PRIVATE
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -19,6 +19,7 @@ package network.crypta.runtime.spi;
  * @see TransferAccessPort
  * @see LifecyclePort
  * @see ConfigPort
+ * @see NodeInfoPort
  */
 public interface RuntimePorts {
   /**
@@ -78,4 +79,16 @@ public interface RuntimePorts {
    * @return configuration runtime port for export, update, and persistence operations
    */
   ConfigPort config();
+
+  /**
+   * Returns the node-info capability exposed to management-facing infrastructure code.
+   *
+   * <p>This port lets higher layers request node greeting metadata and node-reference exports
+   * without depending on daemon-only node, version, localization, compressor, or field-set types.
+   * The returned object should be treated as a live runtime view whose methods produce detached
+   * immutable snapshots.
+   *
+   * @return node-info runtime port for greeting metadata and node-reference exports
+   */
+  NodeInfoPort nodeInfo();
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientHelloMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientHelloMessage.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -113,11 +114,11 @@ public final class ClientHelloMessage extends FCPMessage {
    * and recording the announced client name for later auditing and quota attribution.
    *
    * <p>The method assumes the {@link FCPConnectionHandler} already verified message authenticity,
-   * so it focuses on the happy path: building a node response using the handler's connection UUID
-   * and dispatching it over the same channel. After the response leaves, the handler remembers the
-   * client name so future log lines can refer to it even if the socket closes unexpectedly. The
-   * {@link Node} parameter is currently unused but retained for parity with other {@link
-   * FCPMessage} hooks.
+   * so it focuses on the happy path: fetching greeting metadata from the runtime SPI, building a
+   * node response using the handler's connection UUID, and dispatching it over the same channel.
+   * After the response leaves, the handler remembers the client name so future log lines can refer
+   * to it even if the socket closes unexpectedly. The {@link Node} parameter is currently unused
+   * but retained for parity with other {@link FCPMessage} hooks.
    *
    * <pre>{@code
    * ClientHelloMessage hello = ...;
@@ -131,7 +132,9 @@ public final class ClientHelloMessage extends FCPMessage {
   @Override
   public void run(FCPConnectionHandler handler, Node node) {
     // We know the Hello is valid.
-    FCPMessage msg = new NodeHelloMessage(handler.getConnectionIdentifierUUID().toString());
+    NodeGreetingSnapshot greeting = handler.getServer().runtime().nodeInfo().greeting();
+    FCPMessage msg =
+        new NodeHelloMessage(greeting, handler.getConnectionIdentifierUUID().toString());
     handler.send(msg);
     handler.setClientName(clientName);
   }

--- a/src/main/java/network/crypta/clients/fcp/GetNode.java
+++ b/src/main/java/network/crypta/clients/fcp/GetNode.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -17,7 +18,7 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <ul>
  *   <li>Honors optional flags to include opennet references, private state, and volatile details.
- *   <li>Copies a caller-supplied identifier so responses can be correlated by clients.
+ *   <li>Copies a caller-supplied identifier so clients can correlate responses.
  *   <li>Does not mutate the source field set beyond removing the identifier key.
  * </ul>
  */
@@ -88,14 +89,16 @@ public class GetNode extends FCPMessage {
    * Executes the request by validating access and sending node details back to the client.
    *
    * <p>The handler must already be associated with a fully authorized connection; otherwise a
-   * {@link ProtocolErrorMessage#ACCESS_DENIED} failure is raised. On success, it emits a {@link
-   * NodeData} response populated according to the stored flags, ensuring the caller receives only
-   * the amount of information it asked for. The method performs no retries or partial responses;
-   * any failure propagates via the thrown exception.
+   * {@link ProtocolErrorMessage#ACCESS_DENIED} failure is raised. On success, it requests the
+   * selected node-reference snapshot from the runtime SPI and emits a {@link NodeData} response
+   * populated according to the stored flags, ensuring the caller receives only the amount of
+   * information it asked for. The method performs no retries or partial responses; any failure
+   * propagates via the thrown exception.
    *
    * @param handler connection handler performing access checks and delivering responses; must be
    *     authenticated.
-   * @param node node instance providing current state and references to serialize; not null.
+   * @param node backing node reference retained for {@link FCPMessage} signature parity; the
+   *     runtime SPI supplies the serialized snapshot.
    * @throws MessageInvalidException if the client lacks full access or the request violates
    *     protocol constraints.
    */
@@ -108,6 +111,16 @@ public class GetNode extends FCPMessage {
           requestIdentifier,
           false);
     }
-    handler.send(new NodeData(node, giveOpennetRef, withPrivate, withVolatile, requestIdentifier));
+    handler.send(
+        new NodeData(
+            handler.getServer().runtime().nodeInfo().exportReference(referenceView(), withVolatile),
+            requestIdentifier));
+  }
+
+  private NodeReferenceView referenceView() {
+    if (giveOpennetRef) {
+      return withPrivate ? NodeReferenceView.OPENNET_PRIVATE : NodeReferenceView.OPENNET_PUBLIC;
+    }
+    return withPrivate ? NodeReferenceView.DARKNET_PRIVATE : NodeReferenceView.DARKNET_PUBLIC;
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/NodeData.java
+++ b/src/main/java/network/crypta/clients/fcp/NodeData.java
@@ -1,24 +1,23 @@
 package network.crypta.clients.fcp;
 
+import java.util.Map;
+import java.util.Objects;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
 import network.crypta.support.SimpleFieldSet;
 
 /**
  * Packages node reference data for transmission from the server to an FCP client.
  *
- * <p>This message captures a snapshot of the current node identity and connectivity information
- * produced by the supplied {@link Node}. Callers choose whether to emit opennet or darknet
- * references, whether to include private details intended only for trusted peers, and whether to
- * append transient volatile metadata. Instances are immutable after construction; serialization is
- * deferred until {@link #getFieldSet()} is invoked, so the referenced {@code Node} should remain
- * stable while export occurs. The message is intentionally one-directional: it is created by the
- * server side when answering discovery or status requests and must not be sent from clients.
- * Concurrency expectations match the node: callers should invoke export methods within the node's
- * usual synchronization regime to avoid racing configuration updates.
+ * <p>This message carries a detached {@link NodeReferenceSnapshot} produced by the runtime SPI.
+ * Callers choose the requested reference view before constructing the message, and serialization is
+ * deferred until {@link #getFieldSet()} rebuilds a fresh {@link SimpleFieldSet}. The message is
+ * intentionally one-directional: it is created by the server side when answering discovery or
+ * status requests and must not be sent from clients.
  *
  * <ul>
- *   <li>Selects opennet or darknet representations based on {@code giveOpennetRef}.
- *   <li>Optionally includes private and volatile subsets for richer diagnostics.
+ *   <li>Rebuilds the historical node-reference tree from an immutable runtime snapshot.
  *   <li>Echoes an optional identifier to correlate responses with client requests.
  * </ul>
  */
@@ -26,85 +25,62 @@ public class NodeData extends FCPMessage {
 
   static final String NAME = "NodeData";
 
-  final Node node;
-  final boolean giveOpennetRef;
-  final boolean withPrivate;
-  final boolean withVolatile;
+  final NodeReferenceSnapshot snapshot;
   final String requestIdentifier;
 
   /**
-   * Creates an immutable message wrapper around the node's reference exports.
+   * Creates an immutable message wrapper around a detached node-reference snapshot.
    *
-   * <p>The constructor only stores references and flags; it does not perform expensive exports.
-   * Actual serialization happens when {@link #getFieldSet()} is called, allowing callers to defer
-   * work until just before a response is written. No validation is performed here, so callers must
-   * ensure the {@link Node} has up-to-date reference data and that privacy flags reflect the
-   * intended audience. Providing a {@code null} identifier omits the {@code Identifier} field and
-   * yields an anonymous response. Instances are safe to reuse across requests as long as the
-   * underlying node state remains consistent with the chosen visibility settings.
+   * <p>The constructor stores only the immutable snapshot and optional request identifier; it does
+   * not perform additional runtime lookups. Actual serialization happens when {@link
+   * #getFieldSet()} is called, allowing callers to defer wire reconstruction until just before a
+   * response is written. Providing a {@code null} identifier omits the {@code Identifier} field and
+   * yields an anonymous response.
    *
    * <pre>{@code
-   * NodeData payload = new NodeData(node, true, true, false, "req-42");
+   * NodeData payload =
+   *     new NodeData(
+   *         new NodeReferenceSnapshot(new NodeFieldSet(Map.of("identity", "alpha"), Map.of())),
+   *         "req-42");
    * SimpleFieldSet fs = payload.getFieldSet();
    * }</pre>
    *
-   * @param node Node providing reference data to serialize; must not be null.
-   * @param giveOpennetRef true to export opennet reference, false for darknet details instead.
-   * @param withPrivate true to include private elements intended for trusted peers only.
-   * @param withVolatile true to append transient volatile metadata when available from the node.
+   * @param snapshot runtime-exported node-reference snapshot to serialize
    * @param requestIdentifier optional identifier echoed in the {@code Identifier} field; nullable.
    */
-  public NodeData(
-      Node node,
-      boolean giveOpennetRef,
-      boolean withPrivate,
-      boolean withVolatile,
-      String requestIdentifier) {
-    this.node = node;
-    this.giveOpennetRef = giveOpennetRef;
-    this.withPrivate = withPrivate;
-    this.withVolatile = withVolatile;
+  public NodeData(NodeReferenceSnapshot snapshot, String requestIdentifier) {
+    this.snapshot = Objects.requireNonNull(snapshot);
     this.requestIdentifier = requestIdentifier;
   }
 
   /**
    * Builds the {@link SimpleFieldSet} containing the requested node reference details.
    *
-   * <p>This method invokes the appropriate export routine on the backing {@link Node}, choosing
-   * between opennet and darknet forms and adding private content when requested. When {@code
-   * withVolatile} is set, it merges the node's volatile field set under the {@code volatile} key if
-   * present. If a {@code requestIdentifier} was provided at construction time, it is written under
-   * the {@code Identifier} key so clients can correlate responses. The returned field set is newly
-   * allocated by the node export routines; callers may modify it without affecting shared state.
+   * <p>This method rebuilds the historical node-reference tree from the stored snapshot and writes
+   * the optional identifier under the {@code Identifier} key so clients can correlate responses.
+   * The returned field set is newly allocated for each call; callers may modify it without
+   * affecting the stored snapshot or future serializations.
    *
    * @return SimpleFieldSet containing the selected node reference data; never null.
    */
   @Override
   public SimpleFieldSet getFieldSet() {
-    SimpleFieldSet fs;
-    if (giveOpennetRef) {
-      if (withPrivate) {
-        fs = node.network().exportOpennetPrivateFieldSet();
-      } else {
-        fs = node.network().exportOpennetPublicFieldSet();
-      }
-    } else {
-      if (withPrivate) {
-        fs = node.network().exportDarknetPrivateFieldSet();
-      } else {
-        fs = node.network().exportDarknetPublicFieldSet();
-      }
-    }
-    if (withVolatile) {
-      SimpleFieldSet vol = node.network().exportVolatileFieldSet();
-      if (!vol.isEmpty()) {
-        fs.put("volatile", vol);
-      }
-    }
+    SimpleFieldSet fs = toSimpleFieldSet(snapshot.root());
     if (requestIdentifier != null) {
       fs.putSingle("Identifier", requestIdentifier);
     }
     return fs;
+  }
+
+  private static SimpleFieldSet toSimpleFieldSet(NodeFieldSet source) {
+    SimpleFieldSet target = new SimpleFieldSet(true);
+    for (Map.Entry<String, String> entry : source.directValues().entrySet()) {
+      target.putSingle(entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, NodeFieldSet> entry : source.directSubsets().entrySet()) {
+      target.tput(entry.getKey(), toSimpleFieldSet(entry.getValue()));
+    }
+    return target;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/NodeHelloMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/NodeHelloMessage.java
@@ -1,19 +1,18 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.l10n.NodeL10n;
+import java.util.Objects;
 import network.crypta.node.Node;
-import network.crypta.node.Version;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.compress.Compressor;
 
 /**
  * Outbound server greeting sent over the Freenet Client Protocol (FCP).
  *
- * <p>The message is emitted immediately after accepting an FCP connection so the client can learn
- * peer capabilities before issuing further commands. It advertises the negotiated protocol version,
- * build number, Git revision, and supported compression codecs. The greeting echoes a
- * connection-scoped identifier supplied at construction time so clients can correlate socket
- * handshakes with session state, and it carries a language hint for locale selection.
+ * <p>The message is emitted immediately after accepting an FCP connection, so the client can learn
+ * peer capabilities before issuing further commands. It advertises the negotiated protocol version
+ * alongside the daemon metadata already captured in a detached {@link NodeGreetingSnapshot}. The
+ * greeting echoes a connection-scoped identifier supplied at construction time so clients can
+ * correlate socket handshakes with session state.
  *
  * <p>Instances are immutable after construction and only assemble metadata; they never write to the
  * network or mutate node state. Threads may reuse the same instance safely because all fields are
@@ -31,46 +30,52 @@ public class NodeHelloMessage extends FCPMessage {
   /**
    * Canonical FCP message name used by the wire protocol and registry lookups.
    *
-   * <p>This constant is stable across releases so downstream components can perform equality checks
-   * without depending on instantiated objects.
+   * <p>This constant is stable across releases, so downstream components can perform equality
+   * checks without depending on instantiated objects.
    */
   public static final String NAME = "NodeHello";
 
-  private final String id;
+  private static final String FCP_VERSION = "2.0";
+
+  private final NodeGreetingSnapshot greeting;
+  private final String connectionIdentifier;
 
   /**
-   * Creates a greeting message bound to a connection identifier supplied by the FCP server.
+   * Creates a greeting message from a detached runtime snapshot and connection identifier.
    *
-   * @param id opaque connection identifier chosen by the server; never {@code null}; echoed back to
-   *     clients so they can match greetings to sockets or queued session metadata.
+   * @param greeting runtime snapshot containing node metadata to serialize
+   * @param connectionIdentifier opaque connection identifier chosen by the server; never {@code
+   *     null}; echoed back to clients so they can match greetings to sockets or queued session
+   *     metadata.
    */
-  public NodeHelloMessage(String id) {
-    this.id = id;
+  public NodeHelloMessage(NodeGreetingSnapshot greeting, String connectionIdentifier) {
+    this.greeting = Objects.requireNonNull(greeting, "greeting");
+    this.connectionIdentifier =
+        Objects.requireNonNull(connectionIdentifier, "connectionIdentifier");
   }
 
   /**
    * Builds a {@link SimpleFieldSet} describing the node and its negotiated connection settings.
    *
-   * <p>The returned set is freshly allocated on each call and includes protocol version, node
-   * identity, build number, Git revision, testnet flag, supported compression codecs, the supplied
-   * connection identifier, and a language hint derived from {@link NodeL10n}. All values are
-   * formatted using primitive types or strings ready for FCP serialization.
+   * <p>The returned set is freshly allocated on each call and includes the protocol version, the
+   * stored node metadata snapshot, and the supplied connection identifier. All values are formatted
+   * using primitive types or strings ready for FCP serialization.
    *
    * @return mutable field set ready for encoding; callers may add additional keys before sending
-   *     without affecting subsequent invocations because a new instance is produced each time.
+   *     without affecting later invocations because a new instance is produced each time.
    */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
-    sfs.putSingle("FCPVersion", "2.0");
-    sfs.putSingle("Node", "Cryptad");
-    sfs.putSingle("Version", Version.getVersionString());
-    sfs.put("Build", Version.currentBuildNumber());
-    sfs.putSingle("Revision", Version.gitRevision());
-    sfs.put("Testnet", Node.isTestnetEnabled());
-    sfs.putSingle("CompressionCodecs", Compressor.COMPRESSOR_TYPE.getHelloCompressorDescriptor());
-    sfs.putSingle("ConnectionIdentifier", id);
-    sfs.putSingle("NodeLanguage", NodeL10n.getBase().getSelectedLanguage().toString());
+    sfs.putSingle("FCPVersion", FCP_VERSION);
+    sfs.putSingle("Node", greeting.nodeName());
+    sfs.putSingle("Version", greeting.versionString());
+    sfs.put("Build", greeting.buildNumber());
+    sfs.putSingle("Revision", greeting.revision());
+    sfs.put("Testnet", greeting.testnetEnabled());
+    sfs.putSingle("CompressionCodecs", greeting.compressionCodecs());
+    sfs.putSingle("ConnectionIdentifier", connectionIdentifier);
+    sfs.putSingle("NodeLanguage", greeting.nodeLanguage());
     return sfs;
   }
 

--- a/src/main/java/network/crypta/node/runtime/LegacyNodeInfoPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyNodeInfoPort.java
@@ -1,0 +1,118 @@
+package network.crypta.node.runtime;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.Node;
+import network.crypta.node.Version;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.compress.Compressor;
+
+/**
+ * Adapts the daemon's legacy node-info exports to the runtime SPI's {@link NodeInfoPort}.
+ *
+ * <p>This bridge keeps knowledge of {@link Node}, {@link Version}, {@link NodeL10n}, {@link
+ * Compressor}, and {@link SimpleFieldSet} inside the daemon root module while exposing only
+ * SPI-local DTOs to management-facing code. It preserves the current export semantics by delegating
+ * directly to the daemon's existing node-reference and greeting metadata sources.
+ *
+ * <p>The adapter is intentionally small and read-only. It does not make access-control decisions
+ * and does not perform any FCP framing. Its job is limited to collecting the daemon state needed
+ * for the current node-info slice and translating legacy {@link SimpleFieldSet} trees into the
+ * immutable runtime-spi DTOs used by higher layers.
+ */
+final class LegacyNodeInfoPort implements NodeInfoPort {
+  /** Subset name used when volatile export data is attached to the root reference tree. */
+  private static final String VOLATILE_SUBSET = "volatile";
+
+  /** Live daemon node that remains the source of greeting and node-reference exports. */
+  private final Node node;
+
+  /**
+   * Creates a node-info adapter for one running daemon node.
+   *
+   * @param node live daemon node whose legacy exports back this adapter
+   */
+  LegacyNodeInfoPort(Node node) {
+    this.node = Objects.requireNonNull(node);
+  }
+
+  @Override
+  public NodeGreetingSnapshot greeting() {
+    return new NodeGreetingSnapshot(
+        Version.NODE_NAME,
+        Version.getVersionString(),
+        Version.currentBuildNumber(),
+        Version.gitRevision(),
+        Node.isTestnetEnabled(),
+        Compressor.COMPRESSOR_TYPE.getHelloCompressorDescriptor(),
+        NodeL10n.getBase().getSelectedLanguage().toString());
+  }
+
+  @Override
+  public NodeReferenceSnapshot exportReference(NodeReferenceView view, boolean includeVolatile) {
+    Objects.requireNonNull(view, "view");
+
+    NodeFieldSet root = toNodeFieldSet(exportBaseReference(view));
+    if (!includeVolatile) {
+      return new NodeReferenceSnapshot(root);
+    }
+
+    NodeFieldSet volatileFieldSet = toNodeFieldSet(node.network().exportVolatileFieldSet());
+    if (volatileFieldSet.isEmpty()) {
+      return new NodeReferenceSnapshot(root);
+    }
+
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>(root.directValues());
+    LinkedHashMap<String, NodeFieldSet> directSubsets = new LinkedHashMap<>(root.directSubsets());
+    directSubsets.put(VOLATILE_SUBSET, volatileFieldSet);
+    return new NodeReferenceSnapshot(new NodeFieldSet(directValues, directSubsets));
+  }
+
+  /**
+   * Selects the legacy daemon export that corresponds to one runtime-spi reference view.
+   *
+   * @param view requested node-reference view from the management-facing SPI
+   * @return legacy field-set export that matches the requested reference visibility and network
+   */
+  private SimpleFieldSet exportBaseReference(NodeReferenceView view) {
+    return switch (view) {
+      case DARKNET_PUBLIC -> node.network().exportDarknetPublicFieldSet();
+      case DARKNET_PRIVATE -> node.network().exportDarknetPrivateFieldSet();
+      case OPENNET_PUBLIC -> node.network().exportOpennetPublicFieldSet();
+      case OPENNET_PRIVATE -> node.network().exportOpennetPrivateFieldSet();
+    };
+  }
+
+  /**
+   * Converts one legacy field-set tree into the immutable runtime-spi node tree.
+   *
+   * <p>Only direct values and non-empty child subsets are retained at each level. That matches the
+   * export shape expected by the current node-info slice while avoiding empty placeholder nodes in
+   * the resulting snapshot.
+   *
+   * @param fieldSet legacy field-set tree to convert
+   * @return immutable node tree representing the same exported structure
+   */
+  private static NodeFieldSet toNodeFieldSet(SimpleFieldSet fieldSet) {
+    if (fieldSet.isEmpty()) {
+      return NodeFieldSet.empty();
+    }
+
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>(fieldSet.directKeyValues());
+    LinkedHashMap<String, NodeFieldSet> directSubsets = new LinkedHashMap<>();
+    for (Map.Entry<String, SimpleFieldSet> entry : fieldSet.directSubsets().entrySet()) {
+      NodeFieldSet subset = toNodeFieldSet(entry.getValue());
+      if (!subset.isEmpty()) {
+        directSubsets.put(entry.getKey(), subset);
+      }
+    }
+    return new NodeFieldSet(directValues, directSubsets);
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -7,6 +7,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -18,8 +19,8 @@ import network.crypta.runtime.spi.TransferAccessPort;
  * captures the existing {@link Node} and {@link NodeClientCore} instances and exposes their
  * already-available capabilities through the smaller {@link RuntimePorts} surface. The class adds
  * no policy of its own; each sub-port delegates directly to the legacy implementation, so behavior,
- * timing, file-access semantics, and configuration-management semantics remain aligned with the
- * daemon that existed before the SPI was introduced.
+ * timing, file-access semantics, configuration-management semantics, and node-info exports remain
+ * aligned with the daemon that existed before the SPI was introduced.
  *
  * <p>The adapter is immutable after construction. It is safe to share the instance anywhere the
  * daemon currently threads runtime dependencies, but callers should remember that the returned
@@ -33,6 +34,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final TransferAccessPort transferAccessPort;
   private final LifecyclePort lifecyclePort;
   private final ConfigPort configPort;
+  private final NodeInfoPort nodeInfoPort;
 
   /**
    * Creates a runtime SPI adapter backed by the current daemon internals.
@@ -40,8 +42,8 @@ public final class LegacyRuntimePorts implements RuntimePorts {
    * <p>The constructed adapter keeps direct references to {@code node} and {@code core} and uses
    * them to implement each runtime sub-port with thin delegation only. No data is copied and no
    * validation or normalization is introduced here, so existing daemon semantics remain the source
-   * of truth for execution, randomness, transfer policy, lifecycle state, and configuration
-   * management.
+   * of truth for execution, randomness, transfer policy, lifecycle state, configuration management,
+   * and node-info exports.
    *
    * @param node live daemon node that provides execution, randomness, and lifecycle behavior
    * @param core live client core that provides transfer-policy checks and directory access
@@ -113,6 +115,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
           }
         };
     this.configPort = new LegacyConfigPort(node, core);
+    this.nodeInfoPort = new LegacyNodeInfoPort(node);
   }
 
   /**
@@ -166,5 +169,16 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public ConfigPort config() {
     return configPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps all legacy greeting metadata and node-reference export logic inside
+   * the daemon root module while exposing only SPI-local snapshots upstream.
+   */
+  @Override
+  public NodeInfoPort nodeInfo() {
+    return nodeInfoPort;
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientHelloMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientHelloMessageTest.java
@@ -2,17 +2,22 @@ package network.crypta.clients.fcp;
 
 import java.util.UUID;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
@@ -21,8 +26,13 @@ class ClientHelloMessageTest {
 
   @Mock private FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private Node node;
+
+  @Mock private FCPServer server;
+
+  @Mock private RuntimePorts runtimePorts;
+
+  @Mock private NodeInfoPort nodeInfoPort;
 
   @Test
   void constructor_whenNameMissing_expectException() {
@@ -64,19 +74,33 @@ class ClientHelloMessageTest {
   }
 
   @Test
-  void run_whenInvoked_sendsNodeHelloAndRegistersClient() throws MessageInvalidException {
+  void run_whenInvoked_fetchesGreetingSendsNodeHelloAndRegistersClient()
+      throws MessageInvalidException {
     ClientHelloMessage message = new ClientHelloMessage(fieldSet("deterministic-client", "0.7.0"));
     UUID identifier = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+    NodeGreetingSnapshot greeting =
+        new NodeGreetingSnapshot(
+            "Cryptad", "v-string", 123, "rev-xyz", true, "descriptor", "ENGLISH");
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.nodeInfo()).thenReturn(nodeInfoPort);
+    when(nodeInfoPort.greeting()).thenReturn(greeting);
     when(handler.getConnectionIdentifierUUID()).thenReturn(identifier);
 
     message.run(handler, node);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
-    verify(handler).send(captor.capture());
+    InOrder order = inOrder(nodeInfoPort, handler);
+    order.verify(nodeInfoPort).greeting();
+    order.verify(handler).send(captor.capture());
+    order.verify(handler).setClientName("deterministic-client");
     FCPMessage sentMessage = captor.getValue();
     assertInstanceOf(NodeHelloMessage.class, sentMessage);
-    assertEquals(identifier.toString(), sentMessage.getFieldSet().get("ConnectionIdentifier"));
-    verify(handler).setClientName("deterministic-client");
+    SimpleFieldSet greetingFieldSet = sentMessage.getFieldSet();
+    assertEquals(identifier.toString(), greetingFieldSet.get("ConnectionIdentifier"));
+    assertEquals("Cryptad", greetingFieldSet.get("Node"));
+    assertEquals("v-string", greetingFieldSet.get("Version"));
+    verifyNoInteractions(node);
   }
 
   private static SimpleFieldSet fieldSet(String name, String expectedVersion) {

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
@@ -16,6 +16,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ExecutionPort;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
+import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
@@ -272,6 +274,8 @@ class FCPConnectionInputHandlerTest {
     ctx.server = mock(FCPServer.class);
     ctx.node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
     ctx.core = mock(NodeClientCore.class);
+    ctx.runtimePorts = mock(RuntimePorts.class);
+    ctx.nodeInfoPort = mock(NodeInfoPort.class);
     ctx.persistentFactory = mock(PersistentTempBucketFactory.class);
     ctx.socket = mock(Socket.class);
 
@@ -280,6 +284,13 @@ class FCPConnectionInputHandlerTest {
     when(ctx.handler.getServer()).thenReturn(ctx.server);
     lenient().when(ctx.server.getNode()).thenReturn(ctx.node);
     lenient().when(ctx.server.getCore()).thenReturn(ctx.core);
+    lenient().when(ctx.server.runtime()).thenReturn(ctx.runtimePorts);
+    lenient().when(ctx.runtimePorts.nodeInfo()).thenReturn(ctx.nodeInfoPort);
+    lenient()
+        .when(ctx.nodeInfoPort.greeting())
+        .thenReturn(
+            new NodeGreetingSnapshot(
+                "Cryptad", "v-string", 123, "rev-xyz", false, "descriptor", "ENGLISH"));
     lenient().when(ctx.core.getTempBucketFactory()).thenReturn(ctx.bucketFactory);
     lenient().when(ctx.core.getPersistentTempBucketFactory()).thenReturn(ctx.persistentFactory);
     lenient().when(ctx.handler.isClosed()).thenReturn(false);
@@ -326,6 +337,8 @@ class FCPConnectionInputHandlerTest {
     FCPServer server;
     Node node;
     NodeClientCore core;
+    RuntimePorts runtimePorts;
+    NodeInfoPort nodeInfoPort;
     Socket socket;
     TempBucketFactory bucketFactory;
     PersistentTempBucketFactory persistentFactory;

--- a/src/test/java/network/crypta/clients/fcp/GetNodeTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetNodeTest.java
@@ -2,10 +2,18 @@ package network.crypta.clients.fcp;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -13,10 +21,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,8 +33,13 @@ class GetNodeTest {
 
   @Mock private FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private Node node;
+
+  @Mock private FCPServer server;
+
+  @Mock private RuntimePorts runtimePorts;
+
+  @Mock private NodeInfoPort nodeInfoPort;
 
   @Test
   void constructor_whenFieldsPresent_setsFlagsAndRemovesIdentifier() {
@@ -104,27 +117,41 @@ class GetNodeTest {
     assertEquals("restricted-client", exception.ident);
     assertFalse(exception.global);
     assertEquals("GetNode requires full access", exception.getMessage());
+    verifyNoInteractions(server, runtimePorts, nodeInfoPort, node);
   }
 
-  @Test
-  void run_whenFullAccess_sendsNodeDataWithFlags() throws MessageInvalidException {
+  @ParameterizedTest
+  @CsvSource({
+    "true,true,OPENNET_PRIVATE",
+    "true,false,OPENNET_PUBLIC",
+    "false,true,DARKNET_PRIVATE",
+    "false,false,DARKNET_PUBLIC"
+  })
+  void run_whenFullAccess_requestsMatchingReferenceViewAndSendsNodeData(
+      boolean giveOpennetRef, boolean withPrivate, NodeReferenceView expectedView)
+      throws MessageInvalidException {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("GiveOpennetRef", "true");
-    fs.putSingle("WithPrivate", "false");
+    fs.putSingle("GiveOpennetRef", Boolean.toString(giveOpennetRef));
+    fs.putSingle("WithPrivate", Boolean.toString(withPrivate));
     fs.putSingle("WithVolatile", "true");
     fs.putSingle("Identifier", "req-42");
     GetNode getNode = new GetNode(fs);
+    NodeReferenceSnapshot snapshot =
+        new NodeReferenceSnapshot(new NodeFieldSet(Map.of("identity", "alpha"), Map.of()));
     when(handler.hasFullAccess()).thenReturn(true);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.nodeInfo()).thenReturn(nodeInfoPort);
+    when(nodeInfoPort.exportReference(expectedView, true)).thenReturn(snapshot);
     ArgumentCaptor<NodeData> messageCaptor = ArgumentCaptor.forClass(NodeData.class);
 
     getNode.run(handler, node);
 
+    verify(nodeInfoPort).exportReference(expectedView, true);
     verify(handler).send(messageCaptor.capture());
     NodeData sent = messageCaptor.getValue();
-    assertSame(node, sent.node);
-    assertTrue(sent.giveOpennetRef);
-    assertFalse(sent.withPrivate);
-    assertTrue(sent.withVolatile);
+    assertEquals(snapshot, sent.snapshot);
     assertEquals("req-42", sent.requestIdentifier);
+    verifyNoInteractions(node);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/NodeDataTest.java
+++ b/src/test/java/network/crypta/clients/fcp/NodeDataTest.java
@@ -1,120 +1,79 @@
 package network.crypta.clients.fcp;
 
+import java.util.Map;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class NodeDataTest {
 
-  private static final String VOLATILE_KEY = "volatile";
+  @Mock private Node node;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @ParameterizedTest
-  @CsvSource({"true,true", "true,false", "false,true", "false,false"})
-  void getFieldSet_whenFlagsCombination_selectsCorrectBaseFieldSet(
-      boolean giveOpennetRef, boolean withPrivate) {
-    SimpleFieldSet expected = new SimpleFieldSet(true);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-
-    if (giveOpennetRef && withPrivate) {
-      when(network.exportOpennetPrivateFieldSet()).thenReturn(expected);
-    } else if (giveOpennetRef) {
-      when(network.exportOpennetPublicFieldSet()).thenReturn(expected);
-    } else if (withPrivate) {
-      when(network.exportDarknetPrivateFieldSet()).thenReturn(expected);
-    } else {
-      when(network.exportDarknetPublicFieldSet()).thenReturn(expected);
-    }
-
-    NodeData nodeData =
-        new NodeData(node, giveOpennetRef, withPrivate, /* withVolatile= */ false, null);
+  @Test
+  void getFieldSet_whenSnapshotContainsNestedValues_rebuildsFieldSetRecursively() {
+    NodeReferenceSnapshot snapshot =
+        new NodeReferenceSnapshot(
+            new NodeFieldSet(
+                Map.of("identity", "alpha"),
+                Map.of(
+                    "physical", new NodeFieldSet(Map.of("address", "127.0.0.1"), Map.of()),
+                    "volatile", new NodeFieldSet(Map.of("uptimeSeconds", "42"), Map.of()))));
+    NodeData nodeData = new NodeData(snapshot, "node-identifier-1");
 
     SimpleFieldSet result = nodeData.getFieldSet();
 
-    assertSame(expected, result);
-    assertNull(result.subset(VOLATILE_KEY));
-    assertNull(result.get("Identifier"));
-    verify(network, never()).exportVolatileFieldSet();
+    assertEquals("alpha", result.get("identity"));
+    assertEquals("127.0.0.1", result.get("physical.address"));
+    assertEquals("42", result.get("volatile.uptimeSeconds"));
+    assertEquals("node-identifier-1", result.get("Identifier"));
   }
 
   @Test
-  void getFieldSet_whenWithVolatileAndNonEmpty_exportAddsVolatileSubset() {
-    SimpleFieldSet base = new SimpleFieldSet(true);
-    SimpleFieldSet vol = new SimpleFieldSet(true);
-    vol.putSingle("stat", "value");
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.exportOpennetPublicFieldSet()).thenReturn(base);
-    when(network.exportVolatileFieldSet()).thenReturn(vol);
-    NodeData nodeData =
-        new NodeData(node, /* giveOpennetRef= */ true, /* withPrivate= */ false, true, null);
+  void getFieldSet_whenSnapshotContainsEmptySubset_expectEmptySubsetOmitted() {
+    NodeReferenceSnapshot snapshot =
+        new NodeReferenceSnapshot(
+            new NodeFieldSet(
+                Map.of("identity", "alpha"),
+                Map.of(
+                    "empty",
+                    NodeFieldSet.empty(),
+                    "present",
+                    new NodeFieldSet(Map.of("name", "beta"), Map.of()))));
+    NodeData nodeData = new NodeData(snapshot, null);
 
     SimpleFieldSet result = nodeData.getFieldSet();
 
-    assertSame(base, result);
-    assertSame(vol, result.subset(VOLATILE_KEY));
+    assertEquals("alpha", result.get("identity"));
+    assertEquals("beta", result.get("present.name"));
+    assertNull(result.subset("empty"));
   }
 
   @Test
-  void getFieldSet_whenWithVolatileAndEmpty_exportDoesNotAddVolatileSubset() {
-    SimpleFieldSet base = new SimpleFieldSet(true);
-    SimpleFieldSet emptyVol = new SimpleFieldSet(true);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.exportDarknetPrivateFieldSet()).thenReturn(base);
-    when(network.exportVolatileFieldSet()).thenReturn(emptyVol);
-    NodeData nodeData =
-        new NodeData(node, /* giveOpennetRef= */ false, /* withPrivate= */ true, true, null);
+  void getFieldSet_whenSnapshotEmpty_expectEmptyFieldSetWithoutIdentifier() {
+    NodeData nodeData = new NodeData(NodeReferenceSnapshot.empty(), null);
 
     SimpleFieldSet result = nodeData.getFieldSet();
 
-    assertSame(base, result);
-    assertNull(result.subset(VOLATILE_KEY));
-  }
-
-  @Test
-  void getFieldSet_whenIdentifierProvided_addsIdentifierField() {
-    SimpleFieldSet base = new SimpleFieldSet(true);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.exportOpennetPrivateFieldSet()).thenReturn(base);
-    String identifier = "node-identifier-1";
-    NodeData nodeData =
-        new NodeData(node, /* giveOpennetRef= */ true, /* withPrivate= */ true, false, identifier);
-
-    SimpleFieldSet result = nodeData.getFieldSet();
-
-    assertSame(base, result);
-    assertEquals(identifier, result.get("Identifier"));
+    assertTrue(result.directKeys().isEmpty());
+    assertTrue(result.directSubsets().isEmpty());
   }
 
   @Test
   void getName_returnsStaticName() {
-    NodeData nodeData =
-        new NodeData(node, /* giveOpennetRef= */ true, /* withPrivate= */ false, false, null);
+    NodeData nodeData = new NodeData(NodeReferenceSnapshot.empty(), null);
 
     assertEquals("NodeData", nodeData.getName());
   }
@@ -122,9 +81,7 @@ class NodeDataTest {
   @Test
   void run_whenCalled_throwsInvalidMessageExceptionWithIdentifier() {
     String identifier = "client-id-123";
-    NodeData nodeData =
-        new NodeData(
-            node, /* giveOpennetRef= */ false, /* withPrivate= */ false, false, identifier);
+    NodeData nodeData = new NodeData(NodeReferenceSnapshot.empty(), identifier);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> nodeData.run(null, node));
@@ -138,8 +95,7 @@ class NodeDataTest {
 
   @Test
   void run_whenIdentifierNull_throwsInvalidMessageExceptionWithNullIdentifier() {
-    NodeData nodeData =
-        new NodeData(node, /* giveOpennetRef= */ false, /* withPrivate= */ true, false, null);
+    NodeData nodeData = new NodeData(NodeReferenceSnapshot.empty(), null);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> nodeData.run(null, node));

--- a/src/test/java/network/crypta/clients/fcp/NodeHelloMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/NodeHelloMessageTest.java
@@ -1,15 +1,10 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.l10n.BaseL10n;
-import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
-import network.crypta.node.Version;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.compress.Compressor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -17,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
@@ -25,62 +19,50 @@ class NodeHelloMessageTest {
 
   @Test
   void getFieldSet_whenCalled_populatesExpectedFields() {
-    try (MockedStatic<Version> version = Mockito.mockStatic(Version.class);
-        MockedStatic<Node> node = Mockito.mockStatic(Node.class);
-        MockedStatic<NodeL10n> nodeL10n = Mockito.mockStatic(NodeL10n.class);
-        MockedStatic<Compressor.COMPRESSOR_TYPE> compressor =
-            Mockito.mockStatic(Compressor.COMPRESSOR_TYPE.class)) {
+    NodeGreetingSnapshot greeting =
+        new NodeGreetingSnapshot(
+            "Cryptad", "v-string", 123, "rev-xyz", true, "descriptor", "ENGLISH");
+    NodeHelloMessage message = new NodeHelloMessage(greeting, "connection-1");
 
-      version.when(Version::getVersionString).thenReturn("v-string");
-      version.when(Version::currentBuildNumber).thenReturn(123);
-      version.when(Version::gitRevision).thenReturn("rev-xyz");
-      //noinspection ResultOfMethodCallIgnored
-      node.when(Node::isTestnetEnabled).thenReturn(true);
-      compressor
-          .when(Compressor.COMPRESSOR_TYPE::getHelloCompressorDescriptor)
-          .thenReturn("descriptor");
+    SimpleFieldSet sfs = message.getFieldSet();
 
-      BaseL10n base = Mockito.mock(BaseL10n.class);
-      Mockito.when(base.getSelectedLanguage()).thenReturn(BaseL10n.LANGUAGE.ENGLISH);
-      nodeL10n.when(NodeL10n::getBase).thenReturn(base);
-
-      NodeHelloMessage message = new NodeHelloMessage("connection-1");
-
-      SimpleFieldSet sfs = message.getFieldSet();
-
-      assertAll(
-          () -> assertEquals("2.0", sfs.get("FCPVersion")),
-          () -> assertEquals("Cryptad", sfs.get("Node")),
-          () -> assertEquals("v-string", sfs.get("Version")),
-          () -> assertEquals("123", sfs.get("Build")),
-          () -> assertEquals("rev-xyz", sfs.get("Revision")),
-          () -> assertTrue(Node.isTestnetEnabled()),
-          () -> assertEquals("true", sfs.get("Testnet")),
-          () -> assertEquals("descriptor", sfs.get("CompressionCodecs")),
-          () -> assertEquals("connection-1", sfs.get("ConnectionIdentifier")),
-          () -> assertEquals(BaseL10n.LANGUAGE.ENGLISH.toString(), sfs.get("NodeLanguage")),
-          () -> assertEquals(9, sfs.directKeys().size()));
-    }
+    assertAll(
+        () -> assertEquals("2.0", sfs.get("FCPVersion")),
+        () -> assertEquals("Cryptad", sfs.get("Node")),
+        () -> assertEquals("v-string", sfs.get("Version")),
+        () -> assertEquals("123", sfs.get("Build")),
+        () -> assertEquals("rev-xyz", sfs.get("Revision")),
+        () -> assertEquals("true", sfs.get("Testnet")),
+        () -> assertEquals("descriptor", sfs.get("CompressionCodecs")),
+        () -> assertEquals("connection-1", sfs.get("ConnectionIdentifier")),
+        () -> assertEquals("ENGLISH", sfs.get("NodeLanguage")),
+        () -> assertEquals(9, sfs.directKeys().size()));
   }
 
   @Test
   void getName_whenCalled_returnsNodeHello() {
-    NodeHelloMessage message = new NodeHelloMessage("id");
+    NodeHelloMessage message =
+        new NodeHelloMessage(
+            new NodeGreetingSnapshot("Cryptad", "v", 1, "rev", false, "descriptor", "ENGLISH"),
+            "id");
 
     assertEquals(NodeHelloMessage.NAME, message.getName());
   }
 
   @Test
   void run_whenInvoked_throwsMessageInvalidException() {
-    NodeHelloMessage message = new NodeHelloMessage("id");
+    NodeHelloMessage message =
+        new NodeHelloMessage(
+            new NodeGreetingSnapshot("Cryptad", "v", 1, "rev", false, "descriptor", "ENGLISH"),
+            "id");
 
     MessageInvalidException exception =
         assertThrows(
             MessageInvalidException.class,
             () ->
                 message.run(
-                    Mockito.mock(FCPConnectionHandler.class),
-                    Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS)));
+                    org.mockito.Mockito.mock(FCPConnectionHandler.class),
+                    org.mockito.Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS)));
 
     assertAll(
         () -> assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode),

--- a/src/test/java/network/crypta/node/runtime/LegacyNodeInfoPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyNodeInfoPortTest.java
@@ -1,0 +1,154 @@
+package network.crypta.node.runtime;
+
+import java.util.Map;
+import network.crypta.l10n.BaseL10n;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.Node;
+import network.crypta.node.Version;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.compress.Compressor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyNodeInfoPortTest {
+
+  @Mock private Node node;
+
+  @Mock private NodeNetworkSubsystem network;
+
+  @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  void greeting_whenCalled_mapsExpectedDaemonValuesToSnapshot() {
+    LegacyNodeInfoPort port = new LegacyNodeInfoPort(node);
+
+    try (MockedStatic<Version> version = Mockito.mockStatic(Version.class);
+        MockedStatic<Node> nodeClass = Mockito.mockStatic(Node.class);
+        MockedStatic<NodeL10n> nodeL10n = Mockito.mockStatic(NodeL10n.class);
+        MockedStatic<Compressor.COMPRESSOR_TYPE> compressor =
+            Mockito.mockStatic(Compressor.COMPRESSOR_TYPE.class)) {
+
+      version.when(Version::getVersionString).thenReturn("v-string");
+      version.when(Version::currentBuildNumber).thenReturn(123);
+      version.when(Version::gitRevision).thenReturn("rev-xyz");
+      nodeClass.when(Node::isTestnetEnabled).thenReturn(true);
+      compressor
+          .when(Compressor.COMPRESSOR_TYPE::getHelloCompressorDescriptor)
+          .thenReturn("descriptor");
+
+      BaseL10n base = Mockito.mock(BaseL10n.class);
+      Mockito.when(base.getSelectedLanguage()).thenReturn(BaseL10n.LANGUAGE.ENGLISH);
+      nodeL10n.when(NodeL10n::getBase).thenReturn(base);
+
+      NodeGreetingSnapshot snapshot = port.greeting();
+
+      assertEquals(
+          new NodeGreetingSnapshot(
+              Version.NODE_NAME,
+              "v-string",
+              123,
+              "rev-xyz",
+              true,
+              "descriptor",
+              BaseL10n.LANGUAGE.ENGLISH.toString()),
+          snapshot);
+      verifyNoInteractions(node);
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(NodeReferenceView.class)
+  void exportReference_whenViewRequested_selectsCorrectBaseExport(NodeReferenceView view) {
+    LegacyNodeInfoPort port = new LegacyNodeInfoPort(node);
+    when(node.network()).thenReturn(network);
+    SimpleFieldSet base = new SimpleFieldSet(true);
+    base.putSingle("identity", view.name());
+    SimpleFieldSet physical = new SimpleFieldSet(true);
+    physical.putSingle("host", "127.0.0.1");
+    base.put("physical", physical);
+    stubBaseExport(view, base);
+
+    NodeReferenceSnapshot snapshot = port.exportReference(view, false);
+
+    assertEquals(
+        new NodeReferenceSnapshot(
+            new NodeFieldSet(
+                Map.of("identity", view.name()),
+                Map.of("physical", new NodeFieldSet(Map.of("host", "127.0.0.1"), Map.of())))),
+        snapshot);
+    verifySelectedBaseExport(view);
+    verify(network, never()).exportVolatileFieldSet();
+  }
+
+  @Test
+  void exportReference_whenVolatileDataPresent_attachesVolatileSubset() {
+    LegacyNodeInfoPort port = new LegacyNodeInfoPort(node);
+    when(node.network()).thenReturn(network);
+    SimpleFieldSet base = new SimpleFieldSet(true);
+    base.putSingle("identity", "alpha");
+    SimpleFieldSet volatileFieldSet = new SimpleFieldSet(true);
+    volatileFieldSet.putSingle("uptimeSeconds", "42");
+    when(network.exportDarknetPublicFieldSet()).thenReturn(base);
+    when(network.exportVolatileFieldSet()).thenReturn(volatileFieldSet);
+
+    NodeReferenceSnapshot snapshot = port.exportReference(NodeReferenceView.DARKNET_PUBLIC, true);
+
+    assertEquals("alpha", snapshot.root().directValues().get("identity"));
+    assertEquals(
+        new NodeFieldSet(Map.of("uptimeSeconds", "42"), Map.of()),
+        snapshot.root().directSubsets().get("volatile"));
+  }
+
+  @Test
+  void exportReference_whenVolatileDataEmpty_omitsVolatileSubset() {
+    LegacyNodeInfoPort port = new LegacyNodeInfoPort(node);
+    when(node.network()).thenReturn(network);
+    SimpleFieldSet base = new SimpleFieldSet(true);
+    base.putSingle("identity", "alpha");
+    when(network.exportOpennetPrivateFieldSet()).thenReturn(base);
+    when(network.exportVolatileFieldSet()).thenReturn(new SimpleFieldSet(true));
+
+    NodeReferenceSnapshot snapshot = port.exportReference(NodeReferenceView.OPENNET_PRIVATE, true);
+
+    assertFalse(snapshot.root().directSubsets().containsKey("volatile"));
+    assertNull(snapshot.root().directSubsets().get("volatile"));
+  }
+
+  private void stubBaseExport(NodeReferenceView view, SimpleFieldSet base) {
+    switch (view) {
+      case DARKNET_PUBLIC -> when(network.exportDarknetPublicFieldSet()).thenReturn(base);
+      case DARKNET_PRIVATE -> when(network.exportDarknetPrivateFieldSet()).thenReturn(base);
+      case OPENNET_PUBLIC -> when(network.exportOpennetPublicFieldSet()).thenReturn(base);
+      case OPENNET_PRIVATE -> when(network.exportOpennetPrivateFieldSet()).thenReturn(base);
+    }
+  }
+
+  private void verifySelectedBaseExport(NodeReferenceView view) {
+    switch (view) {
+      case DARKNET_PUBLIC -> verify(network).exportDarknetPublicFieldSet();
+      case DARKNET_PRIVATE -> verify(network).exportDarknetPrivateFieldSet();
+      case OPENNET_PUBLIC -> verify(network).exportOpennetPublicFieldSet();
+      case OPENNET_PRIVATE -> verify(network).exportOpennetPrivateFieldSet();
+    }
+  }
+}

--- a/src/test/java/network/crypta/runtime/spi/NodeFieldSetTest.java
+++ b/src/test/java/network/crypta/runtime/spi/NodeFieldSetTest.java
@@ -1,0 +1,140 @@
+package network.crypta.runtime.spi;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class NodeFieldSetTest {
+
+  @Test
+  void empty_whenCalled_expectEmptyFieldSet() {
+    NodeFieldSet fieldSet = NodeFieldSet.empty();
+
+    assertTrue(fieldSet.isEmpty());
+    assertTrue(fieldSet.directValues().isEmpty());
+    assertTrue(fieldSet.directSubsets().isEmpty());
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonEmptyFieldSets")
+  void isEmpty_whenFieldSetContainsEntries_expectFalse(NodeFieldSet fieldSet) {
+    assertFalse(fieldSet.isEmpty());
+  }
+
+  @Test
+  void constructor_whenSourceMapsMutatedAfterCreation_expectDefensiveCopies() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put("alpha", "1");
+    LinkedHashMap<String, NodeFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put("nested", new NodeFieldSet(Map.of("enabled", "true"), Map.of()));
+
+    NodeFieldSet fieldSet = new NodeFieldSet(directValues, directSubsets);
+
+    directValues.put("alpha", "updated");
+    directValues.put("beta", "2");
+    directSubsets.clear();
+
+    assertEquals(Map.of("alpha", "1"), fieldSet.directValues());
+    assertEquals(
+        Map.of("nested", new NodeFieldSet(Map.of("enabled", "true"), Map.of())),
+        fieldSet.directSubsets());
+  }
+
+  @Test
+  void constructor_whenMapsExposed_expectUnmodifiableViews() {
+    NodeFieldSet fieldSet =
+        new NodeFieldSet(
+            Map.of("alpha", "1"), Map.of("nested", new NodeFieldSet(Map.of(), Map.of())));
+    Map<String, String> directValues = fieldSet.directValues();
+    Map<String, NodeFieldSet> directSubsets = fieldSet.directSubsets();
+    NodeFieldSet emptyFieldSet = NodeFieldSet.empty();
+
+    assertThrows(UnsupportedOperationException.class, () -> directValues.put("beta", "2"));
+    assertThrows(
+        UnsupportedOperationException.class, () -> directSubsets.put("second", emptyFieldSet));
+  }
+
+  @Test
+  void constructor_whenLinkedHashMapsProvided_expectEncounterOrderPreserved() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put("alpha", "1");
+    directValues.put("beta", "2");
+    directValues.put("gamma", "3");
+    LinkedHashMap<String, NodeFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put("first", NodeFieldSet.empty());
+    directSubsets.put("second", new NodeFieldSet(Map.of("name", "value"), Map.of()));
+
+    NodeFieldSet fieldSet = new NodeFieldSet(directValues, directSubsets);
+
+    assertEquals(
+        List.of("alpha", "beta", "gamma"), new ArrayList<>(fieldSet.directValues().keySet()));
+    assertEquals(List.of("first", "second"), new ArrayList<>(fieldSet.directSubsets().keySet()));
+  }
+
+  @Test
+  void constructor_whenDirectValuesNull_expectNullPointerException() {
+    Map<String, NodeFieldSet> directSubsets = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new NodeFieldSet(null, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectSubsetsNull_expectNullPointerException() {
+    Map<String, String> directValues = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new NodeFieldSet(directValues, null));
+  }
+
+  @Test
+  void constructor_whenDirectValuesContainNullKey_expectNullPointerException() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put(null, "value");
+    Map<String, NodeFieldSet> directSubsets = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new NodeFieldSet(directValues, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectValuesContainNullValue_expectNullPointerException() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put("key", null);
+    Map<String, NodeFieldSet> directSubsets = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new NodeFieldSet(directValues, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectSubsetsContainNullKey_expectNullPointerException() {
+    LinkedHashMap<String, NodeFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put(null, NodeFieldSet.empty());
+    Map<String, String> directValues = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new NodeFieldSet(directValues, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectSubsetsContainNullValue_expectNullPointerException() {
+    LinkedHashMap<String, NodeFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put("nested", null);
+    Map<String, String> directValues = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new NodeFieldSet(directValues, directSubsets));
+  }
+
+  private static Stream<NodeFieldSet> nonEmptyFieldSets() {
+    return Stream.of(
+        new NodeFieldSet(Map.of("enabled", "true"), Map.of()),
+        new NodeFieldSet(Map.of(), Map.of("nested", NodeFieldSet.empty())));
+  }
+}


### PR DESCRIPTION
## Summary
- add a JDK-only `NodeInfoPort` to `runtime-spi` with `NodeReferenceView`, `NodeFieldSet`, `NodeReferenceSnapshot`, and `NodeGreetingSnapshot`
- expose `nodeInfo()` from `RuntimePorts` and add the daemon-side `LegacyNodeInfoPort` adapter wired through `LegacyRuntimePorts`
- migrate the FCP node-info slice to detached runtime snapshots by updating `GetNode`, `NodeData`, `ClientHelloMessage`, and `NodeHelloMessage`
- update the focused FCP tests, add `LegacyNodeInfoPortTest` and `NodeFieldSetTest`, and expand Javadoc on the newly added production files

## How to test
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests "network.crypta.clients.fcp.GetNodeTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.NodeDataTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.NodeHelloMessageTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.ClientHelloMessageTest"`
- `./gradlew test --tests "network.crypta.node.runtime.LegacyNodeInfoPortTest"`
- `./gradlew test --tests "network.crypta.runtime.spi.NodeFieldSetTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.FCPConnectionInputHandlerTest"`
- `./gradlew test`
- `./gradlew buildJar`

## Deferred
- peer-management messages, queue and persistent-request surfaces, HTTP or Toadlet or FProxy work, and any generic field-tree unification remain intentionally out of scope for this PR