### PR TITLE
refactor(fcp): Move request queue control to runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RequestQueuePort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RequestQueuePort.java
@@ -1,0 +1,67 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Queue-control capability for persistent-request operations exposed through the runtime SPI.
+ *
+ * <p>This port gives infrastructure code a narrow way to interact with the daemon's
+ * persistent-request queue without traversing daemon-only types such as client contexts,
+ * persistence runners, or ticker implementations. Typical callers are protocol handlers that need
+ * to look up, mutate, remove, or list persistent requests while preserving the daemon's existing
+ * queueing and retry behavior.
+ *
+ * <p>The surface is intentionally small. Callers can observe whether persistent storage has already
+ * been killed, submit one unit of persistent work with an explicit priority, and schedule a plain
+ * delayed retry. The API is JDK-only and does not expose ownership, batching, cancellation, or
+ * scheduler internals. Treat this port as a live runtime view for request-queue control, not as a
+ * general-purpose scheduling abstraction.
+ *
+ * <ul>
+ *   <li>Keep protocol mapping and error handling in the caller.
+ *   <li>Use {@link RequestQueuePriority} to preserve legacy queue ordering.
+ *   <li>Prefer {@link #scheduleLater(Runnable, long)} only for lightweight delayed retries.
+ * </ul>
+ */
+public interface RequestQueuePort {
+  /**
+   * Returns whether the underlying persistence database has already been killed.
+   *
+   * <p>Callers use this as a conservative guard for protocol paths that historically stopped
+   * enqueueing work once persistence became irreversibly unavailable. A {@code true} result means
+   * the storage layer is already gone rather than merely busy, so callers typically preserve the
+   * legacy behavior of skipping further queue interaction entirely.
+   *
+   * @return {@code true} when persistence storage has been killed and new work should not be
+   *     attempted; otherwise {@code false}
+   */
+  boolean isPersistenceDatabaseKilled();
+
+  /**
+   * Submits one persistent-request job using the requested queue priority.
+   *
+   * <p>The task runs on the daemon's persistent job infrastructure using the requested queue
+   * priority. Implementations may reject the submission when persistence is disabled, storage is
+   * already gone, or shutdown has progressed far enough that new work is no longer accepted. In
+   * those cases callers should preserve their existing protocol behavior instead of retrying
+   * blindly.
+   *
+   * @param task persistent-request unit of work to execute on the runtime-owned queue
+   * @param priority requested scheduling priority that preserves the legacy queue semantics
+   * @throws RequestQueueUnavailableException if the runtime cannot accept new persistent-request
+   *     work because persistence is unavailable
+   */
+  void submitPersistentJob(RequestQueueTask task, RequestQueuePriority priority)
+      throws RequestQueueUnavailableException;
+
+  /**
+   * Schedules a plain delayed task using the runtime's lightweight timer facility.
+   *
+   * <p>This is intended for short resubmission delays or backpressure retries. The task is not
+   * persisted, is run at or after the requested delay according to the daemon's existing ticker
+   * semantics, and should therefore remain lightweight and safe to requeue if the caller repeats
+   * the operation.
+   *
+   * @param task delayed task to schedule on the runtime-owned timer facility
+   * @param delayMillis delay in milliseconds before the task should be invoked
+   */
+  void scheduleLater(Runnable task, long delayMillis);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RequestQueuePriority.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RequestQueuePriority.java
@@ -1,0 +1,37 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Queue priorities understood by the runtime request-queue SPI.
+ *
+ * <p>This enum captures only the scheduling distinctions that the current persistent-request
+ * control paths need. The values are intentionally coarse so the SPI can stay stable even if the
+ * daemon continues to use finer-grained native priorities internally. Callers should select the
+ * smallest value that preserves historical behavior rather than treating this as a user-facing or
+ * policy-rich priority system.
+ */
+public enum RequestQueuePriority {
+  /**
+   * Default priority for routine persistent-request lookups or updates.
+   *
+   * <p>Use this for ordinary control operations where low latency is helpful but not urgent enough
+   * to jump ahead of the rest of the persistent-request workload.
+   */
+  NORMAL,
+
+  /**
+   * Elevated priority for urgent removals or similar user-visible control operations.
+   *
+   * <p>This priority preserves the legacy behavior for queue-control actions that should complete
+   * promptly because they directly unblock or stop ongoing persistent work.
+   */
+  HIGH,
+
+  /**
+   * Priority used for persistent listing work, matching the legacy listing queue semantics.
+   *
+   * <p>Listing is intentionally separated from {@link #NORMAL} so callers can preserve the
+   * historical ordering used when listing persistent requests without promoting the work all the
+   * way to {@link #HIGH}.
+   */
+  LISTING
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RequestQueueTask.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RequestQueueTask.java
@@ -1,0 +1,27 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Functional interface representing one persistent-request queue task.
+ *
+ * <p>This interface models the smallest unit of work that the runtime request queue accepts. It is
+ * deliberately narrower than the daemon's legacy job types, so runtime-spi remains JDK-only and
+ * does not expose queue infrastructure details. Typical tasks perform one lookup, mutation, or
+ * removal step and then return promptly.
+ *
+ * <p>The boolean result preserves the daemon's legacy persistent-job convention. Returning {@code
+ * true} requests an early persistence checkpoint after the task completes, while {@code false}
+ * indicates that no immediate checkpoint is needed for this unit of work.
+ */
+@FunctionalInterface
+public interface RequestQueueTask {
+  /**
+   * Executes the task.
+   *
+   * <p>Implementations should finish promptly, avoid blocking unrelated infrastructure work longer
+   * than necessary, and keep protocol-specific error mapping in the caller that submits the task.
+   *
+   * @return {@code true} to request an early persistence checkpoint after execution; {@code false}
+   *     when no immediate checkpoint is needed
+   */
+  boolean run();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RequestQueueUnavailableException.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RequestQueueUnavailableException.java
@@ -1,0 +1,37 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Signals that the runtime request queue cannot accept new persistent-request work.
+ *
+ * <p>This checked exception lets infrastructure code preserve its existing protocol-level mapping
+ * when persistence has been disabled, the database has been killed, shutdown has advanced too far,
+ * or the queue is otherwise unavailable. Keeping this failure as a checked exception makes the
+ * queue boundary explicit and avoids forcing runtime-spi callers to know about daemon-specific
+ * exception types.
+ */
+public class RequestQueueUnavailableException extends Exception {
+  /**
+   * Creates an exception with the supplied detail message.
+   *
+   * <p>Use this constructor when the queue rejection has no more specific underlying cause that is
+   * worth exposing to the caller.
+   *
+   * @param message human-readable explanation of the queue failure for logs or protocol mapping
+   */
+  public RequestQueueUnavailableException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates an exception with the supplied detail message and cause.
+   *
+   * <p>Use this constructor when adapting a daemon-specific queue failure into the JDK-only SPI
+   * boundary while still preserving the original exception for diagnostics.
+   *
+   * @param message human-readable explanation of the queue failure for logs or protocol mapping
+   * @param cause underlying daemon exception that caused the queue submission failure
+   */
+  public RequestQueueUnavailableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -21,6 +21,7 @@ package network.crypta.runtime.spi;
  * @see ConfigPort
  * @see NodeInfoPort
  * @see PeerPort
+ * @see RequestQueuePort
  */
 public interface RuntimePorts {
   /**
@@ -80,6 +81,17 @@ public interface RuntimePorts {
    * @return configuration runtime port for export, update, and persistence operations
    */
   ConfigPort config();
+
+  /**
+   * Returns the persistent-request queue-control capability exposed to infrastructure code.
+   *
+   * <p>This port lets callers submit persistent-request jobs, observe whether the persistence
+   * database has already been killed, and schedule lightweight delayed retries without depending on
+   * daemon-only persistence runners, client contexts, or ticker implementations.
+   *
+   * @return queue-control runtime port for persistent-request work and delayed retries
+   */
+  RequestQueuePort requestQueue();
 
   /**
    * Returns the node-info capability exposed to management-facing infrastructure code.

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -385,8 +385,7 @@ public class FCPConnectionHandler implements Closeable {
   public void setClientName(final String name) {
     this.clientName = name;
     rebootClient = server.registerRebootClient(name, this);
-    rebootClient.queuePendingMessagesOnConnectionRestartAsync(
-        outputHandler, server.getCore().getClientContext());
+    rebootClient.queuePendingMessagesOnConnectionRestartAsync(outputHandler);
     // Create foreverClient lazily. Everything that needs it (especially creating ClientGet's etc.)
     // runs on a database job.
     if (LOG.isDebugEnabled()) LOG.debug("Set client name: {}", name);
@@ -395,8 +394,7 @@ public class FCPConnectionHandler implements Closeable {
       synchronized (this) {
         foreverClient.set(client);
       }
-      client.queuePendingMessagesOnConnectionRestartAsync(
-          outputHandler, server.getCore().getClientContext());
+      client.queuePendingMessagesOnConnectionRestartAsync(outputHandler);
     }
   }
 
@@ -421,8 +419,7 @@ public class FCPConnectionHandler implements Closeable {
       foreverClient.set(client);
       FCPConnectionHandler.this.notifyAll();
     }
-    client.queuePendingMessagesOnConnectionRestartAsync(
-        outputHandler, server.getCore().getClientContext());
+    client.queuePendingMessagesOnConnectionRestartAsync(outputHandler);
     return client;
   }
 

--- a/src/main/java/network/crypta/clients/fcp/GetRequestStatusMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/GetRequestStatusMessage.java
@@ -1,10 +1,10 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.RequestQueuePort;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.NativeThread;
 
 /**
  * FCP message that asks the node to stream the most recent status (and optionally data) for a
@@ -112,37 +112,32 @@ public class GetRequestStatusMessage extends FCPMessage {
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     ClientRequest req = handler.getRebootRequest(global, handler, requestIdentifier);
     if (req == null) {
-      if (node.services().clientCore().killedDatabase()) {
+      RequestQueuePort requestQueuePort = handler.getServer().runtime().requestQueue();
+      if (requestQueuePort.isPersistenceDatabaseKilled()) {
         // Ignore.
         return;
       }
       try {
-        node.services()
-            .clientCore()
-            .getClientContext()
-            .jobRunner
-            .queue(
-                (PersistentJob)
-                    context -> {
-                      ClientRequest req1 =
-                          handler.getForeverRequest(global, handler, requestIdentifier);
-                      if (req1 == null) {
-                        ProtocolErrorMessage msg =
-                            new ProtocolErrorMessage(
-                                ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
-                                false,
-                                null,
-                                requestIdentifier,
-                                global);
-                        handler.send(msg);
-                      } else {
-                        req1.sendPendingMessages(
-                            handler.getOutputHandler(), requestIdentifier, true, onlyData);
-                      }
-                      return false;
-                    },
-                NativeThread.PriorityLevel.NORM_PRIORITY.value);
-      } catch (PersistenceDisabledException _) {
+        requestQueuePort.submitPersistentJob(
+            () -> {
+              ClientRequest req1 = handler.getForeverRequest(global, handler, requestIdentifier);
+              if (req1 == null) {
+                ProtocolErrorMessage msg =
+                    new ProtocolErrorMessage(
+                        ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
+                        false,
+                        null,
+                        requestIdentifier,
+                        global);
+                handler.send(msg);
+              } else {
+                req1.sendPendingMessages(
+                    handler.getOutputHandler(), requestIdentifier, true, onlyData);
+              }
+              return false;
+            },
+            RequestQueuePriority.NORMAL);
+      } catch (RequestQueueUnavailableException _) {
         ProtocolErrorMessage msg =
             new ProtocolErrorMessage(
                 ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, requestIdentifier, global);

--- a/src/main/java/network/crypta/clients/fcp/ListPersistentRequestsMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPersistentRequestsMessage.java
@@ -1,35 +1,19 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.RequestQueuePort;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.NativeThread;
 
 /**
  * Handles the <code>ListPersistentRequests</code> FCP message by streaming identifiers of
- * persistent client requests back to the connected peer. The message traverses the reboot
- * (short-lived) and forever (long-lived) request stores, optionally including global watchers, and
- * signals completion once all restartable and still-running requests have been enumerated.
+ * persistent client requests back to the connected peer.
  *
- * <p>This implementation separates listing work into lightweight jobs that respect output queue
- * backpressure and reuse the existing client {@link ClientContext} scheduling primitives. Each
- * phase schedules itself for later execution when the outbound handler is half full, ensuring that
- * message bursts do not overwhelm the connection. Completion is acknowledged with {@link
- * EndListPersistentRequestsMessage} to keep the client-side protocol in sync.
- *
- * <ul>
- *   <li>Responsibility: enumerate pending restartable requests then running requests.
- *   <li>Backpressure: pauses when {@link FCPConnectionOutputHandler#isQueueHalfFull()} reports a
- *       busy link and reschedules via the context ticker.
- *   <li>Scope: operates per incoming message instance and is not intended to be reused across
- *       connections.
- * </ul>
- *
- * <p>This class is not thread-safe; each instance is expected to run within the handling thread or
- * the associated scheduler of a single connection. The nested job types provide the concrete
- * execution strategy for transient (in-memory) and persistent thread-based listing flows.
+ * <p>The message traverses the reboot (short-lived) and forever (long-lived) request stores,
+ * optionally including global watchers, and signals completion once all restartable and
+ * still-running requests have been enumerated. Backpressure is honored by rescheduling work through
+ * the runtime request-queue SPI when the connection output queue is half full.
  */
 public class ListPersistentRequestsMessage extends FCPMessage {
 
@@ -37,67 +21,39 @@ public class ListPersistentRequestsMessage extends FCPMessage {
 
   /**
    * Optional identifier supplied by the requester and echoed in every generated listing message.
-   * Acts as a correlation token so clients can multiplex multiple listing operations across the
+   * Acts as a correlation token, so clients can multiplex multiple listing operations across the
    * same connection without ambiguity; may be {@code null} when the peer omits the field.
    */
   private final String requestIdentifier;
 
   /**
    * Creates a new message instance based on the incoming field set received from the remote peer.
-   * The optional <code>Identifier</code> value is preserved and echoed in subsequent response
-   * messages so clients can correlate list replies to the originating request.
    *
-   * <p>Construction does not perform validation beyond storing the identifier. Any structural or
-   * semantic validation is deferred to {@link #run(FCPConnectionHandler, Node)}, allowing the
-   * constructor to remain cheap for early parsing stages.
-   *
-   * @param fs parsed fields from the inbound FCP message; expected to include <code>Identifier
-   *     </code> but tolerated when absent. Must not be {@code null}.
+   * @param fs parsed fields from the inbound FCP message; the {@code Identifier} field is optional
    */
   public ListPersistentRequestsMessage(SimpleFieldSet fs) {
     requestIdentifier = fs.get("Identifier");
   }
 
-  /**
-   * Returns an empty field set because the outgoing list initiation message does not carry
-   * additional fields beyond the request name. Listing responses are emitted separately via queued
-   * messages that reuse the identifier supplied at construction time. The returned instance is
-   * fresh for each call, allowing callers to add transient keys if protocol extensions ever require
-   * them.
-   *
-   * @return a new, mutable {@link SimpleFieldSet} with no predefined keys, ready for serialization.
-   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
-  /**
-   * Provides the protocol-visible name used when serializing this message onto the FCP connection.
-   * The constant is shared across all instances and forms the dispatch key clients use to trigger
-   * the listing flow on the remote node. Keeping this name stable is essential for interoperability
-   * with existing FCP clients.
-   *
-   * @return literal string {@value #NAME} that the protocol recognizes.
-   */
   @Override
   public String getName() {
     return NAME;
   }
 
   /**
-   * Base job for enumerating restartable and running persistent requests. The job cooperates with
-   * the {@link FCPConnectionOutputHandler} to avoid overfilling the outbound queue and uses
-   * abstract hooks for rescheduling and completion so concrete subclasses can provide the desired
-   * threading model. Instances track incremental progress counters so repeated invocations continue
-   * where the previous cycle stopped.
+   * Base job for listing restartable and running persistent requests.
    *
-   * <p>The job processes restartable items first, then emits running requests; both phases advance
-   * using incremental progress offsets to avoid re-sending previously delivered entries. When the
-   * queue is congested, the job delegates to {@link #reschedule(ClientContext)} rather than busy
-   * waiting.
+   * <p>The job cooperates with the {@link FCPConnectionOutputHandler} to avoid overfilling the
+   * outbound queue and uses abstract hooks for rescheduling and completion so concrete subclasses
+   * can provide the desired threading model. Instances track incremental progress counters so
+   * repeated invocations continue where the previous cycle stopped.
    */
-  public abstract static class ListJob implements PersistentJob {
+  public abstract static class ListJob {
 
     final PersistentRequestClient client;
     final FCPConnectionOutputHandler outputHandler;
@@ -109,16 +65,18 @@ public class ListPersistentRequestsMessage extends FCPMessage {
     protected final String listRequestIdentifier;
 
     boolean sentRestartJobs;
+    int progressCompleted;
+    int progressRunning;
 
     /**
      * Constructs a listing job for a specific client namespace and output handler.
      *
      * @param client source of persistent requests to enumerate; must remain valid for the job
-     *     lifetime.
+     *     lifetime
      * @param outputHandler connection-scoped handler used to enqueue listing responses while
-     *     respecting output backpressure.
+     *     respecting output backpressure
      * @param listRequestIdentifier identifier echoed in replies so the client can match correlated
-     *     list streams; may be {@code null}.
+     *     list streams; may be {@code null}
      */
     ListJob(
         PersistentRequestClient client,
@@ -129,37 +87,30 @@ public class ListPersistentRequestsMessage extends FCPMessage {
       this.listRequestIdentifier = listRequestIdentifier;
     }
 
-    int progressCompleted = 0;
-    int progressRunning = 0;
-
     /**
      * Executes one step of the listing workflow. The job first queues restartable items and then
      * any currently running requests, rescheduling itself when the outbound queue is congested.
      * Completion is delegated to subclasses so they can decide what to do when no running jobs
-     * remain. The method is intentionally idempotent with respect to progress counters so repeated
-     * invocations continue from the last delivered offset.
+     * remain.
      *
-     * @param context client execution context that provides scheduling and job-runner utilities.
-     * @return always {@code false}; the surrounding scheduler is expected to requeue the task when
-     *     needed.
+     * @return always {@code false}; callers requeue explicitly through {@link #reschedule()}
      */
-    @Override
-    public boolean run(ClientContext context) {
-      boolean continueProcessing = queueRestartJobs(context);
+    final boolean execute() {
+      boolean continueProcessing = queueRestartJobs();
       if (continueProcessing) {
         if (noRunning()) {
-          complete(context);
+          complete();
         } else {
-          queueRunningJobs(context);
+          queueRunningJobs();
         }
       }
       return false;
     }
 
-    private boolean queueRestartJobs(ClientContext context) {
+    private boolean queueRestartJobs() {
       while (!sentRestartJobs) {
         if (outputHandler.isQueueHalfFull()) {
-          reschedule(context);
+          reschedule();
           return false;
         }
         int progress =
@@ -174,17 +125,17 @@ public class ListPersistentRequestsMessage extends FCPMessage {
       return true;
     }
 
-    private void queueRunningJobs(ClientContext context) {
+    private void queueRunningJobs() {
       while (true) {
         if (outputHandler.isQueueHalfFull()) {
-          reschedule(context);
+          reschedule();
           return;
         }
         int progress =
             client.queuePendingMessagesFromRunningRequests(
                 outputHandler, listRequestIdentifier, progressRunning, 30);
         if (progress <= progressRunning) {
-          complete(context);
+          complete();
           return;
         }
         progressRunning = progress;
@@ -193,30 +144,20 @@ public class ListPersistentRequestsMessage extends FCPMessage {
 
     /**
      * Requests that the job be scheduled again at a later time, typically because the connection
-     * output queue is congested. Implementations choose the scheduling mechanism appropriate for
-     * their threading model.
-     *
-     * @param context client context that owns the relevant scheduler and timing facilities.
+     * output queue is congested.
      */
-    abstract void reschedule(ClientContext context);
+    abstract void reschedule();
 
     /**
      * Invoked once all restartable and running requests have been delivered for the associated
-     * client scope. Implementations typically use this to chain into the next client namespace or
-     * to signal completion to the remote peer. The hook runs synchronously with the final listing
-     * step and should therefore complete quickly to avoid stalling the scheduler.
-     *
-     * @param context client context used to queue any follow-up work.
+     * client scope.
      */
-    abstract void complete(ClientContext context);
+    abstract void complete();
 
     /**
-     * Indicates whether the caller should skip enumerating currently running requests. Subclasses
-     * override this to short-circuit the second phase when they have already produced the needed
-     * output or when running requests are intentionally ignored. The default implementation returns
-     * {@code false}, ensuring both phases run for typical list operations.
+     * Indicates whether the caller should skip listing currently running requests.
      *
-     * @return {@code true} to bypass running-request enumeration; {@code false} to proceed.
+     * @return {@code true} to bypass running-request enumeration; {@code false} to proceed
      */
     protected boolean noRunning() {
       return false;
@@ -224,206 +165,157 @@ public class ListPersistentRequestsMessage extends FCPMessage {
   }
 
   /**
-   * Listing job that runs on the caller thread and uses the ticker for deferred rescheduling. This
-   * variant is appropriate for transient reboot clients that do not require persistence across JVM
-   * restarts. It favors low overhead and immediate execution, while still honoring output
-   * backpressure by deferring work via the ticker when necessary.
-   *
-   * <p>Consumers typically instantiate this class to enumerate requests that are expected to be
-   * dropped on node shutdown, such as reboot-scope downloads. Because it executes synchronously, it
-   * should perform minimal work per invocation to avoid blocking the connection handler thread.
+   * The listing job that runs on the caller thread and uses the runtime queue port for deferred
+   * rescheduling.
    */
   public abstract static class TransientListJob extends ListJob implements Runnable {
+    private static final long RESCHEDULE_DELAY_MILLIS = 100L;
 
-    final ClientContext context;
+    final RequestQueuePort requestQueuePort;
 
     /**
-     * Creates a transient listing job bound to a specific client context. The constructor does not
-     * initiate work; callers should invoke {@link #run()} after instantiation to start enumeration.
+     * Creates a transient listing job.
      *
-     * @param client source of requests to enumerate; typically the reboot-scoped client.
-     * @param handler output handler used to enqueue messages while avoiding queue overflows.
-     * @param context runtime context that supplies the ticker for delayed rescheduling.
+     * @param client source of requests to enumerate; typically the reboot-scoped client
+     * @param handler output handler used to enqueue messages while avoiding queue overflows
+     * @param requestQueuePort runtime queue port that supplies delayed rescheduling
      * @param listRequestIdentifier identifier propagated to emitted messages so the requester can
-     *     correlate responses across phases.
+     *     correlate responses across phases
      */
     TransientListJob(
         PersistentRequestClient client,
         FCPConnectionOutputHandler handler,
-        ClientContext context,
+        RequestQueuePort requestQueuePort,
         String listRequestIdentifier) {
       super(client, handler, listRequestIdentifier);
-      this.context = context;
+      this.requestQueuePort = requestQueuePort;
     }
 
     @Override
     public void run() {
-      super.run(context);
+      execute();
     }
 
-    /**
-     * Resubmits the job to the ticker with a short delay when the outbound queue is congested.
-     *
-     * @param context client context providing the ticker scheduler.
-     */
     @Override
-    void reschedule(ClientContext context) {
-      context.ticker.queueTimedJob(this, 100);
+    void reschedule() {
+      requestQueuePort.scheduleLater(this, RESCHEDULE_DELAY_MILLIS);
     }
   }
 
   /**
-   * Listing job that persists by enqueueing itself into the {@link ClientContext#jobRunner} with a
-   * high scheduling priority. Suitable for forever requests that must survive across process
-   * lifetimes and share the persistent job infrastructure. The job honors backpressure via ticker
-   * rescheduling but otherwise runs on worker threads managed by the persistent job runner.
-   *
-   * <p>This variant integrates with the persistence layer; if persistence is disabled, it falls
-   * back to immediately signaling completion to keep the protocol consistent even when local
-   * storage is unavailable.
+   * The listing job that persists by enqueueing itself through the runtime request-queue SPI with
+   * the legacy listing priority.
    */
-  public abstract static class PersistentListJob extends ListJob
-      implements PersistentJob, Runnable {
+  public abstract static class PersistentListJob extends ListJob implements Runnable {
+    private static final long RESCHEDULE_DELAY_MILLIS = 100L;
 
-    final ClientContext context;
+    final RequestQueuePort requestQueuePort;
+    final Runnable queueUnavailableAction;
 
     /**
-     * Creates a persistent listing job wired to the job runner. Invocation does not submit the job;
-     * call {@link #run()} to enqueue it. Because the job may outlive the caller thread, callers
-     * should ensure the supplied {@link ClientContext} remains valid for the duration of the list
-     * operation.
+     * Creates a persistent listing job.
      *
-     * @param client persistent client whose queued and running requests will be listed.
-     * @param handler output handler used to send listing responses while monitoring queue capacity.
-     * @param context client context that owns the persistent job runner and ticker.
+     * @param client persistent client whose queued and running requests will be listed
+     * @param handler output handler used to send listing responses while monitoring queue capacity
+     * @param requestQueuePort runtime queue port that owns persistent job submission and delayed
+     *     rescheduling
      * @param listRequestIdentifier identifier echoed back to the requester for correlation; may be
-     *     {@code null}.
+     *     {@code null}
+     * @param queueUnavailableAction fallback invoked when persistent submission becomes unavailable
      */
     PersistentListJob(
         PersistentRequestClient client,
         FCPConnectionOutputHandler handler,
-        ClientContext context,
-        String listRequestIdentifier) {
+        RequestQueuePort requestQueuePort,
+        String listRequestIdentifier,
+        Runnable queueUnavailableAction) {
       super(client, handler, listRequestIdentifier);
-      this.context = context;
+      this.requestQueuePort = requestQueuePort;
+      this.queueUnavailableAction = queueUnavailableAction;
     }
 
-    /**
-     * Reschedules the job using the ticker when queue pressure requires deferring additional
-     * output.
-     *
-     * @param context client context that provides the ticker.
-     */
     @Override
-    void reschedule(ClientContext context) {
-      context.ticker.queueTimedJob(this, 100);
+    void reschedule() {
+      requestQueuePort.scheduleLater(this, RESCHEDULE_DELAY_MILLIS);
     }
 
-    /**
-     * Queues the job into the persistent job runner at a high priority. When persistence is
-     * disabled, the method falls back to signaling completion immediately so the protocol remains
-     * consistent. The caller retains no ownership of the task after submission; all progress is
-     * tracked internally via {@link ListJob#progressCompleted} and {@link ListJob#progressRunning}.
-     */
     @Override
     public void run() {
       try {
-        context.jobRunner.queue(this, NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1);
-      } catch (PersistenceDisabledException _) {
-        outputHandler.handler.send(new EndListPersistentRequestsMessage(listRequestIdentifier));
+        requestQueuePort.submitPersistentJob(this::execute, RequestQueuePriority.LISTING);
+      } catch (RequestQueueUnavailableException _) {
+        queueUnavailableAction.run();
       }
     }
   }
 
-  /**
-   * Executes the message by spawning listing jobs for reboot, optional global, and forever
-   * persistent request clients. Each phase chains into the next, and the final stage sends {@link
-   * EndListPersistentRequestsMessage} to mark completion. Backpressure is honored via the job
-   * rescheduling logic inside the nested job types.
-   *
-   * @param handler connection handler that supplies client scopes and output routing.
-   * @param node owning node used to access the {@link ClientContext}.
-   * @throws MessageInvalidException if the message cannot be processed for this connection.
-   */
   @Override
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+    RequestQueuePort requestQueuePort = handler.getServer().runtime().requestQueue();
+    FCPConnectionOutputHandler outputHandler = handler.getOutputHandler();
+    Runnable endListing =
+        () -> handler.send(new EndListPersistentRequestsMessage(requestIdentifier));
 
     PersistentRequestClient rebootClient = handler.getRebootClient();
 
     TransientListJob job =
-        new TransientListJob(
-            rebootClient,
-            handler.getOutputHandler(),
-            node.services().clientCore().getClientContext(),
-            requestIdentifier) {
+        new TransientListJob(rebootClient, outputHandler, requestQueuePort, requestIdentifier) {
 
           @Override
-          void complete(ClientContext context) {
-
+          void complete() {
             if (handler.getRebootClient().watchGlobal) {
               PersistentRequestClient globalRebootClient =
                   handler.getServer().getGlobalRebootClient();
-
               TransientListJob job =
                   new TransientListJob(
-                      globalRebootClient, outputHandler, context, listRequestIdentifier) {
+                      globalRebootClient, outputHandler, requestQueuePort, listRequestIdentifier) {
 
                     @Override
-                    void complete(ClientContext context) {
-                      finishComplete(context);
+                    void complete() {
+                      finishPersistentPhase();
                     }
                   };
               job.run();
             } else {
-              finishComplete(context);
+              finishPersistentPhase();
             }
           }
 
-          private void finishComplete(ClientContext context) {
-            try {
-              context.jobRunner.queue(
-                  (PersistentJob)
-                      context1 -> {
-                        PersistentRequestClient foreverClient = handler.getForeverClient();
-                        PersistentListJob job1 =
-                            new PersistentListJob(
-                                foreverClient, outputHandler, context1, listRequestIdentifier) {
+          private void finishPersistentPhase() {
+            PersistentRequestClient foreverClient = handler.getForeverClient();
+            PersistentListJob job1 =
+                new PersistentListJob(
+                    foreverClient,
+                    outputHandler,
+                    requestQueuePort,
+                    listRequestIdentifier,
+                    endListing) {
 
-                              @Override
-                              void complete(ClientContext context1) {
-                                if (handler.getRebootClient().watchGlobal) {
-                                  PersistentRequestClient globalForeverClient =
-                                      handler.getServer().getGlobalForeverClient();
-                                  PersistentListJob job1 =
-                                      new PersistentListJob(
-                                          globalForeverClient,
-                                          outputHandler,
-                                          context1,
-                                          listRequestIdentifier) {
+                  @Override
+                  void complete() {
+                    if (handler.getRebootClient().watchGlobal) {
+                      PersistentRequestClient globalForeverClient =
+                          handler.getServer().getGlobalForeverClient();
+                      PersistentListJob job1 =
+                          new PersistentListJob(
+                              globalForeverClient,
+                              outputHandler,
+                              requestQueuePort,
+                              listRequestIdentifier,
+                              endListing) {
 
-                                        @Override
-                                        void complete(ClientContext context1) {
-                                          finishFinal();
-                                        }
-                                      };
-                                  job1.run(context1);
-                                } else {
-                                  finishFinal();
-                                }
-                              }
-
-                              private void finishFinal() {
-                                outputHandler.handler.send(
-                                    new EndListPersistentRequestsMessage(listRequestIdentifier));
-                              }
-                            };
-                        job1.run(context1);
-                        return false;
-                      },
-                  NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1);
-            } catch (PersistenceDisabledException _) {
-              handler.send(new EndListPersistentRequestsMessage(listRequestIdentifier));
-            }
+                            @Override
+                            void complete() {
+                              endListing.run();
+                            }
+                          };
+                      job1.execute();
+                    } else {
+                      endListing.run();
+                    }
+                  }
+                };
+            job1.run();
           }
         };
     job.run();

--- a/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
@@ -1,11 +1,11 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
 import network.crypta.node.Node;
 import network.crypta.node.RequestStarter;
+import network.crypta.runtime.spi.RequestQueuePort;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.NativeThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +88,7 @@ public final class ModifyPersistentRequest extends FCPMessage {
    * flag mirroring the values supplied by the client. The {@code PriorityClass} field is also
    * present for every message instance; a negative value indicates that the node should leave the
    * existing priority unchanged. When a non-{@code null} client token is supplied, it is encoded as
-   * the {@code ClientToken} field so that subsequent status notifications can be correlated by the
+   * the {@code ClientToken} field so that later status notifications can be correlated by the
    * client application.
    *
    * <p>A new {@link SimpleFieldSet} is allocated on each call and populated only from the immutable
@@ -133,10 +133,11 @@ public final class ModifyPersistentRequest extends FCPMessage {
    * FCPConnectionHandler#getRebootRequest(boolean, FCPConnectionHandler, String)}. When a matching
    * request is found, the change is applied immediately on the caller's thread by invoking {@link
    * ClientRequest#modifyRequest(String, short, FCPServer)} with the stored client token and
-   * priority. If no reboot-persistent request is present, a {@link PersistentJob} is queued on the
-   * client's job runner to search the forever-persistent store using {@link
-   * FCPConnectionHandler#getForeverRequest(boolean, FCPConnectionHandler, String)} and apply the
-   * same modification there.
+   * priority. If no reboot-persistent request is present, the method submits a persistent lookup
+   * task through {@link RequestQueuePort#submitPersistentJob(
+   * network.crypta.runtime.spi.RequestQueueTask, RequestQueuePriority)} to search the
+   * forever-persistent store using {@link FCPConnectionHandler#getForeverRequest(boolean,
+   * FCPConnectionHandler, String)} and apply the same modification there.
    *
    * <p>If neither store contains the referenced identifier, a {@link ProtocolErrorMessage} with
    * code {@link ProtocolErrorMessage#NO_SUCH_IDENTIFIER} is sent back to the client. When the
@@ -156,42 +157,35 @@ public final class ModifyPersistentRequest extends FCPMessage {
 
     ClientRequest req = handler.getRebootRequest(global, handler, requestIdentifier);
     if (req == null) {
+      RequestQueuePort requestQueuePort = handler.getServer().runtime().requestQueue();
       try {
-        node.services()
-            .clientCore()
-            .getClientContext()
-            .jobRunner
-            .queue(
-                (PersistentJob)
-                    context -> {
-                      ClientRequest req1 =
-                          handler.getForeverRequest(global, handler, requestIdentifier);
-                      if (req1 == null) {
-                        LOG.error("Huh ? the request is null!");
-                        ProtocolErrorMessage msg =
-                            new ProtocolErrorMessage(
-                                ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
-                                false,
-                                null,
-                                requestIdentifier,
-                                global);
-                        handler.send(msg);
-                        return false;
-                      } else {
-                        req1.modifyRequest(clientToken, priorityClass, handler.getServer());
-                      }
-                      return true;
-                    },
-                NativeThread.PriorityLevel.NORM_PRIORITY.value);
-      } catch (PersistenceDisabledException _) {
+        requestQueuePort.submitPersistentJob(
+            () -> {
+              ClientRequest req1 = handler.getForeverRequest(global, handler, requestIdentifier);
+              if (req1 == null) {
+                LOG.error("Huh ? the request is null!");
+                ProtocolErrorMessage msg =
+                    new ProtocolErrorMessage(
+                        ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
+                        false,
+                        null,
+                        requestIdentifier,
+                        global);
+                handler.send(msg);
+                return false;
+              }
+              req1.modifyRequest(clientToken, priorityClass, handler.getServer());
+              return true;
+            },
+            RequestQueuePriority.NORMAL);
+      } catch (RequestQueueUnavailableException _) {
         ProtocolErrorMessage msg =
             new ProtocolErrorMessage(
                 ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, requestIdentifier, global);
         handler.send(msg);
       }
     } else {
-      req.modifyRequest(
-          clientToken, priorityClass, node.services().clientCore().getEndpoints().getFCPServer());
+      req.modifyRequest(clientToken, priorityClass, handler.getServer());
     }
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
@@ -14,6 +14,7 @@ import network.crypta.clients.fcp.ListPersistentRequestsMessage.PersistentListJo
 import network.crypta.clients.fcp.ListPersistentRequestsMessage.TransientListJob;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
+import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,8 +158,8 @@ public final class PersistentRequestClient {
    * Returns the currently attached FCP connection handler.
    *
    * <p>The returned handler is mutable over the lifetime of the client and may be {@code null} when
-   * the peer is disconnected. Callers should snapshot the value once and avoid reusing it after
-   * reconnection events to prevent sending on a stale socket.
+   * the peer is disconnected. Callers should have snapshot the value once and avoid reusing it
+   * after reconnection events to prevent sending on a stale socket.
    *
    * @return active {@link FCPConnectionHandler} for this client, or {@code null} when disconnected.
    */
@@ -188,8 +189,8 @@ public final class PersistentRequestClient {
    * currently active connection reference, the reference is cleared. Use this when the underlying
    * transport closes unexpectedly so reconnection logic can proceed cleanly.
    *
-   * @param handler connection instance that was closed; only clears state when it equals the active
-   *     handler.
+   * @param handler connection instance that was closed; only clears the state when it equals the
+   *     active handler.
    */
   public synchronized void onLostConnection(FCPConnectionHandler handler) {
     handler.freeDDAJobs();
@@ -200,7 +201,7 @@ public final class PersistentRequestClient {
    * Marks a persistent request as finished and stages it for acknowledgment.
    *
    * <p>This method moves the request from the running list into the completed-but-unacknowledged
-   * list so the client can emit completion messages on reconnect. It also updates the {@link
+   * list so the client can emit completion messages on reconnection. It also updates the {@link
    * RequestStatusCache} with the final download or upload status. Callers must only invoke this for
    * requests whose {@link ClientRequest#persistence} matches the client; mixing lifetimes is
    * treated as a programmer error. The operation is idempotent for already-moved requests but still
@@ -208,7 +209,7 @@ public final class PersistentRequestClient {
    *
    * @param get finished {@link ClientRequest} that has not yet been acknowledged by the peer; must
    *     belong to this client and have matching persistence.
-   * @throws IllegalStateException if the request persistence does not match the client settings or
+   * @throws IllegalStateException if the request persistence does not match the client settings, or
    *     if the request type is unexpected when updating the cache.
    */
   public void finishedClientRequest(ClientRequest get) {
@@ -277,38 +278,37 @@ public final class PersistentRequestClient {
    * Asynchronously queues pending messages for replay after a connection restart.
    *
    * <p>Depending on the persistence mode, this spins up either a {@link PersistentListJob} or a
-   * {@link TransientListJob} to enumerate requests and emit the necessary responses. The job is run
-   * immediately on the provided {@link ClientContext} but does not block the caller. Completion is
-   * intentionally a no-op because this helper is used during reconnection flows that already manage
-   * lifecycle events.
+   * {@link TransientListJob} to list requests and emit the necessary responses. The job is run
+   * immediately using the connection handler's request-queue runtime port and does not block the
+   * caller. Completion is intentionally a no-op because this helper is used during reconnection
+   * flows that already manage lifecycle events.
    *
    * @param outputHandler handler used to enqueue outgoing FCP messages on the revived connection;
    *     must remain valid for the duration of the listing job.
-   * @param context execution context supplying thread pools and cancellation signals for the
-   *     listing job; must not be {@code null}.
    */
   public void queuePendingMessagesOnConnectionRestartAsync(
-      FCPConnectionOutputHandler outputHandler, ClientContext context) {
+      FCPConnectionOutputHandler outputHandler) {
+    RequestQueuePort requestQueuePort = outputHandler.handler.getServer().runtime().requestQueue();
     if (persistence == Persistence.FOREVER) {
       PersistentListJob job =
-          new PersistentListJob(this, outputHandler, context, null) {
+          new PersistentListJob(this, outputHandler, requestQueuePort, null, () -> {}) {
 
             @Override
-            void complete(ClientContext context) {
+            void complete() {
               // Do nothing.
             }
           };
-      job.run(context);
+      job.run();
     } else {
       TransientListJob job =
-          new TransientListJob(this, outputHandler, context, null) {
+          new TransientListJob(this, outputHandler, requestQueuePort, null) {
 
             @Override
-            void complete(ClientContext context) {
+            void complete() {
               // Do nothing.
             }
           };
-      job.run(context);
+      job.run();
     }
   }
 
@@ -417,10 +417,10 @@ public final class PersistentRequestClient {
    * Removes and optionally cancels a request by its identifier.
    *
    * <p>The method updates the status cache, unlinks the request from internal maps and lists, and
-   * notifies registered completion callbacks. When {@code kill} is true the request is cancelled
+   * notifies registered completion callbacks. When {@code kill} is true the request is canceled
    * before removal. It returns {@code false} if no request with the supplied identifier exists,
-   * leaving internal state unchanged. When a server is not provided a warning is logged because the
-   * caller may miss ancillary cleanup.
+   * leaving internal state unchanged. When a server is not provided, a warning is logged because
+   * the caller may miss ancillary cleanup.
    *
    * @param identifier unique request identifier belonging to this client; must not be {@code null}.
    * @param kill whether to cancel the request before removal to stop any in-flight work.
@@ -554,7 +554,7 @@ public final class PersistentRequestClient {
         LOG.error("BROKEN REQUEST LOADING PERSISTENT REQUEST STATUS: {}", t.getMessage(), t);
         // Consider surfacing this to the user if it becomes frequent.
       }
-      // Deactivation policy depends on callers; keep current behavior.
+      // The deactivation policy depends on callers; keep current behavior.
     }
   }
 
@@ -607,13 +607,11 @@ public final class PersistentRequestClient {
         if (persistence == Persistence.REBOOT)
           server
               .getGlobalRebootClient()
-              .queuePendingMessagesOnConnectionRestartAsync(
-                  connHandler.getOutputHandler(), server.getCore().getClientContext());
+              .queuePendingMessagesOnConnectionRestartAsync(connHandler.getOutputHandler());
         else
           server
               .getGlobalForeverClient()
-              .queuePendingMessagesOnConnectionRestartAsync(
-                  connHandler.getOutputHandler(), server.getCore().getClientContext());
+              .queuePendingMessagesOnConnectionRestartAsync(connHandler.getOutputHandler());
       }
       watchGlobal = true;
     }
@@ -693,7 +691,7 @@ public final class PersistentRequestClient {
   }
 
   /**
-   * Looks up a tracked request by its identifier without altering state.
+   * It looks up a tracked request by its identifier without altering the state.
    *
    * @param identifier request identifier previously registered with this client; must not be {@code
    *     null}.
@@ -737,8 +735,8 @@ public final class PersistentRequestClient {
    * Notifies registered completion callbacks that a request has failed.
    *
    * <p>As with {@link #notifySuccess(ClientRequest)}, the request must belong to this client. The
-   * method does not alter internal state; it only forwards the failure to listeners. Callers
-   * typically pair this with subsequent removal or retry logic.
+   * method does not alter the internal state; it only forwards the failure to listeners. Callers
+   * typically pair this with further removal or retry logic.
    *
    * @param req request that ended in failure; must match this client’s persistence policy.
    * @throws IllegalArgumentException if the request persistence does not match the client policy.
@@ -782,8 +780,9 @@ public final class PersistentRequestClient {
   /**
    * Clears all tracked requests and status cache entries for this client.
    *
-   * <p>Both running and completed queues are emptied and the identifier map is reset. The operation
-   * does not cancel in-flight work; callers should cancel or disconnect separately if required.
+   * <p>Both running and completed queues are emptied, and the identifier map is reset. The
+   * operation does not cancel in-flight work; callers should cancel or disconnect separately if
+   * required.
    */
   public void removeAll() {
     if (statusCache != null) statusCache.clear();
@@ -828,8 +827,8 @@ public final class PersistentRequestClient {
   /**
    * Reloads the status cache from persistent storage when operating in forever mode.
    *
-   * <p>This is typically called during startup to repopulate progress indicators from disk-backed
-   * request state. No effect occurs for reboot-persistent clients.
+   * <p>This is typically called during startup to repopulate progress indicators from the
+   * disk-backed request state. No effect occurs for reboot-persistent clients.
    */
   public void updateRequestStatusCache() {
     updateRequestStatusCache(statusCache);
@@ -874,9 +873,9 @@ public final class PersistentRequestClient {
   /**
    * Reattaches a deserialized or resumed request to this client.
    *
-   * <p>The request is placed into the appropriate queue based on completion state and added to the
-   * identifier map. If an entry with the same identifier already exists and refers to a different
-   * instance, an exception is thrown to prevent corruption.
+   * <p>The request is placed into the appropriate queue based on the completion state and added to
+   * the identifier map. If an entry with the same identifier already exists and refers to a
+   * different instance, an exception is thrown to prevent corruption.
    *
    * @param clientRequest request recovered from persistence or another source; must carry a unique
    *     identifier for this client.

--- a/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
@@ -1,17 +1,17 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
 import network.crypta.node.Node;
+import network.crypta.runtime.spi.RequestQueuePort;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.NativeThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Removes a persistent client request from the node on behalf of an FCP client.
  *
- * <p>This message is emitted by a client that wishes to cancel a request which was previously
+ * <p>This message is emitted by a client that wishes to cancel a request, which was previously
  * registered for persistence, regardless of whether it has finished or is still queued. It carries
  * the opaque request identifier and a flag indicating whether the request was global. Instances are
  * immutable after creation; they simply transport the parameters required for removal and delegate
@@ -70,7 +70,7 @@ public final class RemovePersistentRequest extends FCPMessage {
    * Builds a minimal field set representing this message for transmission.
    *
    * <p>Only the persistent request identifier is serialized because removal requests do not carry
-   * payload data. The returned structure is newly allocated and independent of the instance so it
+   * payload data. The returned structure is newly allocated and independent of the instance, so it
    * can be freely mutated by downstream serialization layers without affecting the stored state.
    *
    * @return a new {@link SimpleFieldSet} containing the {@code Identifier} entry required by the
@@ -121,38 +121,33 @@ public final class RemovePersistentRequest extends FCPMessage {
       req = handler.removeRequestByIdentifier(requestIdentifier, true);
     }
     if (req == null) {
+      RequestQueuePort requestQueuePort = handler.getServer().runtime().requestQueue();
       try {
-        handler
-            .getServer()
-            .getCore()
-            .getClientContext()
-            .jobRunner
-            .queue(
-                (PersistentJob)
-                    context -> {
-                      ClientRequest req1 =
-                          handler.removePersistentForeverRequest(global, requestIdentifier);
-                      if (req1 == null) {
-                        if (LOG.isDebugEnabled()) {
-                          LOG.debug(
-                              "RemovePersistentRequest missing identifier {} (global={})",
-                              requestIdentifier,
-                              global);
-                        }
-                        ProtocolErrorMessage msg =
-                            new ProtocolErrorMessage(
-                                ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
-                                false,
-                                null,
-                                requestIdentifier,
-                                global);
-                        handler.send(msg);
-                        return false;
-                      }
-                      return true;
-                    },
-                NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-      } catch (PersistenceDisabledException _) {
+        requestQueuePort.submitPersistentJob(
+            () -> {
+              ClientRequest req1 =
+                  handler.removePersistentForeverRequest(global, requestIdentifier);
+              if (req1 == null) {
+                if (LOG.isDebugEnabled()) {
+                  LOG.debug(
+                      "RemovePersistentRequest missing identifier {} (global={})",
+                      requestIdentifier,
+                      global);
+                }
+                ProtocolErrorMessage msg =
+                    new ProtocolErrorMessage(
+                        ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
+                        false,
+                        null,
+                        requestIdentifier,
+                        global);
+                handler.send(msg);
+                return false;
+              }
+              return true;
+            },
+            RequestQueuePriority.HIGH);
+      } catch (RequestQueueUnavailableException _) {
         FCPMessage err =
             new ProtocolErrorMessage(
                 ProtocolErrorMessage.PERSISTENCE_DISABLED,

--- a/src/main/java/network/crypta/clients/fcp/WatchGlobal.java
+++ b/src/main/java/network/crypta/clients/fcp/WatchGlobal.java
@@ -8,7 +8,7 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <p>This message is sent by an FCP client when it wants to receive node-wide notifications (such
  * as request lifecycle updates) beyond its own request scope. The handler stores the preference on
- * both the reboot-persistent client and the in-memory forever client so the subscription survives
+ * both the reboot-persistent client and the in-memory forever client, so the subscription survives
  * across reconnections when persistence is available. Applications typically send this once during
  * session initialization and keep the returned verbosity mask aligned with their logging strategy.
  *
@@ -120,17 +120,14 @@ public final class WatchGlobal extends FCPMessage {
    *
    * @param handler active connection handler that owns both persistent and in-memory clients; must
    *     not be {@code null} and is expected to originate the incoming FCP message.
-   * @param node current node instance supplying the client core and FCP server used to register the
-   *     watch; must expose a non-null client core when invoked.
-   * @throws MessageInvalidException if subordinate clients reject the configuration change or the
+   * @param node the current node instance supplying the client core and FCP server used to register
+   *     the watch; must expose a non-null client core when invoked.
+   * @throws MessageInvalidException if subordinate clients reject the configuration change, or the
    *     handler signals a protocol-level validation failure.
    */
   @Override
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    if (!handler
-        .getRebootClient()
-        .setWatchGlobal(
-            enabled, verbosityMask, node.services().clientCore().getEndpoints().getFCPServer())) {
+    if (!handler.getRebootClient().setWatchGlobal(enabled, verbosityMask, handler.getServer())) {
       FCPMessage err =
           new ProtocolErrorMessage(
               ProtocolErrorMessage.PERSISTENCE_DISABLED, false, "Persistence disabled", null, true);

--- a/src/main/java/network/crypta/node/runtime/LegacyRequestQueuePort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRequestQueuePort.java
@@ -1,0 +1,72 @@
+package network.crypta.node.runtime;
+
+import java.util.Objects;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RequestQueuePort;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueTask;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.support.io.NativeThread;
+
+/**
+ * Legacy daemon-backed implementation of the runtime request-queue SPI.
+ *
+ * <p>This adapter keeps persistent-request queue traversal inside the daemon root module while
+ * exposing only the JDK-level runtime SPI surface to infrastructure code. It delegates directly to
+ * the existing {@link NodeClientCore} persistence runner and ticker, translates daemon-specific
+ * queue failures into {@link RequestQueueUnavailableException}, and preserves the priority mapping
+ * historically used by the FCP queue-control paths.
+ *
+ * <p>The adapter is intentionally thin and stateless apart from its reference to the live {@link
+ * NodeClientCore}. It does not add retries, buffering, or policy. Callers therefore see the same
+ * queue acceptance rules, delayed scheduling behavior, and checkpoint semantics that the daemon
+ * already applies internally.
+ */
+public final class LegacyRequestQueuePort implements RequestQueuePort {
+  private static final int LISTING_PRIORITY = NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1;
+
+  private final NodeClientCore core;
+
+  /**
+   * Creates a request-queue adapter backed by the supplied client core.
+   *
+   * <p>The supplied core remains the source of truth for persistence state, queue selection, and
+   * delayed task scheduling throughout the adapter's lifetime.
+   *
+   * @param core live daemon client core that owns the persistence runner and ticker
+   */
+  public LegacyRequestQueuePort(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  @Override
+  public boolean isPersistenceDatabaseKilled() {
+    return core.killedDatabase();
+  }
+
+  @Override
+  public void submitPersistentJob(RequestQueueTask task, RequestQueuePriority priority)
+      throws RequestQueueUnavailableException {
+    Objects.requireNonNull(task);
+    Objects.requireNonNull(priority);
+    try {
+      core.getClientContext().jobRunner.queue(_ -> task.run(), nativePriority(priority));
+    } catch (PersistenceDisabledException e) {
+      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
+    }
+  }
+
+  @Override
+  public void scheduleLater(Runnable task, long delayMillis) {
+    core.getClientContext().ticker.queueTimedJob(Objects.requireNonNull(task), delayMillis);
+  }
+
+  private static int nativePriority(RequestQueuePriority priority) {
+    return switch (priority) {
+      case NORMAL -> NativeThread.PriorityLevel.NORM_PRIORITY.value;
+      case HIGH -> NativeThread.PriorityLevel.HIGH_PRIORITY.value;
+      case LISTING -> LISTING_PRIORITY;
+    };
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -10,6 +10,7 @@ import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
 
@@ -35,6 +36,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final TransferAccessPort transferAccessPort;
   private final LifecyclePort lifecyclePort;
   private final ConfigPort configPort;
+  private final RequestQueuePort requestQueuePort;
   private final NodeInfoPort nodeInfoPort;
   private final PeerPort peerPort;
 
@@ -117,6 +119,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
           }
         };
     this.configPort = new LegacyConfigPort(node, core);
+    this.requestQueuePort = new LegacyRequestQueuePort(core);
     this.nodeInfoPort = new LegacyNodeInfoPort(node);
     this.peerPort = new LegacyPeerPort(node);
   }
@@ -172,6 +175,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public ConfigPort config() {
     return configPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps all legacy persistence-runner and ticker traversals inside the
+   * daemon root module while exposing only queue-control semantics upstream.
+   */
+  @Override
+  public RequestQueuePort requestQueue() {
+    return requestQueuePort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/fcp/GetRequestStatusMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetRequestStatusMessageTest.java
@@ -1,14 +1,12 @@
 package network.crypta.clients.fcp;
 
-import java.lang.reflect.Field;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
-import network.crypta.client.async.PersistentJobRunner;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RequestQueuePort;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueTask;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.NativeThread;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -20,10 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -35,11 +32,10 @@ class GetRequestStatusMessageTest {
 
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPConnectionOutputHandler outputHandler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeClientCore nodeClientCore;
+  @Mock private Node node;
+  @Mock private FCPServer server;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private RequestQueuePort requestQueuePort;
 
   @Test
   void constructor_whenFieldsPresent_setsFlagsAndIdentifier() {
@@ -64,7 +60,6 @@ class GetRequestStatusMessageTest {
     SimpleFieldSet fieldSet = message.getFieldSet();
 
     assertEquals("roundTripId", fieldSet.get("Identifier"));
-    // Ensure other flags are not unintentionally copied into the outgoing field set
     assertNull(fieldSet.get("Global"));
     assertNull(fieldSet.get("OnlyData"));
   }
@@ -87,13 +82,13 @@ class GetRequestStatusMessageTest {
     fs.putSingle("OnlyData", "true");
     GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
 
-    ClientRequest request = mock(ClientRequest.class);
+    ClientRequest request = org.mockito.Mockito.mock(ClientRequest.class);
     when(handler.getRebootRequest(false, handler, identifier)).thenReturn(request);
     when(handler.getOutputHandler()).thenReturn(outputHandler);
 
     message.run(handler, node);
 
-    verify(request).sendPendingMessages(outputHandler, identifier, true, /* onlyData */ true);
+    verify(request).sendPendingMessages(outputHandler, identifier, true, true);
     verify(handler, never()).send(any());
   }
 
@@ -104,18 +99,16 @@ class GetRequestStatusMessageTest {
     fs.putSingle("Identifier", identifier);
     GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
 
+    stubRequestQueuePort();
     when(handler.getRebootRequest(false, handler, identifier)).thenReturn(null);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(nodeClientCore);
-    when(nodeClientCore.killedDatabase()).thenReturn(true);
+    when(requestQueuePort.isPersistenceDatabaseKilled()).thenReturn(true);
 
     message.run(handler, node);
 
     verify(handler, never()).send(any());
-    verify(nodeClientCore).killedDatabase();
-    verifyNoMoreInteractions(nodeClientCore);
+    verify(requestQueuePort).isPersistenceDatabaseKilled();
+    verify(requestQueuePort, never()).submitPersistentJob(any(), any());
+    verifyNoMoreInteractions(requestQueuePort);
   }
 
   @Test
@@ -125,32 +118,24 @@ class GetRequestStatusMessageTest {
     fs.putSingle("Identifier", identifier);
     GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
 
-    ClientRequest queuedRequest = mock(ClientRequest.class);
-    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
-    ClientContext context = contextWithJobRunner(jobRunner);
-
+    ClientRequest queuedRequest = org.mockito.Mockito.mock(ClientRequest.class);
+    stubRequestQueuePort();
     when(handler.getRebootRequest(false, handler, identifier)).thenReturn(null);
     when(handler.getForeverRequest(false, handler, identifier)).thenReturn(queuedRequest);
     when(handler.getOutputHandler()).thenReturn(outputHandler);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(nodeClientCore);
-    when(nodeClientCore.killedDatabase()).thenReturn(false);
-    when(nodeClientCore.getClientContext()).thenReturn(context);
+    when(requestQueuePort.isPersistenceDatabaseKilled()).thenReturn(false);
 
     message.run(handler, node);
 
-    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
-    verify(jobRunner).queue(jobCaptor.capture(), eq(normPriority()));
+    ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
+    verify(requestQueuePort)
+        .submitPersistentJob(taskCaptor.capture(), eq(RequestQueuePriority.NORMAL));
 
-    PersistentJob persistedJob = jobCaptor.getValue();
-    boolean checkpointRequested = persistedJob.run(context);
+    boolean checkpointRequested = taskCaptor.getValue().run();
 
     assertFalse(checkpointRequested);
     verify(handler).getForeverRequest(false, handler, identifier);
-    verify(queuedRequest)
-        .sendPendingMessages(outputHandler, identifier, true, /* onlyData */ false);
+    verify(queuedRequest).sendPendingMessages(outputHandler, identifier, true, false);
     verify(handler, never()).send(any());
   }
 
@@ -161,25 +146,18 @@ class GetRequestStatusMessageTest {
     fs.putSingle("Identifier", identifier);
     GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
 
-    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
-    ClientContext context = contextWithJobRunner(jobRunner);
-
+    stubRequestQueuePort();
     when(handler.getRebootRequest(false, handler, identifier)).thenReturn(null);
     when(handler.getForeverRequest(false, handler, identifier)).thenReturn(null);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(nodeClientCore);
-    when(nodeClientCore.killedDatabase()).thenReturn(false);
-    when(nodeClientCore.getClientContext()).thenReturn(context);
+    when(requestQueuePort.isPersistenceDatabaseKilled()).thenReturn(false);
 
     message.run(handler, node);
 
-    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
-    verify(jobRunner).queue(jobCaptor.capture(), eq(normPriority()));
+    ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
+    verify(requestQueuePort)
+        .submitPersistentJob(taskCaptor.capture(), eq(RequestQueuePriority.NORMAL));
 
-    PersistentJob persistedJob = jobCaptor.getValue();
-    persistedJob.run(context);
+    taskCaptor.getValue().run();
 
     ArgumentCaptor<ProtocolErrorMessage> errorCaptor =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);
@@ -193,23 +171,18 @@ class GetRequestStatusMessageTest {
   }
 
   @Test
-  void run_whenPersistenceDisabledOnQueue_sendsProtocolErrorImmediately() throws Exception {
+  void run_whenQueueUnavailable_sendsProtocolErrorImmediately() throws Exception {
     String identifier = "noPersistence";
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", identifier);
     GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
 
-    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
-    ClientContext context = contextWithJobRunner(jobRunner);
-
+    stubRequestQueuePort();
     when(handler.getRebootRequest(false, handler, identifier)).thenReturn(null);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(nodeClientCore);
-    when(nodeClientCore.killedDatabase()).thenReturn(false);
-    when(nodeClientCore.getClientContext()).thenReturn(context);
-    doThrow(new PersistenceDisabledException()).when(jobRunner).queue(any(), eq(normPriority()));
+    when(requestQueuePort.isPersistenceDatabaseKilled()).thenReturn(false);
+    doThrow(new RequestQueueUnavailableException("disabled"))
+        .when(requestQueuePort)
+        .submitPersistentJob(any(), eq(RequestQueuePriority.NORMAL));
 
     message.run(handler, node);
 
@@ -223,19 +196,9 @@ class GetRequestStatusMessageTest {
     assertFalse(error.fatal);
   }
 
-  private ClientContext contextWithJobRunner(PersistentJobRunner jobRunner) {
-    ClientContext context = mock(ClientContext.class);
-    try {
-      Field field = ClientContext.class.getDeclaredField("jobRunner");
-      field.setAccessible(true);
-      field.set(context, jobRunner);
-    } catch (IllegalAccessException | NoSuchFieldException e) {
-      throw new RuntimeException(e);
-    }
-    return context;
-  }
-
-  private int normPriority() {
-    return NativeThread.PriorityLevel.NORM_PRIORITY.value;
+  private void stubRequestQueuePort() {
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.requestQueue()).thenReturn(requestQueuePort);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ListPersistentRequestsMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPersistentRequestsMessageTest.java
@@ -1,42 +1,14 @@
 package network.crypta.clients.fcp;
 
-import java.util.Random;
-import network.crypta.client.ArchiveManager;
-import network.crypta.client.FetchContext;
-import network.crypta.client.InsertContext;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientContextDefaults;
-import network.crypta.client.async.ClientContextRafFactories;
-import network.crypta.client.async.ClientContextRuntime;
-import network.crypta.client.async.ClientContextServices;
-import network.crypta.client.async.ClientContextStorageFactories;
-import network.crypta.client.async.ClientLayerPersister;
-import network.crypta.client.async.DatastoreChecker;
-import network.crypta.client.async.HealingQueue;
-import network.crypta.client.async.PersistentJob;
-import network.crypta.client.async.USKManager;
-import network.crypta.client.filter.LinkFilterExceptionProvider;
-import network.crypta.config.Config;
-import network.crypta.crypt.MasterSecret;
-import network.crypta.crypt.RandomSource;
-import network.crypta.node.ClientContextResources;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.support.MemoryLimitedJobRunner;
-import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.runtime.spi.RequestQueuePort;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueTask;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.Ticker;
-import network.crypta.support.api.LockableRandomAccessBufferFactory;
-import network.crypta.support.compress.RealCompressor;
-import network.crypta.support.io.FileRandomAccessBufferFactory;
-import network.crypta.support.io.FilenameGenerator;
-import network.crypta.support.io.PersistentFileTracker;
-import network.crypta.support.io.PersistentTempBucketFactory;
-import network.crypta.support.io.TempBucketFactory;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,6 +27,11 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class ListPersistentRequestsMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private FCPServer server;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private RequestQueuePort requestQueuePort;
 
   @Test
   void getName_whenCalled_returnsConstant() {
@@ -77,62 +54,23 @@ class ListPersistentRequestsMessageTest {
   @Test
   void run_whenWatchGlobalDisabled_sendsEndAfterLocalClients() throws Exception {
     String identifier = "req-1";
-    SimpleFieldSet input = new SimpleFieldSet(true);
-    input.putSingle("Identifier", identifier);
-    ListPersistentRequestsMessage message = new ListPersistentRequestsMessage(input);
+    ListPersistentRequestsMessage message = new ListPersistentRequestsMessage(fieldSet(identifier));
 
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    FCPServer server = mock(FCPServer.class);
-    when(server.maxMessageQueueLength()).thenReturn(10);
-    when(handler.getServer()).thenReturn(server);
-
-    FCPConnectionOutputHandler outputHandler = new FCPConnectionOutputHandler(handler);
-    when(handler.getOutputHandler()).thenReturn(outputHandler);
-
+    FCPConnectionOutputHandler outputHandler = newOutputHandler();
     PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
     PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
     when(handler.getRebootClient()).thenReturn(rebootClient);
     when(handler.getForeverClient()).thenReturn(foreverClient);
+    mockQueuesReturningEmpty(identifier, outputHandler, rebootClient, foreverClient);
+    executePersistentTasksImmediately();
 
-    when(rebootClient.queuePendingMessagesOnConnectionRestart(
-            eq(outputHandler), eq(identifier), anyInt(), anyInt()))
-        .thenReturn(0);
-    when(rebootClient.queuePendingMessagesFromRunningRequests(
-            eq(outputHandler), eq(identifier), anyInt(), anyInt()))
-        .thenReturn(0);
-    when(foreverClient.queuePendingMessagesOnConnectionRestart(
-            eq(outputHandler), eq(identifier), anyInt(), anyInt()))
-        .thenReturn(0);
-    when(foreverClient.queuePendingMessagesFromRunningRequests(
-            eq(outputHandler), eq(identifier), anyInt(), anyInt()))
-        .thenReturn(0);
-
-    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
-    Ticker ticker = mock(Ticker.class);
-    ClientContext context = newClientContext(jobRunner, ticker);
-    NodeClientCore core = mock(NodeClientCore.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(core);
-    when(core.getClientContext()).thenReturn(context);
-
-    doAnswer(
-            invocation -> {
-              PersistentJob job = invocation.getArgument(0);
-              return job.run(context);
-            })
-        .when(jobRunner)
-        .queue(any(PersistentJob.class), anyInt());
-
-    message.run(handler, node);
+    message.run(handler, null);
 
     ArgumentCaptor<EndListPersistentRequestsMessage> captor =
         ArgumentCaptor.forClass(EndListPersistentRequestsMessage.class);
     verify(handler).send(captor.capture());
     assertEquals(identifier, captor.getValue().getFieldSet().get("Identifier"));
-
+    verify(requestQueuePort).submitPersistentJob(any(), eq(RequestQueuePriority.LISTING));
     verify(rebootClient).queuePendingMessagesOnConnectionRestart(outputHandler, identifier, 0, 30);
     verify(rebootClient).queuePendingMessagesFromRunningRequests(outputHandler, identifier, 0, 30);
     verify(foreverClient).queuePendingMessagesOnConnectionRestart(outputHandler, identifier, 0, 30);
@@ -142,18 +80,9 @@ class ListPersistentRequestsMessageTest {
   @Test
   void run_whenWatchGlobalEnabled_includesGlobalQueuesThenEnds() throws Exception {
     String identifier = "req-global";
-    SimpleFieldSet input = new SimpleFieldSet(true);
-    input.putSingle("Identifier", identifier);
-    ListPersistentRequestsMessage message = new ListPersistentRequestsMessage(input);
+    ListPersistentRequestsMessage message = new ListPersistentRequestsMessage(fieldSet(identifier));
 
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    FCPServer server = mock(FCPServer.class);
-    when(server.maxMessageQueueLength()).thenReturn(10);
-    when(handler.getServer()).thenReturn(server);
-
-    FCPConnectionOutputHandler outputHandler = new FCPConnectionOutputHandler(handler);
-    when(handler.getOutputHandler()).thenReturn(outputHandler);
-
+    FCPConnectionOutputHandler outputHandler = newOutputHandler();
     PersistentRequestClient rebootClient = mock(PersistentRequestClient.class);
     rebootClient.watchGlobal = true;
     PersistentRequestClient foreverClient = mock(PersistentRequestClient.class);
@@ -164,32 +93,14 @@ class ListPersistentRequestsMessageTest {
     when(handler.getForeverClient()).thenReturn(foreverClient);
     when(server.getGlobalRebootClient()).thenReturn(globalRebootClient);
     when(server.getGlobalForeverClient()).thenReturn(globalForeverClient);
-
     mockQueuesReturningEmpty(identifier, outputHandler, rebootClient, foreverClient);
     mockQueuesReturningEmpty(identifier, outputHandler, globalRebootClient, globalForeverClient);
+    executePersistentTasksImmediately();
 
-    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
-    Ticker ticker = mock(Ticker.class);
-    ClientContext context = newClientContext(jobRunner, ticker);
-    NodeClientCore core = mock(NodeClientCore.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(core);
-    when(core.getClientContext()).thenReturn(context);
-
-    doAnswer(
-            invocation -> {
-              PersistentJob job = invocation.getArgument(0);
-              return job.run(context);
-            })
-        .when(jobRunner)
-        .queue(any(PersistentJob.class), anyInt());
-
-    message.run(handler, node);
+    message.run(handler, null);
 
     verify(handler).send(any(EndListPersistentRequestsMessage.class));
+    verify(requestQueuePort, times(1)).submitPersistentJob(any(), eq(RequestQueuePriority.LISTING));
     verify(globalRebootClient)
         .queuePendingMessagesOnConnectionRestart(outputHandler, identifier, 0, 30);
     verify(globalForeverClient)
@@ -197,18 +108,35 @@ class ListPersistentRequestsMessageTest {
   }
 
   @Test
-  void listJob_whenOutputQueueHalfFull_reschedulesAndStops() {
+  void transientListJob_whenOutputQueueHalfFull_reschedulesViaRequestQueuePort() {
     FCPConnectionOutputHandler outputHandler = mock(FCPConnectionOutputHandler.class);
     when(outputHandler.isQueueHalfFull()).thenReturn(true);
 
     PersistentRequestClient client = mock(PersistentRequestClient.class);
-    TrackingListJob job = new TrackingListJob(client, outputHandler, "id", true);
+    TrackingTransientListJob job =
+        new TrackingTransientListJob(client, outputHandler, requestQueuePort, "id");
 
-    boolean result = job.run(null);
+    job.run();
 
-    assertFalse(result, "run should stop when rescheduled");
-    assertTrue(job.rescheduled, "reschedule should be invoked");
+    verify(requestQueuePort).scheduleLater(job, 100L);
     verifyNoInteractions(client);
+    assertFalse(job.completed);
+  }
+
+  @Test
+  void persistentListJob_whenRun_submitsListingTaskViaRequestQueuePort() throws Exception {
+    FCPConnectionOutputHandler outputHandler = mock(FCPConnectionOutputHandler.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    TrackingPersistentListJob job =
+        new TrackingPersistentListJob(client, outputHandler, requestQueuePort, "id");
+
+    job.run();
+
+    ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
+    verify(requestQueuePort)
+        .submitPersistentJob(taskCaptor.capture(), eq(RequestQueuePriority.LISTING));
+    assertFalse(job.completed);
+    assertFalse(taskCaptor.getValue().run());
   }
 
   @Test
@@ -226,7 +154,7 @@ class ListPersistentRequestsMessageTest {
 
     TrackingListJob job = new TrackingListJob(client, outputHandler, "id", false);
 
-    boolean result = job.run(null);
+    boolean result = job.execute();
 
     assertFalse(result);
     assertTrue(job.completed);
@@ -237,6 +165,27 @@ class ListPersistentRequestsMessageTest {
             eq(outputHandler), eq("id"), restartOffsets.capture(), eq(30));
     assertEquals(0, restartOffsets.getAllValues().get(0));
     assertEquals(1, restartOffsets.getAllValues().get(1));
+  }
+
+  private FCPConnectionOutputHandler newOutputHandler() {
+    when(server.maxMessageQueueLength()).thenReturn(10);
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.requestQueue()).thenReturn(requestQueuePort);
+    FCPConnectionOutputHandler outputHandler = new FCPConnectionOutputHandler(handler);
+    when(handler.getOutputHandler()).thenReturn(outputHandler);
+    return outputHandler;
+  }
+
+  private void executePersistentTasksImmediately() throws Exception {
+    doAnswer(
+            invocation -> {
+              RequestQueueTask task = invocation.getArgument(0);
+              task.run();
+              return null;
+            })
+        .when(requestQueuePort)
+        .submitPersistentJob(any(), eq(RequestQueuePriority.LISTING));
   }
 
   private static void mockQueuesReturningEmpty(
@@ -258,75 +207,13 @@ class ListPersistentRequestsMessageTest {
         .thenReturn(0);
   }
 
-  private static ClientContext newClientContext(ClientLayerPersister jobRunner, Ticker ticker) {
-    PriorityAwareExecutor executor =
-        new PriorityAwareExecutor() {
-
-          @Override
-          public void execute(@NotNull Runnable job) {
-            job.run();
-          }
-
-          @Override
-          public void execute(@NotNull Runnable job, String jobName) {
-            job.run();
-          }
-
-          @Override
-          public void execute(@NotNull Runnable job, String jobName, boolean fromTicker) {
-            job.run();
-          }
-
-          @Override
-          public int[] waitingThreads() {
-            return new int[0];
-          }
-
-          @Override
-          public int[] runningThreads() {
-            return new int[0];
-          }
-
-          @Override
-          public int getWaitingThreadsCount() {
-            return 0;
-          }
-        };
-
-    return new ClientContext(
-        1L,
-        new ClientContextRuntime(
-            jobRunner,
-            executor,
-            mock(MemoryLimitedJobRunner.class),
-            ticker,
-            mock(RandomSource.class),
-            new Random(0),
-            mock(MasterSecret.class)),
-        new ClientContextStorageFactories(
-            mock(PersistentTempBucketFactory.class),
-            mock(TempBucketFactory.class),
-            mock(PersistentFileTracker.class),
-            mock(FilenameGenerator.class),
-            mock(FilenameGenerator.class),
-            mock(FileRandomAccessBufferFactory.class),
-            mock(FileRandomAccessBufferFactory.class)),
-        new ClientContextRafFactories(
-            mock(LockableRandomAccessBufferFactory.class),
-            mock(LockableRandomAccessBufferFactory.class)),
-        new ClientContextServices(
-            new ClientContextResources(mock(ArchiveManager.class), mock(HealingQueue.class)),
-            mock(USKManager.class),
-            mock(RealCompressor.class),
-            mock(DatastoreChecker.class),
-            mock(PersistentRequestRoot.class),
-            mock(LinkFilterExceptionProvider.class)),
-        new ClientContextDefaults(
-            mock(FetchContext.class), mock(InsertContext.class), mock(Config.class)));
+  private static SimpleFieldSet fieldSet(String identifier) {
+    SimpleFieldSet input = new SimpleFieldSet(true);
+    input.putSingle("Identifier", identifier);
+    return input;
   }
 
   private static class TrackingListJob extends ListPersistentRequestsMessage.ListJob {
-    boolean rescheduled;
     boolean completed;
     private final boolean noRunning;
 
@@ -340,18 +227,54 @@ class ListPersistentRequestsMessageTest {
     }
 
     @Override
-    void reschedule(ClientContext context) {
-      rescheduled = true;
+    void reschedule() {
+      // No-op for this focused progress test.
     }
 
     @Override
-    void complete(ClientContext context) {
+    void complete() {
       completed = true;
     }
 
     @Override
     protected boolean noRunning() {
       return noRunning;
+    }
+  }
+
+  private static final class TrackingTransientListJob
+      extends ListPersistentRequestsMessage.TransientListJob {
+    boolean completed;
+
+    TrackingTransientListJob(
+        PersistentRequestClient client,
+        FCPConnectionOutputHandler outputHandler,
+        RequestQueuePort requestQueuePort,
+        String listRequestIdentifier) {
+      super(client, outputHandler, requestQueuePort, listRequestIdentifier);
+    }
+
+    @Override
+    void complete() {
+      completed = true;
+    }
+  }
+
+  private static final class TrackingPersistentListJob
+      extends ListPersistentRequestsMessage.PersistentListJob {
+    boolean completed;
+
+    TrackingPersistentListJob(
+        PersistentRequestClient client,
+        FCPConnectionOutputHandler outputHandler,
+        RequestQueuePort requestQueuePort,
+        String listRequestIdentifier) {
+      super(client, outputHandler, requestQueuePort, listRequestIdentifier, () -> {});
+    }
+
+    @Override
+    void complete() {
+      completed = true;
     }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
@@ -1,45 +1,16 @@
 package network.crypta.clients.fcp;
 
-import java.util.Random;
-import network.crypta.client.ArchiveManager;
-import network.crypta.client.FetchContext;
-import network.crypta.client.InsertContext;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientContextDefaults;
-import network.crypta.client.async.ClientContextRafFactories;
-import network.crypta.client.async.ClientContextRuntime;
-import network.crypta.client.async.ClientContextServices;
-import network.crypta.client.async.ClientContextStorageFactories;
-import network.crypta.client.async.ClientLayerPersister;
-import network.crypta.client.async.DatastoreChecker;
-import network.crypta.client.async.HealingQueue;
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
-import network.crypta.client.async.USKManager;
-import network.crypta.client.filter.LinkFilterExceptionProvider;
-import network.crypta.config.Config;
-import network.crypta.crypt.MasterSecret;
-import network.crypta.crypt.RandomSource;
-import network.crypta.node.ClientContextResources;
-import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.support.MemoryLimitedJobRunner;
-import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.runtime.spi.RequestQueuePort;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueTask;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.Ticker;
-import network.crypta.support.api.LockableRandomAccessBufferFactory;
-import network.crypta.support.compress.RealCompressor;
-import network.crypta.support.io.FileRandomAccessBufferFactory;
-import network.crypta.support.io.FilenameGenerator;
-import network.crypta.support.io.NativeThread;
-import network.crypta.support.io.PersistentFileTracker;
-import network.crypta.support.io.PersistentTempBucketFactory;
-import network.crypta.support.io.TempBucketFactory;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,24 +20,22 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings("java:S100") // test method naming: method_whenCondition_expectOutcome
+@SuppressWarnings("java:S100")
 class ModifyPersistentRequestTest {
 
-  // ---------- Constructor validation ----------
+  @Mock private FCPConnectionHandler handler;
+  @Mock private Node node;
+  @Mock private FCPServer server;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private RequestQueuePort requestQueuePort;
 
   @Test
   void constructor_whenIdentifierMissing_throwsMessageInvalidException() {
@@ -101,7 +70,6 @@ class ModifyPersistentRequestTest {
   void constructor_whenPriorityClassOutOfRange_throwsMessageInvalidException() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "req-2");
-    // RequestStarter.PAUSED_PRIORITY_CLASS == 6, MAXIMUM_PRIORITY_CLASS == 0
     fs.putSingle("PriorityClass", "7");
 
     MessageInvalidException ex =
@@ -126,8 +94,6 @@ class ModifyPersistentRequestTest {
     assertEquals(-1, message.priorityClass);
     assertNull(message.clientToken);
   }
-
-  // ---------- getFieldSet / getName ----------
 
   @Test
   void getFieldSet_whenClientTokenPresent_includesAllFields() throws Exception {
@@ -170,10 +136,8 @@ class ModifyPersistentRequestTest {
     assertEquals("ModifyPersistentRequest", message.getName());
   }
 
-  // ---------- run(): reboot request path ----------
-
   @Test
-  void run_whenRebootRequestExists_modifiesRequestViaNodeFcpServer() throws Exception {
+  void run_whenRebootRequestExists_modifiesRequestViaHandlerServer() throws Exception {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "req-7");
     fs.put("Global", false);
@@ -181,29 +145,16 @@ class ModifyPersistentRequestTest {
     fs.putSingle("ClientToken", "tok");
     ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
 
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    ClientRequest rebootRequest = mock(ClientRequest.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    NodeClientCore core = mock(NodeClientCore.class);
-    FCPServer server = mock(FCPServer.class);
-
+    ClientRequest rebootRequest = org.mockito.Mockito.mock(ClientRequest.class);
     when(handler.getRebootRequest(false, handler, "req-7")).thenReturn(rebootRequest);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(core);
-    ClientEndpoints endpoints = mock(ClientEndpoints.class);
-    when(core.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getFCPServer()).thenReturn(server);
+    when(handler.getServer()).thenReturn(server);
 
     message.run(handler, node);
 
-    verify(handler, times(1)).getRebootRequest(false, handler, "req-7");
-    verify(rebootRequest, times(1)).modifyRequest("tok", (short) 1, server);
+    verify(rebootRequest).modifyRequest("tok", (short) 1, server);
+    verifyNoInteractions(requestQueuePort);
     verify(handler, never()).send(any(FCPMessage.class));
   }
-
-  // ---------- run(): forever request path via job runner ----------
 
   @Test
   void run_whenRebootRequestMissingAndForeverRequestExists_modifiesRequestViaHandlerServer()
@@ -215,80 +166,47 @@ class ModifyPersistentRequestTest {
     fs.putSingle("ClientToken", "new-token");
     ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
 
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    ClientRequest foreverRequest = mock(ClientRequest.class);
-    FCPServer server = mock(FCPServer.class);
+    ClientRequest foreverRequest = org.mockito.Mockito.mock(ClientRequest.class);
+    stubRequestQueuePort();
     when(handler.getRebootRequest(false, handler, "req-8")).thenReturn(null);
     when(handler.getForeverRequest(false, handler, "req-8")).thenReturn(foreverRequest);
-    when(handler.getServer()).thenReturn(server);
-
-    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
-    Ticker ticker = mock(Ticker.class);
-    ClientContext context = newClientContext(jobRunner, ticker);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getClientContext()).thenReturn(context);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(core);
-
-    doAnswer(
-            invocation -> {
-              PersistentJob job = invocation.getArgument(0);
-              job.run(context);
-              return null;
-            })
-        .when(jobRunner)
-        .queue(any(PersistentJob.class), anyInt());
 
     message.run(handler, node);
 
-    verify(jobRunner, times(1))
-        .queue(any(PersistentJob.class), eq(NativeThread.PriorityLevel.NORM_PRIORITY.value));
-    verify(handler, times(1)).getForeverRequest(false, handler, "req-8");
-    verify(foreverRequest, times(1)).modifyRequest("new-token", (short) 4, server);
+    ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
+    verify(requestQueuePort)
+        .submitPersistentJob(taskCaptor.capture(), eq(RequestQueuePriority.NORMAL));
+
+    boolean checkpointRequested = taskCaptor.getValue().run();
+
+    assertTrue(checkpointRequested);
+    verify(foreverRequest).modifyRequest("new-token", (short) 4, server);
     verify(handler, never()).send(any(ProtocolErrorMessage.class));
   }
 
   @Test
-  void run_whenRebootAndForeverRequestsMissing_sendsNoSuchIdentifierErrorFromJob()
+  void run_whenRebootAndForeverRequestsMissing_sendsNoSuchIdentifierErrorFromQueuedTask()
       throws Exception {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "req-9");
     fs.put("Global", false);
     ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
 
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    stubRequestQueuePort();
     when(handler.getRebootRequest(false, handler, "req-9")).thenReturn(null);
     when(handler.getForeverRequest(false, handler, "req-9")).thenReturn(null);
 
-    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
-    Ticker ticker = mock(Ticker.class);
-    ClientContext context = newClientContext(jobRunner, ticker);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getClientContext()).thenReturn(context);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(core);
+    message.run(handler, node);
+
+    ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
+    verify(requestQueuePort)
+        .submitPersistentJob(taskCaptor.capture(), eq(RequestQueuePriority.NORMAL));
+
+    taskCaptor.getValue().run();
 
     ArgumentCaptor<ProtocolErrorMessage> errorCaptor =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);
-
-    doAnswer(
-            invocation -> {
-              PersistentJob job = invocation.getArgument(0);
-              job.run(context);
-              return null;
-            })
-        .when(jobRunner)
-        .queue(any(PersistentJob.class), anyInt());
-
-    message.run(handler, node);
-
-    verify(handler, times(1)).send(errorCaptor.capture());
+    verify(handler).send(errorCaptor.capture());
     ProtocolErrorMessage error = errorCaptor.getValue();
     assertNotNull(error);
     assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.getCode());
@@ -298,41 +216,26 @@ class ModifyPersistentRequestTest {
     assertNull(error.extra);
   }
 
-  // ---------- run(): persistence disabled path ----------
-
   @Test
-  void run_whenPersistenceDisabled_sendsNoSuchIdentifierErrorImmediately() throws Exception {
+  void run_whenQueueUnavailable_sendsNoSuchIdentifierErrorImmediately() throws Exception {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", "req-10");
     fs.put("Global", true);
     ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
 
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    stubRequestQueuePort();
     when(handler.getRebootRequest(true, handler, "req-10")).thenReturn(null);
-
-    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
-    Ticker ticker = mock(Ticker.class);
-    ClientContext context = newClientContext(jobRunner, ticker);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getClientContext()).thenReturn(context);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(core);
-
-    doThrow(new PersistenceDisabledException())
-        .when(jobRunner)
-        .queue(any(PersistentJob.class), anyInt());
+    doThrow(new RequestQueueUnavailableException("disabled"))
+        .when(requestQueuePort)
+        .submitPersistentJob(any(), eq(RequestQueuePriority.NORMAL));
 
     ArgumentCaptor<ProtocolErrorMessage> errorCaptor =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);
 
     message.run(handler, node);
 
-    verify(handler, times(1)).send(errorCaptor.capture());
-    verify(handler, never())
-        .getForeverRequest(anyBoolean(), any(FCPConnectionHandler.class), anyString());
+    verify(handler).send(errorCaptor.capture());
+    verify(handler, never()).getForeverRequest(eq(true), eq(handler), eq("req-10"));
     ProtocolErrorMessage error = errorCaptor.getValue();
     assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.getCode());
     assertFalse(error.fatal);
@@ -341,99 +244,9 @@ class ModifyPersistentRequestTest {
     assertNull(error.extra);
   }
 
-  @Test
-  void run_whenRebootRequestExists_doesNotInteractWithJobRunner() throws Exception {
-    SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", "req-11");
-    fs.put("Global", false);
-    ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
-
-    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
-    ClientRequest rebootRequest = mock(ClientRequest.class);
-    when(handler.getRebootRequest(false, handler, "req-11")).thenReturn(rebootRequest);
-
-    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
-    NodeClientCore core = mock(NodeClientCore.class);
-    ClientEndpoints endpoints = mock(ClientEndpoints.class);
-    when(core.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getFCPServer()).thenReturn(mock(FCPServer.class));
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(core);
-
-    message.run(handler, node);
-
-    verifyNoInteractions(jobRunner);
-  }
-
-  // ---------- Test helpers ----------
-
-  private static ClientContext newClientContext(ClientLayerPersister jobRunner, Ticker ticker) {
-    PriorityAwareExecutor executor =
-        new PriorityAwareExecutor() {
-
-          @Override
-          public void execute(@NotNull Runnable job) {
-            job.run();
-          }
-
-          @Override
-          public void execute(@NotNull Runnable job, String jobName) {
-            job.run();
-          }
-
-          @Override
-          public void execute(@NotNull Runnable job, String jobName, boolean fromTicker) {
-            job.run();
-          }
-
-          @Override
-          public int[] waitingThreads() {
-            return new int[0];
-          }
-
-          @Override
-          public int[] runningThreads() {
-            return new int[0];
-          }
-
-          @Override
-          public int getWaitingThreadsCount() {
-            return 0;
-          }
-        };
-
-    return new ClientContext(
-        1L,
-        new ClientContextRuntime(
-            jobRunner,
-            executor,
-            mock(MemoryLimitedJobRunner.class),
-            ticker,
-            mock(RandomSource.class),
-            new Random(0),
-            mock(MasterSecret.class)),
-        new ClientContextStorageFactories(
-            mock(PersistentTempBucketFactory.class),
-            mock(TempBucketFactory.class),
-            mock(PersistentFileTracker.class),
-            mock(FilenameGenerator.class),
-            mock(FilenameGenerator.class),
-            mock(FileRandomAccessBufferFactory.class),
-            mock(FileRandomAccessBufferFactory.class)),
-        new ClientContextRafFactories(
-            mock(LockableRandomAccessBufferFactory.class),
-            mock(LockableRandomAccessBufferFactory.class)),
-        new ClientContextServices(
-            new ClientContextResources(mock(ArchiveManager.class), mock(HealingQueue.class)),
-            mock(USKManager.class),
-            mock(RealCompressor.class),
-            mock(DatastoreChecker.class),
-            mock(PersistentRequestRoot.class),
-            mock(LinkFilterExceptionProvider.class)),
-        new ClientContextDefaults(
-            mock(FetchContext.class), mock(InsertContext.class), mock(Config.class)));
+  private void stubRequestQueuePort() {
+    when(handler.getServer()).thenReturn(server);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.requestQueue()).thenReturn(requestQueuePort);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/RemovePersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RemovePersistentRequestTest.java
@@ -1,14 +1,12 @@
 package network.crypta.clients.fcp;
 
-import java.lang.reflect.Field;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
-import network.crypta.client.async.PersistentJobRunner;
-import network.crypta.node.NodeClientCore;
+import network.crypta.node.Node;
+import network.crypta.runtime.spi.RequestQueuePort;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueTask;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.NativeThread;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -22,9 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -32,24 +28,17 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings("java:S100") // method naming: method_whenCondition_expectOutcome
+@SuppressWarnings("java:S100")
 class RemovePersistentRequestTest {
 
   private static final String IDENTIFIER = "req-id";
 
   @Mock private FCPConnectionHandler handler;
+  @Mock private Node node;
   @Mock private FCPServer server;
-  @Mock private NodeClientCore core;
-  @Mock private ClientContext clientContext;
-  @Mock private PersistentJobRunner jobRunner;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private RequestQueuePort requestQueuePort;
   @Mock private ClientRequest clientRequest;
-
-  @BeforeEach
-  void setUp() throws Exception {
-    Field jobRunnerField = ClientContext.class.getField("jobRunner");
-    jobRunnerField.setAccessible(true);
-    jobRunnerField.set(clientContext, jobRunner);
-  }
 
   @Test
   void constructor_whenIdentifierMissing_throwsMessageInvalidException() {
@@ -92,70 +81,66 @@ class RemovePersistentRequestTest {
     RemovePersistentRequest message = new RemovePersistentRequest(fs);
     when(handler.removePersistentRebootRequest(false, IDENTIFIER)).thenReturn(clientRequest);
 
-    message.run(handler, null);
+    message.run(handler, node);
 
     verify(handler).removePersistentRebootRequest(false, IDENTIFIER);
     verify(handler, never()).removeRequestByIdentifier(any(), anyBoolean());
-    verifyNoInteractions(jobRunner);
+    verifyNoInteractions(requestQueuePort);
   }
 
   @Test
-  void run_whenNonPersistentRequestFound_skipsPersistenceJob() throws Exception {
+  void run_whenNonPersistentRequestFound_skipsPersistentQueue() throws Exception {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", IDENTIFIER);
     RemovePersistentRequest message = new RemovePersistentRequest(fs);
     when(handler.removePersistentRebootRequest(false, IDENTIFIER)).thenReturn(null);
     when(handler.removeRequestByIdentifier(IDENTIFIER, true)).thenReturn(clientRequest);
 
-    message.run(handler, null);
+    message.run(handler, node);
 
     verify(handler).removePersistentRebootRequest(false, IDENTIFIER);
     verify(handler).removeRequestByIdentifier(IDENTIFIER, true);
     verify(handler, never()).removePersistentForeverRequest(anyBoolean(), any());
-    verifyNoInteractions(jobRunner);
+    verifyNoInteractions(requestQueuePort);
   }
 
   @Test
-  void run_whenQueuedJobRuns_removesForeverRequest() throws Exception {
+  void run_whenQueuedTaskRuns_removesForeverRequest() throws Exception {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", IDENTIFIER);
     fs.put("Global", true);
     RemovePersistentRequest message = new RemovePersistentRequest(fs);
+
+    stubRequestQueuePort();
     when(handler.removePersistentRebootRequest(true, IDENTIFIER)).thenReturn(null);
     when(handler.removePersistentForeverRequest(true, IDENTIFIER)).thenReturn(clientRequest);
-    stubJobRunnerChain();
-    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
-    doAnswer(invocation -> null)
-        .when(jobRunner)
-        .queue(jobCaptor.capture(), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
 
-    message.run(handler, null);
+    message.run(handler, node);
 
-    verify(handler).removePersistentRebootRequest(true, IDENTIFIER);
-    verify(handler, never()).removeRequestByIdentifier(any(), anyBoolean());
-    verify(jobRunner)
-        .queue(any(PersistentJob.class), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
+    ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
+    verify(requestQueuePort)
+        .submitPersistentJob(taskCaptor.capture(), eq(RequestQueuePriority.HIGH));
 
-    PersistentJob captured = jobCaptor.getValue();
-    boolean result = captured.run(clientContext);
+    boolean result = taskCaptor.getValue().run();
 
     assertTrue(result);
     verify(handler).removePersistentForeverRequest(true, IDENTIFIER);
   }
 
   @Test
-  void run_whenPersistenceDisabled_sendsProtocolError() throws Exception {
+  void run_whenQueueUnavailable_sendsPersistenceDisabledProtocolError() throws Exception {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identifier", IDENTIFIER);
     RemovePersistentRequest message = new RemovePersistentRequest(fs);
+
+    stubRequestQueuePort();
     when(handler.removePersistentRebootRequest(false, IDENTIFIER)).thenReturn(null);
     when(handler.removeRequestByIdentifier(IDENTIFIER, true)).thenReturn(null);
-    stubJobRunnerChain();
-    doThrow(new PersistenceDisabledException())
-        .when(jobRunner)
-        .queue(any(PersistentJob.class), anyInt());
+    doThrow(new RequestQueueUnavailableException("disabled"))
+        .when(requestQueuePort)
+        .submitPersistentJob(any(), eq(RequestQueuePriority.HIGH));
 
-    message.run(handler, null);
+    message.run(handler, node);
 
     ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(messageCaptor.capture());
@@ -165,9 +150,9 @@ class RemovePersistentRequestTest {
     assertEquals("Persistence disabled and non-persistent request not found", error.extra);
   }
 
-  private void stubJobRunnerChain() {
+  private void stubRequestQueuePort() {
     when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.getClientContext()).thenReturn(clientContext);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.requestQueue()).thenReturn(requestQueuePort);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
+++ b/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
@@ -1,8 +1,6 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,9 +12,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,13 +24,7 @@ class WatchGlobalTest {
   @Mock private FCPConnectionHandler handler;
   @Mock private PersistentRequestClient rebootClient;
   @Mock private PersistentRequestClient foreverClient;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeClientCore nodeClientCore;
-  @Mock private ClientEndpoints endpoints;
-  @Mock private FCPServer nodeFcpServer;
+  @Mock private Node node;
   @Mock private FCPServer handlerFcpServer;
 
   @Test
@@ -82,8 +74,7 @@ class WatchGlobalTest {
   void run_whenRebootSetWatchGlobalFails_sendsProtocolErrorAndUpdatesForeverClient()
       throws Exception {
     prepareSharedMocks();
-    when(handler.getServer()).thenReturn(handlerFcpServer);
-    when(rebootClient.setWatchGlobal(true, 3, nodeFcpServer)).thenReturn(false);
+    when(rebootClient.setWatchGlobal(true, 3, handlerFcpServer)).thenReturn(false);
     when(handler.getForeverClient()).thenReturn(foreverClient);
 
     WatchGlobal watchGlobal = new WatchGlobal(fieldSet(true, 3));
@@ -99,53 +90,44 @@ class WatchGlobalTest {
     assertTrue(errorFs.getBoolean("Global", false));
     assertEquals("Persistence disabled", errorFs.get("ExtraDescription"));
 
-    verify(rebootClient).setWatchGlobal(true, 3, nodeFcpServer);
+    verify(rebootClient).setWatchGlobal(true, 3, handlerFcpServer);
     verify(foreverClient).setWatchGlobal(true, 3, handlerFcpServer);
   }
 
   @Test
   void run_whenForeverClientMissing_skipsForeverWatchWithoutError() throws Exception {
     prepareSharedMocks();
-    when(rebootClient.setWatchGlobal(false, 9, nodeFcpServer)).thenReturn(true);
+    when(rebootClient.setWatchGlobal(false, 9, handlerFcpServer)).thenReturn(true);
     when(handler.getForeverClient()).thenReturn(null);
 
     WatchGlobal watchGlobal = new WatchGlobal(fieldSet(false, 9));
 
     watchGlobal.run(handler, node);
 
-    verify(rebootClient).setWatchGlobal(false, 9, nodeFcpServer);
-    verify(handler, never()).send(org.mockito.ArgumentMatchers.any(FCPMessage.class));
+    verify(rebootClient).setWatchGlobal(false, 9, handlerFcpServer);
+    verify(handler, never()).send(any(FCPMessage.class));
     verify(handler).getRebootClient();
     verify(handler).getForeverClient();
-    verify(nodeClientCore).getEndpoints();
-    verify(endpoints).getFCPServer();
-    verifyNoMoreInteractions(handler, rebootClient, node, nodeClientCore, nodeFcpServer);
   }
 
   @Test
-  void run_whenSetWatchGlobalSucceeds_updatesBothClientsWithoutError() throws Exception {
+  void run_whenSetWatchGlobalSucceeds_updatesBothClientsWithHandlerServer() throws Exception {
     prepareSharedMocks();
-    when(handler.getServer()).thenReturn(handlerFcpServer);
-    when(rebootClient.setWatchGlobal(false, 7, nodeFcpServer)).thenReturn(true);
+    when(rebootClient.setWatchGlobal(false, 7, handlerFcpServer)).thenReturn(true);
     when(handler.getForeverClient()).thenReturn(foreverClient);
 
     WatchGlobal watchGlobal = new WatchGlobal(fieldSet(false, 7));
 
     watchGlobal.run(handler, node);
 
-    verify(rebootClient).setWatchGlobal(false, 7, nodeFcpServer);
+    verify(rebootClient).setWatchGlobal(false, 7, handlerFcpServer);
     verify(foreverClient).setWatchGlobal(false, 7, handlerFcpServer);
-    verify(handler, never()).send(org.mockito.ArgumentMatchers.any(FCPMessage.class));
+    verify(handler, never()).send(any(FCPMessage.class));
   }
 
   private void prepareSharedMocks() {
     when(handler.getRebootClient()).thenReturn(rebootClient);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(nodeClientCore);
-    when(nodeClientCore.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getFCPServer()).thenReturn(nodeFcpServer);
+    when(handler.getServer()).thenReturn(handlerFcpServer);
   }
 
   private SimpleFieldSet fieldSet(boolean enabled, int verbosityMask) {

--- a/src/test/java/network/crypta/node/runtime/LegacyRequestQueuePortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyRequestQueuePortTest.java
@@ -1,0 +1,124 @@
+package network.crypta.node.runtime;
+
+import java.lang.reflect.Field;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RequestQueuePriority;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.support.Ticker;
+import network.crypta.support.io.NativeThread;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyRequestQueuePortTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private PersistentJobRunner jobRunner;
+  @Mock private Ticker ticker;
+  @Mock private ClientContext clientContext;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    setClientContextField("jobRunner", jobRunner);
+    setClientContextField("ticker", ticker);
+  }
+
+  @Test
+  void isPersistenceDatabaseKilled_whenCoreReportsKilled_delegatesToCore() {
+    LegacyRequestQueuePort port = new LegacyRequestQueuePort(core);
+    when(core.killedDatabase()).thenReturn(true);
+
+    assertTrue(port.isPersistenceDatabaseKilled());
+
+    verify(core).killedDatabase();
+  }
+
+  @Test
+  void submitPersistentJob_whenNormalPriority_mapsToNormPriority() throws Exception {
+    LegacyRequestQueuePort port = new LegacyRequestQueuePort(core);
+    stubClientContext();
+    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
+
+    port.submitPersistentJob(() -> false, RequestQueuePriority.NORMAL);
+
+    verify(jobRunner)
+        .queue(jobCaptor.capture(), eq(NativeThread.PriorityLevel.NORM_PRIORITY.value));
+    assertFalse(jobCaptor.getValue().run(clientContext));
+  }
+
+  @Test
+  void submitPersistentJob_whenHighPriority_mapsToHighPriority() throws Exception {
+    LegacyRequestQueuePort port = new LegacyRequestQueuePort(core);
+    stubClientContext();
+
+    port.submitPersistentJob(() -> true, RequestQueuePriority.HIGH);
+
+    verify(jobRunner).queue(any(), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
+  }
+
+  @Test
+  void submitPersistentJob_whenListingPriority_mapsToLegacyListingPriority() throws Exception {
+    LegacyRequestQueuePort port = new LegacyRequestQueuePort(core);
+    stubClientContext();
+
+    port.submitPersistentJob(() -> true, RequestQueuePriority.LISTING);
+
+    verify(jobRunner).queue(any(), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1));
+  }
+
+  @Test
+  void scheduleLater_whenCalled_delegatesToTicker() {
+    LegacyRequestQueuePort port = new LegacyRequestQueuePort(core);
+    stubClientContext();
+    Runnable task = org.mockito.Mockito.mock(Runnable.class);
+
+    port.scheduleLater(task, 123L);
+
+    verify(ticker).queueTimedJob(task, 123L);
+  }
+
+  @Test
+  void submitPersistentJob_whenPersistenceDisabled_translatesException() throws Exception {
+    LegacyRequestQueuePort port = new LegacyRequestQueuePort(core);
+    stubClientContext();
+    PersistenceDisabledException cause = new PersistenceDisabledException();
+    doThrow(cause).when(jobRunner).queue(any(), anyInt());
+
+    RequestQueueUnavailableException thrown =
+        assertThrows(
+            RequestQueueUnavailableException.class,
+            () -> port.submitPersistentJob(() -> false, RequestQueuePriority.NORMAL));
+
+    assertSame(cause, thrown.getCause());
+  }
+
+  private void setClientContextField(String fieldName, Object value) throws Exception {
+    Field field = ClientContext.class.getField(fieldName);
+    field.setAccessible(true);
+    field.set(clientContext, value);
+  }
+
+  private void stubClientContext() {
+    when(core.getClientContext()).thenReturn(clientContext);
+  }
+}


### PR DESCRIPTION
## Summary
- add a JDK-only request-queue SPI for persistent-request queue control and expose it through `RuntimePorts`
- wire a legacy `NodeClientCore` adapter and migrate the remaining FCP persistent-request / queue-control messages off live daemon traversal
- update the focused FCP/runtime tests and add Javadocs for the new runtime-spi types

## How to test
- `./gradlew -q classes`
- `./gradlew test --tests "network.crypta.node.runtime.LegacyRequestQueuePortTest" --tests "network.crypta.clients.fcp.GetRequestStatusMessageTest" --tests "network.crypta.clients.fcp.ModifyPersistentRequestTest" --tests "network.crypta.clients.fcp.RemovePersistentRequestTest" --tests "network.crypta.clients.fcp.ListPersistentRequestsMessageTest" --tests "network.crypta.clients.fcp.WatchGlobalTest" --tests "network.crypta.clients.fcp.PersistentRequestClientTest" --tests "network.crypta.clients.fcp.FCPServerTest" --tests "network.crypta.clients.fcp.FCPConnectionHandlerTest" --tests "network.crypta.node.NodeClientCoreTest"`