### PR TITLE
refactor(runtime): Move peer management to runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetPeerRequiredException.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetPeerRequiredException.java
@@ -1,0 +1,45 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Signals that a resolved peer cannot satisfy a darknet-only operation.
+ *
+ * <p>This checked exception is part of the peer-management SPI boundary. It tells higher layers
+ * that lookup succeeded, but the requested action only applies to darknet peers. Management-facing
+ * code can keep its own access-control and wire-level error mapping while still distinguishing
+ * "peer not found" from "peer found, but wrong peer family" without depending on daemon-only peer
+ * classes.
+ *
+ * <p>The exception carries the node identifier that resolved to a non-darknet peer. Callers
+ * normally map it to an existing protocol error and should not treat it as a transport or parsing
+ * problem.
+ */
+public final class DarknetPeerRequiredException extends Exception {
+  private final String nodeIdentifier;
+
+  /**
+   * Creates an exception describing a non-darknet peer.
+   *
+   * <p>The supplied identifier becomes part of the exception message, so higher layers can preserve
+   * the current protocol behavior without consulting the daemon state again.
+   *
+   * @param nodeIdentifier identifier of the resolved non-darknet peer; must not be {@code null}
+   */
+  public DarknetPeerRequiredException(String nodeIdentifier) {
+    super("Darknet peer required: " + Objects.requireNonNull(nodeIdentifier, "nodeIdentifier"));
+    this.nodeIdentifier = nodeIdentifier;
+  }
+
+  /**
+   * Returns the identifier of the resolved non-darknet peer.
+   *
+   * <p>This is the same identifier that was accepted by peer lookup and then rejected by the
+   * darknet-only guard.
+   *
+   * @return peer identifier that failed the darknet-only check
+   */
+  public String nodeIdentifier() {
+    return nodeIdentifier;
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetPeerSettingsUpdate.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetPeerSettingsUpdate.java
@@ -1,0 +1,47 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Represents one optional update to darknet-only peer settings.
+ *
+ * <p>Each field is nullable. A {@code null} value means "leave the current setting unchanged",
+ * allowing higher layers to preserve the legacy FCP semantics where missing or empty fields do not
+ * alter the target peer.
+ *
+ * <p>The record deliberately models only the small set of darknet peer flags migrated in this PR.
+ * It is a detached request value rather than a live view of the peer state. Callers are expected to
+ * populate only the fields that were present in the original management request and then pass the
+ * value to {@link PeerPort#updateDarknetPeer(String, DarknetPeerSettingsUpdate)}.
+ *
+ * @param disabled optional disabled flag update; {@code null} leaves the current disabled state
+ *     unchanged
+ * @param listenOnly optional listen-only flag update; {@code null} leaves the current setting
+ *     unchanged
+ * @param burstOnly optional burst-only flag update; {@code null} leaves the current setting
+ *     unchanged
+ * @param ignoreSourcePort optional source-port handling update; {@code null} leaves the current
+ *     setting unchanged
+ * @param allowLocalAddresses optional local-address allowance update; {@code null} leaves the
+ *     current setting unchanged
+ */
+public record DarknetPeerSettingsUpdate(
+    Boolean disabled,
+    Boolean listenOnly,
+    Boolean burstOnly,
+    Boolean ignoreSourcePort,
+    Boolean allowLocalAddresses) {
+  /**
+   * Returns whether this update carries no requested changes.
+   *
+   * <p>This is a structural check only. It does not inspect the current peer state, and it does not
+   * infer whether applying the update would be a no-op for a specific peer instance.
+   *
+   * @return {@code true} when every field is {@code null}
+   */
+  public boolean isEmpty() {
+    return disabled == null
+        && listenOnly == null
+        && burstOnly == null
+        && ignoreSourcePort == null
+        && allowLocalAddresses == null;
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerAddFailureReason.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerAddFailureReason.java
@@ -1,0 +1,25 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Categorizes the legacy add-peer failure reasons preserved by the peer-management SPI.
+ *
+ * <p>The values in this enum let the daemon-side adapter keep the current peer-add behavior while
+ * returning a JDK-only error surface to higher layers. Management code can map these reasons back
+ * to existing protocol errors without inspecting daemon exceptions or peer internals.
+ */
+public enum PeerAddFailureReason {
+  /** The supplied peer reference could not be parsed into a usable legacy peer definition. */
+  REF_PARSE_ERROR,
+
+  /** The reference targets opennet peering, but opennet support is disabled in the runtime. */
+  OPENNET_DISABLED,
+
+  /** The reference failed signature verification during legacy peer creation. */
+  REF_SIGNATURE_INVALID,
+
+  /** The supplied reference resolved to the local node and cannot be added as a remote peer. */
+  CANNOT_PEER_WITH_SELF,
+
+  /** A peer with the same identity is already present, so the new reference is rejected. */
+  DUPLICATE_PEER_REF
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerAddRejectedException.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerAddRejectedException.java
@@ -1,0 +1,42 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Signals that the runtime rejected an add-peer request while preserving legacy failure semantics.
+ *
+ * <p>This checked exception separates protocol-facing add-peer handling from daemon-only error
+ * classes. The runtime adapter chooses one {@link PeerAddFailureReason} and preserves a
+ * human-readable detail message so the caller can continue mapping failures onto the same
+ * protocol-level responses used before the SPI migration.
+ */
+public final class PeerAddRejectedException extends Exception {
+  private final PeerAddFailureReason reason;
+
+  /**
+   * Creates an add-peer rejection with a preserved legacy reason code.
+   *
+   * <p>The detail message is intentionally stored as the exception message because some higher
+   * layers surface that text directly after translating the reason into their own wire-level error
+   * family.
+   *
+   * @param reason categorized legacy failure reason; must not be {@code null}
+   * @param detailMessage human-readable detail that higher layers may surface unchanged
+   */
+  public PeerAddRejectedException(PeerAddFailureReason reason, String detailMessage) {
+    super(detailMessage);
+    this.reason = Objects.requireNonNull(reason, "reason");
+  }
+
+  /**
+   * Returns the categorized legacy failure reason.
+   *
+   * <p>This value is stable enough for protocol mapping and avoids exposing transport-specific or
+   * daemon-specific exception types to callers.
+   *
+   * @return add-peer failure reason
+   */
+  public PeerAddFailureReason reason() {
+    return reason;
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerFieldSet.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerFieldSet.java
@@ -1,0 +1,100 @@
+package network.crypta.runtime.spi;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents one immutable node in a hierarchical peer export tree.
+ *
+ * <p>{@code PeerFieldSet} mirrors the shape of legacy peer exports and peer-reference trees without
+ * exposing daemon-only field-set transport classes through the runtime SPI. Each instance stores
+ * only the direct scalar values and direct named subsets that appear at that level. Callers can
+ * therefore rebuild a nested response structure by walking the tree from the root outward instead
+ * of depending on flattened dotted-key representations.
+ *
+ * <p>Instances are immutable and safe to share after construction. The constructor copies supplied
+ * maps into encounter-order-preserving {@link LinkedHashMap} instances and then exposes
+ * unmodifiable views. Empty maps are normalized to shared empty instances so adapters can return
+ * compact snapshots without leaking mutability. Callers should treat the record as a detached
+ * snapshot value, not as a live view into daemon state.
+ *
+ * @param directValues direct scalar values stored at this tree level
+ * @param directSubsets direct child subsets keyed by the subset name that appears at this level
+ * @see PeerSnapshot
+ */
+public record PeerFieldSet(
+    Map<String, String> directValues, Map<String, PeerFieldSet> directSubsets) {
+  /**
+   * Creates an immutable tree node from direct values and direct child subsets.
+   *
+   * <p>The constructor defensively copies both maps, preserves their encounter order where
+   * possible, and rejects {@code null} keys and values. Passing empty maps is valid and produces an
+   * empty node, but callers should prefer {@link #empty()} when no content exists.
+   *
+   * @param directValues direct scalar values to store at this tree level
+   * @param directSubsets direct child subsets to store at this tree level
+   * @throws NullPointerException if either map, any key, or any value is {@code null}
+   */
+  public PeerFieldSet {
+    directValues = immutableDirectValues(directValues);
+    directSubsets = immutableDirectSubsets(directSubsets);
+  }
+
+  /**
+   * Returns an empty immutable tree node.
+   *
+   * <p>This is a convenience factory for callers that need a canonical representation of "no direct
+   * values and no direct subsets" without allocating mutable maps first. Export adapters can also
+   * use it when optional subsets have been filtered down to nothing.
+   *
+   * @return empty field-set value with no direct values and no direct subsets
+   */
+  public static PeerFieldSet empty() {
+    return new PeerFieldSet(Map.of(), Map.of());
+  }
+
+  /**
+   * Returns whether this node contains neither direct values nor direct subsets.
+   *
+   * <p>This is a structural check only. It does not inspect descendant nodes beyond the already
+   * stored direct subsets because empty descendant nodes should normally have been filtered before
+   * construction by the exporting adapter. Callers can use the result to decide whether an optional
+   * subset should be serialized at all.
+   *
+   * @return {@code true} when this node contains no direct values and no direct subsets
+   */
+  public boolean isEmpty() {
+    return directValues.isEmpty() && directSubsets.isEmpty();
+  }
+
+  private static Map<String, String> immutableDirectValues(Map<String, String> source) {
+    Objects.requireNonNull(source, "directValues");
+    if (source.isEmpty()) {
+      return Map.of();
+    }
+    LinkedHashMap<String, String> copy = LinkedHashMap.newLinkedHashMap(source.size());
+    for (Map.Entry<String, String> entry : source.entrySet()) {
+      copy.put(
+          Objects.requireNonNull(entry.getKey(), "directValues key"),
+          Objects.requireNonNull(entry.getValue(), "directValues value"));
+    }
+    return Collections.unmodifiableMap(copy);
+  }
+
+  private static Map<String, PeerFieldSet> immutableDirectSubsets(
+      Map<String, PeerFieldSet> source) {
+    Objects.requireNonNull(source, "directSubsets");
+    if (source.isEmpty()) {
+      return Map.of();
+    }
+    LinkedHashMap<String, PeerFieldSet> copy = LinkedHashMap.newLinkedHashMap(source.size());
+    for (Map.Entry<String, PeerFieldSet> entry : source.entrySet()) {
+      copy.put(
+          Objects.requireNonNull(entry.getKey(), "directSubsets key"),
+          Objects.requireNonNull(entry.getValue(), "directSubsets value"));
+    }
+    return Collections.unmodifiableMap(copy);
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerPort.java
@@ -1,0 +1,124 @@
+package network.crypta.runtime.spi;
+
+import java.util.List;
+
+/**
+ * Exposes the narrow peer-management capabilities needed by management-facing protocols.
+ *
+ * <p>This port is intentionally limited to the current FCP peer-management family. It provides
+ * detached peer snapshots, add/remove operations, darknet-only peer mutations, and access to the
+ * existing private darknet comment note without exposing daemon internals such as peer classes,
+ * network subsystem types, or legacy field-set transport objects to higher layers.
+ *
+ * <p>The port does not perform access control and does not know about request identifiers or wire
+ * framing. Those concerns remain with the higher layer, which requests a snapshot or mutation
+ * result here and then decides whether and how it should be serialized.
+ *
+ * <p>Implementations are expected to preserve the daemon's current peer-management semantics for
+ * this narrow slice, including the existing distinction between unknown peers, darknet-only
+ * operations, and legacy add-peer rejection reasons. The API is intentionally small, so later PRs
+ * can migrate adjacent message families independently instead of collapsing everything into one
+ * coarse management surface.
+ */
+public interface PeerPort {
+  /**
+   * Lists the currently known peers using the requested export flags.
+   *
+   * <p>The returned values are detached snapshots. Callers can serialize them immediately or pass
+   * them through other protocol-specific mapping without holding references to live peer objects.
+   *
+   * @param includeMetadata whether peer metadata should be attached to each snapshot
+   * @param includeVolatile whether volatile peer status should be attached to each snapshot
+   * @return detached peer snapshots in encounter order
+   */
+  List<PeerSnapshot> list(boolean includeMetadata, boolean includeVolatile);
+
+  /**
+   * Resolves one peer and exports it using the requested flags.
+   *
+   * <p>The lookup semantics remain implementation-defined, but callers should expect the same peer
+   * identifier handling that the legacy daemon path already used for management requests.
+   *
+   * @param nodeIdentifier peer identifier used for lookup
+   * @param includeMetadata whether peer metadata should be attached to the snapshot
+   * @param includeVolatile whether volatile peer status should be attached to the snapshot
+   * @return detached snapshot of the resolved peer
+   * @throws UnknownPeerException if the peer cannot be resolved
+   */
+  PeerSnapshot get(String nodeIdentifier, boolean includeMetadata, boolean includeVolatile)
+      throws UnknownPeerException;
+
+  /**
+   * Adds one peer reference to the runtime using the supplied darknet defaults when applicable.
+   *
+   * <p>The supplied reference is already resolved and parsed at the protocol boundary. The runtime
+   * adapter performs the daemon-side peer creation, self-peer detection, duplicate checks, and
+   * legacy failure mapping that previously lived in the FCP message handler.
+   *
+   * @param reference detached peer-reference tree to add
+   * @param trust darknet trust level to apply when the reference is a darknet peer
+   * @param visibility darknet visibility to apply when the reference is a darknet peer
+   * @return detached snapshot of the newly added peer, including metadata and volatile state
+   * @throws PeerAddRejectedException if the runtime rejects the reference with a preserved legacy
+   *     reason
+   */
+  PeerSnapshot add(PeerFieldSet reference, PeerTrust trust, PeerVisibility visibility)
+      throws PeerAddRejectedException;
+
+  /**
+   * Applies one optional settings update to an existing darknet peer.
+   *
+   * <p>Each nullable field in {@code update} follows the legacy management rule that absent values
+   * mean "leave the current setting unchanged." Implementations may therefore apply only a subset
+   * of the available flags before exporting the updated peer.
+   *
+   * @param nodeIdentifier peer identifier used for lookup
+   * @param update optional darknet settings update
+   * @return detached snapshot of the updated peer, including metadata and volatile state
+   * @throws UnknownPeerException if the peer cannot be resolved
+   * @throws DarknetPeerRequiredException if the resolved peer is not a darknet peer
+   */
+  PeerSnapshot updateDarknetPeer(String nodeIdentifier, DarknetPeerSettingsUpdate update)
+      throws UnknownPeerException, DarknetPeerRequiredException;
+
+  /**
+   * Removes one peer from the runtime.
+   *
+   * <p>The returned snapshot contains only the removal details needed by the current peer-removal
+   * response path. Callers should not expect it to preserve the full exported peer tree.
+   *
+   * @param nodeIdentifier peer identifier used for lookup
+   * @return detached removal result describing the removed peer
+   * @throws UnknownPeerException if the peer cannot be resolved
+   */
+  RemovedPeerSnapshot remove(String nodeIdentifier) throws UnknownPeerException;
+
+  /**
+   * Reads the existing private darknet comment note for one peer.
+   *
+   * <p>This method intentionally exposes only the currently supported private darknet comment note.
+   * It does not attempt to model a general peer-note registry.
+   *
+   * @param nodeIdentifier peer identifier used for lookup
+   * @return current private darknet comment note text
+   * @throws UnknownPeerException if the peer cannot be resolved
+   * @throws DarknetPeerRequiredException if the resolved peer is not a darknet peer
+   */
+  String readPrivateDarknetComment(String nodeIdentifier)
+      throws UnknownPeerException, DarknetPeerRequiredException;
+
+  /**
+   * Writes the private darknet comment note for one peer and returns the stored text.
+   *
+   * <p>Implementations should return the stored note text after applying the update so callers can
+   * emit a detached response without re-reading daemon state through other APIs.
+   *
+   * @param nodeIdentifier peer identifier used for lookup
+   * @param noteText note text to store
+   * @return stored private darknet comment note text
+   * @throws UnknownPeerException if the peer cannot be resolved
+   * @throws DarknetPeerRequiredException if the resolved peer is not a darknet peer
+   */
+  String writePrivateDarknetComment(String nodeIdentifier, String noteText)
+      throws UnknownPeerException, DarknetPeerRequiredException;
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerSnapshot.java
@@ -1,0 +1,55 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Represents an immutable point-in-time export of one peer tree.
+ *
+ * <p>This snapshot is the management-facing value produced by {@link PeerPort} for the current FCP
+ * peer-management family. It intentionally carries only the root tree node and does not encode
+ * request identifiers or other protocol-specific metadata, leaving those concerns to the caller's
+ * wire format.
+ *
+ * <p>The record is immutable and safe to retain after the originating daemon operation completes.
+ * It should be treated as a detached export value that captures one point in time, not as a handle
+ * for later peer mutation or lazy field access.
+ *
+ * @param root root field-set tree for the exported peer
+ * @see PeerFieldSet
+ * @see PeerPort
+ */
+public record PeerSnapshot(PeerFieldSet root) {
+  /**
+   * Creates an immutable peer snapshot.
+   *
+   * @param root root field-set tree for the export; must not be {@code null}
+   * @throws NullPointerException if {@code root} is {@code null}
+   */
+  public PeerSnapshot {
+    Objects.requireNonNull(root, "root");
+  }
+
+  /**
+   * Returns an empty peer snapshot.
+   *
+   * <p>This is primarily useful for tests or for call paths that need a canonical "no exported peer
+   * data" value before any subsets are attached.
+   *
+   * @return snapshot whose root tree has no direct values or subsets
+   */
+  public static PeerSnapshot empty() {
+    return new PeerSnapshot(PeerFieldSet.empty());
+  }
+
+  /**
+   * Returns whether the exported root tree contains no data.
+   *
+   * <p>This delegates to {@link PeerFieldSet#isEmpty()} on the root node and does not inspect any
+   * state outside the stored snapshot.
+   *
+   * @return {@code true} when the root field-set tree is empty
+   */
+  public boolean isEmpty() {
+    return root.isEmpty();
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerTrust.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerTrust.java
@@ -1,0 +1,19 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Selects the trust level assigned to a newly added darknet peer.
+ *
+ * <p>This enum mirrors the current legacy darknet trust choices while keeping the runtime SPI free
+ * of daemon-only enums. Callers are expected to map protocol or UI inputs onto these values before
+ * invoking {@link PeerPort#add(PeerFieldSet, PeerTrust, PeerVisibility)}.
+ */
+public enum PeerTrust {
+  /** Assigns the most restrictive trust level supported by the current legacy darknet logic. */
+  LOW,
+
+  /** Assigns the default trust level used for ordinary darknet peer relationships. */
+  NORMAL,
+
+  /** Assigns the least restrictive trust level supported by the current legacy darknet logic. */
+  HIGH
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerVisibility.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerVisibility.java
@@ -1,0 +1,19 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Selects the visibility assigned to a newly added darknet peer.
+ *
+ * <p>This enum mirrors the current legacy darknet visibility choices while keeping the runtime SPI
+ * free of daemon-only enums. The values intentionally match the existing wire-level semantics used
+ * by the daemon.
+ */
+public enum PeerVisibility {
+  /** Exposes both the peer relationship and the peer name where the legacy daemon allows it. */
+  YES,
+
+  /** Exposes only the peer name while withholding fuller visibility in legacy exports. */
+  NAME_ONLY,
+
+  /** Applies the most private visibility mode supported by the current legacy daemon behavior. */
+  NO
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RemovedPeerSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RemovedPeerSnapshot.java
@@ -1,0 +1,32 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Represents the detached result of a successful peer removal.
+ *
+ * <p>This value keeps only the removal details that the current management responses need after the
+ * peer has already been detached from the live daemon structures. It avoids holding a removed
+ * {@code PeerNode} reference while still preserving the identity and lookup identifier expected by
+ * existing response messages.
+ *
+ * @param identity identity string exported from the removed peer
+ * @param nodeIdentifier node identifier used to resolve the removed peer
+ */
+public record RemovedPeerSnapshot(String identity, String nodeIdentifier) {
+  /**
+   * Creates an immutable peer-removal result.
+   *
+   * <p>Both fields are required because higher layers may include them in separate protocol fields
+   * after the live peer object has already been discarded.
+   *
+   * @param identity identity string exported from the removed peer; must not be {@code null}
+   * @param nodeIdentifier node identifier used to resolve the removed peer; must not be {@code
+   *     null}
+   * @throws NullPointerException if either argument is {@code null}
+   */
+  public RemovedPeerSnapshot {
+    Objects.requireNonNull(identity, "identity");
+    Objects.requireNonNull(nodeIdentifier, "nodeIdentifier");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -20,6 +20,7 @@ package network.crypta.runtime.spi;
  * @see LifecyclePort
  * @see ConfigPort
  * @see NodeInfoPort
+ * @see PeerPort
  */
 public interface RuntimePorts {
   /**
@@ -91,4 +92,16 @@ public interface RuntimePorts {
    * @return node-info runtime port for greeting metadata and node-reference exports
    */
   NodeInfoPort nodeInfo();
+
+  /**
+   * Returns the peer-management capability exposed to management-facing infrastructure code.
+   *
+   * <p>This port lets higher layers list peers, resolve one peer, add or remove peers, adjust
+   * darknet-only peer flags, and read or write the existing private darknet comment note without
+   * depending on daemon-only peer, network, or field-set types. The returned object should be
+   * treated as a live runtime view whose methods produce detached immutable snapshots.
+   *
+   * @return peer-management runtime port for peer inventory and peer mutation
+   */
+  PeerPort peer();
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/UnknownPeerException.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/UnknownPeerException.java
@@ -1,0 +1,41 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Signals that a requested peer could not be resolved.
+ *
+ * <p>Higher layers typically keep the user-facing node identifier from the original request and map
+ * this checked exception onto their existing protocol-specific error responses.
+ *
+ * <p>The exception is intentionally small. It distinguishes lookup failure from other peer
+ * management failures without exposing daemon-only peer maps or protocol-specific message classes
+ * through the runtime SPI.
+ */
+public final class UnknownPeerException extends Exception {
+  private final String nodeIdentifier;
+
+  /**
+   * Creates an exception describing a missing peer.
+   *
+   * <p>The identifier becomes part of the exception message, so callers can preserve existing error
+   * text without reconstructing it later.
+   *
+   * @param nodeIdentifier identifier that could not be resolved; must not be {@code null}
+   */
+  public UnknownPeerException(String nodeIdentifier) {
+    super("Unknown peer: " + Objects.requireNonNull(nodeIdentifier, "nodeIdentifier"));
+    this.nodeIdentifier = nodeIdentifier;
+  }
+
+  /**
+   * Returns the identifier that could not be resolved.
+   *
+   * <p>This is the same lookup identifier supplied to the peer-management port.
+   *
+   * @return missing peer identifier
+   */
+  public String nodeIdentifier() {
+    return nodeIdentifier;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/AddPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/AddPeer.java
@@ -12,21 +12,19 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import network.crypta.client.FetchException;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.io.comm.PeerParseException;
-import network.crypta.io.comm.ReferenceSignatureVerificationException;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
-import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.FSParseException;
 import network.crypta.node.Node;
-import network.crypta.node.OpennetDisabledException;
-import network.crypta.node.PeerNode;
-import network.crypta.node.PeerTooOldException;
 import network.crypta.node.RequestStarter;
-import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.PeerAddFailureReason;
+import network.crypta.runtime.spi.PeerAddRejectedException;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
 import network.crypta.support.MediaType;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
@@ -52,9 +50,6 @@ import org.slf4j.LoggerFactory;
  * <p>Typical callers do not construct this class directly; instead they delegate to {@link
  * FCPMessage#create(String, SimpleFieldSet)} after decoding the message name and fields from the
  * wire.
- *
- * @see PeerMessage
- * @see NodeNetworkSubsystem#addPeerConnection(PeerNode)
  */
 public final class AddPeer extends FCPMessage {
   private static final Logger LOG = LoggerFactory.getLogger(AddPeer.class);
@@ -70,15 +65,15 @@ public final class AddPeer extends FCPMessage {
 
   SimpleFieldSet fs;
   final String messageIdentifier;
-  final FRIEND_TRUST trust;
-  final FRIEND_VISIBILITY visibility;
+  final PeerTrust trust;
+  final PeerVisibility visibility;
 
   /**
    * Creates a new {@link AddPeer} instance from the supplied field set.
    *
    * <p>The constructor extracts the {@code Identifier}, {@code Trust}, and {@code Visibility}
    * fields from {@code fs}, storing the identifier for later replies and converting the trust and
-   * visibility strings to the corresponding {@link FRIEND_TRUST} and {@link FRIEND_VISIBILITY}
+   * visibility strings to the corresponding {@link PeerTrust} and {@link PeerVisibility}
    * enumeration values. The extracted keys are removed from the field set so that the remaining
    * data describes only the peer reference itself or indirections to it such as {@code URL} and
    * {@code File} fields.
@@ -90,7 +85,7 @@ public final class AddPeer extends FCPMessage {
    * @param fs client-supplied field set containing the decoded AddPeer request fields, including
    *     identifier, trust, visibility, and peer reference information; must not be {@code null}
    * @throws MessageInvalidException if required fields are missing, empty, or cannot be converted
-   *     into valid {@link FRIEND_TRUST} or {@link FRIEND_VISIBILITY} values
+   *     into valid {@link PeerTrust} or {@link PeerVisibility} values
    */
   public AddPeer(SimpleFieldSet fs) throws MessageInvalidException {
     this.fs = fs;
@@ -103,7 +98,7 @@ public final class AddPeer extends FCPMessage {
           ProtocolErrorMessage.MISSING_FIELD, "AddPeer requires Trust", messageIdentifier, false);
     }
     try {
-      this.trust = FRIEND_TRUST.valueOf(trustValue);
+      this.trust = PeerTrust.valueOf(trustValue);
       fs.removeValue("Trust");
     } catch (IllegalArgumentException _) {
       throw new MessageInvalidException(
@@ -122,7 +117,7 @@ public final class AddPeer extends FCPMessage {
           false);
     }
     try {
-      this.visibility = FRIEND_VISIBILITY.valueOf(visibilityValue);
+      this.visibility = PeerVisibility.valueOf(visibilityValue);
       fs.removeValue("Visibility");
     } catch (IllegalArgumentException _) {
       throw new MessageInvalidException(
@@ -254,17 +249,17 @@ public final class AddPeer extends FCPMessage {
    * field set, optionally dereferencing a {@code URL} or {@code File} indirection, and parses the
    * resulting text into a structured {@link SimpleFieldSet}.
    *
-   * <p>Depending on whether the {@code opennet} flag is present, the implementation creates either
-   * an opennet or darknet {@link PeerNode}, validates that the reference does not describe the node
-   * itself, and attempts to register the new peer with the node's peer manager. Any parse errors,
-   * signature problems, duplicate identities, or configuration constraints are reported via {@link
+   * <p>Depending on whether the {@code opennet} flag is present, the implementation forwards the
+   * resolved reference to the runtime peer-management port, which performs peer creation,
+   * validation, self-checking, and registration with the node. Any parse errors, signature
+   * problems, duplicate identities, or configuration constraints are reported via {@link
    * MessageInvalidException} with an appropriate {@link ProtocolErrorMessage} code, which the
    * handler will translate into a protocol error response.
    *
    * @param handler connection handler representing the client session that issued the AddPeer
    *     request; used to send back the resulting {@link PeerMessage} or error messages
-   * @param node running node instance to which the new peer should be added and from which client
-   *     fetches and peer database operations are performed
+   * @param node running node instance supplied by the legacy FCP dispatch signature; unused because
+   *     peer-management is delegated through the runtime SPI
    * @throws MessageInvalidException if access is denied, the peer reference cannot be parsed or
    *     verified, the reference describes the node itself, or a peer with the same identity already
    *     exists on the node
@@ -272,10 +267,15 @@ public final class AddPeer extends FCPMessage {
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     ensureFullAccess(handler);
-    fs = resolveFieldSetForReference(node);
-    fs.setEndMarker("End");
-    PeerNode peerNode = createPeer(node);
-    handler.send(new PeerMessage(peerNode, true, true, messageIdentifier));
+    fs = resolveFieldSetForReference(handler);
+    try {
+      PeerSnapshot snapshot =
+          handler.getServer().runtime().peer().add(toPeerFieldSet(fs), trust, visibility);
+      handler.send(new PeerMessage(snapshot, messageIdentifier));
+    } catch (PeerAddRejectedException e) {
+      throw new MessageInvalidException(
+          protocolCodeFor(e.reason()), e.getMessage(), messageIdentifier, false);
+    }
   }
 
   private void ensureFullAccess(FCPConnectionHandler handler) throws MessageInvalidException {
@@ -288,10 +288,11 @@ public final class AddPeer extends FCPMessage {
     }
   }
 
-  private SimpleFieldSet resolveFieldSetForReference(Node node) throws MessageInvalidException {
+  private SimpleFieldSet resolveFieldSetForReference(FCPConnectionHandler handler)
+      throws MessageInvalidException {
     String urlString = fs.get("URL");
     if (urlString != null) {
-      return buildFieldSetFromUrl(urlString, node);
+      return buildFieldSetFromUrl(urlString, handler);
     }
     String fileString = fs.get("File");
     if (fileString != null) {
@@ -300,9 +301,9 @@ public final class AddPeer extends FCPMessage {
     return fs;
   }
 
-  private SimpleFieldSet buildFieldSetFromUrl(String urlString, Node node)
+  private SimpleFieldSet buildFieldSetFromUrl(String urlString, FCPConnectionHandler handler)
       throws MessageInvalidException {
-    StringBuilder ref = fetchReferenceFromUrl(urlString, node);
+    StringBuilder ref = fetchReferenceFromUrl(urlString, handler);
     String refString = ref.toString().trim();
     if (refString.isEmpty()) {
       throw new MessageInvalidException(
@@ -322,10 +323,10 @@ public final class AddPeer extends FCPMessage {
     }
   }
 
-  private StringBuilder fetchReferenceFromUrl(String urlString, Node node)
+  private StringBuilder fetchReferenceFromUrl(String urlString, FCPConnectionHandler handler)
       throws MessageInvalidException {
     try {
-      return tryFetchFromCryptaUriOrUrl(urlString, node);
+      return tryFetchFromCryptaUriOrUrl(urlString, handler);
     } catch (MalformedURLException e) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.URL_PARSE_ERROR,
@@ -341,12 +342,14 @@ public final class AddPeer extends FCPMessage {
     }
   }
 
-  private StringBuilder tryFetchFromCryptaUriOrUrl(String urlString, Node node) throws IOException {
+  private StringBuilder tryFetchFromCryptaUriOrUrl(String urlString, FCPConnectionHandler handler)
+      throws IOException {
     try {
       FreenetURI refUri = new FreenetURI(urlString);
       HighLevelSimpleClient client =
-          node.services()
-              .clientCore()
+          handler
+              .getServer()
+              .getCore()
               .makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
       return AddPeer.getReferenceFromFreenetURI(refUri, client);
     } catch (MalformedURLException | FetchException _) {
@@ -418,82 +421,29 @@ public final class AddPeer extends FCPMessage {
     }
   }
 
-  private PeerNode createPeer(Node node) throws MessageInvalidException {
-    boolean isOpennetRef = fs.getBoolean("opennet", false);
-    PeerNode peerNode = isOpennetRef ? createOpennetPeer(node) : createDarknetPeer(node);
-    ensureNotSelfPeer(node, isOpennetRef, peerNode);
-    addPeerConnection(node, isOpennetRef, peerNode);
-    return peerNode;
+  private static PeerFieldSet toPeerFieldSet(SimpleFieldSet fieldSet) {
+    if (fieldSet.isEmpty()) {
+      return PeerFieldSet.empty();
+    }
+
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>(fieldSet.directKeyValues());
+    LinkedHashMap<String, PeerFieldSet> directSubsets = new LinkedHashMap<>();
+    for (Map.Entry<String, SimpleFieldSet> entry : fieldSet.directSubsets().entrySet()) {
+      PeerFieldSet subset = toPeerFieldSet(entry.getValue());
+      if (!subset.isEmpty()) {
+        directSubsets.put(entry.getKey(), subset);
+      }
+    }
+    return new PeerFieldSet(directValues, directSubsets);
   }
 
-  private PeerNode createOpennetPeer(Node node) throws MessageInvalidException {
-    try {
-      return node.network().createNewOpennetNode(fs);
-    } catch (FSParseException | PeerParseException | PeerTooOldException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.REF_PARSE_ERROR,
-          "Error parsing ref: " + e.getMessage(),
-          messageIdentifier,
-          false);
-    } catch (OpennetDisabledException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.OPENNET_DISABLED,
-          "Error adding ref: " + e.getMessage(),
-          messageIdentifier,
-          false);
-    } catch (ReferenceSignatureVerificationException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.REF_SIGNATURE_INVALID,
-          "Error adding ref: " + e.getMessage(),
-          messageIdentifier,
-          false);
-    }
-  }
-
-  private PeerNode createDarknetPeer(Node node) throws MessageInvalidException {
-    try {
-      return node.network().createNewDarknetNode(fs, trust, visibility);
-    } catch (FSParseException | PeerParseException | PeerTooOldException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.REF_PARSE_ERROR,
-          "Error parsing ref: " + e.getMessage(),
-          messageIdentifier,
-          false);
-    } catch (ReferenceSignatureVerificationException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.REF_SIGNATURE_INVALID,
-          "Error adding ref: " + e.getMessage(),
-          messageIdentifier,
-          false);
-    }
-  }
-
-  private void ensureNotSelfPeer(Node node, boolean isOpennetRef, PeerNode peerNode)
-      throws MessageInvalidException {
-    byte[] nodePubKeyHash =
-        isOpennetRef ? node.network().opennetPubKeyHash() : node.network().darknetPubKeyHash();
-    if (Arrays.equals(peerNode.peerECDSAPubKeyHash, nodePubKeyHash)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.CANNOT_PEER_WITH_SELF,
-          "Node cannot peer with itself",
-          messageIdentifier,
-          false);
-    }
-  }
-
-  private void addPeerConnection(Node node, boolean isOpennetRef, PeerNode peerNode)
-      throws MessageInvalidException {
-    if (!node.network().addPeerConnection(peerNode)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.DUPLICATE_PEER_REF,
-          "Node already has a peer with that identity",
-          messageIdentifier,
-          false);
-    }
-    if (isOpennetRef) {
-      LOG.info("Added opennet peer: {}", peerNode);
-    } else {
-      LOG.info("Added darknet peer: {}", peerNode);
-    }
+  private static int protocolCodeFor(PeerAddFailureReason reason) {
+    return switch (reason) {
+      case REF_PARSE_ERROR -> ProtocolErrorMessage.REF_PARSE_ERROR;
+      case OPENNET_DISABLED -> ProtocolErrorMessage.OPENNET_DISABLED;
+      case REF_SIGNATURE_INVALID -> ProtocolErrorMessage.REF_SIGNATURE_INVALID;
+      case CANNOT_PEER_WITH_SELF -> ProtocolErrorMessage.CANNOT_PEER_WITH_SELF;
+      case DUPLICATE_PEER_REF -> ProtocolErrorMessage.DUPLICATE_PEER_REF;
+    };
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ListPeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeerMessage.java
@@ -1,14 +1,15 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
 
 /**
  * Client-to-node FCP message that requests detailed information about a specific peer maintained by
  * the destination node.
  *
- * <p>This lightweight wrapper is used when a client needs the status of a single peer—for example
+ * <p>This lightweight wrapper is used when a client needs the status of a single peer—for example,
  * to display link health or drive automated peer-admission decisions. It stores the caller-provided
  * request identifier and the field set that supplies {@code NodeIdentifier} during execution. When
  * run, the message enforces full-access permissions, validates the identifier, and emits either a
@@ -87,12 +88,12 @@ public class ListPeerMessage extends FCPMessage {
    * required and validated. Missing values cause a missing-field error; unknown peers produce an
    * {@link UnknownNodeIdentifierMessage}. When the peer exists, a {@link PeerMessage} describing it
    * is sent. The method is synchronous and read-only; it does not retry, cache results, or alter
-   * node state.
+   * the node state.
    *
    * @param handler connection handler that validates permissions and dispatches replies; must not
    *     be {@code null}.
    * @param node target node queried for peer information; must not be {@code null}.
-   * @throws MessageInvalidException when access is denied or required fields are absent.
+   * @throws MessageInvalidException when access is denied or required, fields are absent.
    */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
@@ -111,12 +112,12 @@ public class ListPeerMessage extends FCPMessage {
           requestIdentifier,
           false);
     }
-    PeerNode pn = node.network().getPeerNode(nodeIdentifier);
-    if (pn == null) {
+    try {
+      PeerSnapshot snapshot = handler.getServer().runtime().peer().get(nodeIdentifier, true, true);
+      handler.send(new PeerMessage(snapshot, requestIdentifier));
+    } catch (UnknownPeerException _) {
       FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
       handler.send(msg);
-      return;
     }
-    handler.send(new PeerMessage(pn, true, true, requestIdentifier));
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ListPeerNotesMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeerNotesMessage.java
@@ -1,8 +1,8 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -17,9 +17,9 @@ import network.crypta.support.SimpleFieldSet;
  * followed by {@link EndListPeerNotesMessage}.
  *
  * <p>Concurrency considerations: each instance is used by a single handler invocation and stores no
- * mutable global state, so it is thread-confined by design. The lifetime is short-lived—created
+ * mutable global state, so it is thread-confined by design. The lifetime is short-lived, created
  * when the client issues the command and discarded immediately after the two response messages are
- * sent. Persistent data (the note text) remains managed by the underlying {@link DarknetPeerNode}.
+ * sent. Persistent data (the note text) remains managed behind the runtime peer-management port.
  *
  * <ul>
  *   <li>Validates full-access session credentials before revealing peer notes.
@@ -57,7 +57,7 @@ public class ListPeerNotesMessage extends FCPMessage {
    * <p>The listing logic sends dedicated response messages rather than encoding data inside this
    * object's field set. Consequently, this call intentionally returns a fresh, empty {@link
    * SimpleFieldSet} with freenet-specific escaping enabled. The method is idempotent and creates a
-   * new instance each time so callers cannot accidentally mutate shared state. It should be used
+   * new instance each time, so callers cannot accidentally mutate shared state. It should be used
    * primarily by generic message code paths that expect a field-set representation even when none
    * is meaningful.
    *
@@ -73,7 +73,7 @@ public class ListPeerNotesMessage extends FCPMessage {
    * Provides the protocol-level name for this message type.
    *
    * <p>The returned value matches the identifier expected by FCP clients when requesting darknet
-   * peer notes. It is a stable constant so log messages and routing tables can rely on it for
+   * peer notes. It is a stable constant, so log messages and routing tables can rely on it for
    * comparisons or switch statements. Because it performs no allocation beyond returning a string
    * literal, it is safe for frequent use in performance-sensitive paths.
    *
@@ -92,12 +92,12 @@ public class ListPeerNotesMessage extends FCPMessage {
    * the stored {@link SimpleFieldSet}; missing or unknown identifiers trigger protocol-compliant
    * error responses so clients can retry or repair the request. For darknet peers, the method sends
    * a {@link PeerNote} containing the private comment text followed by an {@link
-   * EndListPeerNotesMessage} marker. Execution is single-pass and does not modify peer state.
+   * EndListPeerNotesMessage} marker. Execution is single-pass and does not modify the peer state.
    *
    * @param handler connection context used to check privileges and emit responses; must not be
    *     {@code null}
-   * @param node local node context that resolves peer identifiers and provides stored note content;
-   *     must not be {@code null}
+   * @param node local node context supplied by the legacy FCP dispatch signature; unused because
+   *     peer-note access is delegated through the runtime SPI
    * @throws MessageInvalidException if access is denied, required fields are missing, or the target
    *     peer is not a darknet peer
    */
@@ -118,27 +118,25 @@ public class ListPeerNotesMessage extends FCPMessage {
           requestIdentifier,
           false);
     }
-    PeerNode pn = node.network().getPeerNode(nodeIdentifier);
-    if (pn == null) {
+    try {
+      String noteText =
+          handler.getServer().runtime().peer().readPrivateDarknetComment(nodeIdentifier);
+      handler.send(
+          new PeerNote(
+              nodeIdentifier,
+              noteText,
+              Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT,
+              requestIdentifier));
+      handler.send(new EndListPeerNotesMessage(nodeIdentifier, requestIdentifier));
+    } catch (UnknownPeerException _) {
       FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
       handler.send(msg);
-      return;
-    }
-    if (!(pn instanceof DarknetPeerNode dpn)) {
+    } catch (DarknetPeerRequiredException _) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.DARKNET_ONLY,
           "ModifyPeer only available for darknet peers",
           requestIdentifier,
           false);
     }
-    // Future enhancement: generalize for multiple peer notes per peer after PeerNode is updated
-    String noteText = dpn.getPrivateDarknetCommentNote();
-    handler.send(
-        new PeerNote(
-            nodeIdentifier,
-            noteText,
-            Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT,
-            requestIdentifier));
-    handler.send(new EndListPeerNotesMessage(nodeIdentifier, requestIdentifier));
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ListPeersMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeersMessage.java
@@ -1,8 +1,7 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
-import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.PeerSnapshot;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -92,8 +91,8 @@ public class ListPeersMessage extends FCPMessage {
    *
    * @param handler connection handler responsible for sending responses; must already be
    *     authenticated for full access.
-   * @param node node instance supplying the current peers; expected to return a live snapshot via
-   *     {@link NodeNetworkSubsystem#peerNodes()}.
+   * @param node node instance supplied by the legacy FCP dispatch signature; unused because peer
+   *     enumeration is delegated through the runtime SPI
    * @throws MessageInvalidException when the handler lacks required access rights or when message
    *     validation fails before any peer data is returned.
    */
@@ -106,9 +105,9 @@ public class ListPeersMessage extends FCPMessage {
           requestIdentifier,
           false);
     }
-    PeerNode[] nodes = node.network().peerNodes();
-    for (PeerNode pn : nodes) {
-      handler.send(new PeerMessage(pn, withMetadata, withVolatile, requestIdentifier));
+    for (PeerSnapshot snapshot :
+        handler.getServer().runtime().peer().list(withMetadata, withVolatile)) {
+      handler.send(new PeerMessage(snapshot, requestIdentifier));
     }
 
     handler.send(new EndListPeersMessage(requestIdentifier));

--- a/src/main/java/network/crypta/clients/fcp/ModifyPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeer.java
@@ -1,11 +1,13 @@
 package network.crypta.clients.fcp;
 
-import java.util.function.Consumer;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.Fields;
 import network.crypta.support.SimpleFieldSet;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Handles the FCP {@code ModifyPeer} command, allowing a client to toggle operational flags on an
@@ -17,9 +19,9 @@ import network.crypta.support.SimpleFieldSet;
  * <p>Use this class when a client needs to adjust connectivity characteristics for a known peer
  * without recreating or deleting it. Typical call patterns originate from the FCP server loop,
  * which instantiates this message from incoming fields and delegates execution to {@link #run}. The
- * implementation delegates synchronization and persistence concerns to {@link Node} and peer
- * implementations; it performs only the protocol-level validation and flag translation. Flags are
- * optional and omitted values leave existing peer settings unchanged.
+ * implementation delegates synchronization and persistence concerns to the runtime peer-management
+ * SPI; it performs only the protocol-level validation and flag translation. Flags are optional and
+ * omitted values leave existing peer settings unchanged.
  *
  * <ul>
  *   <li>Checks for full-access permissions before applying any change.
@@ -31,7 +33,6 @@ import network.crypta.support.SimpleFieldSet;
  *
  * @see FCPMessage
  * @see PeerMessage
- * @see DarknetPeerNode
  */
 public class ModifyPeer extends FCPMessage {
   static final String NAME = "ModifyPeer";
@@ -91,7 +92,8 @@ public class ModifyPeer extends FCPMessage {
    *
    * @param handler connection handler that mediates access checks and message delivery for the
    *     caller; must support full-access operations.
-   * @param node node instance that stores peer records and applies requested state changes.
+   * @param node node instance supplied by the legacy FCP dispatch signature; unused because peer
+   *     mutation is delegated through the runtime SPI
    * @throws MessageInvalidException if access is denied, required fields are missing, or the target
    *     peer is not available as a darknet peer.
    */
@@ -112,44 +114,33 @@ public class ModifyPeer extends FCPMessage {
           requestIdentifier,
           false);
     }
-    PeerNode pn = node.network().getPeerNode(nodeIdentifier);
-    if (pn == null) {
+    DarknetPeerSettingsUpdate update =
+        new DarknetPeerSettingsUpdate(
+            parseOptionalBoolean(fs.get("IsDisabled")),
+            parseOptionalBoolean(fs.get("IsListenOnly")),
+            parseOptionalBoolean(fs.get("IsBurstOnly")),
+            parseOptionalBoolean(fs.get("IgnoreSourcePort")),
+            parseOptionalBoolean(fs.get("AllowLocalAddresses")));
+    try {
+      PeerSnapshot snapshot =
+          handler.getServer().runtime().peer().updateDarknetPeer(nodeIdentifier, update);
+      handler.send(new PeerMessage(snapshot, requestIdentifier));
+    } catch (UnknownPeerException _) {
       FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
       handler.send(msg);
-      return;
-    }
-    if (!(pn instanceof DarknetPeerNode dpn)) {
+    } catch (DarknetPeerRequiredException _) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.DARKNET_ONLY,
           "ModifyPeer only available for darknet peers",
           requestIdentifier,
           false);
     }
-    applyDisableFlag(dpn, fs.get("IsDisabled"));
-    applyBooleanFlag(dpn::setListenOnly, fs.get("IsListenOnly"));
-    applyBooleanFlag(dpn::setBurstOnly, fs.get("IsBurstOnly"));
-    applyBooleanFlag(dpn::setIgnoreSourcePort, fs.get("IgnoreSourcePort"));
-    applyBooleanFlag(dpn::setAllowLocalAddresses, fs.get("AllowLocalAddresses"));
-    handler.send(new PeerMessage(pn, true, true, requestIdentifier));
   }
 
-  private static void applyDisableFlag(DarknetPeerNode dpn, String disableFlag) {
-    if (isNonEmpty(disableFlag)) {
-      if (Fields.stringToBool(disableFlag, false)) {
-        dpn.disablePeer();
-      } else {
-        dpn.enablePeer();
-      }
+  private static @Nullable Boolean parseOptionalBoolean(String flagValue) {
+    if (flagValue == null || flagValue.isEmpty()) {
+      return null;
     }
-  }
-
-  private static void applyBooleanFlag(Consumer<Boolean> setter, String flagValue) {
-    if (isNonEmpty(flagValue)) {
-      setter.accept(Fields.stringToBool(flagValue, false));
-    }
-  }
-
-  private static boolean isNonEmpty(String value) {
-    return value != null && !value.isEmpty();
+    return Fields.stringToBool(flagValue, false);
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
@@ -1,9 +1,9 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.FSParseException;
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.Base64;
 import network.crypta.support.IllegalBase64Exception;
 import network.crypta.support.SimpleFieldSet;
@@ -20,9 +20,9 @@ import org.slf4j.LoggerFactory;
  * operational annotations that are not exposed publicly on the network.
  *
  * <p>On execution, the message handler validates that the connection has full access, resolves the
- * referenced peer within the running {@link Node}, and verifies that the peer is a {@link
- * DarknetPeerNode}. It then parses the note type, decodes the supplied Base64 payload into UTF-8
- * text, and applies the change to the peer instance when the type is supported. Errors in access
+ * referenced peer through the runtime peer-management SPI, and verifies that the requested
+ * operation applies to a darknet peer. It then parses the note type, decodes the supplied Base64
+ * payload into UTF-8 text, and applies the change when the note type is supported. Errors in access
  * control, field presence, parsing, or peer lookup are surfaced as protocol-level failures, either
  * by throwing {@link MessageInvalidException} or by sending dedicated FCP error messages back
  * through the connection handler.
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
  * after construction.
  *
  * @see PeerNote
- * @see DarknetPeerNode
  * @see FCPMessage
  */
 public class ModifyPeerNote extends FCPMessage {
@@ -94,22 +93,21 @@ public class ModifyPeerNote extends FCPMessage {
    * Executes the {@code ModifyPeerNote} request against the running node.
    *
    * <p>This method enforces full-access permissions on the connection, extracts the target peer
-   * identifier and peer-note type from the backing field set, and resolves the peer within the
-   * supplied {@link Node}. Only darknet peers are accepted; other peer types cause a protocol
-   * error. The handler then decodes the Base64-encoded {@code NoteText} value, applies the note to
-   * the peer when the note type is supported, and sends a {@link PeerNote} message back to the
-   * client reflecting the new state. Invalid or missing fields cause {@link
-   * MessageInvalidException} to be thrown or a specific error response to be sent.
+   * identifier and peer-note type from the backing field set, and resolves the peer through the
+   * runtime SPI. Only darknet peers are accepted; other peer types cause a protocol error. The
+   * handler then decodes the Base64-encoded {@code NoteText} value, applies the note when the note
+   * type is supported, and sends a {@link PeerNote} message back to the client reflecting the new
+   * state. Invalid or missing fields cause {@link MessageInvalidException} to be thrown or a
+   * specific error response to be sent.
    *
    * <p>The method is not idempotent with respect to note contents: later calls with the same peer
-   * and note type overwrite the existing note. The call relies on the caller to provide a valid,
-   * running {@link Node} instance; behavior is undefined if the node is stopping or the referenced
-   * peer disappears concurrently.
+   * and note type overwrite the existing note. Behavior is undefined if the node is stopping or the
+   * referenced peer disappears concurrently.
    *
    * @param handler the connection handler that received the request and is used to send any reply
    *     or error messages back to the client; must have full access for the operation to proceed
-   * @param node the owning node instance used to resolve peers and persist note changes; must not
-   *     be {@code null}
+   * @param node node instance supplied by the legacy FCP dispatch signature; unused because peer
+   *     note mutation is delegated through the runtime SPI
    * @throws MessageInvalidException if the caller lacks access rights, required fields are missing
    *     or malformed, or the peer cannot be updated under the current protocol rules
    */
@@ -127,19 +125,6 @@ public class ModifyPeerNote extends FCPMessage {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "Error: NodeIdentifier field missing",
-          requestIdentifier,
-          false);
-    }
-    PeerNode pn = node.network().getPeerNode(nodeIdentifier);
-    if (pn == null) {
-      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
-      handler.send(msg);
-      return;
-    }
-    if (!(pn instanceof DarknetPeerNode dpn)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.DARKNET_ONLY,
-          "ModifyPeerNote only available for darknet peers",
           requestIdentifier,
           false);
     }
@@ -171,13 +156,24 @@ public class ModifyPeerNote extends FCPMessage {
           e);
       return;
     }
-    if (peerNoteType == Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT) {
-      dpn.setPrivateDarknetCommentNote(noteText);
-    } else {
+    if (peerNoteType != Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT) {
       FCPMessage msg = new UnknownPeerNoteTypeMessage(peerNoteType, requestIdentifier);
       handler.send(msg);
       return;
     }
-    handler.send(new PeerNote(nodeIdentifier, noteText, peerNoteType, requestIdentifier));
+    try {
+      String storedNoteText =
+          handler.getServer().runtime().peer().writePrivateDarknetComment(nodeIdentifier, noteText);
+      handler.send(new PeerNote(nodeIdentifier, storedNoteText, peerNoteType, requestIdentifier));
+    } catch (UnknownPeerException _) {
+      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
+      handler.send(msg);
+    } catch (DarknetPeerRequiredException _) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.DARKNET_ONLY,
+          "ModifyPeerNote only available for darknet peers",
+          requestIdentifier,
+          false);
+    }
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
@@ -3,6 +3,7 @@ package network.crypta.clients.fcp;
 import network.crypta.node.FSParseException;
 import network.crypta.node.Node;
 import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.Base64;
 import network.crypta.support.IllegalBase64Exception;
@@ -93,12 +94,12 @@ public class ModifyPeerNote extends FCPMessage {
    * Executes the {@code ModifyPeerNote} request against the running node.
    *
    * <p>This method enforces full-access permissions on the connection, extracts the target peer
-   * identifier and peer-note type from the backing field set, and resolves the peer through the
-   * runtime SPI. Only darknet peers are accepted; other peer types cause a protocol error. The
-   * handler then decodes the Base64-encoded {@code NoteText} value, applies the note when the note
-   * type is supported, and sends a {@link PeerNote} message back to the client reflecting the new
-   * state. Invalid or missing fields cause {@link MessageInvalidException} to be thrown or a
-   * specific error response to be sent.
+   * identifier from the backing field set, and resolves the peer through the runtime SPI before any
+   * note-type-specific handling. Only darknet peers are accepted; other peer types cause a protocol
+   * error. The handler then parses the peer-note type, decodes the Base64-encoded {@code NoteText}
+   * value, applies the note when the note type is supported, and sends a {@link PeerNote} message
+   * back to the client reflecting the new state. Invalid or missing fields cause {@link
+   * MessageInvalidException} to be thrown or a specific error response to be sent.
    *
    * <p>The method is not idempotent with respect to note contents: later calls with the same peer
    * and note type overwrite the existing note. Behavior is undefined if the node is stopping or the
@@ -127,6 +128,10 @@ public class ModifyPeerNote extends FCPMessage {
           "Error: NodeIdentifier field missing",
           requestIdentifier,
           false);
+    }
+    PeerPort peerPort = handler.getServer().runtime().peer();
+    if (!ensureDarknetPeerExists(handler, peerPort, nodeIdentifier)) {
+      return;
     }
     int peerNoteType;
     try {
@@ -162,12 +167,45 @@ public class ModifyPeerNote extends FCPMessage {
       return;
     }
     try {
-      String storedNoteText =
-          handler.getServer().runtime().peer().writePrivateDarknetComment(nodeIdentifier, noteText);
+      String storedNoteText = peerPort.writePrivateDarknetComment(nodeIdentifier, noteText);
       handler.send(new PeerNote(nodeIdentifier, storedNoteText, peerNoteType, requestIdentifier));
     } catch (UnknownPeerException _) {
       FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
       handler.send(msg);
+    } catch (DarknetPeerRequiredException _) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.DARKNET_ONLY,
+          "ModifyPeerNote only available for darknet peers",
+          requestIdentifier,
+          false);
+    }
+  }
+
+  /**
+   * Resolves the target peer through the runtime SPI before any note-type-specific handling.
+   *
+   * <p>The legacy daemon-backed implementation validated peer existence and darknet eligibility
+   * before parsing or validating note contents. The SPI does not expose a generic peer-note
+   * capability probe, so this method uses the existing private-comment read operation as a
+   * non-mutating preflight to preserve the original FCP error precedence.
+   *
+   * @param handler connection handler used to send protocol error responses back to the client
+   * @param peerPort runtime peer-management port used to resolve the target peer
+   * @param nodeIdentifier peer identifier supplied by the FCP client
+   * @return {@code true} if the peer exists and supports darknet notes, otherwise {@code false}
+   *     after sending the appropriate unknown-node response
+   * @throws MessageInvalidException if the peer exists but is not a darknet peer
+   */
+  private boolean ensureDarknetPeerExists(
+      FCPConnectionHandler handler, PeerPort peerPort, String nodeIdentifier)
+      throws MessageInvalidException {
+    try {
+      peerPort.readPrivateDarknetComment(nodeIdentifier);
+      return true;
+    } catch (UnknownPeerException _) {
+      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
+      handler.send(msg);
+      return false;
     } catch (DarknetPeerRequiredException _) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.DARKNET_ONLY,

--- a/src/main/java/network/crypta/clients/fcp/PeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PeerMessage.java
@@ -1,103 +1,68 @@
 package network.crypta.clients.fcp;
 
+import java.util.Map;
+import java.util.Objects;
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerSnapshot;
 import network.crypta.support.SimpleFieldSet;
 
 /**
- * Represents the server-to-client {@code Peer} FCP message built from a {@link PeerNode} snapshot.
- * The message bundles identity information with optional metadata and volatile sections so clients
- * can render a peer list or perform diagnostics without extra node round-trips.
+ * Represents the server-to-client {@code Peer} FCP message built from a detached peer snapshot.
  *
- * <p>This type is lightweight and immutable; each instance captures the peer's exported fields at
- * the time the request is assembled. Callers choose whether to include metadata (calculated with
- * the current wall-clock timestamp) and volatile attributes. The {@link #run(FCPConnectionHandler,
- * Node)} method is unsupported on the client path and always rejects attempts to send this message
- * to the server.
- *
- * <ul>
- *   <li>Exports core peer state, plus optional metadata and volatile snapshots.
- *   <li>Encodes an optional message identifier so clients can correlate responses.
- *   <li>Designed for one-way delivery from server to client; not executed inbound.
- * </ul>
- *
- * <p>Instances are not thread-safe for mutation, but the exported {@link SimpleFieldSet} is
- * detached from the source peer so callers may reuse it across threads once created.
- *
- * @see PeerNode
- * @see SimpleFieldSet
+ * <p>This type is lightweight and immutable; each instance stores only an immutable {@link
+ * PeerSnapshot} plus an optional request identifier. Serialization is deferred until {@link
+ * #getFieldSet()} rebuilds a fresh {@link SimpleFieldSet}, allowing callers to queue the message
+ * without keeping a live daemon peer object in the response.
  */
 public class PeerMessage extends FCPMessage {
   static final String NAME = "Peer";
 
-  final PeerNode pn;
-  final boolean withMetadata;
-  final boolean withVolatile;
+  final PeerSnapshot snapshot;
   final String messageIdentifier;
 
   /**
-   * Creates a {@code PeerMessage} that exports the provided peer snapshot with optional metadata
-   * and volatile sections for downstream FCP clients.
+   * Creates a {@code PeerMessage} that serializes the provided peer snapshot for downstream FCP
+   * clients.
    *
-   * <p>The constructor does not perform deep copies; it defers to the {@link PeerNode} export
-   * helpers when {@link #getFieldSet()} is invoked. Callers should therefore construct this message
-   * close to dispatch time to keep the snapshot representative of the current node state. Supplying
-   * both optional flags allows the receiver to render a complete view, while disabling them can
-   * reduce payload size for bandwidth-sensitive environments.
-   *
-   * <pre>{@code
-   * var message = new PeerMessage(peerNode, true, false, "ui-refresh-42");
-   * sendToClient(message);
-   * }</pre>
-   *
-   * @param pn peer node to serialize; must not be {@code null} when used
-   * @param withMetadata include metadata snapshot using the current wall-clock timestamp
-   * @param withVolatile include transient volatile attributes such as dynamic statistics
+   * @param snapshot detached peer snapshot to serialize
    * @param messageIdentifier optional caller-supplied token to correlate downstream responses
    */
-  public PeerMessage(
-      PeerNode pn, boolean withMetadata, boolean withVolatile, String messageIdentifier) {
-    this.pn = pn;
-    this.withMetadata = withMetadata;
-    this.withVolatile = withVolatile;
+  public PeerMessage(PeerSnapshot snapshot, String messageIdentifier) {
+    this.snapshot = Objects.requireNonNull(snapshot);
     this.messageIdentifier = messageIdentifier;
   }
 
   /**
-   * Builds the {@link SimpleFieldSet} payload representing the peer state for FCP transmission.
-   *
-   * <p>The returned structure always includes the base peer fields exported by {@link
-   * PeerNode#exportFieldSet()}. When {@code withMetadata} is enabled, it appends the current
-   * metadata snapshot using the time of invocation to compute age-sensitive fields. When {@code
-   * withVolatile} is enabled, it includes volatile statistics if present. Empty sections are
-   * omitted to keep the message compact. If a non-null identifier was provided at construction, the
-   * method also adds it under the {@code Identifier} key so clients can match responses.
+   * Builds the {@link SimpleFieldSet} payload representing the stored peer snapshot for FCP
+   * transmission.
    *
    * @return a mutable field set containing base peer data plus any requested optional sections
    */
   @Override
   public SimpleFieldSet getFieldSet() {
-    SimpleFieldSet fs = pn.exportFieldSet();
-    if (withMetadata) {
-      SimpleFieldSet meta = pn.exportMetadataFieldSet(System.currentTimeMillis());
-      if (!meta.isEmpty()) {
-        fs.put("metadata", meta);
-      }
+    SimpleFieldSet fs = toSimpleFieldSet(snapshot.root());
+    if (messageIdentifier != null) {
+      fs.putSingle("Identifier", messageIdentifier);
     }
-    if (withVolatile) {
-      SimpleFieldSet vol = pn.exportVolatileFieldSet();
-      if (!vol.isEmpty()) {
-        fs.put("volatile", vol);
-      }
-    }
-    if (messageIdentifier != null) fs.putSingle("Identifier", messageIdentifier);
     return fs;
+  }
+
+  private static SimpleFieldSet toSimpleFieldSet(PeerFieldSet source) {
+    SimpleFieldSet target = new SimpleFieldSet(true);
+    for (Map.Entry<String, String> entry : source.directValues().entrySet()) {
+      target.putSingle(entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, PeerFieldSet> entry : source.directSubsets().entrySet()) {
+      target.tput(entry.getKey(), toSimpleFieldSet(entry.getValue()));
+    }
+    return target;
   }
 
   /**
    * Returns the fixed FCP message name used on the wire for peer descriptions.
    *
-   * <p>The name is stable and shared across all instances so routing and parsing logic in FCP
+   * <p>The name is stable and shared across all instances, so routing and parsing logic in FCP
    * handlers can match incoming messages efficiently. Because it returns a constant, this method is
    * effectively free of side effects and can be invoked frequently by higher-level dispatchers
    * without additional allocations.

--- a/src/main/java/network/crypta/clients/fcp/RemovePeer.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePeer.java
@@ -1,8 +1,8 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
-import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.RemovedPeerSnapshot;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -30,7 +30,6 @@ import network.crypta.support.SimpleFieldSet;
  * @see PeerRemoved
  * @see UnknownNodeIdentifierMessage
  * @see Node
- * @see PeerNode
  */
 public class RemovePeer extends FCPMessage {
 
@@ -95,11 +94,10 @@ public class RemovePeer extends FCPMessage {
    * <p>The handler must have full access; otherwise a {@link MessageInvalidException} with an
    * {@link ProtocolErrorMessage#ACCESS_DENIED} error is thrown. When the {@code NodeIdentifier}
    * field is missing, the method signals a {@link ProtocolErrorMessage#MISSING_FIELD} error. If a
-   * matching peer exists, it is detached via {@link
-   * NodeNetworkSubsystem#removePeerConnection(PeerNode)} and a {@link PeerRemoved} acknowledgment
-   * is sent. Unknown peer identifiers yield an {@link UnknownNodeIdentifierMessage}. No state
-   * beyond the current invocation is retained, and the method is not idempotent if the peer list
-   * changes between calls.
+   * matching peer exists, it is detached through the runtime peer-management SPI and a {@link
+   * PeerRemoved} acknowledgment is sent. Unknown peer identifiers yield an {@link
+   * UnknownNodeIdentifierMessage}. No state beyond the current invocation is retained, and the
+   * method is not idempotent if the peer list changes between calls.
    *
    * <pre>{@code
    * // Example: remove a peer by its node identifier
@@ -109,8 +107,8 @@ public class RemovePeer extends FCPMessage {
    *
    * @param handler connection handler responsible for sending responses; must provide full-access
    *     privileges for the operation to proceed and must not be null.
-   * @param node target node on which the peer should be removed; must not be null and must support
-   *     lookup of the specified node identifier.
+   * @param node node instance supplied by the legacy FCP dispatch signature; unused because peer
+   *     removal is delegated through the runtime SPI
    * @throws MessageInvalidException when access is denied or required, fields are absent, halting
    *     further processing and surfacing a protocol-level error to the caller.
    */
@@ -131,14 +129,13 @@ public class RemovePeer extends FCPMessage {
           messageIdentifier,
           false);
     }
-    PeerNode pn = node.network().getPeerNode(nodeIdentifier);
-    if (pn == null) {
+    try {
+      RemovedPeerSnapshot removedPeer = handler.getServer().runtime().peer().remove(nodeIdentifier);
+      handler.send(
+          new PeerRemoved(removedPeer.identity(), removedPeer.nodeIdentifier(), messageIdentifier));
+    } catch (UnknownPeerException _) {
       FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, messageIdentifier);
       handler.send(msg);
-      return;
     }
-    String identity = pn.getIdentityString();
-    node.network().removePeerConnection(pn);
-    handler.send(new PeerRemoved(identity, nodeIdentifier, messageIdentifier));
   }
 }

--- a/src/main/java/network/crypta/node/runtime/LegacyPeerPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyPeerPort.java
@@ -1,0 +1,378 @@
+package network.crypta.node.runtime;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.io.comm.PeerParseException;
+import network.crypta.io.comm.ReferenceSignatureVerificationException;
+import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
+import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.FSParseException;
+import network.crypta.node.Node;
+import network.crypta.node.OpennetDisabledException;
+import network.crypta.node.PeerNode;
+import network.crypta.node.PeerTooOldException;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
+import network.crypta.runtime.spi.PeerAddFailureReason;
+import network.crypta.runtime.spi.PeerAddRejectedException;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
+import network.crypta.runtime.spi.RemovedPeerSnapshot;
+import network.crypta.runtime.spi.UnknownPeerException;
+import network.crypta.support.SimpleFieldSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Adapts the daemon's legacy peer-management logic to the runtime SPI's {@link PeerPort}.
+ *
+ * <p>This bridge keeps knowledge of {@link Node}, {@link PeerNode}, {@link DarknetPeerNode}, and
+ * {@link SimpleFieldSet} inside the daemon root module while exposing only SPI-local DTOs to
+ * management-facing code. It preserves the current peer-management behavior by delegating directly
+ * to the daemon's existing peer lookup, export, add, remove, and mutation paths.
+ *
+ * <p>The adapter is intentionally narrow. It exists to keep the peer-management slice migrated in
+ * this PR behind a JDK-only SPI without redesigning the daemon's internal peer model. It converts
+ * legacy field-set exports into detached snapshot trees, translates legacy peer-add failures into
+ * SPI-local exceptions, and applies the small set of darknet-only mutations that the current FCP
+ * message family already supports.
+ */
+final class LegacyPeerPort implements PeerPort {
+  /** Logger used for add-peer events that were already visible through the legacy path. */
+  private static final Logger LOG = LoggerFactory.getLogger(LegacyPeerPort.class);
+
+  /** Subset key used when attaching exported peer metadata to detached snapshots. */
+  private static final String METADATA_SUBSET = "metadata";
+
+  /** Subset key used when attaching exported volatile peer state to detached snapshots. */
+  private static final String VOLATILE_SUBSET = "volatile";
+
+  /** Live daemon node whose legacy network subsystem performs the actual peer operations. */
+  private final Node node;
+
+  /**
+   * Creates a legacy-backed peer-management port for the current daemon runtime.
+   *
+   * @param node daemon node that exposes the legacy peer-management subsystem
+   */
+  LegacyPeerPort(Node node) {
+    this.node = Objects.requireNonNull(node);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public List<PeerSnapshot> list(boolean includeMetadata, boolean includeVolatile) {
+    PeerNode[] peers = node.network().peerNodes();
+    List<PeerSnapshot> snapshots = new ArrayList<>(peers.length);
+    for (PeerNode peer : peers) {
+      snapshots.add(toPeerSnapshot(peer, includeMetadata, includeVolatile));
+    }
+    return List.copyOf(snapshots);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PeerSnapshot get(String nodeIdentifier, boolean includeMetadata, boolean includeVolatile)
+      throws UnknownPeerException {
+    return toPeerSnapshot(resolvePeer(nodeIdentifier), includeMetadata, includeVolatile);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PeerSnapshot add(PeerFieldSet reference, PeerTrust trust, PeerVisibility visibility)
+      throws PeerAddRejectedException {
+    Objects.requireNonNull(reference, "reference");
+    Objects.requireNonNull(trust, "trust");
+    Objects.requireNonNull(visibility, "visibility");
+
+    SimpleFieldSet fieldSet = toSimpleFieldSet(reference);
+    boolean isOpennetRef = fieldSet.getBoolean("opennet", false);
+    PeerNode peer =
+        isOpennetRef ? createOpennetPeer(fieldSet) : createDarknetPeer(fieldSet, trust, visibility);
+    ensureNotSelfPeer(peer, isOpennetRef);
+    if (!node.network().addPeerConnection(peer)) {
+      throw new PeerAddRejectedException(
+          PeerAddFailureReason.DUPLICATE_PEER_REF, "Node already has a peer with that identity");
+    }
+    if (isOpennetRef) {
+      LOG.info("Added opennet peer: {}", peer);
+    } else {
+      LOG.info("Added darknet peer: {}", peer);
+    }
+    return toPeerSnapshot(peer, true, true);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PeerSnapshot updateDarknetPeer(String nodeIdentifier, DarknetPeerSettingsUpdate update)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    Objects.requireNonNull(update, "update");
+    DarknetPeerNode peer = resolveDarknetPeer(nodeIdentifier);
+    applyDisableFlag(peer, update.disabled());
+    applyBooleanFlag(update.listenOnly(), peer::setListenOnly);
+    applyBooleanFlag(update.burstOnly(), peer::setBurstOnly);
+    applyBooleanFlag(update.ignoreSourcePort(), peer::setIgnoreSourcePort);
+    applyBooleanFlag(update.allowLocalAddresses(), peer::setAllowLocalAddresses);
+    return toPeerSnapshot(peer, true, true);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public RemovedPeerSnapshot remove(String nodeIdentifier) throws UnknownPeerException {
+    PeerNode peer = resolvePeer(nodeIdentifier);
+    String identity = peer.getIdentityString();
+    node.network().removePeerConnection(peer);
+    return new RemovedPeerSnapshot(identity, nodeIdentifier);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String readPrivateDarknetComment(String nodeIdentifier)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    return resolveDarknetPeer(nodeIdentifier).getPrivateDarknetCommentNote();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String writePrivateDarknetComment(String nodeIdentifier, String noteText)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    DarknetPeerNode peer = resolveDarknetPeer(nodeIdentifier);
+    peer.setPrivateDarknetCommentNote(noteText);
+    return peer.getPrivateDarknetCommentNote();
+  }
+
+  /**
+   * Resolves one peer by the daemon's existing node-identifier lookup path.
+   *
+   * @param nodeIdentifier peer identifier to resolve through the legacy network subsystem
+   * @return resolved live peer instance from the daemon
+   * @throws UnknownPeerException if the identifier does not match any known peer
+   */
+  private PeerNode resolvePeer(String nodeIdentifier) throws UnknownPeerException {
+    Objects.requireNonNull(nodeIdentifier, "nodeIdentifier");
+    PeerNode peer = node.network().getPeerNode(nodeIdentifier);
+    if (peer == null) {
+      throw new UnknownPeerException(nodeIdentifier);
+    }
+    return peer;
+  }
+
+  /**
+   * Resolves one peer and verifies that it is a darknet peer.
+   *
+   * @param nodeIdentifier peer identifier to resolve through the legacy network subsystem
+   * @return resolved darknet peer instance from the daemon
+   * @throws UnknownPeerException if the identifier does not match any known peer
+   * @throws DarknetPeerRequiredException if the resolved peer is not a darknet peer
+   */
+  private DarknetPeerNode resolveDarknetPeer(String nodeIdentifier)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    PeerNode peer = resolvePeer(nodeIdentifier);
+    if (!(peer instanceof DarknetPeerNode darknetPeer)) {
+      throw new DarknetPeerRequiredException(nodeIdentifier);
+    }
+    return darknetPeer;
+  }
+
+  /**
+   * Creates one opennet peer from a legacy field-set reference.
+   *
+   * @param fieldSet detached peer reference converted back into the legacy field-set format
+   * @return live opennet peer instance created by the daemon
+   * @throws PeerAddRejectedException if legacy peer creation rejects the reference
+   */
+  private PeerNode createOpennetPeer(SimpleFieldSet fieldSet) throws PeerAddRejectedException {
+    try {
+      return node.network().createNewOpennetNode(fieldSet);
+    } catch (FSParseException | PeerParseException | PeerTooOldException e) {
+      throw new PeerAddRejectedException(
+          PeerAddFailureReason.REF_PARSE_ERROR, "Error parsing ref: " + e.getMessage());
+    } catch (OpennetDisabledException e) {
+      throw new PeerAddRejectedException(
+          PeerAddFailureReason.OPENNET_DISABLED, "Error adding ref: " + e.getMessage());
+    } catch (ReferenceSignatureVerificationException e) {
+      throw new PeerAddRejectedException(
+          PeerAddFailureReason.REF_SIGNATURE_INVALID, "Error adding ref: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Creates one darknet peer from a legacy field-set reference and SPI-local defaults.
+   *
+   * @param fieldSet detached peer reference converted back into the legacy field-set format
+   * @param trust SPI-local trust level supplied by the caller
+   * @param visibility SPI-local visibility level supplied by the caller
+   * @return live darknet peer instance created by the daemon
+   * @throws PeerAddRejectedException if legacy peer creation rejects the reference
+   */
+  private PeerNode createDarknetPeer(
+      SimpleFieldSet fieldSet, PeerTrust trust, PeerVisibility visibility)
+      throws PeerAddRejectedException {
+    try {
+      return node.network()
+          .createNewDarknetNode(fieldSet, toLegacyTrust(trust), toLegacyVisibility(visibility));
+    } catch (FSParseException | PeerParseException | PeerTooOldException e) {
+      throw new PeerAddRejectedException(
+          PeerAddFailureReason.REF_PARSE_ERROR, "Error parsing ref: " + e.getMessage());
+    } catch (ReferenceSignatureVerificationException e) {
+      throw new PeerAddRejectedException(
+          PeerAddFailureReason.REF_SIGNATURE_INVALID, "Error adding ref: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Rejects peer references that resolve to the local node's own public-key hash.
+   *
+   * @param peer candidate peer created by the legacy daemon path
+   * @param isOpennetRef whether the reference was classified as opennet
+   * @throws PeerAddRejectedException if the peer resolves to the local node
+   */
+  private void ensureNotSelfPeer(PeerNode peer, boolean isOpennetRef)
+      throws PeerAddRejectedException {
+    byte[] nodePubKeyHash =
+        isOpennetRef ? node.network().opennetPubKeyHash() : node.network().darknetPubKeyHash();
+    if (Arrays.equals(peer.peerECDSAPubKeyHash, nodePubKeyHash)) {
+      throw new PeerAddRejectedException(
+          PeerAddFailureReason.CANNOT_PEER_WITH_SELF, "Node cannot peer with itself");
+    }
+  }
+
+  /**
+   * Maps the SPI-local trust enum onto the daemon's legacy darknet trust enum.
+   *
+   * @param trust SPI-local trust value supplied to the runtime port
+   * @return equivalent legacy trust value expected by the daemon
+   */
+  private static FRIEND_TRUST toLegacyTrust(PeerTrust trust) {
+    return switch (trust) {
+      case LOW -> FRIEND_TRUST.LOW;
+      case NORMAL -> FRIEND_TRUST.NORMAL;
+      case HIGH -> FRIEND_TRUST.HIGH;
+    };
+  }
+
+  /**
+   * Maps the SPI-local visibility enum onto the daemon's legacy darknet visibility enum.
+   *
+   * @param visibility SPI-local visibility value supplied to the runtime port
+   * @return equivalent legacy visibility value expected by the daemon
+   */
+  private static FRIEND_VISIBILITY toLegacyVisibility(PeerVisibility visibility) {
+    return switch (visibility) {
+      case YES -> FRIEND_VISIBILITY.YES;
+      case NAME_ONLY -> FRIEND_VISIBILITY.NAME_ONLY;
+      case NO -> FRIEND_VISIBILITY.NO;
+    };
+  }
+
+  /**
+   * Applies the nullable disabled flag using the legacy enable and disable methods.
+   *
+   * @param peer darknet peer to update
+   * @param disabled nullable disabled flag from the detached update DTO
+   */
+  private static void applyDisableFlag(DarknetPeerNode peer, Boolean disabled) {
+    if (disabled == null) {
+      return;
+    }
+    if (disabled) {
+      peer.disablePeer();
+    } else {
+      peer.enablePeer();
+    }
+  }
+
+  /**
+   * Applies one nullable boolean flag through the supplied legacy setter.
+   *
+   * @param flagValue nullable flag value from the detached update DTO
+   * @param setter legacy setter to invoke only when a value is present
+   */
+  private static void applyBooleanFlag(
+      Boolean flagValue, java.util.function.Consumer<Boolean> setter) {
+    if (flagValue != null) {
+      setter.accept(flagValue);
+    }
+  }
+
+  /**
+   * Exports one live peer into a detached snapshot tree with optional subsets attached.
+   *
+   * @param peer live peer instance supplied by the daemon
+   * @param includeMetadata whether exported metadata should be attached under the metadata subset
+   * @param includeVolatile whether exported volatile state should be attached under the volatile
+   *     subset
+   * @return detached snapshot for the supplied peer
+   */
+  private PeerSnapshot toPeerSnapshot(
+      PeerNode peer, boolean includeMetadata, boolean includeVolatile) {
+    PeerFieldSet root = toPeerFieldSet(peer.exportFieldSet());
+    if (!includeMetadata && !includeVolatile) {
+      return new PeerSnapshot(root);
+    }
+
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>(root.directValues());
+    LinkedHashMap<String, PeerFieldSet> directSubsets = new LinkedHashMap<>(root.directSubsets());
+    if (includeMetadata) {
+      PeerFieldSet metadata =
+          toPeerFieldSet(peer.exportMetadataFieldSet(System.currentTimeMillis()));
+      if (!metadata.isEmpty()) {
+        directSubsets.put(METADATA_SUBSET, metadata);
+      }
+    }
+    if (includeVolatile) {
+      PeerFieldSet volatileFieldSet = toPeerFieldSet(peer.exportVolatileFieldSet());
+      if (!volatileFieldSet.isEmpty()) {
+        directSubsets.put(VOLATILE_SUBSET, volatileFieldSet);
+      }
+    }
+    return new PeerSnapshot(new PeerFieldSet(directValues, directSubsets));
+  }
+
+  /**
+   * Converts one legacy {@link SimpleFieldSet} tree into the detached SPI tree representation.
+   *
+   * @param fieldSet legacy field-set tree exported by the daemon
+   * @return detached peer field-set tree with empty child subsets omitted
+   */
+  private static PeerFieldSet toPeerFieldSet(SimpleFieldSet fieldSet) {
+    if (fieldSet.isEmpty()) {
+      return PeerFieldSet.empty();
+    }
+
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>(fieldSet.directKeyValues());
+    LinkedHashMap<String, PeerFieldSet> directSubsets = new LinkedHashMap<>();
+    for (Map.Entry<String, SimpleFieldSet> entry : fieldSet.directSubsets().entrySet()) {
+      PeerFieldSet subset = toPeerFieldSet(entry.getValue());
+      if (!subset.isEmpty()) {
+        directSubsets.put(entry.getKey(), subset);
+      }
+    }
+    return new PeerFieldSet(directValues, directSubsets);
+  }
+
+  /**
+   * Converts one detached SPI peer tree back into a legacy {@link SimpleFieldSet}.
+   *
+   * @param fieldSet detached peer tree supplied through the runtime SPI
+   * @return legacy field-set tree suitable for daemon peer creation
+   */
+  private static SimpleFieldSet toSimpleFieldSet(PeerFieldSet fieldSet) {
+    SimpleFieldSet simpleFieldSet = new SimpleFieldSet(true);
+    for (Map.Entry<String, String> entry : fieldSet.directValues().entrySet()) {
+      simpleFieldSet.putSingle(entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, PeerFieldSet> entry : fieldSet.directSubsets().entrySet()) {
+      simpleFieldSet.tput(entry.getKey(), toSimpleFieldSet(entry.getValue()));
+    }
+    return simpleFieldSet;
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -8,6 +8,7 @@ import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -35,6 +36,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final LifecyclePort lifecyclePort;
   private final ConfigPort configPort;
   private final NodeInfoPort nodeInfoPort;
+  private final PeerPort peerPort;
 
   /**
    * Creates a runtime SPI adapter backed by the current daemon internals.
@@ -116,6 +118,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
         };
     this.configPort = new LegacyConfigPort(node, core);
     this.nodeInfoPort = new LegacyNodeInfoPort(node);
+    this.peerPort = new LegacyPeerPort(node);
   }
 
   /**
@@ -180,5 +183,16 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public NodeInfoPort nodeInfo() {
     return nodeInfoPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps all legacy peer export and mutation logic inside the daemon root
+   * module while exposing only SPI-local snapshots, DTOs, and exceptions upstream.
+   */
+  @Override
+  public PeerPort peer() {
+    return peerPort;
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
@@ -6,20 +6,20 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.io.comm.ReferenceSignatureVerificationException;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
-import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.FSParseException;
 import network.crypta.node.Node;
-import network.crypta.node.OpennetDisabledException;
-import network.crypta.node.OpennetPeerNode;
-import network.crypta.node.PeerNode;
-import network.crypta.node.PeerTooOldException;
+import network.crypta.runtime.spi.PeerAddFailureReason;
+import network.crypta.runtime.spi.PeerAddRejectedException;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,23 +37,31 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings({"java:S100", "java:S2095", "resource"})
+@SuppressWarnings({"java:S100", "java:S2095"})
 @ExtendWith(MockitoExtension.class)
 class AddPeerTest {
 
   private static final String IDENTIFIER = "test-ident";
 
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Mock private FCPServer server;
+
+  @Mock private RuntimePorts runtimePorts;
+
+  @Mock private PeerPort peerPort;
+
   @Test
   void constructor_whenTrustMissing_throwsMessageInvalidExceptionWithMissingFieldCode() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", IDENTIFIER);
-    // No Trust field
-    fs.putSingle("Visibility", FRIEND_VISIBILITY.YES.name());
+    fs.putSingle("Visibility", PeerVisibility.YES.name());
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> new AddPeer(fs));
@@ -67,7 +76,7 @@ class AddPeerTest {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", IDENTIFIER);
     fs.putSingle("Trust", "NOT_A_VALID_VALUE");
-    fs.putSingle("Visibility", FRIEND_VISIBILITY.YES.name());
+    fs.putSingle("Visibility", PeerVisibility.YES.name());
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> new AddPeer(fs));
@@ -81,8 +90,7 @@ class AddPeerTest {
   void constructor_whenVisibilityMissing_throwsMessageInvalidExceptionWithMissingFieldCode() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", IDENTIFIER);
-    fs.putSingle("Trust", FRIEND_TRUST.NORMAL.name());
-    // No Visibility field
+    fs.putSingle("Trust", PeerTrust.NORMAL.name());
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> new AddPeer(fs));
@@ -96,7 +104,7 @@ class AddPeerTest {
   void constructor_whenVisibilityInvalid_throwsMessageInvalidExceptionWithInvalidFieldCode() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", IDENTIFIER);
-    fs.putSingle("Trust", FRIEND_TRUST.NORMAL.name());
+    fs.putSingle("Trust", PeerTrust.NORMAL.name());
     fs.putSingle("Visibility", "NOT_A_VALID_VALUE");
 
     MessageInvalidException exception =
@@ -109,22 +117,18 @@ class AddPeerTest {
 
   @Test
   void getName_whenCalled_returnsAddPeerConstant() throws MessageInvalidException {
-    SimpleFieldSet fs = minimalValidFieldSet();
-
-    AddPeer addPeer = new AddPeer(fs);
+    AddPeer addPeer = new AddPeer(minimalValidFieldSet());
 
     assertEquals(AddPeer.NAME, addPeer.getName());
   }
 
   @Test
   void getFieldSet_whenCalled_returnsNonNullEmptyFieldSet() throws MessageInvalidException {
-    SimpleFieldSet fs = minimalValidFieldSet();
-
-    AddPeer addPeer = new AddPeer(fs);
+    AddPeer addPeer = new AddPeer(minimalValidFieldSet());
 
     SimpleFieldSet result = addPeer.getFieldSet();
+
     assertNotNull(result);
-    // A freshly created SimpleFieldSet should not contain user data yet.
     assertNull(result.get("Identifier"));
   }
 
@@ -161,12 +165,8 @@ class AddPeerTest {
 
   @Test
   void run_whenHandlerHasNoFullAccess_throwsAccessDenied() throws MessageInvalidException {
-    SimpleFieldSet fs = minimalValidFieldSet();
-    AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    AddPeer addPeer = new AddPeer(minimalValidFieldSet());
     when(handler.hasFullAccess()).thenReturn(false);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
@@ -174,219 +174,80 @@ class AddPeerTest {
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
     assertEquals("AddPeer requires full access", exception.getMessage());
     assertEquals(IDENTIFIER, exception.ident);
-    verifyNoMoreInteractions(node);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
-  void run_whenOpennetRefCreatesPeer_addsPeerAndSendsPeerMessage() throws Exception {
+  void run_whenOpennetRefAccepted_convertsReferenceAndSendsPeerMessage() throws Exception {
     SimpleFieldSet fs = minimalValidFieldSet();
     fs.put("opennet", true);
     AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    PeerSnapshot snapshot = peerSnapshot("peer-one");
+    stubPeerPort();
     when(handler.hasFullAccess()).thenReturn(true);
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    OpennetPeerNode peerNode = mock(OpennetPeerNode.class);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.createNewOpennetNode(any(SimpleFieldSet.class))).thenReturn(peerNode);
-    when(network.opennetPubKeyHash()).thenReturn(new byte[] {1});
-    when(network.addPeerConnection(peerNode)).thenReturn(true);
+    when(peerPort.add(any(PeerFieldSet.class), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES)))
+        .thenReturn(snapshot);
 
     addPeer.run(handler, node);
 
-    verify(network).createNewOpennetNode(any(SimpleFieldSet.class));
-    verify(network).addPeerConnection(peerNode);
+    ArgumentCaptor<PeerFieldSet> referenceCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
+    verify(peerPort).add(referenceCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES));
+    assertEquals("true", referenceCaptor.getValue().directValues().get("opennet"));
     ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(messageCaptor.capture());
-    FCPMessage sent = messageCaptor.getValue();
-    assertNotNull(sent);
-    assertEquals(PeerMessage.class, sent.getClass());
-    PeerMessage peerMessage = (PeerMessage) sent;
+    PeerMessage peerMessage = (PeerMessage) messageCaptor.getValue();
+    assertEquals(snapshot, peerMessage.snapshot);
     assertEquals(IDENTIFIER, peerMessage.messageIdentifier);
+    verifyNoInteractions(node);
   }
 
   @Test
-  void run_whenDarknetRefCreatesPeer_addsPeerWithConfiguredTrustAndVisibility() throws Exception {
-    SimpleFieldSet fs = minimalValidFieldSet();
-    // No opennet flag -> darknet
-    AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+  void run_whenDarknetRefAccepted_mapsConfiguredTrustAndVisibility() throws Exception {
+    AddPeer addPeer = new AddPeer(minimalValidFieldSet());
+    PeerSnapshot snapshot = peerSnapshot("peer-two");
+    stubPeerPort();
     when(handler.hasFullAccess()).thenReturn(true);
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    DarknetPeerNode peerNode = mock(DarknetPeerNode.class);
-    when(node.network().darknetPubKeyHash()).thenReturn(new byte[] {1});
-    when(node.network().addPeerConnection(peerNode)).thenReturn(true);
-
-    when(node.network()
-            .createNewDarknetNode(
-                any(SimpleFieldSet.class), any(FRIEND_TRUST.class), any(FRIEND_VISIBILITY.class)))
-        .thenReturn(peerNode);
+    when(peerPort.add(any(PeerFieldSet.class), any(PeerTrust.class), any(PeerVisibility.class)))
+        .thenReturn(snapshot);
 
     addPeer.run(handler, node);
 
-    ArgumentCaptor<FRIEND_TRUST> trustCaptor = ArgumentCaptor.forClass(FRIEND_TRUST.class);
-    ArgumentCaptor<FRIEND_VISIBILITY> visibilityCaptor =
-        ArgumentCaptor.forClass(FRIEND_VISIBILITY.class);
-
-    verify(node.network())
-        .createNewDarknetNode(
-            any(SimpleFieldSet.class), trustCaptor.capture(), visibilityCaptor.capture());
-    verify(node.network()).addPeerConnection(peerNode);
-
-    assertEquals(FRIEND_TRUST.NORMAL, trustCaptor.getValue());
-    assertEquals(FRIEND_VISIBILITY.YES, visibilityCaptor.getValue());
+    ArgumentCaptor<PeerTrust> trustCaptor = ArgumentCaptor.forClass(PeerTrust.class);
+    ArgumentCaptor<PeerVisibility> visibilityCaptor = ArgumentCaptor.forClass(PeerVisibility.class);
+    verify(peerPort)
+        .add(any(PeerFieldSet.class), trustCaptor.capture(), visibilityCaptor.capture());
+    assertEquals(PeerTrust.NORMAL, trustCaptor.getValue());
+    assertEquals(PeerVisibility.YES, visibilityCaptor.getValue());
   }
 
   @Test
-  void run_whenOpennetRefIsSelf_throwsCannotPeerWithSelf() throws Exception {
-    SimpleFieldSet fs = minimalValidFieldSet();
-    fs.put("opennet", true);
-    AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    when(handler.hasFullAccess()).thenReturn(true);
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    OpennetPeerNode peerNode = mock(OpennetPeerNode.class);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.createNewOpennetNode(any(SimpleFieldSet.class))).thenReturn(peerNode);
-    when(network.opennetPubKeyHash()).thenReturn(null);
-
-    MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
-
-    assertEquals(ProtocolErrorMessage.CANNOT_PEER_WITH_SELF, exception.protocolCode);
-    verify(network, never()).addPeerConnection(any(PeerNode.class));
+  void run_whenAddRejectedWithRefParse_mapsProtocolCode() throws Exception {
+    assertAddRejectedMapsToProtocolCode(
+        PeerAddFailureReason.REF_PARSE_ERROR, ProtocolErrorMessage.REF_PARSE_ERROR);
   }
 
   @Test
-  void run_whenOpennetRefDuplicatePeer_throwsDuplicatePeerRef() throws Exception {
-    SimpleFieldSet fs = minimalValidFieldSet();
-    fs.put("opennet", true);
-    AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    when(handler.hasFullAccess()).thenReturn(true);
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    OpennetPeerNode peerNode = mock(OpennetPeerNode.class);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.createNewOpennetNode(any(SimpleFieldSet.class))).thenReturn(peerNode);
-    when(network.opennetPubKeyHash()).thenReturn(new byte[] {1});
-    when(network.addPeerConnection(peerNode)).thenReturn(false);
-
-    MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
-
-    assertEquals(ProtocolErrorMessage.DUPLICATE_PEER_REF, exception.protocolCode);
+  void run_whenAddRejectedWithOpennetDisabled_mapsProtocolCode() throws Exception {
+    assertAddRejectedMapsToProtocolCode(
+        PeerAddFailureReason.OPENNET_DISABLED, ProtocolErrorMessage.OPENNET_DISABLED);
   }
 
   @Test
-  void run_whenOpennetCreationFailsWithFSParseException_throwsRefParseError() throws Exception {
-    SimpleFieldSet fs = minimalValidFieldSet();
-    fs.put("opennet", true);
-    AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    when(handler.hasFullAccess()).thenReturn(true);
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    when(node.network().createNewOpennetNode(any(SimpleFieldSet.class)))
-        .thenThrow(new FSParseException("parse-error"));
-
-    MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
-
-    assertEquals(ProtocolErrorMessage.REF_PARSE_ERROR, exception.protocolCode);
+  void run_whenAddRejectedWithInvalidSignature_mapsProtocolCode() throws Exception {
+    assertAddRejectedMapsToProtocolCode(
+        PeerAddFailureReason.REF_SIGNATURE_INVALID, ProtocolErrorMessage.REF_SIGNATURE_INVALID);
   }
 
   @Test
-  void run_whenOpennetCreationFailsWithOpennetDisabled_throwsOpennetDisabledError()
-      throws Exception {
-    SimpleFieldSet fs = minimalValidFieldSet();
-    fs.put("opennet", true);
-    AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    when(handler.hasFullAccess()).thenReturn(true);
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    when(node.network().createNewOpennetNode(any(SimpleFieldSet.class)))
-        .thenThrow(new OpennetDisabledException("disabled"));
-
-    MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
-
-    assertEquals(ProtocolErrorMessage.OPENNET_DISABLED, exception.protocolCode);
+  void run_whenAddRejectedWithCannotPeerWithSelf_mapsProtocolCode() throws Exception {
+    assertAddRejectedMapsToProtocolCode(
+        PeerAddFailureReason.CANNOT_PEER_WITH_SELF, ProtocolErrorMessage.CANNOT_PEER_WITH_SELF);
   }
 
   @Test
-  void run_whenOpennetCreationFailsWithInvalidSignature_throwsRefSignatureInvalid()
-      throws Exception {
-    SimpleFieldSet fs = minimalValidFieldSet();
-    fs.put("opennet", true);
-    AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    when(handler.hasFullAccess()).thenReturn(true);
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    when(node.network().createNewOpennetNode(any(SimpleFieldSet.class)))
-        .thenThrow(new ReferenceSignatureVerificationException("bad-sig"));
-
-    MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
-
-    assertEquals(ProtocolErrorMessage.REF_SIGNATURE_INVALID, exception.protocolCode);
-  }
-
-  @Test
-  void run_whenOpennetCreationFailsWithPeerTooOld_throwsRefParseError() throws Exception {
-    SimpleFieldSet fs = minimalValidFieldSet();
-    fs.put("opennet", true);
-    AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    when(handler.hasFullAccess()).thenReturn(true);
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    when(node.network().createNewOpennetNode(any(SimpleFieldSet.class)))
-        .thenThrow(new PeerTooOldException("too-old", 1, null));
-
-    MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
-
-    assertEquals(ProtocolErrorMessage.REF_PARSE_ERROR, exception.protocolCode);
-  }
-
-  @Test
-  void run_whenDarknetCreationFailsWithInvalidSignature_throwsRefSignatureInvalid()
-      throws Exception {
-    SimpleFieldSet fs = minimalValidFieldSet();
-    AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    when(handler.hasFullAccess()).thenReturn(true);
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    when(node.network()
-            .createNewDarknetNode(
-                any(SimpleFieldSet.class), any(FRIEND_TRUST.class), any(FRIEND_VISIBILITY.class)))
-        .thenThrow(new ReferenceSignatureVerificationException("bad-sig"));
-
-    MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
-
-    assertEquals(ProtocolErrorMessage.REF_SIGNATURE_INVALID, exception.protocolCode);
+  void run_whenAddRejectedWithDuplicateRef_mapsProtocolCode() throws Exception {
+    assertAddRejectedMapsToProtocolCode(
+        PeerAddFailureReason.DUPLICATE_PEER_REF, ProtocolErrorMessage.DUPLICATE_PEER_REF);
   }
 
   @Test
@@ -396,22 +257,47 @@ class AddPeerTest {
     fs.putSingle("File", tempDir.toString());
 
     AddPeer addPeer = new AddPeer(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
     when(handler.hasFullAccess()).thenReturn(true);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
 
     assertEquals(ProtocolErrorMessage.NOT_A_FILE_ERROR, exception.protocolCode);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
+  }
+
+  private void assertAddRejectedMapsToProtocolCode(PeerAddFailureReason reason, int protocolCode)
+      throws Exception {
+    AddPeer addPeer = new AddPeer(minimalValidFieldSet());
+    stubPeerPort();
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(peerPort.add(any(PeerFieldSet.class), any(PeerTrust.class), any(PeerVisibility.class)))
+        .thenThrow(new PeerAddRejectedException(reason, "detail-" + reason.name()));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(protocolCode, exception.protocolCode);
+    assertEquals("detail-" + reason.name(), exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  private void stubPeerPort() {
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
   }
 
   private SimpleFieldSet minimalValidFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", IDENTIFIER);
-    fs.putSingle("Trust", FRIEND_TRUST.NORMAL.name());
-    fs.putSingle("Visibility", FRIEND_VISIBILITY.YES.name());
+    fs.putSingle("Trust", PeerTrust.NORMAL.name());
+    fs.putSingle("Visibility", PeerVisibility.YES.name());
+    fs.putSingle("identity", "peer-identity");
     return fs;
+  }
+
+  private static PeerSnapshot peerSnapshot(String identity) {
+    return new PeerSnapshot(new PeerFieldSet(Map.of("identity", identity), Map.of()));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
@@ -1,7 +1,10 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,10 +30,13 @@ class ListPeerMessageTest {
 
   @Mock private FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private Node node;
 
-  @Mock private PeerNode peerNode;
+  @Mock private FCPServer server;
+
+  @Mock private RuntimePorts runtimePorts;
+
+  @Mock private PeerPort peerPort;
 
   @Test
   void constructor_whenIdentifierProvided_removesIdentifierFromFieldSet() {
@@ -61,7 +67,7 @@ class ListPeerMessageTest {
     assertEquals("req-2", thrown.ident);
     assertFalse(thrown.global, "Expected non-global error");
     verify(handler, never()).send(any());
-    verifyNoInteractions(node);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
@@ -79,13 +85,17 @@ class ListPeerMessageTest {
     assertEquals("req-3", thrown.ident);
     assertFalse(thrown.global, "Expected non-global error");
     verify(handler, never()).send(any());
-    verifyNoInteractions(node);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
-  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws MessageInvalidException {
+  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws Exception {
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode("node-unknown")).thenReturn(null);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.get("node-unknown", true, true))
+        .thenThrow(new UnknownPeerException("node-unknown"));
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "req-4");
     fs.putSingle("NodeIdentifier", "node-unknown");
@@ -103,9 +113,16 @@ class ListPeerMessageTest {
   }
 
   @Test
-  void run_whenPeerFound_sendsPeerMessageWithMetadataAndVolatile() throws MessageInvalidException {
+  void run_whenPeerFound_sendsPeerMessageWithMetadataAndVolatile() throws Exception {
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode("node-42")).thenReturn(peerNode);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    PeerSnapshot snapshot =
+        new PeerSnapshot(
+            new network.crypta.runtime.spi.PeerFieldSet(
+                java.util.Map.of("identity", "node-42"), java.util.Map.of()));
+    when(peerPort.get("node-42", true, true)).thenReturn(snapshot);
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "req-5");
     fs.putSingle("NodeIdentifier", "node-42");
@@ -116,9 +133,7 @@ class ListPeerMessageTest {
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());
     PeerMessage peerMessage = assertInstanceOf(PeerMessage.class, captor.getValue());
-    assertEquals(peerNode, peerMessage.pn);
-    assertTrue(peerMessage.withMetadata);
-    assertTrue(peerMessage.withVolatile);
+    assertEquals(snapshot, peerMessage.snapshot);
     assertEquals("req-5", peerMessage.messageIdentifier);
   }
 

--- a/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
@@ -1,8 +1,10 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,11 +32,13 @@ class ListPeerNotesMessageTest {
 
   @Mock private FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private Node node;
 
-  @Mock private PeerNode peerNode;
-  @Mock private DarknetPeerNode darknetPeerNode;
+  @Mock private FCPServer server;
+
+  @Mock private RuntimePorts runtimePorts;
+
+  @Mock private PeerPort peerPort;
 
   @Test
   void constructor_whenIdentifierProvided_removesIdentifierFromFieldSet() {
@@ -84,7 +88,7 @@ class ListPeerNotesMessageTest {
     assertEquals("req-3", thrown.ident);
     assertFalse(thrown.global, "Expected non-global error");
     verify(handler, never()).send(any());
-    verifyNoInteractions(node);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
@@ -102,13 +106,17 @@ class ListPeerNotesMessageTest {
     assertEquals("req-4", thrown.ident);
     assertFalse(thrown.global, "Expected non-global error");
     verify(handler, never()).send(any());
-    verifyNoInteractions(node);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
-  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws MessageInvalidException {
+  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws Exception {
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode("node-unknown")).thenReturn(null);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.readPrivateDarknetComment("node-unknown"))
+        .thenThrow(new UnknownPeerException("node-unknown"));
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "req-5");
     fs.putSingle("NodeIdentifier", "node-unknown");
@@ -126,9 +134,13 @@ class ListPeerNotesMessageTest {
   }
 
   @Test
-  void run_whenPeerIsNotDarknet_throwsDarknetOnly() {
+  void run_whenPeerIsNotDarknet_throwsDarknetOnly() throws Exception {
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode("node-2")).thenReturn(peerNode);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.readPrivateDarknetComment("node-2"))
+        .thenThrow(new DarknetPeerRequiredException("node-2"));
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "req-6");
     fs.putSingle("NodeIdentifier", "node-2");
@@ -145,10 +157,12 @@ class ListPeerNotesMessageTest {
   }
 
   @Test
-  void run_whenPeerIsDarknet_sendsPeerNoteAndEndMessage() throws MessageInvalidException {
+  void run_whenPeerIsDarknet_sendsPeerNoteAndEndMessage() throws Exception {
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode("node-3")).thenReturn(darknetPeerNode);
-    when(darknetPeerNode.getPrivateDarknetCommentNote()).thenReturn("secret-note");
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.readPrivateDarknetComment("node-3")).thenReturn("secret-note");
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "req-7");
     fs.putSingle("NodeIdentifier", "node-3");

--- a/src/test/java/network/crypta/clients/fcp/ListPeersMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeersMessageTest.java
@@ -2,7 +2,9 @@ package network.crypta.clients.fcp;
 
 import java.util.List;
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +24,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
@@ -30,11 +33,13 @@ class ListPeersMessageTest {
 
   @Mock private FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private Node node;
 
-  @Mock private PeerNode peerOne;
-  @Mock private PeerNode peerTwo;
+  @Mock private FCPServer server;
+
+  @Mock private RuntimePorts runtimePorts;
+
+  @Mock private PeerPort peerPort;
 
   @Test
   void constructor_whenFieldsPresent_setsFlagsAndStripsIdentifierFromFieldSet() {
@@ -72,15 +77,20 @@ class ListPeersMessageTest {
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
     assertEquals("id-1", ex.ident);
-    verify(node.network(), never()).peerNodes();
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
     verify(handler, never()).send(any());
   }
 
   @Test
   void run_whenFullAccess_sendsEachPeerFollowedByEnd() throws MessageInvalidException {
     ListPeersMessage message = new ListPeersMessage(buildFieldSet(true, true, "identifier"));
+    PeerSnapshot peerOne = peerSnapshot("peer-one");
+    PeerSnapshot peerTwo = peerSnapshot("peer-two");
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().peerNodes()).thenReturn(new PeerNode[] {peerOne, peerTwo});
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.list(true, true)).thenReturn(List.of(peerOne, peerTwo));
 
     message.run(handler, node);
 
@@ -91,15 +101,11 @@ class ListPeersMessageTest {
     assertEquals(3, sentMessages.size());
 
     PeerMessage firstPeer = (PeerMessage) sentMessages.getFirst();
-    assertEquals(peerOne, firstPeer.pn);
-    assertTrue(firstPeer.withMetadata);
-    assertTrue(firstPeer.withVolatile);
+    assertEquals(peerOne, firstPeer.snapshot);
     assertEquals("identifier", firstPeer.messageIdentifier);
 
     PeerMessage secondPeer = (PeerMessage) sentMessages.get(1);
-    assertEquals(peerTwo, secondPeer.pn);
-    assertTrue(secondPeer.withMetadata);
-    assertTrue(secondPeer.withVolatile);
+    assertEquals(peerTwo, secondPeer.snapshot);
     assertEquals("identifier", secondPeer.messageIdentifier);
 
     EndListPeersMessage endMessage = (EndListPeersMessage) sentMessages.get(2);
@@ -115,7 +121,10 @@ class ListPeersMessageTest {
   void run_whenNoPeersStillEmitsEndMarker() throws MessageInvalidException {
     ListPeersMessage message = new ListPeersMessage(buildFieldSet(false, false, null));
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().peerNodes()).thenReturn(new PeerNode[0]);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.list(false, false)).thenReturn(List.of());
 
     message.run(handler, node);
 
@@ -146,5 +155,11 @@ class ListPeersMessageTest {
       fs.putSingle("Identifier", id);
     }
     return fs;
+  }
+
+  private static PeerSnapshot peerSnapshot(String identity) {
+    return new PeerSnapshot(
+        new network.crypta.runtime.spi.PeerFieldSet(
+            java.util.Map.of("identity", identity), java.util.Map.of()));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
@@ -32,6 +32,7 @@ class ModifyPeerNoteTest {
   private static final String IDENTIFIER = "req-1";
   private static final String NODE_IDENTIFIER = "peer-123";
   private static final String NOTE_TEXT = "Private darknet note";
+  private static final String EXISTING_NOTE = "Existing note";
   private static final int UNKNOWN_PEER_NOTE_TYPE = 99;
 
   @Mock FCPConnectionHandler handler;
@@ -107,11 +108,8 @@ class ModifyPeerNoteTest {
     fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
     fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
-    when(handler.hasFullAccess()).thenReturn(true);
-    when(handler.getServer()).thenReturn(server);
-    when(server.runtime()).thenReturn(runtimePorts);
-    when(runtimePorts.peer()).thenReturn(peerPort);
-    when(peerPort.writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT))
+    stubPeerPort();
+    when(peerPort.readPrivateDarknetComment(NODE_IDENTIFIER))
         .thenThrow(new UnknownPeerException(NODE_IDENTIFIER));
 
     modifyPeerNote.run(handler, node);
@@ -130,11 +128,8 @@ class ModifyPeerNoteTest {
     fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
     fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
-    when(handler.hasFullAccess()).thenReturn(true);
-    when(handler.getServer()).thenReturn(server);
-    when(server.runtime()).thenReturn(runtimePorts);
-    when(runtimePorts.peer()).thenReturn(peerPort);
-    when(peerPort.writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT))
+    stubPeerPort();
+    when(peerPort.readPrivateDarknetComment(NODE_IDENTIFIER))
         .thenThrow(new DarknetPeerRequiredException(NODE_IDENTIFIER));
 
     MessageInvalidException ex =
@@ -146,12 +141,12 @@ class ModifyPeerNoteTest {
   }
 
   @Test
-  void run_whenPeerNoteTypeNotANumber_throwsInvalidField() {
+  void run_whenPeerNoteTypeNotANumber_throwsInvalidField() throws Exception {
     SimpleFieldSet fs = baseFieldSet();
     fs.putSingle("PeerNoteType", "not-a-number");
     fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
-    when(handler.hasFullAccess()).thenReturn(true);
+    stubPeerPort();
 
     MessageInvalidException ex =
         assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
@@ -159,15 +154,16 @@ class ModifyPeerNoteTest {
     assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
     verify(handler, never()).send(any());
-    verifyNoInteractions(server, runtimePorts, peerPort, node);
+    verify(peerPort, never()).writePrivateDarknetComment(any(), any());
+    verifyNoInteractions(node);
   }
 
   @Test
-  void run_whenNoteTextMissing_throwsMissingField() {
+  void run_whenNoteTextMissing_throwsMissingField() throws Exception {
     SimpleFieldSet fs = baseFieldSet();
     fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
-    when(handler.hasFullAccess()).thenReturn(true);
+    stubPeerPort();
 
     MessageInvalidException ex =
         assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
@@ -175,7 +171,8 @@ class ModifyPeerNoteTest {
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
     verify(handler, never()).send(any());
-    verifyNoInteractions(server, runtimePorts, peerPort, node);
+    verify(peerPort, never()).writePrivateDarknetComment(any(), any());
+    verifyNoInteractions(node);
   }
 
   @Test
@@ -184,12 +181,13 @@ class ModifyPeerNoteTest {
     fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
     fs.putSingle("NoteText", "%%%"); // invalid Base64
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
-    when(handler.hasFullAccess()).thenReturn(true);
+    stubPeerPort();
 
     modifyPeerNote.run(handler, node);
 
     verify(handler, never()).send(any());
-    verifyNoInteractions(server, runtimePorts, peerPort, node);
+    verify(peerPort, never()).writePrivateDarknetComment(any(), any());
+    verifyNoInteractions(node);
   }
 
   @Test
@@ -198,17 +196,58 @@ class ModifyPeerNoteTest {
     fs.put("PeerNoteType", UNKNOWN_PEER_NOTE_TYPE);
     fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
-    when(handler.hasFullAccess()).thenReturn(true);
+    stubPeerPort();
 
     modifyPeerNote.run(handler, node);
 
-    verifyNoInteractions(server, runtimePorts, peerPort, node);
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
     assertInstanceOf(UnknownPeerNoteTypeMessage.class, captor.getValue());
     UnknownPeerNoteTypeMessage sent = (UnknownPeerNoteTypeMessage) captor.getValue();
     assertEquals(UNKNOWN_PEER_NOTE_TYPE, sent.peerNoteType);
     assertEquals(IDENTIFIER, sent.messageIdentifier);
+    verify(peerPort, never()).writePrivateDarknetComment(any(), any());
+    verifyNoInteractions(node);
+  }
+
+  @Test
+  void run_whenPeerMissingAndPeerNoteTypeUnsupported_sendsUnknownNodeIdentifierMessage()
+      throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("PeerNoteType", UNKNOWN_PEER_NOTE_TYPE);
+    fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    stubPeerPort();
+    when(peerPort.readPrivateDarknetComment(NODE_IDENTIFIER))
+        .thenThrow(new UnknownPeerException(NODE_IDENTIFIER));
+
+    modifyPeerNote.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, times(1)).send(captor.capture());
+    assertInstanceOf(UnknownNodeIdentifierMessage.class, captor.getValue());
+    verify(peerPort, never()).writePrivateDarknetComment(any(), any());
+    verifyNoInteractions(node);
+  }
+
+  @Test
+  void run_whenPeerNotDarknetAndPeerNoteTypeUnsupported_throwsDarknetOnly() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("PeerNoteType", UNKNOWN_PEER_NOTE_TYPE);
+    fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    stubPeerPort();
+    when(peerPort.readPrivateDarknetComment(NODE_IDENTIFIER))
+        .thenThrow(new DarknetPeerRequiredException(NODE_IDENTIFIER));
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.DARKNET_ONLY, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    verify(handler, never()).send(any());
+    verify(peerPort, never()).writePrivateDarknetComment(any(), any());
+    verifyNoInteractions(node);
   }
 
   @Test
@@ -217,14 +256,12 @@ class ModifyPeerNoteTest {
     fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
     fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
-    when(handler.hasFullAccess()).thenReturn(true);
-    when(handler.getServer()).thenReturn(server);
-    when(server.runtime()).thenReturn(runtimePorts);
-    when(runtimePorts.peer()).thenReturn(peerPort);
+    stubPeerPort();
     when(peerPort.writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT)).thenReturn(NOTE_TEXT);
 
     modifyPeerNote.run(handler, node);
 
+    verify(peerPort, times(1)).readPrivateDarknetComment(NODE_IDENTIFIER);
     verify(peerPort, times(1)).writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT);
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
@@ -241,5 +278,13 @@ class ModifyPeerNoteTest {
     fs.putSingle("Identifier", IDENTIFIER);
     fs.putSingle("NodeIdentifier", NODE_IDENTIFIER);
     return fs;
+  }
+
+  private void stubPeerPort() throws Exception {
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.readPrivateDarknetComment(NODE_IDENTIFIER)).thenReturn(EXISTING_NOTE);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
@@ -1,8 +1,10 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.Base64;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
@@ -17,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,11 +36,13 @@ class ModifyPeerNoteTest {
 
   @Mock FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  Node node;
+  @Mock Node node;
 
-  @Mock DarknetPeerNode darknetPeerNode;
-  @Mock PeerNode peerNode;
+  @Mock FCPServer server;
+
+  @Mock RuntimePorts runtimePorts;
+
+  @Mock PeerPort peerPort;
 
   @Test
   void constructor_whenIdentifierPresent_removesIdentifierFromFieldSet() {
@@ -78,7 +81,7 @@ class ModifyPeerNoteTest {
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
-    verifyNoInteractions(node);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
     verify(handler, never()).send(any());
   }
 
@@ -94,16 +97,22 @@ class ModifyPeerNoteTest {
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
-    verify(node.network(), never()).getPeerNode(anyString());
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
     verify(handler, never()).send(any());
   }
 
   @Test
   void run_whenPeerNotFound_sendsUnknownNodeIdentifierMessage() throws Exception {
     SimpleFieldSet fs = baseFieldSet();
+    fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
+    fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(null);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT))
+        .thenThrow(new UnknownPeerException(NODE_IDENTIFIER));
 
     modifyPeerNote.run(handler, node);
 
@@ -116,11 +125,17 @@ class ModifyPeerNoteTest {
   }
 
   @Test
-  void run_whenPeerIsNotDarknet_throwsDarknetOnly() {
+  void run_whenPeerIsNotDarknet_throwsDarknetOnly() throws Exception {
     SimpleFieldSet fs = baseFieldSet();
+    fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
+    fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(peerNode);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT))
+        .thenThrow(new DarknetPeerRequiredException(NODE_IDENTIFIER));
 
     MessageInvalidException ex =
         assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
@@ -137,7 +152,6 @@ class ModifyPeerNoteTest {
     fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
 
     MessageInvalidException ex =
         assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
@@ -145,7 +159,7 @@ class ModifyPeerNoteTest {
     assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
     verify(handler, never()).send(any());
-    verify(darknetPeerNode, never()).setPrivateDarknetCommentNote(anyString());
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
@@ -154,7 +168,6 @@ class ModifyPeerNoteTest {
     fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
 
     MessageInvalidException ex =
         assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
@@ -162,7 +175,7 @@ class ModifyPeerNoteTest {
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
     verify(handler, never()).send(any());
-    verify(darknetPeerNode, never()).setPrivateDarknetCommentNote(anyString());
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
@@ -172,12 +185,11 @@ class ModifyPeerNoteTest {
     fs.putSingle("NoteText", "%%%"); // invalid Base64
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
 
     modifyPeerNote.run(handler, node);
 
-    verify(darknetPeerNode, never()).setPrivateDarknetCommentNote(anyString());
     verify(handler, never()).send(any());
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
@@ -187,11 +199,10 @@ class ModifyPeerNoteTest {
     fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
 
     modifyPeerNote.run(handler, node);
 
-    verify(darknetPeerNode, never()).setPrivateDarknetCommentNote(anyString());
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
     assertInstanceOf(UnknownPeerNoteTypeMessage.class, captor.getValue());
@@ -207,11 +218,14 @@ class ModifyPeerNoteTest {
     fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT)).thenReturn(NOTE_TEXT);
 
     modifyPeerNote.run(handler, node);
 
-    verify(darknetPeerNode, times(1)).setPrivateDarknetCommentNote(NOTE_TEXT);
+    verify(peerPort, times(1)).writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT);
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
     assertInstanceOf(PeerNote.class, captor.getValue());

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
@@ -1,8 +1,12 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,12 +16,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,11 +35,13 @@ class ModifyPeerTest {
 
   @Mock FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  Node node;
+  @Mock Node node;
 
-  @Mock DarknetPeerNode darknetPeerNode;
-  @Mock PeerNode peerNode;
+  @Mock FCPServer server;
+
+  @Mock RuntimePorts runtimePorts;
+
+  @Mock PeerPort peerPort;
 
   @Test
   void getName_returnsModifyPeerLiteral() {
@@ -67,7 +71,7 @@ class ModifyPeerTest {
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
-    verifyNoInteractions(node);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
     verify(handler, never()).send(any());
   }
 
@@ -83,7 +87,7 @@ class ModifyPeerTest {
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
-    verify(node.network(), never()).getPeerNode(anyString());
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
     verify(handler, never()).send(any());
   }
 
@@ -92,7 +96,11 @@ class ModifyPeerTest {
     SimpleFieldSet fs = baseFieldSet();
     ModifyPeer modifyPeer = new ModifyPeer(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(null);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.updateDarknetPeer(any(), any()))
+        .thenThrow(new UnknownPeerException(NODE_IDENTIFIER));
 
     modifyPeer.run(handler, node);
 
@@ -105,11 +113,15 @@ class ModifyPeerTest {
   }
 
   @Test
-  void run_whenPeerIsNotDarknet_throwsDarknetOnly() {
+  void run_whenPeerIsNotDarknet_throwsDarknetOnly() throws Exception {
     SimpleFieldSet fs = baseFieldSet();
     ModifyPeer modifyPeer = new ModifyPeer(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(peerNode);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.updateDarknetPeer(any(), any()))
+        .thenThrow(new DarknetPeerRequiredException(NODE_IDENTIFIER));
 
     MessageInvalidException ex =
         assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler, node));
@@ -129,24 +141,34 @@ class ModifyPeerTest {
     fs.putSingle("AllowLocalAddresses", "FALSE");
     ModifyPeer modifyPeer = new ModifyPeer(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    PeerSnapshot snapshot =
+        new PeerSnapshot(
+            new network.crypta.runtime.spi.PeerFieldSet(
+                java.util.Map.of("identity", NODE_IDENTIFIER), java.util.Map.of()));
+    when(peerPort.updateDarknetPeer(any(), any())).thenReturn(snapshot);
 
     modifyPeer.run(handler, node);
 
-    verify(darknetPeerNode, times(1)).disablePeer();
-    verify(darknetPeerNode, never()).enablePeer();
-    verify(darknetPeerNode, times(1)).setListenOnly(true);
-    verify(darknetPeerNode, times(1)).setBurstOnly(false);
-    verify(darknetPeerNode, times(1)).setIgnoreSourcePort(true);
-    verify(darknetPeerNode, times(1)).setAllowLocalAddresses(false);
+    ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
+        ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
+    verify(peerPort)
+        .updateDarknetPeer(
+            org.mockito.ArgumentMatchers.eq(NODE_IDENTIFIER), updateCaptor.capture());
+    DarknetPeerSettingsUpdate update = updateCaptor.getValue();
+    assertEquals(Boolean.TRUE, update.disabled());
+    assertEquals(Boolean.TRUE, update.listenOnly());
+    assertEquals(Boolean.FALSE, update.burstOnly());
+    assertEquals(Boolean.TRUE, update.ignoreSourcePort());
+    assertEquals(Boolean.FALSE, update.allowLocalAddresses());
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
     assertInstanceOf(PeerMessage.class, captor.getValue());
     PeerMessage sent = (PeerMessage) captor.getValue();
-    assertSame(darknetPeerNode, sent.pn);
-    assertTrue(sent.withMetadata);
-    assertTrue(sent.withVolatile);
+    assertEquals(snapshot, sent.snapshot);
     assertEquals(IDENTIFIER, sent.messageIdentifier);
   }
 
@@ -156,12 +178,23 @@ class ModifyPeerTest {
     fs.putSingle("IsDisabled", "false");
     ModifyPeer modifyPeer = new ModifyPeer(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.updateDarknetPeer(any(), any()))
+        .thenReturn(
+            new PeerSnapshot(
+                new network.crypta.runtime.spi.PeerFieldSet(
+                    java.util.Map.of("identity", NODE_IDENTIFIER), java.util.Map.of())));
 
     modifyPeer.run(handler, node);
 
-    verify(darknetPeerNode, never()).disablePeer();
-    verify(darknetPeerNode, times(1)).enablePeer();
+    ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
+        ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
+    verify(peerPort)
+        .updateDarknetPeer(
+            org.mockito.ArgumentMatchers.eq(NODE_IDENTIFIER), updateCaptor.capture());
+    assertEquals(Boolean.FALSE, updateCaptor.getValue().disabled());
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());
     assertInstanceOf(PeerMessage.class, captor.getValue());
@@ -177,16 +210,28 @@ class ModifyPeerTest {
     fs.putSingle("AllowLocalAddresses", "");
     ModifyPeer modifyPeer = new ModifyPeer(fs);
     when(handler.hasFullAccess()).thenReturn(true);
-    when(node.network().getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.updateDarknetPeer(any(), any()))
+        .thenReturn(
+            new PeerSnapshot(
+                new network.crypta.runtime.spi.PeerFieldSet(
+                    java.util.Map.of("identity", NODE_IDENTIFIER), java.util.Map.of())));
 
     modifyPeer.run(handler, node);
 
-    verify(darknetPeerNode, never()).disablePeer();
-    verify(darknetPeerNode, never()).enablePeer();
-    verify(darknetPeerNode, never()).setListenOnly(anyBoolean());
-    verify(darknetPeerNode, never()).setBurstOnly(anyBoolean());
-    verify(darknetPeerNode, never()).setIgnoreSourcePort(anyBoolean());
-    verify(darknetPeerNode, never()).setAllowLocalAddresses(anyBoolean());
+    ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
+        ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
+    verify(peerPort)
+        .updateDarknetPeer(
+            org.mockito.ArgumentMatchers.eq(NODE_IDENTIFIER), updateCaptor.capture());
+    DarknetPeerSettingsUpdate update = updateCaptor.getValue();
+    assertNull(update.disabled());
+    assertNull(update.listenOnly());
+    assertNull(update.burstOnly());
+    assertNull(update.ignoreSourcePort());
+    assertNull(update.allowLocalAddresses());
     verify(handler, times(1)).send(any(PeerMessage.class));
   }
 

--- a/src/test/java/network/crypta/clients/fcp/PeerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PeerMessageTest.java
@@ -1,131 +1,82 @@
 package network.crypta.clients.fcp;
 
+import java.util.Map;
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerSnapshot;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class PeerMessageTest {
 
-  @Mock private PeerNode peerNode;
   @Mock private FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private Node node;
 
   @Test
   void getName_whenCalled_returnsPeerConstant() {
-    PeerMessage message = new PeerMessage(peerNode, false, false, null);
+    PeerMessage message = new PeerMessage(PeerSnapshot.empty(), null);
 
     assertEquals("Peer", message.getName());
   }
 
   @Test
-  void getFieldSet_whenAllDataPresent_addsMetadataVolatileAndIdentifier() {
-    SimpleFieldSet base = new SimpleFieldSet(true);
-    base.putSingle("peerKey", "peerValue");
-    SimpleFieldSet metadata = new SimpleFieldSet(true);
-    metadata.putSingle("metaKey", "metaValue");
-    SimpleFieldSet volatileFs = new SimpleFieldSet(true);
-    volatileFs.putSingle("volKey", "volValue");
-    when(peerNode.exportFieldSet()).thenReturn(base);
-    when(peerNode.exportMetadataFieldSet(anyLong())).thenReturn(metadata);
-    when(peerNode.exportVolatileFieldSet()).thenReturn(volatileFs);
-    PeerMessage message = new PeerMessage(peerNode, true, true, "identifier-1");
+  void getFieldSet_whenAllDataPresent_rebuildsSnapshotTreeAndIdentifier() {
+    PeerSnapshot snapshot =
+        new PeerSnapshot(
+            new PeerFieldSet(
+                Map.of("peerKey", "peerValue"),
+                Map.of(
+                    "metadata",
+                    new PeerFieldSet(Map.of("metaKey", "metaValue"), Map.of()),
+                    "volatile",
+                    new PeerFieldSet(Map.of("volKey", "volValue"), Map.of()),
+                    "nested",
+                    new PeerFieldSet(
+                        Map.of(),
+                        Map.of(
+                            "child",
+                            new PeerFieldSet(Map.of("leafKey", "leafValue"), Map.of()))))));
+    PeerMessage message = new PeerMessage(snapshot, "identifier-1");
 
     SimpleFieldSet result = message.getFieldSet();
 
-    assertSame(base, result, "PeerMessage should reuse the base field set from the peer node");
     assertEquals("peerValue", result.get("peerKey"));
-    assertSame(metadata, result.subset("metadata"));
-    assertSame(volatileFs, result.subset("volatile"));
     assertEquals("metaValue", result.get("metadata.metaKey"));
     assertEquals("volValue", result.get("volatile.volKey"));
+    assertEquals("leafValue", result.get("nested.child.leafKey"));
     assertEquals("identifier-1", result.get("Identifier"));
-    verify(peerNode).exportFieldSet();
-    verify(peerNode).exportMetadataFieldSet(anyLong());
-    verify(peerNode).exportVolatileFieldSet();
-    verifyNoMoreInteractions(peerNode);
   }
 
   @Test
-  void getFieldSet_whenNoMetadataOrVolatileFlags_skipExports() {
-    when(peerNode.exportFieldSet()).thenReturn(new SimpleFieldSet(true));
-    PeerMessage message = new PeerMessage(peerNode, false, false, null);
+  void getFieldSet_whenSnapshotHasOnlyRootValues_omitsOptionalSubsets() {
+    PeerMessage message =
+        new PeerMessage(
+            new PeerSnapshot(new PeerFieldSet(Map.of("identity", "alpha"), Map.of())), null);
 
     SimpleFieldSet result = message.getFieldSet();
 
     assertNull(result.subset("metadata"));
     assertNull(result.subset("volatile"));
     assertNull(result.get("Identifier"));
-    verify(peerNode).exportFieldSet();
-    verify(peerNode, never()).exportMetadataFieldSet(anyLong());
-    verify(peerNode, never()).exportVolatileFieldSet();
-    verifyNoMoreInteractions(peerNode);
-  }
-
-  @Test
-  void getFieldSet_whenMetadataEmpty_skipsMetadataSubsetButCallsExport() {
-    SimpleFieldSet base = new SimpleFieldSet(true);
-    when(peerNode.exportFieldSet()).thenReturn(base);
-    when(peerNode.exportMetadataFieldSet(anyLong())).thenReturn(new SimpleFieldSet(true));
-    PeerMessage message = new PeerMessage(peerNode, true, false, null);
-    long start = System.currentTimeMillis();
-
-    SimpleFieldSet result = message.getFieldSet();
-
-    long end = System.currentTimeMillis();
-    assertSame(base, result);
-    assertNull(result.subset("metadata"));
-    ArgumentCaptor<Long> timeCaptor = ArgumentCaptor.forClass(Long.class);
-    verify(peerNode).exportFieldSet();
-    verify(peerNode).exportMetadataFieldSet(timeCaptor.capture());
-    assertTrue(
-        timeCaptor.getValue() >= start && timeCaptor.getValue() <= end,
-        "Timestamp provided to exportMetadataFieldSet should be the current time");
-    verify(peerNode, never()).exportVolatileFieldSet();
-    verifyNoMoreInteractions(peerNode);
-  }
-
-  @Test
-  void getFieldSet_whenVolatileEmpty_skipsVolatileSubsetButCallsExport() {
-    SimpleFieldSet base = new SimpleFieldSet(true);
-    when(peerNode.exportFieldSet()).thenReturn(base);
-    when(peerNode.exportVolatileFieldSet()).thenReturn(new SimpleFieldSet(true));
-    PeerMessage message = new PeerMessage(peerNode, false, true, null);
-
-    SimpleFieldSet result = message.getFieldSet();
-
-    assertSame(base, result);
-    assertNull(result.subset("volatile"));
-    verify(peerNode).exportFieldSet();
-    verify(peerNode).exportVolatileFieldSet();
-    verify(peerNode, never()).exportMetadataFieldSet(anyLong());
-    verifyNoMoreInteractions(peerNode);
+    assertEquals("alpha", result.get("identity"));
+    assertNull(result.subset("nested"));
   }
 
   @Test
   void run_whenCalled_throwsInvalidMessageException() {
-    PeerMessage message = new PeerMessage(peerNode, false, false, null);
+    PeerMessage message = new PeerMessage(PeerSnapshot.empty(), null);
 
     MessageInvalidException thrown =
         assertThrows(MessageInvalidException.class, () -> message.run(handler, node));

--- a/src/test/java/network/crypta/clients/fcp/RemovePeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RemovePeerTest.java
@@ -1,7 +1,10 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
-import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.RemovedPeerSnapshot;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,10 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
@@ -28,10 +29,13 @@ class RemovePeerTest {
 
   @Mock private FCPConnectionHandler handler;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private Node node;
 
-  @Mock private PeerNode peerNode;
+  @Mock private FCPServer server;
+
+  @Mock private RuntimePorts runtimePorts;
+
+  @Mock private PeerPort peerPort;
 
   @Test
   void constructor_removesIdentifierFromFieldSet() {
@@ -77,9 +81,7 @@ class RemovePeerTest {
     assertEquals("RemovePeer requires full access", exception.getMessage());
     assertEquals("id-123", exception.ident);
     assertFalse(exception.global);
-    verify(handler).hasFullAccess();
-    verifyNoMoreInteractions(handler);
-    verifyNoMoreInteractions(node);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
@@ -96,28 +98,22 @@ class RemovePeerTest {
     assertEquals("Error: NodeIdentifier field missing", exception.getMessage());
     assertEquals("id-456", exception.ident);
     assertFalse(exception.global);
-    verify(handler).hasFullAccess();
-    verifyNoMoreInteractions(handler);
-    verifyNoMoreInteractions(node);
+    verifyNoInteractions(server, runtimePorts, peerPort, node);
   }
 
   @Test
-  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws MessageInvalidException {
+  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws Exception {
     when(handler.hasFullAccess()).thenReturn(true);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.getPeerNode("node-missing")).thenReturn(null);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.remove("node-missing")).thenThrow(new UnknownPeerException("node-missing"));
     RemovePeer removePeer = new RemovePeer(buildFieldSet("node-missing", "id-789"));
 
     removePeer.run(handler, node);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
-    verify(handler).hasFullAccess();
-    verify(network).getPeerNode("node-missing");
     verify(handler).send(captor.capture());
-    verify(network, never()).removePeerConnection(any(PeerNode.class));
-    verifyNoMoreInteractions(handler, node);
 
     FCPMessage sent = captor.getValue();
     assertInstanceOf(UnknownNodeIdentifierMessage.class, sent);
@@ -127,25 +123,19 @@ class RemovePeerTest {
   }
 
   @Test
-  void run_whenPeerPresent_removesPeerAndSendsPeerRemoved() throws MessageInvalidException {
+  void run_whenPeerPresent_removesPeerAndSendsPeerRemoved() throws Exception {
     when(handler.hasFullAccess()).thenReturn(true);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.getPeerNode("node-123")).thenReturn(peerNode);
-    when(peerNode.getIdentityString()).thenReturn("identity-xyz");
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.remove("node-123"))
+        .thenReturn(new RemovedPeerSnapshot("identity-xyz", "node-123"));
     RemovePeer removePeer = new RemovePeer(buildFieldSet("node-123", "id-555"));
 
     removePeer.run(handler, node);
 
-    verify(handler).hasFullAccess();
-    verify(network).getPeerNode("node-123");
-    verify(peerNode).getIdentityString();
-    verify(network).removePeerConnection(peerNode);
-
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());
-    verifyNoMoreInteractions(handler, node, peerNode);
 
     FCPMessage sent = captor.getValue();
     assertInstanceOf(PeerRemoved.class, sent);

--- a/src/test/java/network/crypta/node/runtime/LegacyPeerPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyPeerPortTest.java
@@ -1,0 +1,359 @@
+package network.crypta.node.runtime;
+
+import java.util.List;
+import java.util.Map;
+import network.crypta.io.comm.ReferenceSignatureVerificationException;
+import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
+import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.FSParseException;
+import network.crypta.node.Node;
+import network.crypta.node.OpennetDisabledException;
+import network.crypta.node.OpennetPeerNode;
+import network.crypta.node.PeerNode;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
+import network.crypta.runtime.spi.PeerAddFailureReason;
+import network.crypta.runtime.spi.PeerAddRejectedException;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
+import network.crypta.runtime.spi.RemovedPeerSnapshot;
+import network.crypta.runtime.spi.UnknownPeerException;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyPeerPortTest {
+
+  @Mock private Node node;
+
+  @Mock private NodeNetworkSubsystem network;
+
+  @Mock private PeerNode peerOne;
+
+  @Mock private PeerNode peerTwo;
+
+  @Mock private DarknetPeerNode darknetPeer;
+
+  @Mock private OpennetPeerNode opennetPeer;
+
+  @Test
+  void list_whenMetadataAndVolatileRequested_mapsPeerSnapshotsInEncounterOrder() {
+    LegacyPeerPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {peerOne, peerTwo});
+    stubPeerExports(peerOne, "peer-one", "trustLevel", "NORMAL", "CONNECTED");
+    stubPeerExports(peerTwo, "peer-two", null, null, "BACKED_OFF");
+
+    List<PeerSnapshot> snapshots = port.list(true, true);
+
+    assertEquals(2, snapshots.size());
+    assertEquals("peer-one", snapshots.getFirst().root().directValues().get("identity"));
+    assertEquals(
+        "NORMAL",
+        snapshots
+            .getFirst()
+            .root()
+            .directSubsets()
+            .get("metadata")
+            .directValues()
+            .get("trustLevel"));
+    assertEquals(
+        "CONNECTED",
+        snapshots.getFirst().root().directSubsets().get("volatile").directValues().get("status"));
+    assertEquals("peer-two", snapshots.get(1).root().directValues().get("identity"));
+    assertNull(snapshots.get(1).root().directSubsets().get("metadata"));
+    assertEquals(
+        "BACKED_OFF",
+        snapshots.get(1).root().directSubsets().get("volatile").directValues().get("status"));
+    verify(peerOne).exportMetadataFieldSet(anyLong());
+    verify(peerOne).exportVolatileFieldSet();
+    verify(peerTwo).exportMetadataFieldSet(anyLong());
+    verify(peerTwo).exportVolatileFieldSet();
+  }
+
+  @Test
+  void list_whenOptionalExportsDisabled_omitsMetadataAndVolatileSubsets() {
+    LegacyPeerPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {peerOne});
+    stubPeerExports(peerOne, "peer-one", "trustLevel", "NORMAL", "CONNECTED");
+
+    List<PeerSnapshot> snapshots = port.list(false, false);
+
+    assertEquals(1, snapshots.size());
+    assertTrue(snapshots.getFirst().root().directSubsets().isEmpty());
+    verify(peerOne, never()).exportMetadataFieldSet(anyLong());
+    verify(peerOne, never()).exportVolatileFieldSet();
+  }
+
+  @Test
+  void get_whenPeerExists_returnsRequestedSnapshot() throws UnknownPeerException {
+    LegacyPeerPort port = newPort();
+    when(network.getPeerNode("peer-one")).thenReturn(peerOne);
+    stubPeerExports(peerOne, "peer-one", "trustLevel", "NORMAL", "CONNECTED");
+
+    PeerSnapshot snapshot = port.get("peer-one", false, true);
+
+    assertEquals("peer-one", snapshot.root().directValues().get("identity"));
+    assertNull(snapshot.root().directSubsets().get("metadata"));
+    assertEquals(
+        "CONNECTED", snapshot.root().directSubsets().get("volatile").directValues().get("status"));
+  }
+
+  @Test
+  void add_whenOpennetReferenceAccepted_returnsSnapshot() throws Exception {
+    LegacyPeerPort port = newPort();
+    when(network.createNewOpennetNode(any(SimpleFieldSet.class))).thenReturn(opennetPeer);
+    when(network.opennetPubKeyHash()).thenReturn(new byte[] {1});
+    when(network.addPeerConnection(opennetPeer)).thenReturn(true);
+    stubPeerExports(opennetPeer, "opennet-peer", "trustLevel", "NORMAL", "CONNECTED");
+
+    PeerSnapshot snapshot = port.add(opennetReference(), PeerTrust.NORMAL, PeerVisibility.YES);
+
+    ArgumentCaptor<SimpleFieldSet> captor = ArgumentCaptor.forClass(SimpleFieldSet.class);
+    verify(network).createNewOpennetNode(captor.capture());
+    assertEquals("true", captor.getValue().get("opennet"));
+    assertEquals("peer-identity", captor.getValue().get("identity"));
+    assertEquals("opennet-peer", snapshot.root().directValues().get("identity"));
+  }
+
+  @Test
+  void add_whenDarknetReferenceAccepted_mapsTrustAndVisibilityAndReturnsSnapshot()
+      throws Exception {
+    LegacyPeerPort port = newPort();
+    when(network.createNewDarknetNode(
+            any(SimpleFieldSet.class), any(FRIEND_TRUST.class), any(FRIEND_VISIBILITY.class)))
+        .thenReturn(darknetPeer);
+    when(network.darknetPubKeyHash()).thenReturn(new byte[] {1});
+    when(network.addPeerConnection(darknetPeer)).thenReturn(true);
+    stubPeerExports(darknetPeer, "darknet-peer", "trustLevel", "HIGH", "CONNECTED");
+
+    PeerSnapshot snapshot = port.add(darknetReference(), PeerTrust.HIGH, PeerVisibility.NAME_ONLY);
+
+    ArgumentCaptor<FRIEND_TRUST> trustCaptor = ArgumentCaptor.forClass(FRIEND_TRUST.class);
+    ArgumentCaptor<FRIEND_VISIBILITY> visibilityCaptor =
+        ArgumentCaptor.forClass(FRIEND_VISIBILITY.class);
+    verify(network)
+        .createNewDarknetNode(
+            any(SimpleFieldSet.class), trustCaptor.capture(), visibilityCaptor.capture());
+    assertEquals(FRIEND_TRUST.HIGH, trustCaptor.getValue());
+    assertEquals(FRIEND_VISIBILITY.NAME_ONLY, visibilityCaptor.getValue());
+    assertEquals("darknet-peer", snapshot.root().directValues().get("identity"));
+  }
+
+  @Test
+  void add_whenLegacyParseFails_mapsToRefParseError() throws Exception {
+    LegacyPeerPort port = newPort();
+    when(network.createNewOpennetNode(any(SimpleFieldSet.class)))
+        .thenThrow(new FSParseException("bad-ref"));
+
+    PeerAddRejectedException exception =
+        assertThrows(
+            PeerAddRejectedException.class,
+            () -> port.add(opennetReference(), PeerTrust.NORMAL, PeerVisibility.YES));
+
+    assertEquals(PeerAddFailureReason.REF_PARSE_ERROR, exception.reason());
+    assertEquals("Error parsing ref: bad-ref", exception.getMessage());
+  }
+
+  @Test
+  void add_whenOpennetDisabled_mapsToOpennetDisabled() throws Exception {
+    LegacyPeerPort port = newPort();
+    when(network.createNewOpennetNode(any(SimpleFieldSet.class)))
+        .thenThrow(new OpennetDisabledException("disabled"));
+
+    PeerAddRejectedException exception =
+        assertThrows(
+            PeerAddRejectedException.class,
+            () -> port.add(opennetReference(), PeerTrust.NORMAL, PeerVisibility.YES));
+
+    assertEquals(PeerAddFailureReason.OPENNET_DISABLED, exception.reason());
+    assertEquals("Error adding ref: disabled", exception.getMessage());
+  }
+
+  @Test
+  void add_whenSignatureVerificationFails_mapsToSignatureInvalid() throws Exception {
+    LegacyPeerPort port = newPort();
+    when(network.createNewDarknetNode(
+            any(SimpleFieldSet.class), any(FRIEND_TRUST.class), any(FRIEND_VISIBILITY.class)))
+        .thenThrow(new ReferenceSignatureVerificationException("bad-sig"));
+
+    PeerAddRejectedException exception =
+        assertThrows(
+            PeerAddRejectedException.class,
+            () -> port.add(darknetReference(), PeerTrust.NORMAL, PeerVisibility.YES));
+
+    assertEquals(PeerAddFailureReason.REF_SIGNATURE_INVALID, exception.reason());
+    assertEquals("Error adding ref: bad-sig", exception.getMessage());
+  }
+
+  @Test
+  void add_whenReferenceTargetsSelf_mapsToCannotPeerWithSelf() throws Exception {
+    LegacyPeerPort port = newPort();
+    when(network.createNewOpennetNode(any(SimpleFieldSet.class))).thenReturn(opennetPeer);
+    when(network.opennetPubKeyHash()).thenReturn(null);
+
+    PeerAddRejectedException exception =
+        assertThrows(
+            PeerAddRejectedException.class,
+            () -> port.add(opennetReference(), PeerTrust.NORMAL, PeerVisibility.YES));
+
+    assertEquals(PeerAddFailureReason.CANNOT_PEER_WITH_SELF, exception.reason());
+    assertEquals("Node cannot peer with itself", exception.getMessage());
+  }
+
+  @Test
+  void add_whenPeerAlreadyExists_mapsToDuplicatePeerRef() throws Exception {
+    LegacyPeerPort port = newPort();
+    when(network.createNewDarknetNode(
+            any(SimpleFieldSet.class), any(FRIEND_TRUST.class), any(FRIEND_VISIBILITY.class)))
+        .thenReturn(darknetPeer);
+    when(network.darknetPubKeyHash()).thenReturn(new byte[] {1});
+    when(network.addPeerConnection(darknetPeer)).thenReturn(false);
+
+    PeerAddRejectedException exception =
+        assertThrows(
+            PeerAddRejectedException.class,
+            () -> port.add(darknetReference(), PeerTrust.NORMAL, PeerVisibility.YES));
+
+    assertEquals(PeerAddFailureReason.DUPLICATE_PEER_REF, exception.reason());
+    assertEquals("Node already has a peer with that identity", exception.getMessage());
+  }
+
+  @Test
+  void updateDarknetPeer_whenFlagsPresent_appliesRequestedMutationsAndReturnsSnapshot()
+      throws Exception {
+    LegacyPeerPort port = newPort();
+    when(network.getPeerNode("peer-123")).thenReturn(darknetPeer);
+    stubPeerExports(darknetPeer, "peer-123", "trustLevel", "NORMAL", "CONNECTED");
+
+    PeerSnapshot snapshot =
+        port.updateDarknetPeer(
+            "peer-123",
+            new DarknetPeerSettingsUpdate(
+                Boolean.TRUE, Boolean.FALSE, Boolean.TRUE, Boolean.FALSE, Boolean.TRUE));
+
+    verify(darknetPeer).disablePeer();
+    verify(darknetPeer).setListenOnly(false);
+    verify(darknetPeer).setBurstOnly(true);
+    verify(darknetPeer).setIgnoreSourcePort(false);
+    verify(darknetPeer).setAllowLocalAddresses(true);
+    assertEquals("peer-123", snapshot.root().directValues().get("identity"));
+  }
+
+  @Test
+  void remove_whenPeerExists_removesAndReturnsDetachedResult() throws UnknownPeerException {
+    LegacyPeerPort port = newPort();
+    when(network.getPeerNode("peer-123")).thenReturn(peerOne);
+    when(peerOne.getIdentityString()).thenReturn("identity-xyz");
+
+    RemovedPeerSnapshot removedPeer = port.remove("peer-123");
+
+    assertEquals("identity-xyz", removedPeer.identity());
+    assertEquals("peer-123", removedPeer.nodeIdentifier());
+    verify(network).removePeerConnection(peerOne);
+  }
+
+  @Test
+  void remove_whenPeerMissing_throwsUnknownPeerException() {
+    LegacyPeerPort port = newPort();
+    when(network.getPeerNode("missing-peer")).thenReturn(null);
+
+    assertThrows(UnknownPeerException.class, () -> port.remove("missing-peer"));
+  }
+
+  @Test
+  void readPrivateDarknetComment_whenPeerExists_returnsStoredNote()
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    LegacyPeerPort port = newPort();
+    when(network.getPeerNode("peer-123")).thenReturn(darknetPeer);
+    when(darknetPeer.getPrivateDarknetCommentNote()).thenReturn("stored-note");
+
+    assertEquals("stored-note", port.readPrivateDarknetComment("peer-123"));
+  }
+
+  @Test
+  void writePrivateDarknetComment_whenPeerExists_storesAndReturnsUpdatedNote()
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    LegacyPeerPort port = newPort();
+    when(network.getPeerNode("peer-123")).thenReturn(darknetPeer);
+    when(darknetPeer.getPrivateDarknetCommentNote()).thenReturn("stored-note");
+
+    String storedNote = port.writePrivateDarknetComment("peer-123", "updated-note");
+
+    verify(darknetPeer).setPrivateDarknetCommentNote("updated-note");
+    assertEquals("stored-note", storedNote);
+  }
+
+  @Test
+  void readPrivateDarknetComment_whenPeerMissing_throwsUnknownPeerException() {
+    LegacyPeerPort port = newPort();
+    when(network.getPeerNode("missing-peer")).thenReturn(null);
+
+    assertThrows(UnknownPeerException.class, () -> port.readPrivateDarknetComment("missing-peer"));
+  }
+
+  @Test
+  void writePrivateDarknetComment_whenPeerIsNotDarknet_throwsDarknetPeerRequiredException() {
+    LegacyPeerPort port = newPort();
+    when(network.getPeerNode("peer-123")).thenReturn(peerOne);
+
+    assertThrows(
+        DarknetPeerRequiredException.class,
+        () -> port.writePrivateDarknetComment("peer-123", "updated-note"));
+  }
+
+  private LegacyPeerPort newPort() {
+    when(node.network()).thenReturn(network);
+    return new LegacyPeerPort(node);
+  }
+
+  private void stubPeerExports(
+      PeerNode peer,
+      String identity,
+      String metadataKey,
+      String metadataValue,
+      String volatileValue) {
+    when(peer.exportFieldSet()).thenReturn(fieldSet("identity", identity));
+    lenient()
+        .when(peer.exportMetadataFieldSet(anyLong()))
+        .thenReturn(
+            metadataKey == null ? new SimpleFieldSet(true) : fieldSet(metadataKey, metadataValue));
+    lenient()
+        .when(peer.exportVolatileFieldSet())
+        .thenReturn(
+            volatileValue == null ? new SimpleFieldSet(true) : fieldSet("status", volatileValue));
+  }
+
+  private static PeerFieldSet opennetReference() {
+    return new PeerFieldSet(Map.of("opennet", "true", "identity", "peer-identity"), Map.of());
+  }
+
+  private static PeerFieldSet darknetReference() {
+    return new PeerFieldSet(Map.of("identity", "peer-identity"), Map.of());
+  }
+
+  private static SimpleFieldSet fieldSet(String key, String value) {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle(key, value);
+    return fieldSet;
+  }
+}

--- a/src/test/java/network/crypta/runtime/spi/PeerFieldSetTest.java
+++ b/src/test/java/network/crypta/runtime/spi/PeerFieldSetTest.java
@@ -1,0 +1,140 @@
+package network.crypta.runtime.spi;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class PeerFieldSetTest {
+
+  @Test
+  void empty_whenCalled_expectEmptyFieldSet() {
+    PeerFieldSet fieldSet = PeerFieldSet.empty();
+
+    assertTrue(fieldSet.isEmpty());
+    assertTrue(fieldSet.directValues().isEmpty());
+    assertTrue(fieldSet.directSubsets().isEmpty());
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonEmptyFieldSets")
+  void isEmpty_whenFieldSetContainsEntries_expectFalse(PeerFieldSet fieldSet) {
+    assertFalse(fieldSet.isEmpty());
+  }
+
+  @Test
+  void constructor_whenSourceMapsMutatedAfterCreation_expectDefensiveCopies() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put("alpha", "1");
+    LinkedHashMap<String, PeerFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put("nested", new PeerFieldSet(Map.of("enabled", "true"), Map.of()));
+
+    PeerFieldSet fieldSet = new PeerFieldSet(directValues, directSubsets);
+
+    directValues.put("alpha", "updated");
+    directValues.put("beta", "2");
+    directSubsets.clear();
+
+    assertEquals(Map.of("alpha", "1"), fieldSet.directValues());
+    assertEquals(
+        Map.of("nested", new PeerFieldSet(Map.of("enabled", "true"), Map.of())),
+        fieldSet.directSubsets());
+  }
+
+  @Test
+  void constructor_whenMapsExposed_expectUnmodifiableViews() {
+    PeerFieldSet fieldSet =
+        new PeerFieldSet(
+            Map.of("alpha", "1"), Map.of("nested", new PeerFieldSet(Map.of(), Map.of())));
+    Map<String, String> directValues = fieldSet.directValues();
+    Map<String, PeerFieldSet> directSubsets = fieldSet.directSubsets();
+    PeerFieldSet emptyFieldSet = PeerFieldSet.empty();
+
+    assertThrows(UnsupportedOperationException.class, () -> directValues.put("beta", "2"));
+    assertThrows(
+        UnsupportedOperationException.class, () -> directSubsets.put("second", emptyFieldSet));
+  }
+
+  @Test
+  void constructor_whenLinkedHashMapsProvided_expectEncounterOrderPreserved() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put("alpha", "1");
+    directValues.put("beta", "2");
+    directValues.put("gamma", "3");
+    LinkedHashMap<String, PeerFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put("first", PeerFieldSet.empty());
+    directSubsets.put("second", new PeerFieldSet(Map.of("name", "value"), Map.of()));
+
+    PeerFieldSet fieldSet = new PeerFieldSet(directValues, directSubsets);
+
+    assertEquals(
+        List.of("alpha", "beta", "gamma"), new ArrayList<>(fieldSet.directValues().keySet()));
+    assertEquals(List.of("first", "second"), new ArrayList<>(fieldSet.directSubsets().keySet()));
+  }
+
+  @Test
+  void constructor_whenDirectValuesNull_expectNullPointerException() {
+    Map<String, PeerFieldSet> directSubsets = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new PeerFieldSet(null, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectSubsetsNull_expectNullPointerException() {
+    Map<String, String> directValues = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new PeerFieldSet(directValues, null));
+  }
+
+  @Test
+  void constructor_whenDirectValuesContainNullKey_expectNullPointerException() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put(null, "value");
+    Map<String, PeerFieldSet> directSubsets = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new PeerFieldSet(directValues, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectValuesContainNullValue_expectNullPointerException() {
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>();
+    directValues.put("key", null);
+    Map<String, PeerFieldSet> directSubsets = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new PeerFieldSet(directValues, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectSubsetsContainNullKey_expectNullPointerException() {
+    LinkedHashMap<String, PeerFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put(null, PeerFieldSet.empty());
+    Map<String, String> directValues = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new PeerFieldSet(directValues, directSubsets));
+  }
+
+  @Test
+  void constructor_whenDirectSubsetsContainNullValue_expectNullPointerException() {
+    LinkedHashMap<String, PeerFieldSet> directSubsets = new LinkedHashMap<>();
+    directSubsets.put("nested", null);
+    Map<String, String> directValues = Map.of();
+
+    assertThrows(NullPointerException.class, () -> new PeerFieldSet(directValues, directSubsets));
+  }
+
+  private static Stream<PeerFieldSet> nonEmptyFieldSets() {
+    return Stream.of(
+        new PeerFieldSet(Map.of("enabled", "true"), Map.of()),
+        new PeerFieldSet(Map.of(), Map.of("nested", PeerFieldSet.empty())));
+  }
+}


### PR DESCRIPTION
## Summary

- add a JDK-only peer-management SPI in `:runtime-spi`, including detached peer DTOs, add/update/remove error types, and `RuntimePorts#peer()`
- implement `LegacyPeerPort` in the daemon root module and migrate the FCP peer-management message family to use the runtime port instead of direct `node.network()` and live `PeerNode` access
- make `PeerMessage` snapshot-based, update the focused peer-management tests, add `PeerFieldSetTest`, and expand Javadocs for the newly added SPI types and legacy adapter

## How to test

- `./gradlew test --tests "network.crypta.node.runtime.LegacyPeerPortTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.AddPeerTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.ListPeersMessageTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.ListPeerMessageTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.ModifyPeerTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.RemovePeerTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.ListPeerNotesMessageTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.ModifyPeerNoteTest"`
- `./gradlew test --tests "network.crypta.clients.fcp.PeerMessageTest"`
- `./gradlew compileJava`
- `./gradlew test`

## Notes

- base branch: `develop`
- branch: `feature/pr-7-peer-runtime-spi`